### PR TITLE
feat(telegram): allow group members by name or reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,12 @@ Never paste the bot token into an agent conversation.
 
 Only messages from allowlisted Telegram users are handled. Repeat
 `--allowed-user` during setup, or manage the local allowlist later with
-`agent-telegram users list|add ID|remove ID`; running gateways must be restarted
-after an allowlist change. Private chats work directly. In groups and
+`agent-telegram users list|add ID|remove ID`. CLI allowlist edits still require
+a gateway restart. In a group, an already-allowed member can grant someone else
+immediately by telling the bot to accept them, or with `/allow` by name,
+`@username`, or by replying to one of their messages. `/users` lists the
+allowlist and people the bot has already seen in that chat; `/deny` removes
+someone. Private chats work directly. In groups and
 supergroups, mention the bot, use a command addressed to its username (for
 example `/new@your_bot`), or reply to one of its messages. Ambient group traffic
 and messages from non-allowlisted members are ignored by default. Pass
@@ -185,7 +189,9 @@ session under `~/.haskell-agent`; `/new` starts a fresh session, `/session`
 shows the current session ID, `/status` reports queued/retrying/failed work,
 and `/retry` requeues the latest failed turn. Group replies include the
 sender's identity in the agent prompt and are posted as replies to the
-triggering Telegram message.
+triggering Telegram message. The agent can also list, allow, and deny Telegram
+users through gateway-scoped tools, so you can say “also accept messages from
+Hendi” without looking up a numeric user ID.
 
 The default approval mode asks through Telegram inline buttons when a mutating
 tool is requested. `--deny-mutations` disables those tools and `--yolo`

--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -37,7 +37,9 @@ running one or more Telegram gateways as systemd services.
 The module:
 
 - creates a dedicated system user and private home for each instance;
-- writes the non-secret gateway configuration declaratively;
+- writes the non-secret gateway configuration declaratively (`allowedUsers` is
+  the minimum set after each restart; in-chat `/allow` grants persist in
+  `state.json`);
 - loads the BotFather token through systemd credentials, without copying it
   to the Nix store;
 - supplies Bash, Git, and PostgreSQL 18 by default;

--- a/packages/agent-cli/skills/telegram-agent/SKILL.md
+++ b/packages/agent-cli/skills/telegram-agent/SKILL.md
@@ -58,15 +58,18 @@ disables terminal echo and stores the token in a private gateway file.
 
 9. Tell the user to open their new bot and send `/start`. The bot supports
    `/new` for a fresh agent session, `/session` for the current session ID,
-   `/status` for queue/retry state, and `/retry` for the latest failed turn.
-   To use it in a group, an allowlisted Telegram administrator of that group
-   must add the bot. If anyone else adds it, the bot leaves. Then mention its
-   `@username`, reply to one of its messages, or address commands to it (for
-   example `/new@your_bot_username`). Each group or forum topic has a shared
-   agent session. Only messages from allowlisted users are accepted; ambient
-   group traffic is ignored unless setup used `--all-group-messages`. In that
+   `/status` for queue/retry state, `/retry` for the latest failed turn, and
+   `/allow` / `/deny` / `/users` to manage who may talk to it. To use it in a
+   group, an allowlisted Telegram administrator of that group must add the bot.
+   If anyone else adds it, the bot leaves. Then mention its `@username`, reply
+   to one of its messages, or address commands to it (for example
+   `/new@your_bot_username`). Each group or forum topic has a shared agent
+   session. Only messages from allowlisted users are accepted; ambient group
+   traffic is ignored unless setup used `--all-group-messages`. In that
    mode each allowed-user message is considered, but the agent stays silent
-   unless a response would be useful. Text, edited messages, reactions, photos,
+   unless a response would be useful. An already-allowed member can grant
+   someone else immediately by asking the bot to accept them, or with `/allow`
+   by name, `@username`, or by replying to one of their messages. Text, edited messages, reactions, photos,
    documents, audio, video, video notes, animations, stickers, locations,
    contacts, venues, polls, dice, and voice messages are persisted before
    processing.
@@ -87,7 +90,8 @@ disables terminal echo and stores the token in a private gateway file.
   as bot output.
 - Mutating-tool approvals and generic choices use scoped, expiring inline
   buttons. The agent can also send Telegram documents, photos, voice files,
-  and reactions through parent-owned gateway tools.
+  and reactions through parent-owned gateway tools, and can list, allow, or
+  deny Telegram users when an already-allowed person asks it to.
 - Transient Telegram and agent failures use bounded backoff and durable retry
   metadata. `/retry` restores the latest dead-lettered turn.
 - Voice messages are limited to 10 minutes and 20 MB. They are downloaded to a
@@ -96,7 +100,8 @@ disables terminal echo and stores the token in a private gateway file.
 
 ## Management
 
-Use `agent-telegram users list|add ID|remove ID` to manage the local allowlist;
-restart the running gateway after changes. Use `agent-telegram stop` to stop
-the background gateway. Redacted JSON logs and durable queue state live below
-`~/.haskell-agent/gateways/telegram/`.
+Use `agent-telegram users list|add ID|remove ID` to manage the local allowlist
+from the CLI; restart the running gateway after those changes. In chat, `/allow`
+and the `allow_telegram_user` tool apply immediately and do not require a
+restart. Use `agent-telegram stop` to stop the background gateway. Redacted JSON
+logs and durable queue state live below `~/.haskell-agent/gateways/telegram/`.

--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -170,6 +170,9 @@ managedGatewayTools request =
                 "send_voice"
             , reactTool
             , choiceTool
+            , allowUserTool
+            , denyUserTool
+            , listUsersTool
             ]
   where
     sendPathTool name description kind =
@@ -215,6 +218,44 @@ managedGatewayTools request =
             TurnSequential
             (typedToolWithCall "ask_telegram_choice" \call args ->
                 bridgeTool request call "ask_choice" (toChoicePayload args))
+
+    allowUserTool =
+        jsonTool
+            "allow_telegram_user"
+            "Allow another Telegram user to talk to this bot. Use this when an already-allowed user asks to accept messages from someone in the current group. Identify them by name, @username, or numeric user id. Omit query to allow the user this message replies to."
+            [ PropertySchema "query" PropertyString False
+                (Just "Name, @username, or numeric Telegram user id.")
+            , PropertySchema "user_id" PropertyInteger False
+                (Just "Numeric Telegram user id when already known.")
+            ]
+            True
+            TurnSequential
+            (typedToolWithCall "allow_telegram_user" \call args ->
+                bridgeTool request call "allow_user" (toAllowlistPayload args))
+
+    denyUserTool =
+        jsonTool
+            "deny_telegram_user"
+            "Remove a Telegram user from the allowlist so this bot stops accepting their messages."
+            [ PropertySchema "query" PropertyString False
+                (Just "Name, @username, or numeric Telegram user id.")
+            , PropertySchema "user_id" PropertyInteger False
+                (Just "Numeric Telegram user id when already known.")
+            ]
+            True
+            TurnSequential
+            (typedToolWithCall "deny_telegram_user" \call args ->
+                bridgeTool request call "deny_user" (toAllowlistPayload args))
+
+    listUsersTool =
+        jsonTool
+            "list_telegram_users"
+            "List Telegram users currently allowed to talk to this bot, plus people recently seen in this chat so you can allow someone by name without knowing their numeric id."
+            []
+            True
+            TurnSequential
+            (typedToolWithCall "list_telegram_users" \call (_ :: Value) ->
+                bridgeTool request call "list_users" (object []))
 
 data SendPathArgs = SendPathArgs
     { sendPath :: !Text
@@ -266,6 +307,23 @@ toChoicePayload :: ChoiceArgs -> Value
 toChoicePayload args = object
     [ "question" .= args.choiceQuestion
     , "options" .= args.choiceOptions
+    ]
+
+data AllowlistArgs = AllowlistArgs
+    { allowlistQuery :: !(Maybe Text)
+    , allowlistUserId :: !(Maybe Int)
+    }
+
+instance FromJSON AllowlistArgs where
+    parseJSON = objectArgs \input ->
+        AllowlistArgs
+            <$> optText input "query"
+            <*> optInt input "user_id"
+
+toAllowlistPayload :: AllowlistArgs -> Value
+toAllowlistPayload args = object
+    [ "query" .= args.allowlistQuery
+    , "user_id" .= args.allowlistUserId
     ]
 
 bridgeTool

--- a/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
@@ -10,7 +10,7 @@ import Agent.ToolDispatch
     , dispatchToolCall
     , functionToolCall
     )
