### PR TITLE
feat(grok): restrict Grok-root subagent models

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -13,6 +13,7 @@ module Agent.CLI.Auth
     , grokOAuthOptionsFromAuthJson
     , externalAuthSelectionId
     , externalGrokTokenProvider
+    , hasOpenAiAuth
     , loadAuth
     , loadAuthForAccount
     , managedAuthSelectionId

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -21,6 +21,8 @@ import Agent.CLI.Approval ()
 import Agent.CLI.Artifact ()
 import Agent.CLI.Auth
     ( LoadedAuth(..),
+      hasOpenAiAuth,
+      loadAuth,
       loadAuthForAccount,
       preferredOpenAiTokenProvider,
       probeLoadedAuthCredential,
@@ -110,6 +112,7 @@ import Agent.CLI.Project
       withInheritedLastModel )
 import Agent.CLI.Prompt
     ( subscriptionSubagentModelGuidance, systemPromptForTools )
+import Agent.GrokBuild.Dialect.Task (grokRootChildModels)
 import Agent.CLI.PromptHooks
     ( fullscreenAwarePlanHooks, fullscreenAwareSecretHooks )
 import Agent.CLI.Provider.OpenAI
@@ -226,7 +229,8 @@ import Agent.CLI.Subagents.Runtime
       prepareCollaborationSpawn,
       restoreAgentFromDisk,
       runCodexSubagent,
-      runHttpSubagent )
+      runHttpSubagent,
+      runXaiParentSubagent )
 import Agent.CLI.TUI.App
     ( FullscreenInputBuffer,
       FullscreenRuntime,
@@ -1662,7 +1666,23 @@ runAgentInitializedWithLock
         (\_ _ -> pure ())
     rootTurnRef <- newIORef (Nothing :: Maybe RootTurnId)
     agentTypesRef <- newIORef Map.empty
-    let sendToRoot message = do
+    openaiChild <- case provider of
+        XAIProvider -> do
+            available <- hasOpenAiAuth
+            if not available
+                then pure Nothing
+                else loadAuth (Just OpenAIProvider) >>= \case
+                    Left _ -> pure Nothing
+                    Right openaiLoaded ->
+                        pure (Just openaiLoaded.loadedTokenProvider)
+        _ ->
+            pure Nothing
+    let grokAllowedChildModels = case provider of
+            XAIProvider ->
+                Just (grokRootChildModels (isJust openaiChild))
+            _ ->
+                Nothing
+        sendToRoot message = do
             atomicModifyIORef' pendingNotices \xs ->
                 (xs <> [AgentMessage message], ())
             pure (Right "queued")
@@ -1711,6 +1731,7 @@ runAgentInitializedWithLock
                 subscriptionSubagentModelGuidance
                     provider
                     (tokenProviderBillingMode tokenProvider)
+            , multiAllowedChildModels = grokAllowedChildModels
             }
     promptRequest <- loadPrompt options
     let promptText = fmap (\request -> request.managedTurnText) promptRequest
@@ -2092,6 +2113,8 @@ runAgentInitializedWithLock
                     subscriptionSubagentModelGuidance
                         provider
                         (tokenProviderBillingMode tokenProvider)
+                , subagentAllowedChildModels = grokAllowedChildModels
+                , subagentOpenAiChild = openaiChild
                 }
         let conversationRef = startup.startupSessionState.sessionConversation
         atomicModifyIORef' conversationRef \state ->
@@ -2566,10 +2589,9 @@ runAgentInitializedWithLock
                         case multiCtx of
                             Just ctx ->
                                 setSubagentRunner ctx.multiRegistry $
-                                    runHttpSubagent
+                                    runXaiParentSubagent
                                         subagentRuntime
                                         dialect
-                                        XAIProvider
                                         ctx.multiSendToRoot
                                         (\childParams ->
                                             protectXaiOverflow

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -15,6 +15,7 @@ module Agent.CLI.Subagents.Runtime
     , runHttpSubagent
     , runXaiParentSubagent
     , grokSpawnedChildIdentity
+    , usesOpenAiChildTransport
     , validatePersistedSubagentTarget
     ) where
 
