### PR TITLE
fix(responses): bound SSE body reads so a mid-stream stall cannot hang forever

### DIFF
--- a/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
@@ -14,7 +14,7 @@ import Agent.Responses.SSE
     , newSseDecoder
     )
 import Agent.Responses.Types
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (Exception, throwIO, tryAny)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
@@ -24,8 +24,22 @@ import qualified Data.Text.Encoding.Error as Text (lenientDecode)
 import qualified Network.HTTP.Client as HttpClient
 import qualified Network.HTTP.Client.TLS as HttpTls
 import Network.HTTP.Simple hiding (Response)
+import qualified System.Timeout as Timeout
 
 type StreamEventCallback = ResponseStreamEvent -> IO ()
+
+-- | Raised when a streaming body read stalls for longer than the configured
+-- timeout. http-client's responseTimeout only bounds connection setup and
+-- header receipt, so without this the body reader could block forever when the
+-- network path dies without a FIN/RST after headers arrived.
+newtype StreamStalled = StreamStalled Int
+
+instance Show StreamStalled where
+    show (StreamStalled seconds) =
+        "streaming response stalled: no data received for "
+            <> show seconds <> "s"
+
+instance Exception StreamStalled
 
 -- | Provider-specific hooks around the shared Responses HTTP/SSE mechanics.
 data HttpSseConfig = HttpSseConfig
@@ -80,6 +94,19 @@ performResponsesHttpSse
             HttpClient.responseTimeoutMicro (timeoutSeconds * 1_000_000)
         }
 
+    -- Bound each body read so a mid-stream stall cannot hang the turn forever.
+    -- responseTimeout above only covers header receipt; this extends the same
+    -- budget to the streaming body. A timeout throws StreamStalled, which the
+    -- outer tryAny maps to a retryable ConnectionError. A non-positive timeout
+    -- means "no timeout", matching responseTimeoutMicro's semantics.
+    readChunkWithin body
+        | timeoutSeconds <= 0 = HttpClient.brRead body
+        | otherwise =
+            Timeout.timeout (timeoutSeconds * 1_000_000)
+                (HttpClient.brRead body) >>= \case
+                    Just chunk -> pure chunk
+                    Nothing -> throwIO (StreamStalled timeoutSeconds)
+
     handleResponse response = do
         let status = getResponseStatusCode response
         if status >= 200 && status < 300
@@ -97,7 +124,7 @@ performResponsesHttpSse
     consumeSse body = go newSseDecoder []
       where
         go decoder reversedEvents = do
-            chunk <- HttpClient.brRead body
+            chunk <- readChunkWithin body
             if BS.null chunk
                 then case finishSseDecoder decoder of
                     Left err -> pure (Left err)
@@ -121,7 +148,7 @@ performResponsesHttpSse
     consumeBody body = LBS.fromChunks <$> readChunks []
       where
         readChunks reversedChunks = do
-            chunk <- HttpClient.brRead body
+            chunk <- readChunkWithin body
             if BS.null chunk
                 then pure (reverse reversedChunks)
                 else readChunks (chunk : reversedChunks)

--- a/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
@@ -92,6 +92,25 @@ spec = do
                             stopped <- timeout 2_000_000 (cancel worker)
                             stopped `shouldBe` Just ()
 
+        it "aborts a stalled streaming body instead of hanging forever" do
+            recorded <- newIORef []
+            serverRelease <- newEmptyMVar
+            let handler _ = pure (stalledStreamingResponse serverRelease)
+            (withMockGrokTimeout 1 recorded handler \options -> do
+                result <- timeout 5_000_000 $
+                    createResponseWith options
+                        (xaiCredential "token-a")
+                        (helloRequest "hi")
+                case result of
+                    Nothing ->
+                        expectationFailure
+                            "client hung on a stalled stream despite the timeout"
+                    Just (Left (ConnectionError _)) -> pure ()
+                    Just other ->
+                        expectationFailure
+                            ("expected a ConnectionError, got " <> show other))
+                `finally` putMVar serverRelease ()
+
     describe "retry boundaries" do
         it "reports a terminal stream failure after one request" do
             recorded <- newIORef []
@@ -273,11 +292,19 @@ withMockGrok
     -> (RecordedRequest -> IO Wai.Response)
     -> (ClientOptions -> IO a)
     -> IO a
-withMockGrok recorded handler action =
+withMockGrok = withMockGrokTimeout 10
+
+withMockGrokTimeout
+    :: Int
+    -> IORef [RecordedRequest]
+    -> (RecordedRequest -> IO Wai.Response)
+    -> (ClientOptions -> IO a)
+    -> IO a
+withMockGrokTimeout timeoutSecs recorded handler action =
     Warp.testWithApplication (pure app) \port ->
         action defaultClientOptions
             { baseUrl = "http://127.0.0.1:" <> show port <> "/v1"
-            , requestTimeoutSeconds = 10
+            , requestTimeoutSeconds = timeoutSecs
             }
   where
     app waiRequest respond = do
@@ -315,6 +342,19 @@ streamingResponse callbackSeen serverSawCallback =
             writeIORef serverSawCallback (maybe False (const True) seen)
             writeSse write (completedEvent "resp-stream" [])
             flush
+
+-- | Sends response headers and one SSE event, then stalls forever (until the
+-- test releases it). Models a connection that dies without FIN/RST mid-stream:
+-- headers arrive, so http-client's responseTimeout is satisfied, and only the
+-- body-read timeout can rescue the turn.
+stalledStreamingResponse :: MVar () -> Wai.Response
+stalledStreamingResponse release =
+    Wai.responseStream HTTP.status200
+        [("Content-Type", "text/event-stream")]
+        \write flush -> do
+            writeSse write (outputItemDone (assistantMessage "partial"))
+            flush
+            readMVar release
 
 cancellableStreamingResponse :: MVar () -> MVar () -> Wai.Response
 cancellableStreamingResponse callbackSeen serverRelease =


### PR DESCRIPTION
## Problem

`performResponsesHttpSse` set http-client's `responseTimeout` and then looped on `brRead` with **no deadline on the body**. In http-client, `responseTimeout` only bounds connection setup and header receipt; the `BodyReader` returned afterwards does raw blocking `recv` with no timeout.

So a connection that dies without FIN/RST *after* headers arrive (NAT drop, wifi partition, a provider stalling mid-stream during long reasoning) blocked `brRead` indefinitely — `tryAny` never fired and there is no outer `System.Timeout` anywhere in the loop stack. `requestTimeoutSeconds`, documented as the "full streaming-response timeout", did not actually bound the body.

This shared transport backs **agent-xai** and **agent-openrouter**; interactive turns hang until manual Esc/Ctrl-C, and detached Grok subagents / scheduler fires hang forever. (The Claude subprocess path already implements start/inactivity timeouts, confirming the invariant is intended.)

## Fix

Wrap each body read in `System.Timeout` using the same configured budget. A stall throws `StreamStalled`, which the existing `tryAny` maps to a retryable `ConnectionError`. A non-positive timeout keeps "no timeout" semantics (matching `responseTimeoutMicro`). Applies to both the SSE path and the non-2xx failure-body collection.

## Testing

- Adds a Warp-based regression test (`aborts a stalled streaming body instead of hanging forever`): the mock server sends headers + one SSE event then stalls; with a 1s timeout the client returns a `ConnectionError` in ~1s instead of hanging past the 5s test guard.
- Full `agent-xai` suite passes — 57 examples, 0 failures.
- `agent-responses` library type-checks in `nix develop` GHCi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)