### PR TITLE
Add MCP skills protocol support

### DIFF
--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -1,14 +1,20 @@
 -- | Local Model Context Protocol clients over the stdio transport.
 --
 -- Each configured server is started once, initialized, and queried for its
--- read-only tools. The returned 'AppTool' handlers share the retained client;
--- 'closeMcpFleet' must run after all loops and subagents using those handlers
--- have stopped.
+-- read-only tools and (when negotiated) Skills-over-MCP metadata. The
+-- returned handlers share the retained client; 'closeMcpFleet' must run
+-- after all loops and subagents using those handlers have stopped.
 module Agent.MCP
     ( McpServerConfig(..)
     , McpInitState(..)
     , McpServerStatus(..)
     , McpToolRegistration(..)
+    , McpSkillsCapability(..)
+    , McpSkillRegistration(..)
+    , McpSkillEntry(..)
+    , McpSkillResources(..)
+    , McpSkillResource(..)
+    , McpResourceContent(..)
     , McpFleet(..)
     , McpSupervisor
     , McpFleetLease(..)
@@ -26,6 +32,9 @@ module Agent.MCP
     , mcpFleetMetaTools
     , mcpFleetGrokMetaTools
     , mcpFleetStatuses
+    , mcpFleetSkillRegistrations
+    , mcpFleetGetSkill
+    , mcpFleetReadResource
     , normalizeMcpToolResult
     ) where
 
@@ -35,6 +44,9 @@ import Agent.MCP.Fleet
     , mcpFleetGrokMetaTools
     , mcpFleetMetaTools
     , mcpFleetStatuses
+    , mcpFleetSkillRegistrations
+    , mcpFleetGetSkill
+    , mcpFleetReadResource
     , mcpFleetTools
     , startMcpFleet
     , startMcpFleetProgressive
@@ -56,4 +68,10 @@ import Agent.MCP.Types
     , McpServerStatus(..)
     , McpSupervisor
     , McpToolRegistration(..)
+    , McpSkillsCapability(..)
+    , McpSkillRegistration(..)
+    , McpSkillEntry(..)
+    , McpSkillResources(..)
+    , McpSkillResource(..)
+    , McpResourceContent(..)
     )

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -92,7 +92,7 @@ import Data.IORef
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
 import Data.List (find, sortOn)
-import Data.Maybe (catMaybes, isJust)
+import Data.Maybe (catMaybes, isJust, mapMaybe)
 import Data.Ord (Down(..))
 import Data.Scientific (floatingOrInteger)
 import qualified Data.Set as Set
@@ -149,6 +149,8 @@ startMcpClient config = mask \_ -> do
             stderrRef <- newIORef emptyCapturedStderr
             closed <- newMVar False
             lifecycle <- newTVarIO ClientPending
+            skillsCapability <- newTVarIO Nothing
+            discoveredSkills <- newTVarIO []
             reader <- asyncWithUnmask \unmask ->
                 unmask (readerLoop output pending failure)
                     `finally` void (tryAny (hClose output))
@@ -169,6 +171,8 @@ startMcpClient config = mask \_ -> do
                     , clientStderrReader = stderrReader
                     , clientClosed = closed
                     , clientLifecycle = lifecycle
+                    , clientSkillsCapability = skillsCapability
+                    , clientDiscoveredSkills = discoveredSkills
                     }
             pure client
         _ -> do
@@ -235,7 +239,9 @@ ensureMcpClientReadyWith publishReady client = mask \restore -> do
                     closeMcpClient client
                 initialize = do
                     initializeClient client
-                    discoverMcpTools client
+                    (tools, warnings) <- discoverMcpTools client
+                    skillWarnings <- discoverMcpSkills client
+                    pure (tools, warnings <> skillWarnings)
             outcome <-
                 restore (tryAny initialize)
                     `onException` cancelled
@@ -289,7 +295,7 @@ initializeClient client = do
     let timeoutMicros =
             secondsToMicros client.clientConfig.mcpServerStartupTimeoutSeconds
         parameters = object
