### PR TITLE
Add direct no-DOM JSON codec foundation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,6 +18,11 @@ packages:
     packages/claude-agent-sdk-haskell
     packages/agent-claude
 
+source-repository-package
+    type: git
+    location: https://github.com/mpscholten/hermes.git
+    tag: f70adba535051516b51b1aff8147bc77bac4f335
+
 tests: True
 multi-repl: True
 

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,8 @@ packages:
     packages/agent-core
     packages/agent-codex-dialect
     packages/agent-grok-build-dialect
+    packages/agent-json-codec
+    packages/agent-json-hermes
     packages/agent-syntax
     packages/agent-tui
     packages/agent-responses-types

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,30 @@
                     ];
                 };
 
+                agentJsonHermesSource = nix-filter.lib {
+                    root = ./packages/agent-json-hermes;
+                    include = [
+                        "src"
+                        "test"
+                        "benchmark"
+                        "agent-json-hermes.cabal"
+                        "LICENSE"
+                        "README.md"
+                    ];
+                };
+
+                agentJsonCodecSource = nix-filter.lib {
+                    root = ./packages/agent-json-codec;
+                    include = [
+                        "src"
+                        "test"
+                        "benchmark"
+                        "agent-json-codec.cabal"
+                        "LICENSE"
+                        "README.md"
+                    ];
+                };
+
                 agentProcessSource = nix-filter.lib {
                     root = ./packages/agent-process;
                     include = [
@@ -332,6 +356,22 @@
                                 {
                                     src = agentGrokBuildDialectSource;
                                 });
+                        agent-json-codec = localPackage (
+                            pkgs.haskell.lib.overrideSrc
+                                (final.callPackage
+                                    ./packages/agent-json-codec/package.nix
+                                    { })
+                                {
+                                    src = agentJsonCodecSource;
+                                });
+                        agent-json-hermes = localPackage (
+                            pkgs.haskell.lib.overrideSrc
+                                (final.callPackage
+                                    ./packages/agent-json-hermes/package.nix
+                                    { })
+                                {
+                                    src = agentJsonHermesSource;
+                                });
                         agent-responses = localPackage (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-responses/package.nix { }) {
                             src = agentResponsesSource;
                         });
@@ -392,6 +432,8 @@
                 agentProcessPackage = productionHaskellPackages.agent-process;
                 agentCodexDialectPackage = productionHaskellPackages.agent-codex-dialect;
                 agentGrokBuildDialectPackage = productionHaskellPackages.agent-grok-build-dialect;
+                agentJsonCodecPackage = productionHaskellPackages.agent-json-codec;
+                agentJsonHermesPackage = productionHaskellPackages.agent-json-hermes;
                 agentSyntaxPackage = productionHaskellPackages.agent-syntax;
                 agentResponsesTypesPackage = productionHaskellPackages.agent-responses-types;
                 agentResponsesPackage = productionHaskellPackages.agent-responses;
@@ -572,6 +614,8 @@
                 packages.agent-process = agentProcessPackage;
                 packages.agent-codex-dialect = agentCodexDialectPackage;
                 packages.agent-grok-build-dialect = agentGrokBuildDialectPackage;
+                packages.agent-json-codec = agentJsonCodecPackage;
+                packages.agent-json-hermes = agentJsonHermesPackage;
                 packages.agent-syntax = agentSyntaxPackage;
                 packages.agent-tui = agentTuiPackage;
                 packages.agent-store = agentStorePackage;
@@ -606,6 +650,8 @@
                         packages.agent-process
                         packages.agent-codex-dialect
                         packages.agent-grok-build-dialect
+                        packages.agent-json-codec
+                        packages.agent-json-hermes
                         packages.agent-syntax
                         packages.agent-tui
                         packages.agent-responses-types
@@ -647,6 +693,8 @@
                     agent-process = haskellPackages.agent-process;
                     agent-codex-dialect = haskellPackages.agent-codex-dialect;
                     agent-grok-build-dialect = haskellPackages.agent-grok-build-dialect;
+                    agent-json-codec = haskellPackages.agent-json-codec;
+                    agent-json-hermes = haskellPackages.agent-json-hermes;
                     agent-syntax = haskellPackages.agent-syntax;
                     agent-tui = haskellPackages.agent-tui;
                     agent-responses-types = haskellPackages.agent-responses-types;

--- a/flake.nix
+++ b/flake.nix
@@ -259,6 +259,16 @@
                                         (pkgs.haskell.lib.disableSharedLibraries
                                             (pkgs.haskell.lib.disableLibraryProfiling package)));
                     in {
+                        hermes-json =
+                            pkgs.haskell.lib.overrideSrc previous.hermes-json {
+                                src = pkgs.fetchFromGitHub {
+                                    owner = "mpscholten";
+                                    repo = "hermes";
+                                    rev = "f70adba535051516b51b1aff8147bc77bac4f335";
+                                    hash = "sha256-BZEIcQrQTYE7Vf3FVq1EOaeH/dLnFvU+INZZNNQSMcw=";
+                                    fetchSubmodules = true;
+                                };
+                            };
                         pqi = pkgs.haskell.lib.dontCheck
                             (final.callHackageDirect {
                                 pkg = "pqi";

--- a/packages/agent-json-codec/LICENSE
+++ b/packages/agent-json-codec/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2026, digitally induced GmbH
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of the author nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/agent-json-codec/README.md
+++ b/packages/agent-json-codec/README.md
@@ -1,0 +1,29 @@
+# agent-json-codec
+
+Direct JSON codecs for the agent harness.
+
+The public API intentionally has no generic JSON value or object type. Encoders
+write domain values directly to bytes, while decoders consume JSON bytes
+directly into domain values. Unknown forward-compatible fields can be retained
+as opaque, validated `RawJson` values.
+
+```haskell
+encode :: Encoder a -> a -> ByteString
+decode :: Decoder a -> ByteString -> Either DecodeError a
+```
+
+`Encoder` is an abstract exact-size write program backed by Jsonifier. Its
+internal write plan is a size-and-poke program, not a semantic JSON value, and
+is never exposed.
+`RawJson` constructors are private; the unchecked raw writer can therefore
+only receive bytes previously accepted by `validateRawJson` or captured by a
+decoder.
+
+The portable decoder is a strict `ByteString` cursor parser. It validates the
+complete input, supports scalar roots, tracks paths, limits nesting, implements
+last-key-wins duplicate behavior, and constructs only the requested domain
+type. Object codecs declare known fields plus one explicit unknown-field
+decoder.
+
+The optional C++/simdjson backend lives in the separate
+`agent-json-hermes` package so this package remains portable.

--- a/packages/agent-json-codec/agent-json-codec.cabal
+++ b/packages/agent-json-codec/agent-json-codec.cabal
@@ -1,0 +1,68 @@
+cabal-version:      3.0
+name:               agent-json-codec
+version:            0.1.0.0
+synopsis:           Direct JSON codecs without an intermediate DOM
+description:        Typed JSON encoding and decoding for the agent harness,
+                    including opaque retention of validated extension fields.
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             digitally induced GmbH
+maintainer:         marc@digitallyinduced.com
+copyright:          (c) 2026 digitally induced GmbH
+category:           Web
+build-type:         Simple
+extra-source-files: README.md
+
+common common-options
+    default-language: GHC2021
+    default-extensions: BlockArguments
+                      , DerivingStrategies
+                      , DuplicateRecordFields
+                      , GADTs
+                      , LambdaCase
+                      , NoFieldSelectors
+                      , NumericUnderscores
+                      , OverloadedRecordDot
+                      , OverloadedStrings
+                      , RankNTypes
+                      , RecordWildCards
+                      , ScopedTypeVariables
+    ghc-options:      -Wall
+                      -Wcompat
+                      -Widentities
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wpartial-fields
+                      -Werror=incomplete-patterns
+
+library
+    import:           common-options
+    hs-source-dirs:   src
+    exposed-modules:  Agent.Json
+                    , Agent.Json.Decoder
+                    , Agent.Json.Decoder.Backend
+                    , Agent.Json.Encoder
+    other-modules:    Agent.Json.Decoder.Portable
+                    , Agent.Json.Internal
+    build-depends:    base >= 4.17 && < 5
+                    , bytestring >= 0.11 && < 0.13
+                    , containers >= 0.6 && < 0.8
+                    , jsonifier >= 0.2.1.3 && < 0.3
+                    , scientific >= 0.3.7 && < 0.4
+                    , text >= 2.0 && < 2.2
+                    , vector >= 0.12 && < 0.14
+
+test-suite agent-json-codec-test
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Spec.hs
+    build-depends:    agent-json-codec
+                    , aeson >= 2.2 && < 2.4
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , hspec >= 2.11 && < 2.12
+                    , QuickCheck >= 2.14 && < 2.16
+                    , scientific
+                    , text
+

--- a/packages/agent-json-codec/package.nix
+++ b/packages/agent-json-codec/package.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, aeson, base, bytestring, containers, hspec
+, jsonifier, lib, QuickCheck, scientific, text, vector
+}:
+mkDerivation {
+  pname = "agent-json-codec";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base bytestring containers jsonifier scientific text vector
+  ];
+  testHaskellDepends = [
+    aeson base bytestring hspec QuickCheck scientific text
+  ];
+  description = "Direct JSON codecs without an intermediate DOM";
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+}

--- a/packages/agent-json-codec/src/Agent/Json.hs
+++ b/packages/agent-json-codec/src/Agent/Json.hs
@@ -1,0 +1,52 @@
+-- | Opaque JSON values used at protocol boundaries.
+--
+-- This package intentionally does not expose a generic JSON value/object
+-- representation.  'RawJson' is an owned, validated byte slice which may be
+-- forwarded or passed to a typed decoder.
+module Agent.Json
+    ( RawJson
+    , rawJsonBytes
+    , Extensions
+    , emptyExtensions
+    , extensionsFromList
+    , extensionsToList
+    , extensionsSingleton
+    , appendExtension
+    , insertExtension
+    , lookupExtension
+    , deleteExtension
+    ) where
+
+import Agent.Json.Internal (Extensions(..), RawJson(..))
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+
+rawJsonBytes :: RawJson -> BS.ByteString
+rawJsonBytes (RawJson bytes) = bytes
+
+emptyExtensions :: Extensions
+emptyExtensions = Extensions Map.empty
+
+extensionsFromList :: [(Text, RawJson)] -> Extensions
+extensionsFromList = Extensions . Map.fromList
+
+extensionsToList :: Extensions -> [(Text, RawJson)]
+extensionsToList (Extensions values) = Map.toAscList values
+
+extensionsSingleton :: Text -> RawJson -> Extensions
+extensionsSingleton key value = Extensions (Map.singleton key value)
+
+-- | Insert an extension. Duplicate keys use the last value.
+appendExtension :: Text -> RawJson -> Extensions -> Extensions
+appendExtension key value (Extensions values) =
+    Extensions (Map.insert key value values)
+
+insertExtension :: Text -> RawJson -> Extensions -> Extensions
+insertExtension = appendExtension
+
+lookupExtension :: Text -> Extensions -> Maybe RawJson
+lookupExtension key (Extensions values) = Map.lookup key values
+
+deleteExtension :: Text -> Extensions -> Extensions
+deleteExtension key (Extensions values) = Extensions (Map.delete key values)

--- a/packages/agent-json-codec/src/Agent/Json.hs
+++ b/packages/agent-json-codec/src/Agent/Json.hs
@@ -17,6 +17,8 @@ module Agent.Json
     , deleteExtension
     , markExtensionFieldPresent
     , extensionFieldWasPresent
+    , setExtensionsSourceRaw
+    , extensionsSourceRaw
     ) where
 
 import Agent.Json.Internal (Extensions(..), RawJson(..))
@@ -29,38 +31,45 @@ rawJsonBytes :: RawJson -> BS.ByteString
 rawJsonBytes (RawJson bytes) = bytes
 
 emptyExtensions :: Extensions
-emptyExtensions = Extensions Map.empty Set.empty
+emptyExtensions = Extensions Map.empty Set.empty Nothing
 
 extensionsFromList :: [(Text, RawJson)] -> Extensions
 extensionsFromList values =
-    Extensions (Map.fromList values) Set.empty
+    Extensions (Map.fromList values) Set.empty Nothing
 
 extensionsToList :: Extensions -> [(Text, RawJson)]
-extensionsToList (Extensions values _) = Map.toAscList values
+extensionsToList (Extensions values _ _) = Map.toAscList values
 
 extensionsSingleton :: Text -> RawJson -> Extensions
 extensionsSingleton key value =
-    Extensions (Map.singleton key value) Set.empty
+    Extensions (Map.singleton key value) Set.empty Nothing
 
 -- | Insert an extension. Duplicate keys use the last value.
 appendExtension :: Text -> RawJson -> Extensions -> Extensions
-appendExtension key value (Extensions values present) =
-    Extensions (Map.insert key value values) present
+appendExtension key value (Extensions values present source) =
+    Extensions (Map.insert key value values) present source
 
 insertExtension :: Text -> RawJson -> Extensions -> Extensions
 insertExtension = appendExtension
 
 lookupExtension :: Text -> Extensions -> Maybe RawJson
-lookupExtension key (Extensions values _) = Map.lookup key values
+lookupExtension key (Extensions values _ _) = Map.lookup key values
 
 deleteExtension :: Text -> Extensions -> Extensions
-deleteExtension key (Extensions values present) =
-    Extensions (Map.delete key values) present
+deleteExtension key (Extensions values present source) =
+    Extensions (Map.delete key values) present source
 
 markExtensionFieldPresent :: Text -> Extensions -> Extensions
-markExtensionFieldPresent key (Extensions values present) =
-    Extensions values (Set.insert key present)
+markExtensionFieldPresent key (Extensions values present source) =
+    Extensions values (Set.insert key present) source
 
 extensionFieldWasPresent :: Text -> Extensions -> Bool
-extensionFieldWasPresent key (Extensions _ present) =
+extensionFieldWasPresent key (Extensions _ present _) =
     key `Set.member` present
+
+setExtensionsSourceRaw :: RawJson -> Extensions -> Extensions
+setExtensionsSourceRaw source (Extensions values present _) =
+    Extensions values present (Just source)
+
+extensionsSourceRaw :: Extensions -> Maybe RawJson
+extensionsSourceRaw (Extensions _ _ source) = source

--- a/packages/agent-json-codec/src/Agent/Json.hs
+++ b/packages/agent-json-codec/src/Agent/Json.hs
@@ -15,38 +15,52 @@ module Agent.Json
     , insertExtension
     , lookupExtension
     , deleteExtension
+    , markExtensionFieldPresent
+    , extensionFieldWasPresent
     ) where
 
 import Agent.Json.Internal (Extensions(..), RawJson(..))
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Text (Text)
 
 rawJsonBytes :: RawJson -> BS.ByteString
 rawJsonBytes (RawJson bytes) = bytes
 
 emptyExtensions :: Extensions
-emptyExtensions = Extensions Map.empty
+emptyExtensions = Extensions Map.empty Set.empty
 
 extensionsFromList :: [(Text, RawJson)] -> Extensions
-extensionsFromList = Extensions . Map.fromList
+extensionsFromList values =
+    Extensions (Map.fromList values) Set.empty
 
 extensionsToList :: Extensions -> [(Text, RawJson)]
-extensionsToList (Extensions values) = Map.toAscList values
+extensionsToList (Extensions values _) = Map.toAscList values
 
 extensionsSingleton :: Text -> RawJson -> Extensions
-extensionsSingleton key value = Extensions (Map.singleton key value)
+extensionsSingleton key value =
+    Extensions (Map.singleton key value) Set.empty
 
 -- | Insert an extension. Duplicate keys use the last value.
 appendExtension :: Text -> RawJson -> Extensions -> Extensions
-appendExtension key value (Extensions values) =
-    Extensions (Map.insert key value values)
+appendExtension key value (Extensions values present) =
+    Extensions (Map.insert key value values) present
 
 insertExtension :: Text -> RawJson -> Extensions -> Extensions
 insertExtension = appendExtension
 
 lookupExtension :: Text -> Extensions -> Maybe RawJson
-lookupExtension key (Extensions values) = Map.lookup key values
+lookupExtension key (Extensions values _) = Map.lookup key values
 
 deleteExtension :: Text -> Extensions -> Extensions
-deleteExtension key (Extensions values) = Extensions (Map.delete key values)
+deleteExtension key (Extensions values present) =
+    Extensions (Map.delete key values) present
+
+markExtensionFieldPresent :: Text -> Extensions -> Extensions
+markExtensionFieldPresent key (Extensions values present) =
+    Extensions values (Set.insert key present)
+
+extensionFieldWasPresent :: Text -> Extensions -> Bool
+extensionFieldWasPresent key (Extensions _ present) =
+    key `Set.member` present

--- a/packages/agent-json-codec/src/Agent/Json.hs
+++ b/packages/agent-json-codec/src/Agent/Json.hs
@@ -19,6 +19,7 @@ module Agent.Json
     , extensionFieldWasPresent
     , setExtensionsSourceRaw
     , extensionsSourceRaw
+    , clearExtensionsSourceRaw
     ) where
 
 import Agent.Json.Internal (Extensions(..), RawJson(..))
@@ -73,3 +74,7 @@ setExtensionsSourceRaw source (Extensions values present _) =
 
 extensionsSourceRaw :: Extensions -> Maybe RawJson
 extensionsSourceRaw (Extensions _ _ source) = source
+
+clearExtensionsSourceRaw :: Extensions -> Extensions
+clearExtensionsSourceRaw (Extensions values present _) =
+    Extensions values present Nothing

--- a/packages/agent-json-codec/src/Agent/Json/Decoder.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder.hs
@@ -6,6 +6,7 @@
 -- bytes.
 module Agent.Json.Decoder
     ( Decoder
+    , JsonType(..)
     , NamedField
     , UnknownField
     , DecodeError(..)
@@ -23,6 +24,7 @@ module Agent.Json.Decoder
     , list
     , vector
     , nullable
+    , byType
     , maybe
     , rawJson
     , skip
@@ -126,6 +128,9 @@ vector decoder = mapDecoder Vector.fromList (array decoder)
 
 nullable :: Decoder a -> Decoder (Maybe a)
 nullable = NullableDecoder
+
+byType :: (JsonType -> Decoder a) -> Decoder a
+byType = ByTypeDecoder
 
 maybe :: Decoder a -> Decoder (Maybe a)
 maybe = nullable

--- a/packages/agent-json-codec/src/Agent/Json/Decoder.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder.hs
@@ -39,6 +39,7 @@ module Agent.Json.Decoder
     , unknownField
     , mapEither
     , mapDecoder
+    , withRaw
     , decode
     , validateRawJson
     , renderDecodeError
@@ -217,6 +218,9 @@ mapEither = MapDecoder
 
 mapDecoder :: (a -> b) -> Decoder a -> Decoder b
 mapDecoder transform = mapEither (Right . transform)
+
+withRaw :: Decoder a -> Decoder (a, RawJson)
+withRaw = WithRawDecoder
 
 validateRawJson :: BS.ByteString -> Either DecodeError RawJson
 validateRawJson = decode rawJson

--- a/packages/agent-json-codec/src/Agent/Json/Decoder.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder.hs
@@ -29,7 +29,12 @@ module Agent.Json.Decoder
     , rawJson
     , skip
     , object
+    , objectFields
     , field
+    , requiredField
+    , optionalField
+    , defaultField
+    , extensionFields
     , unknownField
     , mapEither
     , mapDecoder
@@ -38,7 +43,7 @@ module Agent.Json.Decoder
     , renderDecodeError
     ) where
 