@@ -116,6 +117,7 @@ import Agent.Responses.Types
 import Agent.Subagents
     ( RunSubagent
     , SubagentId(..)
+    , SubagentIdentity(..)
     , SubagentRegistry
     , SubagentSpawnEnv(..)
     , SubagentStatus(..)
@@ -467,20 +469,31 @@ restoreAgentFromDisk
                             reopenInMemory Nothing Nothing
                     Right (Just (items, meta)) -> do
                         let fields = subagentDiskFields meta
+                            derivedIdentity =
+                                grokSpawnedChildIdentity
+                                    provider
+                                    connection
+                                    mapModel
+                                    parentEffectiveModel
+                                    parentDialect
+                                    fields.diskAgentModel
                             ( expectedProvider
                                 , expectedConnection
                                 , expectedEffectiveModel
                                 , expectedDialect
                                 ) =
                                     if provider == XAIProvider
-                                        then
-                                            grokSpawnedChildIdentity
-                                                provider
-                                                connection
-                                                mapModel
-                                                parentEffectiveModel
-                                                parentDialect
-                                                fields.diskAgentModel
+                                        then case meta of
+                                            CurrentSubagentDiskMeta _ stored
+                                                | stored.targetProvider
+                                                    == OpenAIProvider ->
+                                                    ( stored.targetProvider
+                                                    , stored.targetConnection
+                                                    , stored.targetEffectiveModel
+                                                    , stored.targetDialect
+                                                    )
+                                            _ ->
+                                                derivedIdentity
                                         else
                                             ( provider
                                             , connection
@@ -663,7 +676,22 @@ inheritedGrokChildModel runtime parentModel =
                 Just slug | slug `elem` allowed -> slug
                 _ -> fromMaybe parentModel (listToMaybe allowed)
 
--- | XAI parent runner: Grok children stay on xAI; Luna uses Codex/OpenAI.
+-- | Luna requests and already-OpenAI descendants stay on Codex/OpenAI.
+-- An omitted or non-Luna override from a Luna child must not fall through
+-- to the xAI HTTP runner.
+usesOpenAiChildTransport
+    :: Maybe Provider
+    -> Maybe Provider
+    -> Maybe Text
+    -> Bool
+usesOpenAiChildTransport childSessionProvider parentSessionProvider childModel =
+    childSessionProvider == Just OpenAIProvider
+        || parentSessionProvider == Just OpenAIProvider
+        || maybe False isLunaSubagentModel
+            (childModel >>= canonicalizeGrokChildModel)
+
+-- | XAI parent runner: Grok children stay on xAI; Luna and its descendants
+-- use Codex/OpenAI.
 runXaiParentSubagent
     :: SubagentRuntime
     -> Dialect
@@ -673,27 +701,37 @@ runXaiParentSubagent
 runXaiParentSubagent runtime dialect sendToRoot mkBackend =
     \env previous prompt onEvent -> do
         childModel <- lookupAgentModel runtime.subagentTypes env.subId
-        case childModel >>= canonicalizeGrokChildModel of
-            Just model | isLunaSubagentModel model ->
-                case runtime.subagentOpenAiChild of
-                    Nothing ->
-                        pure $ Left $ LoopUnexpected $
-                            lunaSubagentModel
-                                <> " is unavailable because OpenAI is not signed in."
-                    Just openaiToken ->
-                        runCodexSubagent
-                            runtime
-                                { subagentConnection =
-                                    providerSlug OpenAIProvider
-                                , subagentMapModel = id
-                                }
-                            openaiToken
-                            sendToRoot
-                            env
-                            previous
-                            prompt
-                            onEvent
-            _ ->
+        sessions <- readIORef runtime.subagentSessions
+        identity <- getSubagentIdentity runtime.subagentRegistry env.subId
+        let childSessionProvider =
+                (.subSessionProvider) <$> Map.lookup env.subId sessions
+            parentSessionProvider = do
+                ident <- identity
+                parentId <- ident.identityParent
+                session <- Map.lookup parentId sessions
+                pure session.subSessionProvider
+        if usesOpenAiChildTransport
+                childSessionProvider parentSessionProvider childModel
+            then case runtime.subagentOpenAiChild of
+                Nothing ->
+                    pure $ Left $ LoopUnexpected $
+                        "OpenAI is not signed in; cannot run this subagent on "
+                            <> lunaSubagentModel
+                            <> "."
+                Just openaiToken ->
+                    runCodexSubagent
+                        runtime
+                            { subagentConnection =
+                                providerSlug OpenAIProvider
+                            , subagentMapModel = id
+                            }
+                        openaiToken
+                        sendToRoot
+                        env
+                        previous
+                        prompt
+                        onEvent
+            else
                 runHttpSubagent
                     runtime
                     dialect

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -13,6 +13,8 @@ module Agent.CLI.Subagents.Runtime
     , resolveChildModelAndEffort
     , runCodexSubagent
     , runHttpSubagent
+    , runXaiParentSubagent
+    , grokSpawnedChildIdentity
     , validatePersistedSubagentTarget
     ) where
 
@@ -139,10 +141,13 @@ import Agent.GrokBuild.Dialect.Prompt
 import Agent.GrokBuild.Dialect.Task
     ( GrokSubagentSpec(..)
     , GrokSubagentSpecs
+    , canonicalizeGrokChildModel
     , defaultSubagentType
+    , isLunaSubagentModel
     , lookupAgentModel
     , lookupAgentReasoningEffort
     , lookupAgentType
+    , lunaSubagentModel
     , recordAgentSpec
     )
 import Agent.Tools.MultiAgents
@@ -170,7 +175,7 @@ import Control.Monad (unless, void, when)
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (getCurrentTime, utctDay)
@@ -212,6 +217,8 @@ data SubagentRuntime = SubagentRuntime
     , subagentCreateWorktree
         :: !(Maybe (OsPath -> IO (Either Text SubagentWorktree)))
     , subagentSpawnModelGuidance :: !(Maybe Text)
+    , subagentAllowedChildModels :: !(Maybe [Text])
+    , subagentOpenAiChild :: !(Maybe TokenProvider)
     }
 
 data PreparedChild = PreparedChild
@@ -460,19 +467,36 @@ restoreAgentFromDisk
                             reopenInMemory Nothing Nothing
                     Right (Just (items, meta)) -> do
                         let fields = subagentDiskFields meta
