### PR TITLE
Replace code-mode Node runtime with Bun 1.4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,27 @@
             system:
             let
                 pkgs = import nixpkgs { inherit system; };
+                bun_1_4 = pkgs.bun.overrideAttrs (_old: {
+                    version = "1.4.0";
+                    src = pkgs.fetchurl {
+                        url = {
+                            aarch64-darwin = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-aarch64.zip";
+                            x86_64-darwin = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-x64.zip";
+                            aarch64-linux = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-aarch64.zip";
+                            x86_64-linux = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-x64-baseline.zip";
+                        }.${system};
+                        hash = {
+                            aarch64-darwin = "sha256-xmnpf2Fk4cluBwF0jbmN+ndJKQjL2DlMdVcTSnNd44E=";
+                            x86_64-darwin = "sha256-HQIRuPHcmRGCNEaHrRXnLuhvFUhFpff6R3mUzTQd2bA=";
+                            aarch64-linux = "sha256-SxozLuhhmD65O8/m93D/+U4+MbLDiL2uo8jtNeWO7Q4=";
+                            x86_64-linux = "sha256-GE+0WV8NQBohfPfHjBvEMLqDMU2reouUgFurv3+nCX8=";
+                        }.${system};
+                    };
+                    sourceRoot = {
+                        aarch64-darwin = "bun-darwin-aarch64";
+                        x86_64-darwin = "bun-darwin-x64";
+                    }.${system} or null;
+                });
 
                 # Codex upstream model catalog and fallback instructions.
                 # Fetched at build time (pinned by content hash) instead of
@@ -328,7 +349,7 @@
                             })
                             [
                                 pkgs.git
-                                pkgs.nodejs_22
+                                bun_1_4
                                 pkgs.ripgrep
                             ]);
                         agent-process = localPackage (pkgs.haskell.lib.overrideSrc
@@ -402,7 +423,7 @@
                             })
                             [
                                 pkgs.git
-                                pkgs.nodejs_22
+                                bun_1_4
                                 pkgs.postgresql_18
                             ]);
                         agent-telegram = localPackage (pkgs.haskell.lib.addTestToolDepends
@@ -449,7 +470,7 @@
                                         --prefix PATH : \
                                             "${pkgs.lib.makeBinPath [
                                                 pkgs.ffmpeg
-                                                pkgs.nodejs_22
+                                                bun_1_4
                                                 pkgs.postgresql_18
                                                 haskellPackages.ghc
                                             ]}"
@@ -669,7 +690,7 @@
                         ++ (with pkgs; [
                             cabal2nix
                             ffmpeg
-                            nodejs_22
+                            bun_1_4
                             postgresql_18
                             ripgrep
                         ])

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
@@ -1,6 +1,6 @@
 -- | A fail-closed host for short-lived JavaScript code-mode cells.
 --
--- Every cell gets a fresh Node process. The process can only request effects
+-- Every cell gets a fresh Bun process. The process can only request effects
 -- through the typed 'CodeModeToolHandler' callback; malformed or unexpected
 -- protocol messages terminate the cell.
 {-# LANGUAGE TemplateHaskell #-}
@@ -127,7 +127,6 @@ import Language.Haskell.TH.Syntax
     , runIO
     )
 import System.Posix.Process (getProcessID)
-import Text.Read (readMaybe)
 
 type CodeModeToolHandler =
     Text -> Value -> IO (Either Text Value)
@@ -138,12 +137,11 @@ data ImageDetailVisibility
     deriving (Eq, Show)
 
 data CodeModeConfig = CodeModeConfig
