### PR TITLE
Allow more observational shell chains to overlap

### DIFF
--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -85,11 +85,18 @@ spec = describe "Codex dialect" do
             , "cd src && rg --files"
             , "cd /tmp/repo && git diff -- src/Main.hs"
             , "cd 'packages/agent-core' && ls"
+            , "git status --short"
+            , "git status --short && git diff --check && git log --oneline"
+            , "git -C src log --oneline"
+            , "git diff --stat | head -20"
+            , "git branch"
+            , "cd src && git status --short && git diff"
+            , "cd src; ls"
+            , "gh issue list"
             ]
-            `shouldBe` replicate 8 True
+            `shouldBe` replicate 16 True
         map shellCommandIsReadOnly
-            [ "git status --short"
-            , "git fetch origin"
+            [ "git fetch origin"
             , "cat src/Main.hs > copy"
             , "printf x | tee output"
             , "nix develop -c cabal test"
@@ -99,12 +106,14 @@ spec = describe "Codex dialect" do
             , "git diff --output=copy"
             , "uniq input.txt output.txt"
             , "cd src && nix develop -c cabal test"
-            , "cd src && git status && git diff"
-            , "cd src; ls"
             , "cd -- src && ls"
             , "cd $HOME && ls"
+            , "git branch -d leftover"
+            , "git status --short && git fetch origin"
+            , "git diff | tee output"
+            , "git rebase origin/master"
             ]
-            `shouldBe` replicate 15 False
+            `shouldBe` replicate 16 False
 
     it "derives disjoint apply_patch resources from patch paths" do
         withTempDir \dir -> do

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -82,8 +82,11 @@ spec = describe "Codex dialect" do
             , "git diff -- src/Main.hs"
             , "gh pr view 123 --json statusCheckRollup"
             , "uniq -c file.txt"
+            , "cd src && rg --files"
+            , "cd /tmp/repo && git diff -- src/Main.hs"
+            , "cd 'packages/agent-core' && ls"
             ]
-            `shouldBe` replicate 5 True
+            `shouldBe` replicate 8 True
         map shellCommandIsReadOnly
             [ "git status --short"
             , "git fetch origin"
@@ -95,8 +98,13 @@ spec = describe "Codex dialect" do
             , "sed -n '/pattern/w output' src/Main.hs"
             , "git diff --output=copy"
             , "uniq input.txt output.txt"
+            , "cd src && nix develop -c cabal test"
+            , "cd src && git status && git diff"
+            , "cd src; ls"
+            , "cd -- src && ls"
+            , "cd $HOME && ls"
             ]
-            `shouldBe` replicate 10 False
+            `shouldBe` replicate 15 False
 
     it "derives disjoint apply_patch resources from patch paths" do
         withTempDir \dir -> do

--- a/packages/agent-core/src/Agent/Tools/ShellReadOnly.hs
+++ b/packages/agent-core/src/Agent/Tools/ShellReadOnly.hs
@@ -1,24 +1,33 @@
 -- | Strict observational-shell allowlist used by tool resource claims.
 --
 -- Unknown, mutating, redirected, piped, or compound commands stay exclusive.
+-- A single @cd DIR && COMMAND@ prefix is accepted when DIR is a simple path
+-- and COMMAND itself is observational.
 module Agent.Tools.ShellReadOnly
     ( shellCommandIsReadOnly
     ) where
 
+import Data.Char (isSpace)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified System.FilePath as FilePath
 
 -- | True when the complete command is a recognized read-only invocation.
 shellCommandIsReadOnly :: Text -> Bool
-shellCommandIsReadOnly command
-    | Text.null stripped = False
-    | Text.any (`elem` forbiddenChars) stripped = False
-    | "$(" `Text.isInfixOf` stripped = False
-    | "`" `Text.isInfixOf` stripped = False
-    | "$" `Text.isInfixOf` stripped = False
+shellCommandIsReadOnly command =
+    classifySimple $ maybe stripped id (cdAndCommand stripped)
+  where
+    stripped = Text.strip command
+
+classifySimple :: Text -> Bool
+classifySimple command
+    | Text.null command = False
+    | Text.any (`elem` forbiddenChars) command = False
+    | "$(" `Text.isInfixOf` command = False
+    | "`" `Text.isInfixOf` command = False
+    | "$" `Text.isInfixOf` command = False
     | otherwise =
-        case Text.words stripped of
+        case Text.words command of
             [] -> False
             executable : arguments ->
                 allowedCommand
@@ -26,8 +35,49 @@ shellCommandIsReadOnly command
                         (FilePath.takeFileName (Text.unpack executable)))
                     arguments
   where
-    stripped = Text.strip command
     forbiddenChars = ['\n', '\r', ';', '&', '|', '>', '<']
