### PR TITLE
fix(cli): refresh expired Grok CLI OAuth tokens

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -4,15 +4,22 @@ module Agent.CLI.Auth
     , authErrorNeedsOnboarding
     , GrokAuthState(..)
     , credentialAccountLabel
+    , applyGrokAuthTokens
     , grokCredentialFromAuthJson
     , grokAuthStateFromJson
     , grokAuthStateToJson
     , grokEmailFromAuthJson
+    , grokNeedsRefresh
+    , grokOAuthOptionsFromAuthJson
     , externalAuthSelectionId
+    , externalGrokTokenProvider
     , loadAuth
     , loadAuthForAccount
     , managedAuthSelectionId
     , managedGrokTokenProvider
+    , ExternalGrokLoaded(..)
+    , ExternalGrokSource(..)
+    , refreshGrokLoginPayload
     , openAIOAuthClientId
     , openAiAuthStateChanged
     , openaiAuthStateFromJson
@@ -25,8 +32,13 @@ module Agent.CLI.Auth
     ) where
 
 import Agent.CLI.Auth.Grok
-    ( loadExternalGrokCredentials
+    ( ExternalGrokLoaded(..)
+    , ExternalGrokSource(..)
+    , externalGrokTokenProvider
+    , grokNeedsRefresh
+    , loadExternalGrokCredentials
     , managedGrokTokenProvider
+    , refreshGrokLoginPayload
     )
 import Agent.CLI.Auth.OpenAI
     ( loadOpenAi
@@ -39,10 +51,12 @@ import Agent.CLI.Auth.Types
     , credentialAccountLabel
     , credentialAccountLabelWith
     , externalAuthSelectionId
+    , applyGrokAuthTokens
     , grokAuthStateFromJson
     , grokAuthStateToJson
     , grokCredentialFromAuthJson
     , grokEmailFromAuthJson
+    , grokOAuthOptionsFromAuthJson
     , managedAuthSelectionId
     , openAIOAuthClientId
     , openaiAuthStateFromJson
@@ -201,7 +215,7 @@ loadXai requestedSelectionId = do
                 }
         Nothing -> do
             selected <- lift $
-                selectExternalCredential
+                selectExternalGrok
                     requestedSelectionId
                     <$> loadExternalGrokCredentials
             case selected of
@@ -212,19 +226,24 @@ loadXai requestedSelectionId = do
                                 (accountNotFound
                                     XAIProvider requestedSelectionId))
                             requestedSelectionId
-                Just (selectionId, loaded) -> do
-                    provider <- lift $ reloadableFileCredentialProvider
-                        XAIProvider
-                        SubscriptionBilled
-                        loaded
-                        (fmap snd
-                            . selectExternalCredential (Just selectionId)
-                            <$> loadExternalGrokCredentials)
+                Just loaded -> do
+                    clientId <-
+                        lift $
+                            xaiOAuthClientId
+                                <$> lookupNonEmpty "XAI_OAUTH_CLIENT_ID"
+                    let refreshToken =
+                            XAIAuth.refreshAccessToken
+                                (maybe
+                                    (XAIAuth.defaultOAuthOptions clientId)
+                                    (grokOAuthOptionsFromAuthJson clientId)
+                                    loaded.grokRawJson)
+                    provider <- lift $
+                        externalGrokTokenProvider loaded refreshToken
                     pure LoadedAuth
                         { loadedProvider = XAIProvider
                         , loadedTokenProvider = provider
                         , loadedAccountLabel = pure . credentialAccountLabel
-                        , loadedSelectionId = Just selectionId
+                        , loadedSelectionId = Just loaded.grokSelectionId
                         , loadedOpenAiPool = Nothing
                         }
 
@@ -376,13 +395,24 @@ matchesSelection requested selectionId credential =
                 || requestedId == credential.accountId)
         requested
 
-selectExternalCredential
+selectExternalGrok
     :: Maybe Text
-    -> [(Text, Credential)]
-    -> Maybe (Text, Credential)
-selectExternalCredential requested =
-    find (\(selectionId, credential) ->
-        matchesSelection requested selectionId credential)
+    -> [ExternalGrokLoaded]
+    -> Maybe ExternalGrokLoaded
+selectExternalGrok requested =
+    find \loaded ->
+        matchesSelection
+            requested
+            loaded.grokSelectionId
+            (Credential
+                { accessToken = loaded.grokState.grokAccessToken
+                , accountId =
+                    fromMaybe "grok"
+                        (XAIAuth.accountIdFromAccessToken
+                            loaded.grokState.grokAccessToken)
+                , leaseId = Nothing
+                , provider = XAIProvider
+                })
 
 accountNotFound :: Provider -> Maybe Text -> Text
 accountNotFound provider requested =

--- a/packages/agent-cli/src/Agent/CLI/Auth/Grok.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/Grok.hs
@@ -1,14 +1,21 @@
 module Agent.CLI.Auth.Grok
