### PR TITLE
fix(loop): continue after reasoning-only completions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -633,6 +633,14 @@ renderEventUnlocked config = \case
             (roleWarn config.renderColor (glyphWarn <> message))
         startThinkingSpinnerUnlocked config
     TurnStarted -> do
+        -- A later sample (tool follow-up or empty reasoning continuation)
+        -- must commit any buffered thought before resetting render state.
+        -- Otherwise beginRenderTurn discards the summary without painting it.
+        buffered <-
+            textBufferToText . stateReasoningBuffer
+                <$> readRenderState config
+        unless (Text.null (Text.strip buffered)) $
+            commitThinkingUnlocked config
         now <- getCurrentTime
         modifyRenderState config \state ->
             (beginRenderTurn now state, ())

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -386,6 +386,20 @@ spec = do
                 second <- readIORef config.renderThinkingSpinner
                 second `shouldBe` first
 
+        it "commits buffered reasoning before a continuation TurnStarted" do
+            withRenderConfig True False \config handle path -> do
+                renderEvent config TurnStarted
+                renderEvent config (ReasoningDelta "inspect the loop")
+                renderEvent config TurnStarted
+                buffered <-
+                    textBufferToText . stateReasoningBuffer
+                        <$> readIORef config.renderState
+                buffered `shouldBe` ""
+                hClose handle
+                body <- Text.readFile path
+                body `shouldSatisfy` Text.isInfixOf "inspect the loop"
+                body `shouldSatisfy` Text.isInfixOf "Thought for"
+
         it "shows retry activity on the live thinking status" do
             withRenderConfig True False \config handle path -> do
                 renderEvent config TurnStarted

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -1,5 +1,7 @@
 -- | Provider-neutral agent loop: submit a user turn, dispatch tool calls,
--- feed results back, repeat until the model answers in text or hits a cap.
+-- feed results back, and repeat until the model answers in visible text or
+-- hits a cap. Reasoning-only or otherwise empty completions are treated as
+-- incomplete model steps, not as a finished turn.
 --
 -- Transports close over model, instructions, and tool schemas. This module
 -- only sees 'ToolCall' / 'ToolCallResult' and a 'Backend' callback.
@@ -21,6 +23,7 @@ module Agent.Loop
     , TurnOutput(..)
     , addTokenUsage
     , defaultLoopMaxTurns
+    , defaultLoopMaxEmptyContinuations
     , defaultLoopDispatch
     , emptyTokenUsage
     , emptyTurnOutput
@@ -314,6 +317,21 @@ data LoopError
 defaultLoopMaxTurns :: Int
 defaultLoopMaxTurns = 2000
 
+-- | Extra model samples after a reasoning-only or otherwise empty completion
+-- (no tool calls, no visible assistant text, and no pending steering). The
+-- original empty sample plus this many continuations are allowed before the
+-- loop stops.
+defaultLoopMaxEmptyContinuations :: Int
+defaultLoopMaxEmptyContinuations = 2
+
+hasVisibleAssistantText :: Maybe Text -> Bool
+hasVisibleAssistantText =
+    maybe False (not . Text.null . Text.strip)
+
+emptyContinuationWarning :: Text
+emptyContinuationWarning =
+    "The model produced no assistant text or tool calls after reasoning; stopping."
+
 -- | CLI-facing formatter: unknown tools, handler errors, and crashes stay
 -- in-band as tool output so the model can continue.
 defaultLoopDispatch :: ToolDispatchConfig
@@ -390,7 +408,8 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                     (Left (LoopUnexpected (exceptionSummary exception)))
             protect state progress action =
                 tryAny action >>= either (unexpected state progress) pure
-            go state progress prev turnsUsed inputs steeringCount lastOutput usageAcc = do
+            go state progress prev turnsUsed inputs steeringCount lastOutput
+                    usageAcc emptyContinuations = do
                 writeIORef progressRef (state, progress)
                 if turnsUsed >= config.loopMaxTurns
                     then finish state progress $ case lastOutput of
@@ -442,8 +461,9 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                                     Right (Right BackendResult{..}) -> do
                                         continueCommitted
                                             backendState backendOutput turnsUsed
