### PR TITLE
Discount only input_image data URLs in token estimates

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -93,8 +93,9 @@ buildRemoteCompactionRequest params history =
                 }
 
 -- | Estimate the complete serialized request, including instructions, tools,
--- and all other request-level fields. Inline image data URLs are counted as
--- vision tokens rather than as base64 text; see 'estimateEncodedValue'.
+-- and all other request-level fields. @input_image.image_url@ data URLs are
+-- counted as vision tokens rather than as base64 text; see
+-- 'estimateEncodedValue'.
 estimateRequestTokensWithItems
     :: ResponseCreateParams
     -> [ResponseItem]
@@ -106,9 +107,11 @@ estimateResponseCreateParamsTokens :: ResponseCreateParams -> Int
 estimateResponseCreateParamsTokens = estimateEncodedValue
 
 -- | Estimate serialized JSON at four characters per token, matching the rest
--- of compaction accounting. Inline @data:image/...;base64,...@ payloads are
+-- of compaction accounting. Base64 payloads on @input_image.image_url@ are
 -- replaced with 'resizedImageBytesEstimate' because the model consumes those
--- images as vision tokens, not as the transport encoding.
+-- images as vision tokens, not as the transport encoding. Ordinary strings
+-- that happen to contain a data URL, including tool-output text, stay at raw
+-- size.
 estimateEncodedValue :: Aeson.ToJSON value => value -> Int
 estimateEncodedValue value =
     estimateAdjustedJsonTokens (Aeson.toJSON value)
@@ -130,22 +133,41 @@ resizedImageBytesEstimate = 7_373
 
 mediaEstimateAdjustment :: Aeson.Value -> (Int, Int)
 mediaEstimateAdjustment = \case
+    Aeson.Array values ->
+        foldl'
+            (\acc value -> addPair acc (mediaEstimateAdjustment value))
+            (0, 0)
+            values
+    Aeson.Object fields ->
+        let isInputImage =
+                KeyMap.lookup "type" fields == Just (Aeson.String "input_image")
+        in foldl'
+            (\acc (key, value) ->
+                addPair acc (fieldAdjustment isInputImage key value))
+            (0, 0)
+            (KeyMap.toList fields)
+    _ ->
+        (0, 0)
+  where
+    addPair (payloadAcc, replacementAcc) (payload, replacement) =
+        (payloadAcc + payload, replacementAcc + replacement)
+
+    fieldAdjustment isInputImage key value
+        | isInputImage && key == "image_url" =
+            imageUrlAdjustment value
+        | otherwise =
+            mediaEstimateAdjustment value
+
+imageUrlAdjustment :: Aeson.Value -> (Int, Int)
+imageUrlAdjustment = \case
     Aeson.String text ->
         case parseBase64ImageDataUrl text of
             Just payload ->
                 (Text.length payload, resizedImageBytesEstimate)
             Nothing ->
                 (0, 0)
-    Aeson.Array values ->
-        foldl' addPair (0, 0) values
-    Aeson.Object fields ->
-        foldl' addPair (0, 0) fields
     _ ->
         (0, 0)
-  where
-    addPair acc value =
-        let (payload, replacement) = mediaEstimateAdjustment value
-        in (fst acc + payload, snd acc + replacement)
 
 -- | Return the base64 payload of a @data:image/...;base64,...@ URL.
 -- Hosted HTTP(S) image URLs and non-image data URLs stay at raw size.

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -864,6 +864,35 @@ spec = do
             estimateRequestTokensWithItems params [item]
                 `shouldSatisfy` (< contextWindow)
 
+        it "still counts tool-output data URLs as model-visible text" do
+            let payload = Text.replicate 200_000 "A"
+                item = toolOutput (Aeson.String ("data:image/png;base64," <> payload))
+            estimateItemsTokens [item]
+                `shouldBe` naiveEncodedTokens item
+
+        it "still counts user-text data URLs as model-visible text" do
+            let payload = Text.replicate 200_000 "A"
+            estimateItemsTokens [user ("data:image/png;base64," <> payload)]
+                `shouldBe` naiveEncodedTokens
+                    (user ("data:image/png;base64," <> payload))
+
+        it "discounts structured input_image parts in tool output" do
+            let payload = Text.replicate 200_000 "A"
+                item =
+                    toolOutput $
+                        Aeson.Array $
+                            Vector.fromList
+                                [ Aeson.object
+                                    [ "type" .= ("input_image" :: Text.Text)
+                                    , "image_url" .=
+                                        ("data:image/png;base64," <> payload)
+                                    ]
+                                ]
+                estimated = estimateItemsTokens [item]
+            estimated `shouldSatisfy` (< 5_000)
+            estimated `shouldSatisfy`
+                (>= max 1 (resizedImageBytesEstimate `div` 4))
+
     describe "Codex model metadata" do
         it "derives the 90% auto-compaction limit for curated 272k models" do
             codexModelMetadata "gpt-5.6-luna"
@@ -1075,6 +1104,15 @@ spec = do
         , status = Nothing
         , phase = Nothing
         , passthrough = Nothing
+        , extraFields = KeyMap.empty
+        }
+    toolOutput output = FunctionCallOutputItem FunctionCallOutput
+        { itemId = Nothing
+        , callId = "call-image"
+        , name = Nothing
+        , namespace = Nothing
+        , output
+        , status = Just ItemCompleted
         , extraFields = KeyMap.empty
         }
     assistant text = MessageItem ResponseMessage


### PR DESCRIPTION
## Summary

Follow-up to #599 review: token estimates walked every JSON string, so a `function_call_output` whose `output` was a `data:image/...;base64,...` string was charged as ~1,843 vision tokens even though the model receives that payload as tool-output text.

The replacement now applies only to `image_url` on objects with `"type": "input_image"`. User text and string tool outputs that happen to contain a data URL stay at raw serialized size. Structured `input_image` parts in tool output still get the vision-token discount.

## Tests

- `nix develop -c cabal test agent-openai:agent-openai-test --test-options='--skip Functional'` — 285 examples, 0 failures
- `git diff --check`