### PR TITLE
fix(cli): stop Kitty-encoded Esc from leaking into the composer

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
+++ b/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
@@ -1,12 +1,18 @@
--- | Watch stdin for a bare Esc during an agent turn and soft-cancel.
+-- | Watch stdin for Esc during an agent turn and soft-cancel. Terminals with
+-- the Kitty keyboard protocol active encode the Esc key as @CSI 27 u@ rather
+-- than a bare ESC byte, so the watcher must decode that sequence too.
 module Agent.CLI.CancelWatch
-    ( drainEscapeContinuation
+    ( EscapeContinuation(..)
+    , readEscapeContinuation
+    , escapeContinuationCancels
     , withEscCancel
     , withStdinPaused
     , isBareEscape
     ) where
 
 import Agent.Cancel (CancelFlag, requestCancel)
+import Agent.CLI.Input.KeyDecoder (kittyRelease, parseKittyKey)
+import Agent.CLI.Input.Types (KittyKey(..))
 import Agent.CLI.Terminal (rawAttrs)
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
@@ -19,7 +25,6 @@ import System.IO
     , hGetBuffering
     , hGetChar
     , hIsTerminalDevice
-    , hReady
     , hSetBuffering
     , hWaitForInput
     , stdin
@@ -135,34 +140,64 @@ escLoop cancel paused stopped = go
                                             if c /= '\ESC'
                                                 then go
                                                 else do
-                                                    -- Peek for CSI / SS3 so arrows do not cancel.
+                                                    -- Peek for CSI / SS3 so arrows do not cancel,
+                                                    -- but a Kitty-encoded Esc key press must.
                                                     more <- hWaitForInput stdin 50
                                                     if not more
                                                         then requestCancel cancel
                                                         else do
                                                             c2 <- hGetChar stdin
-                                                            drainEscapeContinuation stdin c2
-                                                            go
+                                                            continuation <-
+                                                                readEscapeContinuation stdin c2
+                                                            if escapeContinuationCancels continuation
+                                                                then requestCancel cancel
+                                                                else go
+
+-- | The tail of an escape sequence read after a leading ESC byte.
+data EscapeContinuation
+    = EscapeCsi !String
+    -- ^ A CSI body, including its final byte when one arrived in time.
+    | EscapeOther
+    deriving (Eq, Show)
 
 -- | Consume the remainder of an escape sequence without ever waiting
 -- indefinitely for a fragmented terminal input. SS3 sequences normally have
 -- one byte after @ESC O@, but terminals, tmux, or a truncated paste may omit
--- it while the writer remains open.
-drainEscapeContinuation :: Handle -> Char -> IO ()
-drainEscapeContinuation h = \case
-    '[' -> drainCsi h
+-- it while the writer remains open. CSI bytes are read with short timed waits
+-- rather than a non-blocking peek: a tail that trickles in must still be
+-- consumed here, or it leaks into the next stdin reader as typed text.
+readEscapeContinuation :: Handle -> Char -> IO EscapeContinuation
+readEscapeContinuation h = \case
+    '[' -> EscapeCsi <$> readCsiTail h
     'O' -> do
         ready <- hWaitForInput h 50
         when ready (void (hGetChar h))
-    _ -> pure ()
+        pure EscapeOther
+    _ -> pure EscapeOther
 
-drainCsi :: Handle -> IO ()
-drainCsi h = go
+readCsiTail :: Handle -> IO String
+readCsiTail h = go (0 :: Int) []
   where
-    go = do
-        ready <- hReady h
-        when ready do
-            c <- hGetChar h
-            if c >= '@' && c <= '~'
-                then pure ()
-                else go
+    go count reversed
+        | count >= 32 = pure (reverse reversed)
+        | otherwise = do
+            ready <- hWaitForInput h 50
+            if not ready
+                then pure (reverse reversed)
+                else do
+                    c <- hGetChar h
+                    let next = c : reversed
+                    if c >= '@' && c <= '~'
+                        then pure (reverse next)
+                        else go (count + 1) next
+
+-- | Kitty's keyboard protocol encodes the Esc key as @CSI 27 u@. A press (or
+-- repeat) of that key must cancel exactly like a bare ESC byte; releases and
+-- every other sequence (arrows, function keys) must not.
+escapeContinuationCancels :: EscapeContinuation -> Bool
+escapeContinuationCancels = \case
+    EscapeCsi body -> case parseKittyKey body of
+        Just KittyKey{kittyCodepoint, kittyEvent} ->
+            kittyCodepoint == 27 && kittyEvent /= kittyRelease
+        Nothing -> False
+    EscapeOther -> False

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -150,6 +150,7 @@ import Agent.CLI.Terminal
     , kittyAltCsiBodies
     , kittyCtrlCsiBodies
     , kittyCtrlUnderscoreCsiBodies
