### PR TITLE
Use vector-native session history assembly

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -121,6 +121,7 @@ import Data.Time.Clock (UTCTime, getCurrentTime, nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.Word (Word64)
+import qualified Data.Vector as Vector
 import Numeric (showHex)
 import System.Directory.OsPath
     ( createDirectory
@@ -899,7 +900,7 @@ loadSessionTurnPage root pool sessionId loader = runExceptT do
         (\storedTurn -> do
             turn <- fromStoredTurn storedTurn.storedTurn
             pure (storedTurn.storedTurnIndex, turn))
-        stored.sessionPageTurns
+        (Vector.toList stored.sessionPageTurns)
     pure SessionTurnPage
         { pageTurns = turns
         , pageGenerationStart = stored.sessionPageGenerationStart
@@ -1307,7 +1308,10 @@ decodeStoredSession
 decodeStoredSession sessionId stored = do
     meta <- except (fromStoredMetadata stored.storedMetadata)
     validateSessionMeta sessionId meta
-    turns <- except $ mapM (fromStoredTurn . (.storedTurn)) stored.storedTurns
+    turns <- except $
+        traverse
+            (fromStoredTurn . (.storedTurn))
+            (Vector.toList stored.storedTurns)
     pure (meta, turns)
 
 toStoredMetadata :: SessionMeta -> Store.SessionMetadata

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -80,6 +80,7 @@ library
                     , time
                     , unix
                     , uuid-types
+                    , vector
 
 benchmark pool-cache-bench
     import:           common-opts

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -119,6 +119,7 @@ benchmark session-history-paging-bench
                     , temporary
                     , text
                     , time
+                    , vector
 
 test-suite agent-store-test
     import:           common-opts

--- a/packages/agent-store/benchmark/SessionHistoryPaging.hs
+++ b/packages/agent-store/benchmark/SessionHistoryPaging.hs
@@ -25,6 +25,7 @@ import Data.List (sort)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (getCurrentTime)
+import qualified Data.Vector as Vector
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Stats
     ( RTSStats(..)
@@ -47,6 +48,8 @@ data Workload
     = FullTranscript
     | ActiveTranscript
     | RecentPage
+    | ListRows
+    | VectorRows
     deriving (Eq, Show)
 
 data Sample = Sample
@@ -119,7 +122,14 @@ runMatrix store turnCounts payloadBytes sampleCount = do
             turnCount
             activeTurns
             payloadBytes
-        forM_ [FullTranscript, ActiveTranscript, RecentPage] \workload -> do
+        forM_
+            [ FullTranscript
+            , ActiveTranscript
+            , RecentPage
+            , ListRows
+            , VectorRows
+            ]
+            \workload -> do
             _ <- measure (workloadAction store sessionKey workload)
             samples <- forM [1 .. sampleCount] \_ ->
                 measure (workloadAction store sessionKey workload)
@@ -206,6 +216,16 @@ workloadAction store sessionKey = \case
     RecentPage ->
         fmap (fmap checksumPage . joinMaybe "recent page") $
             loadRecentSessionTurns (trustedPool store) sessionKey 80
+    ListRows ->
+        fmap (fmap checksumListRows) $
+            withSession
+                (trustedPool store)
+                (Session.statement sessionKey listRowsStatement)
+    VectorRows ->
+        fmap (fmap checksumVectorRows) $
+            withSession
+                (trustedPool store)
+                (Session.statement sessionKey vectorRowsStatement)
 
 joinMaybe
     :: Text
@@ -281,6 +301,18 @@ checksumTurn current stored =
         + maybe 0 Text.length turn.sessionTurnResponseId
         + length turn.sessionTurnItems
 
+checksumListRows :: [(Int64, Maybe Text)] -> Int
+checksumListRows =
+    foldl' checksumRow 0
+
+checksumVectorRows :: Vector.Vector (Int64, Maybe Text) -> Int
+checksumVectorRows =
+    Vector.foldl' checksumRow 0
+
+checksumRow :: Int -> (Int64, Maybe Text) -> Int
+checksumRow current (turnIndex, assistantText) =
+    current + fromIntegral turnIndex + maybe 0 Text.length assistantText
+
 median :: [Sample] -> Sample
 median samples =
     Sample
@@ -303,6 +335,8 @@ printSample turnCount payloadBytes activeTurns workload sample =
             FullTranscript -> "full"
             ActiveTranscript -> "active"
             RecentPage -> "recent"
+            ListRows -> "list-rows"
+            VectorRows -> "vector-rows"
             :: String)
         sample.elapsedMillis
         sample.cpuMillis
@@ -356,3 +390,31 @@ seedSessionStatement =
         )
         (Decoders.singleRow $
             Decoders.column (Decoders.nonNullable Decoders.int8))
+
+listRowsStatement :: Statement Text [(Int64, Maybe Text)]
+listRowsStatement =
+    Statement.preparable
+        benchmarkRowsSql
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.rowList benchmarkRowDecoder)
+
+vectorRowsStatement :: Statement Text (Vector.Vector (Int64, Maybe Text))
+vectorRowsStatement =
+    Statement.preparable
+        benchmarkRowsSql
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.rowVector benchmarkRowDecoder)
+
+benchmarkRowsSql :: Text
+benchmarkRowsSql =
+    "SELECT t.turn_index, t.assistant_text\
+    \ FROM harness.session_turns t\
+    \ JOIN harness.sessions s ON s.session_id = t.session_id\
+    \ WHERE s.session_key = $1 AND s.deleted_at IS NULL\
+    \ ORDER BY t.turn_index ASC"
+
+benchmarkRowDecoder :: Decoders.Row (Int64, Maybe Text)
+benchmarkRowDecoder =
+    (,)
+        <$> Decoders.column (Decoders.nonNullable Decoders.int8)
+        <*> Decoders.column (Decoders.nullable Decoders.text)

