### PR TITLE
feat(telegram): require allowlisted admin for group joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ would be useful; otherwise it stays silent. Telegram must also deliver ambient
 messages to the bot: use BotFather's `/setprivacy` command to disable privacy
 mode for that bot, then remove and re-add the bot to existing groups if needed.
 
+The bot only stays in a group or channel if an allowlisted user who is also a
+Telegram administrator of that chat added it. Anyone else adding it causes the
+bot to leave immediately. Anonymous-admin adds are accepted only when an
+allowlisted user is already an administrator of that chat. Existing groups that
+already have a saved session are kept after upgrading; to authorize another
+group, add the bot as an allowed admin or mention it there.
+
 Each private chat, group, and forum topic is mapped to its own persisted agent
 session under `~/.haskell-agent`; `/new` starts a fresh session, `/session`
 shows the current session ID, `/status` reports queued/retrying/failed work,

--- a/packages/agent-cli/skills/telegram-agent/SKILL.md
+++ b/packages/agent-cli/skills/telegram-agent/SKILL.md
@@ -59,13 +59,14 @@ disables terminal echo and stores the token in a private gateway file.
 9. Tell the user to open their new bot and send `/start`. The bot supports
    `/new` for a fresh agent session, `/session` for the current session ID,
    `/status` for queue/retry state, and `/retry` for the latest failed turn.
-   To use it in a group, add the bot and mention its `@username`, reply to one
-   of its messages, or address commands to it (for example
-   `/new@your_bot_username`). Each group or forum topic has a shared agent
-   session. Only messages from allowlisted users are accepted; ambient group
-   traffic is ignored unless setup used `--all-group-messages`. In that mode
-   each allowed-user message is considered, but the agent stays silent unless
-   a response would be useful. Text, edited messages, reactions, photos,
+   To use it in a group, an allowlisted Telegram administrator of that group
+   must add the bot. If anyone else adds it, the bot leaves. Then mention its
+   `@username`, reply to one of its messages, or address commands to it (for
+   example `/new@your_bot_username`). Each group or forum topic has a shared
+   agent session. Only messages from allowlisted users are accepted; ambient
+   group traffic is ignored unless setup used `--all-group-messages`. In that
+   mode each allowed-user message is considered, but the agent stays silent
+   unless a response would be useful. Text, edited messages, reactions, photos,
    documents, audio, video, video notes, animations, stickers, locations,
    contacts, venues, polls, dice, and voice messages are persisted before
    processing.

--- a/packages/agent-telegram/src/Agent/Telegram.hs
+++ b/packages/agent-telegram/src/Agent/Telegram.hs
@@ -24,6 +24,9 @@ module Agent.Telegram
     , emptyTelegramState
     , classifyTelegramUpdate
     , classifyTelegramUpdateWithMode
+    , groupJoinAuthorized
+    , isAnonymousAdmin
+    , telegramAnonymousAdminUserId
     , storeUpdateAction
     , nextPendingAction
     , checkpointPendingVoiceTranscript
@@ -81,6 +84,9 @@ import Agent.Telegram.Classify
     , checkpointPendingVoiceTranscript
     , classifyTelegramUpdate
     , classifyTelegramUpdateWithMode
+    , groupJoinAuthorized
+    , isAnonymousAdmin
+    , telegramAnonymousAdminUserId
     , isAmbientGroupPrompt
     , nextPendingAction
     , reactionMessageText
@@ -148,7 +154,8 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Int (Int64)
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.List (partition)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -715,7 +722,9 @@ pollForever runtime = do
                 ]
             threadDelay 2_000_000
         Right updates ->
-            forM_ updates (processUpdate runtime)
+            let (memberships, rest) =
+                    partition isMembershipUpdate updates
+            in forM_ (memberships <> rest) (processUpdate runtime)
     pollForever runtime
 
 processUpdate :: TelegramRuntime -> TelegramUpdate -> IO ()
@@ -733,38 +742,93 @@ processUpdate runtime update = do
                 ]
         Right () -> pure ()
 
+isMembershipUpdate :: TelegramUpdate -> Bool
+isMembershipUpdate update =
+    isJust update.updateMyChatMember
+        || maybe False (not . null . (.messageNewChatMembers)) update.updateMessage
+
 classifyUpdate
     :: TelegramRuntime
     -> TelegramUpdate
     -> IO TelegramUpdateAction
-classifyUpdate runtime update =
-    case update.updateMessageReaction of
-        Just reaction
-            | reaction.messageReactionChat.telegramChatType /= "private" -> do
-                state <- readMVar runtime.runtimeStateVar
-                let key = TelegramChatKey
-                        { chatId =
-                            reaction.messageReactionChat.telegramChatId
-                        , messageThreadId = Nothing
-                        }
-                    belongsToBot =
-                        maybe False
-                            (Set.member reaction.messageReactionMessageId)
-                            (Map.lookup key state.outboundMessageIds)
-                pure $
-                    if belongsToBot
-                        then classifyTelegramUpdateWithMode
-                            runtime.runtimeBot
-                            runtime.runtimeAllowedUsers
-                            runtime.runtimeRespondToAllGroupMessages
-                            update
-                        else IgnoreUpdate
-        _ ->
-            pure (classifyTelegramUpdateWithMode
+classifyUpdate runtime update = do
+    state <- readMVar runtime.runtimeStateVar
+    classified <-
+        case classifyTelegramUpdateWithMode
                 runtime.runtimeBot
                 runtime.runtimeAllowedUsers
+                state.authorizedGroupChatIds
                 runtime.runtimeRespondToAllGroupMessages
-                update)
+                update of
+            ReviewGroupJoin chatId actor ->
+                resolveGroupJoin runtime chatId actor
+            action ->
+                pure action
+    pure $ case (classified, update.updateMessageReaction) of
+        (LeaveUnauthorizedGroup _, _) ->
+            classified
+        (_, Just reaction)
+            | reaction.messageReactionChat.telegramChatType /= "private"
+            , not (reactionBelongsToBot state reaction) ->
+                IgnoreUpdate
+        _ ->
+            classified
+
+reactionBelongsToBot :: TelegramState -> TelegramMessageReaction -> Bool
+reactionBelongsToBot state reaction =
+    let key = TelegramChatKey
+            { chatId = reaction.messageReactionChat.telegramChatId
+            , messageThreadId = Nothing
+            }
+    in maybe False
+        (Set.member reaction.messageReactionMessageId)
+        (Map.lookup key state.outboundMessageIds)
+
+resolveGroupJoin
+    :: TelegramRuntime
+    -> Integer
+    -> TelegramUser
+    -> IO TelegramUpdateAction
+resolveGroupJoin runtime chatId actor
+    | actor.userId `Set.notMember` runtime.runtimeAllowedUsers
+    , not (isAnonymousAdmin actor) = do
+        logRejectedJoin chatId actor "adder is not an allowed user"
+        pure (LeaveUnauthorizedGroup chatId)
+    | otherwise =
+        TelegramClient.getChatAdministrators runtime.runtimeClient chatId >>= \case
+            Left err -> do
+                logTelegramEvent "group_admin_lookup_failed"
+                    [ "chat_id" .= chatId
+                    , "user_id" .= actor.userId
+                    , "error" .=
+                        redactToken runtime.runtimeClient.clientToken err
+                    ]
+                logRejectedJoin chatId actor
+                    "could not verify group administrators"
+                pure (LeaveUnauthorizedGroup chatId)
+            Right admins
+                | groupJoinAuthorized runtime.runtimeAllowedUsers actor admins -> do
+                    logTelegramEvent "group_join_authorized"
+                        [ "chat_id" .= chatId
+                        , "user_id" .= actor.userId
+                        ]
+                    pure (AuthorizeGroupChat chatId)
+                | otherwise -> do
+                    logRejectedJoin chatId actor
+                        "adder is not an allowed group administrator"
+                    pure (LeaveUnauthorizedGroup chatId)
+
+logRejectedJoin
+    :: Integer
+    -> TelegramUser
+    -> Text
+    -> IO ()
+logRejectedJoin chatId actor reason =
+    logTelegramEvent "group_join_rejected"
+        [ "chat_id" .= chatId
+        , "user_id" .= actor.userId
+        , "reason" .= reason
+        ]
 
 dispatchForever :: TelegramRuntime -> IO ()
 dispatchForever runtime =
