### PR TITLE
Schedule independent Grok tool calls concurrently

### DIFF
--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -63,6 +63,7 @@ import Agent.Tools.Scheduling
     , ToolResource(..)
     , ToolResourceClaim(..)
     )
+import Agent.Tools.ShellReadOnly (shellCommandIsReadOnly)
 import Agent.Tools.Types
     ( AppTool
     , ApprovalRule(..)
@@ -80,7 +81,6 @@ import Data.Aeson.Types (parseFail)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified System.FilePath as FilePath
 import System.OsPath (unsafeEncodeUtf)
 
 codexTools
@@ -165,91 +165,6 @@ shellCommandResourceClaims env call =
                                 ToolRead
                                 ToolAllPaths
                             ])
-
-shellCommandIsReadOnly :: Text -> Bool
-shellCommandIsReadOnly command
-    | Text.null stripped = False
-    | Text.any (`elem` forbiddenChars) stripped = False
-    | "$(" `Text.isInfixOf` stripped = False
-    | "`" `Text.isInfixOf` stripped = False
-    | "$" `Text.isInfixOf` stripped = False
-    | otherwise =
-        case Text.words stripped of
-            [] -> False
-            executable : arguments ->
-                allowedCommand
-                    (Text.pack
-                        (FilePath.takeFileName (Text.unpack executable)))
-                    arguments
-  where
-    stripped = Text.strip command
-    forbiddenChars = ['\n', '\r', ';', '&', '|', '>', '<']
-
-allowedCommand :: Text -> [Text] -> Bool
-allowedCommand executable arguments
-    | executable `elem`
-        [ "cat", "head", "tail", "grep", "rg", "fd", "ls"
-        , "pwd", "wc", "stat", "file", "jq", "sort", "uniq", "cut"
-        , "tr", "realpath", "basename", "dirname", "which", "du", "df"
-        , "nl", "ps", "test", "diff", "printf", "echo"
-        ] =
-        not (any mutatingFlag arguments)
-            && not (executable == "sort" && any outputFlag arguments)
-    | executable == "find" =
-        not (any findAction arguments)
-    | executable == "sed" =
-        safeSed arguments
-    | executable == "git" =
-        case arguments of
-            subcommand : _ ->
-                subcommand `elem`
-                    [ "diff", "log", "show", "rev-parse"
-                    , "ls-files", "blame", "grep", "merge-base", "rev-list"
-                    , "symbolic-ref", "ls-remote"
-                    ]
-                    && not (any gitMutatingFlag arguments)
-            [] -> False
-    | executable == "gh" =
-        case arguments of
-            "pr" : subcommand : _ ->
-                subcommand `elem` ["view", "list", "checks", "status", "diff"]
-            "repo" : "view" : _ -> True
-            "run" : subcommand : _ -> subcommand `elem` ["list", "view"]
-            "auth" : "status" : _ -> True
-            _ -> False
-    | otherwise = False
-  where
-    mutatingFlag argument =
-        argument `elem` ["-i", "--in-place", "--delete", "-delete"]
-    outputFlag argument =
-        argument == "-o"
-            || "--output" `Text.isPrefixOf` argument
-    findAction argument =
-        argument `elem`
-            [ "-delete", "-exec", "-execdir", "-ok", "-okdir"
-            , "-fprint", "-fprintf", "-fls"
-            ]
-    gitMutatingFlag argument =
-        outputFlag argument
-            || argument `elem`
-                [ "-d", "-D", "-m", "-M", "-c", "-C"
-                , "--delete", "--move", "--copy"
-                ]
-
-safeSed :: [Text] -> Bool
-safeSed = \case
-    "-n" : script : paths ->
-        safePrintScript script
-            && not (null paths)
-            && all (not . Text.isPrefixOf "-") paths
-    _ -> False
-  where
-    safePrintScript raw =
-        let script = Text.dropAround (`elem` ['\'', '"']) raw
-            withoutDigits = Text.filter
-                (\char -> char < '0' || char > '9')
-                script
-        in withoutDigits `elem` ["p", ",p"]
 
 shellDescription :: Text
 shellDescription =

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -81,8 +81,9 @@ spec = describe "Codex dialect" do
             , "sed -n '1,80p' src/Main.hs"
             , "git diff -- src/Main.hs"
             , "gh pr view 123 --json statusCheckRollup"
+            , "uniq -c file.txt"
             ]
-            `shouldBe` replicate 4 True
+            `shouldBe` replicate 5 True
         map shellCommandIsReadOnly
             [ "git status --short"
             , "git fetch origin"
@@ -93,8 +94,9 @@ spec = describe "Codex dialect" do
             , "find . -delete"
             , "sed -n '/pattern/w output' src/Main.hs"
             , "git diff --output=copy"
+            , "uniq input.txt output.txt"
             ]