--- a/packages/agent-store/benchmark/SessionHistoryPaging.hs
+++ b/packages/agent-store/benchmark/SessionHistoryPaging.hs
@@ -46,10 +46,13 @@ import Text.Printf (printf)
 
 data Workload
     = FullTranscript
+    | FullTranscriptListBoundary
     | ActiveTranscript
     | RecentPage
     | ListRows
     | VectorRows
+    | ListRowsRetained
+    | VectorRowsRetained
     deriving (Eq, Show)
 
 data Sample = Sample
@@ -124,10 +127,13 @@ runMatrix store turnCounts payloadBytes sampleCount = do
             payloadBytes
         forM_
             [ FullTranscript
+            , FullTranscriptListBoundary
             , ActiveTranscript
             , RecentPage
             , ListRows
             , VectorRows
+            , ListRowsRetained
+            , VectorRowsRetained
             ]
             \workload -> do
             _ <- measure (workloadAction store sessionKey workload)
@@ -210,6 +216,11 @@ workloadAction store sessionKey = \case
     FullTranscript ->
         fmap (fmap checksumStoredSession . joinMaybe "full transcript") $
             loadSession (trustedPool store) sessionKey
+    FullTranscriptListBoundary ->
+        fmap
+            (fmap checksumStoredSessionListBoundary
+                . joinMaybe "full transcript list boundary") $
+            loadSession (trustedPool store) sessionKey
     ActiveTranscript ->
         fmap (fmap checksumStoredSession . joinMaybe "active transcript") $
             loadActiveSession (trustedPool store) sessionKey
@@ -223,6 +234,16 @@ workloadAction store sessionKey = \case
                 (Session.statement sessionKey listRowsStatement)
     VectorRows ->
         fmap (fmap checksumVectorRows) $
+            withSession
+                (trustedPool store)
+                (Session.statement sessionKey vectorRowsStatement)
+    ListRowsRetained ->
+        fmap (fmap retainListRows) $
+            withSession
+                (trustedPool store)
+                (Session.statement sessionKey listRowsStatement)
+    VectorRowsRetained ->
+        fmap (fmap retainVectorRows) $
             withSession
                 (trustedPool store)
                 (Session.statement sessionKey vectorRowsStatement)
@@ -282,6 +303,13 @@ checksumStoredSession stored =
         (Text.length stored.storedMetadata.sessionMetadataTitle)
         stored.storedTurns
 
+checksumStoredSessionListBoundary :: StoredSession -> Int
+checksumStoredSessionListBoundary stored =
+    foldl'
+        checksumTurn
+        (Text.length stored.storedMetadata.sessionMetadataTitle)
+        (Vector.toList stored.storedTurns)
+
 checksumPage :: SessionTurnPage -> Int
 checksumPage page =
     foldl'
@@ -309,6 +337,15 @@ checksumVectorRows :: Vector.Vector (Int64, Maybe Text) -> Int
 checksumVectorRows =
     Vector.foldl' checksumRow 0
 
+retainListRows :: [(Int64, Maybe Text)] -> Int
+retainListRows = \case
+    [] -> 0
+    row : _ -> checksumRow 0 row
+
+retainVectorRows :: Vector.Vector (Int64, Maybe Text) -> Int
+retainVectorRows rows =
+    maybe 0 (checksumRow 0 . fst) (Vector.uncons rows)
+
 checksumRow :: Int -> (Int64, Maybe Text) -> Int
 checksumRow current (turnIndex, assistantText) =
     current + fromIntegral turnIndex + maybe 0 Text.length assistantText
