### PR TITLE
feat(cli): show generation tokens per second

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -16,6 +16,8 @@ module Agent.CLI
     , formatRepositoryPath
     , formatStartupTimings
     , formatTokenUsage
+    , formatTokensPerSecond
+    , formatUsageWithRate
     , learnAboutUserOnboardingPrompt
     , run
     , withRestoredCurrentDirectory
@@ -45,4 +47,6 @@ import Agent.CLI.Runtime.Types (DevResult(..))
 import Agent.CLI.Status
     ( formatReplStatusLine
     , formatTokenUsage
+    , formatTokensPerSecond
+    , formatUsageWithRate
     )

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -17,10 +17,12 @@ module Agent.CLI.Render
     , emptyRenderState
     , appendRenderReasoning
     , beginRenderTurn
+    , clearRenderTokenRate
     , countGenerationChars
     , formatActivityLine
     , recordRenderTurnRate
     , renderTokensPerSecond
+    , resetRenderGeneration
     , stateLastTokensPerSecond
     , formatElapsed
     , formatLoopError
@@ -178,6 +180,7 @@ data RenderState = RenderState
     , stateStartedAt :: !(Maybe UTCTime)
     , stateToolCalls :: !(Map.Map Text ToolCall)
     , stateGenerationChars :: !Int
+    , stateGenerationStartedAt :: !(Maybe UTCTime)
     , stateLastTokensPerSecond :: !(Maybe Double)
     }
 
@@ -220,6 +223,7 @@ emptyRenderState =
         , stateStartedAt = Nothing
         , stateToolCalls = Map.empty
         , stateGenerationChars = 0
+        , stateGenerationStartedAt = Nothing
         , stateLastTokensPerSecond = Nothing
         }
 
@@ -582,7 +586,26 @@ beginRenderTurn now state =
     emptyRenderState
         { stateThinkingVisible = state.stateThinkingVisible
         , stateStartedAt = Just now
+        , stateGenerationStartedAt = Just now
         , stateLastTokensPerSecond = state.stateLastTokensPerSecond
+        }
+
+-- | Start a new generation-rate window without resetting the turn timer
+-- shown on the thinking spinner.
+resetRenderGeneration :: UTCTime -> RenderState -> RenderState
+resetRenderGeneration now state =
+    state
+        { stateGenerationChars = 0
+        , stateGenerationStartedAt = Just now
+        }
+
+-- | Drop a previous conversation's saved speed after /clear or /new.
+clearRenderTokenRate :: RenderState -> RenderState
+clearRenderTokenRate state =
+    state
+        { stateGenerationChars = 0
+        , stateGenerationStartedAt = Nothing
+        , stateLastTokensPerSecond = Nothing
         }
 
 countGenerationChars :: Text -> RenderState -> RenderState
@@ -592,27 +615,30 @@ countGenerationChars delta state =
             state.stateGenerationChars + Text.length delta
         }
 
+generationElapsedMillis :: UTCTime -> RenderState -> Int
+generationElapsedMillis now state =
+    case state.stateGenerationStartedAt of
+        Nothing -> 0
+        Just started ->
+            max 0 (floor (diffUTCTime now started * 1000))
+
 recordRenderTurnRate :: UTCTime -> TurnOutput -> RenderState -> RenderState
 recordRenderTurnRate now turn state =
-    let millis = case state.stateStartedAt of
-            Nothing -> 0
-            Just started ->
-                max 0 (floor (diffUTCTime now started * 1000))
-    in state
+    state
         { stateLastTokensPerSecond =
             generationTokensPerSecond
                 turn.tokenUsage.outputTokens
                 state.stateGenerationChars
-                millis
+                (generationElapsedMillis now state)
                 <|> state.stateLastTokensPerSecond
         }
 
-renderTokensPerSecond :: RenderState -> Double -> Maybe Double
-renderTokensPerSecond state elapsedSeconds
+renderTokensPerSecond :: UTCTime -> RenderState -> Maybe Double
+renderTokensPerSecond now state
     | Map.null state.stateToolCalls =
         liveTokensPerSecond
             state.stateGenerationChars
-            (max 0 (round (elapsedSeconds * 1000)))
+            (generationElapsedMillis now state)
             <|> state.stateLastTokensPerSecond
     | otherwise = state.stateLastTokensPerSecond
 
@@ -680,10 +706,9 @@ renderEventUnlocked config = \case
                     , ())
         now <- getCurrentTime
         modifyRenderState config \state ->
-            ( setRenderActivity "Retrying response…" state
-                { stateGenerationChars = 0
-                , stateStartedAt = Just now
-                }
+            ( setRenderActivity
+                "Retrying response…"
+                (resetRenderGeneration now state)
             , ()
             )
         putTextLn config.renderStderr
@@ -921,6 +946,7 @@ paintThinkingFrame config = do
 paintThinkingFrameAt :: RenderConfig -> Int -> IO ()
 paintThinkingFrameAt config motionMillis = do
     state <- readRenderState config
+    now <- getCurrentTime
     let activity = state.stateActivity
     elapsed <- thinkingElapsed config
     let glyph =
@@ -934,7 +960,7 @@ paintThinkingFrameAt config motionMillis = do
                 glyph
                 activity
                 elapsed
-                (renderTokensPerSecond state elapsed)
+                (renderTokensPerSecond now state)
     void $ tryIO do
         Text.hPutStr config.renderStderr ("\r\ESC[K" <> line)
         hFlush config.renderStderr

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -17,7 +17,11 @@ module Agent.CLI.Render
     , emptyRenderState
     , appendRenderReasoning
     , beginRenderTurn
+    , countGenerationChars
     , formatActivityLine
+    , recordRenderTurnRate
+    , renderTokensPerSecond
+    , stateLastTokensPerSecond
     , formatElapsed
     , formatLoopError
     , formatLoopErrorAt
@@ -64,6 +68,7 @@ import Agent.CLI.Error
     , formatApiErrorAt
     , formatApiErrorPersistedAt
     )
+import Agent.CLI.Status (formatTokensPerSecond)
 import Agent.CLI.Style
     ( agentBackground
     , glyphCancel
@@ -98,6 +103,8 @@ import Agent.Loop
     , TokenUsage(..)
     , TurnCompletion(..)
     , TurnOutput(..)
+    , generationTokensPerSecond
+    , liveTokensPerSecond
     )
 import Agent.TUI.Presentation
     ( SearchReplaceAction(..)
@@ -119,6 +126,7 @@ import Agent.TextBuffer
     , emptyTextBuffer
     , textBufferToText
     )
+import Control.Applicative ((<|>))
 import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, withMVar)
 import Control.Exception.Safe (tryIO)
