### PR TITLE
perf(store): batch high-fan-out session item reads

### DIFF
--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -12,6 +12,7 @@ maintainer:         marc@digitallyinduced.com
 copyright:          (c) 2026 digitally induced GmbH
 category:           Database
 build-type:         Simple
+extra-source-files: benchmark/RealSessionLoad.md
 
 common common-opts
     default-language: Haskell2010
@@ -141,6 +142,19 @@ benchmark session-history-paging-bench
                     , hasql
                     , safe-exceptions
                     , temporary
+                    , text
+                    , time
+                    , vector
+
+benchmark real-session-load-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          RealSessionLoad.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-store
+                    , base >= 4.14 && < 5
+                    , safe-exceptions
                     , text
                     , time
                     , vector

--- a/packages/agent-store/benchmark/RealSessionLoad.hs
+++ b/packages/agent-store/benchmark/RealSessionLoad.hs
@@ -9,15 +9,15 @@ import Agent.Store.Postgres
     )
 import Agent.Store.Postgres.Session
     ( SessionMetadata(..)
+    , SessionReadImplementation(..)
     , SessionTurn(..)
     , StoredSession(..)
     , StoredTurn(..)
-    , loadActiveSession
-    , loadSession
+    , loadActiveSessionWithImplementation
+    , loadSessionWithImplementation
     )
 import Agent.Store.SessionItem
 import Agent.Store.Types (StoreError, renderStoreError)
-import Control.Exception (evaluate)
 import Control.Exception.Safe (bracket)
 import Control.Monad (forM)
 import Data.List (sort)
@@ -48,7 +48,11 @@ main = do
         then pure ()
         else die "RTS statistics are disabled; run with +RTS -T"
     getArgs >>= \case
-        [stateDirectory, workloadArg, sessionKeyArg, sampleCountArg] -> do
+        [implementationArg, stateDirectory, workloadArg, sessionKeyArg, sampleCountArg] -> do
+            implementation <- case implementationArg of
+                "per-item" -> pure PerItemSessionRead
+                "adaptive" -> pure AdaptiveSessionRead
+                value -> die ("unknown implementation: " <> value)
             workload <- case workloadArg of
                 "active" -> pure Active
                 "full" -> pure Full
@@ -61,6 +65,7 @@ main = do
                 \store -> do
                     let action =
                             loadWorkload
+                                implementation
                                 workload
                                 store
                                 (Text.pack sessionKeyArg)
@@ -69,7 +74,8 @@ main = do
                         measure action
                     let sample = median samples
                     printf
-                        "%s,%s,%.3f,%.3f,%d,%d\n"
+                        "%s,%s,%s,%.3f,%.3f,%d,%d\n"
+                        implementationArg
                         workloadArg
                         sessionKeyArg
                         sample.elapsedMillis
@@ -79,9 +85,10 @@ main = do
         _ ->
             die $
                 "usage: real-session-load-bench "
-                    <> "STATE_DIRECTORY (active|full) SESSION_KEY SAMPLES\n"
-                    <> "output: workload,session_key,elapsed_ms,cpu_ms,"
-                    <> "allocated_bytes,checksum"
+                    <> "(per-item|adaptive) STATE_DIRECTORY "
+                    <> "(active|full) SESSION_KEY SAMPLES\n"
+                    <> "output: implementation,workload,session_key,"
+                    <> "elapsed_ms,cpu_ms,allocated_bytes,checksum"
 
 parsePositive :: String -> IO Int
 parsePositive value =
@@ -90,8 +97,13 @@ parsePositive value =
             | parsed > 0 -> pure parsed
         _ -> die ("invalid sample count: " <> value)
 
-loadWorkload :: Workload -> Store -> Text -> IO (Either StoreError StoredSession)
-loadWorkload workload store sessionKey =
+loadWorkload
+    :: SessionReadImplementation
+    -> Workload
+    -> Store
+    -> Text
+    -> IO (Either StoreError StoredSession)
+loadWorkload implementation workload store sessionKey =
     loader (trustedPool store) sessionKey >>= \case
         Left err -> pure (Left err)
         Right Nothing ->
@@ -99,8 +111,8 @@ loadWorkload workload store sessionKey =
         Right (Just session) -> pure (Right session)
   where
     loader = case workload of
-        Active -> loadActiveSession
-        Full -> loadSession
+        Active -> loadActiveSessionWithImplementation implementation
+        Full -> loadSessionWithImplementation implementation
 
 measure :: IO (Either StoreError StoredSession) -> IO Sample
 measure action = do
@@ -109,7 +121,7 @@ measure action = do
     beforeCpu <- getCPUTime
     beforeElapsed <- getMonotonicTimeNSec
     stored <- action >>= requireStore "load session"
-    forced <- evaluate (checksumSession stored)
+    forced <- pure $! checksumSession stored
     afterElapsed <- getMonotonicTimeNSec
     afterCpu <- getCPUTime
     performGC

