### PR TITLE
fix(responses): surface streamed tool-call arguments as live activity

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -630,18 +630,19 @@ openAiBackendWithRetryPolicyAndReasoningVisibility
         go emittedRawOutput emittedVisibleOutput defaultRetryStatus
       where
         go emittedRawOutput emittedVisibleOutput retryStatus = do
+            -- One projector per attempt: argument-progress counters must
+            -- describe a single provider sample, not the whole retry chain.
+            projectEvent <-
+                Responses.newStreamEventToLoopEvents showRawReasoning
             result <- send request previousResponseId \event -> do
                 if streamOutputObserved event
                     then writeIORef emittedRawOutput True
                     else pure ()
-                mapM_
-                    (\loopEvent -> do
+                projectEvent event
+                    >>= mapM_ \loopEvent -> do
                         when (isVisibleModelOutput loopEvent) $
                             writeIORef emittedVisibleOutput True
-                        onLoopEvent loopEvent)
-                    (Responses.streamEventToLoopEventWithRawReasoning
-                        showRawReasoning
-                        event)
+                        onLoopEvent loopEvent
             emitted <- readIORef emittedRawOutput
             case result of
                 Left apiError

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -9,6 +9,9 @@ module Agent.Responses.LoopBackend
     , responseTokenUsage
     , streamEventToLoopEvent
     , streamEventToLoopEventWithRawReasoning
+    , newStreamEventToLoopEvents
+    , toolArgumentActivityChunkChars
+    , runawayToolArgumentWarningChars
     , streamOutputObserved
     , hasRecoverableIncompleteOutput
     , assistantTextFromResponse
@@ -54,6 +57,9 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
 import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