+
+-- | Strip one @cd DIR && COMMAND@ prefix. Anything more compound stays
+-- exclusive via 'classifySimple'.
+cdAndCommand :: Text -> Maybe Text
+cdAndCommand text = do
+    afterCd <- Text.stripPrefix "cd" (Text.stripStart text)
+    afterSpace <- case Text.uncons afterCd of
+        Just (char, rest) | isSpace char ->
+            Just (Text.dropWhile isSpace rest)
+        _ -> Nothing
+    (dir, afterDir) <- nextToken afterSpace
+    afterAnd <- Text.stripPrefix "&&" (Text.dropWhile isSpace afterDir)
+    let command = Text.strip afterAnd
+    if simpleDirectory dir && not (Text.null command)
+        then Just command
+        else Nothing
+
+nextToken :: Text -> Maybe (Text, Text)
+nextToken text
+    | Text.null text = Nothing
+    | otherwise = case Text.uncons text of
+        Just (quote, rest)
+            | quote == '\'' || quote == '"' ->
+                case Text.break (== quote) rest of
+                    (inside, after)
+                        | Text.null after -> Nothing
+                        | Text.any (== '\\') inside -> Nothing
+                        | otherwise -> Just (inside, Text.drop 1 after)
+        _ ->
+            let (token, rest) = Text.break isSpace text
+            in if Text.null token then Nothing else Just (token, rest)
+
+simpleDirectory :: Text -> Bool
+simpleDirectory dir =
+    not (Text.null dir)
+        && not (Text.isPrefixOf "-" dir)
+        && Text.all allowedDirectoryChar dir
+
+allowedDirectoryChar :: Char -> Bool
+allowedDirectoryChar char =
+    char `notElem`
+        ['$', '`', '\n', '\r', ';', '&', '|', '>', '<', '(', ')', '{', '}', '*', '?', '~', '!']
 
 allowedCommand :: Text -> [Text] -> Bool
 allowedCommand executable arguments

--- a/packages/agent-core/src/Agent/Tools/ShellReadOnly.hs
+++ b/packages/agent-core/src/Agent/Tools/ShellReadOnly.hs
@@ -1,13 +1,12 @@
 -- | Strict observational-shell allowlist used by tool resource claims.
 --
--- Unknown, mutating, redirected, piped, or compound commands stay exclusive.
--- A single @cd DIR && COMMAND@ prefix is accepted when DIR is a simple path
--- and COMMAND itself is observational.
+-- Unknown, mutating, or redirected commands stay exclusive. A command may be
+-- a chain of observational segments joined by @&&@, @;@, or @|@. A segment
+-- may be @cd DIR@ with a simple path.
 module Agent.Tools.ShellReadOnly
     ( shellCommandIsReadOnly
     ) where
 
-import Data.Char (isSpace)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified System.FilePath as FilePath
@@ -15,17 +14,41 @@ import qualified System.FilePath as FilePath
 -- | True when the complete command is a recognized read-only invocation.
 shellCommandIsReadOnly :: Text -> Bool
 shellCommandIsReadOnly command =
-    classifySimple $ maybe stripped id (cdAndCommand stripped)
+    case observationalSegments (Text.strip command) of
+        Just segments@(_ : _) -> all classifySimple segments
+        _ -> False
+
+observationalSegments :: Text -> Maybe [Text]
+observationalSegments command
+    | Text.null command = Nothing
+    | Text.any (`elem` ['\n', '\r', '>', '<']) command = Nothing
+    | "$(" `Text.isInfixOf` command = Nothing
+    | "`" `Text.isInfixOf` command = Nothing
+    | "$" `Text.isInfixOf` command = Nothing
+    | "||" `Text.isInfixOf` command = Nothing
+    | hasBareAmpersand command = Nothing
+    | otherwise =
+        let segments =
+                filter (not . Text.null) $
+                    map Text.strip $
+                        concatMap (Text.splitOn "|") $
+                            concatMap (Text.splitOn "&&") $
+                                Text.splitOn ";" command
+        in if null segments then Nothing else Just segments
+
+hasBareAmpersand :: Text -> Bool
+hasBareAmpersand = go
   where
-    stripped = Text.strip command
+    go text
+        | Text.null text = False
+        | "&&" `Text.isPrefixOf` text = go (Text.drop 2 text)
+        | Text.head text == '&' = True
+        | otherwise = go (Text.drop 1 text)
 
 classifySimple :: Text -> Bool
 classifySimple command
     | Text.null command = False
     | Text.any (`elem` forbiddenChars) command = False
-    | "$(" `Text.isInfixOf` command = False
-    | "`" `Text.isInfixOf` command = False
-    | "$" `Text.isInfixOf` command = False
     | otherwise =
         case Text.words command of
             [] -> False
@@ -37,50 +60,12 @@ classifySimple command
   where
     forbiddenChars = ['\n', '\r', ';', '&', '|', '>', '<']
 
