### PR TITLE
fix(tui): page visual history across compaction from postgres

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -136,6 +136,7 @@ import Agent.CLI.Style
 import Agent.CLI.Subagents.Runtime ()
 import Agent.CLI.TUI.App
     ( FullscreenRuntime,
+      beginFullscreenLiveHistory,
       commitFullscreenImagePreviews,
       commitFullscreenHistoryTurn,
       emitUiEvent,
@@ -570,9 +571,7 @@ handleReplLine
                                     Text.hPutStrLn stderr (roleError color err)
                                 continue
                             Right outcome -> do
-                                fullscreenEvent
-                                    (UiSystemMessage outcome.compactSummary)
-                                let message =
+                                let statsMessage =
                                         "compacted "
                                             <> Text.pack
                                                 (show outcome.compactBeforeTokens)
@@ -583,13 +582,17 @@ handleReplLine
                                             <> Text.pack
                                                 (show (length outcome.compactHistory))
                                             <> " items)"
-                                displayInfo message $
-                                    Text.hPutStrLn stderr
-                                        (roleMuted color
-                                            (glyphSession <> message))
                                 case persist of
-                                    PersistenceDisabled -> pure ()
+                                    PersistenceDisabled ->
+                                        fullscreenEvent
+                                            (UiSystemMessage
+                                                outcome.compactSummary)
                                     PersistenceEnabled slotRef -> do
+                                        forM_ fullscreen
+                                            beginFullscreenLiveHistory
+                                        fullscreenEvent
+                                            (UiSystemMessage
+                                                outcome.compactSummary)
                                         now <- getCurrentTime
                                         handle <- ensureSession slotRef
                                         let turn = SessionTurn
@@ -618,6 +621,10 @@ handleReplLine
                                                 runtime
                                                 (sessionHistoryTurn turnIndex turn)
                                                 HistoryCommitAppend
+                                displayInfo statsMessage $
+                                    Text.hPutStrLn stderr
+                                        (roleMuted color
+                                            (glyphSession <> statsMessage))
                                 continue
                     ReplPlan _
                         | provider == ClaudeCodeProvider -> do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -617,7 +617,7 @@ handleReplLine
                                             commitFullscreenHistoryTurn
                                                 runtime
                                                 (sessionHistoryTurn turnIndex turn)
-                                                HistoryCommitReplace
+                                                HistoryCommitAppend
                                 continue
                     ReplPlan _
                         | provider == ClaudeCodeProvider -> do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -54,6 +54,7 @@ module Agent.CLI.TUI.App
     , runFullscreen
     , commitFullscreenImagePreviews
     , commitFullscreenHistoryTurn
+    , beginFullscreenLiveHistory
     , clearFullscreenHistorySource
     , reloadFullscreenHistorySource
     , setFullscreenHistorySource
@@ -172,6 +173,7 @@ import Agent.CLI.TUI.History
     , historyWindowBlock
     , historyWindowOlderAvailable
     , historyWindowRequest
+    , unarchivedLiveStart
     , historyWindowSetAnchors
     , markHistoryRequest
     , setHistoryWindowTurns
@@ -558,6 +560,13 @@ clearFullscreenHistorySource runtime = do
             , historyPageHasOlder = False
             , historyPageHasNewer = False
             })
+
+beginFullscreenLiveHistory :: FullscreenRuntime -> IO ()
+beginFullscreenLiveHistory runtime = do
+    source <- readIORef runtime.runtimeHistorySource
+    case source of
+        Nothing -> pure ()
+        Just _ -> enqueueAppEvent runtime AppHistoryLiveStarted
 
 commitFullscreenHistoryTurn
     :: FullscreenRuntime
@@ -1359,7 +1368,9 @@ commitLiveHistoryTurn durableTurn commit state =
                 Nothing
                     | commit == HistoryCommitReset -> 0
                     | otherwise ->
