### PR TITLE
Show Telegram agent progress before long-running work

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -826,7 +826,7 @@ runAgentTools
             case resumed of
                 Just (_, turns) ->
                     resumedPlanNeedsApproval
-                        (map turnAssistantText turns)
+                        (map (.turnAssistantText) turns)
                 Nothing -> False
         -- Keep planSessionDir and subagent store root in sync.
         noteSessionDir dir = do

--- a/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
@@ -6,6 +6,7 @@ module Agent.Telegram.Bridge
     , processTelegramCallbacks
     , processBridgeRequestBatch
     , telegramActivityDraftHtml
+    , telegramActivityMessageText
     ) where
 
 import Agent.CLI.GatewayBridge
@@ -31,6 +32,7 @@ import Control.Exception.Safe (SomeException, displayException, try)
 import Control.Monad (forM_, void, when)
 import Data.Aeson (Value(..))
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (IORef, readIORef, writeIORef)
 import Data.List (isPrefixOf, sort)
 import Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
@@ -58,6 +60,8 @@ data TelegramBridgeEnv = TelegramBridgeEnv
     , telegramBridgeChat :: !TelegramChatKey
     , telegramBridgeUserId :: !Integer
     , telegramBridgeReplyTo :: !(Maybe Integer)
+    , telegramBridgeProgressMessageId :: !(IORef (Maybe Integer))
+    , telegramBridgeGroupActivityEnabled :: !Bool
     , telegramBridgeAllowedRoot :: !FilePath
     , telegramBridgeModifyState ::
         !((TelegramState -> TelegramState) -> IO ())
@@ -563,18 +567,56 @@ publishActivity env previous forceRefresh = do
                                 Right value -> Just value
                                 Left _ -> Nothing
     let next = activity <&> \value ->
-            telegramActivityDraftHtml
-                value.managedActivityMessage
-                value.managedActivityReasoning
-                value.managedActivityResponse
-    forM_ next \html ->
-        when (forceRefresh || Just html /= previous) $
-            void $ try @_ @SomeException $
-                Client.sendStreamingDraft
-                    env.telegramBridgeClient
-                    env.telegramBridgeChat
-                    html
+            if env.telegramBridgeChat.chatId < 0
+                    && env.telegramBridgeGroupActivityEnabled
+                then telegramActivityMessageText
+                    value.managedActivityMessage
+                    value.managedActivityReasoning
+                    value.managedActivityResponse
+                else telegramActivityDraftHtml
+                    value.managedActivityMessage
+                    value.managedActivityReasoning
+                    value.managedActivityResponse
+    forM_ next \rendered ->
+        when (forceRefresh || Just rendered /= previous) $
+            if env.telegramBridgeChat.chatId < 0
+                then when env.telegramBridgeGroupActivityEnabled $
+                    publishGroupActivity env rendered
+                else void $ try @_ @SomeException $
+                    Client.sendStreamingDraft
+                        env.telegramBridgeClient
+                        env.telegramBridgeChat
+                        rendered
     pure (next <|> previous)
+
+publishGroupActivity :: TelegramBridgeEnv -> Text -> IO ()
+publishGroupActivity env message =
+    readIORef env.telegramBridgeProgressMessageId >>= \case
+        Just messageId ->
+            void $ Client.editRichMessageText
+                env.telegramBridgeClient
+                env.telegramBridgeChat
+                messageId
+                message
+        Nothing ->
+            Client.sendRichMessage
+                env.telegramBridgeClient
+                env.telegramBridgeChat
+                env.telegramBridgeReplyTo
+                message >>= \case
+                    Right (Just messageId) -> do
+                        writeIORef env.telegramBridgeProgressMessageId
+                            (Just messageId)
+                        env.telegramBridgeModifyState \state ->
+                            state
+                                { outboundMessageIds =
+                                    Map.insertWith
+                                        Set.union
+                                        env.telegramBridgeChat
+                                        (Set.singleton messageId)
+                                        state.outboundMessageIds
+                                }
+                    _ -> pure ()
 
 managedActivityDecoder :: Hermes.Decoder ManagedActivity
 managedActivityDecoder = Hermes.object $
@@ -598,6 +640,25 @@ telegramActivityDraftHtml status reasoningText responseText =
     reasoning = Text.strip reasoningText
     thinkingText =
         Text.takeEnd 1200 $
