### PR TITLE
Show details for background agent work

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -10,6 +10,7 @@ module Agent.CLI.TUI.App
     , agentEntryWindow
     , agentPaneEntryLimit
     , agentPaneVisible
+    , backgroundActivityText
     , completionFlashTransitions
     , conversationScrollbarRenderer
     , choiceRowColumns

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -4,6 +4,7 @@ module Agent.CLI.TUI.Render.Internal
     , agentEntryWindow
     , agentPaneVisible
     , agentPaneEntryLimit
+    , backgroundActivityText
     , conversationScrollbarRenderer
     , choiceRowColumns
     , quickStartVisible
@@ -214,7 +215,7 @@ import Data.IORef ()
 import Data.List
     ( findIndex, intersperse, nub, sort, sortOn )
 import Data.List.NonEmpty ()
-import Data.Maybe ( fromMaybe, isJust, maybeToList )
+import Data.Maybe ( fromMaybe, isJust, listToMaybe, maybeToList )
 import Data.Sequence ( Seq )
 import Data.Text ( Text )
 import Data.Time.Clock ( UTCTime )
@@ -628,7 +629,8 @@ drawPromptActivity state
             withAttr Theme.mutedAttr $
                 terminalTxt
                     (backgroundIndicator motionGlyphSet mode motionMillis
-                        <> " Background work")
+                        <> " "
+                        <> backgroundActivityText state.appAgentEntries)
         | otherwise = emptyWidget
     elapsed =
         " · "
@@ -641,3 +643,30 @@ drawPromptActivity state
         | ui.uiCompletionRemainingMillis > 0 =
             maybe "" formatTokensPerSecond (uiTokensPerSecond ui)
         | otherwise = ""
+
+-- | Describe the child agents which keep the session alive after the root
+-- agent has finished. Prefer their current running step so the status line
+-- shows observable progress instead of an unverifiable generic claim.
+backgroundActivityText :: [AgentEntry] -> Text
+backgroundActivityText entries =
+    case activeEntries of
+        [] -> "Background work"
+        [entry] -> "Background · " <> describe entry
+        _ ->
+            Text.pack (show (length activeEntries))
+                <> " agents · "
+                <> Text.intercalate "; " (map describe (take 2 activeEntries))
+                <> if length activeEntries > 2 then " …" else ""
+  where
+    activeEntries = filter isBackgroundAgentActive entries
+    describe entry =
+        agentDisplayName entry.agentPath
+            <> maybe "" (" — " <>) (currentStep entry)
+    currentStep entry =
+        (.agentStepTitle)
+            <$> listToMaybe
+                ( filter
+                    ((== AgentStepRunning) . (.agentStepState))
+                    entry.agentSteps
+                    <> entry.agentSteps
+                )

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1,6 +1,11 @@
 module Agent.CLI.TUIAppSpec (spec) where
 
-import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.AgentViewport
+    ( AgentEntry(..)
+    , AgentStep(..)
+    , AgentStepState(..)
+    , AgentTarget(..)
+    )
 import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.TUI.App
@@ -10,6 +15,7 @@ import Agent.CLI.TUI.App
     , agentEntryWindow
     , agentPaneEntryLimit
     , agentPaneVisible
+    , backgroundActivityText
     , completionFlashTransitions
     , conversationScrollbarRenderer
     , choiceRowColumns
@@ -111,6 +117,36 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "background activity status" do
+        it "names a running agent and its current step" do
+            backgroundActivityText
+                [ rootEntry
+                , (childEntry 1)
+                    { agentSteps =
+                        [ AgentStep AgentStepCompleted "Read files" Nothing
+                        , AgentStep AgentStepRunning "Running focused tests" Nothing
+                        ]
+                    }
+                ]
+                `shouldBe` "Background · agent-1 — Running focused tests"
+
+        it "summarizes multiple active agents and ignores finished agents" do
+            backgroundActivityText
+                [ rootEntry
+                , (childEntry 1)
+                    { agentSteps = [AgentStep AgentStepRunning "Reading logs" Nothing] }
+                , (childEntry 2)
+                    { agentSteps = [AgentStep AgentStepRunning "Reproducing bug" Nothing] }
+                , (childEntry 3)
+                    { agentSteps = [AgentStep AgentStepRunning "Waiting" Nothing] }
+                , (childEntry 4) { agentStatus = "done" }
+                ]
+                `shouldBe` "3 agents · agent-1 — Reading logs; agent-2 — Reproducing bug …"
+
+        it "falls back to the agent name before its first step arrives" do
+            backgroundActivityText [rootEntry, childEntry 1]
+                `shouldBe` "Background · agent-1"
+
     describe "on-demand syntax loading" do
         it "requests grammars used by fenced file paths" do
             let conversation =


### PR DESCRIPTION
## Summary
- replace the generic `Background work` status with active agent names and current steps
- summarize multiple workers without letting the status line grow unbounded
- cover running, multiple, completed, and not-yet-started agent states

## Validation
- `printf ":load Agent.CLI.TUI.Render.Internal\n:q\n" | nix develop -c cabal repl agent-cli:lib:agent-cli`
- targeted Hspec run: 3 examples, 0 failures
- live tmux smoke test showed: `Background · ui_smoke — $ sleep 20`