-import Agent.Json (RawJson)
+import Agent.Json (Extensions, RawJson, emptyExtensions)
 import Agent.Json.Decoder.Backend
 import Agent.Json.Decoder.Portable
     ( DecodeError(..)
@@ -149,12 +154,47 @@ object
     -> Decoder a
 object = ObjectDecoder
 
+objectFields :: ObjectPlan a -> Decoder a
+objectFields = PlannedObjectDecoder
+
 field
     :: Text
     -> Decoder value
     -> (value -> state -> Either Text state)
     -> NamedField state
 field = NamedField
+
+requiredField :: Text -> Decoder a -> ObjectPlan a
+requiredField name decoder =
+    PlanField PlannedField
+        { plannedName = name
+        , plannedDecoder = decoder
+        , plannedMissing = Left ("missing required field " <> name)
+        , plannedValue = Nothing
+        }
+
+optionalField :: Text -> Decoder a -> ObjectPlan (Maybe a)
+optionalField name decoder =
+    PlanField PlannedField
+        { plannedName = name
+        , plannedDecoder = nullable decoder
+        , plannedMissing = Right Nothing
+        , plannedValue = Nothing
+        }
+
+defaultField :: a -> Text -> Decoder a -> ObjectPlan a
+defaultField fallback name decoder =
+    PlanField PlannedField
+        { plannedName = name
+        , plannedDecoder =
+            mapDecoder (Prelude.maybe fallback id) (nullable decoder)
+        , plannedMissing = Right fallback
+        , plannedValue = Nothing
+        }
+
+extensionFields :: ObjectPlan Extensions
+extensionFields =
+    PlanExtensions emptyExtensions
 
 unknownField
     :: Decoder value

--- a/packages/agent-json-codec/src/Agent/Json/Decoder.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder.hs
@@ -1,0 +1,167 @@
+-- | Direct, typed JSON decoders.
+--
+-- A decoder consumes bytes and constructs the requested Haskell value.  No
+-- generic JSON value representation is exposed.  Object fields are visited
+-- once; an unknown-field callback can use 'rawJson' to retain its validated
+-- bytes.
+module Agent.Json.Decoder
+    ( Decoder
+    , NamedField
+    , UnknownField
+    , DecodeError(..)
+    , PathElement(..)
+    , nullValue
+    , bool
+    , text
+    , string
+    , scientific
+    , int
+    , integer
+    , word
+    , double
+    , array
+    , list
+    , vector
+    , nullable
+    , maybe
+    , rawJson
+    , skip
+    , object
+    , field
+    , unknownField
+    , mapEither
+    , mapDecoder
+    , decode
+    , validateRawJson
+    , renderDecodeError
+    ) where
+
+import Agent.Json (RawJson)
+import Agent.Json.Decoder.Backend
+import Agent.Json.Decoder.Portable
+    ( DecodeError(..)
+    , PathElement(..)
+    , decode
+    , renderDecodeError
+    )
+import qualified Data.ByteString as BS
+import Data.Scientific
+    ( Scientific
+    , base10Exponent
+    , coefficient
+    , toBoundedInteger
+    , toRealFloat
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Vector as Vector
+import qualified Prelude
+import Prelude hiding (maybe)
+
+nullValue :: a -> Decoder a
+nullValue = NullDecoder
+
+bool :: Decoder Bool
+bool = BoolDecoder
+
+text :: Decoder Text
+text = TextDecoder
+
+string :: Decoder String
+string = mapDecoder Text.unpack text
+
+scientific :: Decoder Scientific
+scientific = ScientificDecoder
+
+int :: Decoder Int
+int = mapEither bounded scientific
+  where
+    bounded value =
+        Prelude.maybe
+            (Left "expected an integer in the Int range")
+            Right
+            (toBoundedInteger value)
+
+integer :: Decoder Integer
+integer = mapEither bounded scientific
+  where
+    bounded value
+        | abs decimalExponent > maximumIntegerExponent =
+            Left "integer exponent exceeds the configured safety limit"
+        | decimalExponent >= 0 =
+            Right (coefficient value * 10 ^ decimalExponent)
+        | otherwise =
+            let divisor = 10 ^ negate decimalExponent
+                (quotient, remainder) = coefficient value `quotRem` divisor
+            in if remainder == 0
+                then Right quotient
+                else Left "expected an integer"
+      where
+        decimalExponent = base10Exponent value
+
+    maximumIntegerExponent = 100_000
+
+word :: Decoder Word
+word = mapEither bounded scientific
+  where
+    bounded value =
+        Prelude.maybe
+            (Left "expected a non-negative integer in the Word range")
+            Right
+            (toBoundedInteger value)
+
+double :: Decoder Double
+double = mapDecoder toDouble scientific
+  where
+    toDouble value = toRealFloat value :: Double
+
+array :: Decoder a -> Decoder [a]
+array = ArrayDecoder
+
+list :: Decoder a -> Decoder [a]
+list = array
+
+vector :: Decoder a -> Decoder (Vector.Vector a)
+vector decoder = mapDecoder Vector.fromList (array decoder)
+
+nullable :: Decoder a -> Decoder (Maybe a)
+nullable = NullableDecoder
+
+maybe :: Decoder a -> Decoder (Maybe a)
+maybe = nullable
+
+rawJson :: Decoder RawJson
+rawJson = RawJsonDecoder
+
+skip :: Decoder ()
+skip = SkipDecoder
+
+object
+    :: state
+    -> [NamedField state]
+    -> UnknownField state
+    -> (state -> Either Text a)
+    -> Decoder a
+object = ObjectDecoder
+
+field
+    :: Text
+    -> Decoder value
+    -> (value -> state -> Either Text state)
+    -> NamedField state
+field = NamedField
+
+unknownField
+    :: Decoder value
+    -> (Text -> value -> state -> Either Text state)
+    -> UnknownField state
+unknownField = UnknownField
+
+mapEither :: (a -> Either Text b) -> Decoder a -> Decoder b
+mapEither = MapDecoder
+
+mapDecoder :: (a -> b) -> Decoder a -> Decoder b
+mapDecoder transform = mapEither (Right . transform)
+
+validateRawJson :: BS.ByteString -> Either DecodeError RawJson
+validateRawJson = decode rawJson

--- a/packages/agent-json-codec/src/Agent/Json/Decoder.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder.hs
@@ -30,6 +30,7 @@ module Agent.Json.Decoder
     , skip
     , object
     , objectFields
+    , discriminatedObject
     , field
     , requiredField
     , optionalField
@@ -156,6 +157,15 @@ object = ObjectDecoder
 
 objectFields :: ObjectPlan a -> Decoder a
 objectFields = PlannedObjectDecoder
+
+-- | Select an object decoder from a text discriminator without retaining a
+-- generic object. The portable backend scans the object once for the tag and
+-- then constructs the selected domain value on a second cursor pass.
+discriminatedObject
+    :: Text
+    -> (Text -> Decoder a)
+    -> Decoder a
+discriminatedObject = DiscriminatedObjectDecoder
 
 field
     :: Text

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
@@ -11,6 +11,7 @@ module Agent.Json.Decoder.Backend
     , PlannedFieldMatch(..)
     , matchPlannedField
     , capturePlannedExtension
+    , markPlannedFieldPresent
     , finishObjectPlan
     , objectPlanRequiresRawCapture
     , objectPlanCapturesExtensions
@@ -20,6 +21,7 @@ module Agent.Json.Decoder.Backend
 import Agent.Json
     ( Extensions
     , insertExtension
+    , markExtensionFieldPresent
     )
 import Agent.Json.Internal (RawJson(..))
 import qualified Data.ByteString as BS
@@ -132,6 +134,20 @@ capturePlannedExtension key value = \case
         PlanApply
             (capturePlannedExtension key value functions)
             (capturePlannedExtension key value argument)
+
+markPlannedFieldPresent
+    :: Text
+    -> ObjectPlan result
+    -> ObjectPlan result
+markPlannedFieldPresent key = \case
+    PlanPure result -> PlanPure result
+    PlanExtensions fields ->
+        PlanExtensions (markExtensionFieldPresent key fields)
+    PlanField field -> PlanField field
+    PlanApply functions argument ->
+        PlanApply
+            (markPlannedFieldPresent key functions)
+            (markPlannedFieldPresent key argument)
 
 finishObjectPlan :: ObjectPlan a -> Either Text a
 finishObjectPlan = \case

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
@@ -1,0 +1,45 @@
+-- | Backend interpreter API.
+--
+-- This module is for decoder backend implementations, not application code.
+module Agent.Json.Decoder.Backend
+    ( Decoder(..)
+    , NamedField(..)
+    , UnknownField(..)
+    ) where
+
+import Agent.Json (RawJson)
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+
+data Decoder a where
+    NullDecoder :: a -> Decoder a
+    BoolDecoder :: Decoder Bool
+    TextDecoder :: Decoder Text
+    ScientificDecoder :: Decoder Scientific
+    ArrayDecoder :: Decoder a -> Decoder [a]
+    ObjectDecoder
+        :: state
+        -> [NamedField state]
+        -> UnknownField state
+        -> (state -> Either Text a)
+        -> Decoder a
+    NullableDecoder :: Decoder a -> Decoder (Maybe a)
+    RawJsonDecoder :: Decoder RawJson
+    SkipDecoder :: Decoder ()
+    MapDecoder
+        :: (a -> Either Text b)
+        -> Decoder a
+        -> Decoder b
+
+data NamedField state where
+    NamedField
+        :: Text
+        -> Decoder value
+        -> (value -> state -> Either Text state)
+        -> NamedField state
+
+data UnknownField state where
+    UnknownField
+        :: Decoder value
+        -> (Text -> value -> state -> Either Text state)
+        -> UnknownField state

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
@@ -39,6 +39,10 @@ data Decoder a where
         -> (state -> Either Text a)
         -> Decoder a
     PlannedObjectDecoder :: ObjectPlan a -> Decoder a
+    DiscriminatedObjectDecoder
+        :: Text
+        -> (Text -> Decoder a)
+        -> Decoder a
     NullableDecoder :: Decoder a -> Decoder (Maybe a)
     ByTypeDecoder :: (JsonType -> Decoder a) -> Decoder a
     RawJsonDecoder :: Decoder RawJson
@@ -160,6 +164,7 @@ objectPlanRequiresRawCapture = \case
         ObjectDecoder _ fields unknown _ ->
             any namedRequiresRaw fields || unknownRequiresRaw unknown
         PlannedObjectDecoder plan -> objectPlanRequiresRawCapture plan
+        DiscriminatedObjectDecoder{} -> True
         NullableDecoder decoder -> decoderRequiresRaw decoder
         ByTypeDecoder select ->
             any (decoderRequiresRaw . select)

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
@@ -12,6 +12,7 @@ module Agent.Json.Decoder.Backend
     , matchPlannedField
     , capturePlannedExtension
     , markPlannedFieldPresent
+    , deletePlannedExtension
     , finishObjectPlan
     , objectPlanRequiresRawCapture
     , objectPlanCapturesExtensions
@@ -20,6 +21,7 @@ module Agent.Json.Decoder.Backend
 
 import Agent.Json
     ( Extensions
+    , deleteExtension
     , insertExtension
     , markExtensionFieldPresent
     )
@@ -53,6 +55,9 @@ data Decoder a where
         :: (a -> Either Text b)
         -> Decoder a
         -> Decoder b
+    WithRawDecoder
+        :: Decoder a
+        -> Decoder (a, RawJson)
 
 -- | Backend-only constructor for bytes fully validated by a JSON parser.
 --
@@ -149,6 +154,20 @@ markPlannedFieldPresent key = \case
             (markPlannedFieldPresent key functions)
             (markPlannedFieldPresent key argument)
 
+deletePlannedExtension
+    :: Text
+    -> ObjectPlan result
+    -> ObjectPlan result
+deletePlannedExtension key = \case
+    PlanPure result -> PlanPure result
+    PlanExtensions fields ->
+        PlanExtensions (deleteExtension key fields)
+    PlanField field -> PlanField field
+    PlanApply functions argument ->
+        PlanApply
+            (deletePlannedExtension key functions)
+            (deletePlannedExtension key argument)
+
 finishObjectPlan :: ObjectPlan a -> Either Text a
 finishObjectPlan = \case
     PlanPure value -> Right value
@@ -188,6 +207,7 @@ objectPlanRequiresRawCapture = \case
         RawJsonDecoder -> True
         SkipDecoder -> False
         MapDecoder _ decoder -> decoderRequiresRaw decoder
+        WithRawDecoder{} -> True
     namedRequiresRaw (NamedField _ decoder _) = decoderRequiresRaw decoder
     unknownRequiresRaw (UnknownField decoder _) = decoderRequiresRaw decoder
 

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
@@ -6,9 +6,21 @@ module Agent.Json.Decoder.Backend
     , JsonType(..)
     , NamedField(..)
     , UnknownField(..)
+    , ObjectPlan(..)
+    , PlannedField(..)
+    , PlannedFieldMatch(..)
+    , matchPlannedField
+    , capturePlannedExtension
+    , finishObjectPlan
+    , objectPlanRequiresRawCapture
+    , objectPlanCapturesExtensions
     ) where
 
-import Agent.Json (RawJson)
+import Agent.Json
+    ( Extensions
+    , RawJson
+    , insertExtension
+    )
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 
@@ -24,6 +36,7 @@ data Decoder a where
         -> UnknownField state
         -> (state -> Either Text a)
         -> Decoder a
+    PlannedObjectDecoder :: ObjectPlan a -> Decoder a
     NullableDecoder :: Decoder a -> Decoder (Maybe a)
     ByTypeDecoder :: (JsonType -> Decoder a) -> Decoder a
     RawJsonDecoder :: Decoder RawJson
@@ -32,6 +45,132 @@ data Decoder a where
         :: (a -> Either Text b)
         -> Decoder a
         -> Decoder b
+
+data ObjectPlan a where
+    PlanPure :: a -> ObjectPlan a
+    PlanApply
+        :: ObjectPlan (field -> a)
+        -> ObjectPlan field
+        -> ObjectPlan a
+    PlanField
+        :: PlannedField a
+        -> ObjectPlan a
+    PlanExtensions
+        :: Extensions
+        -> ObjectPlan Extensions
+
+data PlannedField a = PlannedField
+    { plannedName :: !Text
+    , plannedDecoder :: !(Decoder a)
+    , plannedMissing :: !(Either Text a)
+    , plannedValue :: !(Maybe a)
+    }
+
+instance Functor ObjectPlan where
+    fmap transform plan =
+        PlanApply (PlanPure transform) plan
+
+instance Applicative ObjectPlan where
+    pure = PlanPure
+    (<*>) = PlanApply
+
+data PlannedFieldMatch result where
+    PlannedFieldMatch
+        :: Decoder field
+        -> (field -> ObjectPlan result)
+        -> PlannedFieldMatch result
+
+matchPlannedField
+    :: Text
+    -> ObjectPlan result
+    -> Maybe (PlannedFieldMatch result)
+matchPlannedField key = \case
+    PlanPure _ -> Nothing
+    PlanExtensions _ -> Nothing
+    PlanField field
+        | field.plannedName == key ->
+            Just (PlannedFieldMatch
+                field.plannedDecoder
+                (\value -> PlanField field { plannedValue = Just value }))
+        | otherwise -> Nothing
+    PlanApply functions argument ->
+        case matchPlannedField key functions of
+            Just (PlannedFieldMatch decoder rebuild) ->
+                Just (PlannedFieldMatch decoder
+                    (\value -> PlanApply (rebuild value) argument))
+            Nothing -> do
+                PlannedFieldMatch decoder rebuild <-
+                    matchPlannedField key argument
+                pure (PlannedFieldMatch decoder
+                    (\value -> PlanApply functions (rebuild value)))
+
+capturePlannedExtension
+    :: Text
+    -> RawJson
+    -> ObjectPlan result
+    -> ObjectPlan result
+capturePlannedExtension key value = \case
+    PlanPure result -> PlanPure result
+    PlanExtensions fields ->
+        PlanExtensions (insertExtension key value fields)
+    PlanField field -> PlanField field
+    PlanApply functions argument ->
+        PlanApply
+            (capturePlannedExtension key value functions)
+            (capturePlannedExtension key value argument)
+
+finishObjectPlan :: ObjectPlan a -> Either Text a
+finishObjectPlan = \case
+    PlanPure value -> Right value
+    PlanExtensions fields -> Right fields
+    PlanField field ->
+        case field.plannedValue of
+            Just value -> Right value
+            Nothing -> field.plannedMissing
+    PlanApply functions argument ->
+        finishObjectPlan functions <*> finishObjectPlan argument
+
+objectPlanRequiresRawCapture :: ObjectPlan a -> Bool
+objectPlanRequiresRawCapture = \case
+    PlanPure _ -> False
+    PlanExtensions _ -> True
+    PlanField field ->
+        decoderRequiresRaw field.plannedDecoder
+    PlanApply functions argument ->
+        objectPlanRequiresRawCapture functions
+            || objectPlanRequiresRawCapture argument
+  where
+    decoderRequiresRaw :: Decoder value -> Bool
+    decoderRequiresRaw = \case
+        NullDecoder _ -> False
+        BoolDecoder -> False
+        TextDecoder -> False
+        ScientificDecoder -> False
+        ArrayDecoder decoder -> decoderRequiresRaw decoder
+        ObjectDecoder _ fields unknown _ ->
+            any namedRequiresRaw fields || unknownRequiresRaw unknown
+        PlannedObjectDecoder plan -> objectPlanRequiresRawCapture plan
+        NullableDecoder decoder -> decoderRequiresRaw decoder
+        ByTypeDecoder select ->
+            any (decoderRequiresRaw . select)
+                [JsonNull, JsonBoolean, JsonNumber, JsonString, JsonArray, JsonObject]
+        RawJsonDecoder -> True
+        SkipDecoder -> False
+        MapDecoder _ decoder -> decoderRequiresRaw decoder
+    namedRequiresRaw (NamedField _ decoder _) = decoderRequiresRaw decoder
+    unknownRequiresRaw (UnknownField decoder _) = decoderRequiresRaw decoder
+
+objectPlanCapturesExtensions :: ObjectPlan a -> Bool
+objectPlanCapturesExtensions = \case
+    PlanPure _ -> False
+    PlanExtensions _ -> True
+    PlanField _ -> False
+    PlanApply functions argument ->
+        objectPlanCapturesExtensions functions
+            || objectPlanCapturesExtensions argument
+instance Functor Decoder where
+    fmap transform =
+        MapDecoder (Right . transform)
 
 data JsonType
     = JsonNull

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
@@ -14,13 +14,15 @@ module Agent.Json.Decoder.Backend
     , finishObjectPlan
     , objectPlanRequiresRawCapture
     , objectPlanCapturesExtensions
+    , unsafeRawJsonFromValidatedBytes
     ) where
 
 import Agent.Json
     ( Extensions
-    , RawJson
     , insertExtension
     )
+import Agent.Json.Internal (RawJson(..))
+import qualified Data.ByteString as BS
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 
@@ -45,6 +47,14 @@ data Decoder a where
         :: (a -> Either Text b)
         -> Decoder a
         -> Decoder b
+
+-- | Backend-only constructor for bytes fully validated by a JSON parser.
+--
+-- Application code must use 'Agent.Json.Decoder.validateRawJson'. A backend
+-- must copy input-backed bytes before calling this function if its parser
+-- reuses the input buffer.
+unsafeRawJsonFromValidatedBytes :: BS.ByteString -> RawJson
+unsafeRawJsonFromValidatedBytes = RawJson
 
 data ObjectPlan a where
     PlanPure :: a -> ObjectPlan a

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Backend.hs
@@ -3,6 +3,7 @@
 -- This module is for decoder backend implementations, not application code.
 module Agent.Json.Decoder.Backend
     ( Decoder(..)
+    , JsonType(..)
     , NamedField(..)
     , UnknownField(..)
     ) where