-    ( loadExternalGrokCredentials
+    ( ExternalGrokLoaded(..)
+    , ExternalGrokSource(..)
+    , externalGrokTokenProvider
+    , grokNeedsRefresh
+    , loadExternalGrokCredentials
     , managedGrokTokenProvider
+    , refreshGrokLoginPayload
     ) where
 
 import Agent.CLI.Auth.Types
     ( GrokAuthState(..)
+    , applyGrokAuthTokens
     , externalAuthSelectionId
     , grokAuthStateFromJson
     , grokAuthStateToJson
-    , grokCredentialFromAuthJson
+    , grokOAuthOptionsFromAuthJson
+    , xaiOAuthClientId
     )
 import Agent.CLI.CredentialStore
     ( ManagedCredential(..)
@@ -18,12 +25,14 @@ import Agent.CLI.CredentialStore
     , withCredentialRefreshFileLock
     )
 import Agent.CLI.Environment (lookupNonEmpty)
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Agent.Error (ApiError(..))
-import Agent.FileRetry (retryOnFileBusy)
+import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Provider
     ( AccountFailure(..)
+    , BillingMode(SubscriptionBilled)
     , Credential(..)
     , FailedCredential(..)
     , Provider(XAIProvider)
@@ -47,13 +56,39 @@ import Data.Text (Text)
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
 import System.Directory.OsPath (doesFileExist, getHomeDirectory)
-import System.OsPath (unsafeEncodeUtf, (</>))
+import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 
-loadExternalGrokCredentials :: IO [(Text, Credential)]
+data ExternalGrokSource
+    = GrokSourceEnvironment
+    | GrokSourceFile !OsPath
+    deriving (Eq, Show)
+
+data ExternalGrokLoaded = ExternalGrokLoaded
+    { grokSelectionId :: !Text
+    , grokState :: !GrokAuthState
+    , grokSource :: !ExternalGrokSource
+    , grokRawJson :: !(Maybe Text)
+    }
+    deriving (Eq)
+
+instance Show ExternalGrokLoaded where
+    show loaded =
+        "ExternalGrokLoaded { grokSelectionId = "
+            <> show loaded.grokSelectionId
+            <> ", grokState = "
+            <> show loaded.grokState
+            <> ", grokSource = "
+            <> show loaded.grokSource
+            <> ", grokRawJson = "
+            <> maybe "Nothing" (const "Just <redacted>") loaded.grokRawJson
+            <> " }"
+
+loadExternalGrokCredentials :: IO [ExternalGrokLoaded]
 loadExternalGrokCredentials = do
     fromJson <- lookupNonEmpty "GROK_AUTH_JSON"
     fromToken <- lookupNonEmpty "GROK_ACCESS_TOKEN"
     home <- getHomeDirectory
+    now <- getCurrentTime
     let filePath =
             home </> unsafeEncodeUtf ".grok" </> unsafeEncodeUtf "auth.json"
     fileExists <- doesFileExist filePath
@@ -61,19 +96,245 @@ loadExternalGrokCredentials = do
         then Just . TextEncoding.decodeUtf8 . LBS.toStrict
             <$> retryOnFileBusy (LBS.readFile (unsafeToFilePath filePath))
         else pure Nothing
-    let environmentToken =
-            (fromJson >>= grokCredentialFromAuthJson) <|> fromToken
-        sourceCredential source token =
-            (externalAuthSelectionId XAIProvider source, grokCredential token)
-    pure $ catMaybes
-        [ sourceCredential "environment" <$> environmentToken
-        , sourceCredential (toText filePath)
-            <$> (fileJson >>= grokCredentialFromAuthJson)
-        ]
+    let environment = case fromJson >>= \raw ->
+            (raw,) <$> grokAuthStateFromJson now raw of
+            Just (raw, state) ->
+                Just ExternalGrokLoaded
+                    { grokSelectionId =
+                        externalAuthSelectionId XAIProvider "environment"
+                    , grokState = state
+                    , grokSource = GrokSourceEnvironment
+                    , grokRawJson = Just raw
+                    }
+            Nothing ->
+                (\token -> ExternalGrokLoaded
+                    { grokSelectionId =
+                        externalAuthSelectionId XAIProvider "environment"
+                    , grokState =
+                        GrokAuthState token Nothing Nothing Nothing
+                    , grokSource = GrokSourceEnvironment
+                    , grokRawJson = Nothing
+                    }) <$> fromToken
+        file = do
+            raw <- fileJson
+            state <- grokAuthStateFromJson now raw
+            Just ExternalGrokLoaded
+                { grokSelectionId =
+                    externalAuthSelectionId XAIProvider (toText filePath)
+                , grokState = state
+                , grokSource = GrokSourceFile filePath
+                , grokRawJson = Just raw
+                }
+    pure $ catMaybes [environment, file]
 
 grokNeedsRefresh :: UTCTime -> GrokAuthState -> Bool
 grokNeedsRefresh now state =
     maybe False (<= addUTCTime 600 now) state.grokExpiresAt
+
+externalGrokTokenProvider
+    :: ExternalGrokLoaded
+    -> (Text -> IO (Either ApiError XAIAuth.OAuthTokens))
+    -> IO TokenProvider
+externalGrokTokenProvider loaded refresh = do
+    stateRef <- newIORef loaded.grokState
+    payloadRef <- newIORef loaded.grokRawJson
+    refreshLock <- newMVar ()
+    pure $ tokenProvider SubscriptionBilled \failed ->
+        withMVar refreshLock \_ ->
+            withGrokSourceLock loaded.grokSource $
+                externalGrokCredential
+                    loaded.grokSource stateRef payloadRef refresh failed
+
+-- | Refresh an expired Grok OAuth payload used by login/account selection.
+-- File and managed sources persist rotated tokens; environment JSON stays
+-- in-memory for this process.
+refreshGrokLoginPayload
+    :: Maybe Text
+    -> Maybe OsPath
+    -> Text
+    -> IO (Either ApiError (GrokAuthState, Text))
+refreshGrokLoginPayload managedId filePath payload = do
+    clientId <- xaiOAuthClientId <$> lookupNonEmpty "XAI_OAUTH_CLIENT_ID"
+    let refresh =
+            XAIAuth.refreshAccessToken
+                (grokOAuthOptionsFromAuthJson clientId payload)
+        source = maybe GrokSourceEnvironment GrokSourceFile filePath
+    withGrokSourceLock source do
+        now <- getCurrentTime
+        latestPayload <- case filePath of
+            Just path -> readGrokAuthFile path
+            Nothing -> pure (Just payload)
+        case latestPayload >>= grokAuthStateFromJson now of
+            Nothing ->
+                pure $ Left $ CredentialError
+                    "Grok OAuth credential became invalid during refresh"
+            Just current
+                | not (grokNeedsRefresh now current) ->
+                    pure (Right (current, fromMaybe payload latestPayload))
+                | otherwise ->
+                    refreshGrokState refresh current >>= \case
+                        Left err -> pure (Left err)
+                        Right newState -> do
+                            encoded <- persistGrokPayload
+                                managedId filePath
+                                (fromMaybe payload latestPayload)
+                                newState
+                            case encoded of
+                                Left err -> pure (Left err)
+                                Right newPayload ->
+                                    pure (Right (newState, newPayload))
+
+externalGrokCredential
+    :: ExternalGrokSource
+    -> IORef GrokAuthState
+    -> IORef (Maybe Text)
+    -> (Text -> IO (Either ApiError XAIAuth.OAuthTokens))
+    -> Maybe FailedCredential
+    -> IO (Either ApiError Credential)
+externalGrokCredential source stateRef payloadRef refresh failed = do
+    current <- reloadExternalGrok source stateRef payloadRef
+    case failed of
+        Just reported -> credentialsExhaustedForRateLimit reported >>= \case
+            Just err -> pure (Left err)
+            Nothing -> case reported of
+                FailedCredential
+                    { credential = rejected
+                    , failure = AccountAuthenticationRejected
+                    }
+                    | rejected.accessToken /= current.grokAccessToken ->
+                        pure (Right (grokCredential current.grokAccessToken))
+                    | otherwise ->
+                        refreshExternalGrok
+                            source stateRef payloadRef refresh current
+                _ -> pure $ Left $ CredentialError
+                    "unsupported credential failure"
+        Nothing -> do
+            now <- getCurrentTime
+            if grokNeedsRefresh now current
+                then refreshExternalGrok
+                    source stateRef payloadRef refresh current
+                else pure (Right (grokCredential current.grokAccessToken))
+
+reloadExternalGrok
+    :: ExternalGrokSource
+    -> IORef GrokAuthState
+    -> IORef (Maybe Text)
+    -> IO GrokAuthState
+reloadExternalGrok source stateRef payloadRef =
+    case source of
+        GrokSourceEnvironment -> readIORef stateRef
+        GrokSourceFile path -> do
+            now <- getCurrentTime
+            readGrokAuthFile path >>= \case
+                Just raw | Just state <- grokAuthStateFromJson now raw -> do
+                    writeIORef stateRef state
+                    writeIORef payloadRef (Just raw)
+                    pure state
+                _ -> readIORef stateRef
+
+refreshExternalGrok
+    :: ExternalGrokSource
+    -> IORef GrokAuthState
+    -> IORef (Maybe Text)
+    -> (Text -> IO (Either ApiError XAIAuth.OAuthTokens))
+    -> GrokAuthState
+    -> IO (Either ApiError Credential)
+refreshExternalGrok source stateRef payloadRef refresh state =
+    refreshGrokState refresh state >>= \case
+        Left err -> pure (Left err)
+        Right newState -> do
+            original <- readIORef payloadRef
+            persistResult <- persistGrokPayload
+                Nothing
+                (case source of
+                    GrokSourceFile path -> Just path
+                    GrokSourceEnvironment -> Nothing)
+                (fromMaybe
+                    (TextEncoding.decodeUtf8
+                        (LBS.toStrict (Aeson.encode (grokAuthStateToJson state))))
+                    original)
+                newState
+            case persistResult of
+                Left err -> pure (Left err)
+                Right newPayload -> do
+                    writeIORef stateRef newState
+                    writeIORef payloadRef (Just newPayload)
+                    pure (Right (grokCredential newState.grokAccessToken))
+
+refreshGrokState
+    :: (Text -> IO (Either ApiError XAIAuth.OAuthTokens))
+    -> GrokAuthState
+    -> IO (Either ApiError GrokAuthState)
+refreshGrokState refresh state =
+    case state.grokRefreshToken of
+        Nothing ->
+            pure $ Left $ CredentialError
+                "Grok OAuth credential has no refresh token; reconnect the account"
+        Just refreshToken ->
+            refresh refreshToken >>= \case
+                Left err -> pure (Left err)
+                Right tokens -> do
+                    now <- getCurrentTime
+                    pure (Right (grokStateFromTokens now state tokens))
+
+persistGrokPayload
+    :: Maybe Text
+    -> Maybe OsPath
+    -> Text
+    -> GrokAuthState
+    -> IO (Either ApiError Text)
+persistGrokPayload managedId filePath original newState = do
+    let encoded = encodeGrokPayload original newState
+    case managedId of
+        Just credentialId ->
+            loadManagedCredentialById credentialId >>= \case
+                Left err -> pure (Left (ConnectionError err))
+                Right (metadata, secret) -> do
+                    let newAccountId =
+                            fromMaybe metadata.managedAccountId
+                                (XAIAuth.accountIdFromAccessToken
+                                    newState.grokAccessToken)
+                        newMetadata = metadata { managedAccountId = newAccountId }
+                        newSecret = secret { secretPayload = encoded }
+                    upsertManagedCredentialAfterRefresh newMetadata newSecret
+                        >>= \case
+                            Left err -> pure (Left (ConnectionError err))
+                            Right () -> pure (Right encoded)
+        Nothing -> case filePath of
+            Just path -> do
+                writeLazyFileAtomically path 0o600
+                    (LBS.fromStrict (TextEncoding.encodeUtf8 encoded))
+                pure (Right encoded)
+            Nothing ->
+                pure (Right encoded)
+
+encodeGrokPayload :: Text -> GrokAuthState -> Text
+encodeGrokPayload original state =
+    case Aeson.decodeStrict (TextEncoding.encodeUtf8 original) of
+        Just value | Just patched <- applyGrokAuthTokens state value ->
+            TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode patched))
+        _ ->
+            TextEncoding.decodeUtf8
+                (LBS.toStrict (Aeson.encode (grokAuthStateToJson state)))
+
+readGrokAuthFile :: OsPath -> IO (Maybe Text)
+readGrokAuthFile path = do
+    exists <- doesFileExist path
+    if not exists
+        then pure Nothing
+        else Just . TextEncoding.decodeUtf8 . LBS.toStrict
+            <$> retryOnFileBusy (LBS.readFile (unsafeToFilePath path))
+
+withGrokSourceLock :: ExternalGrokSource -> IO a -> IO a
+withGrokSourceLock source action =
+    case source of
+        GrokSourceFile filePath ->
+            withPrivateFileLock
+                (unsafeEncodeUtf
+                    (unsafeToFilePath filePath <> ".refresh.lock"))
+                action
+        GrokSourceEnvironment ->
+            action
 
 managedGrokTokenProvider
     :: ManagedCredential