@@ -169,6 +177,8 @@ data RenderState = RenderState
     , stateActivity :: !Text
     , stateStartedAt :: !(Maybe UTCTime)
     , stateToolCalls :: !(Map.Map Text ToolCall)
+    , stateGenerationChars :: !Int
+    , stateLastTokensPerSecond :: !(Maybe Double)
     }
 
 stateThinkingVisible :: RenderState -> Bool
@@ -195,6 +205,9 @@ stateStartedAt state = state.stateStartedAt
 stateToolCalls :: RenderState -> Map.Map Text ToolCall
 stateToolCalls state = state.stateToolCalls
 
+stateLastTokensPerSecond :: RenderState -> Maybe Double
+stateLastTokensPerSecond state = state.stateLastTokensPerSecond
+
 emptyRenderState :: RenderState
 emptyRenderState =
     RenderState
@@ -206,6 +219,8 @@ emptyRenderState =
         , stateActivity = "Thinking…"
         , stateStartedAt = Nothing
         , stateToolCalls = Map.empty
+        , stateGenerationChars = 0
+        , stateLastTokensPerSecond = Nothing
         }
 
 data MarkdownStreamState = MarkdownStreamState
@@ -567,7 +582,39 @@ beginRenderTurn now state =
     emptyRenderState
         { stateThinkingVisible = state.stateThinkingVisible
         , stateStartedAt = Just now
+        , stateLastTokensPerSecond = state.stateLastTokensPerSecond
         }
+
+countGenerationChars :: Text -> RenderState -> RenderState
+countGenerationChars delta state =
+    state
+        { stateGenerationChars =
+            state.stateGenerationChars + Text.length delta
+        }
+
+recordRenderTurnRate :: UTCTime -> TurnOutput -> RenderState -> RenderState
+recordRenderTurnRate now turn state =
+    let millis = case state.stateStartedAt of
+            Nothing -> 0
+            Just started ->
+                max 0 (floor (diffUTCTime now started * 1000))
+    in state
+        { stateLastTokensPerSecond =
+            generationTokensPerSecond
+                turn.tokenUsage.outputTokens
+                state.stateGenerationChars
+                millis
+                <|> state.stateLastTokensPerSecond
+        }
+
+renderTokensPerSecond :: RenderState -> Double -> Maybe Double
+renderTokensPerSecond state elapsedSeconds
+    | Map.null state.stateToolCalls =
+        liveTokensPerSecond
+            state.stateGenerationChars
+            (max 0 (round (elapsedSeconds * 1000)))
+            <|> state.stateLastTokensPerSecond
+    | otherwise = state.stateLastTokensPerSecond
 
 appendRenderReasoning :: Text -> RenderState -> RenderState
 appendRenderReasoning delta state =
@@ -586,6 +633,8 @@ renderEvent config event =
 renderEventUnlocked :: RenderConfig -> LoopEvent -> IO ()
 renderEventUnlocked config = \case
     TextDelta delta -> do
+        modifyRenderState config \state ->
+            (countGenerationChars delta state, ())
         commitThinkingUnlocked config
         if config.renderColor
             then do
@@ -595,7 +644,9 @@ renderEventUnlocked config = \case
                     (state{statePrintedText = True}, ())
                 Text.hPutStr config.renderStdout delta
                 hFlush config.renderStdout
-    ReasoningDelta delta ->
+    ReasoningDelta delta -> do
+        modifyRenderState config \state ->
+            (countGenerationChars delta state, ())
         appendReasoningUnlocked config delta
     ActivityUpdated activity -> do
         modifyRenderState config \state ->
@@ -627,8 +678,14 @@ renderEventUnlocked config = \case
                         , stateLiveActive = False
                         }
                     , ())
+        now <- getCurrentTime
         modifyRenderState config \state ->
-            (setRenderActivity "Retrying response…" state, ())
+            ( setRenderActivity "Retrying response…" state
+                { stateGenerationChars = 0
+                , stateStartedAt = Just now
+                }
+            , ()
+            )
         putTextLn config.renderStderr
             (roleWarn config.renderColor (glyphWarn <> message))
         startThinkingSpinnerUnlocked config
@@ -649,6 +706,9 @@ renderEventUnlocked config = \case
     -- Pre-tool prose ("I'll check…") is shown before tool lines; the final
     -- tool-free turn is the main answer.
     TurnFinished turn -> do
+        now <- getCurrentTime
+        modifyRenderState config \state ->
+            (recordRenderTurnRate now turn state, ())
         commitThinkingUnlocked config
         when config.renderColor do
             didPrint <- finalizeAssistantBuffer config turn.assistantText
@@ -860,7 +920,8 @@ paintThinkingFrame config = do
 
 paintThinkingFrameAt :: RenderConfig -> Int -> IO ()
 paintThinkingFrameAt config motionMillis = do
-    activity <- (.stateActivity) <$> readRenderState config
+    state <- readRenderState config
+    let activity = state.stateActivity
     elapsed <- thinkingElapsed config
     let glyph =
             foregroundIndicator
@@ -873,6 +934,7 @@ paintThinkingFrameAt config motionMillis = do
                 glyph
                 activity
                 elapsed
+                (renderTokensPerSecond state elapsed)
     void $ tryIO do
         Text.hPutStr config.renderStderr ("\r\ESC[K" <> line)
         hFlush config.renderStderr
@@ -978,11 +1040,15 @@ wrapOne width line
             go rest (acc <> " " <> word)
         | otherwise = acc : go (word : rest) ""
 
--- | One-line live status: spinner, current activity, elapsed time.
-formatActivityLine :: Bool -> Text -> Text -> Double -> Text
-formatActivityLine color glyph activity seconds =
+-- | One-line live status: spinner, current activity, elapsed time, tok/s.
+formatActivityLine :: Bool -> Text -> Text -> Double -> Maybe Double -> Text
+formatActivityLine color glyph activity seconds rate =
     roleThinking color (glyph <> " " <> activity)
-        <> roleMuted color ("  " <> formatElapsed seconds)
+        <> roleMuted color ("  " <> formatElapsed seconds <> rateSuffix)
+  where
+    rateSuffix = case rate of
+        Just value -> " · " <> formatTokensPerSecond value
+        Nothing -> ""
 
 -- | Compact elapsed time: @0.4s@, @12.4s@, @1m20s@.
 formatElapsed :: Double -> Text

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -16,6 +16,8 @@ module Agent.CLI.Runtime
     , formatRepositoryPath
     , formatStartupTimings
     , formatTokenUsage
