### PR TITLE
Preserve incomplete responses for exact retry

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -27,6 +27,7 @@ import Agent.Loop
     , ImageAttachment(..)
     , LoopEvent(..)
     , TokenUsage(..)
+    , TurnCompletion(..)
     , TurnInput(..)
     , TurnOutput(..)
     )
@@ -278,6 +279,7 @@ submitClaudeCodeTurn
                 , toolCalls = []
                 , assistantText = completed.assistantText
                 , tokenUsage = sdkUsageToTokenUsage usage
+                , completion = TurnCompleted
                 }
             commit =
                 commitHostTranscript

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -69,6 +69,7 @@ slashCommands =
     , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)" True
     , cmd "btw" [] "/btw <QUESTION>" "Ask a side question without changing the conversation" True
     , cmd "recap" ["summarize"] "/recap" "Summarize the session so far" False
+    , cmd "retry" [] "/retry" "Retry the last failed turn exactly" False
     , cmd "session" [] "/session" "Print the current session id" False
     , cmd "session-info" ["status", "info"] "/session-info" "Show session details (model, tools, and context usage)" False
     , cmd "afk" [] "/afk [HOST:PATH]" "Move this session into tmux, locally or over SSH" True
@@ -256,6 +257,10 @@ parseSlash catalog raw line = case Text.words line of
                 if null args
                     then ReplRecap
                     else ReplCommandError "usage: /recap"
+            "retry" ->
+                if null args
+                    then ReplRetry
+                    else ReplCommandError "usage: /retry"
             "session" ->
                 if null args
                     then ReplShowSession

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -30,6 +30,8 @@ data ReplAction
     -- ^ Ask an isolated one-shot question over the current context.
     | ReplRecap
     -- ^ Generate a display-only "where was I" recap of the current session.
+    | ReplRetry
+    -- ^ Retry the last failed turn with its original attachments.
     | ReplShowSession
     | ReplShowSessionInfo
     | ReplAfk (Maybe Text)

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -49,7 +49,7 @@ data ProviderTransition = ProviderTransition
 data TurnResult
     = TurnSucceeded
     | TurnCancelled
-    | TurnFailed
+    | TurnFailed !PendingTurn
     | TurnRestartRequested !Text !PendingTurn
     | TurnProviderUnavailable !ApiError !PendingTurn
 

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -92,7 +92,13 @@ import Agent.CLI.Style
     , motionGlyphSet
     , style
     )
-import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..))
+import Agent.Loop
+    ( LoopError(..)
+    , LoopEvent(..)
+    , TokenUsage(..)
+    , TurnCompletion(..)
+    , TurnOutput(..)
+    )
 import Agent.TUI.Presentation
     ( SearchReplaceAction(..)
     , SearchReplaceDiff(..)
@@ -1176,6 +1182,8 @@ formatLoopErrorPersistedAt now = \case
     LoopMaxTurns turn ->
         "Stopped: maximum turns reached."
             <> maybe "" ("\n" <>) turn.assistantText
+    LoopIncomplete turn ->
+        formatIncompleteResponse turn
     LoopNoResponseId ->
         "Provider returned an incomplete response.\nRetry the message."
     LoopUnexpected message ->
@@ -1201,6 +1209,8 @@ formatLoopErrorColoredMaybeAt color maybeNow = \case
     LoopMaxTurns turn ->
         roleError color (glyphErr <> "stopped: max turns reached")
             <> maybe "" (\text -> "\n" <> text) turn.assistantText
+    LoopIncomplete turn ->
+        roleError color (glyphErr <> formatIncompleteResponse turn)
     LoopNoResponseId ->
         roleError color
             (glyphErr
@@ -1214,6 +1224,31 @@ formatLoopErrorColoredMaybeAt color maybeNow = \case
                 <> "\nRetry the message.")
     LoopCancelled _ ->
         roleMuted color (glyphCancel <> "cancelled")
+
+formatIncompleteResponse :: TurnOutput -> Text
+formatIncompleteResponse turn =
+    "Response incomplete: "
+        <> reason
+        <> "."
+        <> tokenDetails
+        <> "\nUse /retry to retry the same message and attachments."
+  where
+    (reason, reasoningTokens) = case turn.completion of
+        TurnIncomplete incompleteReason incompleteReasoningTokens ->
+            (incompleteReason, incompleteReasoningTokens)
+        TurnCompleted -> ("unknown", Nothing)
+    outputTokens = turn.tokenUsage.outputTokens
+    tokenDetails
+        | outputTokens <= 0 && reasoningTokens == Nothing = ""
+        | otherwise =
+            "\nProvider reported "
+                <> Text.pack (show outputTokens)
+                <> " output tokens"
+                <> maybe ""
+                    (\tokens ->
+                        " (" <> Text.pack (show tokens) <> " reasoning tokens)")
+                    reasoningTokens
+                <> "."
 
 formatInterruptedResponse :: Text -> Text
 formatInterruptedResponse details =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -62,7 +62,9 @@ import Agent.CLI.Runtime.Recap ()
 import Agent.CLI.Runtime.Repl.Commands
     ( handleReplLine, preparePromptSkillInputs )
 import Agent.CLI.Runtime.Types
-    ( PendingTurnPresentation, RunResult(RunSwitchProvider) )
+    ( PendingTurnPresentation
+    , RunResult(RunSwitchProvider)
+    )
 import Agent.CLI.Secret ()
 import Agent.CLI.Session ()
 import Agent.CLI.Session.Attachments ()
@@ -181,7 +183,7 @@ import qualified Agent.OpenRouter.Usage as OpenRouterUsage
     ( fetchOpenRouterUsage )
 import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle
-    ( finishTurn, runPendingTurn )
+    ( finishTurn, retryFailedTurn, runPendingTurn )
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text ( null, strip, pack )
@@ -364,6 +366,7 @@ replWithDraft env@SessionEnv
                 env
                 (replWithDraft env)
                 (finishTurn env)
+                (SessionLifecycle.retryFailedTurn sessionContinuation env)
                 slashCatalog
                 skillInvocations
                 stdoutColor

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -27,7 +27,7 @@ import Agent.CLI.Command
                  ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
                  ReplShowTerminal, ReplShowEffort, ReplSetEffort, ReplShowModel,
                  ReplSetModel, ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
-                 ReplBtw, ReplRecap, ReplResume, ReplSearch, ReplClear, ReplNew,
+                 ReplBtw, ReplRecap, ReplRetry, ReplResume, ReplSearch, ReplClear, ReplNew,
                  ReplShowSession, ReplShowSessionInfo, ReplAfk, ReplWorktree,
                  ReplRename, ReplRenameAuto, ReplLogin, ReplUsage, ReplReloadAuth,
                  ReplHelp),
