### PR TITLE
Harden Claude live tools and native subagents

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
+++ b/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
@@ -4,12 +4,21 @@ module Agent.Claude.Internal.Messages
     ( CompletedClaudeTurn(..)
     , ClaudeEventState
     , emptyClaudeEventState
+    , claudeEventStateHasActivity
     , interpretClaudeTurn
+    , streamClaudeProgress
     , streamClaudeMessage
     , remainingClaudeEvents
     ) where
 
 import Agent.Loop (LoopEvent(..))
+import Agent.Loop (NativeAgentStatus(..))
+import Agent.Responses.Types
+    ( FunctionCall(..)
+    , FunctionCallOutput(..)
+    , ItemStatus(..)
+    , ResponseItem(..)
+    )
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
@@ -20,19 +29,25 @@ import Claude.Agent.SDK.Types
     , ContentBlock(..)
     , Message(..)
     , ResultMessage(..)
+    , StreamEvent(..)
     , SystemMessage(..)
     , Usage(..)
     , UserMessage(..)
+    , QueryMessageScope(..)
+    , QueryProgress(..)
     , addUsage
     , emptyUsage
     , messageHasParentToolUseId
+    , messageUuid
     , modelUsageToUsage
     )
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -46,15 +61,26 @@ data CompletedClaudeTurn = CompletedClaudeTurn
     , events :: ![LoopEvent]
     , tokenUsage :: !Usage
     , cumulativeModelUsage :: !(Maybe Usage)
+    , toolItems :: ![ResponseItem]
     } deriving (Eq, Show)
 
 data ClaudeEventState = ClaudeEventState
     { startedToolCalls :: !(Set Text)
+    , startedToolDetails :: !(Map.Map Text ToolCall)
     , finishedToolCalls :: !(Set Text)
+    , toolMessageIds :: !(Map.Map Text [Text])
+    , warnedUnknownTypes :: !(Set Text)
+    , nativeAgentCalls :: !(Map.Map Text ToolCall)
     } deriving (Eq, Show)
 
 emptyClaudeEventState :: ClaudeEventState
-emptyClaudeEventState = ClaudeEventState Set.empty Set.empty
+emptyClaudeEventState =
+    ClaudeEventState
+        Set.empty Map.empty Set.empty Map.empty Set.empty Map.empty
+
+claudeEventStateHasActivity :: ClaudeEventState -> Bool
+claudeEventStateHasActivity state =
+    not (Set.null state.startedToolCalls)
 
 -- | Expose completed top-level tool messages as soon as Claude Code emits
 -- them. In particular, its @Task@ tool remains in flight while a native
@@ -66,7 +92,209 @@ streamClaudeMessage
     -> (ClaudeEventState, [LoopEvent])
 streamClaudeMessage state message
     | messageHasParentToolUseId message = (state, [])
-    | otherwise = advanceToolEvents state (messageToolEvents message)
+    | otherwise =
+        let toolEvents = messageToolEvents message
+            (nextState, events) =
+                advanceToolEvents state toolEvents
+            messageIds =
+                maybe [] (\identifier -> [identifier]) (messageUuid message)
+            withIds =
+                foldl'
+                    (\current toolEvent ->
+                        case toolEvent of
+                            ClaudeToolStarted call ->
+                                current
+                                    { toolMessageIds =
+                                        Map.insertWith
+                                            (<>)
+                                            call.callId
+                                            messageIds
+                                            current.toolMessageIds
+                                    }
+                            _ -> current)
+                    nextState
+                    toolEvents
+        in appendUnknownWarning withIds message events
+
+-- | Apply the query layer's classification before projecting a live Claude
+-- record. Retraction identifiers refer to wire message UUIDs, not tool call
+-- IDs, so the ledger keeps both and can remove the corresponding UI block.
+streamClaudeProgress
+    :: ClaudeEventState
+    -> QueryProgress
+    -> (ClaudeEventState, [LoopEvent])
+streamClaudeProgress state = \case
+    QueryMessageObserved QueryTopLevel message ->
+        let (next, events) = streamClaudeMessage state message
+        in (next, events <> nativeLifecycleEvents state events)
+    QueryMessageObserved (QueryNested parent) message ->
+        nestedNativeEvents state parent message
+    QueryMessagesRetracted scope identifiers
+        | scope == Nothing || scope == Just QueryTopLevel ->
+            let calls =
+                    [ callId
+                    | (callId, messageIds) <-
+                        Map.toList state.toolMessageIds
+                    , any (`elem` identifiers) messageIds
+                    ]
+                next =
+                    state
+                        { startedToolCalls =
+                            foldr Set.delete state.startedToolCalls calls
+                        , startedToolDetails =
+                            foldr Map.delete state.startedToolDetails calls
+                        , finishedToolCalls =
+                            foldr Set.delete state.finishedToolCalls calls
+                        , toolMessageIds =
+                            foldr Map.delete state.toolMessageIds calls
+                        }
+                nativeRetractions =
+                    [ NativeAgentFinished callId NativeAgentCancelled
+                    | callId <- calls
+                    , Just call <- [Map.lookup callId state.startedToolDetails]
+                    , isNativeAgentName call.name
+                    ]
+            in (next, map ToolRetracted calls <> nativeRetractions)
+    QueryMessagesRetracted _ _ ->
+        (state, [])
+
+nativeLifecycleEvents :: ClaudeEventState -> [LoopEvent] -> [LoopEvent]
+nativeLifecycleEvents state = concatMap \case
+    ToolStarted call
+        | isNativeAgentName call.name ->
+            [NativeAgentStarted
+                call.callId
+                Nothing
+                (nativeAgentLabel call)
+                (nativeAgentModel call)]
+    ToolFinished result
+        | Just call <- Map.lookup result.callId state.startedToolDetails
+        , isNativeAgentName call.name ->
+            [NativeAgentFinished
+                result.callId
+                (if "error" `Text.isInfixOf` Text.toLower result.output
+                    then NativeAgentFailed
+                    else NativeAgentCompleted)]
+    _ -> []
+
+nestedNativeEvents
+    :: ClaudeEventState
+    -> Maybe Text
+    -> Message
+    -> (ClaudeEventState, [LoopEvent])
+nestedNativeEvents state parent message =
+    case parent of
+        Nothing -> (state, [])
+        Just identifier ->
+            let tools = messageToolEvents message
+                (nextState, childLifecycle) =
+                    foldl' (\(current, events) -> \case
+                    ClaudeToolStarted call
+                        | isNativeAgentName call.name ->
+                            ( current
+                                { nativeAgentCalls =
+                                    Map.insert
+                                        call.callId
+                                        call
+                                        current.nativeAgentCalls
+                                }
+                            , events
+                                <> [ NativeAgentStarted
+                                        call.callId
+                                        (Just identifier)
+                                        (nativeAgentLabel call)
+                                        (nativeAgentModel call)
+                                   ]
+                            )
+                    ClaudeToolFinished result
+                        | Just call <- Map.lookup
+                            result.callId
+                            current.nativeAgentCalls
+                        , isNativeAgentName call.name ->
+                            ( current
+                                { nativeAgentCalls =
+                                    Map.delete
+                                        result.callId
+                                        current.nativeAgentCalls
+                                }
+                            , events
+                                <> [ NativeAgentFinished
+                                        result.callId
+                                        NativeAgentCompleted
+                                   ]
+                            )
+                    _ -> (current, events))
+                        (state, [])
+                        tools
+                outputEvents = case message of
+                    MessageAssistant assistant
+                        | assistant.error == Nothing ->
+                            [ NativeAgentOutput identifier text
+                            | TextBlock{text} <- assistant.content
+                            , not (Text.null text)
+                            ]
+                    MessageUser user ->
+                        [ NativeAgentOutput identifier output
+                        | ToolResultBlock{content} <- user.content
+                        , let output = maybe "" renderResultContent content
+                        , not (Text.null output)
+                        ]
+                    _ -> []
+            in (nextState, outputEvents <> childLifecycle)
+
+isNativeAgentName :: Text -> Bool
+isNativeAgentName name =
+    Text.toLower name `elem` ["agent", "task"]
+
+nativeAgentLabel :: ToolCall -> Text
+nativeAgentLabel call =
+    fromMaybe call.name (jsonTextField "description" call.arguments)
+
+nativeAgentModel :: ToolCall -> Maybe Text
+nativeAgentModel call = jsonTextField "model" call.arguments
+
+jsonTextField :: Text -> Text -> Maybe Text
+jsonTextField key raw = do
+    Aeson.Object object <-
+        Aeson.decodeStrict (TextEncoding.encodeUtf8 raw)
+    Aeson.String value <- KeyMap.lookup (Key.fromText key) object
+    let stripped = Text.strip value
+    if Text.null stripped then Nothing else Just stripped
+
+appendUnknownWarning
+    :: ClaudeEventState
+    -> Message
+    -> [LoopEvent]
+    -> (ClaudeEventState, [LoopEvent])
+appendUnknownWarning state message events =
+    case unknownToolLikeType message of
+        Just contentType
+            | not (Set.member contentType state.warnedUnknownTypes) ->
+                ( state
+                    { warnedUnknownTypes =
+                        Set.insert contentType state.warnedUnknownTypes
+                    }
+                , events
+                    <> [ WarningRaised
+                            ( "Claude Code emitted unsupported tool-like content `"
+                                <> contentType
+                                <> "`."
+                            )
+                       ]
+                )
+        _ -> (state, events)
+
+unknownToolLikeType :: Message -> Maybe Text
+unknownToolLikeType = \case
+    MessageAssistant assistant ->
+        firstNonEmptyText
+            [ contentType
+            | UnknownContentBlock (Aeson.Object object) <- assistant.content
+            , Just (Aeson.String contentType) <-
+                [KeyMap.lookup "type" object]
+            , "tool" `Text.isInfixOf` Text.toLower contentType
+            ]
+    _ -> Nothing
 
 -- | Emit anything not already exposed by 'streamClaudeMessage'. Assistant
 -- text remains completion-buffered because the SDK can supersede messages;
@@ -128,6 +356,7 @@ interpretClaudeTurn messages result = do
         toolEvents =
             canonicalToolEvents
                 (concatMap messageToolEvents visibleMessages)
+        toolItems = concatMap messageToolItems visibleMessages
         events =
             toolEvents
                 <> maybe [] (pure . TextDelta) assistantText
@@ -143,6 +372,7 @@ interpretClaudeTurn messages result = do
         , events
         , tokenUsage = result.usage
         , cumulativeModelUsage = cumulative
+        , toolItems
         }
 
 validateSubscriptionSource :: [Message] -> Either Text ()
@@ -188,12 +418,109 @@ messageToolEvents = \case
             concatMap assistantBlockEvents assistant.content
     MessageUser user ->
         concatMap userBlockEvents user.content
+    MessageStreamEvent stream ->
+        streamEventToolEvents stream.event
     _ ->
         []