+    , formatTokensPerSecond
+    , formatUsageWithRate
     , learnAboutUserOnboardingPrompt
     , run
     , withRestoredCurrentDirectory

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -16,6 +16,8 @@ module Agent.CLI.Runtime.Internal
     , formatRepositoryPath
     , formatStartupTimings
     , formatTokenUsage
+    , formatTokensPerSecond
+    , formatUsageWithRate
     , learnAboutUserOnboardingPrompt
     , run
     , withRestoredCurrentDirectory
@@ -59,6 +61,8 @@ import Agent.CLI.Status
     , cycleReplInteraction
     , formatReplStatusLine
     , formatTokenUsage
+    , formatTokensPerSecond
+    , formatUsageWithRate
     )
 import Agent.CLI.Terminal ( resolveColor )
 import Agent.CLI.Worktree ( isUnderWorktreeRoot, worktreeRoot )

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -53,7 +53,10 @@ import Agent.CLI.ProviderAvailability ()
 import Agent.CLI.ProviderFallback ()
 import Agent.CLI.ProviderTransition ( PendingTurn, TurnResult )
 import Agent.CLI.Recap ()
-import Agent.CLI.Render ( RenderConfig(renderLock) )
+import Agent.CLI.Render
+    ( RenderConfig(..)
+    , stateLastTokensPerSecond
+    )
 import Agent.CLI.ReplMode
     ( replModeFromState, ReplMode(ReplModeAlwaysApprove) )
 import Agent.CLI.Request ()
@@ -314,12 +317,14 @@ replWithDraft env@SessionEnv
                     when (not (Text.null panel)) (Text.putStrLn panel)
             -- Status sits on the line above λ in minimal mode.
             withSynchronizedOutput terminal stdout do
+                tokenRate <- stateLastTokensPerSecond <$> readIORef render.renderState
                 Text.putStrLn $ formatReplStatusLine stdoutColor termCols
                     (currentModel params)
                     (currentEffort params)
                     idleMode
                     account
                     usage
+                    tokenRate
                 hFlush stdout
             let modeTag
                     | planActive = roleWarn stdoutColor "[plan] "

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -123,7 +123,7 @@ import Agent.Error ()
 import Agent.GrokBuild.Dialect.Goal ()
 import Agent.GrokBuild.Dialect.Runtime ()
 import Agent.GrokBuild.Dialect.Workflow ()
-import Agent.Loop ()
+import Agent.Loop ( emptyTokenUsage )
 import Agent.OpenAI.Compaction ()
 import Agent.OpenAI.Usage ( fetchUsage )
 import Agent.OpenAI.WebSocketClient ()
@@ -317,7 +317,11 @@ replWithDraft env@SessionEnv
                     when (not (Text.null panel)) (Text.putStrLn panel)
             -- Status sits on the line above λ in minimal mode.
             withSynchronizedOutput terminal stdout do
-                tokenRate <- stateLastTokensPerSecond <$> readIORef render.renderState
+                savedRate <-
+                    stateLastTokensPerSecond <$> readIORef render.renderState
+                let tokenRate
+                        | usage == emptyTokenUsage = Nothing
+                        | otherwise = savedRate
                 Text.putStrLn $ formatReplStatusLine stdoutColor termCols
                     (currentModel params)
                     (currentEffort params)

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -81,8 +81,10 @@ import Agent.CLI.Render
     ( RenderConfig(..)
     , RenderState(..)
     , beginRenderTurn
+    , countGenerationChars
     , emptyRenderState
     , putTextLn
+    , recordRenderTurnRate
     , renderEvent
     )
 import Agent.CLI.Session
@@ -711,17 +713,25 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             case fullscreen of
                 Nothing -> renderEvent render event
                 Just runtime -> do
-                    case event of
-                        TurnStarted -> do
-                            now <- getCurrentTime
-                            modifyIORef' renderStateRef (beginRenderTurn now)
-                        TextDelta _ ->
-                            modifyIORef' renderStateRef
-                                (\state -> state{statePrintedText = True})
-                        ToolStarted _ ->
-                            modifyIORef' renderStateRef
-                                (\state -> state{stateActivity = "Running tool…"})
-                        _ -> pure ()
+                    now <- getCurrentTime
+                    modifyIORef' renderStateRef \state ->
+                        case event of
+                            TurnStarted -> beginRenderTurn now state
+                            TextDelta delta ->
+                                countGenerationChars delta
+                                    state{statePrintedText = True}
+                            ReasoningDelta delta ->
+                                countGenerationChars delta state
+                            ResponseRestarted _ ->
+                                state
+                                    { stateGenerationChars = 0
+                                    , stateStartedAt = Just now
+                                    }
+                            ToolStarted _ ->
+                                state{stateActivity = "Running tool…"}
+                            TurnFinished turn ->
+                                recordRenderTurnRate now turn state
+                            _ -> state
                     emitUiEvent runtime (UiLoop event)
         shellToolAllowed call = do
             ghciEnabled <- readIORef ghciEnabledRef

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -81,11 +81,13 @@ import Agent.CLI.Render
     ( RenderConfig(..)
     , RenderState(..)
     , beginRenderTurn
+    , clearRenderTokenRate
     , countGenerationChars
     , emptyRenderState
     , putTextLn
     , recordRenderTurnRate
     , renderEvent
+    , resetRenderGeneration
     )
 import Agent.CLI.Session
 import Agent.CLI.Session.History
@@ -600,6 +602,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 conversationRef
                 planMode
             writeIORef usageRef emptyTokenUsage
+            modifyIORef' renderStateRef clearRenderTokenRate
             writeIORef lastAssistantRef Nothing
             writeIORef pendingNotices []
             writeIORef subagentSessions Map.empty
@@ -723,10 +726,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                             ReasoningDelta delta ->
                                 countGenerationChars delta state
                             ResponseRestarted _ ->
-                                state
-                                    { stateGenerationChars = 0
-                                    , stateStartedAt = Just now
-                                    }
+                                resetRenderGeneration now state
                             ToolStarted _ ->
                                 state{stateActivity = "Running tool…"}
                             TurnFinished turn ->

--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -4,6 +4,8 @@ module Agent.CLI.Status
     , cycleReplInteraction
     , formatReplStatusLine
     , formatTokenUsage
+    , formatTokensPerSecond
+    , formatUsageWithRate
     ) where
 
 import Agent.CLI.Input (terminalTextWidth, truncateDisplayText)
@@ -29,7 +31,8 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 
 -- | Idle prompt chrome: model, reasoning effort, interaction mode, and active
--- account on the left; session token totals right-aligned when possible.
+-- account on the left; session token totals and last tok/s right-aligned
+-- when possible.
 formatReplStatusLine
     :: Bool
     -> Maybe Int