-                        Seq.length state.appUi.uiBlocks
+                        unarchivedLiveStart
+                            state.appUi.uiBlocks
+                            durableTurn.historyTurnBlocks
         (nextBlockId, remappedBlocks) =
             remapHistoryBlocks
                 state.appNextHistoryBlockId
@@ -2679,6 +2690,7 @@ eventMayExposeSyntax = \case
     AppEvent (AppHistoryReset _) -> True
     AppEvent (AppHistoryLoaded _ _) -> True
     AppEvent (AppHistoryCommitted _ _ _) -> True
+    AppEvent AppHistoryLiveStarted -> True
     AppEvent (AppAgentSnapshot _ _) -> True
     _ -> False
 
@@ -2950,6 +2962,15 @@ handleEventInner event = case event of
                         makeVisible
                             (ConversationBlock AgentRoot blockId)
                 queueConversationReflow
+    AppEvent AppHistoryLiveStarted ->
+        modify' \state ->
+            state
+                { appHistoryLiveStart =
+                    case state.appHistoryLiveStart of
+                        Just start -> Just start
+                        Nothing ->
+                            Just (Seq.length state.appUi.uiBlocks)
+                }
     AppEvent (AppHistoryCommitted generation turn commit) -> do
         state <- get
         let currentGeneration =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -170,6 +170,7 @@ import Agent.CLI.TUI.History
     , clearHistoryRequest
     , emptyHistoryWindow
     , historyWindowBlock
+    , historyWindowOlderAvailable
     , historyWindowRequest
     , historyWindowSetAnchors
     , markHistoryRequest
@@ -1356,9 +1357,9 @@ commitLiveHistoryTurn durableTurn commit state =
             case state.appHistoryLiveStart of
                 Just index -> index
                 Nothing
-                    | commit == HistoryCommitAppend ->
+                    | commit == HistoryCommitReset -> 0
+                    | otherwise ->
                         Seq.length state.appUi.uiBlocks
-                    | otherwise -> 0
         (nextBlockId, remappedBlocks) =
             remapHistoryBlocks
                 state.appNextHistoryBlockId
@@ -1367,19 +1368,14 @@ commitLiveHistoryTurn durableTurn commit state =
             durableTurn { historyTurnBlocks = remappedBlocks }
         baseWindow =
             case commit of
-                HistoryCommitAppend -> state.appHistoryWindow
-                HistoryCommitReplace ->
-                    emptyHistoryWindow
-                        state.appHistoryWindow.historyWindowGeneration
-                        historyWindowTurnBudget
-                        historyWindowBlockBudget
-                        historyWindowByteBudget
                 HistoryCommitReset ->
                     emptyHistoryWindow
                         state.appHistoryWindow.historyWindowGeneration
                         historyWindowTurnBudget
                         historyWindowBlockBudget
                         historyWindowByteBudget
+                _ ->
+                    state.appHistoryWindow
         replacementPage =
             HistoryPage
                 { historyPageGeneration =
@@ -1394,13 +1390,13 @@ commitLiveHistoryTurn durableTurn commit state =
                 }
         window =
             case commit of
-                HistoryCommitAppend ->
-                    appendHistoryTurn remappedTurn baseWindow
-                _ ->
+                HistoryCommitReset ->
                     either
                         (const baseWindow)
                         id
                         (applyHistoryPage replacementPage baseWindow)
+                _ ->
+                    appendHistoryTurn remappedTurn baseWindow
         ui = truncateUiBlocks start state.appUi
     in state
         { appUi = ui
@@ -3689,7 +3685,12 @@ scrollConversationBy amount = do
                 pure (Just (top, height, contentHeight))
             Nothing ->
                 pure Nothing
-    case Scroll.conversationScrollGesture amount viewportBounds of
+    case
+        Scroll.conversationScrollGesture
+            (state.appAgentSelected == AgentRoot
+                && historyWindowOlderAvailable state.appHistoryWindow)
+            amount
+            viewportBounds of
         Scroll.IgnoreConversationScroll ->
             pure ()
         Scroll.PauseAndScrollConversation -> do

--- a/packages/agent-cli/src/Agent/CLI/TUI/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/History.hs
@@ -37,6 +37,7 @@ module Agent.CLI.TUI.History
     , historyWindowTurn
     , historyWindowVisible
     , markHistoryRequest
+    , unarchivedLiveStart
     ) where
 
 import Agent.TUI.Model (BlockId, UiBlock(..))
