### PR TITLE
Type structured results and render database output as text

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Database.hs
+++ b/packages/agent-cli/src/Agent/CLI/Database.hs
@@ -15,18 +15,13 @@ import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
 import Agent.Json.Decode (defaultKey)
 import Agent.Json.Decode qualified as Hermes
-import Agent.Json (RawJson, rawJsonBytes)
 import Agent.Tools.Types
     ( AppTool
     , ToolExecutionPolicy(..)
     , jsonTool
     )
-import Data.Aeson (Value)
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 
 data DatabaseScope
     = DatabaseUserScope
@@ -47,18 +42,17 @@ databaseScopeDecoder = Hermes.withText \case
 
 -- | Storage callbacks for the three model-facing database operations.
 --
--- Structured database values are encoded as JSON in the tool result. Conversation
--- search is rendered as labeled text because its results are primarily read by
--- the model and by humans rather than consumed as a machine-readable payload.
+-- Database and conversation-search results are rendered as labeled text because
+-- they are read by the model and humans rather than consumed as an API.
 -- Store errors are already sanitized 'Text' because database exception details
 -- can contain SQL values that should not be copied into the transcript.
 data DatabaseToolsEnv = DatabaseToolsEnv
     { databaseDescribeScope
-        :: !(DatabaseScope -> IO (Either Text Value))
+        :: !(DatabaseScope -> IO (Either Text Text))
     , databaseRunQuery
-        :: !(DatabaseScope -> Text -> IO (Either Text RawJson))
+        :: !(DatabaseScope -> Text -> IO (Either Text Text))
     , databaseRunExecute
-        :: !(DatabaseScope -> Text -> Text -> IO (Either Text Value))
+        :: !(DatabaseScope -> Text -> Text -> IO (Either Text Text))
     , databaseSearchConversations
         :: !(Text -> Int -> IO (Either Text [ConversationSearchMatch]))
     }
@@ -130,7 +124,7 @@ schemaTool env = jsonTool
     True
     ParallelSafe
     (typedTool "database_schema" schemaArgsDecoder \(SchemaArgs scope) ->
-        encodeResult <$> env.databaseDescribeScope scope)
+        env.databaseDescribeScope scope)
 
 queryTool :: DatabaseToolsEnv -> AppTool
 queryTool env = jsonTool
@@ -149,8 +143,7 @@ queryTool env = jsonTool
     (typedTool "database_query" queryArgsDecoder \(QueryArgs scope sql) ->
         if Text.null (Text.strip sql)
             then pure (Left "database query must not be empty")
-            else fmap (Text.decodeUtf8 . rawJsonBytes)
-                <$> env.databaseRunQuery scope sql)
+            else env.databaseRunQuery scope sql)
 
 executeTool :: DatabaseToolsEnv -> AppTool
 executeTool env = jsonTool
@@ -177,11 +170,7 @@ executeTool env = jsonTool
             then pure (Left "database SQL must not be empty")
             else if Text.null (Text.strip purpose)
                 then pure (Left "database change purpose must not be empty")
-                else encodeResult
-                    <$> env.databaseRunExecute
-                        scope
-                        purpose
-                        sql)
+                else env.databaseRunExecute scope purpose sql)
 
 conversationSearchTool :: DatabaseToolsEnv -> AppTool
 conversationSearchTool env = jsonTool
@@ -216,10 +205,6 @@ scopeProperty = PropertySchema
         ( "Durable data scope: user for cross-project personal data, repository "
             <> "for data shared by clones/worktrees, or checkout for this worktree."
         ))
-
-encodeResult :: Either Text Value -> Either Text Text
-encodeResult =
-    fmap (Text.decodeUtf8 . LBS.toStrict . Aeson.encode)
 
 renderConversationSearchResult :: [ConversationSearchMatch] -> Text
 renderConversationSearchResult matches =

--- a/packages/agent-cli/src/Agent/CLI/Database/Store.hs
+++ b/packages/agent-cli/src/Agent/CLI/Database/Store.hs
@@ -46,13 +46,10 @@ import Agent.Store.Postgres.Scope
     , provisionScope
     )
 import Agent.Store.Types (renderStoreError)
-import Agent.Json (RawJson)
-import Agent.Json.Decode (JsonError(..), validateRawJson)
 import Control.Exception.Safe (SomeException, try)
-import Data.Aeson (Value, toJSON)
-import qualified Data.Aeson as Aeson
 import Data.Bits (xor)
 import qualified Data.ByteString as ByteString
+import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -105,17 +102,16 @@ databaseToolsEnvForStore
 databaseToolsEnvForStore store scopes currentSessionId = DatabaseToolsEnv
     { databaseDescribeScope = \selected ->
         withScopeDatabase store (scopeForDatabase scopes selected) \database pool ->
-            fmap (toJSON . map catalogObjectValue)
-                <$> inspectCustomSchema pool database
+            fmap formatCatalog <$> inspectCustomSchema pool database
     , databaseRunQuery = \selected sql ->
         withScopeDatabase store (scopeForDatabase scopes selected) \database pool ->
             queryCustom pool database defaultQueryLimits sql >>= \case
                 Left err -> pure (Left err)
-                Right result -> pure (queryResultValue result)
+                Right result -> pure (Right (formatQueryResult result))
     , databaseRunExecute = \selected purpose sql ->
         withScopeDatabase store (scopeForDatabase scopes selected) \database pool -> do
             sessionId <- currentSessionId
-            fmap executionResultValue <$> executeCustom
+            fmap formatExecutionResult <$> executeCustom
                 (storePool (trustedPool store))
                 pool
                 database
@@ -132,75 +128,88 @@ databaseToolsEnvForStore store scopes currentSessionId = DatabaseToolsEnv
             Right results -> pure $ Right $ map searchResultValue results
     }
 
-queryResultValue :: CustomQueryResult -> Either Text RawJson
-queryResultValue result = do
-    _ <- decodeJsonText "custom query rows" result.customQueryRows
-    case validateRawJson $ Text.encodeUtf8 $
-            "{\"rows\":" <> result.customQueryRows
-                <> ",\"truncated\":"
-                <> (if result.customQueryTruncated then "true" else "false")
-                <> "}" of
-        Left err -> Left ("custom query result: " <> jsonErrorMessage err)
-        Right raw -> Right raw
+formatQueryResult :: CustomQueryResult -> Text
+formatQueryResult result =
+    result.customQueryOutput
+        <> "\n\ntruncated: " <> yesNo result.customQueryTruncated
 