--- | Strip one @cd DIR && COMMAND@ prefix. Anything more compound stays
--- exclusive via 'classifySimple'.
-cdAndCommand :: Text -> Maybe Text
-cdAndCommand text = do
-    afterCd <- Text.stripPrefix "cd" (Text.stripStart text)
-    afterSpace <- case Text.uncons afterCd of
-        Just (char, rest) | isSpace char ->
-            Just (Text.dropWhile isSpace rest)
-        _ -> Nothing
-    (dir, afterDir) <- nextToken afterSpace
-    afterAnd <- Text.stripPrefix "&&" (Text.dropWhile isSpace afterDir)
-    let command = Text.strip afterAnd
-    if simpleDirectory dir && not (Text.null command)
-        then Just command
-        else Nothing
-
-nextToken :: Text -> Maybe (Text, Text)
-nextToken text
-    | Text.null text = Nothing
-    | otherwise = case Text.uncons text of
-        Just (quote, rest)
-            | quote == '\'' || quote == '"' ->
-                case Text.break (== quote) rest of
-                    (inside, after)
-                        | Text.null after -> Nothing
-                        | Text.any (== '\\') inside -> Nothing
-                        | otherwise -> Just (inside, Text.drop 1 after)
-        _ ->
-            let (token, rest) = Text.break isSpace text
-            in if Text.null token then Nothing else Just (token, rest)
-
-simpleDirectory :: Text -> Bool
-simpleDirectory dir =
-    not (Text.null dir)
-        && not (Text.isPrefixOf "-" dir)
-        && Text.all allowedDirectoryChar dir
-
-allowedDirectoryChar :: Char -> Bool
-allowedDirectoryChar char =
-    char `notElem`
-        ['$', '`', '\n', '\r', ';', '&', '|', '>', '<', '(', ')', '{', '}', '*', '?', '~', '!']
-
 allowedCommand :: Text -> [Text] -> Bool
 allowedCommand executable arguments
