### PR TITLE
perf(cli): queue pending inputs with Seq

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -301,9 +301,11 @@ benchmark concurrency-bench
                     , agent-core
                     , base >= 4.17 && < 5
                     , bytestring
+                    , containers
                     , directory
                     , filepath
                     , safe-exceptions
+                    , text
                     , time
 
 test-suite agent-cli-test

--- a/packages/agent-cli/benchmark/Concurrency.hs
+++ b/packages/agent-cli/benchmark/Concurrency.hs
@@ -1,12 +1,34 @@
 module Main (main) where
 
 import Agent.Concurrent (mapConcurrentlyBounded)
+import Agent.CLI.PendingInputs
+    ( PendingInputs
+    , enqueuePendingInput
+    , newPendingInputs
+    , withPendingInputs
+    )
+import Agent.Loop
+    ( Backend(..)
+    , BackendResult(..)
+    , TurnInput(..)
+    , emptyTurnOutput
+    )
+import Agent.Error (ApiError(..))
 import Control.Concurrent (threadDelay)
-import Control.Exception.Safe (SomeException, bracket)
+import Control.Exception.Safe (SomeException, bracket, onException)
 import qualified Control.Exception.Safe as Exception
-import Control.Monad (when)
+import Control.Monad (forM_, when)
 import qualified Data.ByteString as BS
 import Data.List (sort)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , modifyIORef'