@@ -333,10 +370,13 @@ printSample turnCount payloadBytes activeTurns workload sample =
         activeTurns
         (case workload of
             FullTranscript -> "full"
+            FullTranscriptListBoundary -> "full-list-boundary"
             ActiveTranscript -> "active"
             RecentPage -> "recent"
             ListRows -> "list-rows"
             VectorRows -> "vector-rows"
+            ListRowsRetained -> "list-rows-retained"
+            VectorRowsRetained -> "vector-rows-retained"
             :: String)
         sample.elapsedMillis
         sample.cpuMillis

--- a/packages/agent-store/benchmark/SessionHistoryPaging.md
+++ b/packages/agent-store/benchmark/SessionHistoryPaging.md
@@ -1,0 +1,67 @@
+# Session history paging benchmark
+
+This benchmark exercises real PostgreSQL session reads and retains equivalent
+`rowList` and `rowVector` decoder workloads. It reports median elapsed time,
+CPU time, and allocated bytes after one warm-up query.
+
+Build and run:
+
+```sh
+nix develop -c cabal build --offline \
+  agent-store:bench:session-history-paging-bench
+bin=$(nix develop -c cabal list-bin \
+  agent-store:bench:session-history-paging-bench)
+TMPDIR=/tmp "$bin" 1000,5000,10000 4096 5 +RTS -T
+TMPDIR=/tmp "$bin" 10000 4096 11 +RTS -T
+TMPDIR=/tmp "$bin" 10000 16 11 +RTS -T
+```
+
+`TMPDIR=/tmp` keeps the managed PostgreSQL Unix-socket path below PostgreSQL's
+length limit. The benchmark component uses `-O2`; the `agent-store` library was
+built with Cabal's optimized `-O1` build profile. Workloads use 4,096 assistant
+payload bytes per turn and retain 80 active turns.
+
+## Direct row decoder comparison
+
+Both workloads select and checksum the same 10,000 ordered
+`(turn_index, assistant_text)` rows. The benchmark consumes `rowVector`
+directly with `Vector.foldl'`; it never converts it to a list.
+
+Hasql 2.0.1.0 does not implement `rowVector` through a list either. Its result
+decoder allocates a mutable vector at the exact PostgreSQL row count, writes
+each decoded row into it, and freezes it. `rowList` uses a separate strict
+right fold.
+
+These are 11-sample medians:
+
+| payload bytes | decoder | elapsed ms | CPU ms | allocated bytes |
+|---:|:---|---:|---:|---:|
+| 4,096 | `rowList` | 62.254 | 49.419 | 92,972,408 |
+| 4,096 | `rowVector` | 65.157 | 49.926 | 92,812,528 |
+| 16 | `rowList` | 16.357 | 14.684 | 11,295,192 |
+| 16 | `rowVector` | 16.826 | 14.998 | 11,135,368 |
+
+With the representative 4 KiB payload, `rowVector` allocated 0.17% less but
+took 4.66% more elapsed time and 1.03% more CPU time. The roughly 160 KB
+allocation difference across 10,000 rows is the expected avoided list-node
+overhead; row payload decoding dominates the total. With 16-byte payloads,
+Vector saved 1.42% allocation but remained 2.87% slower elapsed and 2.14%
+slower on CPU. The production decoder migration was therefore reverted.
+
+## Session assembly improvement
+
+The investigation also found quadratic ordered grouping in `loadSessions`.
+`Map.fromListWith (flip (++))` repeatedly appended a singleton turn to an
+existing per-session list. The replacement prepends each singleton with
+`Map.fromListWith (++)` and reverses each completed group once.
+
+Before/after medians for the full-transcript workload:
+
+| turns | before elapsed ms | after elapsed ms | before allocated | after allocated |
+|---:|---:|---:|---:|---:|
+| 1,000 | 54.426 | 52.362 | 53,886,960 | 25,994,928 |
+| 5,000 | 383.395 | 271.686 | 1,225,494,776 | 129,839,960 |
+| 10,000 | 1,053.146 | 571.631 | 4,709,280,832 | 259,667,352 |
+
+At 10,000 turns this reduces elapsed time by 45.7% and allocation by 94.5%
+while preserving turn order and the existing list-based API.

--- a/packages/agent-store/benchmark/SessionHistoryPaging.md
+++ b/packages/agent-store/benchmark/SessionHistoryPaging.md
@@ -23,9 +23,10 @@ payload bytes per turn and retain 80 active turns.
 
 ## Direct row decoder comparison
 
-Both workloads select and checksum the same 10,000 ordered
-`(turn_index, assistant_text)` rows. The benchmark consumes `rowVector`
-directly with `Vector.foldl'`; it never converts it to a list.
+The benchmark has two direct decoder comparisons. `list-rows` and
+`vector-rows` checksum the same 10,000 ordered
+`(turn_index, assistant_text)` rows. The `*-rows-retained` variants inspect
+only the first already-decoded row, avoiding a full consumer fold.
 
 Hasql 2.0.1.0 does not implement `rowVector` through a list either. Its result
 decoder allocates a mutable vector at the exact PostgreSQL row count, writes
