### PR TITLE
perf(responses): decode SSE JSON directly from bytes

### DIFF
--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -12,6 +12,7 @@ copyright:          (c) 2026 digitally induced GmbH
 category:           Web
 build-type:         Simple
 extra-source-files: README.md
+                  , benchmark/JsonDecoding.md
 
 common common-opts
     default-language: Haskell2010
@@ -92,4 +93,17 @@ test-suite agent-responses-test
                     , hspec
                     , QuickCheck >= 2.14 && < 2.16
                     , retry
+                    , text
+
+benchmark responses-json-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          JsonDecoding.hs
+    ghc-options:      -O2 -rtsopts
+    build-depends:    aeson >= 2.0
+                    , agent-responses
+                    , agent-responses-types
+                    , base >= 4.14 && < 5
+                    , bytestring
                     , text

--- a/packages/agent-responses/benchmark/JsonDecoding.hs
+++ b/packages/agent-responses/benchmark/JsonDecoding.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Main (main) where
+
+import qualified Agent.Responses.Codec as Codec
+import Agent.Responses.Types
+import Control.Exception (evaluate)
+import Control.Monad (forM)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.List (sortOn)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = Utf8RoundTrip
+    | DirectBytes
+    | CodingUtf8RoundTrip
+    | CodingDirectBytes
+
+data Sample = Sample
+    { wallMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled then pure () else die "run with +RTS -T"
+    getArgs >>= \case
+        [workloadArg, eventCountArg, deltaBytesArg, samplesArg] -> do
+            workload <- parseWorkload workloadArg
+            eventCount <- positive "event count" eventCountArg
+            deltaBytes <- positive "delta bytes" deltaBytesArg
+            sampleCount <- positive "sample count" samplesArg
+            let payloads =
+                    [ makePayload workload index deltaBytes
+                    | index <- [1 .. eventCount]
+                    ]
+            _ <- evaluate (sum (map BS.length payloads))
+            samples <- forM [1 .. sampleCount] \_ ->
+                measure (runWorkload workload payloads)
+            let middle = sortOn (.wallMillis) samples
+                    !! (length samples `div` 2)
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d\n"
+                workloadArg eventCount deltaBytes sampleCount
+                middle.wallMillis middle.cpuMillis middle.allocatedBytes
+        _ -> die $
+            "usage: responses-json-bench WORKLOAD EVENTS DELTA_BYTES SAMPLES\n"
+                <> "workloads: utf8-round-trip, direct-bytes, "
+                <> "coding-utf8-round-trip, coding-direct-bytes"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "utf8-round-trip" -> pure Utf8RoundTrip
+    "direct-bytes" -> pure DirectBytes
+    "coding-utf8-round-trip" -> pure CodingUtf8RoundTrip
+    "coding-direct-bytes" -> pure CodingDirectBytes
+    other -> die ("unknown workload: " <> other)
+
+positive :: String -> String -> IO Int
+positive label raw = case reads raw of
+    [(value, "")] | value > 0 -> pure value
+    _ -> die ("invalid " <> label <> ": " <> raw)
+
+runWorkload :: Workload -> [BS.ByteString] -> IO Int
+runWorkload workload = go checksumSeed
+  where
+    go !checksum [] = pure checksum
+    go !checksum (payload : rest) = do
+        event <- evaluate $ decodePayload $ case workload of
+            Utf8RoundTrip ->
+                TextEncoding.encodeUtf8 (TextEncoding.decodeUtf8 payload)
+            DirectBytes -> payload
+            CodingUtf8RoundTrip ->
+                TextEncoding.encodeUtf8 (TextEncoding.decodeUtf8 payload)
+            CodingDirectBytes -> payload
+        let checksum' =
+                Text.foldl'
+                    (\current character ->
+                        current * 33 + fromEnum character)
+                    (checksum
+                        + maybe 0 id
+                            (responseStreamEventSequenceNumber event)
+                        + eventDeltaLength event)
+                    (streamEventTypeText (responseStreamEventType event))
+        checksum' `seq` go checksum' rest
+
+decodePayload :: BS.ByteString -> ResponseStreamEvent
+decodePayload payload =
+    case Aeson.eitherDecodeStrict' payload of
+        Left err -> error err
+        Right value ->
+            case Codec.decodeResponseStreamEventValue value of
+                Aeson.Error err -> error err
+                Aeson.Success event -> event
+
+eventDeltaLength :: ResponseStreamEvent -> Int
+eventDeltaLength = \case
+    ResponseFunctionCallArgumentsDeltaEvent { delta } ->
+        maybe 0 Text.length delta
+    ResponseCustomToolInputDeltaEvent { delta } ->
+        maybe 0 Text.length delta
+    OtherResponseStreamEvent { eventExtraFields } ->
+        case KeyMap.lookup "delta" eventExtraFields of
+            Just (Aeson.String delta) -> Text.length delta
+            _ -> 0
+    _ -> 0
+
+makePayload :: Workload -> Int -> Int -> BS.ByteString
+makePayload workload sequenceNumber deltaBytes =
+    case workload of
+        Utf8RoundTrip -> makeTextDelta sequenceNumber deltaBytes
+        DirectBytes -> makeTextDelta sequenceNumber deltaBytes
+        CodingUtf8RoundTrip -> makeCodingDelta sequenceNumber deltaBytes
+        CodingDirectBytes -> makeCodingDelta sequenceNumber deltaBytes
+
+makeTextDelta :: Int -> Int -> BS.ByteString
+makeTextDelta sequenceNumber deltaBytes =
+    BS.concat
+        [ "{\"type\":\"response.output_text.delta\""
+        , ",\"sequence_number\":", BS8.pack (show sequenceNumber)
+        , ",\"item_id\":\"msg-", BS8.pack (show sequenceNumber)
+        , "\",\"output_index\":0,\"content_index\":0,\"delta\":\""
+        , BS.replicate deltaBytes 120
+        , "\"}"
+        ]
+
+-- A coding turn is mostly reasoning and assistant text, interspersed with
+-- function-call arguments and custom tool input such as apply_patch.
+makeCodingDelta :: Int -> Int -> BS.ByteString
+makeCodingDelta sequenceNumber deltaBytes =
+    BS.concat
+        [ "{\"type\":\"", eventType, "\""
+        , ",\"sequence_number\":", number
+        , identityFields
+        , ",\"delta\":\"", BS.replicate deltaBytes 120
+        , "\"}"
+        ]
+  where
+    number = BS8.pack (show sequenceNumber)
+    (eventType, identityFields) =
+        case sequenceNumber `mod` 10 of
+            value
+                | value < 5 ->
+                    ( "response.reasoning_summary_text.delta"
+                    , ",\"item_id\":\"rs-1\",\"summary_index\":0"
+                    )
+                | value < 8 ->
+                    ( "response.output_text.delta"
+                    , ",\"item_id\":\"msg-1\",\"output_index\":0,\
+                      \\"content_index\":0"
+                    )
+                | value < 9 ->
+                    ( "response.function_call_arguments.delta"
+                    , ",\"item_id\":\"fc-1\",\"output_index\":1"
+                    )
+                | otherwise ->
+                    ( "response.custom_tool_call_input.delta"
+                    , ",\"item_id\":\"ctc-1\",\"call_id\":\"call-1\",\
+                      \\"output_index\":1"
+                    )
+
+checksumSeed :: Int
+checksumSeed = 5381
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCPU <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    result <- action
+    _ <- evaluate result
+    afterWall <- getMonotonicTimeNSec
+    afterCPU <- getCPUTime
+    afterStats <- getRTSStats
+    pure Sample
+        { wallMillis = fromIntegral (afterWall - beforeWall) / 1.0e6
+        , cpuMillis = fromIntegral (afterCPU - beforeCPU) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        }

--- a/packages/agent-responses/benchmark/JsonDecoding.md
+++ b/packages/agent-responses/benchmark/JsonDecoding.md
@@ -1,0 +1,61 @@
+# Responses JSON decoding benchmark
+
+This benchmark measures the UTF-8 round trip removed from the Responses SSE
+decoder. Inputs are constructed outside the measured interval, vary by sequence
+number to prevent sharing, and decoded results are checksummed.
+
+```console
+nix develop -c cabal build agent-responses:bench:responses-json-bench
+bin=$(nix develop -c cabal list-bin agent-responses:bench:responses-json-bench)
+"$bin" utf8-round-trip 100000 16 9 +RTS -T
+"$bin" direct-bytes 100000 16 9 +RTS -T
+"$bin" coding-utf8-round-trip 100000 16 9 +RTS -T
+"$bin" coding-direct-bytes 100000 16 9 +RTS -T
+```
+
+The workloads decode the same canonical `ResponseStreamEvent`. The baseline
+models the old `ByteString -> Text -> ByteString` path; `direct-bytes` models
+the new path after the SSE block has already been UTF-8 validated.
+The `coding-*` workloads replay the event mix in a normal coding turn: 50%
+reasoning-summary deltas, 30% assistant-text deltas, 10% function-call
+argument deltas, and 10% custom-tool input such as `apply_patch`.
+
+## 2026-08-26 results
+
+Apple M3 Max, 36 GiB RAM, GHC 9.10.3, `-O2`:
+
+| Events | Delta | Workload | Median wall | Haskell allocation |
+|---:|---:|:---|---:|---:|
+| 100,000 | 16 B | UTF-8 round trip | 92.801 ms | 692,842,944 B |
+| 100,000 | 16 B | Direct bytes | 90.164 ms | 646,174,224 B |
+| 20,000 | 1,024 B | UTF-8 round trip | 44.647 ms | 196,555,528 B |
+| 20,000 | 1,024 B | Direct bytes | 41.946 ms | 147,915,832 B |
+| 500 | 65,536 B | UTF-8 round trip | 41.038 ms | 99,793,008 B |
+| 500 | 65,536 B | Direct bytes | 39.171 ms | 32,204,752 B |
+
+Direct byte decoding is 3–6% faster here. Its allocation reduction grows from
+7% for tiny deltas to 68% for 64 KiB deltas.
+
+## Mixed coding-turn results
+
+Apple M3 Max, 36 GiB RAM, GHC 9.10.3, `-O2`, 2026-08-27:
+
+| Events | Delta | Workload | Median wall | Median CPU | Haskell allocation |
+|---:|---:|:---|---:|---:|---:|
+| 100,000 | 16 B | UTF-8 round trip | 101.383 ms | 101.202 ms | 674,449,896 B |
+| 100,000 | 16 B | Direct bytes | 97.889 ms | 97.795 ms | 627,408,664 B |
+| 20,000 | 1,024 B | UTF-8 round trip | 45.908 ms | 45.949 ms | 191,375,808 B |
+| 20,000 | 1,024 B | Direct bytes | 42.790 ms | 42.803 ms | 142,534,096 B |
+| 500 | 65,536 B | UTF-8 round trip | 39.944 ms | 39.941 ms | 99,713,024 B |
+| 500 | 65,536 B | Direct bytes | 38.497 ms | 38.526 ms | 32,167,264 B |
+
+For the mixed coding stream, direct decoding reduces allocation by 7.0% for
+token-sized events, 25.5% for 1 KiB tool-argument chunks, and 67.7% for large
+events. It is 3.4–6.8% faster.
+
+Hermes 0.8.0.0 was also evaluated with a reusable environment and a
+semantics-preserving hybrid decoder. On a representative mixed SSE stream it
+regressed from 3.712 ms / 25,599,736 Haskell-allocated bytes with Aeson to
+6.305 ms / 34,441,224 bytes. At the larger workload it regressed from
+21.174 ms / 136,385,344 bytes to 53.469 ms / 172,133,160 bytes. The runtime
+Hermes integration was therefore rejected rather than shipped.

--- a/packages/agent-responses/package.nix
+++ b/packages/agent-responses/package.nix
@@ -16,6 +16,9 @@ mkDerivation {
     aeson agent-core agent-responses-types base bytestring containers
     hspec QuickCheck retry text
   ];
+  benchmarkHaskellDepends = [
+    aeson agent-responses-types base bytestring text
+  ];
   description = "Provider-neutral Responses codecs and adapters";
   license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
 }