@@ -38,12 +41,13 @@ formatReplStatusLine
     -> ReplMode
     -> Text
     -> TokenUsage
+    -> Maybe Double
     -> Text
-formatReplStatusLine color width model effort mode account usage =
+formatReplStatusLine color width model effort mode account usage rate =
     let left =
             "  " <> Text.intercalate " · " (filter (not . Text.null)
                 [model, effort, replModeLabel mode, account])
-        right = formatTokenUsage usage
+        right = formatUsageWithRate usage rate
         padded = case width of
             Just cols | cols > 0 ->
                 fitStatusLine cols left right
@@ -108,6 +112,27 @@ formatTokenUsage usage
         | usage.cachedTokens > 0 =
             " · " <> formatTokenCount usage.cachedTokens <> " cached"
         | otherwise = ""
+
+-- | Session totals plus a generation rate: @1.2k in · 340 out · 42 tok/s@.
+formatUsageWithRate :: TokenUsage -> Maybe Double -> Text
+formatUsageWithRate usage rate =
+    Text.intercalate " · " $
+        filter (not . Text.null)
+            [ formatTokenUsage usage
+            , maybe "" formatTokensPerSecond rate
+            ]
+
+-- | Compact generation speed: @4.2 tok/s@, @42 tok/s@, @1.2k tok/s@.
+formatTokensPerSecond :: Double -> Text
+formatTokensPerSecond rate
+    | rate < 0.05 = "<0.1 tok/s"
+    | rate < 9.95 =
+        let tenths = round (rate * 10) :: Int
+            whole = tenths `div` 10
+            frac = tenths `mod` 10
+        in Text.pack (show whole <> "." <> show frac <> " tok/s")
+    | otherwise =
+        formatTokenCount (round rate) <> " tok/s"
 
 formatTokenCount :: Int -> Text
 formatTokenCount n

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
@@ -54,7 +54,7 @@ import Agent.CLI.Resume
       groupResumeEntries,
       resumeRelativeAge )
 import Agent.CLI.Secret ()
-import Agent.CLI.Status ( formatTokenUsage )
+import Agent.CLI.Status ( formatTokensPerSecond, formatUsageWithRate )
 import Agent.CLI.Style ( motionGlyphSet )
 import Agent.CLI.TUI.History
     ( HistoryWindow(historyWindowTurns, historyWindowTotalTurns,
@@ -132,7 +132,8 @@ import Agent.TUI.Model
       UiState(uiBlocks, uiAwaitingInput, uiActivity,
               uiCompletionRemainingMillis, uiRunning, uiElapsedMillis, uiFocus,
               uiSelectedBlock, uiPermission, uiFollow, uiRetryCountdown,
-              uiNotice, uiBranch, uiCwd, uiPrompt) )
+              uiNotice, uiBranch, uiCwd, uiPrompt),
+      uiTokensPerSecond )
 import Agent.TUI.Motion
     ( backgroundIndicator,
       foregroundIndicator,
@@ -931,7 +932,10 @@ repositoryHeaderText branch cwd =
 drawHeaderRight :: AppState -> Widget Name
 drawHeaderRight state =
     withAttr Theme.mutedAttr $
-        terminalTxt (formatTokenUsage state.appUi.uiPrompt.promptUsage)
+        terminalTxt
+            (formatUsageWithRate
+                state.appUi.uiPrompt.promptUsage
+                (uiTokensPerSecond state.appUi))
 
 drawLiveTodos :: UiState -> Widget Name
 drawLiveTodos ui =
@@ -1029,10 +1033,14 @@ drawPromptActivity state
     elapsed =
         " · "
             <> formatElapsed (fromIntegral ui.uiElapsedMillis / 1000)
-    right =
-        if ui.uiRunning
-            then formatTokenUsage ui.uiPrompt.promptUsage
-            else ""
+    right
+        | ui.uiRunning =
+            formatUsageWithRate
+                ui.uiPrompt.promptUsage
+                (uiTokensPerSecond ui)
+        | ui.uiCompletionRemainingMillis > 0 =
+            maybe "" formatTokensPerSecond (uiTokensPerSecond ui)
+        | otherwise = ""
 
 drawTranscript :: AppState -> Widget Name
 drawTranscript state =

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -44,6 +44,7 @@ import Agent.CLI.Render
     , renderAssistantText
     , renderPrintedText
     , resetRenderPrintedText
+    , stateLastTokensPerSecond
     , stateStartedAt
     )
 import Agent.CLI.Session
@@ -75,7 +76,7 @@ import Agent.CLI.SessionTitle
     , takeSessionTitleResults
     , titleRefreshIndex
     )
-import Agent.CLI.Status (formatTokenUsage)
+import Agent.CLI.Status (formatUsageWithRate)
 import Agent.CLI.Style
     ( cliWindowTitle
     , glyphSession
@@ -484,9 +485,12 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                         assistantText))
             do
                 model <- readIORef render.renderModelRef
+                tokenRate <-
+                    stateLastTokensPerSecond <$> readIORef render.renderState
                 let turns = Text.pack (show loopResult.turnsUsed)
                     unit = if loopResult.turnsUsed == 1 then " turn" else " turns"
-                    usageDetail = formatTokenUsage loopResult.tokenUsage
+                    usageDetail =
+                        formatUsageWithRate loopResult.tokenUsage tokenRate
                     extra =
                         if Text.null usageDetail
                             then model <> " · " <> turns <> unit

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -85,6 +85,45 @@ spec = do
                     recordRenderTurnRate (addUTCTime 2 startedAt) turn started
             stateLastTokensPerSecond recorded `shouldBe` Just 40
 