+
+messageToolItems :: Message -> [ResponseItem]
+messageToolItems = \case
+    MessageAssistant assistant
+        | assistant.error == Nothing ->
+            concatMap assistantBlockItems assistant.content
+    MessageUser user ->
+        concatMap userBlockItems user.content
+    _ -> []
+  where
+    assistantBlockItems = \case
+        ToolUseBlock{toolUseId, name, input} ->
+            [functionCallItem toolUseId name input]
+        ServerToolUseBlock{toolUseId, name, input} ->
+            [functionCallItem toolUseId name input]
+        _ -> []
+    userBlockItems = \case
+        ToolResultBlock{toolUseId, content, isError} ->
+            [functionOutputItem toolUseId content isError]
+        ServerToolResultBlock{toolUseId, content} ->
+            [functionOutputItem toolUseId content Nothing]
+        _ -> []
+
+functionCallItem :: Text -> Text -> Aeson.Value -> ResponseItem
+functionCallItem callId name input =
+    FunctionCallItem FunctionCall
+        { itemId = Nothing
+        , callId
+        , name
+        , namespace = Nothing
+        , arguments = encodeValue input
+        , encryptedFunctionArgs = Nothing
+        , status = Just ItemCompleted
+        , extraFields =
+            KeyMap.singleton
+                "provider"
+                (Aeson.String "claude-code")
+        }
+
+functionOutputItem
+    :: Text
+    -> Maybe Aeson.Value
+    -> Maybe Bool
+    -> ResponseItem
+functionOutputItem callId content isError =
+    FunctionCallOutputItem FunctionCallOutput
+        { itemId = Nothing
+        , callId
+        , name = Nothing
+        , namespace = Nothing
+        , output = fromMaybe Aeson.Null content
+        , status =
+            Just $
+                if isError == Just True
+                    then ItemIncomplete
+                    else ItemCompleted
+        , extraFields =
+            KeyMap.singleton
+                "provider"
+                (Aeson.String "claude-code")
+        }
+
+streamEventToolEvents :: Aeson.Value -> [ClaudeToolEvent]
+streamEventToolEvents = \case
+    Aeson.Object eventObject
+        | Just (Aeson.String "content_block_start") <-
+            KeyMap.lookup "type" eventObject
+        , Just (Aeson.Object block) <-
+            KeyMap.lookup "content_block" eventObject
+        , Just (Aeson.String blockType) <- KeyMap.lookup "type" block
+        , blockType `elem` ["tool_use", "server_tool_use"]
+        , Just (Aeson.String toolUseId) <- KeyMap.lookup "id" block
+        , Just (Aeson.String name) <- KeyMap.lookup "name" block ->
+            [ ClaudeToolStarted ToolCall
+                { callId = toolUseId
+                , name
+                , arguments =
+                    encodeValue $
+                        fromMaybe
+                            (Aeson.Object KeyMap.empty)
+                            (KeyMap.lookup "input" block)
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+            ]
+    _ -> []
 
 assistantBlockEvents :: ContentBlock -> [ClaudeToolEvent]
 assistantBlockEvents = \case
     ToolUseBlock{toolUseId, name, input} ->
+        [ ClaudeToolStarted ToolCall
+            { callId = toolUseId
+            , name
+            , arguments = encodeValue input
+            , callKind = FunctionCallKind
+            , argumentsEncrypted = False
+            }
+        ]
+    ServerToolUseBlock{toolUseId, name, input} ->
         [ ClaudeToolStarted ToolCall
             { callId = toolUseId
             , name
@@ -216,6 +543,15 @@ userBlockEvents = \case
             [ ClaudeToolFinished ToolCallResult
                 { callId = toolUseId
                 , output
+                , callKind = FunctionCallKind
+                }
+            ]
+    ServerToolResultBlock{toolUseId, content} ->
+        let rawOutput = maybe "" renderResultContent content
+        in
+            [ ClaudeToolFinished ToolCallResult
+                { callId = toolUseId
+                , output = rawOutput
                 , callKind = FunctionCallKind
                 }
             ]
@@ -243,12 +579,30 @@ advanceToolEvents initialState toolEvents =
         -> (ClaudeEventState, [LoopEvent])
     step (state, events) = \case
         ClaudeToolStarted call
-            | Set.member call.callId state.startedToolCalls ->
-                (state, events)
+            | Just previous <- Map.lookup
+                call.callId
+                state.startedToolDetails ->
+                    if previous == call
+                        then (state, events)
+                        else
+                            ( state
+                                { startedToolDetails =
+                                    Map.insert
+                                        call.callId
+                                        call
+                                        state.startedToolDetails
+                                }
+                            , ToolUpdated call : events
+                            )
             | otherwise ->
                 ( state
                     { startedToolCalls =
                         Set.insert call.callId state.startedToolCalls
+                    , startedToolDetails =
+                        Map.insert
+                            call.callId
+                            call
+                            state.startedToolDetails
                     }
                 , ToolStarted call : events
                 )

--- a/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
+++ b/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
@@ -356,7 +356,7 @@ interpretClaudeTurn messages result = do
         toolEvents =
             canonicalToolEvents
                 (concatMap messageToolEvents visibleMessages)
-        toolItems = concatMap messageToolItems visibleMessages
+        toolItems = canonicalToolItems visibleMessages
         events =
             toolEvents
                 <> maybe [] (pure . TextDelta) assistantText
@@ -444,6 +444,19 @@ messageToolItems = \case
         ServerToolResultBlock{toolUseId, content} ->
             [functionOutputItem toolUseId content Nothing]
         _ -> []
+
+canonicalToolItems :: [Message] -> [ResponseItem]
+canonicalToolItems messages =
+    filter keepItem items
+  where
+    items = concatMap messageToolItems messages
+    started =
+        Set.fromList
+            [call.callId | FunctionCallItem call <- items]
+    keepItem = \case
+        FunctionCallOutputItem output ->
+            Set.member output.callId started
+        _ -> True
 
 functionCallItem :: Text -> Text -> Aeson.Value -> ResponseItem
 functionCallItem callId name input =

--- a/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
+++ b/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
@@ -172,7 +172,8 @@ nativeLifecycleEvents state = concatMap \case
         , isNativeAgentName call.name ->
             [NativeAgentFinished
                 result.callId
-                (if "error" `Text.isInfixOf` Text.toLower result.output
+                (if "error:" `Text.isPrefixOf`
+                        Text.toLower (Text.stripStart result.output)
                     then NativeAgentFailed
                     else NativeAgentCompleted)]
     _ -> []

--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -14,10 +14,11 @@ import Agent.Claude.Options
 import Agent.Claude.Internal.Messages
     ( ClaudeEventState
     , CompletedClaudeTurn(..)
+    , claudeEventStateHasActivity
     , emptyClaudeEventState
     , interpretClaudeTurn
     , remainingClaudeEvents
-    , streamClaudeMessage
+    , streamClaudeProgress
     )
 import Agent.Error
     ( ApiError(..)
@@ -91,7 +92,7 @@ import Claude.Agent.SDK.Errors
     , renderClaudeSDKError
     )
 import Claude.Agent.SDK.Query
-    ( queryTurnContentWithMessageValidator
+    ( queryTurnContentWithMessageValidatorAndProgress
     )
 import Claude.Agent.SDK.Types
     ( ClaudeAgentOptions(..)
@@ -230,39 +231,47 @@ submitClaudeCodeTurn
                             content =
                                 claudeUserContent inputImages prompt
                         awaitResult <-
-                            queryTurnContentWithMessageValidator
+                            queryTurnContentWithMessageValidatorAndProgress
                                 turn
                                 content
                                 (\message -> do
                                     validated <-
                                         validateSubscriptionMessage message
-                                    case validated of
-                                        Left err -> pure (Left err)
-                                        Right () -> do
-                                            state <- readIORef eventState
-                                            let (nextState, events) =
-                                                    streamClaudeMessage
-                                                        state
-                                                        message
-                                            writeIORef eventState nextState
-                                            mapM_ onEvent events
-                                            pure (Right ()))
+                                    pure validated)
+                                (\progress -> do
+                                    state <- readIORef eventState
+                                    let (nextState, events) =
+                                            streamClaudeProgress
+                                                state
+                                                progress
+                                    writeIORef eventState nextState
+                                    mapM_ onEvent events)
                                 (\message ->
                                     modifyIORef' messages (message :))
                         case awaitResult of
                             Left sdkError ->
-                                pure (Left sdkError)
+                                do
+                                    state <- readIORef eventState
+                                    if claudeEventStateHasActivity state
+                                        then onEvent ResponseAttemptDiscarded
+                                        else pure ()
+                                    pure (Left sdkError)
                             Right result -> do
                                 turnMessages <- reverse <$> readIORef messages
                                 case interpretClaudeTurn turnMessages result of
                                     Left message ->
-                                        pure $
-                                            Left ResultError
-                                                { subtype = "authentication_error"
-                                                , apiErrorStatus = Nothing
-                                                , errors = [message]
-                                                , result = Nothing
-                                                }
+                                        do
+                                            state <- readIORef eventState
+                                            if claudeEventStateHasActivity state
+                                                then onEvent ResponseAttemptDiscarded
+                                                else pure ()
+                                            pure
+                                                (Left ResultError
+                                                    { subtype = "authentication_error"
+                                                    , apiErrorStatus = Nothing
+                                                    , errors = [message]
+                                                    , result = Nothing
+                                                    })
                                     Right completed -> do
                                         finalEventState <-
                                             readIORef eventState
@@ -309,6 +318,7 @@ submitClaudeCodeTurn
                     transcript
                     completed.sessionId
                     inputs
+                    completed.toolItems
                     completed.assistantText
         mapM_ onEvent (remainingClaudeEvents eventState completed)
         pure (Right (output, commit))
@@ -586,6 +596,7 @@ commitHostTranscript
     -> IORef [ResponseItem]
     -> Text
     -> [TurnInput]
+    -> [ResponseItem]
     -> Maybe Text
     -> IO ()
 commitHostTranscript
@@ -593,8 +604,9 @@ commitHostTranscript
     transcript
     sessionId
     inputs
+    toolItems
     assistantText = do
-    appendHostTranscriptRef transcript inputs assistantText
+    appendHostTranscriptRef transcript inputs toolItems assistantText
     -- Read and enter the exact object installed in the IORef before taking its
     -- StableName. Otherwise the lazy append thunk can later be entered by the
     -- CLI, changing the StableName despite no host-side transcript change.
@@ -622,11 +634,17 @@ appendHostTranscript history inputs assistantText =
 appendHostTranscriptRef
     :: IORef [ResponseItem]
     -> [TurnInput]
+    -> [ResponseItem]
     -> Maybe Text
     -> IO ()
-appendHostTranscriptRef transcript inputs assistantText =
+appendHostTranscriptRef transcript inputs toolItems assistantText =
     atomicModifyIORef' transcript \history ->
-        (appendHostTranscript history inputs assistantText, ())
+        ( history
+            <> turnInputsToItems inputs
+            <> toolItems
+            <> [assistantMessageItem assistantText]
+        , ()
+        )
 
 assistantMessageItem :: Maybe Text -> ResponseItem
 assistantMessageItem assistantText =

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -241,6 +241,64 @@ spec = do
                     _ -> False
                 readIORef observedBeforeResult `shouldReturn` [True]
 
+        it "retracts superseded live tools without committing them" $
+            withFakeClaude \fake ->
+                withEnvironmentVariables
+                    [("FAKE_CLAUDE_RETRACT_TOOL", Just "1")]
+                    do
+                        transcript <- newIORef []
+                        events <- newIORef []
+                        result <- timeout 5_000_000 $
+                            withClaudeCodeBackend
+                                (defaultClaudeCodeOptions
+                                    fake.executable
+                                    fake.workingDirectory)
+                                Nothing
+                                (pure defaultResponseCreateParams)
+                                transcript
+                                \backend ->
+                                    submitBackend backend
+                                        Nothing
+                                        [UserMessage "replace the tool"]
+                                        (\event ->
+                                            modifyIORef' events (<> [event]))
+                        result `shouldSatisfy` \case
+                            Just (Right _) -> True
+                            _ -> False
+                        observed <- readIORef events
+                        observed `shouldContain`
+                            [ ToolStarted expectedFakeToolCall
+                            , ToolRetracted "fake-tool"
+                            ]
+                        history <- readIORef transcript
+                        [call | FunctionCallItem call <- history]
+                            `shouldBe` []
+
+        it "starts from partial tool records and enriches canonical arguments" $
+            withFakeClaude \fake ->
+                withEnvironmentVariables
+                    [("FAKE_CLAUDE_PARTIAL_TOOL", Just "1")]
+                    do
+                        transcript <- newIORef []
+                        events <- newIORef []
+                        _ <- timeout 5_000_000 $
+                            withClaudeCodeBackend
+                                (defaultClaudeCodeOptions
+                                    fake.executable
+                                    fake.workingDirectory)
+                                Nothing
+                                (pure defaultResponseCreateParams)
+                                transcript
+                                \backend ->
+                                    submitBackend backend
+                                        Nothing
+                                        [UserMessage "read it"]
+                                        (\event ->
+                                            modifyIORef' events (<> [event]))
+                        observed <- readIORef events
+                        map eventTag observed `shouldContain`
+                            ["start:{}", "update:{\"file_path\":\"README.md\"}"]
+
         it "forwards pasted images as Claude image content blocks" $
             withFakeClaude \fake -> do
                 transcript <- newIORef []
@@ -1235,8 +1293,14 @@ fakeClaudeScript promptLog startLog argumentLog =
         , "  printf '{\"type\":\"stream_event\",\"uuid\":\"message-start-%s\",\"session_id\":\"%s\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"message-%s\"}}}\\n' \"$turn\" \"$session_id\" \"$turn\""
         , "  printf '{\"type\":\"stream_event\",\"uuid\":\"delta-a-%s\",\"session_id\":\"%s\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"fake \"}}}\\n' \"$turn\" \"$session_id\""
         , "  printf '{\"type\":\"stream_event\",\"uuid\":\"delta-b-%s\",\"session_id\":\"%s\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"response\"}}}\\n' \"$turn\" \"$session_id\""
+        , "  if [ \"$FAKE_CLAUDE_PARTIAL_TOOL\" = 1 ]; then"
+        , "    printf '{\"type\":\"stream_event\",\"uuid\":\"partial-tool-%s\",\"session_id\":\"%s\",\"event\":{\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"fake-tool\",\"name\":\"Read\",\"input\":{}}}}\\n' \"$turn\" \"$session_id\""
+        , "  fi"
         , "  tool_name=${FAKE_CLAUDE_TOOL_NAME:-Read}"
         , "  printf '{\"type\":\"assistant\",\"uuid\":\"tool-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"fake-tool\",\"name\":\"%s\",\"input\":{\"file_path\":\"README.md\"}}]}}\\n' \"$turn\" \"$session_id\" \"$tool_name\""
+        , "  if [ \"$FAKE_CLAUDE_RETRACT_TOOL\" = 1 ]; then"
+        , "    printf '{\"type\":\"system\",\"subtype\":\"model_refusal_fallback\",\"uuid\":\"retract-%s\",\"session_id\":\"%s\",\"retracted_message_uuids\":[\"tool-%s\"]}\\n' \"$turn\" \"$session_id\" \"$turn\""
+        , "  fi"
         , "  if [ \"$FAKE_CLAUDE_PAUSE_AFTER_TOOL\" = 1 ]; then sleep 1; fi"
         , "  printf '{\"type\":\"user\",\"uuid\":\"tool-result-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"fake-tool\",\"content\":\"fake contents\"}]}}\\n' \"$turn\" \"$session_id\""
         , "  printf '{\"type\":\"assistant\",\"uuid\":\"assistant-%s\",\"session_id\":\"%s\",\"message\":{\"id\":\"message-%s\",\"content\":[{\"type\":\"text\",\"text\":\"fake response\"}]}}\\n' \"$turn\" \"$session_id\" \"$turn\""
@@ -1293,6 +1357,12 @@ expectedFakeToolResult = ToolCallResult
     , output = "fake contents"
     , callKind = FunctionCallKind
     }
+
+eventTag :: LoopEvent -> Text
+eventTag = \case
+    ToolStarted call -> "start:" <> call.arguments
+    ToolUpdated call -> "update:" <> call.arguments
+    _ -> ""
 
 looksLikeUuid :: Text -> Bool
 looksLikeUuid value =

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -23,7 +23,9 @@ import Agent.Loop
     )
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types
-    ( MessageContent(..)
+    ( FunctionCall(..)
+    , FunctionCallOutput(..)
+    , MessageContent(..)
     , ReasoningConfig(..)
     , ResponseContentPart(..)
     , ResponseCreateParams(..)
@@ -160,7 +162,18 @@ spec = do
                         [ "hello"
                         , "fake response"
                         ]
-                length history `shouldBe` 2
+                let persistedCalls =
+                        [ (call.callId, call.name, call.arguments)
+                        | FunctionCallItem call <- history
+                        ]
+                    persistedOutputs =
+                        [ output.callId
+                        | FunctionCallOutputItem output <- history
+                        ]
+                persistedCalls `shouldBe`
+                    [("fake-tool", "Read", "{\"file_path\":\"README.md\"}")]
+                persistedOutputs `shouldBe` ["fake-tool"]
+                length history `shouldBe` 4
 
                 submitted <- readFile fake.promptLog
                 submitted `shouldContain`
@@ -613,6 +626,7 @@ spec = do
                         readIORef events `shouldReturn`
                             [ ToolStarted expectedFakeToolCall
                             , ToolFinished expectedFakeToolResult
+                            , ResponseAttemptDiscarded
                             ]
 
         it "reports malformed structured output" $

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -136,6 +136,7 @@ library
                     , Agent.CLI.McpManager
                     , Agent.CLI.ModelConfig
                     , Agent.CLI.Models
+                    , Agent.CLI.NativeAgents
                     , Agent.CLI.Notification
                     , Agent.CLI.Options
                     , Agent.CLI.Permission
@@ -342,6 +343,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ModelPickerSpec
                     , Agent.CLI.ModelConfigSpec
                     , Agent.CLI.ModelsSpec
+                    , Agent.CLI.NativeAgentsSpec
                     , Agent.CLI.ManagedTurnSpec
                     , Agent.CLI.NotificationSpec
                     , Agent.CLI.OptionsSpec

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -80,6 +80,7 @@ import System.IO (hFlush, hIsTerminalDevice, stderr, stdin)
 data AgentTarget
     = AgentRoot
     | AgentChild !SubagentId
+    | AgentNative !Text
     deriving (Eq, Ord, Show)
 
 data AgentStepState
@@ -133,6 +134,7 @@ agentStatusGlyph status = case Text.toLower status of
     "done" -> "✓"
     "error" -> "✕"
     "interrupted" -> "■"
+    "cancelled" -> "■"
     "closed" -> "×"
     "missing" -> "?"
     _ -> "·"

--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -454,6 +454,18 @@ updateManagedActivity event state =
                 { accumulatorKind = "thinking"
                 , accumulatorMessage = "Thinking…"
                 }
+        ToolUpdated _ ->
+            state
+        ToolRetracted _ ->
+            state
+        ResponseAttemptDiscarded ->
+            emptyManagedActivityAccumulator
+        NativeAgentStarted{} ->
+            state
+        NativeAgentOutput{} ->
+            state
+        NativeAgentFinished{} ->
+            state
         TurnFinished _ ->
             state
                 { accumulatorKind = "finished"

--- a/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
@@ -121,11 +121,15 @@ restoreNativeAgents items current =
     Map.union current restored
   where
     outputs = Map.fromList
-        [(output.callId, output) | FunctionCallOutputItem output <- items]
+        [ (output.callId, output)
+        | FunctionCallOutputItem output <- items
+        , isClaudeNativeItem output.extraFields
+        ]
     restored = Map.fromList
         [ (call.callId, restoredView call)
         | FunctionCallItem call <- items
         , isClaudeNativeCall call
+        , Map.member call.callId outputs
         ]
     restoredView call =
         let maybeOutput = Map.lookup call.callId outputs
@@ -165,8 +169,12 @@ restoreNativeAgents items current =
 isClaudeNativeCall :: FunctionCall -> Bool
 isClaudeNativeCall call =
     Text.toLower call.name `elem` ["agent", "task"]
-        && KeyMap.lookup "provider" call.extraFields
-            == Just (Aeson.String "claude-code")
+        && isClaudeNativeItem call.extraFields
+
+isClaudeNativeItem :: KeyMap.KeyMap Aeson.Value -> Bool
+isClaudeNativeItem fields =
+    KeyMap.lookup "provider" fields
+        == Just (Aeson.String "claude-code")
 
 argumentText :: Text -> Text -> Maybe Text
 argumentText key raw = do

--- a/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
@@ -1,0 +1,276 @@
+module Agent.CLI.NativeAgents
+    ( NativeAgentView(..)
+    , applyNativeAgentEvent
+    , nativeAgentEntries
+    , restoreNativeAgents
+    ) where
+
+import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.Loop (LoopEvent(..), NativeAgentStatus(..))
+import Agent.Responses.Types
+    ( FunctionCall(..)
+    , FunctionCallOutput(..)
+    , ItemStatus(..)
+    , ResponseItem(..)
+    )
+import Agent.TUI.Model
+    ( BlockState(..)
+    , UiEvent(..)
+    , UiState
+    , initialUiState
+    , reduceUi
+    )
+import qualified Data.Map.Strict as Map
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LazyByteString
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Text.Encoding.Error (lenientDecode)
+
+data NativeAgentView = NativeAgentView
+    { nativeAgentId :: !Text
+    , nativeAgentParent :: !(Maybe Text)
+    , nativeAgentLabel :: !Text
+    , nativeAgentModel :: !(Maybe Text)
+    , nativeAgentStatus :: !Text
+    , nativeAgentTranscript :: ![Text]
+    , nativeAgentConversation :: !UiState
+    }
+    deriving (Eq, Show)
+
+applyNativeAgentEvent
+    :: LoopEvent
+    -> Map.Map Text NativeAgentView
+    -> Map.Map Text NativeAgentView
+applyNativeAgentEvent event current =
+    case event of
+        TurnStarted ->
+            settleRunningNativeAgents NativeAgentCancelled current
+        ResponseRestarted _ ->
+            settleRunningNativeAgents NativeAgentCancelled current
+        ResponseAttemptDiscarded ->
+            settleRunningNativeAgents NativeAgentCancelled current
+        NativeAgentStarted identifier parent label model ->
+            Map.alter
+                (\case
+                    Nothing ->
+                        Just
+                            (newNativeAgentView
+                                identifier parent label model)
+                    Just view ->
+                        Just view
+                            { nativeAgentParent = parent
+                            , nativeAgentLabel = label
+                            , nativeAgentModel = model
+                            , nativeAgentStatus = "running"
+                            })
+                identifier
+                current
+        NativeAgentOutput identifier output ->
+            let view =
+                    Map.findWithDefault
+                        (newNativeAgentView
+                            identifier Nothing identifier Nothing)
+                        identifier
+                        current
+            in Map.insert identifier
+                view
+                    { nativeAgentTranscript =
+                        view.nativeAgentTranscript <> [output]
+                    , nativeAgentConversation =
+                        reduceUi
+                            (UiLoop (TextDelta output))
+                            view.nativeAgentConversation
+                    }
+                current
+        NativeAgentFinished identifier status ->
+            let view =
+                    Map.findWithDefault
+                        (newNativeAgentView
+                            identifier Nothing identifier Nothing)
+                        identifier
+                        current
+            in Map.insert identifier
+                view
+                    { nativeAgentStatus = nativeAgentStatusText status
+                    , nativeAgentConversation =
+                        reduceUi
+                            (UiTurnEnded (nativeAgentBlockState status))
+                            view.nativeAgentConversation
+                    }
+                current
+        _ -> current
+
+nativeAgentEntries :: Map.Map Text NativeAgentView -> [AgentEntry]
+nativeAgentEntries agents =
+    map (nativeAgentEntry agents) (Map.elems agents)
+
+-- | Reconstruct completed top-level Claude-native agents from the canonical
+-- tool items stored in the root transcript. Live entries win when the same
+-- call is already present.
+restoreNativeAgents
+    :: [ResponseItem]
+    -> Map.Map Text NativeAgentView
+    -> Map.Map Text NativeAgentView
+restoreNativeAgents items current =
+    Map.union current restored
+  where
+    outputs = Map.fromList
+        [(output.callId, output) | FunctionCallOutputItem output <- items]
+    restored = Map.fromList
+        [ (call.callId, restoredView call)
+        | FunctionCallItem call <- items
+        , isClaudeNativeCall call
+        ]
+    restoredView call =
+        let maybeOutput = Map.lookup call.callId outputs
+            outputText = maybe "" (renderOutput . (.output)) maybeOutput
+            terminal = case maybeOutput >>= (.status) of
+                Just ItemIncomplete -> BlockFailed
+                Just (ItemStatusUnknown status)
+                    | Text.toLower status `elem`
+                        ["failed", "error", "cancelled", "canceled"] ->
+                            BlockFailed
+                _ -> BlockComplete
+            started = newNativeAgentView
+                call.callId
+                Nothing
+                (fromMaybe call.name
+                    (argumentText "description" call.arguments))
+                (argumentText "model" call.arguments)
+            withOutput
+                | Text.null (Text.strip outputText) = started
+                | otherwise =
+                    started
+                        { nativeAgentTranscript = [outputText]
+                        , nativeAgentConversation =
+                            reduceUi
+                                (UiLoop (TextDelta outputText))
+                                started.nativeAgentConversation
+                        }
+        in withOutput
+            { nativeAgentStatus =
+                if terminal == BlockFailed then "error" else "done"
+            , nativeAgentConversation =
+                reduceUi
+                    (UiTurnEnded terminal)
+                    withOutput.nativeAgentConversation
+            }
+
+isClaudeNativeCall :: FunctionCall -> Bool
+isClaudeNativeCall call =
+    Text.toLower call.name `elem` ["agent", "task"]
+        && KeyMap.lookup "provider" call.extraFields
+            == Just (Aeson.String "claude-code")
+
+argumentText :: Text -> Text -> Maybe Text
+argumentText key raw = do
+    Aeson.Object object <-
+        Aeson.decodeStrict (TextEncoding.encodeUtf8 raw)
+    Aeson.String value <- KeyMap.lookup (Key.fromText key) object
+    let stripped = Text.strip value
+    if Text.null stripped then Nothing else Just stripped
+
+renderOutput :: Aeson.Value -> Text
+renderOutput = \case
+    Aeson.String text -> text
+    value ->
+        TextEncoding.decodeUtf8With lenientDecode
+            (LazyByteString.toStrict (Aeson.encode value))
+
+settleRunningNativeAgents
+    :: NativeAgentStatus
+    -> Map.Map Text NativeAgentView
+    -> Map.Map Text NativeAgentView
+settleRunningNativeAgents status =
+    Map.map \view ->
+        if view.nativeAgentStatus /= "running"
+            then view
+            else view
+                { nativeAgentStatus = nativeAgentStatusText status
+                , nativeAgentConversation =
+                    reduceUi
+                        (UiTurnEnded (nativeAgentBlockState status))
+                        view.nativeAgentConversation
+                }
+
+nativeAgentBlockState :: NativeAgentStatus -> BlockState
+nativeAgentBlockState = \case
+    NativeAgentRunning -> BlockRunning
+    NativeAgentCompleted -> BlockComplete
+    NativeAgentFailed -> BlockFailed
+    NativeAgentCancelled -> BlockCancelled
+
+newNativeAgentView
+    :: Text
+    -> Maybe Text
+    -> Text
+    -> Maybe Text
+    -> NativeAgentView
+newNativeAgentView identifier parent label model =
+    NativeAgentView
+        { nativeAgentId = identifier
+        , nativeAgentParent = parent
+        , nativeAgentLabel = label
+        , nativeAgentModel = model
+        , nativeAgentStatus = "running"
+        , nativeAgentTranscript = []
+        , nativeAgentConversation =
+            reduceUi (UiLoop TurnStarted) initialUiState
+        }
+
+nativeAgentStatusText :: NativeAgentStatus -> Text
+nativeAgentStatusText = \case
+    NativeAgentRunning -> "running"
+    NativeAgentCompleted -> "done"
+    NativeAgentFailed -> "error"
+    NativeAgentCancelled -> "cancelled"
+
+nativeAgentEntry
+    :: Map.Map Text NativeAgentView
+    -> NativeAgentView
+    -> AgentEntry
+nativeAgentEntry agents view =
+    AgentEntry
+        { agentTarget = AgentNative view.nativeAgentId
+        , agentPath = nativeAgentPath agents Set.empty view
+        , agentStatus = view.nativeAgentStatus
+        , agentModel = view.nativeAgentModel
+        , agentSteps = []
+        , agentTranscript = view.nativeAgentTranscript
+        , agentConversation = view.nativeAgentConversation
+        }
+
+nativeAgentPath
+    :: Map.Map Text NativeAgentView
+    -> Set.Set Text
+    -> NativeAgentView
+    -> Text
+nativeAgentPath agents visited view
+    | Set.member view.nativeAgentId visited =
+        "/native/" <> nativeAgentPathSegment view
+    | otherwise =
+        case view.nativeAgentParent >>= (`Map.lookup` agents) of
+            Nothing -> "/native/" <> nativeAgentPathSegment view
+            Just parent ->
+                nativeAgentPath
+                    agents
+                    (Set.insert view.nativeAgentId visited)
+                    parent
+                    <> "/"
+                    <> nativeAgentPathSegment view
+
+nativeAgentPathSegment :: NativeAgentView -> Text
+nativeAgentPathSegment view =
+    let cleaned =
+            Text.unwords
+                (Text.words
+                    (Text.map
+                        (\char -> if char == '/' then '-' else char)
+                        view.nativeAgentLabel))
+    in if Text.null cleaned then view.nativeAgentId else cleaned

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -818,6 +818,18 @@ renderEventUnlocked config = \case
         case painted of
             Nothing -> pure ()
             Just line -> putTextLn config.renderStderr line
+    ToolUpdated _ ->
+        pure ()
+    ToolRetracted _ ->
+        pure ()
+    ResponseAttemptDiscarded ->
+        pure ()
+    NativeAgentStarted{} ->
+        pure ()
+    NativeAgentOutput{} ->
+        pure ()
+    NativeAgentFinished{} ->
+        pure ()
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
 -- The terminal theme owns the default assistant background.

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -219,6 +219,175 @@ import Data.Time.Clock
     )
 import System.Mem.StableName (StableName, makeStableName)
 
+data NativeAgentView = NativeAgentView
+    { nativeAgentId :: !Text
+    , nativeAgentParent :: !(Maybe Text)
+    , nativeAgentLabel :: !Text
+    , nativeAgentModel :: !(Maybe Text)
+    , nativeAgentStatus :: !Text
+    , nativeAgentTranscript :: ![Text]
+    , nativeAgentConversation :: !UiState
+    }
+
+updateNativeAgents :: IORef (Map.Map Text NativeAgentView) -> LoopEvent -> IO ()
+updateNativeAgents ref event =
+    atomicModifyIORef' ref \current ->
+        case event of
+            TurnStarted ->
+                (settleRunningNativeAgents NativeAgentCancelled current, ())
+            ResponseRestarted _ ->
+                (settleRunningNativeAgents NativeAgentCancelled current, ())
+            ResponseAttemptDiscarded ->
+                (settleRunningNativeAgents NativeAgentCancelled current, ())
+            NativeAgentStarted identifier parent label model ->
+                let update = \case
+                        Nothing ->
+                            Just
+                                (newNativeAgentView
+                                    identifier parent label model)
+                        Just view ->
+                            Just view
+                                { nativeAgentParent = parent
+                                , nativeAgentLabel = label
+                                , nativeAgentModel = model
+                                , nativeAgentStatus = "running"
+                                }
+                in (Map.alter update identifier current, ())
+            NativeAgentOutput identifier output ->
+                let view =
+                        Map.findWithDefault
+                            (newNativeAgentView
+                                identifier Nothing identifier Nothing)
+                            identifier
+                            current
+                    conversation =
+                        reduceUi
+                            (UiLoop (TextDelta output))
+                            view.nativeAgentConversation
+                in ( Map.insert identifier
+                        view
+                            { nativeAgentTranscript =
+                                view.nativeAgentTranscript <> [output]
+                            , nativeAgentConversation = conversation
+                            }
+                        current
+                   , ()
+                   )
+            NativeAgentFinished identifier status ->
+                let view =
+                        Map.findWithDefault
+                            (newNativeAgentView
+                                identifier Nothing identifier Nothing)
+                            identifier
+                            current
+                    conversation =
+                        reduceUi
+                            (UiTurnEnded (nativeAgentBlockState status))
+                            view.nativeAgentConversation
+                in ( Map.insert identifier
+                        view
+                            { nativeAgentStatus =
+                                nativeAgentStatusText status
+                            , nativeAgentConversation = conversation
+                            }
+                        current
+                   , ()
+                   )
+            _ -> (current, ())
+
+settleRunningNativeAgents
+    :: NativeAgentStatus
+    -> Map.Map Text NativeAgentView
+    -> Map.Map Text NativeAgentView
+settleRunningNativeAgents status =
+    Map.map \view ->
+        if view.nativeAgentStatus /= "running"
+            then view
+            else
+                view
+                    { nativeAgentStatus = nativeAgentStatusText status
+                    , nativeAgentConversation =
+                        reduceUi
+                            (UiTurnEnded (nativeAgentBlockState status))
+                            view.nativeAgentConversation
+                    }
+
+nativeAgentBlockState :: NativeAgentStatus -> BlockState
+nativeAgentBlockState = \case
+    NativeAgentRunning -> BlockRunning
+    NativeAgentCompleted -> BlockComplete
+    NativeAgentFailed -> BlockFailed
+    NativeAgentCancelled -> BlockCancelled
+
+newNativeAgentView
+    :: Text
+    -> Maybe Text
+    -> Text
+    -> Maybe Text
+    -> NativeAgentView
+newNativeAgentView identifier parent label model =
+    NativeAgentView
+        { nativeAgentId = identifier
+        , nativeAgentParent = parent
+        , nativeAgentLabel = label
+        , nativeAgentModel = model
+        , nativeAgentStatus = "running"
+        , nativeAgentTranscript = []
+        , nativeAgentConversation =
+            reduceUi (UiLoop TurnStarted) initialUiState
+        }
+
+nativeAgentStatusText :: NativeAgentStatus -> Text
+nativeAgentStatusText = \case
+    NativeAgentRunning -> "running"
+    NativeAgentCompleted -> "done"
+    NativeAgentFailed -> "error"
+    NativeAgentCancelled -> "cancelled"
+
+nativeAgentEntry
+    :: Map.Map Text NativeAgentView
+    -> NativeAgentView
+    -> AgentEntry
+nativeAgentEntry agents view =
+    AgentEntry
+        { agentTarget = AgentNative view.nativeAgentId
+        , agentPath = nativeAgentPath agents Set.empty view
+        , agentStatus = view.nativeAgentStatus
+        , agentModel = view.nativeAgentModel
+        , agentSteps = []
+        , agentTranscript = view.nativeAgentTranscript
+        , agentConversation = view.nativeAgentConversation
+        }
+
+nativeAgentPath
+    :: Map.Map Text NativeAgentView
+    -> Set.Set Text
+    -> NativeAgentView
+    -> Text
+nativeAgentPath agents visited view
+    | Set.member view.nativeAgentId visited =
+        "/native/" <> nativeAgentPathSegment view
+    | otherwise =
+        case view.nativeAgentParent >>= (`Map.lookup` agents) of
+            Nothing -> "/native/" <> nativeAgentPathSegment view
+            Just parent ->
+                nativeAgentPath
+                    agents
+                    (Set.insert view.nativeAgentId visited)
+                    parent
+                    <> "/"
+                    <> nativeAgentPathSegment view
+
+nativeAgentPathSegment :: NativeAgentView -> Text
+nativeAgentPathSegment view =
+    let cleaned =
+            Text.unwords
+                (Text.words
+                    (Text.map
+                        (\char -> if char == '/' then '-' else char)
+                        view.nativeAgentLabel))
+    in if Text.null cleaned then view.nativeAgentId else cleaned
+
 data AgentStepCache = AgentStepCache
     { cachedTranscript :: !(StableName [ResponseItem])
     , cachedVariant :: !(Maybe SubagentStatus)
@@ -323,6 +492,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
     lastFailedTurnRef <- newIORef Nothing
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
     selectedAgent <- newIORef AgentRoot
+    nativeAgentsRef <- newIORef (Map.empty :: Map.Map Text NativeAgentView)
     agentStepCache <- newIORef (Map.empty :: Map.Map AgentTarget AgentStepCache)
     let cachedAgentSteps target variant items build = do
             transcriptName <- makeStableName items
@@ -346,6 +516,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     pure steps
         loadAgentSnapshot includeSummaries = do
             rootItems <- readLiveTranscript conversationRef
+            nativeAgents <- readIORef nativeAgentsRef
             agents <- case multiCtx of
                 Nothing -> pure []
                 Just ctx -> listAgents ctx.multiRegistry Nothing
@@ -354,6 +525,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                         : [ AgentChild agentId
                           | (_, agentId, _) <- agents
                           ]
+                        <> map (\view -> AgentNative view.nativeAgentId)
+                            (Map.elems nativeAgents)
             selected <-
                 atomicModifyIORef' selectedAgent \current ->
                     let reconciled =
@@ -372,6 +545,9 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                                 responseItemPreviewLines 12 items
                             | otherwise ->
                                 []
+                        AgentNative nativeId ->
+                            maybe [] (.nativeAgentTranscript)
+                                (Map.lookup nativeId nativeAgents)
                     | includeSummaries =
                         responseItemPreviewLines 0 items
                     | otherwise = []
@@ -379,6 +555,9 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     | includeSummaries = initialUiState
                     | target /= selected = initialUiState
                     | target == AgentRoot = initialUiState
+                    | AgentNative nativeId <- target =
+                        maybe initialUiState (.nativeAgentConversation)
+                            (Map.lookup nativeId nativeAgents)
                     | otherwise =
                         settleConversation items status $
                             responseItemsToUiStateRelative
@@ -446,7 +625,10 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     conversationFor
                     sessions)
                 agents
-            pure (selected, rootEntry : children)
+            let nativeEntries =
+                    map (nativeAgentEntry nativeAgents)
+                        (Map.elems nativeAgents)
+            pure (selected, rootEntry : children <> nativeEntries)
           where
             materializeChild
                     transcriptLines
@@ -502,6 +684,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 releaseSelectedAgent previous
             case target of
                 AgentRoot -> pure ()
+                AgentNative _ -> pure ()
                 AgentChild agentId -> do
                     session <-
                         (Just <$>
@@ -525,6 +708,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             writeIORef selectedAgent target
         releaseSelectedAgent = \case
             AgentRoot -> pure ()
+            AgentNative _ -> pure ()
             AgentChild agentId -> do
                 sessions <- readIORef subagentSessions
                 forM_ (Map.lookup agentId sessions) \session -> do
@@ -714,6 +898,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , renderWorkspace = toText cwd
             }
         emitLoop event = do
+            updateNativeAgents nativeAgentsRef event
             managedLoopPublisher event
             case fullscreen of
                 Nothing -> renderEvent render event

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -17,6 +17,12 @@ import Agent.CLI.AgentViewport
     , responseItemStepPreviewsRelative
     , responseItemsToUiStateRelative
     )
+import Agent.CLI.NativeAgents
+    ( NativeAgentView(..)
+    , applyNativeAgentEvent
+    , nativeAgentEntries
+    , restoreNativeAgents
+    )
 import Agent.CLI.SessionTitle
     ( SessionTitleEvent(..)
     , SessionTitleFailure(..)
@@ -219,175 +225,6 @@ import Data.Time.Clock
     )
 import System.Mem.StableName (StableName, makeStableName)
 
-data NativeAgentView = NativeAgentView
-    { nativeAgentId :: !Text
-    , nativeAgentParent :: !(Maybe Text)
-    , nativeAgentLabel :: !Text
-    , nativeAgentModel :: !(Maybe Text)
-    , nativeAgentStatus :: !Text
-    , nativeAgentTranscript :: ![Text]
-    , nativeAgentConversation :: !UiState
-    }
-
-updateNativeAgents :: IORef (Map.Map Text NativeAgentView) -> LoopEvent -> IO ()
-updateNativeAgents ref event =
-    atomicModifyIORef' ref \current ->
-        case event of
-            TurnStarted ->
-                (settleRunningNativeAgents NativeAgentCancelled current, ())
-            ResponseRestarted _ ->
-                (settleRunningNativeAgents NativeAgentCancelled current, ())
-            ResponseAttemptDiscarded ->
-                (settleRunningNativeAgents NativeAgentCancelled current, ())
-            NativeAgentStarted identifier parent label model ->
-                let update = \case
-                        Nothing ->
-                            Just
-                                (newNativeAgentView
-                                    identifier parent label model)
-                        Just view ->
-                            Just view
-                                { nativeAgentParent = parent
-                                , nativeAgentLabel = label
-                                , nativeAgentModel = model
-                                , nativeAgentStatus = "running"
-                                }
-                in (Map.alter update identifier current, ())
-            NativeAgentOutput identifier output ->
-                let view =
-                        Map.findWithDefault
-                            (newNativeAgentView
-                                identifier Nothing identifier Nothing)
-                            identifier
-                            current
-                    conversation =
-                        reduceUi
-                            (UiLoop (TextDelta output))
-                            view.nativeAgentConversation
-                in ( Map.insert identifier
-                        view
-                            { nativeAgentTranscript =
-                                view.nativeAgentTranscript <> [output]
-                            , nativeAgentConversation = conversation
-                            }
-                        current
-                   , ()
-                   )
-            NativeAgentFinished identifier status ->
-                let view =
-                        Map.findWithDefault
-                            (newNativeAgentView
-                                identifier Nothing identifier Nothing)
-                            identifier
-                            current
-                    conversation =
-                        reduceUi
-                            (UiTurnEnded (nativeAgentBlockState status))
-                            view.nativeAgentConversation
-                in ( Map.insert identifier
-                        view
-                            { nativeAgentStatus =
-                                nativeAgentStatusText status
-                            , nativeAgentConversation = conversation
-                            }
-                        current
-                   , ()
-                   )
-            _ -> (current, ())
-
-settleRunningNativeAgents
-    :: NativeAgentStatus
-    -> Map.Map Text NativeAgentView
-    -> Map.Map Text NativeAgentView
-settleRunningNativeAgents status =
-    Map.map \view ->
-        if view.nativeAgentStatus /= "running"
-            then view
-            else
-                view
-                    { nativeAgentStatus = nativeAgentStatusText status
-                    , nativeAgentConversation =
-                        reduceUi
-                            (UiTurnEnded (nativeAgentBlockState status))
-                            view.nativeAgentConversation
-                    }
-
-nativeAgentBlockState :: NativeAgentStatus -> BlockState
-nativeAgentBlockState = \case
-    NativeAgentRunning -> BlockRunning
-    NativeAgentCompleted -> BlockComplete
-    NativeAgentFailed -> BlockFailed
-    NativeAgentCancelled -> BlockCancelled
-
-newNativeAgentView
-    :: Text
-    -> Maybe Text
-    -> Text
-    -> Maybe Text
-    -> NativeAgentView
-newNativeAgentView identifier parent label model =
-    NativeAgentView
-        { nativeAgentId = identifier
-        , nativeAgentParent = parent
-        , nativeAgentLabel = label
-        , nativeAgentModel = model
-        , nativeAgentStatus = "running"
-        , nativeAgentTranscript = []
-        , nativeAgentConversation =
-            reduceUi (UiLoop TurnStarted) initialUiState
-        }
-
-nativeAgentStatusText :: NativeAgentStatus -> Text
-nativeAgentStatusText = \case
-    NativeAgentRunning -> "running"
-    NativeAgentCompleted -> "done"
-    NativeAgentFailed -> "error"
-    NativeAgentCancelled -> "cancelled"
-
-nativeAgentEntry
-    :: Map.Map Text NativeAgentView
-    -> NativeAgentView
-    -> AgentEntry
-nativeAgentEntry agents view =
-    AgentEntry
-        { agentTarget = AgentNative view.nativeAgentId
-        , agentPath = nativeAgentPath agents Set.empty view
-        , agentStatus = view.nativeAgentStatus
-        , agentModel = view.nativeAgentModel
-        , agentSteps = []
-        , agentTranscript = view.nativeAgentTranscript
-        , agentConversation = view.nativeAgentConversation
-        }
-
-nativeAgentPath
-    :: Map.Map Text NativeAgentView
-    -> Set.Set Text
-    -> NativeAgentView
-    -> Text
-nativeAgentPath agents visited view
-    | Set.member view.nativeAgentId visited =
-        "/native/" <> nativeAgentPathSegment view
-    | otherwise =
-        case view.nativeAgentParent >>= (`Map.lookup` agents) of
-            Nothing -> "/native/" <> nativeAgentPathSegment view
-            Just parent ->
-                nativeAgentPath
-                    agents
-                    (Set.insert view.nativeAgentId visited)
-                    parent
-                    <> "/"
-                    <> nativeAgentPathSegment view
-
-nativeAgentPathSegment :: NativeAgentView -> Text
-nativeAgentPathSegment view =
-    let cleaned =
-            Text.unwords
-                (Text.words
-                    (Text.map
-                        (\char -> if char == '/' then '-' else char)
-                        view.nativeAgentLabel))
-    in if Text.null cleaned then view.nativeAgentId else cleaned
-
 data AgentStepCache = AgentStepCache
     { cachedTranscript :: !(StableName [ResponseItem])
     , cachedVariant :: !(Maybe SubagentStatus)
@@ -516,7 +353,10 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     pure steps
         loadAgentSnapshot includeSummaries = do
             rootItems <- readLiveTranscript conversationRef
-            nativeAgents <- readIORef nativeAgentsRef
+            nativeAgents <-
+                atomicModifyIORef' nativeAgentsRef \current ->
+                    let restored = restoreNativeAgents rootItems current
+                    in (restored, restored)
             agents <- case multiCtx of
                 Nothing -> pure []
                 Just ctx -> listAgents ctx.multiRegistry Nothing
@@ -625,9 +465,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     conversationFor
                     sessions)
                 agents
-            let nativeEntries =
-                    map (nativeAgentEntry nativeAgents)
-                        (Map.elems nativeAgents)
+            let nativeEntries = nativeAgentEntries nativeAgents
             pure (selected, rootEntry : children <> nativeEntries)
           where
             materializeChild
@@ -898,7 +736,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , renderWorkspace = toText cwd
             }
         emitLoop event = do
-            updateNativeAgents nativeAgentsRef event
+            atomicModifyIORef' nativeAgentsRef \current ->
+                (applyNativeAgentEvent event current, ())
             managedLoopPublisher event
             case fullscreen of
                 Nothing -> renderEvent render event

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2197,6 +2197,9 @@ copyCodeBlock target blockId codeIndex = do
                         <|> selectedBlock state.appUi blockId
                 AgentChild _ ->
                     conversationUiForTarget target state
+                        >>= \ui -> selectedBlock ui blockId
+                AgentNative _ ->
+                    conversationUiForTarget target state
                         >>= \ui -> selectedBlock ui blockId)
                 >>= fencedCodeBlock codeIndex . (.blockBody)
     case code of
@@ -3768,6 +3771,8 @@ applyActiveConversationUiEvent uiEvent = do
             applyLocalUiEvent uiEvent
         target@(AgentChild _) ->
             modify' (applyChildConversationUiEvent target uiEvent)
+        target@(AgentNative _) ->
+            modify' (applyChildConversationUiEvent target uiEvent)
 
 scrollConversationPage :: Direction -> EventM Name AppState ()
 scrollConversationPage direction = do
@@ -4042,6 +4047,9 @@ conversationBlocks target state =
         AgentChild _ ->
             maybe [] (toList . (.uiBlocks))
                 (conversationUiForTarget target state)
+        AgentNative _ ->
+            maybe [] (toList . (.uiBlocks))
+                (conversationUiForTarget target state)
 
 historyBlock :: HistoryWindow -> BlockId -> Maybe UiBlock
 historyBlock window ident =
@@ -4059,6 +4067,9 @@ selectedConversationBlockId target state =
         AgentChild _ ->
             conversationUiForTarget target state
                 >>= (.uiSelectedBlock)
+        AgentNative _ ->
+            conversationUiForTarget target state
+                >>= (.uiSelectedBlock)
 
 selectedConversationBlock
     :: AgentTarget
@@ -4071,6 +4082,8 @@ selectedConversationBlock target state =
                 historyBlock state.appHistoryWindow ident
                     <|> lookupBlock ident state.appUi
             AgentChild _ ->
+                conversationUiForTarget target state >>= lookupBlock ident
+            AgentNative _ ->
                 conversationUiForTarget target state >>= lookupBlock ident
 
 selectConversationBlock
@@ -4102,6 +4115,18 @@ selectConversationBlock target ident = do
                         (applyUiEvent
                             (UiFocusChanged FocusScrollback))
         AgentChild _ -> do
+            modify' \current ->
+                (applyChildConversationUiEvent
+                    target
+                    (UiSelectBlock ident)
+                    current)
+                    { appHistorySelectedBlock = Nothing
+                    , appUi =
+                        reduceUi
+                            (UiFocusChanged FocusScrollback)
+                            current.appUi
+                    }
+        AgentNative _ -> do
             modify' \current ->
                 (applyChildConversationUiEvent
                     target
@@ -4145,6 +4170,18 @@ activateConversationBlock target ident = do
                         (applyUiEvent
                             (UiFocusChanged FocusScrollback))
         AgentChild _ -> do
+            modify' \current ->
+                (applyChildConversationUiEvent
+                    target
+                    (UiActivateBlock ident)
+                    current)
+                    { appHistorySelectedBlock = Nothing
+                    , appUi =
+                        reduceUi
+                            (UiFocusChanged FocusScrollback)
+                            current.appUi
+                    }
+        AgentNative _ -> do
             modify' \current ->
                 (applyChildConversationUiEvent
                     target

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
@@ -565,6 +565,9 @@ conversationUiForTarget target state = case target of
     AgentChild _ ->
         (.agentConversation)
             <$> lookupAgentEntry target state.appAgentEntries
+    AgentNative _ ->
+        (.agentConversation)
+            <$> lookupAgentEntry target state.appAgentEntries
 
 activeConversationUi :: AppState -> UiState
 activeConversationUi state =
@@ -1474,6 +1477,7 @@ submittedUserMessage state target block =
         [terminalTxtWrap block.blockBody]
             <> case target of
                 AgentChild _ -> []
+                AgentNative _ -> []
                 AgentRoot ->
                     zipWith submittedImage [0 ..] $
                         Map.findWithDefault

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -117,6 +117,48 @@ spec = do
             (.agentStatus) <$> selectedAgentEntry refreshed
                 `shouldBe` Just "done"
 
+        it "selects provider-native agents without changing host child identity" do
+            let native =
+                    AgentEntry
+                        { agentTarget = AgentNative "toolu-native"
+                        , agentPath = "/native/explore"
+                        , agentStatus = "running"
+                        , agentModel = Just "claude-sonnet"
+                        , agentSteps = []
+                        , agentTranscript = ["assistant: inspecting"]
+                        , agentConversation = initialUiState
+                        }
+                mixed = entries <> [native]
+                selected =
+                    selectAgentTarget (AgentNative "toolu-native")
+                        (initialAgentViewportState AgentRoot mixed)
+            (.agentTarget) <$> selectedAgentEntry selected
+                `shouldBe` Just (AgentNative "toolu-native")
+            lookupAgentEntry
+                (AgentChild (SubagentId "alpha"))
+                mixed
+                `shouldSatisfy` maybe False ((== "/root/alpha") . (.agentPath))
+
+        it "renders provider-native agents in the shared hierarchy" do
+            let native =
+                    AgentEntry
+                        { agentTarget = AgentNative "toolu-native"
+                        , agentPath = "/native/explore"
+                        , agentStatus = "cancelled"
+                        , agentModel = Just "claude-sonnet"
+                        , agentSteps = []
+                        , agentTranscript = ["assistant: partial result"]
+                        , agentConversation = initialUiState
+                        }
+                rendered =
+                    renderAgentTree
+                        False
+                        (AgentNative "toolu-native")
+                        (entries <> [native])
+            rendered `shouldSatisfy` Text.isInfixOf "explore  ■ cancelled"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "viewing /native/explore"
+
         it "renders hierarchy and transcript panes" do
             let frame = renderAgentViewportFrameFor False 10 70 state
             frame `shouldSatisfy` Text.isInfixOf "hierarchy"

--- a/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
@@ -108,3 +108,38 @@ spec = describe "provider-native agent tracking" do
         view.nativeAgentModel `shouldBe` Just "sonnet"
         view.nativeAgentStatus `shouldBe` "done"
         view.nativeAgentTranscript `shouldBe` ["review complete"]
+
+    it "does not restore unpaired or non-Claude canonical calls" do
+        let claudeFields =
+                KeyMap.singleton "provider"
+                    (Aeson.String "claude-code")
+            otherFields =
+                KeyMap.singleton "provider"
+                    (Aeson.String "openai")
+            call identifier fields = FunctionCallItem FunctionCall
+                { itemId = Nothing
+                , callId = identifier
+                , name = "Task"
+                , namespace = Nothing
+                , arguments = "{}"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                , extraFields = fields
+                }
+            wrongOutput = FunctionCallOutputItem FunctionCallOutput
+                { itemId = Nothing
+                , callId = "claude-unpaired"
+                , name = Nothing
+                , namespace = Nothing
+                , output = Aeson.String "not Claude metadata"
+                , status = Just ItemCompleted
+                , extraFields = otherFields
+                }
+            restored =
+                restoreNativeAgents
+                    [ call "claude-unpaired" claudeFields
+                    , wrongOutput
+                    , call "other" otherFields
+                    ]
+                    Map.empty
+        restored `shouldBe` Map.empty

--- a/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
@@ -69,6 +69,22 @@ spec = describe "provider-native agent tracking" do
         view.nativeAgentStatus `shouldBe` "cancelled"
         states `shouldSatisfy` all (/= BlockRunning)
 
+    it "settles stale running children before the next turn starts" do
+        let tracked =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    Map.empty
+                    [ NativeAgentStarted "child" Nothing "Explore" Nothing
+                    , NativeAgentOutput "child" "partial"
+                    , TurnStarted
+                    ]
+            view = tracked Map.! "child"
+            states =
+                map (.blockState)
+                    (Foldable.toList view.nativeAgentConversation.uiBlocks)
+        view.nativeAgentStatus `shouldBe` "cancelled"
+        states `shouldSatisfy` all (/= BlockRunning)
+
     it "creates and terminates a placeholder for reordered finish events" do
         let tracked =
                 applyNativeAgentEvent

--- a/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
@@ -1,0 +1,110 @@
+module Agent.CLI.NativeAgentsSpec (spec) where
+
+import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.NativeAgents
+import Agent.Loop (LoopEvent(..), NativeAgentStatus(..))
+import Agent.Responses.Types
+    ( FunctionCall(..)
+    , FunctionCallOutput(..)
+    , ItemStatus(..)
+    , ResponseItem(..)
+    )
+import Agent.TUI.Model (BlockState(..), UiBlock(..), UiState(..))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Foldable as Foldable
+import Data.List (find)
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = describe "provider-native agent tracking" do
+    it "retains output that arrives before lifecycle metadata" do
+        let beforeStart =
+                applyNativeAgentEvent
+                    (NativeAgentOutput "child" "working")
+                    Map.empty
+            afterStart =
+                applyNativeAgentEvent
+                    (NativeAgentStarted
+                        "child"
+                        Nothing
+                        "Explore"
+                        (Just "claude-sonnet"))
+                    beforeStart
+            view = afterStart Map.! "child"
+        view.nativeAgentTranscript `shouldBe` ["working"]
+        view.nativeAgentLabel `shouldBe` "Explore"
+        view.nativeAgentModel `shouldBe` Just "claude-sonnet"
+
+    it "builds nested display paths from provider parent identifiers" do
+        let tracked =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    Map.empty
+                    [ NativeAgentStarted
+                        "parent" Nothing "Research / API" Nothing
+                    , NativeAgentStarted
+                        "child" (Just "parent") "Review" Nothing
+                    ]
+            entries = nativeAgentEntries tracked
+            child =
+                find ((== AgentNative "child") . (.agentTarget)) entries
+        (.agentPath) <$> child
+            `shouldBe` Just "/native/Research - API/Review"
+
+    it "settles running children when an attempt is discarded" do
+        let tracked =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    Map.empty
+                    [ NativeAgentStarted "child" Nothing "Explore" Nothing
+                    , NativeAgentOutput "child" "partial"
+                    , ResponseAttemptDiscarded
+                    ]
+            view = tracked Map.! "child"
+            states =
+                map (.blockState)
+                    (Foldable.toList view.nativeAgentConversation.uiBlocks)
+        view.nativeAgentStatus `shouldBe` "cancelled"
+        states `shouldSatisfy` all (/= BlockRunning)
+
+    it "creates and terminates a placeholder for reordered finish events" do
+        let tracked =
+                applyNativeAgentEvent
+                    (NativeAgentFinished "late" NativeAgentFailed)
+                    Map.empty
+            view = tracked Map.! "late"
+        view.nativeAgentStatus `shouldBe` "error"
+        view.nativeAgentTranscript `shouldBe` []
+
+    it "restores completed Claude-native agents from canonical tool items" do
+        let provider =
+                KeyMap.singleton "provider"
+                    (Aeson.String "claude-code")
+            call = FunctionCallItem FunctionCall
+                { itemId = Nothing
+                , callId = "agent-1"
+                , name = "Agent"
+                , namespace = Nothing
+                , arguments =
+                    "{\"description\":\"Review API\",\"model\":\"sonnet\"}"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                , extraFields = provider
+                }
+            output = FunctionCallOutputItem FunctionCallOutput
+                { itemId = Nothing
+                , callId = "agent-1"
+                , name = Nothing
+                , namespace = Nothing
+                , output = Aeson.String "review complete"
+                , status = Just ItemCompleted
+                , extraFields = provider
+                }
+            restored = restoreNativeAgents [call, output] Map.empty
+            view = restored Map.! "agent-1"
+        view.nativeAgentLabel `shouldBe` "Review API"
+        view.nativeAgentModel `shouldBe` Just "sonnet"
+        view.nativeAgentStatus `shouldBe` "done"
+        view.nativeAgentTranscript `shouldBe` ["review complete"]

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -31,6 +31,7 @@ import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
 import qualified Agent.CLI.ModelPickerSpec as ModelPickerSpec
+import qualified Agent.CLI.NativeAgentsSpec as NativeAgentsSpec
 import qualified Agent.CLI.ModelsSpec as ModelsSpec
 import qualified Agent.CLI.NotificationSpec as NotificationSpec
 import qualified Agent.CLI.OptionsSpec as OptionsSpec
@@ -105,6 +106,7 @@ main = hspec do
     McpManagerSpec.spec
     ModelConfigSpec.spec
     ModelPickerSpec.spec
+    NativeAgentsSpec.spec
     ModelsSpec.spec
     NotificationSpec.spec
     OptionsSpec.spec

--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -318,6 +318,19 @@ eventWeight = \case
     TurnStarted -> 1
     TurnFinished _ -> 1
     ToolStarted call -> Text.length call.callId
+    ToolUpdated call -> Text.length call.callId
+    ToolRetracted callId -> Text.length callId
+    ResponseAttemptDiscarded -> 1
+    NativeAgentStarted identifier parent label model ->
+        sum
+            [ Text.length identifier
+            , maybe 0 Text.length parent
+            , Text.length label
+            , maybe 0 Text.length model
+            ]
+    NativeAgentOutput identifier output ->
+        Text.length identifier + Text.length output
+    NativeAgentFinished identifier _ -> Text.length identifier
     ToolOutputUpdated callId output ->
         Text.length callId + Text.length output
     ToolFinished result ->

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -301,9 +301,17 @@ data LoopEvent
     | TurnStarted
     | TurnFinished TurnOutput
     | ToolStarted ToolCall
+    -- | Replace the metadata for an already-visible in-flight tool call.
+    -- Providers may learn canonical arguments after an early live start.
+    | ToolUpdated ToolCall
     -- | Latest accumulated output snapshot for an in-flight tool call.
     | ToolOutputUpdated Text Text
     | ToolFinished ToolCallResult
+    -- | Remove a provider-retracted tool call from the current attempt.
+    | ToolRetracted Text
+    -- | Discard all UI activity emitted by the current response attempt.
+    -- This is distinct from ending the whole turn: a retry may follow.
+    | ResponseAttemptDiscarded
     deriving (Eq, Show)
 
 data LoopConfig = LoopConfig

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -14,6 +14,7 @@ module Agent.Loop
     , LoopConfig(..)
     , LoopExecution(..)
     , LoopEvent(..)
+    , NativeAgentStatus(..)
     , LoopError(..)
     , LoopProgress(..)
     , LoopResult(..)
@@ -312,6 +313,18 @@ data LoopEvent
     -- | Discard all UI activity emitted by the current response attempt.
     -- This is distinct from ending the whole turn: a retry may follow.
     | ResponseAttemptDiscarded
+    -- | Lifecycle/activity from a provider-managed child agent. These agents
+    -- are display-only unless the provider exposes targeted controls.
+    | NativeAgentStarted Text (Maybe Text) Text (Maybe Text)
+    | NativeAgentOutput Text Text
+    | NativeAgentFinished Text NativeAgentStatus
+    deriving (Eq, Show)
+
+data NativeAgentStatus
+    = NativeAgentRunning
+    | NativeAgentCompleted
+    | NativeAgentFailed
+    | NativeAgentCancelled
     deriving (Eq, Show)
 
 data LoopConfig = LoopConfig

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -762,7 +762,8 @@ reduceLoop event state = case event of
             , uiNoticeElapsedMillis = 0
             }
     ResponseRestarted message ->
-        let finalized = finalizeStreams state
+        let finalized =
+                finalizeAttempt BlockFailed (finalizeStreams state)
         in resetGeneration
             finalized
                 { uiRunning = True
@@ -770,6 +771,7 @@ reduceLoop event state = case event of
                 , uiNotice = Just (warningNotice message)
                 , uiNoticeElapsedMillis = 0
                 , uiAttemptStartBlock = Seq.length finalized.uiBlocks
+                , uiToolCalls = Map.empty
                 }
     ToolStarted call
         | isTodoTool call.name ->
@@ -809,6 +811,8 @@ reduceLoop event state = case event of
                             (blockIndex, call)
                             state.uiToolCalls
                     }
+    ToolUpdated call ->
+        updateToolCall call state
     ToolOutputUpdated callId output ->
         updateToolOutput callId output state
     ToolFinished result ->
@@ -845,6 +849,10 @@ reduceLoop event state = case event of
                 | blockIndex < Seq.length state.uiBlocks ->
                     completeTool blockIndex displayed next
             Just _ -> next
+    ToolRetracted callId ->
+        retractToolCall callId state
+    ResponseAttemptDiscarded ->
+        discardResponseAttempt state
     TurnFinished output ->
         let finalized = finalizeStreams state
             continuing = not (null output.toolCalls)
@@ -919,14 +927,21 @@ selectedIndexFor selected remaining =
 removeBlockAt :: Int -> UiState -> UiState
 removeBlockAt index state =
     let remaining = Seq.deleteAt index state.uiBlocks
-        selected =
-            listToMaybe
-                [ block.blockId
-                | idx <- [min index (max 0 (Seq.length remaining - 1))]
-                , idx >= 0
-                , idx < Seq.length remaining
-                , let block = Seq.index remaining idx
-                ]
+        selected
+            | Just selectedId <- state.uiSelectedBlock
+            , any ((== selectedId) . (.blockId)) remaining =
+                Just selectedId
+            | otherwise =
+                listToMaybe
+                    [ block.blockId
+                    | idx <- [min index (max 0 (Seq.length remaining - 1))]
+                    , idx >= 0
+                    , idx < Seq.length remaining
+                    , let block = Seq.index remaining idx
+                    ]
+        adjustIndex oldIndex
+            | oldIndex > index = oldIndex - 1
+            | otherwise = oldIndex
     in state
         { uiBlocks = remaining
         , uiSelectedBlock = selected
@@ -936,6 +951,15 @@ removeBlockAt index state =
                 [ (block.blockId, idx)
                 | (idx, block) <- zip [0 ..] (Foldable.toList remaining)
                 ]
+        , uiToolCalls =
+            Map.mapMaybe
+                (\(blockIndex, call) ->
+                    if blockIndex == index
+                        then Nothing
+                        else Just (adjustIndex blockIndex, call))
+                state.uiToolCalls
+        , uiTurnStartBlock = adjustIndex state.uiTurnStartBlock
+        , uiAttemptStartBlock = adjustIndex state.uiAttemptStartBlock
         }
 
 appendBlock
@@ -1002,6 +1026,96 @@ completeTool blockIndex result state =
                         else block)
                 blockIndex
                 state.uiBlocks
+        }
+
+finalizeAttempt :: BlockState -> UiState -> UiState
+finalizeAttempt terminalState state =
+    state
+        { uiBlocks =
+            Seq.mapWithIndex
+                (\index block ->
+                    if index >= state.uiAttemptStartBlock
+                        && block.blockState == BlockRunning
+                        then block { blockState = terminalState }
+                        else block)
+                state.uiBlocks
+        }
+
+updateToolCall :: ToolCall -> UiState -> UiState
+updateToolCall call state =
+    case Map.lookup call.callId state.uiToolCalls of
+        Nothing -> state
+        Just (blockIndex, previous) ->
+            let title =
+                    toolCallTitleRelative state.uiWorkspaceRoot call
+                body = case canonicalToolName call.name of
+                    "search_replace" ->
+                        formatSearchReplaceDiffRelative
+                            state.uiWorkspaceRoot
+                            call.arguments
+                    _ -> ""
+                blocks
+                    | isTodoTool previous.name = state.uiBlocks
+                    | otherwise =
+                        Seq.adjust
+                            (\block ->
+                                if block.blockCallId == Just call.callId
+                                    then block
+                                        { blockKind = toolBlockKind call.name
+                                        , blockTitle = title
+                                        , blockBody =
+                                            if Text.null body
+                                                then block.blockBody
+                                                else body
+                                        , blockDetail = toolCallInput call
+                                        }
+                                    else block)
+                            blockIndex
+                            state.uiBlocks
+            in state
+                { uiBlocks = blocks
+                , uiActivity = title
+                , uiToolCalls =
+                    Map.insert
+                        call.callId
+                        (blockIndex, call)
+                        state.uiToolCalls
+                }
+
+retractToolCall :: Text -> UiState -> UiState
+retractToolCall callId state =
+    case Map.lookup callId state.uiToolCalls of
+        Nothing -> state
+        Just (_, call)
+            | isTodoTool call.name ->
+                state
+                    { uiToolCalls = Map.delete callId state.uiToolCalls }
+        Just (blockIndex, _) ->
+            case Seq.lookup blockIndex state.uiBlocks of
+                Just block
+                    | block.blockCallId == Just callId ->
+                        removeBlockAt blockIndex state
+                _ ->
+                    state
+                        { uiToolCalls =
+                            Map.delete callId state.uiToolCalls }
+
+discardResponseAttempt :: UiState -> UiState
+discardResponseAttempt state =
+    let boundary =
+            min (Seq.length state.uiBlocks) state.uiAttemptStartBlock
+        blocks = Seq.take boundary state.uiBlocks
+        selected =
+            selectionAfterTruncate blocks state.uiSelectedBlockIndex
+    in state
+        { uiBlocks = blocks
+        , uiSelectedBlock = (.blockId) . snd <$> selected
+        , uiSelectedBlockIndex = fst <$> selected
+        , uiBlockIndices =
+            Map.filter (< boundary) state.uiBlockIndices
+        , uiToolCalls =
+            Map.filter ((< boundary) . fst) state.uiToolCalls
+        , uiGenerating = False
         }
 
 updateToolOutput :: Text -> Text -> UiState -> UiState

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -853,6 +853,12 @@ reduceLoop event state = case event of
         retractToolCall callId state
     ResponseAttemptDiscarded ->
         discardResponseAttempt state
+    NativeAgentStarted{} ->
+        state
+    NativeAgentOutput{} ->
+        state
+    NativeAgentFinished{} ->
+        state
     TurnFinished output ->
         let finalized = finalizeStreams state
             continuing = not (null output.toolCalls)
@@ -1085,7 +1091,12 @@ updateToolCall call state =
 retractToolCall :: Text -> UiState -> UiState
 retractToolCall callId state =
     case Map.lookup callId state.uiToolCalls of
-        Nothing -> state
+        Nothing ->
+            case Seq.findIndexL
+                ((== Just callId) . (.blockCallId))
+                state.uiBlocks of
+                Just blockIndex -> removeBlockAt blockIndex state
+                Nothing -> state
         Just (_, call)
             | isTodoTool call.name ->
                 state

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -309,6 +309,84 @@ spec = describe "fullscreen UI reducer" do
                 block.blockBody `shouldBe` "exit: 0\nclean"
             _ -> expectationFailure "expected one completed tool block"
 
+    it "updates an early tool start in place" do
+        let early = functionToolCall "c1" "Task" "{}"
+            canonical =
+                functionToolCall
+                    "c1"
+                    "Agent"
+                    "{\"description\":\"review the patch\"}"
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted early)
+                    , UiLoop (ToolUpdated canonical)
+                    ]
+        case Foldable.toList state.uiBlocks of
+            [block] -> do
+                block.blockTitle `shouldBe` "Agent"
+                block.blockDetail `shouldBe` ""
+                block.blockState `shouldBe` BlockRunning
+            _ -> expectationFailure "expected one updated tool block"
+        Foldable.toList state.uiToolCalls
+            `shouldBe` [(0, canonical)]
+
+    it "retracts a tool and repairs later tool positions" do
+        let first = functionToolCall "c1" "Task" "{}"
+            second = functionToolCall "c2" "Read" "{\"file_path\":\"README.md\"}"
+            running =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted first)
+                    , UiSystemMessage "between"
+                    , UiLoop (ToolStarted second)
+                    ]
+            retracted =
+                reduceUi (UiLoop (ToolRetracted "c1")) running
+            finished =
+                reduceUi
+                    (UiLoop
+                        (ToolFinished
+                            ToolCallResult
+                                { callId = "c2"
+                                , output = "contents"
+                                , callKind = FunctionCallKind
+                                }))
+                    retracted
+        map (.blockBody) (Foldable.toList finished.uiBlocks)
+            `shouldBe` ["between", "contents"]
+        map (.blockState) (Foldable.toList finished.uiBlocks)
+            `shouldBe` [BlockComplete, BlockComplete]
+        finished.uiToolCalls `shouldBe` mempty
+
+    it "discards only blocks from the current response attempt" do
+        let state =
+                apply
+                    [ UiUserSubmitted "hello"
+                    , UiLoop TurnStarted
+                    , UiLoop (TextDelta "partial")
+                    , UiLoop
+                        (ToolStarted
+                            (functionToolCall "c1" "Task" "{}"))
+                    , UiLoop ResponseAttemptDiscarded
+                    ]
+        map (.blockBody) (Foldable.toList state.uiBlocks)
+            `shouldBe` ["hello"]
+        state.uiToolCalls `shouldBe` mempty
+
+    it "settles running tools when a response restarts" do
+        let state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop
+                        (ToolStarted
+                            (functionToolCall "c1" "Task" "{}"))
+                    , UiLoop (ResponseRestarted "retrying")
+                    ]
+        map (.blockState) (Foldable.toList state.uiBlocks)
+            `shouldBe` [BlockFailed]
+        state.uiToolCalls `shouldBe` mempty
+
     it "renders write_stdin as a shell block" do
         let call = functionToolCall "c1" "write_stdin" "{\"session_id\":3}"
             state = apply [UiLoop TurnStarted, UiLoop (ToolStarted call)]

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -359,6 +359,25 @@ spec = describe "fullscreen UI reducer" do
             `shouldBe` [BlockComplete, BlockComplete]
         finished.uiToolCalls `shouldBe` mempty
 
