### PR TITLE
fix(tools): echo workspace-relative filesystem paths

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -24,13 +24,16 @@ module Agent.CLI.AgentViewport
     , responseItemLines
     , responseItemPreviewLines
     , responseItemStepPreviews
+    , responseItemStepPreviewsRelative
     , responseItemsToUiState
+    , responseItemsToUiStateRelative
+    , agentStepsForStatusRelative
     , lookupAgentEntry
     , selectAgentTarget
     , selectedAgentEntry
     ) where
 
-import Agent.CLI.Render (summarizeToolCall)
+import Agent.CLI.Render (summarizeToolCallRelative)
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.CLI.TextLayout
@@ -351,8 +354,13 @@ responseItemLines = concatMap responseItemLineList
 -- and tool blocks without maintaining a second presentation model.
 responseItemsToUiState :: Bool -> [ResponseItem] -> UiState
 responseItemsToUiState showRawReasoning =
+    responseItemsToUiStateRelative showRawReasoning ""
+
+responseItemsToUiStateRelative :: Bool -> Text -> [ResponseItem] -> UiState
+responseItemsToUiStateRelative showRawReasoning workspace =
     normalizeTranscriptUi
-        . foldl' (appendResponseItem showRawReasoning) initialUiState
+        . foldl' (appendResponseItem showRawReasoning)
+            initialUiState { uiWorkspaceRoot = workspace }
 
 -- | Keep a compact agent preview: the first line for picker context plus
 -- only the most recent logical lines for the live pane. Earlier response
@@ -383,7 +391,10 @@ responseItemPreviewLines count items
 -- folded into their originating calls so the preview shows one semantic step
 -- instead of adjacent @tool: name@ / @tool: completed@ rows.
 responseItemStepPreviews :: Int -> [ResponseItem] -> [AgentStep]
-responseItemStepPreviews count items
+responseItemStepPreviews = responseItemStepPreviewsRelative ""
+
+responseItemStepPreviewsRelative :: Text -> Int -> [ResponseItem] -> [AgentStep]
+responseItemStepPreviewsRelative workspace count items
     | count <= 0 = []
     | otherwise = go count Map.empty (reverse items)
   where
