### PR TITLE
Use maps, sets, and sequences for keyed lookups

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/Options.hs
+++ b/packages/agent-claude/src/Agent/Claude/Options.hs
@@ -16,6 +16,7 @@ import Claude.Agent.SDK.Types
     , defaultClaudeAgentOptions
     )
 import qualified Data.Aeson as Aeson
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 
 -- | Claude's non-interactive permission policies. Neither policy can pause
@@ -91,7 +92,7 @@ setEnvironmentVariable
     -> [(String, String)]
     -> [(String, String)]
 setEnvironmentVariable name value environment =
-    (name, value) : filter ((/= name) . fst) environment
+    Map.toList (Map.insert name value (Map.fromList environment))
 
 emptyMcpConfiguration :: Aeson.Value
 emptyMcpConfiguration =

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -62,9 +62,8 @@ import Agent.TUI.Presentation (liveTodoPanelLines)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef)
-import Data.List (findIndex, sortOn)
+import Data.List (find, findIndex, sortOn)
 import qualified Data.Map.Strict as Map
-import Data.Map.Strict (Map)
 import Data.Maybe (listToMaybe)
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
@@ -158,15 +157,8 @@ initialAgentViewportState selected entries =
     ordered = sortOn (.agentPath) entries
 
 lookupAgentEntry :: AgentTarget -> [AgentEntry] -> Maybe AgentEntry
-lookupAgentEntry target entries =
-    Map.lookup target (agentEntriesByTarget entries)
-
-agentEntriesByTarget :: [AgentEntry] -> Map AgentTarget AgentEntry
-agentEntriesByTarget entries =
-    Map.fromList
-        [ (entry.agentTarget, entry)
-        | entry <- entries
-        ]
+lookupAgentEntry target =
+    find ((== target) . (.agentTarget))
 
 selectedAgentEntry :: AgentViewportState -> Maybe AgentEntry
 selectedAgentEntry state = case state.viewportAll of

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -25,6 +25,7 @@ module Agent.CLI.AgentViewport
     , responseItemPreviewLines
     , responseItemStepPreviews
     , responseItemsToUiState
+    , lookupAgentEntry
     , selectAgentTarget
     , selectedAgentEntry
     ) where
@@ -63,6 +64,7 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef)
 import Data.List (findIndex, sortOn)
 import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import Data.Maybe (listToMaybe)
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
@@ -154,6 +156,17 @@ initialAgentViewportState selected entries =
         }
   where
     ordered = sortOn (.agentPath) entries
+
+lookupAgentEntry :: AgentTarget -> [AgentEntry] -> Maybe AgentEntry
+lookupAgentEntry target entries =
+    Map.lookup target (agentEntriesByTarget entries)
+
+agentEntriesByTarget :: [AgentEntry] -> Map AgentTarget AgentEntry
+agentEntriesByTarget entries =
+    Map.fromList
+        [ (entry.agentTarget, entry)
+        | entry <- entries
+        ]
 
 selectedAgentEntry :: AgentViewportState -> Maybe AgentEntry
 selectedAgentEntry state = case state.viewportAll of

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -99,7 +99,7 @@ import Data.IORef
     , writeIORef
     )
 import Data.List (find)
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe, isJust, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (getCurrentTime)

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -99,7 +99,7 @@ import Data.IORef
     , writeIORef
     )
 import Data.List (find)
-import Data.Maybe (fromMaybe, isJust, listToMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (getCurrentTime)

--- a/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
@@ -45,14 +45,14 @@ import Control.Monad.Trans.Except (ExceptT, throwE)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Either (partitionEithers)
-import Data.Function (on)
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
     , newIORef
     , readIORef
     )
-import Data.List (find, nubBy)
+import Data.Containers.ListUtils (nubOrdOn)
+import Data.List (find)
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -336,7 +336,7 @@ staticOpenAiState now accountId accessToken =
 
 deduplicateOpenAiAccounts :: [OpenAiAccount] -> [OpenAiAccount]
 deduplicateOpenAiAccounts =
-    nubBy ((==) `on` ((.accountId) . (.openAiState)))
+    nubOrdOn ((.accountId) . (.openAiState))
 
 refreshOpenAiAccount
     :: MVar ()

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -19,6 +19,7 @@ module Agent.CLI.Command
     , lookupSlashCommandIn
     , loopScheduleInstruction
     , mkSlashCatalog
+    , slashCatalogWithSkills
     , parseReplLine
     , parseReplLineWithCatalog
     , parseReplLineWithSkills
@@ -52,7 +53,9 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson ((.=))
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Char (isAlphaNum, isDigit, isSpace)
-import Data.List (find, isPrefixOf, sortOn)
+import Data.List (isPrefixOf, sortOn)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Ord (Down(..))
 import Data.Set (Set)
@@ -145,13 +148,16 @@ mkSlashCatalog dialect toolNames skills modelIds =
             Set.fromList
                 (map (Text.toLower . Text.strip) toolNames)
         commands =
-            map (commandForDialect dialect) slashCommands
+            filter
+                (commandAvailable dialect tools)
+                (map (commandForDialect dialect) slashCommands)
     in SlashCatalog
         { slashCatalogDialect = dialect
         , slashCatalogToolNames = tools
-        , slashCatalogCommands =
-            filter (commandAvailable dialect tools) commands
+        , slashCatalogCommands = commands
+        , slashCatalogCommandByName = indexSlashCommands commands
         , slashCatalogSkills = skills
+        , slashCatalogSkillByName = indexSkillCommands skills
         , slashCatalogModelIds = modelIds
         }
 
@@ -168,6 +174,32 @@ commandForDialect dialect command
             }
     | otherwise = command
 
+slashCatalogWithSkills :: [SkillCommand] -> SlashCatalog -> SlashCatalog
+slashCatalogWithSkills skills catalog =
+    catalog
+        { slashCatalogSkills = skills
+        , slashCatalogSkillByName = indexSkillCommands skills
+        }
+
+indexSlashCommands :: [SlashCommand] -> Map Text SlashCommand
+indexSlashCommands commands =
+    Map.fromList
+        [ (name, command)
+        | command <- commands
+        , name <- command.slashName : command.slashAliases
+        ]
+
+indexSkillCommands :: [SkillCommand] -> Map Text SkillCommand
+indexSkillCommands skills =
+    Map.fromList
+        [ (Text.toLower skill.skillCommandName, skill)
+        | skill <- skills
+        ]
+
+normalizeSlashName :: Text -> Text
+normalizeSlashName raw =
+    Text.toLower (Text.dropWhile (== '/') (Text.strip raw))
+
 commandAvailable :: DialectId -> Set Text -> SlashCommand -> Bool
 commandAvailable dialect tools command =
     maybe True (dialect `elem`) command.slashDialects
@@ -180,14 +212,12 @@ lookupSlashCommand =
     lookupSlashCommandFrom slashCommands
 
 lookupSlashCommandIn :: SlashCatalog -> Text -> Maybe SlashCommand
-lookupSlashCommandIn catalog =
-    lookupSlashCommandFrom catalog.slashCatalogCommands
+lookupSlashCommandIn catalog raw =
+    Map.lookup (normalizeSlashName raw) catalog.slashCatalogCommandByName
 
 lookupSlashCommandFrom :: [SlashCommand] -> Text -> Maybe SlashCommand
 lookupSlashCommandFrom commands raw =
-    let name = Text.toLower (Text.dropWhile (== '/') (Text.strip raw))
-    in find (\cmd -> cmd.slashName == name || name `elem` cmd.slashAliases)
-        commands
+    Map.lookup (normalizeSlashName raw) (indexSlashCommands commands)
 
 parseReplLine :: Text -> ReplAction
 parseReplLine =
@@ -196,9 +226,7 @@ parseReplLine =
 parseReplLineWithSkills :: [SkillCommand] -> Text -> ReplAction
 parseReplLineWithSkills skills =
     parseReplLineWithCatalog
-        defaultSlashCatalog
-            { slashCatalogSkills = skills
-            }
+        (slashCatalogWithSkills skills defaultSlashCatalog)
 
 parseReplLineWithCatalog :: SlashCatalog -> Text -> ReplAction
 parseReplLineWithCatalog catalog raw =
@@ -232,7 +260,7 @@ parseSlash :: SlashCatalog -> Text -> Text -> ReplAction
 parseSlash catalog raw line = case Text.words line of
     [] -> unknownCommand "/"
     command : args -> case lookupSlashCommandIn catalog command of
-        Nothing -> case lookupSkillCommand catalog.slashCatalogSkills command of
+        Nothing -> case lookupSkillCommandIn catalog command of
             Just skill ->
                 ReplInvokeSkill
                     skill.skillCommandName
@@ -386,17 +414,16 @@ unknownCommand :: Text -> ReplAction
 unknownCommand command =
     ReplCommandError ("unknown command: " <> command <> " (try /help)")
 
-lookupSkillCommand :: [SkillCommand] -> Text -> Maybe SkillCommand
-lookupSkillCommand skills raw =
-    let name = Text.toLower (Text.dropWhile (== '/') (Text.strip raw))
-    in find ((== name) . Text.toLower . (.skillCommandName)) skills
+lookupSkillCommandIn :: SlashCatalog -> Text -> Maybe SkillCommand
+lookupSkillCommandIn catalog raw =
+    Map.lookup (normalizeSlashName raw) catalog.slashCatalogSkillByName
 
 parseHelpCommand :: SlashCatalog -> [Text] -> ReplAction
 parseHelpCommand catalog = \case
     [] -> ReplHelp Nothing
     [name] -> case lookupSlashCommandIn catalog name of
         Just spec -> ReplHelp (Just spec.slashName)
-        Nothing -> case lookupSkillCommand catalog.slashCatalogSkills name of
+        Nothing -> case lookupSkillCommandIn catalog name of
             Just skill -> ReplHelp (Just skill.skillCommandName)
             Nothing -> unknownCommand name
     _ -> ReplCommandError "usage: /help [NAME]"
@@ -692,9 +719,7 @@ formatSlashHelp color =
 formatSlashHelpWithSkills :: Bool -> [SkillCommand] -> Maybe Text -> Text
 formatSlashHelpWithSkills color skills =
     formatSlashHelpWithCatalog color
-        defaultSlashCatalog
-            { slashCatalogSkills = skills
-            }
+        (slashCatalogWithSkills skills defaultSlashCatalog)
 
 formatSlashHelpWithCatalog
     :: Bool
@@ -711,7 +736,7 @@ formatSlashHelpWithCatalog color catalog = \case
     Just name ->
         case lookupSlashCommandIn catalog name of
             Just spec -> formatSlashHelpRow color spec
-            Nothing -> case lookupSkillCommand catalog.slashCatalogSkills name of
+            Nothing -> case lookupSkillCommandIn catalog name of
                 Just skill -> formatSkillHelpRow color skill
                 Nothing -> roleMuted color ("unknown command: " <> name <> " (try /help)")
 
@@ -767,9 +792,7 @@ slashCompletionCandidatesWithSkills
     -> [String]
 slashCompletionCandidatesWithSkills skills =
     slashCompletionCandidatesWithCatalog
-        defaultSlashCatalog
-            { slashCatalogSkills = skills
-            }
+        (slashCatalogWithSkills skills defaultSlashCatalog)
 
 slashCompletionCandidatesWithSkillsAndModels
     :: [SkillCommand]
@@ -780,10 +803,9 @@ slashCompletionCandidatesWithSkillsAndModels
 slashCompletionCandidatesWithSkillsAndModels
         skills modelIds =
     slashCompletionCandidatesWithCatalog
-        defaultSlashCatalog
-            { slashCatalogSkills = skills
-            , slashCatalogModelIds = modelIds
-            }
+        ((slashCatalogWithSkills skills defaultSlashCatalog)
+            { slashCatalogModelIds = modelIds
+            })
 
 slashCompletionCandidatesWithCatalog
     :: SlashCatalog
@@ -857,9 +879,7 @@ slashMenuForWithModels modelIds =
 slashMenuForWithSkills :: [SkillCommand] -> Text -> Int -> Maybe SlashMenu
 slashMenuForWithSkills skills =
     slashMenuForCatalog
-        defaultSlashCatalog
-            { slashCatalogSkills = skills
-            }
+        (slashCatalogWithSkills skills defaultSlashCatalog)
 
 slashMenuForWithSkillsAndModels
     :: [SkillCommand]
@@ -869,10 +889,9 @@ slashMenuForWithSkillsAndModels
     -> Maybe SlashMenu
 slashMenuForWithSkillsAndModels skills modelIds =
     slashMenuForCatalog
-        defaultSlashCatalog
-            { slashCatalogSkills = skills
-            , slashCatalogModelIds = modelIds
-            }
+        ((slashCatalogWithSkills skills defaultSlashCatalog)
+            { slashCatalogModelIds = modelIds
+            })
 
 slashMenuForCatalog
     :: SlashCatalog

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Command.Types
     ) where
 
 import Agent.Dialect (DialectId)
+import Data.Map.Strict (Map)
 import Data.Set (Set)
 import Data.Text (Text)
 
@@ -119,7 +120,9 @@ data SlashCatalog = SlashCatalog
     { slashCatalogDialect :: !DialectId
     , slashCatalogToolNames :: !(Set Text)
     , slashCatalogCommands :: ![SlashCommand]
+    , slashCatalogCommandByName :: !(Map Text SlashCommand)
     , slashCatalogSkills :: ![SkillCommand]
+    , slashCatalogSkillByName :: !(Map Text SkillCommand)
     , slashCatalogModelIds :: ![Text]
     }
     deriving (Eq, Show)

