### PR TITLE
perf(tui): use chunk accumulators in markdown parsing

### DIFF
--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -54,6 +54,16 @@ library
                     , text >= 2.0 && < 2.2
                     , vty >= 6.4 && < 7
 
+benchmark markdown-accumulators-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          MarkdownAccumulators.hs
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-tui
+                    , base >= 4.17 && < 5
+                    , text >= 2.0 && < 2.2
+
 test-suite agent-tui-test
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-tui/benchmark/MarkdownAccumulators.hs
+++ b/packages/agent-tui/benchmark/MarkdownAccumulators.hs
@@ -1,0 +1,142 @@
+module Main (main) where
+
+import Agent.TUI.Markdown.Inline (Inline(..), inlinePlainText, parseInline)
+import Control.Exception (evaluate)
+import Data.List (sort)
+import qualified Data.Text as Text
+import Data.Text (Text)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Sample = Sample !Double !Double !Integer !Int
+
+data Mode = LinkWorkload | CodeWorkload | EmphasisWorkload
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled then pure () else die "run with +RTS -T"
+    getArgs >>= \case
+        [modeArg, sizeArg, samplesArg] -> do
+            size <- positive sizeArg
+            samples <- positive samplesArg
+            mode <- parseMode modeArg
+            let sources =
+                    [ workload mode size variant
+                    | variant <- [0 .. samples - 1]
+                    ]
+            _ <- evaluate (sum (map Text.length sources))
+            if all (validSource mode . parseInline) sources
+                then pure ()
+                else die "benchmark workload did not parse as intended"
+            results <- mapM (measure mode) sources
+            let Sample elapsed cpu allocated checksum = median results
+            printf "%s,%d,%d,%.3f,%.3f,%d,%d\n"
+                modeArg size samples elapsed cpu allocated checksum
+        _ -> die "usage: markdown-accumulators-bench inline-link|inline-code|inline-emphasis SIZE SAMPLES"
+  where
+    positive raw =
+        case reads raw of
+            [(value, "")] | value > 0 -> pure value
+            _ -> die ("invalid positive integer: " <> raw)
+
+parseMode :: String -> IO Mode
+parseMode = \case
+    "inline-link" -> pure LinkWorkload
+    "inline-code" -> pure CodeWorkload
+    "inline-emphasis" -> pure EmphasisWorkload
+    other -> die ("unknown mode: " <> other)
+
+measure :: Mode -> Text -> IO Sample
+measure mode source = do
+    performGC
+    before <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeClock <- getMonotonicTimeNSec
+    checksum <- evaluate (checksumSource mode source)
+    afterClock <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    performGC
+    after <- getRTSStats
+    _ <- evaluate checksum
+    pure
+        ( Sample
+            (fromIntegral (afterClock - beforeClock) / 1.0e6)
+            (fromIntegral (afterCpu - beforeCpu) / 1.0e9)
+            (fromIntegral (after.allocated_bytes - before.allocated_bytes))
+            checksum
+        )
+
+checksumSource :: Mode -> Text -> Int
+checksumSource mode source =
+    case mode of
+        LinkWorkload -> checksumInline (parseInline source)
+        CodeWorkload -> checksumInline (parseInline source)
+        EmphasisWorkload -> checksumInline (parseInline source)
+  where
+    checksumInline =
+        foldl' step 5381
+    step acc inline =
+        foldl' (\value c -> value * 33 + fromEnum c) (acc * 33 + tag inline) (inlineText inline)
+    tag = \case
+        InlineText _ -> 1
+        InlineCode _ -> 2
+        InlineStrong _ -> 3
+        InlineEmphasis _ -> 4
+        InlineLink _ _ -> 5
+    inlineText = \case
+        InlineText text -> Text.unpack text
+        InlineCode text -> Text.unpack text
+        InlineStrong children -> Text.unpack (inlinePlainText children)
+        InlineEmphasis children -> Text.unpack (inlinePlainText children)
+        InlineLink url children ->
+            Text.unpack (url <> inlinePlainText children)
+
+workload :: Mode -> Int -> Int -> Text
+workload LinkWorkload n variant =
+    "[label\\] "
+        <> Text.replicate n "x"
+        <> variantText variant
+        <> "](https://example.com/a_\\(b\\)/"
+        <> variantText variant
+        <> ") "
+workload CodeWorkload n variant =
+    let ticks = "```"
+    in ticks <> Text.replicate n "code ` payload " <> variantText variant <> ticks
+workload EmphasisWorkload n variant =
+    "**bold "
+        <> Text.replicate n "x"
+        <> " *nested "
+        <> Text.pack (show variant)
+        <> "***"
+variantText :: Int -> Text
+variantText variant = Text.justifyRight 4 '0' (Text.pack (show variant))
+
+validSource :: Mode -> [Inline] -> Bool
+validSource EmphasisWorkload nodes =
+    hasStrong nodes && hasEmphasis nodes
+  where
+    hasStrong = any $ \case
+        InlineStrong _ -> True
+        InlineEmphasis children -> hasStrong children
+        _ -> False
+    hasEmphasis = any $ \case
+        InlineStrong children -> hasEmphasis children
+        InlineEmphasis _ -> True
+        _ -> False
+validSource _ _ = True
+
+median :: [Sample] -> Sample
+median values =
+    Sample
+        (middle [elapsed | Sample elapsed _ _ _ <- values])
+        (middle [cpu | Sample _ cpu _ _ <- values])
+        (middle [allocated | Sample _ _ allocated _ <- values])
+        (middle [checksum | Sample _ _ _ checksum <- values])
+  where
+    middle xs = sort xs !! (length xs `div` 2)

