### PR TITLE
Type reasoning effort by model family

### DIFF
--- a/packages/agent-claude/agent-claude.cabal
+++ b/packages/agent-claude/agent-claude.cabal
@@ -41,6 +41,7 @@ library
                     , Agent.Claude.Auth
                     , Agent.Claude.LoopBackend
                     , Agent.Claude.Options
+                    , Agent.Claude.ReasoningEffort
     other-modules:    Agent.Claude.Internal.Environment
                     , Agent.Claude.Internal.Messages
     build-depends:    base                  >= 4.14 && < 5

--- a/packages/agent-claude/src/Agent/Claude/ReasoningEffort.hs
+++ b/packages/agent-claude/src/Agent/Claude/ReasoningEffort.hs
@@ -1,0 +1,36 @@
+-- | Reasoning effort values projected onto the Claude Code transport.
+module Agent.Claude.ReasoningEffort
+    ( ClaudeReasoningEffort(..)
+    , claudeReasoningEffort
+    , claudeReasoningEffortText
+    ) where
+
+import Agent.ReasoningEffort (ReasoningEffort(..))
+import Data.Text (Text)
+
+data ClaudeReasoningEffort
+    = ClaudeDefault
+    | ClaudeLow
+    | ClaudeMedium
+    | ClaudeHigh
+    | ClaudeXHigh
+    | ClaudeMax
+    deriving (Eq, Ord, Show)
+
+claudeReasoningEffort :: ReasoningEffort -> ClaudeReasoningEffort
+claudeReasoningEffort = \case
+    EffortNone -> ClaudeDefault
+    EffortLow -> ClaudeLow
+    EffortMedium -> ClaudeMedium
+    EffortHigh -> ClaudeHigh
+    EffortXHigh -> ClaudeXHigh
+    EffortMax -> ClaudeMax
+
+claudeReasoningEffortText :: ClaudeReasoningEffort -> Maybe Text
+claudeReasoningEffortText = \case
+    ClaudeDefault -> Nothing
+    ClaudeLow -> Just "low"
+    ClaudeMedium -> Just "medium"
+    ClaudeHigh -> Just "high"
+    ClaudeXHigh -> Just "xhigh"
+    ClaudeMax -> Just "max"

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -46,6 +46,11 @@ import Agent.CLI.Options
 import Agent.CLI.Command.Types
 import Agent.CLI.Style (roleMuted, rolePrompt)
 import Agent.Dialect (DialectId(..))
+import Agent.ReasoningEffort
+    ( ReasoningEffort(..)
+    , parseReasoningEffort
+    , reasoningEffortText
+    )
 import Agent.Responses.Types
 
 import qualified Data.Aeson as Aeson
@@ -169,7 +174,8 @@ commandForDialect dialect command
                 "/effort ["
                     <> Text.intercalate
                         "|"
-                        (reasoningEffortsForDialect dialect)
+                        (map reasoningEffortText
+                            (reasoningEffortsForDialect dialect))
                     <> "]"
             }
     | otherwise = command
@@ -677,7 +683,10 @@ parseModelCommand = \case
     _ -> ReplCommandError "usage: /model [NAME]"
 
 -- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
-setReasoningEffort :: Text -> ResponseCreateParams -> ResponseCreateParams
+setReasoningEffort
+    :: ReasoningEffort
+    -> ResponseCreateParams
+    -> ResponseCreateParams
 setReasoningEffort level ResponseCreateParams{..} =
     ResponseCreateParams
         { reasoning = Just updated
@@ -685,19 +694,23 @@ setReasoningEffort level ResponseCreateParams{..} =
         }
   where
     updated = case reasoning of
-        Just ReasoningConfig{..} -> ReasoningConfig { effort = Just level, .. }
+        Just ReasoningConfig{..} ->
+            ReasoningConfig { effort = Just (reasoningEffortText level), .. }
         Nothing -> ReasoningConfig
             { context = Nothing
-            , effort = Just level
+            , effort = Just (reasoningEffortText level)
             , generateSummary = Nothing
             , reasoningMode = Nothing
             , summary = Nothing
             , extraFields = KeyMap.empty
             }
 
-currentEffort :: ResponseCreateParams -> Text
+currentEffort :: ResponseCreateParams -> ReasoningEffort
 currentEffort params =
-    fromMaybe "low" (params.reasoning >>= (.effort))
+    fromMaybe EffortLow $
+        params.reasoning
+            >>= (.effort)
+            >>= either (const Nothing) Just . parseReasoningEffort
 
 -- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
 setModel :: Text -> ResponseCreateParams -> ResponseCreateParams
@@ -852,7 +865,9 @@ completeSlashArgs catalog cmd word =
 argCompletions :: SlashCatalog -> SlashCommand -> [Text]
 argCompletions catalog spec = case spec.slashName of
     "agents" -> ["limit"]
-    "effort" -> reasoningEffortsForDialect catalog.slashCatalogDialect
+    "effort" ->
+        map reasoningEffortText
+            (reasoningEffortsForDialect catalog.slashCatalogDialect)
     "model" -> catalog.slashCatalogModelIds
     "shell" -> ["ghci", "bash", "both", "none"]
     "help" ->

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Command.Types
     ) where
 
 import Agent.Dialect (DialectId)
+import Agent.ReasoningEffort (ReasoningEffort)
 import Data.Map.Strict (Map)
 import Data.Set (Set)
 import Data.Text (Text)
@@ -21,7 +22,7 @@ data ReplAction
     | ReplExpandedPrompt !Text !Text
       -- ^ Original user-visible text and the model-visible expansion.
     | ReplShowEffort
-    | ReplSetEffort Text
+    | ReplSetEffort ReasoningEffort
     | ReplShowModel
     | ReplSetModel Text
     | ReplToggleAlwaysApprove

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -23,6 +23,11 @@ import System.OsPath (OsPath, unsafeEncodeUtf)
 import Agent.Dialect (DialectId(..))
 import Agent.Loop (defaultLoopMaxTurns)
 import Agent.Provider (Provider(..), parseProvider)
+import Agent.ReasoningEffort
+    ( ReasoningEffort(..)
+    , parseReasoningEffort
+    )
+import qualified Agent.ReasoningEffort as ReasoningEffort
 import Agent.TUI.Motion (MotionMode(..))
 import Data.Foldable (asum)
 import qualified Data.List as List