@@ -24,12 +25,22 @@ data Decoder a where
         -> (state -> Either Text a)
         -> Decoder a
     NullableDecoder :: Decoder a -> Decoder (Maybe a)
+    ByTypeDecoder :: (JsonType -> Decoder a) -> Decoder a
     RawJsonDecoder :: Decoder RawJson
     SkipDecoder :: Decoder ()
     MapDecoder
         :: (a -> Either Text b)
         -> Decoder a
         -> Decoder b
+
+data JsonType
+    = JsonNull
+    | JsonBoolean
+    | JsonNumber
+    | JsonString
+    | JsonArray
+    | JsonObject
+    deriving stock (Eq, Show)
 
 data NamedField state where
     NamedField

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
@@ -248,8 +248,30 @@ parsePlannedObject initialPlan initial = do
         (updatedPlan, afterValue) <-
             case matchPlannedField key plan of
                 Just (PlannedFieldMatch decoder rebuild) -> do
+                    let valueStart = (skipWhitespace nested).position
+                        isExplicitNull =
+                            literalAt "null" (skipWhitespace nested)
                     (value, decodedCursor) <- runDecoder decoder nested
-                    pure (rebuild value, leave decodedCursor)
+                    let rebuilt =
+                            markPlannedFieldPresent key (rebuild value)
+                        withNull
+                            | isExplicitNull
+                                && objectPlanCapturesExtensions rebuilt =
+                                capturePlannedExtension
+                                    key
+                                    (unsafeRawJsonFromValidatedBytes
+                                        (BS.copy
+                                            (BS.take
+                                                ( decodedCursor.position
+                                                    - valueStart
+                                                )
+                                                (BS.drop
+                                                    valueStart
+                                                    decodedCursor.input))))
+                                    rebuilt
+                            | otherwise = rebuilt
+                    pure
+                        (withNull, leave decodedCursor)
                 Nothing
                     | objectPlanCapturesExtensions plan -> do
                         (value, decodedCursor) <-

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
@@ -1,0 +1,489 @@
+module Agent.Json.Decoder.Portable
+    ( DecodeError(..)
+    , PathElement(..)
+    , decode
+    , renderDecodeError
+    ) where
+
+import Agent.Json.Decoder.Backend
+import Agent.Json.Internal (RawJson(..))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Char (chr)
+import Data.Scientific (Scientific)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word8)
+import Text.Read (readMaybe)
+
+data PathElement
+    = PathKey !Text
+    | PathIndex !Int
+    deriving stock (Eq, Show)
+
+data DecodeError = DecodeError
+    { offset :: !Int
+    , path :: ![PathElement]
+    , message :: !Text
+    }
+    deriving stock (Eq, Show)
+
+data Cursor = Cursor
+    { input :: !BS.ByteString
+    , position :: !Int
+    , pathRev :: ![PathElement]
+    , depth :: !Int
+    }
+
+decode :: Decoder a -> BS.ByteString -> Either DecodeError a
+decode decoder bytes = do
+    (value, cursor) <- runDecoder decoder (Cursor bytes 0 [] 0)
+    let finished = skipWhitespace cursor
+    if finished.position == BS.length bytes
+        then Right value
+        else failure finished "expected end of input"
+
+renderDecodeError :: DecodeError -> Text
+renderDecodeError DecodeError { path, offset, message } =
+    "JSON decode error at byte "
+        <> Text.pack (show offset)
+        <> renderPath path
+        <> ": "
+        <> message
+  where
+    renderPath [] = ""
+    renderPath values = " at " <> Text.pack (concatMap renderSegment values)
+    renderSegment segment =
+        case segment of
+            PathKey key -> "/" <> Text.unpack (Text.replace "/" "~1" (Text.replace "~" "~0" key))
+            PathIndex index -> "/" <> show index
+
+runDecoder :: Decoder a -> Cursor -> Either DecodeError (a, Cursor)
+runDecoder decoder initial = case decoder of
+    NullDecoder value -> do
+        cursor <- consumeLiteral "null" initial
+        pure (value, cursor)
+    BoolDecoder -> parseBool initial
+    TextDecoder -> parseString (skipWhitespace initial)
+    ScientificDecoder -> parseScientific (skipWhitespace initial)
+    ArrayDecoder elementDecoder ->
+        parseArray elementDecoder initial
+    ObjectDecoder state fields unknown finish ->
+        parseObject state fields unknown finish initial
+    NullableDecoder inner ->
+        let cursor = skipWhitespace initial
+        in if literalAt "null" cursor
+            then (Nothing,) <$> consumeLiteral "null" cursor
+            else do
+                (value, next) <- runDecoder inner cursor
+                pure (Just value, next)
+    RawJsonDecoder -> do
+        let start = (skipWhitespace initial).position
+        next <- skipJsonValue initial
+        let bytes =
+                BS.copy $
+                    BS.take (next.position - start) $
+                        BS.drop start initial.input
+        pure (RawJson bytes, next)
+    SkipDecoder ->
+        ((),) <$> skipJsonValue initial
+    MapDecoder transform inner -> do
+        (value, next) <- runDecoder inner initial
+        case transform value of
+            Left err -> failure next err
+            Right transformed -> pure (transformed, next)
+
+parseBool :: Cursor -> Either DecodeError (Bool, Cursor)
+parseBool initial
+    | literalAt "true" cursor =
+        (True,) <$> consumeLiteral "true" cursor
+    | literalAt "false" cursor =
+        (False,) <$> consumeLiteral "false" cursor
+    | otherwise = failure cursor "expected a boolean"
+  where
+    cursor = skipWhitespace initial
+
+parseArray
+    :: Decoder a
+    -> Cursor
+    -> Either DecodeError ([a], Cursor)
+parseArray elementDecoder initial = do
+    opened <- descend =<< consumeByte openBracket (skipWhitespace initial)
+    let cursor = skipWhitespace opened
+    if peekByte cursor == Just closeBracket
+        then ([],) <$> (leaveDepth <$> consumeByte closeBracket cursor)
+        else go 0 [] cursor
+  where
+    go index reversed cursor = do
+        nested <- pure (enter (PathIndex index) cursor)
+        (value, afterValue) <- runDecoder elementDecoder nested
+        let afterNested = leave afterValue
+            next = skipWhitespace afterNested
+        case peekByte next of
+            Just byte | byte == comma ->
+                consumeByte comma next
+                    >>= go (index + 1) (value : reversed)
+                    . skipWhitespace
+            Just byte | byte == closeBracket -> do
+                finished <- consumeByte closeBracket next
+                pure (reverse (value : reversed), leaveDepth finished)
+            _ -> failure next "expected ',' or ']'"
+
+parseObject
+    :: state
+    -> [NamedField state]
+    -> UnknownField state
+    -> (state -> Either Text a)
+    -> Cursor
+    -> Either DecodeError (a, Cursor)
+parseObject initialState fields unknown finish initial = do
+    opened <- descend =<< consumeByte openBrace (skipWhitespace initial)
+    let cursor = skipWhitespace opened
+    if peekByte cursor == Just closeBrace
+        then do
+            finished <- consumeByte closeBrace cursor
+            finishObject initialState (leaveDepth finished)
+        else go initialState cursor
+  where
+    go state cursor = do
+        (key, afterKey) <- parseString cursor
+        afterColon <-
+            consumeByte colon (skipWhitespace afterKey)
+        nested <- pure (enter (PathKey key) afterColon)
+        (updatedState, afterValue) <-
+            decodeObjectField key state nested fields unknown
+        let next = skipWhitespace afterValue
+        case peekByte next of
+            Just byte | byte == comma ->
+                consumeByte comma next
+                    >>= go updatedState . skipWhitespace
+            Just byte | byte == closeBrace -> do
+                finished <- consumeByte closeBrace next
+                finishObject updatedState (leaveDepth finished)
+            _ -> failure next "expected ',' or '}'"
+
+    finishObject state cursor =
+        case finish state of
+            Left err -> failure cursor err
+            Right value -> pure (value, cursor)
+
+decodeObjectField
+    :: Text
+    -> state
+    -> Cursor
+    -> [NamedField state]
+    -> UnknownField state
+    -> Either DecodeError (state, Cursor)
+decodeObjectField key state cursor fields unknown =
+    case fields of
+        [] -> case unknown of
+            UnknownField valueDecoder update -> do
+                (value, decodedCursor) <- runDecoder valueDecoder cursor
+                finishUpdate decodedCursor (update key value state)
+        NamedField name valueDecoder update : rest
+            | name == key -> do
+                (value, decodedCursor) <- runDecoder valueDecoder cursor
+                finishUpdate decodedCursor (update value state)
+            | otherwise ->
+                decodeObjectField key state cursor rest unknown
+  where
+    finishUpdate decodedCursor = \case
+        Left err -> failure decodedCursor err
+        Right updated -> pure (updated, leave decodedCursor)
+
+parseString :: Cursor -> Either DecodeError (Text, Cursor)
+parseString initial = do
+    afterQuote <- consumeByte quote (skipWhitespace initial)
+    go [] afterQuote.position afterQuote
+  where
+    go reversedChunks chunkStart cursor =
+        case peekByte cursor of
+            Nothing -> failure cursor "unterminated string"
+            Just byte
+                | byte == quote -> do
+                    chunk <- decodeUtf8Chunk cursor chunkStart cursor.position
+                    finished <- consumeByte quote cursor
+                    pure
+                        (Text.concat (reverse (chunk : reversedChunks)), finished)
+                | byte == backslash -> do
+                    chunk <- decodeUtf8Chunk cursor chunkStart cursor.position
+                    (escaped, afterEscape) <- parseEscape (advance 1 cursor)
+                    go
+                        (escaped : chunk : reversedChunks)
+                        afterEscape.position
+                        afterEscape
+                | byte < 0x20 ->
+                    failure cursor "unescaped control character in string"
+                | otherwise ->
+                    go reversedChunks chunkStart (advance 1 cursor)
+
+decodeUtf8Chunk :: Cursor -> Int -> Int -> Either DecodeError Text
+decodeUtf8Chunk cursor start end =
+    case TextEncoding.decodeUtf8' (BS.take (end - start) (BS.drop start cursor.input)) of
+        Left err ->
+            failure cursor
+                ("invalid UTF-8 in string: " <> Text.pack (show err))
+        Right value -> Right value
+
+parseEscape :: Cursor -> Either DecodeError (Text, Cursor)
+parseEscape cursor =
+    case peekByte cursor of
+        Nothing -> failure cursor "unterminated string escape"
+        Just byte -> case byte of
+            0x22 -> simple "\""
+            0x5c -> simple "\\"
+            0x2f -> simple "/"
+            0x62 -> simple "\b"
+            0x66 -> simple "\f"
+            0x6e -> simple "\n"
+            0x72 -> simple "\r"
+            0x74 -> simple "\t"
+            0x75 -> parseUnicodeEscape (advance 1 cursor)
+            _ -> failure cursor "invalid string escape"
+  where
+    simple value = Right (value, advance 1 cursor)
+
+parseUnicodeEscape :: Cursor -> Either DecodeError (Text, Cursor)
+parseUnicodeEscape cursor = do
+    (first, afterFirst) <- parseHex4 cursor
+    if isHighSurrogate first
+        then do
+            afterSlash <- consumeByte backslash afterFirst
+            afterU <- consumeByte 0x75 afterSlash
+            (second, afterSecond) <- parseHex4 afterU
+            if isLowSurrogate second
+                then pure
+                    ( Text.singleton
+                        (chr
+                            ( 0x10000
+                                + (first - 0xd800) * 0x400
+                                + second
+                                - 0xdc00
+                            ))
+                    , afterSecond
+                    )
+                else failure afterU "expected a low surrogate"
+        else if isLowSurrogate first
+            then failure cursor "unexpected low surrogate"
+            else pure (Text.singleton (chr first), afterFirst)
+
+parseHex4 :: Cursor -> Either DecodeError (Int, Cursor)
+parseHex4 initial =
+    go 4 0 initial
+  where
+    go :: Int -> Int -> Cursor -> Either DecodeError (Int, Cursor)
+    go 0 value cursor = Right (value, cursor)
+    go remaining value cursor = case peekByte cursor >>= hexValue of
+        Nothing -> failure cursor "expected four hexadecimal digits"
+        Just digit ->
+            go (remaining - 1) (value * 16 + digit) (advance 1 cursor)
+
+hexValue :: Word8 -> Maybe Int
+hexValue byte
+    | byte >= 0x30 && byte <= 0x39 =
+        Just (fromIntegral byte - 0x30)
+    | byte >= 0x41 && byte <= 0x46 =
+        Just (fromIntegral byte - 0x41 + 10)
+    | byte >= 0x61 && byte <= 0x66 =
+        Just (fromIntegral byte - 0x61 + 10)
+    | otherwise = Nothing
+
+parseScientific :: Cursor -> Either DecodeError (Scientific, Cursor)
+parseScientific cursor = do
+    end <- scanNumber cursor
+    let bytes =
+            BS.take (end.position - cursor.position) $
+                BS.drop cursor.position cursor.input
+    case readMaybe (BS8.unpack bytes) of
+        Just value -> Right (value, end)
+        Nothing -> failure cursor "invalid JSON number"
+
+scanNumber :: Cursor -> Either DecodeError Cursor
+scanNumber initial = do
+    let afterMinus =
+            if peekByte initial == Just minus
+                then advance 1 initial
+                else initial
+    afterInteger <- case peekByte afterMinus of
+        Just 0x30 ->
+            let next = advance 1 afterMinus
+            in case peekByte next of
+                Just byte | isDigit byte ->
+                    failure next "leading zero in number"
+                _ -> Right next
+        Just byte | byte >= 0x31 && byte <= 0x39 ->
+            Right (takeWhileByte isDigit afterMinus)
+        _ -> failure afterMinus "expected a number"
+    afterFraction <- if peekByte afterInteger == Just dot
+        then do
+            let digits = takeWhileByte isDigit (advance 1 afterInteger)
+            if digits.position == afterInteger.position + 1
+                then failure digits "expected digits after decimal point"
+                else Right digits
+        else Right afterInteger
+    case peekByte afterFraction of
+        Just byte | byte == exponentLower || byte == exponentUpper -> do
+            let afterExponent = advance 1 afterFraction
+                afterSign = case peekByte afterExponent of
+                    Just sign | sign == plus || sign == minus ->
+                        advance 1 afterExponent
+                    _ -> afterExponent
+                digits = takeWhileByte isDigit afterSign
+            if digits.position == afterSign.position
+                then failure digits "expected exponent digits"
+                else Right digits
+        _ -> Right afterFraction
+
+skipJsonValue :: Cursor -> Either DecodeError Cursor
+skipJsonValue initial =
+    let cursor = skipWhitespace initial
+    in case peekByte cursor of
+        Just byte
+            | byte == quote -> snd <$> parseString cursor
+            | byte == openBrace -> skipObject cursor
+            | byte == openBracket -> skipArray cursor
+            | byte == 0x74 -> consumeLiteral "true" cursor
+            | byte == 0x66 -> consumeLiteral "false" cursor
+            | byte == 0x6e -> consumeLiteral "null" cursor
+            | byte == minus || isDigit byte -> scanNumber cursor
+        _ -> failure cursor "expected a JSON value"
+
+skipObject :: Cursor -> Either DecodeError Cursor
+skipObject initial = do
+    cursor <- descend initial >>= consumeByte openBrace
+    let next = skipWhitespace cursor
+    if peekByte next == Just closeBrace
+        then leaveDepth <$> consumeByte closeBrace next
+        else go next
+  where
+    go cursor = do
+        (_, afterKey) <- parseString cursor
+        afterColon <- consumeByte colon (skipWhitespace afterKey)
+        afterValue <- skipJsonValue afterColon
+        let next = skipWhitespace afterValue
+        case peekByte next of
+            Just byte | byte == comma ->
+                consumeByte comma next >>= go . skipWhitespace
+            Just byte | byte == closeBrace ->
+                leaveDepth <$> consumeByte closeBrace next
+            _ -> failure next "expected ',' or '}'"
+
+skipArray :: Cursor -> Either DecodeError Cursor
+skipArray initial = do
+    cursor <- descend initial >>= consumeByte openBracket
+    let next = skipWhitespace cursor
+    if peekByte next == Just closeBracket
+        then leaveDepth <$> consumeByte closeBracket next
+        else go next
+  where
+    go cursor = do
+        afterValue <- skipJsonValue cursor
+        let next = skipWhitespace afterValue
+        case peekByte next of
+            Just byte | byte == comma ->
+                consumeByte comma next >>= go . skipWhitespace
+            Just byte | byte == closeBracket ->
+                leaveDepth <$> consumeByte closeBracket next
+            _ -> failure next "expected ',' or ']'"
+
+skipWhitespace :: Cursor -> Cursor
+skipWhitespace =
+    takeWhileByte isWhitespace
+
+takeWhileByte :: (Word8 -> Bool) -> Cursor -> Cursor
+takeWhileByte predicate cursor =
+    cursor
+        { position =
+            cursor.position
+                + BS.length
+                    (BS.takeWhile predicate (BS.drop cursor.position cursor.input))
+        }
+
+consumeLiteral :: BS.ByteString -> Cursor -> Either DecodeError Cursor
+consumeLiteral literal initial =
+    let cursor = skipWhitespace initial
+    in if literalAt literal cursor
+        then Right (advance (BS.length literal) cursor)
+        else failure cursor ("expected " <> TextEncoding.decodeUtf8 literal)
+
+literalAt :: BS.ByteString -> Cursor -> Bool
+literalAt literal cursor =
+    literal `BS.isPrefixOf` BS.drop cursor.position cursor.input
+
+consumeByte :: Word8 -> Cursor -> Either DecodeError Cursor
+consumeByte expected cursor =
+    case peekByte cursor of
+        Just actual | actual == expected -> Right (advance 1 cursor)
+        _ ->
+            failure cursor
+                ("expected '" <> Text.singleton (chr (fromIntegral expected)) <> "'")
+
+peekByte :: Cursor -> Maybe Word8
+peekByte cursor =
+    BS.indexMaybe cursor.input cursor.position
+
+advance :: Int -> Cursor -> Cursor
+advance amount cursor =
+    cursor { position = cursor.position + amount }
+
+enter :: PathElement -> Cursor -> Cursor
+enter element cursor =
+    cursor
+        { pathRev = element : cursor.pathRev }
+
+descend :: Cursor -> Either DecodeError Cursor
+descend cursor
+    | cursor.depth >= maximumDepth =
+        failure cursor "maximum JSON nesting depth exceeded"
+    | otherwise =
+        Right cursor { depth = cursor.depth + 1 }
+
+leave :: Cursor -> Cursor
+leave cursor =
+    cursor
+        { pathRev = drop 1 cursor.pathRev }
+
+leaveDepth :: Cursor -> Cursor
+leaveDepth cursor =
+    cursor { depth = max 0 (cursor.depth - 1) }
+
+failure :: Cursor -> Text -> Either DecodeError a
+failure cursor reason =
+    Left DecodeError
+        { offset = cursor.position
+        , path = reverse cursor.pathRev
+        , message = reason
+        }
+
+isWhitespace :: Word8 -> Bool
+isWhitespace byte =
+    byte == 0x20 || byte == 0x09 || byte == 0x0a || byte == 0x0d
+
+isDigit :: Word8 -> Bool
+isDigit byte =
+    byte >= 0x30 && byte <= 0x39
+
+isHighSurrogate, isLowSurrogate :: Int -> Bool
+isHighSurrogate value = value >= 0xd800 && value <= 0xdbff
+isLowSurrogate value = value >= 0xdc00 && value <= 0xdfff
+
+maximumDepth :: Int
+maximumDepth = 1024
+
+quote, backslash, openBrace, closeBrace, openBracket, closeBracket :: Word8
+quote = 0x22
+backslash = 0x5c
+openBrace = 0x7b
+closeBrace = 0x7d
+openBracket = 0x5b
+closeBracket = 0x5d
+
+comma, colon, minus, plus, dot, exponentLower, exponentUpper :: Word8
+comma = 0x2c
+colon = 0x3a
+minus = 0x2d
+plus = 0x2b
+dot = 0x2e
+exponentLower = 0x65
+exponentUpper = 0x45

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
@@ -116,6 +116,19 @@ runDecoder decoder initial = case decoder of
         case transform value of
             Left err -> failure next err
             Right transformed -> pure (transformed, next)
