### PR TITLE
fix(loop): continue reasoning-only incomplete responses

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -51,6 +51,7 @@ import Agent.Responses.StreamAssembly
     , finishStreamResponse
     , responseFailureFromState
     )
+import Agent.Responses.LoopBackend (responseNeedsLoopContinuation)
 import qualified Agent.Responses.Codec as ResponsesCodec
 import qualified Agent.Transport.WebSocket as WebSocket
 import Agent.Provider
@@ -96,7 +97,8 @@ import qualified Wuss
 -- | Turn-scoped sticky-routing state shared by every physical transport used
 -- during one logical Codex turn. Codex treats this as a first-write-wins token:
 -- once received from response headers/metadata, it must be replayed unchanged
--- on tool continuations, reconnects, HTTP fallback, and inline compaction.
+-- on tool and empty-model continuations, reconnects, HTTP fallback, and inline
+-- compaction.
 newtype CodexTurnState = CodexTurnState (IORef (Maybe Text))
 
 data CodexConn = CodexWsConn
@@ -124,10 +126,12 @@ resetCodexTurnState (CodexTurnState turnState) =
     atomicModifyIORef' turnState (const (Nothing, ()))
 
 -- | End a normal model request. Tool calls keep the turn open for their output
--- continuation; every other successful response closes the routing scope.
+-- continuation, and empty model steps keep it open for the loop's
+-- previous-response continuation. Every other successful response closes the
+-- routing scope.
 finishCodexTurnStateResponse :: CodexTurnState -> Response -> IO ()
 finishCodexTurnStateResponse turnState response
-    | responseHasToolContinuation response = pure ()
+    | responseKeepsTurnOpen response = pure ()
     | otherwise = resetCodexTurnState turnState
 
 -- | Close a reusable Codex connection before its owning callback returns.
@@ -534,9 +538,10 @@ captureTurnState turnState callback event = do
         Nothing -> pure ()
     callback event
 
-responseHasToolContinuation :: Response -> Bool
-responseHasToolContinuation response =
+responseKeepsTurnOpen :: Response -> Bool
+responseKeepsTurnOpen response =
     any isToolCall response.output
+        || responseNeedsLoopContinuation response
   where
     isToolCall = \case
         FunctionCallItem{} -> True

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1,5 +1,6 @@
 module Agent.OpenAI.LoopBackendSpec (spec) where
 
+import Agent.Cancel (newCancelFlag)
 import Agent.Error
     ( ApiError(..)
     , ErrorType(..)
@@ -13,9 +14,13 @@ import Agent.OpenAI.WebSocketClient
     , readCodexTurnState
     , recordCodexTurnState
     )
-import Agent.Responses.LoopBackend (streamOutputObserved)
+import Agent.Responses.LoopBackend
+    ( responseNeedsLoopContinuation
+    , streamOutputObserved
+    )
 import Agent.Responses.Types
 import Agent.ToolDispatch
+import Agent.Tools.Types (ToolRegistry, mkToolRegistry)
 import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
@@ -258,6 +263,51 @@ spec = do
                 , incompleteReasoningTokens = Just 32000
                 }
             turn.tokenUsage.outputTokens `shouldBe` 32768
