### PR TITLE
Hide internal instruction reload notices

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -213,7 +213,10 @@ import Agent.CLI.Startup.Auth
       recordStartupTiming,
       setStartupNotice,
       startupDie )
-import Agent.CLI.StartupContext ( loadAgentsContext )
+import Agent.CLI.StartupContext
+    ( AgentsContextNotice(..)
+    , loadAgentsContext
+    )
 import Agent.CLI.Style
     ( cliWindowTitle,
       glyphSession,
@@ -2136,10 +2139,16 @@ runAgentInitializedWithLock
             startupWindowTitle = cliWindowTitle cwd titleHint
         setWindowTitle startupWindowTitle
         markStartupStage startup "Loading instructions…"
+        let agentsContextNotice
+                | isNothing resumed && isNothing transition =
+                    ReportAgentsContextLoaded
+                | otherwise =
+                    SuppressAgentsContextLoaded
         startupContext <-
             loadAgentsContext
                 stderrHandle
                 fullscreen
+                agentsContextNotice
                 options
                 dialect
                 home

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -102,7 +102,10 @@ import Agent.CLI.Skills
     ( installSkillCatalogWithOmissions, installSkillToolRoots
     , loadSkillsCatalogQuiet, reservedSlashNames
     )
-import Agent.CLI.StartupContext (loadAgentsContext)
+import Agent.CLI.StartupContext
+    ( AgentsContextNotice(..)
+    , loadAgentsContext
+    )
 import Agent.CLI.Startup.Auth
     ( learnAboutUserOnboardingPrompt
     , markStartupStage
@@ -582,6 +585,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 loadAgentsContext
                     stderrHandle
                     fullscreen
+                    SuppressAgentsContextLoaded
                     options
                     dialect
                     home

--- a/packages/agent-cli/src/Agent/CLI/StartupContext.hs
+++ b/packages/agent-cli/src/Agent/CLI/StartupContext.hs
@@ -1,6 +1,7 @@
--- | Discover repository instructions for a fresh session.
+-- | Discover repository instructions for fresh or regenerated context.
 module Agent.CLI.StartupContext
-    ( loadAgentsContext
+    ( AgentsContextNotice(..)
+    , loadAgentsContext
     ) where
 
 import Agent.CLI.Dialects
@@ -42,12 +43,19 @@ import qualified Data.Text as Text
 import System.IO (Handle)
 import System.OsPath (OsPath)
 
--- | Discover AGENTS.md once for a fresh session. Resumed transcripts keep
--- whatever instructions were already in history; callers pass an empty
--- history after a persisted transcript-replacement boundary.
+data AgentsContextNotice
+    = ReportAgentsContextLoaded
+    | SuppressAgentsContextLoaded
+    deriving (Eq, Show)
+
+-- | Discover AGENTS.md when generated context is needed. Resumed transcripts
+-- keep whatever instructions were already in history; callers pass an empty
+-- history after a persisted transcript-replacement boundary. Regeneration can
+-- suppress the successful-load notice while still reporting read warnings.
 loadAgentsContext
     :: Handle
     -> Maybe FullscreenRuntime
+    -> AgentsContextNotice
     -> CliOptions
     -> Dialect
     -> OsPath
@@ -56,7 +64,7 @@ loadAgentsContext
     -> Maybe Text
     -> IO (IORef (Maybe Text))
 loadAgentsContext
-        stderrHandle fullscreen options dialect home cwd initialItems initialPrevious
+        stderrHandle fullscreen notice options dialect home cwd initialItems initialPrevious
     | not options.optAgentsMd = newIORef Nothing
     | not (null initialItems) || isJust initialPrevious = newIORef Nothing
     | otherwise = do
@@ -72,17 +80,20 @@ loadAgentsContext
         case formatAgentsMdForDialect dialect cwd loaded of
             Nothing -> newIORef Nothing
             Just text -> do
-                let message =
-                        "agents.md: loaded "
-                            <> Text.pack (show (length files))
-                            <> if length files == 1 then " file" else " files"
-                case fullscreen of
-                    Nothing -> do
-                        color <- resolveColor stderrHandle
-                        putTextLn stderrHandle
-                            (roleMuted color (glyphSession <> message))
-                    Just runtime ->
-                        emitUiEvent runtime (UiSystemMessage message)
+                case notice of
+                    SuppressAgentsContextLoaded -> pure ()
+                    ReportAgentsContextLoaded -> do
+                        let message =
+                                "agents.md: loaded "
+                                    <> Text.pack (show (length files))
+                                    <> if length files == 1 then " file" else " files"
+                        case fullscreen of
+                            Nothing -> do
+                                color <- resolveColor stderrHandle
+                                putTextLn stderrHandle
+                                    (roleMuted color (glyphSession <> message))
+                            Just runtime ->
+                                emitUiEvent runtime (UiSystemMessage message)
                 newIORef (Just text)
 
 reportInstructionWarning


### PR DESCRIPTION
## Summary

- distinguish fresh-session AGENTS load notices from internal context regeneration
- suppress the successful-load notice after compaction, reset, resume repair, and model/dialect transitions
- retain the notice for genuinely fresh sessions and continue surfacing instruction read warnings

## Why

Context replacement deliberately reloads generated instructions, but the resulting `agents.md: loaded N files` system block looked like a conversation restart when it appeared late in an existing transcript.

## Validation

- loaded `Agent.CLI.StartupContext`, `Agent.CLI.Session.Runner`, and `Agent.CLI.Runtime.Orchestration` in GHCi
- `agent-cli-test --match resumeNeedsGeneratedContext`: 5 examples, 0 failures
- tmux smoke test: fresh startup showed the load notice; `/new` regenerated context without showing it again
- `git diff --check`