-import Agent.Tools.Types (appToolHandlers)
+import Agent.Tools.Types (AppTool(..), appToolHandlers)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (withAsync, wait)
 import Control.Exception.Safe (bracket)
@@ -52,6 +52,13 @@ spec = describe "Agent.CLI.GatewayBridge" do
                         }
                     result <- wait running
                     result.output `shouldBe` "sent"
+
+    it "advertises Telegram allowlist tools on the managed gateway bridge" $
+        withBridgeRequest \request -> do
+            let names = map (.appToolName) (managedGatewayTools request)
+            names `shouldContain` ["allow_telegram_user"]
+            names `shouldContain` ["deny_telegram_user"]
+            names `shouldContain` ["list_telegram_users"]
 
     it "uses the bridge for mutating-tool approval choices" $
         withBridgeRequest \request -> do

--- a/packages/agent-telegram/src/Agent/Telegram.hs
+++ b/packages/agent-telegram/src/Agent/Telegram.hs
@@ -34,6 +34,12 @@ module Agent.Telegram
     , telegramReactionEmoji
     , telegramReplyText
     , telegramAgentPrompt
+    , telegramCommandArguments
+    , telegramReplyUserIdFromPrompt
+    , telegramUserLabel
+    , recordSeenTelegramUsers
+    , resolveTelegramUser
+    , TelegramUserResolution(..)
     , transcribeWithXAI
     , downloadTelegramMediaAttachmentsWith
     ) where
@@ -84,16 +90,23 @@ import Agent.Telegram.Classify
     , checkpointPendingVoiceTranscript
     , classifyTelegramUpdate
     , classifyTelegramUpdateWithMode
+    , grantableTelegramUser
     , groupJoinAuthorized
     , isAnonymousAdmin
     , telegramAnonymousAdminUserId
     , isAmbientGroupPrompt
     , nextPendingAction
     , reactionMessageText
+    , recordSeenTelegramUsers
+    , resolveTelegramUser
     , storeUpdateAction
     , telegramCommand
+    , telegramCommandArguments
     , telegramReactionEmoji
     , telegramReplyText
