### PR TITLE
Don't count image base64 as context tokens

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -53,8 +53,11 @@ import Control.Exception
     )
 import Data.IORef
 import Control.Monad.Trans.Except (runExceptT)
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Test.Hspec
 
 spec :: Spec
@@ -1185,6 +1188,60 @@ spec = do
                 _ -> False
             readIORef compactCalls `shouldReturn` 0
             readIORef submitCalls `shouldReturn` 0
+
+        it "does not reject a first turn whose size is dominated by an image" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { model = Just "gpt-5.6-sol" }
+                contextWindow =
+                    codexEffectiveContextWindowFor params.model
+                image =
+                    ImageAttachment
+                        { imageMime = "image/png"
+                        , imageBytes = ByteString.replicate (1024 * 1024) 1
+                        }
+                inputs =
+                    [ UserMultimodal
+                        { userText = "what does this screenshot show?"
+                        , userImages = [image]
+                        }
+                    ]
+                items = turnInputsToItems inputs
+                naiveTokens =
+                    Text.length
+                        (TextEncoding.decodeUtf8
+                            (LBS.toStrict (Aeson.encode items)))
+                        `div` 4
+                estimated =
+                    estimateRequestTokensWithItems params items
+            naiveTokens `shouldSatisfy` (> contextWindow)
+            estimated `shouldSatisfy` (< contextWindow)
+            contextState <- newIORef Nothing
+            compactCalls <- newIORef (0 :: Int)
+            submitCalls <- newIORef (0 :: Int)
+            let sender _request = do
+                    modifyIORef' compactCalls (+ 1)
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _ _ _ -> do
+                    modifyIORef' submitCalls (+ 1)
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        , completion = TurnCompleted
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSender
+                        Nothing
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        contextState
+                        base
+            result <- backend.submitTurn [] Nothing inputs (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef compactCalls `shouldReturn` 0
+            readIORef submitCalls `shouldReturn` 1
 
         it "compacts before the next request at the Codex token limit" do
             let oldHistory = [userTextItem "old"]

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -15,6 +15,7 @@ module Agent.OpenAI.Compaction
     , estimateItemsTokens
     , estimateResponseCreateParamsTokens
     , estimateRequestTokensWithItems
+    , resizedImageBytesEstimate
     , trimResponseHistoryToFit
     , sanitizeCompactionHistory
     , collectRecentUserTexts
@@ -92,7 +93,8 @@ buildRemoteCompactionRequest params history =
                 }
 
 -- | Estimate the complete serialized request, including instructions, tools,
--- and all other request-level fields.
+-- and all other request-level fields. Inline image data URLs are counted as
+-- vision tokens rather than as base64 text; see 'estimateEncodedValue'.
 estimateRequestTokensWithItems
     :: ResponseCreateParams
     -> [ResponseItem]
@@ -103,10 +105,71 @@ estimateRequestTokensWithItems params items =
 estimateResponseCreateParamsTokens :: ResponseCreateParams -> Int
 estimateResponseCreateParamsTokens = estimateEncodedValue
 
+-- | Estimate serialized JSON at four characters per token, matching the rest
+-- of compaction accounting. Inline @data:image/...;base64,...@ payloads are
+-- replaced with 'resizedImageBytesEstimate' because the model consumes those
+-- images as vision tokens, not as the transport encoding.
 estimateEncodedValue :: Aeson.ToJSON value => value -> Int
 estimateEncodedValue value =
-    estimateTokens
-        (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode value)))
+    estimateAdjustedJsonTokens (Aeson.toJSON value)
+
+estimateAdjustedJsonTokens :: Aeson.Value -> Int
+estimateAdjustedJsonTokens json =
+    let encoded =
+            TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode json))
+        (payloadBytes, replacementBytes) = mediaEstimateAdjustment json
+        adjusted =
+            max 0 (Text.length encoded - payloadBytes) + replacementBytes
+    in max 1 (adjusted `div` 4)
+
+-- | Approximate model-visible byte cost for one inline image, matching Codex.
+-- Four bytes per token maps this to about 1,843 tokens. Attachments from this
+-- harness use @detail: "auto"@, so original-detail patch counting is unused.
+resizedImageBytesEstimate :: Int
+resizedImageBytesEstimate = 7_373
+
+mediaEstimateAdjustment :: Aeson.Value -> (Int, Int)
+mediaEstimateAdjustment = \case
+    Aeson.String text ->
+        case parseBase64ImageDataUrl text of
+            Just payload ->
+                (Text.length payload, resizedImageBytesEstimate)
+            Nothing ->
+                (0, 0)
+    Aeson.Array values ->
+        foldl' addPair (0, 0) values
+    Aeson.Object fields ->
+        foldl' addPair (0, 0) fields
+    _ ->
+        (0, 0)
+  where
+    addPair acc value =
+        let (payload, replacement) = mediaEstimateAdjustment value
+        in (fst acc + payload, snd acc + replacement)
+
+-- | Return the base64 payload of a @data:image/...;base64,...@ URL.
+-- Hosted HTTP(S) image URLs and non-image data URLs stay at raw size.
+parseBase64ImageDataUrl :: Text -> Maybe Text
+parseBase64ImageDataUrl url
+    | not (hasInsensitivePrefix "data:" url) = Nothing
+    | otherwise =
+        case Text.break (== ',') (Text.drop 5 url) of
+            (_, payload)
+                | Text.null payload -> Nothing
+            (metadata, payload) ->
+                let parts = Text.splitOn ";" metadata
+                    mime = case parts of
+                        (value : _) -> value
+                        [] -> Text.empty
+                    hasBase64 =
+                        any (\part -> Text.toLower part == "base64") parts
+                in if hasBase64 && hasInsensitivePrefix "image/" mime
+                    then Just (Text.drop 1 payload)
+                    else Nothing
+
+hasInsensitivePrefix :: Text -> Text -> Bool
+hasInsensitivePrefix prefix text =
+    Text.toLower (Text.take (Text.length prefix) text) == Text.toLower prefix
 
 contextWindowTruncatedOutputMessage :: Text
 contextWindowTruncatedOutputMessage =