@@ -264,6 +265,25 @@ historyWindowRequest direction window
 
 -- | Mark a request as in flight.  A request that cannot currently be made is
 -- ignored, which keeps event handlers idempotent when scroll ticks coalesce.
+-- | Live start index when archiving a turn that was rendered without
+-- 'UiUserSubmitted'. If the durable blocks already sit at the end of the
+-- live transcript, drop that suffix so 'drawTranscript' does not show both.
+unarchivedLiveStart :: Seq UiBlock -> Seq UiBlock -> Int
+unarchivedLiveStart liveBlocks durableBlocks
+    | Seq.null durableBlocks = liveCount
+    | liveCount >= durableCount
+    , map blockKey (drop (liveCount - durableCount) live)
+        == map blockKey durable =
+        liveCount - durableCount
+    | otherwise = liveCount
+  where
+    live = toList liveBlocks
+    durable = toList durableBlocks
+    liveCount = length live
+    durableCount = length durable
+    blockKey block =
+        (block.blockKind, Text.strip block.blockBody)
+
 markHistoryRequest
     :: HistoryDirection
     -> HistoryWindow

--- a/packages/agent-cli/src/Agent/CLI/TUI/Scroll.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Scroll.hs
@@ -44,19 +44,27 @@ data ConversationScrollGesture
 -- | Decide whether a requested scroll can move the conversation viewport.
 --
 -- Empty sessions intentionally render without a viewport, and a viewport at
--- its top cannot move farther up. Neither case should pause live following.
+-- its top cannot move farther up unless older persisted turns can still be
+-- loaded. The latter must pause live following so a just-requested page is
+-- not immediately scrolled back to the tail.
 conversationScrollGesture
-    :: Int
+    :: Bool
+    -- ^ Whether older persisted turns can still be loaded.
+    -> Int
     -- ^ Signed scroll amount.
     -> Maybe (Int, Int, Int)
     -- ^ Viewport top, viewport height, and content height.
     -> ConversationScrollGesture
-conversationScrollGesture amount viewport
+conversationScrollGesture olderAvailable amount viewport
     | amount == 0 = IgnoreConversationScroll
     | otherwise =
         case viewport of
             Nothing -> IgnoreConversationScroll
             Just (top, height, contentHeight)
+                | amount < 0
+                , top <= 0
+                , olderAvailable ->
+                    PauseAndScrollConversation
                 | amount < 0
                 , top <= 0 ->
                     IgnoreConversationScroll

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -147,6 +147,7 @@ data AppEvent
         !HistoryGeneration
         !HistoryTurn
         !HistoryCommit
+    | AppHistoryLiveStarted
     | AppConversationReflow
     | AppMotionTick
     | AppRecapPoll

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -553,7 +553,10 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                             (sessionHistoryTurn turnIndex turn)
                             (case effect of
                                 TranscriptAppend -> HistoryCommitAppend
-                                TranscriptReplace -> HistoryCommitReplace
+                                -- Compaction replaces model context, not the
+                                -- on-screen transcript. Keep earlier turns
+                                -- scrollable and archive the compact summary.
+                                TranscriptReplace -> HistoryCommitAppend
                                 TranscriptReset -> HistoryCommitReset)
                     when
                         ( not countedMeta.metaTitleIsManual

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 
 module Agent.CLI.TUIHistorySpec (spec) where
@@ -18,7 +20,10 @@ import Agent.TUI.Model
     , BlockState(..)
     , BlockKind(..)
     , UiBlock(..)
+    , UiEvent(..)
+    , UiState(..)
     , initialUiState
+    , reduceUi
     )
 import qualified Data.Sequence as Seq
 import Data.Int (Int64)