+    | executable == "cd" =
+        case arguments of
+            [dir] -> simpleDirectory (unquote dir)
+            _ -> False
     | executable `elem`
         [ "cat", "head", "tail", "grep", "rg", "fd", "ls"
         , "pwd", "wc", "stat", "file", "jq", "sort", "cut"
@@ -97,23 +82,9 @@ allowedCommand executable arguments
     | executable == "sed" =
         safeSed arguments
     | executable == "git" =
-        case arguments of
-            subcommand : _ ->
-                subcommand `elem`
-                    [ "diff", "log", "show", "rev-parse"
-                    , "ls-files", "blame", "grep", "merge-base", "rev-list"
-                    , "symbolic-ref", "ls-remote"
-                    ]
-                    && not (any gitMutatingFlag arguments)
-            [] -> False
+        allowedGit arguments
     | executable == "gh" =
-        case arguments of
-            "pr" : subcommand : _ ->
-                subcommand `elem` ["view", "list", "checks", "status", "diff"]
-            "repo" : "view" : _ -> True
-            "run" : subcommand : _ -> subcommand `elem` ["list", "view"]
-            "auth" : "status" : _ -> True
-            _ -> False
+        allowedGh arguments
     | otherwise = False
   where
     mutatingFlag argument =
@@ -126,12 +97,68 @@ allowedCommand executable arguments
             [ "-delete", "-exec", "-execdir", "-ok", "-okdir"
             , "-fprint", "-fprintf", "-fls"
             ]
-    gitMutatingFlag argument =
-        outputFlag argument
-            || argument `elem`
-                [ "-d", "-D", "-m", "-M", "-c", "-C"
-                , "--delete", "--move", "--copy"
-                ]
+
+allowedGit :: [Text] -> Bool
+allowedGit arguments =
+    case dropGitGlobals arguments of
+        [] -> False
+        subcommand : rest ->
+            subcommand `elem` gitReadOnlySubcommands
+                && not (any gitOutputFlag rest)
+                && not (subcommand == "branch" && any branchMutatingFlag rest)
+  where
+    gitOutputFlag argument =
+        argument == "-o"
+            || "--output" `Text.isPrefixOf` argument
+    branchMutatingFlag argument =
+        argument `elem`
+            [ "-d", "-D", "-m", "-M", "--delete", "--move", "--copy" ]
+
+gitReadOnlySubcommands :: [Text]
+gitReadOnlySubcommands =
+    [ "diff", "log", "show", "rev-parse", "ls-files", "blame", "grep"
+    , "merge-base", "rev-list", "symbolic-ref", "ls-remote", "status"
+    , "branch", "describe", "cat-file", "ls-tree", "version", "help"
+    , "for-each-ref", "name-rev", "shortlog"
+    ]
+
+dropGitGlobals :: [Text] -> [Text]
+dropGitGlobals = \case
+    "-C" : _ : rest -> dropGitGlobals rest
+    "-c" : _ : rest -> dropGitGlobals rest
+    rest -> rest
+
+allowedGh :: [Text] -> Bool
+allowedGh = \case
+    "pr" : subcommand : _ ->
+        subcommand `elem` ["view", "list", "checks", "status", "diff"]
+    "issue" : subcommand : _ ->
+        subcommand `elem` ["view", "list"]
+    "repo" : "view" : _ -> True
+    "run" : subcommand : _ -> subcommand `elem` ["list", "view"]
+    "auth" : "status" : _ -> True
+    _ -> False
+
+simpleDirectory :: Text -> Bool
+simpleDirectory dir =
+    not (Text.null dir)
+        && not (Text.isPrefixOf "-" dir)
+        && Text.all allowedDirectoryChar dir
+
+allowedDirectoryChar :: Char -> Bool
+allowedDirectoryChar char =
+    char `notElem`
+        ['$', '`', '\n', '\r', ';', '&', '|', '>', '<', '(', ')', '{', '}', '*', '?', '~', '!']
+
+unquote :: Text -> Text
+unquote text =
+    case Text.uncons text of
+        Just (quote, rest)
+            | quote == '\'' || quote == '"'
+            , not (Text.null rest)
+            , Text.last rest == quote ->
+                Text.dropEnd 1 rest
+        _ -> text
 
 -- | GNU uniq writes a second positional operand: @uniq [OPTION]... [INPUT [OUTPUT]]@.
 uniqWritesOutput :: [Text] -> Bool

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -120,8 +120,23 @@ spec = describe "Grok Build dialect" do
             grepCall <-
                 toolSchedulingPlanFor registry
                     (functionToolCall "g1" "grep" "{\"pattern\":\"foo\"}")
+            statusChain <-
+                toolSchedulingPlanFor registry
+                    (terminalCall
+                        "t3"
+                        "git status --short && git diff --check"
+                        False)
+            fromGitC <-
+                toolSchedulingPlanFor registry
+                    (terminalCall "t4" "git -C src log --oneline" False)
+            piped <-
+                toolSchedulingPlanFor registry
+                    (terminalCall "t5" "git diff --stat | head -20" False)
             schedulingPlansConflict terminal grepCall `shouldBe` False
             schedulingPlansConflict fromCd grepCall `shouldBe` False
+            schedulingPlansConflict statusChain grepCall `shouldBe` False
+            schedulingPlansConflict fromGitC grepCall `shouldBe` False
+            schedulingPlansConflict piped grepCall `shouldBe` False
             close
 
     it "keeps mutating and background terminal commands exclusive" do

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -111,10 +111,17 @@ spec = describe "Grok Build dialect" do
             terminal <-
                 toolSchedulingPlanFor registry
                     (terminalCall "t1" "sed -n '1,80p' src/Main.hs" False)
+            fromCd <-
+                toolSchedulingPlanFor registry
+                    (terminalCall
+                        "t2"
+                        "cd packages/agent-core && sed -n '1,80p' src/Main.hs"
+                        False)
             grepCall <-
                 toolSchedulingPlanFor registry
                     (functionToolCall "g1" "grep" "{\"pattern\":\"foo\"}")
             schedulingPlansConflict terminal grepCall `shouldBe` False
+            schedulingPlansConflict fromCd grepCall `shouldBe` False
             close
 
     it "keeps mutating and background terminal commands exclusive" do


### PR DESCRIPTION
## Summary

Follow-up to #592. Grok and Codex turns often emit compound observational shells that were exclusive because of `&&`, `|`, `;`, or a false `git -C` mutating flag.

This widens the shared allowlist:

- Split a command on `&&`, `;`, and `|` (not `||` or a bare `&`). Every segment must itself be observational.
- `cd DIR` is an observational segment when `DIR` is a simple path, so `cd src && rg` still works.
- Git global `-C`/`-c` are skipped instead of treated as writes, so `git -C src log` can overlap other reads.
- Additional read-only git subcommands: `status`, `branch` (not `-d`/`-D`/`-m`), `describe`, `cat-file`, `ls-tree`, `version`, `help`, `for-each-ref`, `name-rev`, `shortlog`.
- `gh issue view` / `gh issue list`.

Still exclusive: `git fetch`, `git rebase`, `git branch -d`, redirections, `tee`, `nix develop`, substitutions, and `$HOME`.

Observational claims remain `ToolRead ToolAllPaths`, so these overlap other reads and still serialize against filesystem writes.

## Tests

- `nix develop -c cabal test agent-codex-dialect:test:agent-codex-dialect-test`
- `nix develop -c cabal test agent-grok-build-dialect:test:agent-grok-build-dialect-test`