+    it "removes a completed tool when its provider message is retracted" do
+        let call = functionToolCall "c1" "Task" "{}"
+            completed =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    , UiLoop
+                        (ToolFinished
+                            ToolCallResult
+                                { callId = "c1"
+                                , output = "done"
+                                , callKind = FunctionCallKind
+                                })
+                    ]
+            retracted =
+                reduceUi (UiLoop (ToolRetracted "c1")) completed
+        retracted.uiBlocks `shouldBe` mempty
+        retracted.uiToolCalls `shouldBe` mempty
+
     it "discards only blocks from the current response attempt" do
         let state =
                 apply

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Query.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Query.hs
@@ -3,6 +3,7 @@ module Claude.Agent.SDK.Internal.Query
     ( QueryAccumulator
     , emptyQueryAccumulator
     , consumeQueryMessage
+    , consumeQueryMessageWithProgress
     , canonicalMessages
     ) where
 
@@ -12,6 +13,8 @@ import Claude.Agent.SDK.Types
     , ContentBlock(..)
     , Message(..)
     , MessageOrigin(..)
+    , QueryMessageScope(..)
+    , QueryProgress(..)
     , ResultMessage(..)
     , SystemMessage(..)
     , UserMessage(..)
@@ -44,12 +47,14 @@ data MessageBuffer = MessageBuffer
 data QueryAccumulator = QueryAccumulator
     { ownBuffer :: !MessageBuffer
     , foreignBuffer :: !(Maybe MessageBuffer)
+    , progressSeenIds :: !(Set (MessageScope, Text))
     } deriving (Eq, Show)
 
 emptyQueryAccumulator :: QueryAccumulator
 emptyQueryAccumulator = QueryAccumulator
     { ownBuffer = emptyMessageBuffer
     , foreignBuffer = Nothing
+    , progressSeenIds = Set.empty
     }
 
 emptyMessageBuffer :: MessageBuffer
