### PR TITLE
Use merged upstream Hermes dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,5 +28,5 @@ constraints:
 
 source-repository-package
     type: git
-    location: https://github.com/mpscholten/hermes.git
-    tag: f70adba535051516b51b1aff8147bc77bac4f335
+    location: https://github.com/velveteer/hermes.git
+    tag: c04619a2b490fb49c67cacc0d2eb15368b78505f

--- a/flake.nix
+++ b/flake.nix
@@ -286,9 +286,9 @@
                         hermes-json =
                             pkgs.haskell.lib.overrideSrc previous.hermes-json {
                                 src = pkgs.fetchFromGitHub {
-                                    owner = "mpscholten";
+                                    owner = "velveteer";
                                     repo = "hermes";
-                                    rev = "f70adba535051516b51b1aff8147bc77bac4f335";
+                                    rev = "c04619a2b490fb49c67cacc0d2eb15368b78505f";
                                     hash = "sha256-BZEIcQrQTYE7Vf3FVq1EOaeH/dLnFvU+INZZNNQSMcw=";
                                     fetchSubmodules = true;
                                 };


### PR DESCRIPTION
## Summary

- switch the Cabal Hermes source from the temporary fork to `velveteer/hermes`
- pin Cabal and Nix to upstream merge commit `c04619a2b490fb49c67cacc0d2eb15368b78505f`
- retain the existing Nix source hash because the merged tree is unchanged

## Validation

- `nix develop -c cabal repl agent-json:lib:agent-json`
- Nix `fetchFromGitHub` source/hash realization
- `git diff --check`