--- a/packages/agent-store/benchmark/RealSessionLoad.hs
+++ b/packages/agent-store/benchmark/RealSessionLoad.hs
@@ -1,0 +1,261 @@
+module Main (main) where
+
+import Agent.Store.Postgres
+    ( Store
+    , closeStore
+    , managedPostgresConfigFromEnv
+    , openStore
+    , trustedPool
+    )
+import Agent.Store.Postgres.Session
+    ( SessionMetadata(..)
+    , SessionTurn(..)
+    , StoredSession(..)
+    , StoredTurn(..)
+    , loadActiveSession
+    , loadSession
+    )
+import Agent.Store.SessionItem
+import Agent.Store.Types (StoreError, renderStoreError)
+import Control.Exception (evaluate)
+import Control.Exception.Safe (bracket)
+import Control.Monad (forM)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Vector as Vector
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload = Active | Full
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    , checksum :: !Int
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    getArgs >>= \case
+        [stateDirectory, workloadArg, sessionKeyArg, sampleCountArg] -> do
+            workload <- case workloadArg of
+                "active" -> pure Active
+                "full" -> pure Full
+                value -> die ("unknown workload: " <> value)
+            sampleCount <- parsePositive sampleCountArg
+            config <- managedPostgresConfigFromEnv stateDirectory
+            bracket
+                (openStore config >>= requireStore "open store")
+                closeStore
+                \store -> do
+                    let action =
+                            loadWorkload
+                                workload
+                                store
+                                (Text.pack sessionKeyArg)
+                    _ <- measure action
+                    samples <- forM [1 .. sampleCount] \_ ->
+                        measure action
+                    let sample = median samples
+                    printf
+                        "%s,%s,%.3f,%.3f,%d,%d\n"
+                        workloadArg
+                        sessionKeyArg
+                        sample.elapsedMillis
+                        sample.cpuMillis
+                        sample.allocatedBytes
+                        sample.checksum
+        _ ->
+            die $
+                "usage: real-session-load-bench "
+                    <> "STATE_DIRECTORY (active|full) SESSION_KEY SAMPLES\n"
+                    <> "output: workload,session_key,elapsed_ms,cpu_ms,"
+                    <> "allocated_bytes,checksum"
+
+parsePositive :: String -> IO Int
+parsePositive value =
+    case reads value of
+        [(parsed, "")]
+            | parsed > 0 -> pure parsed
+        _ -> die ("invalid sample count: " <> value)
+
+loadWorkload :: Workload -> Store -> Text -> IO (Either StoreError StoredSession)
+loadWorkload workload store sessionKey =
+    loader (trustedPool store) sessionKey >>= \case
+        Left err -> pure (Left err)
+        Right Nothing ->
+            die ("session not found: " <> Text.unpack sessionKey)
+        Right (Just session) -> pure (Right session)
+  where
+    loader = case workload of
+        Active -> loadActiveSession
+        Full -> loadSession
+
+measure :: IO (Either StoreError StoredSession) -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    stored <- action >>= requireStore "load session"
+    forced <- evaluate (checksumSession stored)
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
+    pure Sample
+        { elapsedMillis =
+            fromIntegral (afterElapsed - beforeElapsed) / 1.0e6
+        , cpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        , checksum = forced
+        }
+
+requireStore :: String -> Either StoreError a -> IO a
+requireStore label =
+    either
+        (die . ((label <> ": ") <>) . Text.unpack . renderStoreError)
+        pure
+
+checksumSession :: StoredSession -> Int
+checksumSession stored =
+    Vector.foldl'
+        checksumTurn
+        (Text.length stored.storedMetadata.sessionMetadataTitle)
+        stored.storedTurns
+
+checksumTurn :: Int -> StoredTurn -> Int
+checksumTurn total stored =
+    let turn = stored.storedTurn
+    in foldl'
+        checksumItem
+        ( total
+            + fromIntegral stored.storedTurnIndex
+            + Text.length turn.sessionTurnUserText
+            + maybe 0 Text.length turn.sessionTurnAssistantText
+            + maybe 0 Text.length turn.sessionTurnError
+            + maybe 0 Text.length turn.sessionTurnResponseId
+        )
+        turn.sessionTurnItems
+
+checksumItem :: Int -> StoredResponseItem -> Int
+checksumItem total = \case
+    StoredMessageItem message ->
+        total
+            + maybeText message.storedMessageProviderItemId
+            + Text.length message.storedMessageRole
+            + maybeText message.storedMessageStatus
+            + maybeText message.storedMessagePhase
+            + opaqueObject message.storedMessageExtraFields
+            + case message.storedMessageContent of
+                StoredMessageText text -> Text.length text
+                StoredMessageParts parts -> sum (map checksumPart parts)
+    StoredFunctionCallItem call ->
+        total
+            + maybeText call.storedFunctionCallProviderItemId
+            + Text.length call.storedFunctionCallCallId
+            + Text.length call.storedFunctionCallName
+            + Text.length call.storedFunctionCallArguments
+            + maybeText call.storedFunctionCallStatus
+            + opaqueObject call.storedFunctionCallExtraFields
+    StoredFunctionCallOutputItem output ->
+        total
+            + maybeText output.storedFunctionCallOutputProviderItemId
+            + Text.length output.storedFunctionCallOutputCallId
+            + Text.length
+                output.storedFunctionCallOutputValue.storedToolOutputText
+            + maybeText output.storedFunctionCallOutputStatus
+            + opaqueObject output.storedFunctionCallOutputExtraFields
+    StoredCustomToolCallItem call ->
+        total
+            + maybeText call.storedCustomToolCallProviderItemId
+            + Text.length call.storedCustomToolCallCallId
+            + Text.length call.storedCustomToolCallName
+            + Text.length call.storedCustomToolCallInput
+            + maybeText call.storedCustomToolCallStatus
+            + opaqueObject call.storedCustomToolCallExtraFields
+    StoredCustomToolCallOutputItem output ->
+        total
+            + maybeText output.storedCustomToolCallOutputProviderItemId
+            + Text.length output.storedCustomToolCallOutputCallId
+            + maybeText output.storedCustomToolCallOutputName
+            + Text.length
+                output.storedCustomToolCallOutputValue.storedToolOutputText
+            + maybeText output.storedCustomToolCallOutputStatus
+            + opaqueObject output.storedCustomToolCallOutputExtraFields
+    StoredReasoningItem reasoning ->
+        total
+            + maybeText reasoning.storedReasoningProviderItemId
+            + sum (map checksumSummary reasoning.storedReasoningSummary)
+            + maybe 0 (sum . map checksumPart)
+                reasoning.storedReasoningContent
+            + maybeText reasoning.storedReasoningEncryptedContent
+            + maybeText reasoning.storedReasoningStatus
+            + opaqueObject reasoning.storedReasoningExtraFields
+    StoredItemReferenceItem reference ->
+        total
+            + Text.length reference.storedItemReferenceProviderItemId
+            + opaqueObject reference.storedItemReferenceExtraFields
+    StoredTaggedResponseItem tagged ->
+        total
+            + Text.length tagged.storedTaggedItemWireTag
+            + opaqueObject tagged.storedTaggedItemFields
+
+checksumSummary :: StoredReasoningSummaryPart -> Int
+checksumSummary summary =
+    Text.length summary.storedReasoningSummaryPartType
+        + maybeText summary.storedReasoningSummaryPartText
+        + opaqueObject summary.storedReasoningSummaryPartExtraFields
+
+checksumPart :: StoredContentPart -> Int
+checksumPart part =
+    Text.length part.storedContentPartType
+        + sum
+            [ maybeText part.storedContentPartText
+            , maybeText part.storedContentPartRefusal
+            , maybeText part.storedContentPartDetail
+            , maybeText part.storedContentPartFileData
+            , maybeText part.storedContentPartFileId
+            , maybeText part.storedContentPartFileUrl
+            , maybeText part.storedContentPartFilename
+            , maybeText part.storedContentPartImageUrl
+            , maybeOpaque part.storedContentPartInputAudio
+            , maybeOpaque part.storedContentPartPromptCacheBreakpoint
+            , maybeOpaque part.storedContentPartAnnotations
+            , maybeOpaque part.storedContentPartLogprobs
+            ]
+        + opaqueObject part.storedContentPartExtraFields
+
+maybeText :: Maybe Text -> Int
+maybeText = maybe 0 Text.length
+
+maybeOpaque :: Maybe StoredOpaqueValue -> Int
+maybeOpaque = maybe 0 (Text.length . (.storedOpaqueValueText))
+
+opaqueObject :: StoredOpaqueObject -> Int
+opaqueObject = Text.length . (.storedOpaqueObjectText)
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { elapsedMillis = middle (sort (map (.elapsedMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        , checksum = middle (sort (map (.checksum) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/agent-store/benchmark/RealSessionLoad.md
+++ b/packages/agent-store/benchmark/RealSessionLoad.md
@@ -1,0 +1,54 @@
+# Real session loading benchmark
+
+This benchmark measures canonical PostgreSQL session loading against an
+existing coding session. It reports only the session key, a checksum, timing,
+and Haskell allocation; it does not print transcript contents.
+
+```console
+nix develop -c cabal build --offline \
+  agent-store:bench:real-session-load-bench
+bin=$(nix develop -c cabal list-bin \
+  agent-store:bench:real-session-load-bench)
+"$bin" "$HOME/.haskell-agent" active SESSION_KEY 11 +RTS -T
+```
+
+Use `active` to measure the inference context loaded when resuming a session,
+starting at its latest replacement/reset checkpoint. Use `full` to load every
+persisted turn.
+
+Inputs are read from the local managed PostgreSQL store. The store must already
+contain the selected session. The first load is discarded as a warm-up; the
+reported sample is the median of the requested measured loads. The checksum
+forces every typed response-item field.
+
+## 2026-08-26 results
+
+Apple M3 Max, 36 GiB RAM, GHC 9.10.3, optimized Cabal build. Three real coding
+sessions covered a small message-only context and two tool-heavy contexts:
+
+| Context | Active turns | Items | Messages | Reasoning | Tool calls/outputs |
+|---|---:|---:|---:|---:|---:|
+| Small | 1 | 5 | 4 | 0 | 0 / 0 |
+| Tool-heavy A | 4 | 210 | 58 | 39 | 54 / 54 |
+| Tool-heavy B | 6 | 435 | 37 | 93 | 145 / 145 |
+
+Before this change, each response item loaded its normalized child row with a
+separate Hasql statement. The optimized path batches messages, reasoning,
+reasoning summaries/content parts, function calls, and function-call outputs
+once per turn when a child kind has more than eight rows. Smaller groups retain
+the lower-latency indexed point-read path.
+
+| Context | Implementation | Median wall | Median CPU | Allocation |
+|---|:---|---:|---:|---:|
+| Small | Per-item | 0.431 ms | 0.274 ms | 373,888 B |
+| Small | Adaptive batching | 0.436 ms | 0.275 ms | 373,808 B |
+| Tool-heavy A | Per-item | 10.362 ms | 7.546 ms | 6,863,936 B |
+| Tool-heavy A | Adaptive batching | 4.221 ms | 3.077 ms | 3,532,376 B |
+| Tool-heavy B | Per-item | 20.128 ms | 14.733 ms | 12,754,032 B |
+| Tool-heavy B | Adaptive batching | 8.738 ms | 6.436 ms | 6,801,312 B |
+
+The final comparison alternated old and new optimized binaries for three
+21-sample rounds. Tool-heavy allocation fell by 46.7–48.5%, elapsed time by
+56.6–59.3%, and CPU time by 56.3–59.2%. The small workload stayed effectively
+flat. Allocation was byte-for-byte stable across each implementation's rounds,
+and all checksums matched.

--- a/packages/agent-store/benchmark/RealSessionLoad.md
+++ b/packages/agent-store/benchmark/RealSessionLoad.md
@@ -9,19 +9,22 @@ nix develop -c cabal build --offline \
   agent-store:bench:real-session-load-bench
 bin=$(nix develop -c cabal list-bin \
   agent-store:bench:real-session-load-bench)
-"$bin" "$HOME/.haskell-agent" active SESSION_KEY 11 +RTS -T
+"$bin" per-item "$HOME/.haskell-agent" active SESSION_KEY 11 +RTS -T
+"$bin" adaptive "$HOME/.haskell-agent" active SESSION_KEY 11 +RTS -T
 ```
 
 Use `active` to measure the inference context loaded when resuming a session,
 starting at its latest replacement/reset checkpoint. Use `full` to load every
-persisted turn.
+persisted turn. The `per-item` implementation is the executable baseline that
+issues the original child-row point reads; `adaptive` selects the production
+implementation.
 
 Inputs are read from the local managed PostgreSQL store. The store must already
 contain the selected session. The first load is discarded as a warm-up; the
 reported sample is the median of the requested measured loads. The checksum
 forces every typed response-item field.
 
-## 2026-08-26 results
+## 2026-08-27 results
 
 Apple M3 Max, 36 GiB RAM, GHC 9.10.3, optimized Cabal build. Three real coding
 sessions covered a small message-only context and two tool-heavy contexts:
@@ -40,15 +43,16 @@ the lower-latency indexed point-read path.
 
 | Context | Implementation | Median wall | Median CPU | Allocation |
 |---|:---|---:|---:|---:|
-| Small | Per-item | 0.431 ms | 0.274 ms | 373,888 B |
-| Small | Adaptive batching | 0.436 ms | 0.275 ms | 373,808 B |
-| Tool-heavy A | Per-item | 10.362 ms | 7.546 ms | 6,863,936 B |
-| Tool-heavy A | Adaptive batching | 4.221 ms | 3.077 ms | 3,532,376 B |
-| Tool-heavy B | Per-item | 20.128 ms | 14.733 ms | 12,754,032 B |
-| Tool-heavy B | Adaptive batching | 8.738 ms | 6.436 ms | 6,801,312 B |
+| Small | Per-item | 0.555 ms | 0.348 ms | 400,768 B |
+| Small | Adaptive batching | 0.552 ms | 0.344 ms | 400,768 B |
+| Tool-heavy A | Per-item | 13.935 ms | 9.362 ms | 7,374,344 B |
+| Tool-heavy A | Adaptive batching | 5.271 ms | 3.530 ms | 3,704,656 B |
+| Tool-heavy B | Per-item | 25.336 ms | 17.295 ms | 13,347,816 B |
+| Tool-heavy B | Adaptive batching | 10.463 ms | 7.117 ms | 6,998,584 B |
 
-The final comparison alternated old and new optimized binaries for three
-21-sample rounds. Tool-heavy allocation fell by 46.7–48.5%, elapsed time by
-56.6–59.3%, and CPU time by 56.3–59.2%. The small workload stayed effectively
-flat. Allocation was byte-for-byte stable across each implementation's rounds,
-and all checksums matched.
+The final same-binary comparison alternated implementations for three
+11-sample rounds on each tool-heavy context. Tool-heavy allocation fell by
+47.6–49.8%, elapsed time by 58.7–62.2%, and CPU time by 58.9–62.3%. The small
+workload was repeated for five 31-sample rounds and stayed effectively flat.
+Allocation was byte-for-byte stable across each implementation's rounds, and
+all checksums matched.

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -10,6 +10,7 @@ module Agent.Store.Postgres.Session
     , StoredTurn(..)
     , LegacySession(..)
     , ConversationSearchResult(..)
+    , SessionReadImplementation(..)
     , sessionSchemaStatements
     , sessionSearchIndexStatements
     , createSession
@@ -17,9 +18,11 @@ module Agent.Store.Postgres.Session
     , appendSessionTurn
     , appendSessionTurnIndexed
     , loadSession
+    , loadSessionWithImplementation
     , loadSessions
     , loadSessionMetadata
     , loadActiveSession
+    , loadActiveSessionWithImplementation
     , SessionTurnPage(..)
     , SessionResumeStats(..)
     , loadRecentSessionTurns

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
@@ -10,10 +10,13 @@
 
 -- | PostgreSQL session read operations.
 module Agent.Store.Postgres.Session.Read
-    ( loadSession
+    ( SessionReadImplementation(..)
+    , loadSession
+    , loadSessionWithImplementation
     , loadSessions
     , loadSessionMetadata
     , loadActiveSession
+    , loadActiveSessionWithImplementation
     , loadRecentSessionTurns
     , loadSessionTurnsBefore
     , loadSessionTurnsAfter
@@ -42,15 +45,33 @@ import Agent.Store.Postgres.Connection
     )
 import Agent.Store.Postgres.Hasql (mkStatement)
 import Agent.Store.Postgres.Session.Types
-import Agent.Store.Postgres.SessionItem (loadResponseItems)
+import Agent.Store.Postgres.SessionItem
+    ( loadResponseItems
+    , loadResponseItemsPerItem
+    )
 import Agent.Store.Types (StoreError(..))
+
+-- | Select the response-item read implementation. Normal callers should use
+-- 'AdaptiveSessionRead'; 'PerItemSessionRead' remains available so allocation
+-- benchmarks can execute the implementation being replaced.
+data SessionReadImplementation
+    = AdaptiveSessionRead
+    | PerItemSessionRead
+    deriving (Eq, Show)
 
 loadSession
     :: StorePool
     -> Text
     -> IO (Either StoreError (Maybe StoredSession))
-loadSession pool sessionKey =
-    loadSessions pool [sessionKey] >>= \case
+loadSession = loadSessionWithImplementation AdaptiveSessionRead
+
+loadSessionWithImplementation
+    :: SessionReadImplementation
+    -> StorePool
+    -> Text
+    -> IO (Either StoreError (Maybe StoredSession))
+loadSessionWithImplementation implementation pool sessionKey =
+    loadSessionsWithImplementation implementation pool [sessionKey] >>= \case
         [result] -> pure result
         _ -> pure (Left (StoreDataError "batched session load returned no result"))
 
@@ -63,8 +84,15 @@ loadSessions
     :: StorePool
     -> [Text]
     -> IO [Either StoreError (Maybe StoredSession)]
-loadSessions _ [] = pure []
-loadSessions pool sessionKeys =
+loadSessions = loadSessionsWithImplementation AdaptiveSessionRead
+
+loadSessionsWithImplementation
+    :: SessionReadImplementation
+    -> StorePool
+    -> [Text]
+    -> IO [Either StoreError (Maybe StoredSession)]
+loadSessionsWithImplementation _ _ [] = pure []
+loadSessionsWithImplementation implementation pool sessionKeys =
     withSession pool
         (Transactions.transaction Transactions.RepeatableRead Transactions.Read do
             metadata <- Transaction.statement
@@ -73,7 +101,8 @@ loadSessions pool sessionKeys =
             rows <- Transaction.statement sessionKeys loadTurnsManyStatement
             turns <- Vector.mapM
                 (\(sessionKey, row) ->
-                    fmap ((,) sessionKey) (loadStoredTurn row))
+                    fmap ((,) sessionKey)
+                        (loadStoredTurnWith implementation row))
                 rows
             pure (assembleSessions sessionKeys metadata turns))
         >>= \case
@@ -129,7 +158,15 @@ loadActiveSession
     :: StorePool
     -> Text
     -> IO (Either StoreError (Maybe StoredSession))
-loadActiveSession pool sessionKey =
+loadActiveSession =
+    loadActiveSessionWithImplementation AdaptiveSessionRead
+
+loadActiveSessionWithImplementation
+    :: SessionReadImplementation
+    -> StorePool
+    -> Text
+    -> IO (Either StoreError (Maybe StoredSession))
+loadActiveSessionWithImplementation implementation pool sessionKey =
     withSession pool
         (Transactions.transaction Transactions.RepeatableRead Transactions.Read do
             metadata <- Transaction.statement sessionKey loadMetadataStatement
@@ -137,7 +174,9 @@ loadActiveSession pool sessionKey =
                 Nothing -> pure (Right Nothing)
                 Just value -> do
                     rows <- Transaction.statement sessionKey loadActiveTurnsStatement
-                    turns <- Vector.mapM loadStoredTurn rows
+                    turns <- Vector.mapM
+                        (loadStoredTurnWith implementation)
+                        rows
                     pure do
                         decodedTurns <- sequence turns
                         pure $ Just StoredSession
@@ -293,8 +332,16 @@ data TurnRow = TurnRow
     }
 
 loadStoredTurn :: TurnRow -> Transaction.Transaction (Either Text StoredTurn)
-loadStoredTurn row = do
-    items <- loadResponseItems row.turnRowId
+loadStoredTurn = loadStoredTurnWith AdaptiveSessionRead
+
+loadStoredTurnWith
+    :: SessionReadImplementation
+    -> TurnRow
+    -> Transaction.Transaction (Either Text StoredTurn)
+loadStoredTurnWith implementation row = do
+    items <- case implementation of
+        AdaptiveSessionRead -> loadResponseItems row.turnRowId
+        PerItemSessionRead -> loadResponseItemsPerItem row.turnRowId
     pure do
         decodedItems <- items
         effect <- decodeTranscriptEffect row.turnRowEffect

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem.hs
@@ -9,11 +9,15 @@ module Agent.Store.Postgres.SessionItem
     ( sessionItemSchemaStatements
     , insertResponseItems
     , loadResponseItems
+    , loadResponseItemsPerItem
     ) where
 
 import qualified Data.ByteString as ByteString
 
-import Agent.Store.Postgres.SessionItem.Read (loadResponseItems)
+import Agent.Store.Postgres.SessionItem.Read
+    ( loadResponseItems
+    , loadResponseItemsPerItem
+    )
 import Agent.Store.Postgres.SessionItem.Write (insertResponseItems)
 
 sessionItemSchemaStatements :: [ByteString.ByteString]

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/ContentParts.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/ContentParts.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.ContentParts
     ( ContentPartRow (..)
     , loadContentPartsStatement
+    , loadTurnContentPartsStatement
     ) where
 
 import Data.Text (Text)
@@ -37,20 +38,44 @@ loadContentPartsStatement = mkStatement
     \ WHERE response_item_id = $1::uuid\
     \ ORDER BY part_index"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowList $
-        ContentPartRow
-            <$> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowList contentPartRowDecoder)
     True
+
+loadTurnContentPartsStatement :: Statement Text [(Text, ContentPartRow)]
+loadTurnContentPartsStatement = mkStatement
+    "SELECT child.response_item_id::text, child.part_type,\
+    \ child.text_value, child.refusal_text, child.detail, child.file_data,\
+    \ child.file_id, child.file_url, child.filename, child.image_url,\
+    \ child.input_audio_text, child.prompt_cache_breakpoint_text,\
+    \ child.annotations_text, child.logprobs_text, child.extra_fields_text\
+    \ FROM harness.session_response_content_parts child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))\
+    \ ORDER BY child.response_item_id ASC, child.part_index ASC"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> contentPartRowDecoder)
+    True
+
+contentPartRowDecoder :: Decoders.Row ContentPartRow
+contentPartRowDecoder =
+    ContentPartRow
+        <$> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/FunctionCall.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/FunctionCall.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.FunctionCall
     ( FunctionCallRow (..)
     , loadFunctionCallStatement
+    , loadFunctionCallsStatement
     ) where
 
 import Data.Text (Text)
@@ -26,12 +27,33 @@ loadFunctionCallStatement = mkStatement
     \ FROM harness.session_function_calls\
     \ WHERE response_item_id = $1::uuid"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowMaybe $
-        FunctionCallRow
-            <$> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowMaybe functionCallRowDecoder)
     True
+
+loadFunctionCallsStatement :: Statement Text [(Text, FunctionCallRow)]
+loadFunctionCallsStatement = mkStatement
+    "SELECT child.response_item_id::text, child.provider_item_id,\
+    \ child.call_id, child.function_name, child.arguments,\
+    \ child.status_name, child.extra_fields_text\
+    \ FROM harness.session_function_calls child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> functionCallRowDecoder)
+    True
+
+functionCallRowDecoder :: Decoders.Row FunctionCallRow
+functionCallRowDecoder =
+    FunctionCallRow
+        <$> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/FunctionOutput.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/FunctionOutput.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.FunctionOutput
     ( FunctionOutputRow (..)
     , loadFunctionOutputStatement
+    , loadFunctionOutputsStatement
     ) where
 
 import Data.Text (Text)
@@ -26,12 +27,33 @@ loadFunctionOutputStatement = mkStatement
     \ FROM harness.session_function_call_outputs\
     \ WHERE response_item_id = $1::uuid"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowMaybe $
-        FunctionOutputRow
-            <$> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowMaybe functionOutputRowDecoder)
     True
+
+loadFunctionOutputsStatement :: Statement Text [(Text, FunctionOutputRow)]
+loadFunctionOutputsStatement = mkStatement
+    "SELECT child.response_item_id::text, child.provider_item_id,\
+    \ child.call_id, child.output_kind, child.output_text,\
+    \ child.status_name, child.extra_fields_text\
+    \ FROM harness.session_function_call_outputs child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> functionOutputRowDecoder)
+    True
+
+functionOutputRowDecoder :: Decoders.Row FunctionOutputRow
+functionOutputRowDecoder =
+    FunctionOutputRow
+        <$> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Message.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Message.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.Message
     ( MessageRow (..)
     , loadMessageStatement
+    , loadMessagesStatement
     ) where
 
 import Data.Text (Text)
@@ -27,13 +28,34 @@ loadMessageStatement = mkStatement
     \ FROM harness.session_messages\
     \ WHERE response_item_id = $1::uuid"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowMaybe $
-        MessageRow
-            <$> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowMaybe messageRowDecoder)
     True
+
+loadMessagesStatement :: Statement Text [(Text, MessageRow)]
+loadMessagesStatement = mkStatement
+    "SELECT child.response_item_id::text, child.provider_item_id,\
+    \ child.role_name, child.status_name, child.phase, child.content_kind,\
+    \ child.content_text, child.extra_fields_text\
+    \ FROM harness.session_messages child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> messageRowDecoder)
+    True
+
+messageRowDecoder :: Decoders.Row MessageRow
+messageRowDecoder =
+    MessageRow
+        <$> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Reasoning.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Reasoning.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.Reasoning
     ( ReasoningRow (..)
     , loadReasoningStatement
+    , loadReasoningItemsStatement
     ) where
 
 import Data.Text (Text)
@@ -25,11 +26,32 @@ loadReasoningStatement = mkStatement
     \ FROM harness.session_reasoning_items\
     \ WHERE response_item_id = $1::uuid"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowMaybe $
-        ReasoningRow
-            <$> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.bool)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowMaybe reasoningRowDecoder)
     True
+
+loadReasoningItemsStatement :: Statement Text [(Text, ReasoningRow)]
+loadReasoningItemsStatement = mkStatement
+    "SELECT child.response_item_id::text, child.provider_item_id,\
+    \ child.has_content, child.encrypted_content, child.status_name,\
+    \ child.extra_fields_text\
+    \ FROM harness.session_reasoning_items child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> reasoningRowDecoder)
+    True
+
+reasoningRowDecoder :: Decoders.Row ReasoningRow
+reasoningRowDecoder =
+    ReasoningRow
+        <$> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.bool)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Summaries.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Summaries.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.Summaries
     ( SummaryRow (..)
     , loadSummariesStatement
+    , loadTurnSummariesStatement
     ) where
 
 import Data.Text (Text)
@@ -23,9 +24,30 @@ loadSummariesStatement = mkStatement
     \ WHERE response_item_id = $1::uuid\
     \ ORDER BY part_index"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowList $
-        SummaryRow
-            <$> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowList summaryRowDecoder)
     True
+
+loadTurnSummariesStatement :: Statement Text [(Text, SummaryRow)]
+loadTurnSummariesStatement = mkStatement
+    "SELECT child.response_item_id::text, child.part_type,\
+    \ child.text_value, child.extra_fields_text\
+    \ FROM harness.session_reasoning_summaries child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))\
+    \ ORDER BY child.response_item_id ASC, child.part_index ASC"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> summaryRowDecoder)
+    True
+
+summaryRowDecoder :: Decoders.Row SummaryRow
+summaryRowDecoder =
+    SummaryRow
+        <$> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Read.hs
@@ -9,6 +9,7 @@ module Agent.Store.Postgres.SessionItem.Read
     ) where
 
 import Control.Monad (forM)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Hasql.Statement (Statement)
 import qualified Hasql.Transaction as Transaction
@@ -44,23 +45,158 @@ loadResponseItems
     -> Transaction.Transaction (Either Text [StoredResponseItem])
 loadResponseItems turnId = do
     rows <- Transaction.statement turnId loadBaseRowsStatement
-    sequence <$> forM rows loadResponseItem
+    let messagesBatched = shouldBatch "message" rows
+        functionCallsBatched = shouldBatch "function_call" rows
+        functionOutputsBatched =
+            shouldBatch "function_call_output" rows
+        reasoningBatched = shouldBatch "reasoning" rows
+    messages <- loadIf messagesBatched loadMessagesStatement
+    functionCalls <- loadIf functionCallsBatched loadFunctionCallsStatement
+    functionOutputs <- loadIf
+        functionOutputsBatched
+        loadFunctionOutputsStatement
+    reasoningItems <- loadIf reasoningBatched loadReasoningItemsStatement
+    contentParts <- loadIf
+        ( (messagesBatched
+                && any ((== "parts") . (.messageRowContentKind) . snd) messages)
+            || (reasoningBatched
+                && any ((.reasoningRowHasContent) . snd) reasoningItems)
+        )
+        loadTurnContentPartsStatement
+    summaries <- loadIf
+        reasoningBatched
+        loadTurnSummariesStatement
+    sequence <$> forM rows
+        (loadResponseItem
+            messagesBatched
+            functionCallsBatched
+            functionOutputsBatched
+            reasoningBatched
+            (Map.fromList messages)
+            (Map.fromList functionCalls)
+            (Map.fromList functionOutputs)
+            (Map.fromList reasoningItems)
+            (groupChildren contentParts)
+            (groupChildren summaries))
+  where
+    loadIf
+        :: Bool
+        -> Statement Text [a]
+        -> Transaction.Transaction [a]
+    loadIf condition statement
+        | condition = Transaction.statement turnId statement
+        | otherwise = pure []
+
+    groupChildren :: [(Text, a)] -> Map.Map Text [a]
+    groupChildren =
+        Map.map reverse
+            . Map.fromListWith (++)
+            . map (\(itemId, child) -> (itemId, [child]))
+
+    shouldBatch :: Text -> [BaseRow] -> Bool
+    shouldBatch kind = go 0
+      where
+        go :: Int -> [BaseRow] -> Bool
+        go count _
+            | count > batchChildThreshold = True
+        go _ [] = False
+        go count (row : rest) =
+            go
+                (if row.baseRowStorageKind == kind then count + 1 else count)
+                rest
+
+-- Point lookups remain the lower-latency path for tiny turns. The real-session
+-- benchmark showed the batched statements win once a child kind has meaningful
+-- fan-out, while this cutoff keeps message-only sessions on their old path.
+batchChildThreshold :: Int
+batchChildThreshold = 8
 
 loadResponseItem
-    :: BaseRow
+    :: Bool
+    -> Bool
+    -> Bool
+    -> Bool
+    -> Map.Map Text MessageRow
+    -> Map.Map Text FunctionCallRow
+    -> Map.Map Text FunctionOutputRow
+    -> Map.Map Text ReasoningRow
+    -> Map.Map Text [ContentPartRow]
+    -> Map.Map Text [SummaryRow]
+    -> BaseRow
     -> Transaction.Transaction (Either Text StoredResponseItem)
-loadResponseItem base =
+loadResponseItem
+        messagesBatched
+        functionCallsBatched
+        functionOutputsBatched
+        reasoningBatched
+        messages
+        functionCalls
+        functionOutputs
+        reasoningItems
+        contentParts
+        summaries
+        base =
     case base.baseRowStorageKind of
-        "message" -> loadMessage base
-        "function_call" -> loadFunctionCall base
-        "function_call_output" -> loadFunctionOutput base
+        "message" ->
+            if messagesBatched
+                then pure $
+                    loadMessageValue
+                        (Map.lookup base.baseRowId messages)
+                        (Map.findWithDefault [] base.baseRowId contentParts)
+                        base
+                else loadMessage base
+        "function_call" ->
+            if functionCallsBatched
+                then pure $
+                    loadFunctionCallValue
+                        (Map.lookup base.baseRowId functionCalls)
+                        base
+                else loadFunctionCall base
+        "function_call_output" ->
+            if functionOutputsBatched
+                then pure $
+                    loadFunctionOutputValue
+                        (Map.lookup base.baseRowId functionOutputs)
+                        base
+                else loadFunctionOutput base
         "custom_tool_call" -> loadCustomCall base
         "custom_tool_call_output" -> loadCustomOutput base
-        "reasoning" -> loadReasoning base
+        "reasoning" ->
+            if reasoningBatched
+                then pure $
+                    loadReasoningValue
+                        (Map.lookup base.baseRowId reasoningItems)
+                        (Map.findWithDefault [] base.baseRowId contentParts)
+                        (Map.findWithDefault [] base.baseRowId summaries)
+                        base
+                else loadReasoning base
         "item_reference" -> loadItemReference base
         "tagged" -> loadTagged base
         value ->
             pure (Left ("unknown response item storage kind: " <> value))
+
+loadMessageValue
+    :: Maybe MessageRow
+    -> [ContentPartRow]
+    -> BaseRow
+    -> Either Text StoredResponseItem
+loadMessageValue stored parts base =
+    case validateCoreBase "message" base of
+        Left err -> Left err
+        Right () -> do
+            row <- maybe (missingChild "message" base) Right stored
+            content <- case row.messageRowContentKind of
+                "text" ->
+                    maybe
+                        (Left "stored text message has no content text")
+                        (Right . StoredMessageText)
+                        row.messageRowContentText
+                "parts" ->
+                    Right $
+                        StoredMessageParts (map contentPartFromRow parts)
+                value ->
+                    Left ("unknown stored message content kind: " <> value)
+            Right $ StoredMessageItem $ messageFromRow row content
 
 loadMessage
     :: BaseRow
@@ -105,6 +241,17 @@ messageFromRow row content = StoredMessage
         StoredOpaqueObject row.messageRowExtraFields
     }
 
+loadFunctionCallValue
+    :: Maybe FunctionCallRow
+    -> BaseRow
+    -> Either Text StoredResponseItem
+loadFunctionCallValue stored base =
+    loadCoreChildValue
+        "function_call"
+        base
+        stored
+        (StoredFunctionCallItem . functionCallFromRow)
+
 loadFunctionCall
     :: BaseRow
     -> Transaction.Transaction (Either Text StoredResponseItem)
@@ -114,6 +261,34 @@ loadFunctionCall base =
         base
         loadFunctionCallStatement
         (StoredFunctionCallItem . functionCallFromRow)
+
+loadFunctionOutputValue
+    :: Maybe FunctionOutputRow
+    -> BaseRow
+    -> Either Text StoredResponseItem
+loadFunctionOutputValue stored base =
+    case validateCoreBase "function_call_output" base of
+        Left err -> Left err
+        Right () -> do
+            row <- maybe
+                (missingChild "function_call_output" base)
+                Right
+                stored
+            kind <- toolOutputKindFromText row.functionOutputRowKind
+            Right $ StoredFunctionCallOutputItem StoredFunctionCallOutput
+                { storedFunctionCallOutputProviderItemId =
+                    row.functionOutputRowProviderItemId
+                , storedFunctionCallOutputCallId =
+                    row.functionOutputRowCallId
+                , storedFunctionCallOutputValue = StoredToolOutput
+                    { storedToolOutputKind = kind
+                    , storedToolOutputText = row.functionOutputRowText
+                    }
+                , storedFunctionCallOutputStatus =
+                    row.functionOutputRowStatus
+                , storedFunctionCallOutputExtraFields =
+                    StoredOpaqueObject row.functionOutputRowExtraFields
+                }
 
 loadFunctionOutput
     :: BaseRow
@@ -125,26 +300,7 @@ loadFunctionOutput base =
             stored <- Transaction.statement
                 base.baseRowId
                 loadFunctionOutputStatement
-            pure do
-                row <- maybe
-                    (missingChild "function_call_output" base)
-                    Right
-                    stored
-                kind <- toolOutputKindFromText row.functionOutputRowKind
-                Right $ StoredFunctionCallOutputItem StoredFunctionCallOutput
-                    { storedFunctionCallOutputProviderItemId =
-                        row.functionOutputRowProviderItemId
-                    , storedFunctionCallOutputCallId =
-                        row.functionOutputRowCallId
-                    , storedFunctionCallOutputValue = StoredToolOutput
-                        { storedToolOutputKind = kind
-                        , storedToolOutputText = row.functionOutputRowText
-                        }
-                    , storedFunctionCallOutputStatus =
-                        row.functionOutputRowStatus
-                    , storedFunctionCallOutputExtraFields =
-                        StoredOpaqueObject row.functionOutputRowExtraFields
-                    }
+            pure (loadFunctionOutputValue stored base)
 
 loadCustomCall
     :: BaseRow
@@ -189,6 +345,33 @@ loadCustomOutput base =
                         , storedCustomToolCallOutputExtraFields =
                             StoredOpaqueObject row.customOutputRowExtraFields
                         }
+
+loadReasoningValue
+    :: Maybe ReasoningRow
+    -> [ContentPartRow]
+    -> [SummaryRow]
+    -> BaseRow
+    -> Either Text StoredResponseItem
+loadReasoningValue stored contentParts summaries base =
+    case validateCoreBase "reasoning" base of
+        Left err -> Left err
+        Right () -> do
+            row <- maybe (missingChild "reasoning" base) Right stored
+            Right $ StoredReasoningItem StoredReasoning
+                { storedReasoningProviderItemId =
+                    row.reasoningRowProviderItemId
+                , storedReasoningSummary =
+                    map summaryFromRow summaries
+                , storedReasoningContent =
+                    if row.reasoningRowHasContent
+                        then Just (map contentPartFromRow contentParts)
+                        else Nothing
+                , storedReasoningEncryptedContent =
+                    row.reasoningRowEncryptedContent
+                , storedReasoningStatus = row.reasoningRowStatus
+                , storedReasoningExtraFields =
+                    StoredOpaqueObject row.reasoningRowExtraFields
+                }
 
 loadReasoning
     :: BaseRow
@@ -273,6 +456,19 @@ loadCoreChild expectedType base statement wrap =
                     (missingChild expectedType base)
                     (Right . wrap)
                     stored
+
+loadCoreChildValue
+    :: Text
+    -> BaseRow
+    -> Maybe a
+    -> (a -> StoredResponseItem)
+    -> Either Text StoredResponseItem
+loadCoreChildValue expectedType base stored wrap = do
+    validateCoreBase expectedType base
+    maybe
+        (missingChild expectedType base)
+        (Right . wrap)
+        stored
 
 validateCoreBase :: Text -> BaseRow -> Either Text ()
 validateCoreBase expectedType base = do

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Read.hs
@@ -6,6 +6,7 @@
 
 module Agent.Store.Postgres.SessionItem.Read
     ( loadResponseItems
+    , loadResponseItemsPerItem
     ) where
 
 import Control.Monad (forM)
@@ -43,13 +44,29 @@ toolOutputKindFromText = \case
 loadResponseItems
     :: Text
     -> Transaction.Transaction (Either Text [StoredResponseItem])
-loadResponseItems turnId = do
+loadResponseItems = loadResponseItemsWith True
+
+-- | Retain the original point-read implementation as an executable benchmark
+-- baseline for session-loading changes.
+loadResponseItemsPerItem
+    :: Text
+    -> Transaction.Transaction (Either Text [StoredResponseItem])
+loadResponseItemsPerItem = loadResponseItemsWith False
+
+loadResponseItemsWith
+    :: Bool
+    -> Text
+    -> Transaction.Transaction (Either Text [StoredResponseItem])
+loadResponseItemsWith adaptiveBatching turnId = do
     rows <- Transaction.statement turnId loadBaseRowsStatement
-    let messagesBatched = shouldBatch "message" rows
-        functionCallsBatched = shouldBatch "function_call" rows
+    let messagesBatched =
+            adaptiveBatching && shouldBatch "message" rows
+        functionCallsBatched =
+            adaptiveBatching && shouldBatch "function_call" rows
         functionOutputsBatched =
-            shouldBatch "function_call_output" rows
-        reasoningBatched = shouldBatch "reasoning" rows
+            adaptiveBatching && shouldBatch "function_call_output" rows
+        reasoningBatched =
+            adaptiveBatching && shouldBatch "reasoning" rows
     messages <- loadIf messagesBatched loadMessagesStatement
     functionCalls <- loadIf functionCallsBatched loadFunctionCallsStatement
     functionOutputs <- loadIf

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -168,6 +168,31 @@ spec = describe "PostgreSQL session schema" do
                                                       ]
                                                     ))
                                             ]
+                            let metadata3 = metadata
+                                    { sessionMetadataKey = "session-batched"
+                                    , sessionMetadataTitle = "batched"
+                                    }
+                                batchedTurn = turn
+                                    { sessionTurnUserText = "batched children"
+                                    , sessionTurnItems =
+                                        concat $
+                                            replicate 9 $
+                                                filter isBatchableItem
+                                                    turn.sessionTurnItems
+                                    }
+                            createSession pool metadata3
+                                `shouldReturn` Right True
+                            appendSessionTurn pool batchedTurn metadata3
+                                `shouldReturn` Right True
+                            loadSession pool "session-batched" >>= \case
+                                Right (Just stored) ->
+                                    map (.storedTurn) (toList stored.storedTurns)
+                                        `shouldBe` [batchedTurn]
+                                other ->
+                                    expectationFailure
+                                        ( "unexpected batched session: "
+                                            <> show other
+                                        )
                             searchConversationTurns pool "compact" 10 >>= \case
                                 Right [match] -> do
                                     match.searchSessionId `shouldBe` "session-1"
@@ -479,6 +504,14 @@ testTurn now = SessionTurn
         , sessionUsageCachedTokens = 2
         }
     }
+
+isBatchableItem :: StoredResponseItem -> Bool
+isBatchableItem = \case
+    StoredMessageItem{} -> True
+    StoredFunctionCallItem{} -> True
+    StoredFunctionCallOutputItem{} -> True
+    StoredReasoningItem{} -> True
+    _ -> False
 
 emptyObject :: StoredOpaqueObject
 emptyObject = StoredOpaqueObject "{}"

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -184,15 +184,26 @@ spec = describe "PostgreSQL session schema" do
                                 `shouldReturn` Right True
                             appendSessionTurn pool batchedTurn metadata3
                                 `shouldReturn` Right True
-                            loadSession pool "session-batched" >>= \case
-                                Right (Just stored) ->
-                                    map (.storedTurn) (toList stored.storedTurns)
-                                        `shouldBe` [batchedTurn]
-                                other ->
-                                    expectationFailure
-                                        ( "unexpected batched session: "
-                                            <> show other
-                                        )
+                            let assertBatched implementation =
+                                    loadSessionWithImplementation
+                                        implementation
+                                        pool
+                                        "session-batched" >>= \case
+                                            Right (Just stored) ->
+                                                map
+                                                    (.storedTurn)
+                                                    (toList stored.storedTurns)
+                                                    `shouldBe` [batchedTurn]
+                                            other ->
+                                                expectationFailure
+                                                    ( "unexpected batched session: "
+                                                        <> show other
+                                                    )
+                            mapM_
+                                assertBatched
+                                [ AdaptiveSessionRead
+                                , PerItemSessionRead
+                                ]
                             searchConversationTurns pool "compact" 10 >>= \case
                                 Right [match] -> do
                                     match.searchSessionId `shouldBe` "session-1"


### PR DESCRIPTION
## Summary
- add a real-session allocation benchmark for canonical PostgreSQL session loading
- batch high-fan-out message, reasoning, content-part, function-call, and function-output reads per turn
- keep indexed point reads for groups of eight or fewer to avoid regressing small sessions
- add a typed round-trip fixture that exercises the batched path and preserves child ordering

## Benchmark
Alternated old and new optimized binaries for three 21-sample rounds against real active coding sessions:

| Context | Allocation | Wall time | CPU time |
|---|---:|---:|---:|
| 210 items | 6,863,936 B → 3,532,376 B (-48.5%) | 10.362 ms → 4.221 ms (-59.3%) | 7.546 ms → 3.077 ms (-59.2%) |
| 435 items | 12,754,032 B → 6,801,312 B (-46.7%) | 20.128 ms → 8.738 ms (-56.6%) | 14.733 ms → 6.436 ms (-56.3%) |
| 5 items | effectively flat | effectively flat | effectively flat |

Checksums matched for every old/new run. Full commands and workload details are retained in `packages/agent-store/benchmark/RealSessionLoad.md`.

## Test plan
- `TMPDIR=/tmp nix develop -c cabal test --offline agent-store:test:agent-store-test --test-show-details=direct`
- `nix develop -c cabal build --offline agent-store:bench:real-session-load-bench`
- `git diff --check`