### PR TITLE
perf(openai): decode buffered responses from bytes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
                     root = ./packages/agent-openai;
                     include = [
                         "app"
+                        "benchmark"
                         "src"
                         "test"
                         "agent-openai.cabal"

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -15,6 +15,7 @@ build-type:         Simple
 extra-source-files: README.md
                   , CHANGELOG.md
                   , UPSTREAM.md
+                  , benchmark/JsonDecoding.md
 
 common common-opts
     default-language: Haskell2010
@@ -142,3 +143,17 @@ test-suite agent-openai-test
                     , http-types
                     , wai
                     , warp
+
+benchmark openai-json-decoding-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          JsonDecoding.hs
+    ghc-options:      -O2
+                      -rtsopts
+    build-depends:    base >= 4.14 && < 5
+                    , agent-openai
+                    , agent-responses-types
+                    , aeson
+                    , bytestring
+                    , text

--- a/packages/agent-openai/benchmark/JsonDecoding.hs
+++ b/packages/agent-openai/benchmark/JsonDecoding.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Main (main) where
+
+import Agent.OpenAI.CompactClient (decodeCompactBodyBytes)
+import Agent.OpenAI.Http
+    ( decodeCodexHttpBody
+    , decodeCodexHttpBodyBytes
+    )
+import Agent.Responses.Types
+    ( MessageContent(..)
+    , Response(..)
+    , ResponseContentPart(..)
+    , ResponseItem(..)
+    , ResponseMessage(..)
+    )
+import Control.Exception (evaluate)
+import Control.Monad (forM)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (sort)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = HttpUtf8RoundTrip
+    | HttpDirectBytes
+    | HttpSseUtf8RoundTrip
+    | HttpSseDirectBytes
+    | CompactUtf8RoundTrip
+    | CompactDirectBytes
+
+data Sample = Sample
+    { wallMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled then pure () else die "run with +RTS -T"
+    getArgs >>= \case
+        [workloadArg, responseCountArg, textBytesArg, samplesArg] -> do
+            workload <- parseWorkload workloadArg
+            responseCount <- positive "response count" responseCountArg
+            textBytes <- positive "text bytes" textBytesArg
+            sampleCount <- positive "sample count" samplesArg
+            let payloadSets =
+                    [ [ makePayload workload
+                            (sampleIndex * responseCount + responseIndex)
+                            textBytes
+                      | responseIndex <- [1 .. responseCount]
+                      ]
+                    | sampleIndex <- [1 .. sampleCount]
+                    ]
+            _ <- evaluate (sum (map (sum . map BS.length) payloadSets))
+            case payloadSets of
+                firstPayloads : _ -> verifyEquivalent workload firstPayloads
+                [] -> die "sample count must be positive"
+            samples <- forM payloadSets \payloads ->
+                measure (runWorkload workload payloads)
+            let medianWall = median (map (.wallMillis) samples)
+                medianCPU = median (map (.cpuMillis) samples)
+                medianAllocation = median (map (.allocatedBytes) samples)
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d\n"
+                workloadArg responseCount textBytes sampleCount
+                medianWall medianCPU medianAllocation
+        _ -> die $
+            "usage: openai-json-decoding-bench WORKLOAD RESPONSES TEXT_BYTES SAMPLES\n"
+                <> "workloads: http-utf8-round-trip, http-direct-bytes, "
+                <> "http-sse-utf8-round-trip, http-sse-direct-bytes, "
+                <> "compact-utf8-round-trip, compact-direct-bytes"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "http-utf8-round-trip" -> pure HttpUtf8RoundTrip
+    "http-direct-bytes" -> pure HttpDirectBytes
+    "http-sse-utf8-round-trip" -> pure HttpSseUtf8RoundTrip
+    "http-sse-direct-bytes" -> pure HttpSseDirectBytes
+    "compact-utf8-round-trip" -> pure CompactUtf8RoundTrip
+    "compact-direct-bytes" -> pure CompactDirectBytes
+    other -> die ("unknown workload: " <> other)
+
+positive :: String -> String -> IO Int
+positive label raw = case reads raw of
+    [(value, "")] | value > 0 -> pure value
+    _ -> die ("invalid " <> label <> ": " <> raw)
+
+median :: Ord a => [a] -> a
+median values = sort values !! (length values `div` 2)
+
+verifyEquivalent :: Workload -> [BS.ByteString] -> IO ()
+verifyEquivalent workload payloads = do
+    let oldChecksum = runWorkload (oldVariant workload) payloads
+        directChecksum = runWorkload (directVariant workload) payloads
+    oldResult <- oldChecksum
+    directResult <- directChecksum
+    if oldResult == directResult
+        then pure ()
+        else die "old and direct decoders produced different checksums"
+
+oldVariant :: Workload -> Workload
+oldVariant = \case
+    HttpUtf8RoundTrip -> HttpUtf8RoundTrip
+    HttpDirectBytes -> HttpUtf8RoundTrip
+    HttpSseUtf8RoundTrip -> HttpSseUtf8RoundTrip
+    HttpSseDirectBytes -> HttpSseUtf8RoundTrip
+    CompactUtf8RoundTrip -> CompactUtf8RoundTrip
+    CompactDirectBytes -> CompactUtf8RoundTrip
+
+directVariant :: Workload -> Workload
+directVariant = \case
+    HttpUtf8RoundTrip -> HttpDirectBytes
+    HttpDirectBytes -> HttpDirectBytes
+    HttpSseUtf8RoundTrip -> HttpSseDirectBytes
+    HttpSseDirectBytes -> HttpSseDirectBytes
+    CompactUtf8RoundTrip -> CompactDirectBytes
+    CompactDirectBytes -> CompactDirectBytes
+
+runWorkload :: Workload -> [BS.ByteString] -> IO Int
+runWorkload workload = go checksumSeed
+  where
+    go !checksum [] = pure checksum
+    go !checksum (payload : rest) = do
+        decoded <- evaluate $ case workload of
+            HttpUtf8RoundTrip ->
+                responseChecksum <$>
+                    decodeCodexHttpBody (Text.decodeUtf8 payload)
+            HttpDirectBytes ->
+                responseChecksum <$> decodeCodexHttpBodyBytes payload
+            HttpSseUtf8RoundTrip ->
+                responseChecksum <$>
+                    decodeCodexHttpBody (Text.decodeUtf8 payload)
+            HttpSseDirectBytes ->
+                responseChecksum <$> decodeCodexHttpBodyBytes payload
+            CompactUtf8RoundTrip ->
+                itemsChecksum <$>
+                    decodeCompactBodyBytes
+                        (Text.encodeUtf8 (Text.decodeUtf8 payload))
+            CompactDirectBytes ->
+                itemsChecksum <$> decodeCompactBodyBytes payload
+        value <- case decoded of
+            Left err -> error (show err)
+            Right result -> evaluate result
+        let checksum' = checksum * 33 + value
+        checksum' `seq` go checksum' rest
+
+responseChecksum :: Response -> Int
+responseChecksum response =
+    Text.length response.responseId + itemsChecksum response.output
+
+itemsChecksum :: [ResponseItem] -> Int
+itemsChecksum = sum . map itemChecksum
+
+itemChecksum :: ResponseItem -> Int
+itemChecksum = \case
+    MessageItem message ->
+        maybe 0 Text.length message.messageId
+            + contentChecksum message.content
+    _ -> 0
+
+contentChecksum :: MessageContent -> Int
+contentChecksum = \case
+    MessageContentText value -> Text.length value
+    MessageContentParts parts -> sum (map partChecksum parts)
+
+partChecksum :: ResponseContentPart -> Int
+partChecksum = \case
+    OutputTextPart { text } -> Text.length text
+    _ -> 0
+
+makePayload :: Workload -> Int -> Int -> BS.ByteString
+makePayload workload responseIndex textBytes =
+    case workload of
+        HttpUtf8RoundTrip -> encode response
+        HttpDirectBytes -> encode response
+        HttpSseUtf8RoundTrip -> sseFrame
+        HttpSseDirectBytes -> sseFrame
+        CompactUtf8RoundTrip -> encode compact
+        CompactDirectBytes -> encode compact
+  where
+    encode = LBS.toStrict . Aeson.encode
+    identifier = Text.pack (show responseIndex)
+    message = Aeson.object
+        [ "type" Aeson..= ("message" :: Text.Text)
+        , "id" Aeson..= ("msg-" <> identifier)
+        , "role" Aeson..= ("assistant" :: Text.Text)
+        , "status" Aeson..= ("completed" :: Text.Text)
+        , "content" Aeson..=
+            [ Aeson.object
+                [ "type" Aeson..= ("output_text" :: Text.Text)
+                , "text" Aeson..= Text.replicate textBytes "x"
+                , "annotations" Aeson..= ([] :: [Aeson.Value])
+                ]
+            ]
+        ]
+    response = Aeson.object
+        [ "id" Aeson..= ("resp-" <> identifier)
+        , "created_at" Aeson..= (1_700_000_000 :: Int)
+        , "error" Aeson..= Aeson.Null
+        , "incomplete_details" Aeson..= Aeson.Null
+        , "model" Aeson..= ("gpt-5.6" :: Text.Text)
+        , "object" Aeson..= ("response" :: Text.Text)
+        , "status" Aeson..= ("completed" :: Text.Text)
+        , "output" Aeson..= [message]
+        ]
+    compact = Aeson.object ["output" Aeson..= [message]]
+    sseResponse = Aeson.object
+        [ "type" Aeson..= ("response.completed" :: Text.Text)
+        , "response" Aeson..= response
+        ]
+    sseFrame = BS.concat
+        [ "event: response.completed\n"
+        , "data: "
+        , encode sseResponse
+        , "\n\n"
+        ]
+
+checksumSeed :: Int
+checksumSeed = 5381
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCPU <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    result <- action
+    _ <- evaluate result
+    afterWall <- getMonotonicTimeNSec
+    afterCPU <- getCPUTime
+    afterStats <- getRTSStats
+    pure Sample
+        { wallMillis = fromIntegral (afterWall - beforeWall) / 1.0e6
+        , cpuMillis = fromIntegral (afterCPU - beforeCPU) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        }

--- a/packages/agent-openai/benchmark/JsonDecoding.md
+++ b/packages/agent-openai/benchmark/JsonDecoding.md
@@ -1,0 +1,57 @@
+# Buffered OpenAI JSON decoding benchmark
+
+This benchmark compares the former
+`ByteString -> Text -> ByteString -> Aeson` path with direct decoding from the
+original buffered HTTP response bytes. It covers ordinary Responses JSON and
+buffered SSE compatibility responses, plus the `/responses/compact` envelope.
+
+Each sample uses a distinct prebuilt payload set so GHC cannot share pure
+decoder results between samples. The decoded response id, message id, and full
+assistant text contribute to the checksum. Old and direct checksums are
+compared before measurement. Wall time, CPU time, and Haskell allocation use
+independent medians.
+
+Build and run:
+
+```sh
+nix develop -c cabal build --offline agent-openai:bench:openai-json-decoding-bench
+bin=$(nix develop -c cabal list-bin agent-openai:bench:openai-json-decoding-bench)
+"$bin" http-utf8-round-trip 10000 64 9 +RTS -T
+"$bin" http-direct-bytes 10000 64 9 +RTS -T
+"$bin" http-sse-utf8-round-trip 10000 64 9 +RTS -T
+"$bin" http-sse-direct-bytes 10000 64 9 +RTS -T
+"$bin" compact-utf8-round-trip 10000 64 9 +RTS -T
+"$bin" compact-direct-bytes 10000 64 9 +RTS -T
+```
+
+## 2026-08-27 results
+
+Apple M3 Max, 36 GiB RAM, GHC 9.10.3, `-O2`, nine samples:
+
+| Path | Responses | Text | Workload | Median wall | Median CPU | Haskell allocation |
+|:---|---:|---:|:---|---:|---:|---:|
+| JSON | 10,000 | 16 B | UTF-8 round trip | 42.071 ms | 41.991 ms | 281,545,512 B |
+| JSON | 10,000 | 16 B | Direct bytes | 40.870 ms | 40.768 ms | 274,893,344 B |
+| JSON | 2,000 | 1 KiB | UTF-8 round trip | 11.796 ms | 11.771 ms | 58,557,600 B |
+| JSON | 2,000 | 1 KiB | Direct bytes | 11.437 ms | 11.413 ms | 57,058,888 B |
+| JSON | 100 | 64 KiB | UTF-8 round trip | 10.897 ms | 10.884 ms | 19,180,552 B |
+| JSON | 100 | 64 KiB | Direct bytes | 10.495 ms | 10.441 ms | 5,934,776 B |
+| SSE | 10,000 | 16 B | UTF-8 round trip | 57.632 ms | 57.583 ms | 364,587,816 B |
+| SSE | 10,000 | 16 B | Direct bytes | 57.277 ms | 57.047 ms | 354,978,200 B |
+| SSE | 2,000 | 1 KiB | UTF-8 round trip | 16.394 ms | 16.382 ms | 81,619,088 B |
+| SSE | 2,000 | 1 KiB | Direct bytes | 16.101 ms | 16.088 ms | 75,455,536 B |
+| SSE | 100 | 64 KiB | UTF-8 round trip | 15.037 ms | 15.011 ms | 32,633,368 B |
+| SSE | 100 | 64 KiB | Direct bytes | 14.870 ms | 14.875 ms | 19,825,080 B |
+| Compact | 10,000 | 16 B | UTF-8 round trip | 16.203 ms | 16.190 ms | 131,272,496 B |
+| Compact | 10,000 | 16 B | Direct bytes | 15.402 ms | 15.378 ms | 127,436,264 B |
+| Compact | 2,000 | 1 KiB | UTF-8 round trip | 6.449 ms | 6.441 ms | 30,796,616 B |
+| Compact | 2,000 | 1 KiB | Direct bytes | 6.141 ms | 6.119 ms | 24,501,304 B |
+| Compact | 100 | 64 KiB | UTF-8 round trip | 10.553 ms | 10.544 ms | 17,919,016 B |
+| Compact | 100 | 64 KiB | Direct bytes | 9.953 ms | 9.930 ms | 5,013,208 B |
+
+Direct decoding allocated less in every workload. The allocation reduction
+grew to 69% for large ordinary JSON responses, 39% for large buffered SSE
+responses, and 72% for large compact responses. Median wall time also improved
+in every case. A repeated token-sized run reproduced the allocation totals;
+direct decoding was 0.2% faster for JSON, 1.9% for SSE, and 4.7% for compact
+responses.

--- a/packages/agent-openai/package.nix
+++ b/packages/agent-openai/package.nix
@@ -26,6 +26,9 @@ mkDerivation {
     hspec http-types retry temporary text time unix vector wai warp
     websockets
   ];
+  benchmarkHaskellDepends = [
+    aeson agent-responses-types base bytestring text
+  ];
   description = "Haskell client for the OpenAI Responses API";
   license = lib.meta.getLicenseFromSpdxId "MIT";
   mainProgram = "agent-openai-login";

--- a/packages/agent-openai/src/Agent/OpenAI/Client.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Client.hs
@@ -24,7 +24,7 @@ import Agent.OpenAI.Features
     ( betaFeaturesHeaderValue
     , remoteCompactionV2Feature
     )
-import Agent.OpenAI.Http (decodeCodexHttpBodyWithModel, postCodexJson)
+import Agent.OpenAI.Http (decodeCodexHttpBodyBytesWithModel, postCodexJson)
 import Agent.OpenAI.ModelMetadata (isCodexResponsesLiteModel)
 import Agent.OpenAI.Request (sanitizeCodexRequest)
 import Agent.OpenAI.WebSocketClient
@@ -320,8 +320,8 @@ responseHandler idleTimeoutMicros modelHint turnState response stream = do
     let status = getStatusCode response
     captureResponseTurnState turnState response
     bodyResult <- readBodyWithIdleTimeout idleTimeoutMicros stream
-    let bodyText = Text.decodeUtf8With Text.lenientDecode
-            (LBS.toStrict (bodyReadBytes bodyResult))
+    let bodyBytes = LBS.toStrict (bodyReadBytes bodyResult)
+        bodyText = Text.decodeUtf8With Text.lenientDecode bodyBytes
     case bodyResult of
         BodyReadTimedOut _
             | status >= 200 && status < 300 ->
@@ -332,7 +332,7 @@ responseHandler idleTimeoutMicros modelHint turnState response stream = do
                     classifyTimedOutHttpFailure status bodyText
         BodyReadComplete _
             | status >= 200 && status < 300 ->
-                pure (decodeCodexHttpBodyWithModel modelHint bodyText)
+                pure (decodeCodexHttpBodyBytesWithModel modelHint bodyBytes)
             | otherwise -> pure $ Left
                 (withRetryAfterHeader response
                     (classifyHttpFailure status bodyText))

--- a/packages/agent-openai/src/Agent/OpenAI/CompactClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/CompactClient.hs
@@ -3,6 +3,7 @@ module Agent.OpenAI.CompactClient
     ( CompactRequest(..)
     , compactConversation
     , compactConversationAt
+    , decodeCompactBodyBytes
     ) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
@@ -99,23 +100,29 @@ compactResponseHandler
 compactResponseHandler response stream = do
     let status = getStatusCode response
     bytes <- Streams.fold mappend mempty stream
-    let bodyText = Text.decodeUtf8With Text.lenientDecode bytes
     if status >= 200 && status < 300
-        then pure (decodeCompactBody bodyText)
-        else pure $ Left (classifyHttpFailure status bodyText)
+        then pure (decodeCompactBodyBytes bytes)
+        else pure $ Left (classifyHttpFailure status (bodyText bytes))
 
-decodeCompactBody :: Text -> Either ApiError [ResponseItem]
-decodeCompactBody bodyText =
-    case Aeson.eitherDecodeStrict (Text.encodeUtf8 bodyText) of
-        Left err -> Left (JsonDecodeError (Text.pack err) bodyText)
+decodeCompactBodyBytes :: BS.ByteString -> Either ApiError [ResponseItem]
+decodeCompactBodyBytes bytes =
+    case Aeson.eitherDecodeStrict bytes of
+        Left err -> Left (JsonDecodeError (Text.pack err) (bodyText bytes))
         Right (Aeson.Object object) ->
             case KeyMap.lookup "output" object of
                 Just value ->
                     case Aeson.fromJSON value of
                         Aeson.Success items -> Right items
                         Aeson.Error err ->
-                            Left (JsonDecodeError (Text.pack err) bodyText)
+                            Left (JsonDecodeError (Text.pack err) (bodyText bytes))
                 Nothing ->
-                    Left (JsonDecodeError "compact response missing output" bodyText)
+                    Left (JsonDecodeError
+                        "compact response missing output"
+                        (bodyText bytes))
         Right _ ->
-            Left (JsonDecodeError "compact response was not an object" bodyText)
+            Left (JsonDecodeError
+                "compact response was not an object"
+                (bodyText bytes))
+
+bodyText :: BS.ByteString -> Text
+bodyText = Text.decodeUtf8With Text.lenientDecode

--- a/packages/agent-openai/src/Agent/OpenAI/Http.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Http.hs
@@ -2,12 +2,14 @@ module Agent.OpenAI.Http
     ( postCodexJson
     , decodeCodexHttpBody
     , decodeCodexHttpBodyWithModel
+    , decodeCodexHttpBodyBytes
+    , decodeCodexHttpBodyBytesWithModel
     , rejectFailedCodexResponse
     ) where
 
 import Agent.Error (ApiError(..), ErrorType(..), errorTypeFromText)
 import Agent.OpenAI.Error (mkOpenAIError)
-import Agent.Responses.SSE (parseSseEvents)
+import Agent.Responses.SSE (parseSseEventsBytes)
 import Agent.Responses.LoopBackend (hasRecoverableIncompleteOutput)
 import Agent.Responses.StreamAssembly
     ( ResponseFailure(..)
@@ -21,6 +23,7 @@ import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -106,31 +109,45 @@ decodeCodexHttpBodyWithModel
     :: Maybe Text
     -> Text
     -> Either ApiError OpenAI.Response
-decodeCodexHttpBodyWithModel modelHint bodyText
-    | looksLikeSse bodyText = do
-        events <- parseSseEvents bodyText
+decodeCodexHttpBodyWithModel modelHint =
+    decodeCodexHttpBodyBytesWithModel modelHint . Text.encodeUtf8
+
+-- | Decode a complete buffered Codex response from its original wire bytes.
+decodeCodexHttpBodyBytes :: BS.ByteString -> Either ApiError OpenAI.Response
+decodeCodexHttpBodyBytes = decodeCodexHttpBodyBytesWithModel Nothing
+
+-- | Decode a complete buffered Codex response from its original wire bytes
+-- while retaining the request model for incomplete response fragments.
+decodeCodexHttpBodyBytesWithModel
+    :: Maybe Text
+    -> BS.ByteString
+    -> Either ApiError OpenAI.Response
+decodeCodexHttpBodyBytesWithModel modelHint bodyBytes
+    | looksLikeSseBytes bodyBytes = do
+        events <- parseSseEventsBytes bodyBytes
         response <- buildStreamResponseWithModel streamConfig modelHint events
         rejectFailedCodexResponse response
     | otherwise =
-        case decodeJsonResponseBody bodyText of
-            Just jsonValue -> decodeResponseValue jsonValue bodyText
+        case decodeJsonResponseBodyBytes bodyBytes of
+            Just jsonValue -> decodeResponseValue jsonValue bodyBytes
             Nothing -> Left (JsonDecodeError
                 "Invalid Codex Responses body"
-                (Text.take 2000 bodyText))
+                (bodyPreview bodyBytes))
 
-decodeJsonResponseBody :: Text -> Maybe Aeson.Value
-decodeJsonResponseBody bodyText =
-    case Aeson.eitherDecodeStrict' (Text.encodeUtf8 (Text.strip bodyText)) of
+decodeJsonResponseBodyBytes :: BS.ByteString -> Maybe Aeson.Value
+decodeJsonResponseBodyBytes bodyBytes =
+    case Aeson.eitherDecodeStrict' bodyBytes of
         Right (Aeson.Object object)
             | Just inner <- KeyMap.lookup "response" object -> Just inner
             | otherwise -> Just (Aeson.Object object)
         _ -> Nothing
 
-decodeResponseValue :: Aeson.Value -> Text -> Either ApiError OpenAI.Response
-decodeResponseValue jsonValue bodyText =
+decodeResponseValue :: Aeson.Value -> BS.ByteString -> Either ApiError OpenAI.Response
+decodeResponseValue jsonValue bodyBytes =
     case Aeson.fromJSON jsonValue of
         Aeson.Success response -> rejectFailedCodexResponse response
-        Aeson.Error err -> Left (JsonDecodeError (Text.pack err) (Text.take 2000 bodyText))
+        Aeson.Error err ->
+            Left (JsonDecodeError (Text.pack err) (bodyPreview bodyBytes))
 
 -- | The Responses endpoint can return HTTP 200 with a terminal
 -- @status: "failed"@ payload. Normalize that wire shape into the same typed
@@ -191,10 +208,14 @@ terminalResponseError response =
                 (failedResponseMessage response)
                 Nothing
 
-looksLikeSse :: Text -> Bool
-looksLikeSse bodyText =
+looksLikeSseBytes :: BS.ByteString -> Bool
+looksLikeSseBytes bodyBytes =
     any
         (\line ->
-            Text.isPrefixOf "event:" line
-                || Text.isPrefixOf "data:" line)
-        (Text.lines bodyText)
+            "event:" `BS.isPrefixOf` line
+                || "data:" `BS.isPrefixOf` line)
+        (BS8.lines bodyBytes)
+
+bodyPreview :: BS.ByteString -> Text
+bodyPreview =
+    Text.take 2000 . Text.decodeUtf8Lenient

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -18,6 +18,25 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "decodeCompactBodyBytes" do
+        it "decodes compacted items directly from wire bytes" do
+            let bytes = LBS.toStrict . Aeson.encode $ Aeson.object
+                    [ "output" .=
+                        [ Aeson.object
+                            [ "type" .= ("message" :: Text.Text)
+                            , "id" .= ("msg-1" :: Text.Text)
+                            , "role" .= ("assistant" :: Text.Text)
+                            , "content" .= ("compacted" :: Text.Text)
+                            ]
+                        ]
+                    ]
+            case decodeCompactBodyBytes bytes of
+                Right [MessageItem message] ->
+                    message.content `shouldBe` MessageContentText "compacted"
+                Right other ->
+                    expectationFailure ("unexpected items: " <> show other)
+                Left err -> expectationFailure (show err)
+
     describe "remote compaction v2" do
         it "builds an exact final compaction trigger and preserves request controls" do
             let reasoningConfig = ReasoningConfig

--- a/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ResponsesSpec.hs
@@ -1,16 +1,21 @@
 module Agent.OpenAI.ResponsesSpec (spec) where
 
+import Agent.Error (ApiError(..))
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as Text
 import Test.Hspec
 
-import Agent.OpenAI.Http (decodeCodexHttpBody)
+import Agent.OpenAI.Http
+    ( decodeCodexHttpBody
+    , decodeCodexHttpBodyBytes
+    )
 import qualified Agent.Responses.Codec as Codec
 import qualified Agent.Responses.Types as Responses
 import Agent.OpenAI.ToolDSL
@@ -67,6 +72,20 @@ spec = do
                     ])
 
     describe "canonical Responses response" do
