### PR TITLE
perf(tui): reuse history indexes

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -282,6 +282,17 @@ benchmark subagent-retention-bench
                     , containers
                     , text
 
+benchmark history-cursor-index-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          HistoryCursorIndex.hs
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-cli
+                    , base >= 4.17 && < 5
+                    , containers
+                    , time
+
 benchmark history-retention-bench
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-cli/benchmark/HistoryCursorIndex.hs
+++ b/packages/agent-cli/benchmark/HistoryCursorIndex.hs
@@ -1,0 +1,312 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
+-- Compare fullscreen history lookups with and without the maintained indexes.
+-- Lookup indexes are built before the timed interval; maintenance measures the
+-- additional block->cursor index construction performed by the new window.
+module Main (main) where
+
+import Control.Exception (evaluate)
+import Control.Monad (forM_)
+import qualified Data.Foldable as Foldable
+import qualified Data.Map.Strict as Map
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats (..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Turn = Turn
+    { turnCursor :: !Int
+    , turnBlocks :: !(Seq Int)
+    }
+
+data LegacyIndexes = LegacyIndexes
+    { legacyTurnsByCursor :: !(Map.Map Int Turn)
+    , legacyBlocksById :: !(Map.Map Int Int)
+    }
+
+data IndexedIndexes = IndexedIndexes
+    { indexedTurnsByCursor :: !(Map.Map Int Turn)
+    , indexedBlocksById :: !(Map.Map Int Int)
+    , indexedBlockCursors :: !(Map.Map Int Int)
+    }
+
+data State = State
+    { stateTurns :: !(Seq Turn)
+    , stateQueries :: ![Int]
+    , stateLegacy :: !LegacyIndexes
+    , stateIndexed :: !IndexedIndexes
+    }
+
+data Sample = Sample
+    { sampleElapsed :: !Double
+    , sampleCpu :: !Double
+    , sampleAllocated :: !Integer
+    , sampleChecksum :: !Int
+    }
+
+data Workload = Configured | Stress
+data WorkloadKind
+    = ConfiguredLookupLegacy
+    | ConfiguredLookupIndexed
+    | ConfiguredMaintenanceLegacy
+    | ConfiguredMaintenanceIndexed
+    | StressLookupLegacy
+    | StressLookupIndexed
+    | StressMaintenanceLegacy
+    | StressMaintenanceIndexed
+
+data Operation = Lookup | Maintenance
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if not enabled then die "run with +RTS -T" else pure ()
+    workload <- getArgs >>= parse
+    printf "workload,operation,implementation,turns,blocks,elapsed_ms,cpu_ms,allocated_bytes,checksum\n"
+    forM_ (modes workload) \(kind, operation, implementation) -> do
+        let (turnCount, blocksPerTurn) = bounds kind
+            -- Keep eight prepared states outside the measured region, while
+            -- retaining seven samples for the reported medians.
+            states =
+                [ buildState sample turnCount blocksPerTurn
+                | sample <- [1 .. 8 :: Int]
+                ]
+        samples <- mapM
+            (\(sample, state) ->
+                measure operation implementation sample state)
+            (zip [1 .. 7 :: Int] states)
+        let middle values = sort values !! (length values `div` 2)
+            elapsed = middle (map (.sampleElapsed) samples)
+            cpu = middle (map (.sampleCpu) samples)
+            allocated = middle (map (.sampleAllocated) samples)
+            checksum = (last samples).sampleChecksum
+        printf "%s,%s,%s,%d,%d,%.3f,%.3f,%d,%d\n"
+            (showWorkload kind) (showOperation operation) implementation
+            turnCount (turnCount * blocksPerTurn) elapsed cpu allocated checksum
+
+parse :: [String] -> IO Workload
+parse ["configured"] = pure Configured
+parse ["stress"] = pure Stress
+parse _ = die "usage: history-cursor-index-bench configured|stress +RTS -T"
+
+showWorkload :: WorkloadKind -> String
+showWorkload ConfiguredLookupLegacy = "configured"
+showWorkload ConfiguredLookupIndexed = "configured"
+showWorkload ConfiguredMaintenanceLegacy = "configured"
+showWorkload ConfiguredMaintenanceIndexed = "configured"
+showWorkload StressLookupLegacy = "stress"
+showWorkload StressLookupIndexed = "stress"
+showWorkload StressMaintenanceLegacy = "stress"
+showWorkload StressMaintenanceIndexed = "stress"
+
+showOperation :: Operation -> String
+showOperation Lookup = "lookup"
+showOperation Maintenance = "maintenance"
+
+bounds :: WorkloadKind -> (Int, Int)
+bounds ConfiguredLookupLegacy = (200, 6)
+bounds ConfiguredLookupIndexed = (200, 6)
+bounds ConfiguredMaintenanceLegacy = (200, 6)
+bounds ConfiguredMaintenanceIndexed = (200, 6)
+bounds StressLookupLegacy = (2000, 12)
+bounds StressLookupIndexed = (2000, 12)
+bounds StressMaintenanceLegacy = (2000, 12)
+bounds StressMaintenanceIndexed = (2000, 12)
+
+modes :: Workload -> [(WorkloadKind, Operation, String)]
+modes Configured =
+    [ (ConfiguredLookupLegacy, Lookup, "legacy")
+    , (ConfiguredLookupIndexed, Lookup, "indexed")
+    , (ConfiguredMaintenanceLegacy, Maintenance, "legacy")
+    , (ConfiguredMaintenanceIndexed, Maintenance, "indexed")
+    ]
+modes Stress =
+    [ (StressLookupLegacy, Lookup, "legacy")
+    , (StressLookupIndexed, Lookup, "indexed")
+    , (StressMaintenanceLegacy, Maintenance, "legacy")
+    , (StressMaintenanceIndexed, Maintenance, "indexed")
+    ]
+
+measure :: Operation -> String -> Int -> State -> IO Sample
+measure operation implementation sample state = do
+    -- Correctness is checked before timing, so the timed path is only the
+    -- operation under comparison.
+    case operation of
+        Lookup -> do
+            let reference = legacyLookup state.stateTurns state.stateQueries
+                candidate = indexedLookup state.stateIndexed state.stateQueries
+            _ <- evaluate
+                (if reference == candidate then () else error "legacy/indexed mismatch")
+            pure ()
+        Maintenance -> do
+            let reference = maintenanceLegacy state.stateTurns
+                candidate = maintenanceIndexed state.stateTurns
+            _ <- evaluate
+                (if reference == candidate then () else error "maintenance mismatch")
+            pure ()
+    -- Touch the prepared state and sample to prevent state hoisting/elision.
+    _ <- evaluate
+        (sample + Seq.length state.stateTurns + length state.stateQueries
+            + forceLegacy state.stateLegacy
+            + forceIndexed state.stateIndexed)
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    let result = case operation of
+            Lookup -> case implementation of
+                "legacy" -> legacyLookup state.stateTurns state.stateQueries
+                _ -> indexedLookup state.stateIndexed state.stateQueries
+            Maintenance -> case implementation of
+                "legacy" -> maintenanceLegacy state.stateTurns
+                _ -> maintenanceIndexed state.stateTurns
+    !checksum <- evaluate result
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
+    _ <- evaluate checksum
+    pure Sample
+        { sampleElapsed = fromIntegral (afterElapsed - beforeElapsed) / 1.0e6
+        , sampleCpu = fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , sampleAllocated =
+            fromIntegral (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        , sampleChecksum = checksum
+        }
+
+buildState :: Int -> Int -> Int -> State
+buildState seed turnCount blocksPerTurn =
+    let turns = buildTurns seed turnCount blocksPerTurn
+    in State turns
+        (buildQueries seed turnCount blocksPerTurn)
+        (buildLegacyIndexes turns)
+        (buildIndexedIndexes turns)
+
+buildTurns :: Int -> Int -> Int -> Seq Turn
+buildTurns seed turnCount blocksPerTurn =
+    Seq.fromList
+        [ Turn cursor
+            (Seq.fromList
+                [ seed * turnCount * blocksPerTurn
+                    + cursor * blocksPerTurn + block
+                | block <- [0 .. blocksPerTurn - 1]
+                ])
+        | cursor <- [0 .. turnCount - 1]
+        ]
+
+buildQueries :: Int -> Int -> Int -> [Int]
+buildQueries seed turnCount blocksPerTurn =
+    [ seed * turnCount * blocksPerTurn
+        + ((index * 7919 + seed * 104729)
+            `mod` (turnCount * blocksPerTurn))
+    | index <- [0 .. turnCount * blocksPerTurn * 2 - 1]
+    ]
+
+buildLegacyIndexes :: Seq Turn -> LegacyIndexes
+buildLegacyIndexes turns =
+    LegacyIndexes
+        (Map.fromList [(turn.turnCursor, turn) | turn <- Foldable.toList turns])
+        (Map.fromList
+            [ (blockId, turn.turnCursor)
+            | turn <- Foldable.toList turns
+            , blockId <- Foldable.toList turn.turnBlocks
+            ])
+
+buildIndexedIndexes :: Seq Turn -> IndexedIndexes
+buildIndexedIndexes turns =
+    let old = buildLegacyIndexes turns
+    in IndexedIndexes old.legacyTurnsByCursor old.legacyBlocksById
+        (Map.fromList
+            [ (blockId, turn.turnCursor)
+            | turn <- Foldable.toList turns
+            , blockId <- Foldable.toList turn.turnBlocks
+            ])
+
+legacyLookup :: Seq Turn -> [Int] -> Int
+legacyLookup turns queries =
+    let base = snd (Foldable.foldl' step (0, 0) queries)
+        anchor = maybe (-1) (.turnCursor) (lastMay (Foldable.toList turns))
+        flashing = length
+            [ block | block <- queries
+            , Just _ <- [findCursor block (Foldable.toList turns)]
+            , block `mod` 7 == 0
+            ]
+        merged = length
+            [ block | block <- queries
+            , Just _ <- [findCursor block (Foldable.toList turns)] ]
+    in base * 31 + anchor * 17 + flashing * 7 + merged
+  where
+    step (!position, !checksum) blockId =
+        let contribution = maybe (-1) id (findCursor blockId (Foldable.toList turns))
+        in (position + 1, checksum * 33 + contribution + position)
+    findCursor _ [] = Nothing
+    findCursor blockId (turn : rest)
+        | blockId `elem` Foldable.toList turn.turnBlocks = Just turn.turnCursor
+        | otherwise = findCursor blockId rest
+    lastMay [] = Nothing
+    lastMay xs = Just (last xs)
+
+indexedLookup :: IndexedIndexes -> [Int] -> Int
+indexedLookup indexes queries =
+    let byBlock = indexes.indexedBlocksById
+        byCursor = indexes.indexedTurnsByCursor
+        base = snd (Foldable.foldl'
+            (\(!position, !checksum) blockId ->
+                let contribution = Map.findWithDefault (-1) blockId byBlock
+                in (position + 1, checksum * 33 + contribution + position))
+            (0, 0) queries)
+        anchor = maybe (-1) (.turnCursor) (snd <$> Map.lookupMax byCursor)
+        flashing = length
+            [ blockId | blockId <- queries
+            , Map.member blockId byBlock, blockId `mod` 7 == 0 ]
+        merged = length [blockId | blockId <- queries, Map.member blockId byBlock]
+    in base * 31 + anchor * 17 + flashing * 7 + merged
+
+-- Both paths construct exactly the two maps maintained by the old window.
+-- The indexed path additionally forces blockCursors, making maintenance cost
+-- visible without changing the canonical checksum.
+maintenanceLegacy :: Seq Turn -> Int
+maintenanceLegacy turns =
+    let indexes = buildLegacyIndexes turns
+        canonical = forceLegacy indexes
+        extra = Map.foldlWithKey'
+            (\acc block cursor -> acc + block + cursor)
+            0 indexes.legacyBlocksById
+    in canonical * 31 + extra
+
+maintenanceIndexed :: Seq Turn -> Int
+maintenanceIndexed turns =
+    let indexes = buildIndexedIndexes turns
+        canonical = forceLegacy
+            (LegacyIndexes indexes.indexedTurnsByCursor indexes.indexedBlocksById)
+        extra = Map.foldlWithKey' (\acc block cursor -> acc + block + cursor)
+            0 indexes.indexedBlockCursors
+    in canonical * 31 + extra
+
+forceLegacy :: LegacyIndexes -> Int
+forceLegacy indexes =
+    let turns = Map.foldlWithKey'
+            (\acc cursor turn -> acc + cursor + Foldable.length turn.turnBlocks)
+            0 indexes.legacyTurnsByCursor
+    in Map.foldlWithKey'
+        (\acc block cursor -> acc + block + cursor)
+        turns indexes.legacyBlocksById
+
+forceIndexed :: IndexedIndexes -> Int
+forceIndexed indexes =
+    forceLegacy
+        (LegacyIndexes indexes.indexedTurnsByCursor indexes.indexedBlocksById)
+        + Map.foldlWithKey'
+            (\acc block cursor -> acc + block + cursor)
+            0 indexes.indexedBlockCursors
+
+sort :: Ord a => [a] -> [a]
+sort [] = []
+sort (x : xs) = sort [y | y <- xs, y <= x] <> [x] <> sort [y | y <- xs, y > x]

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -171,7 +171,9 @@ import Agent.CLI.TUI.History
     , clearHistoryRequest
     , emptyHistoryWindow
     , historyWindowBlock
+    , historyWindowCursorForBlock
     , historyWindowOlderAvailable
+    , historyWindowTurn
     , historyWindowRequest
     , unarchivedLiveStart
     , historyWindowSetAnchors
@@ -1518,25 +1520,15 @@ remapHistoryBlocks nextId =
         (nextId, Seq.empty)
 
 historyContainsBlock :: BlockId -> HistoryWindow -> Bool
-historyContainsBlock blockId =
-    any
-        (any ((== blockId) . (.blockId))
-            . toList
-            . (.historyTurnBlocks))
-        . toList
-        . (.historyWindowTurns)
+historyContainsBlock blockId window =
+    Map.member blockId window.historyWindowBlockCursors
 
 historyCursorForBlock
     :: HistoryWindow
     -> BlockId
     -> Maybe HistoryCursor
 historyCursorForBlock window blockId =
-    (.historyTurnCursor)
-        <$> find
-            (any ((== blockId) . (.blockId))
-                . toList
-                . (.historyTurnBlocks))
-            (toList window.historyWindowTurns)
+    historyWindowCursorForBlock blockId window
 
 historyEdgeCursor
     :: HistoryDirection
@@ -1554,12 +1546,11 @@ historyPageAnchorBlock
     -> HistoryWindow
     -> Maybe BlockId
 historyPageAnchorBlock direction window =
-    edgeTurn >>= edgeBlock
+    historyEdgeCursor direction window
+        >>= \cursor ->
+            historyWindowTurn cursor window
+                >>= edgeBlock
   where
-    turns = window.historyWindowTurns
-    edgeTurn = case direction of
-        HistoryOlder -> turns Seq.!? 0
-        HistoryNewer -> turns Seq.!? (Seq.length turns - 1)
     edgeBlock turn =
         let blocks = turn.historyTurnBlocks
         in case direction of
@@ -2586,9 +2577,7 @@ retainExistingFlashes
     -> Map.Map BlockId Int
 retainExistingFlashes ui =
     Map.filterWithKey
-        (\blockId _ ->
-            any ((== blockId) . (.blockId))
-                (toList ui.uiBlocks))
+        (\blockId _ -> Map.member blockId ui.uiBlockIndices)
 
 uiEventCanCompleteBlocks :: UiEvent -> Bool
 uiEventCanCompleteBlocks = \case
@@ -3604,15 +3593,13 @@ mergeConversationView previous incoming
                     else incoming.uiTodos
             }
   where
-    previousBlocks =
-        Map.fromList
-            [ (block.blockId, block)
-            | block <- toList previous.uiBlocks
-            ]
+    previousBlock ident =
+        Map.lookup ident previous.uiBlockIndices
+            >>= (`Seq.lookup` previous.uiBlocks)
     mergedBlocks =
         fmap
             (\block ->
-                case Map.lookup block.blockId previousBlocks of
+                case previousBlock block.blockId of
                     Just old
                         | sameConversationBlock old block ->
                             block
@@ -3623,7 +3610,7 @@ mergeConversationView previous incoming
     selected =
         case previous.uiSelectedBlock of
             Just ident
-                | Just old <- Map.lookup ident previousBlocks
+                | Just old <- previousBlock ident
                 , Just new <-
                     Map.lookup ident incoming.uiBlockIndices
                         >>= \index -> Seq.lookup index incoming.uiBlocks

--- a/packages/agent-cli/src/Agent/CLI/TUI/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/History.hs
@@ -33,6 +33,7 @@ module Agent.CLI.TUI.History
     , historyWindowSetAnchors
     , historyWindowSetGeneration
     , historyWindowBlock
+    , historyWindowCursorForBlock
     , setHistoryWindowTurns
     , historyWindowTurn
     , historyWindowVisible
@@ -94,6 +95,9 @@ data HistoryWindow = HistoryWindow
     , historyWindowTurns :: !(Seq HistoryTurn)
     , historyWindowTurnsByCursor :: !(Map HistoryCursor HistoryTurn)
     , historyWindowBlocksById :: !(Map BlockId UiBlock)
+    -- | Indexed membership and durable-turn lookup for retained blocks
+    -- (O(log n) with the strict map, rather than a full window scan).
+    , historyWindowBlockCursors :: !(Map BlockId HistoryCursor)
     , historyWindowHasOlder :: !Bool
     , historyWindowHasNewer :: !Bool
     , historyWindowMaxTurns :: !Int
@@ -124,6 +128,7 @@ emptyHistoryWindow generation maxTurns maxBlocks maxBytes =
         , historyWindowTurns = Seq.empty
         , historyWindowTurnsByCursor = Map.empty
         , historyWindowBlocksById = Map.empty
+        , historyWindowBlockCursors = Map.empty
         , historyWindowHasOlder = False
         , historyWindowHasNewer = False
         , historyWindowMaxTurns = max 1 maxTurns
@@ -148,6 +153,12 @@ setHistoryWindowTurns turns window =
         , historyWindowBlocksById =
             Map.fromList
                 [ (block.blockId, block)
+                | turn <- toList turns
+                , block <- toList turn.historyTurnBlocks
+                ]
+        , historyWindowBlockCursors =
+            Map.fromListWith (flip const)
+                [ (block.blockId, turn.historyTurnCursor)
                 | turn <- toList turns
                 , block <- toList turn.historyTurnBlocks
                 ]
@@ -193,6 +204,13 @@ historyWindowBlock :: BlockId -> HistoryWindow -> Maybe UiBlock
 historyWindowBlock ident window =
     Map.lookup ident window.historyWindowBlocksById
 
+historyWindowCursorForBlock
+    :: BlockId
+    -> HistoryWindow
+    -> Maybe HistoryCursor
+historyWindowCursorForBlock ident window =
+    Map.lookup ident window.historyWindowBlockCursors
+
 historyWindowSetAnchors
     :: Maybe HistoryCursor
     -> Maybe HistoryCursor
@@ -206,11 +224,11 @@ historyWindowSetAnchors visible selected window =
   where
     keepLoaded cursor =
         cursor >>= \value ->
-            if value `Set.member` loaded
+            if Map.member value loaded
                 then Just value
                 else Nothing
 
-    loaded = Set.fromList (toList (historyWindowCursors window))
+    loaded = window.historyWindowTurnsByCursor
 
 -- | Switch to a new provider/session generation and discard all materialised
 -- blocks.  Budgets are intentionally retained across the switch.

--- a/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
@@ -48,6 +48,7 @@ import Agent.TUI.Motion
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust)
+import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import Data.Word (Word64)
 
@@ -189,18 +190,16 @@ completionFlashTransitions :: UiState -> UiState -> [BlockId]
 completionFlashTransitions previous next =
     [ block.blockId
     | block <- toList next.uiBlocks
-    , Just oldBlock <- [Map.lookup block.blockId previousById]
+    , Just oldBlock <- [previousBlock block.blockId]
     , blockWasLive oldBlock.blockState
     , block.blockState == BlockComplete
     , block.blockKind
         `elem` [BlockThinking, BlockTool, BlockTodo, BlockShell, BlockEdit]
     ]
   where
-    previousById =
-        Map.fromList
-            [ (block.blockId, block)
-            | block <- toList previous.uiBlocks
-            ]
+    previousBlock ident =
+        Map.lookup ident previous.uiBlockIndices
+            >>= (`Seq.lookup` previous.uiBlocks)
     blockWasLive blockState =
         blockState `elem` [BlockRunning, BlockStreaming]
 

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Agent.CLI.TUIHistorySpec (spec) where
 
@@ -15,6 +16,7 @@ import Agent.Responses.Types
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Foldable (toList)
+import Data.List (nub)
 import Agent.TUI.Model
     ( BlockId(..)
     , BlockState(..)
@@ -26,14 +28,78 @@ import Agent.TUI.Model
     , reduceUi
     )
 import qualified Data.Sequence as Seq
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Int (Int64)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
 import Test.Hspec
+import Test.QuickCheck
 
 spec :: Spec
 spec = describe "bounded fullscreen history window" do
+    it "keeps cursor indexes synchronized across retained turns" do
+        property \(cursors :: [Int]) ->
+            let values :: [Int64]
+                values = take 40 (nub (map (fromIntegral . (`mod` 1000) . abs) cursors))
+                turns = Seq.fromList [turn cursor 1 | cursor <- values]
+                window = setHistoryWindowTurns turns
+                    (emptyHistoryWindow (HistoryGeneration 1) 100 1000 1000000)
+            in indexInvariant window
+
+    it "keeps indexes correct after append, dedupe, eviction, and generation reset" do
+        property \(seed :: Int) ->
+            let base = emptyHistoryWindow (HistoryGeneration 1) 3 100 1000000
+                pages =
+                    [ HistoryPage (HistoryGeneration 1) HistoryNewer
+                        (Seq.fromList [turn (fromIntegral (abs seed `mod` 5)) 1, turn 8 1])
+                        (HistoryCursor 0) 9 False False
+                    , HistoryPage (HistoryGeneration 1) HistoryOlder
+                        (Seq.fromList [turn 2 1, turn 8 1])
+                        (HistoryCursor 0) 9 True True
+                    ]
+                window = foldl
+                    (\current page -> either (const current) id
+                        (applyHistoryPage page current))
+                    base pages
+                appended = appendHistoryTurn (turn 20 1) window
+                remapped =
+                    setHistoryWindowTurns
+                        (fmap (remapTurn (abs seed `mod` 1000))
+                            appended.historyWindowTurns)
+                        appended
+                truncated =
+                    setHistoryWindowTurns
+                        (Seq.take 1 appended.historyWindowTurns)
+                        appended
+                reset = historyWindowSetGeneration (HistoryGeneration 2) appended
+            in indexInvariant window
+                && indexInvariant appended
+                && indexInvariant remapped
+                && indexInvariant truncated
+                && indexInvariant reset
+                && Map.keysSet reset.historyWindowBlockCursors == Set.empty
+                && all
+                    (\block ->
+                        Map.lookup block.blockId reset.historyWindowBlockCursors
+                            == Nothing)
+                    (concatMap (toList . (.historyTurnBlocks)) (toList reset.historyWindowTurns))
+
+    it "keeps the first cursor for duplicate block ids" do
+        let first = turn 1 1
+            duplicate =
+                (turn 2 1)
+                    { historyTurnBlocks =
+                        fmap (\current -> current {blockId = BlockId 10})
+                            ((turn 2 1).historyTurnBlocks)
+                    }
+            window = setHistoryWindowTurns
+                (Seq.fromList [first, duplicate])
+                (emptyHistoryWindow (HistoryGeneration 1) 10 20 1000000)
+        historyWindowCursorForBlock (BlockId 10) window
+            `shouldBe` Just (HistoryCursor 1)
+
     it "allows keyboard scrollback when only persisted history is loaded" do
         let generation = HistoryGeneration 1
             empty = emptyHistoryWindow generation 10 20 1_000_000
@@ -76,6 +142,8 @@ spec = describe "bounded fullscreen history window" do
             Right window -> do
                 historyWindowCursors window
                     `shouldBe` Seq.fromList (map HistoryCursor [10, 11, 12])
+                historyWindowCursorForBlock (BlockId 100) window
+                    `shouldBe` Just (HistoryCursor 10)
                 historyWindowRequest HistoryOlder window
                     `shouldBe`
                         Just HistoryRequest
@@ -113,6 +181,8 @@ spec = describe "bounded fullscreen history window" do
         historyWindowCursors merged
             `shouldBe` Seq.fromList (map HistoryCursor [8, 9, 10, 11])
         historyWindowLoadedBlocks merged `shouldBe` 7
+        historyWindowCursorForBlock (BlockId 100) merged
+            `shouldBe` Just (HistoryCursor 10)
         historyWindowRequest HistoryOlder requested
             `shouldBe` Nothing
 
@@ -467,6 +537,42 @@ block identifier =
         , blockExpanded = False
         , blockCallId = Nothing
         }
+
+indexInvariant :: HistoryWindow -> Bool
+indexInvariant window =
+    let turns = toList window.historyWindowTurns
+        expectedTurns =
+            Map.fromList
+                [ (turn.historyTurnCursor, turn)
+                | turn <- turns
+                ]
+        expectedBlocks =
+            Map.fromList
+                [ (block.blockId, block)
+                | turn <- turns
+                , block <- toList turn.historyTurnBlocks
+                ]
+        expectedCursors =
+            Map.fromListWith (flip const)
+                [ (block.blockId, turn.historyTurnCursor)
+                | turn <- turns
+                , block <- toList turn.historyTurnBlocks
+                ]
+    in window.historyWindowTurnsByCursor == expectedTurns
+        && window.historyWindowBlocksById == expectedBlocks
+        && window.historyWindowBlockCursors == expectedCursors
+
+remapTurn :: Int -> HistoryTurn -> HistoryTurn
+remapTurn offset original =
+    original
+        { historyTurnBlocks =
+            fmap
+                (\current ->
+                    current {blockId = BlockId (offset + blockIdValue current.blockId)})
+                original.historyTurnBlocks
+        }
+  where
+    blockIdValue (BlockId value) = value
 
 isRight :: Either a b -> Bool
 isRight value =


### PR DESCRIPTION
## Summary
- maintain `BlockId -> HistoryCursor` alongside existing retained-history indexes
- reuse turn/block indexes for anchors, block membership, completion flashes, motion transitions, and conversation merges
- add index invariants across paging, append, dedupe, eviction, generation reset, and truncation

Independent from common base `07720c89`.

## Validation
- bounded history tests: **20 examples, 0 failures**, including two 100-case properties
- independent review found all mutations centralize through `setHistoryWindowTurns`; duplicate `BlockId` fallback preserves first-match legacy semantics
- real tmux smoke opened `/resume`, navigated/resumed a persisted session, preserved transcript, and opened the agent viewport

## Benchmark (`-O2`, 7-sample medians)
The benchmark validates legacy/indexed equality and isolates lookup savings from index-maintenance cost.

### Lookup path
| workload | legacy | indexed | legacy alloc | indexed alloc |
|---|---:|---:|---:|---:|
| configured (200 turns / 1200 blocks) | 7.591 ms | 0.163 ms | 63.75 MB | 1.3 KB |
| stress | 3.697 s | 15.9 ms | 27.66 GB | 1.3 KB |

### Index maintenance
| workload | old two maps | new three maps | old alloc | new alloc |
|---|---:|---:|---:|---:|
| configured | 0.032 ms | 0.048 ms | 224 KB | 409 KB |
| stress | 0.573 ms | 1.53 ms | 3.98 MB | 7.57 MB |

The modest page-load/index-build cost is explicit; repeated UI lookups avoid full scans and transient map rebuilding.