--- a/packages/agent-responses/src/Agent/Responses/SSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/SSE.hs
@@ -12,6 +12,7 @@ import qualified Agent.Responses.Codec as ResponsesCodec
 import Agent.Responses.Types (ResponseStreamEvent)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -139,35 +140,40 @@ parseBlockBytes bytes = case Text.decodeUtf8' bytes of
     Left err -> Left $ JsonDecodeError
         ("Invalid UTF-8 in Responses SSE event: " <> Text.pack (show err))
         (Text.take 2000 (Text.decodeUtf8With Text.lenientDecode bytes))
-    Right block -> parseBlock (Text.replace "\r\n" "\n" block)
+    Right _ -> parseBlock bytes
 
-parseBlock :: Text -> Either ApiError (Maybe ResponseStreamEvent)
+parseBlock :: BS.ByteString -> Either ApiError (Maybe ResponseStreamEvent)
 parseBlock block
-    | Text.null dataText = Right Nothing
-    | Text.strip dataText == "[DONE]" = Right Nothing
-    | otherwise = decodeEvent eventType dataText
+    | BS.null dataBytes = Right Nothing
+    | isDonePayload dataBytes = Right Nothing
+    | otherwise = decodeEvent eventType dataBytes
   where
-    blockLines = Text.lines block
+    blockLines = map dropTrailingCarriageReturn (BS8.lines block)
     eventType = Maybe.listToMaybe
