### PR TITLE
fix(tui): show workspace-relative tool paths

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -25,7 +25,7 @@ import Agent.CLI.Style
     )
 import Agent.CLI.Terminal (resolveColor)
 import Agent.JsonText (jsonTextFieldDefault)
-import Agent.OsPath (fromText)
+import Agent.OsPath (fromText, toText)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , canonicalToolName
@@ -66,13 +66,15 @@ approveToolDecision
     -> ToolRegistry
     -> PlanModeEnv
     -> OsPath
+    -> OsPath
     -> ToolCall
     -> IO (Either Text Bool)
-approveToolDecision policyRef allowedToolsRef tools planMode projectRoot call = do
+approveToolDecision
+        policyRef allowedToolsRef tools planMode projectRoot cwd call = do
     approveToolDecisionWithReporterAndPersistence
         (\requested -> do
             color <- resolveColor stderr
-            promptPermission color requested)
+            promptPermission color (toText cwd) requested)
         (\case
             ApprovalWarning message -> do
                 color <- resolveColor stderr

--- a/packages/agent-cli/src/Agent/CLI/Permission.hs
+++ b/packages/agent-cli/src/Agent/CLI/Permission.hs
@@ -16,7 +16,7 @@ import Agent.CLI.Notification
 import Agent.CLI.Options (ApprovalAnswer(..), parseApprovalAnswer)
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import Agent.CLI.Style (glyphWarn, roleMuted, roleSuccess, roleWarn)
-import Agent.TUI.Presentation (permissionToolCallPrompt)
+import Agent.TUI.Presentation (permissionToolCallPromptRelative)
 import Agent.ToolDispatch (ToolCall)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -99,10 +99,10 @@ renderRow color selected label =
 -- | TTY card; non-TTY keeps cooked @y/n/a/A@. Uppercase @A@, @all@, or
 -- @yolo@ enables project-wide auto-approval; lowercase @a@ remembers only the
 -- current tool for this session.
-promptPermission :: Bool -> ToolCall -> IO (Maybe PermissionChoice)
-promptPermission color call = do
+promptPermission :: Bool -> Text -> ToolCall -> IO (Maybe PermissionChoice)
+promptPermission color workspace call = do
     isTty <- hIsTerminalDevice stdin
-    let summary = permissionToolCallPrompt call
+    let summary = permissionToolCallPromptRelative workspace call
     if not isTty
         then cooked color summary
         else do

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -35,6 +35,7 @@ module Agent.CLI.Render
     , formatToolBody
     , formatToolOutput
     , formatToolStarted
+    , formatToolStartedRelative
     , formatTurnStatus
     , putTextLn
     , renderAssistantText
@@ -114,9 +115,12 @@ import Agent.TUI.Presentation
     , SearchReplaceDiff(..)
     , SearchReplaceLine(..)
     , formatToolOutput
+    , formatToolOutputRelative
     , parseSearchReplaceDiff
     , summarizeToolCall
+    , summarizeToolCallRelative
     , toolDetail
+    , workspaceRelativeDisplayPath
     )
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -166,6 +170,7 @@ data RenderConfig = RenderConfig
     , renderModelRef :: !(IORef Text)
     , renderNativeProgress :: !Bool -- ^ Ghostty / WT OSC 9;4; off in tests
     , renderMotionMode :: !MotionMode
+    , renderWorkspace :: !Text
     }
 
 -- | Immutable logical renderer state. IO effects (terminal output and the
@@ -760,13 +765,22 @@ renderEventUnlocked config = \case
         modifyRenderState config \state ->
             ( state
                 { stateToolCalls = Map.insert call.callId call state.stateToolCalls
-                , stateActivity = summarizeToolCall call
+                , stateActivity =
+                    summarizeToolCallRelative config.renderWorkspace call
                 }
             , ()
             )
         unless (isTodoTool call.name) do
-            putTextLn config.renderStderr (formatToolStarted config.renderColor call)
-            let extra = formatToolBody config.renderColor call
+            putTextLn config.renderStderr
+                (formatToolStartedRelative
+                    config.renderColor
+                    config.renderWorkspace
+                    call)
+            let extra =
+                    formatToolBodyRelative
+                        config.renderColor
+                        config.renderWorkspace
+                        call
             unless (Text.null extra) do
                 putTextLn config.renderStderr extra
         when config.renderShowThinking do
@@ -786,7 +800,11 @@ renderEventUnlocked config = \case
             )
         let maybeCall = Map.lookup result.callId calls
             formatted = maybe result.output