-executionResultValue :: CustomExecutionResult -> Value
-executionResultValue result = Aeson.object
-    [ "audit_id" Aeson..= result.customExecutionAuditId
-    , "catalog_before" Aeson..=
-        map catalogObjectValue result.customExecutionCatalogBefore
-    , "catalog_after" Aeson..=
-        map catalogObjectValue result.customExecutionCatalogAfter
-    , "warning" Aeson..= result.customExecutionWarning
+formatExecutionResult :: CustomExecutionResult -> Text
+formatExecutionResult result = Text.intercalate "\n"
+    ( ["audit id: " <> result.customExecutionAuditId]
+        <> maybe [] (\warning -> ["warning: " <> warning])
+            result.customExecutionWarning
+        <> [ ""
+           , "catalog before:"
+           , indentBlock (formatCatalog result.customExecutionCatalogBefore)
+           , ""
+           , "catalog after:"
+           , indentBlock (formatCatalog result.customExecutionCatalogAfter)
+           ]
+    )
+
+formatCatalog :: [CatalogObject] -> Text
+formatCatalog [] = "(no user-defined objects)"
+formatCatalog objects =
+    Text.intercalate "\n\n" (map formatCatalogObject objects)
+
+formatCatalogObject :: CatalogObject -> Text
+formatCatalogObject object = Text.intercalate "\n" $
+    [object.catalogObjectKind <> " " <> object.catalogObjectName]
+        <> optionalCatalogFields definition
+        <> formatSection "columns"
+            (map formatColumn definition.definitionColumns)
+        <> formatSection "constraints"
+            (map formatConstraint definition.definitionConstraints)
+        <> formatSection "indexes"
+            (map formatIndex definition.definitionIndexes)
+  where
+    definition = object.catalogObjectDefinition
+
+optionalCatalogFields :: CatalogDefinition -> [Text]
+optionalCatalogFields definition = catMaybes
+    [ labeled "owner" definition.definitionOwner
+    , labeled "comment" definition.definitionComment
+    , labeled "view definition" definition.definitionView
     ]
+  where
+    labeled label = fmap (\value -> "  " <> label <> ": " <> value)
 
-catalogObjectValue :: CatalogObject -> Value
-catalogObjectValue object = Aeson.object
-    [ "kind" Aeson..= object.catalogObjectKind
-    , "name" Aeson..= object.catalogObjectName
-    , "definition" Aeson..= catalogDefinitionValue
-        object.catalogObjectDefinition
+formatSection :: Text -> [Text] -> [Text]
+formatSection _ [] = []
+formatSection label values =
+    ("  " <> label <> ":") : map ("    - " <>) values
+
+formatColumn :: CatalogColumn -> Text
+formatColumn column = Text.intercalate "; " $
+    [ column.columnName <> " " <> column.columnType
+    , if column.columnNullable then "nullable" else "not null"
     ]
+        <> catMaybes
+            [ fmap ("default " <>) column.columnDefault
+            , fmap ("identity " <>) column.columnIdentity
+            , fmap ("generated " <>) column.columnGenerated
+            , fmap ("comment " <>) column.columnComment
+            ]
 
-catalogDefinitionValue :: CatalogDefinition -> Value
-catalogDefinitionValue definition = Aeson.object
-    [ "owner" Aeson..= definition.definitionOwner
-    , "comment" Aeson..= definition.definitionComment
-    , "view_definition" Aeson..= definition.definitionView
-    , "columns" Aeson..= map catalogColumnValue definition.definitionColumns
-    , "constraints" Aeson..=
-        map catalogConstraintValue definition.definitionConstraints
-    , "indexes" Aeson..= map catalogIndexValue definition.definitionIndexes
-    ]
+formatConstraint :: CatalogConstraint -> Text
+formatConstraint constraint =
+    constraint.constraintName
+        <> " (" <> constraint.constraintType <> "): "
+        <> constraint.constraintDefinition
 
-catalogColumnValue :: CatalogColumn -> Value
-catalogColumnValue column = Aeson.object
-    [ "name" Aeson..= column.columnName
-    , "type" Aeson..= column.columnType
-    , "nullable" Aeson..= column.columnNullable
-    , "default" Aeson..= column.columnDefault
-    , "identity" Aeson..= column.columnIdentity
-    , "generated" Aeson..= column.columnGenerated
-    , "comment" Aeson..= column.columnComment
-    ]
+formatIndex :: CatalogIndex -> Text
+formatIndex index = index.indexName <> ": " <> index.indexDefinition
 
-catalogConstraintValue :: CatalogConstraint -> Value
-catalogConstraintValue constraint = Aeson.object
-    [ "name" Aeson..= constraint.constraintName
-    , "type" Aeson..= constraint.constraintType
-    , "definition" Aeson..= constraint.constraintDefinition
-    ]
+indentBlock :: Text -> Text
+indentBlock = Text.intercalate "\n" . map ("  " <>) . Text.lines
 
-catalogIndexValue :: CatalogIndex -> Value
-catalogIndexValue index = Aeson.object
-    [ "name" Aeson..= index.indexName
-    , "definition" Aeson..= index.indexDefinition
-    ]
+boolText :: Bool -> Text
+boolText True = "true"
+boolText False = "false"
 
-decodeJsonText :: Text -> Text -> Either Text RawJson
-decodeJsonText label value =
-    case validateRawJson (Text.encodeUtf8 value) of
-        Left err -> Left (label <> ": " <> jsonErrorMessage err)
-        Right decoded -> Right decoded
+yesNo :: Bool -> Text
+yesNo True = "yes"
+yesNo False = "no"
 
 searchResultValue :: ConversationSearchResult -> ConversationSearchMatch
 searchResultValue result = ConversationSearchMatch

--- a/packages/agent-cli/src/Agent/CLI/LearnedSkills.hs
+++ b/packages/agent-cli/src/Agent/CLI/LearnedSkills.hs
@@ -1,6 +1,15 @@
 -- | Model-facing tools and startup context for reusable learned skills.
 module Agent.CLI.LearnedSkills
     ( LearnedSkillToolsEnv(..)
+    , LearnedSkillSearchResponse(..)
+    , LearnedSkillSearchMatch(..)
+    , LearnedSkillSummary(..)
+    , LearnedSkillDetails(..)
+    , LearnedSkillRevisionSummary(..)
+    , LearnedSkillRevisionDetails(..)
+    , LearnedSkillSourceDetails(..)
+    , LearnedSkillView(..)
+    , LearnedSkillMutationResponse(..)
     , LearnedSkillCreateRequest(..)
     , LearnedSkillUpdateRequest(..)
     , LearnedSkillArchiveRequest(..)
@@ -39,9 +48,6 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , jsonTool
     )
-import Data.Aeson (Value)
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as LBS
 import Data.Int (Int64)
 import Data.IORef (IORef, modifyIORef', readIORef)
 import Data.List (sortOn)
@@ -50,7 +56,7 @@ import Data.Maybe (fromMaybe, isJust)
 import Data.Ord (Down(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
+import Data.Time.Clock (UTCTime)
 
 data LearnedSkillCreateRequest = LearnedSkillCreateRequest
     { createRequestScope :: !DatabaseScope
@@ -100,19 +106,253 @@ data LearnedSkillRollbackRequest = LearnedSkillRollbackRequest
     }
     deriving (Eq, Show)
 
+data LearnedSkillSearchResponse = LearnedSkillSearchResponse
+    { searchMatches :: ![LearnedSkillSearchMatch]
+    } deriving (Eq, Show)
+
+data LearnedSkillSearchMatch = LearnedSkillSearchMatch
+    { searchMatchSkill :: !LearnedSkillSummary
+    , searchMatchRank :: !Double
+    } deriving (Eq, Show)
+
+data LearnedSkillSummary = LearnedSkillSummary
+    { summaryScope :: !Text
+    , summarySlug :: !Text
+    , summaryTitle :: !Text
+    , summaryDescription :: !Text
+    , summaryAppliesWhen :: !Text
+    , summaryActivation :: !Text
+    , summaryPriority :: !Int64
+    , summaryStatus :: !Text
+    , summaryRevision :: !Int64
+    , summaryUpdatedAt :: !UTCTime
+    } deriving (Eq, Show)
+
+data LearnedSkillDetails = LearnedSkillDetails
+    { detailScope :: !Text
+    , detailSlug :: !Text
+    , detailTitle :: !Text
+    , detailDescription :: !Text
+    , detailAppliesWhen :: !Text
+    , detailInstructions :: !Text
+    , detailActivation :: !Text
+    , detailPriority :: !Int64
+    , detailStatus :: !Text
+    , detailRevision :: !Int64
+    , detailCreatedAt :: !UTCTime
+    , detailUpdatedAt :: !UTCTime
+    } deriving (Eq, Show)
+
+data LearnedSkillRevisionSummary = LearnedSkillRevisionSummary
+    { revisionSummaryRevision :: !Int64
+    , revisionSummaryTitle :: !Text
+    , revisionSummaryDescription :: !Text
+    , revisionSummaryAppliesWhen :: !Text
+    , revisionSummaryActivation :: !Text
+    , revisionSummaryPriority :: !Int64
+    , revisionSummaryStatus :: !Text
+    , revisionSummaryChangeSummary :: !Text
+    , revisionSummaryCreatedAt :: !UTCTime
+    } deriving (Eq, Show)
+
+data LearnedSkillRevisionDetails = LearnedSkillRevisionDetails
+    { revisionDetailRevision :: !Int64
+    , revisionDetailTitle :: !Text
+    , revisionDetailDescription :: !Text
+    , revisionDetailAppliesWhen :: !Text
+    , revisionDetailInstructions :: !Text
+    , revisionDetailActivation :: !Text
+    , revisionDetailPriority :: !Int64
+    , revisionDetailStatus :: !Text
+    , revisionDetailChangeSummary :: !Text
+    , revisionDetailCreatedAt :: !UTCTime
+    } deriving (Eq, Show)
+
+data LearnedSkillSourceDetails = LearnedSkillSourceDetails
+    { sourceDetailRevision :: !Int64
+    , sourceDetailSessionId :: !(Maybe Text)
+    , sourceDetailTurnIndex :: !(Maybe Int64)
+    , sourceDetailResponseItemId :: !(Maybe Text)
+    , sourceDetailEvidence :: !Text
+    , sourceDetailCreatedAt :: !UTCTime
+    } deriving (Eq, Show)
+
+data LearnedSkillView = LearnedSkillView
+    { viewSkill :: !LearnedSkillDetails
+    , viewSelectedRevision :: !LearnedSkillRevisionDetails
+    , viewSources :: ![LearnedSkillSourceDetails]
+    , viewRevisions :: ![LearnedSkillRevisionSummary]
+    } deriving (Eq, Show)
+
+data FilesystemSkillView = FilesystemSkillView
+    { filesystemName :: !Text
+    , filesystemTitle :: !(Maybe Text)
+    , filesystemDescription :: !Text
+    , filesystemWhenToUse :: !(Maybe Text)
+    , filesystemInstructions :: !Text
+    , filesystemSkillFile :: !Text
+    , filesystemSkillDirectory :: !Text
+    } deriving (Eq, Show)
+
+data LearnedSkillMutationResponse = LearnedSkillMutationResponse
+    { mutationStatus :: !Text
+    , mutationSkill :: !LearnedSkillDetails
+    } deriving (Eq, Show)
+
+renderLearnedSkillSearchResponse :: LearnedSkillSearchResponse -> Text
+renderLearnedSkillSearchResponse response =
+    case response.searchMatches of
+        [] -> "(no matching learned skills)"
+        matches -> Text.intercalate "\n\n" $
+            zipWith renderLearnedSkillSearchMatch [1 :: Int ..] matches
+
+renderLearnedSkillSearchMatch :: Int -> LearnedSkillSearchMatch -> Text
+renderLearnedSkillSearchMatch matchNumber match = Text.intercalate "\n"
+    [ "match " <> Text.pack (show matchNumber)
+    , indentText (renderLearnedSkillSummary match.searchMatchSkill)
+    , "  rank: " <> Text.pack (show match.searchMatchRank)
+    ]
+
+renderLearnedSkillSummary :: LearnedSkillSummary -> Text
+renderLearnedSkillSummary summary = Text.intercalate "\n"
+    [ textField "scope" summary.summaryScope
+    , textField "slug" summary.summarySlug
+    , textField "title" summary.summaryTitle
+    , textField "description" summary.summaryDescription
+    , textField "applies when" summary.summaryAppliesWhen
+    , textField "activation" summary.summaryActivation
+    , showField "priority" summary.summaryPriority
+    , textField "status" summary.summaryStatus
+    , showField "revision" summary.summaryRevision
+    , showField "updated at" summary.summaryUpdatedAt
+    ]
+
+renderLearnedSkillDetails :: LearnedSkillDetails -> Text
+renderLearnedSkillDetails detail = Text.intercalate "\n"
+    [ textField "scope" detail.detailScope
+    , textField "slug" detail.detailSlug
+    , textField "title" detail.detailTitle
+    , textField "description" detail.detailDescription
+    , textField "applies when" detail.detailAppliesWhen
+    , blockField "instructions" detail.detailInstructions
+    , textField "activation" detail.detailActivation
+    , showField "priority" detail.detailPriority
+    , textField "status" detail.detailStatus
+    , showField "revision" detail.detailRevision
+    , showField "created at" detail.detailCreatedAt
+    , showField "updated at" detail.detailUpdatedAt
+    ]
+
+renderLearnedSkillRevisionSummary :: LearnedSkillRevisionSummary -> Text
+renderLearnedSkillRevisionSummary revision = Text.intercalate "\n"
+    [ showField "revision" revision.revisionSummaryRevision
+    , textField "title" revision.revisionSummaryTitle
+    , textField "description" revision.revisionSummaryDescription
+    , textField "applies when" revision.revisionSummaryAppliesWhen
+    , textField "activation" revision.revisionSummaryActivation
+    , showField "priority" revision.revisionSummaryPriority
+    , textField "status" revision.revisionSummaryStatus
+    , textField "change summary" revision.revisionSummaryChangeSummary
+    , showField "created at" revision.revisionSummaryCreatedAt
+    ]
+
+renderLearnedSkillRevisionDetails :: LearnedSkillRevisionDetails -> Text
+renderLearnedSkillRevisionDetails revision = Text.intercalate "\n"
+    [ showField "revision" revision.revisionDetailRevision
+    , textField "title" revision.revisionDetailTitle
+    , textField "description" revision.revisionDetailDescription
+    , textField "applies when" revision.revisionDetailAppliesWhen
+    , blockField "instructions" revision.revisionDetailInstructions
+    , textField "activation" revision.revisionDetailActivation
+    , showField "priority" revision.revisionDetailPriority
+    , textField "status" revision.revisionDetailStatus
+    , textField "change summary" revision.revisionDetailChangeSummary
+    , showField "created at" revision.revisionDetailCreatedAt
+    ]
+
+renderLearnedSkillSourceDetails :: LearnedSkillSourceDetails -> Text
+renderLearnedSkillSourceDetails source = Text.intercalate "\n" $
+    [showField "revision" source.sourceDetailRevision]
+        <> maybe [] (pure . textField "session id") source.sourceDetailSessionId
+        <> maybe [] (pure . showField "turn index") source.sourceDetailTurnIndex
+        <> maybe [] (pure . textField "response item id")
+            source.sourceDetailResponseItemId
+        <> [ blockField "evidence" source.sourceDetailEvidence
+           , showField "created at" source.sourceDetailCreatedAt
+           ]
+
+renderLearnedSkillView :: LearnedSkillView -> Text
+renderLearnedSkillView view = Text.intercalate "\n\n"
+    [ "skill:\n" <> indentText (renderLearnedSkillDetails view.viewSkill)
+    , "selected revision:\n"
+        <> indentText
+            (renderLearnedSkillRevisionDetails view.viewSelectedRevision)
+    , renderCollection
+        "sources"
+        renderLearnedSkillSourceDetails
+        view.viewSources
+    , renderCollection
+        "revision history"
+        renderLearnedSkillRevisionSummary
+        view.viewRevisions
+    ]
+
+renderFilesystemSkillView :: FilesystemSkillView -> Text
+renderFilesystemSkillView skill = Text.intercalate "\n" $
+    [ "kind: filesystem"
+    , textField "name" skill.filesystemName
+    ]
+        <> maybe [] (pure . textField "title") skill.filesystemTitle
+        <> [textField "description" skill.filesystemDescription]
+        <> maybe [] (pure . textField "when to use") skill.filesystemWhenToUse
+        <> [ blockField "instructions" skill.filesystemInstructions
+           , textField "skill file" skill.filesystemSkillFile
+           , textField "skill directory" skill.filesystemSkillDirectory
+           ]
+
+renderLearnedSkillMutationResponse :: LearnedSkillMutationResponse -> Text
+renderLearnedSkillMutationResponse response = Text.intercalate "\n"
+    [ textField "status" response.mutationStatus
+    , "skill:"
+    , indentText (renderLearnedSkillDetails response.mutationSkill)
+    ]
+
+renderCollection :: Text -> (value -> Text) -> [value] -> Text
+renderCollection label render values =
+    case values of
+        [] -> label <> ": (none)"
+        _ -> label <> ":\n" <> Text.intercalate "\n\n" (map renderEntry values)
+  where
+    renderEntry value = indentText ("-\n" <> indentText (render value))
+
+textField :: Text -> Text -> Text
+textField label value = label <> ": " <> indentContinuation value
+
+showField :: Show value => Text -> value -> Text
+showField label = textField label . Text.pack . show
+
+blockField :: Text -> Text -> Text
+blockField label value = label <> ":\n" <> indentText value
+
+indentText :: Text -> Text
+indentText = Text.intercalate "\n" . map ("  " <>) . Text.lines
+
+indentContinuation :: Text -> Text
+indentContinuation = Text.intercalate "\n  " . Text.lines
+
 data LearnedSkillToolsEnv = LearnedSkillToolsEnv
     { learnedSkillSearch
-        :: !(Text -> Int -> IO (Either Text Value))
+        :: !(Text -> Int -> IO (Either Text LearnedSkillSearchResponse))
     , learnedSkillRead
-        :: !(DatabaseScope -> Text -> Maybe Integer -> IO (Either Text Value))
+        :: !(DatabaseScope -> Text -> Maybe Integer -> IO (Either Text LearnedSkillView))
     , learnedSkillCreate
-        :: !(LearnedSkillCreateRequest -> IO (Either Text Value))
+        :: !(LearnedSkillCreateRequest -> IO (Either Text LearnedSkillMutationResponse))
     , learnedSkillUpdate
-        :: !(LearnedSkillUpdateRequest -> IO (Either Text Value))
+        :: !(LearnedSkillUpdateRequest -> IO (Either Text LearnedSkillMutationResponse))
     , learnedSkillArchive
-        :: !(LearnedSkillArchiveRequest -> IO (Either Text Value))
+        :: !(LearnedSkillArchiveRequest -> IO (Either Text LearnedSkillMutationResponse))
     , learnedSkillRollback
-        :: !(LearnedSkillRollbackRequest -> IO (Either Text Value))
+        :: !(LearnedSkillRollbackRequest -> IO (Either Text LearnedSkillMutationResponse))
     }
 
 data SearchArgs = SearchArgs !Text !Int
@@ -210,7 +450,7 @@ searchTool env = jsonTool
     (typedTool "skill_search" searchArgsDecoder \(SearchArgs query limit) ->
         case validateSearch query limit of
             Left err -> pure (Left err)
-            Right () -> encodeResult <$> env.learnedSkillSearch query limit)
+            Right () -> fmap renderLearnedSkillSearchResponse <$> env.learnedSkillSearch query limit)
 
 viewTool :: IORef [SkillInvocation] -> LearnedSkillToolsEnv -> AppTool
 viewTool invocationsRef env = jsonTool
@@ -243,8 +483,8 @@ viewTool invocationsRef env = jsonTool
                     Nothing -> do
                         invocations <- readIORef invocationsRef
                         pure $
-                            encodeResult $
-                                filesystemSkillValue
+                            fmap renderFilesystemSkillView $
+                                filesystemSkillView
                                     <$> resolveSkillInvocation
                                         invocations
                                         (normalizeFilesystemSkillName name)
@@ -258,22 +498,21 @@ viewTool invocationsRef env = jsonTool
                 of
                     Left err -> pure (Left err)
                     Right () ->
-                        encodeResult
+                        fmap renderLearnedSkillView
                             <$> env.learnedSkillRead selected name revision)
 
-filesystemSkillValue :: SkillInvocation -> Value
-filesystemSkillValue invocation =
+filesystemSkillView :: SkillInvocation -> FilesystemSkillView
+filesystemSkillView invocation =
     let skill = invocation.invocationSkill
-    in Aeson.object
-        [ "kind" Aeson..= ("filesystem" :: Text)
-        , "name" Aeson..= invocation.invocationName
-        , "title" Aeson..= skill.skillDisplayName
-        , "description" Aeson..= skill.skillDescription
-        , "when_to_use" Aeson..= skill.skillWhenToUse
-        , "instructions" Aeson..= skill.skillBody
-        , "skill_file" Aeson..= toText skill.skillPath
-        , "skill_directory" Aeson..= toText skill.skillDirectory
-        ]
+    in FilesystemSkillView
+        { filesystemName = invocation.invocationName
+        , filesystemTitle = skill.skillDisplayName
+        , filesystemDescription = skill.skillDescription
+        , filesystemWhenToUse = skill.skillWhenToUse
+        , filesystemInstructions = skill.skillBody
+        , filesystemSkillFile = toText skill.skillPath
+        , filesystemSkillDirectory = toText skill.skillDirectory
+        }
 
 normalizeFilesystemSkillName :: Text -> Text
 normalizeFilesystemSkillName raw =
@@ -313,7 +552,7 @@ createTool env = jsonTool
     (typedTool "skill_create" learnedSkillCreateRequestDecoder \request ->
         case validateCreate request of
             Left err -> pure (Left err)
-            Right () -> encodeResult <$> env.learnedSkillCreate request)
+            Right () -> fmap renderLearnedSkillMutationResponse <$> env.learnedSkillCreate request)
 
 updateTool :: LearnedSkillToolsEnv -> AppTool
 updateTool env = jsonTool
@@ -345,7 +584,7 @@ updateTool env = jsonTool
     (typedTool "skill_update" learnedSkillUpdateRequestDecoder \request ->
         case validateUpdate request of
             Left err -> pure (Left err)
-            Right () -> encodeResult <$> env.learnedSkillUpdate request)
+            Right () -> fmap renderLearnedSkillMutationResponse <$> env.learnedSkillUpdate request)
 
 archiveTool :: LearnedSkillToolsEnv -> AppTool
 archiveTool env = jsonTool
@@ -366,7 +605,7 @@ archiveTool env = jsonTool
     (typedTool "skill_archive" learnedSkillArchiveRequestDecoder \request ->
         case validateArchive request of
             Left err -> pure (Left err)
-            Right () -> encodeResult <$> env.learnedSkillArchive request)
+            Right () -> fmap renderLearnedSkillMutationResponse <$> env.learnedSkillArchive request)
 
 rollbackTool :: LearnedSkillToolsEnv -> AppTool
 rollbackTool env = jsonTool
