### PR TITLE
Show Claude subagents while they run

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
+++ b/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
@@ -2,7 +2,11 @@
 -- provider-neutral events expected by the harness.
 module Agent.Claude.Internal.Messages
     ( CompletedClaudeTurn(..)
+    , ClaudeEventState
+    , emptyClaudeEventState
     , interpretClaudeTurn
+    , streamClaudeMessage
+    , remainingClaudeEvents
     ) where
 
 import Agent.Loop (LoopEvent(..))
@@ -43,6 +47,62 @@ data CompletedClaudeTurn = CompletedClaudeTurn
     , tokenUsage :: !Usage
     , cumulativeModelUsage :: !(Maybe Usage)
     } deriving (Eq, Show)
+
+data ClaudeEventState = ClaudeEventState
+    { startedToolCalls :: !(Set Text)
+    , finishedToolCalls :: !(Set Text)
+    } deriving (Eq, Show)
+
+emptyClaudeEventState :: ClaudeEventState
+emptyClaudeEventState = ClaudeEventState Set.empty Set.empty
+
+-- | Expose completed top-level tool messages as soon as Claude Code emits
+-- them. In particular, its @Task@ tool remains in flight while a native
+-- subagent runs, so buffering this event until the final result leaves the UI
+-- blank for the entire child-agent lifetime.
+streamClaudeMessage
+    :: ClaudeEventState
+    -> Message
+    -> (ClaudeEventState, [LoopEvent])
+streamClaudeMessage state message
+    | messageHasParentToolUseId message = (state, [])
+    | otherwise = advanceToolEvents state (messageToolEvents message)
+
+-- | Emit anything not already exposed by 'streamClaudeMessage'. Assistant
+-- text remains completion-buffered because the SDK can supersede messages;
+-- tool lifecycle events are safe to expose incrementally by stable call id.
+remainingClaudeEvents
+    :: ClaudeEventState
+    -> CompletedClaudeTurn
+    -> [LoopEvent]
+remainingClaudeEvents state completed =
+    reverse eventsRev <> textEvents
+  where
+    (_, eventsRev) = foldl' step (state, []) completed.events
+    textEvents =
+        [event | event@TextDelta{} <- completed.events]
+    step (current, events) event = case event of
+        ToolStarted call
+            | Set.member call.callId current.startedToolCalls ->
+                (current, events)
+            | otherwise ->
+                ( current
+                    { startedToolCalls =
+                        Set.insert call.callId current.startedToolCalls
+                    }
+                , event : events
+                )
+        ToolFinished result
+            | Set.member result.callId current.finishedToolCalls ->
+                (current, events)
+            | otherwise ->
+                ( current
+                    { finishedToolCalls =
+                        Set.insert result.callId current.finishedToolCalls
+                    }
+                , event : events
+                )
+        _ -> (current, events)
 
 interpretClaudeTurn
     :: [Message]
@@ -164,30 +224,43 @@ userBlockEvents = \case
 
 canonicalToolEvents :: [ClaudeToolEvent] -> [LoopEvent]
 canonicalToolEvents toolEvents =
-    reverse eventsRev
+    events
   where
-    (_, _, eventsRev) =
-        foldl' step (Set.empty, Set.empty, []) toolEvents
+    (_, events) = advanceToolEvents emptyClaudeEventState toolEvents
+
+advanceToolEvents
+    :: ClaudeEventState
+    -> [ClaudeToolEvent]
+    -> (ClaudeEventState, [LoopEvent])
+advanceToolEvents initialState toolEvents =
+    let (state, eventsRev) =
+            foldl' step (initialState, []) toolEvents
+    in (state, reverse eventsRev)
+  where
     step
-        :: (Set Text, Set Text, [LoopEvent])
+        :: (ClaudeEventState, [LoopEvent])
         -> ClaudeToolEvent
-        -> (Set Text, Set Text, [LoopEvent])
-    step (started, finished, events) = \case
+        -> (ClaudeEventState, [LoopEvent])
+    step (state, events) = \case
         ClaudeToolStarted call
-            | Set.member call.callId started ->
-                (started, finished, events)
+            | Set.member call.callId state.startedToolCalls ->
+                (state, events)
             | otherwise ->