@@ -179,16 +440,7 @@ persistRefreshedGrok
     -> IO (Either ApiError Credential)
 persistRefreshedGrok metadata secret stateRef state tokens = do
     now <- getCurrentTime
-    let newState = GrokAuthState
-            { grokAccessToken = tokens.accessToken
-            , grokRefreshToken =
-                tokens.refreshToken <|> state.grokRefreshToken
-            , grokIdToken = tokens.idToken <|> state.grokIdToken
-            , grokExpiresAt =
-                ((`addUTCTime` now) . fromIntegral
-                    <$> tokens.expiresInSeconds)
-                    <|> OpenAI.parseJwtExp tokens.accessToken
-            }
+    let newState = grokStateFromTokens now state tokens
         newAccountId =
             fromMaybe metadata.managedAccountId
                 (XAIAuth.accountIdFromAccessToken tokens.accessToken)
@@ -204,6 +456,22 @@ persistRefreshedGrok metadata secret stateRef state tokens = do
         Right () -> do
             writeIORef stateRef newState
             pure (Right (grokCredentialFromState newMetadata newState))
+
+grokStateFromTokens
+    :: UTCTime
+    -> GrokAuthState
+    -> XAIAuth.OAuthTokens
+    -> GrokAuthState
+grokStateFromTokens now state tokens = GrokAuthState
+    { grokAccessToken = tokens.accessToken
+    , grokRefreshToken =
+        tokens.refreshToken <|> state.grokRefreshToken
+    , grokIdToken = tokens.idToken <|> state.grokIdToken
+    , grokExpiresAt =
+        ((`addUTCTime` now) . fromIntegral
+            <$> tokens.expiresInSeconds)
+            <|> OpenAI.parseJwtExp tokens.accessToken
+    }
 
 grokCredentialFromState
     :: ManagedCredential