@@ -399,6 +404,34 @@ spec = describe "bounded fullscreen history window" do
                 , "focus on the parser"
                 , "Done"
                 ]
+
+    it "drops a live compact summary that was rendered without a user turn" do
+        let asked =
+                reduceUi (UiAssistantHistory "answer") $
+                    reduceUi (UiUserSubmitted "question") initialUiState
+            live =
+                reduceUi
+                    (UiSystemMessage "Earlier conversation summary")
+                    asked
+            durable =
+                sessionHistoryTurn
+                    (30 :: Int)
+                    ((sessionTurn TranscriptReplace "/compact" [])
+                        { turnAssistantText =
+                            Just "Earlier conversation summary"
+                        })
+        unarchivedLiveStart live.uiBlocks durable.historyTurnBlocks
+            `shouldBe` Seq.length asked.uiBlocks
+
+    it "keeps live blocks when the durable turn is not already on screen" do
+        let live =
+                reduceUi (UiUserSubmitted "question") initialUiState
+            durable =
+                sessionHistoryTurn
+                    (1 :: Int)
+                    (sessionTurn TranscriptAppend "other" [])
+        unarchivedLiveStart live.uiBlocks durable.historyTurnBlocks
+            `shouldBe` Seq.length live.uiBlocks
 
     it "renders manual compaction as a single checkpoint summary" do
         let turnValue =

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -111,6 +111,34 @@ spec = describe "bounded fullscreen history window" do
         historyWindowRequest HistoryOlder requested
             `shouldBe` Nothing
 
+    it "keeps older persisted turns requestable after appending a compaction summary" do
+        let generation = HistoryGeneration 3
+            initial = emptyHistoryWindow generation 200 400 1_000_000
+            recent =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns =
+                        Seq.fromList [turn 10 1, turn 11 1, turn 12 1]
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 13
+                    , historyPageHasOlder = True
+                    , historyPageHasNewer = False
+                    }
+        window <- expectRight (applyHistoryPage recent initial)
+        let compacted = appendHistoryTurn (turn 13 1) window
+        historyWindowCursors compacted
+            `shouldBe` Seq.fromList (map HistoryCursor [10, 11, 12, 13])
+        compacted.historyWindowTotalTurns `shouldBe` 14
+        historyWindowOlderAvailable compacted `shouldBe` True
+        historyWindowRequest HistoryOlder compacted
+            `shouldBe`
+                Just HistoryRequest
+                    { historyRequestGeneration = generation
+                    , historyRequestDirection = HistoryOlder
+                    , historyRequestCursor = Just (HistoryCursor 10)
+                    }
+
     it "resets a non-tail window before archiving a new latest turn" do
         let generation = HistoryGeneration 7
             initial = emptyHistoryWindow generation 200 400 1_000_000

--- a/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
@@ -8,21 +8,25 @@ spec :: Spec
 spec = describe "fullscreen conversation scrolling" do
     describe "conversationScrollGesture" do
         it "ignores scrolling when an empty session has no viewport" do
-            conversationScrollGesture 3 Nothing
+            conversationScrollGesture False 3 Nothing
                 `shouldBe` IgnoreConversationScroll
 
-        it "does not pause following when scrolling up from the top" do
-            conversationScrollGesture (-3) (Just (0, 20, 10))
+        it "does not pause following when scrolling up from the top of a fully loaded short transcript" do
+            conversationScrollGesture False (-3) (Just (0, 20, 10))
                 `shouldBe` IgnoreConversationScroll
+
+        it "pauses following at the top when older persisted turns can still load" do
+            conversationScrollGesture True (-3) (Just (0, 20, 10))
+                `shouldBe` PauseAndScrollConversation
 
         it "pauses only when the viewport can move away from the tail" do
-            conversationScrollGesture (-3) (Just (12, 20, 60))
+            conversationScrollGesture False (-3) (Just (12, 20, 60))
                 `shouldBe` PauseAndScrollConversation
