### PR TITLE
Fix code mode exec scheduling

### DIFF
--- a/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
@@ -336,7 +336,11 @@ execTool host nestedTools description =
         "lark"
         codeModeExecGrammar
         AlwaysReadOnly
-        ParallelSafe
+        -- The JavaScript source is opaque to the outer scheduler and may
+        -- invoke any projected tool, including mutating tools. Treat the
+        -- wrapper as an exclusive call; concurrency requested inside the
+        -- cell remains explicit in the JavaScript (for example Promise.all).
+        TurnSequential
         (typedStreamingTool "exec" (\_emit -> runExec host nestedTools))
 
 runExec

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -556,6 +556,8 @@ spec = describe "code-mode Node host" do
             pure
             created
         toolSet.codeModeNestedToolNames `shouldBe` ["double"]
+        map (.appToolExecution) toolSet.codeModeTools
+            `shouldBe` [TurnSequential, ParallelSafe]
         result <- runRegisteredExec toolSet
             "text(await tools.double({\"value\": 21}));"
         result `shouldSatisfy` Text.isInfixOf "42"


### PR DESCRIPTION
## Summary
- mark the opaque code-mode `exec` wrapper as `TurnSequential`
- preserve explicit concurrency requested inside JavaScript cells
- add a regression assertion for the code-mode tool scheduling classifications

## Rationale
The outer scheduler cannot inspect which projected tools an `exec` cell will invoke. Treating it as `ParallelSafe` could therefore overlap opaque mutating nested calls with other turn-level tool calls.

## Test plan
- `nix develop -c cabal repl agent-core:test:agent-core-test`
- `:main --match "routes nested tools through the approval-aware invoke"` (1 example, 0 failures)
- `git diff --check`