+        it "decodes canonical JSON directly from wire bytes" do
+            let bytes =
+                    LBS.toStrict (Aeson.encode (canonicalResponseJson "completed"))
+            case decodeCodexHttpBodyBytes bytes of
+                Right response -> response.responseId `shouldBe` "resp_1"
+                Left err -> expectationFailure (show err)
+
+        it "rejects invalid UTF-8 in a direct byte response" do
+            decodeCodexHttpBodyBytes (BS.pack [0xff])
+                `shouldBe` Left
+                    (JsonDecodeError
+                        "Invalid Codex Responses body"
+                        "\xfffd")
+
         it "preserves statuses, rich output text, usage, and unknown fields" do
             let original = canonicalResponseJson "failed"
             case Aeson.fromJSON original :: Aeson.Result Responses.Response of
@@ -81,6 +100,19 @@ spec = do
                         ])
                     <> "\n\n"
             case decodeCodexHttpBody body of
+                Right response -> do
+                    response.responseId `shouldBe` "resp_1"
+                    response.status `shouldBe` Responses.ResponseCompleted
+                Left err -> expectationFailure (show err)
+
+        it "decodes a completed SSE payload directly from wire bytes" do
+            let body = "event: response.completed\ndata: "
+                    <> jsonText (Aeson.object
+                        [ "type" .= ("response.completed" :: Text)
+                        , "response" .= canonicalResponseJson "completed"
+                        ])
+                    <> "\n\n"
+            case decodeCodexHttpBodyBytes (Text.encodeUtf8 body) of
                 Right response -> do
                     response.responseId `shouldBe` "resp_1"
                     response.status `shouldBe` Responses.ResponseCompleted