+    , newIORef
+    , readIORef
+    )
+import qualified Data.Text as Text
+import Data.Char (ord)
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Stats
     ( RTSStats(..)
@@ -31,10 +53,20 @@ data Sample = Sample
 
 main :: IO ()
 main = do
+    args <- getArgs
+    case args of
+        ["pending-legacy", count, samples] ->
+            benchmarkPendingInputs False (read count) (read samples)
+        ["pending-seq", count, samples] ->
+            benchmarkPendingInputs True (read count) (read samples)
+        _ -> benchmarkConcurrency args
+
+benchmarkConcurrency :: [String] -> IO ()
+benchmarkConcurrency args = do
     statsEnabled <- getRTSStatsEnabled
     when (not statsEnabled) $
         fail "run with +RTS -T"
-    (count, bytesPerFile, samples) <- parseArgs <$> getArgs
+    let (count, bytesPerFile, samples) = parseArgs args
     withInputFiles count bytesPerFile \paths -> do
         putStrLn
             ("count=" <> show count
@@ -48,6 +80,126 @@ main = do
             (serialRead paths)
         benchmark "attachments-bounded-4" samples
             (boundedRead paths)
+
+benchmarkPendingInputs :: Bool -> Int -> Int -> IO ()
+benchmarkPendingInputs useSequence count sampleCount = do
+    statsEnabled <- getRTSStatsEnabled
+    when (not statsEnabled) $
+        fail "run with +RTS -T"
+    let inputs =
+            [ UserMessage (Text.pack ("pending-" <> show index))
+            | index <- [1 .. max 1 count]
+            ]
+    forM_ [False, True] \failFirst -> do
+        legacyChecksum <- pendingLegacy inputs failFirst
+        sequenceChecksum <- pendingSequence inputs failFirst
+        when (legacyChecksum /= sequenceChecksum) $
+            fail "pending queue implementations disagree on FIFO checksum"
+        let action = if useSequence
+                then pendingSequence inputs failFirst
+                else pendingLegacy inputs failFirst
+        samples <- mapM (const (measure action)) [1 .. max 1 sampleCount]
+        let sample = medianSample samples
+            label = if useSequence then "pending-seq" else "pending-legacy"
+            scenario = if failFirst then "failure-retry" else "success"
+        putStrLn
+            ( label <> " scenario=" <> scenario <> " count=" <> show count
+                <> " samples=" <> show sampleCount
+                <> " elapsed-ms=" <> show sample.sampleElapsedMillis
+                <> " cpu-ms=" <> show sample.sampleCpuMillis
+                <> " allocated-bytes=" <> show sample.sampleAllocatedBytes
+            )
+
+medianSample :: [Sample] -> Sample
+medianSample samples =
+    Sample
+        { sampleElapsedMillis = median (map (.sampleElapsedMillis) samples)
+        , sampleCpuMillis = median (map (.sampleCpuMillis) samples)
+        , sampleAllocatedBytes = median (map (.sampleAllocatedBytes) samples)
+        }
+
+pendingLegacy :: [TurnInput] -> Bool -> IO Int
+pendingLegacy inputs failFirst = do
+    pending <- newIORef ([] :: [TurnInput])
+    mapM_ (\input -> atomicModifyIORef' pending \queued ->
+        (queued <> [input], ())) inputs
+    runLegacy pending failFirst
+
+pendingSequence :: [TurnInput] -> Bool -> IO Int
+pendingSequence inputs failFirst = do
+    pending <- newPendingInputs
+    mapM_ (enqueuePendingInput pending) inputs
+    runSequence pending failFirst
+
+runLegacy :: IORef [TurnInput] -> Bool -> IO Int
+runLegacy pending failFirst = do
+    seen <- newIORef []
+    attempts <- newIORef (0 :: Int)
+    let backend = legacyWithPending pending $ Backend
+            \state _ submitted _ -> do
+                modifyIORef' seen (<> [submitted])
+                attempt <- atomicModifyIORef' attempts (\n -> (n + 1, n + 1))
+                if failFirst && attempt == 1
+                    then pure (Left (ConnectionError "benchmark"))
+                    else pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "benchmark" [] Nothing
+                        , backendState = state
+                        }
+    first <- backend.submitTurn [] Nothing [] (const (pure ()))
+    case first of
+        Left _ | failFirst -> do
+            _ <- backend.submitTurn [] Nothing [] (const (pure ()))
+            pure ()
+        _ -> pure ()
+    checksumInputs . concat <$> readIORef seen
+
+runSequence :: PendingInputs -> Bool -> IO Int
+runSequence pending failFirst = do
+    seen <- newIORef []
+    attempts <- newIORef (0 :: Int)
+    let backend = withPendingInputs pending $ Backend
+            \state _ submitted _ -> do
+                modifyIORef' seen (<> [submitted])
+                attempt <- atomicModifyIORef' attempts (\n -> (n + 1, n + 1))
+                if failFirst && attempt == 1
+                    then pure (Left (ConnectionError "benchmark"))
+                    else pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "benchmark" [] Nothing
+                        , backendState = state
+                        }
+    first <- backend.submitTurn [] Nothing [] (const (pure ()))
+    case first of
+        Left _ | failFirst -> do
+            _ <- backend.submitTurn [] Nothing [] (const (pure ()))
+            pure ()
+        _ -> pure ()
+    checksumInputs . concat <$> readIORef seen
+
+legacyWithPending :: IORef [TurnInput] -> Backend -> Backend
+legacyWithPending pending (Backend submit) =
+    Backend \state previous inputs onEvent -> do
+        queued <- atomicModifyIORef' pending (\xs -> ([], xs))
+        let requeue = atomicModifyIORef' pending (\current ->
+                (queued <> current, ()))
+            prefixed = queued <> inputs
+        result <- submit state previous prefixed onEvent `onException` requeue
+        case result of
+            Left _ -> requeue
+            Right _ -> pure ()
+        pure result
+
+checksumInputs :: [TurnInput] -> Int
+checksumInputs = foldl
+    (\acc input ->
+        Text.foldl' (\value character -> value * 131 + ord character)
+            (acc * 17)
+            (turnInputText input))
+    17
+  where
+    turnInputText input = case input of
+        UserMessage text -> text
+        AgentMessage message -> Text.pack (show message)
+        _ -> Text.pack (show input)
 
 parseArgs :: [String] -> (Int, Int, Int)
 parseArgs = \case
@@ -77,6 +229,7 @@ measure action = do
     checksum `seq` pure ()
     afterElapsed <- getMonotonicTimeNSec
     afterCpu <- getCPUTime
