### PR TITLE
Store session attachments as PostgreSQL bytea

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Session/StoreCodec.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/StoreCodec.hs
@@ -8,9 +8,11 @@ module Agent.CLI.Session.StoreCodec
     , toStoredResponseItem
     ) where
 
+import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -348,10 +350,13 @@ toStoredContentPart = \case
             }
     InputImagePart
         { detail, fileId, imageUrl, promptCacheBreakpoint, extraFields } ->
-            (emptyStoredContentPart "input_image" extraFields)
+            let (storedImageUrl, storedImageBinary) =
+                    separateInlineBinary imageUrl
+            in (emptyStoredContentPart "input_image" extraFields)
                 { storedContentPartDetail = detail
                 , storedContentPartFileId = fileId
-                , storedContentPartImageUrl = imageUrl
+                , storedContentPartImageUrl = storedImageUrl
+                , storedContentPartImageBinary = storedImageBinary
                 , storedContentPartPromptCacheBreakpoint =
                     encodeValue <$> promptCacheBreakpoint
                 }
@@ -359,9 +364,12 @@ toStoredContentPart = \case
         { detail, fileData, fileId, fileUrl, filename
         , promptCacheBreakpoint, extraFields
         } ->
-            (emptyStoredContentPart "input_file" extraFields)
+            let (storedFileData, storedFileBinary) =
+                    separateInlineBinary fileData
+            in (emptyStoredContentPart "input_file" extraFields)
                 { storedContentPartDetail = detail
-                , storedContentPartFileData = fileData
+                , storedContentPartFileData = storedFileData
+                , storedContentPartFileBinary = storedFileBinary
                 , storedContentPartFileId = fileId
                 , storedContentPartFileUrl = fileUrl
                 , storedContentPartFilename = filename
@@ -422,7 +430,10 @@ fromStoredContentPart part = do
             InputImagePart
                 part.storedContentPartDetail
                 part.storedContentPartFileId
-                part.storedContentPartImageUrl
+                ( (renderInlineBinary
+                        <$> part.storedContentPartImageBinary)
+                    <|> part.storedContentPartImageUrl
+                )
                 <$> traverse
                     (decodeValue "stored prompt_cache_breakpoint")
                     part.storedContentPartPromptCacheBreakpoint
@@ -430,7 +441,10 @@ fromStoredContentPart part = do
         "input_file" ->
             InputFilePart
                 part.storedContentPartDetail
-                part.storedContentPartFileData
+                ( (renderInlineBinary
+                        <$> part.storedContentPartFileBinary)
+                    <|> part.storedContentPartFileData
+                )
                 part.storedContentPartFileId
                 part.storedContentPartFileUrl
                 part.storedContentPartFilename
@@ -507,12 +521,50 @@ emptyStoredContentPart partType extraFields = StoredContentPart
     , storedContentPartFileUrl = Nothing
     , storedContentPartFilename = Nothing
     , storedContentPartImageUrl = Nothing
+    , storedContentPartFileBinary = Nothing
+    , storedContentPartImageBinary = Nothing
     , storedContentPartInputAudio = Nothing
     , storedContentPartPromptCacheBreakpoint = Nothing
     , storedContentPartAnnotations = Nothing
     , storedContentPartLogprobs = Nothing
     , storedContentPartExtraFields = encodeObject extraFields
     }