@@ -74,7 +74,10 @@ import Agent.CLI.Provider.Switch
 import Agent.CLI.ProviderAvailability ()
 import Agent.CLI.ProviderFallback ()
 import Agent.CLI.ProviderTransition
-    ( ProviderTransition, TurnResult(TurnProviderUnavailable) )
+    ( PendingTurn
+    , ProviderTransition
+    , TurnResult(TurnProviderUnavailable)
+    )
 import Agent.CLI.Recap ( RecapKind(..), RecapRequest(..) )
 import Agent.CLI.Render
     ( RenderConfig(..),
@@ -197,7 +200,7 @@ import Control.Concurrent.STM ()
 import Control.Exception ( AsyncException(UserInterrupt) )
 import Control.Exception.Safe ( finally, throwIO )
 import Control.Monad ( when, forM_ )
-import Data.IORef ( newIORef, readIORef, writeIORef )
+import Data.IORef ( atomicModifyIORef', newIORef, readIORef, writeIORef )
 import Data.List ()
 import Data.Maybe ( isNothing )
 import Data.Text ( Text )
@@ -231,6 +234,7 @@ handleReplLine
     :: SessionEnv
     -> (Text -> IO RunResult)
     -> (Bool -> TurnResult -> IO RunResult)
+    -> (PendingTurn -> IO RunResult)
     -> SlashCatalog
     -> [SkillInvocation]
     -> Bool
@@ -262,6 +266,7 @@ handleReplLine
             }
         continueWith
         finishTurn
+        retryPendingTurn
         slashCatalog
         skillInvocations
         stdoutColor
@@ -639,6 +644,17 @@ handleReplLine
                             Nothing -> do
                                 runSessionRecap True env RecapManual
                                 continue
+                    ReplRetry ->
+                        atomicModifyIORef'
+                            env.sessionLastFailedTurn
+                            (\pending -> (Nothing, pending))
+                            >>= \case
+                                Just pending -> retryPendingTurn pending
+                                Nothing -> do
+                                    displayInfo
+                                        "No failed turn is available to retry."
+                                        (pure ())
+                                    continue
                     action@ReplResume{} -> handleSessionAction env slashCatalog continue action
                     action@ReplSearch{} -> handleSessionAction env slashCatalog continue action
                     action@ReplClear -> handleSessionAction env slashCatalog continue action

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Session.Lifecycle
     ( SessionContinuation(..)
     , finishTurn
+    , retryFailedTurn
     , runPendingTurn
     ) where
 
@@ -73,6 +74,28 @@ runPendingTurn
 runPendingTurn continuation presentation =
     runPendingTurnWithCooldownRetry continuation True presentation
 
+-- | Retry a failed turn from its retained input checkpoint. The original
+-- inputs are already present in the live transcript after a terminal failure;
+-- submitting them again would duplicate the user message and attachments.
+retryFailedTurn
+    :: SessionContinuation
+    -> SessionEnv
+    -> PendingTurn
+    -> IO RunResult
+retryFailedTurn continuation env pending = do
+    writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
+    syncFullscreenPrompt env
+    case env.sessionFullscreen of
+        Nothing -> pure ()
+        Just runtime -> emitUiEvent runtime UiTurnRestarted
+    writeIORef env.sessionLastFailedTurn Nothing
+    -- The failed turn already owns the persisted/displayed user prompt.
+    -- Keep the retry turn's user text empty so session history does not show
+    -- the same prompt twice.
+    result <- runOneTurn env "" []
+    finishTurnWithCooldownRetry
+        continuation True env pending.pendingExitAfter result
+
 runPendingTurnWithCooldownRetry
     :: SessionContinuation
     -> Bool
@@ -94,6 +117,7 @@ runPendingTurnWithCooldownRetry
                 emitUiEvent runtime UiTurnRestarted
             ContinuePendingTurn ->
                 pure ()
+    writeIORef env.sessionLastFailedTurn Nothing
     result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
     finishTurnWithCooldownRetry
         continuation allowCooldownRetry env pending.pendingExitAfter result
@@ -141,7 +165,9 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
         if exitAfter
             then pure RunQuit
             else continuation.resumeSession env
-    TurnFailed ->
+    TurnFailed pending -> do
+        writeIORef env.sessionLastFailedTurn
+            (Just (setPendingExitAfter exitAfter pending))
         if exitAfter
             then
                 if env.sessionBackground

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -46,7 +46,7 @@ import Agent.CLI.TUI.App
     ( emitUiEvent
     , hasQueuedFullscreenInput
     )
-import Agent.CLI.Turn (runOneTurn)
+import Agent.CLI.Turn (retryCheckpointedTurn, runOneTurn)
 import Agent.Tools.PlanMode (PlanModeEnv(..))
 import Agent.TUI.Model (UiEvent(..))
 import Control.Exception.Safe (throwIO)
@@ -92,7 +92,7 @@ retryFailedTurn continuation env pending = do
     -- The failed turn already owns the persisted/displayed user prompt.
     -- Keep the retry turn's user text empty so session history does not show
     -- the same prompt twice.
-    result <- runOneTurn env "" []
+    result <- retryCheckpointedTurn env
     finishTurnWithCooldownRetry
         continuation True env pending.pendingExitAfter result
 

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -316,6 +316,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
     unavailableProvidersRef <- newIORef unavailableProviders
     startupUnavailableRef <- newIORef startupUnavailable
     restartEffortRef <- newIORef Nothing
+    lastFailedTurnRef <- newIORef Nothing
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
     selectedAgent <- newIORef AgentRoot
     agentStepCache <- newIORef (Map.empty :: Map.Map AgentTarget AgentStepCache)
@@ -954,6 +955,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionPreviewId = previewIdRef
             , sessionInterrupt = interrupt
             , sessionRestartEffort = restartEffortRef
+            , sessionLastFailedTurn = lastFailedTurnRef
             , sessionStoreRoot = storeRoot
             , sessionUsage = usageRef
             , sessionAccount = accountRef

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -26,6 +26,7 @@ import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Responses.Types (ResponseCreateParams)
 import System.OsPath (OsPath)
 import Agent.Provider (Credential, Provider, TokenProvider)
+import Agent.CLI.ProviderTransition (PendingTurn)
 import Agent.Skills (SkillCatalog, SkillInvocation)
 import Agent.Subagents (RootTurnId)
 import Agent.Tools.PlanMode (PlanModeEnv)
@@ -76,6 +77,7 @@ data SessionEnv = SessionEnv
     , sessionPreviewId :: !(IORef Int)
     , sessionInterrupt :: !InterruptState
     , sessionRestartEffort :: !(IORef (Maybe Text))
+    , sessionLastFailedTurn :: !(IORef (Maybe PendingTurn))
     , sessionStoreRoot :: !(IORef (Maybe OsPath))
     , sessionUsage :: !(IORef TokenUsage)
     , sessionAccount :: !(IORef Text)

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -110,6 +110,7 @@ import Agent.Loop
     , LoopProgress(..)
     , LoopResult(..)
     , TurnInput(..)
+    , TurnOutput(..)
     , addTokenUsage
     , runLoopInputsDetailed
     )