--- a/packages/agent-cli/src/Agent/CLI/Auth/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/Types.hs
@@ -5,10 +5,12 @@ module Agent.CLI.Auth.Types
     , credentialAccountLabel
     , credentialAccountLabelWith
     , externalAuthSelectionId
+    , applyGrokAuthTokens
     , grokAuthStateFromJson
     , grokAuthStateToJson
     , grokCredentialFromAuthJson
     , grokEmailFromAuthJson
+    , grokOAuthOptionsFromAuthJson
     , managedAuthSelectionId
     , nonEmptyText
     , openAIOAuthClientId
@@ -187,20 +189,80 @@ grokAuthStateToJson state = Aeson.object
     , "expires_at" .= state.grokExpiresAt
     ]
 
+-- | Patch rotated Grok tokens into an existing auth document, preserving the
+-- grok CLI's nested map and any profile fields around the token object.
+applyGrokAuthTokens :: GrokAuthState -> Aeson.Value -> Maybe Aeson.Value
+applyGrokAuthTokens state = \case
+    Aeson.Object object
+        | hasGrokAccessToken object ->
+            Just (Aeson.Object (updateGrokAuthObject state object))
+        | otherwise ->
+            let updated = KeyMap.map updateNested object
+            in if updated == object
+                then Nothing
+                else Just (Aeson.Object updated)
+    _ -> Nothing
+  where
+    updateNested = \case
+        Aeson.Object nestedObject | hasGrokAccessToken nestedObject ->
+            Aeson.Object (updateGrokAuthObject state nestedObject)
+        nested -> nested
+
+updateGrokAuthObject :: GrokAuthState -> Aeson.Object -> Aeson.Object
+updateGrokAuthObject state object =
+    insertOptional "expires_at" (Aeson.toJSON <$> state.grokExpiresAt)
+        . insertOptional "id_token" (Aeson.String <$> state.grokIdToken)
+        . insertOptional "refresh_token" (Aeson.String <$> state.grokRefreshToken)
+        . insertAccess
+        $ object
+  where
+    insertAccess current
+        | KeyMap.member keyKey current =
+            KeyMap.insert keyKey (Aeson.String state.grokAccessToken)
+                (if KeyMap.member accessKey current
+                    then KeyMap.insert accessKey
+                        (Aeson.String state.grokAccessToken) current
+                    else current)
+        | otherwise =
+            KeyMap.insert accessKey (Aeson.String state.grokAccessToken) current
+    insertOptional _ Nothing current = current
+    insertOptional name (Just value) current =
+        KeyMap.insert (Key.fromText name) value current
+    keyKey = Key.fromText "key"
+    accessKey = Key.fromText "access_token"
+
+-- | Build the xAI OAuth client used to refresh grok CLI / managed JSON.
+-- Nested grok CLI documents carry @oidc_client_id@ and optional team
+-- principal fields that must be echoed on refresh.
+grokOAuthOptionsFromAuthJson :: Text -> Text -> XAIAuth.OAuthOptions
+grokOAuthOptionsFromAuthJson defaultClientId raw =
+    case Aeson.decodeStrict (TextEncoding.encodeUtf8 raw) >>= authObject of
+        Nothing -> XAIAuth.defaultOAuthOptions defaultClientId
+        Just object ->
+            let clientId =
+                    fromMaybe defaultClientId
+                        (textField "oidc_client_id" object)
+                options = XAIAuth.defaultOAuthOptions clientId
+            in options
+                { XAIAuth.principalType = textField "principal_type" object
+                , XAIAuth.principalId = textField "principal_id" object
+                }
+
 authObject :: Aeson.Value -> Maybe Aeson.Object
 authObject = \case
     Aeson.Object object