@@ -803,6 +867,59 @@ telegramWorkerLoop runtime = do
         modifyMVar_ runtime.runtimeScheduled
             (pure . Set.delete key)
     telegramWorkerLoop runtime
+
+unauthorizedGroupLeaveNotice :: Text
+unauthorizedGroupLeaveNotice =
+    "I only join group chats when an authorized admin adds me. Leaving this group."
+
+leaveUnauthorizedGroup
+    :: TelegramRuntime
+    -> TelegramPendingLeave
+    -> IO ()
+leaveUnauthorizedGroup runtime pending = do
+    let key = pending.pendingLeaveChat
+        chatId = key.chatId
+    logTelegramEvent "leaving_unauthorized_group"
+        [ "chat_id" .= chatId
+        , "update_id" .= pending.pendingLeaveUpdateId
+        ]
+    TelegramClient.sendRichMessage
+        runtime.runtimeClient
+        key
+        Nothing
+        unauthorizedGroupLeaveNotice >>= \case
+            Left err ->
+                logTelegramEvent "unauthorized_group_notice_failed"
+                    [ "chat_id" .= chatId
+                    , "error" .=
+                        redactToken runtime.runtimeClient.clientToken err
+                    ]
+            Right _ -> pure ()
+    TelegramClient.leaveChat runtime.runtimeClient chatId >>= \case
+        Left err
+            | isBenignLeaveError err ->
+                logTelegramEvent "unauthorized_group_already_left"
+                    [ "chat_id" .= chatId
+                    , "error" .=
+                        redactToken runtime.runtimeClient.clientToken err
+                    ]
+            | otherwise ->
+                fail (Text.unpack err)
+        Right () ->
+            logTelegramEvent "left_unauthorized_group"
+                [ "chat_id" .= chatId
+                ]
+
+isBenignLeaveError :: Text -> Bool
+isBenignLeaveError err =
+    any (`Text.isInfixOf` Text.toLower err)
+        [ "chat not found"
+        , "bot is not a member"
+        , "chat_id is empty"
+        , "peer_id_invalid"
+        , "bot was kicked"
+        , "bot was blocked"
+        ]
 
 processChatQueue :: TelegramRuntime -> TelegramChatKey -> IO ()
 processChatQueue runtime key =
@@ -856,6 +973,9 @@ processChatQueue runtime key =
                                             (Just pending.pendingMediaMessageId)
                                             replyText))
                                     completed
+                LeaveUnauthorizedChat pending -> do
+                    leaveUnauthorizedGroup runtime pending
+                    modifyState runtime (completePendingAction action)
             case result of
                 Left err -> do
                     delay <- recordPendingFailure
@@ -1009,6 +1129,8 @@ rekeyPendingAction updateId = \case
         RunPendingTurn pending { pendingTurnUpdateId = updateId }
     RunPendingMediaTurn pending ->
         RunPendingMediaTurn pending { pendingMediaUpdateId = updateId }
+    LeaveUnauthorizedChat pending ->
+        LeaveUnauthorizedChat pending { pendingLeaveUpdateId = updateId }
 
 runQueuedMediaTurn :: TelegramRuntime -> TelegramPendingMediaTurn -> IO Text
 runQueuedMediaTurn runtime pending = do
@@ -1300,7 +1422,7 @@ recordPendingFailure runtime action err =
                     (TelegramRetryMetadata 0 Nothing Nothing)
                     (Map.lookup key state.retryMetadata)
             attempts = previous.retryAttempts + 1
-        if attempts >= 5
+        if attempts >= 5 && not (isLeaveAction action)
             then do
                 let withoutAction =
                         (deletePendingAction action state)
@@ -1328,7 +1450,7 @@ recordPendingFailure runtime action err =
                 saveTelegramState runtime.runtimeStatePath next
                 pure (next, Nothing)
             else do
-                let seconds = min 60 (2 ^ attempts)
+                let seconds = min 60 (2 ^ min 6 attempts)
                     retryAt = addUTCTime (fromIntegral seconds) now
                     next = state
                         { retryMetadata =
@@ -1347,6 +1469,7 @@ recordPendingFailure runtime action err =
 failureReply :: PendingChatAction -> Maybe TelegramPendingReply
 failureReply = \case
     DeliverReply _ -> Nothing
+    LeaveUnauthorizedChat _ -> Nothing
     RunPendingTurn pending ->
         Just TelegramPendingReply
             { pendingUpdateId = pending.pendingTurnUpdateId
@@ -1377,19 +1500,27 @@ pendingRetryKey action =
             DeliverReply _ -> "reply"
             RunPendingTurn _ -> "turn"
             RunPendingMediaTurn _ -> "media"
+            LeaveUnauthorizedChat _ -> "leave"
         ]
+
+isLeaveAction :: PendingChatAction -> Bool
+isLeaveAction = \case
+    LeaveUnauthorizedChat _ -> True
+    _ -> False
 
 pendingActionUpdateIdLocal :: PendingChatAction -> Integer
 pendingActionUpdateIdLocal = \case
     DeliverReply pending -> pending.pendingUpdateId
     RunPendingTurn pending -> pending.pendingTurnUpdateId
     RunPendingMediaTurn pending -> pending.pendingMediaUpdateId
+    LeaveUnauthorizedChat pending -> pending.pendingLeaveUpdateId
 
 pendingActionChatLocal :: PendingChatAction -> TelegramChatKey
 pendingActionChatLocal = \case
     DeliverReply pending -> pending.pendingChat
     RunPendingTurn pending -> pending.pendingTurnChat
     RunPendingMediaTurn pending -> pending.pendingMediaChat
+    LeaveUnauthorizedChat pending -> pending.pendingLeaveChat
 
 runAgentTurn
     :: TelegramRuntime

--- a/packages/agent-telegram/src/Agent/Telegram/Classify.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Classify.hs
@@ -7,6 +7,9 @@ module Agent.Telegram.Classify
     , ambientGroupPrompt
     , classifyTelegramUpdate
     , classifyTelegramUpdateWithMode
+    , groupJoinAuthorized
+    , isAnonymousAdmin
+    , telegramAnonymousAdminUserId
     , isAmbientGroupPrompt
     , reactionMessageText
     , telegramCommand
@@ -17,7 +20,7 @@ module Agent.Telegram.Classify
 import Agent.Telegram.Types
 import Control.Applicative ((<|>))
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, maybeToList)
+import Data.Maybe (fromMaybe, isJust, maybeToList)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -28,6 +31,10 @@ data TelegramUpdateAction
     | QueueTurn !Integer !TelegramChatKey !Text !(Maybe TelegramVoice)
     | QueueMediaTurn !TelegramPendingMediaTurn
     | QueueCallback !TelegramPendingCallback