+    , telegramReplyUserIdFromPrompt
+    , telegramUserLabel
+    , TelegramUserResolution(..)
     )
 import Agent.Telegram.Bridge
     ( TelegramBridgeEnv(..)
@@ -378,8 +391,18 @@ manageTelegramUsers command = do
             TelegramUsersRemove userId ->
                 config { telegramAllowedUsers = Set.delete userId users }
     case command of
-        TelegramUsersList ->
-            forM_ (Set.toAscList users) (Text.putStrLn . Text.pack . show)
+        TelegramUsersList -> do
+            stateExists <- doesFileExist (statePathFor home)
+            state <-
+                if stateExists
+                    then loadTelegramState (statePathFor home)
+                    else pure emptyTelegramState
+            let ids = users <> state.allowedUserIds
+            forM_ (Set.toAscList ids) \userId ->
+                Text.putStrLn $
+                    case Map.lookup userId state.seenTelegramUsers of
+                        Just user -> telegramUserLabel user
+                        Nothing -> Text.pack (show userId)
         _ -> do
             when (Set.null updated.telegramAllowedUsers) $
                 die "refusing to remove the last allowed Telegram user"
@@ -387,7 +410,9 @@ manageTelegramUsers command = do
                 (configPath home)
                 0o600
                 (encode updated)
-            Text.putStrLn "Telegram allowlist updated. Restart the gateway to apply it."
+            Text.putStrLn
+                "Telegram allowlist updated. Restart the gateway to apply a CLI \
+                \change. In a group, /allow applies immediately without a restart."
 
 telegramStatus :: IO ()
 telegramStatus = do
@@ -582,7 +607,12 @@ runTelegramWithStore store home config token = do
     let target = resolvedOption.modelTarget
     createDirectoryIfMissing True gatewayDir
     setFileMode (unsafeToFilePath gatewayDir) 0o700
-    state <- loadTelegramState statePath
+    loadedState <- loadTelegramState statePath
+    let state = loadedState
+            { allowedUserIds =
+                loadedState.allowedUserIds <> config.telegramAllowedUsers
+            }
+    when (state /= loadedState) (saveTelegramState statePath state)
     stateVar <- newMVar state
     workQueue <- newChan
     scheduled <- newMVar Set.empty
@@ -594,7 +624,6 @@ runTelegramWithStore store home config token = do
     let runtime = TelegramRuntime
             { runtimeClient = client
             , runtimeBot = bot
-            , runtimeAllowedUsers = config.telegramAllowedUsers
             , runtimeRespondToAllGroupMessages =
                 config.telegramRespondToAllGroupMessages
             , runtimeWorkerCount = config.telegramWorkerCount
@@ -694,7 +723,6 @@ processIsAlive pid =
 data TelegramRuntime = TelegramRuntime
     { runtimeClient :: !TelegramClient
     , runtimeBot :: !TelegramUser
-    , runtimeAllowedUsers :: !(Set Integer)
     , runtimeRespondToAllGroupMessages :: !Bool
     , runtimeWorkerCount :: !Int
     , runtimeGatewayDirectory :: !OsPath
@@ -730,6 +758,7 @@ pollForever runtime = do
 processUpdate :: TelegramRuntime -> TelegramUpdate -> IO ()
 processUpdate runtime update = do
     handled <- tryAny do
+        modifyState runtime (recordSeenTelegramUsers update)
         action <- classifyUpdate runtime update
         modifyState runtime (storeUpdateAction update.updateId action)
     case handled of
@@ -756,7 +785,7 @@ classifyUpdate runtime update = do
     classified <-
         case classifyTelegramUpdateWithMode
                 runtime.runtimeBot
-                runtime.runtimeAllowedUsers
+                state.allowedUserIds
                 state.authorizedGroupChatIds
                 runtime.runtimeRespondToAllGroupMessages
                 update of
@@ -789,8 +818,18 @@ resolveGroupJoin
     -> Integer
     -> TelegramUser
     -> IO TelegramUpdateAction
-resolveGroupJoin runtime chatId actor
-    | actor.userId `Set.notMember` runtime.runtimeAllowedUsers
+resolveGroupJoin runtime chatId actor = do
+    allowedUsers <- readAllowedUsers runtime
+    resolveGroupJoinWith allowedUsers runtime chatId actor
+
+resolveGroupJoinWith
+    :: Set Integer
+    -> TelegramRuntime
+    -> Integer
+    -> TelegramUser
+    -> IO TelegramUpdateAction
+resolveGroupJoinWith allowedUsers runtime chatId actor
+    | actor.userId `Set.notMember` allowedUsers
     , not (isAnonymousAdmin actor) = do
         logRejectedJoin chatId actor "adder is not an allowed user"
         pure (LeaveUnauthorizedGroup chatId)
@@ -807,7 +846,7 @@ resolveGroupJoin runtime chatId actor
                     "could not verify group administrators"
                 pure (LeaveUnauthorizedGroup chatId)
             Right admins
-                | groupJoinAuthorized runtime.runtimeAllowedUsers actor admins -> do
+                | groupJoinAuthorized allowedUsers actor admins -> do
                     logTelegramEvent "group_join_authorized"
                         [ "chat_id" .= chatId
                         , "user_id" .= actor.userId
@@ -842,7 +881,7 @@ scheduleTelegramWorkForever :: TelegramRuntime -> IO ()
 scheduleTelegramWorkForever runtime = do
     processTelegramCallbacks
         runtime.runtimeClient
-        runtime.runtimeAllowedUsers
+        (readAllowedUsers runtime)
         (modifyState runtime)
         (readMVar runtime.runtimeStateVar)
     state <- readMVar runtime.runtimeStateVar
@@ -1002,7 +1041,8 @@ runQueuedTurn runtime pending =
     case telegramCommand pending.pendingTurnText of
         Just "start" -> pure
             "Send a message to start or continue an agent session. \
-            \Use /new for a fresh session and /session for its ID."
+            \Use /new for a fresh session, /session for its ID, and /allow \
+            \in a group to accept another member by name or by replying to them."
         Just "new" -> do
             modifyState runtime \state ->
                 state
@@ -1022,42 +1062,60 @@ runQueuedTurn runtime pending =
                 runtime
                 pending.pendingTurnChat
                 (pending.pendingTurnUpdateId + 1)
+        Just "allow" ->
+            applyAllowlistChange
+                runtime
+                pending.pendingTurnChat.chatId
+                AllowlistGrant
+                Nothing
+                (telegramCommandArguments pending.pendingTurnText)
+        Just "deny" ->
+            applyAllowlistChange
+                runtime
+                pending.pendingTurnChat.chatId
+                AllowlistRevoke
+                Nothing
+                (telegramCommandArguments pending.pendingTurnText)
+        Just "users" ->
+            describeTelegramAllowlist runtime pending.pendingTurnChat.chatId
         Just command -> pure ("Unknown command: /" <> command)
-        Nothing -> case pending.pendingTurnVoice of
-            Nothing ->
-                runAgentTurn
-                    runtime
-                    pending.pendingTurnChat
-                    (telegramTurnUserId runtime pending.pendingTurnChat)
-                    (Just pending.pendingTurnMessageId)
-                    pending.pendingTurnText
-            Just voice ->
-                tryAny (transcribeTelegramVoice runtime pending voice) >>= \case
-                    Left err -> do
-                        logTelegramEvent "voice_transcription_failed"
-                            [ "update_id" .= pending.pendingTurnUpdateId
-                            , "chat_id" .= pending.pendingTurnChat.chatId
-                            , "error" .=
-                                redactToken
-                                    runtime.runtimeClient.clientToken
-                                    (Text.pack (displayException err))
-                            ]
-                        pure
-                            "I could not transcribe that voice message. \
-                            \Check that Codex is installed and logged in, and \
-                            \that the subscription has usage available."
-                    Right prompt -> do
-                        let deliveredPrompt
-                                | isAmbientGroupPrompt pending.pendingTurnText =
-                                    ambientGroupPrompt prompt
-                                | otherwise = prompt
-                        checkpointVoiceTranscript runtime pending deliveredPrompt
-                        runAgentTurn
-                            runtime
-                            pending.pendingTurnChat
-                            (telegramTurnUserId runtime pending.pendingTurnChat)
-                            (Just pending.pendingTurnMessageId)
-                            deliveredPrompt
+        Nothing -> do
+            userId <- telegramTurnUserId runtime pending.pendingTurnChat
+            case pending.pendingTurnVoice of
+                Nothing ->
+                    runAgentTurn
+                        runtime
+                        pending.pendingTurnChat
+                        userId
+                        (Just pending.pendingTurnMessageId)
+                        pending.pendingTurnText
+                Just voice ->
+                    tryAny (transcribeTelegramVoice runtime pending voice) >>= \case
+                        Left err -> do
+                            logTelegramEvent "voice_transcription_failed"
+                                [ "update_id" .= pending.pendingTurnUpdateId
+                                , "chat_id" .= pending.pendingTurnChat.chatId
+                                , "error" .=
+                                    redactToken
+                                        runtime.runtimeClient.clientToken
+                                        (Text.pack (displayException err))
+                                ]
+                            pure
+                                "I could not transcribe that voice message. \
+                                \Check that Codex is installed and logged in, and \
+                                \that the subscription has usage available."
+                        Right prompt -> do
+                            let deliveredPrompt
+                                    | isAmbientGroupPrompt pending.pendingTurnText =
+                                        ambientGroupPrompt prompt
+                                    | otherwise = prompt
+                            checkpointVoiceTranscript runtime pending deliveredPrompt
+                            runAgentTurn
+                                runtime
+                                pending.pendingTurnChat
+                                userId
+                                (Just pending.pendingTurnMessageId)
+                                deliveredPrompt
 
 telegramConversationStatus :: TelegramRuntime -> TelegramChatKey -> IO Text
 telegramConversationStatus runtime key = do
@@ -1173,16 +1231,14 @@ runQueuedMediaTurn runtime pending = do
                     , managedUserId = pending.pendingMediaUserId
                     }
                 request
-        bridgeEnv = TelegramBridgeEnv
-            { telegramBridgeClient = runtime.runtimeClient
-            , telegramBridgeRequest = gatewayRequest
-            , telegramBridgeChat = pending.pendingMediaChat
-            , telegramBridgeUserId = pending.pendingMediaUserId
-            , telegramBridgeReplyTo = Just pending.pendingMediaMessageId
-            , telegramBridgeAllowedRoot =
-                unsafeToFilePath handle.sessionTempDir
-            , telegramBridgeModifyState = modifyState runtime
-            }
+        bridgeEnv =
+            telegramBridgeEnv
+                runtime
+                gatewayRequest
+                pending.pendingMediaChat
+                pending.pendingMediaUserId
+                (Just pending.pendingMediaMessageId)
+                (unsafeToFilePath handle.sessionTempDir)
     createDirectoryIfMissing True bridgeDir
     setFileMode bridgePath 0o700
     priorTurnIndex <-
@@ -1582,16 +1638,14 @@ runManagedAgentTurn
                     , managedUserId = userId
                     }
                 baseRequest
-        bridgeEnv = TelegramBridgeEnv
-            { telegramBridgeClient = runtime.runtimeClient
-            , telegramBridgeRequest = request
-            , telegramBridgeChat = key
-            , telegramBridgeUserId = userId
-            , telegramBridgeReplyTo = replyToMessageId
-            , telegramBridgeAllowedRoot =
-                unsafeToFilePath handle.sessionTempDir
-            , telegramBridgeModifyState = modifyState runtime
-            }
+        bridgeEnv =
+            telegramBridgeEnv
+                runtime
+                request
+                key
+                userId
+                replyToMessageId
+                (unsafeToFilePath handle.sessionTempDir)
     createDirectoryIfMissing True bridgeDir
     setFileMode bridgePath 0o700
     priorTurnIndex <-
@@ -1628,12 +1682,203 @@ runManagedAgentTurn
                                             "agent completed without recording \
                                             \the Telegram turn"
 
-telegramTurnUserId :: TelegramRuntime -> TelegramChatKey -> Integer
+telegramTurnUserId :: TelegramRuntime -> TelegramChatKey -> IO Integer
 telegramTurnUserId runtime key
-    | key.chatId > 0 = key.chatId
-    | Set.size runtime.runtimeAllowedUsers == 1 =
-        Set.findMin runtime.runtimeAllowedUsers
-    | otherwise = 0
+    | key.chatId > 0 = pure key.chatId
+    | otherwise = do
+        allowedUsers <- readAllowedUsers runtime
+        pure
+            if Set.size allowedUsers == 1
+                then Set.findMin allowedUsers
+                else 0
+
+readAllowedUsers :: TelegramRuntime -> IO (Set Integer)
+readAllowedUsers runtime =
+    (.allowedUserIds) <$> readMVar runtime.runtimeStateVar
+
+data AllowlistChange
+    = AllowlistGrant
+    | AllowlistRevoke
+
+telegramBridgeEnv
+    :: TelegramRuntime
+    -> ManagedTurnRequest
+    -> TelegramChatKey
+    -> Integer
+    -> Maybe Integer
+    -> FilePath
+    -> TelegramBridgeEnv
+telegramBridgeEnv runtime request key userId replyTo allowedRoot =
+    TelegramBridgeEnv
+        { telegramBridgeClient = runtime.runtimeClient
+        , telegramBridgeRequest = request
+        , telegramBridgeChat = key
+        , telegramBridgeUserId = userId
+        , telegramBridgeReplyTo = replyTo
+        , telegramBridgeAllowedRoot = allowedRoot
+        , telegramBridgeModifyState = modifyState runtime
+        , telegramBridgeGrantUser =
+            applyAllowlistChange
+                runtime
+                key.chatId
+                AllowlistGrant
+                (telegramReplyUserIdFromPrompt request.managedTurnText)
+        , telegramBridgeRevokeUser =
+            applyAllowlistChange
+                runtime
+                key.chatId
+                AllowlistRevoke
+                (telegramReplyUserIdFromPrompt request.managedTurnText)
+        , telegramBridgeListUsers =
+            describeTelegramAllowlist runtime key.chatId
+        }
+
+applyAllowlistChange
+    :: TelegramRuntime
+    -> Integer
+    -> AllowlistChange
+    -> Maybe Integer
+    -> Text
+    -> IO Text
+applyAllowlistChange runtime chatId change fallbackUserId query = do
+    state <- readMVar runtime.runtimeStateVar
+    case resolveTelegramUser state chatId fallbackUserId query of
+        UnresolvedTelegramUser err ->
+            pure err
+        AmbiguousTelegramUsers users ->
+            pure $
+                "Multiple people match that request:\n"
+                    <> Text.unlines
+                        [ "- " <> telegramUserLabel user
+                        | user <- users
+                        ]
+                    <> "Pass a more specific @username or reply to one of \
+                       \their messages."
+        ResolvedTelegramUser user ->
+            case change of
+                AllowlistGrant -> grantAllowedUser runtime chatId user
+                AllowlistRevoke -> revokeAllowedUser runtime user
+
+grantAllowedUser
+    :: TelegramRuntime
+    -> Integer
+    -> TelegramUser
+    -> IO Text
+grantAllowedUser runtime chatId user = do
+    alreadyAllowed <- modifyMVar runtime.runtimeStateVar \state -> do
+        let already = Set.member user.userId state.allowedUserIds
+            next = state
+                { allowedUserIds = Set.insert user.userId state.allowedUserIds
+                , seenTelegramUsers =
+                    Map.insert user.userId user state.seenTelegramUsers
+                , seenUsersByChat =
+                    Map.insertWith
+                        Set.union
+                        chatId
+                        (Set.singleton user.userId)
+                        state.seenUsersByChat
+                }
+        saveTelegramState runtime.runtimeStatePath next
+        pure (next, already)
+    persistAllowedUserIdsToConfig runtime
+    logTelegramEvent "allowed_user_granted"
+        [ "chat_id" .= chatId
+        , "user_id" .= user.userId
+        ]
+    pure
+        if alreadyAllowed
+            then telegramUserLabel user
+                <> " is already allowed to talk to this bot."
+            else
+                "Now accepting messages from "
+                    <> telegramUserLabel user
+                    <> "."
+
+revokeAllowedUser :: TelegramRuntime -> TelegramUser -> IO Text
+revokeAllowedUser runtime user = do
+    result <- modifyMVar runtime.runtimeStateVar \state ->
+        let remaining = Set.delete user.userId state.allowedUserIds
+        in if Set.null remaining
+            then pure
+                (state, Left "Refusing to remove the last allowed Telegram user.")
+            else if user.userId `Set.notMember` state.allowedUserIds
+                then pure
+                    ( state
+                    , Left
+                        (telegramUserLabel user <> " is not on the allowlist.")
+                    )
+                else do
+                    let next = state { allowedUserIds = remaining }
+                    saveTelegramState runtime.runtimeStatePath next
+                    pure (next, Right remaining)
+    case result of
+        Left message -> pure message
+        Right remaining -> do
+            persistAllowedUserIdsToConfig runtime
+            logTelegramEvent "allowed_user_revoked"
+                [ "user_id" .= user.userId
+                , "remaining" .= Set.size remaining
+                ]
+            pure
+                ("No longer accepting messages from "
+                    <> telegramUserLabel user
+                    <> ".")
+
+describeTelegramAllowlist :: TelegramRuntime -> Integer -> IO Text
+describeTelegramAllowlist runtime chatId = do
+    state <- readMVar runtime.runtimeStateVar
+    let allowed =
+            [ maybe
+                ("user " <> Text.pack (show userId))
+                telegramUserLabel
+                (Map.lookup userId state.seenTelegramUsers)
+            | userId <- Set.toAscList state.allowedUserIds
+            ]
+        seen =
+            [ telegramUserLabel user
+            | userId <-
+                Set.toAscList
+                    (fromMaybe Set.empty (Map.lookup chatId state.seenUsersByChat))
+            , Just user <- [Map.lookup userId state.seenTelegramUsers]
+            , grantableTelegramUser user
+            ]
+    pure $
+        "Allowed users:\n"
+            <> formatLines allowed
+            <> if chatId < 0 && not (null seen)
+                then "\nSeen in this chat:\n" <> formatLines seen
+                else ""
+  where
+    formatLines values =
+        Text.unlines [ "- " <> value | value <- values ]
+
+persistAllowedUserIdsToConfig :: TelegramRuntime -> IO ()
+persistAllowedUserIdsToConfig runtime = do
+    users <- readAllowedUsers runtime
+    let path =
+            runtime.runtimeGatewayDirectory
+                </> unsafeEncodeUtf "config.json"
+    result <- tryAny do
+        exists <- doesFileExist path
+        when exists do
+            bytes <- LBS.readFile (unsafeToFilePath path)
+            case eitherDecode bytes of
+                Left err ->
+                    fail ("could not decode Telegram config: " <> err)
+                Right config ->
+                    writeLazyFileAtomically
+                        path
+                        0o600
+                        (encode config { telegramAllowedUsers = users })
+    case result of
+        Left err ->
+            logTelegramEvent "allowlist_config_persist_failed"
+                [ "error" .=
+                    redactToken
+                        runtime.runtimeClient.clientToken
+                        (Text.pack (displayException err))
+                ]
+        Right () -> pure ()
 
 cleanupManagedTurnMedia :: ManagedTurnRequest -> IO ()
 cleanupManagedTurnMedia request =

--- a/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
@@ -69,6 +69,9 @@ data TelegramBridgeEnv = TelegramBridgeEnv
     , telegramBridgeAllowedRoot :: !FilePath
     , telegramBridgeModifyState ::
         !((TelegramState -> TelegramState) -> IO ())
+    , telegramBridgeGrantUser :: !(Text -> IO Text)
+    , telegramBridgeRevokeUser :: !(Text -> IO Text)
+    , telegramBridgeListUsers :: !(IO Text)
     }
 
 data PathRequest = PathRequest
@@ -110,6 +113,21 @@ data ApprovalRequest = ApprovalRequest
 instance FromJSON ApprovalRequest where
     parseJSON = withObject "ApprovalRequest" \o ->
         ApprovalRequest <$> o .: "tool_name" <*> o .: "arguments"
+
+data AllowlistRequest = AllowlistRequest
+    { allowlistQuery :: !(Maybe Text)
+    , allowlistUserId :: !(Maybe Integer)
+    }
+
+instance FromJSON AllowlistRequest where
+    parseJSON = withObject "AllowlistRequest" \o ->
+        AllowlistRequest <$> o .:? "query" <*> o .:? "user_id"
+
+allowlistRequestQuery :: AllowlistRequest -> Text
+allowlistRequestQuery request =
+    case request.allowlistUserId of
+        Just userId -> Text.pack (show userId)
+        Nothing -> Text.strip (fromMaybe "" request.allowlistQuery)
 
 withTelegramBridge :: TelegramBridgeEnv -> IO a -> IO a
 withTelegramBridge env =
@@ -266,6 +284,18 @@ processBridgeRequest env request =
                         , ("Allow all", "allow_all")
                         , ("Deny", "deny")
                         ]
