### PR TITLE
fix(cli): UTF-8 encode fullscreen window titles

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -134,6 +134,7 @@ import Agent.CLI.Resume
     )
 import Agent.CLI.Render (formatElapsed)
 import Agent.CLI.Style (motionGlyphSet)
+import Agent.CLI.WindowTitle (oscWindowTitleBytes)
 import Agent.CLI.Status (formatTokenUsage)
 import Agent.CLI.Timestamp (currentShortMessageTimestamp)
 import Agent.CLI.Terminal
@@ -647,7 +648,8 @@ setFullscreenWindowTitle runtime title = do
     enqueueAppEvent runtime (AppSetWindowTitle title)
 
 -- | Brick/Vty owns the terminal, so titles must go through Vty output
--- rather than stdout OSC writes.
+-- rather than stdout OSC writes. Use UTF-8 OSC bytes; Vty's title setter
+-- Latin-1 packs the string and garbles braille spinner frames.
 applyStoredFullscreenWindowTitle :: FullscreenRuntime -> V.Output -> IO ()
 applyStoredFullscreenWindowTitle runtime output =
     readIORef runtime.runtimeWindowTitle
@@ -655,7 +657,7 @@ applyStoredFullscreenWindowTitle runtime output =
 
 writeOutputWindowTitle :: V.Output -> Text -> IO ()
 writeOutputWindowTitle output title =
-    V.setOutputWindowTitle output (Text.unpack title)
+    V.outputByteBuffer output (oscWindowTitleBytes title)
 
 setFullscreenImagePreviews
     :: FullscreenRuntime

--- a/packages/agent-cli/src/Agent/CLI/WindowTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/WindowTitle.hs
@@ -3,6 +3,7 @@ module Agent.CLI.WindowTitle
     ( WindowTitleController(..)
     , busyWindowTitle
     , newWindowTitleController
+    , oscWindowTitleBytes
     ) where
 
 import Agent.CLI.Style (spinnerFrames)
@@ -21,7 +22,10 @@ import Control.Concurrent.STM
     , writeTVar
     )
 import Control.Monad (forM_, when)
+import Data.ByteString (ByteString)
 import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 
 data WindowTitleController = WindowTitleController
     { windowTitleSet :: !(Text -> IO ())
@@ -108,3 +112,20 @@ newWindowTitleController motionMode initialTitle withOutputLock writeTitle = do
 
 busyWindowTitle :: Text -> Text -> Text
 busyWindowTitle frame title = frame <> " " <> title
+
+-- | OSC 2 window-title bytes, UTF-8 encoded.
+-- Vty's 'setOutputWindowTitle' Latin-1 packs the title, which garbles braille
+-- spinner frames. Write this payload with 'outputByteBuffer' instead.
+oscWindowTitleBytes :: Text -> ByteString
+oscWindowTitleBytes title =
+    TextEncoding.encodeUtf8
+        ("\ESC]2;" <> sanitizeOscWindowTitle title <> "\a")
+
+sanitizeOscWindowTitle :: Text -> Text
+sanitizeOscWindowTitle =
+    Text.filter \c ->
+        c /= '\ESC'
+            && c /= '\a'
+            && c /= '\n'
+            && c /= '\r'
+            && c /= '\x9c'

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -841,7 +841,8 @@ spec = do
         it "reports a throwing post-compaction hook instead of swallowing it" do
             let history = [userTextItem "old"]
                 threshold = 20
-            contextState <- newIORef (Just (threshold, length history))
+            contextState <- newIORef
+                (Just (reportedOccupancy threshold (length history)))
             events <- newIORef []
             let sender _request =
                     pure (Right remoteCompactionResponse)

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -5,11 +5,14 @@ import Agent.CLI.WindowTitle
     ( WindowTitleController(..)
     , busyWindowTitle
     , newWindowTitleController
+    , oscWindowTitleBytes
     )
 import Agent.TUI.Motion (MotionMode(..))
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import System.OsPath (unsafeEncodeUtf)
+import qualified Data.ByteString as ByteString
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
@@ -85,6 +88,20 @@ spec = do
         it "prefixes busy titles with a spinner frame" do
             busyWindowTitle "⠋" "fix the title"
                 `shouldBe` "⠋ fix the title"
+
+        it "UTF-8 encodes braille spinner frames in OSC window titles" do
+            let bytes = oscWindowTitleBytes (busyWindowTitle "⠋" "fix the title")
+            bytes
+                `shouldBe`
+                    TextEncoding.encodeUtf8 "\ESC]2;⠋ fix the title\a"
+            ByteString.isInfixOf (ByteString.pack [0xE2, 0xA0, 0x8B]) bytes
+                `shouldBe` True
+            ByteString.elem 0x0B bytes `shouldBe` False
+
+        it "strips OSC terminators from window titles" do
+            oscWindowTitleBytes "hi\a there\ESC"
+                `shouldBe`
+                    TextEncoding.encodeUtf8 "\ESC]2;hi there\a"
 
         it "coordinates busy, renamed, and restored titles" do
             written <- newIORef []

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -44,6 +44,7 @@ import Agent.CLI.TUI.App
     , turnCompletionRequiresRedraw
     , uiEventRestartsMotionSchedule
     )
