### PR TITLE
perf(core): index tool scheduling conflicts

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -200,6 +200,7 @@ test-suite agent-core-test
                     , Agent.Tools.MultiAgentsSpec
                     , Agent.Tools.PlanModeSpec
                     , Agent.Tools.SecretSpec
+                    , Agent.Tools.SchedulingSpec
                     , Agent.ToolDSLSpec
                     , Agent.Transport.WebSocketSpec
     build-depends:    base >= 4.14 && < 5

--- a/packages/agent-core/benchmark/ToolScheduling.hs
+++ b/packages/agent-core/benchmark/ToolScheduling.hs
@@ -20,6 +20,9 @@ import Agent.Tools.Scheduling
     ( ToolAccess(..)
     , ToolResource(..)
     , ToolResourceClaim(..)
+    , ToolSchedulingPlan(..)
+    , toolSchedulingWaves
+    , toolSchedulingWavesLegacy
     )
 import Agent.Tools.Types
     ( AppTool
@@ -60,6 +63,14 @@ data Workload
     | NewDisjointPaths
     | NewConflicting
     | ExistingParallel
+    | LegacyDisjoint
+    | IndexedDisjoint
+    | LegacyConflicting
+    | IndexedConflicting
+    | LegacyPath
+    | IndexedPath
+    | LegacyMixed
+    | IndexedMixed
     deriving (Eq, Show)
 
 data Sample = Sample
@@ -80,8 +91,21 @@ main = do
             callCount <- parsePositive "call count" callCountArg
             delayMicros <- parseNonNegative "delay microseconds" delayArg
             sampleCount <- parsePositive "sample count" sampleCountArg
-            samples <- forM [1 .. sampleCount] \_ ->
-                measure (runWorkload workload callCount delayMicros)
+            let preparedSamples =
+                    [ schedulingBenchmark workload callCount sampleSeed
+                    | sampleSeed <- [1 .. sampleCount]
+                    ]
+            validateSchedulingBenchmark preparedSamples
+            samples <- forM
+                (zip [1 :: Int ..] preparedSamples)
+                \(sampleSeed, prepared) ->
+                measure
+                    (runWorkload
+                        workload
+                        callCount
+                        delayMicros
+                        sampleSeed
+                        prepared)
             let result = median samples
             printf
                 "%s,%d,%d,%.3f,%.3f,%d\n"
@@ -96,6 +120,9 @@ main = do
                 "usage: tool-scheduling-bench WORKLOAD CALLS DELAY_US SAMPLES\n"
                     <> "workloads: old-sequential, new-disjoint, "
                     <> "new-disjoint-paths, new-conflicting, existing-parallel"
+                    <> ", legacy-disjoint, indexed-disjoint, "
+                    <> "legacy-conflicting, indexed-conflicting, "
+                    <> "legacy-path, indexed-path, legacy-mixed, indexed-mixed"
 
 parseWorkload :: String -> IO Workload
 parseWorkload = \case
@@ -104,6 +131,14 @@ parseWorkload = \case
     "new-disjoint-paths" -> pure NewDisjointPaths
     "new-conflicting" -> pure NewConflicting
     "existing-parallel" -> pure ExistingParallel
+    "legacy-disjoint" -> pure LegacyDisjoint
+    "indexed-disjoint" -> pure IndexedDisjoint
+    "legacy-conflicting" -> pure LegacyConflicting
+    "indexed-conflicting" -> pure IndexedConflicting
+    "legacy-path" -> pure LegacyPath
+    "indexed-path" -> pure IndexedPath
+    "legacy-mixed" -> pure LegacyMixed
+    "indexed-mixed" -> pure IndexedMixed
     other -> die ("unknown workload: " <> other)
 
 parsePositive :: String -> String -> IO Int
@@ -120,8 +155,19 @@ parseNonNegative label raw =
             | value >= 0 -> pure value
         _ -> die ("invalid " <> label <> ": " <> raw)
 
-runWorkload :: Workload -> Int -> Int -> IO Int
-runWorkload workload callCount delayMicros = do
+runWorkload
+    :: Workload
+    -> Int
+    -> Int
+    -> Int
+    -> Maybe (Scheduler, SchedulingInput)
+    -> IO Int
+runWorkload workload callCount delayMicros sampleSeed prepared
+    | Just (implementation, input) <- prepared =
+        pure
+            (waveChecksum (implementation input)
+                + sampleSeed)
+    | otherwise = do
     turnIndex <- newIORef (0 :: Int)
     state <- newIORef []
     cancel <- newCancelFlag
@@ -169,6 +215,112 @@ runWorkload workload callCount delayMicros = do
     pure $ case result of
         Right LoopResult { turnsUsed } -> turnsUsed + callCount
         Left err -> error (show err)
+
+type Scheduler =
+    [(Int, ToolSchedulingPlan)] -> [[Int]]
+
+type SchedulingInput = [(Int, ToolSchedulingPlan)]
+
+schedulingBenchmark
+    :: Workload
+    -> Int
+    -> Int
+    -> Maybe (Scheduler, SchedulingInput)
+schedulingBenchmark workload count sampleSeed =
+    case workload of
+        LegacyDisjoint -> benchmark toolSchedulingWavesLegacy disjointPlans
+        IndexedDisjoint -> benchmark toolSchedulingWaves disjointPlans
+        LegacyConflicting -> benchmark toolSchedulingWavesLegacy conflictingPlans
+        IndexedConflicting -> benchmark toolSchedulingWaves conflictingPlans
+        LegacyPath -> benchmark toolSchedulingWavesLegacy pathPlans
+        IndexedPath -> benchmark toolSchedulingWaves pathPlans
+        LegacyMixed -> benchmark toolSchedulingWavesLegacy mixedPlans
+        IndexedMixed -> benchmark toolSchedulingWaves mixedPlans
+        _ -> Nothing
+  where
+    benchmark implementation plans =
+        Just
+            ( implementation
+            , zip [0 :: Int ..] (take count plans)
+            )
+    suffix = "-sample-" <> Text.pack (show sampleSeed)
+    disjointPlans =
+        [ ToolResourceClaims
+            [namedClaim ToolWrite ("resource-" <> number <> suffix)]
+        | index <- [1 :: Int ..]
+        , let number = Text.pack (show index)
+        ]
+    conflictingPlans =
+        repeat
+            (ToolResourceClaims
+                [namedClaim ToolWrite ("shared" <> suffix)])
+    pathPlans =
+        [ ToolResourceClaims
+            [ ToolResourceClaim ToolWrite
+                (ToolPath (unsafeEncodeUtf
+                    ("/workspace-" <> show sampleSeed
+                        <> "/file-" <> show index)))
+            ]
+        | index <- [1 :: Int ..]
+        ]
+    mixedPlans =
+        [ mixedPlan index
+        | index <- [1 :: Int ..]
+        ]
+    mixedPlan index =
+        case index `mod` 11 of
+            0 -> ToolExclusive
+            1 -> ToolUnconstrained
+            2 -> ToolResourceClaims
+                [ToolResourceClaim ToolRead ToolAllPaths]
+            3 -> ToolResourceClaims
+                [ToolResourceClaim ToolWrite
+                    (ToolPathTree
+                        (unsafeEncodeUtf
+                            ("/workspace-" <> show sampleSeed <> "/src")))]
+            4 -> ToolResourceClaims
+                [ToolResourceClaim ToolRead
+                    (ToolPath (unsafeEncodeUtf
+                        ("/workspace-" <> show sampleSeed
+                            <> "/src/File-" <> show (index `mod` 17))))]
+            _ -> ToolResourceClaims
+                [namedClaim
+                    (if even index then ToolRead else ToolWrite)
+                    ("resource-" <> Text.pack (show (index `mod` 23))
+                        <> suffix)]
+
+validateSchedulingBenchmark
+    :: [Maybe (Scheduler, SchedulingInput)]
+    -> IO ()
+validateSchedulingBenchmark =
+    mapM_ validate
+  where
+    validate Nothing = pure ()
+    validate (Just (_, input)) =
+        let legacy = toolSchedulingWavesLegacy input
+            indexed = toolSchedulingWaves input
+        in if legacy == indexed
+            then evaluate (waveChecksum legacy) >> pure ()
+            else die "legacy and indexed scheduling differ"
+
+namedClaim :: ToolAccess -> Text -> ToolResourceClaim
+namedClaim access =
+    ToolResourceClaim access . ToolNamedResource
+
+waveChecksum :: [[Int]] -> Int
+waveChecksum =
+    foldl'
+        (\checksum (wave, values) ->
+            foldl'
+                (\acc (position, value) ->
+                    acc * 16777619
+                        + wave * 65537
+                        + position * 257
+                        + value)
+                (checksum * 31 + wave)
+                (zip [1 :: Int ..] values))
+        2166136261
+        . zip [1 :: Int ..]
 
 benchmarkTool :: Workload -> Int -> Int -> Text -> AppTool
 benchmarkTool workload delayMicros index name =

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -54,7 +54,7 @@ import Agent.ToolDispatch
     )
 import Agent.Tools.Scheduling
     ( ToolSchedulingPlan(..)
-    , schedulingPlansConflict
+    , toolSchedulingWaves
     )
 import Agent.Tools.Types
     ( ToolRegistry
@@ -106,7 +106,6 @@ import qualified Data.ByteString as ByteString
 import Data.IORef (newIORef, readIORef, writeIORef)
 import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
-import qualified Data.IntSet as IntSet
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -841,7 +840,10 @@ runToolCalls :: LoopConfig -> [ToolCall] -> IO [ToolCallResult]
 runToolCalls config calls = do
     prepared <- prepareIndexedToolCalls config (zip [0..] calls)
     scheduled <- traverse schedule prepared
-    go scheduled IntMap.empty
+    go
+        (toolSchedulingWaves
+            [(call, call.plan) | call <- scheduled])
+        IntMap.empty
   where
     schedule
         :: IndexedPreparedToolCall
@@ -855,19 +857,12 @@ runToolCalls config calls = do
             }
 
     go
