### PR TITLE
fix(openai): surface dropped websocket frames

### DIFF
--- a/packages/agent-openai/CHANGELOG.md
+++ b/packages/agent-openai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Surface dropped Codex WebSocket frames as loop warnings, including the
+  decode error and a truncated payload, instead of swallowing them.
 - Remove the deprecated `Agent.OpenAI.Responses.Types`,
   `Agent.OpenAI.Responses.Codec`, and `Agent.OpenAI.ResponseMerge`
   compatibility modules. Import their `Agent.Responses.*` counterparts

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -663,11 +663,13 @@ receiveWsResponseWithActions modelHint actions onEvent =
                 let frames' = frames + 1
                     bytes' = bytes + LBS.length msgBytes
                 case ResponsesCodec.decodeResponseStreamEvent msgBytes of
-                    Left _err -> do
-                        -- Codex treats an unrecognised or malformed event as
-                        -- forward-compatible noise. Keep receiving so one
-                        -- bad frame cannot strand an otherwise valid turn.
+                    Left err -> do
+                        -- Keep receiving so one bad frame cannot strand an
+                        -- otherwise valid turn, but surface the dropped
+                        -- payload. Silent decode failures are how a terminal
+                        -- or tool-call frame can leave the loop in thinking.
                         logStreamStats "json_decode_error" frames' bytes'
+                        onEvent (unparsedStreamEvent err msgBytes)
                         loop assembly frames' bytes'
                     Right event -> do
                         onEvent event
@@ -751,6 +753,23 @@ receiveWsResponseWithActions modelHint actions onEvent =
                     (failedStreamResponseMessage failure)
                     failure.failureErrorCode
                     Nothing
+
+unparsedStreamEvent :: String -> LBS.ByteString -> ResponseStreamEvent
+unparsedStreamEvent err bytes =
+    OtherResponseStreamEvent
+        { otherEventType = StreamEventUnknown unparsedStreamEventTypeText
+        , sequenceNumber = Nothing
+        , eventExtraFields = KeyMap.fromList
+            [ (Key.fromText "error", Aeson.String (Text.pack err))
+            , (Key.fromText "payload", Aeson.String (framePreview bytes))
+            ]
+        }
+
+framePreview :: LBS.ByteString -> Text
+framePreview =
+    Text.take 2000
+        . Text.decodeUtf8Lenient
+        . LBS.toStrict
 
 -- | Parse a server @type: error@ event into a structured 'ApiError'.
 --

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -280,6 +280,35 @@ spec = do
                     Just
                         (ActivityUpdated
                             "Warning: unsupported provider event response.future.done")
+            streamEventToLoopEvent
+                (OtherResponseStreamEvent
+                    { otherEventType =
+                        StreamEventUnknown "response.future.done"
+                    , sequenceNumber = Just 42
+                    , eventExtraFields =
+                        KeyMap.singleton "delta" (Aeson.String "partial")
+                    })
+                `shouldBe`
+                    Just
+                        (ActivityUpdated
+                            "Warning: unsupported provider event response.future.done: {\"delta\":\"partial\"}")
+
+        it "surfaces unparsed websocket frames as warnings without marking output" do
+            let event = OtherResponseStreamEvent
+                    { otherEventType =
+                        StreamEventUnknown unparsedStreamEventTypeText
+                    , sequenceNumber = Nothing
+                    , eventExtraFields = KeyMap.fromList
+                        [ (Key.fromText "error", Aeson.String "key \"call_id\" not found")
+                        , (Key.fromText "payload", Aeson.String "{\"type\":\"response.output_item.added\"}")
+                        ]
+                    }
+            streamEventToLoopEvent event
+                `shouldBe`
+                    Just
+                        (WarningRaised
+                            "Codex websocket dropped an unparsed frame: key \"call_id\" not found payload={\"type\":\"response.output_item.added\"}")
+            streamOutputObserved event `shouldBe` False
 
         it "surfaces low Codex usage as a persistent warning" do
             streamEventToLoopEvent

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -223,7 +223,31 @@ spec = do
                 (Aeson.object ["id" Aeson..= ("resp-test" :: Text)])
             , lifecycleFrame "response.completed" (Aeson.object [])
             ]
-            [EventResponseCreated, EventResponseCompleted]
+            [ StreamEventUnknown unparsedStreamEventTypeText
+            , EventResponseCreated
+            , EventResponseCompleted
+            ]
+            \response -> response.output `shouldBe` []
+
+    it "surfaces unparsed function_call items and still completes the turn" do
+        testPartialTerminalResponse
+            [ lifecycleFrame "response.created"
+                (Aeson.object ["id" Aeson..= ("resp-test" :: Text)])
+            , Aeson.encode $ Aeson.object
+                [ "type" Aeson..= ("response.output_item.added" :: Text)
+                , "output_index" Aeson..= (0 :: Int)
+                , "item" Aeson..= Aeson.object
+                    [ "type" Aeson..= ("function_call" :: Text)
+                    , "id" Aeson..= ("fc-1" :: Text)
+                    , "status" Aeson..= ("in_progress" :: Text)
+                    ]
+                ]
+            , lifecycleFrame "response.completed" (Aeson.object [])
+            ]
+            [ EventResponseCreated
+            , StreamEventUnknown unparsedStreamEventTypeText
+            , EventResponseCompleted
+            ]
             \response -> response.output `shouldBe` []
 
     it "returns response.incomplete with the server reason" do