+
+        it "continues reasoning-only max-output stops on the response chain" do
+            let turn = responseToTurnOutput reasoningIncompleteResponse
+            turn.completion `shouldBe` TurnCompleted
+            turn.toolCalls `shouldBe` []
+            turn.assistantText `shouldBe` Nothing
+            turn.tokenUsage.outputTokens `shouldBe` 128000
+
+        it "continues only successful empty response steps" do
+            let cancelled = testResponse "resp-cancelled" []
+            responseNeedsLoopContinuation reasoningIncompleteResponse
+                `shouldBe` True
+            responseNeedsLoopContinuation (testResponse "resp-empty" [])
+                `shouldBe` True
+            responseNeedsLoopContinuation
+                (cancelled
+                    { status = ResponseCancelled
+                    , incompleteDetails = Nothing
+                    })
+                `shouldBe` False
+
+        it "keeps filtered or partially actionable incomplete output terminal" do
+            let incomplete reason output =
+                    (testResponse "resp-incomplete" output)
+                        { status = ResponseIncomplete
+                        , incompleteDetails = Just IncompleteDetails
+                            { reason
+                            , extraFields = KeyMap.empty
+                            }
+                        }
+                filtered = responseToTurnOutput
+                    (incomplete "content_filter" [reasoningItem "rs-filtered"])
+                partialCall = responseToTurnOutput
+                    (incomplete "max_output_tokens"
+                        [ reasoningItem "rs-partial"
+                        , functionCallItem "call-partial" "echo" "{}"
+                        ])
+            filtered.completion `shouldBe` TurnIncomplete
+                { incompleteReason = "content_filter"
+                , incompleteReasoningTokens = Nothing
+                }
+            partialCall.completion `shouldBe` TurnIncomplete
+                { incompleteReason = "max_output_tokens"
+                , incompleteReasoningTokens = Nothing
+                }
 
     describe "streamEventToLoopEvent" do
         it "maps output and summary deltas but hides raw reasoning" do
@@ -520,6 +570,36 @@ spec = do
                 ]
 
     describe "openAiBackendWith" do
+        it "continues a reasoning-only incomplete response by response id" do
+            seenPrevious <- newIORef []
+            remaining <- newIORef
+                [ reasoningIncompleteResponse
+                , testResponse "resp-final" [assistantItem "done"]
+                ]
+            let send _request previous _onEvent = do
+                    modifyIORef' seenPrevious (<> [previous])
+                    atomicModifyIORef' remaining \case
+                        response : rest -> (rest, Right response)
+                        [] -> error "unexpected extra response submission"
+                backend = openAiBackendWith send (pure baseParams)
+            config <- loopConfig backend
+
+            result <- runLoop config Nothing "investigate"
+
+            result `shouldBe` Right LoopResult
+                { finalResponseId = "resp-final"
+                , finalText = Just "done"
+                , turnsUsed = 2
+                , tokenUsage = TokenUsage
+                    { inputTokens = 64000
+                    , outputTokens = 128000
+                    , cachedTokens = 0
+                    }
+                }
+            readIORef seenPrevious `shouldReturn`
+                [Nothing, Just "resp-reasoning-incomplete"]
+            readIORef remaining `shouldReturn` []
+
         it "shows raw reasoning only when explicitly enabled" do
             let send _request _previous onEvent = do
                     onEvent (deltaEvent EventReasoningTextDelta "raw")
@@ -1329,6 +1409,30 @@ submitWithState stateRef backend previous inputs onEvent = do
             writeIORef stateRef backendState
             pure (Right backendOutput)
 
+loopConfig :: Backend -> IO LoopConfig
+loopConfig backend = do
+    state <- newIORef []
+    cancel <- newCancelFlag
+    pure LoopConfig
+        { loopBackend = backend
+        , loopBackendState = BackendStateStore
+            { readBackendState = readIORef state
+            , commitBackendState = writeIORef state
+            }
+        , loopTools = emptyRegistry
+        , loopDispatch = defaultLoopDispatch
+        , loopMaxTurns = defaultLoopMaxTurns
+        , loopOnEvent = const (pure ())
+        , loopApprove = const (pure (Right True))
+        , loopReadSteering = pure []
+        , loopCommitSteering = const (pure ())
+        , loopCancel = cancel
+        }
+
+emptyRegistry :: ToolRegistry
+emptyRegistry =
+    either (error . Text.unpack) id (mkToolRegistry [])
+
 baseParams :: ResponseCreateParams
 baseParams = withModel (Just "gpt-5.6-luna") defaultResponseCreateParams
 
@@ -1444,6 +1548,36 @@ assistantItem text = MessageItem ResponseMessage
     , passthrough = Nothing
     , extraFields = KeyMap.empty
     }
