### PR TITLE
Retry session title generation

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
@@ -29,7 +29,7 @@ import Agent.Responses.Types
     )
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM
-import Control.Exception.Safe (displayException, tryAny)
+import Control.Exception.Safe (SomeException, displayException, tryAny)
 import Control.Monad (forever, void)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -169,7 +169,7 @@ shouldRequestSessionTitle milestone refreshIndex
 titleWorker :: (SessionTitleEvent -> IO ()) -> SessionTitleManager -> IO ()
 titleWorker onEvent manager = forever do
     job <- atomically (readTQueue manager.titleJobs)
-    generated <- tryAny (generateTitle manager job)
+    generated <- generateTitleWithRetry manager job
     accepted <- atomically do
         modifyTVar' manager.titleRequested
             (Set.delete
@@ -206,6 +206,16 @@ titleWorker onEvent manager = forever do
                         , failureGeneration = job.jobGeneration
                         }))
     mapM_ (void . tryAny . onEvent) accepted
+
+generateTitleWithRetry
+    :: SessionTitleManager
+    -> SessionTitleJob
+    -> IO (Either SomeException (Either Text Text))
+generateTitleWithRetry manager job = do
+    firstAttempt <- tryAny (generateTitle manager job)
+    case firstAttempt of
+        Right (Right _) -> pure firstAttempt
+        _ -> tryAny (generateTitle manager job)
 
 generateTitle :: SessionTitleManager -> SessionTitleJob -> IO (Either Text Text)
 generateTitle manager job = do

--- a/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
@@ -31,6 +31,7 @@ import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM
 import Control.Exception.Safe (SomeException, displayException, tryAny)
 import Control.Monad (forever, void)
+import Control.Retry (limitRetries, retrying)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
@@ -211,11 +212,13 @@ generateTitleWithRetry
     :: SessionTitleManager
     -> SessionTitleJob
     -> IO (Either SomeException (Either Text Text))
-generateTitleWithRetry manager job = do
-    firstAttempt <- tryAny (generateTitle manager job)
-    case firstAttempt of
-        Right (Right _) -> pure firstAttempt
-        _ -> tryAny (generateTitle manager job)
+generateTitleWithRetry manager job =
+    retrying (limitRetries 1) shouldRetry \_ ->
+        tryAny (generateTitle manager job)
+  where
+    shouldRetry _ = \case
+        Right (Right _) -> pure False
+        _ -> pure True
 
 generateTitle :: SessionTitleManager -> SessionTitleJob -> IO (Either Text Text)
 generateTitle manager job = do

--- a/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
@@ -137,10 +137,40 @@ spec = describe "Agent.CLI.SessionTitle" do
                         }
                     ]
 
-    it "reports provider failures instead of silently dropping them" do
+    it "retries a failed title request once before reporting its outcome" do
+        attempts <- newIORef (0 :: Int)
         notified <- newEmptyMVar
         let backendFactory _ =
-                Backend \state _ _ _ ->
+                Backend \state _ _ _ -> do
+                    attempt <- atomicModifyIORef' attempts \count ->
+                        let next = count + 1
+                        in (next, next)
+                    pure $ Right BackendResult
+                        { backendOutput =
+                            emptyTurnOutput "title-response" []
+                                (if attempt == 1
+                                    then Nothing
+                                    else Just "Recovered title")
+                        , backendState = state
+                        }
+        withSessionTitleManager backendFactory (pure defaultResponseCreateParams) (putMVar notified) \manager -> do
+            requestSessionTitle manager "session-1" 3 "conversation"
+            takeMVar notified
+                `shouldReturn`
+                    SessionTitleGenerated SessionTitleResult
+                        { resultSessionId = "session-1"
+                        , resultMilestone = 3
+                        , resultTitle = "Recovered title"
+                        , resultGeneration = 0
+                        }
+        readIORef attempts `shouldReturn` 2
+
+    it "reports provider failures instead of silently dropping them" do
+        attempts <- newIORef (0 :: Int)
+        notified <- newEmptyMVar
+        let backendFactory _ =
+                Backend \state _ _ _ -> do
+                    modifyIORef' attempts (+ 1)
                     pure $ Right BackendResult
                         { backendOutput =
                             emptyTurnOutput "title-response" [] Nothing
@@ -156,6 +186,7 @@ spec = describe "Agent.CLI.SessionTitle" do
                         , failureMessage = "provider returned no title text"
                         , failureGeneration = 0
                         }
+        readIORef attempts `shouldReturn` 2
 
 waitForResults :: SessionTitleManager -> Int -> IO [SessionTitleResult]
 waitForResults manager attempts


### PR DESCRIPTION
## Summary
- retry failed session title requests once with `Control.Retry` before surfacing an error
- keep retry handling internal so callers receive only the final outcome
- cover successful recovery and exhausted retries

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test`
- `hspec Agent.CLI.SessionTitleSpec.spec` (9 examples, 0 failures)