-        | hasAccessToken object -> Just object
+        | hasGrokAccessToken object -> Just object
         | otherwise ->
             listToMaybe
                 [ nestedObject
                 | Aeson.Object nestedObject <- KeyMap.elems object
-                , hasAccessToken nestedObject
+                , hasGrokAccessToken nestedObject
                 ]
     _ -> Nothing
-  where
-    hasAccessToken object =
-        isJust (textField "key" object <|> textField "access_token" object)
+
+hasGrokAccessToken :: Aeson.Object -> Bool
+hasGrokAccessToken object =
+    isJust (textField "key" object <|> textField "access_token" object)
 
 utcTimeField :: Text -> Aeson.Object -> Maybe UTCTime
 utcTimeField name object =

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -30,6 +30,8 @@ import Agent.CLI.Auth
     , openaiAuthStateFromJson
     , xaiOAuthClientId
     )
+import Agent.CLI.Auth.Grok (refreshGrokLoginPayload)
+import Agent.Error (ApiError)
 import Agent.CLI.CredentialStore
     ( ManagedAuthKind(..)
     , ManagedCredential(..)
@@ -86,7 +88,7 @@ import Control.Monad (join, void)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.List (nubBy)
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -827,6 +829,35 @@ openAIAccountEmail auth =
     (auth.idToken >>= OpenAI.deriveEmail)
         <|> OpenAI.deriveEmail auth.accessToken
 
+prepareGrokLoginAccount :: LoginAccount -> IO (Either ApiError LoginAccount)
+prepareGrokLoginAccount account
+    | account.loginAuthKind /= ManagedGrokAuthJson =
+        pure (Right account)
+    | Text.null account.loginSecretPayload =
+        pure (Right account)
+    | otherwise =
+        refreshGrokLoginPayload
+            account.loginManagedId
+            grokFilePath
+            account.loginSecretPayload
+            >>= \case
+                Left err -> pure (Left err)
+                Right (state, payload) ->
+                    pure $ Right account
+                        { loginAccessToken = state.grokAccessToken
+                        , loginSecretPayload = payload
+                        , loginAccountId =
+                            fromMaybe account.loginAccountId
+                                (XAIAuth.accountIdFromAccessToken
+                                    state.grokAccessToken)
+                        }
+  where
+    grokFilePath
+        | isJust account.loginManagedId = Nothing
+        | account.loginSource == "environment" = Nothing
+        | otherwise =
+            Just (unsafeEncodeUtf (Text.unpack account.loginSource))
+
 refreshLoginAccount :: LoginAccount -> IO LoginAccount
 refreshLoginAccount account
     | Text.null account.loginAccessToken = pure case account.loginUsage of
@@ -863,32 +894,41 @@ refreshLoginAccount account
                                         (openAIUsage snapshot)
                                 }
         XAIProvider ->