-                (`formatToolOutput` result.output)
+                (\call ->
+                    formatToolOutputRelative
+                        config.renderWorkspace
+                        call
+                        result.output)
                 maybeCall
             painted = case maybeCall of
                 Just call
@@ -1139,7 +1157,10 @@ putTextLn handle text = do
 -- Known coding tools use English verbs (Read / Listed / $) instead of
 -- wire names, matching grok-build's linear chrome while staying Solarized.
 formatToolStarted :: Bool -> ToolCall -> Text
-formatToolStarted color call =
+formatToolStarted color = formatToolStartedRelative color ""
+
+formatToolStartedRelative :: Bool -> Text -> ToolCall -> Text
+formatToolStartedRelative color workspace call =
     let arrow = roleToolArrow color glyphTool
         detail = toolDetail call
     in case toolChrome call.name of
@@ -1159,7 +1180,8 @@ formatToolStarted color call =
                         | otherwise -> " " <> roleToolDetail color detail
                     ToolDetailPath
                         | Text.null detail -> ""
-                        | otherwise -> " " <> renderToolPath color detail
+                        | otherwise ->
+                            " " <> renderToolPath color workspace detail
                     ToolDetailCommand
                         | Text.null detail -> ""
                         | otherwise -> " " <> roleToolCommand color detail
@@ -1214,20 +1236,29 @@ isTodoTool name =
     canonicalToolName name `elem` ["todo_write", "update_plan"]
 
 formatToolBody :: Bool -> ToolCall -> Text
-formatToolBody color call = case canonicalToolName call.name of
-    "search_replace" -> formatSearchReplaceDiff color call.arguments
+formatToolBody color = formatToolBodyRelative color ""
+
+formatToolBodyRelative :: Bool -> Text -> ToolCall -> Text
+formatToolBodyRelative color workspace call = case canonicalToolName call.name of
+    "search_replace" ->
+        formatSearchReplaceDiffRelative color workspace call.arguments
     _ -> ""
 
 -- | Compact unified-diff preview for @search_replace@ arguments.
 formatSearchReplaceDiff :: Bool -> Text -> Text
-formatSearchReplaceDiff color arguments =
+formatSearchReplaceDiff color = formatSearchReplaceDiffRelative color ""
+
+formatSearchReplaceDiffRelative :: Bool -> Text -> Text -> Text
+formatSearchReplaceDiffRelative color workspace arguments =
     let SearchReplaceDiff { diffPath, diffAction, diffLines, diffHiddenLines } =
             parseSearchReplaceDiff arguments
         header = case diffAction of
             Just SearchReplaceCreate ->
-                roleMuted color "  create " <> renderToolPath color diffPath
+                roleMuted color "  create "
+                    <> renderToolPath color workspace diffPath
             Just SearchReplaceDelete ->
-                roleMuted color "  delete " <> renderToolPath color diffPath
+                roleMuted color "  delete "
+                    <> renderToolPath color workspace diffPath
             _ -> ""
         shown = map paintLine diffLines
         more =
@@ -1246,12 +1277,23 @@ formatSearchReplaceDiff color arguments =
         SearchReplaceAdded line ->
             style color [terminalGreen] ("  +" <> line)
 
-renderToolPath :: Bool -> Text -> Text
-renderToolPath color path =
-    let styled = roleToolPath color path
-    in if "/" `Text.isPrefixOf` path
-        then osc8Link color (fileUri (Text.unpack path)) styled
+renderToolPath :: Bool -> Text -> Text -> Text
+renderToolPath color workspace path =
+    let displayed = workspaceRelativeDisplayPath workspace path
+        styled = roleToolPath color displayed
+        absolute = absoluteToolPath workspace path
+    in if "/" `Text.isPrefixOf` absolute
+        then osc8Link color (fileUri (Text.unpack absolute)) styled
         else styled