@@ -389,7 +628,7 @@ rollbackTool env = jsonTool
     (typedTool "skill_rollback" learnedSkillRollbackRequestDecoder \request ->
         case validateRollback request of
             Left err -> pure (Left err)
-            Right () -> encodeResult <$> env.learnedSkillRollback request)
+            Right () -> fmap renderLearnedSkillMutationResponse <$> env.learnedSkillRollback request)
 
 scopeProperty :: PropertySchema
 scopeProperty = PropertySchema
@@ -604,10 +843,6 @@ validateRevisionMetadata :: Text -> Text -> Either Text ()
 validateRevisionMetadata summary evidence = do
     validateRequiredText "skill change_summary" 2000 summary
     validateRequiredText "skill evidence" 8000 evidence
-
-encodeResult :: Either Text Value -> Either Text Text
-encodeResult =
-    fmap (Text.decodeUtf8 . LBS.toStrict . Aeson.encode)
 
 defaultLearnedSkillContextMaxChars :: Int
 defaultLearnedSkillContextMaxChars = 8000

--- a/packages/agent-cli/src/Agent/CLI/LearnedSkills/Store.hs
+++ b/packages/agent-cli/src/Agent/CLI/LearnedSkills/Store.hs
@@ -14,6 +14,15 @@ import Agent.CLI.LearnedSkills
     , LearnedSkillCreateRequest(..)
     , LearnedSkillRollbackRequest(..)
     , LearnedSkillToolsEnv(..)
