### PR TITLE
Unload syntax grammars for hidden terminals

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -409,7 +409,8 @@ newFullscreenRuntimeWithSyntaxLoader
         motionTickQueued <- newTVarIO False
         historyRequests <- newTQueueIO
         syntaxRequests <- newTQueueIO
-        syntaxHighlighter <- newIORef Nothing
+        syntaxHighlighter <-
+            newIORef (SyntaxHighlighterUnloaded 0)
         historySource <- newIORef Nothing
         historyGeneration <- newIORef 0
         dictationJobs <- newTQueueIO
@@ -607,18 +608,25 @@ resetFullscreenHistory runtime initialPage = do
 
 loadSyntaxHighlighterForRuntime :: FullscreenRuntime -> IO ()
 loadSyntaxHighlighterForRuntime runtime = do
-    startedAt <- getMonotonicTimeNSec
-    result <- tryAny runtime.runtimeLoadSyntaxHighlighter
-    finishedAt <- getMonotonicTimeNSec
-    let highlighter = case result of
-            Left _ -> Nothing
-            Right loaded -> either (const Nothing) Just loaded
-    writeIORef runtime.runtimeSyntaxHighlighter highlighter
-    enqueueAppEvent runtime (AppSyntaxHighlighterLoaded highlighter)
-    void $
-        tryAny $
-            runtime.runtimeSyntaxLoadFinished
-                (nanosecondsToNominalDiffTime (finishedAt - startedAt))
+    readIORef runtime.runtimeSyntaxHighlighter >>= \case
+        SyntaxHighlighterInactive _ -> pure ()
+        state -> do
+            let generation = syntaxHighlighterGeneration state
+            startedAt <- getMonotonicTimeNSec
+            result <- tryAny runtime.runtimeLoadSyntaxHighlighter
+            finishedAt <- getMonotonicTimeNSec
+            let highlighter = case result of
+                    Left _ -> Nothing
+                    Right loaded -> either (const Nothing) Just loaded
+            published <-
+                publishSyntaxHighlighter runtime generation highlighter
+            when published $
+                enqueueAppEvent runtime AppSyntaxHighlighterChanged
+            void $
+                tryAny $
+                    runtime.runtimeSyntaxLoadFinished
+                        (nanosecondsToNominalDiffTime
+                            (finishedAt - startedAt))
 
 runSyntaxHighlighterForRuntime :: FullscreenRuntime -> IO ()
 runSyntaxHighlighterForRuntime runtime = do
@@ -628,16 +636,24 @@ runSyntaxHighlighterForRuntime runtime = do
             atomically $
                 (:) <$> readTQueue runtime.runtimeSyntaxRequests
                     <*> flushTQueue runtime.runtimeSyntaxRequests
+        ensureSyntaxHighlighterForRuntime runtime
         readIORef runtime.runtimeSyntaxHighlighter >>= \case
-            Nothing -> pure ()
-            Just highlighter -> do
+            SyntaxHighlighterInactive _ -> pure ()
+            SyntaxHighlighterUnloaded _ -> pure ()
+            SyntaxHighlighterActive _ Nothing -> pure ()
+            SyntaxHighlighterActive generation (Just highlighter) -> do
                 (changed, loaded) <-
                     foldSyntaxRequests highlighter languages
                 when changed do
-                    writeIORef runtime.runtimeSyntaxHighlighter (Just loaded)
-                    enqueueAppEvent
-                        runtime
-                        (AppSyntaxHighlighterLoaded (Just loaded))
+                    published <-
+                        publishSyntaxHighlighter
+                            runtime
+                            generation
+                            (Just loaded)
+                    when published $
+                        enqueueAppEvent
+                            runtime
+                            AppSyntaxHighlighterChanged
   where
     foldSyntaxRequests current = \case
         [] -> pure (False, current)
@@ -648,6 +664,36 @@ runSyntaxHighlighterForRuntime runtime = do
                 Right (Right loaded) -> do
                     (_, final) <- foldSyntaxRequests loaded remaining
                     pure (True, final)
