### PR TITLE
Make conversation search indexable with pg_trgm

### DIFF
--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -30,7 +30,10 @@ import Agent.Store.Postgres.Hasql (mkStatement)
 
 import Agent.Store.Postgres.Connection
 import Agent.Store.Postgres.Scope (customSchemaStatements)
-import Agent.Store.Postgres.Session (sessionSchemaStatements)
+import Agent.Store.Postgres.Session
+    ( sessionSchemaStatements
+    , sessionSearchIndexStatements
+    )
 import Agent.Store.Postgres.Skill
     ( learnedSkillRuntimeGrantStatements
     , learnedSkillSchemaStatements
@@ -149,6 +152,11 @@ coreMigrations =
         , migrationName = "session transcript effects and paging"
         , migrationStatements =
             [migrateSessionTranscriptEffectsStatement]
+        }
+    , Migration
+        { migrationVersion = 9
+        , migrationName = "trigram indexes for conversation search"
+        , migrationStatements = sessionSearchIndexStatements
         }
     ]
 

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -21,6 +21,7 @@ module Agent.Store.Postgres.Session
     , LegacySession(..)
     , ConversationSearchResult(..)
     , sessionSchemaStatements
+    , sessionSearchIndexStatements
     , createSession
     , replaceSessionMetadata
     , appendSessionTurn
@@ -300,6 +301,7 @@ sessionSchemaStatements =
       \ ON harness.session_turns (session_id, turn_index DESC)\
       \ WHERE transcript_effect <> 'append'"
     ]
+    <> sessionSearchIndexStatements
     <> sessionItemSchemaStatements
     <> [ "CREATE TABLE IF NOT EXISTS harness.legacy_session_imports (\
        \ import_id uuid PRIMARY KEY DEFAULT pg_catalog.uuidv7(),\
@@ -327,6 +329,42 @@ sessionSchemaStatements =
        \ BEFORE UPDATE OR DELETE ON harness.session_turns\
        \ FOR EACH ROW EXECUTE FUNCTION harness.reject_session_fact_mutation()"
        ]
+
+-- | Trigram indexes that make the substring branches of conversation search
+-- indexable. Without them the @ILIKE@ fallbacks in 'searchTurnsStatement'
+-- force a sequential scan of @session_turns@ even though the tsvector branch
+-- has a GIN index: an @OR@ can only use a bitmap scan when every branch is
+-- indexable. With @pg_trgm@ indexes on the raw text columns the planner can
+-- combine all three branches with a BitmapOr.
+-- The column-existence guards keep the shared statements safe as a
+-- catch-up migration on partially-shaped legacy stores; on freshly created
+-- schemas they are trivially true.
+sessionSearchIndexStatements :: [ByteString]
+sessionSearchIndexStatements =
+    [ "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+    , "DO $ha$\
+      \ BEGIN\
+      \   IF EXISTS (\
+      \     SELECT 1 FROM information_schema.columns\
+      \     WHERE table_schema = 'harness'\
+      \       AND table_name = 'session_turns'\
+      \       AND column_name = 'user_text'\
+      \   ) THEN\
+      \     CREATE INDEX IF NOT EXISTS session_turns_user_text_trgm_idx\
+      \       ON harness.session_turns USING gin (user_text gin_trgm_ops);\
+      \   END IF;\
+      \   IF EXISTS (\
+      \     SELECT 1 FROM information_schema.columns\
+      \     WHERE table_schema = 'harness'\
+      \       AND table_name = 'session_turns'\
+      \       AND column_name = 'assistant_text'\
+      \   ) THEN\
+      \     CREATE INDEX IF NOT EXISTS session_turns_assistant_text_trgm_idx\
+      \       ON harness.session_turns USING gin (assistant_text gin_trgm_ops);\
+      \   END IF;\
+      \ END\
+      \ $ha$"
+    ]
 
 createSession
     :: StorePool
@@ -1285,7 +1323,7 @@ searchTurnsStatement = mkStatement
     \ WHERE s.deleted_at IS NULL AND (\
     \   t.search_vector @@ query.value\
     \   OR t.user_text ILIKE '%' || $1 || '%'\
-    \   OR coalesce(t.assistant_text, '') ILIKE '%' || $1 || '%'\
+    \   OR t.assistant_text ILIKE '%' || $1 || '%'\
     \ )\
     \ ORDER BY ts_rank_cd(t.search_vector, query.value) DESC,\
     \   t.occurred_at DESC\

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -63,6 +63,9 @@ spec = describe "PostgreSQL session schema" do
         ddl `shouldNotContainBytes` "::json"
         ddl `shouldContainBytes` "search_vector tsvector GENERATED ALWAYS"
         ddl `shouldContainBytes` "USING gin (search_vector)"
+        ddl `shouldContainBytes` "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+        ddl `shouldContainBytes` "USING gin (user_text gin_trgm_ops)"
+        ddl `shouldContainBytes` "USING gin (assistant_text gin_trgm_ops)"
         ddl `shouldContainBytes` "session_events_immutable"
         ddl `shouldContainBytes` "session_turns_immutable"
 


### PR DESCRIPTION
## Problem

`searchTurnsStatement` ORs the tsvector match with `ILIKE '%…%'` substring fallbacks:

```sql
t.search_vector @@ query.value
OR t.user_text ILIKE '%' || $1 || '%'
OR coalesce(t.assistant_text, '') ILIKE '%' || $1 || '%'
```

An `OR` can only use a bitmap scan when **every** branch is indexable. The `ILIKE` branches weren't, so the whole query fell back to a sequential scan of `session_turns` — the existing GIN index on `search_vector` was never used.

## Fix

- Add `pg_trgm` GIN indexes on `session_turns.user_text` and `session_turns.assistant_text`, so the planner combines all three branches with a BitmapOr.
- Drop the `coalesce()` around `assistant_text` — the expression defeated the plain-column index. Semantically identical: a NULL arm can never be the only true OR branch, and the empty-pattern edge case is already matched by the `NOT NULL` `user_text` branch. Verified both forms return identical rows (300 = 300, diff 0) on the benchmark dataset.
- The statements ship in the base schema and as migration 9 for existing stores. The index DDL uses the same column-existence guards as migration 8, so the `ManagedSpec` legacy-store replays (no `session_turns` / no `assistant_text`) skip index creation cleanly.

## Benchmark

Production DDL (dumped from `sessionSchemaStatements`) on PostgreSQL 18.6, 50 sessions x 2000 turns = 100k rows / 195 MB, `EXPLAIN (ANALYZE)` via psql, repeated warm-cache samples:

| Variant | Plan | Warm | Cold |
|---|---|---|---|
| New query + trgm indexes | BitmapOr of 3 GIN indexes, 78 heap blocks | **1.6 ms** | 14.9 ms |
| Old query (coalesce), indexes present | Parallel Seq Scan, 25k buffers | 71 ms | 74.9 ms |
| New query, trgm indexes dropped | Parallel Seq Scan | 73 ms | 73.5 ms |

Both halves are necessary: indexes alone do nothing while the `coalesce()` remains, and the rewrite alone does nothing without the indexes. The gap grows with table size — seq scan is O(table), bitmap is O(matches).

## Tests

- Full `agent-store` suite: 33 examples, 0 failures (includes managed-Postgres migration replays and the live `searchConversationTurns` test).
- New `SessionSpec` DDL assertions for the extension and both trigram indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)