-                                            steeringCount usageAcc
-            continueCommitted state turn turnsUsed steeringCount usageAcc = do
+                                            steeringCount usageAcc emptyContinuations
+            continueCommitted state turn turnsUsed steeringCount usageAcc
+                    emptyContinuations = do
                 writeIORef progressRef (state, ResponseCommitted)
                 protect state ResponseCommitted do
                     -- A cancel that landed during submitTurn after the race chose
@@ -466,7 +486,8 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                                         if null turn.toolCalls
                                             then pure []
                                             else runToolCalls config turn.toolCalls
-                                    cancelledAfter <- isCancelled config.loopCancel
+                                    cancelledAfter <-
+                                        isCancelled config.loopCancel
                                     if cancelledAfter
                                         then finish state ResponseCommitted
                                             (Left (LoopCancelled results))
@@ -475,18 +496,8 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                                             let continuation =
                                                     map CompletedTool results
                                                         <> steering
-                                            if null continuation
-                                                then finish state ResponseCommitted $
-                                                    Right LoopResult
-                                                        { finalResponseId =
-                                                            turn.responseId
-                                                        , finalText =
-                                                            turn.assistantText
-                                                        , turnsUsed =
-                                                            nextTurnsUsed
-                                                        , tokenUsage = usageAcc'
-                                                        }
-                                                else go
+                                            if not (null continuation)
+                                                then go
                                                     state
                                                     ResponseCommitted
                                                     (Just turn.responseId)
@@ -495,12 +506,53 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                                                     (length steering)
                                                     (Just turn)
                                                     usageAcc'
+                                                    0
+                                                else if hasVisibleAssistantText
+                                                    turn.assistantText
+                                                    then finish state ResponseCommitted $
+                                                        Right LoopResult
+                                                            { finalResponseId =
+                                                                turn.responseId
+                                                            , finalText =
+                                                                turn.assistantText
+                                                            , turnsUsed =
+                                                                nextTurnsUsed
+                                                            , tokenUsage = usageAcc'
+                                                            }
+                                                    else if emptyContinuations
+                                                            >= defaultLoopMaxEmptyContinuations
+                                                        then do
+                                                            config.loopOnEvent
+                                                                (WarningRaised
+                                                                    emptyContinuationWarning)
+                                                            finish state ResponseCommitted $
+                                                                Right LoopResult
+                                                                    { finalResponseId =
+                                                                        turn.responseId
+                                                                    , finalText =
+                                                                        turn.assistantText
+                                                                    , turnsUsed =
+                                                                        nextTurnsUsed
+                                                                    , tokenUsage = usageAcc'
+                                                                    }
+                                                        else
+                                                            go
+                                                                state
+                                                                ResponseCommitted
+                                                                (Just turn.responseId)
+                                                                nextTurnsUsed
+                                                                []
+                                                                0
+                                                                (Just turn)
+                                                                usageAcc'
+                                                                (emptyContinuations + 1)
             run =
                 go initialState NoResponseCommitted previousResponseId 0
                     (firstInputs <> initialSteering)
                     (length initialSteering)
                     Nothing
                     emptyTokenUsage
+                    0
         raced <- race (waitLoopEventFailure eventWorker eventPump) run
         execution <- case raced of
             Left failure -> do

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1268,6 +1268,113 @@ spec = describe "runLoop" do
             , tokenUsage = TokenUsage 22 10 2
             }
 