@@ -41,27 +42,55 @@ These are 11-sample medians:
 | 16 | `rowList` | 16.357 | 14.684 | 11,295,192 |
 | 16 | `rowVector` | 16.826 | 14.998 | 11,135,368 |
 
-With the representative 4 KiB payload, `rowVector` allocated 0.17% less but
-took 4.66% more elapsed time and 1.03% more CPU time. The roughly 160 KB
-allocation difference across 10,000 rows is the expected avoided list-node
-overhead; row payload decoding dominates the total. With 16-byte payloads,
-Vector saved 1.42% allocation but remained 2.87% slower elapsed and 2.14%
-slower on CPU. The production decoder migration was therefore reverted.
+With the representative 4 KiB payload, `rowVector` allocated 0.17% less in
+the initial folded comparison. The roughly 160 KB difference across 10,000
+rows is the expected avoided list-node overhead; row payload decoding
+dominates the total. Timing varied between runs and changed direction when
+the full consumer fold was removed, so the direct decoder microbenchmark
+alone does not justify either container.
 
-## Session assembly improvement
+## Vector-native session assembly
 
 The investigation also found quadratic ordered grouping in `loadSessions`.
 `Map.fromListWith (flip (++))` repeatedly appended a singleton turn to an
-existing per-session list. The replacement prepends each singleton with
-`Map.fromListWith (++)` and reverses each completed group once.
+existing per-session list.
 
-Before/after medians for the full-transcript workload:
+An intermediate linear-List implementation prepended each singleton and
+reversed each completed group once. The final implementation instead retains
+Vectors throughout the store read path:
+
+- Hasql statements decode metadata and turns with `rowVector`;
+- contiguous per-session rows are grouped as Vector slices;
+- stored sessions and pages expose Vector turn collections;
+- page `take`, `reverse`, first, and last operations are Vector-native.
+
+The CLI currently converts at its existing List API boundary. The benchmark's
+`full-list-boundary` workload models that conversion explicitly.
+
+Alternating builds of the linear-List commit and the Vector implementation,
+using 7-sample medians:
+
+| turns | implementation | elapsed ms | CPU ms | allocated bytes |
+|---:|:---|---:|---:|---:|
+| 1,000 | linear List | 53.708 | 42.420 | 25,994,880 |
+| 1,000 | Vector | 44.418 | 37.119 | 25,940,328 |
+| 5,000 | linear List | 282.887 | 228.157 | 129,835,952 |
+| 5,000 | Vector | 245.680 | 197.245 | 129,463,584 |
+| 10,000 | linear List | 555.487 | 451.436 | 259,667,040 |
+| 10,000 | Vector | 496.722 | 393.155 | 258,886,312 |
+| 10,000 | Vector plus List boundary | 498.635 | 393.487 | 258,886,624 |
+
+The Vector path is 10.6–17.3% faster elapsed and 12.5–13.6% faster on CPU
+across these sizes. At 10,000 turns the existing CLI List boundary retains a
+10.2% elapsed and 12.8% CPU improvement over the linear-List store.
+
+Compared with the original quadratic implementation:
 
 | turns | before elapsed ms | after elapsed ms | before allocated | after allocated |
 |---:|---:|---:|---:|---:|
-| 1,000 | 54.426 | 52.362 | 53,886,960 | 25,994,928 |
-| 5,000 | 383.395 | 271.686 | 1,225,494,776 | 129,839,960 |
-| 10,000 | 1,053.146 | 571.631 | 4,709,280,832 | 259,667,352 |
+| 1,000 | 54.426 | 44.418 | 53,886,960 | 25,940,328 |
+| 5,000 | 383.395 | 245.680 | 1,225,494,776 | 129,463,584 |
+| 10,000 | 1,053.146 | 496.722 | 4,709,280,832 | 258,886,312 |
 
-At 10,000 turns this reduces elapsed time by 45.7% and allocation by 94.5%
-while preserving turn order and the existing list-based API.
+At 10,000 turns this reduces elapsed time by 52.8% and allocation by 94.5%
+while preserving turn order.

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, async, base, bytestring, containers, contravariant
 , directory, filelock, filepath, hasql, hasql-pool
 , hasql-transaction, hspec, lib, pqi-ffi, process, safe-exceptions
