### PR TITLE
Fix Codex plan state when resuming sessions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Plan
     , renderPlanEnterFrame
     , renderPlanExitFrame
     , extractProposedPlan
+    , resumedPlanNeedsApproval
     , stripProposedPlan
     , renderPlanMarkdown
     , parsePlanDecisionAnswer
@@ -51,7 +52,7 @@ import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe (throwIO)
 import Data.Char (toLower)
 import Data.IORef (IORef)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -347,6 +348,16 @@ extractProposedPlan text =
   where
     openTag = "<proposed_plan>"
     closeTag = "</proposed_plan>"
+
+-- | Whether a resumed transcript ends with a plan that still needs the
+-- user's decision.  Codex presents its plan in assistant text rather than
+-- through an explicit exit tool, so this is the durable signal available
+-- when rebuilding the in-memory plan-mode state on resume.
+resumedPlanNeedsApproval :: [Maybe Text] -> Bool
+resumedPlanNeedsApproval assistantTexts =
+    case reverse [text | Just text <- assistantTexts] of
+        lastText : _ -> isJust (extractProposedPlan lastText)
+        _ -> False
 
 -- | Remove proposed_plan tags for display after the approval UI shows the body.
 stripProposedPlan :: Text -> Text

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -69,7 +69,10 @@ import Agent.CLI.Options
                  optGhci, optBash, optNoYolo) )
 import Agent.CLI.PendingInputs
     ( enqueuePendingInput, newPendingInputs )
-import Agent.CLI.Plan ( cliPlanHooks )
+import Agent.CLI.Plan
+    ( cliPlanHooks
+    , resumedPlanNeedsApproval
+    )
 import Agent.CLI.Project ( saveRememberedModel )
 import Agent.CLI.Prompt ( subscriptionSubagentModelGuidance )
 import Agent.CLI.PromptHooks
@@ -109,7 +112,8 @@ import Agent.CLI.Session
       Persistence(PersistenceDisabled),
       SessionHandle(sessionDir, sessionMeta),
       SessionMeta(metaId, metaTransportModel, metaProvider,
-                  metaConnection, metaModel, metaDialect, metaEffort) )
+                  metaConnection, metaModel, metaDialect, metaEffort),
+      SessionTurn(turnAssistantText) )
 import Agent.CLI.Session.Attachments ()
 import Agent.CLI.Session.Choices ()
 import Agent.CLI.Session.History ()
@@ -198,6 +202,7 @@ import Agent.Tools.MultiAgents
     ( MultiAgentContext(..), SubagentWorktree(..) )
 import Agent.Tools.PlanMode
     ( PlanModeEnv(planSessionDir),
+      activatePlanMode,
       PlanModeHooks(planAskQuestion, PlanModeHooks, planConfirmEnter,
                     planDecideExit),
       PlanDecision(PlanCancel) )
@@ -449,6 +454,10 @@ runAgentTools
         claudeBypassEnabled =
             not options.optNoYolo
                 && (options.optYolo || projectSettings.settingsAutoApprove)
+    -- Plan mode itself is process-local, while the assistant's proposed plan
+    -- is durable in the session transcript. Reconstruct the approval phase
+    -- before entering the REPL so a resumed Codex session cannot interpret
+    -- the user's approval as ordinary steering input.
     -- Provider transitions commit their selection separately: manual switches
     -- immediately, automatic fallbacks only after the replacement succeeds.
     when (isNothing transition) $
@@ -813,6 +822,12 @@ runAgentTools
                 ++ databaseAppTools
                 ++ learnedSkillAppTools
         planMode = coding.codingPlanMode
+        resumedPlanPending =
+            case resumed of
+                Just (_, turns) ->
+                    resumedPlanNeedsApproval
+                        (map turnAssistantText turns)
+                Nothing -> False
         -- Keep planSessionDir and subagent store root in sync.
         noteSessionDir dir = do
             writeIORef planMode.planSessionDir (Just dir)
@@ -840,6 +855,7 @@ runAgentTools
                                                     (join (readIORef codeModeCloseRef)
                                                         `finally`
                                                             cleanupScratch)))))
+    when resumedPlanPending (activatePlanMode planMode)
     runAgentSession
         loaded
         learnAboutUserRequested

--- a/packages/agent-cli/test/Agent/CLI/PlanSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PlanSpec.hs
@@ -66,6 +66,25 @@ spec = do
             extractProposedPlan "no plan here" `shouldBe` Nothing
             extractProposedPlan "<proposed_plan>\nunclosed" `shouldBe` Nothing
 
+    describe "resumedPlanNeedsApproval" do
+        it "restores approval when the latest assistant turn is a proposal" do
+            resumedPlanNeedsApproval
+                [ Just "earlier"
+                , Just "<proposed_plan>\n# Plan\n</proposed_plan>"
+                ]
+                `shouldBe` True
+
+        it "does not restore approval after implementation continues" do
+            resumedPlanNeedsApproval
+                [ Just "<proposed_plan>\n# Plan\n</proposed_plan>"
+                , Just "Implementation complete."
+                ]
+                `shouldBe` False
+
+        it "ignores turns without assistant text" do
+            resumedPlanNeedsApproval [Nothing, Just "ordinary answer"]
+                `shouldBe` False
+
     describe "stripProposedPlan" do
         it "removes the tagged block and keeps surrounding text" do
             stripProposedPlan


### PR DESCRIPTION
Restore Codex plan mode when a resumed transcript ends with a proposed plan.

This prevents resumed sessions from silently ignoring the pending plan. Adds regression coverage for proposal detection.

Tests: targeted Cabal test could not run because the offline Hermes checkout is missing.