### PR TITLE
Make Telegram replies conversational

### DIFF
--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Support.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Support.hs
@@ -311,6 +311,7 @@ reply runtime pending
         let startIndex =
                 fromMaybe 0
                     (Map.lookup checkpointKey state.deliveryCheckpoints)
+            replyToMessageId = pendingReplyTarget pending state
         forM_ (drop startIndex (zip [0 :: Int ..] chunks)) \(index, chunk) ->
             case (index, pending.pendingEditMessageId) of
                 (0, Just messageId) ->
@@ -326,7 +327,7 @@ reply runtime pending
                         runtime.runtimeClient
                         pending.pendingChat
                         (if index == 0
-                            then pending.pendingReplyToMessageId
+                            then replyToMessageId
                             else Nothing)
                         chunk >>= \case
                             Left err -> fail (Text.unpack err)

--- a/packages/agent-telegram/src/Agent/Telegram/Types/State.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Types/State.hs
@@ -16,6 +16,7 @@ module Agent.Telegram.Types.State
     , insertPendingAction
     , enqueuePendingAction
     , deletePendingAction
+    , pendingReplyTarget
     , telegramStateDecoder
     ) where
 
@@ -608,6 +609,25 @@ deletePendingAction action state =
                 (pendingActionChat action)
                 state.pendingQueues
         }
+
+-- | Use Telegram's visible reply chrome only when a newer inbound message is
+-- already waiting in the same conversation. A response to the latest message
+-- reads naturally as the next ordinary chat message.
+pendingReplyTarget :: TelegramPendingReply -> TelegramState -> Maybe Integer
+pendingReplyTarget pending state
+    | hasNewerInbound = pending.pendingReplyToMessageId
+    | otherwise = Nothing
+  where
+    hasNewerInbound =
+        maybe False
+            (any isInbound . Map.elems . snd
+                . Map.split pending.pendingUpdateId)
+            (Map.lookup pending.pendingChat state.pendingQueues)
+    isInbound = \case
+        RunPendingTurn _ -> True
+        RunPendingMediaTurn _ -> True
+        DeliverReply _ -> False
+        LeaveUnauthorizedChat _ -> False
 
 emptyTelegramState :: TelegramState
 emptyTelegramState = TelegramState

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -17,6 +17,7 @@ import Agent.Telegram.Types
     , TelegramPendingMediaTurn(..)
     , TelegramRetryMetadata(..)
     , telegramConfigDecoder
+    , pendingReplyTarget
     , telegramStateDecoder
     , telegramUpdateDecoder
     )
@@ -1062,6 +1063,25 @@ spec = describe "Agent.Telegram" do
             reordered.nextUpdateId `shouldBe` Just 102
 
     describe "durable queue state" do
+        it "only visibly replies when a newer inbound message is queued" do
+            let key = TelegramChatKey 123 Nothing
+                reply = TelegramPendingReply 11 key (Just 77) Nothing "reply"
+                newerTurn = TelegramPendingTurn 12 78 key "next" Nothing
+                latestState = emptyTelegramState
+                    { pendingQueues =
+                        Map.singleton key
+                            (Map.singleton 11 (DeliverReply reply))
+                    }
+                overtakenState = latestState
+                    { pendingQueues =
+                        Map.singleton key $ Map.fromList
+                            [ (11, DeliverReply reply)
+                            , (12, RunPendingTurn newerTurn)
+                            ]
+                    }
+            pendingReplyTarget reply latestState `shouldBe` Nothing
+            pendingReplyTarget reply overtakenState `shouldBe` Just 77
+
         it "loads state written before pending turns were introduced" do
             let decoded = decodeWith telegramStateDecoder
                     (LBS.pack


### PR DESCRIPTION
## Summary
- send direct responses to the latest Telegram message as normal chat messages
- retain explicit reply threading when newer inbound messages have arrived
- cover both delivery cases with a durable queue regression test

## Testing
- `printf ':main\n:q\n' | nix develop -c cabal repl agent-telegram:test:agent-telegram-test` (70 examples, 0 failures)
- `git diff --check`