-, stm, temporary, text, time, unix, uuid-types
+, stm, temporary, text, time, unix, uuid-types, vector
 }:
 mkDerivation {
   pname = "agent-store";
@@ -18,7 +18,7 @@ mkDerivation {
   ];
   benchmarkHaskellDepends = [
     async base containers contravariant hasql safe-exceptions temporary
-    text time
+    text time vector
   ];
   description = "PostgreSQL persistence for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -10,7 +10,7 @@ mkDerivation {
   libraryHaskellDepends = [
     async base bytestring containers contravariant directory filelock
     filepath hasql hasql-pool hasql-transaction pqi-ffi process
-    safe-exceptions stm text time unix uuid-types
+    safe-exceptions stm text time unix uuid-types vector
   ];
   testHaskellDepends = [
     async base bytestring hasql hspec safe-exceptions temporary text

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
@@ -19,12 +19,12 @@ module Agent.Store.Postgres.Session.Read
     , searchConversationTurns
     ) where
 
-import Control.Monad (forM)
 import Data.Functor.Contravariant ((>$<))
 import Data.Int (Int64)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
+import qualified Data.Vector as Vector
 import qualified Hasql.Decoders as Decoders
 import qualified Hasql.Encoders as Encoders
 import qualified Hasql.Session as HasqlSession
@@ -67,8 +67,10 @@ loadSessions pool sessionKeys =
                 sessionKeys
                 loadMetadataManyStatement
             rows <- Transaction.statement sessionKeys loadTurnsManyStatement
-            turns <- forM rows \(sessionKey, row) ->
-                fmap ((,) sessionKey) (loadStoredTurn row)
+            turns <- Vector.mapM
+                (\(sessionKey, row) ->
+                    fmap ((,) sessionKey) (loadStoredTurn row))
+                rows
             pure (assembleSessions sessionKeys metadata turns))
         >>= \case
             Left err -> pure (replicate (length sessionKeys) (Left err))
@@ -77,26 +79,34 @@ loadSessions pool sessionKeys =
 
 assembleSessions
     :: [Text]
-    -> [SessionMetadata]
-    -> [(Text, Either Text StoredTurn)]
+    -> Vector.Vector SessionMetadata
+    -> Vector.Vector (Text, Either Text StoredTurn)
     -> [Either Text (Maybe StoredSession)]
 assembleSessions sessionKeys metadata turns =
     map assemble sessionKeys
   where
     metadataByKey =
-        Map.fromList
-            [(value.sessionMetadataKey, value) | value <- metadata]
+        Vector.foldl'
+            (\byKey value ->
+                Map.insert value.sessionMetadataKey value byKey)
+            Map.empty
+            metadata
     turnsByKey =
-        Map.map reverse $
-            Map.fromListWith (<>)
-                [(sessionKey, [turn]) | (sessionKey, turn) <- turns]
+        Map.fromList
+            [ (sessionKey, Vector.map snd group)
+            | group <- Vector.groupBy
+                (\left right -> fst left == fst right)
+                turns
+            , Just ((sessionKey, _), _) <- [Vector.uncons group]
+            ]
 
     assemble sessionKey =
         case Map.lookup sessionKey metadataByKey of
             Nothing -> Right Nothing
             Just value -> do
                 decodedTurns <-
