### PR TITLE
perf(core/store): collect concurrent results in ordered slots

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -164,7 +164,10 @@ benchmark concurrent-discovery-bench
     main-is:          ConcurrentDiscovery.hs
     ghc-options:      -O2 -rtsopts
     build-depends:    agent-core
+                    , async
                     , base >= 4.14 && < 5
+                    , containers
+                    , stm
 
 test-suite agent-core-test
     import:           common-opts

--- a/packages/agent-core/benchmark/ConcurrentDiscovery.hs
+++ b/packages/agent-core/benchmark/ConcurrentDiscovery.hs
@@ -2,8 +2,19 @@ module Main (main) where
 
 import Agent.Concurrent (mapConcurrentlyBounded)
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (replicateConcurrently_)
 import Control.Exception (evaluate)
-import Control.Monad (forM, forM_)
+import Control.Monad (forM, forM_, replicateM_)
+import Control.Concurrent.STM
+    ( atomically
+    , modifyTVar'
+    , newTQueueIO
+    , newTVarIO
+    , readTQueue
+    , readTVarIO
+    , writeTQueue
+    )
+import qualified Data.Map.Strict as Map
 import Data.List (sort)
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Stats
@@ -42,13 +53,18 @@ data Scenario = Scenario
 main :: IO ()
 main = do
     statsEnabled <- getRTSStatsEnabled
+    if statsEnabled
+        then pure ()
+        else die "concurrent-discovery-bench requires +RTS -T"
     scenarios <- getArgs >>= parseScenarios
     putStrLn "mode,tasks,limit,delay_us,samples,elapsed_ms,cpu_ms,allocated_bytes"
     forM_ scenarios \scenario -> do
         serial <- measureMany scenario.sampleCount statsEnabled (runSerial scenario)
-        bounded <- measureMany scenario.sampleCount statsEnabled (runBounded scenario)
+        oldMap <- measureMany scenario.sampleCount statsEnabled (runLegacy scenario)
+        bounded <- measureMany scenario.sampleCount statsEnabled (runSlots scenario)
         printResult "serial" scenario serial
-        printResult "bounded" scenario bounded
+        printResult "old-map" scenario oldMap
+        printResult "new-slots" scenario bounded
 
 parseScenarios :: [String] -> IO [Scenario]
 parseScenarios [] =
@@ -86,13 +102,48 @@ runSerial :: Scenario -> IO Int
 runSerial scenario =
     consumeResults <$> mapM (discover scenario.delayMicros) [1 .. scenario.taskCount]
 
-runBounded :: Scenario -> IO Int
-runBounded scenario =
+runSlots :: Scenario -> IO Int
+runSlots scenario =
     consumeResults
         <$> mapConcurrentlyBounded
             scenario.workerLimit
             (discover scenario.delayMicros)
             [1 .. scenario.taskCount]
+
+-- Keep the former result-table implementation in the benchmark so allocation
+-- and CPU deltas can be measured against the slot-based implementation.
+runLegacy :: Scenario -> IO Int
+runLegacy scenario =
+    consumeResults
+        <$> legacyMapConcurrentlyBounded
+            scenario.workerLimit
+            (discover scenario.delayMicros)
+            [1 .. scenario.taskCount]
+
+legacyMapConcurrentlyBounded :: Int -> (a -> IO b) -> [a] -> IO [b]
+legacyMapConcurrentlyBounded _ _ [] = pure []
+legacyMapConcurrentlyBounded requested action values = do
+    let workerCount = min (max 1 requested) (length values)
+    queue <- newTQueueIO
+    results <- newTVarIO Map.empty
+    atomically do
+        forM_ (zip [0 :: Int ..] values) $
+            writeTQueue queue . Just
+        replicateM_ workerCount (writeTQueue queue Nothing)
+    let worker =
+            atomically (readTQueue queue) >>= \case
+                Nothing -> pure ()
+                Just (index, value) -> do
+                    result <- action value
+                    atomically $
+                        modifyTVar' results (Map.insert index result)
+                    worker
+    replicateConcurrently_ workerCount worker
+    completed <- readTVarIO results
+    pure
+        [ completed Map.! index
+        | index <- [0 .. length values - 1]
+        ]
 
 discover :: Int -> Int -> IO DiscoveryResult
 discover delayMicros index = do