+    , LearnedSkillDetails(..)
+    , LearnedSkillMutationResponse(..)
+    , LearnedSkillRevisionDetails(..)
+    , LearnedSkillRevisionSummary(..)
+    , LearnedSkillSearchMatch(..)
+    , LearnedSkillSearchResponse(..)
+    , LearnedSkillSourceDetails(..)
+    , LearnedSkillSummary(..)
+    , LearnedSkillView(..)
     , LearnedSkillUpdateRequest(..)
     )
 import Agent.Store.Postgres
@@ -49,7 +58,6 @@ import Agent.Store.Postgres.Skill
     , updateLearnedSkill
     )
 import Agent.Store.Types (StoreError, renderStoreError)
-import Data.Aeson (Value, object, (.=))
 import Data.Bifunctor (first)
 import Data.List (find)
 import Data.Text (Text)
@@ -69,7 +77,8 @@ learnedSkillToolsEnvForStore store scopes currentSessionId =
                 (searchLearnedSkills pool applicableScopes query limit)
                 >>= pure . fmap
                     (\results ->
-                        object ["matches" .= map searchResultValue results])
+                        LearnedSkillSearchResponse
+                            (map searchResultValue results))
         , learnedSkillRead = \selected slug revision ->
             readSkillValue
                 (scopeForDatabase scopes selected)