+    it "continues after a reasoning-only completion until the model answers" do
+        events <- newIORef []
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1" [] Nothing
+            , Right $ emptyTurnOutput "resp-2" [] (Just "done")
+            ]
+        config0 <- testConfig backend
+        let config = config0
+                { loopOnEvent = \event -> modifyIORef' events (event :)
+                }
+        result <- runLoop config Nothing "hello"
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-2"
+            , finalText = Just "done"
+            , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
+            }
+        seen <- readIORef submissions
+        seen `shouldBe`
+            [ (Nothing, [UserMessage "hello"])
+            , (Just "resp-1", [])
+            ]
+        reverse <$> readIORef events `shouldReturn`
+            [ TurnStarted
+            , TurnFinished (emptyTurnOutput "resp-1" [] Nothing)
+            , TurnStarted
+            , TurnFinished (emptyTurnOutput "resp-2" [] (Just "done"))
+            ]
+
+    it "continues after whitespace-only assistant text" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1" [] (Just "  \n")
+            , Right $ emptyTurnOutput "resp-2" [] (Just "done")
+            ]
+        config <- testConfig backend
+        result <- runLoop config Nothing "hello"
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-2"
+            , finalText = Just "done"
+            , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
+            }
+        seen <- readIORef submissions
+        seen `shouldBe`
+            [ (Nothing, [UserMessage "hello"])
+            , (Just "resp-1", [])
+            ]
+
+    it "can call tools after a reasoning-only continuation" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1" [] Nothing
+            , Right $ emptyTurnOutput "resp-2"
+                [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                Nothing
+            , Right $ emptyTurnOutput "resp-3" [] (Just "done")
+            ]
+        config <- testConfig backend
+        result <- runLoop config Nothing "hello"
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-3"
+            , finalText = Just "done"
+            , turnsUsed = 3
+            , tokenUsage = emptyTokenUsage
+            }
+        seen <- readIORef submissions
+        case seen of
+            [ (Nothing, [UserMessage "hello"])
+                , (Just "resp-1", [])
+                , (Just "resp-2", [CompletedTool echoed])
+                ] ->
+                    echoed.output `shouldBe` "echo:hi"
+            other -> expectationFailure ("unexpected submissions: " <> show other)
+
+    it "stops after repeated empty completions and warns" do
+        events <- newIORef []
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1" [] Nothing
+            , Right $ emptyTurnOutput "resp-2" [] Nothing
+            , Right $ emptyTurnOutput "resp-3" [] Nothing
+            ]
+        config0 <- testConfig backend
+        let config = config0
+                { loopOnEvent = \event -> modifyIORef' events (event :)
+                }
+        result <- runLoop config Nothing "hello"
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-3"
+            , finalText = Nothing
+            , turnsUsed = 3
+            , tokenUsage = emptyTokenUsage
+            }
+        length <$> readIORef submissions `shouldReturn` 3
+        reverse <$> readIORef events `shouldReturn`
+            [ TurnStarted
+            , TurnFinished (emptyTurnOutput "resp-1" [] Nothing)
+            , TurnStarted
+            , TurnFinished (emptyTurnOutput "resp-2" [] Nothing)
+            , TurnStarted
+            , TurnFinished (emptyTurnOutput "resp-3" [] Nothing)
+            , WarningRaised
+                "The model produced no assistant text or tool calls after reasoning; stopping."
+            ]
+
     it "injects pending steering at the next committed model boundary" do
         submissions <- newIORef []
         pending <- newIORef []

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -80,6 +80,24 @@ spec = do
                     ])
             rejectFailedCodexResponse response `shouldBe` Right response
 
+        it "keeps an incomplete response that already contains reasoning" do
+            let response = decodeResponse (Aeson.object
+                    [ "id" .= ("response-id" :: Text)
+                    , "created_at" .= (0 :: Int)
+                    , "model" .= ("gpt-5.6-sol" :: Text)
+                    , "status" .= ("incomplete" :: Text)
+                    , "incomplete_details" .= Aeson.object
+                        [ "reason" .= ("max_output_tokens" :: Text) ]
+                    , "output" .=
+                        [ Aeson.object
+                            [ "type" .= ("reasoning" :: Text)
+                            , "id" .= ("rs-1" :: Text)
+                            , "summary" .= ([] :: [Aeson.Value])
+                            ]
+                        ]
+                    ])
+            rejectFailedCodexResponse response `shouldBe` Right response
+
     describe "retryTransientCodexResultWithPolicy" do
         it "retries ordinary Left overloads before returning success" do
             let overload = ProviderError OverloadedError "server_is_overloaded" Nothing
@@ -142,6 +160,34 @@ spec = do
                 (ProviderError ApiErrorType
                     "response.incomplete: max_output_tokens"
                     Nothing)
