### PR TITLE
build: reduce PostgreSQL session-read compile time

### DIFF
--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 
+-- These database statements are dominated by decoding and IO; optimizing the
+-- generated expression trees adds substantially more build cost than value.
+{-# OPTIONS_GHC -O0 #-}
+
 -- | PostgreSQL session read operations.
 module Agent.Store.Postgres.Session.Read
     ( loadSession


### PR DESCRIPTION
## Summary
- compile the PostgreSQL session read/decoder module at `-O0`
- retain optimization for the rest of `agent-store`
- document why this IO-bound module is treated separately

## Measurement
Matched serial GHC 9.10.3 profiling on current master:
- before: `Agent.Store.Postgres.Session.Read` 3.439s
- after: 1.815s
- reduction: 47.2%

## Validation
- `TMPDIR=/tmp cabal test --offline --jobs=1 agent-store-test`: 33 examples, 0 failures
- `nix build .#default --no-link` after rebasing onto latest master
- `git diff --check`