### PR TITLE
Round OpenRouter credit amounts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Login
     , discoverLoginAccounts
     , discoverSelectableLoginAccounts
     , formatLoginAccounts
+    , formatCurrencyAmount
     , initialLoginState
     , loginAccountSelectionId
     , refreshLoginAccount
@@ -89,6 +90,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Containers.ListUtils (nubOrdOn)
 import Data.Maybe (catMaybes, fromMaybe, isJust)
+import Data.Scientific (Scientific, FPFormat(Fixed), formatScientific)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -959,7 +961,11 @@ refreshLoginAccount account
                         "Use `claude auth status` for Claude Code subscription auth."
                 }
   where
-    formatAmount = fmap (("$" <>) . Text.pack . show)
+    formatAmount = fmap formatCurrencyAmount
+
+formatCurrencyAmount :: Scientific -> Text
+formatCurrencyAmount =
+    ("$" <>) . Text.pack . formatScientific Fixed (Just 2)
 
 openAIUsage :: OpenAI.UsageSnapshot -> AccountUsage
 openAIUsage snapshot = AccountUsage

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -91,6 +91,22 @@ spec = do
             renderLoginFrame False (initialLoginState [openai])
                 `shouldSatisfy` Text.isInfixOf "checking usage"
 
+        it "rounds OpenRouter credit amounts to cents" do
+            formatCurrencyAmount 5.317721499 `shouldBe` "$5.32"
+            formatCurrencyAmount 3369.682278501 `shouldBe` "$3369.68"
+            let account = openRouter
+                    { loginUsage =
+                        UsageAvailable AccountUsage
+                            { usagePlan = Nothing
+                            , usageWindows = []
+                            , creditsRemaining = Just "$5.32"
+                            , creditsUsed = Just "$3369.68"
+                            }
+                    }
+                body = renderLoginFrame False (initialLoginState [account])
+            body `shouldSatisfy` Text.isInfixOf "credits $5.32"
+            body `shouldSatisfy` Text.isInfixOf "used $3369.68"
+
 openai :: LoginAccount
 openai = LoginAccount
     { loginManagedId = Nothing


### PR DESCRIPTION
Rounds OpenRouter credit and usage amounts to two decimal places and adds regression coverage.