-        :: [PreparedScheduledToolCall]
+        :: [[PreparedScheduledToolCall]]
         -> IntMap ToolCallResult
         -> IO [ToolCallResult]
     go [] completed =
         pure (IntMap.elems completed)
-    go remaining completed = do
-        let ready = readyCalls remaining
-            readyIndexes = IntSet.fromList (map (.index) ready)
-            pending =
-                filter
-                    (\scheduled ->
-                        IntSet.notMember scheduled.index readyIndexes)
-                    remaining
+    go (ready : pending) completed = do
         batchResults <-
             mapConcurrently
                 (\scheduled -> do
@@ -899,18 +894,6 @@ data PreparedScheduledToolCall = PreparedScheduledToolCall
     , plan :: !ToolSchedulingPlan
     , prepared :: !PreparedToolCall
     }
-
-readyCalls :: [PreparedScheduledToolCall] -> [PreparedScheduledToolCall]
-readyCalls calls =
-    [ call
-    | call <- calls
-    , not
-        (any
-            (\earlier ->
-                earlier.index < call.index
-                    && schedulingPlansConflict earlier.plan call.plan)
-            calls)
-    ]
 
 prepareIndexedToolCalls
     :: LoopConfig

--- a/packages/agent-core/src/Agent/Tools/Scheduling.hs
+++ b/packages/agent-core/src/Agent/Tools/Scheduling.hs
@@ -4,14 +4,23 @@ module Agent.Tools.Scheduling
     , ToolResourceClaim(..)
     , ToolSchedulingPlan(..)
     , schedulingPlansConflict