@@ -198,14 +207,11 @@ learnedSkillToolsEnvForStore store scopes currentSessionId =
                                             selectedRevision.learnedSkillRevisionNumber)
                                 pure do
                                     sources <- sourcesResult
-                                    Right $ object
-                                        [ "skill" .= skillValue skill
-                                        , "selected_revision" .=
-                                            revisionDetailValue selectedRevision
-                                        , "sources" .= map sourceValue sources
-                                        , "revisions" .=
-                                            map revisionValue revisions
-                                        ]
+                                    Right $ LearnedSkillView
+                                        (skillValue skill)
+                                        (revisionDetailValue selectedRevision)
+                                        (map sourceValue sources)
+                                        (map revisionValue revisions)
 
     selectRevision skill revisions requested =
         let revisionNumber =
@@ -251,13 +257,11 @@ storeResultIO
 storeResultIO action =
     first renderStoreError <$> action
 
-mutationResultValue :: LearnedSkillMutationResult -> Either Text Value
+mutationResultValue :: LearnedSkillMutationResult
+    -> Either Text LearnedSkillMutationResponse
 mutationResultValue = \case
     LearnedSkillMutationApplied skill ->
-        Right $ object
-            [ "status" .= ("applied" :: Text)
-            , "skill" .= skillValue skill
-            ]
+        Right $ LearnedSkillMutationResponse "applied" (skillValue skill)
     LearnedSkillMutationAlreadyExists ->
         Left
             "a learned skill with this scope and slug already exists; read it and use skill_update"