-                            expectedEffectiveModel =
-                                maybe
-                                    parentEffectiveModel
-                                    mapModel
-                                    fields.diskAgentModel
-                            expectedDialect =
-                                maybe
-                                    parentDialect
-                                    (dialectIdForModel provider . mapModel)
-                                    fields.diskAgentModel
+                            ( expectedProvider
+                                , expectedConnection
+                                , expectedEffectiveModel
+                                , expectedDialect
+                                ) =
+                                    if provider == XAIProvider
+                                        then
+                                            grokSpawnedChildIdentity
+                                                provider
+                                                connection
+                                                mapModel
+                                                parentEffectiveModel
+                                                parentDialect
+                                                fields.diskAgentModel
+                                        else
+                                            ( provider
+                                            , connection
+                                            , maybe
+                                                parentEffectiveModel
+                                                mapModel
+                                                fields.diskAgentModel
+                                            , maybe
+                                                parentDialect
+                                                (dialectIdForModel provider
+                                                    . mapModel)
+                                                fields.diskAgentModel
+                                            )
                         case validatePersistedSubagentTarget
-                                provider
-                                connection
+                                expectedProvider
+                                expectedConnection
                                 expectedEffectiveModel
                                 expectedDialect
                                 legacyTarget
@@ -481,17 +505,18 @@ restoreAgentFromDisk
                             Right storedTarget
                                 | not
                                     (providerSupportsDialect
-                                        provider storedTarget.targetDialect) ->
+                                        storedTarget.targetProvider
+                                        storedTarget.targetDialect) ->
                                     pure $ Left $
                                         unsupportedDialectMessage
-                                            provider
+                                            storedTarget.targetProvider
                                             agentId
                                             storedTarget.targetDialect
                             Right storedTarget -> do
                                 session <-
                                     getOrInstallSubagentSession
                                         sessionsRef
-                                        provider
+                                        storedTarget.targetProvider
                                         storedTarget.targetConnection
                                         storedTarget.targetEffectiveModel
                                         storedTarget.targetDialect
@@ -598,6 +623,88 @@ freshOpenAiBackendWithTurnState showRawReasoning turnState provider getParams =
                             getParams
                 in submit state previous inputs onEvent
 
+-- | Identity for a Grok-root child, including OpenAI Luna when requested.
+grokSpawnedChildIdentity
+    :: Provider
+    -> Text
+    -> (Text -> Text)
+    -> Text
+    -> DialectId
+    -> Maybe Text
+    -> (Provider, Text, Text, DialectId)
+grokSpawnedChildIdentity
+        parentProvider parentConnection mapModel parentModel parentDialect childModel =
+    case childModel >>= canonicalizeGrokChildModel of
+        Just model
+            | isLunaSubagentModel model ->
+                ( OpenAIProvider
+                , providerSlug OpenAIProvider
+                , lunaSubagentModel
+                , dialectId codexDialect
+                )
+            | otherwise ->
+                (parentProvider, parentConnection, model, parentDialect)
+        Nothing ->
+            ( parentProvider
+            , parentConnection
+            , maybe parentModel mapModel childModel
+            , maybe
+                parentDialect
+                (dialectIdForModel parentProvider . mapModel)
+                childModel
+            )
+
+inheritedGrokChildModel :: SubagentRuntime -> Text -> Text
+inheritedGrokChildModel runtime parentModel =
+    case runtime.subagentAllowedChildModels of
+        Nothing -> parentModel
+        Just allowed ->
+            case canonicalizeGrokChildModel parentModel of
+                Just slug | slug `elem` allowed -> slug
+                _ -> fromMaybe parentModel (listToMaybe allowed)
+
+-- | XAI parent runner: Grok children stay on xAI; Luna uses Codex/OpenAI.
+runXaiParentSubagent
+    :: SubagentRuntime
+    -> Dialect
+    -> Maybe (InterAgentMessage -> IO (Either Text Text))
+    -> (ResponseCreateParams -> Backend)
+    -> RunSubagent
+runXaiParentSubagent runtime dialect sendToRoot mkBackend =
+    \env previous prompt onEvent -> do
+        childModel <- lookupAgentModel runtime.subagentTypes env.subId
+        case childModel >>= canonicalizeGrokChildModel of
+            Just model | isLunaSubagentModel model ->
+                case runtime.subagentOpenAiChild of
+                    Nothing ->
+                        pure $ Left $ LoopUnexpected $
+                            lunaSubagentModel
+                                <> " is unavailable because OpenAI is not signed in."
+                    Just openaiToken ->
+                        runCodexSubagent
+                            runtime
+                                { subagentConnection =
+                                    providerSlug OpenAIProvider
+                                , subagentMapModel = id
+                                }
+                            openaiToken
+                            sendToRoot
+                            env
+                            previous
+                            prompt
+                            onEvent
+            _ ->
+                runHttpSubagent
+                    runtime
+                    dialect
+                    XAIProvider
+                    sendToRoot
+                    mkBackend
+                    env
+                    previous
+                    prompt
+                    onEvent
+
 -- | Child Codex agent: per-agent transcript retained across follow-ups,
 -- independently scoped WebSocket requests, and nested multi-agent tools.
 runCodexSubagent
@@ -607,6 +714,9 @@ runCodexSubagent
     -> RunSubagent
 runCodexSubagent runtime tokenProvider sendToRoot =
     \env previous prompt onEvent -> do
