### PR TITLE
Track ignored Telegram message recency

### DIFF
--- a/packages/agent-telegram/src/Agent/Telegram.hs
+++ b/packages/agent-telegram/src/Agent/Telegram.hs
@@ -38,6 +38,7 @@ module Agent.Telegram
     , telegramReplyUserIdFromPrompt
     , telegramUserLabel
     , recordSeenTelegramUsers
+    , recordLatestInboundMessage
     , resolveTelegramUser
     , TelegramUserResolution(..)
     , transcribeWithXAI

--- a/packages/agent-telegram/src/Agent/Telegram/Classify.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Classify.hs
@@ -19,6 +19,7 @@ module Agent.Telegram.Classify
     , telegramUserLabel
     , telegramReplyUserIdFromPrompt
     , recordSeenTelegramUsers
+    , recordLatestInboundMessage
     , resolveTelegramUser
     , grantableTelegramUser
     , TelegramUserResolution(..)

--- a/packages/agent-telegram/src/Agent/Telegram/Classify/User.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Classify/User.hs
@@ -4,6 +4,7 @@ module Agent.Telegram.Classify.User
     , resolveTelegramUser
     , grantableTelegramUser
     , recordSeenTelegramUsers
+    , recordLatestInboundMessage
     , messageMentionEntities
     , mentionedTelegramUsers
     ) where
@@ -132,6 +133,22 @@ stubTelegramUser userId =
         , userLastName = Nothing
         , userUsername = Nothing
         }
+
+recordLatestInboundMessage :: TelegramUpdate -> TelegramState -> TelegramState
+recordLatestInboundMessage update state =
+    case update.updateMessage of
+        Nothing -> state
+        Just message -> state
+            { latestInboundMessageIds =
+                Map.insertWith
+                    max
+                    TelegramChatKey
+                        { chatId = message.messageChat.telegramChatId
+                        , messageThreadId = message.messageThread
+                        }
+                    message.messageId
+                    state.latestInboundMessageIds
+            }
 
 recordSeenTelegramUsers :: TelegramUpdate -> TelegramState -> TelegramState
 recordSeenTelegramUsers update state =

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Poll.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Poll.hs
@@ -56,6 +56,7 @@ import Agent.Telegram.Classify
     , nextPendingAction
     , reactionMessageText
     , recordSeenTelegramUsers
+    , recordLatestInboundMessage
     , resolveTelegramUser
     , storeUpdateAction
     , telegramCommand
@@ -204,7 +205,8 @@ pollForever runtime = do
 processUpdate :: TelegramRuntime -> TelegramUpdate -> IO ()
 processUpdate runtime update = do
     handled <- tryAny do
-        modifyState runtime (recordSeenTelegramUsers update)
+        modifyState runtime
+            (recordLatestInboundMessage update . recordSeenTelegramUsers update)
         action <- classifyUpdate runtime update
         modifyState runtime (storeUpdateAction update.updateId action)
     case handled of

--- a/packages/agent-telegram/src/Agent/Telegram/Types/State.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Types/State.hs
@@ -127,6 +127,7 @@ data TelegramState = TelegramState
     , allowedUserIds :: !(Set Integer)
     , seenTelegramUsers :: !(Map Integer TelegramUser)
     , seenUsersByChat :: !(Map Integer (Set Integer))
+    , latestInboundMessageIds :: !(Map TelegramChatKey Integer)
     } deriving (Eq, Show)
 
 instance ToJSON TelegramState where
@@ -178,6 +179,10 @@ instance ToJSON TelegramState where
             [ TelegramSeenChatUsers chatId (sort (Set.toList userIds))
             | (chatId, userIds) <- Map.toAscList state.seenUsersByChat
             ]
+        , "latestInboundMessages" .=
+            [ TelegramLatestInboundMessage key messageId
+            | (key, messageId) <- Map.toAscList state.latestInboundMessageIds
+            ]
         ]
 
 telegramStateDecoder :: Hermes.Decoder TelegramState
@@ -228,6 +233,9 @@ telegramStateDecoder = Hermes.object do
         storedSeenByChat <-
             defaultField "seenUsersByChat" []
                 (Hermes.list telegramSeenChatUsersDecoder)
+        storedLatestInbound <-
+            defaultField "latestInboundMessages" []
+                (Hermes.list telegramLatestInboundMessageDecoder)
         let bindings =
                 foldr
                     (\binding ->
@@ -284,7 +292,29 @@ telegramStateDecoder = Hermes.object do
                     [ (seen.seenChatId, Set.fromList seen.seenChatUserIds)
                     | seen <- storedSeenByChat
                     ]
+            , latestInboundMessageIds =
+                Map.fromList
+                    [ (latest.latestInboundChat, latest.latestInboundMessageId)
+                    | latest <- storedLatestInbound
+                    ]
             }
+
+data TelegramLatestInboundMessage = TelegramLatestInboundMessage
+    { latestInboundChat :: !TelegramChatKey
+    , latestInboundMessageId :: !Integer
+    } deriving (Eq, Show)
+
+instance ToJSON TelegramLatestInboundMessage where
+    toJSON latest = object
+        [ "chat" .= latest.latestInboundChat
+        , "messageId" .= latest.latestInboundMessageId
+        ]
+
+telegramLatestInboundMessageDecoder :: Hermes.Decoder TelegramLatestInboundMessage
+telegramLatestInboundMessageDecoder = Hermes.object $
+    TelegramLatestInboundMessage
+        <$> Hermes.atKey "chat" telegramChatKeyDecoder
+        <*> Hermes.atKey "messageId" integerDecoder
 
 data TelegramSeenChatUsers = TelegramSeenChatUsers
     { seenChatId :: !Integer
@@ -611,23 +641,16 @@ deletePendingAction action state =
         }
 
 -- | Use Telegram's visible reply chrome only when a newer inbound message is