+
+reasoningItem :: Text -> ResponseItem
+reasoningItem itemId = ReasoningItemValue ReasoningItem
+    { itemId = Just itemId
+    , summary = []
+    , content = Nothing
+    , encryptedContent = Just "opaque"
+    , status = Just ItemCompleted
+    , extraFields = KeyMap.empty
+    }
+
+reasoningIncompleteResponse :: Response
+reasoningIncompleteResponse =
+    (testResponseWithUsage
+        "resp-reasoning-incomplete"
+        [reasoningItem "rs-1"]
+        (Aeson.object
+            [ "input_tokens" Aeson..= (64000 :: Int)
+            , "output_tokens" Aeson..= (128000 :: Int)
+            , "total_tokens" Aeson..= (192000 :: Int)
+            , "output_tokens_details" Aeson..= Aeson.object
+                [ "reasoning_tokens" Aeson..= (53 :: Int)
+                ]
+            ]))
+        { status = ResponseIncomplete
+        , incompleteDetails = Just IncompleteDetails
+            { reason = "max_output_tokens"
+            , extraFields = KeyMap.empty
+            }
+        }
 
 compactionItem :: Text -> ResponseItem
 compactionItem _ = CompactionItemValue CompactionItem

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -17,7 +17,7 @@ import Data.Text (Text)
 spec :: Spec
 spec = do
   describe "CodexTurnState" do
-    it "keeps the first token through tool calls and clears it at turn end" do
+    it "keeps the first token through continuations and clears it at turn end" do
         turnState <- newCodexTurnState
         recordCodexTurnState turnState " "
         recordCodexTurnState turnState "ts-first"
@@ -40,7 +40,46 @@ spec = do
         readCodexTurnState turnState `shouldReturn` Just "ts-first"
 
         finishCodexTurnStateResponse turnState
