### PR TITLE
Render submitted images in conversation history

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -226,6 +226,7 @@ import Agent.CLI.TUI.ImagePreview
     , previewCountForWidth
     , previewCellSize
     , renderTuiImagePreview
+    , sameNativePreviewLayout
     )
 import Agent.TUI.Markdown
     ( codeWidgetWithSyntaxHighlighting
@@ -413,6 +414,7 @@ newFullscreenRuntimeWithSyntaxLoader
         historyGeneration <- newIORef 0
         dictationJobs <- newTQueueIO
         imagePreviews <- newIORef []
+        submittedImagePlacements <- newIORef []
         imagePreviewRevision <- newIORef 0
         imagePreviewVisible <- newIORef True
         imagePreviewIdBase <- allocateNativePreviewImageIdBase
@@ -463,6 +465,7 @@ newFullscreenRuntimeWithSyntaxLoader
             , runtimeMotionTickQueued = motionTickQueued
             , runtimeMotionMode = motionMode
             , runtimeImagePreviews = imagePreviews
+            , runtimeSubmittedImagePlacements = submittedImagePlacements
             , runtimeImagePreviewRevision = imagePreviewRevision
             , runtimeImagePreviewVisible = imagePreviewVisible
             , runtimeImagePreviewIdBase = imagePreviewIdBase
@@ -694,12 +697,8 @@ commitFullscreenImagePreviews runtime images = do
         if map fst previous == images
             then pure previous
             else prepareFullscreenImagePreviews runtime images
-    -- Submitted images use the ANSI renderer even when the transient overlay
-    -- used Kitty placement, so finish sampling before the Brick render thread.
-    mapM_
-        (\(_, preview) ->
-            void $ pure $! pixelAt preview.previewSample 0 0)
-        prepared
+    -- Unsupported terminals render only the compact image summary. Native
+    -- terminals retain the encoded attachment for a viewport-aware placement.
     enqueueAppEvent runtime (AppCommitImagePreviews prepared)
 
 prepareFullscreenImagePreviews
@@ -1560,12 +1559,20 @@ wrapNativePreviewVty runtime vty
                         if visible
                             then readIORef runtime.runtimeImagePreviews
                             else pure []
-                    let placements =
-                            nativePreviewPlacements
-                                runtime.runtimeImagePreviewIdBase
-                                terminalColumns
-                                terminalRows
-                                previews
+                    submitted <-
+                        if visible
+                            then
+                                readIORef
+                                    runtime.runtimeSubmittedImagePlacements
+                            else pure []
+                    let placements
+                            | null previews = submitted
+                            | otherwise =
+                                nativePreviewPlacements
+                                    runtime.runtimeImagePreviewIdBase
+                                    terminalColumns
+                                    terminalRows
+                                    previews
                         oldImageIds = case previous of
                             Just (_, _, imageIds) -> imageIds
                             Nothing -> []
@@ -2357,6 +2364,8 @@ handleUiEvents uiEvents = do
                 (initial, Nothing, False, False)
                 uiEvents
     put final
+    when (any (== UiConversationCleared) uiEvents) $
+        clearSubmittedImagePlacements final.appRuntime
     case nativeProgress of
         Nothing -> pure ()
         Just active ->
@@ -2886,6 +2895,7 @@ handleEventInner event = case event of
                 { appImagePreviews = []
                 , appSubmittedImagePreviews = submitted
                 }
+        queueConversationReflow
     AppEvent (AppDictationPartial text) -> do
         state <- get
         when (isJust state.appDictation) $
@@ -3051,6 +3061,13 @@ handleEventInner event = case event of
         modify' \state ->
             state { appConversationReflowQueued = False }
         reflowConversation
+        state <- get
+        liftIO $
+            enqueueAppEvent
+                state.appRuntime
+                AppSyncSubmittedImagePlacements
+    AppEvent AppSyncSubmittedImagePlacements ->
+        syncSubmittedImagePlacements
     AppEvent (AppAskPermission summary reply) -> do
         state <- get
         liftIO (state.appRuntime.runtimeNativeProgress False)
@@ -3816,6 +3833,107 @@ reflowConversation = do
                         Scroll.ScrollConversationToEnd ->
                             vScrollToEnd
                                 (viewportScroll ConversationViewport)
+
+syncSubmittedImagePlacements :: EventM Name AppState ()
+syncSubmittedImagePlacements = do
+    state <- get
+    when state.appRuntime.runtimeNativeImagePreviews do
+        let submitted =
+                [ (blockId, index, preview)
+                | (blockId, previews) <-
+                    Map.toAscList state.appSubmittedImagePreviews
+                , (index, preview) <- zip [0 ..] previews
+                ]
+        viewportExtent <- lookupExtent ConversationViewportExtent
+        placements <-
+            case viewportExtent of
+                Nothing -> pure []
+                Just viewportBounds ->
+                    fmap concat $
+                        sequence
+                            [ placementFor
+                                state
+                                viewportBounds
+                                ordinal
+                                blockId
+                                index
+                                preview
+                            | (ordinal, (blockId, index, preview)) <-
+                                zip [0 ..] submitted
+                            ]
+        previous <-
+            liftIO $
+                readIORef
+                    state.appRuntime.runtimeSubmittedImagePlacements
+        when (not (sameNativePreviewLayout previous placements)) $
+            liftIO do
+                writeIORef
+                    state.appRuntime.runtimeSubmittedImagePlacements
+                    placements
+                modifyIORef'
+                    state.appRuntime.runtimeImagePreviewRevision
+                    (+ 1)
+
+placementFor
+    :: AppState
+    -> Extent Name
+    -> Int
+    -> BlockId
+    -> Int
+    -> TuiImagePreview
+    -> EventM Name AppState [NativePreviewPlacement]
+placementFor state viewportBounds ordinal blockId index preview =
+    lookupExtent (ConversationImage blockId index) >>= \case
+        Just imageBounds
+            | extentInside viewportBounds imageBounds ->
+                let Location (column, row) = imageBounds.extentUpperLeft
+                    (columns, rows) = imageBounds.extentSize
+                    imageId =
+                        submittedImageId
+                            state.appRuntime.runtimeImagePreviewIdBase
+                            ordinal
+                in pure
+                    [ NativePreviewPlacement
+                        { nativePreviewImageId = imageId
+                        , nativePreviewRow = row
+                        , nativePreviewColumn = column
+                        , nativePreviewColumns = columns
+                        , nativePreviewRows = rows
+                        , nativePreviewAttachment =
+                            preview.previewKittyAttachment
+                        }
+                    ]
+        _ -> pure []
+
+extentInside :: Extent Name -> Extent Name -> Bool
+extentInside outer inner =
+    innerColumn >= outerColumn
+        && innerRow >= outerRow
+        && innerColumn + innerWidth <= outerColumn + outerWidth
+        && innerRow + innerHeight <= outerRow + outerHeight
+        && innerWidth > 0
+        && innerHeight > 0
+  where
+    Location (outerColumn, outerRow) = outer.extentUpperLeft
+    (outerWidth, outerHeight) = outer.extentSize
+    Location (innerColumn, innerRow) = inner.extentUpperLeft
+    (innerWidth, innerHeight) = inner.extentSize
+
+submittedImageId :: Int -> Int -> Int
+submittedImageId imageIdBase ordinal =
+    fromInteger $
+        ((toInteger imageIdBase + 2 + toInteger ordinal)
+            `mod` 4_294_967_295)
+            + 1
+
+clearSubmittedImagePlacements :: FullscreenRuntime -> EventM Name AppState ()
+clearSubmittedImagePlacements runtime = do
+    previous <-
+        liftIO $ readIORef runtime.runtimeSubmittedImagePlacements
+    when (not (null previous)) $
+        liftIO do
+            writeIORef runtime.runtimeSubmittedImagePlacements []
+            modifyIORef' runtime.runtimeImagePreviewRevision (+ 1)
 
 conversationRenderedReserveRows :: EventM Name AppState Int
 conversationRenderedReserveRows =

--- a/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
@@ -5,6 +5,7 @@ module Agent.CLI.TUI.ImagePreview
     ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
     , nativePreviewPlacements
+    , sameNativePreviewLayout
     , imageDimensions
     , prepareTuiImagePreview
     , previewCountForWidth
@@ -43,6 +44,23 @@ data PreviewCell = PreviewCell
     , cellBottom :: !PixelRGB8
     }
     deriving (Eq, Show)