+    WithRawDecoder inner -> do
+        let start = (skipWhitespace initial).position
+        (value, next) <- runDecoder inner initial
+        pure
+            ( ( value
+              , unsafeRawJsonFromValidatedBytes
+                    (BS.copy
+                        (BS.take
+                            (next.position - start)
+                            (BS.drop start next.input)))
+              )
+            , next
+            )
 
 jsonTypeAt :: Cursor -> Either DecodeError JsonType
 jsonTypeAt initial =
@@ -269,7 +282,8 @@ parsePlannedObject initialPlan initial = do
                                                     valueStart
                                                     decodedCursor.input))))
                                     rebuilt
-                            | otherwise = rebuilt
+                            | otherwise =
+                                deletePlannedExtension key rebuilt
                     pure
                         (withNull, leave decodedCursor)
                 Nothing

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
@@ -73,6 +73,24 @@ runDecoder decoder initial = case decoder of
         parseObject state fields unknown finish initial
     PlannedObjectDecoder plan ->
         parsePlannedObject plan initial
+    DiscriminatedObjectDecoder discriminator select -> do
+        (tag, _) <-
+            runDecoder
+                (ObjectDecoder
+                    Nothing
+                    [ NamedField
+                        discriminator
+                        TextDecoder
+                        (\value _ -> Right (Just value))
+                    ]
+                    (UnknownField SkipDecoder
+                        (\_ () state -> Right state))
+                    (maybe
+                        (Left
+                            ("missing required field " <> discriminator))
+                        Right))
+                initial
+        runDecoder (select tag) initial
     NullableDecoder inner ->
         let cursor = skipWhitespace initial
         in if literalAt "null" cursor

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
@@ -78,6 +78,9 @@ runDecoder decoder initial = case decoder of
             else do
                 (value, next) <- runDecoder inner cursor
                 pure (Just value, next)
+    ByTypeDecoder select -> do
+        valueType <- jsonTypeAt initial
+        runDecoder (select valueType) initial
     RawJsonDecoder -> do
         let start = (skipWhitespace initial).position
         next <- skipJsonValue initial
@@ -93,6 +96,19 @@ runDecoder decoder initial = case decoder of
         case transform value of
             Left err -> failure next err
             Right transformed -> pure (transformed, next)
+
+jsonTypeAt :: Cursor -> Either DecodeError JsonType
+jsonTypeAt initial =
+    let cursor = skipWhitespace initial
+    in case peekByte cursor of
+        Just byte
+            | byte == 0x6e -> Right JsonNull
+            | byte == 0x74 || byte == 0x66 -> Right JsonBoolean
+            | byte == quote -> Right JsonString
+            | byte == openBracket -> Right JsonArray
+            | byte == openBrace -> Right JsonObject
+            | byte == minus || isDigit byte -> Right JsonNumber
+        _ -> failure cursor "expected a JSON value"
 
 parseBool :: Cursor -> Either DecodeError (Bool, Cursor)
 parseBool initial

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
@@ -71,6 +71,8 @@ runDecoder decoder initial = case decoder of
         parseArray elementDecoder initial
     ObjectDecoder state fields unknown finish ->
         parseObject state fields unknown finish initial
+    PlannedObjectDecoder plan ->
+        parsePlannedObject plan initial
     NullableDecoder inner ->
         let cursor = skipWhitespace initial
         in if literalAt "null" cursor
@@ -207,6 +209,54 @@ decodeObjectField key state cursor fields unknown =
     finishUpdate decodedCursor = \case
         Left err -> failure decodedCursor err
         Right updated -> pure (updated, leave decodedCursor)
+
+parsePlannedObject
+    :: ObjectPlan a
+    -> Cursor
+    -> Either DecodeError (a, Cursor)
+parsePlannedObject initialPlan initial = do
+    opened <- consumeByte openBrace (skipWhitespace initial)
+    let cursor = skipWhitespace opened
+    if peekByte cursor == Just closeBrace
+        then do
+            finished <- consumeByte closeBrace cursor
+            finishPlan initialPlan finished
+        else go initialPlan cursor
+  where
+    go plan cursor = do
+        (key, afterKey) <- parseString cursor
+        afterColon <- consumeByte colon (skipWhitespace afterKey)
+        let nested = enter (PathKey key) afterColon
+        (updatedPlan, afterValue) <-
+            case matchPlannedField key plan of
+                Just (PlannedFieldMatch decoder rebuild) -> do
+                    (value, decodedCursor) <- runDecoder decoder nested
+                    pure (rebuild value, leave decodedCursor)
+                Nothing
+                    | objectPlanCapturesExtensions plan -> do
+                        (value, decodedCursor) <-
+                            runDecoder RawJsonDecoder nested
+                        pure
+                            ( capturePlannedExtension key value plan
+                            , leave decodedCursor
+                            )
+                    | otherwise -> do
+                        ((), decodedCursor) <-
+                            runDecoder SkipDecoder nested
+                        pure (plan, leave decodedCursor)
+        let next = skipWhitespace afterValue
+        case peekByte next of
+            Just byte | byte == comma ->
+                consumeByte comma next >>= go updatedPlan . skipWhitespace
+            Just byte | byte == closeBrace -> do
+                finished <- consumeByte closeBrace next
+                finishPlan updatedPlan finished
+            _ -> failure next "expected ',' or '}'"
+
+    finishPlan plan cursor =
+        case finishObjectPlan plan of
+            Left err -> failure cursor err
+            Right value -> pure (value, cursor)
 
 parseString :: Cursor -> Either DecodeError (Text, Cursor)
 parseString initial = do

--- a/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Decoder/Portable.hs
@@ -233,12 +233,12 @@ parsePlannedObject
     -> Cursor
     -> Either DecodeError (a, Cursor)
 parsePlannedObject initialPlan initial = do
-    opened <- consumeByte openBrace (skipWhitespace initial)
+    opened <- descend =<< consumeByte openBrace (skipWhitespace initial)
     let cursor = skipWhitespace opened
     if peekByte cursor == Just closeBrace
         then do
             finished <- consumeByte closeBrace cursor
-            finishPlan initialPlan finished
+            finishPlan initialPlan (leaveDepth finished)
         else go initialPlan cursor
   where
     go plan cursor = do
@@ -268,7 +268,7 @@ parsePlannedObject initialPlan initial = do
                 consumeByte comma next >>= go updatedPlan . skipWhitespace
             Just byte | byte == closeBrace -> do
                 finished <- consumeByte closeBrace next
-                finishPlan updatedPlan finished
+                finishPlan updatedPlan (leaveDepth finished)
             _ -> failure next "expected ',' or '}'"
 
     finishPlan plan cursor =

--- a/packages/agent-json-codec/src/Agent/Json/Encoder.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Encoder.hs
@@ -116,21 +116,26 @@ rawJson =
 
 object :: [Field a] -> Encoder a
 object fields =