-            XAI.fetchGrokUsage Credential
-                { accessToken = account.loginAccessToken
-                , accountId = account.loginAccountId
-                , leaseId = Nothing
-                , provider = XAIProvider
-                } >>= \case
-                Left err ->
-                    pure account
-                        { loginUsage = UsageUnavailable err }
-                Right snapshot ->
+            prepareGrokLoginAccount account >>= \case
+                Left err -> do
+                    now <- getCurrentTime
                     pure account
                         { loginUsage =
-                            UsageAvailable AccountUsage
-                                { usagePlan = Nothing
-                                , usageWindows =
-                                    [ UsageWindow
-                                        { windowName = "current period"
-                                        , usedPercent = snapshot.usedPercent
-                                        , windowSeconds = snapshot.windowSeconds
-                                        , resetsAt = snapshot.resetsAt
-                                        }
-                                    ]
-                                , creditsRemaining = Nothing
-                                , creditsUsed = Nothing
-                                }
+                            UsageUnavailable (formatApiErrorInlineAt now err)
                         }
+                Right prepared ->
+                    XAI.fetchGrokUsage Credential
+                        { accessToken = prepared.loginAccessToken
+                        , accountId = prepared.loginAccountId
+                        , leaseId = Nothing
+                        , provider = XAIProvider
+                        } >>= \case
+                        Left err ->
+                            pure prepared
+                                { loginUsage = UsageUnavailable err }
+                        Right snapshot ->
+                            pure prepared
+                                { loginUsage =
+                                    UsageAvailable AccountUsage
+                                        { usagePlan = Nothing
+                                        , usageWindows =
+                                            [ UsageWindow
+                                                { windowName = "current period"
+                                                , usedPercent = snapshot.usedPercent
+                                                , windowSeconds =
+                                                    snapshot.windowSeconds
+                                                , resetsAt = snapshot.resetsAt
+                                                }
+                                            ]
+                                        , creditsRemaining = Nothing
+                                        , creditsUsed = Nothing
+                                        }
+                                }
         OpenRouterProvider ->
             OpenRouter.fetchOpenRouterUsage account.loginAccessToken >>= \case
                 Left err ->

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -602,6 +602,73 @@ spec = do
             let state = testAuthState "access" "refresh"
             openAiAuthStateChanged state state `shouldBe` False
 