+        agentType <-
+            fromMaybe defaultSubagentType
+                <$> lookupAgentType runtime.subagentTypes env.subId
         childModel <- lookupAgentModel runtime.subagentTypes env.subId
         childEffort <- lookupAgentReasoningEffort runtime.subagentTypes env.subId
         parentParams <- readIORef runtime.subagentParams
@@ -654,25 +764,48 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                     bashEnabled <- readIORef runtime.subagentBashEnabled
                     let codingTools =
                             filterGhciTools ghciEnabled $
-                                filterBashTools bashEnabled coding.codingAppTools
+                                filterBashTools bashEnabled $
+                                    filterChildGrokTools
+                                        agentType coding.codingAppTools
                         tools =
                             codingTools <> runtime.subagentMcpTools
+                        generatedInstructions =
+                            systemPromptForTools
+                                codexDialect
+                                (map (.appToolName) tools)
+                                env.subCwd
+                                sessionTmp
+                                today
+                                True
+                        inheritParentPrompt =
+                            case prepared.preparedParentParams.model of
+                                Just parentModel ->
+                                    not
+                                        ( "grok"
+                                            `Text.isPrefixOf`
+                                                Text.toLower parentModel
+                                        )
+                                Nothing -> True
                         baseInstructions =
-                            fromMaybe
-                                (systemPromptForTools
-                                    codexDialect
-                                    (map (.appToolName) tools)
-                                    env.subCwd
-                                    sessionTmp
-                                    today
-                                    True)
-                                prepared.preparedParentParams.instructions
+                            if inheritParentPrompt
+                                then
+                                    fromMaybe
+                                        generatedInstructions
+                                        prepared.preparedParentParams.instructions
+                                else generatedInstructions
                         instructions =
                             baseInstructions
                                 <> "\n\nYou are a Codex subagent. Complete the assigned task and "
                                 <> "report results clearly. Your agent id is "
                                 <> env.subId.unSubagentId
                                 <> "."
+                                <> case agentType of
+                                    "explore" ->
+                                        " Operate read-only: search and report, do not edit files."
+                                    "plan" ->
+                                        " Produce an implementation plan; do not edit implementation files."
+                                    _ ->
+                                        ""
                         childParams = requestParams OpenAIProvider model instructions
                             (schemasFromAppTools codexDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
@@ -736,11 +869,15 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
         childEffort <-
             lookupAgentReasoningEffort runtime.subagentTypes env.subId
         parentParams <- readIORef runtime.subagentParams
-        let (provisionalModel, _) =
+        let inheritedParentModel =
+                inheritedGrokChildModel
+                    runtime
+                    (fromMaybe "" parentParams.model)
+            (provisionalModel, _) =
                 resolveChildModelAndEffort
                     provider
                     parentParams
-                    (fromMaybe "" parentParams.model)
+                    inheritedParentModel
                     childModel
                     childEffort
             provisionalEffectiveModel =
@@ -947,6 +1084,7 @@ prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoo
                     GenericTaskProtocol -> Nothing
                     NoHostChildAgentProtocol -> Nothing
             , multiSpawnModelGuidance = runtime.subagentSpawnModelGuidance
+            , multiAllowedChildModels = runtime.subagentAllowedChildModels
             }
     pure PreparedChild
         { preparedParentParams = parentParams

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -14,6 +14,7 @@ import Agent.CLI.Subagents.Runtime
     , grokSpawnedChildIdentity
     , restoreAgentFromDisk
     , resolveChildModelAndEffort
+    , usesOpenAiChildTransport
     , validatePersistedSubagentTarget
     )
 import Agent.CLI.Request (requestParams)
@@ -171,6 +172,74 @@ spec = describe "Agent.CLI.SubagentStore" do
                 Nothing
                 `shouldBe`
                     (XAIProvider, "xai", "grok-4.6", GrokBuildDialect)
+
+        it "keeps Luna descendants on OpenAI even without a model override" do
+            usesOpenAiChildTransport
+                (Just OpenAIProvider)
+                Nothing
+                Nothing
+                `shouldBe` True
+            usesOpenAiChildTransport
+                Nothing
+                (Just OpenAIProvider)
+                (Just "gpt-5.6-sol")
+                `shouldBe` True
+            usesOpenAiChildTransport
+                Nothing
+                Nothing
+                (Just "luna")
+                `shouldBe` True
+            usesOpenAiChildTransport
+                Nothing
+                Nothing
+                (Just "grok-4.5")
+                `shouldBe` False
+            usesOpenAiChildTransport Nothing Nothing Nothing
+                `shouldBe` False
+
+        it "restores an inherited Luna descendant under a Grok parent" do
+            withTempDir \dir -> do
+                let agentId = SubagentId "agent-luna-descendant"
+                saveSubagentState
+                    dir
+                    agentId
+                    (testSnapshot
+                        [messageItem RoleUser "inherited"]
+                        (Completed (Just "OK"))
+                        OpenAIProvider
+                        "openai"
+                        "gpt-5.6-luna"
+                        CodexDialect)
+                    `shouldReturn` Right ()
+                sessionsRef <- newIORef Map.empty
+                storeRootRef <- newIORef (Just dir)
+                typesRef <- newIORef Map.empty
+                bracket
+                    (newSubagentRegistry defaultSubagentConfig dir
+                        (\_ _ _ _ -> fail "unexpected subagent runner invocation")
+                        (\_ _ -> pure ()))
+                    closeSubagentRegistry
+                    \registry -> do
+                        restoreAgentFromDisk
+                            XAIProvider
+                            "xai"
+                            id
+                            "grok-4.6"
+                            GrokBuildDialect
+                            Nothing
+                            storeRootRef
+                            registry
+                            sessionsRef
+                            typesRef
+                            agentId
+                            `shouldReturn` Right ()
+                        Just session <-
+                            Map.lookup agentId <$> readIORef sessionsRef
+                        session.subSessionProvider `shouldBe` OpenAIProvider
+                        session.subSessionConnection `shouldBe` "openai"
+                        session.subSessionEffectiveModel
+                            `shouldBe` "gpt-5.6-luna"
+                        session.subSessionDialect `shouldBe` CodexDialect
 
     it "round-trips transcript items and meta" do
         withTempDir \dir -> do

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -11,6 +11,7 @@ import Agent.CLI.Subagents.Runtime
     , lookupOrCreateSubagentSession
     , persistAndEvictSubagentSessionWithStatus
     , prepareCollaborationSpawn