@@ -98,6 +103,105 @@ consumeQueryMessage accumulator message =
                 Right (accumulator, Nothing)
             | otherwise ->
                 consumeOwnMessage accumulator message
+
+-- | Consume a message and report live progress only when it belongs to the
+-- submitted human turn. Autonomous/background records remain transactional
+-- and invisible to the observer.
+consumeQueryMessageWithProgress
+    :: QueryAccumulator
+    -> Message
+    -> Either
+        ClaudeSDKError
+        ( QueryAccumulator
+        , [QueryProgress]
+        , Maybe ([Message], ResultMessage)
+        )
+consumeQueryMessageWithProgress accumulator message = do
+    (next, completed) <- consumeQueryMessage accumulator message
+    let progress = observedProgress accumulator message
+        nextWithProgress = next
+            { progressSeenIds =
+                case progress of
+                    [] -> accumulator.progressSeenIds
+                    _ -> maybe
+                        accumulator.progressSeenIds
+                        (\identifier ->
+                            Set.insert
+                                (messageScope message, identifier)
+                                accumulator.progressSeenIds)
+                        (messageUuid message)
+            }
+    pure (nextWithProgress, progress, completed)
+
+observedProgress :: QueryAccumulator -> Message -> [QueryProgress]
+observedProgress accumulator message
+    | not (belongsToOwnTurn accumulator message) = []
+    | not (messageWouldBeObserved accumulator message) =
+        retractionsFor message
+    | otherwise =
+        retractionsFor message
+            <> [QueryMessageObserved (publicScope message) message]
+
+belongsToOwnTurn :: QueryAccumulator -> Message -> Bool
+belongsToOwnTurn accumulator message =
+    case accumulator.foreignBuffer of
+        Nothing ->
+            messageHasParentToolUseId message
+                || not (beginsForeignTurn message)
+                    && not (isForeignResult message)
+        Just _
+            | messageHasParentToolUseId message -> False
+            | MessageSystem SystemMessage{subtype = "init"} <- message -> True
+            | MessageUser UserMessage{origin} <- message ->
+                isExplicitHumanOrigin origin
+            | MessageResult result <- message ->
+                isHumanOrigin result.origin
+            | otherwise -> False
+  where
+    isForeignResult = \case
+        MessageResult result -> not (isHumanOrigin result.origin)
+        _ -> False
+
+messageWouldBeObserved :: QueryAccumulator -> Message -> Bool
+messageWouldBeObserved accumulator message =
+    case message of
+        MessageResult{} -> messageHasParentToolUseId message
+        MessageConversationReset{} -> False
+        MessageControlRequest{} -> False
+        MessageAssistant AssistantMessage{error = Just _} -> False
+        MessageStreamEvent{} -> not (alreadySeen accumulator.ownBuffer message)
+        _ -> not (alreadySeen accumulator.ownBuffer message)
+  where
+    alreadySeen current candidate =
+        case messageUuid candidate of
+            Nothing -> False
+            Just identifier ->
+                Set.member
+                    (messageScope candidate, identifier)
+                    accumulator.progressSeenIds
+                    || Set.member identifier current.globallyRetractedIds
+                    || Set.member
+                        (messageScope candidate, identifier)
+                        current.retractedIds
+
+retractionsFor :: Message -> [QueryProgress]
+retractionsFor = \case
+    MessageAssistant assistant
+        | not (null assistant.supersedes) ->
+            [ QueryMessagesRetracted
+                (Just (publicScope (MessageAssistant assistant)))
+                assistant.supersedes
+            ]
+    MessageSystem system
+        | system.subtype == "model_refusal_fallback"
+        , not (null system.retractedMessageUuids) ->
+            [QueryMessagesRetracted Nothing system.retractedMessageUuids]
+    _ -> []
+
+publicScope :: Message -> QueryMessageScope
+publicScope message = case messageScope message of
+    TopLevelScope -> QueryTopLevel
+    NestedScope parent -> QueryNested parent
 
 consumeOwnMessage
     :: QueryAccumulator

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Query.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Query.hs
@@ -120,16 +120,9 @@ consumeQueryMessageWithProgress accumulator message = do
     (next, completed) <- consumeQueryMessage accumulator message
     let progress = observedProgress accumulator message
         nextWithProgress = next