+
+ensureSyntaxHighlighterForRuntime :: FullscreenRuntime -> IO ()
+ensureSyntaxHighlighterForRuntime runtime =
+    readIORef runtime.runtimeSyntaxHighlighter >>= \case
+        SyntaxHighlighterUnloaded _ ->
+            loadSyntaxHighlighterForRuntime runtime
+        SyntaxHighlighterActive{} -> pure ()
+        SyntaxHighlighterInactive _ -> pure ()
+
+publishSyntaxHighlighter
+    :: FullscreenRuntime
+    -> Word64
+    -> Maybe SyntaxHighlighter
+    -> IO Bool
+publishSyntaxHighlighter runtime generation highlighter =
+    atomicModifyIORef' runtime.runtimeSyntaxHighlighter \case
+        SyntaxHighlighterUnloaded current
+            | current == generation ->
+                (SyntaxHighlighterActive current highlighter, True)
+        SyntaxHighlighterActive current _
+            | current == generation ->
+                (SyntaxHighlighterActive current highlighter, True)
+        current ->
+            (current, False)
+
+syntaxHighlighterGeneration :: SyntaxHighlighterState -> Word64
+syntaxHighlighterGeneration = \case
+    SyntaxHighlighterUnloaded generation -> generation
+    SyntaxHighlighterActive generation _ -> generation
+    SyntaxHighlighterInactive generation -> generation
 
 nanosecondsToNominalDiffTime :: Word64 -> NominalDiffTime
 nanosecondsToNominalDiffTime nanoseconds =
@@ -2574,23 +2620,48 @@ advanceAppClockNow = do
 noteTerminalFocusLost :: EventM Name AppState ()
 noteTerminalFocusLost = do
     now <- liftIO getMonotonicTimeNSec
+    state <- get
+    liftIO $
+        atomicModifyIORef'
+            state.appRuntime.runtimeSyntaxHighlighter
+            \syntaxState ->
+                ( SyntaxHighlighterInactive
+                    (syntaxHighlighterGeneration syntaxState + 1)
+                , ()
+                )
+    liftIO $ atomically $ void $ flushTQueue
+        state.appRuntime.runtimeSyntaxRequests
     modify' \state ->
         state
             { appTerminalFocus = TerminalUnfocused
             , appFocusLostAt = Just now
             , appAutoRecapShownThisAway = False
             , appLastAutoRecapAttemptAt = Nothing
+            , appSyntaxHighlighter = Nothing
+            , appSyntaxRequested = Set.empty
             }
+    invalidateCache
 
 noteTerminalFocusGained :: EventM Name AppState ()
 noteTerminalFocusGained = do
     maybeRequestAutoRecap
+    state <- get
+    liftIO $
+        atomicModifyIORef'
+            state.appRuntime.runtimeSyntaxHighlighter
+            \case
+                SyntaxHighlighterInactive generation ->
+                    (SyntaxHighlighterUnloaded generation, ())
+                active ->
+                    (active, ())
     modify' \state ->
         state
             { appTerminalFocus = TerminalFocused
             , appFocusLostAt = Nothing
             , appMotionScheduleReset = True
+            , appSyntaxRequested = Set.empty
             }
+    requestVisibleSyntaxLanguages
     invalidateCache
     getVtyHandle >>= liftIO . V.refresh
 
@@ -2695,7 +2766,7 @@ eventMayExposeSyntax = \case
         uiEventMayExposeSyntax uiEvent
     AppEvent (AppUiBatch uiEvents) ->
         any uiEventMayExposeSyntax uiEvents
-    AppEvent (AppSyntaxHighlighterLoaded _) -> True
+    AppEvent AppSyntaxHighlighterChanged -> True
     AppEvent (AppHistoryReset _) -> True
     AppEvent (AppHistoryLoaded _ _) -> True
     AppEvent (AppHistoryCommitted _ _ _) -> True