@@ -101,7 +106,7 @@ data CliOptions = CliOptions
       -- 'defaultMaxConcurrent'.
     , optCompactThreshold :: !(Maybe Int)
       -- ^ OpenAI automatic-compaction threshold in estimated context tokens.
-    , optEffort :: !(Maybe Text)
+    , optEffort :: !(Maybe ReasoningEffort)
       -- ^ 'Nothing' means use 'defaultEffortFor' once the provider is known.
     , optShowRawReasoning :: !Bool
       -- ^ Show raw OpenAI reasoning text instead of summaries only.
@@ -150,12 +155,12 @@ defaultCliOptions = CliOptions
     }
 
 -- | Provider default when @--effort@ is omitted. Grok runs at high effort.
-defaultEffortFor :: Provider -> Text
+defaultEffortFor :: Provider -> ReasoningEffort
 defaultEffortFor = \case
-    XAIProvider -> "high"
-    OpenAIProvider -> "medium"
-    OpenRouterProvider -> "medium"
-    ClaudeCodeProvider -> "xhigh"
+    XAIProvider -> EffortHigh
+    OpenAIProvider -> EffortMedium
+    OpenRouterProvider -> EffortMedium
+    ClaudeCodeProvider -> EffortXHigh
 
 isOneShot :: CliOptions -> Bool
 isOneShot options =
@@ -423,7 +428,7 @@ positiveIntReader :: String -> Options.ReadM Int
 positiveIntReader flag =
     Options.eitherReader (parseInt flag)
 
-effortReader :: Options.ReadM Text
+effortReader :: Options.ReadM ReasoningEffort
 effortReader =
     Options.eitherReader (parseEffort . Text.pack)
 
@@ -465,35 +470,30 @@ parseMotionMode raw = case Text.toLower (Text.pack raw) of
     "off" -> Right MotionOff
     _ -> Left ("--motion expects full, reduced, or off (got " <> raw <> ")")
 
-reasoningEfforts :: [Text]
-reasoningEfforts = ["none", "low", "medium", "high", "xhigh", "max"]
+reasoningEfforts :: [ReasoningEffort]
+reasoningEfforts = ReasoningEffort.reasoningEfforts
 
 -- | Efforts exposed by the active model-facing protocol. Grok accepts
 -- @xhigh@ but rejects the OpenAI-only @max@ value.
-reasoningEffortsForDialect :: DialectId -> [Text]
+reasoningEffortsForDialect :: DialectId -> [ReasoningEffort]
 reasoningEffortsForDialect = \case
-    GrokBuildDialect -> filter (/= "max") reasoningEfforts
+    GrokBuildDialect -> filter (/= EffortMax) reasoningEfforts
     _ -> reasoningEfforts
 
 -- | Replace an effort unsupported by the active model-facing protocol with
 -- its closest supported value. This also cleans up resumed sessions and
 -- provider switches that inherited an effort from another dialect.
-normalizeReasoningEffortForDialect :: DialectId -> Text -> Text
+normalizeReasoningEffortForDialect
+    :: DialectId
+    -> ReasoningEffort
+    -> ReasoningEffort
 normalizeReasoningEffortForDialect dialect effort
     | effort `elem` reasoningEffortsForDialect dialect = effort
-    | dialect == GrokBuildDialect = "high"
+    | dialect == GrokBuildDialect = EffortHigh
     | otherwise = effort
 
-parseEffort :: Text -> Either String Text
-parseEffort raw =
-    let effort = Text.toLower (Text.strip raw)
-    in if effort `elem` reasoningEfforts
-        then Right effort
-        else Left
-            ( "effort must be none, low, medium, high, xhigh, or max (got "
-                <> Text.unpack effort
-                <> ")"
-            )
+parseEffort :: Text -> Either String ReasoningEffort
+parseEffort = either (Left . Text.unpack) Right . parseReasoningEffort
 
 usage :: String
 usage = unlines

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -180,6 +180,10 @@ import Agent.CLI.Runtime.HistorySource
     , loadFullscreenHistoryPage
     , sessionUiPageSize
     )
+import Agent.ReasoningEffort
+    ( parseReasoningEffort
+    , reasoningEffortText
+    )
 import Agent.CLI.Session.History
     ( detectGitBranch,
       foldSessionItems,
@@ -1636,9 +1640,14 @@ runAgentInitializedWithLock
                 fromMaybe
                     (maybe
                         (defaultEffortFor provider)
-                        (.metaEffort)
+                        (either
+                            (const (defaultEffortFor provider))
+                            id
+                            . parseReasoningEffort
+                            . (.metaEffort))
                         (fst <$> resumed))
                     options.optEffort
+        effortText = reasoningEffortText effort
         policy = resolveApprovalPolicy options isTty
             projectSettings.settingsAutoApprove
         claudeBypassEnabled =
@@ -1742,7 +1751,7 @@ runAgentInitializedWithLock
             (trustedPool startup.startupDatabaseStore)
             startup options root
                 inferredTarget { targetDialect = dialectId }
-                (isNothing transition) cwd effort promptText resumed
+                (isNothing transition) cwd effortText promptText resumed
     writeIORef persistSlotRef persist
     forM_ fullscreen \runtime ->
         reservedSessionId persist >>= \case
@@ -1939,7 +1948,7 @@ runAgentInitializedWithLock
             , toolsTransportModel = inferredTarget.targetWireModelId
             , toolsDialect = dialectId
             , toolsCwd = cwd
-            , toolsEffort = effort
+            , toolsEffort = effortText
             , toolsCurrentSessionId =
                 readIORef persistSlotRef >>= currentSessionId
             , toolsLaunchTurn = \handle message -> do
@@ -2064,7 +2073,7 @@ runAgentInitializedWithLock
                     today
                     (isOneShot options)
             params = requestParams provider model instructions
-                (schemasFromAppTools dialect tools) effort
+                (schemasFromAppTools dialect tools) effortText
             initialItems = maybe [] (foldSessionItems . snd) resumed
             initialTurns = maybe [] snd resumed
             resumeNeedsFreshContext =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -20,6 +20,7 @@ import Agent.CLI.Auth ()
 import Agent.CLI.Clipboard ()
 import Agent.CLI.Command
     ( currentEffort, currentModel, mkSlashCatalog )
+import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.CLI.Compaction ()
 import Agent.CLI.Config ()
 import Agent.CLI.Connectivity ()
@@ -324,7 +325,7 @@ replWithDraft env@SessionEnv
                         | otherwise = savedRate
                 Text.putStrLn $ formatReplStatusLine stdoutColor termCols
                     (currentModel params)
-                    (currentEffort params)
+                    (reasoningEffortText (currentEffort params))
                     idleMode
                     account
                     usage

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -127,6 +127,7 @@ import Agent.Provider
     ( Provider(ClaudeCodeProvider, OpenAIProvider),
       providerSlug,
       tokenProviderBillingMode )
+import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Responses.GenericBackend ()
 import Agent.Responses.GenericClient ()
 import Agent.Responses.Types ()
@@ -228,9 +229,10 @@ handleSelection
         params <- readIORef paramsRef
         let message =
                 "effort: "
-                    <> normalizeReasoningEffortForDialect
-                        (dialectId dialect)
-                        (currentEffort params)
+                    <> reasoningEffortText
+                        (normalizeReasoningEffortForDialect
+                            (dialectId dialect)
+                            (currentEffort params))
         displayInfo message $
             Text.putStrLn
                 (roleMuted color (glyphSession <> message))
@@ -296,17 +298,18 @@ handleSelection
     setEffort level = do
         color <- resolveColor stdout
         let supported = reasoningEffortsForDialect (dialectId dialect)
+            levelText = reasoningEffortText level
         if level `elem` supported
             then do
                 setSessionEffort env level
-                displayInfo ("effort set to " <> level) $
+                displayInfo ("effort set to " <> levelText) $
                     Text.putStrLn
                         (roleMuted color
-                            (glyphOk <> "effort set to " <> level))
+                            (glyphOk <> "effort set to " <> levelText))
             else do
                 let message =
                         "effort "