+
+absoluteToolPath :: Text -> Text -> Text
+absoluteToolPath workspace path
+    | "/" `Text.isPrefixOf` path = path
+    | Text.null root = path
+    | path == "." = root
+    | otherwise = root <> "/" <> Text.dropWhile (== '/') path
+  where
+    root = Text.dropWhileEnd (== '/') workspace
 
 truncateToolOutput :: Text -> Text
 truncateToolOutput output =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -858,7 +858,8 @@ prepareAgentIterationTracked
                         ""
                         (toText (takeFileName (takeDirectory initialCwd))
                             <> "/"
-                            <> toText (takeFileName initialCwd)))
+                            <> toText (takeFileName initialCwd))
+                        (toText initialCwd))
                     initialUiState))
                         { uiQueuedInputs = queuedInputDisplays }
     firstFrameReady <-

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Startup.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Startup.hs
@@ -17,6 +17,7 @@ import Agent.CLI.Render ( putTextLn )
 import Agent.CLI.Session.Runtime.Types ( StartupRuntime(..) )
 import Agent.Tools.Types ( AppTool(..) )
 import Agent.ToolDispatch ( canonicalToolName )
+import Agent.OsPath ( toText )
 import Agent.TUI.Model ( UiEvent(..) )
 import Control.Monad ( when )
 import Data.IORef ( readIORef, writeIORef )
@@ -102,6 +103,7 @@ setStartupRepository fullscreen home branch cwd =
                 UiSetRepository
                     branch
                     (formatRepositoryPath home cwd)
+                    (toText cwd)
 
 -- | Drop Ghostty / Windows Terminal native progress (OSC 9;4) on stderr.
 -- Safe when the bar was never shown; unknown terminals ignore the sequence.

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -710,6 +710,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     && nativeProgressAnimationEnabled
                         options.optMotionMode
             , renderMotionMode = options.optMotionMode
+            , renderWorkspace = toText cwd
             }
         emitLoop event = do
             managedLoopPublisher event
@@ -759,10 +760,10 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                             withStdinPaused escPaused $
                                 approveToolDecision
                                     policyRef allowedToolsRef toolRegistry planMode
-                                    projectRoot call
+                                    projectRoot cwd call
                         Just runtime ->
                             approveToolDecisionWithReporterAndPersistence
-                                (requestFullscreenPermission runtime)
+                                (requestFullscreenPermission runtime (toText cwd))
                                 (\case
                                     ApprovalWarning _ -> pure ()
                                     ApprovalSuccess message ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -259,13 +259,7 @@ import Agent.TUI.Motion
     , waitingIndicator
     )
 import Agent.TUI.Presentation