--- a/packages/agent-cli/src/Agent/CLI/Error.hs
+++ b/packages/agent-cli/src/Agent/CLI/Error.hs
@@ -22,7 +22,7 @@ import Agent.Error
     )
 import Control.Exception.Safe (Exception, displayException)
 import Data.Char (isControl, isSpace)
-import Data.List (nub)
+import Data.Containers.ListUtils (nubOrd)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime)
@@ -122,7 +122,7 @@ credentialsExhaustedRetryParts reasons =
 
 exhaustionReasonDetails :: [CredentialExhaustionReason] -> Text
 exhaustionReasonDetails reasons =
-    case nub (map formatExhaustionReason reasons) of
+    case nubOrd (map formatExhaustionReason reasons) of
         [] -> ""
         rendered ->
             "\nObserved account failures: "

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -42,6 +42,7 @@ import Agent.CLI.Command
     , SlashMenu(..)
     , SlashSuggestion(..)
     , defaultSlashCatalog
+    , slashCatalogWithSkills
     , slashMenuForCatalog
     )
 import Agent.CLI.Input.Display
@@ -163,9 +164,7 @@ readReplLineWithSkills
     -> IO ReplLine
 readReplLineWithSkills skills =
     readReplLineConfigured
-        defaultSlashCatalog
-            { slashCatalogSkills = skills
-            }
+        (slashCatalogWithSkills skills defaultSlashCatalog)
         True
 
 readReplLineWithSkillsAndModels
@@ -177,10 +176,9 @@ readReplLineWithSkillsAndModels
     -> IO ReplLine
 readReplLineWithSkillsAndModels skills modelIds =
     readReplLineConfigured
-        defaultSlashCatalog
-            { slashCatalogSkills = skills
-            , slashCatalogModelIds = modelIds
-            }
+        ((slashCatalogWithSkills skills defaultSlashCatalog)
+            { slashCatalogModelIds = modelIds
+            })
         True
 
 readReplLineConfigured

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -87,7 +87,7 @@ import Control.Exception.Safe (bracket, tryAny)
 import Control.Monad (join, void)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
-import Data.List (nubBy)
+import Data.Containers.ListUtils (nubOrdOn)
 import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -298,11 +298,10 @@ replaceAt index replacement accounts =
 discoverLoginAccounts :: IO [LoginAccount]
 discoverLoginAccounts = do
     accounts <- discoverLoginAccountSources
-    pure (nubBy sameAccount accounts)
+    pure (nubOrdOn loginAccountKey accounts)
   where
-    sameAccount left right =
-        left.loginProvider == right.loginProvider
-            && left.loginAccountId == right.loginAccountId
+    loginAccountKey account =
+        (account.loginProvider, account.loginAccountId)
 
 -- | Accounts that can be selected in a live session. Unlike the login
 -- dashboard, disabled managed entries do not shadow usable external sources,
@@ -310,10 +309,7 @@ discoverLoginAccounts = do
 discoverSelectableLoginAccounts :: IO [LoginAccount]
 discoverSelectableLoginAccounts = do
     accounts <- filter (.loginEnabled) <$> discoverLoginAccountSources
-    pure (nubBy sameSelection accounts)
-  where
-    sameSelection left right =
-        loginAccountSelectionId left == loginAccountSelectionId right
+    pure (nubOrdOn loginAccountSelectionId accounts)
 
 loginAccountSelectionId :: LoginAccount -> Text
 loginAccountSelectionId account =

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -1,6 +1,7 @@
 -- | Turn CommonMark-ish assistant text into ANSI-styled terminal output.
 module Agent.CLI.Markdown
-    ( renderMarkdown
+    ( MarkdownFragmentSplit(..)
+    , renderMarkdown
     , renderMarkdownFragment
     , splitMarkdownFragment
     ) where
@@ -265,16 +266,35 @@ renderInlineWith base = Text.concat . map (go base)
 -- until their closing delimiter arrives. A newline makes an unmatched inline
 -- construct literal because the renderer does not span inline markup across
 -- lines.
-splitMarkdownFragment :: Maybe Char -> Text -> (Text, Text, Maybe Char)
+data MarkdownFragmentSplit = MarkdownFragmentSplit
+    { markdownReady :: !Text
+    , markdownPending :: !Text
+    , markdownPrevChar :: !(Maybe Char)
+    }
+    deriving (Eq, Show)
+
+data MarkdownLink = MarkdownLink
+    { markdownLinkText :: !Text
+    , markdownLinkUrl :: !Text
+    , markdownLinkRest :: !Text
+    }
+    deriving (Eq, Show)
+
+splitMarkdownFragment :: Maybe Char -> Text -> MarkdownFragmentSplit
 splitMarkdownFragment initialPrev = go initialPrev []
   where
     go prev chunks t
-        | Text.null t = (Text.concat (reverse chunks), "", prev)
+        | Text.null t =
+            MarkdownFragmentSplit
+                { markdownReady = Text.concat (reverse chunks)
+                , markdownPending = ""
+                , markdownPrevChar = prev
+                }
         | Just (escaped, rest) <- takeEscapedPunctuation t =
             consume (Just escaped) rest
         | Just (code, rest) <- takeInlineCode t =
             consume (lastChar code) rest
-        | Just (_linkText, _url, rest) <- takeLink t =
+        | Just MarkdownLink{markdownLinkRest = rest} <- takeLink t =
             consume (Just ')') rest
         | Just (inner, rest) <- takeEmphasis prev "**" t =
             consume (lastChar inner) rest
@@ -285,7 +305,11 @@ splitMarkdownFragment initialPrev = go initialPrev []
         | Just (inner, rest) <- takeEmphasis prev "_" t =
             consume (lastChar inner) rest
         | shouldWait prev t =
-            (Text.concat (reverse chunks), t, prev)
+            MarkdownFragmentSplit
+                { markdownReady = Text.concat (reverse chunks)
+                , markdownPending = t
+                , markdownPrevChar = prev
+                }
         | otherwise =
             let (plain, rest) =
                     Text.break (`elem` ['\\', '`', '[', '*', '_']) t
@@ -361,7 +385,7 @@ takeInlineCode t =
                         (code, rest') <- findClose n afterClose
                         Just (before <> closeRun <> code, rest')
 
-takeLink :: Text -> Maybe (Text, Text, Text)
+takeLink :: Text -> Maybe MarkdownLink
 takeLink t = do
     afterBracket <- Text.stripPrefix "[" t
     (linkText, afterBracketClose) <- takeLinkLabel afterBracket
@@ -369,7 +393,11 @@ takeLink t = do
     (url, rest) <- takeLinkDestination afterParen
     if Text.null linkText || Text.null url
         then Nothing
-        else Just (linkText, url, rest)
+        else Just MarkdownLink
+            { markdownLinkText = linkText
+            , markdownLinkUrl = url
+            , markdownLinkRest = rest
+            }
 
 linkLabelEnd :: Text -> Maybe Text
 linkLabelEnd = fmap snd . takeLinkLabel

--- a/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
@@ -47,7 +47,6 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlpha, isAlphaNum, isSpace)
 import Data.Foldable (traverse_)
-import Data.List (find)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
@@ -94,6 +93,7 @@ data CatalogModel = CatalogModel
 data ModelCatalog = ModelCatalog
     { catalogConnections :: !(Map Text ModelConnection)
     , catalogModels :: ![CatalogModel]
+    , catalogModelsById :: !(Map Text CatalogModel)
     }
     deriving (Eq, Show)
 
@@ -192,18 +192,21 @@ catalogContextWindowForTransport catalog connectionId modelId wireModelId = do
                     | selected.catalogModelWireId == wireModelId =
                         Just selected
                     | otherwise =
-                        find
-                            (\candidate ->
-                                candidate.catalogModelConnectionId
-                                    == connectionId
-                                    && candidate.catalogModelWireId
-                                        == wireModelId)
-                            catalog.catalogModels
+                        Map.lookup wireModelId
+                            (Map.fromList
+                                [ ( candidate.catalogModelWireId
+                                  , candidate
+                                  )
+                                | candidate <-
+                                    catalogModelsForConnection
+                                        connectionId
+                                        catalog
+                                ])
             in effective >>= (.catalogModelContextWindow)
 
 catalogModelById :: ModelCatalog -> Text -> Maybe CatalogModel
 catalogModelById catalog modelId =
-    find ((== modelId) . (.catalogModelId)) catalog.catalogModels
+    Map.lookup modelId catalog.catalogModelsById
 
 catalogModelsForConnection :: Text -> ModelCatalog -> [CatalogModel]
 catalogModelsForConnection wanted =
@@ -216,8 +219,13 @@ connectionBuiltinProvider connection = case connection.connectionKind of
 
 catalogDefaultForProvider :: ModelCatalog -> Provider -> Maybe CatalogModel
 catalogDefaultForProvider catalog provider =
-    find (.catalogModelDefault) $
-        catalogModelsForConnection (builtinConnectionId provider) catalog
+    case
+        [ model
+        | model <- catalogModelsForConnection (builtinConnectionId provider) catalog
+        , model.catalogModelDefault
+        ] of
+        model : _ -> Just model
+        [] -> Nothing
 
 -- | Decode and validate one standalone file. This is mainly useful for tests;
 -- normal startup should use 'mergeModelConfigs' so defaults can be overlaid.
@@ -371,6 +379,11 @@ validateConfig source config = do
     pure ModelCatalog
         { catalogConnections = connections
         , catalogModels = models
+        , catalogModelsById =
+            Map.fromList
+                [ (model.catalogModelId, model)
+                | model <- models
+                ]
         }
   where
     validateConnection connectionId raw = do

--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -40,7 +40,7 @@ import Agent.Dialect
 import qualified Agent.OpenRouter.Options as OpenRouter
 import qualified Agent.OpenRouter.Request as OpenRouter
 import Agent.Provider (Provider(..))
-import Data.List (findIndex, nub)
+import Data.List (findIndex)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -117,7 +117,7 @@ modelsForProvider catalog provider =
 
 catalogModelIds :: ModelCatalog -> [Text]
 catalogModelIds =
-    nub . map (.modelTarget.targetModelId) . modelCatalog
+    map (.modelTarget.targetModelId) . modelCatalog
 
 defaultModelOptionFor :: ModelCatalog -> Provider -> Maybe ModelOption
 defaultModelOptionFor catalog provider =

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -25,6 +25,8 @@ import Agent.GrokBuild.Dialect.Prompt
     )
 import Agent.OsPath (toText)
 import Agent.Provider (BillingMode(..), Provider(..))
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (Day)
@@ -90,20 +92,21 @@ systemPromptForTools
             , timeContextGuidance
             ]
   where
-    available = hostedSearchToolNames dialect ++ toolNames
+    availableNames = hostedSearchToolNames dialect ++ toolNames
+    available = Set.fromList availableNames
     base = case dialectPromptStyle dialect of
         GrokBuildPromptStyle ->
             grokSystemPromptForTools
                 codingGrokPromptTools
-                available
+                availableNames
                 cwd
                 today
                 isNonInteractive
         CodexPromptStyle ->
-            codexSystemPromptForTools available cwd today
+            codexSystemPromptForTools availableNames cwd today
         GenericResponsesPromptStyle ->
             genericSystemPromptForTools
-                available
+                availableNames
                 cwd
                 today
                 isNonInteractive
@@ -125,9 +128,9 @@ sessionTempGuidance = \case
 
 -- | Keep sensitive values outside model-visible text and tool arguments when
 -- the host exposes the dedicated secret-entry capability.
-secretInputGuidance :: [Text] -> Text
+secretInputGuidance :: Set Text -> Text
 secretInputGuidance available
-    | "ask_secret" `notElem` available = ""
+    | "ask_secret" `Set.notMember` available = ""
     | otherwise =
         Text.unlines
             [ "Secret handling:"
@@ -137,9 +140,9 @@ secretInputGuidance available
             , "- Never read, print, summarize, or otherwise expose the secret file contents."
             ]
 
-learnedSkillGuidance :: [Text] -> Text
+learnedSkillGuidance :: Set Text -> Text
 learnedSkillGuidance available