@@ -157,7 +158,10 @@ import System.Process
 import System.Timeout (timeout)
 
 runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
-runOneTurn env promptText inputs =
+runOneTurn env promptText inputs = do
+    -- A newly submitted turn supersedes any older retry candidate. If this
+    -- attempt fails, finishTurn installs its own PendingTurn afterwards.
+    writeIORef env.sessionLastFailedTurn Nothing
     bracket_
         env.sessionBeginWindowTitleBusy
         env.sessionEndWindowTitleBusy
@@ -298,7 +302,9 @@ runOneTurnBusy env@SessionEnv
     let elapsedDetail extra = case startedAt of
             Nothing -> extra
             Just t0 -> extra <> " · " <> formatElapsed (realToFrac (diffUTCTime finishedAt t0))
-        persistIncomplete retainedItems errorText = case persist of
+        persistIncomplete
+            :: [ResponseItem] -> Text -> Maybe TurnOutput -> IO ()
+        persistIncomplete retainedItems errorText maybeTurn = case persist of
             PersistenceDisabled -> pure ()
             PersistenceEnabled slotRef -> do
                 now <- getCurrentTime
@@ -308,12 +314,12 @@ runOneTurnBusy env@SessionEnv
                 let turn = SessionTurn
                         { turnAt = now
                         , turnUserText = promptText
-                        , turnAssistantText = Nothing
+                        , turnAssistantText = maybeTurn >>= (.assistantText)
                         , turnError = Just errorText
-                        , turnResponseId = Nothing
+                        , turnResponseId = (.responseId) <$> maybeTurn
                         , turnEffect = TranscriptAppend
                         , turnItems = retainedItems
-                        , turnUsage = Nothing
+                        , turnUsage = (.tokenUsage) <$> maybeTurn
                         }
                 (handle', turnIndex) <-
                     appendTurnWithMetaUpdateIndexed handle turn \meta ->
@@ -364,7 +370,7 @@ runOneTurnBusy env@SessionEnv
                         (formatLoopErrorColored color cancelled)
                     putTextLn stderrHandle
                         (formatTurnStatus color "cancelled" (elapsedDetail model))
-            persistIncomplete (inputOnlyTurnItems prepared) "cancelled"
+            persistIncomplete (inputOnlyTurnItems prepared) "cancelled" Nothing
             pure TurnCancelled
         (Nothing, Left err) -> do
             abortSubagentTurn rootTurnId
@@ -415,9 +421,30 @@ runOneTurnBusy env@SessionEnv
                                 (formatLoopErrorColoredAt color finishedAt err)
                             putTextLn stderrHandle
                                 (formatTurnStatus color "error" (elapsedDetail model))
+                    let maybeIncompleteTurn = case err of
+                            LoopIncomplete turn -> Just turn
+                            _ -> Nothing
+                    forM_ maybeIncompleteTurn \turn ->
+                        atomicModifyIORef' usageRef \current ->
+                            (addTokenUsage current turn.tokenUsage, ())
+                    -- Keep the live and resumed model transcript aligned:
+                    -- terminal failures checkpoint only the prepared input.
+                    -- Partial assistant text, response id, usage, and the
+                    -- incomplete reason remain available in turn metadata.
                     persistIncomplete (inputOnlyTurnItems prepared)
                         (formatLoopErrorPersistedAt finishedAt err)
-                    pure TurnFailed
+                        maybeIncompleteTurn
+                    planState <- readIORef planMode.planStateRef
+                    pure $ TurnFailed PendingTurn
+                        { pendingPromptText = promptText
+                        -- ConversationFailed checkpoints the exact stamped
+                        -- inputs (including attachments) in the live
+                        -- transcript. Do not retain a second potentially
+                        -- large copy here.
+                        , pendingInputs = []
+                        , pendingExitAfter = False
+                        , pendingPlanState = planState
+                        }
         (Nothing, Right loopResult) -> do
             finishTerminal (isNothing fullscreen)
                 stdoutHandle terminal wallStarted finishedAt 0

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -7,6 +7,7 @@ module Agent.CLI.Turn
     , grokFrameLastUserInput
     , grokUserQuery
     , restorePlanStateAfterIncomplete
+    , retryCheckpointedTurn
     , runOneTurn
     ) where
 