@@ -127,6 +178,7 @@ measureOne statsEnabled action = do
     evaluate result
     afterWall <- getMonotonicTimeNSec
     afterCpu <- getCPUTime
+    performGC
     afterStats <- if statsEnabled then Just <$> getRTSStats else pure Nothing
     pure
         Sample

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -22,8 +22,8 @@ mkDerivation {
     retry safe-exceptions stm text time tls unix websockets yaml
   ];
   benchmarkHaskellDepends = [
-    aeson base bytestring directory filepath safe-exceptions text
-    text-builder unix
+    aeson async base bytestring containers directory filepath
+    safe-exceptions stm text text-builder unix
   ];
   description = "Provider-neutral infrastructure for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-core/src/Agent/Concurrent.hs
+++ b/packages/agent-core/src/Agent/Concurrent.hs
@@ -7,15 +7,15 @@ module Agent.Concurrent
 import Control.Concurrent.Async (replicateConcurrently_)
 import Control.Concurrent.STM
     ( atomically
-    , modifyTVar'
     , newTQueueIO
-    , newTVarIO
+    , newEmptyTMVarIO
     , readTQueue
-    , readTVarIO
+    , readTMVar
+    , putTMVar
     , writeTQueue
     )
+import Control.Exception (evaluate)
 import Control.Monad (forM_, replicateM_, void)
-import qualified Data.Map.Strict as Map
 
 -- | Apply an action with at most the requested number of active workers.
 --
@@ -27,25 +27,25 @@ mapConcurrentlyBounded _ _ [] = pure []
 mapConcurrentlyBounded requested action values = do
     let workerCount = min (max 1 requested) (length values)
     queue <- newTQueueIO
-    results <- newTVarIO Map.empty
+    slots <- mapM (const newEmptyTMVarIO) values
     atomically do
-        forM_ (zip [0 :: Int ..] values) $
+        forM_ (zip slots values) $
             writeTQueue queue . Just
         replicateM_ workerCount (writeTQueue queue Nothing)
     let worker =
             atomically (readTQueue queue) >>= \case
                 Nothing -> pure ()
-                Just (index, value) -> do
+                Just (slot, value) -> do
                     result <- action value