+
+-- | Compare only the layout that changes while scrolling. Attachments can be
+-- large, so synchronization must not traverse their bytes on every reflow.
+sameNativePreviewLayout
+    :: [NativePreviewPlacement]
+    -> [NativePreviewPlacement]
+    -> Bool
+sameNativePreviewLayout left right =
+    length left == length right
+        && and (zipWith samePlacement left right)
+  where
+    samePlacement a b =
+        a.nativePreviewImageId == b.nativePreviewImageId
+            && a.nativePreviewRow == b.nativePreviewRow
+            && a.nativePreviewColumn == b.nativePreviewColumn
+            && a.nativePreviewColumns == b.nativePreviewColumns
+            && a.nativePreviewRows == b.nativePreviewRows
 
 data NativePreviewPlacement = NativePreviewPlacement
     { nativePreviewImageId :: !Int

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
@@ -96,7 +96,8 @@ import Agent.CLI.TUI.Types
                appTerminalFocus),
       FullscreenRuntime(runtimeMotionMode, runtimeNativeImagePreviews,
                        runtimeColor, runtimeWaveTrough),
-      Name(ChoiceRow, ConversationViewport, AgentRow, AgentPane,
+      Name(ChoiceRow, ConversationViewport, ConversationViewportExtent,
+           ConversationImage, AgentRow, AgentPane,
            AgentPopover, ConversationChunkCache, ConversationReserve,
            QuickStartWorktree, QuickStartResume, QuickStartCommands,
            QuickStartModel, CodeBlockCache, ConversationBlock,
@@ -465,7 +466,7 @@ drawImagePreviews native previews =
                 , hCenter $
                     withAttr Theme.mutedAttr $
                         terminalTxt $
-                            "🖼 "
+                            "[image] "
                                 <> preview.previewMime
                                 <> " · "
                                 <> Text.pack (show preview.previewSourceWidth)
@@ -518,10 +519,11 @@ drawConversationPane :: AppState -> Widget Name
 drawConversationPane state =
     case selectedChildEntry state of
         Just entry ->
-            withVScrollBarRenderer conversationScrollbarRenderer $
-                withVScrollBars OnRight $
-                    viewport ConversationViewport Vertical $
-                        padLeftRight 2 (drawAgentConversation state entry)
+            reportExtent ConversationViewportExtent $
+                withVScrollBarRenderer conversationScrollbarRenderer $
+                    withVScrollBars OnRight $
+                        viewport ConversationViewport Vertical $
+                            padLeftRight 2 (drawAgentConversation state entry)
         Nothing
             | conversationIsEmpty state.appUi
                 && Seq.null
@@ -534,12 +536,13 @@ drawConversationPane state =
             | otherwise ->
                 vBox $
                     historyRangeWidgets state
-                        <> [ withVScrollBarRenderer
-                                conversationScrollbarRenderer $
-                                withVScrollBars OnRight $
-                                    viewport ConversationViewport Vertical $
-                                        padLeftRight 2
-                                            (drawTranscript state)
+                        <> [ reportExtent ConversationViewportExtent $
+                                withVScrollBarRenderer
+                                    conversationScrollbarRenderer $
+                                    withVScrollBars OnRight $
+                                        viewport ConversationViewport Vertical $
+                                            padLeftRight 2
+                                                (drawTranscript state)
                            ]
 
 selectedChildEntry :: AppState -> Maybe AgentEntry
@@ -1472,27 +1475,39 @@ submittedUserMessage state target block =
             <> case target of
                 AgentChild _ -> []
                 AgentRoot ->
-                    map submittedImage $
+                    zipWith submittedImage [0 ..] $
                         Map.findWithDefault
                             []
                             block.blockId
                             state.appSubmittedImagePreviews
   where
-    submittedImage preview =
+    submittedImage index preview =
         padTop (Pad 1) $
-            vBox
-                [ hLimit 36 (renderTuiImagePreview 36 12 preview)
-                , withAttr Theme.userMutedAttr $
-                    terminalTxt $
-                        "🖼 "
-                            <> preview.previewMime
-                            <> " · "
-                            <> Text.pack (show preview.previewSourceWidth)
-                            <> "×"
-                            <> Text.pack (show preview.previewSourceHeight)
-                            <> " · "
-                            <> formatImageSize preview.previewBytes
-                ]
+            vBox $
+                nativePlaceholder index preview
+                    <> [ withAttr Theme.userMutedAttr $
+                            terminalTxt (imageSummary preview)
+                       ]
+
+    nativePlaceholder index preview
+        | not state.appRuntime.runtimeNativeImagePreviews = []
+        | otherwise =
+            let (columns, rows) = previewCellSize 36 12 preview
+            in [ reportExtent
+                    (ConversationImage block.blockId index) $
+                    hLimit columns $
+                        vLimit rows (fill ' ')
+               ]
+
+    imageSummary preview =
+        "[image] "
+            <> preview.previewMime
+            <> " · "
+            <> Text.pack (show preview.previewSourceWidth)
+            <> "×"
+            <> Text.pack (show preview.previewSourceHeight)
+            <> " · "
+            <> formatImageSize preview.previewBytes
 
 timestampedMessage :: AttrName -> Text -> Widget Name -> Widget Name
 timestampedMessage timestampAttr timestamp body

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -29,7 +29,10 @@ import Agent.CLI.Input.Types (ReplLine)
 import Agent.CLI.Interrupt (CtrlCDecision)
 import Agent.CLI.Permission (PermissionChoice)
 import Agent.CLI.Resume (ResumeBrowser, ResumeEntry)
-import Agent.CLI.TUI.ImagePreview (TuiImagePreview)
+import Agent.CLI.TUI.ImagePreview
+    ( NativePreviewPlacement
+    , TuiImagePreview
+    )
 import Agent.CLI.TUI.History
     ( HistoryGeneration
     , HistoryPage
@@ -60,7 +63,9 @@ import qualified Graphics.Vty as V
 
 data Name
     = ConversationViewport
+    | ConversationViewportExtent
     | ConversationReserve
+    | ConversationImage !BlockId !Int
     | OverlayViewport
     | ConversationBlock !AgentTarget !BlockId
     | ConversationChunkCache
@@ -149,6 +154,7 @@ data AppEvent
         !HistoryCommit
     | AppHistoryLiveStarted
     | AppConversationReflow
+    | AppSyncSubmittedImagePlacements
     | AppMotionTick
     | AppRecapPoll
     | AppStop
@@ -207,6 +213,8 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeMotionTickQueued :: !(TVar Bool)
     , runtimeMotionMode :: !MotionMode
     , runtimeImagePreviews :: !(IORef [(ImageAttachment, TuiImagePreview)])
+    , runtimeSubmittedImagePlacements
+        :: !(IORef [NativePreviewPlacement])
     , runtimeImagePreviewRevision :: !(IORef Int)
     , runtimeImagePreviewVisible :: !(IORef Bool)
     , runtimeImagePreviewIdBase :: !Int

--- a/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
@@ -9,6 +9,7 @@ import Agent.CLI.TUI.ImagePreview
     , previewCountForWidth
     , previewCellSize
     , previewImageAt
+    , sameNativePreviewLayout
     )
 import Agent.Loop (ImageAttachment(..))
 import Codec.Picture
@@ -26,6 +27,32 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "sameNativePreviewLayout" do
+        let placement attachment =
+                NativePreviewPlacement
+                    { nativePreviewImageId = 7
+                    , nativePreviewRow = 2
+                    , nativePreviewColumn = 3
+                    , nativePreviewColumns = 20
+                    , nativePreviewRows = 6
+                    , nativePreviewAttachment = attachment
+                    }
+        it "ignores attachment contents when geometry is unchanged" do
+            sameNativePreviewLayout
+                [placement (ImageAttachment "image/png" "first")]
+                [placement (ImageAttachment "image/png" "second")]
+                `shouldBe` True
+
+        it "detects viewport movement" do
+            let moved =
+                    (placement (ImageAttachment "image/png" "bytes"))
+                        { nativePreviewRow = 3
+                        }
+            sameNativePreviewLayout
+                [placement (ImageAttachment "image/png" "bytes")]
+                [moved]
+                `shouldBe` False
+
     describe "imageDimensions" do
         it "reads PNG dimensions without decoding image data" do
             let headerOnlyPng = BS.pack


### PR DESCRIPTION
## Summary
- render submitted images with native Kitty placements inside conversation history
- synchronize image position and visibility with Brick viewport reflows and scrolling
- keep a compact text summary on unsupported terminals and avoid scanning encoded image bytes during layout synchronization

## Testing
- `nix develop -c cabal test --offline agent-cli:test:agent-cli-test --test-options='--match /sameNativePreviewLayout/ --match /imageDimensions/ --match /prepareTuiImagePreview/ --match /nativePreviewPlacements/'` (12 examples, 0 failures)
- tmux TTY smoke: paste and submit an image, then scroll conversation history; observed Kitty placement row updates from 12 to 11, 9, and 8
- `git diff --check origin/master...HEAD`