@@ -158,17 +159,31 @@ import System.Process
 import System.Timeout (timeout)
 
 runOneTurn :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
-runOneTurn env promptText inputs = do
+runOneTurn = runOneTurnWithContext True
+
+-- | Retry after a failed turn whose exact prepared inputs are already
+-- checkpointed in the live transcript. Per-turn plan/startup context must not
+-- be generated again.
+retryCheckpointedTurn :: SessionEnv -> IO TurnResult
+retryCheckpointedTurn env = runOneTurnWithContext False env "" []
+
+runOneTurnWithContext
+    :: Bool
+    -> SessionEnv
+    -> Text
+    -> [TurnInput]
+    -> IO TurnResult
+runOneTurnWithContext includeTurnContext env promptText inputs = do
     -- A newly submitted turn supersedes any older retry candidate. If this
     -- attempt fails, finishTurn installs its own PendingTurn afterwards.
     writeIORef env.sessionLastFailedTurn Nothing
     bracket_
         env.sessionBeginWindowTitleBusy
         env.sessionEndWindowTitleBusy
-        (runOneTurnBusy env promptText inputs)
+        (runOneTurnBusy includeTurnContext env promptText inputs)
 
-runOneTurnBusy :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
-runOneTurnBusy env@SessionEnv
+runOneTurnBusy :: Bool -> SessionEnv -> Text -> [TurnInput] -> IO TurnResult
+runOneTurnBusy includeTurnContext env@SessionEnv
     { sessionLoop = config
     , sessionRender = render
     , sessionConversation = conversationRef
@@ -233,18 +248,27 @@ runOneTurnBusy env@SessionEnv
         PersistenceDisabled -> pure ()
     prev <- readLivePreviousResponseId conversationRef
     beforeItems <- readLiveTranscript conversationRef
-    pendingStartup <- atomicModifyIORef' startupContext \pendingCtx -> (Nothing, pendingCtx)
-    planActive <- isPlanModeActive planMode
-    planPath <- planFilePath planMode
-    let planReminder =
-            if planActive
-                then Just $
-                    planModeReminder
-                        (case env.sessionProvider of
-                            OpenAIProvider -> CompleteWithProposedPlan
-                            _ -> CompleteWithExitTool)
-                        planPath
-                else Nothing
+    pendingStartup <-
+        if includeTurnContext
+            then atomicModifyIORef' startupContext \pendingCtx ->
+                (Nothing, pendingCtx)
+            else pure Nothing
+    planReminder <-
+        if includeTurnContext
+            then do
+                planActive <- isPlanModeActive planMode
+                planPath <- planFilePath planMode
+                pure $
+                    if planActive
+                        then Just $
+                            planModeReminder
+                                (case env.sessionProvider of
+                                    OpenAIProvider -> CompleteWithProposedPlan
+                                    _ -> CompleteWithExitTool)
+                                planPath
+                        else Nothing
+            else pure Nothing
+    let
         turnInputs0 =
             turnInputsWithContext planReminder pendingStartup inputs
     stampedInputs <- stampTurnInputs turnInputs0

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -23,6 +23,11 @@ spec = do
             parseReplLine ":reload" `shouldBe` ReplReload
             parseReplLine "  :reload  " `shouldBe` ReplReload
 
+        it "parses exact-turn retry" do
+            parseReplLine "/retry" `shouldBe` ReplRetry
+            parseReplLine "/retry now"
+                `shouldBe` ReplCommandError "usage: /retry"
+
         it "sends ordinary lines to the model" do
             parseReplLine "list the files" `shouldBe` ReplPrompt "list the files"
             parseReplLine ":status" `shouldBe` ReplPrompt ":status"
@@ -284,6 +289,7 @@ spec = do
                     , "plan"
                     , "btw"
                     , "recap"
+                    , "retry"
                     , "session"
                     , "session-info"
                     , "afk"

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -659,6 +659,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -715,6 +716,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -748,6 +750,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -787,6 +790,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -819,6 +823,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -852,6 +857,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSenderAndHook
@@ -888,6 +894,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSenderAndHook
@@ -1114,6 +1121,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1159,6 +1167,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1201,6 +1210,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWith
@@ -1307,6 +1317,7 @@ spec = do
                                     , toolCalls = []
                                     , assistantText = Just "ok"
                                     , tokenUsage = TokenUsage 20 5 0
+                                    , completion = TurnCompleted
                                     }
                 reconnectingContinuation =
                     withConnectionRecoveryUsing