+    , pathUsesSchedulingTrie
+    , toolSchedulingWaves
+    , toolSchedulingWavesLegacy
     ) where
 
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.IntSet as IntSet
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
+import System.Info (os)
 import System.OsPath
     ( OsPath
     , equalFilePath
     , isAbsolute
     , makeRelative
+    , normalise
     , splitDirectories
     , unsafeEncodeUtf
     )
@@ -86,3 +95,298 @@ pathInside root path
             && case splitDirectories relative of
                 first : _ -> first /= unsafeEncodeUtf ".."
                 [] -> True
+
+-- | Partition model-ordered calls into the same execution waves as repeatedly
+-- selecting calls with no earlier conflicting call. The result preserves
+-- model order within every wave.
+toolSchedulingWaves :: [(a, ToolSchedulingPlan)] -> [[a]]
+toolSchedulingWaves calls =
+    map reverse . IntMap.elems . snd $
+        foldl' scheduleCall (emptySchedulingIndex, IntMap.empty) calls
+  where
+    scheduleCall (index, waves) (value, plan) =
+        let wave = conflictWave index plan
+            index' = recordPlan (wave + 1) plan index
+        in (index', IntMap.insertWith (++) wave [value] waves)
+
+-- | Quadratic reference implementation used to check and benchmark the
+-- indexed scheduler.
+toolSchedulingWavesLegacy :: [(a, ToolSchedulingPlan)] -> [[a]]
+toolSchedulingWavesLegacy calls =
+    go (zip [0 :: Int ..] calls)
+  where
+    go [] = []
+    go remaining =
+        let ready =
+                [ (index, value)
+                | (index, value@(_, plan)) <- remaining
+                , not (any (earlierConflicts index plan) remaining)
+                ]
+            readyIndexes = IntSet.fromList (map fst ready)
+            pending =
+                filter
+                    (\(index, _) -> IntSet.notMember index readyIndexes)
+                    remaining
+        in map (fst . snd) ready : go pending
+
+    earlierConflicts index plan (earlierIndex, (_, earlierPlan)) =
+        earlierIndex < index
+            && schedulingPlansConflict earlierPlan plan
+
+-- Stored wave numbers are one-based, so zero is also the empty frontier.
+data AccessFrontier = AccessFrontier
+    { latestRead :: !Int
+    , latestWrite :: !Int
+    }
+
+data PathTrie = PathTrie
+    { pathSubtree :: !AccessFrontier
+    , pathExact :: !AccessFrontier
+    , pathTree :: !AccessFrontier
+    , pathChildren :: !(Map OsPath PathTrie)
+    }
+
+data SchedulingIndex = SchedulingIndex
+    { latestCall :: !Int
+    , latestExclusive :: !Int
+    , namedResources :: !(Map Text AccessFrontier)
+    , allPathResources :: !AccessFrontier
+    , allPathsClaims :: !AccessFrontier
+    , pathResources :: !PathTrie
+    , nonCanonicalPaths :: ![RecordedPathClaim]
+    , recordedPaths :: ![RecordedPathClaim]
+    }
+
+data RecordedPathClaim = RecordedPathClaim
+    { recordedWave :: !Int
+    , recordedClaim :: !ToolResourceClaim
+    }
+
+emptyFrontier :: AccessFrontier
+emptyFrontier = AccessFrontier 0 0
+
+emptyPathTrie :: PathTrie
+emptyPathTrie = PathTrie emptyFrontier emptyFrontier emptyFrontier Map.empty
+
+emptySchedulingIndex :: SchedulingIndex
+emptySchedulingIndex =
+    SchedulingIndex
+        { latestCall = 0
+        , latestExclusive = 0
+        , namedResources = Map.empty
+        , allPathResources = emptyFrontier
+        , allPathsClaims = emptyFrontier
+        , pathResources = emptyPathTrie
+        , nonCanonicalPaths = []
+        , recordedPaths = []
+        }
+
+conflictWave :: SchedulingIndex -> ToolSchedulingPlan -> Int
+conflictWave index = \case
+    ToolExclusive -> index.latestCall
+    ToolUnconstrained -> index.latestExclusive
+    ToolResourceClaims claims ->
+        foldl'
+            (\wave claim -> max wave (claimConflict index claim))
+            index.latestExclusive
+            claims
+
+claimConflict :: SchedulingIndex -> ToolResourceClaim -> Int
+claimConflict index (ToolResourceClaim access resource) =
+    case resource of
+        ToolNamedResource name ->
+            frontierConflict access $
+                Map.findWithDefault emptyFrontier name index.namedResources
+        ToolAllPaths ->
+            frontierConflict access index.allPathResources
+        ToolPath path ->
+            max
+                (frontierConflict access index.allPathsClaims)
+                (pathResourceConflict index access False path)
+        ToolPathTree path ->
+            max
+                (frontierConflict access index.allPathsClaims)
+                (pathResourceConflict index access True path)
+
+recordPlan :: Int -> ToolSchedulingPlan -> SchedulingIndex -> SchedulingIndex
+recordPlan wave plan index =
+    case plan of
+        ToolUnconstrained ->
+            index { latestCall = max wave index.latestCall }
+        ToolExclusive ->
+            index
+                { latestCall = max wave index.latestCall
+                , latestExclusive = max wave index.latestExclusive
+                }
+        ToolResourceClaims claims ->
+            foldl'
+                (flip (recordClaim wave))
+                index { latestCall = max wave index.latestCall }
+                claims
+
+recordClaim :: Int -> ToolResourceClaim -> SchedulingIndex -> SchedulingIndex
+recordClaim wave (ToolResourceClaim access resource) index =
+    case resource of
+        ToolNamedResource name ->
+            index
+                { namedResources =
+                    Map.alter
+                        (Just . recordAccess wave access
+                            . maybe emptyFrontier id)
+                        name
+                        index.namedResources
+                }
+        ToolAllPaths ->
+            index
+                { allPathResources =
+                    recordAccess wave access index.allPathResources
+                , allPathsClaims =
+                    recordAccess wave access index.allPathsClaims
+                }
+        ToolPath path ->
+            recordPathClaim wave access (ToolPath path) index
+                { allPathResources =
+                    recordAccess wave access index.allPathResources
+                }
+        ToolPathTree path ->
+            recordPathClaim wave access (ToolPathTree path) index
+                { allPathResources =
+                    recordAccess wave access index.allPathResources
+                }
+
+frontierConflict :: ToolAccess -> AccessFrontier -> Int
+frontierConflict ToolRead frontier = frontier.latestWrite
+frontierConflict ToolWrite frontier =
+    max frontier.latestRead frontier.latestWrite
+
+recordAccess :: Int -> ToolAccess -> AccessFrontier -> AccessFrontier
+recordAccess wave ToolRead frontier =
+    frontier { latestRead = max wave frontier.latestRead }
+recordAccess wave ToolWrite frontier =
+    frontier { latestWrite = max wave frontier.latestWrite }
+
+pathResourceConflict
+    :: SchedulingIndex
+    -> ToolAccess
+    -> Bool
+    -> OsPath
+    -> Int
+pathResourceConflict index access queryTree path
+    | canonicalPath path =
+        max
+            (pathConflict access queryTree
+                (splitDirectories path)
+                index.pathResources)
+            (recordedConflict
+                (ToolResourceClaim access
+                    (if queryTree then ToolPathTree path else ToolPath path))
+                index.nonCanonicalPaths)
+    | otherwise =
+        recordedConflict
+            (ToolResourceClaim access
+                (if queryTree then ToolPathTree path else ToolPath path))
+            index.recordedPaths
+
+recordedConflict :: ToolResourceClaim -> [RecordedPathClaim] -> Int
+recordedConflict claim =
+    foldl'
+        (\latest recorded ->
+            if schedulingPlansConflict
+                    (ToolResourceClaims [recorded.recordedClaim])
+                    (ToolResourceClaims [claim])
+                then max latest recorded.recordedWave
+                else latest)
+        0
+
+recordPathClaim
+    :: Int
+    -> ToolAccess
+    -> ToolResource
+    -> SchedulingIndex
+    -> SchedulingIndex
+recordPathClaim wave access resource index =
+    let claim = ToolResourceClaim access resource
+        recorded = RecordedPathClaim wave claim
+        path = case resource of
+            ToolPath value -> value
+            ToolPathTree value -> value
+            _ -> error "recordPathClaim: non-path resource"
+        isTree = case resource of
+            ToolPathTree{} -> True
+            _ -> False
+    in index
+        { pathResources =
+            if canonicalPath path
+                then recordPath wave access isTree
+                    (splitDirectories path)
+                    index.pathResources
+                else index.pathResources
+        , nonCanonicalPaths =
+            if canonicalPath path
+                then index.nonCanonicalPaths
+                else recorded : index.nonCanonicalPaths
+        , recordedPaths = recorded : index.recordedPaths
+        }
+
+-- The trie uses 'Map OsPath', whose component ordering is case-sensitive.
+-- Windows 'equalFilePath' is case-insensitive, so Windows paths must use the
+-- exact conflict predicate retained in 'recordedPaths' instead.
+pathUsesSchedulingTrie :: OsPath -> Bool
+pathUsesSchedulingTrie path =
+    os /= "mingw32"
+        && isAbsolute path
+        && normalise path == path
+
+canonicalPath :: OsPath -> Bool
+canonicalPath = pathUsesSchedulingTrie
+
+pathConflict :: ToolAccess -> Bool -> [OsPath] -> PathTrie -> Int
+pathConflict access queryTree = go 0
+  where
+    go :: Int -> [OsPath] -> PathTrie -> Int
+    go ancestorTrees [] node =
+        maximum
+            [ ancestorTrees
+            , frontierConflict access node.pathTree
+            , if queryTree
+                then frontierConflict access node.pathSubtree
+                else frontierConflict access node.pathExact
+            ]
+    go ancestorTrees (component : rest) node =
+        let ancestorTrees' =
+                max ancestorTrees (frontierConflict access node.pathTree)
+        in case Map.lookup component node.pathChildren of
+            Nothing -> ancestorTrees'
+            Just child -> go ancestorTrees' rest child
+
+recordPath
+    :: Int
+    -> ToolAccess
+    -> Bool
+    -> [OsPath]
+    -> PathTrie
+    -> PathTrie
+recordPath wave access isTree = go
+  where
+    go :: [OsPath] -> PathTrie -> PathTrie
+    go [] node =
+        node
+            { pathSubtree = recordAccess wave access node.pathSubtree
+            , pathExact =
+                if isTree
+                    then node.pathExact
+                    else recordAccess wave access node.pathExact
+            , pathTree =
+                if isTree
+                    then recordAccess wave access node.pathTree
+                    else node.pathTree
+            }
+    go (component : rest) node =
+        node
+            { pathSubtree = recordAccess wave access node.pathSubtree
+            , pathChildren =
+                Map.alter
+                    (Just . go rest . maybe emptyPathTrie id)
+                    component
+                    node.pathChildren
+            }

--- a/packages/agent-core/test/Agent/Tools/SchedulingSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/SchedulingSpec.hs
@@ -1,0 +1,157 @@
+module Agent.Tools.SchedulingSpec (spec) where
+
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    , ToolSchedulingPlan(..)
+    , pathUsesSchedulingTrie
+    , toolSchedulingWaves
+    , toolSchedulingWavesLegacy
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Info (os)
+import System.OsPath (unsafeEncodeUtf)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Gen
+    , chooseInt
+    , counterexample
+    , elements
+    , forAll
+    , listOf
+    , vectorOf
+    )
+
+spec :: Spec
+spec = describe "toolSchedulingWaves" do
+    modifyMaxSuccess (const 200) $
+        prop "matches the legacy wave partition for generated plans" $
+            forAll schedulingPlans \plans ->
+                let indexed = toolSchedulingWaves (zip [0 :: Int ..] plans)
+                    legacy = toolSchedulingWavesLegacy (zip [0 :: Int ..] plans)
+                in counterexample
+                    ("indexed: " <> show indexed <> "\nlegacy: " <> show legacy)
+                    (indexed == legacy)
+
+    it "handles all plan and resource categories in one schedule" do
+        let plans =
+                [ ToolUnconstrained
+                , claims [named ToolRead "cache"]
+                , claims [named ToolWrite "cache"]
+                , claims [path ToolRead "/workspace/src/A.hs"]
+                , claims [tree ToolWrite "/workspace/src"]
+                , claims [ToolResourceClaim ToolRead ToolAllPaths]
+                , ToolExclusive
+                , ToolUnconstrained
+                ]
+            input = zip [0 :: Int ..] plans
+        toolSchedulingWaves input
+            `shouldBe` toolSchedulingWavesLegacy input
+
+    it "disables case-sensitive path trie keys on Windows" do
+        let normalizedAbsolute =
+                unsafeEncodeUtf $
+                    if os == "mingw32"
+                        then "C:\\workspace\\src"
+                        else "/workspace/src"
+        pathUsesSchedulingTrie normalizedAbsolute
+            `shouldBe` (os /= "mingw32")
+
+    it "matches legacy handling of Windows case variants" do
+        let plans =
+                [ claims [tree ToolRead "C:\\Work\\src"]
+                , claims [path ToolWrite "c:\\work\\src\\Main.hs"]
+                ]
+            input = zip [0 :: Int ..] plans
+        toolSchedulingWaves input
+            `shouldBe` toolSchedulingWavesLegacy input
+
+    it "preserves path semantics for fallback path representations" do
+        let paths =
+                [ "/workspace/src"
+                , "/workspace/src/"
+                , "/workspace/./src"
+                , "workspace/src"
+                , "./workspace/src"
+                , "workspace/src/"
+                , "C:\\workspace\\src"
+                , "C:\\workspace\\src\\"
+                ]
+            plans =
+                concatMap
+                    (\raw ->
+                        [ claims [tree ToolRead raw]
+                        , claims [path ToolWrite (raw <> "/Main.hs")]
+                        ])
+                    paths
+            input = zip [0 :: Int ..] plans
+        toolSchedulingWaves input
+            `shouldBe` toolSchedulingWavesLegacy input
+
+schedulingPlans :: Gen [ToolSchedulingPlan]
+schedulingPlans = do
+    size <- chooseInt (0, 25)
+    vectorOf size schedulingPlan
+
+schedulingPlan :: Gen ToolSchedulingPlan
+schedulingPlan =
+    elements [0 :: Int .. 9] >>= \case
+        0 -> pure ToolUnconstrained
+        1 -> pure ToolExclusive
+        _ -> do
+            claimCount <- chooseInt (1, 3)
+            ToolResourceClaims <$> vectorOf claimCount resourceClaim
+
+resourceClaim :: Gen ToolResourceClaim
+resourceClaim = do
+    access <- elements [ToolRead, ToolWrite]
+    resource <- elements [0 :: Int .. 3] >>= \case
+        0 -> ToolNamedResource <$> resourceName
+        1 -> ToolPath . unsafeEncodeUtf <$> filePath
+        2 -> ToolPathTree . unsafeEncodeUtf <$> treePath
+        _ -> pure ToolAllPaths
+    pure (ToolResourceClaim access resource)
+
+resourceName :: Gen Text
+resourceName =
+    Text.pack . ("resource-" <>) . show <$> chooseInt (0, 8)
+
+treePath :: Gen FilePath
+treePath = do
+    variant <- elements [0 :: Int .. 6]
+    components <- listOf (elements ["src", "test", "lib", "nested"])
+    let body = foldPath components
+    pure $ case variant of
+        0 -> "/workspace/" <> body
+        1 -> "/workspace/./" <> body
+        2 -> "/workspace/" <> body <> "/"
+        3 -> "workspace/" <> body
+        4 -> "./workspace/" <> body
+        5 -> "workspace/" <> body <> "/"
+        _ -> "C:\\workspace\\" <> body
+
+filePath :: Gen FilePath
+filePath = do
+    root <- treePath
+    file <- elements ["A.hs", "B.hs", "Main.hs", "Spec.hs"]
+    pure (root <> "/" <> file)
+
+foldPath :: [FilePath] -> FilePath
+foldPath = \case
+    [] -> "."
+    first : rest -> foldl (\left right -> left <> "/" <> right) first rest
+
+claims :: [ToolResourceClaim] -> ToolSchedulingPlan
+claims = ToolResourceClaims
+
+named :: ToolAccess -> Text -> ToolResourceClaim
+named access = ToolResourceClaim access . ToolNamedResource
+
+path :: ToolAccess -> FilePath -> ToolResourceClaim
+path access = ToolResourceClaim access . ToolPath . unsafeEncodeUtf
+
+tree :: ToolAccess -> FilePath -> ToolResourceClaim
+tree access = ToolResourceClaim access . ToolPathTree . unsafeEncodeUtf

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -30,6 +30,7 @@ import qualified Agent.Tools.IOSpec as IOSpec
 import qualified Agent.Tools.MultiAgentsSpec as MultiAgentsSpec
 import qualified Agent.Tools.PlanModeSpec as PlanModeSpec
 import qualified Agent.Tools.SecretSpec as SecretSpec