-                    sequence (Map.findWithDefault [] sessionKey turnsByKey)
+                    sequence
+                        (Map.findWithDefault Vector.empty sessionKey turnsByKey)
                 pure $ Just StoredSession
                     { storedMetadata = value
                     , storedTurns = decodedTurns
@@ -123,7 +133,7 @@ loadActiveSession pool sessionKey =
                 Nothing -> pure (Right Nothing)
                 Just value -> do
                     rows <- Transaction.statement sessionKey loadActiveTurnsStatement
-                    turns <- forM rows loadStoredTurn
+                    turns <- Vector.mapM loadStoredTurn rows
                     pure do
                         decodedTurns <- sequence turns
                         pure $ Just StoredSession
@@ -187,7 +197,7 @@ data PageMode = PageRecent | PageBefore | PageAfter
 loadTurnPage
     :: StorePool
     -> Text
-    -> Transaction.Transaction [TurnRow]
+    -> Transaction.Transaction (Vector.Vector TurnRow)
     -> Int
     -> PageMode
     -> IO (Either StoreError (Maybe SessionTurnPage))
@@ -202,29 +212,25 @@ loadTurnPage pool sessionKey loadRows limit mode =
                     (generationStart, total) <-
                         Transaction.statement sessionKey currentGenerationStatement
                     let visibleRows = case mode of
-                            PageRecent -> reverse (take limit rows0)
-                            PageBefore -> reverse (take limit rows0)
-                            PageAfter -> take limit rows0
-                    turns <- forM visibleRows loadStoredTurn
+                            PageRecent -> Vector.reverse (Vector.take limit rows0)
+                            PageBefore -> Vector.reverse (Vector.take limit rows0)
+                            PageAfter -> Vector.take limit rows0
+                    turns <- Vector.mapM loadStoredTurn visibleRows
                     pure do
                         decoded <- sequence turns
                         let generationEnd =
                                 generationStart + max 0 total - 1
                             (hasOlder, hasNewer) =
-                                case decoded of
-                                    firstTurn : rest ->
-                                        let lastTurn =
-                                                foldl
-                                                    (\_ current -> current)
-                                                    firstTurn
-                                                    rest
+                                case Vector.uncons decoded of
+                                    Just (firstTurn, _) ->
+                                        let lastTurn = Vector.last decoded
                                         in
                                             ( firstTurn.storedTurnIndex
                                                 > generationStart
                                             , lastTurn.storedTurnIndex
                                                 < generationEnd
                                             )
-                                    [] -> case mode of
+                                    Nothing -> case mode of
                                         PageRecent -> (False, False)
                                         PageBefore -> (False, total > 0)
                                         PageAfter -> (total > 0, False)
@@ -336,13 +342,14 @@ flattenDataResult = pure . \case
     Right (Left err) -> Left (StoreDataError err)
     Right (Right value) -> Right value
 
-loadMetadataManyStatement :: Statement [Text] [SessionMetadata]
+loadMetadataManyStatement
+    :: Statement [Text] (Vector.Vector SessionMetadata)
 loadMetadataManyStatement = mkStatement
     (metadataSelectSql
         <> " WHERE session_key = ANY($1::text[]) AND deleted_at IS NULL\
            \ ORDER BY array_position($1::text[], session_key)")
     textArrayParams
-    (Decoders.rowList metadataRow)
+    (Decoders.rowVector metadataRow)
     True
 
 loadMetadataStatement :: Statement Text (Maybe SessionMetadata)
@@ -373,7 +380,8 @@ metadataSelectSql =
     \ cached_tokens, last_recap, last_turn_summary, last_recap_main_turns\
     \ FROM harness.sessions"
 
-loadTurnsManyStatement :: Statement [Text] [(Text, TurnRow)]
+loadTurnsManyStatement
+    :: Statement [Text] (Vector.Vector (Text, TurnRow))
 loadTurnsManyStatement = mkStatement
     "SELECT s.session_key, t.turn_id::text, t.turn_index, t.event_sequence,\
     \ t.occurred_at, t.user_text, t.assistant_text, t.error_text,\
@@ -384,13 +392,13 @@ loadTurnsManyStatement = mkStatement
     \ WHERE s.session_key = ANY($1::text[]) AND s.deleted_at IS NULL\
     \ ORDER BY array_position($1::text[], s.session_key), t.turn_index ASC"
     textArrayParams
-    (Decoders.rowList $
+    (Decoders.rowVector $
         (,)
             <$> Decoders.column (Decoders.nonNullable Decoders.text)
             <*> turnRowDecoder)
     True
 
-loadActiveTurnsStatement :: Statement Text [TurnRow]
+loadActiveTurnsStatement :: Statement Text (Vector.Vector TurnRow)
 loadActiveTurnsStatement = mkStatement
     (turnSelectSql
         <> " WHERE s.session_key = $1\
@@ -404,10 +412,11 @@ loadActiveTurnsStatement = mkStatement
            \ ), 0)\
            \ ORDER BY t.turn_index ASC")
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowList turnRowDecoder)
+    (Decoders.rowVector turnRowDecoder)
     True
 
-loadRecentTurnsStatement :: Statement (Text, Int64) [TurnRow]
+loadRecentTurnsStatement
+    :: Statement (Text, Int64) (Vector.Vector TurnRow)
 loadRecentTurnsStatement = mkStatement
     (turnSelectSql
         <> " WHERE s.session_key = $1\
@@ -424,10 +433,11 @@ loadRecentTurnsStatement = mkStatement
     ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
         <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.int8))
     )
-    (Decoders.rowList turnRowDecoder)
+    (Decoders.rowVector turnRowDecoder)
     True
 
-loadTurnsBeforeStatement :: Statement (Text, Int64, Int64) [TurnRow]
+loadTurnsBeforeStatement
+    :: Statement (Text, Int64, Int64) (Vector.Vector TurnRow)
 loadTurnsBeforeStatement = mkStatement
     (turnSelectSql
         <> " WHERE s.session_key = $1\
@@ -449,10 +459,11 @@ loadTurnsBeforeStatement = mkStatement
         <> ((\(_, _, value) -> value)
             >$< Encoders.param (Encoders.nonNullable Encoders.int8))
     )
-    (Decoders.rowList turnRowDecoder)
+    (Decoders.rowVector turnRowDecoder)
     True
 
-loadTurnsAfterStatement :: Statement (Text, Int64, Int64) [TurnRow]
+loadTurnsAfterStatement
+    :: Statement (Text, Int64, Int64) (Vector.Vector TurnRow)
 loadTurnsAfterStatement = mkStatement
     (turnSelectSql
         <> " WHERE s.session_key = $1\
@@ -474,7 +485,7 @@ loadTurnsAfterStatement = mkStatement
         <> ((\(_, _, value) -> value)
             >$< Encoders.param (Encoders.nonNullable Encoders.int8))
     )