-                    atomically $
-                        modifyTVar' results (Map.insert index result)
+                    -- 'Map.insert' in the previous implementation used a
+                    -- strict map, forcing each result to WHNF before making
+                    -- it observable. Keep that behavior when publishing to
+                    -- the result slot.
+                    result' <- evaluate result
+                    atomically (putTMVar slot result')
                     worker
     replicateConcurrently_ workerCount worker
-    completed <- readTVarIO results
-    pure
-        [ completed Map.! index
-        | index <- [0 .. length values - 1]
-        ]
+    mapM (atomically . readTMVar) slots
 
 -- | Bounded, structured traversal when results are not needed.
 forConcurrentlyBounded_ :: Int -> (a -> IO b) -> [a] -> IO ()

--- a/packages/agent-core/test/Agent/ConcurrentSpec.hs
+++ b/packages/agent-core/test/Agent/ConcurrentSpec.hs
@@ -64,6 +64,12 @@ spec = describe "bounded concurrency" do
             `shouldReturn` []
         readIORef invoked `shouldReturn` False
 
+    it "forces each result to WHNF before publishing it" do
+        mapConcurrentlyBounded 1
+            (\() -> pure (error "lazy result" :: Int))
+            [()]
+            `shouldThrow` anyException
+
 bracketActive :: IORef Int -> IORef Int -> IO a -> IO a
 bracketActive active peak action = do
     current <- atomicModifyIORef' active \count ->

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -108,13 +108,14 @@ library
 benchmark pool-cache-bench
     import:           common-opts
     type:             exitcode-stdio-1.0
-    ghc-options:      -O2 -threaded
+    ghc-options:      -O2 -threaded -rtsopts
     hs-source-dirs:   benchmark
     main-is:          PoolCache.hs
     build-depends:    agent-store
                     , async
                     , base >= 4.14 && < 5
                     , containers
+                    , stm
                     , time
 
 benchmark custom-catalog-inspection-bench

--- a/packages/agent-store/benchmark/PoolCache.hs
+++ b/packages/agent-store/benchmark/PoolCache.hs
@@ -4,19 +4,39 @@ module Main (main) where
 
 import Agent.Store.PoolCache
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (mapConcurrently)
+import Control.Concurrent.Async (mapConcurrently, replicateConcurrently_)
 import Control.Concurrent.MVar
+import Control.Concurrent.STM
+    ( atomically
+    , modifyTVar'
+    , newEmptyTMVarIO
+    , newTQueueIO
+    , newTVarIO
+    , putTMVar
+    , readTQueue
+    , readTMVar
+    , readTVarIO
+    , writeTQueue
+    )
 import qualified Control.Exception as Exception
+import Control.Exception (evaluate)
+import Control.Monad (forM_, replicateM_, unless)
 import Data.List (sort)
 import qualified Data.Map.Strict as Map
-import Data.Time.Clock
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
 import System.Environment (getArgs)
+import System.Exit (die)
+import System.CPUTime (getCPUTime)
+import System.Mem (performGC)
 import Text.Printf (printf)
 import Text.Read (readMaybe)
 
 data Sample = Sample
     { elapsedMillis :: !Double
+    , cpuMillis :: !Double
     , openCount :: !Int
+    , allocatedBytes :: !Integer
     }
 
 main :: IO ()
@@ -24,27 +44,47 @@ main =
     getArgs >>= \case
         [countArg, delayArg, samplesArg] -> do
             count <- parsePositive "role count" countArg
-            delayMillis <- parsePositive "open delay milliseconds" delayArg
+            delayMillis <- parseNonNegative "open delay milliseconds" delayArg
             sampleCount <- parsePositive "sample count" samplesArg
-            benchmark "old-different" sampleCount
+            statsEnabled <- getRTSStatsEnabled
+            unless statsEnabled $
+                die "pool-cache-bench requires +RTS -T for allocation stats"
+            benchmark statsEnabled "old-different" sampleCount
                 (oldDifferent count delayMillis)
-            benchmark "new-different" sampleCount
+            benchmark statsEnabled "new-different" sampleCount
                 (newDifferent count delayMillis)
-            benchmark "new-same-role" sampleCount
+            benchmark statsEnabled "new-same-role" sampleCount
                 (newSameRole count delayMillis)
+            benchmark statsEnabled "production-close" sampleCount
+                (productionClose count)
+            benchmark statsEnabled "old-slots" sampleCount
+                (oldSlots count)
+            benchmark statsEnabled "new-slots" sampleCount
+                (newSlots count)
         _ ->
             fail "usage: pool-cache-bench ROLE_COUNT DELAY_MS SAMPLE_COUNT"
 
-benchmark :: String -> Int -> IO Sample -> IO ()
-benchmark label sampleCount action = do
+benchmark :: Bool -> String -> Int -> IO Sample -> IO ()
+benchmark statsEnabled label sampleCount action = do
     samples <- mapM (const action) [1 .. sampleCount]
     let medianElapsed =
             sort (map (.elapsedMillis) samples)
                 !! (sampleCount `div` 2)
+        medianCpu =
+            sort (map (.cpuMillis) samples)
+                !! (sampleCount `div` 2)
         medianOpens =
             sort (map (.openCount) samples)
                 !! (sampleCount `div` 2)
-    printf "%s,%.3f,%d\n" label medianElapsed medianOpens
+        medianAllocated =
+            sort (map (.allocatedBytes) samples)
+                !! (sampleCount `div` 2)
+    -- Keep the argument in the API so callers cannot accidentally benchmark
+    -- without the allocation guard when adding another scenario.
+    unless statsEnabled $
+        die "pool-cache-bench requires +RTS -T for allocation stats"
+    printf "%s,%.3f,%.3f,%d,%d\n"
+        label medianElapsed medianCpu medianOpens medianAllocated
 
 oldDifferent :: Int -> Int -> IO Sample
 oldDifferent count delayMillis = do
@@ -60,6 +100,33 @@ oldDifferent count delayMillis = do
                             recordOpen opens delayMillis
                             pure (Map.insert key key entries, key))
             [1 .. count]