-            conversationScrollGesture 3 (Just (12, 20, 60))
+            conversationScrollGesture False 3 (Just (12, 20, 60))
                 `shouldBe` PauseAndScrollConversation
 
         it "resumes following when a downward scroll reaches the tail" do
-            conversationScrollGesture 10 (Just (31, 20, 60))
+            conversationScrollGesture False 10 (Just (31, 20, 60))
                 `shouldBe` ResumeConversationFollow
 
     describe "reconcileConversationFollow" do

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
@@ -198,6 +198,8 @@ loadSessionResumeStats pool sessionKey =
 data PageMode = PageRecent | PageBefore | PageAfter
     deriving (Eq, Show)
 
+-- | Load a visual history page. Compaction replacements stay in the
+-- scrollback; only an explicit reset starts a new display generation.
 loadTurnPage
     :: StorePool
     -> Text
@@ -214,7 +216,7 @@ loadTurnPage pool sessionKey loadRows limit mode =
                 Just _ -> do
                     rows0 <- loadRows
                     (generationStart, total) <-
-                        Transaction.statement sessionKey currentGenerationStatement
+                        Transaction.statement sessionKey displayHistoryBoundsStatement
                     let visibleRows = case mode of
                             PageRecent -> Vector.reverse (Vector.take limit rows0)
                             PageBefore -> Vector.reverse (Vector.take limit rows0)
@@ -424,14 +426,9 @@ loadRecentTurnsStatement
 loadRecentTurnsStatement = mkStatement
     (turnSelectSql
         <> " WHERE s.session_key = $1\
-           \ AND t.turn_index >= COALESCE((\
-           \   SELECT checkpoint.turn_index\
-           \   FROM harness.session_turns checkpoint\
-           \   WHERE checkpoint.session_id = s.session_id\
-           \     AND checkpoint.transcript_effect <> 'append'\
-           \   ORDER BY checkpoint.turn_index DESC\
-           \   LIMIT 1\
-           \ ), 0)\
+           \ AND t.turn_index >= "
+        <> displayHistoryStartSql
+        <> "\
            \ ORDER BY t.turn_index DESC\
            \ LIMIT $2")
     ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
