### PR TITLE
perf(responses): index streamed items and buffer text

### DIFF
--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -107,3 +107,18 @@ benchmark responses-json-bench
                     , base >= 4.14 && < 5
                     , bytestring
                     , text
+
+benchmark stream-assembly-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          StreamAssembly.hs
+    ghc-options:      -O2 -rtsopts
+    build-depends:    base >= 4.14 && < 5
+                    , agent-core
+                    , agent-responses
+                    , agent-responses-types
+                    , aeson
+                    , bytestring
+                    , containers
+                    , text

--- a/packages/agent-responses/benchmark/StreamAssembly.hs
+++ b/packages/agent-responses/benchmark/StreamAssembly.hs
@@ -1,0 +1,382 @@
+module Main (main) where
+
+import Agent.Error (ApiError(..))
+import Agent.Responses.StreamAssembly
+    ( ResponseFailure
+    , StreamAssemblyConfig(..)
+    , buildStreamResponseWithModel
+    )
+import Agent.Responses.Types
+import Agent.TextBuffer
+    ( appendTextBuffer
+    , emptyTextBuffer
+    , textBufferToText
+    )
+import Control.Exception (evaluate)
+import Control.Monad (forM)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.IntSet as IntSet
+import Data.List (find, sort)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload
+    = OldText
+    | NewText
+    | OldIndex
+    | NewIndex
+    | OldMixed
+    | NewMixed
+    | ProductionMixed
+    | ProductionExplicit
+    deriving (Eq)
+
+data Item = Item
+    { itemIndex :: !Int
+    , itemId :: !Text
+    , itemCallId :: !Text
+    , itemType :: !Text
+    , itemDone :: !Bool
+    }
+
+data Sample = Sample
+    { wallMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    , resultChecksum :: !Int
+    }
+
+main :: IO ()
+main = do
+    statsEnabled <- getRTSStatsEnabled
+    if statsEnabled then pure () else die "run with +RTS -T"
+    getArgs >>= \case
+        [modeArg, deltaCountArg, itemCountArg, sampleCountArg] -> do
+            workload <- parseWorkload modeArg
+            deltaCount <- parsePositive "delta count" deltaCountArg
+            itemCount <- parsePositive "item count" itemCountArg
+            sampleCount <- parsePositive "sample count" sampleCountArg
+            samples <- forM [1 .. sampleCount] \sampleIndex -> do
+                let chunks =
+                        [ Text.pack
+                            [ toEnum (97 + (sampleIndex + index) `mod` 26)
+                            , toEnum (65 + index `mod` 26)
+                            ]
+                        | index <- [0 .. deltaCount - 1]
+                        ]
+                    items = makeItems sampleIndex itemCount
+                    queries =
+                        [ "id-" <> Text.pack (show
+                            ((index * 37 + sampleIndex) `mod` itemCount))
+                        | index <- [0 .. deltaCount - 1]
+                        ]
+                    productionEvents =
+                        makeProductionEvents
+                            (workload == ProductionExplicit)
+                            sampleIndex
+                            itemCount
+                            deltaCount
+                    -- Event constructors contain parsed response items and
+                    -- JSON objects. Encoding here traverses all nested payloads
+                    -- so parsing/input construction cannot leak into timing.
+                    inputChecksum =
+                        checksumBytes (Aeson.encode productionEvents)
+                _ <- evaluate
+                    (length chunks + length items + length queries
+                        + length productionEvents
+                        + sum (map Text.length chunks)
+                        + inputChecksum)
+                measure
+                    (runWorkload workload chunks items queries productionEvents)
+            let med = median samples
+            printf "%s,%d,%d,%.3f,%.3f,%d,%d\n"
+                modeArg
+                deltaCount
+                itemCount
+                med.wallMillis
+                med.cpuMillis
+                med.allocatedBytes
+                med.resultChecksum
+        _ -> die
+            "usage: stream-assembly-bench MODE DELTAS ITEMS SAMPLES\n\
+            \modes: old-text, new-text, old-index, new-index, old-mixed, \
+            \new-mixed, production-mixed, production-explicit"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "old-text" -> pure OldText
+    "new-text" -> pure NewText
+    "old-index" -> pure OldIndex
+    "new-index" -> pure NewIndex
+    "old-mixed" -> pure OldMixed
+    "new-mixed" -> pure NewMixed
+    "production-mixed" -> pure ProductionMixed
+    "production-explicit" -> pure ProductionExplicit
+    other -> die ("unknown mode: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")] | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+makeItems :: Int -> Int -> [Item]
+makeItems sampleIndex itemCount =
+    [ Item
+        { itemIndex = index
+        , itemId = identity "id-" index
+        , itemCallId = identity "call-" (index * 17)
+        , itemType = if even index then "function_call" else "reasoning"
+        , itemDone = index `mod` 5 == sampleIndex `mod` 5
+        }
+    | index <- [0 .. itemCount - 1]
+    ]
+  where
+    -- Repeated identities exercise the duplicate/minimum-index contract.
+    identity prefix index =
+        prefix <> Text.pack (show (index `mod` max 1 (itemCount * 3 `div` 4)))
+
+runWorkload
+    :: Workload
+    -> [Text]
+    -> [Item]
+    -> [Text]
+    -> [ResponseStreamEvent]
+    -> IO Int
+runWorkload workload chunks items queries productionEvents =
+    evaluate case workload of
+        OldText -> oldText chunks
+        NewText -> newText chunks
+        OldIndex -> oldIndex items queries
+        NewIndex -> newIndex items queries
+        OldMixed -> oldText chunks + oldIndex items queries
+        NewMixed -> newText chunks + newIndex items queries
+        ProductionMixed -> productionChecksum productionEvents
+        ProductionExplicit -> productionChecksum productionEvents
+
+productionChecksum :: [ResponseStreamEvent] -> Int
+productionChecksum events =
+    case buildStreamResponseWithModel
+            productionConfig (Just "benchmark-model") events of
+        Left err -> error ("production assembly failed: " <> show err)
+        Right response ->
+            checksumBytes (Aeson.encode response)
+
+productionConfig :: StreamAssemblyConfig
+productionConfig = StreamAssemblyConfig
+    { missingCompletionMessage = "benchmark stream did not complete"
+    , classifyStreamError = const (ConnectionError "benchmark stream error")
+    , classifyFailedResponse =
+        constResponseFailure (ConnectionError "benchmark response failed")
+    , incompleteAsFailure = False
+    }
+  where
+    constResponseFailure :: ApiError -> ResponseFailure -> ApiError
+    constResponseFailure = const
+
+makeProductionEvents :: Bool -> Int -> Int -> Int -> [ResponseStreamEvent]
+makeProductionEvents explicitIndexes sampleIndex itemCount deltaCount =
+    createdEvent
+        : addedEvents
+        <> deltaEvents
+        <> [completedEvent]
+  where
+    outputCount = itemCount
+    addedEvents = map makeAdded [0 .. outputCount - 1]
+    deltaEvents =
+        [ makeDelta deltaIndex (deltaIndex `mod` outputCount)
+        | deltaIndex <- [0 .. deltaCount - 1]
+        ]
+    createdEvent = ResponseCreatedEvent
+        (Aeson.object ["id" Aeson..= responseId])
+        Nothing
+        KeyMap.empty
+    completedEvent = ResponseCompletedEvent
+        (Aeson.object ["id" Aeson..= responseId])
+        Nothing
+        KeyMap.empty
+    responseId = "bench-response-" <> Text.pack (show sampleIndex)
+
+    makeAdded outputIndex =
+        ResponseOutputItemAddedEvent
+            (parseResponseItem case outputIndex `mod` 3 of
+                0 -> Aeson.object
+                    [ "type" Aeson..= ("function_call" :: Text)
+                    , "id" Aeson..= itemIdentity outputIndex
+                    , "call_id" Aeson..= callIdentity outputIndex
+                    , "name" Aeson..= ("function" :: Text)
+                    , "arguments" Aeson..= ("" :: Text)
+                    ]
+                1 -> Aeson.object
+                    [ "type" Aeson..= ("custom_tool_call" :: Text)
+                    , "id" Aeson..= itemIdentity outputIndex
+                    , "call_id" Aeson..= callIdentity outputIndex
+                    , "name" Aeson..= ("custom" :: Text)
+                    , "input" Aeson..= ("" :: Text)
+                    ]
+                _ -> Aeson.object
+                    [ "type" Aeson..= ("reasoning" :: Text)
+                    , "id" Aeson..= itemIdentity outputIndex
+                    , "summary" Aeson..= ([] :: [Aeson.Value])
+                    ])
+            (Just outputIndex)
+            Nothing
+            KeyMap.empty
+
+    makeDelta deltaIndex outputIndex =
+        case outputIndex `mod` 3 of
+            0 -> ResponseFunctionCallArgumentsDeltaEvent
+                (Just chunk)
+                (Just (itemIdentity outputIndex))
+                explicitIndex
+                Nothing
+                KeyMap.empty
+            1 -> ResponseCustomToolInputDeltaEvent
+                (Just chunk)
+                (Just (itemIdentity outputIndex))
+                (Just (callIdentity outputIndex))
+                explicitIndex
+                Nothing
+                KeyMap.empty
+            _ -> OtherResponseStreamEvent
+                EventReasoningSummaryTextDelta
+                Nothing
+                (KeyMap.fromList
+                    [ ("item_id", Aeson.String (itemIdentity outputIndex))
+                    , ("summary_index", Aeson.toJSON (0 :: Int))
+                    , ("delta", Aeson.String chunk)
+                    ]
+                    <> maybe KeyMap.empty
+                        (KeyMap.singleton "output_index" . Aeson.toJSON)
+                        explicitIndex)
+      where
+        explicitIndex =
+            if explicitIndexes then Just outputIndex else Nothing
+        chunk =
+            Text.pack
+                [ toEnum (97 + (sampleIndex + deltaIndex) `mod` 26)
+                , toEnum (65 + deltaIndex `mod` 26)
+                ]
+
+    itemIdentity outputIndex =
+        "item-" <> Text.pack (show outputIndex)
+    callIdentity outputIndex =
+        "call-" <> Text.pack (show outputIndex)
+
+parseResponseItem :: Aeson.Value -> ResponseItem
+parseResponseItem value =
+    case Aeson.fromJSON value of
+        Aeson.Success item -> item
+        Aeson.Error err -> error ("invalid benchmark response item: " <> err)
+
+oldText :: [Text] -> Int
+oldText =
+    Text.foldl' checksumStep 5381 . foldl' (<>) ""
+
+newText :: [Text] -> Int
+newText =
+    Text.foldl' checksumStep 5381
+        . textBufferToText
+        . foldl' (flip appendTextBuffer) emptyTextBuffer
+
+oldIndex :: [Item] -> [Text] -> Int
+oldIndex items =
+    foldl'
+        (\checksum wanted ->
+            checksum
+                + maybe (-1) (.itemIndex)
+                    (find (\item ->
+                        item.itemId == wanted || item.itemCallId == wanted) items)
+                + maybe (-1) (.itemIndex)
+                    (find (\item ->
+                        not item.itemDone
+                            && item.itemType == queryType wanted) items))
+        0
+
+newIndex :: [Item] -> [Text] -> Int
+newIndex items =
+    let identityIndex = foldl' addIdentities Map.empty items
+        pendingIndex = foldl' addPending Map.empty items
+    in foldl'
+        (\checksum wanted ->
+            checksum
+                + maybe (-1) minimumIndex (Map.lookup wanted identityIndex)
+                + maybe (-1) minimumIndex
+                    (Map.lookup (queryType wanted) pendingIndex))
+        0
+  where
+    addIdentities indexes item =
+        add item.itemCallId item.itemIndex
+            (add item.itemId item.itemIndex indexes)
+    addPending indexes item
+        | item.itemDone = indexes
+        | otherwise = add item.itemType item.itemIndex indexes
+    add key index =
+        Map.insertWith IntSet.union key (IntSet.singleton index)
+    minimumIndex = fst . IntSet.deleteFindMin
+
+queryType :: Text -> Text
+queryType wanted
+    | Text.length wanted `mod` 2 == 0 = "function_call"
+    | otherwise = "reasoning"
+
+checksumStep :: Int -> Char -> Int
+checksumStep checksum character =
+    checksum * 33 + fromEnum character
+
+checksumBytes :: LBS.ByteString -> Int
+checksumBytes =
+    LBS.foldl'
+        (\checksum byte -> checksum * 33 + fromIntegral byte)
+        5381
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    result <- action
+    _ <- evaluate result
+    afterWall <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
+    pure Sample
+        { wallMillis = fromIntegral (afterWall - beforeWall) / 1.0e6
+        , cpuMillis = fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        , resultChecksum = result
+        }
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { wallMillis = middle (sort (map (.wallMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        , resultChecksum =
+            foldl'
+                (\checksum sample ->
+                    checksum * 33 + sample.resultChecksum)
+                5381
+                samples
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/agent-responses/package.nix
+++ b/packages/agent-responses/package.nix
@@ -17,7 +17,8 @@ mkDerivation {
     hspec QuickCheck retry text
   ];
   benchmarkHaskellDepends = [
-    aeson agent-responses-types base bytestring text
+    aeson agent-core agent-responses-types base bytestring containers
+    text
   ];
   description = "Provider-neutral Responses codecs and adapters";
   license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -19,6 +19,12 @@ module Agent.Responses.StreamAssembly
 import Agent.Error (ApiError(..))
 import Agent.Responses.ResponseMerge (mergeDoneResponse)
 import Agent.Responses.Types
+import Agent.TextBuffer
+    ( TextBuffer
+    , appendTextBuffer
+    , textBufferFromText
+    , textBufferToText
+    )
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
@@ -26,6 +32,10 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
+import qualified Data.IntSet as IntSet
+import Data.IntSet (IntSet)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -57,7 +67,17 @@ data ResponseFailure = ResponseFailure
 data ItemProgress = ItemProgress
     { itemValue :: !Aeson.Value
     , itemDone  :: !Bool
+    , itemBuffers :: !ItemBuffers
     }
+
+data ItemBuffers = ItemBuffers
+    { inputBuffer :: !(Maybe TextBuffer)
+    , argumentsBuffer :: !(Maybe TextBuffer)
+    , summaryBuffers :: !(IntMap TextBuffer)
+    }
+
+emptyItemBuffers :: ItemBuffers
+emptyItemBuffers = ItemBuffers Nothing Nothing IntMap.empty
 
 -- | Incremental state shared by HTTP/SSE and reusable WebSocket transports.
 -- Lifecycle response objects are overlaid in wire order; output items are
@@ -65,12 +85,16 @@ data ItemProgress = ItemProgress
 data StreamAssemblyState = StreamAssemblyState
     { responseObject :: !Aeson.Object
     , outputItems    :: !(IntMap ItemProgress)
+    , identityIndexes :: !(Map Text IntSet)
+    , pendingTypeIndexes :: !(Map Text IntSet)
     }
 
 emptyStreamAssemblyState :: StreamAssemblyState
 emptyStreamAssemblyState = StreamAssemblyState
     { responseObject = KeyMap.empty
     , outputItems = IntMap.empty
+    , identityIndexes = Map.empty
+    , pendingTypeIndexes = Map.empty
     }
 
 applyStreamEvent :: StreamAssemblyState -> ResponseStreamEvent -> StreamAssemblyState
@@ -96,7 +120,7 @@ applyStreamEvent state event = case event of
                     updateCustomToolInput outputIndex
                         streamItemId
                         streamCallId
-                        (appendInput inputDelta)
+                        (AppendInput inputDelta)
                         state
                 _ -> state
     ResponseCustomToolInputDoneEvent
@@ -109,7 +133,7 @@ applyStreamEvent state event = case event of
                     updateCustomToolInput outputIndex
                         streamItemId
                         streamCallId
-                        (setInput finalInput)
+                        (SetInput finalInput)
                         state
                 _ -> state
     ResponseFunctionCallArgumentsDeltaEvent
@@ -120,7 +144,7 @@ applyStreamEvent state event = case event of
                 (Just argumentsDelta, Just outputIndex) ->
                     updateFunctionCallArguments outputIndex
                         streamItemId
-                        (appendArguments argumentsDelta)
+                        (AppendArguments argumentsDelta)
                         state
                 _ -> state
     ResponseFunctionCallArgumentsDoneEvent
@@ -129,7 +153,7 @@ applyStreamEvent state event = case event of
                 Just outputIndex ->
                     updateFunctionCallArguments outputIndex
                         streamItemId
-                        (setArguments arguments functionName)
+                        (SetArguments arguments functionName)
                         state
                 Nothing -> state
     ResponseReasoningSummaryPartAddedEvent
@@ -141,7 +165,7 @@ applyStreamEvent state event = case event of
                     updateReasoningSummary outputIndex
                         (fromMaybe "" streamItemId)
                         index
-                        (maybe id const partValue)
+                        (maybe KeepSummary ReplaceSummary partValue)
                         state
                 _ -> state
     ResponseReasoningSummaryTextDoneEvent
@@ -154,7 +178,7 @@ applyStreamEvent state event = case event of
                     updateReasoningSummary outputIndex
                         (fromMaybe "" streamItemId)
                         index
-                        (setObjectText finalText)
+                        (SetSummaryText finalText)
                         state
                 _ -> state
     OtherResponseStreamEvent
@@ -174,7 +198,7 @@ applyStreamEvent state event = case event of
                                 (fromMaybe ""
                                     (textField "item_id" eventExtraFields))
                                 summaryIndex
-                                (appendObjectText delta)
+                                (AppendSummaryText delta)
                                 state
                         Nothing -> state
                 _ -> state
@@ -381,19 +405,117 @@ updateItem
     -> StreamAssemblyState
     -> StreamAssemblyState
 updateItem outputIndex done newValue state =
-    state
-        { outputItems =
-            IntMap.alter
-                (Just . mergeProgress)
-                outputIndex
-                state.outputItems
-        }
+    alterProgress outputIndex (Just . mergeProgress) state
   where
-    mergeProgress Nothing = ItemProgress newValue done
+    mergeProgress Nothing = ItemProgress newValue done emptyItemBuffers
     mergeProgress (Just old) = ItemProgress
         { itemValue = mergeObjects old.itemValue newValue
         , itemDone = old.itemDone || done
+        , itemBuffers = clearOverlaidBuffers newValue old.itemBuffers
         }
+
+alterProgress
+    :: Int
+    -> (Maybe ItemProgress -> Maybe ItemProgress)
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+alterProgress outputIndex update state =
+    let oldProgress = IntMap.lookup outputIndex state.outputItems
+        newProgress = update oldProgress
+        newItems = IntMap.alter (const newProgress) outputIndex state.outputItems
+        withNew = updateProgressIndexes
+            outputIndex oldProgress newProgress state
+    in withNew { outputItems = newItems }
+
+-- Content deltas do not change an existing object's identity, type, or done
+-- status. Avoid rebuilding those secondary indexes on the hot path; creation
+-- and recovery from a non-object value still go through the checked updater.
+alterItemContent
+    :: Int
+    -> (Maybe ItemProgress -> ItemProgress)
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+alterItemContent outputIndex update state =
+    case IntMap.lookup outputIndex state.outputItems of
+        Just old@ItemProgress { itemValue = Aeson.Object{} } ->
+            state
+                { outputItems =
+                    IntMap.insert outputIndex (update (Just old)) state.outputItems
+                }
+        _ ->
+            alterProgress outputIndex (Just . update) state
+
+updateProgressIndexes
+    :: Int
+    -> Maybe ItemProgress
+    -> Maybe ItemProgress
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+updateProgressIndexes outputIndex oldProgress newProgress state =
+    state
+        { identityIndexes =
+            foldl'
+                (\indexes identity -> addIndex identity outputIndex indexes)
+                (foldl'
+                    (\indexes identity ->
+                        removeIndex identity outputIndex indexes)
+                    state.identityIndexes
+                    removedIdentities)
+                addedIdentities
+        , pendingTypeIndexes =
+            maybe id
+                (\itemType -> addIndex itemType outputIndex)
+                newPending
+            $ maybe id
+                (\itemType -> removeIndex itemType outputIndex)
+                oldPending
+            $ state.pendingTypeIndexes
+        }
+  where
+    oldIdentities = maybe [] (itemIdentities . (.itemValue)) oldProgress
+    newIdentities = maybe [] (itemIdentities . (.itemValue)) newProgress
+    removedIdentities =
+        [identity | identity <- oldIdentities, identity `notElem` newIdentities]
+    addedIdentities =
+        [identity | identity <- newIdentities, identity `notElem` oldIdentities]
+    oldPendingCandidate = pendingType =<< oldProgress
+    newPendingCandidate = pendingType =<< newProgress
+    (oldPending, newPending)
+        | oldPendingCandidate == newPendingCandidate = (Nothing, Nothing)
+        | otherwise = (oldPendingCandidate, newPendingCandidate)
+    pendingType progress
+        | progress.itemDone = Nothing
+        | otherwise = objectTextField "type" progress.itemValue
+
+addIndex :: Ord key => key -> Int -> Map key IntSet -> Map key IntSet
+addIndex key outputIndex =
+    Map.insertWith IntSet.union key (IntSet.singleton outputIndex)
+
+removeIndex :: Ord key => key -> Int -> Map key IntSet -> Map key IntSet
+removeIndex key outputIndex =
+    Map.update
+        (\indexes ->
+            let remaining = IntSet.delete outputIndex indexes
+            in if IntSet.null remaining then Nothing else Just remaining)
+        key
+
+clearOverlaidBuffers :: Aeson.Value -> ItemBuffers -> ItemBuffers
+clearOverlaidBuffers (Aeson.Object overlay) buffers =
+    buffers
+        { inputBuffer =
+            if KeyMap.member "input" overlay
+                then Nothing
+                else buffers.inputBuffer
+        , argumentsBuffer =
+            if KeyMap.member "arguments" overlay
+                then Nothing
+                else buffers.argumentsBuffer
+        , summaryBuffers =
+            if KeyMap.member "summary" overlay
+                then IntMap.empty
+                else buffers.summaryBuffers
+        }
+clearOverlaidBuffers _ _ = emptyItemBuffers
 
 updateStreamItem
     :: Maybe Int
@@ -427,14 +549,7 @@ resolveOutputIndex explicitIndex identities state =
 
 findIdentityIndex :: Text -> StreamAssemblyState -> Maybe Int
 findIdentityIndex wanted state =
-    fst <$> IntMap.lookupMin
-        (IntMap.filter (matchesIdentity wanted . (.itemValue)) state.outputItems)
-  where
-    matchesIdentity wanted = \case
-        Aeson.Object object ->
-            textField "id" object == Just wanted
-                || textField "call_id" object == Just wanted
-        _ -> False
+    setMinimum =<< Map.lookup wanted state.identityIndexes
 
 findItemIndex :: Aeson.Value -> StreamAssemblyState -> Maybe Int
 findItemIndex value state =
@@ -445,16 +560,12 @@ findItemIndex value state =
 
 findPendingItemIndex :: Aeson.Value -> StreamAssemblyState -> Maybe Int
 findPendingItemIndex value state =
-    case wantedType of
-        Nothing -> Nothing
-        Just _ ->
-            fst <$> IntMap.lookupMin
-                (IntMap.filter matchesPending state.outputItems)
-  where
-    wantedType = objectTextField "type" value
-    matchesPending progress =
-        not progress.itemDone
-            && objectTextField "type" progress.itemValue == wantedType
+    objectTextField "type" value
+        >>= (\wantedType ->
+            setMinimum =<< Map.lookup wantedType state.pendingTypeIndexes)
+
+setMinimum :: IntSet -> Maybe Int
+setMinimum indexes = fst <$> IntSet.minView indexes
 
 nextOutputIndex :: StreamAssemblyState -> Int
 nextOutputIndex state =
@@ -480,21 +591,19 @@ nonEmpty :: Maybe Text -> Maybe Text
 nonEmpty value = value >>= \text ->
     if Text.null text then Nothing else Just text
 
+data InputUpdate
+    = AppendInput !Text
+    | SetInput !Text
+
 updateCustomToolInput
     :: Int
     -> Maybe Text
     -> Maybe Text
-    -> (Aeson.Object -> Aeson.Object)
+    -> InputUpdate
     -> StreamAssemblyState
     -> StreamAssemblyState
 updateCustomToolInput outputIndex itemId callId updateInput state =
-    state
-        { outputItems =
-            IntMap.alter
-                (Just . updateProgress)
-                outputIndex
-                state.outputItems
-        }
+    alterItemContent outputIndex updateProgress state
   where
     baseObject =
         maybe id
@@ -508,29 +617,52 @@ updateCustomToolInput outputIndex itemId callId updateInput state =
             , ("input", Aeson.String "")
             ]
     updateProgress Nothing =
-        ItemProgress (Aeson.Object (updateInput baseObject)) False
+        applyInputUpdate updateInput
+            (ItemProgress (Aeson.Object baseObject) False emptyItemBuffers)
     updateProgress (Just progress) =
-        progress
-            { itemValue = case progress.itemValue of
-                Aeson.Object object -> Aeson.Object (updateInput object)
-                _ -> Aeson.Object (updateInput baseObject)
-            }
+        applyInputUpdate updateInput
+            progress
+                { itemValue = case progress.itemValue of
+                    Aeson.Object object -> Aeson.Object object
+                    _ -> Aeson.Object baseObject
+                }
+
+applyInputUpdate :: InputUpdate -> ItemProgress -> ItemProgress
+applyInputUpdate inputUpdate progress =
+    case inputUpdate of
+        AppendInput delta ->
+            let current = case progress.itemBuffers.inputBuffer of
+                    Just buffered -> buffered
+                    Nothing ->
+                        textBufferFromText
+                            (fromMaybe "" (objectTextField "input" progress.itemValue))
+            in progress
+                { itemBuffers = progress.itemBuffers
+                    { inputBuffer = Just (appendTextBuffer delta current) }
+                }
+        SetInput input ->
+            progress
+                { itemValue = mapObject
+                    (KeyMap.insert "input" (Aeson.String input))
+                    progress.itemValue
+                , itemBuffers = progress.itemBuffers { inputBuffer = Nothing }
+                }
+
+data SummaryUpdate
+    = KeepSummary
+    | ReplaceSummary !Aeson.Value
+    | SetSummaryText !Text
+    | AppendSummaryText !Text
 
 updateReasoningSummary
     :: Int
     -> Text
     -> Int
-    -> (Aeson.Value -> Aeson.Value)
+    -> SummaryUpdate
     -> StreamAssemblyState
     -> StreamAssemblyState
 updateReasoningSummary outputIndex itemId summaryIndex updatePart state =
-    state
-        { outputItems =
-            IntMap.alter
-                (Just . updateProgress)
-                outputIndex
-                state.outputItems
-        }
+    alterItemContent outputIndex updateProgress state
   where
     baseObject = KeyMap.fromList
         [ ("type", Aeson.String "reasoning")
@@ -538,29 +670,101 @@ updateReasoningSummary outputIndex itemId summaryIndex updatePart state =
         , ("summary", Aeson.Array Vector.empty)
         ]
     updateProgress Nothing =
-        ItemProgress (Aeson.Object (updateSummary baseObject)) False
+        applySummaryUpdate summaryIndex updatePart
+            (ItemProgress
+                (Aeson.Object (ensureSummaryIndex summaryIndex baseObject))
+                False
+                emptyItemBuffers)
     updateProgress (Just progress) =
-        progress
-            { itemValue = case progress.itemValue of
-                Aeson.Object object -> Aeson.Object (updateSummary object)
-                _ -> Aeson.Object (updateSummary baseObject)
+        applySummaryUpdate summaryIndex updatePart
+            progress
+                { itemValue = case progress.itemValue of
+                    Aeson.Object object ->
+                        Aeson.Object (ensureSummaryIndex summaryIndex object)
+                    _ ->
+                        Aeson.Object (ensureSummaryIndex summaryIndex baseObject)
+                }
+
+ensureSummaryIndex :: Int -> Aeson.Object -> Aeson.Object
+ensureSummaryIndex summaryIndex object =
+    let current = case KeyMap.lookup "summary" object of
+            Just (Aeson.Array values) -> values
+            _ -> Vector.empty
+        updated = updateVectorAt summaryIndex id current
+    in KeyMap.insert "summary" (Aeson.Array updated) object
+
+applySummaryUpdate :: Int -> SummaryUpdate -> ItemProgress -> ItemProgress
+applySummaryUpdate summaryIndex summaryUpdate progress
+    | summaryIndex < 0 = progress
+    | otherwise =
+        case summaryUpdate of
+            KeepSummary -> progress
+            ReplaceSummary value ->
+                setSummaryPart value progress
+            SetSummaryText text ->
+                setSummaryPart
+                    (setObjectText text (summaryPart summaryIndex progress.itemValue))
+                    progress
+            AppendSummaryText delta ->
+                let existingBuffer =
+                        fromMaybe
+                            (textBufferFromText
+                                (fromMaybe ""
+                                    (objectTextField "text"
+                                        (summaryPart summaryIndex progress.itemValue))))
+                            (IntMap.lookup summaryIndex
+                                progress.itemBuffers.summaryBuffers)
+                in progress
+                    { itemBuffers = progress.itemBuffers
+                        { summaryBuffers =
+                            IntMap.insert
+                                summaryIndex
+                                (appendTextBuffer delta existingBuffer)
+                                progress.itemBuffers.summaryBuffers
+                        }
+                    }
+  where
+    setSummaryPart value current =
+        current
+            { itemValue = mapObject
+                (\object ->
+                    let summary = case KeyMap.lookup "summary" object of
+                            Just (Aeson.Array values) -> values
+                            _ -> Vector.empty
+                    in KeyMap.insert "summary"
+                        (Aeson.Array
+                            (updateVectorAt summaryIndex (const value) summary))
+                        object)
+                current.itemValue
+            , itemBuffers = current.itemBuffers
+                { summaryBuffers =
+                    IntMap.delete summaryIndex current.itemBuffers.summaryBuffers
+                }
             }
-    updateSummary object =
-        let current = case KeyMap.lookup "summary" object of
-                Just (Aeson.Array values) -> values
-                _ -> Vector.empty
-            updated = updateVectorAt summaryIndex updatePart current
-        in KeyMap.insert "summary" (Aeson.Array updated) object
+
+summaryPart :: Int -> Aeson.Value -> Aeson.Value
+summaryPart summaryIndex = \case
+    Aeson.Object object ->
+        case KeyMap.lookup "summary" object of
+            Just (Aeson.Array summary)
+                | summaryIndex >= 0
+                , summaryIndex < Vector.length summary ->
+                    summary Vector.! summaryIndex
+            _ -> emptySummaryPart
+    _ -> emptySummaryPart
+  where
+    emptySummaryPart =
+        Aeson.object ["type" Aeson..= ("summary_text" :: Text)]
 
 assembledOutput :: StreamAssemblyState -> Aeson.Object -> [Aeson.Value]
 assembledOutput state response =
     map (.itemValue) . IntMap.elems $
         IntMap.unionWith combine
-            state.outputItems
+            (materializeProgress <$> state.outputItems)
             terminalItems
   where
     terminalItems = IntMap.fromList
-        [ (index, ItemProgress value True)
+        [ (index, ItemProgress value True emptyItemBuffers)
         | (index, value) <- zip [0 ..] finalItems
         ]
     finalItems = case KeyMap.lookup "output" response of
@@ -571,10 +775,48 @@ assembledOutput state response =
             ItemProgress
                 (mergeObjects terminal.itemValue streamed.itemValue)
                 True
+                emptyItemBuffers
         | otherwise =
             ItemProgress
                 (mergeObjects streamed.itemValue terminal.itemValue)
                 True
+                emptyItemBuffers
+
+materializeProgress :: ItemProgress -> ItemProgress
+materializeProgress progress =
+    progress
+        { itemValue =
+            materializeSummaries progress.itemBuffers.summaryBuffers
+                $ maybe id
+                    (setTextField "arguments" . textBufferToText)
+                    progress.itemBuffers.argumentsBuffer
+                $ maybe id
+                    (setTextField "input" . textBufferToText)
+                    progress.itemBuffers.inputBuffer
+                $ progress.itemValue
+        , itemBuffers = emptyItemBuffers
+        }
+  where
+    setTextField fieldName text =
+        mapObject (KeyMap.insert fieldName (Aeson.String text))
+
+    materializeSummaries buffers value =
+        IntMap.foldlWithKey'
+            (\value summaryIndex buffer ->
+                mapObject
+                    (\object ->
+                        let summary = case KeyMap.lookup "summary" object of
+                                Just (Aeson.Array values) -> values
+                                _ -> Vector.empty
+                        in KeyMap.insert "summary"
+                            (Aeson.Array
+                                (updateVectorAt summaryIndex
+                                    (setObjectText (textBufferToText buffer))
+                                    summary))
+                            object)
+                    value)
+            value
+            buffers
 
 -- | Does a response fragment already carry a terminal lifecycle status? Only
 -- @completed@/@incomplete@/@failed@/@cancelled@ count; a leftover
@@ -608,29 +850,18 @@ insertMissing key value object
     | KeyMap.member key object = object
     | otherwise = KeyMap.insert key value object
 
-appendInput :: Text -> Aeson.Object -> Aeson.Object
-appendInput delta object =
-    let current = fromMaybe "" (textField "input" object)
-    in KeyMap.insert "input" (Aeson.String (current <> delta)) object
-
-setInput :: Text -> Aeson.Object -> Aeson.Object
-setInput input =
-    KeyMap.insert "input" (Aeson.String input)
+data ArgumentsUpdate
+    = AppendArguments !Text
+    | SetArguments !(Maybe Text) !(Maybe Text)
 
 updateFunctionCallArguments
     :: Int
     -> Maybe Text
-    -> (Aeson.Object -> Aeson.Object)
+    -> ArgumentsUpdate
     -> StreamAssemblyState
     -> StreamAssemblyState
 updateFunctionCallArguments outputIndex itemId updateArgs state =
-    state
-        { outputItems =
-            IntMap.alter
-                (Just . updateProgress)
-                outputIndex
-                state.outputItems
-        }
+    alterItemContent outputIndex updateProgress state
   where
     baseObject =
         maybe id
@@ -641,24 +872,53 @@ updateFunctionCallArguments outputIndex itemId updateArgs state =
             , ("arguments", Aeson.String "")
             ]
     updateProgress Nothing =
-        ItemProgress (Aeson.Object (updateArgs baseObject)) False
+        applyArgumentsUpdate updateArgs
+            (ItemProgress (Aeson.Object baseObject) False emptyItemBuffers)
     updateProgress (Just progress) =
-        progress
-            { itemValue = case progress.itemValue of
-                Aeson.Object object -> Aeson.Object (updateArgs object)
-                _ -> Aeson.Object (updateArgs baseObject)
-            }
+        applyArgumentsUpdate updateArgs
+            progress
+                { itemValue = case progress.itemValue of
+                    Aeson.Object object -> Aeson.Object object
+                    _ -> Aeson.Object baseObject
+                }
 
-appendArguments :: Text -> Aeson.Object -> Aeson.Object
-appendArguments delta object =
-    let current = fromMaybe "" (textField "arguments" object)
-    in KeyMap.insert "arguments" (Aeson.String (current <> delta)) object
+applyArgumentsUpdate :: ArgumentsUpdate -> ItemProgress -> ItemProgress
+applyArgumentsUpdate argumentsUpdate progress =
+    case argumentsUpdate of
+        AppendArguments delta ->
+            let current = case progress.itemBuffers.argumentsBuffer of
+                    Just buffered -> buffered
+                    Nothing ->
+                        textBufferFromText
+                            (fromMaybe ""
+                                (objectTextField "arguments" progress.itemValue))
+            in progress
+                { itemBuffers = progress.itemBuffers
+                    { argumentsBuffer = Just (appendTextBuffer delta current) }
+                }
+        SetArguments arguments functionName ->
+            progress
+                { itemValue =
+                    mapObject
+                        (maybe id
+                            (KeyMap.insert "name" . Aeson.String)
+                            functionName
+                        . maybe id
+                            (KeyMap.insert "arguments" . Aeson.String)
+                            arguments)
+                        progress.itemValue
+                , itemBuffers = progress.itemBuffers
+                    { argumentsBuffer =
+                        case arguments of
+                            Just _ -> Nothing
+                            Nothing -> progress.itemBuffers.argumentsBuffer
+                    }
+                }
 
-setArguments :: Maybe Text -> Maybe Text -> Aeson.Object -> Aeson.Object
-setArguments arguments functionName object =
-    maybe id (KeyMap.insert "name" . Aeson.String) functionName $
-        maybe id (KeyMap.insert "arguments" . Aeson.String) arguments
-            object
+mapObject :: (Aeson.Object -> Aeson.Object) -> Aeson.Value -> Aeson.Value
+mapObject update = \case
+    Aeson.Object object -> Aeson.Object (update object)
+    value -> value
 
 setObjectText :: Text -> Aeson.Value -> Aeson.Value
 setObjectText text = \case
@@ -667,17 +927,6 @@ setObjectText text = \case
     _ -> Aeson.object
         [ "type" Aeson..= ("summary_text" :: Text)
         , "text" Aeson..= text
-        ]
-
-appendObjectText :: Text -> Aeson.Value -> Aeson.Value
-appendObjectText delta = \case
-    Aeson.Object object ->
-        let current = fromMaybe "" (textField "text" object)
-        in Aeson.Object
-            (KeyMap.insert "text" (Aeson.String (current <> delta)) object)
-    _ -> Aeson.object
-        [ "type" Aeson..= ("summary_text" :: Text)
-        , "text" Aeson..= delta
         ]
 
 updateVectorAt

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -269,6 +269,159 @@ spec = describe "buildStreamResponse" do
             other -> expectationFailure
                 ("expected one reasoning summary, got " <> show other)
 
+    it "buffers interleaved argument and sparse summary deltas in wire order" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-interleaved\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc-a\",\"call_id\":\"call-a\",\"name\":\"a\",\"arguments\":\"\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc-b\",\"call_id\":\"call-b\",\"name\":\"b\",\"arguments\":\"\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":2,\"item\":{\"type\":\"reasoning\",\"id\":\"rs-sparse\",\"summary\":[]}}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc-a\",\"delta\":\"a1\"}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc-b\",\"delta\":\"b1\"}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc-a\",\"delta\":\"a2\"}"
+            , sseBlock "response.reasoning_summary_text.delta"
+                "{\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs-sparse\",\"summary_index\":2,\"delta\":\"third \"}"
+            , sseBlock "response.reasoning_summary_text.delta"
+                "{\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs-sparse\",\"summary_index\":2,\"delta\":\"part\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-interleaved\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        [arguments | FunctionCallItem FunctionCall { arguments } <- response.output]
+            `shouldBe` ["a1a2", "b1"]
+        case [summary | ReasoningItemValue ReasoningItem { summary }
+                <- response.output] of
+            [[_, _, ReasoningSummaryPart { text = Just partText }]] ->
+                partText `shouldBe` "third part"
+            other -> expectationFailure
+                ("expected a sparse third summary part, got " <> show other)
+
+    it "lets authoritative done values replace buffered deltas" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-replace\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"custom_tool_call\",\"id\":\"ct-replace\",\"call_id\":\"call-replace\",\"name\":\"apply_patch\",\"input\":\"\"}}"
+            , sseBlock "response.custom_tool_call_input.delta"
+                "{\"type\":\"response.custom_tool_call_input.delta\",\"item_id\":\"ct-replace\",\"delta\":\"stale\"}"
+            , sseBlock "response.custom_tool_call_input.done"
+                "{\"type\":\"response.custom_tool_call_input.done\",\"item_id\":\"ct-replace\",\"input\":\"authoritative\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-replace\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        [input | CustomToolCallItem CustomToolCall { input } <- response.output]
+            `shouldBe` ["authoritative"]
+
+    it "appends deltas after authoritative done values from that value" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-after-done\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"custom_tool_call\",\"id\":\"ct-after\",\"call_id\":\"ct-call\",\"name\":\"custom\",\"input\":\"\"}}"
+            , sseBlock "response.custom_tool_call_input.delta"
+                "{\"type\":\"response.custom_tool_call_input.delta\",\"item_id\":\"ct-after\",\"delta\":\"discarded\"}"
+            , sseBlock "response.custom_tool_call_input.done"
+                "{\"type\":\"response.custom_tool_call_input.done\",\"item_id\":\"ct-after\",\"input\":\"custom-final\"}"
+            , sseBlock "response.custom_tool_call_input.delta"
+                "{\"type\":\"response.custom_tool_call_input.delta\",\"item_id\":\"ct-after\",\"delta\":\"+tail\"}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fn-after\",\"call_id\":\"fn-call\",\"name\":\"function\",\"arguments\":\"\"}}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fn-after\",\"delta\":\"discarded\"}"
+            , sseBlock "response.function_call_arguments.done"
+                "{\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fn-after\",\"arguments\":\"function-final\"}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fn-after\",\"delta\":\"+tail\"}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":2,\"item\":{\"type\":\"reasoning\",\"id\":\"rs-after\",\"summary\":[]}}"
+            , sseBlock "response.reasoning_summary_text.delta"
+                "{\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs-after\",\"summary_index\":0,\"delta\":\"discarded\"}"
+            , sseBlock "response.reasoning_summary_text.done"
+                "{\"type\":\"response.reasoning_summary_text.done\",\"item_id\":\"rs-after\",\"summary_index\":0,\"text\":\"reasoning-final\"}"
+            , sseBlock "response.reasoning_summary_text.delta"
+                "{\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs-after\",\"summary_index\":0,\"delta\":\"+tail\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-after-done\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        [input | CustomToolCallItem CustomToolCall { input } <- response.output]
+            `shouldBe` ["custom-final+tail"]
+        [arguments | FunctionCallItem FunctionCall { arguments } <- response.output]
+            `shouldBe` ["function-final+tail"]
+        [partText
+            | ReasoningItemValue ReasoningItem { summary } <- response.output
+            , ReasoningSummaryPart { text = Just partText } <- summary
+            ] `shouldBe` ["reasoning-final+tail"]
+
+    it "lets terminal output overlay buffered streamed deltas" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-terminal-overlay\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fn-overlay\",\"call_id\":\"fn-overlay-call\",\"name\":\"streamed-name\",\"arguments\":\"\"}}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fn-overlay\",\"delta\":\"buffered-value\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-terminal-overlay\",\"output\":[{\"type\":\"function_call\",\"id\":\"fn-overlay\",\"call_id\":\"fn-overlay-call\",\"name\":\"terminal-name\",\"arguments\":\"terminal-value\"}]}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        [(name, arguments)
+            | FunctionCallItem FunctionCall { name, arguments } <- response.output
+            ] `shouldBe` [("terminal-name", "terminal-value")]
+
+    it "retains the lowest duplicate identity and updates changed indexes" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-duplicates\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"duplicate\",\"call_id\":\"call-0\",\"name\":\"first\",\"arguments\":\"\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"duplicate\",\"call_id\":\"call-1\",\"name\":\"second\",\"arguments\":\"\"}}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"duplicate\",\"delta\":\"lowest\"}"
+            , sseBlock "response.output_item.done"
+                "{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"changed\",\"call_id\":\"call-0\",\"name\":\"first\",\"arguments\":\"first-final\"}}"
+            , sseBlock "response.function_call_arguments.delta"
+                "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"duplicate\",\"delta\":\"remaining\"}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-duplicates\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        [arguments | FunctionCallItem FunctionCall { arguments } <- response.output]
+            `shouldBe` ["first-final", "remaining"]
+
+    it "removes changed pending types from their old type index" do
+        events <- expectRight $ parseSseEvents $ Text.intercalate ""
+            [ sseBlock "response.created"
+                "{\"type\":\"response.created\",\"response\":{\"id\":\"resp-types\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"custom_tool_call\",\"id\":\"old-custom\",\"call_id\":\"old-call\",\"name\":\"old\",\"input\":\"\"}}"
+            , sseBlock "response.output_item.added"
+                "{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"function\",\"call_id\":\"function-call\",\"name\":\"function\",\"arguments\":\"{}\"}}"
+            , sseBlock "response.output_item.done"
+                "{\"type\":\"response.output_item.done\",\"item\":{\"type\":\"custom_tool_call\",\"id\":\"new-custom\",\"call_id\":\"new-call\",\"name\":\"new\",\"input\":\"payload\"}}"
+            , sseBlock "response.completed"
+                "{\"type\":\"response.completed\",\"response\":{\"id\":\"resp-types\"}}"
+            ]
+        response <- expectRight
+            (buildStreamResponseWithModel config (Just "request-model") events)
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["function"]
+        [name | CustomToolCallItem CustomToolCall { name } <- response.output]
+            `shouldBe` ["new"]
+
     it "uses provider classifiers when no terminal response is present" do
         streamEvents <- expectRight $ parseSseEvents $ sseBlock "error"
             "{\"type\":\"error\",\"error\":{\"message\":\"stream broke\"}}"


### PR DESCRIPTION
## Summary
- buffer streamed custom input, function arguments, and reasoning summaries with `TextBuffer`
- maintain identity and pending-type `Map Text IntSet` indexes while preserving lowest-output-index semantics
- add authoritative-overlay/duplicate-index tests and an optimized production assembly benchmark

Independent from common base `07720c89`.

## Validation
- `agent-responses` tests: **63 examples, 0 failures** (including QuickCheck suites)
- production benchmark inputs are deep-forced before timing; base/head output checksums match

## Benchmark (`-O2`, 7-sample medians, `+RTS -T`)
Production mixed, 10k deltas / 100 items:

| | wall | CPU | allocated |
|---|---:|---:|---:|
| base | 49.434 ms | 49.341 ms | 71.73 MB |
| head | 3.860 ms | 3.868 ms | 12.57 MB |

Repeat: 51.035 ms → 3.968 ms with identical checksum.

Rebased onto current master; upstream incomplete-response recovery and live streamed tool-argument visibility are retained and covered by the 63-example suite.