-    ( TodoDisplayLine(..)
-    , TodoDisplayStatus(..)
-    , liveTodoPanelLines
-    , parseTodoList
-    , permissionToolCallPrompt
-    , todoStatusGlyph
-    )
+    ( permissionToolCallPromptRelative )
 import Agent.Loop (ImageAttachment(..), LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick
@@ -917,11 +911,12 @@ withTrackedVtyBuilder build action = do
 
 requestFullscreenPermission
     :: FullscreenRuntime
+    -> Text
     -> ToolCall
     -> IO (Maybe PermissionChoice)
-requestFullscreenPermission runtime call = do
+requestFullscreenPermission runtime workspace call = do
     reply <- newEmptyTMVarIO
-    let summary = permissionToolCallPrompt call
+    let summary = permissionToolCallPromptRelative workspace call
     enqueueAppEvent runtime (AppAskPermission summary reply)
     atomically (readTMVar reply)
 
@@ -2705,7 +2700,7 @@ uiEventMayExposeSyntax = \case
     UiSetPromptEffort _ -> False
     UiSetPromptLimitStatus _ -> False
     UiSetAwaitingInput _ -> False
-    UiSetRepository _ _ -> False
+    UiSetRepository _ _ _ -> False
     UiSetNotice _ -> False
     UiMoveSelection _ -> False
     UiSelectBlock _ -> False

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -250,6 +250,14 @@ spec = do
                 `shouldBe` "◆ $ git status"
             formatToolStarted False (functionToolCall "c3" "search_replace" "{\"file_path\":\"src/A.hs\"}")
                 `shouldBe` "◆ Edited src/A.hs"
+            formatToolStartedRelative
+                False
+                "/Users/marc/.haskell-agent/worktrees/haskell-agent/wt"
+                (functionToolCall
+                    "c3b"
+                    "search_replace"
+                    "{\"file_path\":\"/Users/marc/.haskell-agent/worktrees/haskell-agent/wt/nix/modules/telegram.nix\"}")
+                `shouldBe` "◆ Edited nix/modules/telegram.nix"
             formatToolStarted False
                 (functionToolCall
                     "c4"
@@ -930,6 +938,7 @@ withRenderConfigNativeMode showThinking color native motionMode action = do
                 , renderModelRef = modelRef
                 , renderNativeProgress = native
                 , renderMotionMode = motionMode
+                , renderWorkspace = ""
                 }
         action config handle path
         clearThinking config

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -91,7 +91,7 @@ data TuiAction
     | SetDraft !Text !Int
     | QueueInput !Text
     | StartQueuedInput
-    | SetRepository !Text !Text
+    | SetRepository !Text !Text !Text
     | SetNotice !Text
     | ClearNotice
     | MoveSelection !Int
@@ -582,7 +582,8 @@ applyAction action harness =
         SetDraft text cursor -> applyUi (UiSetDraft text cursor)
         QueueInput text -> applyUi (UiInputQueued text)
         StartQueuedInput -> applyUi UiQueuedInputStarted
-        SetRepository branch cwd -> applyUi (UiSetRepository branch cwd)
+        SetRepository branch cwd workspace ->
+            applyUi (UiSetRepository branch cwd workspace)
         SetNotice text -> applyUi (UiSetNotice (Just (warningNotice text)))
         ClearNotice -> applyUi (UiSetNotice Nothing)
         MoveSelection amount -> applyUi (UiMoveSelection amount)
@@ -737,7 +738,7 @@ genAction =
         , (7, SetDraft <$> genBodyText <*> genCursor)
         , (3, QueueInput <$> genBodyText)
         , (1, pure StartQueuedInput)
-        , (2, SetRepository <$> genLineText <*> genLineText)
+        , (2, SetRepository <$> genLineText <*> genLineText <*> genLineText)
         , (2, SetNotice <$> genLineText)
         , (1, pure ClearNotice)
         , (2, MoveSelection <$> chooseInt (-20, 20))

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -41,13 +41,13 @@ module Agent.TUI.Model
 
 import Agent.TUI.Presentation
     ( TodoDisplayLine
-    , formatSearchReplaceDiff
-    , formatToolOutput
+    , formatSearchReplaceDiffRelative
+    , formatToolOutputRelative
     , todoListFromToolOutput
     , todoListHasInProgress
     , todoListHasOpenWork
     , toolCallInput
-    , toolCallTitle
+    , toolCallTitleRelative
     )
 import Agent.TUI.TextWidth (clampGraphemeCursor)
 import Agent.TUI.Motion
@@ -188,6 +188,7 @@ data UiState = UiState
     , uiPrompt :: !PromptState
     , uiBranch :: !Text
     , uiCwd :: !Text
+    , uiWorkspaceRoot :: !Text
     , uiPermission :: !(Maybe PermissionOverlay)
     , uiNotice :: !(Maybe UiNotice)
     , uiRetryCountdown :: !(Maybe RetryCountdown)
@@ -218,7 +219,7 @@ data UiEvent
     | UiSetPromptEffort !Text
     | UiSetPromptLimitStatus !(Maybe PromptLimitStatus)
     | UiSetAwaitingInput !Bool
-    | UiSetRepository !Text !Text
+    | UiSetRepository !Text !Text !Text
     | UiSetNotice !(Maybe UiNotice)
     | UiMoveSelection !Int
     | UiSelectBlock !BlockId
@@ -271,6 +272,7 @@ initialUiState = UiState
         }
     , uiBranch = ""
     , uiCwd = ""