-    | "skill_search" `notElem` available = ""
+    | "skill_search" `Set.notMember` available = ""
     | otherwise =
         Text.unlines
             [ "Learned skills:"
@@ -174,10 +177,10 @@ ghciGuidanceForDialect dialect =
         GenericResponsesPromptStyle -> ghciGuidance
         ClaudeCodePromptStyle -> ""
 
-ghciGuidanceForTools :: Dialect -> [Text] -> Text
+ghciGuidanceForTools :: Dialect -> Set Text -> Text
 ghciGuidanceForTools dialect available
     | dialectPromptStyle dialect == ClaudeCodePromptStyle = ""
-    | "run_ghci" `notElem` available = ""
+    | "run_ghci" `Set.notMember` available = ""
     | otherwise =
         Text.unlines $
             [ "Prefer ghci for scripting."

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -134,6 +134,8 @@ import Data.Maybe
     ( fromMaybe
     , isJust
     )
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text.IO as Text
 import Data.Time.Clock
@@ -287,7 +289,7 @@ requestModelTargetSwitch
     -> IO (Either Text RunResult)
 requestModelTargetSwitch fullscreen choice persist =
     prepareProviderTransition
-        ManualTransition [] Nothing choice persist >>= \case
+        ManualTransition Set.empty Nothing choice persist >>= \case
             Left err -> pure (Left err)
             Right transition -> do
                 color <- resolveColor stdout
@@ -357,7 +359,7 @@ requestAccountProviderSwitch
                             , transitionAccountId = Just accountId
                             , transitionSessionId = sessionId
                             , transitionPendingTurn = Nothing
-                            , transitionUnavailableProviders = []
+                            , transitionUnavailableProviders = Set.empty
                             , transitionCause = ManualTransition
                             , transitionAutomaticBilling = Nothing
                             }
@@ -538,7 +540,7 @@ chooseAutomaticProviderTransition
     -> Maybe FullscreenRuntime
     -> BillingMode
     -> Provider
-    -> [Provider]
+    -> Set Provider
     -> Maybe Text
     -> PendingTurn
     -> ApiError
@@ -604,7 +606,7 @@ chooseStartupProviderTransition
     -> Maybe FullscreenRuntime
     -> BillingMode
     -> Provider
-    -> [Provider]
+    -> Set Provider
     -> Maybe Text
     -> ApiError
     -> IO (Maybe ProviderTransition)
@@ -655,7 +657,7 @@ chooseStartupProviderTransition
 
 prepareProviderTransition
     :: TransitionCause
-    -> [Provider]
+    -> Set Provider
     -> Maybe PendingTurn
     -> ModelOption
     -> Persistence
@@ -871,10 +873,8 @@ commitBackendOnSuccess home projectRoot committed transition persist (Backend su
             Left _ -> pure ()
         pure result
 
-markUnavailable :: Provider -> [Provider] -> [Provider]
-markUnavailable provider unavailable
-    | provider `elem` unavailable = unavailable
-    | otherwise = unavailable <> [provider]
+markUnavailable :: Provider -> Set Provider -> Set Provider
+markUnavailable = Set.insert
 
 reloadAuth :: Provider -> Maybe TokenProvider -> IO (Either Text Text)
 reloadAuth ClaudeCodeProvider _ =

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -15,7 +15,10 @@ import Agent.CLI.ModelConfig (ModelCatalog)
 import Agent.CLI.Models (ModelOption(..), ModelTarget(..), modelCatalog)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Provider (BillingMode(..), Provider(..))
-import Data.List (nubBy, sortOn)
+import Data.Containers.ListUtils (nubOrdOn)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.List (sortOn)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
@@ -100,7 +103,7 @@ rankedModels = sortOn modelRank . filter hasPriority . modelCatalog
 -- that produced this error, are excluded.
 fallbackCandidates
     :: ModelCatalog
-    -> [Provider]
+    -> Set Provider
     -> Provider
     -> ApiError
     -> [ModelOption]
@@ -113,12 +116,9 @@ fallbackCandidates catalog unavailable current err
                 option.modelTarget.targetProvider /= current
                     && option.modelTarget.targetProvider
                         /= ClaudeCodeProvider
-                    && option.modelTarget.targetProvider `notElem` unavailable)
-            (nubBy sameProvider (rankedModels catalog))
-  where
-    sameProvider left right =
-        left.modelTarget.targetProvider
-            == right.modelTarget.targetProvider
+                    && option.modelTarget.targetProvider
+                        `Set.notMember` unavailable)
+            (nubOrdOn (.modelTarget.targetProvider) (rankedModels catalog))
 
 isUsageExhausted :: ApiError -> Bool
 isUsageExhausted = \case

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -16,6 +16,7 @@ import Agent.Loop (TurnInput)
 import Agent.Provider (BillingMode, Provider)
 import Agent.Tools.PlanMode (PlanModeState)
 import Control.Applicative ((<|>))
+import Data.Set (Set)
 import Data.Text (Text)
 
 data PendingTurn = PendingTurn
@@ -38,7 +39,7 @@ data ProviderTransition = ProviderTransition
     , transitionAccountId :: !(Maybe Text)
     , transitionSessionId :: !(Maybe Text)
     , transitionPendingTurn :: !(Maybe PendingTurn)
-    , transitionUnavailableProviders :: ![Provider]
+    , transitionUnavailableProviders :: !(Set Provider)
     , transitionCause :: !TransitionCause
     -- | Billing class of the session that initiated an automatic fallback.
     -- Preserved across failed replacement providers so the whole chain obeys

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -44,7 +44,8 @@ module Agent.CLI.Render
     ) where
 
 import Agent.CLI.Markdown
-    ( renderMarkdown
+    ( MarkdownFragmentSplit(..)
+    , renderMarkdown
     , renderMarkdownFragment
     , splitMarkdownFragment
     )
@@ -303,13 +304,25 @@ feedProse state input =
         (linePart, rest)
             | Text.null rest ->
                 let source = state.pending <> linePart
-                    (parsedReady, parsedPending, parsedContext) =
+                    MarkdownFragmentSplit
+                        { markdownReady = parsedReady
+                        , markdownPending = parsedPending
+                        , markdownPrevChar = parsedContext
+                        } =
                         splitMarkdownFragment state.context source
                     (stablePrefix, graphemePending) =
                         splitTerminalGraphemeSuffix parsedReady
-                    (ready, reparsedPending, nextContext)
+                    MarkdownFragmentSplit
+                        { markdownReady = ready
+                        , markdownPending = reparsedPending
+                        , markdownPrevChar = nextContext
+                        }
                         | Text.null graphemePending =
-                            (parsedReady, "", parsedContext)
+                            MarkdownFragmentSplit
+                                { markdownReady = parsedReady
+                                , markdownPending = ""
+                                , markdownPrevChar = parsedContext
+                                }
                         | otherwise =
                             splitMarkdownFragment
                                 state.context
@@ -327,7 +340,10 @@ feedProse state input =
                    )
             | otherwise ->
                 let source = state.pending <> linePart <> "\n"
-                    (ready, pending', _) =
+                    MarkdownFragmentSplit
+                        { markdownReady = ready
+                        , markdownPending = pending'
+                        } =
                         splitMarkdownFragment state.context source
                     rendered =
                         renderMarkdownFragment True state.context

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -66,7 +66,7 @@ import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Postgres.Session (ConversationSearchResult(..))
 import Control.Monad (forM)
 import Data.Char (isAlphaNum)
-import Data.List (nub)
+import Data.Containers.ListUtils (nubOrd)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
@@ -407,7 +407,7 @@ cycleResumeSource browser =
             , resumeBrowserIndex = 0
             }
   where
-    providers = nub (map (.resumeProvider) browser.resumeBrowserAll)
+    providers = nubOrd (map (.resumeProvider) browser.resumeBrowserAll)
     first = \case
         [] -> Nothing
         value : _ -> Just value

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -386,6 +386,7 @@ import Data.IORef
       writeIORef )
 import Data.List ()
 import Data.Maybe ( isNothing, fromMaybe, isJust )
+import qualified Data.Set as Set
 import Data.Text ( Text )
 import Data.Time.Clock ( getCurrentTime, utctDay )
 import System.Console.ANSI ()
@@ -638,7 +639,7 @@ runAgent
                                     { transitionTarget = target
                                     , transitionAccountSelectionId = Nothing
                                     , transitionAccountId = Nothing
-                                    , transitionUnavailableProviders = []
+                                    , transitionUnavailableProviders = Set.empty
                                     , transitionCause = ManualTransition
                                     , transitionAutomaticBilling = Nothing
                                     }
@@ -649,7 +650,7 @@ runAgent
                                     , transitionAccountId = Nothing
                                     , transitionSessionId = nextOptions.optResume
                                     , transitionPendingTurn = Nothing
-                                    , transitionUnavailableProviders = []
+                                    , transitionUnavailableProviders = Set.empty
                                     , transitionCause = ManualTransition
                                     , transitionAutomaticBilling = Nothing
                                     }
@@ -1115,7 +1116,7 @@ runAgentInitializedWithLock
     let transitionTarget = (.transitionTarget) <$> transition
         pendingTurn = transition >>= (.transitionPendingTurn)
         unavailableProviders =
-            maybe [] (.transitionUnavailableProviders) transition
+            maybe Set.empty (.transitionUnavailableProviders) transition
         configuredOptionTarget =
             (.modelTarget)
                 <$> (options.optModel >>= resolveConfiguredModel catalog)

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -55,6 +55,7 @@ import Data.IORef
     ( readIORef
     , writeIORef
     )
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (getCurrentTime)
@@ -141,7 +142,7 @@ finishTurnWithCooldownRetry
 finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \case
     TurnSucceeded -> do
         env.sessionQueueRecap RecapTurnSummary
-        writeIORef env.sessionUnavailableProviders []
+        writeIORef env.sessionUnavailableProviders Set.empty
         selectionId <- readIORef env.sessionAccountSelectionId
         accountId <- readIORef env.sessionAccountId
         when

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -72,6 +72,7 @@ import Control.Concurrent.STM (STM)
 import Control.Exception.Safe (Exception)
 import Data.IORef (IORef)
 import Data.Map.Strict (Map)
+import Data.Set (Set)
 import Data.Text (Text)
 import Data.Time.Clock
     ( NominalDiffTime
@@ -107,7 +108,7 @@ data SessionRequest = SessionRequest
     , databaseScopes :: !DatabaseScopes
     , promptRequest :: !(Maybe ManagedTurnRequest)
     , pendingTurn :: !(Maybe PendingTurn)
-    , unavailableProviders :: ![Provider]
+    , unavailableProviders :: !(Set Provider)
     , startupUnavailable :: !(Maybe (STM ApiError))
     , paramsRef :: !(IORef ResponseCreateParams)
     , conversationRef :: !(IORef LiveConversation)

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -32,6 +32,7 @@ import Agent.Subagents (RootTurnId)
 import Agent.Tools.PlanMode (PlanModeEnv)
 import Agent.Store.Postgres.Connection (StorePool)
 import Data.IORef (IORef)
+import Data.Set (Set)
 import Data.Text (Text)
 import Control.Concurrent.STM (STM)
 
@@ -45,7 +46,7 @@ data SessionEnv = SessionEnv
     , sessionConnection :: !Text
     , sessionModelCatalog :: !ModelCatalog
     , sessionDialect :: !Dialect
-    , sessionUnavailableProviders :: !(IORef [Provider])
+    , sessionUnavailableProviders :: !(IORef (Set Provider))
     , sessionStartupUnavailable :: !(IORef (Maybe (STM ApiError)))
     , sessionConversation :: !(IORef LiveConversation)
     , sessionParams :: !(IORef ResponseCreateParams)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -97,6 +97,7 @@ import Agent.CLI.AgentViewport
     , agentDisplayName
     , agentEntryTreeLabelWithGlyphModel
     , agentStatusGlyph
+    , lookupAgentEntry
     )
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.ImagePreview
@@ -110,6 +111,7 @@ import Agent.CLI.Command
     ( SkillCommand
     , SlashCatalog(..)
     , defaultSlashCatalog
+    , slashCatalogWithSkills
     )
 import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.CLI.Resume
@@ -163,9 +165,11 @@ import Agent.CLI.TUI.History
     , applyHistoryPage
     , clearHistoryRequest
     , emptyHistoryWindow
+    , historyWindowBlock
     , historyWindowRequest
     , historyWindowSetAnchors
     , markHistoryRequest
+    , setHistoryWindowTurns
     )
 import Agent.CLI.TUI.LambdaArt
     ( lambdaArtWidget
@@ -789,10 +793,9 @@ readFullscreenLineOrWithModels
         runtime skills modelIds prompt initial wake = do
     readFullscreenLineOrWithCatalog
         runtime
-        defaultSlashCatalog
-            { slashCatalogSkills = skills
-            , slashCatalogModelIds = modelIds
-            }
+        ((slashCatalogWithSkills skills defaultSlashCatalog)
+            { slashCatalogModelIds = modelIds
+            })
         prompt
         initial
         wake
@@ -2814,9 +2817,7 @@ handleEventInner event = case event of
             then pure ()
             else
                 let catalog =
-                        state.appSlashCatalog
-                            { slashCatalogSkills = skills
-                            }
+                        slashCatalogWithSkills skills state.appSlashCatalog
                 in modify' \current -> current
                     { appSlashCatalog = catalog
                     , appSlashIndex = 0
@@ -2985,13 +2986,9 @@ handleEventInner event = case event of
                     AgentRoot -> False
                     target ->
                         fmap (.agentConversation)
-                            (find
-                                ((== target) . (.agentTarget))
-                                state.appAgentEntries)
+                            (lookupAgentEntry target state.appAgentEntries)
                             /= fmap (.agentConversation)
-                                (find
-                                    ((== target) . (.agentTarget))
-                                    mergedEntries)
+                                (lookupAgentEntry target mergedEntries)
         if state.appAgentSelected == normalized
             && state.appAgentEntries == mergedEntries
             then pure ()
@@ -3009,12 +3006,10 @@ handleEventInner event = case event of
                                 then Nothing
                                 else
                                     current.appAgentHover >>= \hover ->
-                                        if any
-                                            ((== hover.agentHoverTarget)
-                                                . (.agentTarget))
-                                            mergedEntries
-                                            then Just hover
-                                            else Nothing
+                                        hover <$
+                                            lookupAgentEntry
+                                                hover.agentHoverTarget
+                                                mergedEntries
                         }
                 when selectedConversationChanged invalidateCache
                 if selectionChanged
@@ -3460,9 +3455,7 @@ preserveAgentConversationView selected previous =
     preserve incoming
         | incoming.agentTarget /= selected = incoming
         | otherwise =
-            case find
-                ((== incoming.agentTarget) . (.agentTarget))
-                previous of
+            case lookupAgentEntry incoming.agentTarget previous of
                 Nothing -> incoming
                 Just old ->
                     incoming
@@ -3815,8 +3808,7 @@ isSubmittedPrompt = \case
     _ -> False
 
 selectedBlock :: UiState -> BlockId -> Maybe UiBlock
-selectedBlock state ident =
-    find ((== ident) . (.blockId)) (toList state.uiBlocks)
+selectedBlock state ident = lookupBlock ident state
 
 conversationBlocks :: AgentTarget -> AppState -> [UiBlock]
 conversationBlocks target state =
@@ -3832,10 +3824,7 @@ conversationBlocks target state =
 
 historyBlock :: HistoryWindow -> BlockId -> Maybe UiBlock
 historyBlock window ident =
-    find ((== ident) . (.blockId)) $
-        concatMap
-            (toList . (.historyTurnBlocks))
-            (toList window.historyWindowTurns)
+    historyWindowBlock ident window
 
 selectedConversationBlockId
     :: AgentTarget
@@ -3856,8 +3845,12 @@ selectedConversationBlock
     -> Maybe UiBlock
 selectedConversationBlock target state =
     selectedConversationBlockId target state >>= \ident ->
-        find ((== ident) . (.blockId))
-            (conversationBlocks target state)
+        case target of
+            AgentRoot ->
+                historyBlock state.appHistoryWindow ident
+                    <|> lookupBlock ident state.appUi
+            AgentChild _ ->
+                conversationUiForTarget target state >>= lookupBlock ident
 
 selectConversationBlock
     :: AgentTarget
@@ -3950,18 +3943,17 @@ mapHistoryBlock
     -> HistoryWindow
     -> HistoryWindow
 mapHistoryBlock ident update window =
-    window
-        { historyWindowTurns =
-            fmap
-                (\turn ->
-                    turn
-                        { historyTurnBlocks =
-                            fmap
-                                (\block ->
-                                    if block.blockId == ident
-                                        then update block
-                                        else block)
-                                turn.historyTurnBlocks
-                        })
-                window.historyWindowTurns
-        }
+    setHistoryWindowTurns
+        (fmap
+            (\turn ->
+                turn
+                    { historyTurnBlocks =
+                        fmap
+                            (\block ->
+                                if block.blockId == ident
+                                    then update block
+                                    else block)
+                            turn.historyTurnBlocks
+                    })
+            window.historyWindowTurns)
+        window

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -12,7 +12,11 @@ module Agent.CLI.TUI.Bridge
     , trimHistory
     ) where
 