-                            <> level
+                            <> levelText
                             <> " is not supported by the active model"
                 displayError message $
                     Text.hPutStrLn stderr (roleError color message)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -137,6 +137,7 @@ import Agent.OpenAI.WebSocketClient ()
 import Agent.OpenRouter.LoopBackend ()
 import Agent.OsPath ( toText )
 import Agent.Provider ( providerSlug )
+import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Responses.GenericBackend ()
 import Agent.Responses.GenericClient ()
 import Agent.Responses.Types ()
@@ -300,7 +301,7 @@ handleSessionAction
                 params <- readIORef paramsRef
                 slot <- readIORef slotRef
                 let model = currentModel params
-                    effort = currentEffort params
+                    effort = reasoningEffortText (currentEffort params)
                     create = case slot of
                         PersistencePending pending _ _ ->
                             pending
@@ -446,7 +447,8 @@ handleSessionAction
                        , "dialect: "
                             <> dialectSlug
                                 (dialectId dialect)
-                       , "effort: " <> currentEffort params
+                       , "effort: "
+                            <> reasoningEffortText (currentEffort params)
                        , "cwd: " <> toText cwd
                        , "shell: "
                             <> shellModeText shellMode

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
@@ -18,6 +18,7 @@ import Agent.CLI.Session.Runtime.Types
 import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.Error (ApiError)
 import Agent.Provider (Provider)
+import Agent.ReasoningEffort (ReasoningEffort)
 import Data.Text (Text)
 import System.OsPath (OsPath)
 
@@ -36,7 +37,7 @@ data RunResult
     | RunResumeSession Text
       -- ^ Persisted session id. Consumed after the current provider-specific
       -- backend shuts down before starting the selected session.
-    | RunSwitchWorktree OsPath Provider Text Text
+    | RunSwitchWorktree OsPath Provider Text ReasoningEffort
       -- ^ Fresh worktree path. Starts a new session after the current backend
       -- and fullscreen UI have shut down, retaining provider, model, and effort.
 

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -17,6 +17,10 @@ import Agent.CLI.Models
     , initialPickerStateResolved
     )
 import Agent.Concurrent (mapConcurrentlyBounded)
+import Agent.ReasoningEffort
+    ( ReasoningEffort
+    , reasoningEffortText
+    )
 import Agent.CLI.Style
     ( roleError
     , roleMuted
@@ -97,9 +101,9 @@ modelChoice
 
 effortChoice
     :: Maybe FullscreenRuntime
-    -> [Text]
-    -> Text
-    -> IO (Maybe Text)
+    -> [ReasoningEffort]
+    -> ReasoningEffort
+    -> IO (Maybe ReasoningEffort)
 effortChoice fullscreen efforts current = case fullscreen of
     Nothing -> pure Nothing
     Just runtime -> do
@@ -108,7 +112,7 @@ effortChoice fullscreen efforts current = case fullscreen of
             runtime
             "Reasoning effort"
             initial
-            [(effort, "") | effort <- efforts]
+            [(reasoningEffortText effort, "") | effort <- efforts]
             >>= \case
                 Just index
                     | index >= 0

--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Session.Interaction
     ( buildPromptState
     , runBtwQuestion
     , setSessionEffort
+    , setSessionEffortText
     , syncFullscreenPrompt
     ) where
 
@@ -51,6 +52,11 @@ import Agent.CLI.TUI.App
     )
 import Agent.Loop (TokenUsage)
 import Agent.Dialect (DialectId, dialectId)
+import Agent.ReasoningEffort
+    ( ReasoningEffort
+    , parseReasoningEffort
+    , reasoningEffortText
+    )
 import Agent.Responses.Types (ResponseCreateParams)
 import Agent.Tools.PlanMode
     ( PlanModeEnv(..)
@@ -70,6 +76,7 @@ import Data.IORef
     )
 import Data.Maybe (isJust)
 import Data.Text (Text)
+import qualified Data.Text as Text
 
 -- | Publish the current session prompt metadata to a retained fullscreen
 -- runtime before replaying a pending turn after a provider rebuild.
@@ -107,10 +114,13 @@ buildPromptState activeDialect params planState policy account accountSelectable
     PromptState
         { promptModel = currentModel params
         , promptEffort =
-            normalizeReasoningEffortForDialect
-                activeDialect
-                (currentEffort params)
-        , promptEffortOptions = reasoningEffortsForDialect activeDialect
+            reasoningEffortText $
+                normalizeReasoningEffortForDialect
+                    activeDialect
+                    (currentEffort params)
+        , promptEffortOptions =
+            map reasoningEffortText
+                (reasoningEffortsForDialect activeDialect)
         , promptMode =
             replModeLabel (replModeFromState planState policy)
         , promptAccount = account
@@ -120,12 +130,13 @@ buildPromptState activeDialect params planState policy account accountSelectable
         , promptAttachments = attachments
         }
 
