### PR TITLE
build: reduce TUI event coordinator compile time

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -1,3 +1,7 @@
+-- This module coordinates IO and Brick events; optimizing its large state
+-- machine costs considerably more than it benefits this non-rendering path.
+{-# OPTIONS_GHC -O0 -Wno-unused-imports #-}
+
 -- | Retained fullscreen terminal application and its session bridge.
 module Agent.CLI.TUI.App
     ( FullscreenInputBuffer


### PR DESCRIPTION
## Summary
- compile the large fullscreen TUI event/IO coordinator at `-O0`
- keep rendering modules optimized
- suppress unused-import warnings scoped to this module because optimization level changes warning attribution

## Measurement
Fresh serial GHC 9.10.3 profiling (`-O1` package default, `-ddump-timings`):
- before: `Agent.CLI.TUI.App` 3.967s
- after: 2.128s
- reduction: 46.4%

## Validation
- `TMPDIR=/tmp cabal test --offline --jobs=1 agent-cli-test`: 1087 examples, 0 failures, 1 pending
- `nix build .#default --no-link`
- `git diff --check`