+    , uiWorkspaceRoot = ""
     , uiPermission = Nothing
     , uiNotice = Nothing
     , uiRetryCountdown = Nothing
@@ -388,8 +390,8 @@ reduceUi event state = case event of
                     then "Ready"
                     else state.uiActivity
             }
-    UiSetRepository branch cwd ->
-        state { uiBranch = branch, uiCwd = cwd }
+    UiSetRepository branch cwd workspace ->
+        state { uiBranch = branch, uiCwd = cwd, uiWorkspaceRoot = workspace }
     UiSetNotice notice ->
         state { uiNotice = notice, uiNoticeElapsedMillis = 0 }
     UiMoveSelection delta ->
@@ -775,7 +777,7 @@ reduceLoop event state = case event of
                 { uiRunning = True
                 , uiGenerating = False
                 , uiAwaitingInput = False
-                , uiActivity = toolCallTitle call
+                , uiActivity = toolCallTitleRelative state.uiWorkspaceRoot call
                 , uiToolCalls =
                     Map.insert
                         call.callId
@@ -785,11 +787,13 @@ reduceLoop event state = case event of
         | otherwise ->
             let
                 kind = toolBlockKind call.name
-                title = toolCallTitle call
+                title = toolCallTitleRelative state.uiWorkspaceRoot call
                 blockIndex = Seq.length state.uiBlocks
                 body = case canonicalToolName call.name of
                     "search_replace" ->
-                        formatSearchReplaceDiff call.arguments
+                        formatSearchReplaceDiffRelative
+                            state.uiWorkspaceRoot
+                            call.arguments
                     _ -> ""
                 detail = toolCallInput call
             in appendBlock kind title body detail
@@ -813,7 +817,12 @@ reduceLoop event state = case event of
                 Nothing -> result
                 Just (_, call) ->
                     result
-                        { output = formatToolOutput call result.output }
+                        { output =
+                            formatToolOutputRelative
+                                state.uiWorkspaceRoot
+                                call
+                                result.output
+                        }
             todos =
                 case activeCall of
                     Just (_, call)

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -6,21 +6,28 @@ module Agent.TUI.Presentation
     , TodoDisplayLine(..)
     , TodoDisplayStatus(..)
     , formatSearchReplaceDiff
+    , formatSearchReplaceDiffRelative
     , formatTodoList
     , formatToolOutput
+    , formatToolOutputRelative
     , liveTodoPanelLines
     , parseSearchReplaceDiff
     , parseTodoList
     , permissionToolCallPrompt
+    , permissionToolCallPromptRelative
     , todoListFromToolOutput
     , summarizeToolCall
+    , summarizeToolCallRelative
     , todoCallPreview
     , todoListHasInProgress
     , todoListHasOpenWork
     , todoStatusGlyph
     , toolCallInput
     , toolCallTitle
+    , toolCallTitleRelative
     , toolDetail
+    , toolPathArgument
+    , workspaceRelativeDisplayPath
     ) where
 
 import Agent.JsonText (jsonTextField, jsonTextFieldDefault)
@@ -41,16 +48,26 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 
 summarizeToolCall :: ToolCall -> Text
-summarizeToolCall call =
+summarizeToolCall = summarizeToolCallRelative ""
+
+-- | Like 'summarizeToolCall', but filesystem paths inside the workspace are
+-- shown relative to that workspace.
+summarizeToolCallRelative :: Text -> ToolCall -> Text
+summarizeToolCallRelative workspace call =
     let verb = toolVerb call.name