-            { progressSeenIds =
-                case progress of
-                    [] -> accumulator.progressSeenIds
-                    _ -> maybe
-                        accumulator.progressSeenIds
-                        (\identifier ->
-                            Set.insert
-                                (messageScope message, identifier)
-                                accumulator.progressSeenIds)
-                        (messageUuid message)
+            { progressSeenIds = applyProgressSeen
+                accumulator.progressSeenIds
+                progress
             }
     pure (nextWithProgress, progress, completed)
 
@@ -137,10 +130,38 @@ observedProgress :: QueryAccumulator -> Message -> [QueryProgress]
 observedProgress accumulator message
     | not (belongsToOwnTurn accumulator message) = []
     | not (messageWouldBeObserved accumulator message) =
-        retractionsFor message
+        retractionsFor accumulator message
     | otherwise =
-        retractionsFor message
+        retractionsFor accumulator message
             <> [QueryMessageObserved (publicScope message) message]
+
+applyProgressSeen
+    :: Set (MessageScope, Text)
+    -> [QueryProgress]
+    -> Set (MessageScope, Text)
+applyProgressSeen = foldl' step
+  where
+    step seen = \case
+        QueryMessageObserved _ message ->
+            maybe seen
+                (\identifier ->
+                    Set.insert (messageScope message, identifier) seen)
+                (messageUuid message)
+        QueryMessagesRetracted scope identifiers ->
+            case scope of
+                Nothing ->
+                    Set.filter
+                        (\(_, identifier) -> identifier `notElem` identifiers)
+                        seen
+                Just public ->
+                    let internal = case public of
+                            QueryTopLevel -> TopLevelScope
+                            QueryNested parent -> NestedScope parent
+                    in foldl'
+                        (\current identifier ->
+                            Set.delete (internal, identifier) current)
+                        seen
+                        identifiers
 
 belongsToOwnTurn :: QueryAccumulator -> Message -> Bool
 belongsToOwnTurn accumulator message =
@@ -184,18 +205,34 @@ messageWouldBeObserved accumulator message =
                         (messageScope candidate, identifier)
                         current.retractedIds
 
-retractionsFor :: Message -> [QueryProgress]
-retractionsFor = \case
+retractionsFor :: QueryAccumulator -> Message -> [QueryProgress]
+retractionsFor accumulator = \case
     MessageAssistant assistant
-        | not (null assistant.supersedes) ->
+        | let identifiers =
+                filter
+                    (\identifier ->
+                        Set.member
+                            ( messageScope (MessageAssistant assistant)
+                            , identifier
+                            )
+                            accumulator.progressSeenIds)
+                    assistant.supersedes
+        , not (null identifiers) ->
             [ QueryMessagesRetracted
                 (Just (publicScope (MessageAssistant assistant)))
-                assistant.supersedes
+                identifiers
             ]
     MessageSystem system
-        | system.subtype == "model_refusal_fallback"
-        , not (null system.retractedMessageUuids) ->
-            [QueryMessagesRetracted Nothing system.retractedMessageUuids]
+        | let identifiers =
+                filter
+                    (\identifier ->
+                        any
+                            ((== identifier) . snd)
+                            accumulator.progressSeenIds)
+                    system.retractedMessageUuids
+        , system.subtype == "model_refusal_fallback"
+        , not (null identifiers) ->
+            [QueryMessagesRetracted Nothing identifiers]
     _ -> []
 
 publicScope :: Message -> QueryMessageScope

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
@@ -2,15 +2,21 @@
 -- top-level @query()@ API.
 module Claude.Agent.SDK.Query
     ( query
+    , queryWithProgress
     , queryContent
+    , queryContentWithProgress
     , queryClient
     , queryClientContent
     , queryTurn
+    , queryTurnWithProgress
     , queryTurnContent
+    , queryTurnContentWithProgress
     , queryTurnWithMessageValidator
     , queryTurnContentWithMessageValidator
+    , queryTurnContentWithMessageValidatorAndProgress
     , receiveResponse
     , receiveResponseWithMessageValidator
+    , receiveResponseWithMessageValidatorAndProgress
     ) where
 
 import Claude.Agent.SDK.Client
@@ -32,14 +38,16 @@ import Claude.Agent.SDK.Errors
     )
 import Claude.Agent.SDK.Internal.Query
     ( QueryAccumulator
-    , consumeQueryMessage
+    , consumeQueryMessageWithProgress
     , emptyQueryAccumulator
     )
 import Claude.Agent.SDK.Types
     ( ClaudeAgentOptions(..)
     , Message
+    , QueryProgress(..)
     , ResultMessage(..)
     , UserContentBlock(..)
+    , messageSessionId
     )
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -55,6 +63,33 @@ query
 query options prompt onMessage =
     queryContent options [UserTextBlock prompt] onMessage
 