+
+separateInlineBinary
+    :: Maybe Text
+    -> (Maybe Text, Maybe StoredBinaryData)
+separateInlineBinary value =
+    case value >>= parseInlineBinary of
+        Just binary -> (Nothing, Just binary)
+        Nothing -> (value, Nothing)
+
+parseInlineBinary :: Text -> Maybe StoredBinaryData
+parseInlineBinary value = do
+    body <- Text.stripPrefix "data:" value
+    let (metadata, payloadWithComma) = Text.breakOn "," body
+        base64Marker = ";base64"
+    payload <- Text.stripPrefix "," payloadWithComma
+    if Text.takeEnd (Text.length base64Marker) metadata /= base64Marker
+        then Nothing
+        else do
+            let mimeType =
+                    Text.dropEnd (Text.length base64Marker) metadata
+            if Text.null mimeType
+                then Nothing
+                else case Base64.decode (TextEncoding.encodeUtf8 payload) of
+                    Left _ -> Nothing
+                    Right bytes -> Just StoredBinaryData
+                        { storedBinaryDataMimeType = mimeType
+                        , storedBinaryDataBytes = bytes
+                        }
+
+renderInlineBinary :: StoredBinaryData -> Text
+renderInlineBinary binary =
+    "data:"
+        <> binary.storedBinaryDataMimeType
+        <> ";base64,"
+        <> TextEncoding.decodeUtf8
+            (Base64.encode binary.storedBinaryDataBytes)
 
 toStoredToolOutput :: Aeson.Value -> StoredToolOutput
 toStoredToolOutput = \case

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -10,6 +10,7 @@ import Agent.Dialect (DialectId(..))
 import Agent.Loop (TokenUsage(..))
 import Agent.Provider (Provider(..))
 import Agent.Responses.Types
+import Agent.Store.SessionItem
 import Agent.Store.Postgres
     ( Store
     , closeStore
@@ -487,6 +488,86 @@ contentPartKind = \case
 spec :: Spec
 spec = describe "Agent.CLI.Session" do
     describe "pure compatibility helpers" do
+        it "stores inline image and file payloads as binary data" do
+            let imageUrl = "data:image/png;base64,cG5nLWJ5dGVz"
+                fileData = "data:text/plain;base64,ZmlsZS1ieXRlcw=="
+                item = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [ InputImagePart
+                            Nothing
+                            Nothing
+                            (Just imageUrl)
+                            Nothing
+                            KeyMap.empty
+                        , InputFilePart
+                            Nothing
+                            (Just fileData)
+                            Nothing
+                            Nothing
+                            (Just "notes.txt")
+                            Nothing
+                            KeyMap.empty
+                        ]
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , passthrough = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+            case toStoredResponseItem item of
+                StoredMessageItem StoredMessage
+                    { storedMessageContent =
+                        StoredMessageParts [imagePart, filePart]
+                    } -> do
+                        imagePart.storedContentPartImageUrl
+                            `shouldBe` Nothing
+                        imagePart.storedContentPartImageBinary
+                            `shouldBe` Just StoredBinaryData
+                                { storedBinaryDataMimeType = "image/png"
+                                , storedBinaryDataBytes = "png-bytes"
+                                }
+                        filePart.storedContentPartFileData
+                            `shouldBe` Nothing
+                        filePart.storedContentPartFileBinary
+                            `shouldBe` Just StoredBinaryData
+                                { storedBinaryDataMimeType = "text/plain"
+                                , storedBinaryDataBytes = "file-bytes"
+                                }
+                stored ->
+                    expectationFailure
+                        ("unexpected stored item: " <> show stored)
+            fromStoredResponseItem (toStoredResponseItem item)
+                `shouldBe` Right item
+
+        it "keeps hosted and malformed attachment URLs as text" do
+            let item = MessageItem ResponseMessage
+                    { messageId = Nothing
+                    , content = MessageContentParts
+                        [ InputImagePart
+                            Nothing
+                            Nothing
+                            (Just "https://example.com/image.png")
+                            Nothing
+                            KeyMap.empty
+                        , InputFilePart
+                            Nothing
+                            (Just "data:text/plain;base64,not base64")
+                            Nothing
+                            Nothing
+                            Nothing
+                            Nothing
+                            KeyMap.empty
+                        ]
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , passthrough = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+            fromStoredResponseItem (toStoredResponseItem item)
+                `shouldBe` Right item
+
         it "keeps the legacy artifact root and safe ids" do
             sessionsRoot (fromFilePath "/home/marc")
                 `shouldBe` fromFilePath "/home/marc/.haskell-agent/sessions"

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -158,6 +158,24 @@ coreMigrations =
         , migrationName = "trigram indexes for conversation search"
         , migrationStatements = sessionSearchIndexStatements
         }
+    , Migration
+        { migrationVersion = 10
+        , migrationName = "binary session attachments"
+        , migrationStatements =
+            [ "ALTER TABLE IF EXISTS\
+              \ harness.session_response_content_parts\
+              \ ADD COLUMN IF NOT EXISTS file_data_mime_type text"
+            , "ALTER TABLE IF EXISTS\
+              \ harness.session_response_content_parts\
+              \ ADD COLUMN IF NOT EXISTS file_data_bytes bytea"
+            , "ALTER TABLE IF EXISTS\
+              \ harness.session_response_content_parts\
+              \ ADD COLUMN IF NOT EXISTS image_mime_type text"
+            , "ALTER TABLE IF EXISTS\
+              \ harness.session_response_content_parts\
+              \ ADD COLUMN IF NOT EXISTS image_bytes bytea"
+            ]
+        }
     ]
 
 -- Version 1 shipped only on the in-development PostgreSQL branch. Empty

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem.hs
@@ -145,6 +145,10 @@ sessionItemSchemaStatements =
       \ file_url text,\
       \ filename text,\
       \ image_url text,\
