### PR TITLE
fix(tui): redraw when background agents finish

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -12,6 +12,7 @@ module Agent.CLI.TUI.App
     , agentPaneVisible
     , backgroundActivityText
     , completionFlashTransitions
+    , completionRequiresRedraw
     , conversationScrollbarRenderer
     , choiceRowColumns
     , choiceClosesOnUiTransition

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -93,7 +93,7 @@ import Agent.CLI.TUI.History ( HistoryCursor(..)
     , setHistoryWindowTurns
     )
 import Agent.CLI.TUI.LambdaArt ( lambdaArtWidget )
-import Agent.CLI.TUI.Motion ( advanceCompletionFlashes , appMotionTiming , completionFlashTransitions , elapsedMillisSince , hasBackgroundActivity , isBackgroundAgentActive , motionDemandFor , motionDemandForTerminalFocus , motionModeForTerminalFocus , nativeProgressKeepaliveDue , nextMotionSchedule , turnCompletionRequiresRedraw , uiEventRestartsMotionSchedule , userActionPending )
+import Agent.CLI.TUI.Motion ( advanceCompletionFlashes , appMotionTiming , completionFlashTransitions , completionRequiresRedraw , elapsedMillisSince , hasBackgroundActivity , isBackgroundAgentActive , motionDemandFor , motionDemandForTerminalFocus , motionModeForTerminalFocus , nativeProgressKeepaliveDue , nextMotionSchedule , uiEventRestartsMotionSchedule , userActionPending )
 import Agent.CLI.TUI.Render ( agentEntryWindow , agentPaneEntryLimit , agentPaneVisible , applyChildConversationUiEvent , choiceRowColumns , conversationUiForTarget , conversationScrollbarRenderer , drawApp , fullscreenBounds , fullscreenSurface , onboardingVisibleRowIndices , normalizeTextOverlayInsertion , maskedSecretText , quickStartRows , quickStartVisible , repositoryHeaderText , resumeSearchCursorColumn , selectedAgentConversation , textOverlayDisplayText )
 import Agent.CLI.TUI.ImagePreview ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
@@ -219,9 +219,11 @@ handleEvent event = do
     when
         ( stateAfterMotionSync.appTerminalFocus == TerminalUnfocused
             && not
-                (turnCompletionRequiresRedraw
+                (completionRequiresRedraw
                     stateBeforeEvent.appUi
-                    stateAfterMotionSync.appUi)
+                    stateBeforeEvent.appAgentEntries
+                    stateAfterMotionSync.appUi
+                    stateAfterMotionSync.appAgentEntries)
         ) $
         continueWithoutRedraw
   where

--- a/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
@@ -4,6 +4,7 @@ module Agent.CLI.TUI.Motion
     , appMotionDemand
     , appMotionTiming
     , completionFlashTransitions
+    , completionRequiresRedraw
     , elapsedMillisSince
     , hasBackgroundActivity
     , isBackgroundAgentActive
@@ -47,6 +48,7 @@ import Agent.TUI.Motion
     )
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Maybe (isJust)
 import qualified Data.Text as Text
 import Data.Word (Word64)
@@ -274,3 +276,26 @@ nativeProgressKeepaliveDue blocked previousBucket ui =
 turnCompletionRequiresRedraw :: UiState -> UiState -> Bool
 turnCompletionRequiresRedraw previous next =
     previous.uiRunning && not next.uiRunning
+
+-- | A completed root turn or child agent gets one final frame while focus
+-- throttling suppresses ordinary snapshot redraws. Check each child rather
+-- than only aggregate background activity so one completion is visible even
+-- when sibling agents keep running.
+completionRequiresRedraw
+    :: UiState
+    -> [AgentEntry]
+    -> UiState
+    -> [AgentEntry]
+    -> Bool
+completionRequiresRedraw previousUi previousAgents nextUi nextAgents =
+    turnCompletionRequiresRedraw previousUi nextUi
+        || not (Set.null (previousActive `Set.difference` nextActive))
+  where
+    previousActive = activeTargets previousAgents
+    nextActive = activeTargets nextAgents
+    activeTargets entries =
+        Set.fromList
+            [ entry.agentTarget
+            | entry <- entries
+            , isBackgroundAgentActive entry
+            ]

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -17,6 +17,7 @@ import Agent.CLI.TUI.App
     , agentPaneVisible
     , backgroundActivityText
     , completionFlashTransitions
+    , completionRequiresRedraw
     , conversationScrollbarRenderer
     , choiceRowColumns
     , choiceClosesOnUiTransition
@@ -896,6 +897,33 @@ spec = do
             turnCompletionRequiresRedraw running finished `shouldBe` True
             turnCompletionRequiresRedraw running continuing `shouldBe` False
             turnCompletionRequiresRedraw finished finished `shouldBe` False
+
+        it "requests an unfocused redraw when any child agent finishes" do
+            let runningChild = childEntry 1
+                sibling = childEntry 2
+                finishedChild =
+                    runningChild { agentStatus = "completed" }
+                stillStreaming =
+                    runningChild
+                        { agentTranscript = ["assistant: still working"] }
+            completionRequiresRedraw
+                initialUiState
+                [rootEntry, runningChild, sibling]
+                initialUiState
+                [rootEntry, finishedChild, sibling]
+                `shouldBe` True
+            completionRequiresRedraw
+                initialUiState
+                [rootEntry, runningChild, sibling]
+                initialUiState
+                [rootEntry, stillStreaming, sibling]
+                `shouldBe` False
+            completionRequiresRedraw
+                initialUiState
+                [rootEntry, runningChild, sibling]
+                initialUiState
+                [rootEntry, sibling]
+                `shouldBe` True
 
         it "retains sub-millisecond time across clock samples" do
             elapsedMillisSince 1000000 1499999


### PR DESCRIPTION
## Summary
- force one fullscreen redraw when any background child transitions out of pending/running while terminal redraws are focus-throttled
- preserve the existing root-turn completion behavior
- cover sibling-still-running, streaming-only, and removed-child cases

## Validation
- `nix develop -c cabal build agent-cli:lib:agent-cli`
- isolated compiled check for all three child-transition cases: passed
- `git diff --check`

The full `agent-cli-test` executable is currently blocked on unchanged `origin/master` by existing type errors in `LearnedSkillsSpec` and `DatabaseSpec`; the changed TUI test module itself compiled successfully before those unrelated modules failed.