-    { nodeExecutable :: !FilePath
+    { bunExecutable :: !FilePath
     , workerScript :: !FilePath
     , startupTimeoutMs :: !Int
     , maxActiveCells :: !Int
     , maxSourceBytes :: !Int
-    , maxOldSpaceMb :: !Int
     , toolHandler :: !CodeModeToolHandler
     , notifyHandler :: !(Text -> IO ())
     , imageDetailVisibility :: !ImageDetailVisibility
@@ -151,12 +149,11 @@ data CodeModeConfig = CodeModeConfig
 
 defaultCodeModeConfig :: FilePath -> CodeModeToolHandler -> CodeModeConfig
 defaultCodeModeConfig script handler = CodeModeConfig
-    { nodeExecutable = "node"
+    { bunExecutable = "bun"
     , workerScript = script
     , startupTimeoutMs = 3000
     , maxActiveCells = 64
     , maxSourceBytes = 1024 * 1024
-    , maxOldSpaceMb = 128
     , toolHandler = handler
     , notifyHandler = \_ -> pure ()
     , imageDetailVisibility = ImageDetailVisible
@@ -199,9 +196,9 @@ embeddedCodeModeWorkerSource =
 -- creates a private file and renames it into place.
 materializeEmbeddedWorker :: IO FilePath
 materializeEmbeddedWorker = do
-    -- Node's permission model implicitly allows reading the entry script by
-    -- its real path. Canonicalize the target directory so a symlinked
-    -- temporary directory (such as macOS @/tmp@) cannot defeat that grant.
+    -- Canonicalize the target directory so Bun receives the stable real path
+    -- even when the platform temporary directory (such as macOS @/tmp@) is a
+    -- symlink.
     tmpDir <- getTemporaryDirectory >>= canonicalizePath
     let bytes = Text.encodeUtf8 embeddedCodeModeWorkerSource
         target =
@@ -306,16 +303,16 @@ newCodeModeHost config =
 -- than an advertised tool that is guaranteed to fail on first use.
 checkCodeModeAvailability :: CodeModeConfig -> IO (Either Text ())
 checkCodeModeAvailability config = do
-    executable <- resolveNodeExecutable config.nodeExecutable
+    executable <- resolveBunExecutable config.bunExecutable
     worker <- resolveWorkerScript config.workerScript
     runtime <- case executable of
         Nothing -> pure Nothing
-        Just path -> Just <$> inspectNode path
+        Just path -> Just <$> inspectBun path
     pure $ case (runtime, worker) of
         (Nothing, _) ->
             Left $
-                "Node/V8 runtime executable was not found: "
-                    <> Text.pack config.nodeExecutable
+                "Bun runtime executable was not found: "
+                    <> Text.pack config.bunExecutable
         (Just (Left err), _) -> Left err
         (_, Nothing) ->
             Left $
@@ -323,39 +320,36 @@ checkCodeModeAvailability config = do
                     <> Text.pack config.workerScript
         (Just (Right ()), Just _) -> Right ()
   where
-    inspectNode executable = do
+    inspectBun executable = do
         checked <- try @_ @SomeException $
-            readProcessWithExitCode executable ["--version"] ""
+            readProcessWithExitCode executable bunFeatureProbe ""
         pure $ case checked of
             Left err ->
                 Left $
-                    "failed to inspect Node/V8 runtime: "
+                    "failed to inspect Bun runtime: "
                         <> Text.pack (displayException err)
             Right (ExitFailure code, _, stderrText) ->
                 Left $
-                    "failed to inspect Node/V8 runtime (exit "
+                    "Bun lacks the vm sandbox features required by code mode (exit "
                         <> Text.pack (show code)
                         <> "): "
                         <> Text.strip (Text.pack stderrText)
-            Right (ExitSuccess, stdoutText, _) ->
-                case nodeMajorVersion (Text.strip (Text.pack stdoutText)) of
-                    Just major
-                        | major >= 22 -> Right ()
-                        | otherwise -> Left $
-                            "code mode requires Node.js 22 or later; found "
-                                <> Text.pack (show major)
-                    Nothing -> Left $
-                        "unable to parse Node.js version: "
-                            <> Text.strip (Text.pack stdoutText)
+            Right (ExitSuccess, _, _) -> Right ()
 
-    nodeMajorVersion :: Text -> Maybe Int
-    nodeMajorVersion raw = do
-        version <- Text.stripPrefix "v" raw
-        let (major, _) = Text.breakOn "." version
-        readMaybe (Text.unpack major)
+bunFeatureProbe :: [String]
+bunFeatureProbe =
+    [ "--smol"
+    , "--no-install"
+    , "--no-env-file"
+    , "--no-addons"
+    , "-e"
+    , "import vm from 'node:vm';"
+        <> "if (typeof vm.createContext !== 'function' || "
+        <> "typeof vm.SourceTextModule !== 'function') process.exit(1);"
+    ]
 
-resolveNodeExecutable :: FilePath -> IO (Maybe FilePath)
-resolveNodeExecutable executable
+resolveBunExecutable :: FilePath -> IO (Maybe FilePath)
+resolveBunExecutable executable
     | any isPathSeparator executable = do
         exists <- doesFileExist executable
         pure (if exists then Just executable else Nothing)
@@ -506,11 +500,11 @@ startCell
     -> [CodeModeToolMetadata]
     -> IO (Either CodeModeError Cell)
 startCell host identifier tools = do
-    resolveNodeExecutable host.hostConfig.nodeExecutable >>= \case
+    resolveBunExecutable host.hostConfig.bunExecutable >>= \case
         Nothing ->
             pure $ Left $ CodeModeStartupError $
-                "Node/V8 runtime executable was not found: "
-                    <> Text.pack host.hostConfig.nodeExecutable
+                "Bun runtime executable was not found: "
+                    <> Text.pack host.hostConfig.bunExecutable
         Just executable -> do
             resolveWorkerScript host.hostConfig.workerScript >>= \case
                 Nothing ->
@@ -520,13 +514,10 @@ startCell host identifier tools = do
                 Just worker -> do
                     started <- try @_ @SomeException $ createProcess $
                         (proc executable
-                            [ "--experimental-permission"
-                            , "--disallow-code-generation-from-strings"
-                            , "--disable-proto=delete"
-                            , "--experimental-vm-modules"
-                            , "--max-old-space-size="
-                                <> show
-                                    (max 16 host.hostConfig.maxOldSpaceMb)
+                            [ "--smol"
+                            , "--no-install"
+                            , "--no-env-file"
+                            , "--no-addons"
                             , worker
                             ])
                             { std_in = CreatePipe

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -40,7 +40,7 @@ import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "code-mode Node host" do
+spec = describe "code-mode Bun host" do
     it "resolves the bundled worker independently of the current directory" do
         worker <- bundledCodeModeWorkerPath
         doesFileExist worker `shouldReturn` True
@@ -187,7 +187,7 @@ spec = describe "code-mode Node host" do
                 }
         closeCodeModeHost host
 
-    it "does not expose Node globals" do
+    it "does not expose runtime globals" do
         let config = defaultCodeModeConfig
                 "data/code-mode/worker.mjs"
                 (\_ _ -> pure $ Left "no tools")


### PR DESCRIPTION
## Summary

- replace the per-cell Node.js runtime with Bun 1.4
- pin official Bun 1.4.0 artifacts for supported Darwin/Linux architectures without updating unrelated nixpkgs dependencies
- probe Bun's required `node:vm` sandbox features before advertising code-mode tools
- run workers with `--smol`, package auto-install/environment loading disabled, and native addons disabled
- retain `vm.SourceTextModule` module semantics, including blocked imports and top-level `return` rejection

## Runtime differences

Bun does not expose Node's experimental permission or `--max-old-space-size` flags. The worker still isolates user code in a fresh process and a `vm` context with string/Wasm code generation disabled; Bun runs in `--smol` mode, but that is not an exact replacement for the former 128 MiB V8 old-space limit.

## Validation

- `nix develop -c bun --version` → `1.4.0`
- focused `code-mode Bun host` suite through GHCi: 26 examples, 0 failures
- verified Bun 1.4 `SourceTextModule` supports suspended top-level `await` across tool calls, timers, waits, and termination
- `git diff --check`


### Live tmux smoke test

Ran the live CLI through `nix develop -c repl` in a 120×36 tmux session using `gpt-5.6-sol` in code mode:

- `exec` computed the sum of squares from 1 through 20 as `2870`
- a second `exec` cell awaited a 10-second timer and returned `bun-live`
- the real TTY rendered both code-mode executions successfully; the delayed cell reported 10.2 seconds wall time
