### PR TITLE
perf(claude): buffer subprocess output chunks

### DIFF
--- a/packages/claude-agent-sdk-haskell/benchmark/OutputBuffer.hs
+++ b/packages/claude-agent-sdk-haskell/benchmark/OutputBuffer.hs
@@ -1,0 +1,290 @@
+module Main (main) where
+
+import Claude.Agent.SDK.Internal.Transport.OutputBuffer
+    ( OutputLine(..)
+    , appendOutputChunk
+    , emptyOutputBuffer
+    , takeOutputLine
+    )
+import Control.Exception (evaluate)
+import qualified Data.ByteString as ByteString
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as ByteString8
+import Data.List (foldl', sort)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+import Prelude hiding (foldl')
+
+data Implementation
+    = Legacy
+    | Chunked
+
+data Workload
+    = LongRecords
+    | SharedStream
+
+data Sample = Sample
+    { wallMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    getArgs >>= \case
+        [implementationArg, sizeArg, chunkSizeArg, recordsArg, samplesArg] -> do
+            (implementation, workload) <-
+                parseImplementation implementationArg
+            size <- parsePositive "record size" sizeArg
+            chunkSize <- parsePositive "chunk size" chunkSizeArg
+            recordCount <- parsePositive "record count" recordsArg
+            sampleCount <- parsePositive "sample count" samplesArg
+            let payloads =
+                    [ makePayload size seed
+                    | seed <- [1 .. recordCount]
+                    ]
+            _ <-
+                evaluate $
+                    sum (map ByteString.length payloads)
+            samples <-
+                mapM
+                    (\sampleIndex ->
+                        measure
+                            (run
+                                implementation
+                                workload
+                                chunkSize
+                                sampleIndex
+                                payloads))
+                    [1 .. sampleCount]
+            let result = median samples
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d\n"
+                implementationArg
+                size
+                chunkSize
+                recordCount
+                result.wallMillis
+                result.cpuMillis
+                result.allocatedBytes
+        _ ->
+            die $
+                "usage: output-buffer-bench IMPLEMENTATION SIZE CHUNK_SIZE "
+                    <> "RECORDS SAMPLES\n"
+                    <> "implementations: legacy, chunked, "
+                    <> "legacy-shared, chunked-shared"
+
+parseImplementation :: String -> IO (Implementation, Workload)
+parseImplementation = \case
+    "legacy" -> pure (Legacy, LongRecords)
+    "chunked" -> pure (Chunked, LongRecords)
+    "legacy-shared" -> pure (Legacy, SharedStream)
+    "chunked-shared" -> pure (Chunked, SharedStream)
+    other -> die ("unknown implementation: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+run
+    :: Implementation
+    -> Workload
+    -> Int
+    -> Int
+    -> [ByteString]
+    -> IO Int
+run implementation workload chunkSize sampleIndex payloads =
+    evaluate $
+        case workload of
+            LongRecords ->
+                sampleIndex
+                    + sum
+                        [ consume
+                            implementation
+                            (varyChunkSize
+                                chunkSize
+                                (sampleSeed + recordIndex))
+                            payload
+                        | (recordIndex, payload) <-
+                            zip [1 ..] payloads
+                        ]
+            SharedStream ->
+                let expected =
+                        map ByteString.init payloads
+                    stream = ByteString.concat payloads
+                    actual =
+                        consumeShared
+                            implementation
+                            (varyChunkSize chunkSize sampleSeed)
+                            stream
+                 in if actual == expected
+                        then
+                            sampleIndex + sum (map checksum actual)
+                        else
+                            error
+                                "shared stream records changed order or content"
+  where
+    sampleSeed = sampleIndex * 1_000_003
+
+consume :: Implementation -> Int -> ByteString -> Int
+consume implementation chunkSize payload =
+    checksum $
+        case implementation of
+            Legacy ->
+                legacyLine (chunksOf chunkSize payload)
+            Chunked ->
+                chunkedLine (chunksOf chunkSize payload)
+
+-- Simulates the former readBoundedLine loop: scan the entire accumulated
+-- strict ByteString, append the next read, then scan from the beginning again.
+legacyLine :: [ByteString] -> ByteString
+legacyLine = go ByteString.empty
+  where
+    go buffered chunks =
+        case ByteString8.elemIndex '\n' buffered of
+            Just newlineIndex ->
+                ByteString.take newlineIndex buffered
+            Nothing ->
+                case chunks of
+                    [] -> buffered
+                    chunk : remaining ->
+                        go (buffered <> chunk) remaining
+
+chunkedLine :: [ByteString] -> ByteString
+chunkedLine chunks =
+    case takeOutputLine maxBound $
+        foldl' appendOutputChunk emptyOutputBuffer chunks of
+        Just (OutputLine line _) ->
+            line
+        Just (OutputLineTooLarge _) ->
+            error "maxBound-sized output line"
+        Nothing ->
+            error "benchmark payload did not end in a newline"
+
+consumeShared
+    :: Implementation
+    -> Int
+    -> ByteString
+    -> [ByteString]
+consumeShared implementation chunkSize stream =
+    case implementation of
+        Legacy ->
+            legacyLines (chunksOf chunkSize stream)
+        Chunked ->
+            chunkedLines (chunksOf chunkSize stream)
+
+legacyLines :: [ByteString] -> [ByteString]
+legacyLines = go ByteString.empty []
+  where
+    go buffered reversed = \case
+        chunks
+            | Just newlineIndex <-
+                ByteString8.elemIndex '\n' buffered ->
+                let (line, withNewline) =
+                        ByteString.splitAt newlineIndex buffered
+                 in go
+                        (ByteString.drop 1 withNewline)
+                        (line : reversed)
+                        chunks
+        [] ->
+            if ByteString.null buffered
+                then reverse reversed
+                else reverse (buffered : reversed)
+        chunk : remaining ->
+            go (buffered <> chunk) reversed remaining
+
+chunkedLines :: [ByteString] -> [ByteString]
+chunkedLines = go emptyOutputBuffer []
+  where
+    go buffered reversed chunks =
+        case takeOutputLine maxBound buffered of
+            Just (OutputLine line remaining) ->
+                go remaining (line : reversed) chunks
+            Just (OutputLineTooLarge _) ->
+                error "maxBound-sized output line"
+            Nothing ->
+                case chunks of
+                    [] -> reverse reversed
+                    chunk : remaining ->
+                        go
+                            (appendOutputChunk buffered chunk)
+                            reversed
+                            remaining
+
+chunksOf :: Int -> ByteString -> [ByteString]
+chunksOf chunkSize bytes
+    | ByteString.null bytes = []
+    | otherwise =
+        let (chunk, remaining) =
+                ByteString.splitAt chunkSize bytes
+         in chunk : chunksOf chunkSize remaining
+
+varyChunkSize :: Int -> Int -> Int
+varyChunkSize base seed =
+    max 1 (base - seed `mod` max 1 (base `div` 8))
+
+checksum :: ByteString -> Int
+checksum bytes
+    | ByteString.null bytes = 0
+    | otherwise =
+        ByteString.length bytes
+            + fromIntegral (ByteString.head bytes)
+            + fromIntegral (ByteString.last bytes)
+
+{-# NOINLINE makePayload #-}
+makePayload :: Int -> Int -> ByteString
+makePayload size seed =
+    ByteString.cons
+        (fromIntegral (97 + seed `mod` 23))
+        (ByteString.replicate (size - 1) 120)
+        <> "\n"
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCPU <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    result <- action
+    _ <- evaluate result
+    afterWall <- getMonotonicTimeNSec
+    afterCPU <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
+    pure Sample
+        { wallMillis =
+            fromIntegral (afterWall - beforeWall) / 1_000_000
+        , cpuMillis =
+            fromIntegral (afterCPU - beforeCPU) / 1_000_000_000
+        , allocatedBytes =
+            fromIntegral
+                ( afterStats.allocated_bytes
+                    - beforeStats.allocated_bytes
+                )
+        }
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { wallMillis = middle (sort (map (.wallMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
+++ b/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
@@ -40,6 +40,7 @@ library
     exposed-modules:  Claude.Agent.SDK
                     , Claude.Agent.SDK.Client
                     , Claude.Agent.SDK.Errors
+                    , Claude.Agent.SDK.Internal.Transport.OutputBuffer
                     , Claude.Agent.SDK.Query
                     , Claude.Agent.SDK.Transport
                     , Claude.Agent.SDK.Types
@@ -63,12 +64,23 @@ library
                     , unix
                     , uuid-types
 
+benchmark output-buffer-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          OutputBuffer.hs
+    ghc-options:      -O2 -rtsopts
+    build-depends:    base >= 4.17 && < 5
+                    , claude-agent-sdk-haskell
+                    , bytestring
+
 test-suite claude-agent-sdk-haskell-test
     import:           common-opts
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Claude.Agent.SDK.ClientSpec
+                    , Claude.Agent.SDK.Internal.Transport.OutputBufferSpec
                     , Claude.Agent.SDK.QuerySpec
                     , Claude.Agent.SDK.TestSupport
     ghc-options:      -threaded

--- a/packages/claude-agent-sdk-haskell/package.nix
+++ b/packages/claude-agent-sdk-haskell/package.nix
@@ -16,6 +16,7 @@ mkDerivation {
     aeson base bytestring containers directory filepath hspec
     safe-exceptions scientific text unix
   ];
+  benchmarkHaskellDepends = [ base bytestring ];
   description = "Haskell SDK for the Claude Agent SDK stream protocol";
   license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/OutputBuffer.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/OutputBuffer.hs
@@ -1,0 +1,204 @@
+module Claude.Agent.SDK.Internal.Transport.OutputBuffer
+    ( OutputBuffer
+    , OutputLine(..)
+    , OutputReadResult(..)
+    , appendOutputChunk
+    , emptyOutputBuffer
+    , finishOutputBuffer
+    , outputPartialLength
+    , readBufferedLine
+    , takeOutputLine
+    ) where
+
+import Control.Exception (IOException, try)
+import qualified Data.ByteString as ByteString
+import Data.ByteString (ByteString)
+import Data.IORef
+    ( IORef
+    , readIORef
+    , writeIORef
+    )
+import System.IO.Error (isEOFError)
+
+data OutputLine
+    = OutputLine !ByteString !OutputBuffer
+    | OutputLineTooLarge !OutputBuffer
+
+data OutputReadResult
+    = OutputReadLine !ByteString
+    | OutputReadEnd
+    | OutputReadTooLarge
+    | OutputReadFailure !IOException
+
+data OutputBuffer = OutputBuffer
+    { completeLines :: ![ByteString]
+    , partialChunksReversed :: ![ByteString]
+    , partialByteLength :: !Int
+    }
+
+emptyOutputBuffer :: OutputBuffer
+emptyOutputBuffer =
+    OutputBuffer
+        { completeLines = []
+        , partialChunksReversed = []
+        , partialByteLength = 0
+        }
+
+-- | Add bytes received from stdout. Each chunk is split on newlines once.
+-- Completed records retain their constituent slices until they are returned.
+appendOutputChunk :: OutputBuffer -> ByteString -> OutputBuffer
+appendOutputChunk buffer chunk
+    | ByteString.null chunk = buffer
+    | otherwise =
+        case ByteString.split newline chunk of
+            [suffix] ->
+                appendPartial suffix buffer
+            first : second : remaining ->
+                let (middle, suffix) =
+                        splitLast second remaining
+                    firstLine =
+                        materializeChunks $
+                            addChunk
+                                first
+                                buffer.partialChunksReversed
+                 in OutputBuffer
+                        { completeLines =
+                            -- readBufferedLine drains queued records before
+                            -- receiving another chunk, so this left side is
+                            -- empty in production. A list keeps the hot
+                            -- dequeue path allocation-free.
+                            buffer.completeLines
+                                <> (firstLine : middle)
+                        , partialChunksReversed =
+                            addChunk suffix []
+                        , partialByteLength =
+                            ByteString.length suffix
+                        }
+            [] -> buffer
+  where
+    newline = 10
+
+takeOutputLine
+    :: Int
+    -> OutputBuffer
+    -> Maybe OutputLine
+takeOutputLine maximumBytes buffer =
+    case buffer.completeLines of
+        [] ->
+            Nothing
+        line : remaining ->
+            Just $
+                if ByteString.length line > maximumBytes
+                    then
+                        OutputLineTooLarge
+                            (buffer { completeLines = remaining })
+                    else
+                        OutputLine
+                            line
+                            (buffer { completeLines = remaining })
+
+-- | Materialize the final unterminated record at EOF.
+--
+-- Precondition: 'takeOutputLine' returned 'Nothing'. 'readBufferedLine'
+-- enforces this by draining every completed record before reading again.
+finishOutputBuffer
+    :: OutputBuffer
+    -> (Maybe ByteString, OutputBuffer)
+finishOutputBuffer buffer
+    | buffer.partialByteLength == 0 =
+        (Nothing, emptyOutputBuffer)
+    | otherwise =
+        ( Just $
+            materializeChunks buffer.partialChunksReversed
+        , emptyOutputBuffer
+        )
+
+outputPartialLength :: OutputBuffer -> Int
+outputPartialLength = (.partialByteLength)
+
+-- | Read one bounded line. An EOF exception is treated like an empty read,
+-- matching Handle.hGetSome behavior across platforms. Non-EOF failures leave
+-- the buffered partial record intact so a caller may retry.
+readBufferedLine
+    :: IORef OutputBuffer
+    -> Int
+    -> (Int -> IO ByteString)
+    -> IO OutputReadResult
+readBufferedLine bufferRef maximumBytes readChunk =
+    go
+  where
+    go = do
+        buffered <- readIORef bufferRef
+        case takeOutputLine maximumBytes buffered of
+            Just (OutputLine line remaining) -> do
+                writeIORef bufferRef remaining
+                pure (OutputReadLine line)
+            Just (OutputLineTooLarge remaining) -> do
+                writeIORef bufferRef remaining
+                pure OutputReadTooLarge
+            Nothing
+                | outputPartialLength buffered > maximumBytes ->
+                    pure OutputReadTooLarge
+                | otherwise -> do
+                    let remainingBytes =
+                            maximumBytes
+                                - outputPartialLength buffered
+                        readSize =
+                            min 8_192 (remainingBytes + 1)
+                    result <-
+                        try (readChunk readSize)
+                            :: IO (Either IOException ByteString)
+                    case result of
+                        Right chunk
+                            | ByteString.null chunk ->
+                                finish buffered
+                            | otherwise -> do
+                                writeIORef
+                                    bufferRef
+                                    (appendOutputChunk buffered chunk)
+                                go
+                        Left exception
+                            | isEOFError exception ->
+                                finish buffered
+                            | otherwise ->
+                                pure (OutputReadFailure exception)
+
+    finish buffered = do
+        let (trailing, empty) = finishOutputBuffer buffered
+        writeIORef bufferRef empty
+        pure case trailing of
+            Nothing -> OutputReadEnd
+            Just line
+                -- The pre-read size guard means an EOF exception cannot
+                -- reach this branch with an oversized partial through the
+                -- transport API. Keep the empty-read and EOF paths identical.
+                | ByteString.length line > maximumBytes ->
+                    OutputReadTooLarge
+                | otherwise ->
+                    OutputReadLine line
+
+appendPartial :: ByteString -> OutputBuffer -> OutputBuffer
+appendPartial bytes buffer =
+    buffer
+        { partialChunksReversed =
+            addChunk bytes buffer.partialChunksReversed
+        , partialByteLength =
+            buffer.partialByteLength + ByteString.length bytes
+        }
+
+addChunk :: ByteString -> [ByteString] -> [ByteString]
+addChunk bytes chunks
+    | ByteString.null bytes = chunks
+    | otherwise = bytes : chunks
+
+materializeChunks :: [ByteString] -> ByteString
+materializeChunks =
+    ByteString.concat . reverse
+
+splitLast :: a -> [a] -> ([a], a)
+splitLast current = \case
+    [] -> ([], current)
+    next : remaining ->
+        let (beforeLast, lastValue) =
+                splitLast next remaining
+         in (current : beforeLast, lastValue)

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/SubprocessCLI.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/SubprocessCLI.hs
@@ -10,6 +10,12 @@ import Claude.Agent.SDK.Errors
 import Claude.Agent.SDK.Internal.Process
     ( terminateProcessGroup
     )
+import Claude.Agent.SDK.Internal.Transport.OutputBuffer
+    ( OutputBuffer
+    , OutputReadResult(..)
+    , emptyOutputBuffer
+    , readBufferedLine
+    )
 import Claude.Agent.SDK.Transport
     ( Transport(..)
     , TransportMode(..)
@@ -47,13 +53,11 @@ import Control.Exception.Safe
     , mask
     , onException
     , throwIO
-    , try
     , tryAny
     )
 import Control.Monad (void)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as ByteString
-import qualified Data.ByteString.Char8 as ByteString8
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
@@ -61,7 +65,6 @@ import Data.IORef
     , readIORef
     , writeIORef
     )
-import qualified Data.Map.Strict as Map
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -80,7 +83,7 @@ import System.IO
     , hSetBinaryMode
     , hSetBuffering
     )
-import System.IO.Error (isDoesNotExistError, isEOFError)
+import System.IO.Error (isDoesNotExistError)
 import System.Posix.Types (ProcessGroupID)
 import System.Process
     ( CreateProcess(..)
@@ -101,7 +104,7 @@ data RunningTransport = RunningTransport
     , processHandle :: !ProcessHandle
     , groupId :: !(Maybe ProcessGroupID)
     , diagnosticBytes :: !(IORef ByteString.ByteString)
-    , outputBytes :: !(IORef ByteString.ByteString)
+    , outputBytes :: !(IORef OutputBuffer)
     , outputReaderState :: !(MVar OutputReaderState)
     , inputWriterState :: !(MVar InputWriterState)
     , inputOpen :: !(IORef Bool)
@@ -240,7 +243,7 @@ startTransport options mode model effort =
                 [inputHandle, outputHandle, errorHandle])
             `onException` stopCreated processGroupId
         diagnosticRef <- newIORef ByteString.empty
-        outputRef <- newIORef ByteString.empty
+        outputRef <- newIORef emptyOutputBuffer
         outputReaderState <-
             newMVar OutputReaderState
                 { outputReaderClosing = False
@@ -494,79 +497,25 @@ readBoundedLine
     -> Int
     -> IO (Either ClaudeSDKError (Maybe ByteString.ByteString))
 readBoundedLine running maximumBytes =
-    go
+    readBufferedLine
+        running.outputBytes
+        maximumBytes
+        (ByteString.hGetSome running.outputHandle)
+        >>= \case
+            OutputReadLine line ->
+                pure (Right (Just line))
+            OutputReadEnd ->
+                pure (Right Nothing)
+            OutputReadTooLarge ->
+                pure (Left oversizedRecordError)
+            OutputReadFailure exception ->
+                pure $
+                    Left $
+                        CLIConnectionError
+                            ( "Failed to read Claude Code output: "
+                                <> Text.pack (show exception)
+                            )
   where
-    go = do
-        buffered <- readIORef running.outputBytes
-        case ByteString8.elemIndex '\n' buffered of
-            Just newlineIndex -> do
-                let (line, withNewline) =
-                        ByteString.splitAt newlineIndex buffered
-                writeIORef
-                    running.outputBytes
-                    (ByteString.drop 1 withNewline)
-                if ByteString.length line > maximumBytes
-                    then pure (Left oversizedRecordError)
-                    else pure (Right (Just line))
-            Nothing
-                | ByteString.length buffered > maximumBytes ->
-                    pure (Left oversizedRecordError)
-                | otherwise -> do
-                    let remainingBytes =
-                            maximumBytes - ByteString.length buffered
-                        readSize =
-                            min 8_192 (remainingBytes + 1)
-                    result <-
-                        try
-                            (ByteString.hGetSome
-                                running.outputHandle
-                                readSize)
-                            :: IO
-                                (Either
-                                    IOException
-                                    ByteString.ByteString)
-                    case result of
-                        Right chunk
-                            | ByteString.null chunk ->
-                                if ByteString.null buffered
-                                    then pure (Right Nothing)
-                                    else do
-                                        writeIORef
-                                            running.outputBytes
-                                            ByteString.empty
-                                        if ByteString.length buffered
-                                                > maximumBytes
-                                            then
-                                                pure
-                                                    (Left
-                                                        oversizedRecordError)
-                                            else
-                                                pure
-                                                    (Right
-                                                        (Just buffered))
-                            | otherwise -> do
-                                writeIORef
-                                    running.outputBytes
-                                    (buffered <> chunk)
-                                go
-                        Left exception
-                            | isEOFError exception ->
-                                if ByteString.null buffered
-                                    then pure (Right Nothing)
-                                    else do
-                                        writeIORef
-                                            running.outputBytes
-                                            ByteString.empty
-                                        pure (Right (Just buffered))
-                            | otherwise ->
-                                pure $
-                                    Left $
-                                        CLIConnectionError
-                                            ( "Failed to read Claude Code output: "
-                                                <> Text.pack
-                                                    (show exception)
-                                            )
-
     oversizedRecordError =
         CLIProtocolError
             ( "Claude Code emitted a structured output record larger than "

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ClientSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ClientSpec.hs
@@ -179,7 +179,7 @@ spec = describe "ClaudeSDKClient subprocess transport" do
 
     it "rejects structured output records larger than the configured limit" do
         withFakeClaude
-            (oneShotScript [Text.replicate 65 "x"])
+            (oneShotScript [successResult "too large"])
             \directory executable -> do
                 result <-
                     query
@@ -193,6 +193,19 @@ spec = describe "ClaudeSDKClient subprocess transport" do
                         "larger than 64 bytes"
                             `Text.isInfixOf` message
                     _ -> False
+
+    it "assembles one structured record emitted across many subprocess writes" do
+        let reply = Text.replicate 20_000 "x"
+        withFakeClaude
+            (multiWriteScript (successResult reply))
+            \directory executable -> do
+                result <-
+                    query
+                        (testOptions executable directory)
+                        "split output"
+                        (const (pure ()))
+                fmap resultText result
+                    `shouldBe` Right (Just reply)
 
     it "aborts a blocked subprocess output read promptly" do
         withFakeClaude blockedOutputScript \directory executable -> do
@@ -1358,6 +1371,29 @@ successResult result =
         <> "\",\"uuid\":\"result\",\"result\":\""
         <> result
         <> "\"}"
+
+multiWriteScript :: Text -> String
+multiWriteScript record =
+    Text.unpack $
+        Text.unlines $
+            [ "#!/bin/sh"
+            , "IFS= read -r _query"
+            ]
+                <> concatMap
+                    (\chunk ->
+                        [ "printf '%s' " <> shellQuote chunk
+                        , "sleep 0.01"
+                        ])
+                    (textChunks 997 record)
+                <> ["printf '\\n'"]
+
+textChunks :: Int -> Text -> [Text]
+textChunks chunkSize value
+    | Text.null value = []
+    | otherwise =
+        let (chunk, remaining) =
+                Text.splitAt chunkSize value
+         in chunk : textChunks chunkSize remaining
 
 assistantLine :: Text -> Text -> Text
 assistantLine sessionId text =

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/Internal/Transport/OutputBufferSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/Internal/Transport/OutputBufferSpec.hs
@@ -1,0 +1,251 @@
+module Claude.Agent.SDK.Internal.Transport.OutputBufferSpec
+    ( spec
+    ) where
+
+import Claude.Agent.SDK.Internal.Transport.OutputBuffer
+    ( OutputBuffer
+    , OutputLine(..)
+    , OutputReadResult(..)
+    , appendOutputChunk
+    , emptyOutputBuffer
+    , finishOutputBuffer
+    , outputPartialLength
+    , readBufferedLine
+    , takeOutputLine
+    )
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as ByteString8
+import Data.IORef
+    ( atomicModifyIORef'
+    , newIORef
+    )
+import System.IO.Error (eofErrorType, mkIOError)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+spec :: Spec
+spec =
+    describe "subprocess output buffering" do
+        it "assembles a line split across 8 KiB reads" do
+            let prefix = ByteString.replicate 8_192 97
+                suffix = ByteString8.pack "tail\n"
+                buffered =
+                    appendOutputChunk
+                        (appendOutputChunk emptyOutputBuffer prefix)
+                        suffix
+            case takeOutputLine 8_196 buffered of
+                Just (OutputLine line remaining) -> do
+                    line `shouldBe` prefix <> "tail"
+                    outputPartialLength remaining `shouldBe` 0
+                _ ->
+                    fail "expected a complete line"
+
+        it "retains and reuses every line and suffix from one chunk" do
+            let buffered =
+                    appendOutputChunk
+                        emptyOutputBuffer
+                        "first\nsecond\npartial"
+            (first, afterFirst) <- expectLine 100 buffered
+            first `shouldBe` "first"
+            (second, afterSecond) <- expectLine 100 afterFirst
+            second `shouldBe` "second"
+            takeOutputLine 100 afterSecond `shouldBeNoLine` ()
+            let (trailing, empty) = finishOutputBuffer afterSecond
+            trailing `shouldBe` Just "partial"
+            outputPartialLength empty `shouldBe` 0
+
+        it "returns an empty record for a leading newline" do
+            let buffered =
+                    appendOutputChunk emptyOutputBuffer "\nnext"
+            (first, remaining) <- expectLine 100 buffered
+            first `shouldBe` ""
+            finishOutputBuffer remaining `shouldBeFinal` Just "next"
+
+        it "does not invent an empty record after a trailing newline" do
+            let buffered =
+                    appendOutputChunk emptyOutputBuffer "last\n"
+            (line, remaining) <- expectLine 100 buffered
+            line `shouldBe` "last"
+            takeOutputLine 100 remaining `shouldBeNoLine` ()
+            finishOutputBuffer remaining `shouldBeFinal` Nothing
+
+        it "drains several queued lines in their original order" do
+            let buffered =
+                    appendOutputChunk
+                        emptyOutputBuffer
+                        "one\ntwo\nthree\nfour\n"
+            (one, afterOne) <- expectLine 100 buffered
+            (two, afterTwo) <- expectLine 100 afterOne
+            (three, afterThree) <- expectLine 100 afterTwo
+            (four, afterFour) <- expectLine 100 afterThree
+            [one, two, three, four]
+                `shouldBe` ["one", "two", "three", "four"]
+            takeOutputLine 100 afterFour `shouldBeNoLine` ()
+
+        it "accepts a record exactly at the configured limit" do
+            let buffered =
+                    appendOutputChunk
+                        emptyOutputBuffer
+                        (ByteString.replicate 64 120 <> "\n")
+            case takeOutputLine 64 buffered of
+                Just (OutputLine line _) ->
+                    ByteString.length line `shouldBe` 64
+                _ ->
+                    fail "expected the boundary-sized line"
+
+        it "rejects a newline-terminated record one byte over the limit" do
+            let buffered =
+                    appendOutputChunk
+                        emptyOutputBuffer
+                        (ByteString.replicate 65 120 <> "\n")
+            case takeOutputLine 64 buffered of
+                Just (OutputLineTooLarge _) ->
+                    pure () :: IO ()
+                _ ->
+                    fail "expected an oversized line"
+
+        it "retains records queued after an oversized line" do
+            let buffered =
+                    appendOutputChunk
+                        emptyOutputBuffer
+                        ( "ok\n"
+                            <> ByteString.replicate 65 120
+                            <> "\nafter\n"
+                        )
+            (first, afterFirst) <- expectLine 64 buffered
+            first `shouldBe` "ok"
+            afterOversized <-
+                case takeOutputLine 64 afterFirst of
+                    Just (OutputLineTooLarge remaining) ->
+                        pure remaining
+                    _ ->
+                        fail "expected the queued oversized line"
+            (lastLine, empty) <- expectLine 64 afterOversized
+            lastLine `shouldBe` "after"
+            takeOutputLine 64 empty `shouldBeNoLine` ()
+
+        it "returns a final record when EOF has no newline" do
+            let buffered =
+                    appendOutputChunk
+                        (appendOutputChunk emptyOutputBuffer "final")
+                        "-record"
+                (trailing, empty) = finishOutputBuffer buffered
+            trailing `shouldBe` Just "final-record"
+            finishOutputBuffer empty `shouldBeFinal` Nothing
+
+        it "returns a buffered partial record for an IOException EOF" do
+            bufferRef <-
+                newIORef $
+                    appendOutputChunk emptyOutputBuffer "partial"
+            result <-
+                readBufferedLine bufferRef 100 \_ ->
+                    ioError $
+                        mkIOError eofErrorType "test EOF" Nothing Nothing
+            case result of
+                OutputReadLine line ->
+                    line `shouldBe` "partial"
+                _ ->
+                    fail "expected the partial line at EOF"
+
+        it "drains queued lines before finishing the EOF partial record" do
+            bufferRef <- newIORef emptyOutputBuffer
+            readsRef <-
+                newIORef
+                    [ Just "one\ntwo\npartial"
+                    , Nothing
+                    ]
+            let readChunk _ =
+                    atomicModifyIORef' readsRef \case
+                        [] ->
+                            ([], "")
+                        Nothing : remaining ->
+                            (remaining, "")
+                        Just chunk : remaining ->
+                            (remaining, chunk)
+                expectReadLine expected = do
+                    result <-
+                        readBufferedLine bufferRef 100 readChunk
+                    case result of
+                        OutputReadLine line ->
+                            line `shouldBe` expected
+                        _ ->
+                            fail "expected a buffered line"
+            expectReadLine "one"
+            expectReadLine "two"
+            expectReadLine "partial"
+            readBufferedLine bufferRef 100 readChunk
+                `shouldReturnReadEnd` ()
+
+        it "rejects an oversized partial before an IOException EOF read" do
+            bufferRef <-
+                newIORef $
+                    appendOutputChunk
+                        emptyOutputBuffer
+                        (ByteString.replicate 65 120)
+            result <-
+                readBufferedLine bufferRef 64 \_ ->
+                    ioError $
+                        mkIOError eofErrorType "test EOF" Nothing Nothing
+            case result of
+                OutputReadTooLarge ->
+                    pure () :: IO ()
+                _ ->
+                    fail "expected the oversized partial to be rejected"
+
+        it "keeps a partial record available after a retryable IOException" do
+            bufferRef <-
+                newIORef $
+                    appendOutputChunk emptyOutputBuffer "partial"
+            failed <-
+                readBufferedLine bufferRef 100 \_ ->
+                    ioError (userError "temporary read failure")
+            case failed of
+                OutputReadFailure _ ->
+                    pure () :: IO ()
+                _ ->
+                    fail "expected a read failure"
+            retried <-
+                readBufferedLine bufferRef 100 \_ ->
+                    pure "\n"
+            case retried of
+                OutputReadLine line ->
+                    line `shouldBe` "partial"
+                _ ->
+                    fail "expected retry to reuse the partial line"
+
+expectLine
+    :: Int
+    -> OutputBuffer
+    -> IO
+        ( ByteString.ByteString
+        , OutputBuffer
+        )
+expectLine maximumBytes buffered =
+    case takeOutputLine maximumBytes buffered of
+        Just (OutputLine line remaining) ->
+            pure (line, remaining)
+        _ ->
+            fail "expected a complete line"
+
+shouldBeNoLine :: Maybe OutputLine -> () -> IO ()
+shouldBeNoLine value _ =
+    case value of
+        Nothing -> pure ()
+        Just _ -> fail "expected no complete line"
+
+shouldBeFinal
+    :: (Maybe ByteString.ByteString, buffer)
+    -> Maybe ByteString.ByteString
+    -> IO ()
+shouldBeFinal (actual, _) expected =
+    actual `shouldBe` expected
+
+shouldReturnReadEnd :: IO OutputReadResult -> () -> IO ()
+shouldReturnReadEnd action _ =
+    action >>= \case
+        OutputReadEnd -> pure ()
+        _ -> fail "expected end of output"

--- a/packages/claude-agent-sdk-haskell/test/Spec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified Claude.Agent.SDK.ClientSpec as ClientSpec
+import qualified Claude.Agent.SDK.Internal.Transport.OutputBufferSpec as OutputBufferSpec
 import qualified Claude.Agent.SDK.QuerySpec as QuerySpec
 import Control.Concurrent (threadDelay)
 import qualified System.Posix.IO.ByteString as PosixByteString
@@ -17,6 +18,7 @@ main =
         _ ->
             hspec do
                 ClientSpec.spec
+                OutputBufferSpec.spec
                 QuerySpec.spec
 
 holdStdinOpen :: FilePath -> IO ()


### PR DESCRIPTION
## Summary
- replace repeated strict `ByteString` append/rescan in subprocess stdout with a chunked bounded-line buffer
- scan chunks once, flatten complete lines once, and preserve queued suffixes/EOF/oversize/IOException behavior
- add pure buffer tests and an end-to-end fake CLI split-write test

Independent from common base `07720c89`.

## Validation
- SDK suite: **57 examples, 0 failures**
- independent review found no queue, EOF, oversize, IOException, or resource-retention defects

## Benchmark (`-O2`, 7-sample medians)
1 MiB record / 8 KiB chunks / 10 records:

| | wall | CPU | allocated |
|---|---:|---:|---:|
| legacy | 26.057 ms | 25.979 ms | 729.92 MB |
| chunked | 0.714 ms | 0.714 ms | 11.00 MB |

Tradeoff: tiny 64-byte shared-line streams regress; 256-byte records converge, while 1 KiB and long structured records win. The target workload is large JSON records.