-    (Decoders.rowList turnRowDecoder)
+    (Decoders.rowVector turnRowDecoder)
     True
 
 currentGenerationStatement :: Statement Text (Int64, Int64)

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
@@ -18,6 +18,7 @@ module Agent.Store.Postgres.Session.Types
 import Data.Int (Int32, Int64)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
+import Data.Vector (Vector)
 
 import Agent.Store.SessionItem (StoredResponseItem)
 
@@ -30,7 +31,7 @@ data SessionLegacyTarget = SessionLegacyTarget
     deriving (Eq, Show)
 
 data SessionTurnPage = SessionTurnPage
-    { sessionPageTurns :: ![StoredTurn]
+    { sessionPageTurns :: !(Vector StoredTurn)
     , sessionPageGenerationStart :: !Int64
     , sessionPageTotal :: !Int64
     , sessionPageHasOlder :: !Bool
@@ -102,7 +103,7 @@ data SessionTurn = SessionTurn
 
 data StoredSession = StoredSession
     { storedMetadata :: !SessionMetadata
-    , storedTurns :: ![StoredTurn]
+    , storedTurns :: !(Vector StoredTurn)
     }
     deriving (Eq, Show)
 

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -116,9 +116,14 @@ spec = describe "PostgreSQL session schema" do
                                 turn2 = turn
                                     { sessionTurnUserText = "batch load"
                                     }
+                                turn3 = turn
+                                    { sessionTurnUserText = "batch load 2"
+                                    }
                             createSession pool metadata2
                                 `shouldReturn` Right True
                             appendSessionTurn pool turn2 metadata2
+                                `shouldReturn` Right True
+                            appendSessionTurn pool turn3 metadata2
                                 `shouldReturn` Right True
                             loadSessions pool [] `shouldReturn` []
                             loadSessions pool
@@ -143,7 +148,9 @@ spec = describe "PostgreSQL session schema" do
                                             [ Right
                                                 (Just
                                                     ( "session-2"
-                                                    , ["batch load"]
+                                                    , [ "batch load"
+                                                      , "batch load 2"
+                                                      ]
                                                     ))
                                             , Right Nothing
                                             , Right
@@ -154,7 +161,9 @@ spec = describe "PostgreSQL session schema" do
                                             , Right
                                                 (Just
                                                     ( "session-2"
-                                                    , ["batch load"]
+                                                    , [ "batch load"
+                                                      , "batch load 2"
+                                                      ]
                                                     ))
                                             ]
                             searchConversationTurns pool "compact" 10 >>= \case

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -5,6 +5,7 @@ module Agent.Store.Postgres.SessionSpec (spec) where
 import Control.Exception.Safe (finally)
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Char8 as ByteString.Char8
+import Data.Foldable (toList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -100,7 +101,8 @@ spec = describe "PostgreSQL session schema" do
                             loadSession pool "session-1" >>= \case
                                 Right (Just stored) -> do
                                     stored.storedMetadata `shouldBe` metadata
-                                    case map (.storedTurn) stored.storedTurns of
+                                    case map (.storedTurn)
+                                        (toList stored.storedTurns) of
                                         [loadedTurn] -> do
                                             loadedTurn `shouldBe` turn
                                         loaded ->
@@ -141,7 +143,7 @@ spec = describe "PostgreSQL session schema" do
                                                         ( (.sessionTurnUserText)
                                                             . (.storedTurn)
                                                         )
-                                                        stored.storedTurns
+                                                        (toList stored.storedTurns)
                                                     ))))
                                         results
                                         `shouldBe`
@@ -237,7 +239,7 @@ spec = describe "PostgreSQL session schema" do
                                         (\storedTurn ->
                                             storedTurn.storedTurn.sessionTurnUserText
                                         )