+
+        it "reads function-call arguments from SSE deltas when completed output is empty" do
+            let body = Text.concat
+                    [ "event: response.output_item.added\n"
+                    , "data: {\"output_index\":0,\"item\":"
+                    , "{\"type\":\"function_call\",\"id\":\"fc-1\",\"call_id\":\"call-1\",\"name\":\"read_file\",\"arguments\":\"\"}"
+                    , "}\n\n"
+                    , "event: response.function_call_arguments.done\n"
+                    , "data: {\"item_id\":\"fc-1\",\"output_index\":0,\"name\":\"read_file\",\"arguments\":\"{\\\"target_file\\\":\\\"README.md\\\"}\"}\n\n"
+                    , "event: response.completed\n"
+                    , "data: "
+                    , Text.decodeUtf8 (LBS.toStrict (Aeson.encode (Aeson.object
+                        [ "response" .= Aeson.object
+                            [ "id" .= ("resp-args" :: Text)
+                            , "created_at" .= (0 :: Int)
+                            , "model" .= ("gpt-test" :: Text)
+                            , "status" .= ("completed" :: Text)
+                            , "output" .= ([] :: [Aeson.Value])
+                            ]
+                        ])))
+                    , "\n\n"
+                    ]
+            case decodeCodexHttpBody body of
+                Right response -> do
+                    response.responseId `shouldBe` "resp-args"
+                    [(name, arguments) | FunctionCallItem FunctionCall { name, arguments } <- response.output]
+                        `shouldBe` [("read_file", "{\"target_file\":\"README.md\"}")]
+                Left err -> expectationFailure ("expected response, got " <> show err)
 
         it "reads an incomplete SSE response that already contains a function call" do
             let body = Text.concat

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -98,6 +98,27 @@ spec = do
                     ])
             rejectFailedCodexResponse response `shouldBe` Right response
 
+        it "rejects a content-filtered incomplete response even with reasoning" do
+            let response = decodeResponse (Aeson.object
+                    [ "id" .= ("response-id" :: Text)
+                    , "created_at" .= (0 :: Int)
+                    , "model" .= ("gpt-5.6-sol" :: Text)
+                    , "status" .= ("incomplete" :: Text)
+                    , "incomplete_details" .= Aeson.object
+                        [ "reason" .= ("content_filter" :: Text) ]
+                    , "output" .=
+                        [ Aeson.object
+                            [ "type" .= ("reasoning" :: Text)
+                            , "id" .= ("rs-1" :: Text)
+                            , "summary" .= ([] :: [Aeson.Value])
+                            ]
+                        ]
+                    ])
+            rejectFailedCodexResponse response
+                `shouldBe` Left (ProviderError ApiErrorType
+                    "response.incomplete: content_filter"
+                    Nothing)
+
     describe "retryTransientCodexResultWithPolicy" do
         it "retries ordinary Left overloads before returning success" do
             let overload = ProviderError OverloadedError "server_is_overloaded" Nothing

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -378,6 +378,57 @@ spec = do
         readIORef completeCount `shouldReturn` 1
         readIORef invalidations `shouldReturn` []
 