@@ -271,83 +275,69 @@ mutationResultValue = \case
     LearnedSkillMutationRevisionNotFound ->
         Left "target learned-skill revision not found"
 
-searchResultValue :: LearnedSkillSearchResult -> Value
-searchResultValue result = object
-    [ "skill" .= skillSummaryValue result.learnedSkillSearchSkill
-    , "rank" .= result.learnedSkillSearchRank
-    ]
+searchResultValue :: LearnedSkillSearchResult -> LearnedSkillSearchMatch
+searchResultValue result = LearnedSkillSearchMatch
+    (skillSummaryValue result.learnedSkillSearchSkill)
+    result.learnedSkillSearchRank
 
-skillSummaryValue :: LearnedSkill -> Value
-skillSummaryValue skill = object
-    [ "scope" .= scopeKindText skill.learnedSkillScope.scopeKind
-    , "slug" .= skill.learnedSkillSlug
-    , "title" .= skill.learnedSkillTitle
-    , "description" .= skill.learnedSkillDescription
-    , "applies_when" .= skill.learnedSkillAppliesWhen
-    , "activation" .=
-        learnedSkillActivationText skill.learnedSkillActivation
-    , "priority" .= skill.learnedSkillPriority
-    , "status" .= learnedSkillStatusText skill.learnedSkillStatus
-    , "revision" .= skill.learnedSkillRevision
-    , "updated_at" .= skill.learnedSkillUpdatedAt
-    ]
+skillSummaryValue :: LearnedSkill -> LearnedSkillSummary
+skillSummaryValue skill = LearnedSkillSummary
+    (scopeKindText skill.learnedSkillScope.scopeKind)
+    skill.learnedSkillSlug
+    skill.learnedSkillTitle
+    skill.learnedSkillDescription
+    skill.learnedSkillAppliesWhen
+    (learnedSkillActivationText skill.learnedSkillActivation)
+    (fromIntegral skill.learnedSkillPriority)
+    (learnedSkillStatusText skill.learnedSkillStatus)
+    skill.learnedSkillRevision
+    skill.learnedSkillUpdatedAt
 
-skillValue :: LearnedSkill -> Value
-skillValue skill = object
-    [ "scope" .= scopeKindText skill.learnedSkillScope.scopeKind
-    , "slug" .= skill.learnedSkillSlug
-    , "title" .= skill.learnedSkillTitle
-    , "description" .= skill.learnedSkillDescription
-    , "applies_when" .= skill.learnedSkillAppliesWhen
-    , "instructions" .= skill.learnedSkillInstructions
-    , "activation" .=
-        learnedSkillActivationText skill.learnedSkillActivation
-    , "priority" .= skill.learnedSkillPriority
-    , "status" .= learnedSkillStatusText skill.learnedSkillStatus
-    , "revision" .= skill.learnedSkillRevision
-    , "created_at" .= skill.learnedSkillCreatedAt
-    , "updated_at" .= skill.learnedSkillUpdatedAt
-    ]
+skillValue :: LearnedSkill -> LearnedSkillDetails
+skillValue skill = LearnedSkillDetails
+    (scopeKindText skill.learnedSkillScope.scopeKind)
+    skill.learnedSkillSlug
+    skill.learnedSkillTitle
+    skill.learnedSkillDescription
+    skill.learnedSkillAppliesWhen
+    skill.learnedSkillInstructions
+    (learnedSkillActivationText skill.learnedSkillActivation)
+    (fromIntegral skill.learnedSkillPriority)
+    (learnedSkillStatusText skill.learnedSkillStatus)
+    skill.learnedSkillRevision
+    skill.learnedSkillCreatedAt
+    skill.learnedSkillUpdatedAt
 
-revisionValue :: LearnedSkillRevision -> Value
-revisionValue revision = object
-    [ "revision" .= revision.learnedSkillRevisionNumber
-    , "title" .= revision.learnedSkillRevisionTitle
-    , "description" .= revision.learnedSkillRevisionDescription
-    , "applies_when" .= revision.learnedSkillRevisionAppliesWhen
-    , "activation" .=
-        learnedSkillActivationText
-            revision.learnedSkillRevisionActivation
-    , "priority" .= revision.learnedSkillRevisionPriority
-    , "status" .=
-        learnedSkillStatusText revision.learnedSkillRevisionStatus
-    , "change_summary" .= revision.learnedSkillRevisionSummary
-    , "created_at" .= revision.learnedSkillRevisionCreatedAt
-    ]
+revisionValue :: LearnedSkillRevision -> LearnedSkillRevisionSummary
+revisionValue revision = LearnedSkillRevisionSummary
+    revision.learnedSkillRevisionNumber
+    revision.learnedSkillRevisionTitle
+    revision.learnedSkillRevisionDescription
+    revision.learnedSkillRevisionAppliesWhen
+    (learnedSkillActivationText revision.learnedSkillRevisionActivation)
+    (fromIntegral revision.learnedSkillRevisionPriority)
+    (learnedSkillStatusText revision.learnedSkillRevisionStatus)
+    revision.learnedSkillRevisionSummary
+    revision.learnedSkillRevisionCreatedAt
 
-revisionDetailValue :: LearnedSkillRevision -> Value
-revisionDetailValue revision = object
-    [ "revision" .= revision.learnedSkillRevisionNumber
-    , "title" .= revision.learnedSkillRevisionTitle
-    , "description" .= revision.learnedSkillRevisionDescription
-    , "applies_when" .= revision.learnedSkillRevisionAppliesWhen
-    , "instructions" .= revision.learnedSkillRevisionInstructions
-    , "activation" .=
-        learnedSkillActivationText
-            revision.learnedSkillRevisionActivation
-    , "priority" .= revision.learnedSkillRevisionPriority
-    , "status" .=
-        learnedSkillStatusText revision.learnedSkillRevisionStatus
-    , "change_summary" .= revision.learnedSkillRevisionSummary
-    , "created_at" .= revision.learnedSkillRevisionCreatedAt
-    ]
+revisionDetailValue :: LearnedSkillRevision -> LearnedSkillRevisionDetails
+revisionDetailValue revision = LearnedSkillRevisionDetails
+    revision.learnedSkillRevisionNumber
+    revision.learnedSkillRevisionTitle
+    revision.learnedSkillRevisionDescription
+    revision.learnedSkillRevisionAppliesWhen
+    revision.learnedSkillRevisionInstructions
+    (learnedSkillActivationText revision.learnedSkillRevisionActivation)
+    (fromIntegral revision.learnedSkillRevisionPriority)
+    (learnedSkillStatusText revision.learnedSkillRevisionStatus)
+    revision.learnedSkillRevisionSummary
+    revision.learnedSkillRevisionCreatedAt
 