-setSessionEffort :: SessionEnv -> Text -> IO ()
+setSessionEffort :: SessionEnv -> ReasoningEffort -> IO ()
 setSessionEffort env level = do
     modifyIORef' env.sessionParams (setReasoningEffort level)
+    let levelText = reasoningEffortText level
     case env.sessionFullscreen of
         Just runtime ->
-            emitUiEvent runtime (UiSetPromptEffort level)
+            emitUiEvent runtime (UiSetPromptEffort levelText)
         Nothing -> pure ()
     case env.sessionPersist of
         PersistenceDisabled -> pure ()
@@ -135,17 +146,24 @@ setSessionEffort env level = do
                 PersistencePending pending sessionId tempDir ->
                     writeIORef slotRef
                         (PersistencePending
-                            pending { createEffort = level }
+                            pending { createEffort = levelText }
                             sessionId
                             tempDir)
                 PersistenceActive handle -> do
-                    let meta = handle.sessionMeta { metaEffort = level }
+                    let meta =
+                            handle.sessionMeta { metaEffort = levelText }
                     writeSessionMeta
                         handle.sessionPool
                         handle.sessionMetaPath
                         meta
                     writeIORef slotRef
                         (PersistenceActive handle { sessionMeta = meta })
+
+setSessionEffortText :: SessionEnv -> Text -> IO ()
+setSessionEffortText env level =
+    case parseReasoningEffort level of
+        Left err -> ioError (userError (Text.unpack err))
+        Right effort -> setSessionEffort env effort
 
 runBtwQuestion :: Bool -> SessionEnv -> Text -> IO ()
 runBtwQuestion registerCancel env question = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -32,7 +32,7 @@ import Agent.CLI.Runtime.Types
     , StartupFailure(..)
     )
 import Agent.CLI.Session.Interaction
-    ( setSessionEffort
+    ( setSessionEffortText
     , syncFullscreenPrompt
     )
 import Agent.CLI.Session.Retry (waitAndRetryPendingTurn)
@@ -180,7 +180,7 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
                     Just _ -> pure ()
                 continueAfterTurn continuation env
     TurnRestartRequested level pending -> do
-        setSessionEffort env level
+        setSessionEffortText env level
         writeIORef env.sessionPlanMode.planStateRef pending.pendingPlanState
         case env.sessionFullscreen of
             Just runtime ->

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -97,7 +97,10 @@ import Agent.CLI.Session.History
     , writeLiveTranscript
     )
 import Agent.CLI.SessionEnv (SessionEnv(..))
-import Agent.CLI.Session.Interaction (runBtwQuestion, setSessionEffort)
+import Agent.CLI.Session.Interaction
+    ( runBtwQuestion
+    , setSessionEffortText
+    )
 import Agent.CLI.Skills
     ( installSkillCatalogWithOmissions, installSkillToolRoots
     , loadSkillsCatalogQuiet, reservedSlashNames
@@ -992,7 +995,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             }
     writeIORef generatedContextReloadRef reloadGeneratedContextSafely
     writeIORef startup.startupRestartEffort \level -> do
-        setSessionEffort env level
+        setSessionEffortText env level
         writeIORef restartEffortRef (Just level)
         requestCancel toolEnv.toolCancel
     forM_ fullscreen \runtime ->

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -106,6 +106,7 @@ import Agent.OpenAI.WebSocketClient
     )
 import System.OsPath (OsPath)
 import Agent.Provider (Provider(..), TokenProvider, providerSlug)
+import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Responses.LoopBackend
     ( statelessResponsesBackendWithRawReasoning
     )
@@ -1146,8 +1147,11 @@ resolveChildModelAndEffort
   where
     model = fromMaybe inheritedModel childModel
     inheritedEffort = case parentParams.reasoning of
-        Just cfg -> fromMaybe (defaultEffortFor provider) cfg.effort
-        Nothing -> defaultEffortFor provider
+        Just cfg ->
+            fromMaybe
+                (reasoningEffortText (defaultEffortFor provider))
+                cfg.effort
+        Nothing -> reasoningEffortText (defaultEffortFor provider)
     defaultChildEffort
         | provider == OpenAIProvider
         , model == "gpt-5.6-luna"

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.CommandSpec (spec) where
 import Agent.CLI.Command
 import Agent.CLI.Afk
 import Agent.Dialect (DialectId(..))
+import Agent.ReasoningEffort (ReasoningEffort(..))
 import Agent.Responses.Types
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.List (isInfixOf)
@@ -53,11 +54,11 @@ spec = do
             parseReplLine "  /Effort  " `shouldBe` ReplShowEffort
 
         it "sets a valid effort level" do
-            parseReplLine "/effort none" `shouldBe` ReplSetEffort "none"
-            parseReplLine "/effort high" `shouldBe` ReplSetEffort "high"
-            parseReplLine "/effort XHIGH" `shouldBe` ReplSetEffort "xhigh"
-            parseReplLine "/effort MAX" `shouldBe` ReplSetEffort "max"
-            parseReplLine "/effort medium" `shouldBe` ReplSetEffort "medium"
+            parseReplLine "/effort none" `shouldBe` ReplSetEffort EffortNone
+            parseReplLine "/effort high" `shouldBe` ReplSetEffort EffortHigh
+            parseReplLine "/effort XHIGH" `shouldBe` ReplSetEffort EffortXHigh
+            parseReplLine "/effort MAX" `shouldBe` ReplSetEffort EffortMax
+            parseReplLine "/effort medium" `shouldBe` ReplSetEffort EffortMedium
 
         it "toggles always-approve from slash and colon aliases" do
             parseReplLine "/always-approve" `shouldBe` ReplToggleAlwaysApprove
@@ -664,8 +665,9 @@ spec = do
 
     describe "setReasoningEffort" do
         it "writes effort onto an empty reasoning config" do
-            let updated = setReasoningEffort "high" defaultResponseCreateParams
-            currentEffort updated `shouldBe` "high"
+            let updated =
+                    setReasoningEffort EffortHigh defaultResponseCreateParams
+            currentEffort updated `shouldBe` EffortHigh
             fmap (.effort) updated.reasoning `shouldBe` Just (Just "high")
 
         it "preserves other reasoning fields" do
@@ -681,8 +683,8 @@ spec = do
                             }
                         , ..
                         }