+            "allow_user" ->
+                withPayload current \(payload :: AllowlistRequest) ->
+                    Right . Just . String
+                        <$> env.telegramBridgeGrantUser
+                            (allowlistRequestQuery payload)
+            "deny_user" ->
+                withPayload current \(payload :: AllowlistRequest) ->
+                    Right . Just . String
+                        <$> env.telegramBridgeRevokeUser
+                            (allowlistRequestQuery payload)
+            "list_users" ->
+                Right . Just . String <$> env.telegramBridgeListUsers
             other ->
                 pure (Left ("unknown Telegram bridge request: " <> other))
 
@@ -388,16 +418,17 @@ removeRequestBindings env requestId =
 
 processTelegramCallbacks
     :: TelegramClient
-    -> Set.Set Integer
+    -> IO (Set.Set Integer)
     -> ((TelegramState -> TelegramState) -> IO ())
     -> IO TelegramState
     -> IO ()
-processTelegramCallbacks client allowedUsers modifyState readState =
+processTelegramCallbacks client readAllowedUsers modifyState readState =
     readState >>= \state ->
         case Map.lookupMin state.pendingCallbacks of
             Nothing -> pure ()
             Just (updateId, callback) -> do
                 now <- getCurrentTime
+                allowedUsers <- readAllowedUsers
                 case Map.lookup callback.pendingCallbackData state.callbackBindings of
                     Nothing ->
                         finishInvalid updateId callback