+            if Text.null reasoning
+                then status
+                else
+                    if status `elem`
+                        ["Thinking…", "Writing reply…", "Finishing…"]
+                        then reasoning
+                        else status <> "\n" <> reasoning
+    response = Text.takeEnd 2600 responseText
+
+
+telegramActivityMessageText :: Text -> Text -> Text -> Text
+telegramActivityMessageText status reasoningText responseText =
+    Text.takeEnd 4096 $
+        Text.intercalate "\n\n" $
+            filter (not . Text.null) [thinkingText, response]
+  where
+    reasoning = Text.strip reasoningText
+    thinkingText =
+        Text.takeEnd 1400 $
             if Text.null reasoning
                 then status
                 else

--- a/packages/agent-telegram/src/Agent/Telegram/Client.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Client.hs
@@ -15,6 +15,7 @@ module Agent.Telegram.Client
     , sendRichMessage
     , sendMessageWithKeyboard
     , editMessageText
+    , editRichMessageText
     , answerCallbackQuery
     , sendTelegramDocument
     , sendTelegramPhoto
@@ -461,6 +462,20 @@ editMessageText client key messageId text =
         , "reply_markup" .= object
             [ "inline_keyboard" .= ([] :: [[Value]])
             ]
+        ]
+
+editRichMessageText
+    :: TelegramClient
+    -> TelegramChatKey
+    -> Integer
+    -> Text
+    -> IO (Either Text ())
+editRichMessageText client key messageId text =
+    requestUnit client "editMessageText" $ object
+        [ "chat_id" .= key.chatId
+        , "message_id" .= messageId
+        , "text" .= markdownToTelegramHtml text
+        , "parse_mode" .= ("HTML" :: Text)
         ]
 
 answerCallbackQuery

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Allowlist.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Allowlist.hs
@@ -123,6 +123,7 @@ import Data.Aeson
     )
 import qualified Data.ByteString.Lazy as LBS
 import Data.Int (Int64)
+import Data.IORef (IORef)
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Map.Strict as Map
 import Data.List (sortOn)
@@ -192,15 +193,19 @@ telegramBridgeEnv
     -> TelegramChatKey
     -> Integer
     -> Maybe Integer
+    -> IORef (Maybe Integer)
+    -> Bool
     -> FilePath
     -> TelegramBridgeEnv
-telegramBridgeEnv runtime request key userId replyTo allowedRoot =
+telegramBridgeEnv runtime request key userId replyTo progressMessageId groupActivityEnabled allowedRoot =
     TelegramBridgeEnv
         { telegramBridgeClient = runtime.runtimeClient
         , telegramBridgeRequest = request
         , telegramBridgeChat = key
         , telegramBridgeUserId = userId
         , telegramBridgeReplyTo = replyTo
+        , telegramBridgeProgressMessageId = progressMessageId
+        , telegramBridgeGroupActivityEnabled = groupActivityEnabled
         , telegramBridgeAllowedRoot = allowedRoot
         , telegramBridgeModifyState = modifyState runtime
         , telegramBridgeGrantUser =

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Poll.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Poll.hs
@@ -421,7 +421,7 @@ processChatQueue runtime key =
                         Just _ -> runQueuedTurn runtime pending
                     modifyState runtime \state ->
                         let completed = completePendingAction action state
-                        in case telegramReplyText pending.pendingTurnText response of
+                        in case telegramReplyText pending.pendingTurnText response.telegramTurnText of
                             Nothing -> completed
                             Just replyText ->
                                 enqueuePendingAction
@@ -430,6 +430,7 @@ processChatQueue runtime key =
                                             pending.pendingTurnUpdateId
                                             pending.pendingTurnChat
                                             (Just pending.pendingTurnMessageId)
+                                            response.telegramTurnProgressMessageId
                                             replyText))
                                     completed
                 RunPendingMediaTurn pending -> do
@@ -442,7 +443,7 @@ processChatQueue runtime key =
                         Just _ -> runQueuedMediaTurn runtime pending
                     modifyState runtime \state ->
                         let completed = completePendingAction action state
-                        in case telegramReplyText pending.pendingMediaText response of
+                        in case telegramReplyText pending.pendingMediaText response.telegramTurnText of
                             Nothing -> completed
                             Just replyText ->
                                 enqueuePendingAction