-                ( Set.insert call.callId started
-                , finished
+                ( state
+                    { startedToolCalls =
+                        Set.insert call.callId state.startedToolCalls
+                    }
                 , ToolStarted call : events
                 )
         ClaudeToolFinished result
-            | not (Set.member result.callId started)
-                || Set.member result.callId finished ->
-                (started, finished, events)
+            | not (Set.member result.callId state.startedToolCalls)
+                || Set.member result.callId state.finishedToolCalls ->
+                (state, events)
             | otherwise ->
-                ( started
-                , Set.insert result.callId finished
+                ( state
+                    { finishedToolCalls =
+                        Set.insert result.callId state.finishedToolCalls
+                    }
                 , ToolFinished result : events
                 )
 

--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -12,8 +12,12 @@ import Agent.Claude.Options
     , toClaudeAgentOptions
     )
 import Agent.Claude.Internal.Messages
-    ( CompletedClaudeTurn(..)
+    ( ClaudeEventState
+    , CompletedClaudeTurn(..)
+    , emptyClaudeEventState
     , interpretClaudeTurn
+    , remainingClaudeEvents
+    , streamClaudeMessage
     )
 import Agent.Error
     ( ApiError(..)
@@ -216,6 +220,7 @@ submitClaudeCodeTurn
                     \turn -> do
                         history <- readIORef transcript
                         messages <- newIORef []
+                        eventState <- newIORef emptyClaudeEventState
                         let prompt =
                                 buildClaudePrompt
                                     params
@@ -228,7 +233,20 @@ submitClaudeCodeTurn
                             queryTurnContentWithMessageValidator
                                 turn
                                 content
-                                validateSubscriptionMessage
+                                (\message -> do
+                                    validated <-
+                                        validateSubscriptionMessage message
+                                    case validated of
+                                        Left err -> pure (Left err)
+                                        Right () -> do
+                                            state <- readIORef eventState
+                                            let (nextState, events) =
+                                                    streamClaudeMessage
+                                                        state
+                                                        message
+                                            writeIORef eventState nextState
+                                            mapM_ onEvent events
+                                            pure (Right ()))
                                 (\message ->
                                     modifyIORef' messages (message :))
                         case awaitResult of
@@ -246,11 +264,14 @@ submitClaudeCodeTurn
                                                 , result = Nothing
                                                 }
                                     Right completed -> do
+                                        finalEventState <-
+                                            readIORef eventState
                                         completeTurn
                                             turn
                                             completed
                                             result
                                             inputs
+                                            finalEventState
                                             onEvent
                 pure (either (Left . sdkErrorToApiError) Right result)
   where
@@ -265,9 +286,10 @@ submitClaudeCodeTurn
         -> CompletedClaudeTurn
         -> ResultMessage
         -> [TurnInput]
+        -> ClaudeEventState
         -> (LoopEvent -> IO ())
         -> IO (Either ClaudeSDKError (TurnOutput, IO ()))
-    completeTurn turn completed result inputs onEvent = do
+    completeTurn turn completed result inputs eventState onEvent = do
         usage <- resolveTurnUsage
             turn
             completed.tokenUsage
@@ -288,7 +310,7 @@ submitClaudeCodeTurn
                     completed.sessionId
                     inputs
                     completed.assistantText
-        mapM_ onEvent completed.events
+        mapM_ onEvent (remainingClaudeEvents eventState completed)
         pure (Right (output, commit))
 
 collectTurnInputs :: [TurnInput] -> IO (Text, [ImageAttachment], [FilePath])

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -199,6 +199,7 @@ spec = do
                         fake.workingDirectory <> "/result-emitted"
                 result <- withEnvironmentVariables
                     [ ("FAKE_CLAUDE_TOOL_NAME", Just "Task")
+                    , ("FAKE_CLAUDE_PAUSE_AFTER_TOOL", Just "1")
                     , ("FAKE_CLAUDE_RESULT_MARKER", Just resultMarker)
                     ]
                     $ timeout 5_000_000
@@ -1222,6 +1223,7 @@ fakeClaudeScript promptLog startLog argumentLog =
         , "  printf '{\"type\":\"stream_event\",\"uuid\":\"delta-b-%s\",\"session_id\":\"%s\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"response\"}}}\\n' \"$turn\" \"$session_id\""
         , "  tool_name=${FAKE_CLAUDE_TOOL_NAME:-Read}"
         , "  printf '{\"type\":\"assistant\",\"uuid\":\"tool-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"fake-tool\",\"name\":\"%s\",\"input\":{\"file_path\":\"README.md\"}}]}}\\n' \"$turn\" \"$session_id\" \"$tool_name\""
+        , "  if [ \"$FAKE_CLAUDE_PAUSE_AFTER_TOOL\" = 1 ]; then sleep 1; fi"
         , "  printf '{\"type\":\"user\",\"uuid\":\"tool-result-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"fake-tool\",\"content\":\"fake contents\"}]}}\\n' \"$turn\" \"$session_id\""
         , "  printf '{\"type\":\"assistant\",\"uuid\":\"assistant-%s\",\"session_id\":\"%s\",\"message\":{\"id\":\"message-%s\",\"content\":[{\"type\":\"text\",\"text\":\"fake response\"}]}}\\n' \"$turn\" \"$session_id\" \"$turn\""
         , "  result_session_id=${FAKE_CLAUDE_RESULT_SESSION_ID:-$session_id}"

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -47,6 +47,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
+    , doesFileExist
     , getTemporaryDirectory
     , removeDirectoryRecursive
     , removeFile
@@ -189,6 +190,42 @@ spec = do
                     "<--setting-sources>\n<>"
                 arguments `shouldContain` "<--no-chrome>"
                 arguments `shouldNotContain` "<--ax-screen-reader>"
+
+        it "publishes Claude Task starts before the terminal result" $
+            withFakeClaude \fake -> do
+                transcript <- newIORef []
+                observedBeforeResult <- newIORef []
+                let resultMarker =
+                        fake.workingDirectory <> "/result-emitted"
+                result <- withEnvironmentVariables
+                    [ ("FAKE_CLAUDE_TOOL_NAME", Just "Task")
+                    , ("FAKE_CLAUDE_RESULT_MARKER", Just resultMarker)
+                    ]
+                    $ timeout 5_000_000
+                    $ withClaudeCodeBackend
+                        (defaultClaudeCodeOptions
+                            fake.executable
+                            fake.workingDirectory)
+                        Nothing
+                        (pure defaultResponseCreateParams)
+                        transcript
+                        \backend ->
+                            submitBackend backend
+                                Nothing
+                                [UserMessage "spawn a reviewer"]
+                                \case
+                                    ToolStarted call
+                                        | call.name == "Task" -> do
+                                            resultAlreadyEmitted <-
+                                                doesFileExist resultMarker
+                                            modifyIORef'
+                                                observedBeforeResult
+                                                (<> [not resultAlreadyEmitted])
+                                    _ -> pure ()
+                result `shouldSatisfy` \case
+                    Just (Right _) -> True
+                    _ -> False
+                readIORef observedBeforeResult `shouldReturn` [True]
 
         it "forwards pasted images as Claude image content blocks" $
             withFakeClaude \fake -> do
@@ -572,7 +609,10 @@ spec = do
                                         && "was active"
                                             `Text.isInfixOf` message
                             _ -> False
-                        readIORef events `shouldReturn` []
+                        readIORef events `shouldReturn`
+                            [ ToolStarted expectedFakeToolCall
+                            , ToolFinished expectedFakeToolResult
+                            ]
 
         it "reports malformed structured output" $
             withFakeClaude \fake ->
@@ -1180,10 +1220,12 @@ fakeClaudeScript promptLog startLog argumentLog =
         , "  printf '{\"type\":\"stream_event\",\"uuid\":\"message-start-%s\",\"session_id\":\"%s\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"message-%s\"}}}\\n' \"$turn\" \"$session_id\" \"$turn\""
         , "  printf '{\"type\":\"stream_event\",\"uuid\":\"delta-a-%s\",\"session_id\":\"%s\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"fake \"}}}\\n' \"$turn\" \"$session_id\""
         , "  printf '{\"type\":\"stream_event\",\"uuid\":\"delta-b-%s\",\"session_id\":\"%s\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"response\"}}}\\n' \"$turn\" \"$session_id\""
-        , "  printf '{\"type\":\"assistant\",\"uuid\":\"tool-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"fake-tool\",\"name\":\"Read\",\"input\":{\"file_path\":\"README.md\"}}]}}\\n' \"$turn\" \"$session_id\""
+        , "  tool_name=${FAKE_CLAUDE_TOOL_NAME:-Read}"
+        , "  printf '{\"type\":\"assistant\",\"uuid\":\"tool-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"fake-tool\",\"name\":\"%s\",\"input\":{\"file_path\":\"README.md\"}}]}}\\n' \"$turn\" \"$session_id\" \"$tool_name\""
         , "  printf '{\"type\":\"user\",\"uuid\":\"tool-result-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"fake-tool\",\"content\":\"fake contents\"}]}}\\n' \"$turn\" \"$session_id\""
         , "  printf '{\"type\":\"assistant\",\"uuid\":\"assistant-%s\",\"session_id\":\"%s\",\"message\":{\"id\":\"message-%s\",\"content\":[{\"type\":\"text\",\"text\":\"fake response\"}]}}\\n' \"$turn\" \"$session_id\" \"$turn\""
         , "  result_session_id=${FAKE_CLAUDE_RESULT_SESSION_ID:-$session_id}"
+        , "  if [ -n \"$FAKE_CLAUDE_RESULT_MARKER\" ]; then : > \"$FAKE_CLAUDE_RESULT_MARKER\"; fi"
         , "  cumulative_input=$((turn * 2))"
         , "  cumulative_cache_creation=$((turn * 3))"
         , "  cumulative_cache_read=$((turn * 5))"


### PR DESCRIPTION
## Summary
- stream Claude Code top-level tool lifecycle events before the terminal result arrives
- keep nested `parent_tool_use_id` records and supersedable assistant text completion-buffered
- deduplicate streamed tool starts and finishes against canonical completion events
- add a regression fixture proving a Claude Task start is published before the result

## Validation
- `nix develop -c cabal test agent-claude-test --test-show-details=direct` (31 examples, 0 failures)
- `printf ':quit\\n' | nix develop -c cabal repl agent-claude:lib:agent-claude`
- `nix develop -c cabal build agent-cli:exe:agent-cli`
- fullscreen tmux smoke test with Claude Sonnet: captured a live spinning `Agent` block at 7.9s while the native subagent was still running
- `git diff --check`