-            `shouldBe` replicate 9 False
+            `shouldBe` replicate 10 False
 
     it "derives disjoint apply_patch resources from patch paths" do
         withTempDir \dir -> do

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -80,6 +80,7 @@ library
                     , Agent.Tools.PlanMode
                     , Agent.Tools.Secret
                     , Agent.Tools.Scheduling
+                    , Agent.Tools.ShellReadOnly
                     , Agent.Tools.Types
                     , Agent.Transport.WebSocket
     hs-source-dirs:   src

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -143,6 +143,7 @@ benchmark tool-scheduling-bench
     ghc-options:      -O2 -rtsopts
     build-depends:    agent-core
                     , base >= 4.14 && < 5
+                    , filepath
                     , text
 
 benchmark loop-events-bench

--- a/packages/agent-core/benchmark/ToolScheduling.hs
+++ b/packages/agent-core/benchmark/ToolScheduling.hs
@@ -51,11 +51,13 @@ import System.CPUTime (getCPUTime)
 import System.Environment (getArgs)
 import System.Exit (die)
 import System.Mem (performGC)
+import System.OsPath (unsafeEncodeUtf)
 import Text.Printf (printf)
 
 data Workload
     = OldSequential
     | NewDisjoint
+    | NewDisjointPaths
     | NewConflicting
     | ExistingParallel
     deriving (Eq, Show)
@@ -93,12 +95,13 @@ main = do
             die $
                 "usage: tool-scheduling-bench WORKLOAD CALLS DELAY_US SAMPLES\n"
                     <> "workloads: old-sequential, new-disjoint, "
-                    <> "new-conflicting, existing-parallel"
+                    <> "new-disjoint-paths, new-conflicting, existing-parallel"
 
 parseWorkload :: String -> IO Workload
 parseWorkload = \case
     "old-sequential" -> pure OldSequential
     "new-disjoint" -> pure NewDisjoint
+    "new-disjoint-paths" -> pure NewDisjointPaths
     "new-conflicting" -> pure NewConflicting
     "existing-parallel" -> pure ExistingParallel
     other -> die ("unknown workload: " <> other)
@@ -187,6 +190,9 @@ benchmarkTool workload delayMicros index name =
         NewDisjoint ->
             withToolResourceClaims
                 (const (pure (Right [writeClaim resourceName])))
+        NewDisjointPaths ->
+            withToolResourceClaims
+                (const (pure (Right [pathWriteClaim index])))
         NewConflicting ->
             withToolResourceClaims
                 (const (pure (Right [writeClaim "shared"])))
@@ -194,6 +200,9 @@ benchmarkTool workload delayMicros index name =
     resourceName = "resource-" <> Text.pack (show index)
     writeClaim resource =
         ToolResourceClaim ToolWrite (ToolNamedResource resource)
+    pathWriteClaim n =
+        ToolResourceClaim ToolWrite
+            (ToolPath (unsafeEncodeUtf ("file-" <> show n)))
 
 measure :: IO Int -> IO Sample
 measure action = do

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -22,8 +22,8 @@ mkDerivation {
     retry safe-exceptions stm text time tls unix websockets yaml
   ];
   benchmarkHaskellDepends = [
-    aeson base bytestring directory safe-exceptions text text-builder
-    unix
+    aeson base bytestring directory filepath safe-exceptions text
+    text-builder unix
   ];
   description = "Provider-neutral infrastructure for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Tool.hs
@@ -13,7 +13,7 @@ import Agent.ToolDSL
     , PropertyType(..)
     )
 import Agent.ToolDispatch (ToolCall(..), typedTool)
-import Agent.Tools.Ghci.Classify (GhciClass(..))
+import Agent.Tools.Ghci.Classify (GhciClass(..), classifyGhciInput)
 import Agent.Tools.Ghci.Runtime
     ( GhciOutcome(..)
     , GhciResult(..)
@@ -21,11 +21,17 @@ import Agent.Tools.Ghci.Runtime
     , classifyGhci
     , evalGhci
     )
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    )
 import Agent.Tools.Types
     ( AppTool
     , ApprovalRule(..)
     , ToolExecutionPolicy(..)
     , jsonAppToolWithExecution
+    , withToolResourceClaims
     )
 import Data.Aeson (FromJSON(..), Object)
 import qualified Data.Aeson as Aeson
@@ -55,6 +61,7 @@ optionalTimeout object =
 
 runGhciTool :: GhciSession -> AppTool
 runGhciTool session =