--- already waiting in the same conversation. A response to the latest message
--- reads naturally as the next ordinary chat message.
+-- visible in the same conversation. A response to the latest message reads
+-- naturally as the next ordinary chat message.
 pendingReplyTarget :: TelegramPendingReply -> TelegramState -> Maybe Integer
-pendingReplyTarget pending state
-    | hasNewerInbound = pending.pendingReplyToMessageId
-    | otherwise = Nothing
-  where
-    hasNewerInbound =
-        maybe False
-            (any isInbound . Map.elems . snd
-                . Map.split pending.pendingUpdateId)
-            (Map.lookup pending.pendingChat state.pendingQueues)
-    isInbound = \case
-        RunPendingTurn _ -> True
-        RunPendingMediaTurn _ -> True
-        DeliverReply _ -> False
-        LeaveUnauthorizedChat _ -> False
+pendingReplyTarget pending state = do
+    target <- pending.pendingReplyToMessageId
+    case Map.lookup pending.pendingChat state.latestInboundMessageIds of
+        Just latest | latest <= target -> Nothing
+        -- Missing recency is possible for work restored from older state.
+        -- Keep the target conservatively rather than misattribute the reply.
+        _ -> Just target
 
 emptyTelegramState :: TelegramState
 emptyTelegramState = TelegramState
@@ -645,4 +668,5 @@ emptyTelegramState = TelegramState
     , allowedUserIds = Set.empty
     , seenTelegramUsers = Map.empty
     , seenUsersByChat = Map.empty
+    , latestInboundMessageIds = Map.empty
     }

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -1063,24 +1063,27 @@ spec = describe "Agent.Telegram" do
             reordered.nextUpdateId `shouldBe` Just 102
 
     describe "durable queue state" do
-        it "only visibly replies when a newer inbound message is queued" do
-            let key = TelegramChatKey 123 Nothing
+        it "tracks ignored messages when choosing visible reply targets" do
+            update <- (decodeWith telegramUpdateDecoder
+                (LBS.pack "{\"update_id\":12,\"message\":{\"message_id\":78,\"from\":{\"id\":789},\"chat\":{\"id\":-1001,\"type\":\"group\"},\"text\":\"ambient message\"}}")
+                :: Either String TelegramUpdate)
+                `shouldReturnRight` "Telegram update should decode"
+            let key = TelegramChatKey (-1001) Nothing
                 reply = TelegramPendingReply 11 key (Just 77) Nothing "reply"
-                newerTurn = TelegramPendingTurn 12 78 key "next" Nothing
-                latestState = emptyTelegramState
-                    { pendingQueues =
-                        Map.singleton key
-                            (Map.singleton 11 (DeliverReply reply))
-                    }
-                overtakenState = latestState
-                    { pendingQueues =
-                        Map.singleton key $ Map.fromList
-                            [ (11, DeliverReply reply)
-                            , (12, RunPendingTurn newerTurn)
-                            ]
-                    }
+                unknownState = emptyTelegramState
+                latestState = unknownState
+                    { latestInboundMessageIds = Map.singleton key 77 }
+                ignoredNewerState =
+                    storeUpdateAction update.updateId IgnoreUpdate
+                        (recordLatestInboundMessage update latestState)
+            pendingReplyTarget reply unknownState `shouldBe` Just 77
             pendingReplyTarget reply latestState `shouldBe` Nothing
-            pendingReplyTarget reply overtakenState `shouldBe` Just 77
+            pendingReplyTarget reply ignoredNewerState `shouldBe` Just 77
+            restored <- (decodeWith telegramStateDecoder (encode ignoredNewerState)
+                :: Either String TelegramState)
+                `shouldReturnRight` "Telegram state should decode"
+            Map.lookup key restored.latestInboundMessageIds `shouldBe` Just 78
+            pendingReplyTarget reply restored `shouldBe` Just 77
 
         it "loads state written before pending turns were introduced" do
             let decoded = decodeWith telegramStateDecoder
@@ -1223,6 +1226,7 @@ spec = describe "Agent.Telegram" do
                     , "allowedUserIds" .= ([] :: [Integer])
                     , "seenTelegramUsers" .= ([] :: [TelegramUser])
                     , "seenUsersByChat" .= ([] :: [Value])
+                    , "latestInboundMessages" .= ([] :: [Value])
                     ]
             encode state `shouldBe` encode expected
 


### PR DESCRIPTION
## Summary
- persist the latest inbound Telegram message ID for each chat/topic before classification
- include ignored ambient group messages when deciding whether an answer needs explicit reply threading
- conservatively retain reply targets when loading legacy state without recency information
- add regression coverage for ignored-message recency and state persistence

Follow-up to #671 and addresses its automated review feedback.

## Testing
- `printf ':main\n:q\n' | nix develop -c cabal repl agent-telegram:test:agent-telegram-test` (71 examples, 0 failures)
- `git diff --check`