-                updated = setReasoningEffort "xhigh" original
-            currentEffort updated `shouldBe` "xhigh"
+                updated = setReasoningEffort EffortXHigh original
+            currentEffort updated `shouldBe` EffortXHigh
             case updated.reasoning of
                 Just config -> do
                     config.context `shouldBe` Just "256k"
@@ -692,7 +694,7 @@ spec = do
 
     describe "currentEffort" do
         it "defaults to low when reasoning is missing" do
-            currentEffort defaultResponseCreateParams `shouldBe` "low"
+            currentEffort defaultResponseCreateParams `shouldBe` EffortLow
 
     describe "setModel" do
         it "writes the model onto request params" do

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -5,6 +5,7 @@ import Agent.Dialect (DialectId(..))
 import Agent.Loop (defaultLoopMaxTurns)
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (Provider(..))
+import Agent.ReasoningEffort (ReasoningEffort(..))
 import Agent.TUI.Motion (MotionMode(..))
 import Test.Hspec
 
@@ -43,7 +44,7 @@ spec = do
                     , optMaxTurns = 3
                     , optMaxConcurrentAgents = Just 64
                     , optCompactThreshold = Just 1200
-                    , optEffort = Just "high"
+                    , optEffort = Just EffortHigh
                     , optPrompt = Just "hello"
                     })
 
@@ -59,13 +60,13 @@ spec = do
 
         it "accepts none, xhigh, and max effort" do
             parseArgs ["--effort", "none"]
-                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "none" })
+                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just EffortNone })
             parseArgs ["--effort", "xhigh"]
-                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "xhigh" })
+                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just EffortXHigh })
             parseArgs ["--effort", "max"]
-                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "max" })
+                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just EffortMax })
             parseArgs ["--effort", "HIGH"]
-                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just "high" })
+                `shouldBe` Right (RunAgent defaultCliOptions { optEffort = Just EffortHigh })
 
         it "keeps raw OpenAI reasoning hidden unless explicitly requested" do
             defaultCliOptions.optShowRawReasoning `shouldBe` False
@@ -109,7 +110,7 @@ spec = do
                 ]
                 `shouldBe` Right (RunAgent defaultCliOptions
                     { optModel = Just "second"
-                    , optEffort = Just "high"
+                    , optEffort = Just EffortHigh
                     })
 
         it "applies approval flags in command-line order" do
@@ -326,25 +327,31 @@ spec = do
 
     describe "defaultEffortFor" do
         it "uses provider-specific effort defaults" do
-            defaultEffortFor XAIProvider `shouldBe` "high"
-            defaultEffortFor OpenAIProvider `shouldBe` "medium"
-            defaultEffortFor OpenRouterProvider `shouldBe` "medium"
-            defaultEffortFor ClaudeCodeProvider `shouldBe` "xhigh"
+            defaultEffortFor XAIProvider `shouldBe` EffortHigh
+            defaultEffortFor OpenAIProvider `shouldBe` EffortMedium
+            defaultEffortFor OpenRouterProvider `shouldBe` EffortMedium
+            defaultEffortFor ClaudeCodeProvider `shouldBe` EffortXHigh
 
     describe "reasoningEffortsForDialect" do
         it "does not offer OpenAI max effort to Grok models" do
             reasoningEffortsForDialect GrokBuildDialect
-                `shouldBe` ["none", "low", "medium", "high", "xhigh"]
+                `shouldBe`
+                    [ EffortNone
+                    , EffortLow
+                    , EffortMedium
+                    , EffortHigh
+                    , EffortXHigh
+                    ]
             reasoningEffortsForDialect CodexDialect
                 `shouldBe` reasoningEfforts
 
         it "maps inherited max effort to high for Grok models" do
-            normalizeReasoningEffortForDialect GrokBuildDialect "max"
-                `shouldBe` "high"
-            normalizeReasoningEffortForDialect GrokBuildDialect "xhigh"
-                `shouldBe` "xhigh"
-            normalizeReasoningEffortForDialect CodexDialect "max"
-                `shouldBe` "max"
+            normalizeReasoningEffortForDialect GrokBuildDialect EffortMax
+                `shouldBe` EffortHigh
+            normalizeReasoningEffortForDialect GrokBuildDialect EffortXHigh
+                `shouldBe` EffortXHigh
+            normalizeReasoningEffortForDialect CodexDialect EffortMax
+                `shouldBe` EffortMax
 
     describe "isOneShot" do
         it "is true for text, prompt-file, and managed-turn-file input" do

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -35,6 +35,7 @@ import Agent.CLI.ReplMode
     , replModeFromState
     )
 import Agent.Dialect (DialectId(..))
+import Agent.ReasoningEffort (ReasoningEffort(..))
 import Agent.Loop (LoopEvent(..), TokenUsage(..), emptyTokenUsage)
 import Agent.MCP
     ( McpInitState(..)
@@ -248,7 +249,7 @@ spec = do
                         , promptAccount = "grok@example.com"
                         }
                 openAiParams =
-                    setReasoningEffort "medium" $
+                    setReasoningEffort EffortMedium $
                         setModel "gpt-5.6-sol" defaultResponseCreateParams
                 replacement =
                     buildPromptState
@@ -275,7 +276,9 @@ spec = do
             let prompt =
                     buildPromptState
                         GrokBuildDialect
-                        (setReasoningEffort "max" defaultResponseCreateParams)
+                        (setReasoningEffort
+                            EffortMax
+                            defaultResponseCreateParams)
                         PlanInactive
                         PromptMutating
                         "grok@example.com"

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -46,6 +46,7 @@ library
                     , Agent.InterAgentMessage
                     , Agent.Provider
                     , Agent.Provider.Options
+                    , Agent.ReasoningEffort
                     , Agent.Loop
                     , Agent.MCP
                     , Agent.JsonText