-        detail = toolDetail call
+        detail = case toolPathArgument call of
+            Just path -> workspaceRelativeDisplayPath workspace path
+            Nothing -> toolDetail call
     in if Text.null detail then verb else verb <> " " <> detail
 
 -- | Complete question shown before a mutating tool call is approved.
 -- Command-like tools include their full input: a first-line activity summary
 -- is not enough for multiline @do@ blocks or shell scripts.
 permissionToolCallPrompt :: ToolCall -> Text
-permissionToolCallPrompt call =
+permissionToolCallPrompt = permissionToolCallPromptRelative ""
+
+permissionToolCallPromptRelative :: Text -> ToolCall -> Text
+permissionToolCallPromptRelative workspace call =
     displayTerminalText case canonicalToolName call.name of
         "run_ghci" ->
             detailedPrompt
@@ -72,7 +89,7 @@ permissionToolCallPrompt call =
             "Archive learned skill " <> skillIdentity call.arguments <> "?"
         "skill_rollback" ->
             "Restore learned skill " <> skillIdentity call.arguments <> "?"
-        _ -> "Allow " <> summarizeToolCall call <> "?"
+        _ -> "Allow " <> summarizeToolCallRelative workspace call <> "?"
   where
     detailedPrompt question input
         | Text.null (Text.strip input) = question
@@ -82,9 +99,12 @@ permissionToolCallPrompt call =
 -- separately as code, so keeping them out of the heading avoids an unbounded
 -- single terminal row and leaves a useful activity label.
 toolCallTitle :: ToolCall -> Text
-toolCallTitle call
+toolCallTitle = toolCallTitleRelative ""
+
+toolCallTitleRelative :: Text -> ToolCall -> Text
+toolCallTitleRelative workspace call
     | canonicalToolName call.name == "run_ghci" = "$ ghci"
-    | otherwise = summarizeToolCall call
+    | otherwise = summarizeToolCallRelative workspace call
 
 -- | Full invocation text that benefits from dedicated code rendering.
 toolCallInput :: ToolCall -> Text
@@ -131,12 +151,16 @@ parseSearchReplaceDiff arguments =
         }
 
 formatSearchReplaceDiff :: Text -> Text
-formatSearchReplaceDiff arguments =
+formatSearchReplaceDiff = formatSearchReplaceDiffRelative ""
+
+formatSearchReplaceDiffRelative :: Text -> Text -> Text
+formatSearchReplaceDiffRelative workspace arguments =
     let SearchReplaceDiff { diffPath, diffAction, diffLines, diffHiddenLines } =
             parseSearchReplaceDiff arguments
+        displayedPath = workspaceRelativeDisplayPath workspace diffPath
         header = case diffAction of
-            Just SearchReplaceCreate -> "  create " <> diffPath
-            Just SearchReplaceDelete -> "  delete " <> diffPath
+            Just SearchReplaceCreate -> "  create " <> displayedPath
+            Just SearchReplaceDelete -> "  delete " <> displayedPath
             _ -> ""
         shown = map formatLine diffLines
         more
@@ -167,6 +191,58 @@ formatToolOutput call output = case canonicalToolName call.name of
     "todo_write" -> formatTodoList output
     "update_plan" -> formatTodoList output
     _ -> output