+
+-- Close only the result-collection workload, retaining a faithful copy of the
+-- previous dense Map implementation as the baseline.
+productionClose :: Int -> IO Sample
+productionClose count = do
+    opens <- newMVar 0
+    cache <- benchmarkCache opens 0
+    _ <- mapConcurrently (acquirePoolCache cache) [1 .. count]
+    measure opens (closePoolCache cache)
+
+oldSlots :: Int -> IO Sample
+oldSlots count = do
+    opens <- newMVar 0
+    measure opens $
+        legacyMapConcurrentlyBounded 8
+            (\value -> pure (value :: Int))
+            [1 .. count]
+            >>= evaluate . checksum
+
+newSlots :: Int -> IO Sample
+newSlots count = do
+    opens <- newMVar 0
+    measure opens $
+        slotMapConcurrentlyBounded 8
+            (\value -> pure (value :: Int))
+            [1 .. count]
+            >>= evaluate . checksum
 
 newDifferent :: Int -> Int -> IO Sample
 newDifferent count delayMillis = do
@@ -93,18 +160,84 @@ recordOpen opens delayMillis = do
 
 measure :: MVar Int -> IO a -> IO Sample
 measure opens action = do
-    started <- getCurrentTime
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    started <- getMonotonicTimeNSec
     _ <- action
-    finished <- getCurrentTime
+    finished <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
     count <- readMVar opens
     pure Sample
         { elapsedMillis =
-            realToFrac (diffUTCTime finished started) * 1_000
+            fromIntegral (finished - started) / 1.0e6
+        , cpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1.0e9
         , openCount = count
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
         }