@@ -451,6 +452,7 @@ processChatQueue runtime key =
                                             pending.pendingMediaUpdateId
                                             pending.pendingMediaChat
                                             (Just pending.pendingMediaMessageId)
+                                            response.telegramTurnProgressMessageId
                                             replyText))
                                     completed
                 LeaveUnauthorizedChat pending -> do
@@ -477,14 +479,14 @@ processChatQueue runtime key =
                     processChatQueue runtime key
                 Right () -> processChatQueue runtime key
 
-runQueuedTurn :: TelegramRuntime -> TelegramPendingTurn -> IO Text
+runQueuedTurn :: TelegramRuntime -> TelegramPendingTurn -> IO TelegramTurnResponse
 runQueuedTurn runtime pending =
     case telegramCommand pending.pendingTurnText of
-        Just "start" -> pure
+        Just "start" -> withoutProgress $ pure
             "Send a message to start or continue an agent session. \
             \Use /new for a fresh session, /session for its ID, and /allow \
             \in a group to accept another member by name or by replying to them."
-        Just "new" -> do
+        Just "new" -> withoutProgress do
             modifyState runtime \state ->
                 state
                     { bindings = Map.delete
@@ -492,34 +494,36 @@ runQueuedTurn runtime pending =
                         state.bindings
                     }
             pure "Started a new conversation. Send your next prompt."
-        Just "session" -> do
+        Just "session" -> withoutProgress do
             state <- readMVar runtime.runtimeStateVar
             pure case lookupBinding pending.pendingTurnChat state of
                 Nothing -> "No session yet. Send a prompt to create one."
                 Just sessionId -> "Session: " <> sessionId
-        Just "status" -> telegramConversationStatus runtime pending.pendingTurnChat
-        Just "retry" ->
+        Just "status" -> withoutProgress $
+            telegramConversationStatus runtime pending.pendingTurnChat
+        Just "retry" -> withoutProgress $
             retryLastDeadLetter
                 runtime
                 pending.pendingTurnChat
                 (pending.pendingTurnUpdateId + 1)
-        Just "allow" ->
+        Just "allow" -> withoutProgress $
             applyAllowlistChange
                 runtime
                 pending.pendingTurnChat.chatId
                 AllowlistGrant
                 Nothing
                 (telegramCommandArguments pending.pendingTurnText)
-        Just "deny" ->
+        Just "deny" -> withoutProgress $
             applyAllowlistChange
                 runtime
                 pending.pendingTurnChat.chatId
                 AllowlistRevoke
                 Nothing
                 (telegramCommandArguments pending.pendingTurnText)
-        Just "users" ->
+        Just "users" -> withoutProgress $
             describeTelegramAllowlist runtime pending.pendingTurnChat.chatId
-        Just command -> pure ("Unknown command: /" <> command)
+        Just command -> withoutProgress $
+            pure ("Unknown command: /" <> command)
         Nothing -> do
             userId <- telegramTurnUserId runtime pending.pendingTurnChat
             case pending.pendingTurnVoice of
@@ -541,10 +545,11 @@ runQueuedTurn runtime pending =
                                         runtime.runtimeClient.clientToken
                                         (Text.pack (displayException err))
                                 ]
-                            pure
+                            pure $ TelegramTurnResponse
                                 "I could not transcribe that voice message. \
                                 \Check that Codex is installed and logged in, and \
                                 \that the subscription has usage available."
+                                Nothing
                         Right prompt -> do
                             let deliveredPrompt
                                     | isAmbientGroupPrompt pending.pendingTurnText =
@@ -557,6 +562,9 @@ runQueuedTurn runtime pending =
                                 userId
                                 (Just pending.pendingTurnMessageId)
                                 deliveredPrompt
+
+withoutProgress :: IO Text -> IO TelegramTurnResponse
+withoutProgress action = (`TelegramTurnResponse` Nothing) <$> action
 
 telegramConversationStatus :: TelegramRuntime -> TelegramChatKey -> IO Text
 telegramConversationStatus runtime key = do

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Support.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Support.hs
@@ -288,7 +288,8 @@ modifyState runtime update =
 
 reply :: TelegramRuntime -> TelegramPendingReply -> IO ()
 reply runtime pending