@@ -1365,6 +1376,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1428,6 +1440,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1473,6 +1486,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = usage
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1514,6 +1528,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1570,6 +1585,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1621,6 +1637,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1658,6 +1675,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = emptyTokenUsage
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1716,6 +1734,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1774,6 +1793,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWithSender
@@ -1847,6 +1867,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWith
@@ -1883,6 +1904,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Just "ok"
                         , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
                         }
                 backend =
                     autoCompactOpenAiBackendWith

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -3,7 +3,14 @@ module Agent.CLI.RenderSpec (spec) where
 import Agent.CLI.Render
 import Agent.CLI.Style (motionGlyphSet)
 import Agent.Error (ApiError(..), ErrorType(..), credentialsExhausted)
-import Agent.Loop (LoopError(..), LoopEvent(..), TurnOutput(..), emptyTokenUsage)
+import Agent.Loop
+    ( LoopError(..)
+    , LoopEvent(..)
+    , TokenUsage(..)
+    , TurnCompletion(..)
+    , TurnOutput(..)
+    , emptyTokenUsage
+    )
 import Agent.ToolDispatch
     ( ToolCallKind(..)
     , ToolCallResult(..)
@@ -231,8 +238,27 @@ spec = do
                 , toolCalls = []
                 , assistantText = Just "almost"
                 , tokenUsage = emptyTokenUsage
+                , completion = TurnCompleted
                 })
                 `shouldSatisfy` (/= "")
+
+        it "reports incomplete output and hidden reasoning usage" do
+            let rendered = formatLoopError (LoopIncomplete TurnOutput
+                    { responseId = "r"
+                    , toolCalls = []
+                    , assistantText = Nothing
+                    , tokenUsage = emptyTokenUsage
+                        { outputTokens = 32768 }
+                    , completion = TurnIncomplete
+                        { incompleteReason = "max_output_tokens"
+                        , incompleteReasoningTokens = Just 32000
+                        }
+                    })
+            rendered `shouldSatisfy`
+                Text.isInfixOf "max_output_tokens"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "32000 reasoning tokens"
+            rendered `shouldSatisfy` Text.isInfixOf "/retry"
 
         it "renders exhausted credentials as actionable user-facing text" do
             let now = UTCTime (fromGregorian 2026 8 22) 0