+import Data.IORef (atomicModifyIORef', newIORef)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -82,12 +88,12 @@ statelessResponsesBackendWithRawReasoning
 statelessResponsesBackendWithRawReasoning showRawReasoning send getParams =
     Backend \history _previousResponseId inputs onEvent -> do
         baseParams <- getParams
+        projectEvent <- newStreamEventToLoopEvents showRawReasoning
         let newItems = turnInputsToItems inputs
             requestItems = history <> newItems
             request = withRequestInput baseParams requestItems
         result <- send request \event ->
-            mapM_ onEvent
-                (streamEventToLoopEventWithRawReasoning showRawReasoning event)
+            projectEvent event >>= mapM_ onEvent
         case result of
             Left err -> pure (Left err)
             Right response ->
@@ -634,6 +640,162 @@ streamEventToLoopEventWithRawReasoning showRawReasoning = \case
                 _ -> Nothing
             Nothing -> Nothing
     _ -> Nothing
+
+-- | Stateful projection of one streamed response attempt into loop events.
+--
+-- On top of 'streamEventToLoopEventWithRawReasoning' this surfaces streamed
+-- tool-call arguments as live activity. Argument deltas map to no visible
+-- loop event on their own, so a model writing a large tool call — or stuck in
+-- a degenerate repetition loop inside one (observed as multi-minute
+-- 128k-output-token samples whose arguments repeat @\\u0000@ or a hallucinated
+-- path segment) — previously looked like endless silent reasoning until the
+-- provider's output-token cap ended the turn.
+--
+-- Build one projector per response attempt so counters describe a single
+-- provider sample.
+newStreamEventToLoopEvents
+    :: Bool
+    -> IO (ResponseStreamEvent -> IO [LoopEvent])
+newStreamEventToLoopEvents showRawReasoning = do
+    stateRef <- newIORef emptyToolArgumentStreamState
+    pure \event -> do
+        argumentEvents <- atomicModifyIORef' stateRef \state ->
+            toolArgumentStreamStep event state
+        pure $
+            maybeToList
+                (streamEventToLoopEventWithRawReasoning showRawReasoning event)
+                <> argumentEvents
+
+-- | Emit an updated argument-streaming activity after this many additional
+-- streamed argument characters.
+toolArgumentActivityChunkChars :: Int
+toolArgumentActivityChunkChars = 8192
+
+-- | Warn after every additional this many streamed argument characters in a
+-- single response. The largest legitimate call observed in practice is well
+-- under half of this; degenerate repetition loops run to the provider's
+-- output-token cap (hundreds of thousands of characters).
+runawayToolArgumentWarningChars :: Int
+runawayToolArgumentWarningChars = 100000
+
+data ToolArgumentStreamState = ToolArgumentStreamState
+    { toolNamesById :: !(Map Text Text)
+    , currentToolName :: !(Maybe Text)
+    , streamedArgumentChars :: !Int
+    , announcedArgumentChars :: !Int
+    , warnedArgumentChars :: !Int
+    }
+
+emptyToolArgumentStreamState :: ToolArgumentStreamState
+emptyToolArgumentStreamState = ToolArgumentStreamState
+    { toolNamesById = Map.empty
+    , currentToolName = Nothing
+    , streamedArgumentChars = 0
+    , announcedArgumentChars = 0
+    , warnedArgumentChars = 0
+    }
+
+toolArgumentStreamStep
+    :: ResponseStreamEvent
+    -> ToolArgumentStreamState
+    -> (ToolArgumentStreamState, [LoopEvent])
+toolArgumentStreamStep event state = case event of
+    ResponseOutputItemAddedEvent { item = FunctionCallItem call } ->
+        announceToolCall call.name
+            (maybeToList call.itemId <> [call.callId])
+            state
+    ResponseOutputItemAddedEvent { item = CustomToolCallItem call } ->
+        announceToolCall call.name
+            (maybeToList call.itemId <> [call.callId])
+            state
+    ResponseFunctionCallArgumentsDeltaEvent { delta = Just deltaText, streamItemId } ->
+        countToolArgumentChars
+            (resolveToolName [streamItemId] state)
+            (Text.length deltaText)
+            state
+    ResponseCustomToolInputDeltaEvent
+        { delta = Just deltaText, streamItemId, streamCallId } ->
+            countToolArgumentChars
+                (resolveToolName [streamItemId, streamCallId] state)
+                (Text.length deltaText)
+                state
+    _ -> (state, [])
+
+announceToolCall
+    :: Text
+    -> [Text]
+    -> ToolArgumentStreamState
+    -> (ToolArgumentStreamState, [LoopEvent])
+announceToolCall name identities state =
+    ( state
+        { toolNamesById =
+            foldr (\identity -> Map.insert identity name)
+                state.toolNamesById
+                identities
+        , currentToolName = Just name
+        }
+    , [ActivityUpdated (writingToolCallActivity name Nothing)]
+    )
+
+resolveToolName :: [Maybe Text] -> ToolArgumentStreamState -> Text
+resolveToolName identities state =
+    fromMaybe (fromMaybe "tool" state.currentToolName) $
+        firstJust
+            [ Map.lookup identity state.toolNamesById
+            | Just identity <- identities
+            ]
+  where
+    firstJust = foldr (<|>) Nothing
+
+countToolArgumentChars
+    :: Text
+    -> Int
+    -> ToolArgumentStreamState
+    -> (ToolArgumentStreamState, [LoopEvent])
+countToolArgumentChars name deltaChars state =
+    let total = state.streamedArgumentChars + deltaChars
+        announce =
+            total - state.announcedArgumentChars
+                >= toolArgumentActivityChunkChars
+        warn =
+            total - state.warnedArgumentChars
+                >= runawayToolArgumentWarningChars
+    in
+    ( state
+        { streamedArgumentChars = total
+        , announcedArgumentChars =
+            if announce then total else state.announcedArgumentChars
+        , warnedArgumentChars =
+            if warn then total else state.warnedArgumentChars
+        }
+    , [ ActivityUpdated (writingToolCallActivity name (Just total))
+      | announce
+      ]
+        <> [ WarningRaised (runawayToolArgumentWarning name total)
+           | warn
+           ]
+    )
+
+writingToolCallActivity :: Text -> Maybe Int -> Text
+writingToolCallActivity name total =
+    "Writing " <> name <> " call…"
+        <> foldMap
+            (\chars -> " (" <> formatCharCount chars <> ")")
+            total
+
+runawayToolArgumentWarning :: Text -> Int -> Text
+runawayToolArgumentWarning name total =
+    "The model has streamed "
+        <> formatCharCount total
+        <> " of "
+        <> name
+        <> " arguments in one response; it may be stuck in a repetition loop."
+
+formatCharCount :: Int -> Text
+formatCharCount chars
+    | chars >= 10000 =
+        Text.pack (show (chars `div` 1000)) <> "k chars"
+    | otherwise = Text.pack (show chars) <> " chars"
 
 -- | Whether a stream event proves the provider has begun producing response
 -- output. These events make replay unsafe even when they do not map to a

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -16,7 +16,8 @@ import Agent.Provider
     , tokenProvider
     )
 import Agent.Responses.LoopBackend