-    | Just emoji <- telegramReactionEmoji pending.pendingText
+    | Nothing <- pending.pendingEditMessageId
+    , Just emoji <- telegramReactionEmoji pending.pendingText
     , Just messageId <- pending.pendingReplyToMessageId = do
         TelegramClient.setMessageReaction
             runtime.runtimeClient
@@ -305,48 +306,63 @@ reply runtime pending
         let chunks = case splitTelegramText 4096 pending.pendingText of
                 [] -> ["(empty response)"]
                 values -> values
-            checkpointKey =
-                Text.intercalate ":"
-                    [ Text.pack (show pending.pendingChat.chatId)
-                    , maybe
-                        "-"
-                        (Text.pack . show)
-                        pending.pendingChat.messageThreadId
-                    , Text.pack (show pending.pendingUpdateId)
-                    , "reply"
-                    ]
+            checkpointKey = replyCheckpointKey pending
         state <- readMVar runtime.runtimeStateVar
         let startIndex =
                 fromMaybe 0
                     (Map.lookup checkpointKey state.deliveryCheckpoints)
         forM_ (drop startIndex (zip [0 :: Int ..] chunks)) \(index, chunk) ->
-            TelegramClient.sendRichMessage
-                runtime.runtimeClient
-                pending.pendingChat
-                (if index == 0
-                    then pending.pendingReplyToMessageId
-                    else Nothing)
-                chunk >>= \case
-                    Left err -> fail (Text.unpack err)
-                    Right messageId ->
-                        modifyState runtime \current ->
-                            current
-                                { deliveryCheckpoints =
-                                    Map.insert
-                                        checkpointKey
-                                        (index + 1)
-                                        current.deliveryCheckpoints
-                                , outboundMessageIds =
-                                    maybe
-                                        current.outboundMessageIds
-                                        (\sentId ->
-                                            Map.insertWith
-                                                Set.union
-                                                pending.pendingChat
-                                                (Set.singleton sentId)
-                                                current.outboundMessageIds)
-                                        messageId
-                                }
+            case (index, pending.pendingEditMessageId) of
+                (0, Just messageId) ->
+                    TelegramClient.editRichMessageText
+                        runtime.runtimeClient
+                        pending.pendingChat
+                        messageId
+                        chunk >>= \case
+                            Left err -> fail (Text.unpack err)
+                            Right () -> checkpoint (index + 1) Nothing
+                _ ->
+                    TelegramClient.sendRichMessage
+                        runtime.runtimeClient
+                        pending.pendingChat
+                        (if index == 0
+                            then pending.pendingReplyToMessageId
+                            else Nothing)
+                        chunk >>= \case
+                            Left err -> fail (Text.unpack err)
+                            Right messageId -> checkpoint (index + 1) messageId
+      where
+        checkpoint nextIndex messageId =
+            modifyState runtime \current ->
+                current
+                    { deliveryCheckpoints =
+                        Map.insert
+                            (replyCheckpointKey pending)
+                            nextIndex
+                            current.deliveryCheckpoints
+                    , outboundMessageIds =
+                        maybe
+                            current.outboundMessageIds
+                            (\sentId ->
+                                Map.insertWith
+                                    Set.union
+                                    pending.pendingChat
+                                    (Set.singleton sentId)
+                                    current.outboundMessageIds)
+                            messageId
+                    }
+
+replyCheckpointKey :: TelegramPendingReply -> Text
+replyCheckpointKey pending =
+    Text.intercalate ":"
+        [ Text.pack (show pending.pendingChat.chatId)
+        , maybe
+            "-"
+            (Text.pack . show)
+            pending.pendingChat.messageThreadId
+        , Text.pack (show pending.pendingUpdateId)
+        , "reply"
+        ]
 
 withTelegramProgress
     :: TelegramClient

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
@@ -122,6 +122,7 @@ import Data.Aeson
     )
 import qualified Data.ByteString.Lazy as LBS
 import Data.Int (Int64)
+import Data.IORef (newIORef, readIORef)
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Map.Strict as Map
 import Data.List (sortOn)
@@ -177,8 +178,17 @@ import Text.Read (readMaybe)
 import Agent.Telegram.Internal.Runtime.Types
 import Agent.Telegram.Internal.Allowlist
 import Agent.Telegram.Internal.Support