-import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.AgentViewport
+    ( AgentEntry(..)
+    , AgentTarget(..)
+    , lookupAgentEntry
+    )
 import Agent.TUI.Model (UiEvent(..), UiState(..))
 import Agent.Loop (LoopEvent(..))
 import Data.Text (Text)
@@ -119,8 +123,9 @@ normalizeAgentSelection
     -> [AgentEntry]
     -> AgentTarget
 normalizeAgentSelection selected entries
-    | any ((== selected) . (.agentTarget)) entries = selected
-    | otherwise = AgentRoot
+    | selected == AgentRoot = selected
+    | otherwise =
+        maybe AgentRoot (const selected) (lookupAgentEntry selected entries)
 
 -- | Normalize the current shared selection against an available target set.
 reconcileAgentSelection

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Edit.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Edit.hs
@@ -13,8 +13,9 @@ import Agent.CLI.Input.Types (DisplayCell(..))
 import Agent.TUI.TextWidth (clampGraphemeCursor)
 import Data.ByteString (ByteString)
 import Data.Char (isControl)
-import Data.List (foldl')
+import Data.Foldable (toList)
 import Data.Maybe (fromMaybe)
+import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -195,19 +196,19 @@ draftCursorLocation text requestedCursor =
 verticalCursorMove :: Int -> Text -> Int -> Maybe Int
 verticalCursorMove delta text requestedCursor =
     let cursor = clampGraphemeCursor text requestedCursor
-        draftLines = Text.splitOn "\n" text
+        draftLines = Seq.fromList (Text.splitOn "\n" text)
         (row, column) = draftCursorLocation text cursor
         targetRow = row + delta
-    in if targetRow < 0 || targetRow >= length draftLines
+    in if targetRow < 0 || targetRow >= Seq.length draftLines
         then Nothing
-        else
+        else do
+            line <- Seq.lookup targetRow draftLines
             let lineStart =
                     sum
-                        [ Text.length line + 1
-                        | line <- take targetRow draftLines
+                        [ Text.length prefix + 1
+                        | prefix <- toList (Seq.take targetRow draftLines)
                         ]
-                line = draftLines !! targetRow
-            in Just (lineStart + offsetAtColumn line column)
+            Just (lineStart + offsetAtColumn line column)
 
 -- | Source offset of the grapheme boundary in a single line that renders
 -- closest to the requested terminal column without crossing it.

--- a/packages/agent-cli/src/Agent/CLI/TUI/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/History.hs
@@ -32,15 +32,19 @@ module Agent.CLI.TUI.History
     , historyWindowSelected
     , historyWindowSetAnchors
     , historyWindowSetGeneration
+    , historyWindowBlock
+    , setHistoryWindowTurns
     , historyWindowTurn
     , historyWindowVisible
     , markHistoryRequest
     ) where
 
-import Agent.TUI.Model (UiBlock(..))
-import Data.Foldable (find, toList)
+import Agent.TUI.Model (BlockId, UiBlock(..))
+import Data.Foldable (toList)
 import Data.Int (Int64)
 import Data.List (sortOn)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import qualified Data.Sequence as Seq
 import Data.Sequence (Seq)
 import qualified Data.Set as Set
@@ -87,6 +91,8 @@ data HistoryRequest = HistoryRequest
 data HistoryWindow = HistoryWindow
     { historyWindowGeneration :: !HistoryGeneration
     , historyWindowTurns :: !(Seq HistoryTurn)
+    , historyWindowTurnsByCursor :: !(Map HistoryCursor HistoryTurn)
+    , historyWindowBlocksById :: !(Map BlockId UiBlock)
     , historyWindowHasOlder :: !Bool
     , historyWindowHasNewer :: !Bool
     , historyWindowMaxTurns :: !Int
@@ -115,6 +121,8 @@ emptyHistoryWindow generation maxTurns maxBlocks maxBytes =
     HistoryWindow
         { historyWindowGeneration = generation
         , historyWindowTurns = Seq.empty
+        , historyWindowTurnsByCursor = Map.empty
+        , historyWindowBlocksById = Map.empty
         , historyWindowHasOlder = False
         , historyWindowHasNewer = False
         , historyWindowMaxTurns = max 1 maxTurns
@@ -125,6 +133,23 @@ emptyHistoryWindow generation maxTurns maxBlocks maxBytes =
         , historyWindowPending = Set.empty
         , historyWindowVisibleAnchor = Nothing
         , historyWindowSelectedAnchor = Nothing
+        }
+
+setHistoryWindowTurns :: Seq HistoryTurn -> HistoryWindow -> HistoryWindow
+setHistoryWindowTurns turns window =
+    window
+        { historyWindowTurns = turns
+        , historyWindowTurnsByCursor =
+            Map.fromList
+                [ (turn.historyTurnCursor, turn)
+                | turn <- toList turns
+                ]
+        , historyWindowBlocksById =
+            Map.fromList
+                [ (block.blockId, block)
+                | turn <- toList turns
+                , block <- toList turn.historyTurnBlocks
+                ]
         }
 
 historyWindowLoadedTurns :: HistoryWindow -> Int
@@ -160,9 +185,12 @@ historyWindowTurn
     :: HistoryCursor
     -> HistoryWindow
     -> Maybe HistoryTurn
-historyWindowTurn cursor =
-    find (\turn -> turn.historyTurnCursor == cursor)
-        . (.historyWindowTurns)
+historyWindowTurn cursor window =
+    Map.lookup cursor window.historyWindowTurnsByCursor
+
+historyWindowBlock :: BlockId -> HistoryWindow -> Maybe UiBlock
+historyWindowBlock ident window =
+    Map.lookup ident window.historyWindowBlocksById
 
 historyWindowSetAnchors
     :: Maybe HistoryCursor
@@ -190,17 +218,17 @@ historyWindowSetGeneration
     -> HistoryWindow
     -> HistoryWindow
 historyWindowSetGeneration generation window =
-    window
-        { historyWindowGeneration = generation
-        , historyWindowTurns = Seq.empty
-        , historyWindowHasOlder = False
-        , historyWindowHasNewer = False
-        , historyWindowGenerationStart = HistoryCursor 0
-        , historyWindowTotalTurns = 0
-        , historyWindowPending = Set.empty
-        , historyWindowVisibleAnchor = Nothing
-        , historyWindowSelectedAnchor = Nothing
-        }
+    setHistoryWindowTurns Seq.empty $
+        window
+            { historyWindowGeneration = generation
+            , historyWindowHasOlder = False
+            , historyWindowHasNewer = False
+            , historyWindowGenerationStart = HistoryCursor 0
+            , historyWindowTotalTurns = 0
+            , historyWindowPending = Set.empty
+            , historyWindowVisibleAnchor = Nothing
+            , historyWindowSelectedAnchor = Nothing
+            }
 
 historyWindowCanRequest
     :: HistoryDirection
@@ -329,7 +357,8 @@ mergePage page window =
         case direction of
             HistoryOlder -> incoming <> existing
             HistoryNewer -> existing <> incoming
-    window' = window { historyWindowTurns = uniqueTurns (sortTurns merged) }
+    window' =
+        setHistoryWindowTurns (uniqueTurns (sortTurns merged)) window
 
 sortTurns :: Seq HistoryTurn -> Seq HistoryTurn
 sortTurns = Seq.fromList . sortOn (.historyTurnCursor) . toList
@@ -421,15 +450,11 @@ evictOne :: HistoryDirection -> HistoryWindow -> HistoryWindow
 evictOne direction window =
     case direction of
         HistoryOlder ->
-            window
-                { historyWindowTurns = dropFirst
-                , historyWindowHasOlder = True
-                }
+            setHistoryWindowTurns dropFirst $
+                window { historyWindowHasOlder = True }
         HistoryNewer ->
-            window
-                { historyWindowTurns = dropLast
-                , historyWindowHasNewer = True
-                }
+            setHistoryWindowTurns dropLast $
+                window { historyWindowHasNewer = True }
   where
     turns = window.historyWindowTurns
     dropFirst =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
@@ -28,7 +28,8 @@ import Agent.CLI.AgentViewport
       AgentTarget(..),
       agentDisplayName,
       agentEntryTreeLabelWithGlyphModel,
-      agentStatusGlyph )
+      agentStatusGlyph,
+      lookupAgentEntry )
 import Agent.CLI.Artifact ()
 import Agent.CLI.Clipboard ( formatImageSize )
 import Agent.CLI.Command ()
@@ -209,7 +210,7 @@ import Data.Char ()
 import Data.Foldable ( toList )
 import Data.IORef ()
 import Data.List
-    ( find, findIndex, intersperse, nub, sort, sortOn )
+    ( findIndex, intersperse, nub, sort, sortOn )
 import Data.List.NonEmpty ()
 import Data.Maybe ( fromMaybe, isJust, maybeToList )
 import Data.Sequence ( Seq )
@@ -552,17 +553,14 @@ selectedAgentConversation
     -> Maybe AgentEntry
 selectedAgentConversation selected entries = case selected of
     AgentRoot -> Nothing
-    target ->
-        find ((== target) . (.agentTarget)) entries
+    target -> lookupAgentEntry target entries
 
 conversationUiForTarget :: AgentTarget -> AppState -> Maybe UiState
 conversationUiForTarget target state = case target of
     AgentRoot -> Just state.appUi
     AgentChild _ ->
         (.agentConversation)
-            <$> find
-                ((== target) . (.agentTarget))
-                state.appAgentEntries
+            <$> lookupAgentEntry target state.appAgentEntries
 
 activeConversationUi :: AppState -> UiState
 activeConversationUi state =
@@ -729,9 +727,7 @@ agentPopoverLayers state =
         (False, _) -> []
         (_, Nothing) -> []
         (True, Just hover) ->
-            case find
-                ((== hover.agentHoverTarget) . (.agentTarget))
-                state.appAgentEntries of
+            case lookupAgentEntry hover.agentHoverTarget state.appAgentEntries of
                 Nothing -> []
                 Just entry -> [positionAgentPopover state hover entry]
 

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -35,7 +35,8 @@ import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.List (find, partition)
+import Data.List (partition)
+import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -45,8 +46,14 @@ requireToolRegistry tools =
     either (ioError . userError . Text.unpack) pure (mkToolRegistry tools)
 
 lookupAppTool :: Text -> [AppTool] -> Maybe AppTool
-lookupAppTool name =
-    find (\tool -> tool.appToolName == canonicalToolName name)
+lookupAppTool name tools =
+    Map.lookup (canonicalToolName name) byName
+  where
+    byName =
+        Map.fromList
+            [ (canonicalToolName tool.appToolName, tool)
+            | tool <- tools
+            ]
 
 -- | Built-in Responses @web_search@ tool, enabled for every provider by default.
 -- The host runs the search server-side; the agent loop never dispatches it.

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -2,7 +2,8 @@ module Agent.CLI.MarkdownSpec (spec) where
 
 import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Markdown