+import Agent.CLI.WindowTitle (oscWindowTitleBytes)
 import Agent.CLI.TUI.Types
     ( ChoiceOverlay(..)
     , ChoicePresentation(..)
@@ -376,8 +377,8 @@ spec = do
             readIORef events `shouldReturn` [Right ()]
 
     describe "fullscreen window title" do
-        it "replays the stored session title through Vty output" do
-            titles <- newIORef ([] :: [String])
+        it "replays the stored session title as UTF-8 OSC bytes" do
+            titles <- newIORef ([] :: [ByteString.ByteString])
             input <- newFullscreenInputBuffer
             runtime <- newFullscreenRuntime
                 input
@@ -395,16 +396,21 @@ spec = do
                 False
                 initialUiState
             (_, output) <- VMock.mockTerminal (80, 24)
-            setFullscreenWindowTitle runtime "New session"
+            let title = "⠋ New session"
+            setFullscreenWindowTitle runtime title
             readIORef runtime.runtimeWindowTitle
-                `shouldReturn` Just "New session"
+                `shouldReturn` Just title
             applyStoredFullscreenWindowTitle
                 runtime
                 output
-                    { V.setOutputWindowTitle =
-                        \title -> modifyIORef' titles (<> [title])
+                    { V.outputByteBuffer =
+                        \bytes -> modifyIORef' titles (<> [bytes])
                     }
-            readIORef titles `shouldReturn` ["New session"]
+            actual <- readIORef titles
+            actual `shouldBe` [oscWindowTitleBytes title]
+            actual
+                `shouldSatisfy`
+                    any (ByteString.isInfixOf (ByteString.pack [0xE2, 0xA0, 0x8B]))
 
     describe "fullscreen Vty ownership" do
         it "shuts down the rebuilt Vty when exit follows suspension" do


### PR DESCRIPTION
## Summary
Fullscreen busy titles animate a braille spinner, but Vty's `setOutputWindowTitle` Latin-1 packs the string. Each 3-byte spinner codepoint was truncated to its low byte, so the tab title cycled through unrelated characters instead of one rotating loader.

Write OSC 2 titles as UTF-8 through Vty `outputByteBuffer` instead, and keep terminator bytes out of the payload.

## Test plan
- [x] `cabal test agent-cli --test-options='-m "window title"'` (UTF-8 braille payload, terminator stripping, fullscreen Vty output)
- [ ] Start a fullscreen session, run a turn, and confirm the tab title shows a single animated braille spinner rather than cycling ASCII/control junk