@@ -413,7 +424,8 @@ responseItemStepPreviews count items
                         AgentStep
                             { agentStepState = state
                             , agentStepTitle =
-                                summarizeToolCall
+                                summarizeToolCallRelative
+                                    workspace
                                     (functionToolCall
                                         call.callId
                                         call.name
@@ -434,7 +446,8 @@ responseItemStepPreviews count items
                         AgentStep
                             { agentStepState = state
                             , agentStepTitle =
-                                summarizeToolCall
+                                summarizeToolCallRelative
+                                    workspace
                                     (customToolCall
                                         call.callId
                                         call.name
@@ -498,7 +511,15 @@ agentStepsForStatus
     -> SubagentStatus
     -> [ResponseItem]
     -> [AgentStep]
-agentStepsForStatus count status items
+agentStepsForStatus = agentStepsForStatusRelative ""
+
+agentStepsForStatusRelative
+    :: Text
+    -> Int
+    -> SubagentStatus
+    -> [ResponseItem]
+    -> [AgentStep]
+agentStepsForStatusRelative workspace count status items
     | count <= 0 = []
     | otherwise = take count $ case status of
         Pending ->
@@ -533,7 +554,7 @@ agentStepsForStatus count status items
         NotFound ->
             AgentStep AgentStepFailed "Agent unavailable" Nothing : settled
   where
-    recent = responseItemStepPreviews count items
+    recent = responseItemStepPreviewsRelative workspace count items
     settled = map settleStep recent
 
     settleStep step

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -45,6 +45,7 @@ module Agent.CLI.Render
     , setRenderActivity
     , streamMarkdown
     , summarizeToolCall
+    , summarizeToolCallRelative
     , thinkingMaxWidth
     , truncateToolOutput
     , wrapThinkingLines

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -11,11 +11,11 @@ import Agent.CLI.AgentViewport
     , AgentStep
     , AgentTarget(..)
     , AgentViewportEnv(..)
-    , agentStepsForStatus
+    , agentStepsForStatusRelative
     , formatAgentStatus
     , responseItemPreviewLines
-    , responseItemStepPreviews
-    , responseItemsToUiState
+    , responseItemStepPreviewsRelative
+    , responseItemsToUiStateRelative
     )
 import Agent.CLI.SessionTitle
     ( SessionTitleEvent(..)
@@ -381,8 +381,9 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     | target == AgentRoot = initialUiState
                     | otherwise =
                         settleConversation items status $
-                            responseItemsToUiState
+                            responseItemsToUiStateRelative
                                 options.optShowRawReasoning
+                                (toText cwd)
                                 items
                 settleConversation items status conversation =
                     case status of
@@ -428,7 +429,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                         AgentRoot
                         Nothing
                         rootItems
-                        (responseItemStepPreviews 2)
+                        (responseItemStepPreviewsRelative (toText cwd) 2)
             let rootEntry = AgentEntry
                     { agentTarget = AgentRoot
                     , agentPath = "/root"
@@ -460,7 +461,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     target
                     (Just status)
                     items
-                    (agentStepsForStatus 2 status)
+                    (agentStepsForStatusRelative (toText cwd) 2 status)
                 let transcript =
                         transcriptLines target items
                             <> case status of

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -252,6 +252,32 @@ spec = do
             body True
                 `shouldBe` Just "Visible summary\nprivate detail"
 
+        it "shows workspace-relative tool titles when hydrating a child transcript" do
+            let workspace = "/Users/marc/.haskell-agent/worktrees/haskell-agent/wt"
+                ui =
+                    responseItemsToUiStateRelative False workspace
+                        [ functionCallItem
+                            "call-1"
+                            "read_file"
+                            ("{\"target_file\":\""
+                                <> workspace
+                                <> "/nix/modules/telegram.nix\"}")
+                            (Just ItemCompleted)
+                        ]
+            map (.blockTitle) (toList ui.uiBlocks)
+                `shouldBe` ["Read nix/modules/telegram.nix"]
+            map (.agentStepTitle)
+                (responseItemStepPreviewsRelative workspace 1
+                    [ functionCallItem
+                        "call-1"
+                        "search_replace"
+                        ("{\"file_path\":\""
+                            <> workspace
+                            <> "/nix/modules/telegram.nix\"}")
+                        (Just ItemCompleted)
+                    ])
+                `shouldBe` ["Edited nix/modules/telegram.nix"]
+
     describe "responseItemStepPreviews" do
         it "coalesces tool calls with their outputs and returns newest first" do
             let steps =

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/ApplyPatch.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/ApplyPatch.hs
@@ -10,13 +10,14 @@ module Agent.Codex.Dialect.ApplyPatch
     , applyPatchGrammar
     ) where
 
+import Agent.OsPath (fromText, relativeDisplayPath)
 import Agent.Tools.IO
     ( deleteTextFile
     , readTextFile
     , resolveUnderCwd
     , writeTextFile
     )
-import Agent.Tools.Types (ToolEnv)
+import Agent.Tools.Types (ToolEnv(..))
 import Control.Monad (unless)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
@@ -230,7 +231,7 @@ prepareHunks env hunks = go hunks Map.empty [] [] [] []
     go [] _ actions added modified deleted =
         pure
             ( reverse actions
-            , summary added modified deleted
+            , summary env.toolCwd added modified deleted
             )
     go (hunk : rest) files actions added modified deleted = case hunk of
         AddFile path contents -> do
@@ -384,10 +385,13 @@ joinFileLines newLines original
     | otherwise =
         Text.intercalate "\n" newLines
 
-summary :: [FilePath] -> [FilePath] -> [FilePath] -> Text
-summary added modified deleted =
+summary :: OsPath -> [FilePath] -> [FilePath] -> [FilePath] -> Text
+summary workspace added modified deleted =
     Text.unlines $
         "Success. Updated the following files:"
-            : [ "A " <> Text.pack p | p <- reverse added ]
-            ++ [ "M " <> Text.pack p | p <- reverse modified ]
-            ++ [ "D " <> Text.pack p | p <- reverse deleted ]
+            : [ "A " <> display p | p <- reverse added ]
+            ++ [ "M " <> display p | p <- reverse modified ]
+            ++ [ "D " <> display p | p <- reverse deleted ]
+  where
+    display path =
+        relativeDisplayPath workspace (fromText (Text.pack path))

--- a/packages/agent-core/src/Agent/OsPath.hs
+++ b/packages/agent-core/src/Agent/OsPath.hs
@@ -5,6 +5,8 @@
 module Agent.OsPath
     ( directoryChain
     , fromText
+    , normalizeLexically
+    , relativeDisplayPath
     , toText
     , unsafeToFilePath
     ) where
@@ -12,7 +14,18 @@ module Agent.OsPath
 import Control.Exception.Safe (impureThrow)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.OsPath (OsPath, decodeUtf, takeDirectory)
+import System.OsPath
+    ( OsPath
+    , decodeUtf
+    , dropTrailingPathSeparator
+    , isAbsolute
+    , joinPath
+    , makeRelative
+    , normalise
+    , splitDirectories
+    , takeDirectory
+    , (</>)
+    )
 import qualified System.OsPath as OsPath
 
 -- | Directories from @root@ through @cwd@, inclusive.
@@ -30,6 +43,61 @@ directoryChain root cwd =
         | otherwise = (dir :) <$> walk parent
       where
         parent = takeDirectory dir
+
+-- | Resolve @.@ and @..@ without touching the filesystem.
+--
+-- Use only for lexical display or containment. Symlinks can make a normalized
+-- spelling name a different target than the OS would resolve.
+normalizeLexically :: OsPath -> OsPath
+normalizeLexically path =
+    case foldl' step [] (splitDirectories (normalise path)) of
+        [] -> dot
+        components -> dropTrailingPathSeparator (joinPath components)
+  where
+    step acc component
+        | component == dot = acc
+        | component == dotdot =
+            case acc of
+                [] -> [dotdot]
+                [root] | isAbsolute root -> acc
+                prefix
+                    | last prefix == dotdot -> prefix <> [dotdot]
+                    | otherwise -> init prefix
+        | otherwise = acc <> [component]
+
+-- | Present @path@ relative to @workspace@ when it is inside that tree.
+-- Already-relative paths are rewritten through the workspace so @src/../a@
+-- becomes @a@. Paths outside the workspace stay absolute after normalization.
+relativeDisplayPath :: OsPath -> OsPath -> Text
+relativeDisplayPath workspace path
+    | Text.null (toText path) = ""
+    | Text.null (toText workspace) = toText (normalizeLexically path)
+    | otherwise =
+        let root = dropTrailingPathSeparator (normalizeLexically workspace)
+            candidate = normalizeLexically path
+            absolute =
+                normalizeLexically $
+                    if isAbsolute candidate then candidate else root </> candidate
+            relative = makeRelative root absolute
+        in if isInsideRelative relative
+            then
+                if isDot relative
+                    then "."
+                    else toText relative
+            else toText absolute
+  where
+    isDot rel = rel == dot || Text.null (toText rel)
+    isInsideRelative rel =
+        not (isAbsolute rel)
+            && case splitDirectories rel of
+                first : _ | first == dotdot -> False
+                _ -> True
+
+dot :: OsPath
+dot = fromText "."
+
+dotdot :: OsPath
+dotdot = fromText ".."
 
 -- | Pure UTF encoding for path values that originate as Unicode text.
 fromText :: Text -> OsPath

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -1,6 +1,7 @@
 -- | Workspace-confined filesystem helpers for coding tools.
 module Agent.Tools.FileSystem
     ( deleteTextFile
+    , displayPathInWorkspace
     , listDirectoryEntries
     , readTextFile
     , renameTextFile
@@ -11,7 +12,7 @@ module Agent.Tools.FileSystem
 
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.Concurrent (mapConcurrentlyBounded)
-import Agent.OsPath (toText, unsafeToFilePath)
+import Agent.OsPath (relativeDisplayPath, toText, unsafeToFilePath)
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Exception.Safe (SomeException, try, tryIO)
 import Data.Text (Text)
@@ -119,6 +120,13 @@ isInside root path
             && case splitDirectories relative of
                 (first : _) | first == unsafeEncodeUtf ".." -> False
                 _ -> True
+
+-- | Present a resolved filesystem path relative to the tool workspace.
+displayPathInWorkspace :: ToolEnv -> OsPath -> IO Text
+displayPathInWorkspace env path =
+    try @_ @SomeException (canonicalizePath env.toolCwd) >>= \case
+        Right cwd -> pure (relativeDisplayPath cwd path)
+        Left _ -> pure (relativeDisplayPath env.toolCwd path)
 
 readTextFile :: OsPath -> IO (Either Text Text)
 readTextFile path =

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
@@ -15,7 +15,11 @@ import Agent.ToolDispatch
     , typedTool
     )
 import Agent.Tools.FileSystem.GitIgnore (isGitIgnored)
-import Agent.Tools.IO (listDirectoryEntries, resolveForRead)
+import Agent.Tools.IO
+    ( displayPathInWorkspace
+    , listDirectoryEntries
+    , resolveForRead
+    )
 import Agent.Tools.Scheduling
     ( ToolAccess(..)
     , ToolResource(..)
@@ -83,25 +87,27 @@ maxListItems = 200
 runListDir :: ToolEnv -> ListDirArgs -> IO (Either Text Text)
 runListDir env args = resolveForRead env (fromText args.targetDirectory) >>= \case
     Left err -> pure (Left err)
-    Right path -> doesDirectoryExist path >>= \case
-        False -> pure $ Left $
-            "Error: " <> args.targetDirectory <> " is not a valid directory"
-        True ->
-            collectDir env.toolCwd path >>= \case
-                Left err -> pure (Left err)
-                Right entries -> do
-                    let (shown, truncated) = capNodes maxListItems entries
-                        tree = renderTree 0 shown
-                        notice
-                            | truncated =
-                                "\nLarge directory summarized; some nested entries were omitted."
-                            | otherwise = ""
-                    pure $ Right $
-                        "Directory listing for "
-                            <> args.targetDirectory
-                            <> ":\n"
-                            <> tree
-                            <> notice
+    Right path -> do
+        display <- displayPathInWorkspace env path
+        doesDirectoryExist path >>= \case
+            False -> pure $ Left $
+                "Error: " <> display <> " is not a valid directory"
+            True ->
+                collectDir env.toolCwd path >>= \case
+                    Left err -> pure (Left err)
+                    Right entries -> do
+                        let (shown, truncated) = capNodes maxListItems entries
+                            tree = renderTree 0 shown
+                            notice
+                                | truncated =
+                                    "\nLarge directory summarized; some nested entries were omitted."
+                                | otherwise = ""
+                        pure $ Right $
+                            "Directory listing for "
+                                <> display
+                                <> ":\n"
+                                <> tree
+                                <> notice
 
 data DirNode
     = FileNode OsPath

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
@@ -13,7 +13,7 @@ import Agent.ToolDispatch
     , toolArgumentsValue
     , typedTool
     )
-import Agent.Tools.IO (readTextFile, resolveForRead)
+import Agent.Tools.IO (displayPathInWorkspace, readTextFile, resolveForRead)
 import Agent.Tools.Scheduling
     ( ToolAccess(..)
     , ToolResource(..)
@@ -101,7 +101,9 @@ runReadFile env args = resolveForRead env (fromText args.targetFile) >>= \case
             pure $ Left
                 "PDF rendering is not available. Use an explicit terminal conversion tool if available, or convert the file to text first."
         | otherwise -> doesFileExist path >>= \case
-            False -> pure $ Left $ "File not found: " <> args.targetFile
+            False -> do
+                display <- displayPathInWorkspace env path
+                pure $ Left $ "File not found: " <> display
             True -> readTextFile path >>= \case
                 Left err -> pure (Left err)
                 Right content -> do

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -5,6 +5,7 @@ module Agent.Tools.IO
     , combineCommandOutput
     , commandResultOutput
     , formatCommandResult
+    , displayPathInWorkspace
     , resolveForRead
     , resolveUnderCwd
     , readTextFile
@@ -31,6 +32,7 @@ import Agent.OsPath (unsafeToFilePath)
 import Agent.Process (terminateProcessGroup)
 import Agent.Tools.FileSystem
     ( deleteTextFile
+    , displayPathInWorkspace
     , listDirectoryEntries
     , readTextFile
     , renameTextFile

--- a/packages/agent-core/test/Agent/OsPathSpec.hs
+++ b/packages/agent-core/test/Agent/OsPathSpec.hs
@@ -2,7 +2,14 @@
 
 module Agent.OsPathSpec (spec) where
 
-import Agent.OsPath (directoryChain, fromText, toText, unsafeToFilePath)
+import Agent.OsPath
+    ( directoryChain
+    , fromText
+    , normalizeLexically
+    , relativeDisplayPath
+    , toText
+    , unsafeToFilePath
+    )
 import qualified Data.Text as Text
 import System.OsPath (decodeUtf, pack, unsafeFromChar)
 import Test.Hspec
@@ -25,6 +32,36 @@ spec = describe "Agent.OsPath" do
         it "falls back to cwd when cwd is outside root" do
             directoryChain (fromText "/repo") (fromText "/other/pkg")
                 `shouldBe` [fromText "/other/pkg"]
+
+    describe "normalizeLexically" do
+        it "collapses dots and parent directories" do
+            toText (normalizeLexically (fromText "/repo/./src/../nix/foo.nix"))
+                `shouldBe` "/repo/nix/foo.nix"
+            toText (normalizeLexically (fromText "/repo/"))
+                `shouldBe` "/repo"
+            toText (normalizeLexically (fromText "src/../nix/foo.nix"))
+                `shouldBe` "nix/foo.nix"
+
+        it "does not climb above an absolute root" do
+            toText (normalizeLexically (fromText "/repo/../etc"))
+                `shouldBe` "/etc"
+
+    describe "relativeDisplayPath" do
+        it "shows workspace-relative paths after lexical normalization" do
+            let workspace = fromText "/Users/marc/.haskell-agent/worktrees/haskell-agent/wt"
+            relativeDisplayPath
+                workspace
+                (fromText "/Users/marc/.haskell-agent/worktrees/haskell-agent/wt/./nix/../nix/modules/telegram.nix")
+                `shouldBe` "nix/modules/telegram.nix"
+            relativeDisplayPath workspace workspace `shouldBe` "."
+            relativeDisplayPath workspace (fromText "src/../nix/foo.nix")
+                `shouldBe` "nix/foo.nix"
+            relativeDisplayPath workspace (fromText "/tmp/outside.hs")
+                `shouldBe` "/tmp/outside.hs"
+            relativeDisplayPath
+                (fromText "/worktree")
+                (fromText "/worktree-other/Foo.hs")
+                `shouldBe` "/worktree-other/Foo.hs"
 
     it "converts Text to and from a UTF path" do
         let text = "/tmp/日本語"

--- a/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
@@ -137,6 +137,28 @@ spec = do
                         , "- flake.lock"
                         ]
 
+        it "echoes workspace-relative paths when the model used an absolute directory" do
+            withTempDir \dir -> do
+                let workspace = dir </> "workspace"
+                    docs = workspace </> "docs"
+                createDirectory workspace
+                createDirectory docs
+                writeFile (docs </> "readme.md") "ok\n"
+                env <- defaultToolEnv (unsafeEncodeUtf workspace)
+                result <-
+                    dispatchToolCall testConfig
+                        [(listDirTool env).appToolHandler]
+                        (functionToolCall "list-abs" "list_dir"
+                            ("{\"target_directory\":\""
+                                <> Text.pack workspace
+                                <> "\"}"))
+                result.output
+                    `shouldBe` Text.unlines
+                        [ "Directory listing for .:"
+                        , "- docs/"
+                        , "  - readme.md"
+                        ]
+
         it "fails when the target directory cannot be listed" do
             withTempDir \dir -> do
                 let workspace = dir </> "workspace"

--- a/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
+++ b/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
@@ -92,6 +92,7 @@ test-suite agent-grok-build-dialect-test
     main-is:          Spec.hs
     other-modules:    Agent.GrokBuild.DialectSpec
                     , Agent.GrokBuild.RuntimeSpec
+                    , Agent.GrokBuild.SearchReplaceSpec
                     , Agent.GrokBuild.TaskSpec
                     , Agent.GrokBuild.WebLspSpec
     build-depends:    agent-grok-build-dialect

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
@@ -17,7 +17,12 @@ import Agent.ToolDispatch
     )
 import Agent.Tools.FileSystem.GitIgnore (isGitIgnored)
 import Agent.GrokBuild.Dialect.Common (jsonTool)
-import Agent.Tools.IO (readTextFile, resolveUnderCwd, writeTextFile)
+import Agent.Tools.IO
+    ( displayPathInWorkspace
+    , readTextFile
+    , resolveUnderCwd
+    , writeTextFile
+    )
 import Agent.Tools.Scheduling
     ( ToolAccess(..)
     , ToolResource(..)
@@ -150,26 +155,23 @@ runSearchReplaceBody env args
 
 createNewFile :: ToolEnv -> SearchReplaceArgs -> ExceptT Text IO Text
 createNewFile env args = do
-    path <- resolvePath env args.filePath
-    gitignoreGuard env path args.filePath
+    (path, display) <- resolveDisplayPath env args.filePath
+    gitignoreGuard env path display
     exists <- lift (doesFileExist path)
     when exists do
         existing <- ExceptT (readTextFile path)
         unless (Text.null existing) $
             throwE "An empty old_string cannot overwrite an existing non-empty file."
-    writeCreated path
-  where
-    writeCreated path = do
-        ExceptT (writeTextFile path args.newString)
-        pure ("The file " <> args.filePath <> " has been created successfully.")
+    ExceptT (writeTextFile path args.newString)
+    pure ("The file " <> display <> " has been created successfully.")
 
 replaceInFile :: ToolEnv -> SearchReplaceArgs -> ExceptT Text IO Text
 replaceInFile env args = do
-    path <- resolvePath env args.filePath
-    gitignoreGuard env path args.filePath
+    (path, display) <- resolveDisplayPath env args.filePath
+    gitignoreGuard env path display
     exists <- lift (doesFileExist path)
     unless exists $
-        throwE ("File not found: " <> args.filePath)
+        throwE ("File not found: " <> display)
     content <- ExceptT (readTextFile path)
     let count = countOccurrences args.oldString content
     when (count == 0) $
@@ -183,14 +185,20 @@ replaceInFile env args = do
     ExceptT (writeTextFile path updated)
     pure $
         if args.replaceAll && count > 1
-            then "The file " <> args.filePath
+            then "The file " <> display
                 <> " has been updated. All occurrences were successfully replaced."
-            else "The file " <> args.filePath
+            else "The file " <> display
                 <> " has been updated successfully."
 
 resolvePath :: ToolEnv -> Text -> ExceptT Text IO OsPath
 resolvePath env path =
     ExceptT (resolveUnderCwd env (fromText path))
+
+resolveDisplayPath :: ToolEnv -> Text -> ExceptT Text IO (OsPath, Text)
+resolveDisplayPath env requested = do
+    path <- resolvePath env requested
+    display <- lift (displayPathInWorkspace env path)
+    pure (path, display)
 
 gitignoreGuard :: ToolEnv -> OsPath -> Text -> ExceptT Text IO ()
 gitignoreGuard env path display = do

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/SearchReplaceSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/SearchReplaceSpec.hs
@@ -1,0 +1,53 @@
+module Agent.GrokBuild.SearchReplaceSpec (spec) where
+
+import Agent.GrokBuild.Dialect.Runtime
+    ( GrokCodingTools(..)
+    , newGrokCodingTools
+    )
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
+import Agent.Tools.Types (AppTool(..), defaultToolEnv)
+import Data.IORef (newIORef)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+import System.Directory (createDirectory)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.OsPath (unsafeEncodeUtf)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "search_replace" do
+    it "echoes workspace-relative paths when the model used an absolute path" do
+        withSystemTempDirectory "agent-search-replace" \dir -> do
+            let sourceDir = dir </> "src"
+                absolute = Text.pack (sourceDir </> "Main.hs")
+            createDirectory sourceDir
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            typesRef <- newIORef Map.empty
+            coding <- newGrokCodingTools env Nothing Nothing typesRef
+            result <-
+                dispatchToolCall testConfig
+                    (map (.appToolHandler) coding.grokAppTools)
+                    (functionToolCall
+                        "edit-abs"
+                        "search_replace"
+                        ("{\"file_path\":\""
+                            <> absolute
+                            <> "\",\"old_string\":\"\",\"new_string\":\"hi\\n\"}"))
+            coding.grokClose
+            result.output
+                `shouldBe` "The file src/Main.hs has been created successfully."
+
+testConfig :: ToolDispatchConfig
+testConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    }

--- a/packages/agent-grok-build-dialect/test/Spec.hs
+++ b/packages/agent-grok-build-dialect/test/Spec.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import qualified Agent.GrokBuild.DialectSpec as DialectSpec
 import qualified Agent.GrokBuild.RuntimeSpec as RuntimeSpec
+import qualified Agent.GrokBuild.SearchReplaceSpec as SearchReplaceSpec
 import qualified Agent.GrokBuild.TaskSpec as TaskSpec
 import qualified Agent.GrokBuild.WebLspSpec as WebLspSpec
 import Test.Hspec (hspec)
@@ -10,5 +11,6 @@ main :: IO ()
 main = hspec do
     DialectSpec.spec
     RuntimeSpec.spec
+    SearchReplaceSpec.spec
     TaskSpec.spec
     WebLspSpec.spec

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -31,6 +31,7 @@ module Agent.TUI.Presentation
     ) where
 
 import Agent.JsonText (jsonTextField, jsonTextFieldDefault)
+import Agent.OsPath (fromText, relativeDisplayPath)
 import Agent.TUI.TextWidth (displayTerminalText)
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -217,18 +218,11 @@ rewriteToolPathInText workspace call output =
         Nothing -> output
 
 -- | Show @path@ relative to @workspace@ when it is inside that tree.
--- Already-relative paths and paths outside the workspace are unchanged.
+-- Already-relative paths are rewritten through the workspace so @src/../a@
+-- becomes @a@. Paths outside the workspace stay absolute after normalization.
 workspaceRelativeDisplayPath :: Text -> Text -> Text
-workspaceRelativeDisplayPath workspace path
-    | Text.null root || Text.null candidate = path
-    | candidate == root = "."
-    | Just relative <- Text.stripPrefix (root <> "/") candidate
-    , not (Text.null relative) =
-        relative
-    | otherwise = path
-  where
-    root = Text.dropWhileEnd (== '/') workspace
-    candidate = Text.dropWhileEnd (== '/') path
+workspaceRelativeDisplayPath workspace path =
+    relativeDisplayPath (fromText workspace) (fromText path)
 
 -- | Filesystem path argument used in tool chrome, when the tool has one.
 toolPathArgument :: ToolCall -> Maybe Text

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -38,6 +38,12 @@ spec = describe "tool presentation" do
         workspaceRelativeDisplayPath workspace "/tmp/outside.hs"
             `shouldBe` "/tmp/outside.hs"
         workspaceRelativeDisplayPath
+            workspace
+            (workspace <> "/./nix/../nix/modules/telegram.nix")
+            `shouldBe` "nix/modules/telegram.nix"
+        workspaceRelativeDisplayPath workspace "src/../nix/foo.nix"
+            `shouldBe` "nix/foo.nix"
+        workspaceRelativeDisplayPath
             "/worktree"
             "/worktree-other/Foo.hs"
             `shouldBe` "/worktree-other/Foo.hs"


### PR DESCRIPTION
## Summary

Follow-up to #602. Chrome was already relative; the model still saw absolute worktree paths in tool results, so it kept copying them.

- `search_replace`, `list_dir`, `read_file`, and `apply_patch` now report workspace-relative paths to the model
- Agent-pane / restored child transcripts use the session cwd for the same tool titles
- Display stripping lexically normalizes `./` and `..` before stripping the workspace prefix

This is still not Grok Build’s `DisplayCwd` overlay rewrite. Our worktree *is* the workspace; we want worktree-relative paths, not a fake original-repo absolute.

## Test plan

- [x] `cabal test agent-core` (OsPath + listDir absolute-path)
- [x] `cabal test agent-tui` (lexical display)
- [x] `cabal test agent-grok-build-dialect` (search_replace absolute edit)
- [x] `cabal test agent-cli --test-options='-m responseItemsToUiState'`