+    , grokSpawnedChildIdentity
     , restoreAgentFromDisk
     , resolveChildModelAndEffort
     , validatePersistedSubagentTarget
@@ -132,6 +133,44 @@ spec = describe "Agent.CLI.SubagentStore" do
                 Nothing
                 Nothing
                 `shouldBe` ("gpt-5.6-terra", "medium")
+
+    describe "Grok-root child identity" do
+        it "routes Luna to OpenAI Codex" do
+            grokSpawnedChildIdentity
+                XAIProvider
+                "xai"
+                id
+                "grok-4.6"
+                GrokBuildDialect
+                (Just "luna")
+                `shouldBe`
+                    ( OpenAIProvider
+                    , "openai"
+                    , "gpt-5.6-luna"
+                    , CodexDialect
+                    )
+
+        it "keeps grok-4.5 on the Grok parent" do
+            grokSpawnedChildIdentity
+                XAIProvider
+                "xai"
+                id
+                "grok-4.6"
+                GrokBuildDialect
+                (Just "grok-4.5")
+                `shouldBe`
+                    (XAIProvider, "xai", "grok-4.5", GrokBuildDialect)
+
+        it "inherits the Grok parent when model is omitted" do
+            grokSpawnedChildIdentity
+                XAIProvider
+                "xai"
+                id
+                "grok-4.6"
+                GrokBuildDialect
+                Nothing
+                `shouldBe`
+                    (XAIProvider, "xai", "grok-4.6", GrokBuildDialect)
 
     it "round-trips transcript items and meta" do
         withTempDir \dir -> do

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -242,6 +242,7 @@ spec = describe "schemasFromAppTools" do
                         , multiPrepareSpawn = Nothing
                         , multiSendToRoot = Nothing
                         , multiSpawnModelGuidance = Nothing
+                        , multiAllowedChildModels = Nothing
                         }
                     schemas =
                         schemasFromAppTools

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -109,6 +109,8 @@ data MultiAgentContext = MultiAgentContext
     , multiSendToRoot :: !(Maybe (InterAgentMessage -> IO (Either Text Text)))
       -- | Optional provider/billing-specific guidance for model overrides.
     , multiSpawnModelGuidance :: !(Maybe Text)
+      -- | When set, spawn_subagent may only use these model slugs (or inherit).
+    , multiAllowedChildModels :: !(Maybe [Text])
     }
 
 multiAgentNamespace :: Text

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -396,6 +396,7 @@ spec = describe "Agent.Tools.MultiAgents" do
                 , multiPrepareSpawn = Nothing
                 , multiSendToRoot = Just deliverRoot
                 , multiSpawnModelGuidance = Nothing
+                , multiAllowedChildModels = Nothing
                 }
         result <- dispatchToolCall defaultLoopDispatch
             (appToolHandlers (multiAgentTools context))
@@ -429,6 +430,7 @@ rootContext registry sendToRoot = MultiAgentContext
     , multiPrepareSpawn = Nothing
     , multiSendToRoot = sendToRoot
     , multiSpawnModelGuidance = Nothing
+    , multiAllowedChildModels = Nothing
     }
 
 childContext :: SubagentRegistry -> SubagentId -> Int -> IO MultiAgentContext

--- a/packages/agent-grok-build-dialect/benchmark/WorkflowSnapshots.hs
+++ b/packages/agent-grok-build-dialect/benchmark/WorkflowSnapshots.hs
@@ -89,13 +89,16 @@ main =
             (\_ _ -> pure ())
 
     rootContext registry = MultiAgentContext
-        registry
-        Nothing
-        0
-        taskPathRoot
-        (pure Nothing)
-        Nothing
-        Nothing
-        Nothing
-        Nothing
-        Nothing
+        { multiRegistry = registry
+        , multiCwd = unsafeEncodeUtf "/tmp"
+        , multiSelfId = Nothing
+        , multiDepth = 0
+        , multiTaskPath = taskPathRoot
+        , multiRootTurnId = pure Nothing
+        , multiResumeFromDisk = Nothing
+        , multiCreateWorktree = Nothing
+        , multiPrepareSpawn = Nothing
+        , multiSendToRoot = Nothing
+        , multiSpawnModelGuidance = Nothing
+        , multiAllowedChildModels = Nothing
+        }

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
@@ -19,6 +19,12 @@ module Agent.GrokBuild.Dialect.Task
     , lookupAgentModel
     , lookupAgentReasoningEffort
     , spawnManagedGrokSubagent