+    performMajorGC
     afterStats <- getRTSStats
     pure Sample
         { sampleElapsedMillis =

--- a/packages/agent-cli/src/Agent/CLI/PendingInputs.hs
+++ b/packages/agent-cli/src/Agent/CLI/PendingInputs.hs
@@ -1,24 +1,83 @@
 -- | Queue parent inputs that must survive failed or interrupted submissions.
 module Agent.CLI.PendingInputs
-    ( withPendingInputs
+    ( PendingInputs
+    , newPendingInputs
+    , clearPendingInputs
+    , enqueuePendingInput
+    , withPendingInputs
     ) where
 
 import Agent.Loop (Backend(..), TurnInput)
-import Control.Exception.Safe (onException)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
+import Control.Exception.Safe (mask, onException)
+import Data.Foldable (toList)
 import Data.IORef (IORef, atomicModifyIORef')
+import qualified Data.IORef
+import qualified Data.Sequence as Seq
 
-withPendingInputs :: IORef [TurnInput] -> Backend -> Backend
-withPendingInputs pending (Backend submit) =
-    Backend \state previous inputs onEvent -> do
-        queued <- atomicModifyIORef' pending \xs -> ([], xs)
-        let requeue =
-                atomicModifyIORef' pending \current ->
-                    (queued <> current, ())
-            prefixed
-                | null queued = inputs
-                | otherwise = queued <> inputs
-        result <- submit state previous prefixed onEvent `onException` requeue
-        case result of
-            Left _ -> requeue
-            Right _ -> pure ()
-        pure result
+data PendingState = PendingState
+    { pendingEpoch :: !Word
+    , pendingQueue :: !(Seq.Seq TurnInput)
+    }
+
+data PendingBatch = PendingBatch !Word !(Seq.Seq TurnInput)
+
+data PendingInputs = PendingInputs
+    (IORef PendingState)
+    (MVar ())
+
+newPendingInputs :: IO PendingInputs
+newPendingInputs = PendingInputs
+    <$> Data.IORef.newIORef (PendingState 0 Seq.empty)
+    <*> newMVar ()
+
+clearPendingInputs :: PendingInputs -> IO ()
+clearPendingInputs (PendingInputs pending _) =
+    atomicModifyIORef' pending \state ->
+        (state { pendingEpoch = epochOf state + 1
+               , pendingQueue = Seq.empty
+               }, ())
+
+enqueuePendingInput :: PendingInputs -> TurnInput -> IO ()
+enqueuePendingInput (PendingInputs pending _) input =
+    atomicModifyIORef' pending \state ->
+        (state { pendingQueue = queueOf state Seq.|> input }, ())
+
+drainPendingInputs :: IORef PendingState -> IO PendingBatch
+drainPendingInputs pending =
+    atomicModifyIORef' pending \state ->
+        (state { pendingQueue = Seq.empty }
+        , PendingBatch (epochOf state) (queueOf state))
+
+requeuePendingInputs :: IORef PendingState -> PendingBatch -> IO ()
+requeuePendingInputs pending (PendingBatch epoch queued) =
+    atomicModifyIORef' pending \state ->
+        if epochOf state == epoch
+            then (state { pendingQueue = queued <> queueOf state }, ())
+            else (state, ())
+
+epochOf :: PendingState -> Word
+epochOf (PendingState epoch _) = epoch
+
+queueOf :: PendingState -> Seq.Seq TurnInput
+queueOf (PendingState _ queue) = queue
+
+withPendingInputs :: PendingInputs -> Backend -> Backend
+withPendingInputs (PendingInputs pending lifecycle) (Backend submit) =
+    Backend \state previous inputs onEvent ->
+        mask \restore ->
+            withMVar lifecycle \_ -> do
+                batch <- drainPendingInputs pending
+                let queued = case batch of
+                        PendingBatch _ values -> values
+                    requeue = requeuePendingInputs pending batch
+                    prefixed
+                        | Seq.null queued = inputs
+                        | otherwise = toList queued <> inputs
+                result <- restore
+                    (submit state previous prefixed onEvent)
+                    `onException` requeue
+                case result of
+                    Left _ -> requeue
+                    Right _ -> pure ()
+                pure result

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -97,7 +97,11 @@ import Agent.CLI.Options
                  optPrompt, optPromptFile, optManagedTurnFile,
                  optScreenMode, optGhci, optBash, optResume, optCwd),
       ScreenMode(ScreenMinimal) )
-import Agent.CLI.PendingInputs ( withPendingInputs )
+import Agent.CLI.PendingInputs
+    ( enqueuePendingInput
+    , newPendingInputs
+    , withPendingInputs
+    )
 import Agent.CLI.Plan ( cliPlanHooks )
 import Agent.CLI.Project
     ( ProjectAccount(..),
@@ -1655,7 +1659,7 @@ runAgentInitializedWithLock
     subagentSessions <- newIORef Map.empty
     subagentStoreRoot <- newIORef Nothing
     subagentForkSource <- newIORef (Nothing :: Maybe (IO [ResponseItem]))
-    pendingNotices <- newIORef ([] :: [TurnInput])
+    pendingNotices <- newPendingInputs
     let maxConcurrentAgents =
             fromMaybe defaultMaxConcurrent $
                 options.optMaxConcurrentAgents
@@ -1685,8 +1689,7 @@ runAgentInitializedWithLock
             _ ->
                 Nothing
         sendToRoot message = do
-            atomicModifyIORef' pendingNotices \xs ->
-                (xs <> [AgentMessage message], ())
+            enqueuePendingInput pendingNotices (AgentMessage message)
             pure (Right "queued")
         createSubagentWorktree source =
             createWorktree source (worktreeRoot home) >>= \case
@@ -1814,13 +1817,8 @@ runAgentInitializedWithLock
                 atomicModifyIORef' mcpStatusPhaseRef \previous ->
                     (Just isConnecting, previous == Just True && not isConnecting)
             when (settled && not (null statuses)) $
-                atomicModifyIORef' pendingNotices \notices ->
-                    ( notices
-                        <> [ UserMessage
-                                (formatMcpModelNoticeFor dialectId statuses)
-                           ]
-                    , ()
-                    )
+                enqueuePendingInput pendingNotices
+                    (UserMessage (formatMcpModelNoticeFor dialectId statuses))
     mcpLease <-
         try @_ @SomeException
             (if progressiveMcp
@@ -1900,8 +1898,8 @@ runAgentInitializedWithLock
     case multiCtx of
         Just ctx -> do
             setSubagentOnComplete ctx.multiRegistry \agentId status -> do
-                atomicModifyIORef' pendingNotices \xs ->
-                    (xs <> [UserMessage (formatCompletionNotice agentId status)], ())
+                enqueuePendingInput pendingNotices
+                    (UserMessage (formatCompletionNotice agentId status))
             setSubagentOnSettled ctx.multiRegistry \agentId status -> do
                 sessions <- readIORef subagentSessions
                 case Map.lookup agentId sessions of

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -53,6 +53,7 @@ import Agent.CLI.LearnedSkills.Store
     ( loadApplicableLearnedSkillsForStore
     )
 import Agent.CLI.Options (CliOptions(..), isOneShot)
+import Agent.CLI.PendingInputs (clearPendingInputs)
 import Agent.CLI.Runtime.Types
     ( PendingTurnPresentation(..)
     , RunResult(..)
@@ -605,13 +606,13 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             writeIORef usageRef emptyTokenUsage
             modifyIORef' renderStateRef clearRenderTokenRate
             writeIORef lastAssistantRef Nothing
-            writeIORef pendingNotices []
             writeIORef subagentSessions Map.empty
             writeIORef selectedAgent AgentRoot
             writeIORef agentStepCache Map.empty
             case multiCtx of
                 Just ctx -> resetSubagentRegistry ctx.multiRegistry
                 Nothing -> pure ()
+            clearPendingInputs pendingNotices
             reloadGeneratedContext
         refreshSkills queueContext = do
             refreshed <- loadSkillsCatalogQuiet

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -23,6 +23,7 @@ import Agent.CLI.Options
     , CliOptions
     )
 import Agent.CLI.ProviderTransition (PendingTurn)
+import Agent.CLI.PendingInputs (PendingInputs)
 import Agent.CLI.Session
     ( LegacySubagentTarget
     , Persistence
@@ -43,7 +44,6 @@ import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
 import Agent.Loop
     ( Backend
     , TokenUsage
-    , TurnInput
     )
 import qualified Agent.MCP as MCP
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -129,7 +129,7 @@ data SessionRequest = SessionRequest
     , multiCtx :: !(Maybe MultiAgentContext)
     , rootTurnRef :: !(IORef (Maybe RootTurnId))
     , subagentSessions :: !(IORef (Map SubagentId SubagentSession))
-    , pendingNotices :: !(IORef [TurnInput])
+    , pendingNotices :: !PendingInputs
     , storeRoot :: !SubagentStoreRoot
     , agentTypes :: !GrokSubagentSpecs
     , legacyTarget :: !(Maybe LegacySubagentTarget)

--- a/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
@@ -5,7 +5,11 @@ import Agent.CLI.Connectivity
     , transientRetryDelayMicros
     , withConnectionRecoveryUsing
     )
-import Agent.CLI.PendingInputs (withPendingInputs)
+import Agent.CLI.PendingInputs
+    ( enqueuePendingInput
+    , newPendingInputs
+    , withPendingInputs
+    )
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
     ( Backend(..)
@@ -145,7 +149,8 @@ spec = describe "withConnectionRecovery" do
 
     it "does not duplicate queued inputs across reconnect attempts" do
         attempts <- newIORef (0 :: Int)
-        pending <- newIORef [UserMessage "queued"]
+        pending <- newPendingInputs
+        enqueuePendingInput pending (UserMessage "queued")
         seen <- newIORef []
         let backend =
                 withPendingInputs pending $
@@ -174,7 +179,6 @@ spec = describe "withConnectionRecovery" do
                 , backendState = []
                 }
         readIORef seen `shouldReturn` [expected, expected]
-        readIORef pending `shouldReturn` []
 
     it "restarts partial output after a transient provider error" do
         attempts <- newIORef (0 :: Int)

--- a/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
@@ -1,6 +1,11 @@
 module Agent.CLI.PendingInputsSpec (spec) where
 
-import Agent.CLI.PendingInputs (withPendingInputs)
+import Agent.CLI.PendingInputs
+    ( clearPendingInputs
+    , enqueuePendingInput
+    , newPendingInputs
+    , withPendingInputs
+    )
 import Agent.Error (ApiError(..))
 import Agent.Loop
     ( Backend(..)
@@ -8,15 +13,22 @@ import Agent.Loop
     , TurnInput(..)
     , emptyTurnOutput
     )
+import Control.Concurrent
+    ( forkIO
+    , newEmptyMVar
+    , putMVar
+    , takeMVar
+    )
 import Control.Exception.Safe (tryAny)
 import Data.Either (isLeft)
-import Data.IORef
+import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import Test.Hspec
 
 spec :: Spec
 spec = describe "withPendingInputs" do
     it "commits queued inputs after a successful submission" do
-        pending <- newIORef [UserMessage "child result"]
+        pending <- newPendingInputs
+        enqueuePendingInput pending (UserMessage "child result")
         seen <- newIORef []
         let backend = withPendingInputs pending $ Backend
                 \state _ inputs _ -> do
@@ -30,24 +42,142 @@ spec = describe "withPendingInputs" do
             [UserMessage "parent"] (const (pure ()))
         readIORef seen `shouldReturn`
             [UserMessage "child result", UserMessage "parent"]
-        readIORef pending `shouldReturn` []
 
     it "requeues inputs when the backend returns an error" do
         let queued = [UserMessage "child result"]
-        pending <- newIORef queued
+        pending <- newPendingInputs
+        mapM_ (enqueuePendingInput pending) queued
         let backend = withPendingInputs pending $ Backend
                 \_ _ _ _ -> pure (Left (ConnectionError "offline"))
         _ <- backend.submitTurn [] Nothing
             [UserMessage "parent"] (const (pure ()))
-        readIORef pending `shouldReturn` queued
+        seen <- newIORef []
+        let retry = withPendingInputs pending $ Backend
+                \state _ inputs _ -> do
+                    writeIORef seen inputs
+                    pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "response" [] Nothing
+                        , backendState = state
+                        }
+        _ <- retry.submitTurn [] Nothing [] (const (pure ()))
+        readIORef seen `shouldReturn` queued
 
     it "requeues inputs when submission is interrupted by an exception" do
         let queued = [UserMessage "child result"]
-        pending <- newIORef queued
+        pending <- newPendingInputs
+        mapM_ (enqueuePendingInput pending) queued
         let backend = withPendingInputs pending $ Backend
                 \_ _ _ _ -> ioError (userError "interrupted")
         result <- tryAny $
             backend.submitTurn [] Nothing
                 [UserMessage "parent"] (const (pure ()))
         result `shouldSatisfy` isLeft
-        readIORef pending `shouldReturn` queued
+        seen <- newIORef []
+        let retry = withPendingInputs pending $ Backend
+                \state _ inputs _ -> do
+                    writeIORef seen inputs
+                    pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "response" [] Nothing
+                        , backendState = state
+                        }
+        _ <- retry.submitTurn [] Nothing [] (const (pure ()))
+        readIORef seen `shouldReturn` queued
+
+    it "prepends drained inputs ahead of concurrent enqueues when requeuing" do
+        pending <- newPendingInputs
+        enqueuePendingInput pending (UserMessage "old")
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        let backend = withPendingInputs pending $ Backend
+                \_ _ _ _ -> do
+                    putMVar entered ()
+                    takeMVar release
+                    pure (Left (ConnectionError "offline"))
+        done <- newEmptyMVar
+        _ <- forkIO $ backend.submitTurn [] Nothing [] (const (pure ())) >>= putMVar done
+        takeMVar entered
+        enqueuePendingInput pending (UserMessage "new")
+        putMVar release ()
+        _ <- takeMVar done
+        seen <- newIORef []
+        let retry = withPendingInputs pending $ Backend
+                \state _ inputs _ -> do
+                    writeIORef seen inputs
+                    pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "response" [] Nothing
+                        , backendState = state
+                        }
+        _ <- retry.submitTurn [] Nothing [] (const (pure ()))
+        readIORef seen `shouldReturn`
+            [UserMessage "old", UserMessage "new"]
+
+    it "clears queued inputs" do
+        pending <- newPendingInputs
+        enqueuePendingInput pending (UserMessage "stale")
+        clearPendingInputs pending
+        seen <- newIORef []
+        let backend = withPendingInputs pending $ Backend
+                \state _ inputs _ -> do
+                    writeIORef seen inputs
+                    pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "response" [] Nothing
+                        , backendState = state
+                        }
+        _ <- backend.submitTurn [] Nothing [] (const (pure ()))
+        readIORef seen `shouldReturn` []
+
+    it "does not resurrect a batch cleared during an in-flight failure" do
+        pending <- newPendingInputs
+        enqueuePendingInput pending (UserMessage "stale")
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        let backend = withPendingInputs pending $ Backend
+                \_ _ _ _ -> do
+                    putMVar entered ()
+                    takeMVar release
+                    pure (Left (ConnectionError "offline"))
+        done <- newEmptyMVar
+        _ <- forkIO $ backend.submitTurn [] Nothing [] (const (pure ())) >>= putMVar done
+        takeMVar entered
+        clearPendingInputs pending
+        putMVar release ()
+        _ <- takeMVar done
+        seen <- newIORef []
+        let retry = withPendingInputs pending $ Backend
+                \state _ inputs _ -> do
+                    writeIORef seen inputs
+                    pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "response" [] Nothing
+                        , backendState = state
+                        }
+        _ <- retry.submitTurn [] Nothing [] (const (pure ()))
+        readIORef seen `shouldReturn` []
+
+    it "serializes concurrent submission batches" do
+        pending <- newPendingInputs
+        enqueuePendingInput pending (UserMessage "first")
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        seen <- newIORef []
+        let backend = withPendingInputs pending $ Backend
+                \state _ inputs _ -> do
+                    modifyIORef' seen (<> [inputs])
+                    putMVar entered ()
+                    takeMVar release
+                    pure $ Left (ConnectionError "offline")
+        done1 <- newEmptyMVar
+        done2 <- newEmptyMVar
+        _ <- forkIO $ backend.submitTurn [] Nothing [] (const (pure ())) >>= putMVar done1
+        takeMVar entered
+        enqueuePendingInput pending (UserMessage "second")
+        _ <- forkIO $ backend.submitTurn [] Nothing [] (const (pure ())) >>= putMVar done2
+        putMVar release ()
+        _ <- takeMVar done1
+        -- The second submission cannot overtake the first batch.
+        takeMVar entered
+        putMVar release ()
+        _ <- takeMVar done2
+        readIORef seen `shouldReturn`
+            [ [UserMessage "first"]
+            , [UserMessage "first", UserMessage "second"]
+            ]


### PR DESCRIPTION
## Summary
- encapsulate pending notices in a `Seq` FIFO
- serialize submissions, mask drain/commit/requeue, and tag drained batches with an epoch so reset cannot resurrect stale items
- clear only after subagent teardown callbacks settle
- keep enqueues nonblocking while a backend submit is active

Independent from common base `07720c89`.

## Validation
- PendingInputs focused tests: **7 pass**
- connectivity/recovery focused tests: **9 pass**
- covers async exception, concurrent enqueue, concurrent submission, clear during failure, FIFO retry, and stale teardown notices

## Benchmark (`-O2`, 7-sample medians, 1k notices)
| scenario | legacy | Seq | legacy alloc | Seq alloc |
|---|---:|---:|---:|---:|
| success | 1.99 ms | 0.037 ms | 28.15 MB | 0.318 MB |
| failure + retry | 1.946 ms | 0.052 ms | 28.26 MB | 0.358 MB |

Common path: at 10 notices both implementations are 0.001–0.002 ms; no material small-queue regression.