@@ -403,6 +429,7 @@ spec = do
                     , toolCalls = []
                     , assistantText = Just "Complete"
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 activity <- stateActivity <$> readIORef config.renderState
                 activity `shouldBe` "Retrying response…"
@@ -430,6 +457,7 @@ spec = do
                     , toolCalls = []
                     , assistantText = Nothing
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 hClose handle
                 body <- Text.readFile path
@@ -451,6 +479,7 @@ spec = do
                     , toolCalls = []
                     , assistantText = Nothing
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 (stateReasoningBuffer <$> readIORef config.renderState)
                     `shouldReturn` emptyTextBuffer
@@ -480,6 +509,7 @@ spec = do
                     , toolCalls = []
                     , assistantText = Nothing
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 hClose handle
                 body <- Text.readFile path
@@ -500,6 +530,7 @@ spec = do
                     , toolCalls = []
                     , assistantText = Nothing
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 hClose handle
                 body <- Text.readFile path
@@ -530,6 +561,7 @@ spec = do
                     , toolCalls = []
                     , assistantText = Nothing
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 hClose handle
                 body <- Text.readFile path
@@ -557,6 +589,7 @@ spec = do
                         , toolCalls = []
                         , assistantText = Nothing
                         , tokenUsage = emptyTokenUsage
+                        , completion = TurnCompleted
                         })
                     hClose handle
                     actual <- stripTerminalControls <$> Text.readFile path
@@ -588,6 +621,7 @@ spec = do
                     , toolCalls = []
                     , assistantText = Nothing
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 hClose handle
                 actual <- stripTerminalControls <$> Text.readFile path
@@ -606,6 +640,7 @@ spec = do
                     , toolCalls = []
                     , assistantText = Nothing
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 hClose handle
                 body <- stripTerminalControls <$> Text.readFile path
@@ -624,6 +659,7 @@ spec = do
                     , toolCalls = [call]
                     , assistantText = Nothing
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 hClose handle
                 body <- Text.readFile path
@@ -637,6 +673,7 @@ spec = do
                     , toolCalls = []
                     , assistantText = Just "see `file.txt`"
                     , tokenUsage = emptyTokenUsage
+                    , completion = TurnCompleted
                     })
                 hClose handle
                 body <- Text.readFile path

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -82,6 +82,25 @@ spec = do
             finishConversation prepared ConversationFailed
                 `shouldBe` finishConversation prepared ConversationCancelled
 
+        it "retains failed multimodal input exactly once for retry" do
+            let image = ImageAttachment "image/png" "png-bytes"
+                multimodalPrepared = PreparedTurn
+                    { preparedBeforeItems = history
+                    , preparedConsumedStartup = Nothing
+                    , preparedTurnInputs =
+                        [UserMultimodal "inspect this" [image]]
+                    }
+                final = applyConversationPatch
+                    (finishConversation
+                        multimodalPrepared
+                        ConversationFailed)
+                    runningState
+            final.conversationTranscript
+                `shouldBe`
+                    history
+                        <> turnInputsToItems
+                            [UserMultimodal "inspect this" [image]]
+
         it "restores startup without changing conversation state for retry" do
             let final = applyConversationPatch
                     (finishConversation

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -16,6 +16,7 @@ module Agent.Loop
     , LoopProgress(..)
     , LoopResult(..)
     , TokenUsage(..)
+    , TurnCompletion(..)
     , TurnInput(..)
     , TurnOutput(..)
     , addTokenUsage
@@ -191,7 +192,16 @@ data TurnOutput = TurnOutput
     , toolCalls :: ![ToolCall]
     , assistantText :: !(Maybe Text)
     , tokenUsage :: !TokenUsage
+    , completion :: !TurnCompletion
     } deriving (Eq, Show)
+
+data TurnCompletion
+    = TurnCompleted
+    | TurnIncomplete
+        { incompleteReason :: !Text
+        , incompleteReasoningTokens :: !(Maybe Int)
+        }
+    deriving (Eq, Show)
 
 data LoopProgress
     = NoResponseCommitted
@@ -210,6 +220,7 @@ emptyTurnOutput responseId toolCalls assistantText = TurnOutput
     , toolCalls
     , assistantText
     , tokenUsage = emptyTokenUsage
+    , completion = TurnCompleted
     }
 
 data BackendResult = BackendResult
@@ -288,6 +299,7 @@ data LoopError
     -- boundary; this remains the terminal fallback for unwrapped backends.
     | LoopTransportAfterOutput ApiError
     | LoopMaxTurns TurnOutput
+    | LoopIncomplete TurnOutput
     | LoopNoResponseId
     -- | An unexpected synchronous exception escaped a backend, approval
     -- callback, event sink, or other loop-owned IO action. Keeping it in-band
@@ -445,35 +457,44 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                             config.loopCommitSteering steeringCount
                             config.loopOnEvent (TurnFinished turn)
                             let nextTurnsUsed = turnsUsed + 1