--- a/packages/agent-core/src/Agent/ReasoningEffort.hs
+++ b/packages/agent-core/src/Agent/ReasoningEffort.hs
@@ -1,0 +1,147 @@
+-- | Provider-neutral reasoning effort and provider-specific wire domains.
+--
+-- Keep the canonical value in CLI and persistence state. Convert to text only
+-- at protocol boundaries such as 'ReasoningConfig', whose schema is deliberately
+-- open for forwards-compatible Responses API fields.
+module Agent.ReasoningEffort
+    ( ReasoningEffort(..)
+    , OpenAIReasoningEffort(..)
+    , GrokReasoningEffort(..)
+    , ClaudeReasoningEffort(..)
+    , reasoningEfforts
+    , reasoningEffortText
+    , parseReasoningEffort
+    , openAIReasoningEffort
+    , openAIReasoningEffortText
+    , grokReasoningEffort
+    , grokReasoningEffortText
+    , claudeReasoningEffort
+    , claudeReasoningEffortText
+    ) where
+
+import Data.Aeson (FromJSON(..), ToJSON(..), withText)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data ReasoningEffort
+    = EffortNone
+    | EffortLow
+    | EffortMedium
+    | EffortHigh
+    | EffortXHigh
+    | EffortMax
+    deriving (Bounded, Enum, Eq, Ord, Show)
+
+reasoningEfforts :: [ReasoningEffort]
+reasoningEfforts = [minBound .. maxBound]
+
+reasoningEffortText :: ReasoningEffort -> Text
+reasoningEffortText = \case
+    EffortNone -> "none"
+    EffortLow -> "low"
+    EffortMedium -> "medium"
+    EffortHigh -> "high"
+    EffortXHigh -> "xhigh"
+    EffortMax -> "max"
+
+parseReasoningEffort :: Text -> Either Text ReasoningEffort
+parseReasoningEffort raw =
+    let value = Text.toLower (Text.strip raw)
+    in case value of
+        "none" -> Right EffortNone
+        "low" -> Right EffortLow
+        "medium" -> Right EffortMedium
+        "high" -> Right EffortHigh
+        "xhigh" -> Right EffortXHigh
+        "max" -> Right EffortMax
+        _ -> Left
+            ("effort must be none, low, medium, high, xhigh, or max (got "
+                <> raw <> ")")
+
+instance ToJSON ReasoningEffort where
+    toJSON = toJSON . reasoningEffortText
+
+instance FromJSON ReasoningEffort where
+    parseJSON = withText "ReasoningEffort" $
+        either (fail . Text.unpack) pure . parseReasoningEffort
+
+data OpenAIReasoningEffort
+    = OpenAINone
+    | OpenAILow
+    | OpenAIMedium
+    | OpenAIHigh
+    | OpenAIXHigh
+    | OpenAIMax
+    deriving (Eq, Ord, Show)
+
+openAIReasoningEffort :: ReasoningEffort -> OpenAIReasoningEffort
+openAIReasoningEffort = \case
+    EffortNone -> OpenAINone
+    EffortLow -> OpenAILow
+    EffortMedium -> OpenAIMedium
+    EffortHigh -> OpenAIHigh
+    EffortXHigh -> OpenAIXHigh
+    EffortMax -> OpenAIMax
+
+openAIReasoningEffortText :: OpenAIReasoningEffort -> Text
+openAIReasoningEffortText = \case
+    OpenAINone -> "none"
+    OpenAILow -> "low"
+    OpenAIMedium -> "medium"
+    OpenAIHigh -> "high"
+    OpenAIXHigh -> "xhigh"
+    OpenAIMax -> "max"
+
+data GrokReasoningEffort
+    = GrokNone
+    | GrokLow
+    | GrokMedium
+    | GrokHigh
+    | GrokXHigh
+    deriving (Eq, Ord, Show)
+
+-- | Grok has no @max@ value. Resumed or inherited @max@ state is normalized
+-- to @high@ at this final defensive boundary.
+grokReasoningEffort :: ReasoningEffort -> GrokReasoningEffort
+grokReasoningEffort = \case
+    EffortNone -> GrokNone
+    EffortLow -> GrokLow
+    EffortMedium -> GrokMedium
+    EffortHigh -> GrokHigh
+    EffortXHigh -> GrokXHigh
+    EffortMax -> GrokHigh
+
+grokReasoningEffortText :: GrokReasoningEffort -> Text
+grokReasoningEffortText = \case
+    GrokNone -> "low"
+    GrokLow -> "low"
+    GrokMedium -> "medium"
+    GrokHigh -> "high"
+    GrokXHigh -> "xhigh"
+
+data ClaudeReasoningEffort
+    = ClaudeDefault
+    | ClaudeLow
+    | ClaudeMedium
+    | ClaudeHigh
+    | ClaudeXHigh
+    | ClaudeMax
+    deriving (Eq, Ord, Show)
+
+claudeReasoningEffort :: ReasoningEffort -> ClaudeReasoningEffort
+claudeReasoningEffort = \case
+    EffortNone -> ClaudeDefault
+    EffortLow -> ClaudeLow
+    EffortMedium -> ClaudeMedium
+    EffortHigh -> ClaudeHigh
+    EffortXHigh -> ClaudeXHigh
+    EffortMax -> ClaudeMax
+
+claudeReasoningEffortText :: ClaudeReasoningEffort -> Maybe Text
+claudeReasoningEffortText = \case
+    ClaudeDefault -> Nothing
+    ClaudeLow -> Just "low"
+    ClaudeMedium -> Just "medium"
+    ClaudeHigh -> Just "high"
+    ClaudeXHigh -> Just "xhigh"
+    ClaudeMax -> Just "max"

--- a/packages/agent-core/src/Agent/ReasoningEffort.hs
+++ b/packages/agent-core/src/Agent/ReasoningEffort.hs
@@ -5,18 +5,9 @@
 -- open for forwards-compatible Responses API fields.
 module Agent.ReasoningEffort
     ( ReasoningEffort(..)
-    , OpenAIReasoningEffort(..)
-    , GrokReasoningEffort(..)
-    , ClaudeReasoningEffort(..)
     , reasoningEfforts
     , reasoningEffortText
     , parseReasoningEffort
-    , openAIReasoningEffort
-    , openAIReasoningEffortText
-    , grokReasoningEffort
-    , grokReasoningEffortText
-    , claudeReasoningEffort
-    , claudeReasoningEffortText
     ) where
 
 import Data.Aeson (FromJSON(..), ToJSON(..), withText)
@@ -64,84 +55,3 @@ instance ToJSON ReasoningEffort where
 instance FromJSON ReasoningEffort where
     parseJSON = withText "ReasoningEffort" $
         either (fail . Text.unpack) pure . parseReasoningEffort
