### PR TITLE
Read prompt files as plain text

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/ManagedTurn.hs
+++ b/packages/agent-cli/src/Agent/CLI/ManagedTurn.hs
@@ -8,6 +8,7 @@ module Agent.CLI.ManagedTurn
     , managedTurnRequestWithFiles
     , managedTurnRequestWithGateway
     , renderManagedTurnPrompt
+    , loadTextPrompt
     , loadManagedTurnRequest
     , managedTurnInputs
     ) where
@@ -34,6 +35,7 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.IO as Text
 import System.Directory.OsPath (doesFileExist)
 import System.OsPath (OsPath)
 
@@ -137,6 +139,11 @@ managedTurnRequestWithGateway bridgeDirectory context request =
         { managedTurnBridgeDirectory = Just bridgeDirectory
         , managedTurnContext = Just context
         }
+
+loadTextPrompt :: OsPath -> IO ManagedTurnRequest
+loadTextPrompt path =
+    managedTurnRequestFromText . Text.strip
+        <$> Text.readFile (unsafeToFilePath path)
 
 loadManagedTurnRequest :: OsPath -> IO (Either Text ManagedTurnRequest)
 loadManagedTurnRequest path = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Selection.hs
@@ -15,6 +15,7 @@ import Agent.CLI.AgentViewport
     )
 import Agent.CLI.ManagedTurn
     ( ManagedTurnRequest
+    , loadTextPrompt
     , loadManagedTurnRequest
     , managedTurnRequestFromText
     )
@@ -78,8 +79,7 @@ loadPrompt options =
     of
     (Just text, _, _) ->
         pure (Just (managedTurnRequestFromText (Text.strip text)))
-    (_, Just path, _) ->
-        loadManagedTurnRequest path >>= either (die . Text.unpack) (pure . Just)
+    (_, Just path, _) -> Just <$> loadTextPrompt path
     (_, _, Just path) ->
         loadManagedTurnRequest path >>= either (die . Text.unpack) (pure . Just)
     _ -> pure Nothing

--- a/packages/agent-cli/test/Agent/CLI/ManagedTurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ManagedTurnSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.ManagedTurn
     , ManagedTurnRequest(..)
     , managedTurnInputs
     , managedTurnRequestFromText
+    , loadTextPrompt
     , loadManagedTurnRequest
     , renderManagedTurnPrompt
     )
@@ -29,6 +30,14 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.CLI.ManagedTurn" do
+    it "loads --prompt-file as plain text" $
+        withManagedTempDir \dir -> do
+            let pathFile = dir </> "prompt.txt"
+                path = fromText (Text.pack pathFile)
+            Text.writeFile pathFile "  inspect this project\ncarefully  \n"
+            loadTextPrompt path `shouldReturn`
+                managedTurnRequestFromText "inspect this project\ncarefully"
+
     it "round-trips a prompt-file request through JSON" $
         withManagedTempDir \dir -> do
             let request = managedTurnRequestFromText "hello"


### PR DESCRIPTION
## Summary

- read `--prompt-file` contents as UTF-8 text instead of managed-turn JSON
- preserve the versioned JSON decoder for `--managed-turn-file`
- trim prompt-file contents consistently with inline `-p` prompts
- add focused regression coverage

## Validation

- `Agent.CLI.ManagedTurnSpec`: 4 examples, 0 failures
- end-to-end OpenAI CLI run using `--prompt-file`: `PROMPT_FILE_OK`, exit 0
- `git diff --check`