+    withToolResourceClaims ghciResourceClaims $
     jsonAppToolWithExecution "run_ghci" ghciDescription
         [ PropertySchema "expression" PropertyString True $ Just
             "Haskell expression, statement, or GHCi :command to evaluate."
@@ -66,6 +73,18 @@ runGhciTool session =
         (ClassifyReadOnly (isGhciReadOnlyCall session))
         TurnSequential
         (typedTool "run_ghci" (runGhci session))
+
+ghciResourceClaims
+    :: ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+ghciResourceClaims call =
+    pure $ case decodeExpression call.arguments of
+        Just expression
+            | classifyGhciInput expression == Just GhciPure ->
+                Right
+                    [ToolResourceClaim ToolWrite (ToolNamedResource "ghci")]
+        _ ->
+            Left "effectful GHCi remains exclusive"
 
 ghciDescription :: Text
 ghciDescription =

--- a/packages/agent-core/src/Agent/Tools/ShellReadOnly.hs
+++ b/packages/agent-core/src/Agent/Tools/ShellReadOnly.hs
@@ -1,0 +1,96 @@
+-- | Strict observational-shell allowlist used by tool resource claims.
+--
+-- Unknown, mutating, redirected, piped, or compound commands stay exclusive.
+module Agent.Tools.ShellReadOnly
+    ( shellCommandIsReadOnly
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified System.FilePath as FilePath
+
+-- | True when the complete command is a recognized read-only invocation.
+shellCommandIsReadOnly :: Text -> Bool
+shellCommandIsReadOnly command
+    | Text.null stripped = False
+    | Text.any (`elem` forbiddenChars) stripped = False
+    | "$(" `Text.isInfixOf` stripped = False
+    | "`" `Text.isInfixOf` stripped = False
+    | "$" `Text.isInfixOf` stripped = False
+    | otherwise =
+        case Text.words stripped of
+            [] -> False
+            executable : arguments ->
+                allowedCommand
+                    (Text.pack
+                        (FilePath.takeFileName (Text.unpack executable)))
+                    arguments
+  where
+    stripped = Text.strip command
+    forbiddenChars = ['\n', '\r', ';', '&', '|', '>', '<']
+
+allowedCommand :: Text -> [Text] -> Bool
+allowedCommand executable arguments
+    | executable `elem`
+        [ "cat", "head", "tail", "grep", "rg", "fd", "ls"
+        , "pwd", "wc", "stat", "file", "jq", "sort", "uniq", "cut"
+        , "tr", "realpath", "basename", "dirname", "which", "du", "df"
+        , "nl", "ps", "test", "diff", "printf", "echo"
+        ] =
+        not (any mutatingFlag arguments)
+            && not (executable == "sort" && any outputFlag arguments)
+    | executable == "find" =
+        not (any findAction arguments)
+    | executable == "sed" =
+        safeSed arguments
+    | executable == "git" =
+        case arguments of
+            subcommand : _ ->
+                subcommand `elem`
+                    [ "diff", "log", "show", "rev-parse"
+                    , "ls-files", "blame", "grep", "merge-base", "rev-list"
+                    , "symbolic-ref", "ls-remote"
+                    ]
+                    && not (any gitMutatingFlag arguments)
+            [] -> False
+    | executable == "gh" =
+        case arguments of
+            "pr" : subcommand : _ ->
+                subcommand `elem` ["view", "list", "checks", "status", "diff"]
+            "repo" : "view" : _ -> True
+            "run" : subcommand : _ -> subcommand `elem` ["list", "view"]
+            "auth" : "status" : _ -> True
+            _ -> False
+    | otherwise = False
+  where
+    mutatingFlag argument =
+        argument `elem` ["-i", "--in-place", "--delete", "-delete"]
+    outputFlag argument =
+        argument == "-o"
+            || "--output" `Text.isPrefixOf` argument
+    findAction argument =
+        argument `elem`
+            [ "-delete", "-exec", "-execdir", "-ok", "-okdir"
+            , "-fprint", "-fprintf", "-fls"
+            ]
+    gitMutatingFlag argument =
+        outputFlag argument
+            || argument `elem`
+                [ "-d", "-D", "-m", "-M", "-c", "-C"
+                , "--delete", "--move", "--copy"
+                ]
+
+safeSed :: [Text] -> Bool
+safeSed = \case
+    "-n" : script : paths ->
+        safePrintScript script
+            && not (null paths)
+            && all (not . Text.isPrefixOf "-") paths
+    _ -> False
+  where
+    safePrintScript raw =
+        let script = Text.dropAround (`elem` ['\'', '"']) raw
+            withoutDigits = Text.filter
+                (\char -> char < '0' || char > '9')
+                script
+        in withoutDigits `elem` ["p", ",p"]

--- a/packages/agent-core/src/Agent/Tools/ShellReadOnly.hs
+++ b/packages/agent-core/src/Agent/Tools/ShellReadOnly.hs
@@ -33,12 +33,15 @@ allowedCommand :: Text -> [Text] -> Bool
 allowedCommand executable arguments
     | executable `elem`
         [ "cat", "head", "tail", "grep", "rg", "fd", "ls"
-        , "pwd", "wc", "stat", "file", "jq", "sort", "uniq", "cut"
+        , "pwd", "wc", "stat", "file", "jq", "sort", "cut"
         , "tr", "realpath", "basename", "dirname", "which", "du", "df"
         , "nl", "ps", "test", "diff", "printf", "echo"
         ] =
         not (any mutatingFlag arguments)
             && not (executable == "sort" && any outputFlag arguments)
+    | executable == "uniq" =
+        not (any mutatingFlag arguments)
+            && not (uniqWritesOutput arguments)
     | executable == "find" =
         not (any findAction arguments)
     | executable == "sed" =
@@ -79,6 +82,16 @@ allowedCommand executable arguments
                 [ "-d", "-D", "-m", "-M", "-c", "-C"
                 , "--delete", "--move", "--copy"
                 ]
+
+-- | GNU uniq writes a second positional operand: @uniq [OPTION]... [INPUT [OUTPUT]]@.
+uniqWritesOutput :: [Text] -> Bool
+uniqWritesOutput arguments =
+    length positional >= 2
+  where
+    positional =
+        filter
+            (\argument -> argument /= "--" && not ("-" `Text.isPrefixOf` argument))
+            arguments
 
 safeSed :: [Text] -> Bool
 safeSed = \case

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -2,7 +2,9 @@ module Agent.Tools.GhciSpec (spec) where
 
 import Agent.Cancel (requestCancel, resetCancel)
 import System.OsPath (decodeUtf, unsafeEncodeUtf)
-import Agent.Tools.Types (defaultToolEnv)
+import Agent.ToolDispatch (functionToolCall)
+import Agent.Tools.FileSystem.Grep (grepTool)
+import Agent.Tools.Scheduling (schedulingPlansConflict)
 import Agent.Tools.Ghci
     ( GhciClass(..)
     , GhciOutcome(..)
@@ -14,10 +16,16 @@ import Agent.Tools.Ghci
     , defaultGhciExtensions
     , evalGhci
     , newGhciSession
+    , runGhciTool
     , suspendGhciSession
     , typeLooksEffectful
     )
-import Agent.Tools.Types (ToolEnv(..))
+import Agent.Tools.Types
+    ( ToolEnv(..)
+    , defaultToolEnv
+    , mkToolRegistry
+    , toolSchedulingPlanFor
+    )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (mapConcurrently, wait, withAsync)
 import Control.Exception.Safe (SomeException, bracket, try)
@@ -55,6 +63,38 @@ spec = describe "Agent.Tools.Ghci" do
             typeLooksEffectful "1 + 1 :: Num a => a" `shouldBe` False
             typeLooksEffectful "id :: a -> a" `shouldBe` False
             typeLooksEffectful "getLine :: IO String" `shouldBe` True
+
+    describe "scheduling" do
+        it "lets statically pure GHCi overlap filesystem reads" do
+            withTempEnv \env ->
+                bracket (newGhciSession env) closeGhciSession \ghci -> do
+                    let registry =
+                            either (error . Text.unpack) id $
+                                mkToolRegistry [runGhciTool ghci, grepTool env]
+                        pureCall =
+                            functionToolCall
+                                "gh1"
+                                "run_ghci"
+                                "{\"expression\":\":type id\",\"description\":\"type\"}"
+                        otherPure =
+                            functionToolCall
+                                "gh2"
+                                "run_ghci"
+                                "{\"expression\":\":kind Maybe\",\"description\":\"kind\"}"
+                        effectful =
+                            functionToolCall
+                                "gh3"
+                                "run_ghci"
+                                "{\"expression\":\":reload\",\"description\":\"reload\"}"
+                        grepCall =
+                            functionToolCall "g1" "grep" "{\"pattern\":\"foo\"}"
+                    purePlan <- toolSchedulingPlanFor registry pureCall
+                    otherPlan <- toolSchedulingPlanFor registry otherPure
+                    effectPlan <- toolSchedulingPlanFor registry effectful
+                    grepPlan <- toolSchedulingPlanFor registry grepCall
+                    schedulingPlansConflict purePlan grepPlan `shouldBe` False
+                    schedulingPlansConflict purePlan otherPlan `shouldBe` True
+                    schedulingPlansConflict effectPlan grepPlan `shouldBe` True
 
     describe "defaultGhciExtensions" do
         it "covers the extra extensions this repo enables on top of GHC2021" do

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
@@ -4,10 +4,20 @@ import Agent.OsPath (fromText)
 import System.OsPath (OsPath)
 import Agent.ToolArgs (objectArgs, optBool, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
-import Agent.ToolDispatch (typedTool)
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , decodeToolArguments
+    , toolArgumentsValue
+    , typedTool
+    )
 import Agent.Tools.FileSystem.GitIgnore (isGitIgnored)
 import Agent.GrokBuild.Dialect.Common (jsonTool)
 import Agent.Tools.IO (readTextFile, resolveUnderCwd, writeTextFile)
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    )
 import Agent.Tools.PlanMode
     ( PlanModeEnv
     , isPlanFileEditTarget
@@ -20,6 +30,7 @@ import Agent.Tools.Types
     ( AppTool
     , ToolEnv(..)
     , ToolExecutionPolicy(..)
+    , withToolResourceClaims
     )
 import Control.Monad (unless, when)
 import Control.Monad.Trans.Class (lift)
@@ -51,7 +62,9 @@ instance FromJSON SearchReplaceArgs where
         <*> (fromMaybe False <$> optBool object "replace_all")
 
 searchReplaceTool :: ToolEnv -> PlanModeEnv -> AppTool
-searchReplaceTool env planMode = jsonTool "search_replace" searchReplaceDescription
+searchReplaceTool env planMode =
+    withToolResourceClaims (searchReplaceResourceClaims env) $
+    jsonTool "search_replace" searchReplaceDescription
     [ PropertySchema "file_path" PropertyString True $ Just
         "The path to the file to modify. Relative paths are resolved within the workspace. Absolute paths are accepted only when they resolve within the workspace."
     , PropertySchema "old_string" PropertyString True $ Just
@@ -64,6 +77,22 @@ searchReplaceTool env planMode = jsonTool "search_replace" searchReplaceDescript
     False
     TurnSequential
     (typedTool "search_replace" (runSearchReplace env planMode))
+
+searchReplaceResourceClaims
+    :: ToolEnv
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+searchReplaceResourceClaims env call =
+    case
+        decodeToolArguments (toolArgumentsValue call.arguments)
+            :: Either Text SearchReplaceArgs
+    of
+        Left err -> pure (Left err)
+        Right args ->
+            resolveUnderCwd env (fromText args.filePath)
+                >>= pure . fmap
+                    (\resolved ->
+                        [ToolResourceClaim ToolWrite (ToolPath resolved)])
 
 searchReplaceDescription :: Text
 searchReplaceDescription =

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
@@ -1,7 +1,12 @@
 module Agent.GrokBuild.Dialect.SearchReplace (searchReplaceTool) where
 
 import Agent.OsPath (fromText)
-import System.OsPath (OsPath)
+import System.OsPath
+    ( OsPath
+    , equalFilePath
+    , takeDirectory
+    , takeFileName
+    )
 import Agent.ToolArgs (objectArgs, optBool, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch
@@ -45,7 +50,6 @@ import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath (doesFileExist)
-import System.OsPath (equalFilePath)
 
 data SearchReplaceArgs = SearchReplaceArgs
     { filePath :: Text
@@ -90,9 +94,24 @@ searchReplaceResourceClaims env call =
         Left err -> pure (Left err)
         Right args ->
             resolveUnderCwd env (fromText args.filePath)
-                >>= pure . fmap
-                    (\resolved ->
-                        [ToolResourceClaim ToolWrite (ToolPath resolved)])
+                >>= pure . fmap claimsForResolved
+
+claimsForResolved :: OsPath -> [ToolResourceClaim]
+claimsForResolved resolved
+    | isGitIgnorePolicyPath resolved =
+        [ToolResourceClaim ToolWrite ToolAllPaths]
+    | otherwise =
+        [ToolResourceClaim ToolWrite (ToolPath resolved)]
+
+-- | Ignore-policy edits change what later replacements may write, so they
+-- conflict with every filesystem claim rather than only the ignore file path.
+isGitIgnorePolicyPath :: OsPath -> Bool
+isGitIgnorePolicyPath path =
+    takeFileName path == fromText ".gitignore"
+        || (takeFileName path == fromText "exclude"
+            && takeFileName (takeDirectory path) == fromText "info"
+            && takeFileName (takeDirectory (takeDirectory path))
+                == fromText ".git")
 
 searchReplaceDescription :: Text
 searchReplaceDescription =

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
@@ -2,9 +2,20 @@ module Agent.GrokBuild.Dialect.Terminal (runTerminalCmdTool) where
 
 import Agent.ToolArgs (objectArgs, optBool, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
-import Agent.ToolDispatch (typedStreamingTool)
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , decodeToolArguments
+    , toolArgumentsValue
+    , typedStreamingTool
+    )
 import Agent.Tools.Dangerous (commandLooksLikeRmRf, forbiddenRmRfReason)
 import Agent.GrokBuild.Dialect.Common (jsonTool, optionalTimeout, stripAnsi)
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    )
+import Agent.Tools.ShellReadOnly (shellCommandIsReadOnly)
 import Agent.GrokBuild.Dialect.Shell
     ( GrokSession
     , hasUnwaitedBackgroundOp
@@ -18,6 +29,7 @@ import Agent.Tools.IO
 import Agent.Tools.Types
     ( AppTool
     , ToolExecutionPolicy(..)
+    , withToolResourceClaims
     )
 import Data.Aeson (FromJSON(..))
 import Data.Maybe (fromMaybe)
@@ -39,7 +51,9 @@ instance FromJSON TerminalArgs where
         <*> (fromMaybe False <$> optBool object "background")
 
 runTerminalCmdTool :: GrokSession -> AppTool
-runTerminalCmdTool session = jsonTool "run_terminal_cmd" terminalDescription
+runTerminalCmdTool session =
+    withToolResourceClaims terminalResourceClaims $
+    jsonTool "run_terminal_cmd" terminalDescription
     [ PropertySchema "command" PropertyString True $ Just
         "The bash command to run."
     , PropertySchema "timeout" PropertyInteger False $ Just
@@ -52,6 +66,24 @@ runTerminalCmdTool session = jsonTool "run_terminal_cmd" terminalDescription
     False
     TurnSequential
     (typedStreamingTool "run_terminal_cmd" (runTerminal session))
+
+terminalResourceClaims
+    :: ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+terminalResourceClaims call =
+    pure $ do
+        args <-
+            decodeToolArguments (toolArgumentsValue call.arguments)
+                :: Either Text TerminalArgs
+        if args.background
+            then Left "background terminal commands remain exclusive"
+            else if not (shellCommandIsReadOnly args.command)
+                then Left "shell command is not in the read-only allowlist"
+                else Right
+                    [ ToolResourceClaim
+                        ToolRead
+                        ToolAllPaths
+                    ]
 
 terminalDescription :: Text
 terminalDescription =

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Todo.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Todo.hs
@@ -4,10 +4,19 @@ module Agent.GrokBuild.Dialect.Todo
     ) where
 
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
-import Agent.ToolDispatch (typedTool)
+import Agent.ToolDispatch (ToolCall, typedTool)
 import Agent.GrokBuild.Dialect.Common (jsonTool)
 import Agent.GrokBuild.Dialect.Shell (GrokSession(..))
-import Agent.Tools.Types (AppTool, ToolExecutionPolicy(..))
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    )
+import Agent.Tools.Types
+    ( AppTool
+    , ToolExecutionPolicy(..)
+    , withToolResourceClaims
+    )
 import Control.Monad (foldM)
 import Data.Aeson
     ( FromJSON(..)
@@ -66,7 +75,9 @@ instance FromJSON TodoWriteArgs where
         <*> object .: "todos"
 
 todoWriteTool :: GrokSession -> AppTool
-todoWriteTool session = jsonTool "todo_write" todoWriteDescription
+todoWriteTool session =
+    withToolResourceClaims todoWriteResourceClaims $
+    jsonTool "todo_write" todoWriteDescription
     [ PropertySchema "merge" PropertyBoolean False $ Just
         "Optional. When true (default), merges the provided todos into the existing list by id. When false, the provided todos replace the existing list."
     , PropertySchema "todos" (PropertyArray todoUpdateSchema) True $ Just
@@ -87,6 +98,13 @@ todoWriteTool session = jsonTool "todo_write" todoWriteDescription
             False
             (Just "The status of the todo item.")
         ]
+
+todoWriteResourceClaims
+    :: ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+todoWriteResourceClaims _ =
+    pure $ Right
+        [ToolResourceClaim ToolWrite (ToolNamedResource "todos")]
 
 todoWriteDescription :: Text
 todoWriteDescription =

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -18,12 +18,21 @@ import Agent.GrokBuild.Dialect.Runtime
 import Agent.GrokBuild.Dialect.TaskControl (validateTaskIds)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
 import Agent.OsPath (unsafeToFilePath)
-import Agent.Tools.Types (AppTool(..), defaultToolEnv)
+import Agent.ToolDispatch (ToolCall, functionToolCall)
+import Agent.Tools.Scheduling (schedulingPlansConflict)
+import Agent.Tools.Types
+    ( AppTool(..)
+    , ToolRegistry
+    , defaultToolEnv
+    , mkToolRegistry
+    , toolSchedulingPlanFor
+    )
 import Control.Concurrent.MVar (readMVar)
 import Control.Exception.Safe (bracket)
 import Data.Bits ((.&.))
 import Data.IORef (newIORef)
 import qualified Data.Map.Strict as Map
+import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import System.Directory (doesFileExist)
@@ -73,6 +82,93 @@ spec = describe "Grok Build dialect" do
             names `shouldNotContain` ["shell_command", "apply_patch"]
             coding.grokClose
 
+    it "derives disjoint search_replace resources from file paths" do
+        withGrokRegistry \registry close -> do
+            first <- toolSchedulingPlanFor registry (replace "r1" "a.txt")
+            second <- toolSchedulingPlanFor registry (replace "r2" "b.txt")
+            same <- toolSchedulingPlanFor registry (replace "r3" "a.txt")
+            schedulingPlansConflict first second `shouldBe` False
+            schedulingPlansConflict first same `shouldBe` True
+            close
+
+    it "lets observational terminal commands overlap filesystem reads" do
+        withGrokRegistry \registry close -> do
+            terminal <-
+                toolSchedulingPlanFor registry
+                    (terminalCall "t1" "sed -n '1,80p' src/Main.hs" False)
+            grepCall <-
+                toolSchedulingPlanFor registry
+                    (functionToolCall "g1" "grep" "{\"pattern\":\"foo\"}")
+            schedulingPlansConflict terminal grepCall `shouldBe` False
+            close
+
+    it "keeps mutating and background terminal commands exclusive" do
+        withGrokRegistry \registry close -> do
+            grepCall <-
+                toolSchedulingPlanFor registry
+                    (functionToolCall "g1" "grep" "{\"pattern\":\"foo\"}")
+            mutating <-
+                toolSchedulingPlanFor registry
+                    (terminalCall "t1" "nix develop -c cabal test" False)
+            background <-
+                toolSchedulingPlanFor registry
+                    (terminalCall "t2" "sed -n '1,80p' src/Main.hs" True)
+            schedulingPlansConflict mutating grepCall `shouldBe` True
+            schedulingPlansConflict background grepCall `shouldBe` True
+            close
+
+    it "isolates todo_write from filesystem tools" do
+        withGrokRegistry \registry close -> do
+            todo <-
+                toolSchedulingPlanFor registry
+                    (functionToolCall
+                        "td1"
+                        "todo_write"
+                        "{\"todos\":[{\"id\":\"1\",\"content\":\"x\",\"status\":\"pending\"}]}")
+            otherTodo <-
+                toolSchedulingPlanFor registry
+                    (functionToolCall
+                        "td2"
+                        "todo_write"
+                        "{\"todos\":[{\"id\":\"2\",\"content\":\"y\",\"status\":\"pending\"}]}")
+            readCall <-
+                toolSchedulingPlanFor registry
+                    (functionToolCall
+                        "rf1"
+                        "read_file"
+                        "{\"target_file\":\"a.txt\"}")
+            schedulingPlansConflict todo readCall `shouldBe` False
+            schedulingPlansConflict todo otherTodo `shouldBe` True
+            close
+
+    it "lets statically pure GHCi overlap filesystem reads" do
+        withGrokRegistry \registry close -> do
+            pureGhci <-
+                toolSchedulingPlanFor registry
+                    (functionToolCall
+                        "gh1"
+                        "run_ghci"
+                        "{\"expression\":\":type id\",\"description\":\"type\"}")
+            effectful <-
+                toolSchedulingPlanFor registry
+                    (functionToolCall
+                        "gh2"
+                        "run_ghci"
+                        "{\"expression\":\":reload\",\"description\":\"reload\"}")
+            otherPure <-
+                toolSchedulingPlanFor registry
+                    (functionToolCall
+                        "gh3"
+                        "run_ghci"
+                        "{\"expression\":\":kind Maybe\",\"description\":\"kind\"}")
+            grepCall <-
+                toolSchedulingPlanFor registry
+                    (functionToolCall "g1" "grep" "{\"pattern\":\"foo\"}")
+            schedulingPlansConflict pureGhci grepCall `shouldBe` False
+            schedulingPlansConflict pureGhci otherPure `shouldBe` True
+            schedulingPlansConflict effectful grepCall `shouldBe` True
+            close
+
     it "owns a private temporary shell environment file until session close" do
         path <- withTempDir \dir -> do
             env <- defaultToolEnv (unsafeEncodeUtf dir)
@@ -105,3 +201,36 @@ spec = describe "Grok Build dialect" do
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir = withSystemTempDirectory "agent-grok-build-dialect"
+
+withGrokRegistry
+    :: (ToolRegistry -> IO () -> IO a)
+    -> IO a
+withGrokRegistry action =
+    withTempDir \dir -> do
+        env <- defaultToolEnv (unsafeEncodeUtf dir)
+        typesRef <- newIORef Map.empty
+        coding <- newGrokCodingTools env Nothing Nothing typesRef
+        let registry =
+                either (error . Text.unpack) id $
+                    mkToolRegistry coding.grokAppTools
+        action registry coding.grokClose
+
+replace :: Text -> Text -> ToolCall
+replace ident path =
+    functionToolCall ident "search_replace" $
+        "{\"file_path\":\""
+            <> path
+            <> "\",\"old_string\":\"x\",\"new_string\":\"y\"}"
+
+terminalCall :: Text -> Text -> Bool -> ToolCall
+terminalCall ident command background =
+    functionToolCall ident "run_terminal_cmd" $
+        "{\"command\":"
+            <> jsonString command
+            <> ",\"description\":\"probe\",\"background\":"
+            <> (if background then "true" else "false")
+            <> "}"
+
+jsonString :: Text -> Text
+jsonString text =
+    "\"" <> Text.replace "\"" "\\\"" text <> "\""

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -91,6 +91,21 @@ spec = describe "Grok Build dialect" do
             schedulingPlansConflict first same `shouldBe` True
             close
 
+    it "serializes gitignore policy edits against other filesystem writes" do
+        withGrokRegistry \registry close -> do
+            ignoreFile <-
+                toolSchedulingPlanFor registry (replace "g1" ".gitignore")
+            nestedIgnore <-
+                toolSchedulingPlanFor registry (replace "g2" "src/.gitignore")
+            exclude <-
+                toolSchedulingPlanFor registry
+                    (replace "g3" ".git/info/exclude")
+            other <- toolSchedulingPlanFor registry (replace "r1" "a.txt")
+            schedulingPlansConflict ignoreFile other `shouldBe` True
+            schedulingPlansConflict nestedIgnore other `shouldBe` True
+            schedulingPlansConflict exclude other `shouldBe` True
+            close
+
     it "lets observational terminal commands overlap filesystem reads" do
         withGrokRegistry \registry close -> do
             terminal <-
@@ -115,6 +130,10 @@ spec = describe "Grok Build dialect" do
                     (terminalCall "t2" "sed -n '1,80p' src/Main.hs" True)
             schedulingPlansConflict mutating grepCall `shouldBe` True
             schedulingPlansConflict background grepCall `shouldBe` True
+            uniqOutput <-
+                toolSchedulingPlanFor registry
+                    (terminalCall "t3" "uniq input.txt output.txt" False)
+            schedulingPlansConflict uniqOutput grepCall `shouldBe` True
             close
 
     it "isolates todo_write from filesystem tools" do


### PR DESCRIPTION
## Summary

Recent sessions still serialized several tools that do not share state. Over the last 48 hours that was mostly Grok `search_replace` (1,576 calls; 349 multi-edit batches) plus exclusive `run_terminal_command`, `todo_write`, and `run_ghci` calls sitting next to `grep` / `read_file`.

This change gives those tools resource claims so the existing scheduler can overlap independent work:

- `search_replace` claims a write on the resolved file, matching `apply_patch`. Same-file edits stay ordered; disjoint files and unrelated reads can overlap. Edits to `.gitignore` or `.git/info/exclude` claim a workspace-wide write so they serialize against other filesystem tools (later replacements consult `git check-ignore`).
- Observational `run_terminal_command` reuses the Codex read-only allowlist. Background, unrecognized, and `uniq INPUT OUTPUT` commands stay exclusive.
- `todo_write` claims a named `todos` resource, so it no longer barriers filesystem tools.
- Statically pure `run_ghci` (`:type`, bindings, info commands) claims a named `ghci` resource. Effectful or unknown expressions stay exclusive.

The Codex allowlist now lives in `Agent.Tools.ShellReadOnly` so both dialects share it.

## Benchmark

Optimized `agent-core:bench:tool-scheduling-bench`, GHC 9.10.3 `-O2`, `+RTS -T`. Eight handlers each sleep 20 ms; median of seven samples. `old-sequential` is the previous exclusive Grok path; `new-disjoint-paths` is per-file `search_replace` writes.

```
nix develop -c cabal build --offline --enable-optimization=2 agent-core:bench:tool-scheduling-bench
bin=$(nix develop -c cabal list-bin agent-core:bench:tool-scheduling-bench)
"$bin" old-sequential 8 20000 7 +RTS -T
"$bin" new-disjoint-paths 8 20000 7 +RTS -T
"$bin" new-conflicting 8 20000 7 +RTS -T
```

| Workload | Wall (ms) | CPU (ms) | Allocated |
|---|---:|---:|---:|
| `old-sequential` | 188.732 | 0.409 | 122,208 B |
| `new-disjoint-paths` | 24.145 | 0.112 | 157,472 B |
| `new-conflicting` | 185.104 | 0.474 | 126,632 B |

Disjoint path writes are about **7.8×** lower wall time. Conflicting writes stay sequential. Repeating `new-disjoint-paths` gave 24.783 ms, so the measurement is stable. Extra allocation in the path-write case is claim construction on the synthetic tools, not handler I/O.

## Tests

- `nix develop -c cabal test agent-core:test:agent-core-test` — 368 examples, 0 failures
- `nix develop -c cabal test agent-codex-dialect:test:agent-codex-dialect-test` — 9 examples, 0 failures
- `nix develop -c cabal test agent-grok-build-dialect:test:agent-grok-build-dialect-test` — 38 examples, 0 failures