+      \ file_data_mime_type text,\
+      \ file_data_bytes bytea,\
+      \ image_mime_type text,\
+      \ image_bytes bytea,\
       \ input_audio_text text,\
       \ prompt_cache_breakpoint_text text,\
       \ annotations_text text,\

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/ContentParts.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/ContentParts.hs
@@ -3,6 +3,7 @@ module Agent.Store.Postgres.SessionItem.Mapping.Statements.ContentParts
     , loadContentPartsStatement
     ) where
 
+import Data.ByteString (ByteString)
 import Data.Text (Text)
 import qualified Hasql.Decoders as Decoders
 import qualified Hasql.Encoders as Encoders
@@ -20,6 +21,10 @@ data ContentPartRow = ContentPartRow
     , contentPartRowFileUrl :: !(Maybe Text)
     , contentPartRowFilename :: !(Maybe Text)
     , contentPartRowImageUrl :: !(Maybe Text)
+    , contentPartRowFileDataMimeType :: !(Maybe Text)
+    , contentPartRowFileDataBytes :: !(Maybe ByteString)
+    , contentPartRowImageMimeType :: !(Maybe Text)
+    , contentPartRowImageBytes :: !(Maybe ByteString)
     , contentPartRowInputAudio :: !(Maybe Text)
     , contentPartRowPromptCacheBreakpoint :: !(Maybe Text)
     , contentPartRowAnnotations :: !(Maybe Text)
@@ -30,7 +35,8 @@ data ContentPartRow = ContentPartRow
 loadContentPartsStatement :: Statement Text [ContentPartRow]
 loadContentPartsStatement = mkStatement
     "SELECT part_type, text_value, refusal_text, detail, file_data, file_id,\
-    \ file_url, filename, image_url, input_audio_text,\
+    \ file_url, filename, image_url, file_data_mime_type, file_data_bytes,\
+    \ image_mime_type, image_bytes, input_audio_text,\
     \ prompt_cache_breakpoint_text, annotations_text, logprobs_text,\
     \ extra_fields_text\
     \ FROM harness.session_response_content_parts\
@@ -48,6 +54,10 @@ loadContentPartsStatement = mkStatement
             <*> Decoders.column (Decoders.nullable Decoders.text)
             <*> Decoders.column (Decoders.nullable Decoders.text)
             <*> Decoders.column (Decoders.nullable Decoders.text)
+            <*> Decoders.column (Decoders.nullable Decoders.text)
+            <*> Decoders.column (Decoders.nullable Decoders.bytea)
+            <*> Decoders.column (Decoders.nullable Decoders.text)
+            <*> Decoders.column (Decoders.nullable Decoders.bytea)
             <*> Decoders.column (Decoders.nullable Decoders.text)
             <*> Decoders.column (Decoders.nullable Decoders.text)
             <*> Decoders.column (Decoders.nullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Read.hs
@@ -351,6 +351,14 @@ contentPartFromRow row = StoredContentPart
     , storedContentPartFileUrl = row.contentPartRowFileUrl
     , storedContentPartFilename = row.contentPartRowFilename
     , storedContentPartImageUrl = row.contentPartRowImageUrl
+    , storedContentPartFileBinary =
+        StoredBinaryData
+            <$> row.contentPartRowFileDataMimeType
+            <*> row.contentPartRowFileDataBytes
+    , storedContentPartImageBinary =
+        StoredBinaryData
+            <$> row.contentPartRowImageMimeType
+            <*> row.contentPartRowImageBytes
     , storedContentPartInputAudio =
         StoredOpaqueValue <$> row.contentPartRowInputAudio
     , storedContentPartPromptCacheBreakpoint =

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Write.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Write.hs
@@ -10,6 +10,7 @@ module Agent.Store.Postgres.SessionItem.Write
     ) where
 
 import Control.Monad (forM_)