+    | AuthorizeGroupChat !Integer
+    | RevokeGroupChat !Integer
+    | ReviewGroupJoin !Integer !TelegramUser
+    | LeaveUnauthorizedGroup !Integer
     deriving (Eq, Show)
 
 storeUpdateAction
@@ -41,12 +48,36 @@ storeUpdateAction updateId action current
     | otherwise =
         advanceOffset case action of
             IgnoreUpdate -> current
+            ReviewGroupJoin _ _ -> current
+            AuthorizeGroupChat chatId ->
+                current
+                    { authorizedGroupChatIds =
+                        Set.insert chatId current.authorizedGroupChatIds
+                    }
+            RevokeGroupChat chatId ->
+                current
+                    { authorizedGroupChatIds =
+                        Set.delete chatId current.authorizedGroupChatIds
+                    }
+            LeaveUnauthorizedGroup chatId ->
+                enqueuePendingAction
+                    (LeaveUnauthorizedChat
+                        (TelegramPendingLeave
+                            updateId
+                            (TelegramChatKey chatId Nothing)))
+                    (dropPendingChat chatId current)
+                        { authorizedGroupChatIds =
+                            Set.delete
+                                chatId
+                                current.authorizedGroupChatIds
+                        }
             QueueTurn messageId key text voice ->