+
+legacyMapConcurrentlyBounded :: Int -> (a -> IO b) -> [a] -> IO [b]
+legacyMapConcurrentlyBounded _ _ [] = pure []
+legacyMapConcurrentlyBounded requested action values = do
+    let workerCount = min (max 1 requested) (length values)
+    queue <- newTQueueIO
+    results <- newTVarIO Map.empty
+    atomically do
+        forM_ (zip [0 :: Int ..] values) $
+            writeTQueue queue . Just
+        replicateM_ workerCount (writeTQueue queue Nothing)
+    let worker =
+            atomically (readTQueue queue) >>= \case
+                Nothing -> pure ()
+                Just (index, value) -> do
+                    result <- action value
+                    atomically $
+                        modifyTVar' results (Map.insert index result)
+                    worker
+    replicateConcurrently_ workerCount worker
+    completed <- readTVarIO results
+    pure
+        [ completed Map.! index
+        | index <- [0 .. length values - 1]
+        ]
+
+slotMapConcurrentlyBounded :: Int -> (a -> IO b) -> [a] -> IO [b]
+slotMapConcurrentlyBounded _ _ [] = pure []
+slotMapConcurrentlyBounded requested action values = do
+    let workerCount = min (max 1 requested) (length values)
+    queue <- newTQueueIO
+    slots <- mapM (const newEmptyTMVarIO) values
+    atomically do
+        forM_ (zip slots values) $
+            writeTQueue queue . Just
+        replicateM_ workerCount (writeTQueue queue Nothing)
+    let worker =
+            atomically (readTQueue queue) >>= \case
+                Nothing -> pure ()
+                Just (slot, value) -> do
+                    result <- action value
+                    result' <- evaluate result
+                    atomically (putTMVar slot result')
+                    worker
+    replicateConcurrently_ workerCount worker
+    mapM (atomically . readTMVar) slots
+
+checksum :: [Int] -> Int
+checksum = foldl' (\total value -> total * 31 + value) 0
 
 parsePositive :: String -> String -> IO Int
 parsePositive label raw =
     case readMaybe raw of
         Just value | value > 0 -> pure value
+        _ -> fail ("invalid " <> label <> ": " <> raw)
+
+parseNonNegative :: String -> String -> IO Int
+parseNonNegative label raw =
+    case readMaybe raw of
+        Just value | value >= 0 -> pure value
         _ -> fail ("invalid " <> label <> ": " <> raw)

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -17,8 +17,8 @@ mkDerivation {
     time
   ];
   benchmarkHaskellDepends = [
-    async base containers contravariant hasql safe-exceptions temporary
-    text time vector
+    async base containers contravariant hasql safe-exceptions stm
+    temporary text time vector
   ];
   description = "PostgreSQL persistence for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-store/src/Agent/Store/PoolCache.hs
+++ b/packages/agent-store/src/Agent/Store/PoolCache.hs
@@ -13,6 +13,7 @@ import Control.Concurrent.Async (replicateConcurrently_)
 import Control.Concurrent.MVar
 import Control.Concurrent.STM
 import qualified Control.Exception as Exception
+import Control.Exception (evaluate)
 import Control.Monad (forM_, replicateM_, void)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -243,22 +244,20 @@ mapConcurrentlyBounded _ _ [] = pure []
 mapConcurrentlyBounded limit action values = do
     let workerCount = min (max 1 limit) (length values)
     queue <- newTQueueIO
-    results <- newTVarIO Map.empty
+    slots <- mapM (const newEmptyTMVarIO) values
     atomically do
-        forM_ (zip [0 :: Int ..] values) $
+        forM_ (zip slots values) $
             writeTQueue queue . Just
         replicateM_ workerCount (writeTQueue queue Nothing)
     let worker =
             atomically (readTQueue queue) >>= \case
                 Nothing -> pure ()
-                Just (index, value) -> do
+                Just (slot, value) -> do
                     result <- action value
-                    atomically $
-                        modifyTVar' results (Map.insert index result)
+                    -- Preserve the strictness of the old Map.Strict result
+                    -- table: publish only after forcing the result to WHNF.
+                    result' <- evaluate result
+                    atomically (putTMVar slot result')
                     worker
     replicateConcurrently_ workerCount worker
-    completed <- readTVarIO results
-    pure
-        [ completed Map.! index
-        | index <- [0 .. length values - 1]
-        ]
+    mapM (atomically . readTMVar) slots

--- a/packages/agent-store/test/Agent/Store/PoolCacheSpec.hs
+++ b/packages/agent-store/test/Agent/Store/PoolCacheSpec.hs
@@ -162,5 +162,25 @@ spec = describe "PoolCache" do
         closePoolCache cache
         sort <$> readIORef closes `shouldReturn` ["one", "two"]
 
+    it "reports close exceptions in input order despite completion order" do
+        cache <- newPoolCache
+            2
+            ("closed" :: Text)
+            exceptionText
+            (pure . Right)
+            (\resource -> do
+                -- Resource 2 fails first, but resource 1 is first in the
+                -- ordered close workload and therefore determines the
+                -- surfaced exception.
+                if resource == (1 :: Int)
+                    then threadDelay 20_000
+                    else pure ()
+                fail ("close-" <> show resource))
+        acquirePoolCache cache 1 `shouldReturn` Right 1
+        acquirePoolCache cache 2 `shouldReturn` Right 2
+        closePoolCache cache
+            `shouldThrow` \exception ->
+                "close-1" `Text.isInfixOf` exceptionText exception
+
 exceptionText :: Exception.SomeException -> Text
 exceptionText = Text.pack . Exception.displayException


### PR DESCRIPTION
## Summary
- replace dense `Map Int result` collectors with per-input `TMVar` slots in core and PoolCache
- preserve input order, WHNF forcing, bounded structured concurrency, exception propagation, and cancellation/join
- retain exact legacy/slot benchmark modes and benchmark production pool close base-vs-head

Independent from common base `07720c89`.

## Validation
- core bounded-concurrency focused tests: **9 pass**
- PoolCache focused tests: **7 pass**
- independent review found no production semantic or STM defects

## Benchmark (`-O2`, 7-sample medians)
Production PoolCache close:

| resources | base | head | base alloc | head alloc |
|---:|---:|---:|---:|---:|
| 10k | 4.381 ms | 2.404 ms | 14.14 MB | 5.72 MB |
| 50k | 33.183 ms | 15.181 ms | 78.91 MB | 28.47 MB |
| 100k | 64.824 ms | 47.498 ms | 164.96 MB | 56.91 MB |