--- a/packages/agent-responses-types/src/Agent/Responses/Types.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types.hs
@@ -71,6 +71,7 @@ module Agent.Responses.Types
     , responseStreamEventSequenceNumber
     , streamEventTypeText
     , parseStreamEventWithType
+    , unparsedStreamEventTypeText
     ) where
 
 import Agent.Responses.Types.Common

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Streaming.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Streaming.hs
@@ -6,6 +6,7 @@ module Agent.Responses.Types.Streaming
     , responseStreamEventSequenceNumber
     , streamEventTypeText
     , parseStreamEventWithType
+    , unparsedStreamEventTypeText
     ) where
 
 import Agent.Responses.Types.Common
@@ -150,6 +151,12 @@ streamEventTypeText = \case
     EventResponseMetadata -> "response.metadata"
     EventResponsesApiWebSocketTiming -> "responsesapi.websocket_timing"
     StreamEventUnknown value -> value
+
+-- | Synthetic event type used when a WebSocket frame cannot be decoded.
+-- This is not a provider wire type; the receiver invents it so dropped
+-- frames remain visible in the agent loop.
+unparsedStreamEventTypeText :: Text
+unparsedStreamEventTypeText = "websocket.unparsed_frame"
 
 parseStreamEventType :: Text -> StreamEventType
 parseStreamEventType value = case value of

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -52,6 +52,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as LBS
 import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import Data.Maybe (fromMaybe, isJust, mapMaybe, maybeToList)
 import Data.Text (Text)
@@ -605,10 +606,18 @@ streamEventToLoopEventWithRawReasoning showRawReasoning = \case
         | index > 0 ->
             Just (ReasoningDelta "\n\n")
     OtherResponseStreamEvent
-        { otherEventType = StreamEventUnknown eventType } ->
+        { otherEventType
+        , eventExtraFields
+        }
+        | streamEventTypeText otherEventType == unparsedStreamEventTypeText ->
+            Just (WarningRaised (unparsedStreamFrameWarning eventExtraFields))
+    OtherResponseStreamEvent
+        { otherEventType = StreamEventUnknown eventType
+        , eventExtraFields
+        } ->
             Just
                 (ActivityUpdated
-                    ("Warning: unsupported provider event " <> eventType))
+                    (unknownProviderEventWarning eventType eventExtraFields))
     OtherResponseStreamEvent
         { otherEventType = EventCodexRateLimits
         , eventExtraFields
@@ -645,9 +654,35 @@ streamOutputObserved event = case event of
     ResponseCustomToolInputDoneEvent{} -> True
     ResponseReasoningSummaryPartAddedEvent{} -> True
     ResponseReasoningSummaryTextDoneEvent{} -> True
+    OtherResponseStreamEvent { otherEventType }
+        | streamEventTypeText otherEventType == unparsedStreamEventTypeText ->
+            False
     _ ->
         responseStreamEventType event /= EventCodexRateLimits
             && isJust (streamEventToLoopEvent event)
+
+unknownProviderEventWarning :: Text -> Aeson.Object -> Text
+unknownProviderEventWarning eventType extras =
+    "Warning: unsupported provider event "
+        <> eventType
+        <> foldMap (": " <>) (objectPreview extras)
+
+unparsedStreamFrameWarning :: Aeson.Object -> Text
+unparsedStreamFrameWarning extras =
+    "Codex websocket dropped an unparsed frame"
+        <> foldMap (": " <>) (nonEmptyText extras "error")
+        <> foldMap (" payload=" <>) (nonEmptyText extras "payload")
+
+objectPreview :: Aeson.Object -> Maybe Text
+objectPreview extras
+    | KeyMap.null extras = Nothing
+    | otherwise =
+        Just
+            . Text.take 500
+            . Text.decodeUtf8Lenient
+            . LBS.toStrict
+            . Aeson.encode
+            $ Aeson.Object extras
 
 extraDeltaText :: Aeson.Object -> Maybe Text
 extraDeltaText extras = nonEmptyText extras "delta" <|> nonEmptyText extras "text"


### PR DESCRIPTION
## Summary

Codex WebSocket frames that fail `FromJSON` were discarded as forward-compatible noise. A rejected `output_item` or terminal event then left the agent loop waiting in thinking with no log.

- Keep receiving after a decode failure so one bad frame cannot strand a healthy turn
- Emit a `WarningRaised` with the Aeson error and a truncated payload
- Include extra-field previews on unknown-but-valid event types
- Do not treat unparsed frames as model output, so replay-safe retries still apply

## Test plan

- [x] `cabal repl agent-openai:test:agent-openai-test` then `:main --match streamEventToLoopEvent --match receiveWsResponseWithActions` (16 examples, 0 failures)
- [ ] CI `agent-openai` / `agent-responses` tests