-sourceValue :: LearnedSkillSource -> Value
-sourceValue source = object
-    [ "revision" .= source.learnedSkillSourceRevision
-    , "session_id" .= source.learnedSkillSourceSessionKey
-    , "turn_index" .= source.learnedSkillSourceTurnIndex
-    , "response_item_id" .= source.learnedSkillSourceResponseItemId
-    , "evidence" .= source.learnedSkillSourceEvidence
-    , "created_at" .= source.learnedSkillSourceCreatedAt
-    ]
+sourceValue :: LearnedSkillSource -> LearnedSkillSourceDetails
+sourceValue source = LearnedSkillSourceDetails
+    source.learnedSkillSourceRevision
+    source.learnedSkillSourceSessionKey
+    source.learnedSkillSourceTurnIndex
+    source.learnedSkillSourceResponseItemId
+    source.learnedSkillSourceEvidence
+    source.learnedSkillSourceCreatedAt

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -33,14 +33,12 @@ import Control.Exception.Safe (SomeException, displayException, tryAny)
 import Control.Monad (filterM)
 import Data.Aeson
     ( FromJSON(..)
-    , Object
     , Value(..)
     , withObject
     , (.:)
     , (.:?)
     , (.!=)
     )
-import Data.Aeson.Key (Key)
 import System.OsPath (OsPath, unsafeEncodeUtf)
 import Data.Aeson.Types (Parser)
 import qualified Data.ByteString as BS
@@ -156,7 +154,6 @@ data Frontmatter = Frontmatter
 
 instance FromJSON Frontmatter where
     parseJSON = withObject "Skill frontmatter" \o -> do
-        allowed <- o .:? "allowed-tools"
         metadata <- o .:? "metadata" .!= Map.empty
         Frontmatter
             <$> o .: "name"
@@ -166,7 +163,7 @@ instance FromJSON Frontmatter where
             <*> o .:? "argument-hint"
             <*> (o .:? "user-invocable" .!= True)
             <*> (o .:? "disable-model-invocation" .!= False)
-            <*> parseAllowedTools allowed
+            <*> ((.unAllowedTools) <$> (o .:? "allowed-tools" .!= AllowedTools []))
             <*> o .:? "model"
             <*> o .:? "effort"
             <*> o .:? "license"
@@ -183,18 +180,44 @@ instance FromJSON SkillContextMode where
                     <> Text.unpack value)
         _ -> fail "activation must be a string"
 
-parseAllowedTools :: Maybe Value -> Parser [Text]
-parseAllowedTools = \case
-    Nothing -> pure []
-    Just (String text) ->
-        pure (filter (not . Text.null) (Text.words (Text.replace "," " " text)))
-    Just (Array values) ->
-        traverse
-            (\case
-                String text -> pure text
-                _ -> fail "allowed-tools entries must be strings")
-            (foldr (:) [] values)
-    Just _ -> fail "allowed-tools must be a string or list of strings"
+newtype AllowedTools = AllowedTools { unAllowedTools :: [Text] }
+
+instance FromJSON AllowedTools where
+    parseJSON = \case
+        String text ->
+            pure $ AllowedTools $
+                filter (not . Text.null)
+                    (Text.words (Text.replace "," " " text))
+        Array values ->
+            AllowedTools <$> traverse
+                (\case
+                    String text -> pure text
+                    _ -> fail "allowed-tools entries must be strings")
+                (foldr (:) [] values)
+        _ -> fail "allowed-tools must be a string or list of strings"
+
+data OpenAiInterface = OpenAiInterface
+    { interfaceDisplayName :: !(Maybe Text)
+    , interfaceShortDescription :: !(Maybe Text)
+    , interfaceDefaultPrompt :: !(Maybe Text)
+    , interfaceArgumentHint :: !(Maybe Text)
+    }
+
+instance FromJSON OpenAiInterface where
+    parseJSON = withObject "agents/openai.yaml interface" \o ->
+        OpenAiInterface
+            <$> o .:? "display_name"
+            <*> o .:? "short_description"
+            <*> o .:? "default_prompt"
+            <*> o .:? "argument_hint"
+
+newtype OpenAiPolicy = OpenAiPolicy
+    { policyAllowImplicitInvocation :: Maybe Bool
+    }
+
+instance FromJSON OpenAiPolicy where
+    parseJSON = withObject "agents/openai.yaml policy" \o ->
+        OpenAiPolicy <$> o .:? "allow_implicit_invocation"
 
 data OpenAiMetadata = OpenAiMetadata
     { openAiDisplayName :: !(Maybe Text)
@@ -206,24 +229,17 @@ data OpenAiMetadata = OpenAiMetadata
 
 instance FromJSON OpenAiMetadata where
     parseJSON = withObject "agents/openai.yaml" \o -> do
-        interface <- o .:? "interface"
-        policy <- o .:? "policy"
-        let interfaceFields = interface >>= valueObject
-            policyFields = policy >>= valueObject
-        OpenAiMetadata
-            <$> optionalField interfaceFields "display_name"
-            <*> optionalField interfaceFields "short_description"
-            <*> optionalField interfaceFields "default_prompt"
-            <*> optionalField interfaceFields "argument_hint"
-            <*> optionalField policyFields "allow_implicit_invocation"
-
-valueObject :: Value -> Maybe Object
-valueObject (Object fields) = Just fields
-valueObject _ = Nothing
-
-optionalField :: FromJSON a => Maybe Object -> Key -> Parser (Maybe a)
-optionalField fields key =
-    maybe (pure Nothing) (\object -> object .:? key) fields
+        interface <- (o .:? "interface" :: Parser (Maybe OpenAiInterface))
+        policy <- (o .:? "policy" :: Parser (Maybe OpenAiPolicy))
+        pure OpenAiMetadata
+            { openAiDisplayName = interface >>= (.interfaceDisplayName)
+            , openAiShortDescription =
+                interface >>= (.interfaceShortDescription)
+            , openAiDefaultPrompt = interface >>= (.interfaceDefaultPrompt)
+            , openAiArgumentHint = interface >>= (.interfaceArgumentHint)
+            , openAiAllowImplicit =
+                policy >>= (.policyAllowImplicitInvocation)
+            }
 
 defaultSkillCatalogMaxChars :: Int
 defaultSkillCatalogMaxChars = 8000

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Items.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Items.hs
@@ -14,6 +14,7 @@ module Agent.Responses.Types.Items
     , CustomToolCallOutput(..)
     , ReasoningItem(..)
     , ReasoningSummaryPart(..)
+    , reasoningSummaryPartDecoder
     , ItemReference(..)
     , ResponseAgentMessage(..)
     , InternalChatMetadata(..)

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Streaming.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Streaming.hs
@@ -13,7 +13,12 @@ module Agent.Responses.Types.Streaming
     ) where
 
 import Agent.Responses.Types.Common