+    , lunaSubagentModel
+    , lunaSubagentEffort
+    , grokRootChildModels
+    , canonicalizeGrokChildModel
+    , resolveRequestedGrokChildModel
+    , isLunaSubagentModel
     ) where
 
 import Agent.InterAgentMessage (plainInterAgentContent)
@@ -76,6 +82,91 @@ runtimeSubagentType = "runtime-bounded"
 knownSubagentTypes :: [Text]
 knownSubagentTypes = ["general-purpose", "explore", "plan"]
 
+-- | OpenAI child slug allowed from a Grok root when OpenAI auth is present.
+lunaSubagentModel :: Text
+lunaSubagentModel = "gpt-5.6-luna"
+
+-- | Grok-root Luna children always run at high reasoning effort.
+lunaSubagentEffort :: Text
+lunaSubagentEffort = "high"
+
+-- | Models a Grok-root spawn_subagent call may select.
+grokRootChildModels :: Bool -> [Text]
+grokRootChildModels openaiAvailable =
+    "grok-4.6" : "grok-4.5" : [lunaSubagentModel | openaiAvailable]
+
+isLunaSubagentModel :: Text -> Bool
+isLunaSubagentModel = (== lunaSubagentModel)
+
+-- | Map a model-facing slug onto the Grok-root allowlist, if it is one.
+canonicalizeGrokChildModel :: Text -> Maybe Text
+canonicalizeGrokChildModel raw =
+    case folded of
+        "grok-4.6" -> Just "grok-4.6"
+        "grok-4-6" -> Just "grok-4.6"
+        "grok4.6" -> Just "grok-4.6"
+        "grok4-6" -> Just "grok-4.6"
+        "grok-4.5" -> Just "grok-4.5"
+        "grok-4-5" -> Just "grok-4.5"
+        "grok4.5" -> Just "grok-4.5"
+        "grok4-5" -> Just "grok-4.5"
+        "gpt-5.6-luna" -> Just lunaSubagentModel
+        "gpt-5-6-luna" -> Just lunaSubagentModel
+        "gpt5.6luna" -> Just lunaSubagentModel
+        "gpt5-6luna" -> Just lunaSubagentModel
+        "luna" -> Just lunaSubagentModel
+        "openai/gpt-5.6-luna" -> Just lunaSubagentModel
+        "openai/gpt-5-6-luna" -> Just lunaSubagentModel
+        _ -> Nothing
+  where
+    folded =
+        Text.toLower
+            $ Text.replace "_" "-"
+            $ Text.filter (/= ' ')
+            $ Text.strip raw
+
+-- | 'Nothing' policy keeps historical passthrough. A Just allowlist rejects
+-- unknown slugs and canonicalizes aliases. Omitting model still inherits.
+resolveRequestedGrokChildModel
+    :: Maybe [Text]
+    -> Maybe Text
+    -> Either Text (Maybe Text)
+resolveRequestedGrokChildModel Nothing requested = Right requested
+resolveRequestedGrokChildModel _ Nothing = Right Nothing
+resolveRequestedGrokChildModel (Just allowed) (Just raw) =
+    case canonicalizeGrokChildModel raw of
+        Just canonical
+            | canonical `elem` allowed -> Right (Just canonical)
+            | otherwise -> Left (unknownChildModelMessage raw allowed)
+        Nothing -> Left (unknownChildModelMessage raw allowed)
+
+unknownChildModelMessage :: Text -> [Text] -> Text
+unknownChildModelMessage raw allowed =
+    "Unknown spawn_subagent model '"
+        <> raw
+        <> "'. Valid model slugs: "
+        <> Text.intercalate ", " allowed
+        <> ". Omit `model` to inherit the parent model."
+
+grokChildModelGuidance :: [Text] -> Text
+grokChildModelGuidance slugs =
+    "If you choose an explicit model, you may ONLY use model slugs from this list:\n"
+        <> Text.intercalate "\n" (map ("- " <>) slugs)
+        <> "\n\nIf you do not explicitly request a model, omit `model` to inherit the parent model."
+        <> lunaNote
+  where
+    lunaNote
+        | lunaSubagentModel `elem` slugs =
+            " Use `"
+                <> lunaSubagentModel
+                <> "` for small, bounded tasks; it runs at high reasoning effort."
+        | otherwise = ""
+
+taskModelProperty :: Maybe [Text] -> Text
+taskModelProperty = \case
+    Just slugs -> grokChildModelGuidance slugs
+    Nothing -> "Optional model slug. Omit to inherit the parent model."
+
 data GrokSubagentSpec = GrokSubagentSpec
     { agentType :: !Text
     , modelOverride :: !(Maybe Text)
@@ -130,7 +221,7 @@ sanitizeOptional value = value >>= \raw ->
 
 taskTool :: OsPath -> MultiAgentContext -> GrokSubagentSpecs -> AppTool
 taskTool baseCwd ctx specsRef =
-    jsonAppToolWithExecution "task" taskDescription
+    jsonAppToolWithExecution "task" (taskDescription ctx.multiAllowedChildModels)
         [ PropertySchema "prompt" PropertyString True $ Just
             "The full task prompt for the subagent to execute."
         , PropertySchema "description" PropertyString True $ Just
@@ -144,7 +235,7 @@ taskTool baseCwd ctx specsRef =
         , PropertySchema "cwd" PropertyString False $ Just
             "Explicit working directory for the subagent. Mutually exclusive with isolation=\"worktree\"."
         , PropertySchema "model" PropertyString False $ Just
-            "Optional model slug. Omit to inherit the parent model."
+            (taskModelProperty ctx.multiAllowedChildModels)
         , PropertySchema "isolation" (PropertyEnum ["none", "worktree"]) False $ Just
             "Isolation mode: \"none\" (default, shared workspace) or \"worktree\" (isolated git worktree). Worktree mode prevents child edits from affecting the parent workspace until explicitly applied."
         ]
@@ -157,8 +248,8 @@ taskApproval ctx = case ctx.multiSelfId of
     Nothing -> AlwaysPrompt
     Just _ -> AlwaysReadOnly
 
-taskDescription :: Text
-taskDescription =
+taskDescription :: Maybe [Text] -> Text
+taskDescription allowedModels =
     "Start a subagent that works on a task independently and reports back.\n\n\
     \Agent types:\n\n\
     \- **general-purpose**: General purpose agent for multi-step tasks. Can delegate further work with spawn_subagent while below the harness nesting limit.\n\
@@ -178,6 +269,7 @@ taskDescription =
     \- The resumed agent must use the same subagent_type as the source.\n\n\
     \Isolation mode:\n\
     \- Use isolation=\"worktree\" to run the child in an isolated git worktree. The worktree is preserved after completion and its path is returned in the output."
+    <> maybe "" (\slugs -> "\n\n" <> grokChildModelGuidance slugs) allowedModels
 
 runTask
     :: OsPath
@@ -201,11 +293,20 @@ runTask baseCwd ctx typesRef args
     , Just iso <- args.isolation
     , isWorktreeIsolation iso =
         pure (Left "cwd and isolation are mutually exclusive.")
-    | otherwise = mask \restore ->
-        resolveTaskWorkspace baseCwd ctx args >>= \case
+    | otherwise =
+        case resolveRequestedGrokChildModel ctx.multiAllowedChildModels args.model of
             Left err -> pure (Left err)
-            Right (childCwd, worktree) ->
-                restore (spawnFresh childCwd worktree ctx typesRef args)
+            Right model -> mask \restore ->
+                resolveTaskWorkspace baseCwd ctx args >>= \case
+                    Left err -> pure (Left err)
+                    Right (childCwd, worktree) ->
+                        restore
+                            (spawnFresh
+                                childCwd
+                                worktree
+                                ctx
+                                typesRef
+                                args { model })
 
 spawnFresh
     :: OsPath
@@ -220,7 +321,10 @@ spawnFresh childCwd worktree ctx typesRef args = mask \restore -> do
     let spec = GrokSubagentSpec
             { agentType = args.subagentType
             , modelOverride = args.model
-            , reasoningEffortOverride = Nothing
+            , reasoningEffortOverride =
+                if maybe False isLunaSubagentModel args.model
+                    then Just lunaSubagentEffort
+                    else Nothing
             }
         worktreePath = (.subagentWorktreePath) <$> ownedWorktree
         prepare agentId = do

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
@@ -513,6 +513,7 @@ rootContext registry = MultiAgentContext
     Nothing
     Nothing
     Nothing
+    Nothing
 
 childContext registry = MultiAgentContext
     registry
@@ -521,6 +522,7 @@ childContext registry = MultiAgentContext
     1
     taskPathRoot
     (pure Nothing)
+    Nothing
     Nothing
     Nothing
     Nothing

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
@@ -22,6 +22,7 @@ import Agent.Tools.Types
     , jsonToolParameters
     )
 import Control.Concurrent.MVar
