### PR TITLE
Add remote HTTP MCP transport and OAuth foundations

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -56,3 +56,25 @@ protected-resource discovery, authorization-server discovery, dynamic client
 registration, and refresh-token exchange are available in the MCP OAuth layer.
 Until the interactive PKCE login UI is wired in, an access token can be supplied
 as the redacted `MCP_ACCESS_TOKEN` environment entry.
+
+### OAuth token refresh
+
+Remote servers can point `env.MCP_OAUTH_TOKEN_FILE` at a private JSON token
+record:
+
+```json
+{
+  "client_id": "registered-public-client-id",
+  "token_endpoint": "https://example.com/oauth/token",
+  "access_token": "...",
+  "refresh_token": "...",
+  "expires_at": null
+}
+```
+
+The access token is loaded for each request. If the server returns `401`, the
+client takes an in-process and cross-process exclusive refresh lock, re-reads
+the record, exchanges its refresh token, atomically persists the new access
+and rotated refresh tokens with mode `0600`, and retries the MCP request once.
+A failed refresh returns an actionable error instead of repeatedly attempting
+the authorization flow.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -35,3 +35,24 @@ Enabled servers are shared with subagents. Only tools explicitly annotated
 `server__tool`. Progressive startup exposes `mcp_search` and `mcp_call` while
 servers connect, then publishes each server's read-only catalog. Failed stdio
 transports are restarted once before a progressive call is retried.
+
+## Remote Streamable HTTP servers
+
+Remote MCP endpoints use `url` instead of `command`:
+
+```json
+{
+  "mcpServers": {
+    "remote": {
+      "url": "https://example.com/mcp",
+      "env": { "MCP_ACCESS_TOKEN": "..." }
+    }
+  }
+}
+```
+
+The client preserves the `Mcp-Session-Id` returned by initialization. OAuth
+protected-resource discovery, authorization-server discovery, dynamic client
+registration, and refresh-token exchange are available in the MCP OAuth layer.
+Until the interactive PKCE login UI is wired in, an access token can be supplied
+as the redacted `MCP_ACCESS_TOKEN` environment entry.

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -153,6 +153,7 @@ library
                     , Agent.CLI.Command
                     , Agent.CLI.Config
                     , Agent.CLI.CredentialStore
+                    , Agent.CLI.McpOAuthStore
                     , Agent.CLI.Database
                     , Agent.CLI.Database.Store
                     , Agent.CLI.Database.Storage

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -154,6 +154,7 @@ library
                     , Agent.CLI.Config
                     , Agent.CLI.CredentialStore
                     , Agent.CLI.McpOAuthStore
+                    , Agent.CLI.McpOAuth
                     , Agent.CLI.Database
                     , Agent.CLI.Database.Store
                     , Agent.CLI.Database.Storage
@@ -257,7 +258,9 @@ library
                     , bytestring
                     , colour >= 2.3
                     , containers
+                    , crypton
                     , directory
+                    , entropy
                     , filelock
                     , filepath
                     , haskeline >= 0.8 && < 0.9
@@ -267,6 +270,7 @@ library
                     , hasql-pool >= 1.3 && < 2
                     , JuicyPixels
                     , mtl
+                    , memory
                     , network
                     , network-uri
                     , optparse-applicative >= 0.18 && < 0.19

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -3,12 +3,12 @@
 , agent-openrouter, agent-process, agent-responses
 , agent-responses-types, agent-store, agent-syntax, agent-tui
 , agent-xai, ansi-terminal, async, base, base64-bytestring, brick