+    it "rejects content-filtered incomplete reasoning instead of recovering it" do
+        frames <- newIORef
+            [ lifecycleFrame "response.created"
+                (Aeson.object ["id" Aeson..= ("resp-test" :: Text)])
+            , Aeson.encode $ Aeson.object
+                [ "type" Aeson..= ("response.output_item.done" :: Text)
+                , "item" Aeson..= Aeson.object
+                    [ "type" Aeson..= ("reasoning" :: Text)
+                    , "id" Aeson..= ("rs-1" :: Text)
+                    , "summary" Aeson..= ([] :: [Aeson.Value])
+                    ]
+                ]
+            , lifecycleFrame "response.incomplete"
+                (Aeson.object
+                    [ "incomplete_details" Aeson..= Aeson.object
+                        [ "reason" Aeson..=
+                            ("content_filter" :: Text)
+                        ]
+                    ])
+            ]
+        receiveCount <- newIORef (0 :: Int)
+        completeCount <- newIORef (0 :: Int)
+        invalidations <- newIORef ([] :: [Text])
+        callbackTypes <- newIORef ([] :: [StreamEventType])
+        let actions = WebSocketReceiveActions
+                { receiveFrame = do
+                    modifyIORef' receiveCount (+ 1)
+                    atomicModifyIORef' frames \case
+                        frame : rest -> (rest, Right frame)
+                        [] -> error "unexpected receive after terminal event"
+                , completeRequest = modifyIORef' completeCount (+ 1)
+                , invalidateRequest = \reason ->
+                    modifyIORef' invalidations (<> [reason])
+                }
+            onEvent event =
+                modifyIORef' callbackTypes
+                    (<> [responseStreamEventType event])
+
+        result <- receiveWsResponseWithActions
+            (Just "gpt-test") actions onEvent
+
+        result `shouldBe` Left
+            (ProviderError ApiErrorType
+                "response.incomplete: content_filter"
+                Nothing)
+        readIORef callbackTypes `shouldReturn`
+            [EventResponseCreated, EventOutputItemDone, EventResponseIncomplete]
+        readIORef completeCount `shouldReturn` 0
+        readIORef invalidations `shouldReturn`
+            ["WebSocket response incomplete"]
+
     it "recovers assembled tool calls when the socket dies after output_item.done" do
         remaining <- newIORef
             [ Right $ lifecycleFrame "response.created"

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -325,6 +325,59 @@ spec = do
         readIORef completeCount `shouldReturn` 1
         readIORef invalidations `shouldReturn` []
 
+    it "keeps an incomplete response that already contains reasoning" do
+        frames <- newIORef
+            [ lifecycleFrame "response.created"
+                (Aeson.object ["id" Aeson..= ("resp-test" :: Text)])
+            , Aeson.encode $ Aeson.object
+                [ "type" Aeson..= ("response.output_item.done" :: Text)
+                , "item" Aeson..= Aeson.object
+                    [ "type" Aeson..= ("reasoning" :: Text)
+                    , "id" Aeson..= ("rs-1" :: Text)
+                    , "summary" Aeson..= ([] :: [Aeson.Value])
+                    ]
+                ]
+            , lifecycleFrame "response.incomplete"
+                (Aeson.object
+                    [ "incomplete_details" Aeson..= Aeson.object
+                        [ "reason" Aeson..=
+                            ("max_output_tokens" :: Text)
+                        ]
+                    ])
+            ]
+        receiveCount <- newIORef (0 :: Int)
+        completeCount <- newIORef (0 :: Int)
+        invalidations <- newIORef ([] :: [Text])
+        callbackTypes <- newIORef ([] :: [StreamEventType])
+        let actions = WebSocketReceiveActions
+                { receiveFrame = do
+                    modifyIORef' receiveCount (+ 1)
+                    atomicModifyIORef' frames \case
+                        frame : rest -> (rest, Right frame)
+                        [] -> error "unexpected receive after terminal event"
+                , completeRequest = modifyIORef' completeCount (+ 1)
+                , invalidateRequest = \reason ->
+                    modifyIORef' invalidations (<> [reason])
+                }
+            onEvent event =
+                modifyIORef' callbackTypes
+                    (<> [responseStreamEventType event])
+
+        result <- receiveWsResponseWithActions
+            (Just "gpt-test") actions onEvent
+
+        case result of
+            Right response -> do
+                response.responseId `shouldBe` "resp-test"
+                response.status `shouldBe` ResponseIncomplete
+                [itemId | ReasoningItemValue ReasoningItem { itemId } <- response.output]
+                    `shouldBe` [Just "rs-1"]
+            other -> expectationFailure ("expected incomplete response, got " <> show other)
+        readIORef callbackTypes `shouldReturn`
+            [EventResponseCreated, EventOutputItemDone, EventResponseIncomplete]
+        readIORef completeCount `shouldReturn` 1
+        readIORef invalidations `shouldReturn` []
+
     it "recovers assembled tool calls when the socket dies after output_item.done" do
         remaining <- newIORef
             [ Right $ lifecycleFrame "response.created"

--- a/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
@@ -135,6 +135,8 @@ retainForResponse = \case
     ResponseOutputItemDoneEvent {} -> True
     ResponseCustomToolInputDeltaEvent {} -> True
     ResponseCustomToolInputDoneEvent {} -> True
+    ResponseFunctionCallArgumentsDeltaEvent {} -> True
+    ResponseFunctionCallArgumentsDoneEvent {} -> True
     ResponseReasoningSummaryPartAddedEvent {} -> True
     ResponseReasoningSummaryTextDoneEvent {} -> True
     event

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -120,8 +120,10 @@ withRequestInput ResponseCreateParams{..} items =
         normalizedItems = map normalizeRequestItem items
         requestItems
             | any isAdditionalTools prefix =
-                map stripResponsesLiteImageDetails normalizedItems
-            | otherwise = normalizedItems
+                ensureReasoningHasFollowingItem
+                    (map stripResponsesLiteImageDetails normalizedItems)
+            | otherwise =
+                ensureReasoningHasFollowingItem normalizedItems
     in
     ResponseCreateParams
         { input = Just
@@ -245,6 +247,29 @@ normalizeAssistantPart = \case
             , extraFields
             }
     part -> part
+
+-- | Responses rejects a trailing reasoning item with @missing_following_item@.
+-- Stateless backends resend the local transcript, so splice an empty assistant
+-- message when the last item is reasoning. Backends that send only deltas plus
+-- @previous_response_id@ never include that trailing reasoning in @input@.
+ensureReasoningHasFollowingItem :: [ResponseItem] -> [ResponseItem]
+ensureReasoningHasFollowingItem items =
+    case reverse items of
+        ReasoningItemValue{} : _ ->
+            items <> [emptyAssistantFollowupItem]
+        _ -> items
+
+emptyAssistantFollowupItem :: ResponseItem
+emptyAssistantFollowupItem = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentParts
+        [OutputTextPart "" Nothing Nothing KeyMap.empty]
+    , role = RoleAssistant
+    , status = Nothing
+    , phase = Nothing
+    , passthrough = Nothing
+    , extraFields = KeyMap.empty
+    }
 
 turnInputsToItems :: [TurnInput] -> [ResponseItem]
 turnInputsToItems = map turnInputToItem
@@ -385,13 +410,22 @@ responseToTurnOutput response = TurnOutput
     }
 
 -- | An incomplete response can still finish the turn when it already contains