-    ( renderMarkdown
+    ( MarkdownFragmentSplit(..)
+    , renderMarkdown
     , renderMarkdownFragment
     , splitMarkdownFragment
     )
@@ -270,41 +271,59 @@ spec = do
 
     describe "splitMarkdownFragment" do
         it "holds a bold span until its closing delimiter arrives" do
-            let (ready1, pending1, context1) =
-                    splitMarkdownFragment Nothing "say **"
-                (ready2, pending2, context2) =
-                    splitMarkdownFragment context1 (pending1 <> "hello")
-                (ready3, pending3, _context3) =
-                    splitMarkdownFragment context2 (pending2 <> "** there")
-                out = renderMarkdownFragment True context2 ready3
-            ready1 `shouldBe` "say "
-            pending1 `shouldBe` "**"
-            ready2 `shouldBe` ""
-            pending2 `shouldBe` "**hello"
-            pending3 `shouldBe` ""
+            let split1 = splitMarkdownFragment Nothing "say **"
+                split2 =
+                    splitMarkdownFragment
+                        split1.markdownPrevChar
+                        (split1.markdownPending <> "hello")
+                split3 =
+                    splitMarkdownFragment
+                        split2.markdownPrevChar
+                        (split2.markdownPending <> "** there")
+                out =
+                    renderMarkdownFragment
+                        True
+                        split2.markdownPrevChar
+                        split3.markdownReady
+            split1.markdownReady `shouldBe` "say "
+            split1.markdownPending `shouldBe` "**"
+            split2.markdownReady `shouldBe` ""
+            split2.markdownPending `shouldBe` "**hello"
+            split3.markdownPending `shouldBe` ""
             stripAnsi out `shouldBe` "hello there"
 
         it "handles a bold delimiter split one star at a time" do
-            let (ready1, pending1, context1) =
-                    splitMarkdownFragment Nothing "*"
-                (ready2, pending2, context2) =
-                    splitMarkdownFragment context1 (pending1 <> "*a*")
-                (ready3, pending3, _context3) =
-                    splitMarkdownFragment context2 (pending2 <> "*")
-            ready1 `shouldBe` ""
-            ready2 `shouldBe` ""
-            pending3 `shouldBe` ""
-            stripAnsi (renderMarkdownFragment True context2 ready3)
+            let split1 = splitMarkdownFragment Nothing "*"
+                split2 =
+                    splitMarkdownFragment
+                        split1.markdownPrevChar
+                        (split1.markdownPending <> "*a*")
+                split3 =
+                    splitMarkdownFragment
+                        split2.markdownPrevChar
+                        (split2.markdownPending <> "*")
+            split1.markdownReady `shouldBe` ""
+            split2.markdownReady `shouldBe` ""
+            split3.markdownPending `shouldBe` ""
+            stripAnsi
+                (renderMarkdownFragment
+                    True
+                    split2.markdownPrevChar
+                    split3.markdownReady)
                 `shouldBe` "a"
 
         it "does not turn a chunked snake_case identifier into emphasis" do
-            let (ready1, pending1, context1) =
-                    splitMarkdownFragment Nothing "snake"
-                (ready2, pending2, _context2) =
-                    splitMarkdownFragment context1 (pending1 <> "_case_name")
-            pending2 `shouldBe` ""
-            renderMarkdownFragment True Nothing ready1
-                <> renderMarkdownFragment True context1 ready2
+            let split1 = splitMarkdownFragment Nothing "snake"
+                split2 =
+                    splitMarkdownFragment
+                        split1.markdownPrevChar
+                        (split1.markdownPending <> "_case_name")
+            split2.markdownPending `shouldBe` ""
+            renderMarkdownFragment True Nothing split1.markdownReady
+                <> renderMarkdownFragment
+                    True
+                    split1.markdownPrevChar
+                    split2.markdownReady
                 `shouldBe` "snake_case_name"
 
 allEqual :: Eq a => [a] -> Bool

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -22,6 +22,7 @@ import Agent.Error
     )
 import Agent.Provider (BillingMode(..), Provider(..))
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), addUTCTime)
@@ -67,7 +68,7 @@ spec = do
                     ( model.modelTarget.targetProvider
                     , model.modelTarget.targetModelId
                     ))
-                (fallbackCandidates catalog [] XAIProvider exhausted)
+                (fallbackCandidates catalog Set.empty XAIProvider exhausted)
                 `shouldBe`
                     [ (OpenAIProvider, "gpt-5.6-sol")
                     , (OpenRouterProvider, "stealth/ox-alpha")
@@ -79,32 +80,32 @@ spec = do
                     ( model.modelTarget.targetProvider
                     , model.modelTarget.targetModelId
                     ))
-                (fallbackCandidates catalog [] OpenAIProvider exhausted)
+                (fallbackCandidates catalog Set.empty OpenAIProvider exhausted)
                 `shouldBe`
                     [ (XAIProvider, "grok-4.6")
                     , (OpenRouterProvider, "stealth/ox-alpha")
                     ]
 
         it "never automatically enters or leaves the Claude Code provider" do
-            fallbackCandidates catalog [] ClaudeCodeProvider exhausted
+            fallbackCandidates catalog Set.empty ClaudeCodeProvider exhausted
                 `shouldBe` []
             map (.modelTarget.targetProvider)
-                (fallbackCandidates catalog [] OpenAIProvider exhausted)
+                (fallbackCandidates catalog Set.empty OpenAIProvider exhausted)
                 `shouldSatisfy` (ClaudeCodeProvider `notElem`)
 
         it "skips providers already found unavailable" do
             map (.modelTarget.targetProvider)
-                (fallbackCandidates catalog [OpenAIProvider] XAIProvider exhausted)
+                (fallbackCandidates catalog (Set.singleton OpenAIProvider) XAIProvider exhausted)
                 `shouldBe` [OpenRouterProvider]
 
         it "accepts direct usage-limit errors from every provider" do
-            fallbackCandidates catalog [] OpenRouterProvider
+            fallbackCandidates catalog Set.empty OpenRouterProvider
                 (ProviderError UsageLimitReached "quota exhausted" (Just 3600))
                 `shouldSatisfy` (not . null)
 
         it "accepts other definitive account and billing exhaustion errors" do
             map
-                (not . null . fallbackCandidates catalog [] XAIProvider)
+                (not . null . fallbackCandidates catalog Set.empty XAIProvider)
                 [ ProviderError UsageBalanceExhausted "balance exhausted" Nothing
                 , ProviderError QuotaExceeded "quota exhausted" Nothing
                 , ProviderError UsageNotIncluded "not included" Nothing
@@ -113,17 +114,17 @@ spec = do
                 `shouldBe` replicate 4 True
 
         it "does not switch for transient capacity failures" do
-            fallbackCandidates catalog [] XAIProvider
+            fallbackCandidates catalog Set.empty XAIProvider
                 (ProviderError OverloadedError "busy" (Just 30))
                 `shouldBe` []
 
         it "can continue past a replacement provider with rejected auth" do
             map (.modelTarget.targetProvider)
-                (fallbackCandidates catalog [XAIProvider] OpenAIProvider
+                (fallbackCandidates catalog (Set.singleton XAIProvider) OpenAIProvider
                     (ProviderError AuthenticationError "rejected" Nothing))
                 `shouldBe` [OpenRouterProvider]
             map (.modelTarget.targetProvider)
-                (fallbackCandidates catalog [XAIProvider] OpenAIProvider
+                (fallbackCandidates catalog (Set.singleton XAIProvider) OpenAIProvider
                     (CredentialError "credential file is invalid"))
                 `shouldBe` [OpenRouterProvider]
 

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -6,6 +6,7 @@ import Agent.CLI.ProviderTransition
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (BillingMode(..), Provider(..))
 import Agent.Tools.PlanMode (PlanModeState(..))
+import qualified Data.Set as Set
 import Data.Text (Text)
 import Test.Hspec
 
@@ -69,7 +70,7 @@ transition sessionId pending = ProviderTransition
     , transitionAccountId = Nothing
     , transitionSessionId = sessionId
     , transitionPendingTurn = pending
-    , transitionUnavailableProviders = [XAIProvider]
+    , transitionUnavailableProviders = Set.singleton XAIProvider
     , transitionCause = AutomaticFallback
     , transitionAutomaticBilling = Just SubscriptionBilled
     }

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/ApplyPatch.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/ApplyPatch.hs
@@ -26,8 +26,11 @@ import Control.Monad.Trans.Except
     , runExceptT
     , throwE
     )
+import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath (doesFileExist)
@@ -261,7 +264,7 @@ prepareHunks env hunks = go hunks Map.empty [] [] [] []
                             <> Text.pack path
                             <> "': "
                             <> err
-                Right lines_ -> pure lines_
+                Right lines_ -> pure (toList lines_)
             let newContents = joinFileLines newLines original
             case moveTo of
                 Nothing ->
@@ -318,63 +321,61 @@ resolvePath :: ToolEnv -> FilePath -> ExceptT Text IO OsPath
 resolvePath env path =
     ExceptT (resolveUnderCwd env (unsafeEncodeUtf path))
 
-applyChunks :: [UpdateChunk] -> [Text] -> Either Text [Text]
-applyChunks chunks start = foldl applyOne (Right start) chunks
+applyChunks :: [UpdateChunk] -> [Text] -> Either Text (Seq Text)
+applyChunks chunks start =
+    foldl applyOne (Right (Seq.fromList start)) chunks
   where
     applyOne (Left err) _ = Left err
     applyOne (Right lines_) chunk = applyChunk chunk lines_
 
-applyChunk :: UpdateChunk -> [Text] -> Either Text [Text]
+applyChunk :: UpdateChunk -> Seq Text -> Either Text (Seq Text)
 applyChunk chunk fileLines =
     let afterContext = case chunk.chunkContext of
             Nothing -> 0
             Just ctx ->
-                fromMaybe (length fileLines)
-                    (findIndexEqual ctx fileLines)
+                fromMaybe (Seq.length fileLines)
+                    (Seq.elemIndexL ctx fileLines)
         searchFrom = case chunk.chunkContext of
             Nothing -> 0
             Just _ -> afterContext + 1
-    in if null chunk.chunkOld
+        oldLines = Seq.fromList chunk.chunkOld
+        newLines = Seq.fromList chunk.chunkNew
+    in if Seq.null oldLines
         then
             let insertAt
                     | chunk.chunkEof || chunk.chunkContext == Nothing =
-                        length fileLines
+                        Seq.length fileLines
                     | otherwise = searchFrom
-            in Right (insertAtPos insertAt chunk.chunkNew fileLines)
-        else case findSequence chunk.chunkOld fileLines searchFrom of
+            in Right (insertAtPos insertAt newLines fileLines)
+        else case findSequence oldLines fileLines searchFrom of
             Nothing ->
                 -- Retry from the start when the @@ context did not pin a unique site.
-                case findSequence chunk.chunkOld fileLines 0 of
+                case findSequence oldLines fileLines 0 of
                     Nothing -> Left "Failed to find expected lines in the file to update"
-                    Just idx -> Right (replaceAt idx (length chunk.chunkOld) chunk.chunkNew fileLines)
+                    Just idx ->
+                        Right (replaceAt idx (Seq.length oldLines) newLines fileLines)
             Just idx ->
-                Right (replaceAt idx (length chunk.chunkOld) chunk.chunkNew fileLines)
+                Right (replaceAt idx (Seq.length oldLines) newLines fileLines)
 
-findIndexEqual :: Text -> [Text] -> Maybe Int
-findIndexEqual needle = go 0
-  where
-    go _ [] = Nothing
-    go i (x : xs)
-        | x == needle = Just i
-        | otherwise = go (i + 1) xs
-
-findSequence :: [Text] -> [Text] -> Int -> Maybe Int
+findSequence :: Seq Text -> Seq Text -> Int -> Maybe Int
 findSequence needle haystack from
-    | null needle = Just from
+    | Seq.null needle = Just from
     | otherwise = go from
   where
+    needleLength = Seq.length needle
+    haystackLength = Seq.length haystack
     go i
-        | i > length haystack - length needle = Nothing
-        | take (length needle) (drop i haystack) == needle = Just i
+        | i > haystackLength - needleLength = Nothing
+        | Seq.take needleLength (Seq.drop i haystack) == needle = Just i
         | otherwise = go (i + 1)
 
-replaceAt :: Int -> Int -> [Text] -> [Text] -> [Text]
+replaceAt :: Int -> Int -> Seq Text -> Seq Text -> Seq Text
 replaceAt idx count newLines fileLines =
-    take idx fileLines ++ newLines ++ drop (idx + count) fileLines
+    Seq.take idx fileLines <> newLines <> Seq.drop (idx + count) fileLines
 
-insertAtPos :: Int -> [Text] -> [Text] -> [Text]
+insertAtPos :: Int -> Seq Text -> Seq Text -> Seq Text
 insertAtPos idx newLines fileLines =
-    take idx fileLines ++ newLines ++ drop idx fileLines
+    Seq.take idx fileLines <> newLines <> Seq.drop idx fileLines
 
 joinFileLines :: [Text] -> Text -> Text
 joinFileLines newLines original

--- a/packages/agent-core/src/Agent/Error.hs
+++ b/packages/agent-core/src/Agent/Error.hs
@@ -45,7 +45,7 @@ data ErrorType
     | CyberPolicyError
     | MisalignmentPolicyViolation
     | UnknownErrorType !Text
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
 -- | Redacted, structured reason why a credential entered cooldown.
 --
@@ -61,7 +61,7 @@ data CredentialExhaustionReason
         { exhaustionErrorType :: !(Maybe ErrorType)
         , exhaustionStatusCode :: !(Maybe Int)
         }
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
 -- | Whether retrying can help, and which layer should own the retry.
 --

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -99,7 +99,9 @@ import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import Data.IORef (newIORef, readIORef, writeIORef)
-import qualified Data.Map.Strict as Map
+import qualified Data.IntMap.Strict as IntMap
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntSet as IntSet
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -802,7 +804,7 @@ runToolCalls :: LoopConfig -> [ToolCall] -> IO [ToolCallResult]
 runToolCalls config calls = do
     prepared <- prepareIndexedToolCalls config (zip [0..] calls)
     scheduled <- traverse schedule prepared
-    go scheduled Map.empty
+    go scheduled IntMap.empty
   where
     schedule
         :: IndexedPreparedToolCall
@@ -817,17 +819,17 @@ runToolCalls config calls = do
 
     go
         :: [PreparedScheduledToolCall]
-        -> Map.Map Int ToolCallResult
+        -> IntMap ToolCallResult
         -> IO [ToolCallResult]
     go [] completed =
-        pure (map snd (Map.toAscList completed))
+        pure (IntMap.elems completed)
     go remaining completed = do
         let ready = readyCalls remaining
-            readyIndexes = Map.fromList [(call.index, ()) | call <- ready]
+            readyIndexes = IntSet.fromList (map (.index) ready)
             pending =
                 filter
                     (\scheduled ->
-                        Map.notMember scheduled.index readyIndexes)
+                        IntSet.notMember scheduled.index readyIndexes)
                     remaining
         batchResults <-
             mapConcurrently