+    , kittyEscapeCsiBodies
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
     , kittySuperVCsiBodies
@@ -890,12 +891,23 @@ fullscreenVtyConfig =
     V.defaultConfig
         { V.configPreferredColorMode = Just V.FullColor
         , V.configInputMap =
+            -- The Esc key itself: with the Kitty disambiguate flag pushed the
+            -- terminal sends Esc as @CSI 27 u@. Vty has no CSI-u table, so an
+            -- unmapped body decodes as bare Esc followed by its payload as
+            -- typed text — cancelling a turn then left "[27u" in the composer
+            -- (and in the next prompt sent to the model).
             [ ( Nothing
               , "\ESC[" <> body
-              , V.EvKey V.KEnter [V.MShift]
+              , V.EvKey V.KEsc []
               )
-            | body <- shiftEnterCsiBodies
+            | body <- kittyEscapeCsiBodies
             ]
+            <> [ ( Nothing
+                 , "\ESC[" <> body
+                 , V.EvKey V.KEnter [V.MShift]
+                 )
+               | body <- shiftEnterCsiBodies
+               ]
             <> [ ( Nothing
                  , "\ESC[" <> body
                  , V.EvKey (V.KChar character) [V.MCtrl]

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -246,14 +246,15 @@ kittySuperVCsiBodies = kittyModifiedCsiBodies 'v' 9
 -- | CSI bodies emitted by Kitty's keyboard protocol for the Esc key. The
 -- disambiguate flag re-encodes Esc as @CSI 27 u@ so it is distinguishable
 -- from a sequence introducer; terminals may add the encoded modifier field
--- (1 = none) and an explicit key-press event, and modified presses such as
--- Shift+Esc carry higher modifier values. Every variant must decode to Esc:
+-- (1 = none) and an explicit key-press event. The protocol's eight modifier
+-- bits (including Hyper, Meta, Caps Lock, and Num Lock) make 256 the highest
+-- encoded value. Every variant must decode to Esc:
 -- an unmapped body leaks its payload into the composer as literal text
 -- (observed as prompts beginning with @[27u@).
 kittyEscapeCsiBodies :: [String]
 kittyEscapeCsiBodies =
     [ "27" <> modifier <> event <> "u"
-    | modifier <- "" : [";" <> show encoded | encoded <- [1 .. 16 :: Int]]
+    | modifier <- "" : [";" <> show encoded | encoded <- [1 .. 256 :: Int]]
     , event <- ["", ":1"]
     , not (null modifier) || event /= ":1"
     ]

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -21,6 +21,7 @@ module Agent.CLI.Terminal
     , kittyCtrlCsiBodies
     , kittyCtrlUnderscoreCsiBodies
     , kittyCtrlVCsiBodies
+    , kittyEscapeCsiBodies
     , kittySuperVCsiBodies
     , shiftEnterCsiBodies
     , kittyKeyboardDisambiguatePush
@@ -241,6 +242,21 @@ kittyCtrlUnderscoreCsiBodies =
 kittyCtrlVCsiBodies, kittySuperVCsiBodies :: [String]
 kittyCtrlVCsiBodies = kittyCtrlCsiBodies 'v'
 kittySuperVCsiBodies = kittyModifiedCsiBodies 'v' 9
+
+-- | CSI bodies emitted by Kitty's keyboard protocol for the Esc key. The
+-- disambiguate flag re-encodes Esc as @CSI 27 u@ so it is distinguishable
+-- from a sequence introducer; terminals may add the encoded modifier field
+-- (1 = none) and an explicit key-press event, and modified presses such as
+-- Shift+Esc carry higher modifier values. Every variant must decode to Esc:
+-- an unmapped body leaks its payload into the composer as literal text
+-- (observed as prompts beginning with @[27u@).
+kittyEscapeCsiBodies :: [String]
+kittyEscapeCsiBodies =
+    [ "27" <> modifier <> event <> "u"
+    | modifier <- "" : [";" <> show encoded | encoded <- [1 .. 16 :: Int]]
+    , event <- ["", ":1"]
+    , not (null modifier) || event /= ":1"
+    ]
 
 kittyModifiedCsiBodies :: Char -> Int -> [String]
 kittyModifiedCsiBodies character encodedModifier =

--- a/packages/agent-cli/test/Agent/CLI/CancelWatchSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CancelWatchSpec.hs
@@ -1,7 +1,12 @@
 module Agent.CLI.CancelWatchSpec (spec) where
 
-import Agent.CLI.CancelWatch (drainEscapeContinuation, isBareEscape)
-import System.IO (hClose)
+import Agent.CLI.CancelWatch
+    ( EscapeContinuation(..)
+    , escapeContinuationCancels
+    , isBareEscape
+    , readEscapeContinuation
+    )
+import System.IO (BufferMode(..), hClose, hPutStr, hFlush, hSetBuffering)
 import System.Posix.IO (createPipe, fdToHandle)
 import System.Timeout (timeout)
 import Test.Hspec
@@ -17,13 +22,54 @@ spec = do
             isBareEscape "" `shouldBe` False
             isBareEscape "a" `shouldBe` False
 
-    describe "drainEscapeContinuation" do
+    describe "readEscapeContinuation" do
         it "does not block forever on an incomplete SS3 sequence" do
             (readFd, writeFd) <- createPipe
             readHandle <- fdToHandle readFd
             writeHandle <- fdToHandle writeFd
             result <- timeout 500000 $
-                drainEscapeContinuation readHandle 'O'
+                readEscapeContinuation readHandle 'O'
             hClose readHandle
             hClose writeHandle
-            result `shouldBe` Just ()
+            result `shouldBe` Just EscapeOther
+
+        it "consumes a complete CSI body including the final byte" do
+            (readFd, writeFd) <- createPipe
+            readHandle <- fdToHandle readFd
+            writeHandle <- fdToHandle writeFd
+            hSetBuffering writeHandle NoBuffering
+            hPutStr writeHandle "27u"
+            hFlush writeHandle
+            result <- timeout 1000000 $
+                readEscapeContinuation readHandle '['
+            hClose readHandle
+            hClose writeHandle
+            result `shouldBe` Just (EscapeCsi "27u")
+
+        it "returns a fragmented CSI tail instead of leaving it buffered" do
+            (readFd, writeFd) <- createPipe
+            readHandle <- fdToHandle readFd
+            writeHandle <- fdToHandle writeFd
+            hSetBuffering writeHandle NoBuffering
+            hPutStr writeHandle "27"
+            hFlush writeHandle
+            result <- timeout 1000000 $
+                readEscapeContinuation readHandle '['
+            hClose readHandle
+            hClose writeHandle
+            result `shouldBe` Just (EscapeCsi "27")
+
+    describe "escapeContinuationCancels" do
+        it "cancels on a Kitty-encoded Esc key press" do
+            escapeContinuationCancels (EscapeCsi "27u") `shouldBe` True
+            escapeContinuationCancels (EscapeCsi "27;1u") `shouldBe` True
+            escapeContinuationCancels (EscapeCsi "27;1:1u") `shouldBe` True
+
+        it "ignores Esc key releases" do
+            escapeContinuationCancels (EscapeCsi "27;1:3u") `shouldBe` False
+
+        it "ignores arrows, other keys, and non-CSI tails" do
+            escapeContinuationCancels (EscapeCsi "A") `shouldBe` False
+            escapeContinuationCancels (EscapeCsi "13;2u") `shouldBe` False
+            escapeContinuationCancels (EscapeCsi "27") `shouldBe` False
+            escapeContinuationCancels EscapeOther `shouldBe` False

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -291,7 +291,14 @@ spec = do
             mapM_
                 (\body -> mappings `shouldContain`
                     [(Nothing, "\ESC[" <> body, V.EvKey V.KEsc [])])
-                ["27u", "27;1u", "27;1:1u", "27;2u", "27;5:1u"]
+                [ "27u"
+                , "27;1u"
+                , "27;1:1u"
+                , "27;2u"
+                , "27;5:1u"
+                , "27;65u"
+                , "27;256:1u"
+                ]
 
         it "maps enhanced-keyboard sequences before Vty decodes them" do
             let mappings = V.configInputMap fullscreenVtyConfig

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -286,6 +286,13 @@ spec = do
             after.uiPrompt.promptModel `shouldBe` "gpt-5.6-sol"
 
     describe "fullscreenVtyConfig" do
+        it "maps the Kitty-encoded Esc key so its payload cannot leak" do
+            let mappings = V.configInputMap fullscreenVtyConfig
+            mapM_
+                (\body -> mappings `shouldContain`
+                    [(Nothing, "\ESC[" <> body, V.EvKey V.KEsc [])])
+                ["27u", "27;1u", "27;1:1u", "27;2u", "27;5:1u"]
+
         it "maps enhanced-keyboard sequences before Vty decodes them" do
             let mappings = V.configInputMap fullscreenVtyConfig
             mappings `shouldContain`


### PR DESCRIPTION
## Problem

Several recent prompts reached the model as `[27ugo` instead of `go`. With the Kitty keyboard disambiguate flag pushed (which the fullscreen TUI does), terminals encode the **Esc key as `CSI 27 u`**. `fullscreenVtyConfig` mapped modified CSI-u chords (ctrl/alt/super/shift-enter) but not Esc itself, so Vty decoded `ESC[27u` as bare Esc **plus the payload `[27u` as typed text**. Cancelling a stuck turn with Esc therefore corrupted the next prompt — feeding the model out-of-distribution garbage that also correlates with the runaway-generation sessions (#641's diagnosis).

Reproduced deterministically: `tmux send-keys -H 1b 5b 32 37 75` into a live TUI put `[27u` in the composer.

## Fix

- `kittyEscapeCsiBodies` in `Agent.CLI.Terminal`: every Kitty Esc encoding (plain `27u`, encoded-modifier `27;N u`, explicit press `:1` variants) — mapped to `KEsc` in `fullscreenVtyConfig`.
- Minimal-mode Esc watcher (`Agent.CLI.CancelWatch`): a Kitty-encoded Esc **press now soft-cancels** (previously it was silently drained, so Esc-cancel didn't work at all under the protocol), releases are ignored, and the CSI tail is consumed with short timed reads instead of a non-blocking `hReady` peek so a fragmented tail can no longer leak into the next stdin reader.

## Validation

- New specs: Esc-body input map coverage, `escapeContinuationCancels` (press/release/arrows), timed CSI-tail consumption on complete/fragmented/SS3 input.
- Live tmux check on the dev build: injected `ESC[27u` and `ESC[27;1u` no longer corrupt the composer; typing afterwards yields a clean prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)