+import qualified Agent.Tools.SchedulingSpec as SchedulingSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
 import Test.Hspec (hspec)
 
@@ -64,5 +65,6 @@ main = hspec do
     MultiAgentsSpec.spec
     PlanModeSpec.spec
     SecretSpec.spec
+    SchedulingSpec.spec
     DangerousSpec.spec
     WebSocketSpec.spec


### PR DESCRIPTION
## Summary
- precompute exact tool-execution waves with indexed named/path resource frontiers
- preserve legacy barriers, model order, cancellation, and malformed/noncanonical path semantics
- use exact fallback for all Windows paths because `equalFilePath` is case-insensitive there
- retain legacy planner in tests/benchmark for full output equivalence

Independent from common base `07720c89`.

## Validation
- `agent-core` suite: **383 examples, 0 failures**
- generated and exhaustive legacy/indexed wave comparisons, including Windows case variants

## Benchmark (`-O2`, 7-sample medians, 2,000 calls)
| workload | legacy | indexed | legacy alloc | indexed alloc |
|---|---:|---:|---:|---:|
| disjoint | 35.770 ms | 0.557 ms | 48.88 MB | 2.28 MB |
| path | 1127.220 ms | 3.382 ms | 8.65 GB | 18.89 MB |
| mixed | 184.156 ms | 0.870 ms | 1.061 GB | 5.35 MB |

Small 8/32-call workloads showed no material regression.