+        it "keeps the turn timer when a generation restarts" do
+            let startedAt = UTCTime (fromGregorian 2026 1 2) 0
+                started = beginRenderTurn startedAt $
+                    emptyRenderState
+                        { stateGenerationChars = 16
+                        , stateLastTokensPerSecond = Just 12
+                        }
+                restartedAt = addUTCTime 3 startedAt
+                restarted = resetRenderGeneration restartedAt started
+                turn =
+                    (emptyTurnOutput "r1" [] (Just "hi"))
+                        { tokenUsage =
+                            TokenUsage
+                                { inputTokens = 10
+                                , outputTokens = 80
+                                , cachedTokens = 0
+                                }
+                        }
+                recorded =
+                    recordRenderTurnRate (addUTCTime 2 restartedAt) turn restarted
+            stateStartedAt restarted `shouldBe` stateStartedAt started
+            restarted.stateGenerationChars `shouldBe` 0
+            restarted.stateGenerationStartedAt `shouldBe` Just restartedAt
+            stateLastTokensPerSecond recorded `shouldBe` Just 40
+
+        it "drops a previous conversation's saved rate" do
+            let started =
+                    beginRenderTurn
+                        (UTCTime (fromGregorian 2026 1 2) 0)
+                        emptyRenderState
+                            { stateLastTokensPerSecond = Just 42
+                            , stateGenerationChars = 16
+                            }
+                cleared = clearRenderTokenRate started
+            stateLastTokensPerSecond cleared `shouldBe` Nothing
+            cleared.stateGenerationChars `shouldBe` 0
+            cleared.stateGenerationStartedAt `shouldBe` Nothing
+            stateStartedAt cleared `shouldBe` stateStartedAt started
+
         it "streams markdown through a pure state transition" do
             let (state1, first) = streamMarkdown "hello\n" emptyRenderState
                 (state2, second) = streamMarkdown "world\n" state1

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -23,7 +23,7 @@ import Agent.TextBuffer
     , textBufferToText
     )
 import Agent.TUI.Motion (MotionMode(..), foregroundIndicator)
-import Control.Concurrent (forkIO)
+import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, takeMVar)
 import Control.Exception (finally)
 import Control.Monad (forM_)
@@ -31,7 +31,8 @@ import Data.IORef (newIORef, readIORef)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (UTCTime(..), addUTCTime)
+import Data.Maybe (fromMaybe)
+import Data.Time.Clock (UTCTime(..), addUTCTime, diffUTCTime, getCurrentTime)
 import System.Directory (getTemporaryDirectory, removeFile)
 import System.IO (BufferMode(..), Handle, hClose, hSetBuffering, openTempFile)
 import Test.Hspec
@@ -123,6 +124,21 @@ spec = do
             cleared.stateGenerationChars `shouldBe` 0
             cleared.stateGenerationStartedAt `shouldBe` Nothing
             stateStartedAt cleared `shouldBe` stateStartedAt started
+
+        it "keeps spinner elapsed time across ResponseRestarted" do
+            withRenderConfig True False \config _handle _path -> do
+                renderEvent config TurnStarted
+                before <- readIORef config.renderState
+                threadDelay 1_100_000
+                renderEvent config (ResponseRestarted "retry")
+                after <- readIORef config.renderState
+                now <- getCurrentTime
+                let started = fromMaybe now after.stateStartedAt
+                    elapsed = realToFrac (diffUTCTime now started) :: Double
+                stateStartedAt after `shouldBe` stateStartedAt before
+                after.stateGenerationStartedAt
+                    `shouldNotBe` after.stateStartedAt
+                elapsed `shouldSatisfy` (>= 1.0)
 
         it "streams markdown through a pure state transition" do
             let (state1, first) = streamMarkdown "hello\n" emptyRenderState

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -10,6 +10,7 @@ import Agent.Loop
     , TurnCompletion(..)
     , TurnOutput(..)
     , emptyTokenUsage
+    , emptyTurnOutput
     )
 import Agent.ToolDispatch
     ( ToolCallKind(..)
@@ -59,6 +60,30 @@ spec = do
                         visible
             stateThinkingVisible started `shouldBe` True
             statePrintedText started `shouldBe` False
+
+        it "preserves last tok/s across a new generation" do
+            let started =
+                    beginRenderTurn
+                        (UTCTime (fromGregorian 2026 1 2) 0)
+                        emptyRenderState
+                            { stateLastTokensPerSecond = Just 42 }
+            stateLastTokensPerSecond started `shouldBe` Just 42
+
+        it "records provider output tokens per second" do
+            let startedAt = UTCTime (fromGregorian 2026 1 2) 0
+                started = beginRenderTurn startedAt emptyRenderState
+                turn =
+                    (emptyTurnOutput "r1" [] (Just "hi"))
+                        { tokenUsage =
+                            TokenUsage
+                                { inputTokens = 10
+                                , outputTokens = 80
+                                , cachedTokens = 0
+                                }
+                        }
+                recorded =
+                    recordRenderTurnRate (addUTCTime 2 startedAt) turn started
+            stateLastTokensPerSecond recorded `shouldBe` Just 40
 
         it "streams markdown through a pure state transition" do
             let (state1, first) = streamMarkdown "hello\n" emptyRenderState
@@ -157,8 +182,10 @@ spec = do
 
     describe "formatActivityLine" do
         it "joins spinner, activity, and elapsed" do
-            formatActivityLine False "⠋" "Thinking…" 1.2
+            formatActivityLine False "⠋" "Thinking…" 1.2 Nothing
                 `shouldBe` "⠋ Thinking…  1.2s"
+            formatActivityLine False "⠋" "Writing…" 1.2 (Just 42)
+                `shouldBe` "⠋ Writing…  1.2s · 42 tok/s"
 
     describe "formatToolStarted" do
         it "renders English verbs for known tools" do

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -15,6 +15,8 @@ import Agent.CLI
     , formatRepositoryPath
     , formatStartupTimings
     , formatTokenUsage
+    , formatTokensPerSecond
+    , formatUsageWithRate
     , withRestoredCurrentDirectory
     )
 import Agent.CLI.Command (setModel, setReasoningEffort)
@@ -191,39 +193,49 @@ spec = do
     describe "formatReplStatusLine" do
         it "shows model, effort, interaction mode, and active account" do
             formatReplStatusLine False Nothing "grok-4.6" "high"
-                ReplModeNormal "person@example.com" emptyTokenUsage
+                ReplModeNormal "person@example.com" emptyTokenUsage Nothing
                 `shouldBe` "  grok-4.6 · high · ask · person@example.com"
             formatReplStatusLine False Nothing "gpt-5.1-codex" "medium"
-                ReplModeAlwaysApprove "" emptyTokenUsage
+                ReplModeAlwaysApprove "" emptyTokenUsage Nothing
                 `shouldBe` "  gpt-5.1-codex · medium · yolo"
             formatReplStatusLine False Nothing "gpt-5.1" "low"
-                ReplModePlan "" emptyTokenUsage
+                ReplModePlan "" emptyTokenUsage Nothing
                 `shouldBe` "  gpt-5.1 · low · plan"
 
         it "appends session usage when no width is known" do
             formatReplStatusLine False Nothing "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
+                Nothing
                 `shouldBe` "  grok-4.6 · high · ask  1.2k in · 340 out"
+
+        it "appends last generation speed next to usage" do
+            formatReplStatusLine False Nothing "grok-4.6" "high" ReplModeNormal ""
+                TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
+                (Just 42)
+                `shouldBe` "  grok-4.6 · high · ask  1.2k in · 340 out · 42 tok/s"
 
         it "right-aligns session usage when the TTY is wide enough" do
             formatReplStatusLine False (Just 48) "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
