### PR TITLE
fix(telegram): process update batches in ascending id order to stop dropping updates

### DIFF
--- a/packages/agent-telegram/src/Agent/Telegram.hs
+++ b/packages/agent-telegram/src/Agent/Telegram.hs
@@ -167,8 +167,8 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Int (Int64)
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Map.Strict as Map
-import Data.List (partition)
-import Data.Maybe (fromMaybe, isJust)
+import Data.List (sortOn)
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -750,9 +750,15 @@ pollForever runtime = do
                 ]
             threadDelay 2_000_000
         Right updates ->
-            let (memberships, rest) =
-                    partition isMembershipUpdate updates
-            in forM_ (memberships <> rest) (processUpdate runtime)
+            -- Process updates in ascending update_id order. storeUpdateAction
+            -- advances the poll offset (nextUpdateId) monotonically and
+            -- updateAlreadyStored drops anything at or below it, so handling a
+            -- higher-id update before a lower-id one in the same batch would
+            -- advance the offset past the lower-id update and silently drop it
+            -- — a queued message or approval callback lost, and getUpdates
+            -- never returns it again. Telegram already returns updates sorted;
+            -- sort defensively to keep the offset invariant robust.
+            forM_ (sortOn (.updateId) updates) (processUpdate runtime)
     pollForever runtime
 
 processUpdate :: TelegramRuntime -> TelegramUpdate -> IO ()
@@ -770,11 +776,6 @@ processUpdate runtime update = do
                         (Text.pack (displayException err))
                 ]
         Right () -> pure ()
-
-isMembershipUpdate :: TelegramUpdate -> Bool
-isMembershipUpdate update =
-    isJust update.updateMyChatMember
-        || maybe False (not . null . (.messageNewChatMembers)) update.updateMessage
 
 classifyUpdate
     :: TelegramRuntime

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -998,6 +998,30 @@ spec = describe "Agent.Telegram" do
                     (LeaveUnauthorizedChat
                         (TelegramPendingLeave 40 key))
 
+        it "keeps every update when a batch is applied in ascending id order" do
+            -- pollForever must process a getUpdates batch in ascending
+            -- update_id order: storeUpdateAction advances the offset
+            -- monotonically, so applying a higher-id update first makes
+            -- updateAlreadyStored drop the lower-id one. Two messages live in
+            -- different chats (ids 100 and 101) so no per-chat batching hides
+            -- the effect.
+            let keyA = TelegramChatKey 100100 Nothing
+                keyB = TelegramChatKey 200200 Nothing
+                apply uid messageId key =
+                    storeUpdateAction uid (QueueTurn messageId key "hi" Nothing)
+                ascending =
+                    apply 101 20 keyB (apply 100 10 keyA emptyTelegramState)
+                reordered =
+                    apply 100 10 keyA (apply 101 20 keyB emptyTelegramState)
+            -- Ascending order keeps both messages.
+            Map.member keyA ascending.pendingQueues `shouldBe` True
+            Map.member keyB ascending.pendingQueues `shouldBe` True
+            -- Processing the higher id first silently drops the lower-id
+            -- message: the bug the poll-loop sort prevents.
+            Map.member keyB reordered.pendingQueues `shouldBe` True
+            Map.member keyA reordered.pendingQueues `shouldBe` False
+            reordered.nextUpdateId `shouldBe` Just 102
+
     describe "durable queue state" do
         it "loads state written before pending turns were introduced" do
             let decoded = eitherDecode


### PR DESCRIPTION
## Problem

`pollForever` partitioned each `getUpdates` batch with `partition isMembershipUpdate` and processed memberships **first**. But `storeUpdateAction` advances the poll offset (`nextUpdateId`) monotonically via `max (updateId+1) …`, and `updateAlreadyStored` treats anything at or below the offset as already handled.

So a batch like `[userMessage(update_id=100), someoneJoined(update_id=101, new_chat_members)]` was reordered to `[101, 100]`:

1. Processing 101 advances the offset to 102.
2. Processing 100 then hits `updateAlreadyStored` (`102 > 100`), so its classified `QueueTurn`/`QueueCallback` is discarded without being enqueued.
3. The offset 102 is persisted, so `getUpdates` never returns update 100 again.

The allowed user's message — or an approval-button `callback_query` — is silently lost with no error. Any batch where a membership update outranks a preceding regular update triggers this, which is common in active groups.

## Fix

Process updates in ascending `update_id` order (sorted defensively; Telegram already returns them sorted). This keeps the offset invariant intact and is also chronologically correct: a message that predates a membership change should be handled with the pre-change state, not skipped. Membership-first ordering was both unnecessary (a `my_chat_member` "bot added" always precedes messages from that chat) and, in the reverse case, semantically wrong (it would reject a message that was sent before the bot lost authorization).

## Testing

- Adds a regression test (`keeps every update when a batch is applied in ascending id order`): an ascending batch keeps both messages; processing the higher id first drops the lower-id one and leaves the offset at 102.
- Full `agent-telegram` suite passes — **68 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)