+import Data.Either (isLeft)
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
@@ -39,7 +40,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             (\_ _ -> pure ())
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing Nothing
+                (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
             parameters = fromMaybe [] (jsonToolParameters tool)
         let isolationTypes =
@@ -61,7 +62,37 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         expectAlwaysPrompt tool.appToolApproval
         closeSubagentRegistry registry
 
-    it "defaults run_in_background and spawns a background agent" do
+    it "canonicalizes Grok-root child model aliases" do
+        canonicalizeGrokChildModel "Grok 4.6" `shouldBe` Just "grok-4.6"
+        canonicalizeGrokChildModel "grok-4-5" `shouldBe` Just "grok-4.5"
+        canonicalizeGrokChildModel "luna" `shouldBe` Just lunaSubagentModel
+        canonicalizeGrokChildModel "openai/gpt-5.6-luna"
+            `shouldBe` Just lunaSubagentModel
+        canonicalizeGrokChildModel "grok-4-1-fast" `shouldBe` Nothing
+        canonicalizeGrokChildModel "grok-4.6-mini" `shouldBe` Nothing
+
+    it "rejects unknown Grok-root child models against the allowlist" do
+        resolveRequestedGrokChildModel
+            (Just (grokRootChildModels True))
+            (Just "grok-4-1-fast")
+            `shouldSatisfy` isLeft
+        resolveRequestedGrokChildModel
+            (Just (grokRootChildModels False))
+            (Just lunaSubagentModel)
+            `shouldSatisfy` isLeft
+        resolveRequestedGrokChildModel
+            (Just (grokRootChildModels True))
+            (Just "luna")
+            `shouldBe` Right (Just lunaSubagentModel)
+        resolveRequestedGrokChildModel
+            (Just (grokRootChildModels True))
+            Nothing
+            `shouldBe` Right Nothing
+        grokRootChildModels False `shouldBe` ["grok-4.6", "grok-4.5"]
+        grokRootChildModels True
+            `shouldBe` ["grok-4.6", "grok-4.5", lunaSubagentModel]
+
+    it "advertises the Grok-root allowlist and records Luna at high effort" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ prompt _ -> pure $ Right LoopResult
                 { finalResponseId = "c"
@@ -73,6 +104,52 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing
+                (Just (grokRootChildModels True))
+            tool = taskTool (fromFilePath "/tmp") ctx typesRef
+        tool.appToolDescription `shouldSatisfy`
+            Text.isInfixOf "gpt-5.6-luna"
+        tool.appToolDescription `shouldSatisfy`
+            Text.isInfixOf "ONLY use model slugs"
+        result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+            (functionToolCall "c1" "task"
+                "{\"prompt\":\"hello\",\"description\":\"luna child\",\"model\":\"luna\"}")
+        result.output `shouldSatisfy` Text.isInfixOf "Subagent started in background"
+        specs <- Map.elems <$> readIORef typesRef
+        map (\entry -> entry.modelOverride) specs
+            `shouldBe` [Just lunaSubagentModel]
+        map (\entry -> entry.reasoningEffortOverride) specs
+            `shouldBe` [Just lunaSubagentEffort]
+        closeSubagentRegistry registry
+
+    it "rejects grok-4-1-fast when a Grok-root allowlist is set" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        typesRef <- newIORef Map.empty
+        let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
+                (pure Nothing) Nothing Nothing Nothing Nothing Nothing
+                (Just (grokRootChildModels True))
+            tool = taskTool (fromFilePath "/tmp") ctx typesRef
+        result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+            (functionToolCall "c1" "task"
+                "{\"prompt\":\"hello\",\"description\":\"search\",\"model\":\"grok-4-1-fast\"}")
+        result.output `shouldSatisfy`
+            Text.isInfixOf "Unknown spawn_subagent model"
+        Map.null <$> readIORef typesRef `shouldReturn` True
+        closeSubagentRegistry registry
+
+    it "defaults run_in_background and spawns a background agent" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ prompt _ -> pure $ Right LoopResult
+                { finalResponseId = "c"
+                , finalText = Just ("done:" <> interAgentMessagePayload prompt)
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                })
+            (\_ _ -> pure ())
+        typesRef <- newIORef Map.empty
+        let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
+                (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -90,7 +167,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             (observeSpec typesRef observed)
             (\_ _ -> pure ())
         let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing Nothing
+                (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         _ <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task" raceArgs)
@@ -120,7 +197,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         let restore _ =
                 pure (Left "persisted subagent dialect is incompatible")
             ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
-                (pure Nothing) (Just restore) Nothing Nothing Nothing Nothing
+                (pure Nothing) (Just restore) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -155,7 +232,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let childId = SubagentId "agent-child"
             ctx = MultiAgentContext registry (fromFilePath "/tmp") (Just childId) 1 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing Nothing
+                (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         expectAlwaysReadOnly tool.appToolApproval
         closeSubagentRegistry registry
@@ -168,7 +245,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let createIsolated = cleanupLease cleaned
             ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot (pure Nothing)
-                Nothing (Just createIsolated) Nothing Nothing Nothing
+                Nothing (Just createIsolated) Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -189,7 +266,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         registry <- closedRegistry
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
-                (pure Nothing) Nothing (Just (cleanupLease cleaned)) Nothing Nothing Nothing
+                (pure Nothing) Nothing (Just (cleanupLease cleaned)) Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task" worktreeArgs)


### PR DESCRIPTION
## Summary
Grok 4.6 was inventing `grok-4-1-fast` for `spawn_subagent`. Grok-root children may now only use:

- `grok-4.6`
- `grok-4.5`
- `gpt-5.6-luna` at high reasoning, when OpenAI is signed in

Unknown slugs are rejected with that allowlist. Omitting `model` still inherits the parent when it is 4.6 or 4.5. Luna children run on OpenAI with the Codex dialect.

## Tmux smoke
One-shot Grok 4.6 in tmux (`--minimal --yolo`):

- `spawn_subagent model=grok-4-1-fast` → `Unknown spawn_subagent model 'grok-4-1-fast'. Valid model slugs: grok-4.6, grok-4.5, gpt-5.6-luna.`
- `spawn_subagent model=grok-4.5` explore child completed with `OK`

## Tests
- Grok TaskSpec: alias canonicalization, allowlist rejection, Luna high-effort recording
- CLI SubagentStoreSpec: Grok-root child identity (Luna → OpenAI Codex)