### PR TITLE
Hide fenced code language labels

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -55,11 +55,7 @@ renderMarkdown color text
     cleaned = displayTerminalText text
     renderChunk (FenceText prose) = renderProse prose
     renderChunk (FenceBlock block) =
-        let header
-                | Text.null block.fencedInfo = ""
-                | otherwise = md [terminalCyan] block.fencedInfo <> "\n"
-            body = renderFenceBody block.fencedBody
-        in header <> body
+        renderFenceBody block.fencedBody
 
 renderProse :: Text -> Text
 renderProse text =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
@@ -1530,12 +1530,9 @@ codeBlockHeader
     -> Int
     -> Text
     -> Widget Name
-codeBlockHeader state target blockId codeIndex language =
+codeBlockHeader state target blockId codeIndex _language =
     hBox
-        [ if Text.null language
-            then emptyWidget
-            else withAttr Theme.mutedAttr (terminalTxt language)
-        , vLimit 1 (fill ' ')
+        [ vLimit 1 (fill ' ')
         , clickable name $
             withAttr
                 (Composer.controlAttr state name Theme.controlLinkAttr)

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -70,11 +70,11 @@ spec = do
             out `shouldSatisfy` Text.isInfixOf "use `code` here"
             Text.count "`code`" out `shouldBe` 1
 
-        it "dims fence bodies and drops fence markers" do
+        it "dims fence bodies and drops fence markers and language labels" do
             let out = renderMarkdown True "```haskell\nmain = pure ()\n```"
             out `shouldSatisfy` Text.isInfixOf "main = pure ()"
             out `shouldSatisfy` (not . Text.isInfixOf "```")
-            out `shouldSatisfy` Text.isInfixOf "haskell"
+            out `shouldSatisfy` (not . Text.isInfixOf "haskell")
             out `shouldSatisfy` Text.isInfixOf "\ESC["
 
         it "supports tilde fences" do

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -48,11 +48,7 @@ import qualified Graphics.Vty as V
 
 markdownWidget :: Ord n => Text -> Widget n
 markdownWidget =
-    markdownWidgetWithCodeControls \_ language ->
-        if Text.null language
-            then emptyWidget
-            else withAttr Theme.mutedAttr
-                (txt (displayTerminalText language))
+    markdownWidgetWithCodeControls \_ _ -> emptyWidget
 
 -- | Render Markdown with application-level click targets for links.
 markdownWidgetWithLinks
@@ -65,11 +61,7 @@ markdownWidgetWithLinks linkName =
         Nothing
         linkName
         (\_ widget -> widget)
-        (\_ language ->
-            if Text.null language
-                then emptyWidget
-                else withAttr Theme.mutedAttr
-                    (txt (displayTerminalText language)))
+        (\_ _ -> emptyWidget)
 
 -- | Render Markdown, allowing callers to add an interactive control to each
 -- fenced code block header. Code block indices are one-based.

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -274,6 +274,11 @@ spec = describe "fullscreen Markdown rendering" do
         prose `shouldSatisfy` not . Text.any isControl
         code `shouldSatisfy` not . Text.any isControl
 
+    it "hides fenced code language labels" do
+        let rendered = Text.concat (renderRows 40 "```haskell\nmain = pure ()\n```")
+        rendered `shouldSatisfy` Text.isInfixOf "main = pure ()"
+        rendered `shouldSatisfy` (not . Text.isInfixOf "haskell")
+
     it "renders numbered controls for fenced code block headers" do
         let widget :: Widget ()
             widget =


### PR DESCRIPTION
## Summary
- hide fenced-code language labels in fullscreen Markdown blocks
- hide the same labels in the ANSI CLI renderer
- retain syntax highlighting, code indexing, and copy controls
- add regression coverage for both renderer paths

## Validation
- loaded `agent-cli` and `agent-tui` together in GHCi
- targeted `agent-cli` Markdown test passed
- targeted `agent-tui` fullscreen Markdown test passed
- live tmux smoke check rendered `text` and `haskell` fences without labels while retaining Copy controls
- `git diff --check`