+
+-- | Rewrite workspace-absolute filesystem paths in tool chrome/output without
+-- touching file contents returned by @read_file@.
+formatToolOutputRelative :: Text -> ToolCall -> Text -> Text
+formatToolOutputRelative workspace call output =
+    formatToolOutput call $
+        if shouldRelativizeToolOutput call
+            then rewriteToolPathInText workspace call output
+            else output
+
+shouldRelativizeToolOutput :: ToolCall -> Bool
+shouldRelativizeToolOutput call =
+    canonicalToolName call.name
+        `elem` ["search_replace", "list_dir", "apply_patch"]
+
+rewriteToolPathInText :: Text -> ToolCall -> Text -> Text
+rewriteToolPathInText workspace call output =
+    case toolPathArgument call of
+        Just path ->
+            let displayed = workspaceRelativeDisplayPath workspace path
+            in if path == displayed
+                then output
+                else Text.replace path displayed output
+        Nothing -> output
+
+-- | Show @path@ relative to @workspace@ when it is inside that tree.
+-- Already-relative paths and paths outside the workspace are unchanged.
+workspaceRelativeDisplayPath :: Text -> Text -> Text
+workspaceRelativeDisplayPath workspace path
+    | Text.null root || Text.null candidate = path
+    | candidate == root = "."
+    | Just relative <- Text.stripPrefix (root <> "/") candidate
+    , not (Text.null relative) =
+        relative
+    | otherwise = path
+  where
+    root = Text.dropWhileEnd (== '/') workspace
+    candidate = Text.dropWhileEnd (== '/') path
+
+-- | Filesystem path argument used in tool chrome, when the tool has one.
+toolPathArgument :: ToolCall -> Maybe Text
+toolPathArgument call =
+    nonEmptyPath $ case canonicalToolName call.name of
+        "read_file" -> jsonTextFieldDefault "target_file" call.arguments
+        "list_dir" -> jsonTextFieldDefault "target_directory" call.arguments
+        "search_replace" -> jsonTextFieldDefault "file_path" call.arguments
+        "apply_patch" -> fromMaybe "" (firstPatchPath call.arguments)
+        _ -> ""
+  where
+    nonEmptyPath text =
+        let stripped = Text.strip text
+        in if Text.null stripped then Nothing else Just stripped
 
 data TodoDisplayStatus
     = TodoDisplayPending

--- a/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
@@ -142,7 +142,7 @@ generatedUiEvent = frequency
     , (3, UiInputQueued <$> generatedText)
     , (3, UiInputPromoted <$> generatedText)
     , (3, UiSetPromptEffort <$> generatedText)
-    , (3, UiSetRepository <$> generatedText <*> generatedText)
+    , (3, UiSetRepository <$> generatedText <*> generatedText <*> generatedText)
     , (3, UiSetNotice <$> generatedNotice)
     , (3, UiMoveSelection <$> chooseInt (-20, 20))
     , (3, UiSelectBlock . BlockId <$> chooseInt (-10, 30))

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -771,6 +771,48 @@ spec = describe "fullscreen UI reducer" do
         finished.uiRetryCountdown `shouldBe` Nothing
         uiNeedsTick finished `shouldBe` False
 