@@ -455,7 +486,7 @@ processTelegramCallbacks client allowedUsers modifyState readState =
                                     }
                 processTelegramCallbacks
                     client
-                    allowedUsers
+                    readAllowedUsers
                     modifyState
                     readState
   where

--- a/packages/agent-telegram/src/Agent/Telegram/Classify.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Classify.hs
@@ -13,18 +13,28 @@ module Agent.Telegram.Classify
     , isAmbientGroupPrompt
     , reactionMessageText
     , telegramCommand
+    , telegramCommandArguments
     , telegramReactionEmoji
     , telegramReplyText
+    , telegramUserLabel
+    , telegramReplyUserIdFromPrompt
+    , recordSeenTelegramUsers
+    , resolveTelegramUser
+    , grantableTelegramUser
+    , TelegramUserResolution(..)
     ) where
 
 import Agent.Telegram.Types
 import Control.Applicative ((<|>))
+import Data.Char (isDigit)
+import Data.List (nubBy)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust, maybeToList)
+import Data.Maybe (fromMaybe, isJust, mapMaybe, maybeToList)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Text.Read (readMaybe)
 
 data TelegramUpdateAction
     = IgnoreUpdate
@@ -530,7 +540,7 @@ classifyMessageLike edited bot sender respondToAllGroupMessages message =
                 , pendingMediaChat = key
                 , pendingMediaUserId = sender.userId
                 , pendingMediaText =
-                    messageContextPrefix message <> promptText
+                    messageContextPrefix bot message <> promptText
                 , pendingMediaAttachments = messageMediaAttachments message
                 , pendingMediaEdited = edited
                 , pendingMediaGroupId = message.messageMediaGroupId
@@ -541,6 +551,11 @@ classifyMessageLike edited bot sender respondToAllGroupMessages message =
         , Just target <- explicitCommandTarget (Text.strip rawText)
         , not (botUsernameMatches bot target) =
             IgnoreUpdate
+        | Just rawText <- messageContentText message
+        , telegramCommand rawText /= Nothing =
+            if hasTelegramMedia message
+                then queueMedia (attributeGroupText sender (Text.strip rawText))
+                else queueText (attributeGroupText sender (Text.strip rawText))
         | messageRepliesToBot bot message =
             queueGroupReply
         | Just rawText <- messageContentText message
@@ -556,7 +571,8 @@ classifyMessageLike edited bot sender respondToAllGroupMessages message =
         case message.messageVoice of
             Just voice ->
                 QueueTurn message.messageId key
-                    (attributeGroupMessage sender "[Voice message]")
+                    (messageContextPrefix bot message
+                        <> attributeGroupMessage sender "[Voice message]")
                     (Just voice)
             Nothing
                 | hasTelegramMedia message ->
@@ -628,10 +644,11 @@ classifyMessageLike edited bot sender respondToAllGroupMessages message =
         | otherwise =
             QueueTurn message.messageId key clean Nothing
       where
+        rewritten = rewriteGrantCommand message rawText
         clean
-            | telegramCommand rawText /= Nothing = Text.strip rawText
+            | telegramCommand rewritten /= Nothing = Text.strip rewritten
             | otherwise =
-                Text.strip (messageContextPrefix message <> rawText)
+                Text.strip (messageContextPrefix bot message <> rewritten)
 
 hasTelegramMedia :: TelegramMessage -> Bool
 hasTelegramMedia = not . null . messageMediaAttachments
@@ -814,9 +831,9 @@ messageContentText message =
                 Just ("[Dice: " <> dice.diceEmoji <> " " <> Text.pack (show dice.diceValue) <> "]")
             | otherwise -> Nothing
 
-messageContextPrefix :: TelegramMessage -> Text
-messageContextPrefix message =
-    forwarded <> replied
+messageContextPrefix :: TelegramUser -> TelegramMessage -> Text
+messageContextPrefix bot message =
+    forwarded <> replied <> mentioned
   where
     forwarded =
         case message.messageForwardOrigin of
@@ -824,14 +841,29 @@ messageContextPrefix message =
             Just _ -> "[Forwarded Telegram message]\n"
     replied =
         case message.messageReplyTo of
-            Just replyMessage
-                | Just content <- messageContentText replyMessage ->
-                    "[Replying to Telegram message "
+            Just replyMessage ->
+                "[Replying to Telegram message "
                     <> Text.pack (show replyMessage.messageId)
-                    <> ": "
-                    <> Text.take 1000 (Text.replace "\n" " " content)
+                    <> maybe
+                        ""
+                        (\user -> " from " <> telegramUserLabel user)
+                        replyMessage.messageFrom
+                    <> maybe
+                        ""
+                        (\content ->
+                            ": "
+                                <> Text.take 1000
+                                    (Text.replace "\n" " " content))
+                        (messageContentText replyMessage)
                     <> "]\n"
-            _ -> ""
+            Nothing -> ""
+    mentioned =
+        case mentionLabels bot message of
+            [] -> ""
+            labels ->
+                "[Telegram mentions: "
+                    <> Text.intercalate "; " labels
+                    <> "]\n"
 
 messageRepliesToBot :: TelegramUser -> TelegramMessage -> Bool
 messageRepliesToBot bot message =
@@ -953,11 +985,7 @@ pendingTurnSeparator = "\n\n---\n\n"
 
 telegramUserLabel :: TelegramUser -> Text
 telegramUserLabel user =
-    let name = Text.unwords
-            [ value
-            | Just value <- [user.userFirstName, user.userLastName]
-            , not (Text.null (Text.strip value))
-            ]
+    let name = telegramUserDisplayName user
         username = ("@" <>) <$> user.userUsername
         identityParts =
             filter (not . Text.null)
@@ -966,6 +994,262 @@ telegramUserLabel user =
                 , "user " <> Text.pack (show user.userId)
                 ]
     in Text.intercalate ", " identityParts