+            ((responseWithOutput
+                [ ReasoningItemValue ReasoningItem
+                    { itemId = Just "rs-1"
+                    , summary = []
+                    , content = Nothing
+                    , encryptedContent = Nothing
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+                ])
+                { status = ResponseIncomplete
+                , incompleteDetails = Just IncompleteDetails
+                    { reason = "max_output_tokens"
+                    , extraFields = KeyMap.empty
+                    }
+                })
+        readCodexTurnState turnState `shouldReturn` Just "ts-first"
+
+        finishCodexTurnStateResponse turnState
             (responseWithOutput [])
+        readCodexTurnState turnState `shouldReturn` Just "ts-first"
+
+        finishCodexTurnStateResponse turnState
+            (responseWithOutput
+                [ MessageItem ResponseMessage
+                    { messageId = Just "msg-1"
+                    , content = MessageContentParts
+                        [ OutputTextPart
+                            "done"
+                            Nothing
+                            Nothing
+                            KeyMap.empty
+                        ]
+                    , role = RoleAssistant
+                    , status = Just ItemCompleted
+                    , phase = Nothing
+                    , passthrough = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                ])
         readCodexTurnState turnState `shouldReturn` Nothing
 
   describe "buildCodexWsHeaders" do

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -14,6 +14,7 @@ module Agent.Responses.LoopBackend
     , runawayToolArgumentWarningChars
     , streamOutputObserved
     , hasRecoverableIncompleteOutput
+    , responseNeedsLoopContinuation
     , assistantTextFromResponse
     , toolResultToItem
     , withRequestInput
@@ -405,30 +406,59 @@ responseToTurnOutput response = TurnOutput
     , assistantText = assistantTextFromResponse response
     , tokenUsage = responseTokenUsage response
     , completion = case response.status of
-        ResponseIncomplete -> TurnIncomplete
-            { incompleteReason =
-                maybe "unknown" (.reason) response.incompleteDetails
-            , incompleteReasoningTokens =
-                response.usage
-                    >>= (.outputTokensDetails)
-                    >>= (.reasoningTokens)
-            }
+        ResponseIncomplete
+            | hasContinuableReasoningOnlyOutput response -> TurnCompleted
+            | otherwise -> TurnIncomplete
+                { incompleteReason =
+                    maybe "unknown" (.reason) response.incompleteDetails
+                , incompleteReasoningTokens =
+                    response.usage
+                        >>= (.outputTokensDetails)
+                        >>= (.reasoningTokens)
+                }
         _ -> TurnCompleted
     }
 
--- | An incomplete response can still finish the turn when it already contains
--- executable tool calls or assistant text, or when it is a continuable
--- reasoning-only stop. @max_output_tokens@ during reasoning is handed to the
--- loop as an empty completion so it can continue the chain. Reasons such as
--- @content_filter@ stay transport failures, as do completely empty incomplete
--- responses, so a replay-safe fallback can still run.
+-- | Whether this successful response requires an empty continuation on its
+-- committed response chain.
+responseNeedsLoopContinuation :: Response -> Bool
+responseNeedsLoopContinuation response = case response.status of
+    ResponseCompleted ->
+        not (responseHasToolCalls response)
+            && not (responseHasVisibleAssistantText response)
+    ResponseIncomplete -> hasContinuableReasoningOnlyOutput response
+    _ -> False
+
+-- | Whether the transport should retain an incomplete response instead of
+-- converting it to an 'ApiError'. Partial tool/text output is retained so the
+-- committed response can be reported without replaying it, but remains
+-- 'TurnIncomplete'. A reasoning-only @max_output_tokens@ stop instead becomes
+-- an empty completion so the loop can continue the response chain. Reasons
+-- such as @content_filter@ stay transport failures, as do completely empty
+-- incomplete responses, so a replay-safe fallback can still run.
 hasRecoverableIncompleteOutput :: Response -> Bool
 hasRecoverableIncompleteOutput response =
-    not (null (mapMaybe responseItemToToolCall response.output))
-        || maybe False (not . Text.null . Text.strip)
-            (assistantTextFromResponse response)
-        || (any isReasoningOutput response.output
-            && isContinuableIncompleteReason response)
+    responseHasToolCalls response
+        || responseHasVisibleAssistantText response
+        || hasContinuableReasoningOnlyOutput response
+
+-- A reasoning-only max-output stop is an intermediate model sample. Mark it
+-- completed at the loop boundary so the core loop continues from its committed
+-- response id. Partial text or tool calls remain terminal incomplete output:
+-- executing either could act on a truncated response.
+hasContinuableReasoningOnlyOutput :: Response -> Bool
+hasContinuableReasoningOnlyOutput response =
+    not (null response.output)
+        && all isReasoningOutput response.output
+        && isContinuableIncompleteReason response
+
+responseHasToolCalls :: Response -> Bool
+responseHasToolCalls =
+    not . null . mapMaybe responseItemToToolCall . (.output)
+
+responseHasVisibleAssistantText :: Response -> Bool
+responseHasVisibleAssistantText =
+    maybe False (not . Text.null . Text.strip) . assistantTextFromResponse
 
 isReasoningOutput :: ResponseItem -> Bool
 isReasoningOutput = \case


### PR DESCRIPTION
## Summary

- map reasoning-only `response.incomplete(max_output_tokens)` samples to an empty successful loop step
- continue with the committed `previous_response_id` while leaving filtered, empty, text, and tool-call incomplete responses terminal
- retain Codex sticky turn state across empty response continuations

## Diagnosis

The transport already accepted a reasoning-only max-output response so the loop could continue it. `responseToTurnOutput` then classified every incomplete response as `TurnIncomplete`, and the core loop terminated before its existing empty-completion continuation path.

This is separate from the misleading long-running `Thinking…` state fixed in #641: those observed 128k-token samples were runaway tool-call arguments. This patch covers the genuine reasoning-only incomplete lifecycle edge found while tracing the same failure path.

## Validation

- `nix develop -c cabal repl agent-responses:test:agent-responses-test`: 57 examples, 0 failures
- `nix develop -c cabal repl agent-openai:test:agent-openai-test`: 295 examples, 0 failures, 1 live-auth test pending
- focused integration spec verifies the second submission uses `previous_response_id`
- focused Codex state spec verifies routing state survives empty continuations and clears on final text