@@ -2738,7 +2809,10 @@ requestVisibleSyntaxLanguages = do
             syntaxLanguagesForBlocks (visibleConversationBlocks state)
         missing =
             Set.difference languages state.appSyntaxRequested
-    unless (Set.null missing) do
+    when
+        ( state.appTerminalFocus /= TerminalUnfocused
+            && not (Set.null missing)
+        ) do
         liftIO $
             atomically $
                 mapM_
@@ -2933,13 +3007,21 @@ handleEventInner event = case event of
         vty <- getVtyHandle
         liftIO (writeOutputWindowTitle (V.outputIface vty) title)
         modify' \current -> current { appWindowTitle = Just title }
-    AppEvent (AppSyntaxHighlighterLoaded highlighter) ->
-        case highlighter of
-            Nothing -> pure ()
-            Just loaded -> do
-                modify' \current ->
-                    current { appSyntaxHighlighter = Just loaded }
-                invalidateCache
+    AppEvent AppSyntaxHighlighterChanged -> do
+        state <- get
+        when (state.appTerminalFocus /= TerminalUnfocused) do
+            highlighter <-
+                liftIO $
+                    readIORef state.appRuntime.runtimeSyntaxHighlighter
+            modify' \current ->
+                current
+                    { appSyntaxHighlighter =
+                        case highlighter of
+                            SyntaxHighlighterActive _ loaded -> loaded
+                            SyntaxHighlighterUnloaded _ -> Nothing
+                            SyntaxHighlighterInactive _ -> Nothing
+                    }
+            invalidateCache
     AppEvent (AppHistoryReset page) -> do
         modify' (resetHistoryPage page)
         invalidateCache

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -18,6 +18,7 @@ module Agent.CLI.TUI.Types
     , PendingAppEvent(..)
     , PendingUiEvent(..)
     , ResumeOverlay(..)
+    , SyntaxHighlighterState(..)
     , TerminalFocus(..)
     , TextInputMode(..)
     , TextOverlay(..)
@@ -143,7 +144,7 @@ data AppEvent
     | AppDictationFinished !(Either Text Text)
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
     | AppSetWindowTitle !Text
-    | AppSyntaxHighlighterLoaded !(Maybe SyntaxHighlighter)
+    | AppSyntaxHighlighterChanged
     | AppHistoryReset !HistoryPage
     | AppHistoryLoaded
         !HistoryRequest
@@ -176,6 +177,17 @@ data FullscreenInput = FullscreenInput
     , fullscreenInputQueued :: !Bool
     , fullscreenInputDisplay :: !(Maybe Text)
     }
+
+-- | Runtime ownership of the syntax grammar cache. Keeping the active bit and
+-- cache in one 'IORef' makes focus-loss eviction atomic with worker updates:
+-- an XML load which finishes late cannot restore a cache after the terminal
+-- has moved into the background.
+data SyntaxHighlighterState
+    = SyntaxHighlighterUnloaded !Word64
+      -- ^ Enabled, but the lightweight syntax index has not been loaded yet.
+    | SyntaxHighlighterActive !Word64 !(Maybe SyntaxHighlighter)
+      -- ^ Loading was attempted; 'Nothing' records a failed initializer.
+    | SyntaxHighlighterInactive !Word64
 
 newtype FullscreenInputBuffer =
     FullscreenInputBuffer (TVar (Seq FullscreenInput))
@@ -226,7 +238,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeSyntaxLoadFinished :: !(NominalDiffTime -> IO ())
     , runtimeSyntaxRequests :: !(TQueue Text)
     , runtimeSyntaxHighlighter
-        :: !(IORef (Maybe SyntaxHighlighter))
+        :: !(IORef SyntaxHighlighterState)
     , runtimeInitial :: !UiState
     , runtimeSessionActions :: !(IORef FullscreenSessionActions)
     , runtimeHistoryRequests :: !(TQueue HistoryRequest)

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -16,6 +16,7 @@ import Agent.CLI.TUI.Types
     , AppEventMailbox(..)
     , FullscreenRuntime(..)
     , PendingAppEvent(..)