-    ( statelessResponsesBackend
+    ( newStreamEventToLoopEvents
+    , statelessResponsesBackend
     , statelessResponsesBackendWithRawReasoning
     , tokenProviderStatelessResponsesBackend
     , turnInputsToItems
@@ -24,6 +25,8 @@ import Agent.Responses.LoopBackend
     )
 import Agent.Responses.Types
     ( MessageContent(..)
+    , CustomToolCall(..)
+    , FunctionCall(..)
     , FunctionCallOutput(..)
     , InternalChatMetadata(..)
     , ReasoningItem(..)
@@ -46,7 +49,12 @@ import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
-spec = describe "tokenProviderStatelessResponsesBackend" do
+spec = do
+    backendSpec
+    streamProjectionSpec
+
+backendSpec :: Spec
+backendSpec = describe "tokenProviderStatelessResponsesBackend" do
     it "encodes file attachments as input_file parts" do
         let image = ImageAttachment "image/png" "png-bytes"
             file = FileAttachment (Just "notes.txt") "text/plain" "file-bytes"
@@ -184,9 +192,7 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
                 { tag = "additional_tools"
                 , fields = KeyMap.empty
                 }
-            params = defaultResponseCreateParams
-                { input = Just (ResponseInputItems [prefix])
-                }
+            params = paramsWithInputItems [prefix]
             request = withRequestInput params (turnInputsToItems [UserMessage "hello"])
         case request.input of
             Just (ResponseInputItems (first : second : _)) -> do
@@ -197,9 +203,7 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
     it "replaces arbitrary prior input instead of replaying it as a prefix" do
         let stale = turnInputsToItems [UserMessage "stale"]
             fresh = turnInputsToItems [UserMessage "fresh"]
-            params = defaultResponseCreateParams
-                { input = Just (ResponseInputItems stale)
-                }
+            params = paramsWithInputItems stale
             request = withRequestInput params fresh
         request.input `shouldBe` Just (ResponseInputItems fresh)
 
@@ -218,14 +222,12 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
                 [item] -> item
                 _ -> error "expected one stale user item"
             fresh = turnInputsToItems [UserMessage "fresh"]
-            params = defaultResponseCreateParams
-                { input = Just (ResponseInputItems
-                    [ additional
-                    , markedDeveloper
-                    , unmarkedDeveloper
-                    , stale
-                    ])
-                }
+            params = paramsWithInputItems
+                [ additional
+                , markedDeveloper
+                , unmarkedDeveloper
+                , stale
+                ]
             request = withRequestInput params fresh
         request.input `shouldBe` Just
             (ResponseInputItems (additional : markedDeveloper : fresh))
@@ -265,9 +267,7 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
                 , status = Nothing
                 , extraFields = KeyMap.empty
                 }
-            params = defaultResponseCreateParams
-                { input = Just (ResponseInputItems [additional])
-                }
+            params = paramsWithInputItems [additional]
             request = withRequestInput params [imageMessage, toolOutput]
         case request.input of
             Just (ResponseInputItems
@@ -313,6 +313,131 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
                 <> turnInputsToItems [UserMessage "continue"]
             request = withRequestInput defaultResponseCreateParams items
         request.input `shouldBe` Just (ResponseInputItems items)
+
+-- | Streamed tool-call arguments map to no visible loop delta of their own.
+-- Without the projected activity below, a model writing a large call — or
+-- degenerating into a repetition loop inside one — looks like endless silent
+-- reasoning until the provider's output-token cap fails the turn.
+streamProjectionSpec :: Spec
+streamProjectionSpec = describe "newStreamEventToLoopEvents" do
+    it "announces a streamed function call by name" do
+        projectEvent <- newStreamEventToLoopEvents False
+        events <- projectEvent (functionCallAdded "fc-1" "call-1" "shell_command")
+        events `shouldBe` [ActivityUpdated "Writing shell_command call…"]
+
+    it "reports argument progress at chunk boundaries" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent (functionCallAdded "fc-1" "call-1" "shell_command")
+        quiet <- projectEvent
+            (argumentsDelta "fc-1" (Text.replicate 100 "x"))
+        quiet `shouldBe` []
+        loud <- projectEvent
+            (argumentsDelta "fc-1" (Text.replicate 9900 "y"))
+        loud `shouldBe`
+            [ActivityUpdated "Writing shell_command call… (10k chars)"]
+
+    it "warns once per runaway argument window" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent (functionCallAdded "fc-1" "call-1" "shell_command")
+        let bigDelta = Text.replicate 60000 "z"
+        first <- projectEvent (argumentsDelta "fc-1" bigDelta)
+        first `shouldBe`
+            [ActivityUpdated "Writing shell_command call… (60k chars)"]
+        second <- projectEvent (argumentsDelta "fc-1" bigDelta)
+        second `shouldBe`
+            [ ActivityUpdated "Writing shell_command call… (120k chars)"
+            , WarningRaised
+                ("The model has streamed 120k chars of shell_command "
+                    <> "arguments in one response; it may be stuck in a "
+                    <> "repetition loop.")
+            ]
+        third <- projectEvent (argumentsDelta "fc-1" bigDelta)
+        third `shouldBe`
+            [ActivityUpdated "Writing shell_command call… (180k chars)"]
+
+    it "counts custom tool input as argument streaming" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent (customToolCallAdded "ct-1" "call-9" "apply_patch")
+        loud <- projectEvent
+            (customInputDelta "ct-1" "call-9" (Text.replicate 10000 "p"))
+        loud `shouldBe`
+            [ActivityUpdated "Writing apply_patch call… (10k chars)"]
+
+    it "keeps plain deltas mapped through the pure projection" do
+        projectEvent <- newStreamEventToLoopEvents False
+        events <- projectEvent OtherResponseStreamEvent
+            { otherEventType = EventOutputTextDelta
+            , sequenceNumber = Just 1
+            , eventExtraFields =
+                KeyMap.singleton "delta" (Aeson.String "hi")
+            }
+        events `shouldBe` [TextDelta "hi"]
+
+functionCallAdded :: Text.Text -> Text.Text -> Text.Text -> ResponseStreamEvent
+functionCallAdded functionItemId functionCallId functionName =
+    ResponseOutputItemAddedEvent
+        { item = FunctionCallItem FunctionCall
+            { itemId = Just functionItemId
+            , callId = functionCallId
+            , name = functionName
+            , namespace = Nothing
+            , arguments = ""
+            , encryptedFunctionArgs = Nothing
+            , status = Nothing
+            , extraFields = KeyMap.empty
+            }
+        , outputIndex = Just 0
+        , sequenceNumber = Just 1
+        , eventExtraFields = KeyMap.empty
+        }
+
+customToolCallAdded :: Text.Text -> Text.Text -> Text.Text -> ResponseStreamEvent
+customToolCallAdded customItemId customCallId customName =
+    ResponseOutputItemAddedEvent
+        { item = CustomToolCallItem CustomToolCall
+            { itemId = Just customItemId
+            , callId = customCallId
+            , name = customName
+            , namespace = Nothing
+            , input = ""
+            , status = Nothing
+            , extraFields = KeyMap.empty
+            }
+        , outputIndex = Just 0
+        , sequenceNumber = Just 1
+        , eventExtraFields = KeyMap.empty
+        }
+
+argumentsDelta :: Text.Text -> Text.Text -> ResponseStreamEvent
+argumentsDelta deltaItemId deltaText =
+    ResponseFunctionCallArgumentsDeltaEvent
+        { delta = Just deltaText
+        , streamItemId = Just deltaItemId
+        , streamOutputIndex = Just 0
+        , sequenceNumber = Nothing
+        , eventExtraFields = KeyMap.empty
+        }
+
+customInputDelta :: Text.Text -> Text.Text -> Text.Text -> ResponseStreamEvent
+customInputDelta deltaItemId deltaCallId deltaText =
+    ResponseCustomToolInputDeltaEvent
+        { delta = Just deltaText
+        , streamItemId = Just deltaItemId
+        , streamCallId = Just deltaCallId
+        , streamOutputIndex = Just 0
+        , sequenceNumber = Nothing
+        , eventExtraFields = KeyMap.empty
+        }
+
+-- | 'input' is also a field on 'CustomToolCall', so a record update on
+-- 'ResponseCreateParams' is ambiguous here. Rebuild from the constructor.
+paramsWithInputItems :: [ResponseItem] -> ResponseCreateParams
+paramsWithInputItems items = case defaultResponseCreateParams of
+    ResponseCreateParams{..} ->
+        ResponseCreateParams
+            { input = Just (ResponseInputItems items)
+            , ..
+            }
 
 credential :: String -> Credential
 credential label = Credential


### PR DESCRIPTION
## Problem: "stuck in reasoning"

Reported from session `2026-08-27-b5c94a16`: the agent sometimes appears to reason forever until the user cancels. The suspected reasoning-event parser and terminal-event handling turned out to be fine — the session store shows what actually happens:

- Four recent gpt-5.6-sol turns ran 30–60 minutes and failed with `Response incomplete: max_output_tokens` at **exactly 128000 output tokens but only 0–53 reasoning tokens** (`2026-08-27-a1c0c006`, `2026-08-27-767f8000`, `2026-08-27-747d5487`, `2026-08-26-61027c54`); several more were cancelled mid-flight, including the reported session.
- Two runaway samples completed and were persisted: `shell_command` calls whose `workdir` degenerates into **256k chars of JSON-escaped NUL characters** in one case and **220k chars of hallucinated `task_<uuid>/` path segments** in the other.

So the model degenerates into a repetition loop **inside function-call arguments**. `response.function_call_arguments.delta` / `response.custom_tool_call_input.delta` events mapped to no loop event, so the entire runaway rendered as endless silent "Thinking…" — indistinguishable from stuck reasoning. A healthy large `apply_patch` call was equally invisible.

## Fix

New stateful per-attempt stream projector `newStreamEventToLoopEvents` in `Agent.Responses.LoopBackend`, layered on the existing pure mapping:

- announces streamed function/custom tool calls by name: `Writing shell_command call…`
- refreshes the activity with a running count every 8192 streamed argument chars: `Writing apply_patch call… (56k chars)`
- raises a warning every 100k argument chars in one response: *"The model has streamed 120k chars of shell_command arguments in one response; it may be stuck in a repetition loop."* — so a degenerate sample is recognizable and cancellable within seconds instead of after ~40 minutes at the output-token cap

Wired into both the stateless Responses backend (HTTP, xAI, OpenRouter inherit it) and the Codex WebSocket backend. One projector per attempt keeps counters scoped to a single provider sample; replay safety is unchanged because argument deltas already counted as observed output. `ActivityUpdated`/`WarningRaised` flow through the existing minimal renderer, TUI, gateway bridge, and telegram paths — no new event variants.

## Validation

- 5 new specs in `LoopBackendSpec` (announce, chunk boundaries, warning windows, custom tool input, pure-projection passthrough)
- full `agent-responses` (54) and `agent-openai` (287) suites pass in GHCi
- live tmux smoke on gpt-5.6-sol: status line shows `⠦ Writing apply_patch call… (8197 chars) · 1m31s` while arguments stream, and the turn completes normally

## Runaway abort cap (second commit)

The WebSocket receive loop now hard-stops a response after 300k streamed argument characters, invalidates the request, and fails the turn with a typed non-retryable error — every observed runaway trips it within seconds-to-minutes instead of 30–60 min, and no legitimate call comes close (largest seen: 30k).

🤖 Generated with [Claude Code](https://claude.com/claude-code)