-                enqueueIncomingAction
-                    (RunPendingTurn
-                        (TelegramPendingTurn
-                            updateId messageId key text voice))
-                    current
+                authorizeGroupKey key $
+                    enqueueIncomingAction
+                        (RunPendingTurn
+                            (TelegramPendingTurn
+                                updateId messageId key text voice))
+                        current
             QueueMediaTurn pending ->
                 let prepared = pending
                         { pendingMediaUpdateId = updateId
@@ -58,17 +89,19 @@ storeUpdateAction updateId action current
                                 pending.pendingMediaMessageId
                                 current
                             else current
-                in enqueueIncomingAction
-                    (RunPendingMediaTurn prepared)
-                    replaced
+                in authorizeGroupKey pending.pendingMediaChat $
+                    enqueueIncomingAction
+                        (RunPendingMediaTurn prepared)
+                        replaced
             QueueCallback pending ->
-                current
-                    { pendingCallbacks =
-                        Map.insert
-                            pending.pendingCallbackUpdateId
-                            pending
-                            current.pendingCallbacks
-                    }
+                maybe id authorizeGroupKey pending.pendingCallbackChat $
+                    current
+                        { pendingCallbacks =
+                            Map.insert
+                                pending.pendingCallbackUpdateId
+                                pending
+                                current.pendingCallbacks
+                        }
   where
     advanceOffset state =
         state
@@ -162,18 +195,22 @@ pendingActionParts = \case
     DeliverReply pending ->
         (pending.pendingText, [], 0, fromMaybe 0 pending.pendingReplyToMessageId,
             False, Nothing)
+    LeaveUnauthorizedChat _ ->
+        ("", [], 0, 0, False, Nothing)
 
 pendingActionUpdateIdLocal :: PendingChatAction -> Integer
 pendingActionUpdateIdLocal = \case
     DeliverReply pending -> pending.pendingUpdateId
     RunPendingTurn pending -> pending.pendingTurnUpdateId
     RunPendingMediaTurn pending -> pending.pendingMediaUpdateId
+    LeaveUnauthorizedChat pending -> pending.pendingLeaveUpdateId
 
 pendingActionChatLocal :: PendingChatAction -> TelegramChatKey
 pendingActionChatLocal = \case
     DeliverReply pending -> pending.pendingChat
     RunPendingTurn pending -> pending.pendingTurnChat
     RunPendingMediaTurn pending -> pending.pendingMediaChat
+    LeaveUnauthorizedChat pending -> pending.pendingLeaveChat
 
 removePendingMessage
     :: TelegramChatKey
@@ -200,6 +237,168 @@ removePendingMessage key messageId state =
         RunPendingMediaTurn pending ->
             pending.pendingMediaMessageId == messageId
         DeliverReply _ -> False
+        LeaveUnauthorizedChat _ -> False
+
+telegramAnonymousAdminUserId :: Integer
+telegramAnonymousAdminUserId = 1087968824
+
+isAnonymousAdmin :: TelegramUser -> Bool
+isAnonymousAdmin user =
+    user.userId == telegramAnonymousAdminUserId
+        || user.userUsername == Just "GroupAnonymousBot"
+
+isGroupChatType :: Text -> Bool
+isGroupChatType chatType =
+    chatType == "group"
+        || chatType == "supergroup"
+        || chatType == "channel"
+
+chatMemberIsPresent :: TelegramChatMember -> Bool
+chatMemberIsPresent member =
+    case member.chatMemberStatus of
+        "creator" -> True
+        "administrator" -> True
+        "member" -> True
+        "restricted" -> member.chatMemberIsMember == Just True
+        _ -> False
+
+chatMemberIsAdministrator :: TelegramChatMember -> Bool
+chatMemberIsAdministrator member =
+    member.chatMemberStatus == "creator"
+        || member.chatMemberStatus == "administrator"
+
+groupJoinAuthorized
+    :: Set Integer
+    -> TelegramUser
+    -> [TelegramChatMember]
+    -> Bool
+groupJoinAuthorized allowedUsers actor admins =
+    let adminIds =
+            Set.fromList
+                [ member.chatMemberUser.userId
+                | member <- admins
+                , chatMemberIsAdministrator member
+                ]
+    in if isAnonymousAdmin actor
+        then any (`Set.member` allowedUsers) (Set.toList adminIds)
+        else actor.userId `Set.member` allowedUsers
+            && actor.userId `Set.member` adminIds
+
+dropPendingChat :: Integer -> TelegramState -> TelegramState
+dropPendingChat chatId state =
+    state
+        { pendingQueues =
+            Map.filterWithKey
+                (\key _ -> key.chatId /= chatId)
+                state.pendingQueues
+        }
+
+authorizeGroupKey :: TelegramChatKey -> TelegramState -> TelegramState
+authorizeGroupKey key state
+    | key.chatId < 0 =
+        state
+            { authorizedGroupChatIds =
+                Set.insert key.chatId state.authorizedGroupChatIds
+            }
+    | otherwise = state
+
+classifyGroupJoin
+    :: Set Integer
+    -> Set Integer
+    -> Integer
+    -> TelegramUser
+    -> TelegramUpdateAction
+classifyGroupJoin allowedUsers authorizedGroups chatId actor
+    | chatId `Set.member` authorizedGroups = IgnoreUpdate
+    | actor.userId `Set.member` allowedUsers || isAnonymousAdmin actor =
+        ReviewGroupJoin chatId actor
+    | otherwise = LeaveUnauthorizedGroup chatId
+
+classifyMyChatMember
+    :: Set Integer
+    -> Set Integer
+    -> TelegramChatMemberUpdated
+    -> TelegramUpdateAction
+classifyMyChatMember allowedUsers authorizedGroups membership
+    | not (isGroupChatType membership.chatMemberUpdatedChat.telegramChatType) =
+        IgnoreUpdate
+    | chatMemberIsPresent membership.chatMemberUpdatedNew =
+        classifyGroupJoin
+            allowedUsers
+            authorizedGroups
+            membership.chatMemberUpdatedChat.telegramChatId
+            membership.chatMemberUpdatedFrom
+    | chatMemberIsPresent membership.chatMemberUpdatedOld =
+        RevokeGroupChat membership.chatMemberUpdatedChat.telegramChatId
+    | otherwise = IgnoreUpdate
+
+botAddedInMessage :: TelegramUser -> TelegramMessage -> Bool
+botAddedInMessage bot message =
+    any (\user -> user.userId == bot.userId) message.messageNewChatMembers
+
+classifyBotAddedMessage
+    :: Set Integer
+    -> Set Integer
+    -> TelegramMessage
+    -> TelegramUpdateAction
+classifyBotAddedMessage allowedUsers authorizedGroups message
+    | not (isGroupChatType message.messageChat.telegramChatType) =
+        IgnoreUpdate
+    | otherwise =
+        case message.messageFrom of
+            Just sender ->
+                classifyGroupJoin
+                    allowedUsers
+                    authorizedGroups
+                    message.messageChat.telegramChatId
+                    sender
+            Nothing ->
+                LeaveUnauthorizedGroup message.messageChat.telegramChatId
+
+inboundGroupChatId :: TelegramUpdate -> Maybe Integer
+inboundGroupChatId update =
+    (update.updateMyChatMember >>= chatIdFromChat . (.chatMemberUpdatedChat))
+        <|> (update.updateMessage >>= chatIdFromChat . (.messageChat))
+        <|> (update.updateEditedMessage >>= chatIdFromChat . (.messageChat))
+        <|> (update.updateMessageReaction >>= chatIdFromChat . (.messageReactionChat))
+        <|> (update.updateCallbackQuery
+            >>= (.callbackQueryMessage)
+            >>= chatIdFromChat . (.messageChat))
+  where
+    chatIdFromChat chat =
+        if isGroupChatType chat.telegramChatType
+            then Just chat.telegramChatId
+            else Nothing
+
+isMembershipAction :: TelegramUpdateAction -> Bool
+isMembershipAction = \case
+    AuthorizeGroupChat _ -> True
+    RevokeGroupChat _ -> True
+    ReviewGroupJoin _ _ -> True
+    LeaveUnauthorizedGroup _ -> True
+    _ -> False
+
+isAuthorizingGroupAction :: TelegramUpdateAction -> Bool
+isAuthorizingGroupAction = \case
+    QueueTurn _ _ text _ -> not (isAmbientGroupPrompt text)
+    QueueMediaTurn pending ->
+        not (isAmbientGroupPrompt pending.pendingMediaText)
+    QueueCallback _ -> True
+    _ -> False
+
+enforceGroupAuthorization
+    :: Set Integer
+    -> TelegramUpdate
+    -> TelegramUpdateAction
+    -> TelegramUpdateAction
+enforceGroupAuthorization authorizedGroups update action
+    | isMembershipAction action = action
+    | Just chatId <- inboundGroupChatId update
+    , chatId `Set.notMember` authorizedGroups
+    , not (isAuthorizingGroupAction action)
+        || isJust update.updateMessageReaction =
+        LeaveUnauthorizedGroup chatId
+    | otherwise = action
 
 classifyTelegramUpdate
     :: TelegramUser
@@ -207,7 +406,7 @@ classifyTelegramUpdate
     -> TelegramUpdate
     -> TelegramUpdateAction
 classifyTelegramUpdate bot allowedUsers =
-    classifyTelegramUpdateWithMode bot allowedUsers False
+    classifyTelegramUpdateWithMode bot allowedUsers Set.empty False
 
 setActionUpdateId :: Integer -> TelegramUpdateAction -> TelegramUpdateAction
 setActionUpdateId updateId = \case
@@ -237,68 +436,59 @@ classifyTelegramReaction allowedUsers update =
 classifyTelegramUpdateWithMode
     :: TelegramUser
     -> Set Integer
+    -> Set Integer
     -> Bool
     -> TelegramUpdate
     -> TelegramUpdateAction
-classifyTelegramUpdateWithMode bot allowedUsers respondToAllGroupMessages update =
-    case update of
-        TelegramUpdate
-            { updateMessage = Just message
-            , updateEditedMessage = _
-            , updateMessageReaction = _
-            , updateCallbackQuery = _
-            }
-            | Just sender <- message.messageFrom
-            , sender.userId `Set.member` allowedUsers ->
-                setActionUpdateId update.updateId
-                    (classifyMessageLike
-                        False
-                        bot
-                        sender
-                        respondToAllGroupMessages
-                        message)
-        TelegramUpdate
-            { updateMessage = Nothing
-            , updateEditedMessage = Just message
-            , updateMessageReaction = _
-            , updateCallbackQuery = _
-            }
-            | Just sender <- message.messageFrom
-            , sender.userId `Set.member` allowedUsers ->
-                setActionUpdateId update.updateId
-                    (classifyMessageLike
-                        True
-                        bot
-                        sender
-                        respondToAllGroupMessages
-                        message)
-        TelegramUpdate
-            { updateMessageReaction = Just reaction
-            , updateCallbackQuery = _
-            }
-            | reaction.messageReactionChat.telegramChatType == "private" ->
+classifyTelegramUpdateWithMode bot allowedUsers authorizedGroups respondToAllGroupMessages update =
+    enforceGroupAuthorization authorizedGroups update $
+        case update of
+            TelegramUpdate { updateMyChatMember = Just membership } ->
+                classifyMyChatMember allowedUsers authorizedGroups membership
+            TelegramUpdate { updateMessage = Just message }
+                | botAddedInMessage bot message ->
+                    classifyBotAddedMessage allowedUsers authorizedGroups message
+            TelegramUpdate { updateMessage = Just message }
+                | Just sender <- message.messageFrom
+                , sender.userId `Set.member` allowedUsers ->
+                    setActionUpdateId update.updateId
+                        (classifyMessageLike
+                            False
+                            bot
+                            sender
+                            respondToAllGroupMessages
+                            message)
+            TelegramUpdate { updateEditedMessage = Just message }
+                | Just sender <- message.messageFrom
+                , sender.userId `Set.member` allowedUsers ->
+                    setActionUpdateId update.updateId
+                        (classifyMessageLike
+                            True
+                            bot
+                            sender
+                            respondToAllGroupMessages
+                            message)
+            TelegramUpdate { updateMessageReaction = Just _ } ->
                 classifyTelegramReaction allowedUsers update
-        TelegramUpdate
-            { updateCallbackQuery = Just callback
-            }
-            | sender <- callback.callbackQueryFrom
-            , sender.userId `Set.member` allowedUsers
-            , Just callbackData <- callback.callbackQueryData ->
-                QueueCallback TelegramPendingCallback
-                    { pendingCallbackUpdateId = update.updateId
-                    , pendingCallbackQueryId = callback.callbackQueryId
-                    , pendingCallbackUserId = sender.userId
-                    , pendingCallbackChat =
-                        (\message -> TelegramChatKey
-                            { chatId = message.messageChat.telegramChatId
-                            , messageThreadId = message.messageThread
-                            })
-                            <$> callback.callbackQueryMessage
-                    , pendingCallbackMessageId =
-                        (.messageId) <$> callback.callbackQueryMessage
-                    , pendingCallbackData = callbackData
-                    }
-        _ -> IgnoreUpdate
+            TelegramUpdate { updateCallbackQuery = Just callback }
+                | sender <- callback.callbackQueryFrom
+                , sender.userId `Set.member` allowedUsers
+                , Just callbackData <- callback.callbackQueryData ->
+                    QueueCallback TelegramPendingCallback
+                        { pendingCallbackUpdateId = update.updateId
+                        , pendingCallbackQueryId = callback.callbackQueryId
+                        , pendingCallbackUserId = sender.userId
+                        , pendingCallbackChat =
+                            (\message -> TelegramChatKey
+                                { chatId = message.messageChat.telegramChatId
+                                , messageThreadId = message.messageThread
+                                })
+                                <$> callback.callbackQueryMessage
+                        , pendingCallbackMessageId =
+                            (.messageId) <$> callback.callbackQueryMessage
+                        , pendingCallbackData = callbackData
+                        }
+            _ -> IgnoreUpdate
 
 classifyMessageLike
     :: Bool

--- a/packages/agent-telegram/src/Agent/Telegram/Client.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Client.hs
@@ -19,6 +19,8 @@ module Agent.Telegram.Client
     , sendTelegramDocument
     , sendTelegramPhoto
     , sendTelegramVoice
+    , getChatAdministrators
+    , leaveChat
     , redactToken
     ) where
 
