### PR TITLE
fix(telegram): stop emptying harness config.json on gateway start

### DIFF
--- a/nix/modules/telegram.nix
+++ b/nix/modules/telegram.nix
@@ -433,18 +433,24 @@ in
 
           harness_config=${lib.escapeShellArg "${instance.homeDirectory}/.haskell-agent/config.json"}
           managed_config="$(mktemp "$harness_config.XXXXXX")"
-          if [ -f "$harness_config" ]; then
+          # jq applies the filter to each input value. `jq ... /dev/null` and
+          # `jq ... empty-file` both succeed with no output, which previously
+          # replaced ~/.haskell-agent/config.json with a 0-byte file and made
+          # every managed turn exit 1. Whitespace-only files are also blank:
+          # `-s` is true for them, but the merge filter then writes nothing.
+          if [ -s "$harness_config" ] && grep -q '[^[:space:]]' "$harness_config"; then
             jq --slurpfile managed ${lib.escapeShellArg generatedMcpConfig} \
               '.mcpInitStrategy = $managed[0].mcpInitStrategy
                | .mcpServers = $managed[0].mcpServers' \
               "$harness_config" > "$managed_config"
           else
-            jq --slurpfile managed ${lib.escapeShellArg generatedMcpConfig} \
+            jq -n --slurpfile managed ${lib.escapeShellArg generatedMcpConfig} \
               '{ version: 1,
                  mcpInitStrategy: $managed[0].mcpInitStrategy,
                  mcpServers: $managed[0].mcpServers }' \
-              /dev/null > "$managed_config"
+              > "$managed_config"
           fi
+          jq -e . "$managed_config" >/dev/null
           chmod 0600 "$managed_config"
           mv -f "$managed_config" "$harness_config"
         '';

--- a/nix/tests/telegram-module.nix
+++ b/nix/tests/telegram-module.nix
@@ -257,6 +257,9 @@ pkgs.runCommand "haskell-agent-telegram-module-test"
       and .environment.MODULE_TEST == "present"
       and (.ExecStart | endswith("/bin/agent-telegram run"))
       and (.preStart | contains("$CREDENTIALS_DIRECTORY/telegram-token"))
+      and (.preStart | contains("jq -n --slurpfile managed"))
+      and (.preStart | contains("jq -e ."))
+      and (.preStart | contains("[ -s \"$harness_config\" ] && grep -q '[^[:space:]]' \"$harness_config\""))
       and (.preStart | contains(".mcpInitStrategy = $managed[0].mcpInitStrategy"))
       and (.preStart | contains(".mcpServers = $managed[0].mcpServers"))
     ' >/dev/null

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -342,8 +342,15 @@ harnessConfigPath home =
         </> unsafeEncodeUtf ".haskell-agent"
         </> unsafeEncodeUtf "config.json"
 
--- | Load and validate the machine-wide configuration. A missing file is the
--- empty default. Decode, I/O, and semantic validation failures remain
+isBlankJson :: LBS.ByteString -> Bool
+isBlankJson =
+    LBS.null . LBS.dropWhile isJsonWhitespace
+  where
+    isJsonWhitespace byte =
+        byte == 9 || byte == 10 || byte == 13 || byte == 32
+
+-- | Load and validate the machine-wide configuration. A missing or empty file
+-- is the empty default. Decode, I/O, and semantic validation failures remain
 -- distinguishable to the CLI through their error text.
 loadHarnessConfig :: OsPath -> IO (Either Text HarnessConfig)
 loadHarnessConfig home = do
@@ -364,15 +371,18 @@ loadHarnessConfig home = do
                                 <> Text.pack (displayException exception)
                             )
                     Right bytes -> Right bytes
-                config <- case Aeson.eitherDecode' bytes of
-                    Left err ->
-                        Left
-                            ( "Invalid "
-                                <> Text.pack (unsafeToFilePath path)
-                                <> ": "
-                                <> Text.pack err
-                            )
-                    Right parsed -> Right parsed
+                config <-
+                    if isBlankJson bytes
+                        then Right defaultHarnessConfig
+                        else case Aeson.eitherDecode' bytes of
+                            Left err ->
+                                Left
+                                    ( "Invalid "
+                                        <> Text.pack (unsafeToFilePath path)
+                                        <> ": "
+                                        <> Text.pack err
+                                    )
+                            Right parsed -> Right parsed
                 validateHarnessConfig config
 
 -- | Persist the machine-wide harness configuration with owner-only

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -34,6 +34,16 @@ spec = describe "Agent.CLI.Config" do
         withTempDir "agent-config-" \home ->
             loadHarnessConfig home `shouldReturn` Right defaultHarnessConfig
 
+    it "defaults when the global config is empty" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home ""
+            loadHarnessConfig home `shouldReturn` Right defaultHarnessConfig
+
+    it "defaults when the global config is only whitespace" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home " \n\t"
+            loadHarnessConfig home `shouldReturn` Right defaultHarnessConfig
+
     it "loads MCP servers with defaults and deterministic map ordering" $
         withTempDir "agent-config-" \home -> do
             writeConfig home

--- a/packages/agent-telegram/src/Agent/Telegram/Classify.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Classify.hs
@@ -156,21 +156,37 @@ mergePendingActions previous incoming =
         (incomingText, incomingMedia, incomingUser, incomingMessageId,
             incomingEdited, incomingGroup) =
                 pendingActionParts incoming
