### PR TITLE
fix(responses): treat dropped mid-stream response as incomplete, not completed

### DIFF
--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -577,14 +577,14 @@ assembledOutput state response =
                 True
 
 -- | Does a response fragment already carry a terminal lifecycle status? Only
--- @completed@/@incomplete@/@failed@ count; a leftover @in_progress@/@queued@
--- status from an earlier streaming frame must be overwritten with the status
--- implied by the terminal event.
+-- @completed@/@incomplete@/@failed@/@cancelled@ count; a leftover
+-- @in_progress@/@queued@ status from an earlier streaming frame must be
+-- overwritten with the status implied by the terminal event.
 fragmentHasTerminalStatus :: Aeson.Object -> Bool
 fragmentHasTerminalStatus object =
     case KeyMap.lookup "status" object of
         Just (Aeson.String status) ->
-            status `elem` ["completed", "incomplete", "failed"]
+            status `elem` ["completed", "incomplete", "failed", "cancelled"]
         _ -> False
 
 responseValueFor :: ResponseStreamEvent -> Maybe Aeson.Value

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -198,9 +198,16 @@ finishStreamResponse modelHint state terminalEvent = do
             "Cannot assemble a non-terminal response event"
             (jsonPreview terminalEvent)
     let terminalFragment = responseValueFor terminalEvent
+        -- Only trust a status carried by the terminal fragment when it is
+        -- itself a terminal status. The socket-death recovery path
+        -- (finishAssembledIncomplete) feeds the accumulated stream object back
+        -- in as the fragment, and that object still holds the non-terminal
+        -- "in_progress"/"queued" status copied from the response.created frame.
+        -- Preserving it there would leak a running status into a finished
+        -- response and make a dropped connection look like a completed turn.
         withStatus = case terminalFragment of
             Just (Aeson.Object object)
-                | KeyMap.member "status" object -> state.responseObject
+                | fragmentHasTerminalStatus object -> state.responseObject
             _ -> KeyMap.insert "status" (Aeson.String terminalStatus)
                     state.responseObject
         withDefaults =
@@ -568,6 +575,17 @@ assembledOutput state response =
             ItemProgress
                 (mergeObjects streamed.itemValue terminal.itemValue)
                 True
+
+-- | Does a response fragment already carry a terminal lifecycle status? Only
+-- @completed@/@incomplete@/@failed@ count; a leftover @in_progress@/@queued@
+-- status from an earlier streaming frame must be overwritten with the status
+-- implied by the terminal event.
+fragmentHasTerminalStatus :: Aeson.Object -> Bool
+fragmentHasTerminalStatus object =
+    case KeyMap.lookup "status" object of
+        Just (Aeson.String status) ->
+            status `elem` ["completed", "incomplete", "failed"]
+        _ -> False
 
 responseValueFor :: ResponseStreamEvent -> Maybe Aeson.Value
 responseValueFor = \case

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -86,6 +86,25 @@ spec = describe "buildStreamResponse" do
                 Left (ConnectionError
                     "failed: response.incomplete: max_output_tokens")
 
+    it "recovers a dropped stream after response.created as incomplete" do
+        -- A real response.created frame carries status "in_progress". When the
+        -- socket dies mid-stream the recovery path must force an "incomplete"
+        -- status rather than leaking the stale "in_progress" through, which
+        -- would otherwise be classified as a completed turn.
+        let created = ResponseCreatedEvent
+                (Aeson.object
+                    [ "id" Aeson..= ("resp-dropped" :: Text)
+                    , "created_at" Aeson..= (0 :: Int)
+                    , "model" Aeson..= ("test" :: Text)
+                    , "status" Aeson..= ("in_progress" :: Text)
+                    ])
+                Nothing
+                mempty
+            state = applyStreamEvent emptyStreamAssemblyState created
+        response <- expectRight (finishAssembledIncomplete (Just "test") state)
+        response.status `shouldBe` ResponseIncomplete
+        response.responseId `shouldBe` "resp-dropped"
+
     it "replaces indexed added items with done items without duplicates" do
         events <- expectRight $ parseSseEvents $ Text.intercalate ""
             [ sseBlock "response.created"

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -57,6 +57,17 @@ spec = describe "buildStreamResponse" do
         [name | FunctionCallItem FunctionCall { name } <- response.output]
             `shouldBe` ["shell_command"]
 
+    it "preserves a cancelled status carried by response.done" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-cancelled\"}}"
+            , sseBlock "response.done"
+                "{\"type\":\"response.done\",\"response\":{\"status\":\"cancelled\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        response.status `shouldBe` ResponseCancelled
+
     it "assembles minimal created and completed lifecycle fragments" do
         events <- expectRight $ parseSseEvents $ Text.intercalate ""
             [ sseBlock "response.created"


### PR DESCRIPTION
## Problem

A mid-stream disconnect on a Responses stream (socket death or the 300s idle timeout) was **silently recorded as a completed turn**.

`response.created` frames carry `"status":"in_progress"`, which `overlayLifecycle` merges into the accumulated stream object. On recovery, `finishAssembledIncomplete` re-feeds that object into `finishStreamResponse` as the terminal fragment, but the status guard `KeyMap.member "status" object -> state.responseObject` trusted *any* status present — so it kept `in_progress` instead of forcing `incomplete`.

Downstream, `rejectFailedCodexResponse` falls through `_ -> Right response`, and `responseToTurnOutput` maps any non-incomplete status to `TurnCompleted`. Net effect: a dropped connection produces a "finished" turn with empty output (disconnect right after creation) or a tool call whose arguments were assembled only from partial `function_call_arguments.delta` frames (truncated JSON handed to tool dispatch). `hasRecoverableIncompleteOutput` is never consulted.

This affects the OpenAI, xAI, and OpenRouter transports that share this assembly code. Existing tests missed it because every fixture's `response.created` omits the `status` field — the only shape where the intended `incomplete` insertion actually fired.

## Fix

Preserve the terminal fragment's status only when it is *itself* a terminal status (`completed`/`incomplete`/`failed`) via a new `fragmentHasTerminalStatus`; otherwise force the status implied by the terminal event. Normal completed/incomplete/failed wire paths are unchanged.

## Testing

- `agent-responses` library type-checks in `nix develop` GHCi.
- Full `agent-responses` suite passes — **50 examples, 0 failures**, including a new regression test (`recovers a dropped stream after response.created as incomplete`) that fails on the pre-fix code (it returned `ResponseInProgress`) and all existing adversarial property tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)