--- a/packages/agent-responses/src/Agent/Responses/SSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/SSE.hs
@@ -5,6 +5,7 @@ module Agent.Responses.SSE
     , feedSseDecoder
     , finishSseDecoder
     , parseSseEvents
+    , parseSseEventsBytes
     ) where
 
 import Agent.Error (ApiError(..))
@@ -80,8 +81,13 @@ finishSseDecoder decoder = do
 
 -- | Decode a complete SSE body into the canonical typed Responses event union.
 parseSseEvents :: Text -> Either ApiError [ResponseStreamEvent]
-parseSseEvents sseText = do
-    (decoder, events) <- feedSseDecoder newSseDecoder (Text.encodeUtf8 sseText)
+parseSseEvents = parseSseEventsBytes . Text.encodeUtf8
+
+-- | Decode a complete SSE body without converting its validated wire bytes
+-- through 'Text' first.
+parseSseEventsBytes :: BS.ByteString -> Either ApiError [ResponseStreamEvent]
+parseSseEventsBytes bytes = do
+    (decoder, events) <- feedSseDecoder newSseDecoder bytes
     trailing <- finishSseDecoder decoder
     pure (events <> trailing)
 


### PR DESCRIPTION
## Summary

- decode buffered Codex JSON and SSE responses directly from their original bytes
- decode `/responses/compact` output directly from bytes, converting to text only for diagnostics
- add direct-byte JSON, SSE, and compact-response coverage
- add a reproducible optimized benchmark and include it in the Nix-filtered package source

## Benchmark

Apple M3 Max, GHC 9.10.3, `-O2`, nine samples. Direct decoding reduced allocation in every workload; for 64 KiB response text:

| Path | Before | Direct bytes | Reduction |
|---|---:|---:|---:|
| JSON | 19,180,552 B | 5,934,776 B | 69% |
| Buffered SSE | 32,633,368 B | 19,825,080 B | 39% |
| Compact | 17,919,016 B | 5,013,208 B | 72% |

Median wall time improved in every measured case. Full commands and raw medians are recorded in `packages/agent-openai/benchmark/JsonDecoding.md`.

## Validation

- `agent-openai` GHCi suite: 291 examples, 0 failures, 1 credential-gated pending test
- `agent-responses` GHCi suite: 50 examples, 0 failures
- optimized benchmark built and ran with `+RTS -T`
- `nix flake check --no-build --no-write-lock-file`