-                            results <-
-                                if null turn.toolCalls
-                                    then pure []
-                                    else runToolCalls config turn.toolCalls
-                            cancelledAfter <- isCancelled config.loopCancel
-                            if cancelledAfter
-                                then finish state ResponseCommitted
-                                    (Left (LoopCancelled results))
-                                else do
-                                    steering <- config.loopReadSteering
-                                    let continuation =
-                                            map CompletedTool results <> steering
-                                    if null continuation
-                                        then finish state ResponseCommitted $
-                                            Right LoopResult
-                                                { finalResponseId = turn.responseId
-                                                , finalText = turn.assistantText
-                                                , turnsUsed = nextTurnsUsed
-                                                , tokenUsage = usageAcc'
-                                                }
-                                        else go
-                                            state
-                                            ResponseCommitted
-                                            (Just turn.responseId)
-                                            nextTurnsUsed
-                                            continuation
-                                            (length steering)
-                                            (Just turn)
-                                            usageAcc'
+                            case turn.completion of
+                                TurnIncomplete{} ->
+                                    finish state ResponseCommitted
+                                        (Left (LoopIncomplete turn))
+                                TurnCompleted -> do
+                                    results <-
+                                        if null turn.toolCalls
+                                            then pure []
+                                            else runToolCalls config turn.toolCalls
+                                    cancelledAfter <- isCancelled config.loopCancel
+                                    if cancelledAfter
+                                        then finish state ResponseCommitted
+                                            (Left (LoopCancelled results))
+                                        else do
+                                            steering <- config.loopReadSteering
+                                            let continuation =
+                                                    map CompletedTool results
+                                                        <> steering
+                                            if null continuation
+                                                then finish state ResponseCommitted $
+                                                    Right LoopResult
+                                                        { finalResponseId =
+                                                            turn.responseId
+                                                        , finalText =
+                                                            turn.assistantText
+                                                        , turnsUsed =
+                                                            nextTurnsUsed
+                                                        , tokenUsage = usageAcc'
+                                                        }
+                                                else go
+                                                    state
+                                                    ResponseCommitted
+                                                    (Just turn.responseId)
+                                                    nextTurnsUsed
+                                                    continuation
+                                                    (length steering)
+                                                    (Just turn)
+                                                    usageAcc'
             run =
                 go initialState NoResponseCommitted previousResponseId 0
                     (firstInputs <> initialSteering)

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -454,7 +454,6 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                         then finish state ResponseCommitted
                             (Left (LoopCancelled []))
                         else do
-                            config.loopCommitSteering steeringCount
                             config.loopOnEvent (TurnFinished turn)
                             let nextTurnsUsed = turnsUsed + 1
                             case turn.completion of
@@ -462,6 +461,7 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                                     finish state ResponseCommitted
                                         (Left (LoopIncomplete turn))
                                 TurnCompleted -> do
+                                    config.loopCommitSteering steeringCount
                                     results <-
                                         if null turn.toolCalls
                                             then pure []

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1307,6 +1307,7 @@ spec = describe "runLoop" do
     it "commits terminal incomplete responses without running their tools" do
         submissions <- newIORef []
         calls <- newIORef ([] :: [Text])
+        pending <- newIORef ["keep this guidance"]
         backend <- scriptedBackend submissions
             [ Right TurnOutput
                 { responseId = "resp-incomplete"
@@ -1325,6 +1326,10 @@ spec = describe "runLoop" do
                 { loopOnEvent = \case
                     ToolStarted call -> modifyIORef' calls (<> [call.callId])
                     _ -> pure ()
+                , loopReadSteering = map UserMessage <$> readIORef pending
+                , loopCommitSteering = \count ->
+                    atomicModifyIORef' pending \messages ->
+                        (drop count messages, ())
                 }
         execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
         execution.executionProgress `shouldBe` ResponseCommitted
@@ -1343,6 +1348,13 @@ spec = describe "runLoop" do
                         }
                     })
         readIORef calls `shouldReturn` []
+        readIORef submissions `shouldReturn`
+            [ (Nothing
+              , [ UserMessage "hello"
+                , UserMessage "keep this guidance"
+                ])
+            ]
+        readIORef pending `shouldReturn` ["keep this guidance"]
 
 --------------------------------------------------------------------------------
 -- Helpers

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1249,12 +1249,14 @@ spec = describe "runLoop" do
                 , toolCalls = [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
                 , assistantText = Just "calling"
                 , tokenUsage = TokenUsage 10 4 2
+                , completion = TurnCompleted
                 }
             , Right TurnOutput
                 { responseId = "resp-2"
                 , toolCalls = []
                 , assistantText = Just "done"
                 , tokenUsage = TokenUsage 12 6 0
+                , completion = TurnCompleted
                 }
             ]
         config <- testConfig backend
@@ -1301,6 +1303,46 @@ spec = describe "runLoop" do
             , (Just "resp-1", [UserMessage "use the existing schema"])
             ]
         readIORef pending `shouldReturn` []