+    it "shows worktree-relative paths for edits" do
+        let workspace =
+                "/Users/marc/.haskell-agent/worktrees/haskell-agent/wt"
+            path = workspace <> "/nix/modules/telegram.nix"
+            call =
+                functionToolCall
+                    "edit-abs"
+                    "search_replace"
+                    ("{\"file_path\":\""
+                        <> path
+                        <> "\",\"old_string\":\"old\",\"new_string\":\"new\"}")
+            started =
+                apply
+                    [ UiSetRepository "main" "~/project" workspace
+                    , UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    ]
+            finished =
+                reduceUi
+                    (UiLoop
+                        (ToolFinished
+                            ToolCallResult
+                                { callId = "edit-abs"
+                                , output =
+                                    "The file "
+                                        <> path
+                                        <> " has been updated successfully."
+                                , callKind = FunctionCallKind
+                                }))
+                    started
+        case Foldable.toList started.uiBlocks of
+            [block] ->
+                block.blockTitle
+                    `shouldBe` "Edited nix/modules/telegram.nix"
+            _ -> expectationFailure "expected one running edit block"
+        case Foldable.toList finished.uiBlocks of
+            [block] ->
+                block.blockBody
+                    `shouldBe`
+                        "The file nix/modules/telegram.nix has been updated successfully."
+            _ -> expectationFailure "expected one completed edit block"
+
     it "shows a search-replace diff while the tool is running" do
         let call =
                 functionToolCall

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -10,6 +10,57 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "tool presentation" do
+    it "shows filesystem paths relative to the workspace" do
+        let workspace =
+                "/Users/marc/.haskell-agent/worktrees/haskell-agent/wt"
+            absolute = workspace <> "/nix/modules/telegram.nix"
+            edit =
+                functionToolCall
+                    "edit"
+                    "search_replace"
+                    ("{\"file_path\":\"" <> absolute <> "\"}")
+            listing =
+                functionToolCall
+                    "ls"
+                    "list_dir"
+                    ("{\"target_directory\":\"" <> workspace <> "\"}")
+            readCall =
+                functionToolCall
+                    "read"
+                    "read_file"
+                    ("{\"target_file\":\"" <> absolute <> "\"}")
+        workspaceRelativeDisplayPath workspace absolute
+            `shouldBe` "nix/modules/telegram.nix"
+        workspaceRelativeDisplayPath workspace (workspace <> "/")
+            `shouldBe` "."
+        workspaceRelativeDisplayPath workspace "src/Main.hs"
+            `shouldBe` "src/Main.hs"
+        workspaceRelativeDisplayPath workspace "/tmp/outside.hs"
+            `shouldBe` "/tmp/outside.hs"
+        workspaceRelativeDisplayPath
+            "/worktree"
+            "/worktree-other/Foo.hs"
+            `shouldBe` "/worktree-other/Foo.hs"
+        summarizeToolCallRelative workspace edit
+            `shouldBe` "Edited nix/modules/telegram.nix"
+        summarizeToolCallRelative workspace listing
+            `shouldBe` "Listed ."
+        toolCallTitleRelative workspace readCall
+            `shouldBe` "Read nix/modules/telegram.nix"
+        permissionToolCallPromptRelative workspace edit
+            `shouldBe` "Allow Edited nix/modules/telegram.nix?"
+        formatToolOutputRelative
+            workspace
+            edit
+            ("The file " <> absolute <> " has been updated successfully.")
+            `shouldBe`
+                "The file nix/modules/telegram.nix has been updated successfully."
+        formatToolOutputRelative workspace listing
+            ("Directory listing for " <> workspace <> ":\nFoo.hs")
+            `shouldBe` "Directory listing for .:\nFoo.hs"
+        formatToolOutputRelative workspace readCall absolute
+            `shouldBe` absolute
+
     it "extracts tool details from function and custom calls" do
         toolDetail
             (functionToolCall "read" "read_file"


### PR DESCRIPTION
## Summary

Grok TUI was showing full worktree paths in tool chrome:

```
✓ Edited /Users/marc/.haskell-agent/worktrees/haskell-agent/<id>/nix/modules/telegram.nix
```

It now shows the workspace-relative path, even when the model passed an absolute one:

```
✓ Edited nix/modules/telegram.nix
```

This is display-only. Tool arguments are unchanged, `read_file` contents are not rewritten, and OSC-8 file links still target the absolute path.

## How grok-build does this

Grok Build has two layers:

1. **TUI display stripping** (what this PR matches). The pager converts absolute tool paths to cwd-relative ones before painting chrome:
   - `make_relative_path` in `xai-grok-pager/src/acp/tracker.rs` strips `current_dir()` from list_dir/grep paths (empty remainder becomes `.`)
   - `xai-grok-pager-render/src/render/tool_paths.rs` uses `display_path.strip_prefix(cwd)` for expanded Read/Edit headers
   - ACP conversion comments that path relativization for display happens on the TUI side

2. **`DisplayCwd` for worktree/fork overlays** (not in this PR). When a session runs on a worktree overlay, grok-build keeps the *model-facing* cwd as the original project path:
   - `resolve_model_path` rewrites absolute display-cwd prefixes onto the real overlay cwd
   - `PathRewriter` rewrites overlay paths in tool *output* back to the original project path before the client sees them
   - That is so conversation history keeps using `/home/user/project/...` instead of `/root/.grok/worktrees/...`

We already prompt the model with the real worktree as `Working directory`, so it copies that prefix. Stripping it in chrome is the same user-facing result as grok-build's pager layer. We are not adding the overlay-fiction `DisplayCwd` rewrite.

## Test plan

- [x] `cabal test agent-tui`
- [x] `cabal test agent-cli --test-options='-m formatToolStarted'`
- [ ] Confirm in a live Grok worktree session that `Edited` / `Read` / `Listed` lines show repo-relative paths