### PR TITLE
Expose shell tools directly in OpenAI code mode

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
@@ -1,5 +1,5 @@
 -- | Session wiring for Codex catalog models: per-model metadata lookup and
--- the code-mode (@tool_mode: code_mode_only@) tool surface.
+-- direct or code-only tool surfaces.
 --
 -- The nested-invoke slot decouples construction order: the code-mode tool set
 -- is built during orchestration (where the wire tool list and instructions
@@ -8,12 +8,14 @@
 -- closed.
 module Agent.CLI.CodeModeRuntime
     ( CodeModeSessionRuntime(..)
+    , CodeModeToolProjection(..)
     , CodeModeNestedSlot
     , CodexCatalogSession(..)
     , newCodeModeNestedSlot
     , setCodeModeNestedInvoke
     , loadCodexCatalogModelInfo
     , codexCatalogDefaultEffort
+    , projectCodeModeTools
     , codeModeSessionRuntimeFor
     ) where
 
@@ -108,12 +110,37 @@ data CodexCatalogSession = CodexCatalogSession
 
 data CodeModeSessionRuntime = CodeModeSessionRuntime
     { codeModeWireTools :: ![AppTool]
-      -- ^ @exec@ and @wait@: the only locally dispatched tools advertised on
-      -- the wire in code-only mode.
+      -- ^ The @exec@ and @wait@ code-mode entry points.
+    , codeModeDirectTools :: ![AppTool]
+      -- ^ Conventional tools that remain provider-visible alongside code mode.
     , codeModeNestedSlot :: !CodeModeNestedSlot
     , codeModeNestedToolNames :: ![Text]
     , codeModeClose :: !(IO ())
     }
+
+-- | Provider-visible versus JavaScript-nested tools for one catalog mode.
+--
+-- For code-only models we deliberately retain the native shell entry points
+-- as direct tools: shell execution already has a purpose-built process/session
+-- API, so forcing a single command through a JavaScript cell adds no
+-- orchestration value. They remain in the nested set as well, since code mode
+-- may need to compose shell calls with other tools in one JavaScript cell.
+data CodeModeToolProjection = CodeModeToolProjection
+    { directCodeModeTools :: ![AppTool]
+    , nestedCodeModeTools :: ![AppTool]
+    }
+
+projectCodeModeTools :: ToolMode -> [AppTool] -> CodeModeToolProjection
+projectCodeModeTools mode tools = case mode of
+    ConventionalToolMode -> CodeModeToolProjection tools []
+    CodeToolMode -> CodeModeToolProjection tools tools
+    CodeOnlyToolMode -> CodeModeToolProjection
+        { directCodeModeTools = filter isDirectShellTool tools
+        , nestedCodeModeTools = tools
+        }
+  where
+    isDirectShellTool tool =
+        tool.appToolName `elem` ["shell_command", "write_stdin"]
 
 -- | Resolve catalog metadata for the active model. With ChatGPT credentials
 -- the live @/models@ catalog is fetched at session start (Codex parity:
@@ -185,41 +212,53 @@ codexCatalogDefaultEffort info =
     reasoningEffortText
         <$> (info >>= defaultReasoningEffortForInfo)
 
--- | Build the code-mode session runtime when the catalog selects
--- @code_mode_only@ for this model. 'Right Nothing' keeps conventional tools;
+-- | Build the code-mode session runtime when the catalog selects code mode.
+-- 'Right Nothing' keeps conventional tools;
 -- 'Left' reports why code mode could not start (the caller should warn and
 -- fall back to direct tools rather than refuse to start the session).
 codeModeSessionRuntimeFor
     :: Maybe ModelInfo
     -> [AppTool]
     -> IO (Either Text (Maybe CodeModeSessionRuntime))
-codeModeSessionRuntimeFor maybeInfo nestedTools =
+codeModeSessionRuntimeFor maybeInfo tools =
     case maybeInfo of
         Nothing -> pure (Right Nothing)
         Just info ->
             case toolModeForInfo ConventionalToolMode info of
                 ConventionalToolMode -> pure (Right Nothing)
-                -- Mixed code mode (direct tools plus exec) is not implemented;
-                -- no shipped catalog model requests it.
+                -- Mixed mode also augments every direct tool description with
+                -- its JavaScript invocation. Keep the established direct-mode
+                -- fallback until that provider projection is implemented.
                 CodeToolMode -> pure (Right Nothing)
-                CodeOnlyToolMode -> do
-                    slot <- newCodeModeNestedSlot
-                    workerPath <- codeModeWorkerPath
-                    built <- newCodeModeToolSet
+                CodeOnlyToolMode ->
+                    buildRuntime
+                        info
                         CodeOnlyToolMode
-                        (imageDetailVisibilityFor info)
-                        workerPath
-                        (invokeThroughSlot slot)
-                        (map nestedSpecFor nestedTools)
-                    pure $ case built of
-                        Left err -> Left err
-                        Right toolSet -> Right $ Just CodeModeSessionRuntime
-                            { codeModeWireTools = toolSet.codeModeTools
-                            , codeModeNestedSlot = slot
-                            , codeModeNestedToolNames =
-                                toolSet.codeModeNestedToolNames
-                            , codeModeClose = toolSet.closeCodeModeToolSet
-                            }
+                        (projectCodeModeTools CodeOnlyToolMode tools)
+
+buildRuntime
+    :: ModelInfo
+    -> ToolMode
+    -> CodeModeToolProjection
+    -> IO (Either Text (Maybe CodeModeSessionRuntime))
+buildRuntime info mode projection = do
+    slot <- newCodeModeNestedSlot
+    workerPath <- codeModeWorkerPath
+    built <- newCodeModeToolSet
+        mode
+        (imageDetailVisibilityFor info)
+        workerPath
+        (invokeThroughSlot slot)
+        (map nestedSpecFor projection.nestedCodeModeTools)
+    pure $ case built of
+        Left err -> Left err
+        Right toolSet -> Right $ Just CodeModeSessionRuntime
+            { codeModeWireTools = toolSet.codeModeTools
+            , codeModeDirectTools = projection.directCodeModeTools
+            , codeModeNestedSlot = slot
+            , codeModeNestedToolNames = toolSet.codeModeNestedToolNames
+            , codeModeClose = toolSet.closeCodeModeToolSet
+            }
 
 imageDetailVisibilityFor :: ModelInfo -> ImageDetailVisibility
 imageDetailVisibilityFor _info = ImageDetailVisible

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -360,7 +360,9 @@ runAgentSession
                 Just codeMode ->
                     schemasFromAppToolsCodeMode
                         dialect
-                        codeMode.codeModeWireTools
+                        ( codeMode.codeModeWireTools
+                            <> codeMode.codeModeDirectTools
+                        )
                 Nothing -> schemasFromAppTools dialect tools
             environmentContextBlock =
                 (.catalogEnvironmentContext) <$> catalogSession

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -1,6 +1,10 @@
 module Agent.CLI.ToolsSpec (spec) where
 
 import Agent.CLI.Tools
+import Agent.CLI.CodeModeRuntime
+    ( CodeModeToolProjection(..)
+    , projectCodeModeTools
+    )
 import Agent.Dialect
     ( claudeCodeDialect
     , codexDialect
@@ -20,8 +24,9 @@ import Agent.ToolDispatch (noArgsTool)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.Codex.Dialect.ApplyPatch (applyPatchGrammar)
 import Agent.Tools.MultiAgents (MultiAgentContext(..), multiAgentTools)
+import Agent.Tools.CodeMode.Tool (ToolMode(..))
 import Agent.Tools.Types
-    ( AppTool
+    ( AppTool(..)
     , ApprovalRule(..)
     , freeformApplyPatchAppTool
     , jsonAppTool
@@ -37,6 +42,15 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "schemasFromAppTools" do
+    it "keeps native shell tools both direct and nested for code-only models" do
+        let tools = map testTool
+                ["read_file", "shell_command", "write_stdin", "apply_patch"]
+            projection = projectCodeModeTools CodeOnlyToolMode tools
+        map (.appToolName) projection.directCodeModeTools
+            `shouldBe` ["shell_command", "write_stdin"]
+        map (.appToolName) projection.nestedCodeModeTools
+            `shouldBe` ["read_file", "shell_command", "write_stdin", "apply_patch"]
+
     it "enables built-in web_search ahead of app tools" do
         case schemasFromAppTools codexDialect [jsonTool] of
             KnownResponseTool ToolWebSearch : _ -> pure ()


### PR DESCRIPTION
## Summary

- keep `shell_command` and `write_stdin` provider-visible for OpenAI code-only models
- retain both shell tools inside the Bun/code-mode namespace for composed JavaScript orchestration
- route direct and nested calls through the same existing Haskell tool registry
- add regression coverage for the dual exposure

## Validation

- `nix develop -c cabal repl agent-cli:test:agent-cli-test`
- `Agent.CLI.ToolsSpec`: 13 examples, 0 failures
- `git diff --check`