+import Data.ByteString (ByteString)
 import Data.Functor.Contravariant ((>$<))
 import Data.Int (Int32)
 import Data.Text (Text)
@@ -122,6 +123,10 @@ data ContentPartParams = ContentPartParams
     , contentPartFileUrl :: !(Maybe Text)
     , contentPartFilename :: !(Maybe Text)
     , contentPartImageUrl :: !(Maybe Text)
+    , contentPartFileDataMimeType :: !(Maybe Text)
+    , contentPartFileDataBytes :: !(Maybe ByteString)
+    , contentPartImageMimeType :: !(Maybe Text)
+    , contentPartImageBytes :: !(Maybe ByteString)
     , contentPartInputAudio :: !(Maybe Text)
     , contentPartPromptCacheBreakpoint :: !(Maybe Text)
     , contentPartAnnotations :: !(Maybe Text)
@@ -313,6 +318,18 @@ insertContentParts itemId parts =
                 , contentPartFileUrl = part.storedContentPartFileUrl
                 , contentPartFilename = part.storedContentPartFilename
                 , contentPartImageUrl = part.storedContentPartImageUrl
+                , contentPartFileDataMimeType =
+                    (.storedBinaryDataMimeType)
+                        <$> part.storedContentPartFileBinary
+                , contentPartFileDataBytes =
+                    (.storedBinaryDataBytes)
+                        <$> part.storedContentPartFileBinary
+                , contentPartImageMimeType =
+                    (.storedBinaryDataMimeType)
+                        <$> part.storedContentPartImageBinary
+                , contentPartImageBytes =
+                    (.storedBinaryDataBytes)
+                        <$> part.storedContentPartImageBinary
                 , contentPartInputAudio =
                     opaqueValueText <$> part.storedContentPartInputAudio
                 , contentPartPromptCacheBreakpoint =
@@ -517,10 +534,11 @@ insertContentPartStatement = mkStatement
     "INSERT INTO harness.session_response_content_parts\
     \ (response_item_id, part_index, part_type, text_value, refusal_text,\
     \ detail, file_data, file_id, file_url, filename, image_url,\
+    \ file_data_mime_type, file_data_bytes, image_mime_type, image_bytes,\
     \ input_audio_text, prompt_cache_breakpoint_text, annotations_text,\
     \ logprobs_text, extra_fields_text)\
     \ VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,\
-    \ $12, $13, $14, $15, $16)"
+    \ $12, $13, $14, $15, $16, $17, $18, $19, $20)"
     ( fieldParam (.contentPartResponseItemId) (Encoders.param (Encoders.nonNullable Encoders.text))
         <> fieldParam (.contentPartIndex) (Encoders.param (Encoders.nonNullable Encoders.int4))
         <> fieldParam (.contentPartType) (Encoders.param (Encoders.nonNullable Encoders.text))
@@ -532,6 +550,10 @@ insertContentPartStatement = mkStatement
         <> fieldParam (.contentPartFileUrl) (Encoders.param (Encoders.nullable Encoders.text))
         <> fieldParam (.contentPartFilename) (Encoders.param (Encoders.nullable Encoders.text))
         <> fieldParam (.contentPartImageUrl) (Encoders.param (Encoders.nullable Encoders.text))
+        <> fieldParam (.contentPartFileDataMimeType) (Encoders.param (Encoders.nullable Encoders.text))
+        <> fieldParam (.contentPartFileDataBytes) (Encoders.param (Encoders.nullable Encoders.bytea))
+        <> fieldParam (.contentPartImageMimeType) (Encoders.param (Encoders.nullable Encoders.text))
+        <> fieldParam (.contentPartImageBytes) (Encoders.param (Encoders.nullable Encoders.bytea))
         <> fieldParam (.contentPartInputAudio) (Encoders.param (Encoders.nullable Encoders.text))
         <> fieldParam (.contentPartPromptCacheBreakpoint) (Encoders.param (Encoders.nullable Encoders.text))
         <> fieldParam (.contentPartAnnotations) (Encoders.param (Encoders.nullable Encoders.text))

--- a/packages/agent-store/src/Agent/Store/SessionItem.hs
+++ b/packages/agent-store/src/Agent/Store/SessionItem.hs
@@ -9,6 +9,7 @@ module Agent.Store.SessionItem
     , StoredOpaqueValue(..)
     , StoredToolOutputKind(..)
     , StoredToolOutput(..)
+    , StoredBinaryData(..)
     , StoredMessageContent(..)
     , StoredContentPart(..)
     , StoredMessage(..)
@@ -25,6 +26,7 @@ module Agent.Store.SessionItem
     , storedResponseItemRepresentation
     ) where
 
