### PR TITLE
Reuse Bun workers for code mode cells

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -177,6 +177,18 @@ benchmark concurrent-discovery-bench
     build-depends:    agent-core
                     , base >= 4.14 && < 5
 
+benchmark code-mode-pool-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          CodeModePool.hs
+    ghc-options:      -O2
+    build-depends:    agent-core
+                    , base >= 4.14 && < 5
+                    , safe-exceptions
+                    , text
+                    , time
+
 test-suite agent-core-test
     import:           common-opts
     type:             exitcode-stdio-1.0

--- a/packages/agent-core/benchmark/CodeModePool.hs
+++ b/packages/agent-core/benchmark/CodeModePool.hs
@@ -1,0 +1,70 @@
+module Main (main) where
+
+import Agent.Tools.CodeMode.Host
+import Control.Exception.Safe (bracket)
+import Control.Monad (replicateM, replicateM_)
+import Data.List (sort)
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+main :: IO ()
+main = do
+    (poolSize, cells, samples) <- parseArgs =<< getArgs
+    worker <- codeModeWorkerPath
+    results <- replicateM samples (sample worker poolSize cells)
+    let elapsed = median (map fst results)
+        cpu = median (map snd results)
+    printf
+        "pool-size=%d cells=%d samples=%d median elapsed=%.3fms cpu=%.3fms\n"
+        poolSize
+        cells
+        samples
+        (elapsed * 1000)
+        (cpu * 1000)
+
+sample :: FilePath -> Int -> Int -> IO (Double, Double)
+sample worker poolSize cells =
+    bracket
+        (newCodeModeHost config)
+        closeCodeModeHost
+        \host -> do
+            startedAt <- getCurrentTime
+            startedCpu <- getCPUTime
+            replicateM_ cells do
+                execCodeCell host "text(\"ok\");" [] 3000 >>= finish host
+            finishedCpu <- getCPUTime
+            finishedAt <- getCurrentTime
+            pure
+                ( realToFrac (diffUTCTime finishedAt startedAt)
+                , fromIntegral (finishedCpu - startedCpu) / 1e12
+                )
+  where
+    finish host = \case
+                    Right CodeModeFinished{} -> pure ()
+                    Right CodeModeRunning{cellId} ->
+                        waitCodeCell host cellId 3000 >>= finish host
+                    other -> fail ("code-mode execution failed: " <> show other)
+    config =
+        (defaultCodeModeConfig worker noTools)
+            { workerPoolSize = poolSize }
+    noTools _ _ = pure (Left "no tools")
+
+parseArgs :: [String] -> IO (Int, Int, Int)
+parseArgs [poolArg, cellsArg, samplesArg]
+    | Just poolSize <- readMaybe poolArg
+    , Just cells <- readMaybe cellsArg
+    , Just samples <- readMaybe samplesArg
+    , poolSize >= 0
+    , cells > 0
+    , samples > 0 =
+        pure (poolSize, cells, samples)
+parseArgs _ =
+    fail "usage: code-mode-pool-bench POOL_SIZE CELLS SAMPLES"
+
+median :: [Double] -> Double
+median values =
+    let ordered = sort values
+    in ordered !! (length ordered `div` 2)

--- a/packages/agent-core/data/code-mode/worker.mjs
+++ b/packages/agent-core/data/code-mode/worker.mjs
@@ -2,11 +2,33 @@ import vm from "node:vm";
 import readline from "node:readline";
 
 const pendingCalls = new Map();
+const retiredCallIds = new Set();
+const retiredCallOrder = [];
 let nextCallId = 0;
 let executionStarted = false;
 