@@ -223,10 +225,29 @@ getUpdates client offset =
               , "edited_message"
               , "message_reaction"
               , "callback_query"
+              , "my_chat_member"
               ] :: [Text]
             )
         ]
             <> maybe [] (\value -> ["offset" .= value]) offset
+
+getChatAdministrators
+    :: TelegramClient
+    -> Integer
+    -> IO (Either Text [TelegramChatMember])
+getChatAdministrators client chatId =
+    telegramRequest client "getChatAdministrators"
+        (object ["chat_id" .= chatId])
+        15 >>= \case
+        Left err -> pure (Left err)
+        Right response -> pure (decodeTelegramResponse response)
+
+leaveChat
+    :: TelegramClient
+    -> Integer
+    -> IO (Either Text ())
+leaveChat client chatId =
+    requestUnit client "leaveChat" (object ["chat_id" .= chatId])
 
 getTelegramBot :: TelegramClient -> IO TelegramUser
 getTelegramBot client =

--- a/packages/agent-telegram/src/Agent/Telegram/Types.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Types.hs
@@ -16,6 +16,7 @@ module Agent.Telegram.Types
     , TelegramPendingTurn(..)
     , TelegramPendingReply(..)
     , TelegramPendingMediaTurn(..)
+    , TelegramPendingLeave(..)
     , TelegramPendingCallback(..)
     , TelegramRetryMetadata(..)
     , TelegramDeadLetter(..)
@@ -38,6 +39,8 @@ module Agent.Telegram.Types
     , TelegramDice(..)
     , TelegramUser(..)
     , TelegramChat(..)
+    , TelegramChatMember(..)
+    , TelegramChatMemberUpdated(..)
     , TelegramMessage(..)
     , TelegramReactionType(..)
     , TelegramMessageReaction(..)
@@ -68,7 +71,7 @@ import Data.Aeson (Value)
 import qualified Data.Aeson as Aeson
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
-import Data.List (sortOn)
+import Data.List (sort, sortOn)
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -97,6 +100,10 @@ instance ToJSON PendingChatAction where
             [ "kind" .= ("media_turn" :: Text)
             , "mediaTurn" .= pending
             ]
+        LeaveUnauthorizedChat pending -> object
+            [ "kind" .= ("leave" :: Text)
+            , "leave" .= pending
+            ]
 
 instance FromJSON PendingChatAction where
     parseJSON = withObject "PendingChatAction" \o -> do
@@ -105,6 +112,7 @@ instance FromJSON PendingChatAction where
             "reply" -> DeliverReply <$> o .: "reply"
             "turn" -> RunPendingTurn <$> o .: "turn"
             "media_turn" -> RunPendingMediaTurn <$> o .: "mediaTurn"
+            "leave" -> LeaveUnauthorizedChat <$> o .: "leave"
             _ -> fail ("unknown pending Telegram action: " <> Text.unpack kind)
 
 instance ToJSON TelegramApprovalMode where
@@ -261,6 +269,7 @@ data TelegramState = TelegramState
     , deliveryCheckpoints :: !(Map Text Int)
     , deadLetters :: ![TelegramDeadLetter]
     , outboundMessageIds :: !(Map TelegramChatKey (Set Integer))
+    , authorizedGroupChatIds :: !(Set Integer)
     } deriving (Eq, Show)
 
 instance ToJSON TelegramState where
@@ -289,6 +298,12 @@ instance ToJSON TelegramState where
                 | queue <- Map.elems state.pendingQueues
                 , RunPendingMediaTurn pending <- Map.elems queue
                 ]
+        , "pendingLeaves" .=
+            sortOn (.pendingLeaveUpdateId)
+                [ pending
+                | queue <- Map.elems state.pendingQueues
+                , LeaveUnauthorizedChat pending <- Map.elems queue
+                ]
         , "pendingCallbacks" .= Map.elems state.pendingCallbacks
         , "callbackBindings" .= Map.elems state.callbackBindings
         , "retryMetadata" .= Map.toList state.retryMetadata
@@ -298,6 +313,7 @@ instance ToJSON TelegramState where
             [ TelegramOutboundMessages key (Set.toList messageIds)
             | (key, messageIds) <- Map.toList state.outboundMessageIds
             ]
+        , "authorizedGroupChats" .= sort (Set.toList state.authorizedGroupChatIds)
         ]
 
 instance FromJSON TelegramState where
@@ -314,6 +330,9 @@ instance FromJSON TelegramState where
         pendingReplies <- o .:? "pendingReplies" .!= ([] :: [TelegramPendingReply])
         pendingMediaTurns <-
             o .:? "pendingMediaTurns" .!= ([] :: [TelegramPendingMediaTurn])
+        pendingLeaves <-
+            o .:? "pendingLeaves" .!= ([] :: [TelegramPendingLeave])
+        storedAuthorized <- o .:? "authorizedGroupChats"
         storedCallbacks <-
             o .:? "pendingCallbacks" .!= ([] :: [TelegramPendingCallback])
         storedCallbackBindings <-