-, bytestring, colour, containers, deepseq, directory, filelock
-, filepath, haskeline, hasql-pool, hspec, http-client
-, http-client-tls, http-types, JuicyPixels, lib, mtl, network
-, network-uri, optparse-applicative, process, QuickCheck, retry
-, safe-exceptions, scientific, stm, tagsoup, text, time
-, transformers, unix, vector, vty, vty-crossplatform
+, bytestring, colour, containers, crypton, deepseq, directory
+, entropy, filelock, filepath, haskeline, hasql-pool, hspec
+, http-client, http-client-tls, http-types, JuicyPixels, lib
+, memory, mtl, network, network-uri, optparse-applicative, process
+, QuickCheck, retry, safe-exceptions, scientific, stm, tagsoup
+, text, time, transformers, unix, vector, vty, vty-crossplatform
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -22,11 +22,12 @@ mkDerivation {
     agent-grok-build-dialect agent-json agent-openai agent-openrouter
     agent-process agent-responses agent-responses-types agent-store
     agent-syntax agent-tui agent-xai ansi-terminal async base
-    base64-bytestring brick bytestring colour containers directory
-    filelock filepath haskeline hasql-pool http-client http-client-tls
-    http-types JuicyPixels mtl network network-uri optparse-applicative
-    process retry safe-exceptions scientific stm tagsoup text time
-    transformers unix vector vty vty-crossplatform
+    base64-bytestring brick bytestring colour containers crypton
+    directory entropy filelock filepath haskeline hasql-pool
+    http-client http-client-tls http-types JuicyPixels memory mtl
+    network network-uri optparse-applicative process retry
+    safe-exceptions scientific stm tagsoup text time transformers unix
+    vector vty vty-crossplatform
   ];
   executableHaskellDepends = [
     aeson agent-responses agent-responses-types agent-store base

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -56,10 +56,11 @@ defaultLspStartupTimeoutMilliseconds = 15000
 defaultLspShutdownTimeoutMilliseconds :: Int
 defaultLspShutdownTimeoutMilliseconds = 5000
 
--- | One local stdio MCP server. Environment values are intentionally kept
+-- | One local stdio or remote HTTP MCP server. Environment values are intentionally kept
 -- opaque: callers must not include them in diagnostics.
 data McpServerConfig = McpServerConfig
     { mcpEnabled :: !Bool
+    , mcpUrl :: !(Maybe Text)
     , mcpCommand :: !Text
     , mcpArgs :: ![Text]
     , mcpCwd :: !(Maybe Text)
@@ -159,6 +160,8 @@ instance Show McpServerConfig where
     show server =
         "McpServerConfig { mcpEnabled = "
             <> show server.mcpEnabled
+            <> ", mcpUrl = "
+            <> show server.mcpUrl
             <> ", mcpCommand = "
             <> show server.mcpCommand
             <> ", mcpArgs = "
@@ -177,6 +180,7 @@ instance Aeson.ToJSON McpServerConfig where
     toJSON server =
         Aeson.object
             [ "enabled" Aeson..= server.mcpEnabled
+            , "url" Aeson..= server.mcpUrl
             , "command" Aeson..= server.mcpCommand
             , "args" Aeson..= server.mcpArgs
             , "cwd" Aeson..= server.mcpCwd
@@ -267,7 +271,8 @@ mcpServerConfigDecoder =
     Hermes.object $
         McpServerConfig
             <$> defaultKey True "enabled" Hermes.bool
-            <*> Hermes.atKey "command" Hermes.text
+            <*> optionalKey "url" Hermes.text
+            <*> defaultKey "" "command" Hermes.text
             <*> defaultKey [] "args" (Hermes.list Hermes.text)
             <*> optionalKey "cwd" Hermes.text
             <*> defaultKey Map.empty "env" textMapDecoder
@@ -439,8 +444,10 @@ validateHarnessConfig config = do
     validateServer label server = do
         when (Text.null (Text.strip label)) $
             Left "MCP server label must not be empty"
-        when (Text.null (Text.strip server.mcpCommand)) $
-            Left ("MCP server " <> quote label <> " has an empty command")
+        let hasUrl = maybe False (not . Text.null . Text.strip) server.mcpUrl
+            hasCommand = not (Text.null (Text.strip server.mcpCommand))
+        when (hasUrl == hasCommand) $
+            Left ("MCP server " <> quote label <> " must configure exactly one of url or command")
         when (server.mcpStartupTimeoutSeconds < 1) $
             Left
                 ( "MCP server "

--- a/packages/agent-cli/src/Agent/CLI/McpManager.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager.hs
@@ -313,6 +313,7 @@ promptNewServer config =
                                     ( label
                                     , McpServerConfig
                                         { mcpEnabled = True
+                                        , mcpUrl = Nothing
                                         , mcpCommand = command
                                         , mcpArgs = arguments
                                         , mcpCwd = Nothing

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Agent.CLI.McpOAuth
+    ( loginMcp
+    , logoutMcp
+    ) where
+
+import Agent.CLI.McpOAuthStore (mcpOAuthStorePath, saveMcpOAuth)
+import qualified Agent.MCP.OAuth as OAuth
+import Crypto.Hash (Digest, SHA256, hash)
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Base64.URL as Base64
+import qualified Data.ByteString.Lazy as LBS
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Encoding
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Types.URI (urlEncode)
+import Network.Socket
+    ( AddrInfo(..), Socket, SockAddr(..), SocketType(Stream), accept, bind, close
+    , defaultHints, defaultProtocol, getAddrInfo, getSocketName, listen
+    , setSocketOption, socket, SocketOption(ReuseAddr)
+    )
+import qualified Network.Socket.ByteString as Socket
+import qualified System.Directory.OsPath as Dir
+import qualified System.Entropy
+import System.Exit (ExitCode(..))
+import System.Process (rawSystem)
+import System.Timeout (timeout)
+import Control.Exception.Safe (bracket, tryAny)
+import Control.Monad (when)
+
+loginMcp :: Text -> IO ()
+loginMcp serverUrl = do
+    manager <- newTlsManager
+    resource <- OAuth.discoverProtectedResource manager serverUrl >>= either failText pure
+    authIssuer <- case resource.authorizationServers of
+        issuer : _ -> pure issuer
+        [] -> failText "MCP OAuth metadata did not advertise an authorization server"
+    metadata <- OAuth.discoverAuthorizationServer manager authIssuer >>= either failText pure
+    bracket (openCallbackSocket) close $ \listener -> do
+        port <- callbackPort listener
+        let redirect = "http://127.0.0.1:" <> Text.pack (show port) <> "/callback"
+        registration <- case metadata.registrationEndpoint of
+            Nothing -> pure (OAuth.ClientRegistration "mcp-client" Nothing)
+            Just endpoint ->
+                OAuth.registerClient manager endpoint [redirect] metadata.scopesSupportedByServer
+                    >>= either failText pure
+        verifier <- randomUrlBytes 32
+        state <- randomUrlBytes 24
+        let challenge = Base64.encodeUnpadded (BA.convert (hash (Encoding.encodeUtf8 verifier) :: Digest SHA256))
+            scope = Text.unwords metadata.scopesSupportedByServer
+            authUrl = metadata.authorizationEndpoint
+                <> "?response_type=code&client_id=" <> encode registration.clientId
+                <> "&redirect_uri=" <> encode redirect
+                <> "&code_challenge=" <> Encoding.decodeUtf8 challenge
+                <> "&code_challenge_method=S256&state=" <> encode state
+                <> if Text.null scope then "" else "&scope=" <> encode scope
+        putStrLn ("Opening browser for MCP authorization: " <> Text.unpack authUrl)
+        _ <- openBrowser authUrl
+        callback <- timeout (5 * 60 * 1000000) (receiveCallback listener)
+            >>= maybe (failText "Timed out waiting for MCP OAuth callback") pure
+        when (callback.state /= Just state) (failText "MCP OAuth callback state mismatch")
+        code <- maybe (failText "MCP OAuth callback did not contain an authorization code") pure callback.code
+        OAuth.exchangeAuthorizationCode manager metadata.tokenEndpoint registration.clientId code redirect verifier
+            >>= \case
+                OAuth.OAuthTokenFailure err -> failText err
+                OAuth.OAuthTokenSuccess tokens -> do
+                    now <- round <$> getPOSIXTime
+                    let tokenFile = OAuth.OAuthTokenFile
+                            registration.clientId metadata.tokenEndpoint tokens.accessToken
+                            (fromMaybe "" tokens.refreshToken)
+                            (fmap (\seconds -> now + seconds) tokens.expiresIn)
+                    when (Text.null tokenFile.tokenRefreshToken) $
+                        putStrLn "Warning: MCP provider returned no refresh token; reauthorization may be required."
+                    saveMcpOAuth serverUrl tokenFile >>= either failText (const (putStrLn "MCP authorization saved."))
+
+logoutMcp :: Text -> IO ()
+logoutMcp server = do
+    home <- Dir.getHomeDirectory
+    let path = mcpOAuthStorePath home server
+    exists <- Dir.doesFileExist path
+    when exists (Dir.removeFile path)
+
+data Callback = Callback { code :: Maybe Text, state :: Maybe Text }
+
+openCallbackSocket :: IO Socket
+openCallbackSocket = do
+    addr : _ <- getAddrInfo (Just defaultHints { addrSocketType = Stream }) (Just "127.0.0.1") (Just "0")
+    sock <- socket (addrFamily addr) Stream defaultProtocol
+    setSocketOption sock ReuseAddr 1
+    bind sock (addrAddress addr)
+    listen sock 1
+    pure sock
+
+callbackPort :: Socket -> IO Int
+callbackPort sock = do
+    SockAddrInet port _ <- getSocketName sock
+    pure (fromIntegral port)
+
+receiveCallback :: Socket -> IO Callback
+receiveCallback listener = bracket (fst <$> accept listener) close $ \sock -> do
+    bytes <- Socket.recv sock 8192
+    let requestLine = case BS8.lines bytes of line : _ -> line; _ -> ""
+        target = case BS8.words requestLine of _method : path : _ -> path; _ -> "/"
+        query = snd (BS.break (== 63) target)
+        params = parseQuery (BS.drop 1 query)
+        response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: "
+            <> Encoding.encodeUtf8 (Text.pack (show (LBS.length OAuth.oauthCallbackSuccessPage)))
+            <> "\r\nConnection: close\r\n\r\n" <> LBS.toStrict OAuth.oauthCallbackSuccessPage
+    Socket.sendAll sock response
+    pure Callback { code = lookup "code" params, state = lookup "state" params }
+
+parseQuery :: BS.ByteString -> [(Text, Text)]
+parseQuery raw = map parsePair (filter (not . BS.null) (BS.split 38 raw))
+  where
+    parsePair item =
+        let (key, value) = BS.break (== 61) item
+        in (decode key, decode (BS.drop 1 value))
+    decode = Encoding.decodeUtf8 . urlDecode
+    urlDecode = BS.concat . go
+    go input = case BS.uncons input of
+        Nothing -> []
+        Just (37, a) -> case BS.uncons a of
+            Just (x, b) -> case BS.uncons b of
+                Just (y, rest) -> maybe [BS.singleton 37] (\v -> [BS.singleton v]) (hex x y) <> go rest
+                _ -> [BS.singleton 37] <> go a
+            _ -> [BS.singleton 37] <> go a
+        Just (43, rest) -> BS.singleton 32 : go rest
+        Just (x, rest) -> BS.singleton x : go rest
+    hex x y = do
+        a <- digit x
+        b <- digit y
+        pure (a * 16 + b)
+    digit c
+        | c >= 48 && c <= 57 = Just (c - 48)
+        | c >= 65 && c <= 70 = Just (c - 55)
+        | c >= 97 && c <= 102 = Just (c - 87)
+        | otherwise = Nothing
+
+randomUrlBytes :: Int -> IO Text
+randomUrlBytes n = do
+    bytes <- System.Entropy.getEntropy n
+    pure (Encoding.decodeUtf8 (Base64.encodeUnpadded bytes))
+
+encode :: Text -> Text
+encode = Encoding.decodeUtf8 . urlEncode True . Encoding.encodeUtf8
+
+openBrowser :: Text -> IO Bool
+openBrowser url = do
+    result <- tryAny (rawSystem "open" [Text.unpack url])
+    case result of
+        Right ExitSuccess -> pure True
+        _ -> do
+            result' <- tryAny (rawSystem "xdg-open" [Text.unpack url])
+            pure (case result' of Right ExitSuccess -> True; _ -> False)
+
+failText :: Text -> IO a
+failText = ioError . userError . Text.unpack

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -54,19 +54,21 @@ loginMcp serverUrl = do
         state <- randomUrlBytes 24
         let challenge = Base64.encodeUnpadded (BA.convert (hash (Encoding.encodeUtf8 verifier) :: Digest SHA256))
             scope = Text.unwords metadata.scopesSupportedByServer
+            resourceUrl = fromMaybe serverUrl resource.resource
             authUrl = metadata.authorizationEndpoint
                 <> "?response_type=code&client_id=" <> encode registration.clientId
                 <> "&redirect_uri=" <> encode redirect
                 <> "&code_challenge=" <> Encoding.decodeUtf8 challenge
                 <> "&code_challenge_method=S256&state=" <> encode state
-                <> if Text.null scope then "" else "&scope=" <> encode scope
+                <> (if Text.null scope then "" else "&scope=" <> encode scope)
+                <> "&resource=" <> encode resourceUrl
         putStrLn ("Opening browser for MCP authorization: " <> Text.unpack authUrl)
         _ <- openBrowser authUrl
         callback <- timeout (5 * 60 * 1000000) (receiveCallback listener)
             >>= maybe (failText "Timed out waiting for MCP OAuth callback") pure
         when (callback.state /= Just state) (failText "MCP OAuth callback state mismatch")
         code <- maybe (failText "MCP OAuth callback did not contain an authorization code") pure callback.code
-        OAuth.exchangeAuthorizationCode manager metadata.tokenEndpoint registration.clientId code redirect verifier
+        OAuth.exchangeAuthorizationCode manager metadata.tokenEndpoint registration.clientId code redirect verifier (Just resourceUrl)
             >>= \case
                 OAuth.OAuthTokenFailure err -> failText err
                 OAuth.OAuthTokenSuccess tokens -> do

--- a/packages/agent-cli/src/Agent/CLI/McpOAuthStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuthStore.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Agent.CLI.McpOAuthStore
+    ( McpOAuthRecord(..), loadMcpOAuth, mcpOAuthStorePath
+    , saveMcpOAuth, withMcpOAuthRefreshLock ) where
+
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
+import Agent.FileRetry (writeLazyFileAtomically)
+import Agent.OsPath (unsafeToFilePath)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
+import Control.Exception.Safe (tryAny)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Data.Char (ord)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Numeric (showHex)
+import System.Directory.OsPath (createDirectoryIfMissing, doesFileExist, getHomeDirectory)
+import System.IO.Unsafe (unsafePerformIO)
+import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
+import System.Posix.Files (setFileMode)
+
+data McpOAuthRecord = McpOAuthRecord
+    { mcpOAuthServer :: !Text
+    , mcpOAuthClientId :: !Text
+    , mcpOAuthClientSecret :: !(Maybe Text)
+    , mcpOAuthAccessToken :: !Text
+    , mcpOAuthRefreshToken :: !(Maybe Text)
+    , mcpOAuthExpiresAt :: !(Maybe Integer)
+    } deriving (Eq)
+
+instance Show McpOAuthRecord where
+    show record = "McpOAuthRecord { mcpOAuthServer = " <> show record.mcpOAuthServer
+        <> ", mcpOAuthClientId = <redacted>, mcpOAuthClientSecret = <redacted>"
+        <> ", mcpOAuthAccessToken = <redacted>, mcpOAuthRefreshToken = "
+        <> show (maybe False (const True) record.mcpOAuthRefreshToken)
+        <> ", mcpOAuthExpiresAt = " <> show record.mcpOAuthExpiresAt <> " }"
+
+instance Aeson.ToJSON McpOAuthRecord where
+    toJSON record = Aeson.object
+        [ "server" Aeson..= record.mcpOAuthServer, "client_id" Aeson..= record.mcpOAuthClientId
+        , "client_secret" Aeson..= record.mcpOAuthClientSecret, "access_token" Aeson..= record.mcpOAuthAccessToken
+        , "refresh_token" Aeson..= record.mcpOAuthRefreshToken, "expires_at" Aeson..= record.mcpOAuthExpiresAt ]
+
+instance Aeson.FromJSON McpOAuthRecord where
+    parseJSON = Aeson.withObject "McpOAuthRecord" $ \object ->
+        McpOAuthRecord <$> object Aeson..: "server" <*> object Aeson..: "client_id"
+            <*> object Aeson..:? "client_secret" <*> object Aeson..: "access_token"
+            <*> object Aeson..:? "refresh_token" <*> object Aeson..:? "expires_at"
+
+mcpOAuthStorePath :: OsPath -> Text -> OsPath
+mcpOAuthStorePath home server = home </> unsafeEncodeUtf ".haskell-agent" </> unsafeEncodeUtf "credentials"
+    </> unsafeEncodeUtf "mcp" </> unsafeEncodeUtf (hexName server <> ".json")
+  where hexName = Text.unpack . Text.concatMap (Text.pack . (`showHex` "") . ord)
+
+loadMcpOAuth :: Text -> IO (Either Text (Maybe McpOAuthRecord))
+loadMcpOAuth server = do
+    home <- getHomeDirectory
+    let path = mcpOAuthStorePath home server
+    exists <- doesFileExist path
+    if not exists then pure (Right Nothing) else do
+        result <- tryAny (LBS.readFile (unsafeToFilePath path))
+        pure $ case result of
+            Left exception -> Left (Text.pack (show exception))
+            Right bytes -> either (Left . Text.pack) (Right . Just) (Aeson.eitherDecode bytes)
+
+saveMcpOAuth :: McpOAuthRecord -> IO (Either Text ())
+saveMcpOAuth record = do
+    home <- getHomeDirectory
+    let path = mcpOAuthStorePath home record.mcpOAuthServer
+    result <- tryAny $ do
+        createDirectoryIfMissing True (takeDirectory path)
+        setFileMode (unsafeToFilePath (takeDirectory path)) 0o700
+        writeLazyFileAtomically path 0o600 (Aeson.encode record)
+    pure $ either (Left . Text.pack . show) Right result
+
+withMcpOAuthRefreshLock :: Text -> IO a -> IO a
+withMcpOAuthRefreshLock server action = withMVar refreshThreadLock $ const $ do
+    home <- getHomeDirectory
+    withPrivateFileLock (takeDirectory (mcpOAuthStorePath home server) </> unsafeEncodeUtf "refresh.lock") action
+
+refreshThreadLock :: MVar ()
+refreshThreadLock = unsafePerformIO (newMVar ())
+{-# NOINLINE refreshThreadLock #-}

--- a/packages/agent-cli/src/Agent/CLI/McpOAuthStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuthStore.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Agent.CLI.McpOAuthStore
-    ( McpOAuthRecord(..), loadMcpOAuth, mcpOAuthStorePath
-    , saveMcpOAuth, withMcpOAuthRefreshLock ) where
+    ( loadMcpOAuth, mcpOAuthStorePath, saveMcpOAuth
+    , withMcpOAuthRefreshLock
+    ) where
 
 import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Agent.FileRetry (writeLazyFileAtomically)
+import Agent.MCP.OAuth (OAuthTokenFile)
 import Agent.OsPath (unsafeToFilePath)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception.Safe (tryAny)
@@ -19,40 +21,14 @@ import System.IO.Unsafe (unsafePerformIO)
 import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 
-data McpOAuthRecord = McpOAuthRecord
-    { mcpOAuthServer :: !Text
-    , mcpOAuthClientId :: !Text
-    , mcpOAuthClientSecret :: !(Maybe Text)
-    , mcpOAuthAccessToken :: !Text
-    , mcpOAuthRefreshToken :: !(Maybe Text)
-    , mcpOAuthExpiresAt :: !(Maybe Integer)
-    } deriving (Eq)
-
-instance Show McpOAuthRecord where
-    show record = "McpOAuthRecord { mcpOAuthServer = " <> show record.mcpOAuthServer
-        <> ", mcpOAuthClientId = <redacted>, mcpOAuthClientSecret = <redacted>"
-        <> ", mcpOAuthAccessToken = <redacted>, mcpOAuthRefreshToken = "
-        <> show (maybe False (const True) record.mcpOAuthRefreshToken)
-        <> ", mcpOAuthExpiresAt = " <> show record.mcpOAuthExpiresAt <> " }"
-
-instance Aeson.ToJSON McpOAuthRecord where
-    toJSON record = Aeson.object
-        [ "server" Aeson..= record.mcpOAuthServer, "client_id" Aeson..= record.mcpOAuthClientId
-        , "client_secret" Aeson..= record.mcpOAuthClientSecret, "access_token" Aeson..= record.mcpOAuthAccessToken
-        , "refresh_token" Aeson..= record.mcpOAuthRefreshToken, "expires_at" Aeson..= record.mcpOAuthExpiresAt ]
-
-instance Aeson.FromJSON McpOAuthRecord where
-    parseJSON = Aeson.withObject "McpOAuthRecord" $ \object ->
-        McpOAuthRecord <$> object Aeson..: "server" <*> object Aeson..: "client_id"
-            <*> object Aeson..:? "client_secret" <*> object Aeson..: "access_token"
-            <*> object Aeson..:? "refresh_token" <*> object Aeson..:? "expires_at"
-
 mcpOAuthStorePath :: OsPath -> Text -> OsPath
-mcpOAuthStorePath home server = home </> unsafeEncodeUtf ".haskell-agent" </> unsafeEncodeUtf "credentials"
-    </> unsafeEncodeUtf "mcp" </> unsafeEncodeUtf (hexName server <> ".json")
-  where hexName = Text.unpack . Text.concatMap (Text.pack . (`showHex` "") . ord)
+mcpOAuthStorePath home server = home </> unsafeEncodeUtf ".haskell-agent"
+    </> unsafeEncodeUtf "credentials" </> unsafeEncodeUtf "mcp"
+    </> unsafeEncodeUtf (hexName server <> ".json")
+  where
+    hexName = Text.unpack . Text.concatMap (Text.pack . (`showHex` "") . ord)
 
-loadMcpOAuth :: Text -> IO (Either Text (Maybe McpOAuthRecord))
+loadMcpOAuth :: Text -> IO (Either Text (Maybe OAuthTokenFile))
 loadMcpOAuth server = do
     home <- getHomeDirectory
     let path = mcpOAuthStorePath home server
@@ -63,20 +39,22 @@ loadMcpOAuth server = do
             Left exception -> Left (Text.pack (show exception))
             Right bytes -> either (Left . Text.pack) (Right . Just) (Aeson.eitherDecode bytes)
 
-saveMcpOAuth :: McpOAuthRecord -> IO (Either Text ())
-saveMcpOAuth record = do
+saveMcpOAuth :: Text -> OAuthTokenFile -> IO (Either Text ())
+saveMcpOAuth server record = do
     home <- getHomeDirectory
-    let path = mcpOAuthStorePath home record.mcpOAuthServer
-    result <- tryAny $ do
+    let path = mcpOAuthStorePath home server
+    result <- tryAny do
         createDirectoryIfMissing True (takeDirectory path)
         setFileMode (unsafeToFilePath (takeDirectory path)) 0o700
         writeLazyFileAtomically path 0o600 (Aeson.encode record)
     pure $ either (Left . Text.pack . show) Right result
 
 withMcpOAuthRefreshLock :: Text -> IO a -> IO a
-withMcpOAuthRefreshLock server action = withMVar refreshThreadLock $ const $ do
+withMcpOAuthRefreshLock server action = withMVar refreshThreadLock $ const do
     home <- getHomeDirectory
-    withPrivateFileLock (takeDirectory (mcpOAuthStorePath home server) </> unsafeEncodeUtf "refresh.lock") action
+    withPrivateFileLock
+        (takeDirectory (mcpOAuthStorePath home server) </> unsafeEncodeUtf "refresh.lock")
+        action
 
 refreshThreadLock :: MVar ()
 refreshThreadLock = unsafePerformIO (newMVar ())

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Options
     , ApprovalPolicy(..)
     , CliOptions(..)
     , Command(..)
+    , McpCommand(..)
     , ScreenMode(..)
     , StorageCommand(..)
     , defaultCliOptions
@@ -40,12 +41,18 @@ data Command
     = ShowHelp
     | ShowVersion
     | Login
+    | Mcp McpCommand
     | ListSessions
     | ShowSession Text
     | WaitSession Text
     | ImportSession (Maybe OsPath)
     | Storage StorageCommand
     | RunAgent CliOptions
+    deriving (Eq, Show)
+
+data McpCommand
+    = McpLogin Text
+    | McpLogout Text
     deriving (Eq, Show)
 
 -- | Administrative commands for the harness-managed PostgreSQL server.
@@ -224,6 +231,9 @@ commandParser =
             <> Options.command "sessions"
                 (Options.info sessionsParser
                     (Options.progDesc "Administer persisted sessions"))
+            <> Options.command "mcp"
+                (Options.info mcpParser
+                    (Options.progDesc "Authorize remote MCP servers"))
             <> Options.command "storage"
                 (Options.info storageParser
                     (Options.progDesc "Administer managed PostgreSQL storage"))
@@ -282,6 +292,18 @@ storageParser =
         Options.command name
             (Options.info (pure (Storage command))
                 (Options.progDesc description))
+
+mcpParser :: Options.Parser Command
+mcpParser = Mcp <$> Options.hsubparser
+    ( Options.command "login"
+        (Options.info
+            (McpLogin . Text.pack <$> Options.argument Options.str (Options.metavar "URL"))
+            (Options.progDesc "Authorize an MCP server with OAuth PKCE"))
+    <> Options.command "logout"
+        (Options.info
+            (McpLogout . Text.pack <$> Options.argument Options.str (Options.metavar "URL"))
+            (Options.progDesc "Remove saved MCP OAuth credentials"))
+    )
 
 type OptionUpdate = CliOptions -> CliOptions
 
@@ -501,6 +523,8 @@ usage = unlines
     , "       agent-cli login"
     , "       agent-cli sessions [list]"
     , "       agent-cli sessions show <session-id>"
+    , "       agent-cli mcp login <url>"
+    , "       agent-cli mcp logout <url>"
     , "       agent-cli storage <status|start|stop|migrate|doctor>"
     , ""
     , "  -p, --prompt TEXT       Run one prompt and exit"

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -27,6 +27,7 @@ import Agent.CLI.AgentSessions
     ( closeSessionThreadManager, newSessionThreadManager )
 import Agent.CLI.Interrupt ( catchUserInterrupt )
 import Agent.CLI.Login ( runLoginManager )
+import Agent.CLI.McpOAuth (loginMcp, logoutMcp)
 import Agent.CLI.McpStatus
     ( formatMcpModelNotice
     , formatMcpModelNoticeFor
@@ -35,6 +36,7 @@ import Agent.CLI.McpStatus
 import Agent.CLI.Options
     ( CliOptions
     , Command(..)
+    , McpCommand(..)
     , parseArgs
     , usage
     )
@@ -133,6 +135,8 @@ devMainResume resumeId = do
             color <- resolveColor stderr
             runLoginManager color
             pure DevQuit
+        Right (Mcp (McpLogin url)) -> loginMcp url >> pure DevQuit
+        Right (Mcp (McpLogout url)) -> logoutMcp url >> pure DevQuit
         Right ListSessions -> runListSessions >> pure DevQuit
         Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
         Right (WaitSession sessionId) -> runWaitSession sessionId >> pure DevQuit
@@ -155,6 +159,8 @@ run = do
         Right Login -> do
             color <- resolveColor stderr
             runLoginManager color
+        Right (Mcp (McpLogin url)) -> loginMcp url
+        Right (Mcp (McpLogout url)) -> logoutMcp url
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
         Right (WaitSession sessionId) -> runWaitSession sessionId

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -47,6 +47,7 @@ import Agent.CLI.Lsp
     ( LspStartup(..), closeLspRuntime, lspRuntimeTool, newLspRuntime )
 import Agent.CLI.ManagedTurn ( ManagedTurnRequest(..) )
 import Agent.CLI.McpManager ()
+import Agent.CLI.McpOAuthStore (mcpOAuthStorePath)
 import Agent.CLI.McpStatus
     ( formatMcpModelNoticeFor,
       formatMcpProgress,
@@ -223,7 +224,7 @@ import Data.Text ()
 import Data.Time.Clock ()
 import System.Console.ANSI ()
 import System.Console.ANSI.Codes ()
-import System.Directory.OsPath ()
+import System.Directory.OsPath (getHomeDirectory)
 import System.Environment ()
 import System.Exit ()
 import System.IO ()
@@ -244,7 +245,7 @@ import qualified Agent.MCP as MCP
                       mcpServerName, mcpServerUrl, mcpServerCommand, mcpServerArgs, mcpServerCwd,
                       mcpServerEnv, mcpServerStartupTimeoutSeconds) )
 import qualified Data.Map.Strict as Map
-    ( toAscList, empty, lookup )
+    ( toAscList, empty, lookup, notMember )
 import qualified Agent.OpenAI.Auth as OpenAI ()
 import qualified Agent.OpenRouter as OpenRouter
     ( clientOptionsFromEnv, mapModel )
@@ -569,6 +570,7 @@ runAgentTools
                 (sessionId, tempDir) <- allocateSessionTemp root
                 pure (tempDir, Just sessionId)
     setToolSessionTmp baseToolEnv (Just sessionTmp)
+    home <- getHomeDirectory
     let cleanupScratch = do
             cleanupPendingPersistence persist
             forM_ ephemeralSessionId \sessionId -> do
@@ -587,7 +589,11 @@ runAgentTools
                 , MCP.mcpServerEnv =
                     [ (Text.unpack name, Text.unpack value)
                     | (name, value) <- Map.toAscList config.mcpEnv
-                    ]
+                    ] <> case config.mcpUrl of
+                        Just url
+                            | Map.notMember "MCP_OAUTH_TOKEN_FILE" config.mcpEnv ->
+                                [("MCP_OAUTH_TOKEN_FILE", unsafeToFilePath (mcpOAuthStorePath home url))]
+                        _ -> []
                 , MCP.mcpServerStartupTimeoutSeconds =
                     config.mcpStartupTimeoutSeconds
                 , MCP.mcpServerRequestTimeoutSeconds =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -241,7 +241,7 @@ import qualified Agent.MCP as MCP
       McpFleet(mcpFleetRegistrations, mcpFleetWarnings),
       McpFleetLease(mcpLeaseFleet),
       McpServerConfig(mcpServerRequestTimeoutSeconds, McpServerConfig,
-                      mcpServerName, mcpServerCommand, mcpServerArgs, mcpServerCwd,
+                      mcpServerName, mcpServerUrl, mcpServerCommand, mcpServerArgs, mcpServerCwd,
                       mcpServerEnv, mcpServerStartupTimeoutSeconds) )
 import qualified Data.Map.Strict as Map
     ( toAscList, empty, lookup )
@@ -578,6 +578,7 @@ runAgentTools
         mcpServerConfigs =
             [ MCP.McpServerConfig
                 { MCP.mcpServerName = label
+                , MCP.mcpServerUrl = config.mcpUrl
                 , MCP.mcpServerCommand = Text.unpack config.mcpCommand
                 , MCP.mcpServerArgs = map Text.unpack config.mcpArgs
                 , MCP.mcpServerCwd =

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -59,6 +59,7 @@ spec = describe "Agent.CLI.Config" do
                     Map.lookup "alpha" config.configMcpServers
                         `shouldBe` Just McpServerConfig
                             { mcpEnabled = False
+                            , mcpUrl = Nothing
                             , mcpCommand = "a"
                             , mcpArgs = ["one"]
                             , mcpCwd = Just "/tmp"
@@ -69,6 +70,7 @@ spec = describe "Agent.CLI.Config" do
                     Map.lookup "zeta" config.configMcpServers
                         `shouldBe` Just McpServerConfig
                             { mcpEnabled = True
+                            , mcpUrl = Nothing
                             , mcpCommand = "z"
                             , mcpArgs = []
                             , mcpCwd = Nothing
@@ -76,6 +78,16 @@ spec = describe "Agent.CLI.Config" do
                             , mcpStartupTimeoutSeconds = 30
                             , mcpRequestTimeoutSeconds = 60
                             }
+
+    it "loads remote MCP servers by URL" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home
+                "{\"mcpServers\":{\"remote\":{\"url\":\"https://example.test/mcp\"}}}"
+            result <- loadHarnessConfig home
+            fmap (Map.lookup "remote" . (.configMcpServers)) result
+                `shouldSatisfy` \case
+                    Right (Just server) -> server.mcpUrl == Just "https://example.test/mcp"
+                    _ -> False
 
     it "loads the MCP initialization strategy" $
         withTempDir "agent-config-" \home -> do
@@ -168,7 +180,7 @@ spec = describe "Agent.CLI.Config" do
             writeConfig home
                 "{\"mcpServers\":{\"broken\":{\"command\":\" \"}}}"
             loadHarnessConfig home
-                `shouldReturn` Left "MCP server 'broken' has an empty command"
+                `shouldReturn` Left "MCP server 'broken' must configure exactly one of url or command"
 
             writeConfig home
                 "{\"mcpServers\":{\"broken\":{\"command\":\"ok\",\"startupTimeoutSeconds\":0}}}"
@@ -190,6 +202,7 @@ spec = describe "Agent.CLI.Config" do
         withTempDir "agent-config-" \home -> do
             let server = McpServerConfig
                     { mcpEnabled = True
+                    , mcpUrl = Nothing
                     , mcpCommand = "nix"
                     , mcpArgs = ["run", "/tmp/seo-mcp"]
                     , mcpCwd = Just "/tmp"
@@ -212,6 +225,7 @@ spec = describe "Agent.CLI.Config" do
                     { configMcpServers =
                         Map.singleton "broken" McpServerConfig
                             { mcpEnabled = True
+                            , mcpUrl = Nothing
                             , mcpCommand = ""
                             , mcpArgs = []
                             , mcpCwd = Nothing
@@ -222,7 +236,7 @@ spec = describe "Agent.CLI.Config" do
                     }
             saveHarnessConfig home broken
                 `shouldReturn`
-                    Left "MCP server 'broken' has an empty command"
+                    Left "MCP server 'broken' must configure exactly one of url or command"
 
 writeConfig :: OsPath -> LBS.ByteString -> IO ()
 writeConfig home bytes = do

--- a/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
@@ -107,6 +107,7 @@ spec = describe "Agent.CLI.McpManager" do
 server :: Bool -> Text.Text -> McpServerConfig
 server enabled command = McpServerConfig
     { mcpEnabled = enabled
+    , mcpUrl = Nothing
     , mcpCommand = command
     , mcpArgs = []
     , mcpCwd = Nothing

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -50,6 +50,7 @@ library
                     , Agent.ReasoningEffort
                     , Agent.Loop
                     , Agent.MCP
+                    , Agent.MCP.OAuth
                     , Agent.JsonText
                     , Agent.OsPath
                     , Agent.Http.Header
@@ -96,7 +97,6 @@ library
                     , Agent.MCP.Fleet
                     , Agent.MCP.Supervisor
                     , Agent.MCP.Types
-                    , Agent.MCP.OAuth
                     , Agent.Subagents.Registry.Internal.Core
                     , Agent.Subagents.Registry.Internal.Operations
                     , Agent.Subagents.Registry.Internal.Types
@@ -118,6 +118,7 @@ library
                     , crypton-connection
                     , directory
                     , filepath
+                    , filelock
                     , http-client
                     , http-client-tls
                     , http-types

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -96,6 +96,7 @@ library
                     , Agent.MCP.Fleet
                     , Agent.MCP.Supervisor
                     , Agent.MCP.Types
+                    , Agent.MCP.OAuth
                     , Agent.Subagents.Registry.Internal.Core
                     , Agent.Subagents.Registry.Internal.Operations
                     , Agent.Subagents.Registry.Internal.Types
@@ -117,6 +118,8 @@ library
                     , crypton-connection
                     , directory
                     , filepath
+                    , http-client
+                    , http-types
                     , process
                     , retry >= 0.9.3.1 && < 0.10
                     , resourcet

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -119,6 +119,7 @@ library
                     , directory
                     , filepath
                     , http-client
+                    , http-client-tls
                     , http-types
                     , process
                     , retry >= 0.9.3.1 && < 0.10

--- a/packages/agent-core/benchmark/McpStartup.hs
+++ b/packages/agent-core/benchmark/McpStartup.hs
@@ -178,6 +178,7 @@ middle values = values !! (length values `div` 2)
 fakeConfig :: FilePath -> Int -> Int -> McpServerConfig
 fakeConfig script delayMillis index = McpServerConfig
     { mcpServerName = "fake-" <> Text.pack (show index)
+    , mcpServerUrl = Nothing
     , mcpServerCommand = script
     , mcpServerArgs = [show (fromIntegral delayMillis / 1000 :: Double)]
     , mcpServerCwd = Nothing

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,9 +1,10 @@
 { mkDerivation, aeson, agent-json, agent-process
 , agent-responses-types, async, base, base64-bytestring, bytestring
-, containers, crypton-connection, directory, filepath, hspec, lib
-, process, QuickCheck, resourcet, retry, safe-exceptions
-, scientific, stm, template-haskell, text, text-builder, time, tls
-, transformers, unix, vector, websockets, yaml
+, containers, crypton-connection, directory, filelock, filepath
+, hspec, http-client, http-client-tls, http-types, lib, process
+, QuickCheck, resourcet, retry, safe-exceptions, scientific, stm
+, template-haskell, text, text-builder, time, tls, transformers
+, unix, vector, websockets, yaml
 }:
 mkDerivation {
   pname = "agent-core";
@@ -13,9 +14,10 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-json agent-process agent-responses-types async base
     base64-bytestring bytestring containers crypton-connection
-    directory filepath process resourcet retry safe-exceptions
-    scientific stm template-haskell text time tls transformers unix
-    vector websockets yaml
+    directory filelock filepath http-client http-client-tls http-types
+    process resourcet retry safe-exceptions scientific stm
+    template-haskell text time tls transformers unix vector websockets
+    yaml
   ];
   testHaskellDepends = [
     aeson agent-json agent-responses-types async base base64-bytestring

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -103,6 +103,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.Vector as Vector
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import System.Environment (getEnvironment)
 import System.Directory (getCurrentDirectory)
 import System.IO
@@ -574,6 +575,7 @@ httpRequestMcpWithId client timeoutMicros url method parameters requestId = do
                 <> maybe mempty ("id" .=) requestId
                 <> "method" .= method
                 <> AesonEncoding.pair "params" parameters
+
         perform token = do
             let headers = [("Content-Type", "application/json"), ("Accept", "application/json, text/event-stream")]
                     <> maybe [] (\value -> [("Authorization", "Bearer " <> TextEncoding.encodeUtf8 value)]) token

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -554,20 +554,20 @@ httpRequestMcp client timeoutMicros url method parameters = do
     requestId <- atomicModifyIORef' client.clientNextId (\current -> (current + 1, current))
     request <- parseRequest (Text.unpack url)
     session <- readIORef client.clientHttpSession
-    file <- case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
-        Nothing -> pure Nothing
+    fileResult <- case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
+        Nothing -> pure (Right Nothing)
         Just path -> OAuth.loadOAuthTokenFile path >>= \case
+            Left err -> pure (Left err)
             Right (OAuth.OAuthTokenFile _ _ token _ expiresAt) -> do
-                now <- floor <$> getPOSIXTime
+                now <- round <$> getPOSIXTime
                 if maybe False (<= now + 60) expiresAt
                     then OAuth.refreshOAuthTokenFile mcpHttpManager path >>= \case
-                        Right (OAuth.OAuthTokenFile _ _ refreshed _ _) -> pure (Just refreshed)
-                        Left _ -> pure (Just token)
-                    else pure (Just token)
-            Left _ -> pure Nothing
-    let configuredToken = case file of
-            Just token -> Just token
-            Nothing -> fmap Text.pack (lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv)
+                        Left err -> pure (Left err)
+                        Right (OAuth.OAuthTokenFile _ _ refreshed _ _) -> pure (Right (Just refreshed))
+                    else pure (Right (Just token))
+    let configuredToken = case fileResult of
+            Right (Just token) -> Just token
+            _ -> fmap Text.pack (lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv)
         body = AesonEncodingInternal.encodingToLazyByteString $ Aeson.pairs
             ("jsonrpc" .= ("2.0" :: Text) <> "id" .= requestId <> "method" .= method <> AesonEncoding.pair "params" parameters)
         perform token = do

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -574,7 +574,14 @@ httpRequestMcp client timeoutMicros url method parameters = do
                 let bytes = LBS.toStrict (responseBody response)
                 if BS.null bytes
                     then pure (Right (rawJsonFromEncoding (Aeson.toEncoding (object []))))
-                    else pure (either (Left . ("Invalid MCP HTTP response: " <>) . Text.pack . show) Right (Json.decodeEither rawJsonDecoder bytes))
+                    else case Json.decodeEither rawJsonDecoder bytes of
+                        Right value -> pure (Right value)
+                        Left jsonError ->
+                            case find (BS8.isPrefixOf "data: ") (BS8.lines bytes) of
+                                Just eventData ->
+                                    pure (either (Left . ("Invalid MCP SSE response: " <>) . Text.pack . show) Right
+                                        (Json.decodeEither rawJsonDecoder (BS8.drop 6 eventData)))
+                                Nothing -> pure (Left ("Invalid MCP HTTP response: " <> Text.pack (show jsonError)))
 
 sendNotification
     :: McpClient

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -125,6 +125,7 @@ import System.Process
 import System.Timeout (timeout)
 import System.IO.Unsafe (unsafePerformIO)
 import Agent.MCP.Types
+import qualified Agent.MCP.OAuth as OAuth
 import Network.HTTP.Client (Manager, RequestBody(..), httpLbs, parseRequest, responseBody, responseHeaders, responseStatus)
 import qualified Network.HTTP.Client as HC
 import Network.HTTP.Client.TLS (newTlsManager)
@@ -552,36 +553,47 @@ httpRequestMcp client timeoutMicros url method parameters = do
     requestId <- atomicModifyIORef' client.clientNextId (\current -> (current + 1, current))
     request <- parseRequest (Text.unpack url)
     session <- readIORef client.clientHttpSession
-    let body = AesonEncodingInternal.encodingToLazyByteString $ Aeson.pairs
+    file <- case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
+        Nothing -> pure Nothing
+        Just path -> OAuth.loadOAuthTokenFile path >>= \case
+            Right (OAuth.OAuthTokenFile _ _ token _ _) -> pure (Just token)
+            Left _ -> pure Nothing
+    let configuredToken = case file of
+            Just token -> Just token
+            Nothing -> fmap Text.pack (lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv)
+        body = AesonEncodingInternal.encodingToLazyByteString $ Aeson.pairs
             ("jsonrpc" .= ("2.0" :: Text) <> "id" .= requestId <> "method" .= method <> AesonEncoding.pair "params" parameters)
-        configuredToken = lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv
-        headers = [("Content-Type", "application/json"), ("Accept", "application/json, text/event-stream")]
-            <> maybe [] (\token -> [("Authorization", "Bearer " <> BS8.pack token)]) configuredToken
-            <> maybe [] (\value -> [("Mcp-Session-Id", TextEncoding.encodeUtf8 value)]) session
-        request' = request { HC.method = "POST", HC.requestBody = RequestBodyLBS body, HC.requestHeaders = headers }
-    result <- tryAny (timeout (max 1 timeoutMicros) (httpLbs request' mcpHttpManager))
-    case result of
+        perform token = do
+            let headers = [("Content-Type", "application/json"), ("Accept", "application/json, text/event-stream")]
+                    <> maybe [] (\value -> [("Authorization", "Bearer " <> TextEncoding.encodeUtf8 value)]) token
+                    <> maybe [] (\value -> [("Mcp-Session-Id", TextEncoding.encodeUtf8 value)]) session
+                request' = request { HC.method = "POST", HC.requestBody = RequestBodyLBS body, HC.requestHeaders = headers }
+            tryAny (timeout (max 1 timeoutMicros) (httpLbs request' mcpHttpManager))
+        decodeResponse response
+            | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 =
+                pure (Left ("MCP HTTP request failed with status " <> Text.pack (show (statusCode (responseStatus response)))))
+            | otherwise = do
+                forM_ (lookup "Mcp-Session-Id" (responseHeaders response)) (writeIORef client.clientHttpSession . Just . TextEncoding.decodeUtf8)
+                let bytes = LBS.toStrict (responseBody response)
+                if BS.null bytes then pure (Right (rawJsonFromEncoding (Aeson.toEncoding (object []))))
+                else case Json.decodeEither rawJsonDecoder bytes of
+                    Right value -> pure (Right value)
+                    Left jsonError -> case find (BS8.isPrefixOf "data: ") (BS8.lines bytes) of
+                        Just eventData -> pure (either (Left . ("Invalid MCP SSE response: " <>) . Text.pack . show) Right (Json.decodeEither rawJsonDecoder (BS8.drop 6 eventData)))
+                        Nothing -> pure (Left ("Invalid MCP HTTP response: " <> Text.pack (show jsonError)))
+    perform configuredToken >>= \case
         Left exception -> pure (Left ("MCP HTTP request failed: " <> exceptionSummary exception))
         Right Nothing -> pure (Left ("MCP request " <> method <> " timed out"))
         Right (Just response)
-            | statusCode (responseStatus response) == 401 ->
-                pure (Left "MCP server requires OAuth authorization; configure MCP OAuth credentials")
-            | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 ->
-                pure (Left ("MCP HTTP request failed with status " <> Text.pack (show (statusCode (responseStatus response)))))
-            | otherwise -> do
-                forM_ (lookup "Mcp-Session-Id" (responseHeaders response)) $ \value ->
-                    writeIORef client.clientHttpSession (Just (TextEncoding.decodeUtf8 value))
-                let bytes = LBS.toStrict (responseBody response)
-                if BS.null bytes
-                    then pure (Right (rawJsonFromEncoding (Aeson.toEncoding (object []))))
-                    else case Json.decodeEither rawJsonDecoder bytes of
-                        Right value -> pure (Right value)
-                        Left jsonError ->
-                            case find (BS8.isPrefixOf "data: ") (BS8.lines bytes) of
-                                Just eventData ->
-                                    pure (either (Left . ("Invalid MCP SSE response: " <>) . Text.pack . show) Right
-                                        (Json.decodeEither rawJsonDecoder (BS8.drop 6 eventData)))
-                                Nothing -> pure (Left ("Invalid MCP HTTP response: " <> Text.pack (show jsonError)))
+            | statusCode (responseStatus response) == 401 -> case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
+                Nothing -> pure (Left "MCP server requires OAuth authorization; configure MCP OAuth credentials")
+                Just path -> OAuth.refreshOAuthTokenFile mcpHttpManager path >>= \case
+                    Left err -> pure (Left ("MCP OAuth refresh failed: " <> err))
+                    Right (OAuth.OAuthTokenFile _ _ token _ _) -> perform (Just token) >>= \case
+                        Right (Just retryResponse) -> decodeResponse retryResponse
+                        Right Nothing -> pure (Left ("MCP request " <> method <> " timed out"))
+                        Left retryException -> pure (Left ("MCP HTTP request failed: " <> exceptionSummary retryException))
+            | otherwise -> decodeResponse response
 
 sendNotification
     :: McpClient

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -18,7 +18,6 @@ import Agent.Tools.Types
     )
 import Agent.ToolDispatch (typedTool)
 import Agent.Concurrent (forConcurrentlyBounded_)
-import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
@@ -170,16 +169,16 @@ startMcpClient config = case config.mcpServerUrl of
                 let client = McpClient
                         { clientConfig = config
                         , clientHttpSession = session
-                        , clientInput = input
-                        , clientProcess = processHandle
+                        , clientInput = Just input
+                        , clientProcess = Just processHandle
                         , clientGroupId = groupId
                         , clientNextId = nextId
                         , clientPending = pending
                         , clientFailure = failure
                         , clientWriteLock = writeLock
                         , clientStderr = stderrRef
-                        , clientReader = reader
-                        , clientStderrReader = stderrReader
+                        , clientReader = Just reader
+                        , clientStderrReader = Just stderrReader
                         , clientClosed = closed
                         , clientLifecycle = lifecycle
                         }
@@ -196,34 +195,25 @@ mcpHttpManager = unsafePerformIO newTlsManager
 {-# NOINLINE mcpHttpManager #-}
 
 startMcpHttpClient :: McpServerConfig -> Text -> IO McpClient
-startMcpHttpClient config url = mask $ \_ -> do
-    -- Keep the existing client record/lifecycle while using synchronous HTTP.
-    -- An exited helper process supplies the legacy handles needed by shutdown.
-    created <- createProcess ((proc "true" [])
-        { std_in = CreatePipe, std_out = CreatePipe, std_err = CreatePipe })
-    case created of
-        (Just input, Just output, Just errOutput, processHandle) -> do
-            nextId <- newIORef 1
-            pending <- newTVarIO IntMap.empty
-            failure <- newTVarIO Nothing
-            writeLock <- newMVar ()
-            stderrRef <- newIORef emptyCapturedStderr
-            closed <- newMVar False
-            lifecycle <- newTVarIO ClientPending
-            session <- newIORef Nothing
-            reader <- asyncWithUnmask $ \unmask -> unmask (threadDelay maxBound)
-            stderrReader <- asyncWithUnmask $ \unmask -> unmask (threadDelay maxBound)
-            pure McpClient
-                { clientConfig = config, clientHttpSession = session
-                , clientInput = input, clientProcess = processHandle
-                , clientGroupId = Nothing, clientNextId = nextId
-                , clientPending = pending, clientFailure = failure
-                , clientWriteLock = writeLock, clientStderr = stderrRef
-                , clientReader = reader, clientStderrReader = stderrReader
-                , clientClosed = closed, clientLifecycle = lifecycle }
-        _ -> ioError (userError "MCP HTTP client setup failed")
-  where
-    _ = url
+startMcpHttpClient config _url = mask $ \_ -> do
+    nextId <- newIORef 1
+    pending <- newTVarIO IntMap.empty
+    failure <- newTVarIO Nothing
+    writeLock <- newMVar ()
+    stderrRef <- newIORef emptyCapturedStderr
+    closed <- newMVar False
+    lifecycle <- newTVarIO ClientPending
+    session <- newIORef Nothing
+    -- HTTP has no subprocess or background reader.  Its lifecycle is driven
+    -- by requestMcp and closeMcpClient below.
+    pure McpClient
+        { clientConfig = config, clientHttpSession = session
+        , clientInput = Nothing, clientProcess = Nothing
+        , clientGroupId = Nothing, clientNextId = nextId
+        , clientPending = pending, clientFailure = failure
+        , clientWriteLock = writeLock, clientStderr = stderrRef
+        , clientReader = Nothing, clientStderrReader = Nothing
+        , clientClosed = closed, clientLifecycle = lifecycle }
 
 data InitializeRole
     = InitializeLeader
@@ -552,6 +542,17 @@ requestMcp client timeoutMicros method parameters = do
 httpRequestMcp :: McpClient -> Int -> Text -> Text -> Aeson.Encoding -> IO (Either Text RawJson)
 httpRequestMcp client timeoutMicros url method parameters = do
     requestId <- atomicModifyIORef' client.clientNextId (\current -> (current + 1, current))
+    httpRequestMcpWithId client timeoutMicros url method parameters (Just requestId)
+
+httpNotificationMcp :: McpClient -> Int -> Text -> Text -> Aeson.Encoding -> IO (Either Text ())
+httpNotificationMcp client timeoutMicros url method parameters =
+    fmap (fmap (const ())) $
+        httpRequestMcpWithId client timeoutMicros url method parameters Nothing
+
+httpRequestMcpWithId
+    :: McpClient -> Int -> Text -> Text -> Aeson.Encoding -> Maybe Int
+    -> IO (Either Text RawJson)
+httpRequestMcpWithId client timeoutMicros url method parameters requestId = do
     request <- parseRequest (Text.unpack url)
     session <- readIORef client.clientHttpSession
     fileResult <- case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
@@ -568,8 +569,11 @@ httpRequestMcp client timeoutMicros url method parameters = do
     let configuredToken = case fileResult of
             Right (Just token) -> Just token
             _ -> fmap Text.pack (lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv)
-        body = AesonEncodingInternal.encodingToLazyByteString $ Aeson.pairs
-            ("jsonrpc" .= ("2.0" :: Text) <> "id" .= requestId <> "method" .= method <> AesonEncoding.pair "params" parameters)
+        body = AesonEncodingInternal.encodingToLazyByteString $ Aeson.pairs $
+            "jsonrpc" .= ("2.0" :: Text)
+                <> maybe mempty ("id" .=) requestId
+                <> "method" .= method
+                <> AesonEncoding.pair "params" parameters
         perform token = do
             let headers = [("Content-Type", "application/json"), ("Accept", "application/json, text/event-stream")]
                     <> maybe [] (\value -> [("Authorization", "Bearer " <> TextEncoding.encodeUtf8 value)]) token
@@ -582,7 +586,8 @@ httpRequestMcp client timeoutMicros url method parameters = do
             | otherwise = do
                 forM_ (lookup "Mcp-Session-Id" (responseHeaders response)) (writeIORef client.clientHttpSession . Just . TextEncoding.decodeUtf8)
                 let bytes = LBS.toStrict (responseBody response)
-                if BS.null bytes then pure (Right (rawJsonFromEncoding (Aeson.toEncoding (object []))))
+                if BS.null bytes
+                    then pure (Right (rawJsonFromEncoding (Aeson.toEncoding (object []))))
                 else case Json.decodeEither rawJsonDecoder bytes of
                     Right value -> pure (Right value)
                     Left jsonError -> case find (BS8.isPrefixOf "data: ") (BS8.lines bytes) of
@@ -609,8 +614,7 @@ sendNotification
     -> IO (Either Text ())
 sendNotification client method parameters =
     case client.clientConfig.mcpServerUrl of
-        Just url -> fmap (fmap (const ())) $
-            httpRequestMcp client
+        Just url -> httpNotificationMcp client
                 (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
                 url method parameters
         Nothing -> sendMessage client . Aeson.pairs $
@@ -621,10 +625,12 @@ sendNotification client method parameters =
 sendMessage :: McpClient -> Aeson.Encoding -> IO (Either Text ())
 sendMessage client message =
     tryAny
-        (withMVar client.clientWriteLock \_ -> do
-            LBS.hPutStr client.clientInput
-                (AesonEncodingInternal.encodingToLazyByteString message <> "\n")
-            hFlush client.clientInput)
+        (case client.clientInput of
+            Nothing -> ioError (userError "MCP client has no stdio transport")
+            Just input -> withMVar client.clientWriteLock \_ -> do
+                LBS.hPutStr input
+                    (AesonEncodingInternal.encodingToLazyByteString message <> "\n")
+                hFlush input)
         >>= \case
             Left exception -> do
                 let err = "MCP write failed: " <> exceptionSummary exception
@@ -759,13 +765,46 @@ closeMcpClient client =
                                     (Left "MCP server closed")
                         _ ->
                             writeTVar client.clientLifecycle ClientClosed
-                void $ tryAny (hClose client.clientInput)
-                terminateProcessGroup client.clientGroupId client.clientProcess
-                stopWorker client.clientReader
-                stopWorker client.clientStderrReader
+                forM_ client.clientInput \input ->
+                    void $ tryAny (hClose input)
+                forM_ client.clientProcess $ \processHandle ->
+                    terminateProcessGroup client.clientGroupId processHandle
+                when (isJust client.clientConfig.mcpServerUrl) $
+                    closeHttpSession client
+                forM_ client.clientReader stopWorker
+                forM_ client.clientStderrReader stopWorker
                 failClient client.clientPending client.clientFailure
                     "MCP server closed"
                 pure True
+
+-- Streamable HTTP sessions are explicitly terminated with DELETE when the
+-- server assigned a session id.  Failure is intentionally ignored during
+-- shutdown: the local client is already being closed and the server may have
+-- expired the session independently.
+closeHttpSession :: McpClient -> IO ()
+closeHttpSession client = do
+    session <- readIORef client.clientHttpSession
+    case (client.clientConfig.mcpServerUrl, session) of
+        (Just url, Just sessionId) -> void $ tryAny do
+            request <- parseRequest (Text.unpack url)
+            bearer <- case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
+                Just path -> either (const Nothing)
+                    (\(OAuth.OAuthTokenFile _ _ token _ _) -> Just token)
+                    <$> OAuth.loadOAuthTokenFile path
+                Nothing -> pure $ fmap Text.pack
+                    (lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv)
+            let request' = request
+                    { HC.method = "DELETE"
+                    , HC.requestHeaders =
+                        [ ("Mcp-Session-Id", TextEncoding.encodeUtf8 sessionId)
+                        ]
+                        <> maybe [] (\token ->
+                            [ ("Authorization", "Bearer " <> TextEncoding.encodeUtf8 token) ])
+                            bearer
+                    }
+            void $ timeout (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
+                (httpLbs request' mcpHttpManager)
+        _ -> pure ()
 
 stopWorker :: Async () -> IO ()
 stopWorker worker = do

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -99,6 +99,7 @@ import Data.Ord (Down(..))
 import Data.Scientific (floatingOrInteger)
 import qualified Data.Set as Set
 import Data.Text (Text)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
@@ -556,7 +557,13 @@ httpRequestMcp client timeoutMicros url method parameters = do
     file <- case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
         Nothing -> pure Nothing
         Just path -> OAuth.loadOAuthTokenFile path >>= \case
-            Right (OAuth.OAuthTokenFile _ _ token _ _) -> pure (Just token)
+            Right (OAuth.OAuthTokenFile _ _ token _ expiresAt) -> do
+                now <- floor <$> getPOSIXTime
+                if maybe False (<= now + 60) expiresAt
+                    then OAuth.refreshOAuthTokenFile mcpHttpManager path >>= \case
+                        Right (OAuth.OAuthTokenFile _ _ refreshed _ _) -> pure (Just refreshed)
+                        Left _ -> pure (Just token)
+                    else pure (Just token)
             Left _ -> pure Nothing
     let configuredToken = case file of
             Just token -> Just token

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -18,6 +18,7 @@ import Agent.Tools.Types
     )
 import Agent.ToolDispatch (typedTool)
 import Agent.Concurrent (forConcurrentlyBounded_)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
@@ -63,7 +64,7 @@ import Control.Exception.Safe
     , throwIO
     , tryAny
     )
-import Control.Monad (forM, unless, void, when)
+import Control.Monad (forM, forM_, unless, void, when)
 import Data.Aeson
     ( ToJSON(toJSON)
     , Value
@@ -88,6 +89,7 @@ import Data.IORef
     , atomicModifyIORef'
     , newIORef
     , readIORef
+    , writeIORef
     )
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
@@ -121,27 +123,84 @@ import System.Process
     , proc
     )
 import System.Timeout (timeout)
+import System.IO.Unsafe (unsafePerformIO)
 import Agent.MCP.Types
+import Network.HTTP.Client (Manager, RequestBody(..), httpLbs, parseRequest, responseBody, responseHeaders, responseStatus)
+import qualified Network.HTTP.Client as HC
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Types (statusCode)
 startMcpClient :: McpServerConfig -> IO McpClient
-startMcpClient config = mask \_ -> do
-    processEnvironment <- mergedEnvironment config.mcpServerEnv
-    let processSpec =
-            (proc config.mcpServerCommand config.mcpServerArgs)
-                { cwd = config.mcpServerCwd
-                , env = Just processEnvironment
-                , std_in = CreatePipe
-                , std_out = CreatePipe
-                , std_err = CreatePipe
-                , create_group = True
-                }
-    created <- createProcess processSpec
+startMcpClient config = case config.mcpServerUrl of
+    Just url -> startMcpHttpClient config url
+    Nothing -> mask \_ -> do
+        processEnvironment <- mergedEnvironment config.mcpServerEnv
+        let processSpec =
+                (proc config.mcpServerCommand config.mcpServerArgs)
+                    { cwd = config.mcpServerCwd
+                    , env = Just processEnvironment
+                    , std_in = CreatePipe
+                    , std_out = CreatePipe
+                    , std_err = CreatePipe
+                    , create_group = True
+                    }
+        created <- createProcess processSpec
+        case created of
+            (Just input, Just output, Just errOutput, processHandle) -> do
+                groupId <- getPid processHandle
+                hSetBinaryMode input True
+                hSetBinaryMode output True
+                hSetBinaryMode errOutput True
+                hSetBuffering input LineBuffering
+                nextId <- newIORef 1
+                pending <- newTVarIO IntMap.empty
+                failure <- newTVarIO Nothing
+                writeLock <- newMVar ()
+                stderrRef <- newIORef emptyCapturedStderr
+                closed <- newMVar False
+                lifecycle <- newTVarIO ClientPending
+                reader <- asyncWithUnmask \unmask ->
+                    unmask (readerLoop output pending failure)
+                        `finally` void (tryAny (hClose output))
+                stderrReader <- asyncWithUnmask \unmask ->
+                    unmask (stderrLoop errOutput stderrRef)
+                        `finally` void (tryAny (hClose errOutput))
+                session <- newIORef Nothing
+                let client = McpClient
+                        { clientConfig = config
+                        , clientHttpSession = session
+                        , clientInput = input
+                        , clientProcess = processHandle
+                        , clientGroupId = groupId
+                        , clientNextId = nextId
+                        , clientPending = pending
+                        , clientFailure = failure
+                        , clientWriteLock = writeLock
+                        , clientStderr = stderrRef
+                        , clientReader = reader
+                        , clientStderrReader = stderrReader
+                        , clientClosed = closed
+                        , clientLifecycle = lifecycle
+                        }
+                pure client
+            _ -> do
+                let (_, _, _, processHandle) = created
+                groupId <- getPid processHandle
+                terminateProcessGroup groupId processHandle
+                closeOptionalHandles created
+                ioError (userError "MCP server did not provide all stdio pipes")
+
+mcpHttpManager :: Manager
+mcpHttpManager = unsafePerformIO newTlsManager
+{-# NOINLINE mcpHttpManager #-}
+
+startMcpHttpClient :: McpServerConfig -> Text -> IO McpClient
+startMcpHttpClient config url = mask $ \_ -> do
+    -- Keep the existing client record/lifecycle while using synchronous HTTP.
+    -- An exited helper process supplies the legacy handles needed by shutdown.
+    created <- createProcess ((proc "true" [])
+        { std_in = CreatePipe, std_out = CreatePipe, std_err = CreatePipe })
     case created of
         (Just input, Just output, Just errOutput, processHandle) -> do
-            groupId <- getPid processHandle
-            hSetBinaryMode input True
-            hSetBinaryMode output True
-            hSetBinaryMode errOutput True
-            hSetBuffering input LineBuffering
             nextId <- newIORef 1
             pending <- newTVarIO IntMap.empty
             failure <- newTVarIO Nothing
@@ -149,34 +208,20 @@ startMcpClient config = mask \_ -> do
             stderrRef <- newIORef emptyCapturedStderr
             closed <- newMVar False
             lifecycle <- newTVarIO ClientPending
-            reader <- asyncWithUnmask \unmask ->
-                unmask (readerLoop output pending failure)
-                    `finally` void (tryAny (hClose output))
-            stderrReader <- asyncWithUnmask \unmask ->
-                unmask (stderrLoop errOutput stderrRef)
-                    `finally` void (tryAny (hClose errOutput))
-            let client = McpClient
-                    { clientConfig = config
-                    , clientInput = input
-                    , clientProcess = processHandle
-                    , clientGroupId = groupId
-                    , clientNextId = nextId
-                    , clientPending = pending
-                    , clientFailure = failure
-                    , clientWriteLock = writeLock
-                    , clientStderr = stderrRef
-                    , clientReader = reader
-                    , clientStderrReader = stderrReader
-                    , clientClosed = closed
-                    , clientLifecycle = lifecycle
-                    }
-            pure client
-        _ -> do
-            let (_, _, _, processHandle) = created
-            groupId <- getPid processHandle
-            terminateProcessGroup groupId processHandle
-            closeOptionalHandles created
-            ioError (userError "MCP server did not provide all stdio pipes")
+            session <- newIORef Nothing
+            reader <- asyncWithUnmask $ \unmask -> unmask (threadDelay maxBound)
+            stderrReader <- asyncWithUnmask $ \unmask -> unmask (threadDelay maxBound)
+            pure McpClient
+                { clientConfig = config, clientHttpSession = session
+                , clientInput = input, clientProcess = processHandle
+                , clientGroupId = Nothing, clientNextId = nextId
+                , clientPending = pending, clientFailure = failure
+                , clientWriteLock = writeLock, clientStderr = stderrRef
+                , clientReader = reader, clientStderrReader = stderrReader
+                , clientClosed = closed, clientLifecycle = lifecycle }
+        _ -> ioError (userError "MCP HTTP client setup failed")
+  where
+    _ = url
 
 data InitializeRole
     = InitializeLeader
@@ -465,9 +510,10 @@ requestMcp
     -> IO (Either Text RawJson)
 requestMcp client timeoutMicros method parameters = do
     failed <- readTVarIO client.clientFailure
-    case failed of
-        Just err -> pure (Left err)
-        Nothing -> do
+    case (failed, client.clientConfig.mcpServerUrl) of
+        (Just err, _) -> pure (Left err)
+        (Nothing, Just url) -> httpRequestMcp client timeoutMicros url method parameters
+        (Nothing, Nothing) -> do
             requestId <- atomicModifyIORef' client.clientNextId \current ->
                 (current + 1, current)
             response <- newEmptyTMVarIO
@@ -501,16 +547,50 @@ requestMcp client timeoutMicros method parameters = do
                                             ((timeoutMicros + 999999) `div` 1000000))
                                     <> " seconds"
 
+httpRequestMcp :: McpClient -> Int -> Text -> Text -> Aeson.Encoding -> IO (Either Text RawJson)
+httpRequestMcp client timeoutMicros url method parameters = do
+    requestId <- atomicModifyIORef' client.clientNextId (\current -> (current + 1, current))
+    request <- parseRequest (Text.unpack url)
+    session <- readIORef client.clientHttpSession
+    let body = AesonEncodingInternal.encodingToLazyByteString $ Aeson.pairs
+            ("jsonrpc" .= ("2.0" :: Text) <> "id" .= requestId <> "method" .= method <> AesonEncoding.pair "params" parameters)
+        configuredToken = lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv
+        headers = [("Content-Type", "application/json"), ("Accept", "application/json, text/event-stream")]
+            <> maybe [] (\token -> [("Authorization", "Bearer " <> BS8.pack token)]) configuredToken
+            <> maybe [] (\value -> [("Mcp-Session-Id", TextEncoding.encodeUtf8 value)]) session
+        request' = request { HC.method = "POST", HC.requestBody = RequestBodyLBS body, HC.requestHeaders = headers }
+    result <- tryAny (timeout (max 1 timeoutMicros) (httpLbs request' mcpHttpManager))
+    case result of
+        Left exception -> pure (Left ("MCP HTTP request failed: " <> exceptionSummary exception))
+        Right Nothing -> pure (Left ("MCP request " <> method <> " timed out"))
+        Right (Just response)
+            | statusCode (responseStatus response) == 401 ->
+                pure (Left "MCP server requires OAuth authorization; configure MCP OAuth credentials")
+            | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 ->
+                pure (Left ("MCP HTTP request failed with status " <> Text.pack (show (statusCode (responseStatus response)))))
+            | otherwise -> do
+                forM_ (lookup "Mcp-Session-Id" (responseHeaders response)) $ \value ->
+                    writeIORef client.clientHttpSession (Just (TextEncoding.decodeUtf8 value))
+                let bytes = LBS.toStrict (responseBody response)
+                if BS.null bytes
+                    then pure (Right (rawJsonFromEncoding (Aeson.toEncoding (object []))))
+                    else pure (either (Left . ("Invalid MCP HTTP response: " <>) . Text.pack . show) Right (Json.decodeEither rawJsonDecoder bytes))
+
 sendNotification
     :: McpClient
     -> Text
     -> Aeson.Encoding
     -> IO (Either Text ())
 sendNotification client method parameters =
-    sendMessage client . Aeson.pairs $
-        "jsonrpc" .= ("2.0" :: Text)
-            <> "method" .= method
-            <> AesonEncoding.pair "params" parameters
+    case client.clientConfig.mcpServerUrl of
+        Just url -> fmap (fmap (const ())) $
+            httpRequestMcp client
+                (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
+                url method parameters
+        Nothing -> sendMessage client . Aeson.pairs $
+            "jsonrpc" .= ("2.0" :: Text)
+                <> "method" .= method
+                <> AesonEncoding.pair "params" parameters
 
 sendMessage :: McpClient -> Aeson.Encoding -> IO (Either Text ())
 sendMessage client message =

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Agent.MCP.OAuth
+    ( OAuthTokens(..), OAuthTokenResponse(..), refreshAccessToken ) where
+
+import Control.Exception.Safe (tryAny)
+import qualified Data.Aeson as Aeson
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Encoding
+import Network.HTTP.Client (Manager, RequestBody(..), httpLbs, parseRequest, responseBody, responseStatus)
+import qualified Network.HTTP.Client as HC
+import Network.HTTP.Types (statusCode)
+import Network.HTTP.Types.URI (urlEncodeAsForm)
+
+data OAuthTokens = OAuthTokens
+    { accessToken :: !Text
+    , refreshToken :: !(Maybe Text)
+    , expiresIn :: !(Maybe Int)
+    } deriving (Eq)
+
+instance Show OAuthTokens where
+    show tokens = "OAuthTokens { accessToken = <redacted>, refreshToken = " <> show (maybe False (const True) tokens.refreshToken) <> " }"
+
+data OAuthTokenResponse = OAuthTokenSuccess !OAuthTokens | OAuthTokenFailure !Text
+    deriving (Eq, Show)
+
+refreshAccessToken :: Manager -> Text -> Text -> Text -> IO OAuthTokenResponse
+refreshAccessToken manager endpoint clientId oldRefresh = do
+    result <- tryAny $ do
+        request <- parseRequest (Text.unpack endpoint)
+        let body = urlEncodeAsForm
+                [("grant_type", "refresh_token"), ("refresh_token", Encoding.encodeUtf8 oldRefresh), ("client_id", Encoding.encodeUtf8 clientId)]
+            request' = request { HC.method = "POST", HC.requestBody = RequestBodyLBS body, HC.requestHeaders = [("Content-Type", "application/x-www-form-urlencoded")] }
+        httpLbs request' manager
+    case result of
+        Left e -> pure (OAuthTokenFailure (Text.pack (show e)))
+        Right response
+            | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (OAuthTokenFailure "OAuth token request failed")
+            | otherwise -> pure $ either (OAuthTokenFailure . Text.pack) OAuthTokenSuccess (Aeson.eitherDecode (responseBody response))
+
+instance Aeson.FromJSON OAuthTokens where
+    parseJSON = Aeson.withObject "OAuthTokens" $ \o -> OAuthTokens <$> o Aeson..: "access_token" <*> o Aeson..:? "refresh_token" <*> o Aeson..:? "expires_in"

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -1,9 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Agent.MCP.OAuth
-    ( OAuthTokens(..), OAuthTokenResponse(..), refreshAccessToken ) where
+    ( OAuthTokens(..), OAuthTokenResponse(..), ProtectedResourceMetadata(..)
+    , AuthorizationServerMetadata(..), ClientRegistration(..)
+    , discoverProtectedResource, discoverAuthorizationServer, registerClient
+    , refreshAccessToken
+    ) where
 
 import Control.Exception.Safe (tryAny)
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
@@ -12,31 +17,70 @@ import qualified Network.HTTP.Client as HC
 import Network.HTTP.Types (statusCode)
 import Network.HTTP.Types.URI (urlEncodeAsForm)
 
-data OAuthTokens = OAuthTokens
-    { accessToken :: !Text
-    , refreshToken :: !(Maybe Text)
-    , expiresIn :: !(Maybe Int)
-    } deriving (Eq)
-
+data OAuthTokens = OAuthTokens { accessToken :: !Text, refreshToken :: !(Maybe Text), expiresIn :: !(Maybe Int) } deriving (Eq)
 instance Show OAuthTokens where
     show tokens = "OAuthTokens { accessToken = <redacted>, refreshToken = " <> show (maybe False (const True) tokens.refreshToken) <> " }"
+data OAuthTokenResponse = OAuthTokenSuccess !OAuthTokens | OAuthTokenFailure !Text deriving (Eq, Show)
 
-data OAuthTokenResponse = OAuthTokenSuccess !OAuthTokens | OAuthTokenFailure !Text
-    deriving (Eq, Show)
+data ProtectedResourceMetadata = ProtectedResourceMetadata { resource :: !(Maybe Text), authorizationServers :: ![Text], scopesSupported :: ![Text] } deriving (Eq, Show)
+instance Aeson.FromJSON ProtectedResourceMetadata where
+    parseJSON = Aeson.withObject "ProtectedResourceMetadata" $ \o -> ProtectedResourceMetadata <$> o Aeson..:? "resource" <*> o Aeson..:? "authorization_servers" Aeson..!= [] <*> o Aeson..:? "scopes_supported" Aeson..!= []
+
+data AuthorizationServerMetadata = AuthorizationServerMetadata { issuer :: !(Maybe Text), authorizationEndpoint :: !Text, tokenEndpoint :: !Text, registrationEndpoint :: !(Maybe Text), codeChallengeMethodsSupported :: ![Text], scopesSupportedByServer :: ![Text] } deriving (Eq, Show)
+instance Aeson.FromJSON AuthorizationServerMetadata where
+    parseJSON = Aeson.withObject "AuthorizationServerMetadata" $ \o -> AuthorizationServerMetadata <$> o Aeson..:? "issuer" <*> o Aeson..: "authorization_endpoint" <*> o Aeson..: "token_endpoint" <*> o Aeson..:? "registration_endpoint" <*> o Aeson..:? "code_challenge_methods_supported" Aeson..!= [] <*> o Aeson..:? "scopes_supported" Aeson..!= []
+
+data ClientRegistration = ClientRegistration { clientId :: !Text, clientSecret :: !(Maybe Text) } deriving (Eq)
+instance Show ClientRegistration where
+    show registration = "ClientRegistration { clientId = <redacted>, clientSecret = " <> show (maybe False (const True) registration.clientSecret) <> " }"
+instance Aeson.FromJSON ClientRegistration where
+    parseJSON = Aeson.withObject "ClientRegistration" $ \o -> ClientRegistration <$> o Aeson..: "client_id" <*> o Aeson..:? "client_secret"
+
+discoverProtectedResource :: Manager -> Text -> IO (Either Text ProtectedResourceMetadata)
+discoverProtectedResource manager resourceUrl = getJson manager (metadataRoot resourceUrl <> "/.well-known/oauth-protected-resource")
+
+discoverAuthorizationServer :: Manager -> Text -> IO (Either Text AuthorizationServerMetadata)
+discoverAuthorizationServer manager issuerUrl = getJson manager (trimTrailingSlash issuerUrl <> "/.well-known/oauth-authorization-server")
+
+registerClient :: Manager -> Text -> [Text] -> [Text] -> IO (Either Text ClientRegistration)
+registerClient manager registrationUrl redirectUris scopes = do
+    result <- tryAny $ do
+        request <- parseRequest (Text.unpack registrationUrl)
+        let payload = Aeson.encode $ Aeson.object ["redirect_uris" Aeson..= redirectUris, "token_endpoint_auth_method" Aeson..= ("none" :: Text), "grant_types" Aeson..= ["authorization_code", "refresh_token" :: Text], "response_types" Aeson..= ["code" :: Text], "scope" Aeson..= Text.unwords scopes]
+            request' = request { HC.method = "POST", HC.requestBody = RequestBodyLBS payload, HC.requestHeaders = [("Content-Type", "application/json"), ("Accept", "application/json")] }
+        httpLbs request' manager
+    case result of
+        Left exception -> pure (Left (Text.pack (show exception)))
+        Right response | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (Left "OAuth client registration failed")
+                       | otherwise -> decodeBody response
 
 refreshAccessToken :: Manager -> Text -> Text -> Text -> IO OAuthTokenResponse
 refreshAccessToken manager endpoint clientId oldRefresh = do
     result <- tryAny $ do
         request <- parseRequest (Text.unpack endpoint)
-        let body = urlEncodeAsForm
-                [("grant_type", "refresh_token"), ("refresh_token", Encoding.encodeUtf8 oldRefresh), ("client_id", Encoding.encodeUtf8 clientId)]
+        let body = urlEncodeAsForm [("grant_type", "refresh_token"), ("refresh_token", Encoding.encodeUtf8 oldRefresh), ("client_id", Encoding.encodeUtf8 clientId)]
             request' = request { HC.method = "POST", HC.requestBody = RequestBodyLBS body, HC.requestHeaders = [("Content-Type", "application/x-www-form-urlencoded")] }
         httpLbs request' manager
     case result of
         Left e -> pure (OAuthTokenFailure (Text.pack (show e)))
-        Right response
-            | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (OAuthTokenFailure "OAuth token request failed")
-            | otherwise -> pure $ either (OAuthTokenFailure . Text.pack) OAuthTokenSuccess (Aeson.eitherDecode (responseBody response))
+        Right response | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (OAuthTokenFailure "OAuth token request failed")
+                       | otherwise -> pure $ either (OAuthTokenFailure . Text.pack) OAuthTokenSuccess (Aeson.eitherDecode (responseBody response))
 
-instance Aeson.FromJSON OAuthTokens where
-    parseJSON = Aeson.withObject "OAuthTokens" $ \o -> OAuthTokens <$> o Aeson..: "access_token" <*> o Aeson..:? "refresh_token" <*> o Aeson..:? "expires_in"
+getJson :: Aeson.FromJSON value => Manager -> Text -> IO (Either Text value)
+getJson manager url = do
+    result <- tryAny $ do
+        request <- parseRequest (Text.unpack url)
+        httpLbs request { HC.requestHeaders = [("Accept", "application/json")] } manager
+    case result of
+        Left exception -> pure (Left (Text.pack (show exception)))
+        Right response | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (Left "OAuth metadata request failed")
+                       | otherwise -> decodeBody response
+
+decodeBody :: Aeson.FromJSON value => HC.Response LBS.ByteString -> IO (Either Text value)
+decodeBody response = pure $ either (Left . Text.pack) Right (Aeson.eitherDecode (responseBody response))
+metadataRoot :: Text -> Text
+metadataRoot url = case Text.breakOn "://" url of
+    (scheme, rest) | Text.null rest -> trimTrailingSlash url
+                   | otherwise -> scheme <> "://" <> Text.takeWhile (/= '/') (Text.drop 3 rest)
+trimTrailingSlash :: Text -> Text
+trimTrailingSlash t = Text.dropWhileEnd (== '/') t

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -72,11 +72,11 @@ refreshOAuthTokenFile manager path = withMVar oauthRefreshLock $ \_ ->
         Right current -> refreshAccessToken manager current.tokenEndpoint current.tokenClientId current.tokenRefreshToken >>= \case
             OAuthTokenFailure err -> pure (Left err)
             OAuthTokenSuccess tokens -> do
-                now <- floor <$> getPOSIXTime
+                now <- round <$> getPOSIXTime
                 let updated = current
                         { tokenAccessToken = tokens.accessToken
                         , tokenRefreshToken = maybe current.tokenRefreshToken id tokens.refreshToken
-                        , tokenExpiresAt = fmap (now +) tokens.expiresIn
+                        , tokenExpiresAt = fmap (fromIntegral now +) tokens.expiresIn
                         }
                 writeLazyFileAtomically (unsafeEncodeUtf path) (ownerReadMode .|. ownerWriteMode) (Aeson.encode updated)
                 pure (Right updated)

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -4,11 +4,18 @@ module Agent.MCP.OAuth
     , AuthorizationServerMetadata(..), ClientRegistration(..)
     , discoverProtectedResource, discoverAuthorizationServer, registerClient
     , refreshAccessToken, oauthCallbackSuccessPage
+    , OAuthTokenFile(..), loadOAuthTokenFile, refreshOAuthTokenFile
     ) where
 
+import Agent.FileRetry (writeLazyFileAtomically)
+import System.OsPath (unsafeEncodeUtf)
+import Data.Bits ((.|.))
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception.Safe (tryAny)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import System.Posix.Files (ownerReadMode, ownerWriteMode)
+import System.IO.Unsafe (unsafePerformIO)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
@@ -20,6 +27,57 @@ data OAuthTokens = OAuthTokens { accessToken :: !Text, refreshToken :: !(Maybe T
 instance Show OAuthTokens where
     show tokens = "OAuthTokens { accessToken = <redacted>, refreshToken = " <> show (maybe False (const True) tokens.refreshToken) <> " }"
 data OAuthTokenResponse = OAuthTokenSuccess !OAuthTokens | OAuthTokenFailure !Text deriving (Eq, Show)
+
+data OAuthTokenFile = OAuthTokenFile
+    { tokenClientId :: !Text
+    , tokenEndpoint :: !Text
+    , tokenAccessToken :: !Text
+    , tokenRefreshToken :: !Text
+    , tokenExpiresAt :: !(Maybe Int)
+    } deriving (Eq)
+
+instance Show OAuthTokenFile where
+    show _ = "OAuthTokenFile { tokens = <redacted> }"
+
+instance Aeson.FromJSON OAuthTokenFile where
+    parseJSON = Aeson.withObject "OAuthTokenFile" $ \o -> OAuthTokenFile
+        <$> o Aeson..: "client_id" <*> o Aeson..: "token_endpoint"
+        <*> o Aeson..: "access_token" <*> o Aeson..: "refresh_token"
+        <*> o Aeson..:? "expires_at"
+
+instance Aeson.ToJSON OAuthTokenFile where
+    toJSON t = Aeson.object
+        [ "client_id" Aeson..= t.tokenClientId
+        , "token_endpoint" Aeson..= t.tokenEndpoint
+        , "access_token" Aeson..= t.tokenAccessToken
+        , "refresh_token" Aeson..= t.tokenRefreshToken
+        , "expires_at" Aeson..= t.tokenExpiresAt
+        ]
+
+loadOAuthTokenFile :: FilePath -> IO (Either Text OAuthTokenFile)
+loadOAuthTokenFile path = do
+    result <- tryAny (LBS.readFile path)
+    pure $ case result of
+        Left exception -> Left ("MCP OAuth token file unavailable: " <> Text.pack (show exception))
+        Right bytes -> either (Left . Text.pack) Right (Aeson.eitherDecode bytes)
+
+refreshOAuthTokenFile :: Manager -> FilePath -> IO (Either Text OAuthTokenFile)
+refreshOAuthTokenFile manager path = withMVar oauthRefreshLock $ \_ -> do
+    loadOAuthTokenFile path >>= \file -> case file of
+        Left err -> pure (Left err)
+        Right current -> refreshAccessToken manager current.tokenEndpoint current.tokenClientId current.tokenRefreshToken >>= \case
+            OAuthTokenFailure err -> pure (Left err)
+            OAuthTokenSuccess tokens -> do
+                let updated = current
+                        { tokenAccessToken = tokens.accessToken
+                        , tokenRefreshToken = maybe current.tokenRefreshToken id tokens.refreshToken
+                        }
+                writeLazyFileAtomically (unsafeEncodeUtf path) (ownerReadMode .|. ownerWriteMode) (Aeson.encode updated)
+                pure (Right updated)
+
+oauthRefreshLock :: MVar ()
+oauthRefreshLock = unsafePerformIO (newMVar ())
+{-# NOINLINE oauthRefreshLock #-}
 
 data ProtectedResourceMetadata = ProtectedResourceMetadata { resource :: !(Maybe Text), authorizationServers :: ![Text], scopesSupported :: ![Text] } deriving (Eq, Show)
 instance Aeson.FromJSON ProtectedResourceMetadata where

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -138,17 +138,18 @@ refreshAccessToken manager endpoint clientId oldRefresh = do
         Right response | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (OAuthTokenFailure "OAuth token request failed")
                        | otherwise -> pure $ either (OAuthTokenFailure . Text.pack) OAuthTokenSuccess (Aeson.eitherDecode (responseBody response))
 
-exchangeAuthorizationCode :: Manager -> Text -> Text -> Text -> Text -> Text -> IO OAuthTokenResponse
-exchangeAuthorizationCode manager endpoint clientId code redirectUri verifier = do
+exchangeAuthorizationCode :: Manager -> Text -> Text -> Text -> Text -> Text -> Maybe Text -> IO OAuthTokenResponse
+exchangeAuthorizationCode manager endpoint clientId code redirectUri verifier resource = do
     result <- tryAny $ do
         request <- parseRequest (Text.unpack endpoint)
-        let request' = urlEncodedBody
+        let parameters =
                 [ ("grant_type", "authorization_code")
                 , ("code", Encoding.encodeUtf8 code)
                 , ("redirect_uri", Encoding.encodeUtf8 redirectUri)
                 , ("client_id", Encoding.encodeUtf8 clientId)
                 , ("code_verifier", Encoding.encodeUtf8 verifier)
-                ] request { HC.method = "POST" }
+                ] <> maybe [] (\value -> [("resource", Encoding.encodeUtf8 value)]) resource
+            request' = urlEncodedBody parameters request { HC.method = "POST" }
         httpLbs request' manager
     case result of
         Left e -> pure (OAuthTokenFailure (Text.pack (show e)))

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -19,6 +19,7 @@ import qualified Data.ByteString.Lazy as LBS
 import System.Posix.Files (ownerReadMode, ownerWriteMode)
 import System.IO.Unsafe (unsafePerformIO)
 import Data.Text (Text)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
 import Network.HTTP.Client (Manager, RequestBody(..), httpLbs, parseRequest, responseBody, responseStatus, urlEncodedBody)
@@ -71,9 +72,11 @@ refreshOAuthTokenFile manager path = withMVar oauthRefreshLock $ \_ ->
         Right current -> refreshAccessToken manager current.tokenEndpoint current.tokenClientId current.tokenRefreshToken >>= \case
             OAuthTokenFailure err -> pure (Left err)
             OAuthTokenSuccess tokens -> do
+                now <- floor <$> getPOSIXTime
                 let updated = current
                         { tokenAccessToken = tokens.accessToken
                         , tokenRefreshToken = maybe current.tokenRefreshToken id tokens.refreshToken
+                        , tokenExpiresAt = fmap (now +) tokens.expiresIn
                         }
                 writeLazyFileAtomically (unsafeEncodeUtf path) (ownerReadMode .|. ownerWriteMode) (Aeson.encode updated)
                 pure (Right updated)

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -3,7 +3,7 @@ module Agent.MCP.OAuth
     ( OAuthTokens(..), OAuthTokenResponse(..), ProtectedResourceMetadata(..)
     , AuthorizationServerMetadata(..), ClientRegistration(..)
     , discoverProtectedResource, discoverAuthorizationServer, registerClient
-    , refreshAccessToken, oauthCallbackSuccessPage
+    , refreshAccessToken, exchangeAuthorizationCode, oauthCallbackSuccessPage
     , OAuthTokenFile(..), loadOAuthTokenFile, refreshOAuthTokenFile
     ) where
 
@@ -18,6 +18,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import System.Posix.Files (ownerReadMode, ownerWriteMode)
 import System.IO.Unsafe (unsafePerformIO)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Text as Text
@@ -77,6 +78,7 @@ refreshOAuthTokenFile manager path = withMVar oauthRefreshLock $ \_ ->
                         { tokenAccessToken = tokens.accessToken
                         , tokenRefreshToken = maybe current.tokenRefreshToken id tokens.refreshToken
                         , tokenExpiresAt = fmap (fromIntegral now +) tokens.expiresIn
+
                         }
                 writeLazyFileAtomically (unsafeEncodeUtf path) (ownerReadMode .|. ownerWriteMode) (Aeson.encode updated)
                 pure (Right updated)
@@ -135,6 +137,28 @@ refreshAccessToken manager endpoint clientId oldRefresh = do
         Left e -> pure (OAuthTokenFailure (Text.pack (show e)))
         Right response | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (OAuthTokenFailure "OAuth token request failed")
                        | otherwise -> pure $ either (OAuthTokenFailure . Text.pack) OAuthTokenSuccess (Aeson.eitherDecode (responseBody response))
+
+exchangeAuthorizationCode :: Manager -> Text -> Text -> Text -> Text -> Text -> IO OAuthTokenResponse
+exchangeAuthorizationCode manager endpoint clientId code redirectUri verifier = do
+    result <- tryAny $ do
+        request <- parseRequest (Text.unpack endpoint)
+        let request' = urlEncodedBody
+                [ ("grant_type", "authorization_code")
+                , ("code", Encoding.encodeUtf8 code)
+                , ("redirect_uri", Encoding.encodeUtf8 redirectUri)
+                , ("client_id", Encoding.encodeUtf8 clientId)
+                , ("code_verifier", Encoding.encodeUtf8 verifier)
+                ] request { HC.method = "POST" }
+        httpLbs request' manager
+    case result of
+        Left e -> pure (OAuthTokenFailure (Text.pack (show e)))
+        Right response
+            | statusCode (responseStatus response) < 200
+                || statusCode (responseStatus response) >= 300 ->
+                pure (OAuthTokenFailure "OAuth authorization-code exchange failed")
+            | otherwise ->
+                pure $ either (OAuthTokenFailure . Text.pack) OAuthTokenSuccess
+                    (Aeson.eitherDecode (responseBody response))
 
 getJson :: Aeson.FromJSON value => Manager -> Text -> IO (Either Text value)
 getJson manager url = do

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -12,10 +12,9 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
-import Network.HTTP.Client (Manager, RequestBody(..), httpLbs, parseRequest, responseBody, responseStatus)
+import Network.HTTP.Client (Manager, RequestBody(..), httpLbs, parseRequest, responseBody, responseStatus, urlEncodedBody)
 import qualified Network.HTTP.Client as HC
 import Network.HTTP.Types (statusCode)
-import Network.HTTP.Types.URI (urlEncodeAsForm)
 
 data OAuthTokens = OAuthTokens { accessToken :: !Text, refreshToken :: !(Maybe Text), expiresIn :: !(Maybe Int) } deriving (Eq)
 instance Show OAuthTokens where
@@ -58,8 +57,7 @@ refreshAccessToken :: Manager -> Text -> Text -> Text -> IO OAuthTokenResponse
 refreshAccessToken manager endpoint clientId oldRefresh = do
     result <- tryAny $ do
         request <- parseRequest (Text.unpack endpoint)
-        let body = urlEncodeAsForm [("grant_type", "refresh_token"), ("refresh_token", Encoding.encodeUtf8 oldRefresh), ("client_id", Encoding.encodeUtf8 clientId)]
-            request' = request { HC.method = "POST", HC.requestBody = RequestBodyLBS body, HC.requestHeaders = [("Content-Type", "application/x-www-form-urlencoded")] }
+        let request' = urlEncodedBody [("grant_type", "refresh_token"), ("refresh_token", Encoding.encodeUtf8 oldRefresh), ("client_id", Encoding.encodeUtf8 clientId)] request { HC.method = "POST" }
         httpLbs request' manager
     case result of
         Left e -> pure (OAuthTokenFailure (Text.pack (show e)))
@@ -84,3 +82,10 @@ metadataRoot url = case Text.breakOn "://" url of
                    | otherwise -> scheme <> "://" <> Text.takeWhile (/= '/') (Text.drop 3 rest)
 trimTrailingSlash :: Text -> Text
 trimTrailingSlash t = Text.dropWhileEnd (== '/') t
+
+instance Aeson.FromJSON OAuthTokens where
+    parseJSON = Aeson.withObject "OAuthTokens" $ \object ->
+        OAuthTokens
+            <$> object Aeson..: "access_token"
+            <*> object Aeson..:? "refresh_token"
+            <*> object Aeson..:? "expires_in"

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -11,7 +11,9 @@ import Agent.FileRetry (writeLazyFileAtomically)
 import System.OsPath (unsafeEncodeUtf)
 import Data.Bits ((.|.))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (bracket, tryAny)
+import qualified System.FileLock as FileLock
+import System.Posix.IO (OpenFileFlags(..), OpenMode(ReadWrite), closeFd, defaultFileFlags, openFd)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import System.Posix.Files (ownerReadMode, ownerWriteMode)
@@ -62,7 +64,8 @@ loadOAuthTokenFile path = do
         Right bytes -> either (Left . Text.pack) Right (Aeson.eitherDecode bytes)
 
 refreshOAuthTokenFile :: Manager -> FilePath -> IO (Either Text OAuthTokenFile)
-refreshOAuthTokenFile manager path = withMVar oauthRefreshLock $ \_ -> do
+refreshOAuthTokenFile manager path = withMVar oauthRefreshLock $ \_ ->
+    withOAuthFileLock path $ do
     loadOAuthTokenFile path >>= \file -> case file of
         Left err -> pure (Left err)
         Right current -> refreshAccessToken manager current.tokenEndpoint current.tokenClientId current.tokenRefreshToken >>= \case
@@ -74,6 +77,14 @@ refreshOAuthTokenFile manager path = withMVar oauthRefreshLock $ \_ -> do
                         }
                 writeLazyFileAtomically (unsafeEncodeUtf path) (ownerReadMode .|. ownerWriteMode) (Aeson.encode updated)
                 pure (Right updated)
+
+withOAuthFileLock :: FilePath -> IO a -> IO a
+withOAuthFileLock tokenPath action = do
+    let lockPath = tokenPath <> ".refresh.lock"
+    bracket
+        (openFd lockPath ReadWrite defaultFileFlags { creat = Just 0o600, cloexec = True })
+        closeFd
+        (const (FileLock.withFileLock lockPath FileLock.Exclusive (const action)))
 
 oauthRefreshLock :: MVar ()
 oauthRefreshLock = unsafePerformIO (newMVar ())

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -3,7 +3,7 @@ module Agent.MCP.OAuth
     ( OAuthTokens(..), OAuthTokenResponse(..), ProtectedResourceMetadata(..)
     , AuthorizationServerMetadata(..), ClientRegistration(..)
     , discoverProtectedResource, discoverAuthorizationServer, registerClient
-    , refreshAccessToken
+    , refreshAccessToken, oauthCallbackSuccessPage
     ) where
 
 import Control.Exception.Safe (tryAny)
@@ -82,6 +82,10 @@ metadataRoot url = case Text.breakOn "://" url of
                    | otherwise -> scheme <> "://" <> Text.takeWhile (/= '/') (Text.drop 3 rest)
 trimTrailingSlash :: Text -> Text
 trimTrailingSlash t = Text.dropWhileEnd (== '/') t
+
+-- | UTF-8 success page served by the interactive OAuth callback listener.
+oauthCallbackSuccessPage :: LBS.ByteString
+oauthCallbackSuccessPage = "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width\"><title>Connected</title><style>body{margin:0;min-height:100vh;display:grid;place-items:center;background:#0b1020;color:#e8ecf5;font:16px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}.card{max-width:430px;margin:24px;padding:36px;border:1px solid #28324a;border-radius:20px;background:#131a2d;box-shadow:0 24px 70px #0008;text-align:center}.check{display:grid;place-items:center;width:56px;height:56px;margin:0 auto 20px;border-radius:50%;background:#173d31;color:#6ee7b7;font-size:30px}h1{margin:0 0 10px;font-size:24px}p{margin:0;color:#aab4ca;line-height:1.55}</style></head><body><main class=\"card\"><div class=\"check\">&#10003;</div><h1>MCP connected</h1><p>Authorization completed successfully. You can close this tab and return to Haskell Agent.</p></main></body></html>"
 
 instance Aeson.FromJSON OAuthTokens where
     parseJSON = Aeson.withObject "OAuthTokens" $ \object ->

--- a/packages/agent-core/src/Agent/MCP/Types.hs
+++ b/packages/agent-core/src/Agent/MCP/Types.hs
@@ -224,16 +224,18 @@ data McpFleetLease = McpFleetLease
 data McpClient = McpClient
     { clientConfig :: !McpServerConfig
     , clientHttpSession :: !(IORef (Maybe Text))
-    , clientInput :: !Handle
-    , clientProcess :: !ProcessHandle
+    -- Stdio transports own a process and input pipe; remote HTTP transports
+    -- leave these fields empty and perform requests synchronously.
+    , clientInput :: !(Maybe Handle)
+    , clientProcess :: !(Maybe ProcessHandle)
     , clientGroupId :: !(Maybe ProcessGroupID)
     , clientNextId :: !(IORef Int)
     , clientPending :: !(TVar (IntMap.IntMap (TMVar (Either Text RawJson))))
     , clientFailure :: !(TVar (Maybe Text))
     , clientWriteLock :: !(MVar ())
     , clientStderr :: !(IORef CapturedStderr)
-    , clientReader :: !(Async ())
-    , clientStderrReader :: !(Async ())
+    , clientReader :: !(Maybe (Async ()))
+    , clientStderrReader :: !(Maybe (Async ()))
     , clientClosed :: !(MVar Bool)
     , clientLifecycle :: !(TVar McpClientLifecycle)
     }

--- a/packages/agent-core/src/Agent/MCP/Types.hs
+++ b/packages/agent-core/src/Agent/MCP/Types.hs
@@ -113,6 +113,7 @@ import System.Timeout (timeout)
 
 data McpServerConfig = McpServerConfig
     { mcpServerName :: !Text
+    , mcpServerUrl :: !(Maybe Text)
     , mcpServerCommand :: !FilePath
     , mcpServerArgs :: ![String]
     , mcpServerCwd :: !(Maybe FilePath)
@@ -125,6 +126,7 @@ instance Show McpServerConfig where
     show config =
         "McpServerConfig"
             <> " { mcpServerName = " <> show config.mcpServerName
+            <> ", mcpServerUrl = " <> show config.mcpServerUrl
             <> ", mcpServerCommand = " <> show config.mcpServerCommand
             <> ", mcpServerArgs = " <> show config.mcpServerArgs
             <> ", mcpServerCwd = " <> show config.mcpServerCwd
@@ -221,6 +223,7 @@ data McpFleetLease = McpFleetLease
 -- and 'closeMcpSupervisor' performs the final deterministic shutdown.
 data McpClient = McpClient
     { clientConfig :: !McpServerConfig
+    , clientHttpSession :: !(IORef (Maybe Text))
     , clientInput :: !Handle
     , clientProcess :: !ProcessHandle
     , clientGroupId :: !(Maybe ProcessGroupID)

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -39,6 +39,7 @@ spec = describe "Agent.MCP" do
     it "redacts configured environment values from Show" do
         let rendered = show McpServerConfig
                 { mcpServerName = "private"
+                , mcpServerUrl = Nothing
                 , mcpServerCommand = "/bin/server"
                 , mcpServerArgs = []
                 , mcpServerCwd = Nothing
@@ -89,6 +90,7 @@ spec = describe "Agent.MCP" do
                 (\names -> modifyIORef' started (<> [names]))
                 [ McpServerConfig
                     { mcpServerName = "fake"
+                    , mcpServerUrl = Nothing
                     , mcpServerCommand = script
                     , mcpServerArgs = []
                     , mcpServerCwd = Nothing
@@ -478,6 +480,7 @@ countStarts path = length . lines <$> readFile path
 concurrentConfig :: FilePath -> FilePath -> Text.Text -> McpServerConfig
 concurrentConfig script barrier name = McpServerConfig
     { mcpServerName = name
+    , mcpServerUrl = Nothing
     , mcpServerCommand = script
     , mcpServerArgs = [barrier, Text.unpack name]
     , mcpServerCwd = Nothing
@@ -495,6 +498,7 @@ progressiveConfig script delay name =
 baseConfig :: Text.Text -> FilePath -> McpServerConfig
 baseConfig name command = McpServerConfig
     { mcpServerName = name
+    , mcpServerUrl = Nothing
     , mcpServerCommand = command
     , mcpServerArgs = []
     , mcpServerCwd = Nothing


### PR DESCRIPTION
## Summary
- add provider-agnostic remote Streamable HTTP MCP transport
- support JSON/SSE responses, session IDs, notifications, and session shutdown
- discover OAuth protected-resource and authorization-server metadata dynamically
- support dynamic client registration and PKCE browser login
- persist per-server credentials privately and wire them into configured remote servers
- refresh before expiry or after one 401, atomically persist rotated refresh tokens, and retry once
- serialize refreshes across threads and processes
- retain existing local stdio MCP compatibility
- add login/logout commands and a styled UTF-8 callback page

## Validation
- `nix develop -c cabal build agent-core agent-cli --offline`
- agent-core tests: 420 examples, 0 failures
- tmux CLI smoke test
- live standards-compliant remote MCP OAuth smoke test
- local integration server verified 401 -> refresh -> rotated-token persistence -> successful MCP retry

No MCP provider URL, issuer, authorization endpoint, token endpoint, registration endpoint, client id, or scope is hardcoded; these are supplied by configuration or discovered from OAuth metadata.