-
-data OpenAIReasoningEffort
-    = OpenAINone
-    | OpenAILow
-    | OpenAIMedium
-    | OpenAIHigh
-    | OpenAIXHigh
-    | OpenAIMax
-    deriving (Eq, Ord, Show)
-
-openAIReasoningEffort :: ReasoningEffort -> OpenAIReasoningEffort
-openAIReasoningEffort = \case
-    EffortNone -> OpenAINone
-    EffortLow -> OpenAILow
-    EffortMedium -> OpenAIMedium
-    EffortHigh -> OpenAIHigh
-    EffortXHigh -> OpenAIXHigh
-    EffortMax -> OpenAIMax
-
-openAIReasoningEffortText :: OpenAIReasoningEffort -> Text
-openAIReasoningEffortText = \case
-    OpenAINone -> "none"
-    OpenAILow -> "low"
-    OpenAIMedium -> "medium"
-    OpenAIHigh -> "high"
-    OpenAIXHigh -> "xhigh"
-    OpenAIMax -> "max"
-
-data GrokReasoningEffort
-    = GrokNone
-    | GrokLow
-    | GrokMedium
-    | GrokHigh
-    | GrokXHigh
-    deriving (Eq, Ord, Show)
-
--- | Grok has no @max@ value. Resumed or inherited @max@ state is normalized
--- to @high@ at this final defensive boundary.
-grokReasoningEffort :: ReasoningEffort -> GrokReasoningEffort
-grokReasoningEffort = \case
-    EffortNone -> GrokNone
-    EffortLow -> GrokLow
-    EffortMedium -> GrokMedium
-    EffortHigh -> GrokHigh
-    EffortXHigh -> GrokXHigh
-    EffortMax -> GrokHigh
-
-grokReasoningEffortText :: GrokReasoningEffort -> Text
-grokReasoningEffortText = \case
-    GrokNone -> "low"
-    GrokLow -> "low"
-    GrokMedium -> "medium"
-    GrokHigh -> "high"
-    GrokXHigh -> "xhigh"
-
-data ClaudeReasoningEffort
-    = ClaudeDefault
-    | ClaudeLow
-    | ClaudeMedium
-    | ClaudeHigh
-    | ClaudeXHigh
-    | ClaudeMax
-    deriving (Eq, Ord, Show)
-
-claudeReasoningEffort :: ReasoningEffort -> ClaudeReasoningEffort
-claudeReasoningEffort = \case
-    EffortNone -> ClaudeDefault
-    EffortLow -> ClaudeLow
-    EffortMedium -> ClaudeMedium
-    EffortHigh -> ClaudeHigh
-    EffortXHigh -> ClaudeXHigh
-    EffortMax -> ClaudeMax
-
-claudeReasoningEffortText :: ClaudeReasoningEffort -> Maybe Text
-claudeReasoningEffortText = \case
-    ClaudeDefault -> Nothing
-    ClaudeLow -> Just "low"
-    ClaudeMedium -> Just "medium"
-    ClaudeHigh -> Just "high"
-    ClaudeXHigh -> Just "xhigh"
-    ClaudeMax -> Just "max"

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -57,6 +57,7 @@ library
                     , Agent.OpenAI.Usage
                     , Agent.OpenAI.Client
                     , Agent.OpenAI.Request
+                    , Agent.OpenAI.ReasoningEffort
                     , Agent.OpenAI.Features
                     , Agent.OpenAI.ModelMetadata
                     , Agent.OpenAI.WebSocketClient

--- a/packages/agent-openai/package.nix
+++ b/packages/agent-openai/package.nix
@@ -1,8 +1,8 @@
-{ mkDerivation, aeson, agent-core, agent-responses, agent-responses-types, async, base, base64-bytestring
-, bytestring, case-insensitive, containers, directory, exceptions
-, filepath, HsOpenSSL, hspec, http-client
-, http-conduit, http-streams, http-types
-, io-streams, lib, network-uri, retry, safe-exceptions
+{ mkDerivation, aeson, agent-core, agent-responses
+, agent-responses-types, async, base, base64-bytestring, bytestring
+, case-insensitive, containers, directory, exceptions, filepath
+, HsOpenSSL, hspec, http-client, http-conduit, http-streams
+, http-types, io-streams, lib, network-uri, retry, safe-exceptions
 , temporary, text, time, unix, vector, wai, warp, websockets, wuss
 }:
 mkDerivation {
@@ -12,20 +12,21 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson agent-core agent-responses agent-responses-types base base64-bytestring bytestring containers
-    directory exceptions filepath HsOpenSSL http-client http-conduit http-streams
-    io-streams network-uri retry safe-exceptions text time vector
-    websockets wuss
+    aeson agent-core agent-responses agent-responses-types base
+    bytestring containers directory exceptions filepath HsOpenSSL
+    http-client http-conduit http-streams io-streams network-uri retry
+    safe-exceptions text time vector websockets wuss
   ];
   executableHaskellDepends = [
     agent-core base directory filepath text
   ];
   testHaskellDepends = [
-    aeson agent-core agent-responses agent-responses-types async base base64-bytestring bytestring case-insensitive
-    directory filepath hspec http-types retry temporary text time unix
-    vector wai warp websockets
+    aeson agent-core agent-responses agent-responses-types async base
+    base64-bytestring bytestring case-insensitive directory filepath
+    hspec http-types retry temporary text time unix vector wai warp
+    websockets
   ];
   description = "Haskell client for the OpenAI Responses API";
-  license = lib.licenses.bsd3;
+  license = lib.meta.getLicenseFromSpdxId "MIT";
   mainProgram = "agent-openai-login";
 }

--- a/packages/agent-openai/src/Agent/OpenAI/ReasoningEffort.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/ReasoningEffort.hs
@@ -1,0 +1,36 @@
+-- | Reasoning effort values accepted by the OpenAI transport.
+module Agent.OpenAI.ReasoningEffort
+    ( OpenAIReasoningEffort(..)
+    , openAIReasoningEffort
+    , openAIReasoningEffortText
+    ) where
+
+import Agent.ReasoningEffort (ReasoningEffort(..))
+import Data.Text (Text)
+
+data OpenAIReasoningEffort
+    = OpenAINone
+    | OpenAILow
+    | OpenAIMedium
+    | OpenAIHigh
+    | OpenAIXHigh
+    | OpenAIMax
+    deriving (Eq, Ord, Show)
+
+openAIReasoningEffort :: ReasoningEffort -> OpenAIReasoningEffort
+openAIReasoningEffort = \case
+    EffortNone -> OpenAINone
+    EffortLow -> OpenAILow
+    EffortMedium -> OpenAIMedium
+    EffortHigh -> OpenAIHigh
+    EffortXHigh -> OpenAIXHigh
+    EffortMax -> OpenAIMax
+
+openAIReasoningEffortText :: OpenAIReasoningEffort -> Text
+openAIReasoningEffortText = \case
+    OpenAINone -> "none"
+    OpenAILow -> "low"
+    OpenAIMedium -> "medium"
+    OpenAIHigh -> "high"
+    OpenAIXHigh -> "xhigh"
+    OpenAIMax -> "max"