@@ -325,15 +344,23 @@ instance FromJSON TelegramState where
         deadLetters <- o .:? "deadLetters" .!= []
         outboundMessages <-
             o .:? "outboundMessages" .!= ([] :: [TelegramOutboundMessages])
-        pure TelegramState
-            { telegramStateVersion = 2
-            , nextUpdateId
-            , bindings =
+        let bindings =
                 foldr
                     (\binding ->
                         Map.insert binding.bindingChat binding.bindingSessionId)
                     Map.empty
                     storedBindings
+            authorizedGroupChatIds = case storedAuthorized of
+                Just ids -> Set.fromList ids
+                Nothing -> Set.fromList
+                    [ key.chatId
+                    | key <- Map.keys bindings
+                    , key.chatId < 0
+                    ]
+        pure TelegramState
+            { telegramStateVersion = 2
+            , nextUpdateId
+            , bindings
             , pendingQueues =
                 foldl'
                     (flip insertPendingAction)
@@ -341,6 +368,7 @@ instance FromJSON TelegramState where
                     ( map RunPendingTurn pendingTurns
                         <> map DeliverReply pendingReplies
                         <> map RunPendingMediaTurn pendingMediaTurns
+                        <> map LeaveUnauthorizedChat pendingLeaves
                     )
             , pendingCallbacks =
                 Map.fromList
@@ -360,6 +388,7 @@ instance FromJSON TelegramState where
                     [ (messages.outboundChat, Set.fromList messages.outboundIds)
                     | messages <- outboundMessages
                     ]
+            , authorizedGroupChatIds
             }
 
 data TelegramOutboundMessages = TelegramOutboundMessages
@@ -460,6 +489,23 @@ instance FromJSON TelegramPendingMediaTurn where
             <*> o .:? "attachments" .!= []
             <*> o .:? "edited" .!= False
             <*> o .:? "mediaGroupId"
+
+data TelegramPendingLeave = TelegramPendingLeave
+    { pendingLeaveUpdateId :: !Integer
+    , pendingLeaveChat :: !TelegramChatKey
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramPendingLeave where
+    toJSON pending = object
+        [ "updateId" .= pending.pendingLeaveUpdateId
+        , "chat" .= pending.pendingLeaveChat
+        ]
+
+instance FromJSON TelegramPendingLeave where
+    parseJSON = withObject "TelegramPendingLeave" \o ->
+        TelegramPendingLeave
+            <$> o .: "updateId"
+            <*> o .: "chat"
 
 data TelegramPendingCallback = TelegramPendingCallback
     { pendingCallbackUpdateId :: !Integer
@@ -623,6 +669,34 @@ instance FromJSON TelegramChat where
     parseJSON = withObject "TelegramChat" \o ->
         TelegramChat <$> o .: "id" <*> o .: "type"
 
+data TelegramChatMember = TelegramChatMember
+    { chatMemberUser :: !TelegramUser
+    , chatMemberStatus :: !Text
+    , chatMemberIsMember :: !(Maybe Bool)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramChatMember where
+    parseJSON = withObject "TelegramChatMember" \o ->
+        TelegramChatMember
+            <$> o .: "user"
+            <*> o .: "status"
+            <*> o .:? "is_member"
+
+data TelegramChatMemberUpdated = TelegramChatMemberUpdated
+    { chatMemberUpdatedChat :: !TelegramChat
+    , chatMemberUpdatedFrom :: !TelegramUser
+    , chatMemberUpdatedOld :: !TelegramChatMember
+    , chatMemberUpdatedNew :: !TelegramChatMember
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramChatMemberUpdated where
+    parseJSON = withObject "TelegramChatMemberUpdated" \o ->
+        TelegramChatMemberUpdated
+            <$> o .: "chat"
+            <*> o .: "from"
+            <*> o .: "old_chat_member"
+            <*> o .: "new_chat_member"
+
 data TelegramMessage = TelegramMessage
     { messageId :: !Integer
     , messageFrom :: !(Maybe TelegramUser)
@@ -647,6 +721,7 @@ data TelegramMessage = TelegramMessage
     , messageForwardOrigin :: !(Maybe Value)
     , messageEditDate :: !(Maybe Integer)
     , messageReplyTo :: !(Maybe TelegramMessage)
+    , messageNewChatMembers :: ![TelegramUser]
     } deriving (Eq, Show)
 
 instance FromJSON TelegramMessage where
@@ -675,6 +750,7 @@ instance FromJSON TelegramMessage where
             <*> o .:? "forward_origin"
             <*> o .:? "edit_date"
             <*> o .:? "reply_to_message"
+            <*> (o .:? "new_chat_members" .!= [])
 
 data TelegramReactionType = TelegramReactionType
     { reactionType :: !Text
@@ -959,6 +1035,7 @@ data TelegramUpdate = TelegramUpdate
     , updateEditedMessage :: !(Maybe TelegramMessage)
     , updateMessageReaction :: !(Maybe TelegramMessageReaction)
     , updateCallbackQuery :: !(Maybe TelegramCallbackQuery)
+    , updateMyChatMember :: !(Maybe TelegramChatMemberUpdated)
     } deriving (Eq, Show)
 
 instance FromJSON TelegramUpdate where
@@ -969,6 +1046,7 @@ instance FromJSON TelegramUpdate where
             <*> o .:? "edited_message"
             <*> o .:? "message_reaction"
             <*> o .:? "callback_query"
+            <*> o .:? "my_chat_member"
 
 data TelegramCallbackQuery = TelegramCallbackQuery
     { callbackQueryId :: !Text
@@ -1019,6 +1097,7 @@ data PendingChatAction
     = DeliverReply !TelegramPendingReply
     | RunPendingTurn !TelegramPendingTurn
     | RunPendingMediaTurn !TelegramPendingMediaTurn
+    | LeaveUnauthorizedChat !TelegramPendingLeave
     deriving (Eq, Show)
 
 pendingActionUpdateId :: PendingChatAction -> Integer
@@ -1026,12 +1105,14 @@ pendingActionUpdateId = \case
     DeliverReply pending -> pending.pendingUpdateId
     RunPendingTurn pending -> pending.pendingTurnUpdateId
     RunPendingMediaTurn pending -> pending.pendingMediaUpdateId
+    LeaveUnauthorizedChat pending -> pending.pendingLeaveUpdateId
 
 pendingActionChat :: PendingChatAction -> TelegramChatKey
 pendingActionChat = \case
     DeliverReply pending -> pending.pendingChat
     RunPendingTurn pending -> pending.pendingTurnChat
     RunPendingMediaTurn pending -> pending.pendingMediaChat
+    LeaveUnauthorizedChat pending -> pending.pendingLeaveChat
 
 insertPendingAction
     :: PendingChatAction
@@ -1070,4 +1151,5 @@ emptyTelegramState = TelegramState
     , deliveryCheckpoints = Map.empty
     , deadLetters = []
     , outboundMessageIds = Map.empty
+    , authorizedGroupChatIds = Set.empty
     }

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -10,8 +10,10 @@ import Agent.Telegram.Types
     , TelegramMedia(..)
     , TelegramMediaKind(..)
     , TelegramCallbackBinding(..)
+    , TelegramChatMember(..)
     , TelegramDeadLetter(..)
     , TelegramPendingCallback(..)
+    , TelegramPendingLeave(..)
     , TelegramPendingMediaTurn(..)
     , TelegramRetryMetadata(..)
     )
@@ -532,18 +534,24 @@ spec = describe "Agent.Telegram" do
                 , userUsername = Just "HarnessBot"
                 }
             allowedUsers = Set.singleton 456
-            classify bytes = do
-                update <- (eitherDecode (LBS.pack bytes)
-                    :: Either String TelegramUpdate)
-                    `shouldReturnRight` "Telegram update should decode"
-                pure (classifyTelegramUpdate bot allowedUsers update)
-            classifyAll bytes = do
+            authorizedGroups = Set.singleton (-1001)
+            allowedUser = TelegramUser
+                { userId = 456
+                , userIsBot = False
+                , userFirstName = Just "Marc"
+                , userLastName = Nothing
+                , userUsername = Nothing
+                }
+            classifyWith respondToAll authorized bytes = do
                 update <- (eitherDecode (LBS.pack bytes)
                     :: Either String TelegramUpdate)
                     `shouldReturnRight` "Telegram update should decode"
                 pure
                     (classifyTelegramUpdateWithMode
-                        bot allowedUsers True update)
+                        bot allowedUsers authorized respondToAll update)
+            classify = classifyWith False Set.empty
+            classifyAuthorized = classifyWith False authorizedGroups
+            classifyAll = classifyWith True authorizedGroups
 
         it "routes an allowed mention into the shared group session" do
             action <- classify
@@ -639,20 +647,20 @@ spec = describe "Agent.Telegram" do
                     \[Voice message]"
                     (Just (TelegramVoice "voice-file" 4 Nothing Nothing))
 
-        it "ignores ambient group traffic, other bots' commands, and blocked users" do
+        it "leaves unauthorized groups on ambient traffic, other bots' commands, and blocked users" do
             ambient <- classify
                 "{\"update_id\":27,\"message\":{\
                 \\"message_id\":85,\"from\":{\"id\":456},\
                 \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
                 \\"text\":\"hello everyone\"}}"
-            ambient `shouldBe` IgnoreUpdate
+            ambient `shouldBe` LeaveUnauthorizedGroup (-1001)
 
             otherBot <- classify
                 "{\"update_id\":28,\"message\":{\
                 \\"message_id\":86,\"from\":{\"id\":456},\
                 \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
                 \\"text\":\"/new@OtherBot\"}}"
-            otherBot `shouldBe` IgnoreUpdate
+            otherBot `shouldBe` LeaveUnauthorizedGroup (-1001)
 
             repliedOtherBot <- classify
                 "{\"update_id\":29,\"message\":{\
@@ -662,13 +670,27 @@ spec = describe "Agent.Telegram" do
                 \\"reply_to_message\":{\"message_id\":70,\
                 \\"from\":{\"id\":999,\"is_bot\":true},\
                 \\"chat\":{\"id\":-1001,\"type\":\"group\"}}}}"
-            repliedOtherBot `shouldBe` IgnoreUpdate
+            repliedOtherBot `shouldBe` LeaveUnauthorizedGroup (-1001)
 
             blocked <- classify
                 "{\"update_id\":30,\"message\":{\
                 \\"message_id\":88,\"from\":{\"id\":123},\
                 \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
                 \\"text\":\"@HarnessBot hello\"}}"
+            blocked `shouldBe` LeaveUnauthorizedGroup (-1001)
+
+        it "ignores ambient group traffic, other bots' commands, and blocked users in authorized groups" do
+            ambient <- classifyAuthorized
+                "{\"update_id\":27,\"message\":{\"message_id\":85,\"from\":{\"id\":456},\"chat\":{\"id\":-1001,\"type\":\"group\"},\"text\":\"hello everyone\"}}"
+            ambient `shouldBe` IgnoreUpdate
+            otherBot <- classifyAuthorized
+                "{\"update_id\":28,\"message\":{\"message_id\":86,\"from\":{\"id\":456},\"chat\":{\"id\":-1001,\"type\":\"group\"},\"text\":\"/new@OtherBot\"}}"
+            otherBot `shouldBe` IgnoreUpdate
+            repliedOtherBot <- classifyAuthorized
+                "{\"update_id\":29,\"message\":{\"message_id\":87,\"from\":{\"id\":456},\"chat\":{\"id\":-1001,\"type\":\"group\"},\"text\":\"/new@OtherBot\",\"reply_to_message\":{\"message_id\":70,\"from\":{\"id\":999,\"is_bot\":true},\"chat\":{\"id\":-1001,\"type\":\"group\"}}}}"
+            repliedOtherBot `shouldBe` IgnoreUpdate
+            blocked <- classifyAuthorized
+                "{\"update_id\":30,\"message\":{\"message_id\":88,\"from\":{\"id\":123},\"chat\":{\"id\":-1001,\"type\":\"group\"},\"text\":\"@HarnessBot hello\"}}"
             blocked `shouldBe` IgnoreUpdate
 
         it "suppresses the ambient no-reply marker but not normal replies" do
@@ -721,6 +743,121 @@ spec = describe "Agent.Telegram" do
                 \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
                 \\"text\":\"/new@OtherBot\"}}"
             otherBot `shouldBe` IgnoreUpdate
+
+        it "rejects group joins from people who are not allowed admins" do
+            foreigner <- classify
+                "{\"update_id\":40,\"my_chat_member\":{\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"from\":{\"id\":123,\"first_name\":\"Eve\"},\
+                \\"old_chat_member\":{\"user\":{\"id\":999,\"is_bot\":true},\
+                \\"status\":\"left\"},\
+                \\"new_chat_member\":{\"user\":{\"id\":999,\"is_bot\":true},\
+                \\"status\":\"member\"}}}"
+            foreigner `shouldBe` LeaveUnauthorizedGroup (-1001)
+
+            addedByAdmin <- classify
+                "{\"update_id\":41,\"my_chat_member\":{\
+                \\"chat\":{\"id\":-1001,\"type\":\"supergroup\"},\
+                \\"from\":{\"id\":456,\"first_name\":\"Marc\"},\
+                \\"old_chat_member\":{\"user\":{\"id\":999,\"is_bot\":true},\
+                \\"status\":\"left\"},\
+                \\"new_chat_member\":{\"user\":{\"id\":999,\"is_bot\":true},\
+                \\"status\":\"member\"}}}"
+            addedByAdmin `shouldBe` ReviewGroupJoin (-1001) allowedUser
+                { userFirstName = Just "Marc" }
+
+            alreadyAuthorized <- classifyAuthorized
+                "{\"update_id\":42,\"my_chat_member\":{\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"from\":{\"id\":123},\
+                \\"old_chat_member\":{\"user\":{\"id\":999,\"is_bot\":true},\
+                \\"status\":\"left\"},\
+                \\"new_chat_member\":{\"user\":{\"id\":999,\"is_bot\":true},\
+                \\"status\":\"member\"}}}"
+            alreadyAuthorized `shouldBe` IgnoreUpdate
+
+            removed <- classifyAuthorized
+                "{\"update_id\":43,\"my_chat_member\":{\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"from\":{\"id\":123},\
+                \\"old_chat_member\":{\"user\":{\"id\":999,\"is_bot\":true},\
+                \\"status\":\"member\"},\
+                \\"new_chat_member\":{\"user\":{\"id\":999,\"is_bot\":true},\
+                \\"status\":\"left\"}}}"
+            removed `shouldBe` RevokeGroupChat (-1001)
+
+            serviceAdd <- classify
+                "{\"update_id\":44,\"message\":{\
+                \\"message_id\":91,\"from\":{\"id\":123},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"new_chat_members\":[{\"id\":999,\"is_bot\":true,\
+                \\"username\":\"HarnessBot\"}]}}"
+            serviceAdd `shouldBe` LeaveUnauthorizedGroup (-1001)
+
+        it "authorizes a group only when an allowed user is a chat administrator" do
+            let admin =
+                    TelegramChatMember allowedUser "administrator" Nothing
+                member =
+                    TelegramChatMember allowedUser "member" Nothing
+                foreignAdmin = TelegramChatMember
+                    TelegramUser
+                        { userId = 123
+                        , userIsBot = False
+                        , userFirstName = Just "Eve"
+                        , userLastName = Nothing
+                        , userUsername = Nothing
+                        }
+                    "administrator"
+                    Nothing
+                anonymous = TelegramUser
+                    { userId = telegramAnonymousAdminUserId
+                    , userIsBot = True
+                    , userFirstName = Just "Group"
+                    , userLastName = Nothing
+                    , userUsername = Just "GroupAnonymousBot"
+                    }
+            groupJoinAuthorized allowedUsers allowedUser [admin]
+                `shouldBe` True
+            groupJoinAuthorized allowedUsers allowedUser [member]
+                `shouldBe` False
+            groupJoinAuthorized allowedUsers allowedUser [foreignAdmin]
+                `shouldBe` False
+            groupJoinAuthorized allowedUsers anonymous [admin]
+                `shouldBe` True
+            groupJoinAuthorized allowedUsers anonymous [foreignAdmin]
+                `shouldBe` False
+            isAnonymousAdmin anonymous `shouldBe` True
+            isAnonymousAdmin allowedUser `shouldBe` False
+
+        it "authorizes a group after an allowed user targets the bot there" do
+            let key = TelegramChatKey (-1001) Nothing
+                state = storeUpdateAction
+                    22
+                    (QueueTurn 80 key "@HarnessBot hello" Nothing)
+                    emptyTelegramState
+            state.authorizedGroupChatIds `shouldBe` Set.singleton (-1001)
+            nextPendingAction key state `shouldBe`
+                Just
+                    (RunPendingTurn
+                        (TelegramPendingTurn 22 80 key "@HarnessBot hello" Nothing))
+
+        it "queues a leave and drops other work for unauthorized groups" do
+            let key = TelegramChatKey (-1001) Nothing
+                turn = TelegramPendingTurn 10 77 key "hello" Nothing
+                seeded = emptyTelegramState
+                    { authorizedGroupChatIds = Set.singleton (-1001)
+                    , pendingQueues =
+                        Map.singleton key (Map.singleton 10 (RunPendingTurn turn))
+                    }
+                state = storeUpdateAction
+                    40
+                    (LeaveUnauthorizedGroup (-1001))
+                    seeded
+            state.authorizedGroupChatIds `shouldBe` Set.empty
+            nextPendingAction key state `shouldBe`
+                Just
+                    (LeaveUnauthorizedChat
+                        (TelegramPendingLeave 40 key))
 
     describe "durable queue state" do
         it "loads state written before pending turns were introduced" do
@@ -789,6 +926,31 @@ spec = describe "Agent.Telegram" do
                         , (9, RunPendingTurn secondTurn)
                         ])
 