-import Agent.Responses.Types.Items (ResponseItem, responseItemDecoder)
+import Agent.Responses.Types.Items
+    ( ReasoningSummaryPart
+    , ResponseItem
+    , reasoningSummaryPartDecoder
+    , responseItemDecoder
+    )
 import Agent.Responses.Types.Response (Response, responseDecoder)
 import Data.Aeson hiding (TaggedObject)
 import qualified Data.Hermes as Hermes
@@ -356,7 +361,7 @@ data ResponseStreamEvent
         { streamItemId      :: !(Maybe Text)
         , streamOutputIndex :: !(Maybe Int)
         , summaryIndex      :: !(Maybe Int)
-        , partValue         :: !(Maybe RawJson)
+        , partValue         :: !(Maybe ReasoningSummaryPart)
         , sequenceNumber    :: !(Maybe Int)
 
         }
@@ -615,7 +620,7 @@ eventDecoder wireType = Hermes.object do
                 <$> optionalAtKey "item_id" Hermes.text
                 <*> optionalAtKey "output_index" Hermes.int
                 <*> optionalAtKey "summary_index" Hermes.int
-                <*> optionalAtKey "part" rawJsonDecoder
+                <*> optionalAtKey "part" reasoningSummaryPartDecoder
                 <*> pure sequenceNumber
         EventReasoningSummaryTextDone ->
             ResponseReasoningSummaryTextDoneEvent

--- a/packages/agent-store/src/Agent/Store/Custom/QueryResult.hs
+++ b/packages/agent-store/src/Agent/Store/Custom/QueryResult.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Boundary encoding for arbitrary custom-query result rows.
+-- | Text rendering for arbitrary custom-query result rows.
 --
--- Unlike harness-owned records, the columns returned by a user query are not
--- known when the Haskell statement is compiled. This adapter turns that
--- dynamic row shape into one opaque result payload for the CLI boundary.
+-- Hasql decoders require a statically known result shape, while user queries
+-- select columns dynamically. PostgreSQL therefore renders each row into one
+-- labeled text value that Hasql can decode without exposing JSON at the store
+-- boundary.
 module Agent.Store.Custom.QueryResult
     ( CustomQueryResult(..)
     , customQueryStatement
@@ -20,7 +21,7 @@ import Hasql.Statement (Statement)
 import qualified Hasql.Statement as Statement
 
 data CustomQueryResult = CustomQueryResult
-    { customQueryRows :: !Text
+    { customQueryOutput :: !Text
     , customQueryTruncated :: !Bool
     }
     deriving (Eq, Show)
@@ -35,10 +36,18 @@ customQueryStatement rowCap query =
     cap = Text.pack (show rowCap)
     capPlusOne = Text.pack (show overflowCap)
     sql =
-        "select coalesce(jsonb_agg("
-            <> "q._ha_row order by q._ha_row_number"
-            <> ") filter (where q._ha_row_number <= " <> cap
-            <> "), '[]'::jsonb)::text,"
+        "select coalesce(string_agg("
+            <> "'row ' || q._ha_row_number::text || E':\n' || "
+            <> "coalesce((select string_agg("
+            <> "'  ' || field.key || ': ' || "
+            <> "replace(coalesce(field.value #>> '{}', 'null'), "
+            <> "E'\n', E'\n    '), E'\n' "
+            <> "order by field.key) "
+            <> "from jsonb_each(q._ha_row) as field), "
+            <> "'  (empty row)'), "
+            <> "E'\n\n' order by q._ha_row_number) "
+            <> "filter (where q._ha_row_number <= " <> cap <> "), "
+            <> "'(no rows)'),"
             <> " coalesce(max(q._ha_row_number), 0) > " <> cap
             <> " from ("
             <> "select to_jsonb(_ha_data) as _ha_row, "

--- a/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
@@ -155,7 +155,7 @@ queryCustom scopePool database limits rawQuery =
                 Left err -> pure (Left err)
                 Right (Left err) -> pure (Left err)
                 Right (Right result)
-                    | encodedSize result.customQueryRows
+                    | encodedSize result.customQueryOutput
                         > limits.queryMaxOutputBytes ->
                         pure $ Left $
                             "database query result exceeds "

--- a/packages/agent-store/test/Agent/Store/Postgres/CustomSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/CustomSpec.hs
@@ -44,7 +44,7 @@ spec = describe "custom PostgreSQL SQL normalization" do
                 , customExecutionWarning = Nothing
                 }
 
-    it "returns typed catalogs and JSON text only at the query boundary" $
+    it "returns typed catalogs and labeled query text" $
         withSystemTempDirectory "ha" \stateDirectory -> do
             let
                 config = defaultManagedPostgresConfig stateDirectory ""
@@ -125,9 +125,12 @@ spec = describe "custom PostgreSQL SQL normalization" do
                                                             (\queryResult ->
                                                                 not
                                                                     queryResult.customQueryTruncated
-                                                                    && "\"title\": \"one\""
+                                                                    && "title: one"
                                                                         `Text.isInfixOf`
-                                                                            queryResult.customQueryRows)
+                                                                            queryResult.customQueryOutput
+                                                                    && not
+                                                                        ("{\"" `Text.isInfixOf`
+                                                                            queryResult.customQueryOutput))
                                                     pure ()
                         )
                         (closeStore store)


### PR DESCRIPTION
## Summary

- replace learned-skill storage callbacks' untyped `Value` payloads with typed DTOs, then render their model-facing results as labeled text
- render database schema, query, and execution results as readable labeled text rather than returning JSON
- type skill frontmatter compatibility fields and streamed reasoning summary parts

Arbitrary SQL has a runtime-defined row shape, while Hasql requires a static decoder. PostgreSQL now collapses those rows directly into one labeled text result, so JSON never crosses the store boundary and the CLI needs no generic value decoder. Learned-skill DTOs likewise remain typed until explicit text rendering; they no longer require `ToJSON` instances.

## Validation

- `nix develop -c cabal repl agent-responses-types:lib:agent-responses-types --repl-options='-e :quit'`
- `nix develop -c cabal repl agent-core:lib:agent-core --repl-options='-e :quit'`
- `nix develop -c cabal repl agent-store:lib:agent-store --repl-options='-e :quit'`
- `nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options='-e :quit'`
- targeted managed-PostgreSQL integration test for labeled arbitrary-query output
- `git diff --check origin/master...HEAD`