-runQueuedMediaTurn :: TelegramRuntime -> TelegramPendingMediaTurn -> IO Text
+data TelegramTurnResponse = TelegramTurnResponse
+    { telegramTurnText :: !Text
+    , telegramTurnProgressMessageId :: !(Maybe Integer)
+    }
+
+runQueuedMediaTurn
+    :: TelegramRuntime
+    -> TelegramPendingMediaTurn
+    -> IO TelegramTurnResponse
 runQueuedMediaTurn runtime pending = do
+    progressMessageId <- newIORef Nothing
     handle <- sessionForPrompt runtime pending.pendingMediaChat pending.pendingMediaText
     let agentPrompt = telegramAgentPrompt pending.pendingMediaText
     attachments <- downloadTelegramMediaAttachments runtime handle pending
@@ -225,6 +235,8 @@ runQueuedMediaTurn runtime pending = do
                 pending.pendingMediaChat
                 pending.pendingMediaUserId
                 (Just pending.pendingMediaMessageId)
+                progressMessageId
+                (not (isAmbientGroupPrompt pending.pendingMediaText))
                 (unsafeToFilePath handle.sessionTempDir)
     createDirectoryIfMissing True bridgeDir
     setFileMode bridgePath 0o700
@@ -242,7 +254,7 @@ runQueuedMediaTurn runtime pending = do
                 handle
                 gatewayRequest)
             `finally` cleanupTelegramBridge runtime bridgePath bridgeDir