--- a/packages/agent-telegram/src/Agent/Telegram.hs
+++ b/packages/agent-telegram/src/Agent/Telegram.hs
@@ -124,6 +124,7 @@ import Agent.FileRetry (writeLazyFileAtomically)
 import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (Provider, parseProvider)
+import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Store.Postgres
     ( Store
     , managedPostgresConfigFromEnv
@@ -583,7 +584,10 @@ runTelegramWithStore store home config token = do
         (die . Text.unpack)
         pure
     let provider = config.telegramProvider
-        effort = fromMaybe (defaultEffortFor provider) config.telegramEffort
+        effort =
+            fromMaybe
+                (reasoningEffortText (defaultEffortFor provider))
+                config.telegramEffort
         root = sessionsRoot home
         gatewayDir = gatewayDirectory home
         statePath = statePathFor home

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -43,6 +43,7 @@ library
                     , Agent.XAI.Error
                     , Agent.XAI.LoopBackend
                     , Agent.XAI.Options
+                    , Agent.XAI.ReasoningEffort
                     , Agent.XAI.Request
                     , Agent.XAI.Stream
                     , Agent.XAI.Transcription

--- a/packages/agent-xai/src/Agent/XAI/ReasoningEffort.hs
+++ b/packages/agent-xai/src/Agent/XAI/ReasoningEffort.hs
@@ -1,0 +1,36 @@
+-- | Reasoning effort values accepted by the xAI Grok transport.
+module Agent.XAI.ReasoningEffort
+    ( GrokReasoningEffort(..)
+    , grokReasoningEffort
+    , grokReasoningEffortText
+    ) where
+
+import Agent.ReasoningEffort (ReasoningEffort(..))
+import Data.Text (Text)
+
+data GrokReasoningEffort
+    = GrokNone
+    | GrokLow
+    | GrokMedium
+    | GrokHigh
+    | GrokXHigh
+    deriving (Eq, Ord, Show)
+
+-- | Grok has no @max@ value. Resumed or inherited @max@ state is normalized
+-- to @high@ at this final defensive boundary.
+grokReasoningEffort :: ReasoningEffort -> GrokReasoningEffort
+grokReasoningEffort = \case
+    EffortNone -> GrokNone
+    EffortLow -> GrokLow
+    EffortMedium -> GrokMedium
+    EffortHigh -> GrokHigh
+    EffortXHigh -> GrokXHigh
+    EffortMax -> GrokHigh
+
+grokReasoningEffortText :: GrokReasoningEffort -> Text
+grokReasoningEffortText = \case
+    GrokNone -> "low"
+    GrokLow -> "low"
+    GrokMedium -> "medium"
+    GrokHigh -> "high"
+    GrokXHigh -> "xhigh"

--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -12,9 +12,11 @@ import Agent.Responses.Request
     )
 import Agent.ReasoningEffort
     ( ReasoningEffort(..)
-    , grokReasoningEffort
-    , grokReasoningEffortText
     , parseReasoningEffort
+    )
+import Agent.XAI.ReasoningEffort
+    ( grokReasoningEffort
+    , grokReasoningEffortText
     )
 import Agent.Responses.Types
 import Agent.XAI.Options (ClientOptions(..))

--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -10,6 +10,12 @@ import Agent.Responses.Request
     , mapResponseTools
     , selectConfiguredModel
     )
+import Agent.ReasoningEffort
+    ( ReasoningEffort(..)
+    , grokReasoningEffort
+    , grokReasoningEffortText
+    , parseReasoningEffort
+    )
 import Agent.Responses.Types
 import Agent.XAI.Options (ClientOptions(..))
 import qualified Data.Aeson.Key as Key
@@ -111,19 +117,13 @@ hostedXSearchTool :: ResponseTool
 hostedXSearchTool = knownResponseTool ToolXSearch KeyMap.empty
 
 xaiReasoningEffort :: Maybe Text -> Text
-xaiReasoningEffort = \case
-    Nothing -> "high"
-    Just "low" -> "low"
-    Just "none" -> "low"
-    Just "minimal" -> "low"
-    Just "medium" -> "medium"
-    Just "high" -> "high"
-    Just "xhigh" -> "xhigh"
-    -- The shared UI supports OpenAI's @max@ effort, but Grok's proxy rejects
-    -- it. Keep this projection defensive for resumed sessions and callers
-    -- that construct canonical requests directly.
-    Just "max" -> "high"
-    _ -> "high"
+xaiReasoningEffort value =
+    grokReasoningEffortText . grokReasoningEffort $
+        case value of
+            Nothing -> EffortHigh
+            Just "minimal" -> EffortLow
+            Just raw ->
+                either (const EffortHigh) id (parseReasoningEffort raw)
 
 requestInputItems :: ResponseCreateParams -> [ResponseItem]
 requestInputItems request = case request.input of


### PR DESCRIPTION
## Summary
- add a canonical `ReasoningEffort` enum and typed OpenAI, Grok, and Claude effort domains
- migrate CLI parsing, runtime state, slash commands, selection UI, and worktree transitions away from free-form effort text
- keep storage and generic Responses wire strings compatible while projecting Grok efforts through a provider-specific type
- preserve Grok behavior by mapping `none` to `low`, `max` to `high`, and passing `xhigh` through

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli` — all 142 modules loaded
- `nix develop -c cabal repl agent-xai:test:agent-xai-test`, then `:main` — 56 examples, 0 failures, 1 pending live test
- targeted CLI regression test for invalid effort parsing — 1 example, 0 failures
- full CLI suite exercised in GHCi: affected effort tests passed; 26 unrelated PostgreSQL tests failed because the worktree-derived Unix socket path exceeded PostgreSQL's path limit
- fullscreen tmux smoke test with Grok 4.6: `max` remained unavailable/rejected and `xhigh` updated the live status