-                                        stored.storedTurns
+                                        (toList stored.storedTurns)
                                         `shouldBe`
                                             [ "/compact"
                                             , "/question-1"
@@ -249,7 +251,8 @@ spec = describe "PostgreSQL session schema" do
                                         ("unexpected active session: " <> show other)
                             loadRecentSessionTurns pool "session-1" 2 >>= \case
                                 Right (Just page) -> do
-                                    map (.storedTurnIndex) page.sessionPageTurns
+                                    map (.storedTurnIndex)
+                                        (toList page.sessionPageTurns)
                                         `shouldBe` [4, 5]
                                     page.sessionPageGenerationStart
                                         `shouldBe` 2
@@ -261,7 +264,8 @@ spec = describe "PostgreSQL session schema" do
                                         ("unexpected recent page: " <> show other)
                             loadSessionTurnsBefore pool "session-1" 4 2 >>= \case
                                 Right (Just page) -> do
-                                    map (.storedTurnIndex) page.sessionPageTurns
+                                    map (.storedTurnIndex)
+                                        (toList page.sessionPageTurns)
                                         `shouldBe` [2, 3]
                                     page.sessionPageHasOlder `shouldBe` False
                                     page.sessionPageHasNewer `shouldBe` True
@@ -270,7 +274,8 @@ spec = describe "PostgreSQL session schema" do
                                         ("unexpected before page: " <> show other)
                             loadSessionTurnsAfter pool "session-1" 3 2 >>= \case
                                 Right (Just page) -> do
-                                    map (.storedTurnIndex) page.sessionPageTurns
+                                    map (.storedTurnIndex)
+                                        (toList page.sessionPageTurns)
                                         `shouldBe` [4, 5]
                                     page.sessionPageHasOlder `shouldBe` True
                                     page.sessionPageHasNewer `shouldBe` False
@@ -279,7 +284,7 @@ spec = describe "PostgreSQL session schema" do
                                         ("unexpected after page: " <> show other)
                             loadSessionTurnsBefore pool "session-1" 2 2 >>= \case
                                 Right (Just page) -> do
-                                    page.sessionPageTurns `shouldBe` []
+                                    toList page.sessionPageTurns `shouldBe` []
                                     page.sessionPageHasOlder `shouldBe` False
                                     page.sessionPageHasNewer `shouldBe` True
                                 other ->
@@ -287,7 +292,7 @@ spec = describe "PostgreSQL session schema" do
                                         ("unexpected empty before page: " <> show other)
                             loadSessionTurnsAfter pool "session-1" 5 2 >>= \case
                                 Right (Just page) -> do
-                                    page.sessionPageTurns `shouldBe` []
+                                    toList page.sessionPageTurns `shouldBe` []
                                     page.sessionPageHasOlder `shouldBe` True
                                     page.sessionPageHasNewer `shouldBe` False
                                 other ->


### PR DESCRIPTION
## Summary

- decode session metadata and turn rows directly into `Vector`
- retain Vectors through batched grouping, stored sessions, and page operations
- eliminate quadratic ordered List grouping while preserving database order
- retain folded and no-fold `rowList`/`rowVector` PostgreSQL workloads
- benchmark the existing CLI List boundary explicitly
- add multi-turn batched-load ordering regression coverage

## Implementation

Hasql 2.0.1.0 implements `rowVector` directly: it allocates an exactly-sized mutable vector, writes decoded rows, and freezes it. Session rows now stay vector-native through `agent-store`:

- `rowVector` for metadata-many and turn queries
- contiguous per-session Vector slices for grouping
- `Vector` fields in stored sessions and turn pages
- Vector-native `take`, `reverse`, first, and last operations

The existing CLI API still consumes Lists. Conversion happens only at that boundary and has a dedicated `full-list-boundary` benchmark workload.

## Performance

Alternating optimized builds of the linear-List commit and Vector candidate, 7-sample medians, 4,096-byte turn payloads:

| turns | implementation | elapsed | CPU | allocation |
|---:|:---|---:|---:|---:|
| 1,000 | linear List | 53.708 ms | 42.420 ms | 25,994,880 B |
| 1,000 | Vector | 44.418 ms | 37.119 ms | 25,940,328 B |
| 5,000 | linear List | 282.887 ms | 228.157 ms | 129,835,952 B |
| 5,000 | Vector | 245.680 ms | 197.245 ms | 129,463,584 B |
| 10,000 | linear List | 555.487 ms | 451.436 ms | 259,667,040 B |
| 10,000 | Vector | 496.722 ms | 393.155 ms | 258,886,312 B |
| 10,000 | Vector + CLI List boundary | 498.635 ms | 393.487 ms | 258,886,624 B |

Vector is 10.6–17.3% faster elapsed and 12.5–13.6% faster on CPU. At 10,000 turns the current List boundary still retains a 10.2% elapsed and 12.8% CPU improvement.

Compared with the original quadratic implementation, the final 10,000-turn path reduces elapsed time by 52.8% and allocation by 94.5%.

Direct folded/no-fold decoder workloads remain in the benchmark. Their timing is noisy and does not independently justify either container; the production improvement comes from keeping the whole store assembly/page path vector-native.

## Validation

- `TMPDIR=/tmp nix develop -c cabal repl agent-store:test:agent-store-test -v0`, then `:main`: 33 examples, 0 failures
- multi-package `agent-store` + `agent-cli` GHCi typecheck
- alternating optimized List/Vector benchmark builds at 1,000, 5,000, and 10,000 turns
- repeated 10,000-turn runs and explicit CLI List-boundary workload
- `git diff --check`
- regenerated `packages/agent-store/package.nix`