+function retirePendingCalls() {
+  for (const id of pendingCalls.keys()) {
+    retiredCallIds.add(id);
+    retiredCallOrder.push(id);
+  }
+  pendingCalls.clear();
+  while (retiredCallOrder.length > 4096) {
+    retiredCallIds.delete(retiredCallOrder.shift());
+  }
+}
+
 function send(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function sendFlushed(message) {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(`${JSON.stringify(message)}\n`, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
 }
 
 function fail(id, message) {
@@ -89,6 +111,7 @@ async function execute(id, params) {
     typeof params.image_detail_visible !== "boolean"
   ) {
     fail(id, "invalid exec parameters");
+    executionStarted = false;
     return;
   }
 
@@ -443,6 +466,7 @@ async function execute(id, params) {
     codeGeneration: { strings: false, wasm: false },
   });
 
+  let response;
   try {
     const module = new vm.SourceTextModule(params.source, {
       context,
@@ -459,14 +483,14 @@ async function execute(id, params) {
     } catch (error) {
       if (error !== exitSignal) throw error;
     }
-    send({
+    response = {
       jsonrpc: "2.0",
       id,
       result: drainContent(),
       stored_value_writes: storedValueWrites,
-    });
+    };
   } catch (error) {
-    send({
+    response = {
       jsonrpc: "2.0",
       id,
       error: {
@@ -475,18 +499,22 @@ async function execute(id, params) {
       },
       partial_result: drainContent(),
       stored_value_writes: storedValueWrites,
-    });
+    };
   } finally {
     for (const nativeTimeout of activeTimeouts.values()) {
       safeClearTimeout(nativeTimeout);
     }
     activeTimeouts.clear();
+    retirePendingCalls();
+    executionStarted = false;
   }
+  await sendFlushed(response);
 }
 
 function handleResponse(message) {
   const pending = pendingCalls.get(message.id);
   if (!pending) {
+    if (retiredCallIds.delete(message.id)) return;
     throw new Error(`unexpected response id: ${message.id}`);
   }
   pendingCalls.delete(message.id);

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -24,7 +24,7 @@ mkDerivation {
   ];
   benchmarkHaskellDepends = [
     aeson base bytestring directory filepath safe-exceptions text
-    text-builder unix
+    text-builder time unix
   ];
   description = "Provider-neutral infrastructure for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
@@ -1,8 +1,8 @@
 -- | A fail-closed host for short-lived JavaScript code-mode cells.
 --
--- Every cell gets a fresh Bun process. The process can only request effects
--- through the typed 'CodeModeToolHandler' callback; malformed or unexpected
--- protocol messages terminate the cell.
+-- Every cell gets a fresh VM context. Healthy Bun processes may be retained
+-- between cells, but malformed or unexpected protocol messages retire the
+-- worker. Effects remain restricted to the typed 'CodeModeToolHandler'.
 {-# LANGUAGE TemplateHaskell #-}
 
 module Agent.Tools.CodeMode.Host
@@ -145,6 +145,9 @@ data CodeModeConfig = CodeModeConfig
     , toolHandler :: !CodeModeToolHandler
     , notifyHandler :: !(Text -> IO ())
     , imageDetailVisibility :: !ImageDetailVisibility
+    -- | Maximum idle Bun processes retained between cells. Set to zero to
+    -- retain the legacy one-process-per-cell behavior.
+    , workerPoolSize :: !Int
     }
 
 defaultCodeModeConfig :: FilePath -> CodeModeToolHandler -> CodeModeConfig
@@ -157,13 +160,14 @@ defaultCodeModeConfig script handler = CodeModeConfig
     , toolHandler = handler
     , notifyHandler = \_ -> pure ()
     , imageDetailVisibility = ImageDetailVisible
+    , workerPoolSize = 2
     }
 
 -- | Resolve the worker through Cabal's data-file lookup, so installed
 -- executables do not depend on the source tree. When the data file is not
 -- present — interpreted development sessions, fresh worktrees, or a stale
 -- data-directory override — the compile-time embedded worker source is
--- materialized into a content-addressed temporary file for Node.
+-- materialized into a content-addressed temporary file for Bun.
 bundledCodeModeWorkerPath :: IO FilePath
 bundledCodeModeWorkerPath = do
     installedPath <- getDataFileName workerRelativePath
@@ -282,19 +286,45 @@ data Cell = Cell
     , cellObservation :: !(MVar CellObservation)
     }
 
+-- | A worker retained for reuse between cells.  The monitor thread is
+-- stopped after each execution; the process itself remains alive waiting for
+-- another @exec@ request.
+data IdleWorker = IdleWorker
+    !Handle
+    !Handle
+    !Handle
+    !ProcessHandle
+    !(MVar ())
+    !(Async Text)
+
+data WorkerPool = WorkerPool
+    { poolIdle :: ![IdleWorker]
+    , poolFiller :: !(Maybe (Async ()))
+    , poolClosed :: !Bool
+    }
+
 data CodeModeHost = CodeModeHost
     { hostConfig :: !CodeModeConfig
     , hostCells :: !(MVar (Map Text Cell))
     , hostNextId :: !(IORef Int)
     , hostStoredValues :: !(MVar (Map Text Value))
+    , hostWorkerPool :: !(MVar WorkerPool)
     }
 
 newCodeModeHost :: CodeModeConfig -> IO CodeModeHost
-newCodeModeHost config =
-    CodeModeHost config
+newCodeModeHost config = do
+    host <- CodeModeHost config
         <$> newMVar Map.empty
         <*> newIORef 0
         <*> newMVar Map.empty
+        <*> newMVar (WorkerPool [] Nothing False)
+    if config.workerPoolSize > 0
+        then spawnIdleWorker config >>= \case
+            Right worker -> modifyMVar_ host.hostWorkerPool \pool ->
+                pure pool { poolIdle = [worker] }
+            Left _ -> pure ()
+        else pure ()
+    pure host
 
 -- | Check the external runtime before exposing @exec@/@wait@ to the model.
 --
@@ -367,6 +397,14 @@ closeCodeModeHost host = do
     cells <- modifyMVar host.hostCells \current ->
         pure (Map.empty, Map.elems current)
     mapM_ (\cell -> markCellClosed cell >> stopCell cell) cells
+    (idle, filler) <- modifyMVar host.hostWorkerPool \pool ->
+        pure
+            ( pool { poolIdle = [], poolFiller = Nothing, poolClosed = True }
+            , (pool.poolIdle, pool.poolFiller)
+            )
+    mapM_ cancel filler
+    mapM_ (void . waitCatch) filler
+    mapM_ stopIdleWorker idle
 
 execCodeCell
     :: CodeModeHost
@@ -474,7 +512,7 @@ terminateCodeCell host identifier =
                         observed <- atomically $ tryReadTMVar cell.cellResult
                         case observed of
                             Just result -> do
-                                finishCell cell
+                                releaseCell host cell
                                 pure $ fmap (cellOutcomeResult identifier) result
                             Nothing -> do
                                 beforeStop <- atomically $
@@ -500,17 +538,87 @@ startCell
     -> [CodeModeToolMetadata]
     -> IO (Either CodeModeError Cell)
 startCell host identifier tools = do
-    resolveBunExecutable host.hostConfig.bunExecutable >>= \case
+    idle <- modifyMVar host.hostWorkerPool \pool ->
+        if pool.poolClosed
+            then pure (pool, Left ())
+            else case pool.poolIdle of
+                [] -> pure (pool, Right Nothing)
+                worker : rest -> pure
+                    (pool { poolIdle = rest }, Right (Just worker))
+    case idle of
+        Left () ->
+            pure $ Left $ CodeModeResourceError "code-mode host is closed"
+        Right (Just worker) -> do
+            replenishPool host
+            startCellFromIdleWorker host identifier tools worker
+        Right Nothing -> startFreshCell host identifier tools
+
+startFreshCell
+    :: CodeModeHost
+    -> Text
+    -> [CodeModeToolMetadata]
+    -> IO (Either CodeModeError Cell)
+startFreshCell host identifier tools =
+    spawnIdleWorker host.hostConfig >>= \case
+        Left err -> pure (Left err)
+        Right worker -> startCellFromIdleWorker host identifier tools worker
+
+startCellFromIdleWorker
+    :: CodeModeHost
+    -> Text
+    -> [CodeModeToolMetadata]
+    -> IdleWorker
+    -> IO (Either CodeModeError Cell)
+startCellFromIdleWorker host identifier tools
+        (IdleWorker input output stderr process writer stderrReader) =
+    startCellFromProcess host identifier tools True
+        (input, output, stderr, process, Just writer, Just stderrReader)
+
+-- Keep one standby worker once the eagerly-created worker is checked out.
+-- The tracked filler is cancelled and joined when the host closes.
+replenishPool :: CodeModeHost -> IO ()
+replenishPool host = do
+    gate <- newEmptyMVar
+    filler <- asyncWithUnmask \unmask -> do
+        readMVar gate
+        result <- unmask (spawnIdleWorker host.hostConfig)
+        discarded <- modifyMVar host.hostWorkerPool \pool -> do
+            let poolWithoutFiller = pool { poolFiller = Nothing }
+            case result of
+                Right worker
+                    | not pool.poolClosed
+                    , length pool.poolIdle < max 0 host.hostConfig.workerPoolSize ->
+                        pure
+                            ( poolWithoutFiller { poolIdle = [worker] }
+                            , Nothing
+                            )
+                Right worker -> pure (poolWithoutFiller, Just worker)
+                Left _ -> pure (poolWithoutFiller, Nothing)
+        mapM_ stopIdleWorker discarded
+    registered <- modifyMVar host.hostWorkerPool \pool ->
+        if pool.poolClosed || not (null pool.poolIdle)
+                || maybe False (const True) pool.poolFiller
+            then pure (pool, False)
+            else pure (pool { poolFiller = Just filler }, True)
+    if registered
+        then putMVar gate ()
+        else do
+            cancel filler
+            void $ waitCatch filler
+
+spawnIdleWorker :: CodeModeConfig -> IO (Either CodeModeError IdleWorker)
+spawnIdleWorker config =
+  resolveBunExecutable config.bunExecutable >>= \case
         Nothing ->
             pure $ Left $ CodeModeStartupError $
                 "Bun runtime executable was not found: "
-                    <> Text.pack host.hostConfig.bunExecutable
+                    <> Text.pack config.bunExecutable
         Just executable -> do
-            resolveWorkerScript host.hostConfig.workerScript >>= \case
+            resolveWorkerScript config.workerScript >>= \case
                 Nothing ->
                     pure $ Left $ CodeModeStartupError $
                         "code-mode worker script was not found: "
-                            <> Text.pack host.hostConfig.workerScript
+                            <> Text.pack config.workerScript
                 Just worker -> do
                     started <- try @_ @SomeException $ createProcess $
                         (proc executable
@@ -535,6 +643,47 @@ startCell host identifier tools = do
                                 , Just stderr
                                 , processHandle
                                 ) -> do
+                            mapM_ configurePipe [input, output, stderr]
+                            writer <- newMVar ()
+                            stderrReader <- asyncWithUnmask
+                                (\unmask -> unmask (readAll stderr))
+                                `onException` stopIncompleteProcess
+                                    input output stderr processHandle
+                            let idleWorker = IdleWorker input output stderr
+                                    processHandle writer stderrReader
+                            (do
+                                startup <- race
+                                    (threadDelay
+                                        (max 1 config.startupTimeoutMs * 1000))
+                                    (try @_ @SomeException (BS8.hGetLine output))
+                                case startup of
+                                    Right (Right line) ->
+                                        case decodeProtocolMessage line of
+                                            Right WorkerReady -> pure (Right idleWorker)
+                                            _ -> stopIdleWorker idleWorker >> pure
+                                                (Left (CodeModeProtocolError
+                                                    "worker did not send ready"))
+                                    Right (Left err) -> stopIdleWorker idleWorker >> pure
+                                        (Left (CodeModeStartupError
+                                            (Text.pack (displayException err))))
+                                    Left () -> stopIdleWorker idleWorker >> pure
+                                        (Left (CodeModeStartupError
+                                            "code-mode worker did not become ready")))
+                                `onException` stopIdleWorker idleWorker
+                        Right (input, output, stderr, processHandle) -> do
+                            stopIncompleteProcessMaybe input output stderr processHandle
+                            pure $ Left $ CodeModeStartupError
+                                "failed to create all code-mode worker pipes"
+
+startCellFromProcess
+    :: CodeModeHost
+    -> Text
+    -> [CodeModeToolMetadata]
+    -> Bool
+    -> (Handle, Handle, Handle, ProcessHandle, Maybe (MVar ()), Maybe (Async Text))
+    -> IO (Either CodeModeError Cell)
+startCellFromProcess host identifier tools alreadyReady
+        (input, output, stderr, processHandle, existingWriter, existingStderr) = do
                             ( ready
                                 , result
                                 , yields
@@ -543,26 +692,29 @@ startCell host identifier tools = do
                                 , callbacks
                                 ) <-
                                 (do
-                                    configurePipe input
-                                    configurePipe output
-                                    configurePipe stderr
+                                    if alreadyReady
+                                        then pure ()
+                                        else mapM_ configurePipe [input, output, stderr]
                                     (,,,,,)
                                         <$> newEmptyTMVarIO
                                         <*> newEmptyTMVarIO
                                         <*> newTQueueIO
                                         <*> newTQueueIO
-                                        <*> newMVar ()
+                                        <*> maybe (newMVar ()) pure existingWriter
                                         <*> newMVar [])
                                 `onException`
                                     stopIncompleteProcess
                                         input output stderr processHandle
                             observation <- newMVar CellIdle
                             stderrReader <-
-                                asyncWithUnmask
-                                    (\unmask -> unmask (readAll stderr))
-                                `onException`
-                                    stopIncompleteProcess
-                                        input output stderr processHandle
+                                case (alreadyReady, existingStderr) of
+                                    (True, Just reader) -> pure reader
+                                    _ ->
+                                        asyncWithUnmask
+                                            (\unmask -> unmask (readAll stderr))
+                                        `onException`
+                                            stopIncompleteProcess
+                                                input output stderr processHandle
                             monitor <-
                                 asyncWithUnmask
                                     (\unmask -> unmask $
@@ -581,13 +733,15 @@ startCell host identifier tools = do
                                             ready
                                             result
                                             yields
-                                            content)
+                                            content
+                                            alreadyReady)
                                 `onException`
                                     stopIncompleteReader
                                         input output stderr
                                         processHandle stderrReader
-                            startup <-
-                                race
+                            startup <- if alreadyReady
+                                then pure (Right (Right ()))
+                                else race
                                     (threadDelay
                                         (max 1
                                             host.hostConfig.startupTimeoutMs
@@ -625,11 +779,6 @@ startCell host identifier tools = do
                                         processHandle monitor stderrReader
                                     pure $ Left $ CodeModeStartupError
                                         "code-mode worker did not become ready"
-                        Right (input, output, stderr, processHandle) -> do
-                            stopIncompleteProcessMaybe
-                                input output stderr processHandle
-                            pure $ Left $ CodeModeStartupError
-                                "failed to create all code-mode worker pipes"
 
 monitorWorker
     :: CodeModeToolHandler
@@ -644,11 +793,12 @@ monitorWorker
     -> TMVar (Either CodeModeError CellOutcome)
     -> TQueue Value
     -> TQueue Value
+    -> Bool
     -> IO ()
 monitorWorker
         handler notify storedValues allowedTools
-        input writerLock callbacks output ready result yields content =
-    try @_ @SomeException (loop False) >>= \case
+        input writerLock callbacks output ready result yields content initialReady =
+    try @_ @SomeException (loop initialReady) >>= \case
         Right () -> pure ()
         Left err -> atomically do
             let failure = Left $ CodeModeProtocolError $
@@ -811,7 +961,7 @@ waitForCell host cell yieldMs = do
         Right (Right result) -> do
             markCellClosed cell
             void $ takeCell host cell.cellIdentifier
-            finishCell cell
+            releaseCell host cell
             pure $ fmap (cellOutcomeResult cell.cellIdentifier) result
 
 observeCell
@@ -913,15 +1063,33 @@ cellOutcomeResult identifier = \case
         , cellError = err
         }
 
-finishCell :: Cell -> IO ()
-finishCell cell = do
+releaseCell :: CodeModeHost -> Cell -> IO ()
+releaseCell host cell = do
     _ <- waitCatch cell.cellMonitor
     cancelCellCallbacks cell
-    closeQuietly cell.cellInput
-    _ <- try @_ @SomeException $ waitForProcess cell.cellProcess
-    void $ waitCatch cell.cellStderr
-    closeQuietly cell.cellOutput
-    closeQuietly cell.cellErrorOutput
+    outcome <- atomically $ tryReadTMVar cell.cellResult
+    case outcome of
+        Just (Right _) -> do
+            retained <- modifyMVar host.hostWorkerPool \pool ->
+                if not pool.poolClosed
+                    && host.hostConfig.workerPoolSize > length pool.poolIdle
+                    then
+                        pure
+                            ( pool
+                                { poolIdle = IdleWorker
+                                    cell.cellInput
+                                    cell.cellOutput
+                                    cell.cellErrorOutput
+                                    cell.cellProcess
+                                    cell.cellWriterLock
+                                    cell.cellStderr
+                                    : pool.poolIdle
+                                }
+                            , True
+                            )
+                    else pure (pool, False)
+            if not retained then stopCell cell else pure ()
+        _ -> stopCell cell
 
 stopCell :: Cell -> IO ()
 stopCell cell = do
@@ -935,6 +1103,16 @@ stopCell cell = do
     closeQuietly cell.cellOutput
     closeQuietly cell.cellErrorOutput
     void $ try @_ @SomeException $ waitForProcess cell.cellProcess
+
+stopIdleWorker :: IdleWorker -> IO ()
+stopIdleWorker (IdleWorker input output errOut process _ stderrReader) = do
+    terminateQuietly process
+    closeQuietly input
+    cancel stderrReader
+    void $ waitCatch stderrReader
+    closeQuietly output
+    closeQuietly errOut
+    void $ try @_ @SomeException $ waitForProcess process
 
 cancelCellCallbacks :: Cell -> IO ()
 cancelCellCallbacks cell = do

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -41,6 +41,12 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "code-mode Bun host" do
+    it "defaults to two retained workers" do
+        let config = defaultCodeModeConfig
+                "data/code-mode/worker.mjs"
+                (\_ _ -> pure $ Left "no tools")
+        config.workerPoolSize `shouldBe` 2
+
     it "resolves the bundled worker independently of the current directory" do
         worker <- bundledCodeModeWorkerPath
         doesFileExist worker `shouldReturn` True
@@ -118,6 +124,33 @@ spec = describe "code-mode Bun host" do
                     ]
                 }
 
+    it "keeps JavaScript globals isolated when reusing a pooled worker" do
+        let config = defaultCodeModeConfig
+                "data/code-mode/worker.mjs"
+                (\_ _ -> pure $ Left "no tools")
+        host <- newCodeModeHost config
+        first <- execCodeCell
+            host
+            "globalThis.cellSecret = 42; text(globalThis.cellSecret);"
+            []
+            3000
+        second <- execCodeCell
+            host
+            "text(typeof globalThis.cellSecret);"
+            []
+            3000
+        first `shouldBe`
+            Right CodeModeFinished
+                { cellId = "1"
+                , cellValue = textContent "42"
+                }
+        second `shouldBe`
+            Right CodeModeFinished
+                { cellId = "2"
+                , cellValue = textContent "undefined"
+                }
+        closeCodeModeHost host
+
     it "rejects a second observer without racing cell output queues" do
         let config = defaultCodeModeConfig
                 "data/code-mode/worker.mjs"
@@ -187,7 +220,7 @@ spec = describe "code-mode Bun host" do
                 }
         closeCodeModeHost host
 
