### PR TITLE
perf(cli): build Responses Lite tools with reverse accumulators

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -306,6 +306,24 @@ benchmark concurrency-bench
                     , safe-exceptions
                     , time
 
+benchmark responses-lite-tools-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          ResponsesLiteTools.hs
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-cli
+                    , agent-core
+                    , agent-responses
+                    , agent-responses-types
+                    , aeson
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , containers
+                    , deepseq
+                    , text
+                    , vector
+
 test-suite agent-cli-test
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-cli/benchmark/ResponsesLiteTools.hs
+++ b/packages/agent-cli/benchmark/ResponsesLiteTools.hs
@@ -1,0 +1,266 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- | Production-shaped benchmark for Responses Lite tool construction.
+--
+-- The legacy implementation is kept locally so this benchmark can compare
+-- the same workload without checking out a second tree.
+-- Run with:
+--   nix develop -c cabal run responses-lite-tools-bench -- 7 +RTS -T
+-- For interactive inspection:
+--   nix develop -c cabal repl agent-cli:bench:responses-lite-tools-bench
+module Main (main) where
+
+import Agent.CLI.Request (requestParams)
+import Agent.CLI.Tools (webSearchTool)
+import Agent.Provider (Provider(..))
+import Agent.Responses.Types
+import Control.Applicative ((<|>))
+import Control.DeepSeq (force)
+import Control.Exception (evaluate)
+import Control.Monad (forM, unless)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (sort)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Vector as Vector
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.CPUTime (getCPUTime)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled $
+        die "RTS statistics are disabled; run with +RTS -T"
+    args <- getArgs
+    (sizes, sampleCount) <- case args of
+        [] -> pure ([10, 100, 1000, 10000], 7)
+        [raw] -> do
+            samples <- parsePositive "sample count" raw
+            pure ([10, 100, 1000, 10000], samples)
+        [mode, count, raw] -> do
+            unless (mode == "compare") $
+                die "only MODE=compare is supported"
+            size <- parsePositive "tool count" count
+            samples <- parsePositive "sample count" raw
+            pure ([size], samples)
+        _ -> die "usage: responses-lite-tools-bench [MODE COUNT SAMPLES]"
+    putStrLn "size,optimized_ms,legacy_ms,optimized_cpu_ms,legacy_cpu_ms,optimized_alloc_bytes,legacy_alloc_bytes,checksum"
+    mapM_ (\size -> do
+        samples <- forM [1 .. sampleCount] \sampleIndex -> do
+            let tools = workload size sampleIndex
+                optimized = productionValues tools
+                legacy = legacyValues tools
+            optimizedValues <- evaluate (force optimized)
+            legacyValues' <- evaluate (force legacy)
+            unless (optimizedValues == legacyValues') $
+                die ("implementation mismatch at size " <> show size)
+            let checksum = encodedChecksum optimizedValues
+                legacyChecksum = encodedChecksum legacyValues'
+            unless (checksum == legacyChecksum) $
+                die ("checksum mismatch at size " <> show size)
+            (optimizedSample, legacySample) <-
+                if even sampleIndex
+                    then do
+                        optimizedSample <- measure
+                            (evaluate (encodedChecksum (productionValues tools)))
+                        legacySample <- measure
+                            (evaluate (encodedChecksum (legacyValues tools)))
+                        pure (optimizedSample, legacySample)
+                    else do
+                        legacySample <- measure
+                            (evaluate (encodedChecksum (legacyValues tools)))
+                        optimizedSample <- measure
+                            (evaluate (encodedChecksum (productionValues tools)))
+                        pure (optimizedSample, legacySample)
+            pure (optimizedSample, legacySample, checksum)
+        let optimizedSamples = map first samples
+            legacySamples = map second samples
+            checksum = last (map third samples)
+            optimizedMedian = median optimizedSamples
+            legacyMedian = median legacySamples
+        printf
+            "%d,%.3f,%.3f,%.3f,%.3f,%d,%d,%d\n"
+            size
+            optimizedMedian.elapsedMillis
+            legacyMedian.elapsedMillis
+            optimizedMedian.cpuMillis
+            legacyMedian.cpuMillis
+            optimizedMedian.allocatedBytes
+            legacyMedian.allocatedBytes
+            checksum) sizes
+  where
+    first (value, _, _) = value
+    second (_, value, _) = value
+    third (_, _, value) = value
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")] | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+-- Distinct tool names per sample prevent the benchmark from measuring reused
+-- thunks. The mix also exercises grouped, nested, and top-level tools.
+workload :: Int -> Int -> [ResponseTool]
+workload size sampleIndex =
+    [ case index `mod` 5 of
+        0 -> functionTool name
+        1 -> customTool name
+        2 -> namespaceTool "functions" (Just description) [functionTool name]
+        3 -> namespaceTool "editor" Nothing [functionTool name]
+        _ -> webSearchTool
+    | index <- [0 .. size - 1]
+    , let name = "tool-" <> Text.pack (show sampleIndex) <> "-" <> Text.pack (show index)
+    , let description = "namespace-" <> Text.pack (show sampleIndex)
+    ]
+
+productionValues :: [ResponseTool] -> [Aeson.Value]
+productionValues tools =
+    case (requestParams OpenAIProvider "gpt-5.6-sol" "instructions" tools "high").input of
+        Just (ResponseInputItems (AdditionalToolsItemValue item : _)) -> item.tools
+        _ -> []
+
+legacyValues :: [ResponseTool] -> [Aeson.Value]
+legacyValues tools =
+    case groupedValues of
+        [] -> ungroupedValues
+        _ ->
+            let namespaceValue = Aeson.object
+                    [ "type" Aeson..= ("namespace" :: Text)
+                    , "name" Aeson..= ("functions" :: Text)
+                    , "description" Aeson..= namespaceDescription
+                    , "tools" Aeson..= groupedValues
+                    ]
+                insertionIndex = fromMaybe 0 firstGroupedPosition
+            in take insertionIndex ungroupedValues
+                <> [namespaceValue]
+                <> drop insertionIndex ungroupedValues
+  where
+    (firstGroupedPosition, groupedValues, namespaceDescription, ungroupedValues) =
+        foldl collect (Nothing, [], "", []) tools
+
+    collect (firstPosition, grouped, description, ungrouped) tool =
+        case legacyGroupedToolValues tool of
+            Just (values, nextDescription) ->
+                ( firstPosition <|> Just (length ungrouped)
+                , grouped <> values
+                , fromMaybe description nextDescription
+                , ungrouped
+                )
+            Nothing ->
+                (firstPosition, grouped, description, ungrouped <> [Aeson.toJSON tool])
+
+legacyGroupedToolValues :: ResponseTool -> Maybe ([Aeson.Value], Maybe Text)
+legacyGroupedToolValues tool = case tool of
+    FunctionToolValue{} -> Just ([Aeson.toJSON tool], Nothing)
+    KnownResponseTool ToolCustom _ -> Just ([Aeson.toJSON tool], Nothing)
+    UnknownResponseTool tagged
+        | tagged.tag == "custom" -> Just ([Aeson.toJSON tool], Nothing)
+    KnownResponseTool ToolNamespace tagged
+        | textField "name" tagged.fields == Just "functions" ->
+            Just
+                ( arrayField "tools" tagged.fields
+                , nonBlank =<< textField "description" tagged.fields
+                )
+    _ -> Nothing
+
+functionTool :: Text -> ResponseTool
+functionTool toolName = FunctionToolValue FunctionTool
+    { name = toolName
+    , description = Nothing
+    , parameters = Nothing
+    , strict = Just True
+    , extraFields = KeyMap.empty
+    }
+
+customTool :: Text -> ResponseTool
+customTool toolName = KnownResponseTool ToolCustom TaggedObject
+    { tag = "custom"
+    , fields = KeyMap.singleton (Key.fromText "name") (Aeson.String toolName)
+    }
+
+namespaceTool :: Text -> Maybe Text -> [ResponseTool] -> ResponseTool
+namespaceTool namespaceName namespaceDescription nestedTools =
+    KnownResponseTool ToolNamespace TaggedObject
+        { tag = "namespace"
+        , fields = KeyMap.fromList $
+            [ (Key.fromText "name", Aeson.String namespaceName)
+            , (Key.fromText "tools", Aeson.toJSON nestedTools)
+            ]
+            <> case namespaceDescription of
+                Just description ->
+                    [(Key.fromText "description", Aeson.String description)]
+                Nothing -> []
+        }
+
+textField :: Text -> Aeson.Object -> Maybe Text
+textField name object =
+    case KeyMap.lookup (Key.fromText name) object of
+        Just (Aeson.String value) -> Just value
+        _ -> Nothing
+
+arrayField :: Text -> Aeson.Object -> [Aeson.Value]
+arrayField name object =
+    case KeyMap.lookup (Key.fromText name) object of
+        Just (Aeson.Array values) -> Vector.toList values
+        _ -> []
+
+nonBlank :: Text -> Maybe Text
+nonBlank value
+    | Text.null (Text.strip value) = Nothing
+    | otherwise = Just value
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    checksum <- action >>= evaluate
+    _ <- evaluate checksum
+    afterWall <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
+    pure Sample
+        { elapsedMillis =
+            fromIntegral (afterWall - beforeWall) / 1.0e6
+        , cpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        }
+
+encodedChecksum :: [Aeson.Value] -> Int
+encodedChecksum values =
+    BS.foldl'
+        (\checksum byte -> checksum * 33 + fromIntegral byte)
+        5381
+        (LBS.toStrict (Aeson.encode values))
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { elapsedMillis = middle (map (.elapsedMillis) samples)
+        , cpuMillis = middle (map (.cpuMillis) samples)
+        , allocatedBytes = middle (map (.allocatedBytes) samples)
+        }
+  where
+    middle values = sort values !! (length values `div` 2)

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -44,7 +44,7 @@ mkDerivation {
   benchmarkHaskellDepends = [
     aeson agent-core agent-responses agent-store base brick bytestring
     containers deepseq directory filepath JuicyPixels safe-exceptions
-    text time vty
+    text time vector vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli/src/Agent/CLI/Request.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 -- | Construction of provider-neutral Responses requests.
 module Agent.CLI.Request
     ( requestParams
@@ -13,6 +15,7 @@ import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.List (foldl')
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -197,33 +200,40 @@ updateResponsesLitePrefix instructionText maybeTools existingInput =
 -- namespace; hosted tools and non-default namespaces remain top-level.
 responsesLiteToolValues :: [ResponseTool] -> [Aeson.Value]
 responsesLiteToolValues tools =
-    case groupedValues of
+    case groupedValuesRev of
         [] -> ungroupedValues
         _ ->
             let namespaceValue = Aeson.object
                     [ "type" Aeson..= ("namespace" :: Text)
                     , "name" Aeson..= ("functions" :: Text)
                     , "description" Aeson..= namespaceDescription
-                    , "tools" Aeson..= groupedValues
+                    , "tools" Aeson..= reverse groupedValuesRev
                     ]
                 insertionIndex = fromMaybe 0 firstGroupedPosition
-            in take insertionIndex ungroupedValues
-                <> [namespaceValue]
-                <> drop insertionIndex ungroupedValues
+                (before, after) = splitAt insertionIndex ungroupedValues
+            in before <> (namespaceValue : after)
   where
-    (firstGroupedPosition, groupedValues, namespaceDescription, ungroupedValues) =
-        foldl collect (Nothing, [], "", []) tools
+    (firstGroupedPosition, groupedValuesRev, namespaceDescription, ungroupedValuesRev, _) =
+        foldl' collect (Nothing, [], "", [], 0 :: Int) tools
 
-    collect (firstPosition, grouped, description, ungrouped) tool =
+    collect (!firstPosition, !grouped, !description, !ungrouped, !count) tool =
         case groupedToolValues tool of
             Just (values, nextDescription) ->
-                ( firstPosition <|> Just (length ungrouped)
-                , grouped <> values
+                ( firstPosition <|> Just count
+                , foldl' (flip (:)) grouped values
                 , fromMaybe description nextDescription
                 , ungrouped
+                , count
                 )
             Nothing ->
-                (firstPosition, grouped, description, ungrouped <> [Aeson.toJSON tool])
+                ( firstPosition
+                , grouped
+                , description
+                , Aeson.toJSON tool : ungrouped
+                , count + 1
+                )
+
+    ungroupedValues = reverse ungroupedValuesRev
 
 groupedToolValues :: ResponseTool -> Maybe ([Aeson.Value], Maybe Text)
 groupedToolValues tool = case tool of

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -118,6 +118,67 @@ spec = describe "requestParams" do
                         map Just ["lookup", "exec", "existing", "last"]
             _ -> expectationFailure "expected three top-level Lite tools"
 
+    it "preserves interleaving around multiple nested functions namespaces" do
+        let params =
+                requestParams
+                    OpenAIProvider
+                    "gpt-5.6-sol"
+                    ""
+                    [ webSearchTool
+                    , namespaceTool "functions" (Just "first") [functionTool "a"]
+                    , namespaceTool "editor" Nothing [functionTool "edit"]
+                    , functionTool "b"
+                    , namespaceTool "functions" (Just "last") [functionTool "c"]
+                    , webSearchTool
+                    ]
+                    "high"
+            tools = additionalToolValues params
+        map toolIdentity tools `shouldBe`
+            [ (Just "web_search", Nothing)
+            , (Just "namespace", Just "functions")
+            , (Just "namespace", Just "editor")
+            , (Just "web_search", Nothing)
+            ]
+        case functionsNamespaceTools tools of
+            values -> map (jsonTextField "name") values
+                `shouldBe` map Just ["a", "b", "c"]
+        case findValue
+                (\value -> toolIdentity value == (Just "namespace", Just "functions"))
+                tools of
+            Just functions ->
+                jsonTextField "description" functions `shouldBe` Just "last"
+            Nothing -> expectationFailure "expected functions namespace"
+
+    it "omits empty functions namespaces and retains non-function tools" do
+        let params =
+                requestParams
+                    OpenAIProvider
+                    "gpt-5.6-sol"
+                    ""
+                    [ namespaceTool "functions" (Just "empty") []
+                    , webSearchTool
+                    ]
+                    "high"
+        additionalToolValues params `shouldBe`
+            [Aeson.toJSON webSearchTool]
+
+    it "emits the expected encoded Lite tools JSON" do
+        let params =
+                requestParams
+                    OpenAIProvider
+                    "gpt-5.6-sol"
+                    ""
+                    [ functionTool "first"
+                    , webSearchTool
+                    , customTool "last"
+                    ]
+                    "high"
+            encoded = Aeson.encode (additionalToolValues params)
+            expected =
+                "[{\"type\":\"namespace\",\"name\":\"functions\",\"description\":\"\",\"tools\":[{\"type\":\"function\",\"name\":\"first\",\"strict\":true},{\"type\":\"custom\",\"name\":\"last\"}]},{\"type\":\"web_search\"}]"
+        (Aeson.decode encoded :: Maybe Aeson.Value)
+            `shouldBe` Aeson.decode expected
+
     it "refreshes the Lite prefix without dropping pending input" do
         let pending = userMessage "keep me"
             original = appendInputItem pending $


### PR DESCRIPTION
## Summary
- build Responses Lite grouped/ungrouped tool JSON with strict reverse accumulators
- track insertion count directly and reverse/split once
- preserve exact namespace expansion, description, and ordering semantics

Independent from common base `07720c89`.

## Validation
- focused RequestSpec: **9 examples, 0 failures**
- benchmark validates exact optimized/legacy `Aeson.Value` equality and encoded checksum

## Benchmark (`-O2`, 7-sample medians)
| tools | optimized | legacy | optimized alloc | legacy alloc |
|---:|---:|---:|---:|---:|
| 10 | 0.006 ms | 0.006 ms | 40.8 KB | 41.3 KB |
| 100 | 0.048 ms | 0.057 ms | 350 KB | 494 KB |
| 1k | 0.482 ms | 2.274 ms | 3.14 MB | 17.66 MB |
| 10k | 7.698 ms | 213.669 ms | 31.22 MB | 2.185 GB |