+                Nothing
                 `shouldBe` "  grok-4.6 · high · ask        1.2k in · 340 out"
 
         it "drops usage rather than wrapping when only the state fits" do
             formatReplStatusLine False (Just 24) "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
+                Nothing
                 `shouldBe` "  grok-4.6 · high · ask"
 
         it "truncates the state when a narrow pane cannot fit it" do
             formatReplStatusLine False (Just 20) "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
+                Nothing
                 `shouldBe` "  grok-4.6 · high ·…"
 
         it "measures and truncates wide model names in terminal columns" do
             let line =
                     formatReplStatusLine False (Just 16) "模型模型" "high"
-                        ReplModeNormal "" emptyTokenUsage
+                        ReplModeNormal "" emptyTokenUsage Nothing
             terminalTextWidth line `shouldBe` 16
             line `shouldBe` "  模型模型 · hi…"
 
@@ -363,6 +375,25 @@ spec = do
                 , outputTokens = 1500000
                 , cachedTokens = 0
                 } `shouldBe` "13k in · 1.5M out"
+
+    describe "formatTokensPerSecond" do
+        it "uses one decimal below 10 and compact counts above" do
+            formatTokensPerSecond 0.04 `shouldBe` "<0.1 tok/s"
+            formatTokensPerSecond 4.2 `shouldBe` "4.2 tok/s"
+            formatTokensPerSecond 42 `shouldBe` "42 tok/s"
+            formatTokensPerSecond 12500 `shouldBe` "13k tok/s"
+
+        it "joins usage and rate" do
+            formatUsageWithRate emptyTokenUsage (Just 42)
+                `shouldBe` "42 tok/s"
+            formatUsageWithRate
+                TokenUsage
+                    { inputTokens = 1200
+                    , outputTokens = 340
+                    , cachedTokens = 0
+                    }
+                (Just 42)
+                `shouldBe` "1.2k in · 340 out · 42 tok/s"
 
 withTempDir :: String -> (FilePath -> IO a) -> IO a
 withTempDir prefix action = do

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -27,7 +27,12 @@ module Agent.Loop
     , defaultLoopDispatch
     , emptyTokenUsage
     , emptyTurnOutput
+    , estimateTokensFromChars
+    , generationTokensPerSecond
+    , liveTokenRateMinMillis
+    , liveTokensPerSecond
     , runLoop
+    , tokensPerSecond
     , runLoopInputs
     , runLoopInputsDetailed
     ) where
@@ -189,6 +194,38 @@ addTokenUsage a b = TokenUsage
     , outputTokens = a.outputTokens + b.outputTokens
     , cachedTokens = a.cachedTokens + b.cachedTokens
     }
+
+-- | Rough streamed-text estimate: about four Unicode scalars per token.
+estimateTokensFromChars :: Int -> Int
+estimateTokensFromChars chars = (max 0 chars + 3) `div` 4
+
+-- | Output tokens per second from a token count and elapsed milliseconds.
+tokensPerSecond :: Int -> Int -> Maybe Double
+tokensPerSecond tokens millis
+    | tokens <= 0 = Nothing
+    | millis <= 0 = Nothing
+    | otherwise =
+        Just (fromIntegral tokens * 1000 / fromIntegral millis)
+
+-- | Prefer provider-reported output tokens; fall back to the streamed-text
+-- estimate when usage is missing.
+generationTokensPerSecond :: Int -> Int -> Int -> Maybe Double
+generationTokensPerSecond reportedOutput chars millis =
+    tokensPerSecond
+        ( if reportedOutput > 0
+            then reportedOutput
+            else estimateTokensFromChars chars
+        )
+        millis
+
+-- | Live tok/s is noisy on the first few hundred milliseconds of a stream.
+liveTokenRateMinMillis :: Int
+liveTokenRateMinMillis = 400
+
+liveTokensPerSecond :: Int -> Int -> Maybe Double
+liveTokensPerSecond chars millis
+    | millis < liveTokenRateMinMillis = Nothing
+    | otherwise = tokensPerSecond (estimateTokensFromChars chars) millis
 
 data TurnOutput = TurnOutput
     { responseId :: !Text

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -69,6 +69,21 @@ spec = describe "runLoop" do
         (mempty <> usage, usage <> mempty)
             `shouldBe` (usage, usage)
 
+    it "estimates tokens from streamed characters and reports tokens/sec" do
+        estimateTokensFromChars 0 `shouldBe` 0
+        estimateTokensFromChars 1 `shouldBe` 1
+        estimateTokensFromChars 4 `shouldBe` 1
+        estimateTokensFromChars 16 `shouldBe` 4
+        tokensPerSecond 0 1000 `shouldBe` Nothing
+        tokensPerSecond 100 0 `shouldBe` Nothing
+        tokensPerSecond 100 1000 `shouldBe` Just 100
+        tokensPerSecond 40 2000 `shouldBe` Just 20
+        generationTokensPerSecond 80 16 1000 `shouldBe` Just 80
+        generationTokensPerSecond 0 16 1000 `shouldBe` Just 4
+        liveTokensPerSecond 16 (liveTokenRateMinMillis - 1) `shouldBe` Nothing
+        liveTokensPerSecond 16 liveTokenRateMinMillis
+            `shouldBe` tokensPerSecond 4 liveTokenRateMinMillis
+
     it "threads previous_response_id and sends only CompletedTool on the follow-up" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -488,6 +488,10 @@ reduceUi event state = case event of
             , uiToolCalls = Map.empty
             , uiRetryCountdown = Nothing
             , uiTodos = []
+            , uiGenerating = False
+            , uiGenerationChars = 0
+            , uiGenerationMillis = 0
+            , uiLastTokensPerSecond = Nothing
             }
     UiSetFollow follow ->
         state

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -33,6 +33,7 @@ module Agent.TUI.Model
     , visibleTodoList
     , uiNextDeadlineMillis
     , uiNeedsTick
+    , uiTokensPerSecond
     , warningNotice
     , advanceUiTime
     ) where
@@ -54,15 +55,18 @@ import Agent.TUI.Motion
     )
 import Agent.Loop
     ( LoopEvent(..)
-    , TokenUsage
+    , TokenUsage(..)
     , TurnOutput(..)
     , emptyTokenUsage
+    , generationTokensPerSecond
+    , liveTokensPerSecond
     )
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallResult(..)
     , canonicalToolName
     )