-        [ Text.strip (Text.drop 6 line)
+        [ Text.strip (Text.decodeUtf8 (BS.drop 6 line))
         | line <- blockLines
-        , "event:" `Text.isPrefixOf` line
+        , "event:" `BS.isPrefixOf` line
         ]
-    dataText = Text.intercalate "\n"
-        [ stripOptionalSpace (Text.drop 5 line)
+    dataBytes = BS.intercalate "\n"
+        [ stripOptionalSpace (BS.drop 5 line)
         | line <- blockLines
-        , "data:" `Text.isPrefixOf` line
+        , "data:" `BS.isPrefixOf` line
         ]
 
-    stripOptionalSpace line = Maybe.fromMaybe line (Text.stripPrefix " " line)
+    stripOptionalSpace line = Maybe.fromMaybe line (BS.stripPrefix " " line)
+
+isDonePayload :: BS.ByteString -> Bool
+isDonePayload bytes =
+    "[DONE]" `BS.isInfixOf` bytes
+        && Text.strip (Text.decodeUtf8 bytes) == "[DONE]"
 
 -- A malformed JSON payload should not tear down an otherwise healthy stream.
 -- Codex skips such frames (notably partial/unparseable output_item events)
 -- and continues decoding subsequent events. Framing/UTF-8 failures remain
 -- hard errors because there is no safe way to recover their boundaries.
-decodeEvent :: Maybe Text -> Text -> Either ApiError (Maybe ResponseStreamEvent)
-decodeEvent eventType dataText =
-    case Aeson.eitherDecodeStrict' (Text.encodeUtf8 dataText) of
+decodeEvent :: Maybe Text -> BS.ByteString -> Either ApiError (Maybe ResponseStreamEvent)
+decodeEvent eventType dataBytes =
+    case Aeson.eitherDecodeStrict' dataBytes of
         Left _ -> Right Nothing
         Right value ->
             let decoded = case eventType of

--- a/packages/agent-responses/test/Agent/Responses/SSESpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/SSESpec.hs
@@ -61,6 +61,11 @@ spec = describe "Responses SSE decoder" do
                 <> "data: " <> completedJson <> "\n\n"
         eventTypes events `shouldBe` [EventResponseCompleted]
 
+    it "accepts Unicode whitespace around the done sentinel" do
+        events <- expectRight $ parseSseEvents $
+            "data: \x2003[DONE]\x2003\n\n" <> completedBlock
+        eventTypes events `shouldBe` [EventResponseCompleted]
+
     it "skips malformed event payloads while preserving unknown events" do
         events <- expectRight $ parseSseEvents $ Text.intercalate ""
             [ sseBlock "response.output_item.done"


### PR DESCRIPTION
## Summary
- remove the `ByteString -> Text -> ByteString` round trip from every Responses SSE JSON frame
- preserve strict UTF-8 validation and existing malformed-frame behavior
- keep CRLF, multiline data, comments, and Unicode-whitespace `[DONE]` semantics covered
- add an `-O2` allocation benchmark with both isolated text deltas and a mixed normal coding stream

## Mixed coding-loop benchmark
The retained mixed workload is 50% reasoning-summary deltas, 30% assistant-text deltas, 10% function-call argument deltas, and 10% custom-tool input such as `apply_patch`.

| Events | Delta | Allocation before → after | Wall time before → after |
|---:|---:|---:|---:|
| 100,000 | 16 B | 674,449,896 B → 627,408,664 B (-7.0%) | 101.383 ms → 97.889 ms (-3.4%) |
| 20,000 | 1 KiB | 191,375,808 B → 142,534,096 B (-25.5%) | 45.908 ms → 42.790 ms (-6.8%) |
| 500 | 64 KiB | 99,713,024 B → 32,167,264 B (-67.7%) | 39.944 ms → 38.497 ms (-3.6%) |

The representative 100,000 × 16 B case was repeated for three 11-sample rounds; allocation reduction stayed at 7.0%, with direct-byte decoding faster in every round.

## Test plan
- `nix develop -c cabal test --offline agent-responses:test:agent-responses-test --test-show-details=direct`
- `nix develop -c cabal build --offline agent-responses:bench:responses-json-bench`
- mixed benchmark matrix documented in `packages/agent-responses/benchmark/JsonDecoding.md`
- `git diff --check`