@@ -888,10 +951,7 @@ estimateTokens text = max 1 (Text.length text `div` 4)
 
 estimateItemsTokens :: [ResponseItem] -> Int
 estimateItemsTokens items =
-    sum
-        [ estimateTokens (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode item)))
-        | item <- items
-        ]
+    sum [estimateEncodedValue item | item <- items]
 
 -- | Collect recent real user message texts (newest last), skipping /compact markers.
 collectRecentUserTexts :: Int -> [ResponseItem] -> [Text]

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -9,6 +9,7 @@ import Data.Aeson ((.=))
 import Agent.Provider
 import Agent.Responses.Types
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
 import Data.Either (isLeft)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -837,6 +838,32 @@ spec = do
                                 "Output exceeded the available model context and was truncated")
                 _ -> False
 
+    describe "image payload token estimates" do
+        it "does not treat inline image payloads as model-visible text" do
+            let payload = Text.replicate 1_200_000 "A"
+                item = imageUser payload
+                naiveTokens = naiveEncodedTokens item
+                estimated = estimateItemsTokens [item]
+            naiveTokens `shouldSatisfy` (> 250_000)
+            estimated `shouldSatisfy` (< 5_000)
+            estimated `shouldSatisfy`
+                (>= max 1 (resizedImageBytesEstimate `div` 4))
+
+        it "still counts ordinary text at four characters per token" do
+            let text = Text.replicate 8_000 "x"
+            estimateItemsTokens [user text]
+                `shouldSatisfy` (> 1_500)
+
+        it "keeps a first-turn image request under the Codex context window" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { model = Just "gpt-5.6-sol" }
+                payload = Text.replicate 1_200_000 "A"
+                item = imageUser payload
+                contextWindow = codexEffectiveContextWindowFor params.model
+            naiveEncodedTokens item `shouldSatisfy` (> contextWindow)
+            estimateRequestTokensWithItems params [item]
+                `shouldSatisfy` (< contextWindow)
+
     describe "Codex model metadata" do
         it "derives the 90% auto-compaction limit for curated 272k models" do
             codexModelMetadata "gpt-5.6-luna"
@@ -1017,9 +1044,33 @@ spec = do
                     "Codex compaction requires an OpenAI credential" Nothing)
 
   where
+    naiveEncodedTokens :: Aeson.ToJSON a => a -> Int
+    naiveEncodedTokens value =
+        Text.length
+            (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode value)))
+            `div` 4
+
     user text = MessageItem ResponseMessage
         { messageId = Nothing
         , content = MessageContentParts [InputTextPart text Nothing KeyMap.empty]
+        , role = RoleUser
+        , status = Nothing
+        , phase = Nothing
+        , passthrough = Nothing
+        , extraFields = KeyMap.empty
+        }
+    imageUser payload = MessageItem ResponseMessage
+        { messageId = Nothing
+        , content = MessageContentParts
+            [ InputTextPart "inspect this" Nothing KeyMap.empty
+            , InputImagePart
+                { detail = Just "auto"
+                , fileId = Nothing
+                , imageUrl = Just ("data:image/png;base64," <> payload)
+                , promptCacheBreakpoint = Nothing
+                , extraFields = KeyMap.empty
+                }
+            ]
         , role = RoleUser
         , status = Nothing
         , phase = Nothing


### PR DESCRIPTION
## Summary

Attaching a ~1 MB PNG on the first turn was rejected locally with `initial request cannot fit within the model context window`. Occupancy used JSON length / 4, so the image data URL was counted as ~350k text tokens against the Codex 258k window. The model consumes that screenshot as vision tokens, not as base64.

This matches Codex token accounting:

- Subtract `data:image/...;base64,...` payloads from the serialized request
- Replace each image with a fixed 7,373-byte vision cost (~1,843 tokens)
- Keep four-characters-per-token estimates for ordinary text

Oversized text prompts still reject before provider submission.

## Tests

- `nix develop -c cabal test agent-openai:agent-openai-test --test-options='--skip Functional'` — 282 examples, 0 failures
- `nix develop -c cabal test agent-cli:agent-cli-test --test-options='--match autoCompactOpenAiBackendWith'` — 20 examples, 0 failures
- `git diff --check`