+import Control.Applicative ((<|>))
 import qualified Data.Foldable as Foldable
 import qualified Data.Map.Strict as Map
 import Data.Maybe (listToMaybe)
@@ -193,6 +197,10 @@ data UiState = UiState
     , uiAttemptStartBlock :: !Int
     , uiToolCalls :: !(Map.Map Text (Int, ToolCall))
     , uiTodos :: ![TodoDisplayLine]
+    , uiGenerating :: !Bool
+    , uiGenerationChars :: !Int
+    , uiGenerationMillis :: !Int
+    , uiLastTokensPerSecond :: !(Maybe Double)
     }
     deriving (Eq, Show)
 
@@ -272,6 +280,10 @@ initialUiState = UiState
     , uiAttemptStartBlock = 0
     , uiToolCalls = Map.empty
     , uiTodos = []
+    , uiGenerating = False
+    , uiGenerationChars = 0
+    , uiGenerationMillis = 0
+    , uiLastTokensPerSecond = Nothing
     }
 
 -- | Checklist shown above the prompt during a turn, or while an item is still
@@ -368,6 +380,8 @@ reduceUi event state = case event of
         (if awaiting then finalizeStreams state else state)
             { uiAwaitingInput = awaiting
             , uiRunning = if awaiting then False else state.uiRunning
+            , uiGenerating =
+                if awaiting then False else state.uiGenerating
             , uiActivity =
                 if awaiting && state.uiCompletionRemainingMillis == 0
                     then "Ready"
@@ -507,6 +521,7 @@ reduceUi event state = case event of
             , uiBlockIndices =
                 Map.filter (< Seq.length blocks) state.uiBlockIndices
             , uiRunning = False
+            , uiGenerating = False
             , uiActivity = "Restarting…"
             , uiNotice =
                 Just (progressNotice "Restarting current turn…")
@@ -542,6 +557,10 @@ advanceUiTime rawElapsedMillis state =
             if state.uiRunning
                 then state.uiElapsedMillis + elapsedMillis
                 else state.uiElapsedMillis
+        , uiGenerationMillis =
+            if state.uiGenerating
+                then state.uiGenerationMillis + elapsedMillis
+                else state.uiGenerationMillis
         , uiActivity =
             if state.uiCompletionRemainingMillis > 0
                 && completionRemainingMillis == 0
@@ -551,6 +570,44 @@ advanceUiTime rawElapsedMillis state =
         , uiNotice = notice
         , uiNoticeElapsedMillis =
             if notice == Nothing then 0 else noticeElapsedMillis
+        }
+
+-- | Live generation speed while the model is streaming; otherwise the last
+-- completed model response.
+uiTokensPerSecond :: UiState -> Maybe Double
+uiTokensPerSecond state
+    | state.uiGenerating =
+        liveTokensPerSecond
+            state.uiGenerationChars
+            state.uiGenerationMillis
+            <|> state.uiLastTokensPerSecond
+    | otherwise = state.uiLastTokensPerSecond
+
+resetGeneration :: UiState -> UiState
+resetGeneration state =
+    state
+        { uiGenerating = True
+        , uiGenerationChars = 0
+        , uiGenerationMillis = 0
+        }
+
+appendGenerationChars :: Text -> UiState -> UiState
+appendGenerationChars delta state =
+    state
+        { uiGenerationChars =
+            state.uiGenerationChars + Text.length delta
+        }
+
+snapshotGenerationRate :: TokenUsage -> UiState -> UiState
+snapshotGenerationRate usage state =
+    state
+        { uiGenerating = False
+        , uiLastTokensPerSecond =
+            generationTokensPerSecond
+                usage.outputTokens
+                state.uiGenerationChars
+                state.uiGenerationMillis
+                <|> state.uiLastTokensPerSecond
         }
 
 uiNeedsTick :: UiState -> Bool
@@ -665,24 +722,31 @@ millisecondsUntilNextDisplayedSecond remainingMillis =
 reduceLoop :: LoopEvent -> UiState -> UiState
 reduceLoop event state = case event of
     TurnStarted ->
-        state
-            { uiRunning = True
-            , uiAwaitingInput = False
-            , uiActivity = "Thinking…"
-            , uiNotice = Nothing
-            , uiNoticeElapsedMillis = 0
-            , uiElapsedMillis = 0
-            , uiCompletionRemainingMillis = 0
-            , uiTurnStartBlock = Seq.length state.uiBlocks
-            , uiAttemptStartBlock = Seq.length state.uiBlocks
-            , uiToolCalls = Map.empty
-            }
+        resetGeneration
+            state
+                { uiRunning = True
+                , uiAwaitingInput = False
+                , uiActivity = "Thinking…"
+                , uiNotice = Nothing
+                , uiNoticeElapsedMillis = 0
+                , uiElapsedMillis = 0
+                , uiCompletionRemainingMillis = 0
+                , uiTurnStartBlock = Seq.length state.uiBlocks
+                , uiAttemptStartBlock = Seq.length state.uiBlocks
+                , uiToolCalls = Map.empty
+                }
     ReasoningDelta delta ->
-        appendOrExtend BlockThinking "Thought" delta BlockStreaming state
-            { uiActivity = "Thinking…" }
+        appendOrExtend BlockThinking "Thought" delta BlockStreaming $
+            appendGenerationChars delta state
+                { uiActivity = "Thinking…"
+                , uiGenerating = True
+                }
     TextDelta delta ->
-        appendOrExtend BlockAssistant "Assistant" delta BlockStreaming state
-            { uiActivity = "Writing…" }
+        appendOrExtend BlockAssistant "Assistant" delta BlockStreaming $
+            appendGenerationChars delta state
+                { uiActivity = "Writing…"
+                , uiGenerating = True
+                }
     ActivityUpdated activity ->
         state { uiActivity = activity }
     WarningRaised warning ->
@@ -692,17 +756,19 @@ reduceLoop event state = case event of
             }
     ResponseRestarted message ->
         let finalized = finalizeStreams state