--- a/packages/agent-tui/package.nix
+++ b/packages/agent-tui/package.nix
@@ -12,6 +12,7 @@ mkDerivation {
     agent-core agent-syntax base brick containers hspec QuickCheck text
     vty
   ];
+  benchmarkHaskellDepends = [ base text ];
   description = "Retained terminal UI for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
@@ -124,15 +124,18 @@ styledSpan previous marker constructor text = do
 -- remaining @**@ closes its surrounding strong span.
 findClosing :: Text -> Maybe Char -> Text -> Maybe (Text, Text)
 findClosing marker initialPrevious input =
-    scan initialPrevious "" input
+    scan initialPrevious [] input
   where
-    scan previous consumed remaining
+    -- Keep the last consumed character separately from the reverse chunk
+    -- list. In particular, checking a delimiter must not flatten the chunks
+    -- merely to discover the preceding character.
+    scan lastSeen consumed remaining
         | Text.null remaining = Nothing
         | Text.any (== '\n') (Text.take 1 remaining) = Nothing
         | marker `Text.isPrefixOf` remaining
-        , canClose marker previous (Text.drop (Text.length marker) remaining) =
+        , canClose marker lastSeen (Text.drop (Text.length marker) remaining) =
             Just
-                ( consumed
+                ( Text.concat (reverse consumed)
                 , Text.drop (Text.length marker) remaining
                 )
         | Just (_, rest) <- escapedPunctuation remaining =
@@ -156,15 +159,15 @@ findClosing marker initialPrevious input =
             let consumedLength = Text.length remaining - Text.length rest
                 chunk = Text.take consumedLength remaining
             in scan
-                (lastCharacter chunk <|> previous)
-                (consumed <> chunk)
+                (lastCharacter chunk <|> lastSeen)
+                (chunk : consumed)
                 rest
 
         completeStyled nestedMarker source = do
             afterOpen <- Text.stripPrefix nestedMarker source
-            if canOpen nestedMarker previous afterOpen
+            if canOpen nestedMarker lastSeen afterOpen
                 then do
-                    (_, rest) <- findClosing nestedMarker previous afterOpen
+                    (_, rest) <- findClosing nestedMarker lastSeen afterOpen
                     pure rest
                 else Nothing
 
@@ -174,7 +177,7 @@ codeSpan text =
         tickCount = Text.length ticks
     in if tickCount == 0
         then Nothing
-        else findClose tickCount "" afterOpen
+        else findClose tickCount [] afterOpen
   where
     findClose tickCount body remaining
         | Text.null remaining = Nothing
@@ -186,23 +189,23 @@ codeSpan text =
                 else
                     let (run, afterRun) = Text.span (== '`') atTicks
                     in if Text.length run == tickCount
-                        then Just (body <> before, afterRun)
+                        then Just (Text.concat (reverse (before : body)), afterRun)
                         else findClose
                             tickCount
-                            (body <> before <> run)
+                            (run : before : body)
                             afterRun
 
 linkSpan :: Text -> Maybe (Text, Text, Text)
 linkSpan text = do
     afterOpen <- Text.stripPrefix "[" text
-    (label, afterLabel) <- takeLinkLabel 0 "" afterOpen
+    (label, afterLabel) <- takeLinkLabel 0 [] afterOpen
     afterDestinationOpen <- Text.stripPrefix "(" afterLabel
-    (url, rest) <- takeDestination 0 "" afterDestinationOpen
+    (url, rest) <- takeDestination 0 [] afterDestinationOpen
     if Text.null label
         then Nothing
         else Just (url, label, rest)
 
-takeLinkLabel :: Int -> Text -> Text -> Maybe (Text, Text)
+takeLinkLabel :: Int -> [Char] -> Text -> Maybe (Text, Text)
 takeLinkLabel depth consumed remaining =
     case Text.uncons remaining of
         Nothing -> Nothing
@@ -212,23 +215,21 @@ takeLinkLabel depth consumed remaining =
                 Just (escaped, rest)
                     | isAsciiPunctuation escaped ->
                         takeLinkLabel depth
-                            (consumed <> Text.pack ['\\', escaped])
+                            (escaped : '\\' : consumed)
                             rest
-                _ -> takeLinkLabel depth (consumed <> "\\") afterSlash
+                _ -> takeLinkLabel depth ('\\' : consumed) afterSlash
         Just ('[', rest) ->
-            takeLinkLabel (depth + 1) (consumed <> "[") rest
+            takeLinkLabel (depth + 1) ('[' : consumed) rest
         Just (']', rest)
             | depth == 0
             , Text.isPrefixOf "(" rest ->
-                Just (consumed, rest)
+                Just (Text.pack (reverse consumed), rest)
             | depth > 0 ->
-                takeLinkLabel (depth - 1) (consumed <> "]") rest
+                takeLinkLabel (depth - 1) (']' : consumed) rest
         Just (character, rest) ->
-            takeLinkLabel depth
-                (consumed <> Text.singleton character)
-                rest
+            takeLinkLabel depth (character : consumed) rest
 
-takeDestination :: Int -> Text -> Text -> Maybe (Text, Text)
+takeDestination :: Int -> [Char] -> Text -> Maybe (Text, Text)
 takeDestination depth consumed remaining =
     case Text.uncons remaining of
         Nothing -> Nothing
@@ -238,19 +239,17 @@ takeDestination depth consumed remaining =
                 Just (escaped, rest)
                     | isAsciiPunctuation escaped ->
                         takeDestination depth
-                            (consumed <> Text.singleton escaped)
+                            (escaped : consumed)
                             rest
-                _ -> takeDestination depth (consumed <> "\\") afterSlash
+                _ -> takeDestination depth ('\\' : consumed) afterSlash
         Just ('(', rest) ->
-            takeDestination (depth + 1) (consumed <> "(") rest
+            takeDestination (depth + 1) ('(' : consumed) rest
         Just (')', rest)
-            | depth == 0 -> Just (consumed, rest)
+            | depth == 0 -> Just (Text.pack (reverse consumed), rest)
             | otherwise ->
-                takeDestination (depth - 1) (consumed <> ")") rest
+                takeDestination (depth - 1) (')' : consumed) rest
         Just (character, rest) ->
-            takeDestination depth
-                (consumed <> Text.singleton character)
-                rest
+            takeDestination depth (character : consumed) rest
 
 bareUrlSpan :: Text -> Maybe (Text, Text)
 bareUrlSpan text = do
@@ -363,8 +362,17 @@ lastCharacter :: Text -> Maybe Char
 lastCharacter text = snd <$> Text.unsnoc text
 
 coalesceText :: [Inline] -> [Inline]
-coalesceText = foldr step []
+coalesceText = go
   where
-    step (InlineText left) (InlineText right : rest) =
-        InlineText (left <> right) : rest
-    step inline rest = inline : rest
+    go [] = []
+    go (InlineText first : rest) =
+        let (adjacent, remaining) = List.span isText rest
+            chunks =
+                first
+                    : [text | InlineText text <- adjacent]
+        in InlineText (Text.concat chunks) : go remaining
+    go (inline : rest) = inline : go rest
+
+    isText = \case
+        InlineText _ -> True
+        _ -> False

--- a/packages/agent-tui/test/Agent/TUI/Markdown/InlineSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/Markdown/InlineSpec.hs
@@ -1,6 +1,7 @@
 module Agent.TUI.Markdown.InlineSpec (spec) where
 
 import Agent.TUI.Markdown.Inline
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -116,3 +117,19 @@ spec = describe "shared inline Markdown parsing" do
     it "coalesces long plain input" do
         parseInline "plain text"
             `shouldBe` [InlineText "plain text"]
+
+    it "preserves escaped delimiters in long link labels and destinations" do
+        parseInline "[a\\]b](https://example.com/a\\(b\\))"
+            `shouldBe`
+                [ InlineLink
+                    "https://example.com/a(b)"
+                    [InlineText "a]b"]
+                ]
+
+    it "keeps unmatched multi-backtick spans literal" do
+        parseInline "``unfinished"
+            `shouldBe` [InlineText "``unfinished"]
+
+    it "does not flatten prior text while scanning repeated unmatched markers" do
+        let source = Text.replicate 200 "* "
+        parseInline source `shouldBe` [InlineText source]


### PR DESCRIPTION
## Summary
- replace growing strict-`Text` accumulators in inline Markdown parsing with reverse chunks and one final flatten
- preserve the preceding character separately so delimiter checks never flatten accumulated chunks
- add escapes, nesting, malformed tick/link, and repeated-marker regressions
- intentionally leave fenced-code assembly unchanged after its isolated benchmark showed no meaningful speedup

Independent from common base `07720c89`.

## Validation
- `agent-tui` suite: **181 examples, 0 failures**
- exhaustive base/head differential over ~1.11M short syntax strings plus 20k random strings: identical AST output
- live tmux smoke rendered nested emphasis, link, inline code, and fenced Haskell; exit 0

## Benchmark (`-O2`, 7-sample medians, identical base/head workload)
At 10k:

| workload | base | head | base alloc | head alloc |
|---|---:|---:|---:|---:|
| link | 5.666 ms | 0.157 ms | 52.5 MB | 1.60 MB |
| code | 51.161 ms | 1.287 ms | 755 MB | 4.87 MB |
| emphasis | 10.240 ms | 3.504 ms | 65.2 MB | 14.38 MB |