+queryWithProgress
+    :: ClaudeAgentOptions
+    -> Text
+    -> (QueryProgress -> IO ())
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryWithProgress options prompt onProgress onMessage =
+    queryContentWithProgress
+        options
+        [UserTextBlock prompt]
+        onProgress
+        onMessage
+
+queryTurnContentWithProgress
+    :: ClaudeSDKTurn
+    -> [UserContentBlock]
+    -> (QueryProgress -> IO ())
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryTurnContentWithProgress turn content onProgress onMessage =
+    queryTurnContentWithMessageValidatorAndProgress
+        turn
+        content
+        (const (pure (Right ())))
+        onProgress
+        onMessage
+
 -- | Run a self-contained query with structured user content.
 queryContent
     :: ClaudeAgentOptions
@@ -62,6 +97,19 @@ queryContent
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 queryContent options content onMessage =
+    queryContentWithProgress
+        options
+        content
+        (const (pure ()))
+        onMessage
+
+queryContentWithProgress
+    :: ClaudeAgentOptions
+    -> [UserContentBlock]
+    -> (QueryProgress -> IO ())
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryContentWithProgress options content onProgress onMessage =
     withClaudeSDKClient options \client ->
         withClaudeSDKTurn
             client
@@ -70,7 +118,12 @@ queryContent options content onMessage =
             options.model
             options.effort
             \turn -> do