-        in finalized
-            { uiRunning = True
-            , uiActivity = "Retrying response…"
-            , uiNotice = Just (warningNotice message)
-            , uiNoticeElapsedMillis = 0
-            , uiAttemptStartBlock = Seq.length finalized.uiBlocks
-            }
+        in resetGeneration
+            finalized
+                { uiRunning = True
+                , uiActivity = "Retrying response…"
+                , uiNotice = Just (warningNotice message)
+                , uiNoticeElapsedMillis = 0
+                , uiAttemptStartBlock = Seq.length finalized.uiBlocks
+                }
     ToolStarted call
         | isTodoTool call.name ->
             state
                 { uiRunning = True
+                , uiGenerating = False
                 , uiAwaitingInput = False
                 , uiActivity = toolCallTitle call
                 , uiToolCalls =
@@ -725,6 +791,7 @@ reduceLoop event state = case event of
                 BlockRunning (Just call.callId)
                 state
                     { uiRunning = True
+                    , uiGenerating = False
                     , uiAwaitingInput = False
                     , uiActivity = title
                     , uiToolCalls =
@@ -777,7 +844,7 @@ reduceLoop event state = case event of
                         appendBlock BlockAssistant "Assistant" text ""
                             BlockComplete Nothing finalized
                 _ -> finalized
-        in withFallback
+        in snapshotGenerationRate output.tokenUsage withFallback
             { uiRunning = continuing
             , uiActivity =
                 if continuing
@@ -953,6 +1020,13 @@ finalizeTurn terminalState state =
                         else block)
                 state.uiBlocks
         , uiRunning = False
+        , uiGenerating = False
+        , uiLastTokensPerSecond =
+            state.uiLastTokensPerSecond
+                <|> generationTokensPerSecond
+                    0
+                    state.uiGenerationChars
+                    state.uiGenerationMillis
         , uiActivity =
             if terminalState == BlockComplete
                 then "Finished"

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -642,6 +642,47 @@ spec = describe "fullscreen UI reducer" do
         uiTokensPerSecond afterNext `shouldBe` Just 200
         afterNext.uiGenerationMillis `shouldBe` 0
 
+    it "keeps turn elapsed time when a response restarts" do
+        let streaming =
+                advanceUiTime 800 $
+                    apply
+                        [ UiLoop TurnStarted
+                        , UiLoop (TextDelta "abcdefghijklmnop")
+                        ]
+            restarted =
+                reduceUi (UiLoop (ResponseRestarted "retrying")) streaming
+        streaming.uiElapsedMillis `shouldBe` 800
+        restarted.uiElapsedMillis `shouldBe` 800
+        restarted.uiGenerationMillis `shouldBe` 0
+        restarted.uiGenerationChars `shouldBe` 0
+        restarted.uiGenerating `shouldBe` True
+        restarted.uiActivity `shouldBe` "Retrying response…"
+
+    it "drops last tok/s when the conversation is cleared" do
+        let finished =
+                reduceUi
+                    (UiLoop
+                        (TurnFinished
+                            ((emptyTurnOutput "r1" [] (Just "abcdefghijklmnop"))
+                                { tokenUsage =
+                                    TokenUsage
+                                        { inputTokens = 20
+                                        , outputTokens = 80
+                                        , cachedTokens = 0
+                                        }
+                                })))
+                    (advanceUiTime liveTokenRateMinMillis $
+                        apply
+                            [ UiLoop TurnStarted
+                            , UiLoop (TextDelta "abcdefghijklmnop")
+                            ])
+            cleared = reduceUi UiConversationCleared finished
+        uiTokensPerSecond finished `shouldBe` Just 200
+        uiTokensPerSecond cleared `shouldBe` Nothing
+        cleared.uiLastTokensPerSecond `shouldBe` Nothing
+        cleared.uiGenerationChars `shouldBe` 0
+        cleared.uiGenerating `shouldBe` False
+
     it "briefly settles on Finished before returning to Ready" do
         let finished =
                 apply

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -7,7 +7,10 @@ import Agent.TUI.Presentation
     )
 import Agent.Loop
     ( LoopEvent(..)
+    , TokenUsage(..)
+    , TurnOutput(..)
     , emptyTurnOutput
+    , liveTokenRateMinMillis
     )
 import Agent.ToolDispatch
     ( ToolCallResult(..)
@@ -600,6 +603,44 @@ spec = describe "fullscreen UI reducer" do
         nonEmptyIdle.uiElapsedMillis `shouldBe` 0
         running.uiElapsedMillis `shouldBe` 200
         after.uiElapsedMillis `shouldBe` 200
+
+    it "reports live and completed tokens per second" do
+        let call = functionToolCall "c1" "read_file" "{\"target_file\":\"A.hs\"}"
+            streaming =
+                advanceUiTime liveTokenRateMinMillis $
+                    apply
+                        [ UiLoop TurnStarted
+                        , UiLoop (TextDelta "abcdefghijklmnop")
+                        ]
+            reported usage tools =
+                (emptyTurnOutput "r1" tools (Just "abcdefghijklmnop"))
+                    { tokenUsage = usage }
+            usage =
+                TokenUsage
+                    { inputTokens = 20
+                    , outputTokens = 80
+                    , cachedTokens = 0
+                    }
+            finished =
+                reduceUi
+                    (UiLoop (TurnFinished (reported usage [])))
+                    streaming
+            duringTools =
+                reduceUi (UiLoop (ToolStarted call)) $
+                    reduceUi
+                        (UiLoop (TurnFinished (reported usage [call])))
+                        streaming
+            afterNext = reduceUi (UiLoop TurnStarted) finished
+        uiTokensPerSecond streaming `shouldBe` Just 10
+        uiTokensPerSecond finished `shouldBe` Just 200
+        finished.uiGenerating `shouldBe` False
+        uiTokensPerSecond duringTools `shouldBe` Just 200
+        duringTools.uiGenerating `shouldBe` False
+        duringTools.uiGenerationMillis `shouldBe` liveTokenRateMinMillis
+        (advanceUiTime 5000 duringTools).uiGenerationMillis
+            `shouldBe` liveTokenRateMinMillis
+        uiTokensPerSecond afterNext `shouldBe` Just 200
+        afterNext.uiGenerationMillis `shouldBe` 0
 
     it "briefly settles on Finished before returning to Ready" do
         let finished =


### PR DESCRIPTION
## Summary
The harness now shows **tokens per second** next to the existing usage chrome.

- **Fullscreen header**: session usage plus live/last rate (`1.2k in · 340 out · 42 tok/s`)
- **Activity line** while a turn is running (`Thinking… · 5.0s` with `4.8 tok/s` on the right)
- **Idle REPL status** and **inline thinking spinner**
- **Finished notice** (`✓ ok · grok-4.6 · 1 turn · 14k in · 120 out · 22 tok/s`)

Live rates estimate from streamed text (~4 chars/token) after 400ms so the first frames stay quiet. When a model response finishes, the rate uses provider-reported output tokens over generation time (tool runtime is excluded). During tools and between turns the last completed generation rate stays on screen.

## Test plan
- [x] `agent-core` / `agent-tui` / `agent-cli` tok/s and format unit tests
- [x] tmux fullscreen smoke: header and activity line showed `4.8 tok/s`
- [x] `--minimal --yolo -p` finished line showed `22 tok/s`