-    in RunPendingMediaTurn TelegramPendingMediaTurn
-        { pendingMediaUpdateId = pendingActionUpdateIdLocal incoming
-        , pendingMediaMessageId = incomingMessageId
-        , pendingMediaChat = pendingActionChatLocal incoming
-        , pendingMediaUserId =
-            if incomingUser == 0 then previousUser else incomingUser
-        , pendingMediaText =
+        mergedText =
             Text.intercalate
                 pendingTurnSeparator
                 (filter (not . Text.null)
                     [Text.strip previousText, Text.strip incomingText])
-        , pendingMediaAttachments = previousMedia <> incomingMedia
-        , pendingMediaEdited = incomingEdited
-        , pendingMediaGroupId = incomingGroup <|> previousGroup
-        }
+        mergedAttachments = previousMedia <> incomingMedia
+        mergedUser =
+            if incomingUser == 0 then previousUser else incomingUser
+        mergedGroup = incomingGroup <|> previousGroup
+        chat = pendingActionChatLocal incoming
+        updateId = pendingActionUpdateIdLocal incoming
+    in if null mergedAttachments && not incomingEdited
+        then RunPendingTurn
+            TelegramPendingTurn
+                { pendingTurnUpdateId = updateId
+                , pendingTurnMessageId = incomingMessageId
+                , pendingTurnChat = chat
+                , pendingTurnText = mergedText
+                , pendingTurnVoice = Nothing
+                }
+        else RunPendingMediaTurn
+            TelegramPendingMediaTurn
+                { pendingMediaUpdateId = updateId
+                , pendingMediaMessageId = incomingMessageId
+                , pendingMediaChat = chat
+                , pendingMediaUserId = mergedUser
+                , pendingMediaText = mergedText
+                , pendingMediaAttachments = mergedAttachments
+                , pendingMediaEdited = incomingEdited
+                , pendingMediaGroupId = mergedGroup
+                }
 
 pendingActionParts
     :: PendingChatAction

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -1075,13 +1075,55 @@ spec = describe "Agent.Telegram" do
                     first
             nextPendingAction key second `shouldBe`
                 Just
+                    (RunPendingTurn
+                        (TelegramPendingTurn
+                            11
+                            78
+                            key
+                            "first\n\n---\n\nsecond"
+                            Nothing))
+
+        it "coalesces a later photo into a managed media turn" do
+            let key = TelegramChatKey 123 Nothing
+                photo =
+                    TelegramMedia
+                        { telegramMediaKind = TelegramMediaPhoto
+                        , telegramMediaFile =
+                            Just TelegramFileMedia
+                                { fileMediaFileId = "large"
+                                , fileMediaName = Nothing
+                                , fileMediaMimeType = Just "image/jpeg"
+                                , fileMediaFileSize = Just 1024
+                                , fileMediaDuration = Nothing
+                                }
+                        , telegramMediaDescription = "[Photo]"
+                        }
+                first = storeUpdateAction
+                    10
+                    (QueueTurn 77 key "first" Nothing)
+                    emptyTelegramState
+                second = storeUpdateAction
+                    11
+                    (QueueMediaTurn TelegramPendingMediaTurn
+                        { pendingMediaUpdateId = 11
+                        , pendingMediaMessageId = 78
+                        , pendingMediaChat = key
+                        , pendingMediaUserId = 456
+                        , pendingMediaText = "second"
+                        , pendingMediaAttachments = [photo]
+                        , pendingMediaEdited = False
+                        , pendingMediaGroupId = Nothing
+                        })
+                    first
+            nextPendingAction key second `shouldBe`
+                Just
                     (RunPendingMediaTurn TelegramPendingMediaTurn
                         { pendingMediaUpdateId = 11
                         , pendingMediaMessageId = 78
                         , pendingMediaChat = key
-                        , pendingMediaUserId = 0
+                        , pendingMediaUserId = 456
                         , pendingMediaText = "first\n\n---\n\nsecond"
-                        , pendingMediaAttachments = []
+                        , pendingMediaAttachments = [photo]
                         , pendingMediaEdited = False
                         , pendingMediaGroupId = Nothing
                         })


### PR DESCRIPTION
## Summary
- The NixOS Telegram module seeded `~/.haskell-agent/config.json` with `jq ... /dev/null`. jq applies the filter to each input value, so `/dev/null` (and an already-empty file) succeed with **zero output** and replace the harness config with a 0-byte file.
- The Telegram gateway then failed every managed turn with `session failed with exit code 1` (`Invalid .../config.json: Unexpected end-of-input`).
- Use `jq -n` when the file is missing, empty, or whitespace-only, validate JSON before replacing, treat blank `config.json` as the default, and keep text-only coalesced bursts as ordinary turns instead of empty media turns.

A production instance was recovered by writing a valid harness `config.json`. Group members who are not on `allowedUsers` are still ignored even when they reply to the bot; add their Telegram user IDs to that instance's allowlist if they should be able to talk to it.

## Test plan
- [x] `cabal test agent-cli:test:agent-cli-test --test-options='-m Config'`
- [x] `cabal test agent-telegram:test:agent-telegram-test`
- [x] Reproduced `jq ... /dev/null` producing 0 bytes vs `jq -n` producing JSON
- [ ] Linux CI `nixos-module` check (the module test is Linux-only)