+    describe "applyGrokAuthTokens" do
+        it "updates grok CLI nested key/refresh fields without dropping profile data" do
+            let expiresAt = addUTCTime 3600 epoch
+                original = Aeson.object
+                    [ "https://auth.x.ai::cli-id" .= Aeson.object
+                        [ "auth_mode" .= ("oidc" :: Text)
+                        , "email" .= ("marc@example.com" :: Text)
+                        , "key" .= ("stale" :: Text)
+                        , "oidc_client_id" .= ("cli-id" :: Text)
+                        , "principal_id" .= ("user-1" :: Text)
+                        , "principal_type" .= ("user" :: Text)
+                        , "refresh_token" .= ("refresh-old" :: Text)
+                        ]
+                    ]
+                state = GrokAuthState
+                    "fresh" (Just "refresh-new") (Just "id-new") (Just expiresAt)
+            case applyGrokAuthTokens state original of
+                Nothing -> expectationFailure "expected patched grok CLI JSON"
+                Just patched ->
+                    case grokAuthStateFromJson epoch
+                        (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode patched))) of
+                        Nothing ->
+                            expectationFailure "expected patched Grok auth state"
+                        Just parsed -> do
+                            parsed.grokAccessToken `shouldBe` "fresh"
+                            parsed.grokRefreshToken `shouldBe` Just "refresh-new"
+                            grokEmailFromAuthJson
+                                (TextEncoding.decodeUtf8
+                                    (LBS.toStrict (Aeson.encode patched)))
+                                `shouldBe` Just "marc@example.com"
+                            grokOAuthOptionsFromAuthJson "default"
+                                (TextEncoding.decodeUtf8
+                                    (LBS.toStrict (Aeson.encode patched)))
+                                `shouldSatisfy` \options ->
+                                    options.clientId == "cli-id"
+                                        && options.principalType == Just "user"
+                                        && options.principalId == Just "user-1"
+
+        it "updates a flat access_token document" do
+            let original = Aeson.object
+                    [ "access_token" .= ("stale" :: Text)
+                    , "refresh_token" .= ("refresh-old" :: Text)
+                    ]
+                state = GrokAuthState "fresh" (Just "refresh-new") Nothing Nothing
+            applyGrokAuthTokens state original
+                `shouldBe` Just
+                    (Aeson.object
+                        [ "access_token" .= ("fresh" :: Text)
+                        , "refresh_token" .= ("refresh-new" :: Text)
+                        ])
+
+    describe "grokNeedsRefresh" do
+        it "refreshes tokens at or inside the 10-minute skew" do
+            grokNeedsRefresh epoch
+                (GrokAuthState "tok" (Just "refresh") Nothing
+                    (Just (addUTCTime 600 epoch)))
+                `shouldBe` True
+            grokNeedsRefresh epoch
+                (GrokAuthState "tok" (Just "refresh") Nothing
+                    (Just (addUTCTime 601 epoch)))
+                `shouldBe` False
+
+        it "does not refresh when expiry is unknown" do
+            grokNeedsRefresh epoch
+                (GrokAuthState "tok" (Just "refresh") Nothing Nothing)
+                `shouldBe` False
+
     describe "grokCredentialFromAuthJson" do
         it "accepts a plain access_token object or a nested grok CLI map" do
             grokCredentialFromAuthJson "{\"access_token\":\"abc\"}"
@@ -703,6 +770,135 @@ spec = do
                 getNextToken provider Nothing `shouldReturn`
                     Right adoptedManagedGrok
                 readIORef refreshes `shouldReturn` 0
+
+    describe "externalGrokTokenProvider" do
+        it "refreshes an expiring grok CLI file and preserves nested profile fields" $
+            withTempHome \home -> do
+                now <- getCurrentTime
+                let path = grokAuthPath home
+                    original = nestedGrokAuthJson "stale" "refresh-old"
+                        (Just (addUTCTime (-1) now))
+                writeGrokAuthFile home original
+                refreshes <- newIORef (0 :: Int)
+                let loaded = ExternalGrokLoaded
+                        { grokSelectionId = "file"
+                        , grokState = expiringGrokState now
+                        , grokSource = GrokSourceFile path
+                        , grokRawJson = Just original
+                        }
+                    refresh refreshToken = do
+                        refreshToken `shouldBe` "refresh-old"
+                        modifyIORef' refreshes (+ 1)
+                        pure (Right refreshedGrokTokens)
+                provider <- externalGrokTokenProvider loaded refresh
+                getNextToken provider Nothing `shouldReturn`
+                    Right (grokCredentialFor "fresh")
+                getNextToken provider Nothing `shouldReturn`
+                    Right (grokCredentialFor "fresh")
+                readIORef refreshes `shouldReturn` 1
+                persisted <- LBS.readFile (toFilePath path)
+                grokAuthStateFromJson now
+                    (TextEncoding.decodeUtf8 (LBS.toStrict persisted))
+                    `shouldSatisfy` \case
+                        Just state ->
+                            state.grokAccessToken == "fresh"
+                                && state.grokRefreshToken == Just "refresh-new"
+                        Nothing -> False
+                grokEmailFromAuthJson
+                    (TextEncoding.decodeUtf8 (LBS.toStrict persisted))
+                    `shouldBe` Just "marc@example.com"
+
+        it "force-refreshes an unexpired file after auth rejection" $
+            withTempHome \home -> do
+                now <- getCurrentTime
+                let path = grokAuthPath home
+                    original = nestedGrokAuthJson "stale" "refresh-old"
+                        (Just (addUTCTime 3600 now))
+                    loaded = ExternalGrokLoaded
+                        { grokSelectionId = "file"
+                        , grokState = unexpiredGrokState now
+                        , grokSource = GrokSourceFile path
+                        , grokRawJson = Just original
+                        }
+                writeGrokAuthFile home original
+                provider <- externalGrokTokenProvider loaded
+                    (const (pure (Right refreshedGrokTokens)))
+                getNextToken provider
+                    (Just
+                        (FailedCredential
+                            staleGrok
+                            AccountAuthenticationRejected
+                            testAuthenticationReason))
+                    `shouldReturn` Right (grokCredentialFor "fresh")
+
+        it "adopts a token rotated on disk without refreshing" $
+            withTempHome \home -> do
+                now <- getCurrentTime
+                refreshes <- newIORef (0 :: Int)
+                let path = grokAuthPath home
+                    stale = nestedGrokAuthJson "stale" "refresh-old"
+                        (Just (addUTCTime (-1) now))
+                    current = nestedGrokAuthJson "adopted" "refresh-adopted"
+                        (Just (addUTCTime 3600 now))
+                    loaded = ExternalGrokLoaded
+                        { grokSelectionId = "file"
+                        , grokState = expiringGrokState now
+                        , grokSource = GrokSourceFile path
+                        , grokRawJson = Just stale
+                        }
+                    refresh _ = do
+                        modifyIORef' refreshes (+ 1)
+                        pure (Right refreshedGrokTokens)
+                writeGrokAuthFile home current
+                provider <- externalGrokTokenProvider loaded refresh
+                getNextToken provider Nothing `shouldReturn`
+                    Right (grokCredentialFor "adopted")
+                readIORef refreshes `shouldReturn` 0
+
+        it "fails closed when an expired file has no refresh token" $
+            withTempHome \home -> do
+                now <- getCurrentTime
+                let path = grokAuthPath home
+                    expiresAt = addUTCTime (-1) now
+                    raw = TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode $
+                        Aeson.object
+                            [ "access_token" .= ("stale" :: Text)
+                            , "expires_at" .= expiresAt
+                            ]
+                    state = GrokAuthState "stale" Nothing Nothing (Just expiresAt)
+                    loaded = ExternalGrokLoaded
+                        { grokSelectionId = "file"
+                        , grokState = state
+                        , grokSource = GrokSourceFile path
+                        , grokRawJson = Just raw
+                        }
+                writeGrokAuthFile home raw
+                provider <- externalGrokTokenProvider loaded
+                    (\_ -> expectationFailure "refresh should not run"
+                        >> fail "refresh")
+                result <- getNextToken provider Nothing
+                case result of
+                    Left (CredentialError message) ->
+                        Text.unpack message `shouldContain` "no refresh token"
+                    other ->
+                        expectationFailure
+                            ("expected CredentialError, got " <> show other)
+
+    describe "refreshGrokLoginPayload" do
+        it "returns a still-valid grok CLI file without contacting xAI" $
+            withTempHome \home -> do
+                now <- getCurrentTime
+                let path = grokAuthPath home
+                    payload = nestedGrokAuthJson "live" "refresh-live"
+                        (Just (addUTCTime 3600 now))
+                writeGrokAuthFile home payload
+                refreshGrokLoginPayload Nothing (Just path) payload >>= \case
+                    Left err ->
+                        expectationFailure ("expected live payload, got " <> show err)
+                    Right (state, returned) -> do
+                        state.grokAccessToken `shouldBe` "live"
+                        grokNeedsRefresh now state `shouldBe` False
+                        returned `shouldBe` payload
 
     describe "staticCredentialProvider" do
         it "preserves rate-limit cooldowns for managed bearer tokens" do