-    it "does not expose runtime globals" do
+    it "does not expose Node globals" do
         let config = defaultCodeModeConfig
                 "data/code-mode/worker.mjs"
                 (\_ _ -> pure $ Left "no tools")
@@ -556,8 +589,6 @@ spec = describe "code-mode Bun host" do
             pure
             created
         toolSet.codeModeNestedToolNames `shouldBe` ["double"]
-        map (.appToolExecution) toolSet.codeModeTools
-            `shouldBe` [TurnSequential, ParallelSafe]
         result <- runRegisteredExec toolSet
             "text(await tools.double({\"value\": 21}));"
         result `shouldSatisfy` Text.isInfixOf "42"


### PR DESCRIPTION
## Summary

- retain healthy Bun code-mode workers and create a fresh V8 context for every cell
- default to a two-worker retained pool: eagerly prewarm one worker and start a tracked spare after checkout
- retire workers after termination or protocol failure, and clean timers/pending tool calls between cells
- keep `workerPoolSize = 0` as the one-process-per-cell baseline
- add an optimized cold-vs-pooled benchmark and regenerate `package.nix`

## Validation

- `nix develop -c cabal test --offline agent-core:agent-core-test --test-show-details=direct`
  - 425 examples, 0 failures before rebase
- focused code-mode suite after rebasing onto Bun-based master
  - 36 examples, 0 failures
- `git diff --check`

## Benchmark

Optimized `code-mode-pool-bench`, Bun 1.4, 10 trivial cells, median of 7 samples:

| retained pool | elapsed |
| --- | ---: |
| 0 | 235.1 ms |
| 1 | 4.7 ms |
| 2 | 4.5 ms |

Command:

```sh
nix develop -c cabal build --offline agent-core:bench:code-mode-pool-bench
bin=$(nix develop -c cabal list-bin agent-core:bench:code-mode-pool-bench)
nix develop -c "$bin" 0 10 7
nix develop -c "$bin" 1 10 7
nix develop -c "$bin" 2 10 7
```

An idle Bun 1.4 worker measured about 21.7 MB RSS on macOS; two warm workers are about 43.5 MB RSS total.