-    let reserved =
-            Set.fromList
-                [ key
-                | Field { fieldName = Just key } <- fields
+    Encoder \value ->
+        let known =
+                concat
+                    [ renderField value
+                    | Field
+                        { fieldName = Just _
+                        , renderField
+                        } <- fields
+                    ]
+            emitted = Set.fromList (map fst known)
+            extensions =
+                [ entry
+                | Field
+                    { fieldName = Nothing
+                    , renderField
+                    } <- fields
+                , entry@(key, _) <- renderField value
+                , key `Set.notMember` emitted
                 ]
-        withoutReserved (key, _) = key `Set.notMember` reserved
-    in Encoder \value ->
-        Jsonifier.object $
-            concatMap
-                (\Field { fieldName, renderField } ->
-                    case fieldName of
-                        Just _ -> renderField value
-                        Nothing ->
-                            filter withoutReserved (renderField value))
-                fields
+        in Jsonifier.object (known <> extensions)
 
 objectWithExtensions
     :: (a -> Extensions)

--- a/packages/agent-json-codec/src/Agent/Json/Encoder.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Encoder.hs
@@ -7,6 +7,7 @@ module Agent.Json.Encoder
     ( Encoder
     , Field
     , encode
+    , choose
     , contramap
     , nullValue
     , bool
@@ -56,6 +57,12 @@ data Field a =
 encode :: Encoder a -> a -> BS.ByteString
 encode (Encoder renderValue) =
     Jsonifier.toByteString . renderValue
+
+choose :: (value -> Encoder value) -> Encoder value
+choose select =
+    Encoder \value ->
+        case select value of
+            Encoder renderValue -> renderValue value
 
 contramap :: (b -> a) -> Encoder a -> Encoder b
 contramap transform (Encoder renderValue) =

--- a/packages/agent-json-codec/src/Agent/Json/Encoder.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Encoder.hs
@@ -1,0 +1,182 @@
+-- | Direct JSON encoding.
+--
+-- An 'Encoder' compiles a domain value to a private exact-size write program.
+-- Jsonifier's 'Json' type is a @(size, poke)@ program rather than a semantic
+-- JSON value tree; it is never exposed by this module.
+module Agent.Json.Encoder
+    ( Encoder
+    , Field
+    , encode
+    , contramap
+    , nullValue
+    , bool
+    , text
+    , string
+    , scientific
+    , int
+    , integer
+    , word
+    , double
+    , list
+    , vector
+    , maybe
+    , rawJson
+    , object
+    , objectWithExtensions
+    , field
+    , optionalField
+    , nullableField
+    , extensionsField
+    ) where
+
+import Agent.Json
+    ( Extensions
+    , RawJson
+    , extensionsToList
+    , rawJsonBytes
+    )
+import qualified Data.ByteString as BS
+import Data.Scientific (Scientific)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Jsonifier
+import qualified Prelude
+import Prelude hiding (maybe)
+
+newtype Encoder a =
+    Encoder (a -> Jsonifier.Json)
+
+data Field a =
+    Field
+        { fieldName :: !(Maybe Text)
+        , renderField :: !(a -> [(Text, Jsonifier.Json)])
+        }
+
+encode :: Encoder a -> a -> BS.ByteString
+encode (Encoder renderValue) =
+    Jsonifier.toByteString . renderValue
+
+contramap :: (b -> a) -> Encoder a -> Encoder b
+contramap transform (Encoder renderValue) =
+    Encoder (renderValue . transform)
+
+nullValue :: Encoder a
+nullValue = Encoder (const Jsonifier.null)
+
+bool :: Encoder Bool
+bool = Encoder Jsonifier.bool
+
+text :: Encoder Text
+text = Encoder Jsonifier.textString
+
+string :: Encoder String
+string = contramap Text.pack text
+
+scientific :: Encoder Scientific
+scientific = Encoder Jsonifier.scientificNumber
+
+int :: Encoder Int
+int = Encoder Jsonifier.intNumber
+
+integer :: Encoder Integer
+integer = Encoder (Jsonifier.scientificNumber . fromInteger)
+
+word :: Encoder Word
+word = Encoder Jsonifier.wordNumber
+
+double :: Encoder Double
+double = Encoder \value ->
+    if isNaN value || isInfinite value
+        then Jsonifier.null
+        else Jsonifier.doubleNumber value
+
+list :: Encoder a -> Encoder [a]
+list (Encoder renderValue) =
+    Encoder (Jsonifier.array . map renderValue)
+
+vector :: Foldable collection => Encoder a -> Encoder (collection a)
+vector (Encoder renderValue) =
+    Encoder (Jsonifier.array . foldr (\value rest -> renderValue value : rest) [])
+
+maybe :: Encoder a -> Encoder (Maybe a)
+maybe (Encoder renderValue) =
+    Encoder (Prelude.maybe Jsonifier.null renderValue)
+
+rawJson :: Encoder RawJson
+rawJson =
+    Encoder (Jsonifier.fromByteString . rawJsonBytes)
+
+object :: [Field a] -> Encoder a
+object fields =
+    let reserved =
+            Set.fromList
+                [ key
+                | Field { fieldName = Just key } <- fields
+                ]
+        withoutReserved (key, _) = key `Set.notMember` reserved
+    in Encoder \value ->
+        Jsonifier.object $
+            concatMap
+                (\Field { fieldName, renderField } ->
+                    case fieldName of
+                        Just _ -> renderField value
+                        Nothing ->
+                            filter withoutReserved (renderField value))
+                fields
+
+objectWithExtensions
+    :: (a -> Extensions)
+    -> [Field a]
+    -> Encoder a
+objectWithExtensions getExtensions fields =
+    object (fields <> [extensionsField getExtensions])
+
+field
+    :: Text
+    -> Encoder value
+    -> (object -> value)
+    -> Field object
+field key (Encoder renderValue) getValue =
+    Field
+        { fieldName = Just key
+        , renderField = \objectValue ->
+            [(key, renderValue (getValue objectValue))]
+        }
+
+optionalField
+    :: Text
+    -> Encoder value
+    -> (object -> Maybe value)
+    -> Field object
+optionalField key (Encoder renderValue) getValue =
+    Field
+        { fieldName = Just key
+        , renderField = \objectValue -> case getValue objectValue of
+            Nothing -> []
+            Just value -> [(key, renderValue value)]
+        }
+
+nullableField
+    :: Text
+    -> Encoder value
+    -> (object -> Maybe value)
+    -> Field object
+nullableField key (Encoder renderValue) getValue =
+    Field
+        { fieldName = Just key
+        , renderField = \objectValue ->
+            [(key, Prelude.maybe Jsonifier.null renderValue (getValue objectValue))]
+        }
+
+extensionsField :: (object -> Extensions) -> Field object
+extensionsField getExtensions =
+    Field
+        { fieldName = Nothing
+        , renderField =
+            map
+                (\(key, value) ->
+                    (key, Jsonifier.fromByteString (rawJsonBytes value)))
+                . extensionsToList
+                . getExtensions
+        }

--- a/packages/agent-json-codec/src/Agent/Json/Encoder.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Encoder.hs
@@ -24,6 +24,7 @@ module Agent.Json.Encoder
     , rawJson
     , object
     , objectWithExtensions
+    , objectWithExtensionsWhen
     , field
     , optionalField
     , nullableField
@@ -143,6 +144,24 @@ objectWithExtensions
     -> Encoder a
 objectWithExtensions getExtensions fields =
     object (fields <> [extensionsField getExtensions])
+
+objectWithExtensionsWhen
+    :: (a -> Extensions)
+    -> (a -> Text -> Bool)
+    -> [Field a]
+    -> Encoder a
+objectWithExtensionsWhen getExtensions include fields =
+    object (map gated fields <> [extensionsField getExtensions])
+  where
+    gated fieldValue@Field{fieldName = Nothing} = fieldValue
+    gated Field{fieldName = Just key, renderField} =
+        Field
+            { fieldName = Just key
+            , renderField = \value ->
+                if include value key
+                    then renderField value
+                    else []
+            }
 
 field
     :: Text

--- a/packages/agent-json-codec/src/Agent/Json/Internal.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Internal.hs
@@ -22,19 +22,24 @@ instance Show RawJson where
 data Extensions = Extensions
     !(Map Text RawJson)
     !(Set Text)
+    !(Maybe RawJson)
 
 instance Eq Extensions where
-    Extensions left _ == Extensions right _ = left == right
+    Extensions left _ _ == Extensions right _ _ = left == right
 
 instance Show Extensions where
-    showsPrec precedence (Extensions values _) =
+    showsPrec precedence (Extensions values _ _) =
         showsPrec precedence values
 
 instance Semigroup Extensions where
-    Extensions left leftPresent <> Extensions right rightPresent =
+    Extensions left leftPresent leftSource
+        <> Extensions right rightPresent rightSource =
         Extensions
             (Map.union right left)
             (leftPresent <> rightPresent)
+            (case rightSource of
+                Just{} -> rightSource
+                Nothing -> leftSource)
 
 instance Monoid Extensions where
-    mempty = Extensions Map.empty mempty
+    mempty = Extensions Map.empty mempty Nothing

--- a/packages/agent-json-codec/src/Agent/Json/Internal.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Internal.hs
@@ -6,6 +6,7 @@ module Agent.Json.Internal
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
+import Data.Set (Set)
 import Data.Text (Text)
 
 -- | A validated JSON value kept as bytes.  The constructor is private outside
@@ -18,12 +19,22 @@ instance Show RawJson where
 
 -- | Unknown object members, indexed by their key.  Inserting a key replaces
 -- the previous value (the wire policy is last-key-wins).
-newtype Extensions = Extensions (Map Text RawJson)
-    deriving stock (Eq, Show)
+data Extensions = Extensions
+    !(Map Text RawJson)
+    !(Set Text)
+
+instance Eq Extensions where
+    Extensions left _ == Extensions right _ = left == right
+
+instance Show Extensions where
+    showsPrec precedence (Extensions values _) =
+        showsPrec precedence values
 
 instance Semigroup Extensions where
-    Extensions left <> Extensions right =
-        Extensions (Map.union right left)
+    Extensions left leftPresent <> Extensions right rightPresent =
+        Extensions
+            (Map.union right left)
+            (leftPresent <> rightPresent)
 
 instance Monoid Extensions where
-    mempty = Extensions Map.empty
+    mempty = Extensions Map.empty mempty

--- a/packages/agent-json-codec/src/Agent/Json/Internal.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Internal.hs
@@ -1,0 +1,21 @@
+module Agent.Json.Internal
+    ( RawJson(..)
+    , Extensions(..)
+    ) where
+
+import qualified Data.ByteString as BS
+import Data.Map.Strict (Map)
+import Data.Text (Text)
+
+-- | A validated JSON value kept as bytes.  The constructor is private outside
+-- this package; values are made by 'validateRawJson' or the raw decoder.
+newtype RawJson = RawJson BS.ByteString
+    deriving stock (Eq, Ord)
+
+instance Show RawJson where
+    show (RawJson bytes) = "RawJson <" <> show (BS.length bytes) <> " bytes>"
+
+-- | Unknown object members, indexed by their key.  Inserting a key replaces
+-- the previous value (the wire policy is last-key-wins).
+newtype Extensions = Extensions (Map Text RawJson)
+    deriving stock (Eq, Show)

--- a/packages/agent-json-codec/src/Agent/Json/Internal.hs
+++ b/packages/agent-json-codec/src/Agent/Json/Internal.hs
@@ -4,6 +4,7 @@ module Agent.Json.Internal
     ) where
 
 import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 
@@ -19,3 +20,10 @@ instance Show RawJson where
 -- the previous value (the wire policy is last-key-wins).
 newtype Extensions = Extensions (Map Text RawJson)
     deriving stock (Eq, Show)
+
+instance Semigroup Extensions where
+    Extensions left <> Extensions right =
+        Extensions (Map.union right left)
+
+instance Monoid Extensions where
+    mempty = Extensions Map.empty

--- a/packages/agent-json-codec/test/Spec.hs
+++ b/packages/agent-json-codec/test/Spec.hs
@@ -99,6 +99,22 @@ expectRight = \case
     Left err -> expectationFailure (show err) >> error "unreachable"
     Right value -> pure value
 
+data Planned = Planned
+    { plannedName :: !Text
+    , plannedCount :: !Int
+    , plannedEnabled :: !(Maybe Bool)
+    , plannedExtensions :: !Extensions
+    }
+
+plannedDecoder :: Decoder.Decoder Planned
+plannedDecoder =
+    Decoder.objectFields $
+        Planned
+            <$> Decoder.requiredField "name" Decoder.text
+            <*> Decoder.defaultField 0 "count" Decoder.int
+            <*> Decoder.optionalField "enabled" Decoder.bool
+            <*> Decoder.extensionFields
+
 main :: IO ()
 main = hspec do
     describe "portable direct decoder" do
@@ -176,6 +192,21 @@ main = hspec do
             Decoder.decode Decoder.scientific "-12.5e2"
                 `shouldBe` Right (-1250)
             Decoder.decode (Decoder.nullValue ()) "null" `shouldBe` Right ()
+
+        it "decodes heterogeneous object fields applicatively in one pass" do
+            planned <- expectRight $
+                Decoder.decode plannedDecoder
+                    ( "{\"name\":\"first\",\"count\":1,\"name\":\"last\","
+                        <> "\"enabled\":null,\"future\":{\"x\":1}}"
+                    )
+            planned.plannedName `shouldBe` "last"
+            planned.plannedCount `shouldBe` 1
+            planned.plannedEnabled `shouldBe` Nothing
+            rawJsonBytes
+                <$> lookupExtension
+                    "future"
+                    planned.plannedExtensions
+                `shouldBe` Just "{\"x\":1}"
 
     describe "direct encoder" do
         it "round-trips domain values without a JSON tree" do

--- a/packages/agent-json-codec/test/Spec.hs
+++ b/packages/agent-json-codec/test/Spec.hs
@@ -256,6 +256,18 @@ main = hspec do
                     decoded.plannedExtensions
                 `shouldBe` Just "null"
 
+        it "removes a prior null when a duplicate value follows" do
+            decoded <- expectRight $
+                Decoder.decode plannedDecoder
+                    ( "{\"name\":\"Ada\",\"enabled\":null,"
+                        <> "\"enabled\":true}"
+                    )
+            decoded.plannedEnabled `shouldBe` Just True
+            lookupExtension
+                "enabled"
+                decoded.plannedExtensions
+                `shouldBe` Nothing
+
         it "selects tagged object codecs without a generic object" do
             Decoder.decode taggedDecoder
                 "{\"value\":\"first\",\"type\":\"text\"}"

--- a/packages/agent-json-codec/test/Spec.hs
+++ b/packages/agent-json-codec/test/Spec.hs
@@ -245,14 +245,14 @@ main = hspec do
         it "tracks known field presence and retains explicit null" do
             decoded <- expectRight $
                 Decoder.decode plannedDecoder
-                    "{\"name\":\"Ada\",\"active\":null}"
+                    "{\"name\":\"Ada\",\"enabled\":null}"
             extensionFieldWasPresent
-                "active"
+                "enabled"
                 decoded.plannedExtensions
                 `shouldBe` True
             rawJsonBytes
                 <$> lookupExtension
-                    "active"
+                    "enabled"
                     decoded.plannedExtensions
                 `shouldBe` Just "null"
 

--- a/packages/agent-json-codec/test/Spec.hs
+++ b/packages/agent-json-codec/test/Spec.hs
@@ -115,6 +115,18 @@ plannedDecoder =
             <*> Decoder.optionalField "enabled" Decoder.bool
             <*> Decoder.extensionFields
 
+taggedDecoder :: Decoder.Decoder Text
+taggedDecoder =
+    Decoder.discriminatedObject "type" \case
+        "text" ->
+            Decoder.objectFields $
+                Decoder.requiredField "value" Decoder.text
+                    <* Decoder.defaultField () "type" (() <$ Decoder.text)
+        tag ->
+            Decoder.mapEither
+                (const (Left ("unknown tag " <> tag)))
+                Decoder.skip
+
 main :: IO ()
 main = hspec do
     describe "portable direct decoder" do
@@ -207,6 +219,14 @@ main = hspec do
                     "future"
                     planned.plannedExtensions
                 `shouldBe` Just "{\"x\":1}"
+
+        it "selects tagged object codecs without a generic object" do
+            Decoder.decode taggedDecoder
+                "{\"value\":\"first\",\"type\":\"text\"}"
+                `shouldBe` Right "first"
+            Decoder.decode taggedDecoder
+                "{\"type\":\"ignored\",\"type\":\"text\",\"value\":\"last\"}"
+                `shouldBe` Right "last"
 
     describe "direct encoder" do
         it "round-trips domain values without a JSON tree" do

--- a/packages/agent-json-codec/test/Spec.hs
+++ b/packages/agent-json-codec/test/Spec.hs
@@ -127,6 +127,18 @@ taggedDecoder =
                 (const (Left ("unknown tag " <> tag)))
                 Decoder.skip
 
+plannedNestedDecoder :: Decoder.Decoder ()
+plannedNestedDecoder =
+    Decoder.byType \case
+        Decoder.JsonNull -> Decoder.nullValue ()
+        Decoder.JsonObject ->
+            Decoder.objectFields $
+                Decoder.defaultField
+                    ()
+                    "x"
+                    plannedNestedDecoder
+        _ -> () <$ Decoder.skip
+
 main :: IO ()
 main = hspec do
     describe "portable direct decoder" do
@@ -198,6 +210,16 @@ main = hspec do
                         <> BS.replicate nesting 0x5d
             Decoder.validateRawJson input `shouldSatisfy` isLeft
 
+        it "enforces the depth limit for applicative objects" do
+            let nesting = 1_025
+                input =
+                    BS.concat
+                        (replicate nesting "{\"x\":")
+                        <> "null"
+                        <> BS.replicate nesting 0x7d
+            Decoder.decode plannedNestedDecoder input
+                `shouldSatisfy` isLeft
+
         it "accepts scalar roots" do
             Decoder.decode Decoder.bool "true" `shouldBe` Right True
             Decoder.decode Decoder.text "\"hello\"" `shouldBe` Right "hello"
@@ -258,6 +280,23 @@ main = hspec do
             BS8.count '"' encoded `shouldSatisfy` (> 0)
             Decoder.decode personDecoder encoded
                 `shouldBe` Right value { extensions = emptyExtensions }
+
+        it "retains an extension for an absent optional field" do
+            explicitNull <- expectRight $
+                Decoder.validateRawJson "null"
+            let value = Person
+                    { name = "Ada"
+                    , age = 1
+                    , active = Nothing
+                    , tags = []
+                    , extensions =
+                        insertExtension
+                            "active"
+                            explicitNull
+                            emptyExtensions
+                    }
+                encoded = Encoder.encode personEncoder value
+            encoded `shouldSatisfy` BS8.isInfixOf "\"active\":null"
 
         it "escapes control characters and unicode directly" do
             let value = "quote: \" slash: \\ newline:\n snowman: ☃"

--- a/packages/agent-json-codec/test/Spec.hs
+++ b/packages/agent-json-codec/test/Spec.hs
@@ -268,6 +268,14 @@ main = hspec do
                 decoded.plannedExtensions
                 `shouldBe` Nothing
 
+        it "captures the complete source for a decoded value" do
+            (_, raw) <- expectRight $
+                Decoder.decode
+                    (Decoder.withRaw plannedDecoder)
+                    "{\"name\":\"Ada\",\"enabled\":true}"
+            rawJsonBytes raw
+                `shouldBe` "{\"name\":\"Ada\",\"enabled\":true}"
+
         it "selects tagged object codecs without a generic object" do
             Decoder.decode taggedDecoder
                 "{\"value\":\"first\",\"type\":\"text\"}"

--- a/packages/agent-json-codec/test/Spec.hs
+++ b/packages/agent-json-codec/test/Spec.hs
@@ -1,0 +1,314 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Main (main) where
+
+import Agent.Json
+import qualified Agent.Json.Decoder as Decoder
+import qualified Agent.Json.Encoder as Encoder
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Either (isLeft, isRight)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck
+
+data Person = Person
+    { name :: !Text
+    , age :: !Int
+    , active :: !(Maybe Bool)
+    , tags :: ![Text]
+    , extensions :: !Extensions
+    }
+    deriving stock (Eq, Show)
+
+data PersonState = PersonState
+    { personName :: !(Maybe Text)
+    , personAge :: !(Maybe Int)
+    , personActive :: !(Maybe Bool)
+    , personTags :: !(Maybe [Text])
+    , personExtensions :: !Extensions
+    }
+
+emptyPersonState :: PersonState
+emptyPersonState = PersonState
+    { personName = Nothing
+    , personAge = Nothing
+    , personActive = Nothing
+    , personTags = Nothing
+    , personExtensions = emptyExtensions
+    }
+
+personDecoder :: Decoder.Decoder Person
+personDecoder =
+    Decoder.object
+        emptyPersonState
+        fields
+        (Decoder.unknownField Decoder.rawJson
+            \key value state ->
+                Right state
+                    { personExtensions =
+                        insertExtension
+                            key
+                            value
+                            state.personExtensions
+                    })
+        finish
+  where
+    fields =
+        [ Decoder.field "name" Decoder.text \value state ->
+            Right state { personName = Just value }
+        , Decoder.field "age" Decoder.int \value state ->
+            Right state { personAge = Just value }
+        , Decoder.field "active"
+            (Decoder.nullable Decoder.bool) \value state ->
+            Right state { personActive = value }
+        , Decoder.field "tags"
+            (Decoder.array Decoder.text) \value state ->
+            Right state { personTags = Just value }
+        ]
+
+    finish PersonState {..} = do
+        person <- Person
+            <$> required "name" personName
+            <*> required "age" personAge
+            <*> Right personActive
+            <*> required "tags" personTags
+            <*> Right personExtensions
+        pure person
+
+    required fieldLabel =
+        maybe (Left ("missing required field " <> fieldLabel)) Right
+
+personEncoder :: Encoder.Encoder Person
+personEncoder = Encoder.object
+    [ Encoder.field "name" Encoder.text (.name)
+    , Encoder.field "age" Encoder.int (.age)
+    , Encoder.nullableField "active" Encoder.bool (.active)
+    , Encoder.field "tags" (Encoder.list Encoder.text) (.tags)
+    , Encoder.extensionsField (.extensions)
+    ]
+
+expectRight :: Show error => Either error value -> IO value
+expectRight = \case
+    Left err -> expectationFailure (show err) >> error "unreachable"
+    Right value -> pure value
+
+main :: IO ()
+main = hspec do
+    describe "portable direct decoder" do
+        it "decodes typed fields and retains unknown values opaquely" do
+            let input =
+                    "{\"name\":\"Ada\",\"age\":37,\"active\":true,"
+                        <> "\"tags\":[\"math\",\"code\"],"
+                        <> "\"vendor\":{\"nested\":[1,true,null]}}"
+            person <- expectRight (Decoder.decode personDecoder input)
+            person.name `shouldBe` "Ada"
+            person.age `shouldBe` 37
+            person.active `shouldBe` Just True
+            person.tags `shouldBe` ["math", "code"]
+            rawJsonBytes
+                <$> lookupExtension "vendor" person.extensions
+                `shouldBe` Just "{\"nested\":[1,true,null]}"
+
+        it "uses last-key-wins semantics" do
+            person <- expectRight $
+                Decoder.decode personDecoder
+                    ( "{\"name\":\"first\",\"name\":\"last\","
+                        <> "\"age\":1,\"tags\":[]}"
+                    )
+            person.name `shouldBe` "last"
+
+        it "reports nested paths for type errors" do
+            case Decoder.decode personDecoder
+                "{\"name\":\"Ada\",\"age\":1,\"tags\":[\"ok\",false]}" of
+                Left err ->
+                    err.path
+                        `shouldBe`
+                            [ Decoder.PathKey "tags"
+                            , Decoder.PathIndex 1
+                            ]
+                Right _ -> expectationFailure "expected decoding to fail"
+
+        it "rejects malformed JSON and trailing bytes" do
+            mapM_
+                (\input ->
+                    Decoder.decode Decoder.rawJson input
+                        `shouldSatisfy` isLeft)
+                [ ""
+                , "01"
+                , "1."
+                , "1e"
+                , "\"\\uD800\""
+                , "\"\x01\""
+                , "[1,]"
+                , "{\"a\":1,}"
+                , "{\"a\":[1,2}"
+                , "true false"
+                , "+1"
+                , ".1"
+                , "00"
+                , "1e+"
+                , "\"\\x20\""
+                , "{\"a\" 1}"
+                ]
+
+        it "rejects invalid UTF-8" do
+            Decoder.validateRawJson (BS.pack [0x22, 0xc0, 0xaf, 0x22])
+                `shouldSatisfy` isLeft
+
+        it "enforces the nesting-depth limit" do
+            let nesting = 1_025
+                input =
+                    BS.replicate nesting 0x5b
+                        <> "0"
+                        <> BS.replicate nesting 0x5d
+            Decoder.validateRawJson input `shouldSatisfy` isLeft
+
+        it "accepts scalar roots" do
+            Decoder.decode Decoder.bool "true" `shouldBe` Right True
+            Decoder.decode Decoder.text "\"hello\"" `shouldBe` Right "hello"
+            Decoder.decode Decoder.scientific "-12.5e2"
+                `shouldBe` Right (-1250)
+            Decoder.decode (Decoder.nullValue ()) "null" `shouldBe` Right ()
+
+    describe "direct encoder" do
+        it "round-trips domain values without a JSON tree" do
+            extension <- expectRight $
+                Decoder.validateRawJson "{\"enabled\":true}"
+            let expected = Person
+                    { name = "Ada"
+                    , age = 37
+                    , active = Nothing
+                    , tags = ["math", "code"]
+                    , extensions =
+                        insertExtension "vendor" extension emptyExtensions
+                    }
+                encoded = Encoder.encode personEncoder expected
+            Decoder.decode personDecoder encoded `shouldBe` Right expected
+
+        it "does not let extensions override typed fields" do
+            staleName <- expectRight $
+                Decoder.validateRawJson "\"stale\""
+            let value = Person
+                    { name = "current"
+                    , age = 1
+                    , active = Just False
+                    , tags = []
+                    , extensions =
+                        insertExtension "name" staleName emptyExtensions
+                    }
+                encoded = Encoder.encode personEncoder value
+            BS8.count '"' encoded `shouldSatisfy` (> 0)
+            Decoder.decode personDecoder encoded
+                `shouldBe` Right value { extensions = emptyExtensions }
+
+        it "escapes control characters and unicode directly" do
+            let value = "quote: \" slash: \\ newline:\n snowman: ☃"
+                encoded = Encoder.encode Encoder.text value
+            Decoder.decode Decoder.text encoded `shouldBe` Right value
+
+        it "encodes non-finite doubles as null" do
+            Encoder.encode Encoder.double (0 / 0) `shouldBe` "null"
+            Encoder.encode Encoder.double (1 / 0) `shouldBe` "null"
+
+    describe "numeric safety" do
+        it "rejects pathological Integer exponents without exponentiating" do
+            Decoder.decode Decoder.integer "1e-1000000000"
+                `shouldSatisfy` isLeft
+
+    describe "opaque raw JSON" do
+        it "copies validated bytes so they survive source reuse" do
+            let source = "{\"a\":[1,2,3]}"
+            raw <- expectRight (Decoder.validateRawJson source)
+            rawJsonBytes raw `shouldBe` source
+
+    describe "differential conformance" do
+        prop "validates generated JSON accepted by Aeson" $
+            withMaxSuccess 1_000 \(tree :: JsonTree) ->
+                let bytes = renderJsonTree tree
+                in counterexample (BS8.unpack bytes) $
+                    isRight (Decoder.validateRawJson bytes)
+                        .&&. isRight
+                            (Aeson.eitherDecodeStrict bytes
+                                :: Either String Aeson.Value)
+
+data JsonTree
+    = JsonNull
+    | JsonBool !Bool
+    | JsonNumber !Int
+    | JsonText !Text
+    | JsonArray ![JsonTree]
+    | JsonObject ![(Text, JsonTree)]
+    deriving stock (Eq, Show)
+
+instance Arbitrary JsonTree where
+    arbitrary = sized go
+      where
+        go size
+            | size <= 0 = oneof scalars
+            | otherwise = frequency
+                [ (5, oneof scalars)
+                , (2, JsonArray
+                    <$> resize (size `div` 2) arbitrary)
+                , (2, JsonObject
+                    <$> resize (size `div` 2)
+                        (listOf ((,) <$> jsonText <*> arbitrary)))
+                ]
+
+        scalars =
+            [ pure JsonNull
+            , JsonBool <$> arbitrary
+            , JsonNumber <$> chooseInt (-1_000_000, 1_000_000)
+            , JsonText <$> jsonText
+            ]
+
+        jsonText =
+            Text.pack <$> listOf
+                (arbitraryUnicodeChar `suchThat` \character ->
+                    character < '\xD800' || character > '\xDFFF')
+
+    shrink = \case
+        JsonArray values ->
+            map JsonArray (shrink values) <> values
+        JsonObject fields ->
+            [ JsonObject (take index fields <> drop (index + 1) fields)
+            | index <- [0 .. length fields - 1]
+            ] <> map snd fields
+        JsonText value ->
+            JsonText . Text.pack <$> shrink (Text.unpack value)
+        JsonNumber value -> JsonNumber <$> shrink value
+        JsonBool _ -> [JsonNull]
+        JsonNull -> []
+
+renderJsonTree :: JsonTree -> BS.ByteString
+renderJsonTree = \case
+    JsonNull -> "null"
+    JsonBool value -> Encoder.encode Encoder.bool value
+    JsonNumber value -> Encoder.encode Encoder.int value
+    JsonText value -> Encoder.encode Encoder.text value
+    JsonArray values ->
+        BS.concat
+            [ "["
+            , BS.intercalate "," (map renderJsonTree values)
+            , "]"
+            ]
+    JsonObject fields ->
+        BS.concat
+            [ "{"
+            , BS.intercalate ","
+                [ BS.concat
+                    [ Encoder.encode Encoder.text key
+                    , ":"
+                    , renderJsonTree value
+                    ]
+                | (key, value) <- fields
+                ]
+            , "}"
+            ]
+

--- a/packages/agent-json-codec/test/Spec.hs
+++ b/packages/agent-json-codec/test/Spec.hs
@@ -242,6 +242,18 @@ main = hspec do
                     planned.plannedExtensions
                 `shouldBe` Just "{\"x\":1}"
 
+        it "tracks known field presence and retains explicit null" do
+            decoded <- expectRight $
+                Decoder.decode plannedDecoder
+                    "{\"name\":\"Ada\",\"active\":null}"
+            extensionFieldWasPresent
+                "active"
+                decoded.extensions
+                `shouldBe` True
+            rawJsonBytes
+                <$> lookupExtension "active" decoded.extensions
+                `shouldBe` Just "null"
+
         it "selects tagged object codecs without a generic object" do
             Decoder.decode taggedDecoder
                 "{\"value\":\"first\",\"type\":\"text\"}"

--- a/packages/agent-json-codec/test/Spec.hs
+++ b/packages/agent-json-codec/test/Spec.hs
@@ -248,10 +248,12 @@ main = hspec do
                     "{\"name\":\"Ada\",\"active\":null}"
             extensionFieldWasPresent
                 "active"
-                decoded.extensions
+                decoded.plannedExtensions
                 `shouldBe` True
             rawJsonBytes
-                <$> lookupExtension "active" decoded.extensions
+                <$> lookupExtension
+                    "active"
+                    decoded.plannedExtensions
                 `shouldBe` Just "null"
 
         it "selects tagged object codecs without a generic object" do

--- a/packages/agent-json-hermes/LICENSE
+++ b/packages/agent-json-hermes/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2026, digitally induced GmbH
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of the author nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/agent-json-hermes/README.md
+++ b/packages/agent-json-hermes/README.md
@@ -1,0 +1,10 @@
+# agent-json-hermes
+
+Hermes/simdjson backend for `agent-json-codec`.
+
+Sessions are mutable and single-threaded. Allocate one session per concurrent
+stream with `withDecoderSession`.
+
+Hermes 0.8 exposes only `raw_json_token()`, which is not a complete nested
+array or object. Codecs that retain `RawJson` therefore use the portable direct
+backend until Hermes exposes a complete dependent object fold/raw-value API.

--- a/packages/agent-json-hermes/README.md
+++ b/packages/agent-json-hermes/README.md
@@ -5,6 +5,7 @@ Hermes/simdjson backend for `agent-json-codec`.
 Sessions are mutable and single-threaded. Allocate one session per concurrent
 stream with `withDecoderSession`.
 
-Hermes 0.8 exposes only `raw_json_token()`, which is not a complete nested
-array or object. Codecs that retain `RawJson` therefore use the portable direct
-backend until Hermes exposes a complete dependent object fold/raw-value API.
+This package currently pins the small Hermes extension proposed upstream in
+[velveteer/hermes#33](https://github.com/velveteer/hermes/pull/33). It adds a
+stateful dependent object fold and complete `raw_json()` access, allowing typed
+fields and opaque nested extensions to be decoded in one forward pass.

--- a/packages/agent-json-hermes/agent-json-hermes.cabal
+++ b/packages/agent-json-hermes/agent-json-hermes.cabal
@@ -1,0 +1,70 @@
+cabal-version:      3.0
+name:               agent-json-hermes
+version:            0.1.0.0
+synopsis:           Hermes backend for direct agent JSON codecs
+description:        Scoped Hermes decoding sessions for direct typed agent
+                    JSON codecs, with no generic JSON value representation.
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             digitally induced GmbH
+maintainer:         marc@digitallyinduced.com
+copyright:          (c) 2026 digitally induced GmbH
+category:           Web
+build-type:         Simple
+extra-source-files: README.md
+                  , benchmark/README.md
+
+common common-options
+    default-language: GHC2021
+    default-extensions: BlockArguments
+                      , DerivingStrategies
+                      , GADTs
+                      , LambdaCase
+                      , NoFieldSelectors
+                      , OverloadedRecordDot
+                      , OverloadedStrings
+    ghc-options:      -Wall
+                      -Wcompat
+                      -Widentities
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wpartial-fields
+                      -Werror=incomplete-patterns
+
+library
+    import:           common-options
+    hs-source-dirs:   src
+    exposed-modules:  Agent.Json.Decoder.Hermes
+    build-depends:    agent-json-codec == 0.1.0.0
+                    , base >= 4.17 && < 5
+                    , bytestring >= 0.11 && < 0.13
+                    , hermes-json >= 0.8 && < 0.9
+                    , safe-exceptions >= 0.1.7 && < 0.2
+                    , text >= 2.0 && < 2.2
+
+test-suite agent-json-hermes-test
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Spec.hs
+    build-depends:    agent-json-codec
+                    , agent-json-hermes
+                    , async >= 2.2 && < 2.3
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , hspec >= 2.11 && < 2.12
+                    , text
+
+benchmark direct-json-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          JsonCodec.hs
+    ghc-options:      -O2 -rtsopts
+    build-depends:    agent-json-codec
+                    , agent-json-hermes
+                    , aeson >= 2.2 && < 2.4
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , jsonifier >= 0.2.1.3 && < 0.3
+                    , text

--- a/packages/agent-json-hermes/benchmark/JsonCodec.hs
+++ b/packages/agent-json-hermes/benchmark/JsonCodec.hs
@@ -1,0 +1,294 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Main (main) where
+
+import qualified Agent.Json.Decoder as Decoder
+import qualified Agent.Json.Decoder.Hermes as Hermes
+import qualified Agent.Json.Encoder as Encoder
+import Control.Exception (evaluate)
+import Control.Monad (forM)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as Lazy
+import Data.List (sortOn)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Jsonifier
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = PortableDecode
+    | HermesDecode
+    | AesonDecode
+    | DirectEncode
+    | JsonifierEncode
+    | AesonEncode
+
+data BenchRecord = BenchRecord
+    { recordId :: !Int
+    , recordName :: !Text
+    , recordActive :: !Bool
+    , recordBody :: !Text
+    }
+    deriving stock (Eq, Show)
+
+data RecordState = RecordState
+    { stateId :: !(Maybe Int)
+    , stateName :: !(Maybe Text)
+    , stateActive :: !(Maybe Bool)
+    , stateBody :: !(Maybe Text)
+    }
+
+data Sample = Sample
+    { wallMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+instance Aeson.FromJSON BenchRecord where
+    parseJSON = Aeson.withObject "BenchRecord" \objectValue ->
+        BenchRecord
+            <$> objectValue Aeson..: "id"
+            <*> objectValue Aeson..: "name"
+            <*> objectValue Aeson..: "active"
+            <*> objectValue Aeson..: "body"
+
+instance Aeson.ToJSON BenchRecord where
+    toJSON record =
+        Aeson.object
+            [ "id" Aeson..= record.recordId
+            , "name" Aeson..= record.recordName
+            , "active" Aeson..= record.recordActive
+            , "body" Aeson..= record.recordBody
+            ]
+    toEncoding record =
+        Aeson.pairs
+            ( "id" Aeson..= record.recordId
+                <> "name" Aeson..= record.recordName
+                <> "active" Aeson..= record.recordActive
+                <> "body" Aeson..= record.recordBody
+            )
+
+recordDecoder :: Decoder.Decoder BenchRecord
+recordDecoder =
+    Decoder.object
+        (RecordState Nothing Nothing Nothing Nothing)
+        [ Decoder.field "id" Decoder.int \value state ->
+            Right state { stateId = Just value }
+        , Decoder.field "name" Decoder.text \value state ->
+            Right state { stateName = Just value }
+        , Decoder.field "active" Decoder.bool \value state ->
+            Right state { stateActive = Just value }
+        , Decoder.field "body" Decoder.text \value state ->
+            Right state { stateBody = Just value }
+        ]
+        (Decoder.unknownField Decoder.skip
+            \_ () state -> Right state)
+        \state ->
+            BenchRecord
+                <$> required "id" state.stateId
+                <*> required "name" state.stateName
+                <*> required "active" state.stateActive
+                <*> required "body" state.stateBody
+  where
+    required label =
+        maybe (Left ("missing " <> label)) Right
+
+recordEncoder :: Encoder.Encoder BenchRecord
+recordEncoder = Encoder.object
+    [ Encoder.field "id" Encoder.int (.recordId)
+    , Encoder.field "name" Encoder.text (.recordName)
+    , Encoder.field "active" Encoder.bool (.recordActive)
+    , Encoder.field "body" Encoder.text (.recordBody)
+    ]
+
+main :: IO ()
+main = do
+    statsEnabled <- getRTSStatsEnabled
+    if statsEnabled then pure () else die "run with +RTS -T"
+    getArgs >>= \case
+        [workloadArg, recordCountArg, bodyBytesArg, sampleCountArg] -> do
+            workload <- parseWorkload workloadArg
+            recordCount <- positive "record count" recordCountArg
+            bodyBytes <- positive "body bytes" bodyBytesArg
+            sampleCount <- positive "sample count" sampleCountArg
+            let records = map (makeRecord bodyBytes) [1 .. recordCount]
+                payloads = map encodeFixture records
+            _ <- evaluate $
+                sum (map BS.length payloads)
+                    + sum (map (.recordId) records)
+            validateImplementations records payloads
+            samples <- Hermes.withDecoderSession \session ->
+                forM [1 .. sampleCount] \_ ->
+                    measure (runWorkload workload session records payloads)
+            let middle =
+                    sortOn (.wallMillis) samples
+                        !! (length samples `div` 2)
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d\n"
+                workloadArg
+                recordCount
+                bodyBytes
+                sampleCount
+                middle.wallMillis
+                middle.cpuMillis
+                middle.allocatedBytes
+        _ -> die $
+            "usage: direct-json-bench WORKLOAD RECORDS BODY_BYTES SAMPLES\n"
+                <> "workloads: portable-decode, hermes-decode, aeson-decode, "
+                <> "direct-encode, jsonifier-encode, aeson-encode"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "portable-decode" -> pure PortableDecode
+    "hermes-decode" -> pure HermesDecode
+    "aeson-decode" -> pure AesonDecode
+    "direct-encode" -> pure DirectEncode
+    "jsonifier-encode" -> pure JsonifierEncode
+    "aeson-encode" -> pure AesonEncode
+    other -> die ("unknown workload: " <> other)
+
+positive :: String -> String -> IO Int
+positive label raw = case reads raw of
+    [(value, "")] | value > 0 -> pure value
+    _ -> die ("invalid " <> label <> ": " <> raw)
+
+runWorkload
+    :: Workload
+    -> Hermes.DecoderSession
+    -> [BenchRecord]
+    -> [BS.ByteString]
+    -> IO Int
+runWorkload workload session records payloads =
+    case workload of
+        PortableDecode ->
+            decodeLoop
+                (\bytes -> pure (Decoder.decode recordDecoder bytes))
+                payloads
+        HermesDecode ->
+            decodeLoop (Hermes.decodeIO session recordDecoder) payloads
+        AesonDecode ->
+            decodeLoop
+                (\bytes -> pure (Aeson.eitherDecodeStrict' bytes))
+                payloads
+        DirectEncode ->
+            encodeLoop (Encoder.encode recordEncoder) records
+        JsonifierEncode ->
+            encodeLoop encodeJsonifier records
+        AesonEncode ->
+            encodeLoop (Lazy.toStrict . Aeson.encode) records
+
+decodeLoop
+    :: (BS.ByteString -> IO (Either error BenchRecord))
+    -> [BS.ByteString]
+    -> IO Int
+decodeLoop decodeOne =
+    go checksumSeed
+  where
+    go !checksum [] = pure checksum
+    go !checksum (payload : rest) = do
+        decoded <- decodeOne payload
+        record <- case decoded of
+            Left _ -> error "benchmark decoder rejected a fixture"
+            Right value -> evaluate value
+        let checksum' = checksumRecord checksum record
+        checksum' `seq` go checksum' rest
+
+encodeLoop
+    :: (BenchRecord -> BS.ByteString)
+    -> [BenchRecord]
+    -> IO Int
+encodeLoop encodeOne =
+    go checksumSeed
+  where
+    go !checksum [] = pure checksum
+    go !checksum (record : rest) = do
+        bytes <- evaluate (encodeOne record)
+        let checksum' =
+                checksum * 33
+                    + BS.length bytes
+                    + fromIntegral (BS.head bytes)
+        checksum' `seq` go checksum' rest
+
+validateImplementations
+    :: [BenchRecord]
+    -> [BS.ByteString]
+    -> IO ()
+validateImplementations records payloads =
+    case (records, payloads) of
+        (expected : _, payload : _) -> do
+            let portable = Decoder.decode recordDecoder payload
+                aeson = Aeson.eitherDecodeStrict' payload
+            hermes <- Hermes.withDecoderSession \session ->
+                Hermes.decodeIO session recordDecoder payload
+            if portable == Right expected
+                    && hermes == Right expected
+                    && aeson == Right expected
+                    && all (isValidEncoding expected)
+                        [ Encoder.encode recordEncoder expected
+                        , encodeJsonifier expected
+                        , Lazy.toStrict (Aeson.encode expected)
+                        ]
+                then pure ()
+                else die "benchmark implementations disagree"
+        _ -> die "benchmark requires non-empty fixtures"
+  where
+    isValidEncoding expected bytes =
+        Aeson.eitherDecodeStrict' bytes
+            == Right expected
+
+makeRecord :: Int -> Int -> BenchRecord
+makeRecord bodyBytes identifier = BenchRecord
+    { recordId = identifier
+    , recordName = "record-" <> Text.pack (show identifier)
+    , recordActive = even identifier
+    , recordBody = Text.replicate bodyBytes "x"
+    }
+
+encodeFixture :: BenchRecord -> BS.ByteString
+encodeFixture = Lazy.toStrict . Aeson.encode
+
+encodeJsonifier :: BenchRecord -> BS.ByteString
+encodeJsonifier record =
+    Jsonifier.toByteString $
+        Jsonifier.object
+            [ ("id", Jsonifier.intNumber record.recordId)
+            , ("name", Jsonifier.textString record.recordName)
+            , ("active", Jsonifier.bool record.recordActive)
+            , ("body", Jsonifier.textString record.recordBody)
+            ]
+
+checksumRecord :: Int -> BenchRecord -> Int
+checksumRecord checksum record =
+    Text.foldl'
+        (\current character -> current * 33 + fromEnum character)
+        (checksum + record.recordId + fromEnum record.recordActive)
+        record.recordBody
+
+checksumSeed :: Int
+checksumSeed = 5381
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCPU <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    result <- action
+    _ <- evaluate result
+    afterWall <- getMonotonicTimeNSec
+    afterCPU <- getCPUTime
+    afterStats <- getRTSStats
+    pure Sample
+        { wallMillis = fromIntegral (afterWall - beforeWall) / 1.0e6
+        , cpuMillis = fromIntegral (afterCPU - beforeCPU) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        }

--- a/packages/agent-json-hermes/benchmark/README.md
+++ b/packages/agent-json-hermes/benchmark/README.md
@@ -1,0 +1,54 @@
+# Direct JSON codec benchmark
+
+This benchmark compares the no-DOM portable and Hermes decoders with Aeson,
+and the exact-size direct encoder with Jsonifier and Aeson. Inputs are
+constructed outside the measured interval, vary by identifier to prevent
+sharing, and decoded results are checksummed.
+
+```console
+nix develop -c cabal build agent-json-hermes:bench:direct-json-bench
+bin=$(nix develop -c cabal list-bin agent-json-hermes:bench:direct-json-bench)
+"$bin" hermes-decode 100000 32 7 +RTS -T
+"$bin" jsonifier-encode 100000 32 7 +RTS -T
+```
+
+Arguments are workload, record count, bytes in the body field, and samples.
+RTS allocation excludes simdjson's C++ allocations.
+
+## 2026-08-26 baseline
+
+Apple M3 Max, 36 GiB RAM, GHC 9.10.3, `-O2`, seven samples:
+
+| Records | Body | Workload | Median wall | Haskell allocation |
+|---:|---:|:---|---:|---:|
+| 100,000 | 32 B | portable decode | 117.158 ms | 1,067,516,600 B |
+| 100,000 | 32 B | Hermes decode | 91.020 ms | 450,902,312 B |
+| 100,000 | 32 B | Aeson decode | 58.369 ms | 400,425,472 B |
+| 20,000 | 1 KiB | portable decode | 89.518 ms | 1,023,296,856 B |
+| 20,000 | 1 KiB | Hermes decode | 46.059 ms | 107,723,104 B |
+| 20,000 | 1 KiB | Aeson decode | 58.400 ms | 96,385,584 B |
+| 1,000 | 64 KiB | portable decode | 207.104 ms | 2,695,093,856 B |
+| 1,000 | 64 KiB | Hermes decode | 87.627 ms | 67,128,392 B |
+| 1,000 | 64 KiB | Aeson decode | 150.850 ms | 66,666,376 B |
+| 100,000 | 32 B | direct encode | 26.304 ms | 186,826,696 B |
+| 100,000 | 32 B | Aeson encode | 32.366 ms | 671,592,552 B |
+| 20,000 | 1 KiB | direct encode | 21.540 ms | 57,354,152 B |
+| 20,000 | 1 KiB | Aeson encode | 25.062 ms | 151,284,008 B |
+| 1,000 | 64 KiB | direct encode | 51.180 ms | 64,698,968 B |
+| 1,000 | 64 KiB | Aeson encode | 57.938 ms | 141,169,152 B |
+
+The direct encoder numbers above include the public codec interpreter. Its
+private Jsonifier write-plan primitive measured 10.653 ms / 49,727,736 bytes
+for the tiny case before that interpreter overhead.
+
+An experimental bytestring `Builder` encoder measured 125.324 ms for the tiny
+case and 3,615.572 ms for the 64 KiB case, so it was rejected. The retained
+direct encoder wraps Jsonifier's private exact-size write program; no generic
+JSON value is exposed or constructed.
+
+Hermes wins for larger typed records but remains slower for tiny objects in
+this generic codec interpreter. A dedicated dependent object-fold primitive in
+Hermes is the next optimization: the current 0.8 API materializes an update
+list. Codecs retaining opaque `RawJson` currently use the portable backend
+because Hermes 0.8 exposes only `raw_json_token()`, not the complete raw bytes
+for nested arrays and objects.

--- a/packages/agent-json-hermes/benchmark/README.md
+++ b/packages/agent-json-hermes/benchmark/README.md
@@ -47,8 +47,6 @@ direct encoder wraps Jsonifier's private exact-size write program; no generic
 JSON value is exposed or constructed.
 
 Hermes wins for larger typed records but remains slower for tiny objects in
-this generic codec interpreter. A dedicated dependent object-fold primitive in
-Hermes is the next optimization: the current 0.8 API materializes an update
-list. Codecs retaining opaque `RawJson` currently use the portable backend
-because Hermes 0.8 exposes only `raw_json_token()`, not the complete raw bytes
-for nested arrays and objects.
+this generic codec interpreter. The production Responses path now uses the
+dependent object-fold and complete raw-value extension proposed upstream in
+`velveteer/hermes#33`; this table predates that focused event specialization.

--- a/packages/agent-json-hermes/package.nix
+++ b/packages/agent-json-hermes/package.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, aeson, agent-json-codec, async, base, bytestring
+, hermes-json, hspec, jsonifier, lib, safe-exceptions, text
+}:
+mkDerivation {
+  pname = "agent-json-hermes";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    agent-json-codec base bytestring hermes-json safe-exceptions text
+  ];
+  testHaskellDepends = [
+    agent-json-codec async base bytestring hspec text
+  ];
+  benchmarkHaskellDepends = [
+    aeson agent-json-codec base bytestring jsonifier text
+  ];
+  description = "Hermes backend for direct agent JSON codecs";
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
+}

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -4,18 +4,11 @@ module Agent.Json.Decoder.Hermes
     , withDecoderSession
     , decodeIO
     , decodeHermesIO
-    , textDeltaEventDecoder
-    , TextDeltaFields(..)
     ) where
 
 import qualified Agent.Json.Decoder as DecoderAPI
 import Agent.Json.Decoder.Backend
-import Agent.Json
-    ( Extensions
-    , RawJson
-    , emptyExtensions
-    , insertExtension
-    )
+import Agent.Json (RawJson)
 import qualified Data.ByteString as BS
 import qualified Data.Hermes as Hermes
 import qualified Data.Text as Text
@@ -167,58 +160,6 @@ isWhitespace byte =
 openBrace, openBracket :: Word8
 openBrace = 0x7b
 openBracket = 0x5b
-
--- | Optimized decoder for the common Responses text-delta wire shape.
---
--- It is intentionally domain-neutral: callers supply the already validated
--- event name from the transport and receive only the fields needed by stream
--- assembly. Unknown members are recursively validated and skipped.
-data TextDeltaFields = TextDeltaFields
-    { sequenceNumber :: !(Maybe Int)
-    , itemId :: !(Maybe Text)
-    , outputIndex :: !(Maybe Int)
-    , contentIndex :: !(Maybe Int)
-    , delta :: !(Maybe Text)
-    , logprobs :: !(Maybe RawJson)
-    , extensions :: !Extensions
-    }
-
-textDeltaEventDecoder :: Hermes.Decoder TextDeltaFields
-textDeltaEventDecoder =
-    Hermes.objectFold
-        (TextDeltaFields
-            Nothing Nothing Nothing Nothing Nothing Nothing
-            emptyExtensions)
-        \key state -> case key of
-            "sequence_number" ->
-                (\value -> state { sequenceNumber = Just value })
-                    <$> Hermes.int
-            "item_id" ->
-                (\value -> state { itemId = Just value })
-                    <$> Hermes.text
-            "output_index" ->
-                (\value -> state { outputIndex = Just value })
-                    <$> Hermes.int
-            "content_index" ->
-                (\value -> state { contentIndex = Just value })
-                    <$> Hermes.int
-            "delta" ->
-                (\value -> state { delta = Just value })
-                    <$> Hermes.text
-            "logprobs" ->
-                (\value -> state { logprobs = Just value })
-                    <$> rawJsonValue
-            "type" -> state <$ Hermes.text
-            _ ->
-                (\value ->
-                    state
-                        { extensions =
-                            insertExtension
-                                key
-                                value
-                                state.extensions
-                        })
-                    <$> rawJsonValue
 
 rawJsonValue :: Hermes.Decoder RawJson
 rawJsonValue =

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -56,6 +56,10 @@ decoderRequiresRawCapture = \case
     ObjectDecoder _ fields unknown _ ->
         any namedFieldRequiresRawCapture fields
             || unknownFieldRequiresRawCapture unknown
+    PlannedObjectDecoder _ ->
+        -- Hermes 0.8 cannot apply heterogeneous planned fields in one pass.
+        -- Keep the portable direct interpreter until the dependent fold lands.
+        True
     NullableDecoder inner ->
         decoderRequiresRawCapture inner
     ByTypeDecoder select ->
@@ -102,6 +106,8 @@ toHermes = \case
                 initialState
                 updates
         either (fail . Text.unpack) pure (finish state)
+    PlannedObjectDecoder _ ->
+        fail "planned objects require the portable direct backend"
     NullableDecoder inner ->
         Hermes.nullable (toHermes inner)
     ByTypeDecoder select -> do

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -1,0 +1,151 @@
+-- | Hermes/simdjson decoder-session boundary.
+module Agent.Json.Decoder.Hermes
+    ( DecoderSession
+    , withDecoderSession
+    , decodeIO
+    ) where
+
+import qualified Agent.Json.Decoder as DecoderAPI
+import Agent.Json.Decoder.Backend
+import qualified Data.ByteString as BS
+import qualified Data.Hermes as Hermes
+import qualified Data.Text as Text
+import Data.Word (Word8)
+import Control.Exception.Safe (tryAny)
+import Control.Monad (foldM)
+
+newtype DecoderSession =
+    DecoderSession Hermes.HermesEnv
+
+withDecoderSession :: (DecoderSession -> IO a) -> IO a
+withDecoderSession action =
+    Hermes.withHermesEnv_ (action . DecoderSession)
+
+decodeIO
+    :: DecoderSession
+    -> Decoder a
+    -> BS.ByteString
+    -> IO (Either DecoderAPI.DecodeError a)
+decodeIO (DecoderSession environment) decoder bytes =
+    case decoderRequiresRawCapture decoder of
+        True ->
+            pure (DecoderAPI.decode decoder bytes)
+        False -> case firstNonWhitespace bytes of
+            Just byte
+                | byte /= openBrace && byte /= openBracket ->
+                    pure (DecoderAPI.decode decoder bytes)
+            _ -> do
+                result <- tryAny $
+                    Hermes.parseByteStringIO
+                        environment
+                        (toHermes decoder)
+                        bytes
+                pure $ case result of
+                    Left _ ->
+                        DecoderAPI.decode decoder bytes
+                    Right value -> Right value
+
+decoderRequiresRawCapture :: Decoder a -> Bool
+decoderRequiresRawCapture = \case
+    NullDecoder _ -> False
+    BoolDecoder -> False
+    TextDecoder -> False
+    ScientificDecoder -> False
+    ArrayDecoder elementDecoder ->
+        decoderRequiresRawCapture elementDecoder
+    ObjectDecoder _ fields unknown _ ->
+        any namedFieldRequiresRawCapture fields
+            || unknownFieldRequiresRawCapture unknown
+    NullableDecoder inner ->
+        decoderRequiresRawCapture inner
+    RawJsonDecoder -> True
+    SkipDecoder -> False
+    MapDecoder _ inner ->
+        decoderRequiresRawCapture inner
+
+namedFieldRequiresRawCapture :: NamedField state -> Bool
+namedFieldRequiresRawCapture (NamedField _ decoder _) =
+    decoderRequiresRawCapture decoder
+
+unknownFieldRequiresRawCapture :: UnknownField state -> Bool
+unknownFieldRequiresRawCapture (UnknownField decoder _) =
+    decoderRequiresRawCapture decoder
+
+toHermes :: Decoder a -> Hermes.Decoder a
+toHermes = \case
+    NullDecoder value -> do
+        isNull <- Hermes.isNull
+        if isNull then pure value else fail "expected null"
+    BoolDecoder -> Hermes.bool
+    TextDecoder -> Hermes.text
+    ScientificDecoder -> Hermes.scientific
+    ArrayDecoder elementDecoder ->
+        Hermes.list (toHermes elementDecoder)
+    ObjectDecoder initialState fields unknown finish -> do
+        updates <-
+            Hermes.objectAsKeyValues
+                (\key -> hermesObjectField key fields unknown)
+                (pure ())
+        state <-
+            foldM
+                (\current (update, ()) ->
+                    either (fail . Text.unpack) pure (update current))
+                initialState
+                updates
+        either (fail . Text.unpack) pure (finish state)
+    NullableDecoder inner ->
+        Hermes.nullable (toHermes inner)
+    RawJsonDecoder ->
+        fail "RawJson requires the portable direct backend"
+    SkipDecoder ->
+        validateValue
+    MapDecoder transform inner -> do
+        value <- toHermes inner
+        either (fail . Text.unpack) pure (transform value)
+
+hermesObjectField
+    :: Text.Text
+    -> [NamedField state]
+    -> UnknownField state
+    -> Hermes.Decoder (state -> Either Text.Text state)
+hermesObjectField key fields unknown =
+    case fields of
+        [] -> case unknown of
+            UnknownField decoder update ->
+                update key <$> toHermes decoder
+        NamedField name decoder update : rest
+            | name == key ->
+                update <$> toHermes decoder
+            | otherwise ->
+                hermesObjectField key rest unknown
+
+validateValue :: Hermes.Decoder ()
+validateValue =
+    Hermes.getType >>= \case
+        Hermes.VArray ->
+            () <$ Hermes.list validateValue
+        Hermes.VObject ->
+            () <$ Hermes.objectAsKeyValues
+                (const validateValue)
+                (pure ())
+        Hermes.VNumber ->
+            () <$ Hermes.scientific
+        Hermes.VString ->
+            () <$ Hermes.text
+        Hermes.VBoolean ->
+            () <$ Hermes.bool
+        Hermes.VNull -> do
+            isNull <- Hermes.isNull
+            if isNull then pure () else fail "expected null"
+
+firstNonWhitespace :: BS.ByteString -> Maybe Word8
+firstNonWhitespace =
+    BS.find (not . isWhitespace)
+
+isWhitespace :: Word8 -> Bool
+isWhitespace byte =
+    byte == 0x20 || byte == 0x09 || byte == 0x0a || byte == 0x0d
+
+openBrace, openBracket :: Word8
+openBrace = 0x7b
+openBracket = 0x5b

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -12,7 +12,6 @@ import Agent.Json (RawJson)
 import qualified Data.ByteString as BS
 import qualified Data.Hermes as Hermes
 import qualified Data.Text as Text
-import Data.Text (Text)
 import Data.Word (Word8)
 import Control.Exception.Safe (tryAny)
 

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -58,6 +58,15 @@ decoderRequiresRawCapture = \case
             || unknownFieldRequiresRawCapture unknown
     NullableDecoder inner ->
         decoderRequiresRawCapture inner
+    ByTypeDecoder select ->
+        any (decoderRequiresRawCapture . select)
+            [ JsonNull
+            , JsonBoolean
+            , JsonNumber
+            , JsonString
+            , JsonArray
+            , JsonObject
+            ]
     RawJsonDecoder -> True
     SkipDecoder -> False
     MapDecoder _ inner ->
@@ -95,6 +104,9 @@ toHermes = \case
         either (fail . Text.unpack) pure (finish state)
     NullableDecoder inner ->
         Hermes.nullable (toHermes inner)
+    ByTypeDecoder select -> do
+        valueType <- hermesJsonType
+        toHermes (select valueType)
     RawJsonDecoder ->
         fail "RawJson requires the portable direct backend"
     SkipDecoder ->
@@ -137,6 +149,16 @@ validateValue =
         Hermes.VNull -> do
             isNull <- Hermes.isNull
             if isNull then pure () else fail "expected null"
+
+hermesJsonType :: Hermes.Decoder JsonType
+hermesJsonType =
+    Hermes.getType >>= \case
+        Hermes.VArray -> pure JsonArray
+        Hermes.VObject -> pure JsonObject
+        Hermes.VNumber -> pure JsonNumber
+        Hermes.VString -> pure JsonString
+        Hermes.VBoolean -> pure JsonBoolean
+        Hermes.VNull -> pure JsonNull
 
 firstNonWhitespace :: BS.ByteString -> Maybe Word8
 firstNonWhitespace =

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -101,13 +101,13 @@ toHermes = \case
                     | otherwise ->
                         current <$ validateValue
         either (fail . Text.unpack) pure (finishObjectPlan plan)
-    discriminated@DiscriminatedObjectDecoder{} ->
-        Hermes.withRawJsonByteString \bytes ->
-            case DecoderAPI.decode discriminated (BS.copy bytes) of
-                Left err ->
-                    fail (Text.unpack
-                        (DecoderAPI.renderDecodeError err))
-                Right value -> pure value
+    DiscriminatedObjectDecoder discriminator select ->
+        Hermes.object do
+            -- Select the branch, reset the On Demand object, then decode the
+            -- selected shape with Hermes. Extracting raw JSON here would
+            -- consume and reparse the complete object.
+            tag <- Hermes.atKey discriminator Hermes.text
+            Hermes.liftObjectDecoder (toHermes (select tag))
     NullableDecoder inner ->
         Hermes.nullable (toHermes inner)
     ByTypeDecoder select -> do
@@ -121,18 +121,7 @@ toHermes = \case
         value <- toHermes inner
         either (fail . Text.unpack) pure (transform value)
     WithRawDecoder inner ->
-        Hermes.withRawJsonByteString \bytes ->
-            case DecoderAPI.decode inner (BS.copy bytes) of
-                Left err ->
-                    fail
-                        (Text.unpack
-                            (DecoderAPI.renderDecodeError err))
-                Right value ->
-                    pure
-                        ( value
-                        , unsafeRawJsonFromValidatedBytes
-                            (BS.copy bytes)
-                        )
+        hermesWithRaw inner
 
 hermesObjectField
     :: Text.Text
@@ -197,5 +186,40 @@ openBracket = 0x5b
 
 rawJsonValue :: Hermes.Decoder RawJson
 rawJsonValue =
-    Hermes.withRawJsonByteString \bytes ->
-        pure (unsafeRawJsonFromValidatedBytes (BS.copy bytes))
+    Hermes.withRawJsonByteString copyRawJson
+
+hermesWithRaw :: Decoder a -> Hermes.Decoder (a, RawJson)
+hermesWithRaw inner =
+    Hermes.getType >>= \case
+        -- raw_json() consumes an On Demand value. Objects can be reset and
+        -- decoded again inside the same simdjson document, avoiding a copy
+        -- followed by a second portable parse.
+        Hermes.VObject ->
+            Hermes.withRawJsonByteString \bytes -> do
+                value <- Hermes.object $
+                    Hermes.liftObjectDecoder (toHermes inner)
+                raw <- copyRawJson bytes
+                pure (value, raw)
+        -- Hermes currently exposes object reset but not the equivalent array
+        -- reset primitive. Keep the compatibility fallback for other shapes,
+        -- sharing one owned copy between decoding and raw retention.
+        _ ->
+            Hermes.withRawJsonByteString \bytes -> do
+                let owned = BS.copy bytes
+                owned `seq`
+                    case DecoderAPI.decode inner owned of
+                        Left err ->
+                            fail
+                                (Text.unpack
+                                    (DecoderAPI.renderDecodeError err))
+                        Right value ->
+                            pure
+                                ( value
+                                , unsafeRawJsonFromValidatedBytes owned
+                                )
+
+copyRawJson :: BS.ByteString -> Hermes.Decoder RawJson
+copyRawJson bytes =
+    let owned = BS.copy bytes
+    in owned `seq`
+        pure (unsafeRawJsonFromValidatedBytes owned)

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -92,7 +92,7 @@ toHermes = \case
                                     (unsafeRawJsonFromValidatedBytes
                                         "null")
                                     rebuilt
-                                else rebuilt
+                                else deletePlannedExtension key rebuilt
                 Nothing
                     | objectPlanCapturesExtensions current ->
                         (\raw ->
@@ -120,6 +120,19 @@ toHermes = \case
     MapDecoder transform inner -> do
         value <- toHermes inner
         either (fail . Text.unpack) pure (transform value)
+    WithRawDecoder inner ->
+        Hermes.withRawJsonByteString \bytes ->
+            case DecoderAPI.decode inner (BS.copy bytes) of
+                Left err ->
+                    fail
+                        (Text.unpack
+                            (DecoderAPI.renderDecodeError err))
+                Right value ->
+                    pure
+                        ( value
+                        , unsafeRawJsonFromValidatedBytes
+                            (BS.copy bytes)
+                        )
 
 hermesObjectField
     :: Text.Text

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -31,7 +31,7 @@ decodeIO (DecoderSession environment) decoder bytes =
     case firstNonWhitespace bytes of
         Just byte
             | byte /= openBrace && byte /= openBracket ->
-            pure (DecoderAPI.decode decoder bytes)
+                pure (DecoderAPI.decode decoder bytes)
         _ -> do
             result <- decodeHermesIO
                 (DecoderSession environment)
@@ -86,6 +86,13 @@ toHermes = \case
                     | otherwise ->
                         current <$ validateValue
         either (fail . Text.unpack) pure (finishObjectPlan plan)
+    discriminated@DiscriminatedObjectDecoder{} ->
+        Hermes.withRawJsonByteString \bytes ->
+            case DecoderAPI.decode discriminated (BS.copy bytes) of
+                Left err ->
+                    fail (Text.unpack
+                        (DecoderAPI.renderDecodeError err))
+                Right value -> pure value
     NullableDecoder inner ->
         Hermes.nullable (toHermes inner)
     ByTypeDecoder select -> do

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -3,13 +3,23 @@ module Agent.Json.Decoder.Hermes
     ( DecoderSession
     , withDecoderSession
     , decodeIO
+    , decodeHermesIO
+    , textDeltaEventDecoder
+    , TextDeltaFields(..)
     ) where
 
 import qualified Agent.Json.Decoder as DecoderAPI
 import Agent.Json.Decoder.Backend
+import Agent.Json
+    ( Extensions
+    , RawJson
+    , emptyExtensions
+    , insertExtension
+    )
 import qualified Data.ByteString as BS
 import qualified Data.Hermes as Hermes
 import qualified Data.Text as Text
+import Data.Text (Text)
 import Data.Word (Word8)
 import Control.Exception.Safe (tryAny)
 import Control.Monad (foldM)
@@ -30,6 +40,7 @@ decodeIO (DecoderSession environment) decoder bytes =
     case decoderRequiresRawCapture decoder of
         True ->
             pure (DecoderAPI.decode decoder bytes)
+<<<<<<< ours
         False -> case firstNonWhitespace bytes of
             Just byte
                 | byte /= openBrace && byte /= openBracket ->
@@ -83,6 +94,33 @@ namedFieldRequiresRawCapture (NamedField _ decoder _) =
 unknownFieldRequiresRawCapture :: UnknownField state -> Bool
 unknownFieldRequiresRawCapture (UnknownField decoder _) =
     decoderRequiresRawCapture decoder
+=======
+        _ -> do
+            result <- decodeHermesIO
+                (DecoderSession environment)
+                (toHermes decoder)
+                bytes
+            pure $ case result of
+                Left _ ->
+                    DecoderAPI.decode decoder bytes
+                right -> right
+
+decodeHermesIO
+    :: DecoderSession
+    -> Hermes.Decoder a
+    -> BS.ByteString
+    -> IO (Either DecoderAPI.DecodeError a)
+decodeHermesIO (DecoderSession environment) decoder bytes = do
+    result <- tryAny $
+        Hermes.parseByteStringIO environment decoder bytes
+    pure $ case result of
+        Left err ->
+            Left (DecoderAPI.DecodeError
+                0
+                []
+                (Text.pack (show err)))
+        Right value -> Right value
+>>>>>>> theirs
 
 toHermes :: Decoder a -> Hermes.Decoder a
 toHermes = \case
@@ -114,7 +152,11 @@ toHermes = \case
         valueType <- hermesJsonType
         toHermes (select valueType)
     RawJsonDecoder ->
+<<<<<<< ours
         fail "RawJson requires the portable direct backend"
+=======
+        rawJsonValue
+>>>>>>> theirs
     SkipDecoder ->
         validateValue
     MapDecoder transform inner -> do
@@ -177,3 +219,60 @@ isWhitespace byte =
 openBrace, openBracket :: Word8
 openBrace = 0x7b
 openBracket = 0x5b
+
+-- | Optimized decoder for the common Responses text-delta wire shape.
+--
+-- It is intentionally domain-neutral: callers supply the already validated
+-- event name from the transport and receive only the fields needed by stream
+-- assembly. Unknown members are recursively validated and skipped.
+data TextDeltaFields = TextDeltaFields
+    { sequenceNumber :: !(Maybe Int)
+    , itemId :: !(Maybe Text)
+    , outputIndex :: !(Maybe Int)
+    , contentIndex :: !(Maybe Int)
+    , delta :: !(Maybe Text)
+    , logprobs :: !(Maybe RawJson)
+    , extensions :: !Extensions
+    }
+
+textDeltaEventDecoder :: Hermes.Decoder TextDeltaFields
+textDeltaEventDecoder =
+    Hermes.objectFold
+        (TextDeltaFields
+            Nothing Nothing Nothing Nothing Nothing Nothing
+            emptyExtensions)
+        \key state -> case key of
+            "sequence_number" ->
+                (\value -> state { sequenceNumber = Just value })
+                    <$> Hermes.int
+            "item_id" ->
+                (\value -> state { itemId = Just value })
+                    <$> Hermes.text
+            "output_index" ->
+                (\value -> state { outputIndex = Just value })
+                    <$> Hermes.int
+            "content_index" ->
+                (\value -> state { contentIndex = Just value })
+                    <$> Hermes.int
+            "delta" ->
+                (\value -> state { delta = Just value })
+                    <$> Hermes.text
+            "logprobs" ->
+                (\value -> state { logprobs = Just value })
+                    <$> rawJsonValue
+            "type" -> state <$ Hermes.text
+            _ ->
+                (\value ->
+                    state
+                        { extensions =
+                            insertExtension
+                                key
+                                value
+                                state.extensions
+                        })
+                    <$> rawJsonValue
+
+rawJsonValue :: Hermes.Decoder RawJson
+rawJsonValue =
+    Hermes.withRawJsonByteString \bytes ->
+        pure (unsafeRawJsonFromValidatedBytes (BS.copy bytes))

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -77,7 +77,22 @@ toHermes = \case
         plan <- Hermes.objectFold initialPlan \key current ->
             case matchPlannedField key current of
                 Just (PlannedFieldMatch decoder rebuild) ->
-                    rebuild <$> toHermes decoder
+                    do
+                        isNull <- Hermes.isNull
+                        value <- toHermes decoder
+                        let rebuilt =
+                                markPlannedFieldPresent
+                                    key
+                                    (rebuild value)
+                        pure $
+                            if isNull
+                                && objectPlanCapturesExtensions rebuilt
+                                then capturePlannedExtension
+                                    key
+                                    (unsafeRawJsonFromValidatedBytes
+                                        "null")
+                                    rebuilt
+                                else rebuilt
                 Nothing
                     | objectPlanCapturesExtensions current ->
                         (\raw ->

--- a/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
+++ b/packages/agent-json-hermes/src/Agent/Json/Decoder/Hermes.hs
@@ -22,7 +22,6 @@ import qualified Data.Text as Text
 import Data.Text (Text)
 import Data.Word (Word8)
 import Control.Exception.Safe (tryAny)
-import Control.Monad (foldM)
 
 newtype DecoderSession =
     DecoderSession Hermes.HermesEnv
@@ -37,64 +36,10 @@ decodeIO
     -> BS.ByteString
     -> IO (Either DecoderAPI.DecodeError a)
 decodeIO (DecoderSession environment) decoder bytes =
-    case decoderRequiresRawCapture decoder of
-        True ->
+    case firstNonWhitespace bytes of
+        Just byte
+            | byte /= openBrace && byte /= openBracket ->
             pure (DecoderAPI.decode decoder bytes)
-<<<<<<< ours
-        False -> case firstNonWhitespace bytes of
-            Just byte
-                | byte /= openBrace && byte /= openBracket ->
-                    pure (DecoderAPI.decode decoder bytes)
-            _ -> do
-                result <- tryAny $
-                    Hermes.parseByteStringIO
-                        environment
-                        (toHermes decoder)
-                        bytes
-                pure $ case result of
-                    Left _ ->
-                        DecoderAPI.decode decoder bytes
-                    Right value -> Right value
-
-decoderRequiresRawCapture :: Decoder a -> Bool
-decoderRequiresRawCapture = \case
-    NullDecoder _ -> False
-    BoolDecoder -> False
-    TextDecoder -> False
-    ScientificDecoder -> False
-    ArrayDecoder elementDecoder ->
-        decoderRequiresRawCapture elementDecoder
-    ObjectDecoder _ fields unknown _ ->
-        any namedFieldRequiresRawCapture fields
-            || unknownFieldRequiresRawCapture unknown
-    PlannedObjectDecoder _ ->
-        -- Hermes 0.8 cannot apply heterogeneous planned fields in one pass.
-        -- Keep the portable direct interpreter until the dependent fold lands.
-        True
-    NullableDecoder inner ->
-        decoderRequiresRawCapture inner
-    ByTypeDecoder select ->
-        any (decoderRequiresRawCapture . select)
-            [ JsonNull
-            , JsonBoolean
-            , JsonNumber
-            , JsonString
-            , JsonArray
-            , JsonObject
-            ]
-    RawJsonDecoder -> True
-    SkipDecoder -> False
-    MapDecoder _ inner ->
-        decoderRequiresRawCapture inner
-
-namedFieldRequiresRawCapture :: NamedField state -> Bool
-namedFieldRequiresRawCapture (NamedField _ decoder _) =
-    decoderRequiresRawCapture decoder
-
-unknownFieldRequiresRawCapture :: UnknownField state -> Bool
-unknownFieldRequiresRawCapture (UnknownField decoder _) =
-    decoderRequiresRawCapture decoder
-=======
         _ -> do
             result <- decodeHermesIO
                 (DecoderSession environment)
@@ -120,7 +65,6 @@ decodeHermesIO (DecoderSession environment) decoder bytes = do
                 []
                 (Text.pack (show err)))
         Right value -> Right value
->>>>>>> theirs
 
 toHermes :: Decoder a -> Hermes.Decoder a
 toHermes = \case
@@ -133,30 +77,30 @@ toHermes = \case
     ArrayDecoder elementDecoder ->
         Hermes.list (toHermes elementDecoder)
     ObjectDecoder initialState fields unknown finish -> do
-        updates <-
-            Hermes.objectAsKeyValues
-                (\key -> hermesObjectField key fields unknown)
-                (pure ())
-        state <-
-            foldM
-                (\current (update, ()) ->
-                    either (fail . Text.unpack) pure (update current))
-                initialState
-                updates
+        state <- Hermes.objectFold initialState
+            \key current ->
+                hermesObjectField key current fields unknown
         either (fail . Text.unpack) pure (finish state)
-    PlannedObjectDecoder _ ->
-        fail "planned objects require the portable direct backend"
+    PlannedObjectDecoder initialPlan -> do
+        plan <- Hermes.objectFold initialPlan \key current ->
+            case matchPlannedField key current of
+                Just (PlannedFieldMatch decoder rebuild) ->
+                    rebuild <$> toHermes decoder
+                Nothing
+                    | objectPlanCapturesExtensions current ->
+                        (\raw ->
+                            capturePlannedExtension key raw current)
+                            <$> toHermes RawJsonDecoder
+                    | otherwise ->
+                        current <$ validateValue
+        either (fail . Text.unpack) pure (finishObjectPlan plan)
     NullableDecoder inner ->
         Hermes.nullable (toHermes inner)
     ByTypeDecoder select -> do
         valueType <- hermesJsonType
         toHermes (select valueType)
     RawJsonDecoder ->
-<<<<<<< ours
-        fail "RawJson requires the portable direct backend"
-=======
         rawJsonValue
->>>>>>> theirs
     SkipDecoder ->
         validateValue
     MapDecoder transform inner -> do
@@ -165,19 +109,24 @@ toHermes = \case
 
 hermesObjectField
     :: Text.Text
+    -> state
     -> [NamedField state]
     -> UnknownField state
-    -> Hermes.Decoder (state -> Either Text.Text state)
-hermesObjectField key fields unknown =
+    -> Hermes.Decoder state
+hermesObjectField key current fields unknown =
     case fields of
         [] -> case unknown of
-            UnknownField decoder update ->
-                update key <$> toHermes decoder
+            UnknownField decoder update -> do
+                value <- toHermes decoder
+                either (fail . Text.unpack) pure
+                    (update key value current)
         NamedField name decoder update : rest
-            | name == key ->
-                update <$> toHermes decoder
+            | name == key -> do
+                value <- toHermes decoder
+                either (fail . Text.unpack) pure
+                    (update value current)
             | otherwise ->
-                hermesObjectField key rest unknown
+                hermesObjectField key current rest unknown
 
 validateValue :: Hermes.Decoder ()
 validateValue =
@@ -185,9 +134,8 @@ validateValue =
         Hermes.VArray ->
             () <$ Hermes.list validateValue
         Hermes.VObject ->
-            () <$ Hermes.objectAsKeyValues
-                (const validateValue)
-                (pure ())
+            () <$ Hermes.objectFold ()
+                (\_ () -> validateValue)
         Hermes.VNumber ->
             () <$ Hermes.scientific
         Hermes.VString ->

--- a/packages/agent-json-hermes/test/Spec.hs
+++ b/packages/agent-json-hermes/test/Spec.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Main (main) where
+
+import qualified Agent.Json.Decoder as Decoder
+import qualified Agent.Json.Decoder.Hermes as Hermes
+import Control.Concurrent.Async (concurrently)
+import Data.Either (isLeft)
+import Data.Text (Text)
+import Test.Hspec
+
+data Person = Person
+    { name :: !Text
+    , age :: !Int
+    }
+    deriving stock (Eq, Show)
+
+data PersonState = PersonState
+    { stateName :: !(Maybe Text)
+    , stateAge :: !(Maybe Int)
+    }
+
+personDecoder :: Decoder.Decoder Person
+personDecoder =
+    Decoder.object
+        (PersonState Nothing Nothing)
+        [ Decoder.field "name" Decoder.text \value state ->
+            Right state { stateName = Just value }
+        , Decoder.field "age" Decoder.int \value state ->
+            Right state { stateAge = Just value }
+        ]
+        (Decoder.unknownField Decoder.skip
+            \_ () state -> Right state)
+        \state ->
+            Person
+                <$> required "name" state.stateName
+                <*> required "age" state.stateAge
+  where
+    required label =
+        maybe (Left ("missing " <> label)) Right
+
+main :: IO ()
+main = hspec do
+    describe "Hermes direct backend" do
+        it "matches the portable backend while reusing a session" do
+            let inputs =
+                    [ "{\"name\":\"Ada\",\"age\":37,\"vendor\":{\"x\":1}}"
+                    , "{\"age\":85,\"name\":\"Grace\"}"
+                    ]
+            Hermes.withDecoderSession \session ->
+                mapM_
+                    (\input -> do
+                        actual <- Hermes.decodeIO session personDecoder input
+                        actual
+                            `shouldBe`
+                                Decoder.decode personDecoder input)
+                    inputs
+
+        it "fully validates skipped unknown values" do
+            Hermes.withDecoderSession \session -> do
+                result <-
+                    Hermes.decodeIO session personDecoder
+                        "{\"name\":\"Ada\",\"age\":37,\"vendor\":[1,]}"
+                result `shouldSatisfy` isLeft
+
+        it "rejects trailing input after a valid object" do
+            Hermes.withDecoderSession \session -> do
+                result <-
+                    Hermes.decodeIO session personDecoder
+                        "{\"name\":\"Ada\",\"age\":37} trailing"
+                result `shouldSatisfy` isLeft
+
+        it "uses the portable direct path for scalar roots" do
+            Hermes.withDecoderSession \session ->
+                Hermes.decodeIO session Decoder.text "\"hello\""
+                    `shouldReturn` Right "hello"
+
+        it "decodes concurrent streams with independent sessions" do
+            let decode input =
+                    Hermes.withDecoderSession \session ->
+                        Hermes.decodeIO session personDecoder input
+            (first, second) <- concurrently
+                (decode "{\"name\":\"Ada\",\"age\":37}")
+                (decode "{\"name\":\"Grace\",\"age\":85}")
+            first `shouldBe` Right (Person "Ada" 37)
+            second `shouldBe` Right (Person "Grace" 85)

--- a/packages/agent-json-hermes/test/Spec.hs
+++ b/packages/agent-json-hermes/test/Spec.hs
@@ -111,21 +111,44 @@ main = hspec do
             second `shouldBe` Right (Person "Grace" 85)
 
         it "captures complete nested raw extensions in one Hermes pass" do
-            Hermes.withDecoderSession \session -> do
-                result <- Hermes.decodeIO session envelopeDecoder
+            result <-
+                Hermes.withDecoderSession \session ->
+                    Hermes.decodeIO session envelopeDecoder
                     "{\"name\":\"Ada\",\"future\":{\"nested\":[1,true,null]}}"
-                case result of
-                    Left err -> expectationFailure (show err)
-                    Right envelope ->
-                        rawJsonBytes
-                            <$> lookupExtension
-                                "future"
-                                envelope.envelopeExtensions
-                            `shouldBe`
-                                Just "{\"nested\":[1,true,null]}"
+            case result of
+                Left err -> expectationFailure (show err)
+                Right envelope ->
+                    rawJsonBytes
+                        <$> lookupExtension
+                            "future"
+                            envelope.envelopeExtensions
+                        `shouldBe`
+                            Just "{\"nested\":[1,true,null]}"
+
+        it "captures and decodes the same object after raw capture" do
+            let input = "{\"age\":37,\"name\":\"Ada\"}"
+            result <-
+                Hermes.withDecoderSession \session ->
+                    Hermes.decodeIO session
+                        (Decoder.withRaw personDecoder)
+                        input
+            case result of
+                Left err -> expectationFailure (show err)
+                Right (person, raw) -> do
+                    person `shouldBe` Person "Ada" 37
+                    rawJsonBytes raw `shouldBe` input
 
         it "decodes unordered discriminated objects without a DOM" do
             Hermes.withDecoderSession \session -> do
                 Hermes.decodeIO session taggedTextDecoder
                     "{\"value\":\"ok\",\"type\":\"text\"}"
                     `shouldReturn` Right "ok"
+
+        it "uses the final duplicate discriminator" do
+            Hermes.withDecoderSession \session -> do
+                let input =
+                        "{\"type\":\"unknown\",\"value\":\"ok\","
+                            <> "\"type\":\"text\"}"
+                Hermes.decodeIO session taggedTextDecoder input
+                    `shouldReturn`
+                        Decoder.decode taggedTextDecoder input

--- a/packages/agent-json-hermes/test/Spec.hs
+++ b/packages/agent-json-hermes/test/Spec.hs
@@ -28,6 +28,18 @@ envelopeDecoder =
         Envelope
             <$> Decoder.requiredField "name" Decoder.text
             <*> Decoder.extensionFields
+
+taggedTextDecoder :: Decoder.Decoder Text
+taggedTextDecoder =
+    Decoder.discriminatedObject "type" \case
+        "text" ->
+            Decoder.objectFields $
+                Decoder.requiredField "value" Decoder.text
+                    <* Decoder.defaultField () "type" (() <$ Decoder.text)
+        tag ->
+            Decoder.mapEither
+                (const (Left ("unknown tag " <> tag)))
+                Decoder.skip
 data PersonState = PersonState
     { stateName :: !(Maybe Text)
     , stateAge :: !(Maybe Int)
@@ -111,3 +123,9 @@ main = hspec do
                                 envelope.envelopeExtensions
                             `shouldBe`
                                 Just "{\"nested\":[1,true,null]}"
+
+        it "decodes unordered discriminated objects without a DOM" do
+            Hermes.withDecoderSession \session -> do
+                Hermes.decodeIO session taggedTextDecoder
+                    "{\"value\":\"ok\",\"type\":\"text\"}"
+                    `shouldReturn` Right "ok"

--- a/packages/agent-json-hermes/test/Spec.hs
+++ b/packages/agent-json-hermes/test/Spec.hs
@@ -4,6 +4,7 @@ module Main (main) where
 
 import qualified Agent.Json.Decoder as Decoder
 import qualified Agent.Json.Decoder.Hermes as Hermes
+import Agent.Json (Extensions, lookupExtension, rawJsonBytes)
 import Control.Concurrent.Async (concurrently)
 import Data.Either (isLeft)
 import Data.Text (Text)
@@ -15,6 +16,18 @@ data Person = Person
     }
     deriving stock (Eq, Show)
 
+data Envelope = Envelope
+    { envelopeName :: !Text
+    , envelopeExtensions :: !Extensions
+    }
+    deriving stock (Eq, Show)
+
+envelopeDecoder :: Decoder.Decoder Envelope
+envelopeDecoder =
+    Decoder.objectFields $
+        Envelope
+            <$> Decoder.requiredField "name" Decoder.text
+            <*> Decoder.extensionFields
 data PersonState = PersonState
     { stateName :: !(Maybe Text)
     , stateAge :: !(Maybe Int)
@@ -84,3 +97,17 @@ main = hspec do
                 (decode "{\"name\":\"Grace\",\"age\":85}")
             first `shouldBe` Right (Person "Ada" 37)
             second `shouldBe` Right (Person "Grace" 85)
+
+        it "captures complete nested raw extensions in one Hermes pass" do
+            Hermes.withDecoderSession \session -> do
+                result <- Hermes.decodeIO session envelopeDecoder
+                    "{\"name\":\"Ada\",\"future\":{\"nested\":[1,true,null]}}"
+                case result of
+                    Left err -> expectationFailure (show err)
+                    Right envelope ->
+                        rawJsonBytes
+                            <$> lookupExtension
+                                "future"
+                                envelope.envelopeExtensions
+                            `shouldBe`
+                                Just "{\"nested\":[1,true,null]}"


### PR DESCRIPTION
## Stack

- **This PR:** reusable codec foundation
- **Next:** #625 — Responses protocol and transport migration

## Summary

This is PR 1 of the Aeson removal series. It introduces direct typed JSON codecs without adding a replacement `Value`/`Object` DOM.

### `agent-json-codec`

- `Decoder a`: strict `ByteString -> Either DecodeError a`, directly constructing `a`
- `Encoder a`: direct exact-size write program backed by Jsonifier, producing one strict `ByteString`
- declarative known object fields plus an explicit unknown-field decoder
- required/optional/nullable scalar, array, object, and mapped codecs
- path-aware errors, full-input validation, scalar roots, nesting limits, JSON number grammar, UTF-8/surrogate validation, and last-key-wins duplicate behavior
- opaque `RawJson` and `Extensions` for lossless forward-compatible fields
- private raw constructor: unchecked raw encoding only accepts bytes previously validated/captured by a decoder
- portable implementation has no Hermes/C++ dependency

### `agent-json-hermes`

- separate optional package so Windows/mobile/web builds can use the portable package
- one explicitly scoped, single-threaded `HermesEnv` per stream/worker
- interprets the same typed decoder definitions with simdjson
- recursively validates ignored values rather than relying on partial On Demand validation
- falls back to the direct portable interpreter for scalar roots and for rich error reporting after Hermes rejects an input
- uses a small pinned Hermes extension for a stateful dependent object fold and complete `raw_json()` capture

The Hermes extension is proposed upstream as [velveteer/hermes#33](https://github.com/velveteer/hermes/pull/33). It avoids key/value update lists and lets opaque nested extensions be retained in the same forward pass.

No existing runtime package is migrated in this PR.

## No-DOM invariant

The public API exposes no generic JSON value or object. Domain structures encode directly to bytes and bytes decode directly to domain structures. Jsonifier's internal `Json` is kept private and is a `(size, poke)` write program, not a semantic tree.

Aeson appears only in tests/benchmarks as a temporary differential oracle and baseline.

## Tests

- typed object decoding and encoding round trips
- opaque unknown-field retention and typed-field precedence
- duplicate keys
- malformed/trailing JSON
- invalid UTF-8 and surrogate escapes
- nesting and pathological numeric-exponent limits
- non-finite double policy
- 1,000 generated valid JSON documents compared with Aeson validation
- reused Hermes session equivalence
- malformed skipped-value and trailing-input rejection
- separate concurrent Hermes sessions

## Benchmarks

Apple M3 Max, GHC 9.10.3, `-O2`, seven samples. Full commands and allocation caveats are checked into `packages/agent-json-hermes/benchmark/README.md`.

### Typed decode

| Records | Body | Portable | Hermes | Aeson |
|---:|---:|---:|---:|---:|
| 100,000 | 32 B | 117.2 ms | 91.0 ms | 58.4 ms |
| 20,000 | 1 KiB | 89.5 ms | 46.1 ms | 58.4 ms |
| 1,000 | 64 KiB | 207.1 ms | 87.6 ms | 150.9 ms |

Hermes scales better for larger typed payloads. The checked-in Responses benchmark in the stacked migration also measures the new dependent fold end to end.

### Direct encode

| Records | Body | Direct codec | Aeson |
|---:|---:|---:|---:|
| 100,000 | 32 B | 26.3 ms / 186.8 MB | 32.4 ms / 671.6 MB |
| 20,000 | 1 KiB | 21.5 ms / 57.4 MB | 25.4 ms / 151.3 MB |
| 1,000 | 64 KiB | 51.2 ms / 64.7 MB | 59.1 ms / 141.1 MB |

An experimental bytestring Builder implementation was rejected after severe large-string regressions.

## Validation

- `agent-json-codec`: 21 examples + 1,000 generated documents
- `agent-json-hermes`: 7 examples
- both optimized benchmark components build
- `nix build .#agent-json-codec .#agent-json-hermes`
- `nix flake check --no-build`
- `git diff --check`




