### PR TITLE
Syntax highlight exec JavaScript

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -2843,8 +2843,8 @@ syntaxLanguagesForBlock block =
                 (resolveFenceLanguage . (.fencedInfo))
                 (fencedBlocks block.blockBody)
         BlockShell
-            | not (Text.null (Text.strip block.blockDetail)) ->
-                ["haskell"]
+            | Just language <- blockCodeLanguage block ->
+                [language]
         _ -> []
 
 syncMotionDemand :: EventM Name AppState ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render.hs
@@ -113,7 +113,8 @@ import Agent.TUI.Markdown
       markdownWidgetWithLinks,
       markdownWidgetWithSyntaxHighlightingAndLinks )
 import Agent.TUI.Model
-    ( conversationIsEmpty,
+    ( blockCodeLanguage,
+      conversationIsEmpty,
       reduceUi,
       visibleTodoList,
       BlockId,
@@ -1651,7 +1652,10 @@ accentCodeBlock
     code
     body =
     accentBlockWithSections state target ui block waveElapsed accent title $
-        [ codeWidgetWithSyntaxHighlighting syntaxHighlighter "haskell" code
+        [ codeWidgetWithSyntaxHighlighting
+            syntaxHighlighter
+            (fromMaybe "text" (blockCodeLanguage block))
+            code
         | not (Text.null (Text.strip code))
         ]
             <> [ terminalTxtWrap body

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -72,6 +72,7 @@ import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch
     ( ToolCallKind(..)
     , ToolCallResult(..)
+    , customToolCall
     , functionToolCall
     )
 import Agent.TUI.Model
@@ -105,6 +106,19 @@ spec = do
                         initialUiState
             syntaxLanguagesForBlocks (toList conversation.uiBlocks)
                 `shouldBe` Set.fromList ["haskell", "python"]
+
+        it "requests the JavaScript grammar for exec source" do
+            let conversation =
+                    reduceUi
+                        (UiLoop
+                            (ToolStarted
+                                (customToolCall
+                                    "exec-1"
+                                    "exec"
+                                    "const answer = 42;")))
+                        initialUiState
+            syntaxLanguagesForBlocks (toList conversation.uiBlocks)
+                `shouldBe` Set.singleton "javascript"
 
     describe "externalUrlCommand" do
         it "opens HTTP(S) URLs without passing through a shell" do

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -37,6 +37,7 @@ module Agent.TUI.Model
     , uiTokensPerSecond
     , warningNotice
     , advanceUiTime
+    , blockCodeLanguage
     ) where
 
 import Agent.TUI.Presentation
@@ -1395,7 +1396,7 @@ isTodoTool name =
 
 toolBlockKind :: Text -> BlockKind
 toolBlockKind rawName
-    | name `elem` ["run_terminal_cmd", "shell_command", "write_stdin", "run_ghci"] =
+    | name `elem` ["run_terminal_cmd", "shell_command", "write_stdin", "run_ghci", "exec"] =
         BlockShell
     | name `elem` ["search_replace", "apply_patch"] =
         BlockEdit
@@ -1404,6 +1405,16 @@ toolBlockKind rawName
     | otherwise = BlockTool
   where
     name = canonicalToolName rawName
+
+-- | Syntax grammar for code carried in a shell-style tool block.
+-- The title is retained alongside the source after the original call leaves
+-- the live-tool map, so it also identifies exec's JavaScript code here.
+blockCodeLanguage :: UiBlock -> Maybe Text
+blockCodeLanguage block
+    | block.blockKind /= BlockShell = Nothing
+    | Text.null (Text.strip block.blockDetail) = Nothing
+    | block.blockTitle == "$ exec" = Just "javascript"
+    | otherwise = Just "haskell"
 
 outputLooksFailed :: Text -> Bool
 outputLooksFailed output =

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -15,6 +15,7 @@ import Agent.Loop
 import Agent.ToolDispatch
     ( ToolCallResult(..)
     , ToolCallKind(..)
+    , customToolCall
     , functionToolCall
     )
 import qualified Data.Foldable as Foldable
@@ -431,6 +432,18 @@ spec = describe "fullscreen UI reducer" do
                     `shouldBe` "do { putStrLn \"one\"; putStrLn \"two\" }"
                 state.uiActivity `shouldBe` "$ ghci"
             _ -> expectationFailure "expected one running GHCi block"
+
+    it "stores exec source as JavaScript code" do
+        let source = "const answer = await tools.read_file({target_file: \"A.hs\"});"
+            call = customToolCall "c1" "exec" source
+            state = apply [UiLoop TurnStarted, UiLoop (ToolStarted call)]
+        case Foldable.toList state.uiBlocks of
+            [block] -> do
+                block.blockKind `shouldBe` BlockShell
+                block.blockTitle `shouldBe` "$ exec"
+                block.blockDetail `shouldBe` source
+                blockCodeLanguage block `shouldBe` Just "javascript"
+            _ -> expectationFailure "expected one running exec block"
 
     it "renders the public Grok terminal alias as a shell block" do
         let call = functionToolCall


### PR DESCRIPTION
## Summary
- classify retained `exec` invocations as code blocks
- use the JavaScript syntax grammar for exec source while retaining Haskell highlighting for GHCi
- load the JavaScript grammar on demand when an exec block is visible

## Validation
- focused agent-tui reducer test in GHCi
- focused agent-cli syntax-loading test in GHCi
- live tmux TTY smoke test confirming distinct colors for JavaScript keywords, strings, operators, and calls
- `git diff --check`