-            [ "protocolVersion" .= ("2025-11-25" :: Text)
+            [ "protocolVersion" .= ("2026-07-28" :: Text)
             , "capabilities" .= object []
             , "clientInfo" .= object
                 [ "name" .= ("haskell-agent" :: Text)
@@ -300,10 +306,49 @@ initializeClient client = do
         (Aeson.toEncoding parameters)
     case result of
         Left err -> startupFailure client err
-        Right _ ->
+        Right response -> do
+            case parseSkillsCapability response of
+                Left err -> startupFailure client ("invalid initialize response: " <> err)
+                Right capability ->
+                    atomically $
+                        writeTVar client.clientSkillsCapability capability
             sendNotification client "notifications/initialized"
                 (Aeson.toEncoding (object []))
                 >>= either (startupFailure client) pure
+
+parseSkillsCapability :: RawJson -> Either Text (Maybe McpSkillsCapability)
+parseSkillsCapability raw =
+    case Json.decodeEither capabilitiesDecoder (rawJsonBytes raw) of
+        Left err -> Left err.jsonErrorMessage
+        Right capabilities ->
+            case capabilities of
+                Nothing -> Right Nothing
+                Just value -> decodeExtensions value
+  where
+    capabilitiesDecoder =
+        Json.object (Json.optionalKey "capabilities" rawJsonDecoder)
+    decodeExtensions capabilities =
+        case Json.decodeEither extensionsDecoder (rawJsonBytes capabilities) of
+            Left err -> Left err.jsonErrorMessage
+            Right extensions -> case extensions of
+                Nothing -> Right Nothing
+                Just value -> decodeSkills value
+    extensionsDecoder =
+        Json.object (Json.optionalKey "extensions" rawJsonDecoder)
+    decodeSkills extensions =
+        case Json.decodeEither skillsDecoder (rawJsonBytes extensions) of
+            Left err -> Left err.jsonErrorMessage
+            Right Nothing -> Right Nothing
+            Right (Just raw) ->
+                case Json.decodeEither directoryDecoder (rawJsonBytes raw) of
+                    Left err -> Left err.jsonErrorMessage
+                    Right directoryRead ->
+                        Right (Just McpSkillsCapability{mcpSkillsDirectoryRead = directoryRead})
+    skillsDecoder =
+        Json.object
+            (Json.atKeyOptional "io.modelcontextprotocol/skills" rawJsonDecoder)
+    directoryDecoder =
+        Json.object (Json.defaultKey False "directoryRead" Json.bool)
 
 startupFailure :: McpClient -> Text -> IO a
 startupFailure client err = do
@@ -364,6 +409,101 @@ discoverMcpTools client = go Nothing [] []
         (,)
             <$> Json.defaultKey [] "tools" (Json.list mcpToolDecoder)
             <*> Json.optionalKey "nextCursor" rawJsonDecoder
+
+-- | Enumerate skill metadata only.  Skill resources are intentionally not
+-- fetched here; hosts retrieve and verify SKILL.md when the user activates a
+-- skill.
+discoverMcpSkills :: McpClient -> IO [Text]
+discoverMcpSkills client = do
+    capability <- readTVarIO client.clientSkillsCapability
+    case capability of
+        Nothing -> pure []
+        Just _ -> go Nothing []
+  where
+    go cursor warnings = do
+        let parameters = maybe
+                (Aeson.toEncoding (object []))
+                (\value -> Aeson.pairs
+                    (AesonEncoding.pair "cursor" (rawJsonEncoding value)))
+                cursor
+        requestMcp client
+            (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
+            "skills/list" parameters >>= \case
+            Left err -> pure ["MCP server " <> client.clientConfig.mcpServerName
+                <> " skills/list failed: " <> err]
+            Right result ->
+                case parseSkillPage result of
+                    Left err -> pure ["MCP server "
+                        <> client.clientConfig.mcpServerName
+                        <> " returned invalid skills/list response: " <> err]
+                    Right (rawSkills, nextCursor) -> do
+                        let skills = mapMaybe decodeSkill rawSkills
+                            invalid = length skills /= length rawSkills
+                        atomically $ modifyTVar' client.clientDiscoveredSkills
+                            (<> skills)
+                        let pageWarnings =
+                                [ "MCP server " <> client.clientConfig.mcpServerName
+                                    <> " returned invalid skills/list entry"
+                                | invalid
+                                ]
+                        case nextCursor of
+                            Nothing -> pure (warnings <> pageWarnings)
+                            Just next -> go (Just next) (warnings <> pageWarnings)
+
+    parseSkillPage raw =
+        case Json.decodeEither pageDecoder (rawJsonBytes raw) of
+            Left err -> Left err.jsonErrorMessage
+            Right page -> Right page
+    pageDecoder = Json.object $
+        (,) <$> Json.defaultKey [] "skills" (Json.list rawJsonDecoder)
+            <*> Json.optionalKey "nextCursor" rawJsonDecoder
+    decodeSkill value =
+        case Json.decodeEither mcpSkillEntryDecoder (rawJsonBytes value) of
+            Left _ -> Nothing
+            Right skill -> Just skill
+
+-- | Retrieve one skill manifest by URI.  Unlike 'skills/list', this also
+-- supports servers whose catalog is not enumerable.
+getMcpSkill :: McpClient -> Text -> IO (Either Text McpSkillEntry)
+getMcpSkill client uri = do
+    capability <- readTVarIO client.clientSkillsCapability
+    case capability of
+        Nothing -> pure (Left ("MCP server "
+            <> client.clientConfig.mcpServerName
+            <> " does not support io.modelcontextprotocol/skills"))
+        Just _ -> do
+            let parameters = Aeson.toEncoding (object ["uri" .= uri])
+            requestMcp client
+                (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
+                "skills/get" parameters >>= \case
+                Left err -> pure (Left err)
+                Right result ->
+                    case Json.decodeEither
+                            (Json.object (Json.atKey "skill" mcpSkillEntryDecoder))
+                            (rawJsonBytes result) of
+                        Left err -> pure (Left ("invalid skills/get response: "
+                            <> err.jsonErrorMessage))
+                        Right skill -> pure (Right skill)
+
+-- | Read one or more resource contents using the standard MCP resources/read
+-- method.  This does not activate a skill; callers must perform their own
+-- approval, frontmatter, and manifest verification.
+readMcpResource :: McpClient -> Text -> IO (Either Text [McpResourceContent])
+readMcpResource client uri = do
+    let parameters = Aeson.toEncoding (object ["uri" .= uri])
+    requestMcp client
+        (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
+        "resources/read" parameters >>= \case
+        Left err -> pure (Left err)
+        Right result ->
+            case Json.decodeEither
+                    (Json.object
+                        (Json.defaultKey [] "contents"
+                            (Json.list mcpResourceContentDecoder)))
+                    (rawJsonBytes result) of
+                Left err -> pure (Left ("invalid resources/read response: "
+                    <> err.jsonErrorMessage))
+                Right contents -> pure (Right contents)
 
 appToolFor :: McpClient -> McpTool -> AppTool
 appToolFor client tool = AppTool

--- a/packages/agent-core/src/Agent/MCP/Fleet.hs
+++ b/packages/agent-core/src/Agent/MCP/Fleet.hs
@@ -135,6 +135,27 @@ sameServerConfigs left right =
 mcpFleetTools :: McpFleet -> [AppTool]
 mcpFleetTools = map (.mcpRegistrationTool) . (.mcpFleetRegistrations)
 
+-- | Snapshot the metadata advertised by every Skills-over-MCP server.  The
+-- server name is deliberately retained alongside each URI: URIs are only
+-- unique within an MCP server.
+mcpFleetSkillRegistrations :: McpFleet -> IO [McpSkillRegistration]
+mcpFleetSkillRegistrations fleet = readTVarIO fleet.mcpFleetSkills
+
+mcpFleetGetSkill :: McpFleet -> Text -> Text -> IO (Either Text McpSkillEntry)
+mcpFleetGetSkill fleet server uri = do
+    clients <- readTVarIO fleet.mcpFleetClients
+    case Map.lookup server clients of
+        Nothing -> pure (Left ("unknown MCP server: " <> server))
+        Just client -> getMcpSkill client uri
+
+mcpFleetReadResource
+    :: McpFleet -> Text -> Text -> IO (Either Text [McpResourceContent])
+mcpFleetReadResource fleet server uri = do
+    clients <- readTVarIO fleet.mcpFleetClients
+    case Map.lookup server clients of
+        Nothing -> pure (Left ("unknown MCP server: " <> server))
+        Just client -> readMcpResource client uri
+
 -- | Snapshot server status without triggering initialization or other I/O.
 mcpFleetStatuses :: McpFleet -> IO [McpServerStatus]
 mcpFleetStatuses fleet = do
@@ -183,6 +204,13 @@ startMcpFleetWithProgress reportActive configs = mask \restore -> do
             `onException` closeOwnedClients ownedClients
     let (clients, registrations, warnings, failures) =
             foldr collectServerResult ([], [], [], Map.empty) results
+    skills <- fmap concat $ forM clients \client -> do
+        entries <- readTVarIO client.clientDiscoveredSkills
+        pure
+            [ McpSkillRegistration client.clientConfig.mcpServerName entry
+            | entry <- entries
+            ]
+    skillsVar <- newTVarIO skills
     catalog <- newTVarIO $
         Map.fromList
             [ (registration.mcpRegistrationTool.appToolName, McpCatalogEntry client tool)
@@ -204,6 +232,7 @@ startMcpFleetWithProgress reportActive configs = mask \restore -> do
     let
         fleet = McpFleet
             { mcpFleetRegistrations = registrations
+            , mcpFleetSkills = skillsVar
             , mcpFleetWarnings = warnings
             , mcpFleetClients = clientsVar
             , mcpFleetServerOrder = map (.mcpServerName) configs
@@ -322,6 +351,7 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
     catalog <- newTVarIO Map.empty
     ownedClients <- newIORef []
     clientsVar <- newTVarIO Map.empty
+    skillsVar <- newTVarIO []
     reconnects <- Map.fromList <$> mapM
         (\config -> do
             lock <- newMVar ()
@@ -356,6 +386,7 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
             ]
         fleet = McpFleet
             { mcpFleetRegistrations = []
+            , mcpFleetSkills = skillsVar
             , mcpFleetWarnings = warnings
             , mcpFleetClients = clientsVar
             , mcpFleetServerOrder = map (.mcpServerName) configs
@@ -371,7 +402,14 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
                 (publishCatalogEntries catalog client)
                 client >>= \case
                 Left _ -> pure ()
-                Right _ -> pure ()
+                Right _ -> do
+                    entries <- readTVarIO client.clientDiscoveredSkills
+                    atomically $ modifyTVar' skillsVar \current ->
+                        current
+                            <> [ McpSkillRegistration
+                                    client.clientConfig.mcpServerName entry
+                                | entry <- entries
+                                ]
             void (reportFleetStatuses reportStatuses fleet)
     atomically $
         writeTVar clientsVar $

--- a/packages/agent-core/src/Agent/MCP/Types.hs
+++ b/packages/agent-core/src/Agent/MCP/Types.hs
@@ -63,10 +63,7 @@ import Control.Exception.Safe
     , tryAny
     )
 import Control.Monad (forM, unless, void, when)
-import Data.Aeson
-    ( object
-    , (.=)
-    )
+import Data.Aeson (object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
@@ -162,8 +159,43 @@ data McpServerStatus = McpServerStatus
     , mcpStatusToolCount :: !Int
     } deriving (Eq, Show)
 
+mcpSkillEntryDecoder :: Json.Decoder McpSkillEntry
+mcpSkillEntryDecoder = Json.object do
+    mcpSkillUri <- Json.atKey "uri" Json.text
+    mcpSkillFrontmatter <- Json.atKey "frontmatter" rawJsonDecoder
+    mcpSkillResources <- Json.atKey "resources" mcpSkillResourcesDecoder
+    pure McpSkillEntry{..}
+
+mcpSkillResourcesDecoder :: Json.Decoder McpSkillResources
+mcpSkillResourcesDecoder =
+    Json.getType >>= \case
+        Json.VString -> do
+            value <- Json.text
+            if value == "dynamic"
+                then pure McpSkillResourcesDynamic
+                else fail "resources must be an array or \"dynamic\""
+        Json.VArray ->
+            McpSkillResourcesListed <$> Json.list mcpSkillResourceDecoder
+        _ -> fail "resources must be an array or \"dynamic\""
+
+mcpSkillResourceDecoder :: Json.Decoder McpSkillResource
+mcpSkillResourceDecoder = Json.object do
+    mcpSkillResourceUri <- Json.atKey "uri" Json.text
+    mcpSkillResourceDigest <- Json.atKey "digest" Json.text
+    mcpSkillResourceSize <- Json.atKey "size" Json.int
+    pure McpSkillResource{..}
+
+mcpResourceContentDecoder :: Json.Decoder McpResourceContent
+mcpResourceContentDecoder = Json.object do
+    mcpResourceUri <- Json.atKey "uri" Json.text
+    mcpResourceMimeType <- Json.optionalKey "mimeType" Json.text
+    mcpResourceText <- Json.optionalKey "text" Json.text
+    mcpResourceBlob <- Json.optionalKey "blob" Json.text
+    pure McpResourceContent{..}
+
 data McpFleet = McpFleet
     { mcpFleetRegistrations :: ![McpToolRegistration]
+    , mcpFleetSkills :: !(TVar [McpSkillRegistration])
     , mcpFleetWarnings :: ![Text]
     , mcpFleetClients :: !(TVar (Map.Map Text McpClient))
     , mcpFleetServerOrder :: ![Text]
@@ -233,7 +265,44 @@ data McpClient = McpClient
     , clientStderrReader :: !(Async ())
     , clientClosed :: !(MVar Bool)
     , clientLifecycle :: !(TVar McpClientLifecycle)
+    -- Set after initialize.  A missing value means the server did not
+    -- negotiate the optional Skills over MCP extension.
+    , clientSkillsCapability :: !(TVar (Maybe McpSkillsCapability))
+    , clientDiscoveredSkills :: !(TVar [McpSkillEntry])
     }
+
+data McpSkillsCapability = McpSkillsCapability
+    { mcpSkillsDirectoryRead :: !Bool
+    } deriving (Eq, Show)
+
+data McpSkillRegistration = McpSkillRegistration
+    { mcpSkillServer :: !Text
+    , mcpSkillEntry :: !McpSkillEntry
+    } deriving (Eq, Show)
+
+data McpSkillResources
+    = McpSkillResourcesListed ![McpSkillResource]
+    | McpSkillResourcesDynamic
+    deriving (Eq, Show)
+
+data McpSkillResource = McpSkillResource
+    { mcpSkillResourceUri :: !Text
+    , mcpSkillResourceDigest :: !Text
+    , mcpSkillResourceSize :: !Int
+    } deriving (Eq, Show)
+
+data McpSkillEntry = McpSkillEntry
+    { mcpSkillUri :: !Text
+    , mcpSkillFrontmatter :: !RawJson
+    , mcpSkillResources :: !McpSkillResources
+    } deriving (Eq, Show)
+
+data McpResourceContent = McpResourceContent
+    { mcpResourceUri :: !Text
+    , mcpResourceMimeType :: !(Maybe Text)
+    , mcpResourceText :: !(Maybe Text)
+    , mcpResourceBlob :: !(Maybe Text)
+    } deriving (Eq, Show)
 
 data McpClientLifecycle
     = ClientPending

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -121,6 +121,39 @@ spec = describe "Agent.MCP" do
                     firstResult.output `shouldBe` "first response"
                     second.output `shouldBe` "second response"
 
+    it "discovers and reads Skills over MCP without fetching content during listing" $
+        withSkillsFakeServer \script -> do
+            fleet <- startMcpFleet [baseConfig "skills" script]
+            bracket (pure fleet) closeMcpFleet \_ -> do
+                registrations <- mcpFleetSkillRegistrations fleet
+                case registrations of
+                    [McpSkillRegistration "skills" entry] -> do
+                        entry.mcpSkillUri
+                            `shouldBe` "skill://demo/SKILL.md"
+                        entry.mcpSkillResources
+                            `shouldBe`
+                                McpSkillResourcesListed
+                                    [ McpSkillResource
+                                        "skill://demo/SKILL.md"
+                                        "sha256:demo"
+                                        42
+                                    ]
+                        mcpFleetGetSkill fleet "skills"
+                            "skill://demo/SKILL.md"
+                            `shouldReturn` Right entry
+                        mcpFleetReadResource fleet "skills"
+                            "skill://demo/SKILL.md"
+                            `shouldReturn`
+                                Right
+                                    [ McpResourceContent
+                                        "skill://demo/SKILL.md"
+                                        (Just "text/markdown")
+                                        (Just "---\nname: demo\n---\n")
+                                        Nothing
+                                    ]
+                    other -> expectationFailure
+                        ("unexpected skill registrations: " <> show other)
+
     it "starts servers concurrently and preserves configured tool order" $
         withConcurrentFakeServer \script barrier -> do
             progress <- newIORef []
@@ -420,6 +453,19 @@ withFakeServer action = do
         removeFile
         action
 
+withSkillsFakeServer :: (FilePath -> IO a) -> IO a
+withSkillsFakeServer action = do
+    temporary <- getTemporaryDirectory
+    bracket
+        (do
+            (path, handle) <- openTempFile temporary "agent-mcp-skills.sh"
+            LBS.hPutStr handle skillsFakeServer
+            hClose handle
+            setFileMode path 0o700
+            pure path)
+        removeFile
+        action
+
 withCountingFakeServer :: (FilePath -> FilePath -> IO a) -> IO a
 withCountingFakeServer = withCountingServer countingFakeServer
 
@@ -589,6 +635,30 @@ fakeServer =
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"second response\"}]}}'\n\
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"first response\"}]}}'\n\
     \      fi\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+skillsFakeServer :: LBS.ByteString
+skillsFakeServer =
+    "#!/bin/sh\n\
+    \while IFS= read -r line; do\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2026-07-28\",\"capabilities\":{\"extensions\":{\"io.modelcontextprotocol/skills\":{}}},\"serverInfo\":{\"name\":\"skills\",\"version\":\"1\"}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"skills/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"resultType\":\"complete\",\"skills\":[{\"uri\":\"skill://demo/SKILL.md\",\"frontmatter\":{\"name\":\"demo\",\"description\":\"Demo skill\"},\"resources\":[{\"uri\":\"skill://demo/SKILL.md\",\"digest\":\"sha256:demo\",\"size\":42}]}]}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"skills/get\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"resultType\":\"complete\",\"skill\":{\"uri\":\"skill://demo/SKILL.md\",\"frontmatter\":{\"name\":\"demo\",\"description\":\"Demo skill\"},\"resources\":[{\"uri\":\"skill://demo/SKILL.md\",\"digest\":\"sha256:demo\",\"size\":42}]}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"resources/read\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":5,\"result\":{\"contents\":[{\"uri\":\"skill://demo/SKILL.md\",\"mimeType\":\"text/markdown\",\"text\":\"---\\nname: demo\\n---\\n\"}]}}'\n\
     \      ;;\n\
     \  esac\n\
     \done\n"


### PR DESCRIPTION
## Summary

- negotiate the draft `io.modelcontextprotocol/skills` extension using MCP protocol version `2026-07-28`
- discover paginated `skills/list` metadata without eagerly fetching skill resources
- add typed support for static and dynamic skill manifests, `skills/get`, and `resources/read`
- preserve the originating MCP server alongside each skill URI in fleet state, including progressive startup
- export the new skill discovery and lazy retrieval APIs from `Agent.MCP`

## Scope

This implements the client/protocol foundation from draft SEP-2640. It does not yet merge MCP-served skills into the filesystem-backed CLI skill catalog or activation UI; that follow-up needs async activation, manifest verification, approval handling, and supporting-resource routing.

The optional `resources/directory/read` capability is parsed but not exposed yet.

## Testing

```text
printf ':main\n:q\n' | nix develop -c cabal repl agent-core:test:agent-core-test
```

Result: 421 examples, 0 failures.

`git diff --check` also passes.

Specification reference: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640