@@ -446,14 +443,9 @@ loadTurnsBeforeStatement = mkStatement
     (turnSelectSql
         <> " WHERE s.session_key = $1\
            \ AND t.turn_index < $2\
-           \ AND t.turn_index >= COALESCE((\
-           \   SELECT checkpoint.turn_index\
-           \   FROM harness.session_turns checkpoint\
-           \   WHERE checkpoint.session_id = s.session_id\
-           \     AND checkpoint.transcript_effect <> 'append'\
-           \   ORDER BY checkpoint.turn_index DESC\
-           \   LIMIT 1\
-           \ ), 0)\
+           \ AND t.turn_index >= "
+        <> displayHistoryStartSql
+        <> "\
            \ ORDER BY t.turn_index DESC\
            \ LIMIT $3")
     ( ((\(value, _, _) -> value)
@@ -472,14 +464,9 @@ loadTurnsAfterStatement = mkStatement
     (turnSelectSql
         <> " WHERE s.session_key = $1\
            \ AND t.turn_index > $2\
-           \ AND t.turn_index >= COALESCE((\
-           \   SELECT checkpoint.turn_index\
-           \   FROM harness.session_turns checkpoint\
-           \   WHERE checkpoint.session_id = s.session_id\
-           \     AND checkpoint.transcript_effect <> 'append'\
-           \   ORDER BY checkpoint.turn_index DESC\
-           \   LIMIT 1\
-           \ ), 0)\
+           \ AND t.turn_index >= "
+        <> displayHistoryStartSql
+        <> "\
            \ ORDER BY t.turn_index ASC\
            \ LIMIT $3")
     ( ((\(value, _, _) -> value)
@@ -492,8 +479,23 @@ loadTurnsAfterStatement = mkStatement
     (Decoders.rowVector turnRowDecoder)
     True
 
-currentGenerationStatement :: Statement Text (Int64, Int64)
-currentGenerationStatement = mkStatement
+-- | Visual history continues across compaction replacements. Only an explicit
+-- reset (@/clear@, @/new@) hides earlier turns from scrollback. Model resume
+-- context still clips at the latest replace-or-reset via
+-- 'loadActiveTurnsStatement'.
+displayHistoryStartSql :: Text
+displayHistoryStartSql =
+    "COALESCE((\
+    \   SELECT checkpoint.turn_index\
+    \   FROM harness.session_turns checkpoint\
+    \   WHERE checkpoint.session_id = s.session_id\
+    \     AND checkpoint.transcript_effect = 'reset'\
+    \   ORDER BY checkpoint.turn_index DESC\
+    \   LIMIT 1\
+    \ ), 0)"
+
+displayHistoryBoundsStatement :: Statement Text (Int64, Int64)
+displayHistoryBoundsStatement = mkStatement
     "WITH target AS (\
     \ SELECT session_id\
     \ FROM harness.sessions\
@@ -503,7 +505,7 @@ currentGenerationStatement = mkStatement
     \   SELECT t.turn_index\
     \   FROM harness.session_turns t\
     \   JOIN target ON target.session_id = t.session_id\
-    \   WHERE t.transcript_effect <> 'append'\
+    \   WHERE t.transcript_effect = 'reset'\
     \   ORDER BY t.turn_index DESC\
     \   LIMIT 1\
     \ ), 0) AS start_index\

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -189,7 +189,7 @@ spec = describe "PostgreSQL session schema" do
                         (closeStore store)
                 ) `finally` cleanup
 
-    it "pages the active transcript around the latest replacement checkpoint" $
+    it "keeps compaction as a model checkpoint while paging visual history across it" $
         withSystemTempDirectory "ha" \stateDirectory -> do
             let
                 config = defaultManagedPostgresConfig stateDirectory ""
@@ -255,8 +255,8 @@ spec = describe "PostgreSQL session schema" do
                                         (toList page.sessionPageTurns)
                                         `shouldBe` [4, 5]
                                     page.sessionPageGenerationStart
-                                        `shouldBe` 2
-                                    page.sessionPageTotal `shouldBe` 4
+                                        `shouldBe` 0
+                                    page.sessionPageTotal `shouldBe` 6
                                     page.sessionPageHasOlder `shouldBe` True
                                     page.sessionPageHasNewer `shouldBe` False
                                 other ->
@@ -267,7 +267,7 @@ spec = describe "PostgreSQL session schema" do
                                     map (.storedTurnIndex)
                                         (toList page.sessionPageTurns)
                                         `shouldBe` [2, 3]
-                                    page.sessionPageHasOlder `shouldBe` False
+                                    page.sessionPageHasOlder `shouldBe` True
                                     page.sessionPageHasNewer `shouldBe` True
                                 other ->
                                     expectationFailure
@@ -284,12 +284,15 @@ spec = describe "PostgreSQL session schema" do
                                         ("unexpected after page: " <> show other)
                             loadSessionTurnsBefore pool "session-1" 2 2 >>= \case
                                 Right (Just page) -> do
-                                    toList page.sessionPageTurns `shouldBe` []
+                                    map (.storedTurnIndex)
+                                        (toList page.sessionPageTurns)
+                                        `shouldBe` [0, 1]
                                     page.sessionPageHasOlder `shouldBe` False
                                     page.sessionPageHasNewer `shouldBe` True
                                 other ->
                                     expectationFailure
-                                        ("unexpected empty before page: " <> show other)
+                                        ("unexpected pre-compact before page: "
+                                            <> show other)
                             loadSessionTurnsAfter pool "session-1" 5 2 >>= \case
                                 Right (Just page) -> do
                                     toList page.sessionPageTurns `shouldBe` []
@@ -308,6 +311,79 @@ spec = describe "PostgreSQL session schema" do
                                 other ->
                                     expectationFailure
                                         ("unexpected resume stats: " <> show other)
+                        )
+                        (closeStore store)
+                ) `finally` cleanup
+
+    it "clips visual history at an explicit reset, not at compaction" $
+        withSystemTempDirectory "ha" \stateDirectory -> do
+            let
+                config = defaultManagedPostgresConfig stateDirectory ""
+                cleanup = do
+                    _ <- stopManagedPostgres config
+                    pure ()
+            (openStore config >>= \case
+                Left err -> expectationFailure ("could not open store: " <> show err)
+                Right store ->
+                    finally
+                        (do
+                            let pool = trustedPool store
+                                now = read "2026-08-23 12:00:00 UTC"
+                                metadata = testMetadata now
+                                append effect user =
+                                    appendSessionTurn pool
+                                        ((testTurn now)
+                                            { sessionTurnUserText = user
+                                            , sessionTurnAssistantText = Just "done"
+                                            , sessionTurnEffect = effect
+                                            })
+                                        metadata
+                            createSession pool metadata
+                                `shouldReturn` Right True
+                            append TranscriptAppend "/before-1"
+                                `shouldReturn` Right True
+                            append TranscriptReplace "/compact"
+                                `shouldReturn` Right True
+                            append TranscriptAppend "/after-compact"
+                                `shouldReturn` Right True
+                            append TranscriptReset "/clear"
+                                `shouldReturn` Right True
+                            append TranscriptAppend "/after-clear"
+                                `shouldReturn` Right True
+                            loadActiveSession pool "session-1" >>= \case
+                                Right (Just stored) ->
+                                    map
+                                        (\storedTurn ->
+                                            storedTurn.storedTurn.sessionTurnUserText
+                                        )
+                                        (toList stored.storedTurns)
+                                        `shouldBe` ["/clear", "/after-clear"]
+                                other ->
+                                    expectationFailure
+                                        ("unexpected active session: " <> show other)
+                            loadRecentSessionTurns pool "session-1" 10 >>= \case
+                                Right (Just page) -> do
+                                    map
+                                        (\storedTurn ->
+                                            storedTurn.storedTurn.sessionTurnUserText
+                                        )
+                                        (toList page.sessionPageTurns)
+                                        `shouldBe` ["/clear", "/after-clear"]
+                                    page.sessionPageGenerationStart
+                                        `shouldBe` 3
+                                    page.sessionPageTotal `shouldBe` 2
+                                    page.sessionPageHasOlder `shouldBe` False
+                                other ->
+                                    expectationFailure
+                                        ("unexpected recent page: " <> show other)
+                            loadSessionTurnsBefore pool "session-1" 3 10 >>= \case
+                                Right (Just page) -> do
+                                    toList page.sessionPageTurns `shouldBe` []
+                                    page.sessionPageHasOlder `shouldBe` False
+                                other ->
+                                    expectationFailure
+                                        ("unexpected before-reset page: "
+                                            <> show other)
                         )
                         (closeStore store)
                 ) `finally` cleanup


### PR DESCRIPTION
## Summary
- Visual transcript paging now reads older Postgres turns across compaction/`replace` checkpoints. Model resume context still starts at the latest compact/reset.
- Compaction commits append to the on-screen history window instead of wiping it (`hasOlder = false`), so live `/compact` keeps earlier scrollback.
- Scrolling up at the top of a short page pauses follow when older persisted turns can still load, so the next page is not immediately pulled back to the tail.

This restores PgUp/wheel-up in long resumed sessions: the TUI pages the stored transcript instead of treating compaction as the start of scrollback.

## Tests
- `agent-cli-test -m 'bounded fullscreen history window|fullscreen conversation scrolling'`
- `agent-cli-test -m 'keeps pre-compaction|still clears displayed history'`
- `agent-store-test -m compaction` (with short `TMPDIR`)