+
+telegramUserDisplayName :: TelegramUser -> Text
+telegramUserDisplayName user =
+    Text.unwords
+        [ value
+        | Just value <- [user.userFirstName, user.userLastName]
+        , not (Text.null (Text.strip value))
+        ]
+
+rewriteGrantCommand :: TelegramMessage -> Text -> Text
+rewriteGrantCommand message raw =
+    case telegramCommand raw of
+        Just command
+            | command == "allow" || command == "deny"
+            , Text.null (telegramCommandArguments raw) ->
+                case grantTargetUser message of
+                    Just user -> "/" <> command <> " " <> Text.pack (show user.userId)
+                    Nothing -> raw
+        _ -> raw
+
+grantTargetUser :: TelegramMessage -> Maybe TelegramUser
+grantTargetUser message =
+    case message.messageReplyTo >>= (.messageFrom) of
+        Just user | grantableTelegramUser user -> Just user
+        _ ->
+            case filter grantableTelegramUser (mentionedTelegramUsers message) of
+                [user] -> Just user
+                _ -> Nothing
+
+mentionLabels :: TelegramUser -> TelegramMessage -> [Text]
+mentionLabels bot message =
+    filter (not . Text.null)
+        [ label
+        | label <- mapMaybe (mentionLabel bot) (messageMentionEntities message)
+        ]
+
+mentionLabel :: TelegramUser -> (Text, Maybe TelegramUser) -> Maybe Text
+mentionLabel bot (snippet, mentionedUser)
+    | Just user <- mentionedUser
+    , user.userId == bot.userId =
+        Nothing
+    | Just user <- mentionedUser =
+        Just (telegramUserLabel user)
+    | botUsernameMatches bot mentionName =
+        Nothing
+    | Text.null mentionName =
+        Nothing
+    | otherwise =
+        Just (Text.strip snippet)
+  where
+    mentionName =
+        Text.strip (Text.dropWhile (== '@') (Text.strip snippet))
+
+messageMentionEntities :: TelegramMessage -> [(Text, Maybe TelegramUser)]
+messageMentionEntities message =
+    let text = fromMaybe "" (message.messageText <|> message.messageCaption)
+        entities = message.messageEntities <> message.messageCaptionEntities
+    in
+        [ (utf16Slice entity.entityOffset entity.entityLength text, entity.entityUser)
+        | entity <- entities
+        , entity.entityType == "mention" || entity.entityType == "text_mention"
+        ]
+
+mentionedTelegramUsers :: TelegramMessage -> [TelegramUser]
+mentionedTelegramUsers message =
+    nubBy (\left right -> left.userId == right.userId) $
+        mapMaybe snd (messageMentionEntities message)
+
+utf16Slice :: Int -> Int -> Text -> Text
+utf16Slice offset length text =
+    utf16Take length (utf16Drop offset text)
+
+utf16Drop :: Int -> Text -> Text
+utf16Drop n text
+    | n <= 0 = text
+    | otherwise = case Text.uncons text of
+        Nothing -> ""
+        Just (char, rest)
+            | fromEnum char >= 0x10000 -> utf16Drop (n - 2) rest
+            | otherwise -> utf16Drop (n - 1) rest
+
+utf16Take :: Int -> Text -> Text
+utf16Take n text
+    | n <= 0 = ""
+    | otherwise = case Text.uncons text of
+        Nothing -> ""
+        Just (char, rest)
+            | fromEnum char >= 0x10000 ->
+                if n >= 2
+                    then Text.cons char (utf16Take (n - 2) rest)
+                    else ""
+            | otherwise -> Text.cons char (utf16Take (n - 1) rest)
+
+grantableTelegramUser :: TelegramUser -> Bool
+grantableTelegramUser user =
+    not user.userIsBot
+        && not (isAnonymousAdmin user)
+        && user.userId > 0
+
+stubTelegramUser :: Integer -> TelegramUser
+stubTelegramUser userId =
+    TelegramUser
+        { userId
+        , userIsBot = False
+        , userFirstName = Nothing
+        , userLastName = Nothing
+        , userUsername = Nothing
+        }
+
+data TelegramUserResolution
+    = ResolvedTelegramUser TelegramUser
+    | AmbiguousTelegramUsers [TelegramUser]
+    | UnresolvedTelegramUser Text
+    deriving (Eq, Show)
+
+resolveTelegramUser
+    :: TelegramState
+    -> Integer
+    -> Maybe Integer
+    -> Text
+    -> TelegramUserResolution
+resolveTelegramUser state chatId fallbackUserId rawQuery
+    | Text.null query =
+        case fallbackUserId of
+            Just userId -> resolveById userId
+            Nothing ->
+                UnresolvedTelegramUser
+                    "Reply to their message, mention them, or pass a name, \
+                    \@username, or numeric Telegram user id."
+    | Just userId <- parsePositiveUserId query = resolveById userId
+    | otherwise =
+        uniqueMatches
+            (preferChatLocal
+                (filter (userMatchesQuery query) candidates))
+  where
+    query = normalizeUserQuery rawQuery
+    candidates =
+        nubBy (\left right -> left.userId == right.userId)
+            (Map.elems state.seenTelegramUsers)
+
+    resolveById userId =
+        case Map.lookup userId state.seenTelegramUsers of
+            Just user -> grantResolved user
+            Nothing -> grantResolved (stubTelegramUser userId)
+
+    preferChatLocal matches =
+        let local =
+                filter
+                    (\user ->
+                        maybe
+                            False
+                            (Set.member user.userId)
+                            (Map.lookup chatId state.seenUsersByChat))
+                    matches
+        in if null local then matches else local
+
+    uniqueMatches = \case
+        [user] -> grantResolved user
+        [] ->
+            UnresolvedTelegramUser
+                ("I have not seen anyone matching "
+                    <> rawQuery
+                    <> " in this chat yet. Reply to one of their messages \
+                       \with /allow, mention them, or have them send a \
+                       \message here first.")
+        users -> AmbiguousTelegramUsers users
+
+    grantResolved user
+        | grantableTelegramUser user = ResolvedTelegramUser user
+        | otherwise =
+            UnresolvedTelegramUser
+                "That Telegram account cannot be added to the allowlist."
+
+normalizeUserQuery :: Text -> Text
+normalizeUserQuery raw =
+    let stripped = Text.strip raw
+        withoutAt = fromMaybe stripped (Text.stripPrefix "@" stripped)
+        folded = Text.toCaseFold withoutAt
+    in case Text.stripPrefix "user " folded of
+        Just rest | not (Text.null rest) && Text.all isDigit rest -> rest
+        _ -> folded
+
+parsePositiveUserId :: Text -> Maybe Integer
+parsePositiveUserId text = do
+    userId <- readMaybe (Text.unpack text)
+    if userId > 0 then Just userId else Nothing
+
+userMatchesQuery :: Text -> TelegramUser -> Bool
+userMatchesQuery query user =
+    query == Text.pack (show user.userId)
+        || maybe False ((== query) . Text.toCaseFold) user.userUsername
+        || maybe False ((== query) . Text.toCaseFold . Text.strip) user.userFirstName
+        || maybe False ((== query) . Text.toCaseFold . Text.strip) user.userLastName
+        || (let name = Text.toCaseFold (telegramUserDisplayName user)
+            in not (Text.null name) && name == query)
+
+recordSeenTelegramUsers :: TelegramUpdate -> TelegramState -> TelegramState
+recordSeenTelegramUsers update state =
+    foldl' recordOne state (telegramObservedUsers update)
+  where
+    recordOne current (chatId, user) =
+        current
+            { seenTelegramUsers =
+                Map.insert user.userId user current.seenTelegramUsers
+            , seenUsersByChat =
+                Map.insertWith
+                    Set.union
+                    chatId
+                    (Set.singleton user.userId)
+                    current.seenUsersByChat
+            }
+
+telegramObservedUsers :: TelegramUpdate -> [(Integer, TelegramUser)]
+telegramObservedUsers update =
+    nubBy
+        (\(leftChat, leftUser) (rightChat, rightUser) ->
+            leftChat == rightChat && leftUser.userId == rightUser.userId)
+        (maybe [] usersFromMessage update.updateMessage
+            <> maybe [] usersFromMessage update.updateEditedMessage
+            <> maybe [] usersFromReaction update.updateMessageReaction
+            <> maybe [] usersFromCallback update.updateCallbackQuery
+            <> maybe [] usersFromMembership update.updateMyChatMember)
+
+usersFromMessage :: TelegramMessage -> [(Integer, TelegramUser)]
+usersFromMessage message =
+    let chatId = message.messageChat.telegramChatId
+        people =
+            maybeToList message.messageFrom
+                <> maybeToList (message.messageReplyTo >>= (.messageFrom))
+                <> message.messageNewChatMembers
+                <> mentionedTelegramUsers message
+    in map (\user -> (chatId, user)) people
+
+usersFromReaction :: TelegramMessageReaction -> [(Integer, TelegramUser)]
+usersFromReaction reaction =
+    map
+        (\user -> (reaction.messageReactionChat.telegramChatId, user))
+        (maybeToList reaction.messageReactionUser)
+
+usersFromCallback :: TelegramCallbackQuery -> [(Integer, TelegramUser)]
+usersFromCallback callback =
+    (maybe
+        []
+        (\message -> [(message.messageChat.telegramChatId, callback.callbackQueryFrom)])
+        callback.callbackQueryMessage)
+        <> maybe [] usersFromMessage callback.callbackQueryMessage
+
+usersFromMembership :: TelegramChatMemberUpdated -> [(Integer, TelegramUser)]
+usersFromMembership membership =
+    let chatId = membership.chatMemberUpdatedChat.telegramChatId
+    in map
+        (\user -> (chatId, user))
+        [ membership.chatMemberUpdatedFrom
+        , membership.chatMemberUpdatedOld.chatMemberUser
+        , membership.chatMemberUpdatedNew.chatMemberUser
+        ]
 
 reactionMessageText :: TelegramMessageReaction -> Text
 reactionMessageText reaction