-                result <- queryTurnContent turn content onMessage
+                result <-
+                    queryTurnContentWithProgress
+                        turn
+                        content
+                        onProgress
+                        onMessage
                 pure ((, pure ()) <$> result)
 
 -- | Submit a prompt through a persistent client and continue its active
@@ -113,6 +166,19 @@ queryTurn
 queryTurn turn prompt onMessage =
     queryTurnContent turn [UserTextBlock prompt] onMessage
 
+queryTurnWithProgress
+    :: ClaudeSDKTurn
+    -> Text
+    -> (QueryProgress -> IO ())
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryTurnWithProgress turn prompt onProgress onMessage =
+    queryTurnContentWithProgress
+        turn
+        [UserTextBlock prompt]
+        onProgress
+        onMessage
+
 -- | Submit structured user content and receive one complete response.
 queryTurnContent
     :: ClaudeSDKTurn
@@ -145,6 +211,26 @@ queryTurnContentWithMessageValidator
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 queryTurnContentWithMessageValidator turn content validateMessage onMessage = do
+    queryTurnContentWithMessageValidatorAndProgress
+        turn
+        content
+        validateMessage
+        (const (pure ()))
+        onMessage
+
+-- | Like 'queryTurnContentWithMessageValidator', with a live observer that
+-- runs after query routing and canonicalization state updates. It sees only
+-- records belonging to the submitted human turn; autonomous/background
+-- records remain hidden.
+queryTurnContentWithMessageValidatorAndProgress
+    :: ClaudeSDKTurn
+    -> [UserContentBlock]
+    -> (Message -> IO (Either ClaudeSDKError ()))
+    -> (QueryProgress -> IO ())
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryTurnContentWithMessageValidatorAndProgress
+    turn content validateMessage onProgress onMessage = do
     completed <-
         timeout
             (max 1 (turnTimeoutMicros turn))
@@ -152,9 +238,10 @@ queryTurnContentWithMessageValidator turn content validateMessage onMessage = do
                 sendQueryContent turn content >>= \case
                     Left err -> pure (Left err)
                     Right () ->
-                        receiveResponseWithMessageValidator
+                        receiveResponseWithMessageValidatorAndProgress
                             turn
                             validateMessage
+                            onProgress
                             onMessage
     case completed of
         Nothing ->
@@ -183,6 +270,21 @@ receiveResponseWithMessageValidator
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 receiveResponseWithMessageValidator turn validateMessage onMessage =
+    receiveResponseWithMessageValidatorAndProgress
+        turn
+        validateMessage
+        (const (pure ()))
+        onMessage
+
+-- | Receive a response with classified live query progress.
+receiveResponseWithMessageValidatorAndProgress
+    :: ClaudeSDKTurn
+    -> (Message -> IO (Either ClaudeSDKError ()))
+    -> (QueryProgress -> IO ())
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+receiveResponseWithMessageValidatorAndProgress
+    turn validateMessage onProgress onMessage =
     go emptyQueryAccumulator False
   where
     go
@@ -218,12 +320,22 @@ receiveResponseWithMessageValidator turn validateMessage onMessage =
                     Left err ->
                         pure (Left err)
                     Right () ->
-                        case consumeQueryMessage accumulator message of
+                        case
+                            consumeQueryMessageWithProgress
+                                accumulator
+                                message
+                        of
                             Left err ->
                                 pure (Left err)
-                            Right (nextAccumulator, Nothing) ->
-                                go nextAccumulator True
-                            Right (_, Just (messages, result)) -> do
+                            Right (nextAccumulator, progress, Nothing) -> do
+                                validatedProgress <-
+                                    validateProgressSessions turn progress
+                                case validatedProgress of
+                                    Left err -> pure (Left err)
+                                    Right () -> do
+                                        mapM_ onProgress progress
+                                        go nextAccumulator True
+                            Right (_, progress, Just (messages, result)) -> do
                                 accepted <-
                                     acceptTurnSessionId
                                         turn
@@ -232,8 +344,26 @@ receiveResponseWithMessageValidator turn validateMessage onMessage =
                                     Left err ->
                                         pure (Left err)
                                     Right () -> do
+                                        mapM_ onProgress progress
                                         mapM_ onMessage messages
                                         pure (Right result)
+
+validateProgressSessions
+    :: ClaudeSDKTurn
+    -> [QueryProgress]
+    -> IO (Either ClaudeSDKError ())
+validateProgressSessions turn =
+    go
+  where
+    go [] = pure (Right ())
+    go (progress : rest) =
+        case progress of
+            QueryMessageObserved _ message
+                | Just sessionId <- messageSessionId message ->
+                    acceptTurnSessionId turn sessionId >>= \case
+                        Left err -> pure (Left err)
+                        Right () -> go rest
+            _ -> go rest
 
 timeoutError :: ClaudeSDKTurn -> Text -> IO ClaudeSDKError
 timeoutError turn reason = do

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
@@ -328,9 +328,12 @@ receiveResponseWithMessageValidatorAndProgress
                             Left err ->
                                 pure (Left err)
                             Right (nextAccumulator, progress, Nothing) -> do
