### PR TITLE
Add composable Nix skill packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ Install [Nix](https://nixos.org/download/) with flakes enabled, then install
 nix profile add github:digitallyinduced/haskell-agent
 ```
 
+The flake also exposes skills as composable Nix packages. NixOS and
+nix-darwin configurations can use the complete built-in bundle without
+copying skill sources into a home directory:
+
+```nix
+environment.sessionVariables.HASKELL_AGENT_BUILTIN_SKILLS =
+  "${inputs.haskell-agent.packages.${pkgs.system}.skills}";
+```
+
+Downstream flakes can build their own skill packages with
+`inputs.haskell-agent.lib.skillsFor pkgs` and combine them with
+`mkSkillBundle`.
+
 ## Run
 
 Start an interactive session:

--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,17 @@
             skylighting,
             ...
         }:
-        flake-utils.lib.eachDefaultSystem (
+        let
+            skillsFor = pkgs: import ./nix/skills.nix { inherit pkgs; };
+        in
+        {
+            lib = { inherit skillsFor; };
+        }
+        // flake-utils.lib.eachDefaultSystem (
             system:
             let
                 pkgs = import nixpkgs { inherit system; };
+                skillLib = skillsFor pkgs;
                 bun_1_4 = pkgs.bun.overrideAttrs (_old: {
                     version = "1.4.0";
                     src = pkgs.fetchurl {
@@ -69,18 +76,18 @@
                     rev = intercom2xSkillsRev;
                     hash = "sha256-zyLCqcygYUKkReLX+UchnhvhFa5Rz3eo+rIaR4wUsSM=";
                 };
-                attachGithubAssetsSkill = pkgs.runCommand
-                    "attach-github-assets-skill-${intercom2xSkillsRev}"
-                    { nativeBuildInputs = [ pkgs.patch ]; }
-                    ''
-                        sourceSkill="${intercom2xSkills}/plugins/pr-tools/skills/attach-github-assets"
-                        targetSkill="$out/attach-github-assets"
-                        mkdir -p "$out"
-                        cp -R "$sourceSkill" "$targetSkill"
-                        chmod -R u+w "$out"
-                        cp "${intercom2xSkills}/LICENSE" "$targetSkill/LICENSE"
-                        patch -l -d "$targetSkill" -p1 < ${./patches/attach-github-assets.patch}
-                    '';
+                attachGithubAssetsSkill = skillLib.mkSkill {
+                    name = "attach-github-assets";
+                    src = intercom2xSkills;
+                    skillPath = "plugins/pr-tools/skills/attach-github-assets";
+                    patches = [ ./patches/attach-github-assets.patch ];
+                    licensePath = "LICENSE";
+                };
+                builtInSkills = [ attachGithubAssetsSkill ];
+                builtInSkillsBundle = skillLib.mkSkillBundle {
+                    name = "haskell-agent-skills";
+                    skills = builtInSkills;
+                };
 
                 agentOpenaiSource = nix-filter.lib {
                     root = ./packages/agent-openai;
@@ -475,7 +482,7 @@
                                 ]).overrideAttrs
                                 (old: {
                                     preCheck = (old.preCheck or "") + ''
-                                        export HASKELL_AGENT_BUILTIN_SKILLS=${attachGithubAssetsSkill}
+                                        export HASKELL_AGENT_BUILTIN_SKILLS=${builtInSkillsBundle}
                                     '';
                                 }));
                         agent-telegram = localPackage (pkgs.haskell.lib.addTestToolDepends
@@ -521,7 +528,7 @@
                                         --set-default AGENT_SYNTAX_DIR \
                                             "${skylightingSyntaxDirectory}" \
                                         --prefix HASKELL_AGENT_BUILTIN_SKILLS : \
-                                            "${attachGithubAssetsSkill}" \
+                                            "${builtInSkillsBundle}" \
                                         --prefix PATH : \
                                             "${pkgs.lib.makeBinPath [
                                                 pkgs.ffmpeg
@@ -689,6 +696,8 @@
                 packages.claude-agent-sdk-haskell = claudeAgentSdkHaskellPackage;
                 packages.agent-claude = agentClaudePackage;
                 packages.agent-openai-login = agentOpenaiExecutables;
+                packages.skills = builtInSkillsBundle;
+                packages.skills-attach-github-assets = attachGithubAssetsSkill;
 
                 apps.default = flake-utils.lib.mkApp {
                     drv = self.packages.${system}.agent-cli;
@@ -733,7 +742,7 @@
                         export AGENT_POSTGRES_BIN=${pkgs.postgresql_18}/bin
                         # Expose nix-fetched built-in skills to GHCi without
                         # copying their upstream files into the checkout.
-                        export HASKELL_AGENT_BUILTIN_SKILLS="${attachGithubAssetsSkill}''${HASKELL_AGENT_BUILTIN_SKILLS:+:$HASKELL_AGENT_BUILTIN_SKILLS}"
+                        export HASKELL_AGENT_BUILTIN_SKILLS="${builtInSkillsBundle}''${HASKELL_AGENT_BUILTIN_SKILLS:+:$HASKELL_AGENT_BUILTIN_SKILLS}"
                         # Development builds embed the nix-fetched Codex catalog
                         # at compile time; provision it into the checkout.
                         if [ -d packages/agent-openai ]; then

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,27 @@
                     hash = "sha256-rIrhB6DXL+NHa0MK+xYepOZ9ouRG13iu/ESCgWBVmAc=";
                 };
 
+                intercom2xSkillsRev =
+                    "59213af0a2db9321ef10355ff24e9bd619151b6b";
+                intercom2xSkills = pkgs.fetchFromGitHub {
+                    owner = "intercom";
+                    repo = "2x-skills";
+                    rev = intercom2xSkillsRev;
+                    hash = "sha256-zyLCqcygYUKkReLX+UchnhvhFa5Rz3eo+rIaR4wUsSM=";
+                };
+                attachGithubAssetsSkill = pkgs.runCommand
+                    "attach-github-assets-skill-${intercom2xSkillsRev}"
+                    { nativeBuildInputs = [ pkgs.patch ]; }
+                    ''
+                        sourceSkill="${intercom2xSkills}/plugins/pr-tools/skills/attach-github-assets"
+                        targetSkill="$out/attach-github-assets"
+                        mkdir -p "$out"
+                        cp -R "$sourceSkill" "$targetSkill"
+                        chmod -R u+w "$out"
+                        cp "${intercom2xSkills}/LICENSE" "$targetSkill/LICENSE"
+                        patch -l -d "$targetSkill" -p1 < ${./patches/attach-github-assets.patch}
+                    '';
+
                 agentOpenaiSource = nix-filter.lib {
                     root = ./packages/agent-openai;
                     include = [
@@ -442,15 +463,21 @@
                                     src = agentStoreSource;
                                 })
                             [ pkgs.postgresql_18 ]);
-                        agent-cli = localPackage (pkgs.haskell.lib.addTestToolDepends
-                            (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-cli/package.nix { }) {
-                                src = agentCliSource;
-                            })
-                            [
-                                pkgs.git
-                                bun_1_4
-                                pkgs.postgresql_18
-                            ]);
+                        agent-cli = localPackage (
+                            (pkgs.haskell.lib.addTestToolDepends
+                                (pkgs.haskell.lib.overrideSrc
+                                    (final.callPackage ./packages/agent-cli/package.nix { })
+                                    { src = agentCliSource; })
+                                [
+                                    pkgs.git
+                                    bun_1_4
+                                    pkgs.postgresql_18
+                                ]).overrideAttrs
+                                (old: {
+                                    preCheck = (old.preCheck or "") + ''
+                                        export HASKELL_AGENT_BUILTIN_SKILLS=${attachGithubAssetsSkill}
+                                    '';
+                                }));
                         agent-telegram = localPackage (pkgs.haskell.lib.addTestToolDepends
                             (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-telegram/package.nix { }) {
                                 src = agentTelegramSource;
@@ -493,6 +520,8 @@
                                     wrapProgram "$out/bin/agent-cli" \
                                         --set-default AGENT_SYNTAX_DIR \
                                             "${skylightingSyntaxDirectory}" \
+                                        --prefix HASKELL_AGENT_BUILTIN_SKILLS : \
+                                            "${attachGithubAssetsSkill}" \
                                         --prefix PATH : \
                                             "${pkgs.lib.makeBinPath [
                                                 pkgs.ffmpeg
@@ -702,6 +731,9 @@
                     shellHook = ''
                         export AGENT_SYNTAX_DIR=${skylightingSyntaxDirectory}
                         export AGENT_POSTGRES_BIN=${pkgs.postgresql_18}/bin
+                        # Expose nix-fetched built-in skills to GHCi without
+                        # copying their upstream files into the checkout.
+                        export HASKELL_AGENT_BUILTIN_SKILLS="${attachGithubAssetsSkill}''${HASKELL_AGENT_BUILTIN_SKILLS:+:$HASKELL_AGENT_BUILTIN_SKILLS}"
                         # Development builds embed the nix-fetched Codex catalog
                         # at compile time; provision it into the checkout.
                         if [ -d packages/agent-openai ]; then

--- a/nix/skills.nix
+++ b/nix/skills.nix
@@ -1,0 +1,55 @@
+{ pkgs }:
+
+let
+  inherit (pkgs) lib;
+in
+{
+  # Build one Agent Skill as a store path whose immediate children are skills.
+  # The source may be a fetched repository; skillPath selects the skill within it.
+  mkSkill =
+    {
+      name,
+      src,
+      skillPath ? ".",
+      patches ? [ ],
+      licensePath ? null,
+      postPatch ? "",
+    }:
+    pkgs.runCommand "${name}-skill"
+      {
+        nativeBuildInputs = lib.optional (patches != [ ]) pkgs.patch;
+      }
+      ''
+        sourceSkill="${src}/${skillPath}"
+        targetSkill="$out/${name}"
+
+        if [ ! -f "$sourceSkill/SKILL.md" ]; then
+          echo "mkSkill: missing $sourceSkill/SKILL.md" >&2
+          exit 1
+        fi
+
+        mkdir -p "$out"
+        cp -R "$sourceSkill" "$targetSkill"
+        chmod -R u+w "$targetSkill"
+        ${lib.concatMapStringsSep "\n" (patch: ''
+          patch -l -d "$targetSkill" -p1 < ${patch}
+        '') patches}
+        ${lib.optionalString (licensePath != null) ''
+          cp "${src}/${licensePath}" "$targetSkill/LICENSE"
+        ''}
+        ${lib.optionalString (postPatch != "") ''
+          (cd "$targetSkill"; ${postPatch})
+        ''}
+      '';
+
+  # Merge independently built skill roots into one root consumable by the agent.
+  mkSkillBundle =
+    {
+      name ? "agent-skills",
+      skills,
+    }:
+    pkgs.symlinkJoin {
+      inherit name;
+      paths = skills;
+    };
+}

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -30,7 +30,7 @@ import Agent.CLI.Terminal (resolveColor)
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Skills
 import Agent.Tools.Types (ToolEnv, setToolSkillRoots)
-import Control.Monad (void, when)
+import Control.Monad (filterM, void, when)
 import Data.IORef (IORef, modifyIORef', writeIORef)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -80,15 +80,25 @@ loadSkillsCatalogQuiet
 loadSkillsCatalogQuiet options home projectRoot cwd
     | not options.optSkills = pure (SkillCatalog [] [])
     | otherwise = do
-        builtinRoot <- packagedSkillsRoot cwd
+        builtinRoots <- packagedSkillsRoots cwd
         discoverSkills SkillDiscoverOptions
             { skillsHome = home
             , skillsProjectRoot = projectRoot
             , skillsCwd = cwd
             , skillsMaxDepth = 6
             , skillsBuiltinRoots =
-                [(AgentSkills, unsafeEncodeUtf builtinRoot)]
+                [ (AgentSkills, unsafeEncodeUtf root)
+                | root <- builtinRoots
+                ]
             }
+
+packagedSkillsRoots :: OsPath -> IO [FilePath]
+packagedSkillsRoots cwd = do
+    packagedRoot <- packagedSkillsRoot cwd
+    externalRoots <-
+        maybe [] FilePath.splitSearchPath
+            <$> Environment.lookupEnv "HASKELL_AGENT_BUILTIN_SKILLS"
+    filterM Directory.doesDirectoryExist (packagedRoot : externalRoots)
 
 packagedSkillsRoot :: OsPath -> IO FilePath
 packagedSkillsRoot cwd = do

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -76,6 +76,20 @@ spec = describe "Agent.CLI.Skills" do
         map (.skillScope) matching `shouldBe` [BuiltinSkill]
         map (.skillModelInvocable) matching `shouldBe` [True]
 
+    it "loads the Nix-provided GitHub asset attachment skill" do
+        catalog <- loadSkillsCatalog
+            defaultCliOptions
+            (fromFilePath "/tmp")
+            (fromFilePath "/tmp")
+            (fromFilePath "/tmp")
+            False
+        let matching =
+                filter ((== "attach-github-assets") . (.skillName))
+                    catalog.catalogSkills
+        map (.skillScope) matching `shouldBe` [BuiltinSkill]
+        map (.skillModelInvocable) matching `shouldBe` [True]
+        map (.skillUserInvocable) matching `shouldBe` [True]
+
     it "loads the packaged learn-about-user skill" do
         catalog <- loadSkillsCatalog
             defaultCliOptions

--- a/patches/attach-github-assets.patch
+++ b/patches/attach-github-assets.patch
@@ -1,0 +1,39 @@
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -1,11 +1,10 @@
+ ---
+ name: attach-github-assets
+ description: Upload local files (screenshots, screen recordings, images, videos) to GitHub as user-attachment assets and return markdown-ready URLs for PR descriptions, issue bodies, or PR/issue comments.
++argument-hint: "<file-path> [additional-file-paths...]"
++user-invocable: true
+ metadata:
+-  user-invocable: true
+-  argument-hint: "<file-path> [additional-file-paths...]"
+-  keywords:
+-    - pr-image
++  keywords: pr-image
+ allowed-tools: Bash Read Glob
+ ---
+
+@@ -51,15 +50,18 @@
+ ### Step 2: Run the upload script — once per file
+
+ ```bash
+-${CLAUDE_PLUGIN_ROOT}/skills/attach-github-assets/scripts/upload.sh "<file-path>"
++bash "<skill_directory>/scripts/upload.sh" "<file-path>"
+ ```
+
+-The script auto-detects the repo ID from `git remote` and MIME type from extension. Returns the asset URL on stdout, exits non-zero on failure.
++Use the absolute `skill_directory` returned by `view_skill`; do not use the
++literal placeholder. The script auto-detects the repo ID from `git remote` and
++MIME type from extension. Returns the asset URL on stdout, exits non-zero on
++failure.
+
+ To override repo ID (e.g. uploading from a worktree whose remote isn't the target repo):
+
+ ```bash
+-${CLAUDE_PLUGIN_ROOT}/skills/attach-github-assets/scripts/upload.sh "<file-path>" <repo_id>
++bash "<skill_directory>/scripts/upload.sh" "<file-path>" <repo_id>
+ ```
+
+ Run the script **once per file** — never batch into a single invocation, never substitute `curl` or a different upload mechanism.


### PR DESCRIPTION
## Summary

- add reusable `mkSkill` and `mkSkillBundle` Nix helpers, exposed through `flake.lib.skillsFor`
- expose the complete built-in bundle as `packages.<system>.skills` and individual skills as separate flake packages
- fetch Intercom's `attach-github-assets` skill from a pinned `2x-skills` revision and fixed hash
- apply a small harness-compatibility patch during the Nix build instead of vendoring upstream files
- discover additional built-in skill roots through `HASKELL_AGENT_BUILTIN_SKILLS`
- document composition from NixOS and nix-darwin configurations
- keep skills entirely outside Cabal data files and the source checkout

Upstream: https://github.com/intercom/2x-skills/tree/main/plugins/pr-tools/skills/attach-github-assets

## Validation

- `nix flake show --no-write-lock-file`
- `nix build .#skills .#skills-attach-github-assets --no-link`
- `nix build .#checks.aarch64-darwin.agent-cli --no-link`
- `printf ':main --match "GitHub asset attachment"\\n:q\\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test`