@@ -999,6 +1283,21 @@ telegramCommand text = do
         value : _ -> Just value
     withoutSlash <- Text.stripPrefix "/" firstWord
     pure (Text.toLower (Text.takeWhile (/= '@') withoutSlash))
+
+telegramCommandArguments :: Text -> Text
+telegramCommandArguments text =
+    case Text.words (Text.strip text) of
+        _command : rest -> Text.unwords rest
+        [] -> ""
+
+telegramReplyUserIdFromPrompt :: Text -> Maybe Integer
+telegramReplyUserIdFromPrompt prompt = do
+    rest <- Text.stripPrefix
+        "[Replying to Telegram message "
+        (Text.takeWhile (/= '\n') (Text.stripStart prompt))
+    let afterUser = snd (Text.breakOn ", user " rest)
+    digits <- Text.stripPrefix ", user " afterUser
+    parsePositiveUserId (Text.takeWhile isDigit digits)
 
 checkpointPendingVoiceTranscript
     :: Integer

--- a/packages/agent-telegram/src/Agent/Telegram/Types/State.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Types/State.hs
@@ -18,7 +18,7 @@ module Agent.Telegram.Types.State
     , deletePendingAction
     ) where
 
-import Agent.Telegram.Types.Wire (TelegramMedia, TelegramVoice)
+import Agent.Telegram.Types.Wire (TelegramMedia, TelegramUser(..), TelegramVoice)
 import Data.Aeson
     ( FromJSON(..)
     , ToJSON(..)
@@ -110,6 +110,9 @@ data TelegramState = TelegramState
     , deadLetters :: ![TelegramDeadLetter]
     , outboundMessageIds :: !(Map TelegramChatKey (Set Integer))
     , authorizedGroupChatIds :: !(Set Integer)
+    , allowedUserIds :: !(Set Integer)
+    , seenTelegramUsers :: !(Map Integer TelegramUser)
+    , seenUsersByChat :: !(Map Integer (Set Integer))
     } deriving (Eq, Show)
 
 instance ToJSON TelegramState where
@@ -154,6 +157,13 @@ instance ToJSON TelegramState where
             | (key, messageIds) <- Map.toList state.outboundMessageIds
             ]
         , "authorizedGroupChats" .= sort (Set.toList state.authorizedGroupChatIds)
+        , "allowedUserIds" .= sort (Set.toList state.allowedUserIds)
+        , "seenTelegramUsers" .=
+            sortOn (.userId) (Map.elems state.seenTelegramUsers)
+        , "seenUsersByChat" .=
+            [ TelegramSeenChatUsers chatId (sort (Set.toList userIds))
+            | (chatId, userIds) <- Map.toAscList state.seenUsersByChat
+            ]
         ]
 
 instance FromJSON TelegramState where
@@ -184,6 +194,12 @@ instance FromJSON TelegramState where
         deadLetters <- o .:? "deadLetters" .!= []
         outboundMessages <-
             o .:? "outboundMessages" .!= ([] :: [TelegramOutboundMessages])
+        storedAllowedUsers <-
+            o .:? "allowedUserIds" .!= ([] :: [Integer])
+        storedSeenUsers <-
+            o .:? "seenTelegramUsers" .!= ([] :: [TelegramUser])
+        storedSeenByChat <-
+            o .:? "seenUsersByChat" .!= ([] :: [TelegramSeenChatUsers])
         let bindings =
                 foldr
                     (\binding ->
@@ -229,7 +245,33 @@ instance FromJSON TelegramState where
                     | messages <- outboundMessages
                     ]
             , authorizedGroupChatIds
+            , allowedUserIds = Set.fromList storedAllowedUsers
+            , seenTelegramUsers =
+                Map.fromList
+                    [ (user.userId, user)
+                    | user <- storedSeenUsers
+                    ]
+            , seenUsersByChat =
+                Map.fromList
+                    [ (seen.seenChatId, Set.fromList seen.seenChatUserIds)
+                    | seen <- storedSeenByChat
+                    ]
             }
+
+data TelegramSeenChatUsers = TelegramSeenChatUsers
+    { seenChatId :: !Integer
+    , seenChatUserIds :: ![Integer]
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramSeenChatUsers where
+    toJSON seen = object
+        [ "chatId" .= seen.seenChatId
+        , "userIds" .= seen.seenChatUserIds
+        ]
+
+instance FromJSON TelegramSeenChatUsers where
+    parseJSON = withObject "TelegramSeenChatUsers" \o ->
+        TelegramSeenChatUsers <$> o .: "chatId" <*> (o .:? "userIds" .!= [])
 
 data TelegramOutboundMessages = TelegramOutboundMessages
     { outboundChat :: !TelegramChatKey
@@ -519,4 +561,7 @@ emptyTelegramState = TelegramState
     , deadLetters = []
     , outboundMessageIds = Map.empty
     , authorizedGroupChatIds = Set.empty
+    , allowedUserIds = Set.empty
+    , seenTelegramUsers = Map.empty
+    , seenUsersByChat = Map.empty
     }

--- a/packages/agent-telegram/src/Agent/Telegram/Types/Wire.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Types/Wire.hs
@@ -19,6 +19,7 @@ module Agent.Telegram.Types.Wire
     , TelegramPoll(..)
     , TelegramDice(..)
     , TelegramUser(..)
+    , TelegramMessageEntity(..)
     , TelegramChat(..)
     , TelegramChatMember(..)
     , TelegramChatMemberUpdated(..)
@@ -79,14 +80,38 @@ data TelegramUser = TelegramUser
     , userUsername :: !(Maybe Text)
     } deriving (Eq, Show)
 
+instance ToJSON TelegramUser where
+    toJSON user = object
+        [ "id" .= user.userId
+        , "isBot" .= user.userIsBot
+        , "firstName" .= user.userFirstName
+        , "lastName" .= user.userLastName
+        , "username" .= user.userUsername
+        ]
+
 instance FromJSON TelegramUser where
     parseJSON = withObject "TelegramUser" \o ->
         TelegramUser
             <$> o .: "id"
-            <*> (o .:? "is_bot" .!= False)
-            <*> o .:? "first_name"
-            <*> o .:? "last_name"
+            <*> (o .:? "is_bot" >>= maybe (o .:? "isBot" .!= False) pure)
+            <*> (o .:? "first_name" >>= maybe (o .:? "firstName") (pure . Just))
+            <*> (o .:? "last_name" >>= maybe (o .:? "lastName") (pure . Just))
             <*> o .:? "username"
+
+data TelegramMessageEntity = TelegramMessageEntity
+    { entityType :: !Text
+    , entityOffset :: !Int
+    , entityLength :: !Int
+    , entityUser :: !(Maybe TelegramUser)
+    } deriving (Eq, Show)
+
+instance FromJSON TelegramMessageEntity where
+    parseJSON = withObject "TelegramMessageEntity" \o ->
+        TelegramMessageEntity
+            <$> o .: "type"
+            <*> o .: "offset"
+            <*> o .: "length"
+            <*> o .:? "user"
 
 data TelegramChat = TelegramChat
     { telegramChatId :: !Integer
@@ -150,6 +175,8 @@ data TelegramMessage = TelegramMessage
     , messageEditDate :: !(Maybe Integer)
     , messageReplyTo :: !(Maybe TelegramMessage)
     , messageNewChatMembers :: ![TelegramUser]
+    , messageEntities :: ![TelegramMessageEntity]
+    , messageCaptionEntities :: ![TelegramMessageEntity]
     } deriving (Eq, Show)
 
 instance FromJSON TelegramMessage where