-    (case result of
+    response <- (case result of
         Left err -> fail (Text.unpack err)
         Right _ ->
             loadSessionHandle
@@ -265,6 +277,7 @@ runQueuedMediaTurn runtime pending = do
                                         "agent completed without recording \
                                         \the Telegram turn")
         `finally` cleanupManagedTurnMedia request
+    TelegramTurnResponse response <$> readIORef progressMessageId
 
 checkpointVoiceTranscript
     :: TelegramRuntime
@@ -518,6 +531,7 @@ failureReply = \case
             { pendingUpdateId = pending.pendingTurnUpdateId
             , pendingChat = pending.pendingTurnChat
             , pendingReplyToMessageId = Just pending.pendingTurnMessageId
+            , pendingEditMessageId = Nothing
             , pendingText =
                 "This turn failed after 5 attempts. Send /retry to try it again."
             }
@@ -526,6 +540,7 @@ failureReply = \case
             { pendingUpdateId = pending.pendingMediaUpdateId
             , pendingChat = pending.pendingMediaChat
             , pendingReplyToMessageId = Just pending.pendingMediaMessageId
+            , pendingEditMessageId = Nothing
             , pendingText =
                 "This media turn failed after 5 attempts. Send /retry to try it again."
             }
@@ -571,7 +586,7 @@ runAgentTurn
     -> Integer
     -> Maybe Integer
     -> Text
-    -> IO Text
+    -> IO TelegramTurnResponse
 runAgentTurn runtime key userId replyToMessageId prompt = do
     handle <- sessionForPrompt runtime key prompt
     let agentPrompt = telegramAgentPrompt prompt
@@ -581,6 +596,7 @@ runAgentTurn runtime key userId replyToMessageId prompt = do
         key
         userId
         replyToMessageId
+        (not (isAmbientGroupPrompt prompt))
         (managedTurnRequestFromText agentPrompt)
         agentPrompt
 
@@ -589,11 +605,12 @@ telegramAgentPrompt prompt =
     prompt
         <> "\n\n[Telegram delivery context: You are conversing in Telegram. \
         \Keep messages concise and conversational; avoid terminal-style \
-        \verbosity unless the user asks for detail. If you need to use tools \
-        \or do substantial work before you can answer, first emit one short \
-        \commentary progress sentence before the first tool call. For \
-        \example: Ich schaue mir das kurz an. Do not wait for findings \
-        \before this initial update. Skip it when you can answer immediately \
+        \verbosity unless the user asks for detail. Follow the language and \
+        \style of the conversation. If you need to use tools or do substantial \
+        \work before you can answer, first emit one short commentary progress \
+        \sentence before the first tool call, in that same language and style. \
+        \For example: I'll take a quick look. Do not wait for findings before \
+        \this initial update. Skip it when you can answer immediately \
         \or when no reply should be sent. Your answer and available \
         \reasoning summaries are shown to the user as a live Telegram draft \
         \while you work, followed by your normal final response. If the best \
@@ -608,11 +625,13 @@ runManagedAgentTurn
     -> TelegramChatKey
     -> Integer
     -> Maybe Integer
+    -> Bool
     -> ManagedTurnRequest
     -> Text
-    -> IO Text
+    -> IO TelegramTurnResponse
 runManagedAgentTurn
-        runtime handle key userId replyToMessageId baseRequest expectedPrompt = do
+        runtime handle key userId replyToMessageId groupActivityEnabled baseRequest expectedPrompt = do
+    progressMessageId <- newIORef Nothing
     let bridgeDir =
             handle.sessionTempDir
                 </> unsafeEncodeUtf
@@ -637,12 +656,14 @@ runManagedAgentTurn
                 key
                 userId
                 replyToMessageId
+                progressMessageId
+                groupActivityEnabled
                 (unsafeToFilePath handle.sessionTempDir)
     createDirectoryIfMissing True bridgeDir
     setFileMode bridgePath 0o700
     priorTurnIndex <-
         latestPersistedTurnIndex runtime handle.sessionMeta.metaId
-    (withTelegramBridge bridgeEnv $
+    response <- (withTelegramBridge bridgeEnv $
         launchManagedTurnBounded
             runtime.runtimeProcessManager
             False
@@ -673,6 +694,7 @@ runManagedAgentTurn
                                         fail
                                             "agent completed without recording \
                                             \the Telegram turn"
+    TelegramTurnResponse response <$> readIORef progressMessageId
 
 telegramTurnUserId :: TelegramRuntime -> TelegramChatKey -> IO Integer
 telegramTurnUserId runtime key

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
@@ -589,7 +589,12 @@ telegramAgentPrompt prompt =
     prompt
         <> "\n\n[Telegram delivery context: You are conversing in Telegram. \
         \Keep messages concise and conversational; avoid terminal-style \
-        \verbosity unless the user asks for detail. Your answer and available \
+        \verbosity unless the user asks for detail. If you need to use tools \
+        \or do substantial work before you can answer, first emit one short \
+        \commentary progress sentence before the first tool call. For \
+        \example: Ich schaue mir das kurz an. Do not wait for findings \
+        \before this initial update. Skip it when you can answer immediately \
+        \or when no reply should be sent. Your answer and available \
         \reasoning summaries are shown to the user as a live Telegram draft \
         \while you work, followed by your normal final response. If the best \
         \complete response \

--- a/packages/agent-telegram/src/Agent/Telegram/Types/State.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Types/State.hs
@@ -349,6 +349,7 @@ data TelegramPendingReply = TelegramPendingReply
     { pendingUpdateId :: !Integer
     , pendingChat :: !TelegramChatKey
     , pendingReplyToMessageId :: !(Maybe Integer)
+    , pendingEditMessageId :: !(Maybe Integer)
     , pendingText :: !Text
     } deriving (Eq, Show)
 
@@ -357,6 +358,7 @@ instance ToJSON TelegramPendingReply where
         [ "updateId" .= pending.pendingUpdateId
         , "chat" .= pending.pendingChat
         , "replyToMessageId" .= pending.pendingReplyToMessageId
+        , "editMessageId" .= pending.pendingEditMessageId
         , "text" .= pending.pendingText
         ]
 
@@ -366,6 +368,7 @@ telegramPendingReplyDecoder = Hermes.object $
             <$> Hermes.atKey "updateId" integerDecoder
             <*> Hermes.atKey "chat" telegramChatKeyDecoder
             <*> Hermes.optionalKey "replyToMessageId" integerDecoder
+            <*> Hermes.optionalKey "editMessageId" integerDecoder
             <*> Hermes.atKey "text" Hermes.text
 
 data TelegramPendingMediaTurn = TelegramPendingMediaTurn

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -66,6 +66,10 @@ spec = describe "Agent.Telegram" do
             prompt `shouldSatisfy`
                 Text.isInfixOf "Keep messages concise and conversational"
             prompt `shouldSatisfy`
+                Text.isInfixOf "before the first tool call"
+            prompt `shouldSatisfy`
+                Text.isInfixOf "Do not wait for findings"
+            prompt `shouldSatisfy`
                 Text.isPrefixOf "Inspect the failing tests"
 
     describe "telegramActivityDraftHtml" do

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -70,6 +70,11 @@ spec = describe "Agent.Telegram" do
             prompt `shouldSatisfy`
                 Text.isInfixOf "Do not wait for findings"
             prompt `shouldSatisfy`
+                Text.isInfixOf "Follow the language and style"
+            prompt `shouldSatisfy`
+                Text.isInfixOf "For example: I'll take a quick look."
+            prompt `shouldNotSatisfy` Text.isInfixOf "Ich schaue"
+            prompt `shouldSatisfy`
                 Text.isPrefixOf "Inspect the failing tests"
 
     describe "telegramActivityDraftHtml" do
@@ -81,6 +86,14 @@ spec = describe "Agent.Telegram" do
                 `shouldBe`
                 "<tg-thinking>Checking &lt;files&gt;</tg-thinking>\
                 \<p>Found &amp; fixed<br>Done</p>"
+
+    describe "telegramActivityMessageText" do
+        it "renders group progress without private-chat draft markup" do
+            Bridge.telegramActivityMessageText
+                "Writing reply…"
+                "Prüfe die Dateien"
+                "Fast fertig"
+                `shouldBe` "Prüfe die Dateien\n\nFast fertig"
 
     describe "parseTelegramArgs" do
         it "runs the configured gateway by default" do
@@ -1070,9 +1083,9 @@ spec = describe "Agent.Telegram" do
                 secondTurn =
                     TelegramPendingTurn 9 76 secondKey "other" Nothing
                 firstReply =
-                    TelegramPendingReply 11 firstKey (Just 77) "reply"
+                    TelegramPendingReply 11 firstKey (Just 77) Nothing "reply"
                 secondReply =
-                    TelegramPendingReply 8 secondKey (Just 75) "other reply"
+                    TelegramPendingReply 8 secondKey (Just 75) Nothing "other reply"
                 decoded = decodeWith telegramStateDecoder
                     (LBS.pack
                         "{\"nextUpdateId\":12,\"bindings\":[{\
@@ -1155,7 +1168,7 @@ spec = describe "Agent.Telegram" do
         it "writes keyed state using the legacy JSON array fields" do
             let key = TelegramChatKey 123 Nothing
                 turn = TelegramPendingTurn 10 77 key "hello" Nothing
-                reply = TelegramPendingReply 11 key (Just 77) "reply"
+                reply = TelegramPendingReply 11 key (Just 77) Nothing "reply"
                 state = emptyTelegramState
                     { nextUpdateId = Just 12
                     , bindings = Map.singleton key "session-1"
@@ -1323,7 +1336,7 @@ spec = describe "Agent.Telegram" do
             let key = TelegramChatKey 123 Nothing
                 newerTurn = TelegramPendingTurn 12 79 key "later" Nothing
                 olderTurn = TelegramPendingTurn 10 77 key "first" Nothing
-                middleReply = TelegramPendingReply 11 key (Just 77) "reply"
+                middleReply = TelegramPendingReply 11 key (Just 77) Nothing "reply"
                 state = emptyTelegramState
                     { pendingQueues =
                         Map.singleton key $ Map.fromList
@@ -1338,7 +1351,7 @@ spec = describe "Agent.Telegram" do
         it "keeps delivery ahead of later inbound work" do
             let key = TelegramChatKey 123 Nothing
                 turn = TelegramPendingTurn 12 79 key "later" Nothing
-                reply = TelegramPendingReply 11 key (Just 77) "reply"
+                reply = TelegramPendingReply 11 key (Just 77) Nothing "reply"
                 state = emptyTelegramState
                     { pendingQueues =
                         Map.singleton key $ Map.fromList


### PR DESCRIPTION
## Summary
- prompt Telegram agents to acknowledge long-running work before the first tool call
- keep prompt instructions in English while matching the conversation language and style
- fall back to a normal editable progress message in group chats, where native Telegram drafts are unsupported
- replace the progress message with the final response and preserve durable delivery retries
- suppress group progress for ambient messages that may intentionally produce no reply

## Test plan
- `printf ":main\n:q\n" | nix develop -c cabal repl agent-telegram:test:agent-telegram-test`
- 70 examples, 0 failures