### PR TITLE
Preserve idle composer draft on Escape

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -350,8 +350,8 @@ handleComposerKey
                 EscapeDismissSlashMenu ->
                     modify' \current ->
                         current { appSlashDismissed = True }
-                EscapeClearDraft ->
-                    cancelOrClear
+                EscapePreserveDraft ->
+                    pure ()
         V.EvKey V.KBackTab []
             | ui.uiAwaitingInput ->
                 submitRaw (ReplCycleMode ui.uiDraft)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Logic.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Logic.hs
@@ -91,14 +91,14 @@ currentSlashMenu state
 data ComposerEscapeAction
     = EscapeCancelTurn
     | EscapeDismissSlashMenu
-    | EscapeClearDraft
+    | EscapePreserveDraft
     deriving (Eq, Show)
 
 composerEscapeAction :: Bool -> Bool -> ComposerEscapeAction
 composerEscapeAction awaitingInput hasSlashMenu
     | not awaitingInput = EscapeCancelTurn
     | hasSlashMenu = EscapeDismissSlashMenu
-    | otherwise = EscapeClearDraft
+    | otherwise = EscapePreserveDraft
 
 selectedSlashSuggestion :: AppState -> SlashMenu -> Maybe SlashSuggestion
 selectedSlashSuggestion state menu =

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -71,11 +71,11 @@ spec = describe "fullscreen composer" do
             (ReplText "ordinary follow-up")
             `shouldBe` Nothing
 
-    it "dismisses slash completion or clears the draft while idle" do
+    it "dismisses slash completion or preserves the draft while idle" do
         composerEscapeAction True True
             `shouldBe` EscapeDismissSlashMenu
         composerEscapeAction True False
-            `shouldBe` EscapeClearDraft
+            `shouldBe` EscapePreserveDraft
 
     it "tracks the multiline cursor location" do
         draftCursorLocation "one\ntwo" 6 `shouldBe` (1, 2)


### PR DESCRIPTION
## Summary
- make bare Escape a no-op for an idle fullscreen composer
- keep Escape behavior for active-turn cancellation and slash-menu dismissal
- update composer action coverage to require draft preservation

## Validation
- `nix develop -c cabal build agent-cli:exe:agent-cli`
- tmux TTY smoke test: typed `escape-preserves-this-draft`, sent `Escape`, and verified the draft remained present
- `git diff --check`

## Test-suite note
`nix develop -c cabal test agent-cli:agent-cli-test --test-options="--match fullscreen composer"` compiled the changed production modules and `TUIComposerSpec`, but the suite executable is currently blocked by unrelated existing type errors in `DatabaseSpec` and `LearnedSkillsSpec`.