+    , SyntaxHighlighterState(..)
     )
 import Agent.TUI.Model
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
@@ -264,6 +265,9 @@ hasPendingUnavailableSyntax :: FullscreenRuntime -> IO Bool
 hasPendingUnavailableSyntax runtime = do
     let AppEventMailbox pendingRef = runtime.runtimeMailbox
     pending <- readTVarIO pendingRef
-    pure case toList pending of
-        [PendingEvent (AppSyntaxHighlighterLoaded Nothing)] -> True
+    syntaxState <- readIORef runtime.runtimeSyntaxHighlighter
+    pure case (toList pending, syntaxState) of
+        ( [PendingEvent AppSyntaxHighlighterChanged]
+            , SyntaxHighlighterActive _ Nothing
+            ) -> True
         _ -> False

--- a/packages/agent-syntax/README.md
+++ b/packages/agent-syntax/README.md
@@ -7,9 +7,10 @@ Renderer-independent syntax highlighting for the universal agent harness.
 `syntax-loading-bench` retains the previous eager-loading path as a baseline
 and compares it with initialization plus on-demand grammar loading. Each sample
 loads from `AGENT_SYNTAX_DIR`, highlights a generated source block with every
-requested grammar to force the result, performs a major GC while the grammar
-cache remains live, and reports median wall time, CPU time, allocated bytes,
-and live bytes.
+requested grammar to force the result, and performs a major GC. The
+`on-demand-released` workload clears the runtime-style cache reference before
+that collection; the other workloads retain it as baselines. The benchmark
+reports median wall time, CPU time, allocated bytes, and live bytes.
 
 Build the optimized benchmark and run equivalent workloads with:
 
@@ -23,8 +24,10 @@ bin=$(cabal list-bin agent-syntax:bench:syntax-loading-bench)
 "$bin" on-demand none 50 7
 "$bin" eager haskell 50 7
 "$bin" on-demand haskell 50 7
+"$bin" on-demand-released haskell 50 7
 "$bin" eager haskell,javascript,python,typescript,json,xml,bash 500 7
 "$bin" on-demand haskell,javascript,python,typescript,json,xml,bash 500 7