@@ -1069,6 +1265,39 @@ refreshedGrokTokens =
 freshManagedGrok :: Credential
 freshManagedGrok =
     Credential "fresh" "account" Nothing XAIProvider
+
+grokCredentialFor :: Text -> Credential
+grokCredentialFor token =
+    Credential token "grok" Nothing XAIProvider
+
+grokAuthPath :: OsPath -> OsPath
+grokAuthPath home =
+    fromFilePath (toFilePath home </> ".grok" </> "auth.json")
+
+writeGrokAuthFile :: OsPath -> Text -> IO ()
+writeGrokAuthFile home raw = do
+    createDirectoryIfMissing True (toFilePath home </> ".grok")
+    LBS.writeFile
+        (toFilePath home </> ".grok" </> "auth.json")
+        (LBS.fromStrict (TextEncoding.encodeUtf8 raw))
+
+nestedGrokAuthJson :: Text -> Text -> Maybe UTCTime -> Text
+nestedGrokAuthJson token refresh expiresAt =
+    TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode $
+        Aeson.object
+            [ "https://auth.x.ai::cli-id" .= Aeson.object
+                ( [ "auth_mode" .= ("oidc" :: Text)
+                  , "email" .= ("marc@example.com" :: Text)
+                  , "key" .= token
+                  , "oidc_client_id" .= ("cli-id" :: Text)
+                  , "refresh_token" .= refresh
+                  ]
+                    <> maybe
+                        []
+                        (\time -> ["expires_at" .= time])
+                        expiresAt
+                )
+            ]
 
 testAuthState :: Text -> Text -> AuthState
 testAuthState access refresh =


### PR DESCRIPTION
## Summary
- Refresh `~/.grok/auth.json` (and `GROK_AUTH_JSON`) with the OAuth refresh token instead of failing when the access token expires.
- Persist rotated tokens back into the nested grok CLI document, including `key`, `refresh_token`, and `expires_at`, without dropping profile fields.
- Refresh before usage/account selection so an expired Grok file is not treated as “no xai account has verified available usage”.
- Force a refresh after authentication rejection, and adopt a file that another process already rotated.

Managed Grok accounts already refreshed. File credentials from the grok CLI did not, which is what broke CI and local Grok logins after six hours.

## Test plan
- [x] `cabal test agent-cli --test-options='--match=externalGrokTokenProvider' --test-options='--match=managedGrokTokenProvider' --test-options='--match=applyGrokAuthTokens' --test-options='--match=refreshGrokLoginPayload' --test-options='--match=loadAuth'`
- [ ] CI Nix flake check, including `agent-cli-functional-xai-hello-world`