@@ -179,6 +206,8 @@ instance FromJSON TelegramMessage where
             <*> o .:? "edit_date"
             <*> o .:? "reply_to_message"
             <*> (o .:? "new_chat_members" .!= [])
+            <*> (o .:? "entities" .!= [])
+            <*> (o .:? "caption_entities" .!= [])
 
 data TelegramReactionType = TelegramReactionType
     { reactionType :: !Text

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -542,7 +542,8 @@ spec = describe "Agent.Telegram" do
                         , pendingMediaChat = TelegramChatKey (-1001) Nothing
                         , pendingMediaUserId = 456
                         , pendingMediaText =
-                            "[Telegram group message from Marc, user 456]\n\
+                            "[Replying to Telegram message 77 from user 999]\n\
+                            \[Telegram group message from Marc, user 456]\n\
                             \[Document: report.pdf]"
                         , pendingMediaAttachments =
                             [ TelegramMedia
@@ -648,7 +649,8 @@ spec = describe "Agent.Telegram" do
                 QueueTurn
                     83
                     (TelegramChatKey (-1001) Nothing)
-                    "[Telegram group message from Marc, user 456]\ncontinue"
+                    "[Replying to Telegram message 70 from @HarnessBot, user 999]\n\
+                    \[Telegram group message from Marc, user 456]\ncontinue"
                     Nothing
 
             commandAction <- classify
@@ -680,7 +682,8 @@ spec = describe "Agent.Telegram" do
                 QueueTurn
                     85
                     (TelegramChatKey (-1002) (Just 7))
-                    "[Telegram group message from Marc, user 456]\n\
+                    "[Replying to Telegram message 71 from @HarnessBot, user 999]\n\
+                    \[Telegram group message from Marc, user 456]\n\
                     \[Voice message]"
                     (Just (TelegramVoice "voice-file" 4 Nothing Nothing))
 
@@ -866,6 +869,105 @@ spec = describe "Agent.Telegram" do
             isAnonymousAdmin anonymous `shouldBe` True
             isAnonymousAdmin allowedUser `shouldBe` False
 
+        it "rewrites a reply /allow command into the other member's user id" do
+            action <- classifyAuthorized
+                "{\"update_id\":51,\"message\":{\
+                \\"message_id\":101,\
+                \\"from\":{\"id\":456,\"first_name\":\"Marc\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"/allow\",\
+                \\"reply_to_message\":{\"message_id\":100,\
+                \\"from\":{\"id\":789,\"first_name\":\"Hendi\",\
+                \\"username\":\"hendi\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"hello\"}}}"
+            action `shouldBe`
+                QueueTurn
+                    101
+                    (TelegramChatKey (-1001) Nothing)
+                    "/allow 789"
+                    Nothing
+
+        it "keeps a named /allow command so the gateway can resolve it later" do
+            action <- classifyAuthorized
+                "{\"update_id\":52,\"message\":{\
+                \\"message_id\":102,\
+                \\"from\":{\"id\":456,\"first_name\":\"Marc\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"/allow Hendi\"}}"
+            action `shouldBe`
+                QueueTurn
+                    102
+                    (TelegramChatKey (-1001) Nothing)
+                    "/allow Hendi"
+                    Nothing
+
+        it "includes reply identity and mentions in the agent prompt" do
+            action <- classifyAuthorized
+                "{\"update_id\":53,\"message\":{\
+                \\"message_id\":103,\
+                \\"from\":{\"id\":456,\"first_name\":\"Marc\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"@HarnessBot also accept messages from Hendi\",\
+                \\"entities\":[{\"offset\":0,\"length\":12,\"type\":\"mention\"},\
+                \{\"offset\":38,\"length\":5,\"type\":\"text_mention\",\
+                \\"user\":{\"id\":789,\"first_name\":\"Hendi\",\
+                \\"username\":\"hendi\"}}],\
+                \\"reply_to_message\":{\"message_id\":100,\
+                \\"from\":{\"id\":789,\"first_name\":\"Hendi\",\
+                \\"username\":\"hendi\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"can I use the bot?\"}}}"
+            action `shouldBe`
+                QueueTurn
+                    103
+                    (TelegramChatKey (-1001) Nothing)
+                    "[Replying to Telegram message 100 from Hendi, @hendi, user 789: \
+                    \can I use the bot?]\n\
+                    \[Telegram mentions: Hendi, @hendi, user 789]\n\
+                    \[Telegram group message from Marc, user 456]\n\
+                    \also accept messages from Hendi"
+                    Nothing
+
+        it "records ignored group members so they can be allowed by name" do
+            update <- (eitherDecode
+                (LBS.pack
+                    "{\"update_id\":54,\"message\":{\
+                    \\"message_id\":104,\
+                    \\"from\":{\"id\":789,\"first_name\":\"Hendi\",\
+                    \\"username\":\"hendi\"},\
+                    \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                    \\"text\":\"hello everyone\"}}")
+                :: Either String TelegramUpdate)
+                `shouldReturnRight` "ignored group update should decode"
+            classifyAuthorized
+                "{\"update_id\":54,\"message\":{\
+                \\"message_id\":104,\
+                \\"from\":{\"id\":789,\"first_name\":\"Hendi\",\
+                \\"username\":\"hendi\"},\
+                \\"chat\":{\"id\":-1001,\"type\":\"group\"},\
+                \\"text\":\"hello everyone\"}}"
+                >>= (`shouldBe` IgnoreUpdate)
+            let state = recordSeenTelegramUsers update emptyTelegramState
+                hendi = TelegramUser
+                    { userId = 789
+                    , userIsBot = False
+                    , userFirstName = Just "Hendi"
+                    , userLastName = Nothing
+                    , userUsername = Just "hendi"
+                    }
+            Map.lookup 789 state.seenTelegramUsers `shouldBe` Just hendi
+            Map.lookup (-1001) state.seenUsersByChat
+                `shouldBe` Just (Set.singleton 789)
+            resolveTelegramUser state (-1001) Nothing "Hendi"
+                `shouldBe` ResolvedTelegramUser hendi
+            resolveTelegramUser state (-1001) Nothing "@hendi"
+                `shouldBe` ResolvedTelegramUser hendi
+            telegramReplyUserIdFromPrompt
+                "[Replying to Telegram message 100 from Hendi, @hendi, user 789: hi]\n\
+                \please allow them"
+                `shouldBe` Just 789
+
         it "authorizes a group after an allowed user targets the bot there" do
             let key = TelegramChatKey (-1001) Nothing
                 state = storeUpdateAction
@@ -1035,6 +1137,9 @@ spec = describe "Agent.Telegram" do
                     , "deadLetters" .= ([] :: [TelegramDeadLetter])
                     , "outboundMessages" .= ([] :: [Value])
                     , "authorizedGroupChats" .= ([] :: [Integer])
+                    , "allowedUserIds" .= ([] :: [Integer])
+                    , "seenTelegramUsers" .= ([] :: [TelegramUser])
+                    , "seenUsersByChat" .= ([] :: [Value])
                     ]
             (eitherDecode (encode state) :: Either String Value)
                 `shouldBe` Right expected


### PR DESCRIPTION
## Summary
- Already-allowlisted Telegram users can grant others from the group without looking up a numeric user ID.
- `/allow` works by reply, name, or `@username`; `/deny` and `/users` manage the live allowlist. Conversational grants use `allow_telegram_user` / `deny_telegram_user` / `list_telegram_users`.
- The gateway records people it has seen (including ignored group messages) and applies grants immediately, persisting extras in `state.json` so NixOS config regeneration does not wipe them.

## Test plan
- [x] `cabal repl agent-telegram:test:agent-telegram-test` — 66 examples, 0 failures
- [x] `cabal test agent-cli:test:agent-cli-test --test-options='--match GatewayBridge'` — 4 examples, 0 failures
- Restart `agent-telegram` with this build, then in a group: reply to another member with `/allow`, or ask the bot to accept them by name. Confirm `/users` lists them and their next message is handled without a gateway restart.