+"$bin" on-demand-released haskell,javascript,python,typescript,json,xml,bash 500 7
 "$bin" eager haskell 5000 7
 "$bin" on-demand haskell 5000 7
 ```

--- a/packages/agent-syntax/benchmark/SyntaxLoading.hs
+++ b/packages/agent-syntax/benchmark/SyntaxLoading.hs
@@ -13,6 +13,7 @@ import Agent.Syntax
 -- safe-exceptions does not re-export it.
 import Control.Exception (evaluate)
 import Control.Monad (foldM, forM)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.List (sort)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -32,6 +33,7 @@ import Text.Printf (printf)
 data Workload
     = Eager
     | OnDemand
+    | OnDemandReleased
 
 data Sample = Sample
     { elapsedMillis :: !Double
@@ -77,7 +79,7 @@ main = do
             die $
                 "usage: syntax-loading-bench WORKLOAD LANGUAGES "
                     <> "SOURCE_LINES SAMPLES\n"
-                    <> "workloads: eager, on-demand\n"
+                    <> "workloads: eager, on-demand, on-demand-released\n"
                     <> "LANGUAGES is none or a comma-separated list\n"
                     <> "output: workload,language_count,source_lines,samples,"
                     <> "elapsed_ms,cpu_ms,allocated_bytes,live_bytes"
@@ -86,6 +88,7 @@ parseWorkload :: String -> IO Workload
 parseWorkload = \case
     "eager" -> pure Eager
     "on-demand" -> pure OnDemand
+    "on-demand-released" -> pure OnDemandReleased
     other -> die ("unknown workload: " <> other)
 
 parseLanguages :: String -> IO [Text]
@@ -106,18 +109,30 @@ parsePositive label raw =
 
 measure :: Workload -> FilePath -> [Text] -> Text -> IO Sample
 measure workload syntaxDirectory languages source = do
+    cache <- newIORef Nothing
     performGC
     beforeStats <- getRTSStats
     beforeCpu <- getCPUTime
     beforeElapsed <- getMonotonicTimeNSec
-    highlighter <- buildHighlighter workload syntaxDirectory languages
-    checksum <- evaluate (highlightChecksum highlighter languages source)
+    checksum <-
+        buildStoredHighlighter
+            cache
+            workload
+            syntaxDirectory
+            languages
+            source
+    case workload of
+        OnDemandReleased -> writeIORef cache Nothing
+        _ -> pure ()
     performGC
     afterStats <- getRTSStats
     afterElapsed <- getMonotonicTimeNSec
     afterCpu <- getCPUTime
-    -- Keep the loaded grammar cache live through the measured collection.
-    _ <- evaluate highlighter
+    -- Model the runtime IORef which owns the grammar cache. The released
+    -- workload clears that owner before collection, just as a hidden terminal
+    -- does; the other workloads keep their cache live as baselines.
+    retained <- readIORef cache
+    _ <- evaluate retained
     _ <- evaluate checksum
     pure
         Sample
@@ -131,6 +146,18 @@ measure workload syntaxDirectory languages source = do
             , liveBytes =
                 fromIntegral afterStats.gc.gcdetails_live_bytes
             }
+
+buildStoredHighlighter
+    :: IORef (Maybe SyntaxHighlighter)
+    -> Workload
+    -> FilePath
+    -> [Text]
+    -> Text
+    -> IO Int
+buildStoredHighlighter cache workload syntaxDirectory languages source = do
+    highlighter <- buildHighlighter workload syntaxDirectory languages
+    writeIORef cache (Just highlighter)
+    evaluate (highlightChecksum highlighter languages source)
 
 buildHighlighter
     :: Workload
@@ -151,6 +178,8 @@ buildHighlighter workload syntaxDirectory languages =
                         >>= requireHighlighter)
                 initial
                 languages
+        OnDemandReleased ->
+            buildHighlighter OnDemand syntaxDirectory languages
 
 requireHighlighter
     :: Either Text SyntaxHighlighter


### PR DESCRIPTION
## Summary

- evict loaded Skylighting grammar maps when the terminal reports `EvLostFocus`
- lazily rebuild only the syntax languages visible after `EvGainedFocus`
- guard asynchronous loader publication with cache generations so a load started before focus loss cannot restore an evicted cache
- drain stale language requests, invalidate Brick caches, and avoid retaining highlighter snapshots in queued app events
- extend the optimized syntax-loading benchmark with a released-cache workload

## Memory benchmark

Built with `-O2` and measured live heap after a major GC:

| Workload | Retained | Released |
| --- | ---: | ---: |
| Haskell, 50 lines | 968,336 B | 105,424 B |
| 7 grammars, 500 lines | 2,418,792 B | 111,720 B |

Commands:

```sh
nix develop -c cabal build --offline --enable-optimization=2 agent-syntax:bench:syntax-loading-bench
bin=$(nix develop -c cabal list-bin agent-syntax:bench:syntax-loading-bench)
"$bin" on-demand haskell 50 7
"$bin" on-demand-released haskell 50 7
"$bin" on-demand haskell,javascript,python,typescript,json,xml,bash 500 7
"$bin" on-demand-released haskell,javascript,python,typescript,json,xml,bash 500 7
```

The freed heap becomes reusable by the RTS; process RSS may not drop immediately.

## Validation

- loaded all 142 `agent-cli` library modules in GHCi after the final changes
- focused `TUIBridgeSpec` syntax-loader test passed
- optimized syntax benchmark built and ran across one- and seven-grammar workloads
- live fullscreen agent smoke-tested in tmux
- `git diff --check`