+        it "seeds authorized group chats from legacy group bindings" do
+            let groupKey = TelegramChatKey (-1001) Nothing
+                privateKey = TelegramChatKey 123 Nothing
+                decoded = eitherDecode
+                    (LBS.pack
+                        "{\"bindings\":[{\
+                        \\"chat\":{\"chatId\":-1001},\"sessionId\":\"group\"},{\
+                        \\"chat\":{\"chatId\":123},\"sessionId\":\"private\"}]}")
+                    :: Either String TelegramState
+            state <- decoded `shouldReturnRight`
+                "legacy Telegram bindings should decode"
+            state.authorizedGroupChatIds `shouldBe` Set.singleton (-1001)
+            Map.lookup groupKey state.bindings `shouldBe` Just "group"
+            Map.lookup privateKey state.bindings `shouldBe` Just "private"
+
+        it "keeps an explicit empty authorized group set" do
+            let decoded = eitherDecode
+                    (LBS.pack
+                        "{\"authorizedGroupChats\":[],\"bindings\":[{\
+                        \\"chat\":{\"chatId\":-1001},\"sessionId\":\"group\"}]}")
+                    :: Either String TelegramState
+            state <- decoded `shouldReturnRight`
+                "explicit authorized group chats should decode"
+            state.authorizedGroupChatIds `shouldBe` Set.empty
+
         it "preserves first-match semantics for duplicate legacy bindings" do
             let key = TelegramChatKey 123 Nothing
                 decoded = eitherDecode