@@ -841,13 +843,13 @@ runToolCalls config calls = do
                     (\result acc ->
                         maybe
                             acc
-                            (\(index, value) -> Map.insert index value acc)
+                            (\(index, value) -> IntMap.insert index value acc)
                             result)
                     completed
                     batchResults
         cancelled <- isCancelled config.loopCancel
         if cancelled
-            then pure (map snd (Map.toAscList completed'))
+            then pure (IntMap.elems completed')
             else go pending completed'
 
 data IndexedPreparedToolCall = IndexedPreparedToolCall

--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -107,6 +107,7 @@ import Data.IORef
     , newIORef
     , readIORef
     )
+import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
 import Data.List (find, sortOn)
 import Data.Maybe (catMaybes, isJust)
@@ -715,7 +716,7 @@ data McpClient = McpClient
     , clientProcess :: !ProcessHandle
     , clientGroupId :: !(Maybe ProcessGroupID)
     , clientNextId :: !(IORef Int)
-    , clientPending :: !(TVar (Map.Map Int (TMVar (Either Text Value))))
+    , clientPending :: !(TVar (IntMap.IntMap (TMVar (Either Text Value))))
     , clientFailure :: !(TVar (Maybe Text))
     , clientWriteLock :: !(MVar ())
     , clientStderr :: !(IORef CapturedStderr)
@@ -1554,7 +1555,7 @@ startMcpClient config = mask \_ -> do
             hSetBinaryMode errOutput True
             hSetBuffering input LineBuffering
             nextId <- newIORef 1
-            pending <- newTVarIO Map.empty
+            pending <- newTVarIO IntMap.empty
             failure <- newTVarIO Nothing
             writeLock <- newMVar ()
             stderrRef <- newIORef emptyCapturedStderr
@@ -1844,7 +1845,7 @@ requestMcp client timeoutMicros method parameters = do
                 (current + 1, current)
             response <- newEmptyTMVarIO
             atomically $
-                modifyTVar' client.clientPending (Map.insert requestId response)
+                modifyTVar' client.clientPending (IntMap.insert requestId response)
             let message = object
                     [ "jsonrpc" .= ("2.0" :: Text)
                     , "id" .= requestId
@@ -1854,7 +1855,7 @@ requestMcp client timeoutMicros method parameters = do
             sendMessage client message >>= \case
                 Left err -> do
                     atomically $
-                        modifyTVar' client.clientPending (Map.delete requestId)
+                        modifyTVar' client.clientPending (IntMap.delete requestId)
                     pure (Left err)
                 Right () -> do
                     timed <- timeout (max 1 timeoutMicros)
@@ -1864,7 +1865,7 @@ requestMcp client timeoutMicros method parameters = do
                         Nothing -> do
                             atomically $
                                 modifyTVar' client.clientPending
-                                    (Map.delete requestId)
+                                    (IntMap.delete requestId)
                             pure . Left $
                                 "MCP request "
                                     <> method
@@ -1897,7 +1898,7 @@ sendMessage client message =
 
 readerLoop
     :: Handle
-    -> TVar (Map.Map Int (TMVar (Either Text Value)))
+    -> TVar (IntMap.IntMap (TMVar (Either Text Value)))
     -> TVar (Maybe Text)
     -> IO ()
 readerLoop output pending failure =
@@ -1915,7 +1916,7 @@ readerLoop output pending failure =
         loop
 
 routeResponse
-    :: TVar (Map.Map Int (TMVar (Either Text Value)))
+    :: TVar (IntMap.IntMap (TMVar (Either Text Value)))
     -> Value
     -> IO ()
 routeResponse pending (Object fields) =
@@ -1924,8 +1925,8 @@ routeResponse pending (Object fields) =
         Just ident -> do
             destination <- atomically do
                 current <- readTVar pending
-                writeTVar pending (Map.delete ident current)
-                pure (Map.lookup ident current)
+                writeTVar pending (IntMap.delete ident current)
+                pure (IntMap.lookup ident current)
             case destination of
                 Nothing -> pure ()
                 Just response ->
@@ -1979,14 +1980,14 @@ capturedStderrText captured =
                 <> body
 
 failClient
-    :: TVar (Map.Map Int (TMVar (Either Text Value)))
+    :: TVar (IntMap.IntMap (TMVar (Either Text Value)))
     -> TVar (Maybe Text)
     -> Text
     -> IO ()
 failClient = failPending
 
 failPending
-    :: TVar (Map.Map Int (TMVar (Either Text Value)))
+    :: TVar (IntMap.IntMap (TMVar (Either Text Value)))
     -> TVar (Maybe Text)
     -> Text
     -> IO ()
@@ -1995,9 +1996,9 @@ failPending pending failure err =
         existing <- readTVar failure
         when (existing == Nothing) (writeTVar failure (Just err))
         requests <- readTVar pending
-        writeTVar pending Map.empty
+        writeTVar pending IntMap.empty
         mapM_ (\response -> void (tryPutTMVar response (Left err)))
-            (Map.elems requests)
+            (IntMap.elems requests)
 
 closeMcpClient :: McpClient -> IO ()
 closeMcpClient client =

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -37,7 +37,7 @@ data Provider
     | XAIProvider
     | OpenRouterProvider
     | ClaudeCodeProvider
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
 providerSlug :: Provider -> Text
 providerSlug = \case

--- a/packages/agent-core/src/Agent/Provider/Options.hs
+++ b/packages/agent-core/src/Agent/Provider/Options.hs
@@ -5,6 +5,8 @@ module Agent.Provider.Options
     , parseModelOverrides
     ) where
 
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -33,9 +35,9 @@ parseInt value = case reads value of
 --
 -- Whitespace around each side is ignored. Empty or malformed entries are
 -- skipped so one bad override does not discard the remaining valid entries.
-parseModelOverrides :: Text -> [(Text, Text)]
+parseModelOverrides :: Text -> Map Text Text
 parseModelOverrides raw =
-    Maybe.mapMaybe parseEntry (Text.splitOn "," raw)
+    Map.fromList (Maybe.mapMaybe parseEntry (Text.splitOn "," raw))
   where
     parseEntry entry = case Text.breakOn "=" entry of
         (source, target)

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -45,7 +45,7 @@ import System.OsPath (OsPath, unsafeEncodeUtf)
 import Data.Aeson.Types (Parser)
 import qualified Data.ByteString as BS
 import Data.Char (isAlphaNum)
-import Data.List (find, sort, sortOn)
+import Data.List (sort, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
@@ -613,13 +613,20 @@ resolveSkillInvocation
     -> Text
     -> Either Text SkillInvocation
 resolveSkillInvocation invocations rawName =
-    case find ((== Text.toLower rawName) . Text.toLower . (.invocationName)) invocations of
+    case Map.lookup (Text.toLower rawName) (skillInvocationsByName invocations) of
         Just invocation -> Right invocation
         Nothing ->
             Left $
                 "unknown skill: "
                     <> rawName
                     <> availableSuffix invocations
+
+skillInvocationsByName :: [SkillInvocation] -> Map Text SkillInvocation
+skillInvocationsByName invocations =
+    Map.fromList
+        [ (Text.toLower invocation.invocationName, invocation)
+        | invocation <- invocations
+        ]
 
 resolveSkillMentions
     :: [SkillInvocation]

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -30,7 +30,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (parseEither)
-import Data.List (find)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -175,8 +175,13 @@ decodeToolArguments value =
 
 findHandler :: Text -> [ToolHandler] -> Maybe ToolHandler
 findHandler name handlers =
-    find ((== name) . handlerName) handlers
-        <|> find ((== canonicalToolName name) . handlerName) handlers
+    Map.lookup name byName <|> Map.lookup (canonicalToolName name) byName
+  where
+    byName =
+        Map.fromList
+            [ (handlerName handler, handler)
+            | handler <- handlers
+            ]
 
 -- | Codex namespaced tools may arrive as @collaboration.spawn_agent@ or
 -- legacy @multi_agent_v1.spawn_agent@ (and concatenated Display forms).

--- a/packages/agent-core/src/Agent/Tools/PlanMode.hs
+++ b/packages/agent-core/src/Agent/Tools/PlanMode.hs
@@ -47,6 +47,7 @@ import Control.Applicative ((<|>))
 import Control.Exception.Safe (tryAny)
 import Data.Aeson (FromJSON(..), withObject)
 import Data.IORef
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -458,6 +459,8 @@ runAskUserQuestion env args
                 Right answer -> pure (Right (question.question, answer))
         | otherwise = do
             let choices = map formatOption question.options
+                labelsByChoice =
+                    Map.fromList (zip choices (map (.label) question.options))
             answer <- env.planHooks.planAskQuestion question.question choices
             pure $ case answer of
                 Nothing -> Left "No answer from user."
@@ -466,9 +469,7 @@ runAskUserQuestion env args
                 Just text ->
                     Right
                         ( question.question
-                        , fromMaybe text
-                            (lookup text
-                                (zip choices (map (.label) question.options)))
+                        , fromMaybe text (Map.lookup text labelsByChoice)
                         )
 
     askMultiple :: AskUserQuestion -> IO (Either Text Text)
@@ -478,6 +479,8 @@ runAskUserQuestion env args
         doneChoice = "Done selecting"
         choose selected remaining = do
             let displayed = map formatOption remaining
+                labelsByDisplayed =
+                    Map.fromList (zip displayed (map (.label) remaining))
                 choices = displayed <> [doneChoice]
                 prompt
                     | null selected = question.question
@@ -496,7 +499,7 @@ runAskUserQuestion env args
                             else pure
                                 (Right (Text.intercalate ", " (reverse selected)))
                     | Just label <-
-                        lookup raw (zip displayed (map (.label) remaining)) ->
+                        Map.lookup raw labelsByDisplayed ->
                             choose
                                 (label : selected)
                                 [ option

--- a/packages/agent-core/test/Agent/Provider/OptionsSpec.hs
+++ b/packages/agent-core/test/Agent/Provider/OptionsSpec.hs
@@ -2,6 +2,7 @@ module Agent.Provider.OptionsSpec (spec) where
 
 import Agent.Provider.Options
 import Control.Exception.Safe (bracket)
+import qualified Data.Map.Strict as Map
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Test.Hspec
 
@@ -11,9 +12,10 @@ spec = describe "Agent.Provider.Options" do
         it "parses valid entries, trims whitespace, and skips malformed ones" do
             parseModelOverrides "local = remote,broken,=missing,also=,x=y=z"
                 `shouldBe`
-                    [ ("local", "remote")
-                    , ("x", "y=z")
-                    ]
+                    Map.fromList
+                        [ ("local", "remote")
+                        , ("x", "y=z")
+                        ]
 
     describe "environment lookup" do
         it "distinguishes empty, invalid, and valid values" $

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
@@ -32,7 +32,7 @@ import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (mapConcurrently)
 import Data.Aeson (FromJSON(..))
-import Data.List (nub)
+import Data.Containers.ListUtils (nubOrd)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -261,7 +261,7 @@ validateTaskIds taskIds
     | otherwise = Right resolvedIds
   where
     resolvedIds =
-        nub
+        nubOrd
             [ stripped
             | taskId <- taskIds
             , let stripped = Text.strip taskId

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -79,7 +79,10 @@ import Data.IORef
     , newIORef
     , readIORef
     )
-import Data.List (find, nub)
+import Data.Containers.ListUtils (nubOrd)
+import Data.Foldable (toList)
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
 import Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -127,7 +130,7 @@ data AccountEntry = AccountEntry
 type AccountDiscovery = [Text] -> IO (Either ApiError [AuthState])
 
 data PoolState = PoolState
-    { stateEntries :: ![AccountEntry]
+    { stateEntries :: !(Seq AccountEntry)
     , stateEmptyExhaustion
         :: !(Maybe (UTCTime, [CredentialExhaustionReason]))
     , stateCounter :: !Int
@@ -212,13 +215,13 @@ buildPool
     -> Maybe AccountDiscovery
     -> IO Pool
 buildPool initial emptyRetryAt refresh discovery = do
-    entries <- mapM mkEntry initial
+    entries <- Seq.fromList <$> mapM mkEntry initial
     now <- getCurrentTime
     let offset = floor (toRational (utctDayTime now) * 1000) :: Int
     state <- newIORef PoolState
         { stateEntries = entries
         , stateEmptyExhaustion = (, []) <$> emptyRetryAt
-        , stateCounter = offset `mod` max 1 (length entries)
+        , stateCounter = offset `mod` max 1 (Seq.length entries)
         , stateDiscovery = Nothing
         }
     pure Pool
@@ -253,9 +256,10 @@ getAccessTokenWithDiscovery
     -> Bool
     -> IO (Either ApiError (Text, Text))
 getAccessTokenWithDiscovery pool allowDiscovery = do
-    entries <- (.stateEntries) <$> readIORef pool.poolState
-    let accountIdsAtCheckout = map (.entryAccountId) entries
-    result <- go (length entries)
+    poolState <- readIORef pool.poolState
+    let entries = poolState.stateEntries
+        accountIdsAtCheckout = map (.entryAccountId) (toList entries)
+    result <- go (Seq.length entries)
     case result of
         Left exhausted@CredentialsExhausted
             { retryAt = previousRetryAt
@@ -266,7 +270,7 @@ getAccessTokenWithDiscovery pool allowDiscovery = do
                     True -> getAccessTokenWithDiscovery pool False
                     False -> do
                         current <- readIORef pool.poolState
-                        if null current.stateEntries
+                        if Seq.null current.stateEntries
                             then
                                 let (retryAt, reasons) =
                                         fromMaybe
@@ -408,8 +412,9 @@ claimDiscovery
     -> PoolState
     -> (PoolState, DiscoveryClaim)
 claimDiscovery accountIdsAtCheckout promise current =
-    let knownAccountIds = map (.entryAccountId) current.stateEntries
-    in if any (`notElem` accountIdsAtCheckout) knownAccountIds
+    let knownAccountIds = map (.entryAccountId) (toList current.stateEntries)
+        checkout = Set.fromList accountIdsAtCheckout
+    in if any (`Set.notMember` checkout) knownAccountIds
         then (current, DiscoveryAlreadyAdded)
         else case current.stateDiscovery of
             Just active -> (current, DiscoveryWait active)
@@ -440,12 +445,13 @@ finishDiscovery outcome candidates current =
 
 appendEntries :: [AccountEntry] -> PoolState -> (PoolState, Bool)
 appendEntries candidates current =
-    let known = Set.fromList (map (.entryAccountId) current.stateEntries)
+    let known = Set.fromList (map (.entryAccountId) (toList current.stateEntries))
         (newEntries, _) = foldl addCandidate ([], known) candidates
         added = not (null newEntries)
     in
         ( current
-            { stateEntries = current.stateEntries <> reverse newEntries
+            { stateEntries =
+                current.stateEntries <> Seq.fromList (reverse newEntries)
             , stateEmptyExhaustion =
                 if added then Nothing else current.stateEmptyExhaustion
             }
@@ -478,14 +484,14 @@ pickAccount pool = do
     now <- getCurrentTime
     (entries, startIdx, emptyExhaustion) <-
         atomicModifyIORef' pool.poolState selectStart
-    case entries of
-        [] -> pure (Left (fromMaybe (now, []) emptyExhaustion))
-        _ -> do
+    if Seq.null entries
+        then pure (Left (fromMaybe (now, []) emptyExhaustion))
+        else do
             available <- tryFrom entries startIdx now 0
             case available of
                 Just entry -> pure (Right entry)
                 Nothing -> do
-                    cooldowns <- fmap catMaybes $ forM entries \entry ->
+                    cooldowns <- fmap catMaybes $ forM (toList entries) \entry ->
                         effectiveCooldown . (.accountCooldowns)
                             <$> readIORef entry.entryState
                     case cooldowns of
@@ -494,29 +500,30 @@ pickAccount pool = do
                             let active = first : rest
                             in pure $ Left
                                 ( minimum (map fst active)
-                                , nub (concatMap snd active)
+                                , nubOrd (concatMap snd active)
                                 )
   where
-    selectStart current =
-        case current.stateEntries of
-            [] ->
-                ( current
-                , ([], 0, current.stateEmptyExhaustion)
+    selectStart current
+        | Seq.null current.stateEntries =
+            ( current
+            , (Seq.empty, 0, current.stateEmptyExhaustion)
+            )
+        | otherwise =
+            let entries = current.stateEntries
+                n = Seq.length entries
+                startIdx = current.stateCounter `mod` n
+                nextCounter = (current.stateCounter + 1) `mod` n
+            in
+                ( current { stateCounter = nextCounter }
+                , (entries, startIdx, current.stateEmptyExhaustion)
                 )
-            entries ->
-                let n = length entries
-                    startIdx = current.stateCounter `mod` n
-                    nextCounter = (current.stateCounter + 1) `mod` n
-                in
-                    ( current { stateCounter = nextCounter }
-                    , (entries, startIdx, current.stateEmptyExhaustion)
-                    )
 
     tryFrom entries startIdx now offset
-        | offset >= length entries = pure Nothing
+        | offset >= Seq.length entries = pure Nothing
         | otherwise = do
-            let entry =
-                    entries !! ((startIdx + offset) `mod` length entries)
+            let n = Seq.length entries
+                entry =
+                    Seq.index entries ((startIdx + offset) `mod` n)
             cooldown <- atomicModifyAccount entry \current ->
                 let updated = expireCooldowns now current
                 in (updated, effectiveCooldown updated.accountCooldowns)
@@ -696,8 +703,9 @@ claimAuthRecoveryAt now rejectedAccessToken current
 --------------------------------------------------------------------------------
 
 allAccountIds :: Pool -> IO [Text]
-allAccountIds pool =
-    map (.entryAccountId) . (.stateEntries) <$> readIORef pool.poolState
+allAccountIds pool = do
+    poolState <- readIORef pool.poolState
+    pure (map (.entryAccountId) (toList poolState.stateEntries))
 
 readAccountState :: Pool -> Text -> IO (Maybe AuthState)
 readAccountState pool targetAccountId =
@@ -713,8 +721,8 @@ data AccountSnapshot = AccountSnapshot
 
 snapshotAccounts :: Pool -> IO [AccountSnapshot]
 snapshotAccounts pool = do
-    entries <- (.stateEntries) <$> readIORef pool.poolState
-    forM entries \entry -> do
+    poolState <- readIORef pool.poolState
+    forM (toList poolState.stateEntries) \entry -> do
         state <- readIORef entry.entryState
         pure AccountSnapshot
             { snapshotAuth = state.accountAuth
@@ -770,10 +778,13 @@ forceRefresh pool targetAccountId =
 
 findEntry :: Pool -> Text -> IO (Maybe AccountEntry)
 findEntry pool targetAccountId = do
-    entries <- (.stateEntries) <$> readIORef pool.poolState
-    pure $ find
-        ((== targetAccountId) . (.entryAccountId))
-        entries
+    poolState <- readIORef pool.poolState
+    let entries = poolState.stateEntries
+    pure $
+        Seq.findIndexL
+            ((== targetAccountId) . (.entryAccountId))
+            entries
+            >>= (`Seq.lookup` entries)
 
 updateAccount
     :: Pool
@@ -850,7 +861,7 @@ effectiveCooldown cooldowns =
         active ->
             Just
                 ( maximum (map (.cooldownUntil) active)
-                , nub (map (.cooldownReason) active)
+                , nubOrd (map (.cooldownReason) active)
                 )
 
 genericAuthReason :: CredentialExhaustionReason

--- a/packages/agent-openai/src/Agent/OpenAI/Features.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Features.hs
@@ -4,7 +4,7 @@ module Agent.OpenAI.Features
     , betaFeaturesHeaderValue
     ) where
 
-import Data.List (nub)
+import Data.Containers.ListUtils (nubOrd)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -15,6 +15,6 @@ remoteCompactionV2Feature = "remote_compaction_v2"
 -- | Render a comma-separated @x-codex-beta-features@ value.
 betaFeaturesHeaderValue :: [Text] -> Maybe Text
 betaFeaturesHeaderValue features =
-    case nub (filter (not . Text.null) (map Text.strip features)) of
+    case nubOrd (filter (not . Text.null) (map Text.strip features)) of
         [] -> Nothing
         values -> Just (Text.intercalate "," values)

--- a/packages/agent-openrouter/agent-openrouter.cabal
+++ b/packages/agent-openrouter/agent-openrouter.cabal
@@ -55,6 +55,7 @@ library
                     , text
                     , bytestring
                     , aeson                 >= 2.0
+                    , containers
                     , http-client
                     , http-client-tls
                     , http-conduit
@@ -81,6 +82,7 @@ test-suite agent-openrouter-test
                     , agent-responses
                     , agent-responses-types
                     , agent-openrouter
+                    , containers
                     , hspec
                     , aeson
                     , text

--- a/packages/agent-openrouter/package.nix
+++ b/packages/agent-openrouter/package.nix
@@ -1,19 +1,23 @@
-{ mkDerivation, aeson, agent-core, agent-responses, agent-responses-types, base, bytestring
-, case-insensitive, hspec, http-client, http-client-tls, http-conduit, http-types
-, lib, retry, safe-exceptions, scientific, text, time, wai, warp
+{ mkDerivation, aeson, agent-core, agent-responses
+, agent-responses-types, base, bytestring, case-insensitive
+, containers, hspec, http-client, http-client-tls, http-conduit
+, http-types, lib, retry, safe-exceptions, scientific, text, time
+, wai, warp
 }:
 mkDerivation {
   pname = "agent-openrouter";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson agent-core agent-responses agent-responses-types base bytestring http-client http-client-tls
-    http-conduit http-types retry safe-exceptions scientific text time
+    aeson agent-core agent-responses agent-responses-types base
+    bytestring containers http-client http-client-tls http-conduit
+    http-types retry safe-exceptions scientific text time
   ];
   testHaskellDepends = [
-    aeson agent-core agent-responses agent-responses-types base bytestring case-insensitive
-    hspec http-types retry text time wai warp
+    aeson agent-core agent-responses agent-responses-types base
+    bytestring case-insensitive containers hspec http-types retry text
+    time wai warp
   ];
   description = "Haskell client for the OpenRouter Responses transport";
-  license = lib.licenses.bsd3;
+  license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Options.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Options.hs
@@ -10,6 +10,8 @@ import Agent.Provider.Options
     , lookupNonEmptyEnv
     , parseModelOverrides
     )
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -17,7 +19,7 @@ import qualified Data.Text as Text
 data ClientOptions = ClientOptions
     { baseUrl :: !String
       -- ^ OpenRouter API prefix including the @/v1@ segment.
-    , modelOverrides :: ![(Text, Text)]
+    , modelOverrides :: !(Map Text Text)
       -- ^ Exact-match request-model to OpenRouter-model overrides.
     , defaultModel :: !Text
       -- ^ Target when the request model is absent or not an OpenRouter slug.
@@ -32,7 +34,7 @@ data ClientOptions = ClientOptions
 defaultClientOptions :: ClientOptions
 defaultClientOptions = ClientOptions
     { baseUrl = "https://openrouter.ai/api/v1"
-    , modelOverrides = []
+    , modelOverrides = Map.empty
     , defaultModel = "openai/gpt-5.1"
     , requestTimeoutSeconds = 600
     , httpReferer = Nothing
@@ -50,7 +52,7 @@ clientOptionsFromEnv = do
     appTitle <- lookupNonEmptyEnv "OPENROUTER_APP_TITLE"
     pure ClientOptions
         { baseUrl = Maybe.fromMaybe defaultClientOptions.baseUrl baseUrl
-        , modelOverrides = maybe [] (parseModelOverrides . Text.pack) modelMap
+        , modelOverrides = maybe Map.empty (parseModelOverrides . Text.pack) modelMap
         , defaultModel = maybe defaultClientOptions.defaultModel Text.pack defaultModel
         , requestTimeoutSeconds = Maybe.fromMaybe defaultClientOptions.requestTimeoutSeconds
             timeoutSeconds

--- a/packages/agent-openrouter/test/Agent/OpenRouter/RequestSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/RequestSpec.hs
@@ -9,6 +9,7 @@ import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -20,7 +21,7 @@ spec = do
     describe "mapModel" do
         it "prefers exact overrides, passes slugs through, and falls back otherwise" do
             let options = defaultClientOptions
-                    { modelOverrides = [("gpt-5.1", "anthropic/claude-sonnet-4")]
+                    { modelOverrides = Map.fromList [("gpt-5.1", "anthropic/claude-sonnet-4")]
                     , defaultModel = "openai/gpt-5.1"
                     }
             mapModel options "gpt-5.1" `shouldBe` "anthropic/claude-sonnet-4"

--- a/packages/agent-responses/src/Agent/Responses/Request.hs
+++ b/packages/agent-responses/src/Agent/Responses/Request.hs
@@ -7,6 +7,8 @@ module Agent.Responses.Request
     ) where
 
 import Agent.Responses.Types
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 
@@ -45,14 +47,14 @@ setResponseModel selected ResponseCreateParams{..} =
 -- | Apply an exact override, preserve a provider-native model identifier, or
 -- fall back to the configured default when no model was supplied.
 selectConfiguredModel
-    :: [(Text, Text)]
+    :: Map Text Text
     -> (Text -> Bool)
     -> Text
     -> Maybe Text
     -> Text
 selectConfiguredModel overrides isNative defaultModel = \case
     Nothing -> defaultModel
-    Just model -> case lookup model overrides of
+    Just model -> case Map.lookup model overrides of
         Just target -> target
         Nothing
             | isNative model -> model

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -24,7 +24,8 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Map.Strict as Map
+import qualified Data.IntMap.Strict as IntMap
+import Data.IntMap.Strict (IntMap)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -63,13 +64,13 @@ data ItemProgress = ItemProgress
 -- indexed so an @output_item.done@ replaces its earlier @added@ form.
 data StreamAssemblyState = StreamAssemblyState
     { responseObject :: !Aeson.Object
-    , outputItems    :: !(Map.Map Int ItemProgress)
+    , outputItems    :: !(IntMap ItemProgress)
     }
 
 emptyStreamAssemblyState :: StreamAssemblyState
 emptyStreamAssemblyState = StreamAssemblyState
     { responseObject = KeyMap.empty
-    , outputItems = Map.empty
+    , outputItems = IntMap.empty
     }
 
 applyStreamEvent :: StreamAssemblyState -> ResponseStreamEvent -> StreamAssemblyState
@@ -375,7 +376,7 @@ updateItem
 updateItem outputIndex done newValue state =
     state
         { outputItems =
-            Map.alter
+            IntMap.alter
                 (Just . mergeProgress)
                 outputIndex
                 state.outputItems
@@ -419,8 +420,8 @@ resolveOutputIndex explicitIndex identities state =
 
 findIdentityIndex :: Text -> StreamAssemblyState -> Maybe Int
 findIdentityIndex wanted state =
-    fst <$> Map.lookupMin
-        (Map.filter (matchesIdentity wanted . (.itemValue)) state.outputItems)
+    fst <$> IntMap.lookupMin
+        (IntMap.filter (matchesIdentity wanted . (.itemValue)) state.outputItems)
   where
     matchesIdentity wanted = \case
         Aeson.Object object ->
@@ -440,8 +441,8 @@ findPendingItemIndex value state =
     case wantedType of
         Nothing -> Nothing
         Just _ ->
-            fst <$> Map.lookupMin
-                (Map.filter matchesPending state.outputItems)
+            fst <$> IntMap.lookupMin
+                (IntMap.filter matchesPending state.outputItems)
   where
     wantedType = objectTextField "type" value
     matchesPending progress =
@@ -450,7 +451,7 @@ findPendingItemIndex value state =
 
 nextOutputIndex :: StreamAssemblyState -> Int
 nextOutputIndex state =
-    maybe 0 ((+ 1) . fst) (Map.lookupMax state.outputItems)
+    maybe 0 ((+ 1) . fst) (IntMap.lookupMax state.outputItems)
 
 itemIdentities :: Aeson.Value -> [Text]
 itemIdentities = \case
@@ -482,7 +483,7 @@ updateCustomToolInput
 updateCustomToolInput outputIndex itemId callId updateInput state =
     state
         { outputItems =
-            Map.alter
+            IntMap.alter
                 (Just . updateProgress)
                 outputIndex
                 state.outputItems
@@ -518,7 +519,7 @@ updateReasoningSummary
 updateReasoningSummary outputIndex itemId summaryIndex updatePart state =
     state
         { outputItems =
-            Map.alter
+            IntMap.alter
                 (Just . updateProgress)
                 outputIndex
                 state.outputItems
@@ -546,12 +547,12 @@ updateReasoningSummary outputIndex itemId summaryIndex updatePart state =
 
 assembledOutput :: StreamAssemblyState -> Aeson.Object -> [Aeson.Value]
 assembledOutput state response =
-    map (.itemValue) . Map.elems $
-        Map.unionWith combine
+    map (.itemValue) . IntMap.elems $
+        IntMap.unionWith combine
             state.outputItems
             terminalItems
   where
-    terminalItems = Map.fromList
+    terminalItems = IntMap.fromList
         [ (index, ItemProgress value True)
         | (index, value) <- zip [0 ..] finalItems
         ]

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -608,7 +608,7 @@ updateFunctionCallArguments
 updateFunctionCallArguments outputIndex itemId updateArgs state =
     state
         { outputItems =
-            Map.alter
+            IntMap.alter
                 (Just . updateProgress)
                 outputIndex
                 state.outputItems

--- a/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
@@ -283,18 +283,24 @@ assembleCatalog
 assembleCatalog objects columns constraints indexes =
     map assembleObject objects
   where
-    columnsByObject = Map.fromListWith (flip (<>))
-        [ (row.catalogColumnRowObjectId, [row.catalogColumnRowValue])
-        | row <- columns
-        ]
-    constraintsByObject = Map.fromListWith (flip (<>))
-        [ (row.catalogConstraintRowObjectId, [row.catalogConstraintRowValue])
-        | row <- constraints
-        ]
-    indexesByObject = Map.fromListWith (flip (<>))
-        [ (row.catalogIndexRowObjectId, [row.catalogIndexRowValue])
-        | row <- indexes
-        ]
+    columnsByObject =
+        Map.map reverse $
+            Map.fromListWith (<>)
+                [ (row.catalogColumnRowObjectId, [row.catalogColumnRowValue])
+                | row <- columns
+                ]
+    constraintsByObject =
+        Map.map reverse $
+            Map.fromListWith (<>)
+                [ (row.catalogConstraintRowObjectId, [row.catalogConstraintRowValue])
+                | row <- constraints
+                ]
+    indexesByObject =
+        Map.map reverse $
+            Map.fromListWith (<>)
+                [ (row.catalogIndexRowObjectId, [row.catalogIndexRowValue])
+                | row <- indexes
+                ]
     assembleObject :: CatalogObjectRow -> CatalogObject
     assembleObject row = CatalogObject
         { catalogObjectKind = row.catalogRowKind

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
@@ -87,8 +87,9 @@ assembleSessions sessionKeys metadata turns =
         Map.fromList
             [(value.sessionMetadataKey, value) | value <- metadata]
     turnsByKey =
-        Map.fromListWith (flip (++))
-            [(sessionKey, [turn]) | (sessionKey, turn) <- turns]
+        Map.map reverse $
+            Map.fromListWith (<>)
+                [(sessionKey, [turn]) | (sessionKey, turn) <- turns]
 
     assemble sessionKey =
         case Map.lookup sessionKey metadataByKey of

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -26,6 +26,7 @@ module Agent.TUI.Model
     , moveWordLeft
     , moveWordRight
     , reduceUi
+    , lookupBlock
     , selectedBlockIndex
     , timestampNewMessageBlocks
     , progressNotice
@@ -1033,18 +1034,27 @@ moveSelection delta state =
 
 selectBlock :: BlockId -> UiState -> UiState
 selectBlock ident state =
-    case Map.lookup ident state.uiBlockIndices of
+    case lookupBlockIndex ident state of
         Nothing -> state
-        Just index -> case Seq.lookup index state.uiBlocks of
-            Just block
-                | block.blockId == ident ->
-                    state
-                        { uiSelectedBlock = Just ident
-                        , uiSelectedBlockIndex = Just index
-                        , uiFollow =
-                            index == Seq.length state.uiBlocks - 1
-                        }
-            _ -> state
+        Just (index, _) ->
+            state
+                { uiSelectedBlock = Just ident
+                , uiSelectedBlockIndex = Just index
+                , uiFollow =
+                    index == Seq.length state.uiBlocks - 1
+                }
+
+lookupBlock :: BlockId -> UiState -> Maybe UiBlock
+lookupBlock ident state =
+    snd <$> lookupBlockIndex ident state
+
+lookupBlockIndex :: BlockId -> UiState -> Maybe (Int, UiBlock)
+lookupBlockIndex ident state = do
+    index <- Map.lookup ident state.uiBlockIndices
+    block <- Seq.lookup index state.uiBlocks
+    if block.blockId == ident
+        then Just (index, block)
+        else Nothing
 
 selectedBlockIndex :: UiState -> Int
 selectedBlockIndex state =

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -55,6 +55,7 @@ library
                     , text
                     , bytestring
                     , aeson                 >= 2.0
+                    , containers
                     , async
                     , http-client
                     , http-client-tls
@@ -84,6 +85,7 @@ test-suite agent-xai-test
                     , agent-responses
                     , agent-responses-types
                     , agent-xai
+                    , containers
                     , async
                     , hspec
                     , aeson

--- a/packages/agent-xai/package.nix
+++ b/packages/agent-xai/package.nix
@@ -1,21 +1,23 @@
-{ mkDerivation, aeson, agent-core, agent-responses, agent-responses-types, async, base
-, base64-bytestring, bytestring, case-insensitive, hspec
-, http-client, http-client-tls, http-conduit, http-types, lib, retry, safe-exceptions
-, scientific, text, time, wai, warp, process, websockets, wuss
+{ mkDerivation, aeson, agent-core, agent-responses
+, agent-responses-types, async, base, base64-bytestring, bytestring
+, case-insensitive, containers, hspec, http-client, http-client-tls
+, http-conduit, http-types, lib, process, retry, safe-exceptions
+, scientific, text, time, wai, warp, websockets, wuss
 }:
 mkDerivation {
   pname = "agent-xai";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson agent-core agent-responses agent-responses-types async base base64-bytestring bytestring
-    http-client http-client-tls http-conduit retry safe-exceptions scientific
-    text time process websockets wuss
+    aeson agent-core agent-responses agent-responses-types async base
+    bytestring containers http-client http-client-tls http-conduit
+    process retry safe-exceptions scientific text time websockets wuss
   ];
   testHaskellDepends = [
-    aeson agent-core agent-responses agent-responses-types async base base64-bytestring bytestring
-    case-insensitive hspec http-types retry safe-exceptions text wai warp
+    aeson agent-core agent-responses agent-responses-types async base
+    base64-bytestring bytestring case-insensitive containers hspec
+    http-types retry safe-exceptions text wai warp
   ];
   description = "Haskell client for the xAI Grok subscription transport";
-  license = lib.licenses.bsd3;
+  license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-xai/src/Agent/XAI/Options.hs
+++ b/packages/agent-xai/src/Agent/XAI/Options.hs
@@ -15,6 +15,8 @@ import Agent.Provider.Options
     , lookupNonEmptyEnv
     , parseModelOverrides
     )
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -63,7 +65,7 @@ grokPlatformArch = case SysInfo.arch of
 data ClientOptions = ClientOptions
     { baseUrl :: !String
       -- ^ Subscription proxy base URL including the @/v1@ segment.
-    , modelOverrides :: ![(Text, Text)]
+    , modelOverrides :: !(Map Text Text)
       -- ^ Exact-match request-model to xAI-model overrides.
     , defaultModel :: !Text
       -- ^ Target for non-Grok model names without an explicit override.
@@ -76,7 +78,7 @@ data ClientOptions = ClientOptions
 defaultClientOptions :: ClientOptions
 defaultClientOptions = ClientOptions
     { baseUrl = "https://cli-chat-proxy.grok.com/v1"
-    , modelOverrides = []
+    , modelOverrides = Map.empty
     , defaultModel = "grok-4.6"
     , requestTimeoutSeconds = 600
     , clientVersion = defaultGrokClientVersion
@@ -92,7 +94,7 @@ clientOptionsFromEnv = do
     clientVersion <- lookupNonEmptyEnv "XAI_GROK_CLIENT_VERSION"
     pure ClientOptions
         { baseUrl = Maybe.fromMaybe defaultClientOptions.baseUrl baseUrl
-        , modelOverrides = maybe [] (parseModelOverrides . Text.pack) modelMap
+        , modelOverrides = maybe Map.empty (parseModelOverrides . Text.pack) modelMap
         , defaultModel = maybe defaultClientOptions.defaultModel Text.pack defaultModel
         , requestTimeoutSeconds = Maybe.fromMaybe defaultClientOptions.requestTimeoutSeconds
             timeoutSeconds

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -14,6 +14,7 @@ import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -24,7 +25,7 @@ spec = do
     describe "mapModel" do
         it "prefers exact overrides, passes grok names through, and falls back otherwise" do
             let options = defaultClientOptions
-                    { modelOverrides = [("gpt-5.6-sol", "grok-4.6-mini")]
+                    { modelOverrides = Map.fromList [("gpt-5.6-sol", "grok-4.6-mini")]
                     , defaultModel = "grok-4.6"
                     }
             mapModel options "gpt-5.6-sol" `shouldBe` "grok-4.6-mini"

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/SubprocessCLI.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/SubprocessCLI.hs
@@ -62,6 +62,7 @@ import Data.IORef
     , writeIORef
     )
 import qualified Data.Map.Strict as Map
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -742,7 +743,7 @@ setEnvironmentVariable
     -> [(String, String)]
     -> [(String, String)]
 setEnvironmentVariable name value environment =
-    (name, value) : filter ((/= name) . fst) environment
+    Map.toList (Map.insert name value (Map.fromList environment))
 
 subprocessArguments
     :: ClaudeAgentOptions


### PR DESCRIPTION
## Summary
- look up TUI blocks, history turns, slash commands, skills, and catalog models by `Map` instead of scanning lists
- track unavailable providers, tool availability, and uniqueness with `Set` / `nubOrdOn`
- store dense integer keys in `IntMap` / `IntSet` for tool scheduling, stream assembly, and MCP pending RPCs
- use `Seq` for apply-patch line edits and OpenAI account round-robin
- replace association-list upserts, zip+lookup choice tables, and quadratic `fromListWith (flip (++))` grouping

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli`
- `nix develop -c cabal test agent-core agent-tui agent-openai agent-openrouter agent-xai agent-responses agent-codex-dialect agent-grok-build-dialect --test-show-details=failures`
- `nix develop -c cabal test agent-cli --test-show-details=failures --test-options='--match "/Agent.CLI.Markdown|Agent.CLI.Command|Agent.CLI.ModelConfig|Agent.CLI.ProviderFallback|Agent.CLI.ProviderTransition|Agent.CLI.TUIHistory|Agent.CLI.TUIProperty|Agent.CLI.TUIApp|Agent.CLI.TUIComposer|Agent.CLI.Models|Agent.CLI.Error|Agent.CLI.Resume|Agent.CLI.Login|Agent.CLI.Prompt|Agent.CLI.Tools|Agent.CLI.TUIBridge/"'`
- `git diff --check`