--- executable tool calls or assistant text. Empty @max_output_tokens@ stops
--- remain transport failures so a replay-safe fallback can still run.
+-- executable tool calls, assistant text, or a reasoning item. Reasoning-only
+-- stops are handed to the loop as empty completions so it can continue the
+-- chain instead of retrying the same sample. Completely empty
+-- @max_output_tokens@ stops remain transport failures so a replay-safe
+-- fallback can still run.
 hasRecoverableIncompleteOutput :: Response -> Bool
 hasRecoverableIncompleteOutput response =
     not (null (mapMaybe responseItemToToolCall response.output))
         || maybe False (not . Text.null . Text.strip)
             (assistantTextFromResponse response)
+        || any isReasoningOutput response.output
+
+isReasoningOutput :: ResponseItem -> Bool
+isReasoningOutput = \case
+    ReasoningItemValue{} -> True
+    _ -> False
 
 responseTokenUsage :: Response -> TokenUsage
 responseTokenUsage response =

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -410,22 +410,34 @@ responseToTurnOutput response = TurnOutput
     }
 
 -- | An incomplete response can still finish the turn when it already contains
--- executable tool calls, assistant text, or a reasoning item. Reasoning-only
--- stops are handed to the loop as empty completions so it can continue the
--- chain instead of retrying the same sample. Completely empty
--- @max_output_tokens@ stops remain transport failures so a replay-safe
--- fallback can still run.
+-- executable tool calls or assistant text, or when it is a continuable
+-- reasoning-only stop. @max_output_tokens@ during reasoning is handed to the
+-- loop as an empty completion so it can continue the chain. Reasons such as
+-- @content_filter@ stay transport failures, as do completely empty incomplete
+-- responses, so a replay-safe fallback can still run.
 hasRecoverableIncompleteOutput :: Response -> Bool
 hasRecoverableIncompleteOutput response =
     not (null (mapMaybe responseItemToToolCall response.output))
         || maybe False (not . Text.null . Text.strip)
             (assistantTextFromResponse response)
-        || any isReasoningOutput response.output
+        || (any isReasoningOutput response.output
+            && isContinuableIncompleteReason response)
 
 isReasoningOutput :: ResponseItem -> Bool
 isReasoningOutput = \case
     ReasoningItemValue{} -> True
     _ -> False
+
+isContinuableIncompleteReason :: Response -> Bool
+isContinuableIncompleteReason response =
+    maybe False ((`elem` continuableIncompleteReasons) . (.reason))
+        response.incompleteDetails
+
+-- | Incomplete reasons where the model can still produce tools or text on a
+-- follow-up sample. Safety/filter stops are not continuable.
+continuableIncompleteReasons :: [Text]
+continuableIncompleteReasons =
+    ["max_output_tokens"]
 
 responseTokenUsage :: Response -> TokenUsage
 responseTokenUsage response =

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -111,6 +111,26 @@ applyStreamEvent state event = case event of
                         (setInput finalInput)
                         state
                 _ -> state