+import Data.ByteString (ByteString)
 import Data.Text (Text)
 
 data StoredResponseItemRepresentation
@@ -54,6 +56,12 @@ data StoredToolOutput = StoredToolOutput
     }
     deriving (Eq, Show)
 
+data StoredBinaryData = StoredBinaryData
+    { storedBinaryDataMimeType :: !Text
+    , storedBinaryDataBytes :: !ByteString
+    }
+    deriving (Eq, Show)
+
 data StoredMessageContent
     = StoredMessageText !Text
     | StoredMessageParts ![StoredContentPart]
@@ -69,6 +77,8 @@ data StoredContentPart = StoredContentPart
     , storedContentPartFileUrl :: !(Maybe Text)
     , storedContentPartFilename :: !(Maybe Text)
     , storedContentPartImageUrl :: !(Maybe Text)
+    , storedContentPartFileBinary :: !(Maybe StoredBinaryData)
+    , storedContentPartImageBinary :: !(Maybe StoredBinaryData)
     , storedContentPartInputAudio :: !(Maybe StoredOpaqueValue)
     , storedContentPartPromptCacheBreakpoint :: !(Maybe StoredOpaqueValue)
     , storedContentPartAnnotations :: !(Maybe StoredOpaqueValue)

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -372,6 +372,21 @@ testTurn now = SessionTurn
                         StoredOpaqueObject
                             "{\"provider_extension\":true}"
                     }
+                , (emptyContentPart "input_image")
+                    { storedContentPartImageBinary =
+                        Just StoredBinaryData
+                            { storedBinaryDataMimeType = "image/png"
+                            , storedBinaryDataBytes = "png-bytes"
+                            }
+                    }
+                , (emptyContentPart "input_file")
+                    { storedContentPartFilename = Just "notes.txt"
+                    , storedContentPartFileBinary =
+                        Just StoredBinaryData
+                            { storedBinaryDataMimeType = "text/plain"
+                            , storedBinaryDataBytes = "file-bytes"
+                            }
+                    }
                 ]
             , storedMessageRole = "developer"
             , storedMessageStatus = Just "in_progress"
@@ -494,6 +509,8 @@ emptyContentPart partType = StoredContentPart
     , storedContentPartFileUrl = Nothing
     , storedContentPartFilename = Nothing
     , storedContentPartImageUrl = Nothing
+    , storedContentPartFileBinary = Nothing
+    , storedContentPartImageBinary = Nothing
     , storedContentPartInputAudio = Nothing
     , storedContentPartPromptCacheBreakpoint = Nothing
     , storedContentPartAnnotations = Nothing


### PR DESCRIPTION
## Summary
- decode canonical inline image and file data URLs at the session storage boundary
- persist attachment bytes in PostgreSQL `bytea` columns alongside MIME metadata
- reconstruct provider-compatible data URLs when loading sessions while retaining legacy text/hosted URL fallback
- add migration 10 plus Hasql read/write support and regression coverage

## Validation
- `nix develop -c cabal build agent-cli:test:agent-cli-test agent-store:test:agent-store-test`
- codec binary-storage regression tests
- 6,400 generated response-content-part storage round trips
- real PostgreSQL response-item round trip with image and file `bytea` payloads (`TMPDIR=/tmp`)
- `git diff --check`
