### PR TITLE
Render exec source instead of completion metadata

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -1221,6 +1221,7 @@ toolChrome name = case canonicalToolName name of
     "shell_command" -> ToolChromeShell
     "write_stdin" -> ToolChrome "Continued" ToolDetailMuted
     "run_ghci" -> ToolChromeShell
+    "exec" -> ToolChrome "$ exec" ToolDetailNone
     "get_task_output" -> ToolChrome "Read" ToolDetailMuted
     "wait_tasks" -> ToolChrome "Waited" ToolDetailMuted
     "kill_task" -> ToolChrome "Killed" ToolDetailMuted
@@ -1255,6 +1256,7 @@ formatToolBodyRelative :: Bool -> Text -> ToolCall -> Text
 formatToolBodyRelative color workspace call = case canonicalToolName call.name of
     "search_replace" ->
         formatSearchReplaceDiffRelative color workspace call.arguments
+    "exec" -> roleToolCommand color call.arguments
     _ -> ""
 
 -- | Compact unified-diff preview for @search_replace@ arguments.

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -105,12 +105,14 @@ toolCallTitle = toolCallTitleRelative ""
 toolCallTitleRelative :: Text -> ToolCall -> Text
 toolCallTitleRelative workspace call
     | canonicalToolName call.name == "run_ghci" = "$ ghci"
+    | canonicalToolName call.name == "exec" = "$ exec"
     | otherwise = summarizeToolCallRelative workspace call
 
 -- | Full invocation text that benefits from dedicated code rendering.
 toolCallInput :: ToolCall -> Text
 toolCallInput call = case canonicalToolName call.name of
     "run_ghci" -> jsonTextFieldDefault "expression" call.arguments
+    "exec" -> call.arguments
     _ -> ""
 
 data SearchReplaceAction
@@ -176,6 +178,7 @@ formatSearchReplaceDiffRelative workspace arguments =
 
 formatToolOutput :: ToolCall -> Text -> Text
 formatToolOutput call output = case canonicalToolName call.name of
+    "exec" -> completedExecOutput output
     name | name `elem` ["spawn_agent", "spawn_agent_in_worktree"] ->
         maybe output ("Agent: " <>) (nonEmptyJsonText "task_name" output)
     "wait_agent" ->
@@ -192,6 +195,18 @@ formatToolOutput call output = case canonicalToolName call.name of
     "todo_write" -> formatTodoList output
     "update_plan" -> formatTodoList output
     _ -> output
+
+-- The exec protocol keeps status and timing metadata for the model. In the
+-- transcript, the invocation itself already communicates successful
+-- completion, so retain only the script's meaningful output.
+completedExecOutput :: Text -> Text
+completedExecOutput output
+    | "Script completed\n" `Text.isPrefixOf` output =
+        case Text.breakOn "\nOutput:\n" output of
+            (_, rest)
+                | Text.null rest -> output
+                | otherwise -> Text.drop (Text.length "\nOutput:\n") rest
+    | otherwise = output
 
 -- | Rewrite workspace-absolute filesystem paths in tool chrome/output without
 -- touching file contents returned by @read_file@.

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -114,6 +114,22 @@ spec = describe "tool presentation" do
                 "Evaluate this Haskell code in GHCi?\n\n\
                 \do { putStrLn \"one\"; putStrLn \"two\" }"
 
+    it "renders exec source and hides successful protocol boilerplate" do
+        let source = "const result = await tools.grep({pattern: \"needle\"});\ntext(result);"
+            call = customToolCall "exec" "exec" source
+        toolCallTitle call `shouldBe` "$ exec"
+        toolCallInput call `shouldBe` source
+        formatToolOutput call
+            "Script completed\nWall time 0.1 seconds\nOutput:\nmatch"
+            `shouldBe` "match"
+        formatToolOutput call
+            "Script completed\nWall time 0.0 seconds\nOutput:\n"
+            `shouldBe` ""
+        formatToolOutput call
+            "Script failed\nWall time 0.1 seconds\nOutput:\nScript error:\nboom"
+            `shouldBe`
+                "Script failed\nWall time 0.1 seconds\nOutput:\nScript error:\nboom"
+
     it "shows complete multiline code and shell commands for permission" do
         permissionToolCallPrompt
             (functionToolCall


### PR DESCRIPTION
## Summary
- render the JavaScript submitted to `exec` in retained and append-only CLI views
- hide successful `Script completed`, wall-time, and `Output:` protocol boilerplate
- preserve verbose failed-execution diagnostics

## Validation
- focused `agent-tui` presentation test in GHCi
- loaded `agent-cli:lib:agent-cli` successfully in GHCi
- live tmux TTY smoke test
- `git diff --check`