+
+    it "commits terminal incomplete responses without running their tools" do
+        submissions <- newIORef []
+        calls <- newIORef ([] :: [Text])
+        backend <- scriptedBackend submissions
+            [ Right TurnOutput
+                { responseId = "resp-incomplete"
+                , toolCalls =
+                    [functionToolCall "c1" "echo" "{\"message\":\"unsafe\"}"]
+                , assistantText = Just "partial"
+                , tokenUsage = TokenUsage 120 32768 0
+                , completion = TurnIncomplete
+                    { incompleteReason = "max_output_tokens"
+                    , incompleteReasoningTokens = Just 32000
+                    }
+                }
+            ]
+        config0 <- testConfig backend
+        let config = config0
+                { loopOnEvent = \case
+                    ToolStarted call -> modifyIORef' calls (<> [call.callId])
+                    _ -> pure ()
+                }
+        execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+        execution.executionProgress `shouldBe` ResponseCommitted
+        execution.executionResult `shouldBe`
+            Left
+                (LoopIncomplete TurnOutput
+                    { responseId = "resp-incomplete"
+                    , toolCalls =
+                        [functionToolCall
+                            "c1" "echo" "{\"message\":\"unsafe\"}"]
+                    , assistantText = Just "partial"
+                    , tokenUsage = TokenUsage 120 32768 0
+                    , completion = TurnIncomplete
+                        { incompleteReason = "max_output_tokens"
+                        , incompleteReasoningTokens = Just 32000
+                        }
+                    })
+        readIORef calls `shouldReturn` []
 
 --------------------------------------------------------------------------------
 -- Helpers

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -235,6 +235,30 @@ spec = do
                 , cachedTokens = 80
                 }
 
+        it "preserves incomplete reason and hidden reasoning usage" do
+            let response =
+                    (testResponseWithUsage "resp-incomplete" []
+                        (Aeson.object
+                            [ "input_tokens" Aeson..= (120 :: Int)
+                            , "output_tokens" Aeson..= (32768 :: Int)
+                            , "total_tokens" Aeson..= (32888 :: Int)
+                            , "output_tokens_details" Aeson..= Aeson.object
+                                [ "reasoning_tokens" Aeson..= (32000 :: Int)
+                                ]
+                            ]))
+                        { status = ResponseIncomplete
+                        , incompleteDetails = Just IncompleteDetails
+                            { reason = "max_output_tokens"
+                            , extraFields = KeyMap.empty
+                            }
+                        }
+                turn = responseToTurnOutput response
+            turn.completion `shouldBe` TurnIncomplete
+                { incompleteReason = "max_output_tokens"
+                , incompleteReasoningTokens = Just 32000
+                }
+            turn.tokenUsage.outputTokens `shouldBe` 32768
+
     describe "streamEventToLoopEvent" do
         it "maps output and summary deltas but hides raw reasoning" do
             streamEventToLoopEvent (deltaEvent EventOutputTextDelta "hello")

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -226,7 +226,7 @@ spec = do
             [EventResponseCreated, EventResponseCompleted]
             \response -> response.output `shouldBe` []
 
-    it "rejects response.incomplete with the server reason" do
+    it "returns response.incomplete with the server reason" do
         frames <- newIORef
             [ lifecycleFrame "response.created"
                 (Aeson.object ["id" Aeson..= ("resp-test" :: Text)])

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -30,6 +30,7 @@ import Agent.Loop
     , ImageAttachment(..)
     , LoopEvent(..)
     , TokenUsage(..)
+    , TurnCompletion(..)
     , TurnInput(..)
     , TurnOutput(..)
     , emptyTokenUsage
@@ -371,6 +372,16 @@ responseToTurnOutput response = TurnOutput
     , toolCalls = mapMaybe responseItemToToolCall response.output
     , assistantText = assistantTextFromResponse response
     , tokenUsage = responseTokenUsage response
+    , completion = case response.status of
+        ResponseIncomplete -> TurnIncomplete
+            { incompleteReason =
+                maybe "unknown" (.reason) response.incompleteDetails
+            , incompleteReasoningTokens =
+                response.usage
+                    >>= (.outputTokensDetails)
+                    >>= (.reasoningTokens)
+            }
+        _ -> TurnCompleted
     }
 
 -- | An incomplete response can still finish the turn when it already contains


### PR DESCRIPTION
## Summary
- carry recoverable incomplete Responses through the backend as typed turn output, preserving response IDs, partial text, and provider token usage
- stop incomplete turns before tool dispatch and render the provider reason plus hidden reasoning usage
- add `/retry` to retry the failed turn from its retained input checkpoint without duplicating text or attachments
- persist incomplete-turn diagnostics and usage while keeping the live and resumed model transcripts aligned

## Tests
- `TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp nix develop -c cabal test --offline agent-core:test:agent-core-test agent-openai:test:agent-openai-test agent-cli:test:agent-cli-test --test-show-details=direct`
- `TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp nix develop -c cabal test --offline agent-responses:test:agent-responses-test agent-claude:test:agent-claude-test --test-show-details=direct`
- `TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp nix develop -c cabal build --offline all`