-                                validatedProgress <-
-                                    validateProgressSessions turn progress
-                                case validatedProgress of
+                                sessionAccepted <-
+                                    validateLiveProgressSession
+                                        turn
+                                        message
+                                        progress
+                                case sessionAccepted of
                                     Left err -> pure (Left err)
                                     Right () -> do
                                         mapM_ onProgress progress
@@ -348,22 +351,17 @@ receiveResponseWithMessageValidatorAndProgress
                                         mapM_ onMessage messages
                                         pure (Right result)
 
-validateProgressSessions
+validateLiveProgressSession
     :: ClaudeSDKTurn
+    -> Message
     -> [QueryProgress]
     -> IO (Either ClaudeSDKError ())
-validateProgressSessions turn =
-    go
-  where
-    go [] = pure (Right ())
-    go (progress : rest) =
-        case progress of
-            QueryMessageObserved _ message
-                | Just sessionId <- messageSessionId message ->
-                    acceptTurnSessionId turn sessionId >>= \case
-                        Left err -> pure (Left err)
-                        Right () -> go rest
-            _ -> go rest
+validateLiveProgressSession turn message progress
+    | null progress = pure (Right ())
+    | otherwise =
+        case messageSessionId message of
+            Nothing -> pure (Right ())
+            Just sessionId -> acceptTurnSessionId turn sessionId
 
 timeoutError :: ClaudeSDKTurn -> Text -> IO ClaudeSDKError
 timeoutError turn reason = do

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Types.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Types.hs
@@ -21,7 +21,10 @@ module Claude.Agent.SDK.Types
     , StreamEvent(..)
     , ConversationResetMessage(..)
     , Message(..)
+    , QueryMessageScope(..)
+    , QueryProgress(..)
     , messageUuid
+    , messageSessionId
     , messageParentToolUseId
     , messageHasParentToolUseId
     ) where
@@ -313,6 +316,16 @@ data Message
     | MessageUnknown !Value
     deriving (Eq, Show)
 
+data QueryMessageScope
+    = QueryTopLevel
+    | QueryNested !(Maybe Text)
+    deriving (Eq, Ord, Show)
+
+data QueryProgress
+    = QueryMessageObserved !QueryMessageScope !Message
+    | QueryMessagesRetracted !(Maybe QueryMessageScope) ![Text]
+    deriving (Eq, Show)
+
 messageUuid :: Message -> Maybe Text
 messageUuid = \case
     MessageUser message -> message.uuid
@@ -326,11 +339,30 @@ messageUuid = \case
         nonEmptyRawText "uuid" object
     MessageUnknown _ -> Nothing
 
+messageSessionId :: Message -> Maybe Text
+messageSessionId = \case
+    MessageUser message -> nonEmptyRawText "session_id" message.raw
+    MessageAssistant message -> message.sessionId
+    MessageSystem message -> message.sessionId
+    MessageResult message -> Just message.sessionId
+    MessageStreamEvent message -> message.sessionId
+    MessageConversationReset message -> message.sessionId
+    MessageControlRequest object -> nonEmptyRawText "session_id" object
+    MessageUnknown (Aeson.Object object) ->
+        nonEmptyRawText "session_id" object
+    MessageUnknown _ -> Nothing
+
 messageParentToolUseId :: Message -> Maybe Text
 messageParentToolUseId = \case
     MessageUser message -> message.parentToolUseId
     MessageAssistant message -> message.parentToolUseId
+    MessageSystem message -> nonEmptyRawText "parent_tool_use_id" message.raw
+    MessageResult message -> nonEmptyRawText "parent_tool_use_id" message.raw
     MessageStreamEvent message -> message.parentToolUseId
+    MessageConversationReset message ->
+        nonEmptyRawText "parent_tool_use_id" message.raw
+    MessageControlRequest object ->
+        nonEmptyRawText "parent_tool_use_id" object
     MessageUnknown (Aeson.Object object) ->
         nonEmptyRawText "parent_tool_use_id" object
     _ -> Nothing

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
@@ -209,6 +209,126 @@ spec = describe "query" do
         show messages `shouldNotContain` "background answer"
         show messages `shouldNotContain` "background tool output"
 
+    it "classifies live own and nested records while hiding foreign turns" do
+        let topTool =
+                "{\"type\":\"assistant\",\"uuid\":\"top-tool\",\
+                \\"session_id\":\"" <> testSessionId <> "\",\
+                \\"message\":{\"content\":[{\"type\":\"tool_use\",\
+                \\"id\":\"agent-tool\",\"name\":\"Agent\",\"input\":{}}]}}"
+            nestedText =
+                "{\"type\":\"assistant\",\"uuid\":\"nested-text\",\
+                \\"parent_tool_use_id\":\"agent-tool\",\
+                \\"session_id\":\"" <> testSessionId <> "\",\
+                \\"message\":{\"content\":[{\"type\":\"text\",\
+                \\"text\":\"child progress\"}]}}"
+            nestedResult =
+                "{\"type\":\"result\",\"subtype\":\"success\",\
+                \\"is_error\":false,\"session_id\":\"" <> testSessionId <> "\",\
+                \\"uuid\":\"nested-result\",\
+                \\"parent_tool_use_id\":\"agent-tool\",\
+                \\"result\":\"child complete\"}"
+            backgroundUser =
+                "{\"type\":\"user\",\"uuid\":\"background-user\",\
+                \\"session_id\":\"" <> testSessionId <> "\",\
+                \\"origin\":{\"kind\":\"task_notification\"},\
+                \\"message\":{\"role\":\"user\",\"content\":\"background\"}}"
+            backgroundAssistant =
+                "{\"type\":\"assistant\",\"uuid\":\"background-assistant\",\
+                \\"session_id\":\"" <> testSessionId <> "\",\
+                \\"message\":{\"content\":[{\"type\":\"text\",\
+                \\"text\":\"must stay hidden\"}]}}"
+            backgroundResult =
+                "{\"type\":\"result\",\"subtype\":\"success\",\
+                \\"is_error\":false,\"session_id\":\"" <> testSessionId <> "\",\
+                \\"uuid\":\"background-result\",\
+                \\"origin\":{\"kind\":\"task_notification\"}}"
+        (result, progress) <- runQueryProgress
+            [ topTool
+            , nestedText
+            , nestedResult
+            , backgroundUser
+            , backgroundAssistant
+            , backgroundResult
+            , successResult testSessionId
+            ]
+
+        _ <- expectRight result
+        progress `shouldSatisfy` any \case
+            QueryMessageObserved QueryTopLevel message ->
+                messageUuid message == Just "top-tool"
+            _ -> False
+        progress `shouldSatisfy` any \case
+            QueryMessageObserved
+                (QueryNested (Just "agent-tool"))
+                message ->
+                    messageUuid message == Just "nested-text"
+            _ -> False
+        progress `shouldSatisfy` any \case
+            QueryMessageObserved
+                (QueryNested (Just "agent-tool"))
+                message ->
+                    messageUuid message == Just "nested-result"
+            _ -> False
+        show progress `shouldNotContain` "must stay hidden"
+        show progress `shouldNotContain` "background-result"
+
+    it "reports scoped and global retractions before replacement records" do
+        let replacement =
+                "{\"type\":\"assistant\",\"uuid\":\"replacement\",\
+                \\"supersedes\":[\"old\"],\"session_id\":\""
+                    <> testSessionId
+                    <> "\",\"message\":{\"content\":[{\"type\":\"text\",\
+                    \\"text\":\"new\"}]}}"
+            fallback =
+                "{\"type\":\"system\",\"subtype\":\"model_refusal_fallback\",\
+                \\"session_id\":\"" <> testSessionId <> "\",\
+                \\"uuid\":\"fallback\",\
+                \\"retracted_message_uuids\":[\"replacement\"]}"
+        (result, progress) <- runQueryProgress
+            [ assistantLine "old" "old"
+            , replacement
+            , fallback
+            , successResult testSessionId
+            ]
+
+        _ <- expectRight result
+        map progressTag progress `shouldBe`
+            [ "message:old"
+            , "retract:top:old"
+            , "message:replacement"
+            , "retract:global:replacement"
+            , "message:fallback"
+            ]
+
+    it "deduplicates live progress by UUID without changing canonical output" do
+        (result, progress) <- runQueryProgress
+            [ assistantLine "same" "first"
+            , assistantLine "same" "duplicate"
+            , successResult testSessionId
+            ]
+
+        _ <- expectRight result
+        filter (Text.isInfixOf "message:same" . progressTag) progress
+            `shouldSatisfy` \case
+                [_] -> True
+                _ -> False
+
+    it "rejects a mismatched live message before exposing progress" do
+        let wrongSession =
+                "{\"type\":\"assistant\",\"uuid\":\"wrong-session\",\
+                \\"session_id\":\"123e4567-e89b-42d3-a456-426614174999\",\
+                \\"message\":{\"content\":[{\"type\":\"tool_use\",\
+                \\"id\":\"agent-tool\",\"name\":\"Agent\",\"input\":{}}]}}"
+        (result, progress) <- runQueryProgress
+            [wrongSession, successResult testSessionId]
+
+        result `shouldSatisfy` \case
+            Left (CLIProtocolError message) ->
+                "while 123e4567-e89b-42d3-a456-426614174000 was active"
+                    `Text.isInfixOf` message
+            _ -> False
+        progress `shouldBe` []
+
     it "treats an origin-less result as the human result for compatibility" do
         (result, messages) <- runQueryLines
             [ "{\"type\":\"user\",\"uuid\":\"background-user\",\
@@ -466,6 +586,34 @@ runQueryLines linesToEmit =
                     modifyIORef' messagesRef (<> [message]))
         messages <- readIORef messagesRef
         pure (result, messages)
+
+runQueryProgress
+    :: [Text]
+    -> IO (Either ClaudeSDKError ResultMessage, [QueryProgress])
+runQueryProgress linesToEmit =
+    withFakeClaude (oneShotScript linesToEmit) \directory executable -> do
+        progressRef <- newIORef []
+        result <-
+            queryWithProgress
+                (testOptions executable directory)
+                "hello"
+                (\progress ->
+                    modifyIORef' progressRef (<> [progress]))
+                (\_ -> pure ())
+        progress <- readIORef progressRef
+        pure (result, progress)
+
+progressTag :: QueryProgress -> Text
+progressTag = \case
+    QueryMessageObserved _ message ->
+        "message:" <> maybe "anonymous" id (messageUuid message)
+    QueryMessagesRetracted scope identifiers ->
+        "retract:" <> scopeTag scope <> ":" <> Text.intercalate "," identifiers
+  where
+    scopeTag = \case
+        Nothing -> "global"
+        Just QueryTopLevel -> "top"
+        Just QueryNested{} -> "nested"
 
 canonicalResponseLines :: [Text]
 canonicalResponseLines =

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
@@ -313,21 +313,31 @@ spec = describe "query" do
                 [_] -> True
                 _ -> False
 
-    it "rejects a mismatched live message before exposing progress" do
-        let wrongSession =
-                "{\"type\":\"assistant\",\"uuid\":\"wrong-session\",\
-                \\"session_id\":\"123e4567-e89b-42d3-a456-426614174999\",\
+    it "rejects mismatched live tool and nested-result messages without progress" do
+        let wrongSessionId =
+                "123e4567-e89b-42d3-a456-426614174999"
+            wrongTool =
+                "{\"type\":\"assistant\",\"uuid\":\"wrong-tool\",\
+                \\"session_id\":\"" <> wrongSessionId <> "\",\
                 \\"message\":{\"content\":[{\"type\":\"tool_use\",\
                 \\"id\":\"agent-tool\",\"name\":\"Agent\",\"input\":{}}]}}"
-        (result, progress) <- runQueryProgress
-            [wrongSession, successResult testSessionId]
-
-        result `shouldSatisfy` \case
-            Left (CLIProtocolError message) ->
-                "while 123e4567-e89b-42d3-a456-426614174000 was active"
-                    `Text.isInfixOf` message
-            _ -> False
-        progress `shouldBe` []
+            wrongNestedResult =
+                "{\"type\":\"result\",\"subtype\":\"success\",\
+                \\"is_error\":false,\"uuid\":\"wrong-nested-result\",\
+                \\"parent_tool_use_id\":\"agent-tool\",\
+                \\"session_id\":\"" <> wrongSessionId <> "\",\
+                \\"result\":\"must stay hidden\"}"
+        mapM_
+            (\wrongMessage -> do
+                (result, progress) <- runQueryProgress
+                    [wrongMessage, successResult testSessionId]
+                result `shouldSatisfy` \case
+                    Left (CLIProtocolError message) ->
+                        "while 123e4567-e89b-42d3-a456-426614174000 was active"
+                            `Text.isInfixOf` message
+                    _ -> False
+                progress `shouldBe` [])
+            [wrongTool, wrongNestedResult]
 
     it "treats an origin-less result as the human result for compatibility" do
         (result, messages) <- runQueryLines


### PR DESCRIPTION
## Summary

- classify Claude live messages after own/foreign-turn routing and session validation
- handle partial-to-canonical tool updates, UUID supersession, retractions, retries, failures, and cancellation cleanup
- support ordinary and server tool records while warning safely on unknown tool-like protocol variants
- persist only canonical Claude-executed tool calls/results without returning them for host re-execution
- expose Claude `Agent`/`Task` children as read-only provider-native entries in `/agents`, including nested paths, live output, terminal settlement, and restoration from persisted paired tool items

## Safety properties

- nested `parent_tool_use_id` output never leaks into the root transcript
- autonomous/foreign Claude turns never publish root progress
- wrong-session live records are rejected before publication
- rejected or superseded attempts leave no phantom/running blocks
- Claude-owned tools remain `TurnOutput.toolCalls = []`, preventing double execution
- only paired, provider-marked Claude Agent/Task records are restored into `/agents`

## Validation

- Claude SDK: 47 examples, 0 failures
- `agent-claude-test`: 33 examples, 0 failures
- `agent-tui-test`: 183 examples, 0 failures
- provider-native CLI focused suite: 9 examples, 0 failures
- full `agent-cli-test` compiled and ran 1,102 examples; unrelated PostgreSQL tests were blocked by the checkout's overlong Unix socket path, while non-PostgreSQL tests passed
- `nix flake check`: passed all 16 aarch64-darwin checks
- rebased onto current `origin/master` and rebuilt affected libraries successfully
- fullscreen tmux launch exercised the real TTY and Claude error-cleanup path; live child spawning was blocked by Claude Code's session-limit HTTP 429