+    ResponseFunctionCallArgumentsDeltaEvent
+        { delta, streamItemId, streamOutputIndex } ->
+            case ( delta
+                 , resolveOutputIndex streamOutputIndex [streamItemId] state
+                 ) of
+                (Just argumentsDelta, Just outputIndex) ->
+                    updateFunctionCallArguments outputIndex
+                        streamItemId
+                        (appendArguments argumentsDelta)
+                        state
+                _ -> state
+    ResponseFunctionCallArgumentsDoneEvent
+        { arguments, functionName, streamItemId, streamOutputIndex } ->
+            case resolveOutputIndex streamOutputIndex [streamItemId] state of
+                Just outputIndex ->
+                    updateFunctionCallArguments outputIndex
+                        streamItemId
+                        (setArguments arguments functionName)
+                        state
+                Nothing -> state
     ResponseReasoningSummaryPartAddedEvent
         { streamItemId, streamOutputIndex, summaryIndex, partValue } ->
             case ( summaryIndex
@@ -577,6 +597,49 @@ appendInput delta object =
 setInput :: Text -> Aeson.Object -> Aeson.Object
 setInput input =
     KeyMap.insert "input" (Aeson.String input)
+
+updateFunctionCallArguments
+    :: Int
+    -> Maybe Text
+    -> (Aeson.Object -> Aeson.Object)
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+updateFunctionCallArguments outputIndex itemId updateArgs state =
+    state
+        { outputItems =
+            Map.alter
+                (Just . updateProgress)
+                outputIndex
+                state.outputItems
+        }
+  where
+    baseObject =
+        maybe id
+            (KeyMap.insert "id" . Aeson.String)
+            itemId
+        $ KeyMap.fromList
+            [ ("type", Aeson.String "function_call")
+            , ("arguments", Aeson.String "")
+            ]
+    updateProgress Nothing =
+        ItemProgress (Aeson.Object (updateArgs baseObject)) False
+    updateProgress (Just progress) =
+        progress
+            { itemValue = case progress.itemValue of
+                Aeson.Object object -> Aeson.Object (updateArgs object)
+                _ -> Aeson.Object (updateArgs baseObject)
+            }
+
+appendArguments :: Text -> Aeson.Object -> Aeson.Object
+appendArguments delta object =
+    let current = fromMaybe "" (textField "arguments" object)
+    in KeyMap.insert "arguments" (Aeson.String (current <> delta)) object
+
+setArguments :: Maybe Text -> Maybe Text -> Aeson.Object -> Aeson.Object
+setArguments arguments functionName object =
+    maybe id (KeyMap.insert "name" . Aeson.String) functionName $
+        maybe id (KeyMap.insert "arguments" . Aeson.String) arguments
+            object
 
 setObjectText :: Text -> Aeson.Value -> Aeson.Value
 setObjectText text = \case

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -26,6 +26,7 @@ import Agent.Responses.Types
     ( MessageContent(..)
     , FunctionCallOutput(..)
     , InternalChatMetadata(..)
+    , ReasoningItem(..)
     , ResponseContentPart(..)
     , ResponseItem(..)
     , ResponseMessage(..)
@@ -281,6 +282,38 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
             other -> expectationFailure
                 ("unexpected normalized Lite input: " <> show other)
 
+    it "appends an empty assistant message after a trailing reasoning item" do
+        let reasoning = ReasoningItemValue ReasoningItem
+                { itemId = Just "rs-1"
+                , summary = []
+                , content = Nothing
+                , encryptedContent = Nothing
+                , status = Nothing
+                , extraFields = KeyMap.empty
+                }
+            user = turnInputsToItems [UserMessage "hello"]
+            params = defaultResponseCreateParams
+            request = withRequestInput params (user <> [reasoning])
+        case request.input of
+            Just (ResponseInputItems items) -> do
+                length items `shouldBe` 3
+                last items `shouldSatisfy` isEmptyAssistantFollowup
+            _ -> expectationFailure "expected request input items"
+
+    it "does not invent a follow-up when reasoning already has a successor" do
+        let reasoning = ReasoningItemValue ReasoningItem
+                { itemId = Just "rs-1"
+                , summary = []
+                , content = Nothing
+                , encryptedContent = Nothing
+                , status = Nothing
+                , extraFields = KeyMap.empty
+                }
+            items = turnInputsToItems [UserMessage "hello"] <> [reasoning]
+                <> turnInputsToItems [UserMessage "continue"]
+            request = withRequestInput defaultResponseCreateParams items
+        request.input `shouldBe` Just (ResponseInputItems items)
+
 credential :: String -> Credential
 credential label = Credential
     { accessToken = "token-" <> Text.pack label
@@ -306,6 +339,16 @@ isUserMessage = \case
             && case message.content of
                 MessageContentParts [InputTextPart{ text = value }] ->
                     value == "hello"
+                _ -> False
+    _ -> False
+
+isEmptyAssistantFollowup :: ResponseItem -> Bool
+isEmptyAssistantFollowup = \case
+    MessageItem message ->
+        message.role == RoleAssistant
+            && case message.content of
+                MessageContentParts [OutputTextPart{ text = value }] ->
+                    Text.null value
                 _ -> False
     _ -> False
 

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -145,6 +145,52 @@ spec = describe "buildStreamResponse" do
             other -> expectationFailure
                 ("expected one custom tool call, got " <> show other)
 
+    it "assembles function-call arguments without output_item.done" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-args\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc-1\",\"call_id\":\"call-1\",\"name\":\"read_file\",\"arguments\":\"\"}}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc-1\",\"output_index\":0,\"delta\":\"{\\\"target_file\\\":\\\"\"}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc-1\",\"delta\":\"README.md\\\"}\"}"
+            , sseBlock "response.function_call_arguments.done"
+                "{\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc-1\",\"name\":\"read_file\",\"arguments\":\"{\\\"target_file\\\":\\\"README.md\\\"}\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-args\",\"output\":[]}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        case response.output of
+            [FunctionCallItem FunctionCall { name, arguments }] ->
+                (name, arguments)
+                    `shouldBe` ("read_file", "{\"target_file\":\"README.md\"}")
+            other -> expectationFailure
+                ("expected one function call, got " <> show other)
+
+    it "assembles a function call after a reasoning item from argument events" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-reason-then-call\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs-1\",\"summary\":[]}}"
+            , sseBlock "response.output_item.done"
+                "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs-1\",\"summary\":[]}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc-1\",\"call_id\":\"call-1\",\"name\":\"echo\",\"arguments\":\"\"}}"
+            , sseBlock "response.function_call_arguments.done"
+                "{\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc-1\",\"output_index\":1,\"name\":\"echo\",\"arguments\":\"{\\\"message\\\":\\\"hi\\\"}\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-reason-then-call\",\"output\":[]}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["echo"]
+        [arguments | FunctionCallItem FunctionCall { arguments } <- response.output]
+            `shouldBe` ["{\"message\":\"hi\"}"]
+
     it "assembles reasoning summary part and text events by item id" do
         events <- expectRight $ parseSseEvents $ Text.intercalate ""
             [ sseBlock "response.created"


### PR DESCRIPTION
## Summary
The agent loop stopped whenever a model sample had no tool calls, even if it also had no visible assistant text. A reasoning-only Responses sample therefore ended the turn while the UI was still in thinking.

This continues those empty samples on the committed response chain (`previous_response_id`, no new input), keeps thinking open until there is text, tools, or the empty-continuation cap, and recovers tool calls that arrive after reasoning.

## Changes
- Continue after empty / reasoning-only completions instead of finishing the turn.
- Cap consecutive empty samples at 2 extra continuations and warn before stopping.
- Treat reasoning items as recoverable incomplete output so Codex does not fail the sample and replay it.
- Assemble `function_call_arguments` deltas after reasoning, including when `response.completed` has `output: []`.
- For stateless transports, append an empty assistant item after a trailing reasoning item so the API does not reject `missing_following_item`.

## Tests
- `agent-core` `runLoop`: empty continuation, whitespace-only text, tools after reasoning, empty-continuation cap, existing steering path.
- `agent-responses`: function-call argument assembly and trailing-reasoning request follow-up.
- `agent-openai`: reasoning-only incomplete HTTP/WebSocket responses and SSE argument assembly.