@@ -826,6 +988,7 @@ spec = describe "Agent.Telegram" do
                     , "pendingTurns" .= [turn]
                     , "pendingReplies" .= [reply]
                     , "pendingMediaTurns" .= ([] :: [TelegramPendingMediaTurn])
+                    , "pendingLeaves" .= ([] :: [TelegramPendingLeave])
                     , "pendingCallbacks" .= ([] :: [TelegramPendingCallback])
                     , "callbackBindings" .= ([] :: [TelegramCallbackBinding])
                     , "retryMetadata" .=
@@ -834,6 +997,7 @@ spec = describe "Agent.Telegram" do
                         ([] :: [(Text.Text, Int)])
                     , "deadLetters" .= ([] :: [TelegramDeadLetter])
                     , "outboundMessages" .= ([] :: [Value])
+                    , "authorizedGroupChats" .= ([] :: [Integer])
                     ]
             (eitherDecode (encode state) :: Either String Value)
                 `shouldBe` Right expected


### PR DESCRIPTION
## Summary
- The Telegram bot now stays in a group or channel only when an allowlisted user who is also a Telegram administrator of that chat added it.
- Foreign joins are rejected immediately via `my_chat_member` (with `new_chat_members` as a fallback), including when someone is admin of their own group.
- Unauthorized group traffic queues `leaveChat` with a short notice. Membership updates are processed before other updates in the same poll batch so `--all-group-messages` cannot leak first.
- Authorized group IDs are persisted. Existing session bindings for group chats are seeded on upgrade. An allowlisted mention, command, or reply can authorize a group; ambient messages and reactions cannot.

## Test plan
- [x] `nix develop -c cabal test --offline agent-telegram --test-show-details=direct` (59 examples, 0 failures)