### PR TITLE
Render streamed tool calls immediately

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -415,15 +415,15 @@ renderEventUnlocked config = \case
                 putTextLn config.renderStdout ""
     ToolStarted call -> do
         commitThinkingUnlocked config
-        modifyRenderState config \state ->
+        alreadyVisible <- modifyRenderState config \state ->
             ( state
                 { stateToolCalls = Map.insert call.callId call state.stateToolCalls
                 , stateActivity =
                     summarizeToolCallRelative config.renderWorkspace call
                 }
-            , ()
+            , Map.member call.callId state.stateToolCalls
             )
-        unless (isTodoTool call.name) do
+        unless (alreadyVisible || isTodoTool call.name) do
             putTextLn config.renderStderr
                 (formatToolStartedRelative
                     config.renderColor
@@ -470,8 +470,38 @@ renderEventUnlocked config = \case
         case painted of
             Nothing -> pure ()
             Just line -> putTextLn config.renderStderr line
-    ToolUpdated _ ->
-        pure ()
+    ToolUpdated call -> do
+        previous <- modifyRenderState config \state ->
+            ( state
+                { stateToolCalls =
+                    Map.insert call.callId call state.stateToolCalls
+                , stateActivity =
+                    summarizeToolCallRelative config.renderWorkspace call
+                }
+            , Map.lookup call.callId state.stateToolCalls
+            )
+        -- An early streamed start may only show a placeholder. Append the
+        -- canonical rendering once when the done item supplies arguments;
+        -- the later execution-time ToolStarted is deduplicated by call id.
+        when
+            ( maybe False
+                (Text.null . Text.strip . (.arguments))
+                previous
+                && not (Text.null (Text.strip call.arguments))
+                && not (isTodoTool call.name)
+            ) do
+                putTextLn config.renderStderr
+                    (formatToolStartedRelative
+                        config.renderColor
+                        config.renderWorkspace
+                        call)
+                let extra =
+                        formatToolBodyRelative
+                            config.renderColor
+                            config.renderWorkspace
+                            call
+                unless (Text.null extra) do
+                    putTextLn config.renderStderr extra
     ToolRetracted _ ->
         pure ()
     ResponseAttemptDiscarded ->

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -28,6 +28,7 @@ import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, takeMVar)
 import Control.Exception (finally)
 import Control.Monad (forM_)
 import Data.IORef (newIORef, readIORef)
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Calendar (fromGregorian)
@@ -431,6 +432,23 @@ spec = do
             rendered `shouldSatisfy` Text.isInfixOf "Retry the message."
 
     describe "renderEvent" do
+        it "prints canonical streamed tool metadata once" do
+            withRenderConfig False False \config handle path -> do
+                let early = functionToolCall "c1" "shell_command" ""
+                    canonical =
+                        functionToolCall
+                            "c1"
+                            "shell_command"
+                            "{\"command\":\"git status\"}"
+                renderEvent config (ToolStarted early)
+                renderEvent config (ToolUpdated canonical)
+                renderEvent config (ToolStarted canonical)
+                hClose handle
+                body <- Text.readFile path
+                Text.count "◆ $ git status" body `shouldBe` 1
+                calls <- stateToolCalls <$> readIORef config.renderState
+                calls `shouldBe` Map.singleton "c1" canonical
+
         it "keeps concurrent tool lines intact" do
             withRenderConfig False False \config handle path -> do
                 let events =

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -568,6 +568,18 @@ streamEventToLoopEventWithRawReasoning
     -> ResponseStreamEvent
     -> Maybe LoopEvent
 streamEventToLoopEventWithRawReasoning showRawReasoning = \case
+    -- Publish a tool block as soon as the provider announces the output item.
+    -- The loop will still execute the call only after the complete response
+    -- has been assembled; this event is purely a live UI projection.
+    ResponseOutputItemAddedEvent { item }
+        | Just call <- responseItemToToolCall item ->
+            Just (ToolStarted call)
+    -- Providers commonly send the call arguments in deltas and include the
+    -- complete call in the corresponding done event. Replace the placeholder
+    -- block's metadata/body before the core loop starts executing it.
+    ResponseOutputItemDoneEvent { item }
+        | Just call <- responseItemToToolCall item ->
+            Just (ToolUpdated call)
     ResponseReasoningSummaryPartAddedEvent
         { summaryIndex = Just index }
         | index > 0 ->
@@ -688,11 +700,11 @@ toolArgumentStreamStep
     -> (ToolArgumentStreamState, [LoopEvent])
 toolArgumentStreamStep event state = case event of
     ResponseOutputItemAddedEvent { item = FunctionCallItem call } ->
-        announceToolCall call.name
+        announceToolCall (namespacedToolName call.namespace call.name)
             (maybeToList call.itemId <> [call.callId])
             state
     ResponseOutputItemAddedEvent { item = CustomToolCallItem call } ->
-        announceToolCall call.name
+        announceToolCall (namespacedToolName call.namespace call.name)
             (maybeToList call.itemId <> [call.callId])
             state
     ResponseFunctionCallArgumentsDeltaEvent { delta = Just deltaText, streamItemId } ->

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -375,16 +375,73 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
             request = withRequestInput defaultResponseCreateParams items
         request.input `shouldBe` Just (ResponseInputItems items)
 
--- | Streamed tool-call arguments map to no visible loop delta of their own.
--- Without the projected activity below, a model writing a large call — or
--- degenerating into a repetition loop inside one — looks like endless silent
--- reasoning until the provider's output-token cap fails the turn.
+-- | Streamed tool calls are announced immediately, while argument deltas map
+-- to activity updates at coarse boundaries. Without the projected activity
+-- below, a model writing a large call — or degenerating into a repetition
+-- loop inside one — looks like endless silent reasoning until the provider's
+-- output-token cap fails the turn.
 streamProjectionSpec :: Spec
 streamProjectionSpec = describe "newStreamEventToLoopEvents" do
-    it "announces a streamed function call by name" do
+    it "publishes a streamed function call immediately" do
         projectEvent <- newStreamEventToLoopEvents False
         events <- projectEvent (functionCallAdded "fc-1" "call-1" "shell_command")
-        events `shouldBe` [ActivityUpdated "Writing shell_command call…"]
+        events `shouldBe`
+            [ ToolStarted
+                (functionToolCall "call-1" "shell_command" "")
+            , ActivityUpdated "Writing shell_command call…"
+            ]
+
+    it "replaces streamed tool metadata with the canonical done item" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent (functionCallAdded "fc-1" "call-1" "shell_command")
+        events <- projectEvent
+            (functionCallDone
+                "fc-1"
+                "call-1"
+                "shell_command"
+                "{\"command\":\"git status\"}")
+        events `shouldBe`
+            [ ToolUpdated
+                (functionToolCall
+                    "call-1"
+                    "shell_command"
+                    "{\"command\":\"git status\"}")
+            ]
+
+    it "publishes a streamed custom tool call immediately" do
+        projectEvent <- newStreamEventToLoopEvents False
+        events <- projectEvent
+            (customToolCallAdded "ct-1" "call-9" "apply_patch")
+        events `shouldBe`
+            [ ToolStarted ToolCall
+                { callId = "call-9"
+                , name = "apply_patch"
+                , arguments = ""
+                , callKind = CustomCallKind
+                , argumentsEncrypted = False
+                }
+            , ActivityUpdated "Writing apply_patch call…"
+            ]
+
+    it "updates a streamed custom tool from its done item" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent
+            (customToolCallAdded "ct-1" "call-9" "apply_patch")
+        events <- projectEvent
+            (customToolCallDone
+                "ct-1"
+                "call-9"
+                "apply_patch"
+                "*** Begin Patch")
+        events `shouldBe`
+            [ ToolUpdated ToolCall
+                { callId = "call-9"
+                , name = "apply_patch"
+                , arguments = "*** Begin Patch"
+                , callKind = CustomCallKind
+                , argumentsEncrypted = False
+                }
+            ]
 
     it "reports argument progress at chunk boundaries" do
         projectEvent <- newStreamEventToLoopEvents False
@@ -437,6 +494,15 @@ streamProjectionSpec = describe "newStreamEventToLoopEvents" do
             }
         events `shouldBe` [TextDelta "hi"]
 
+functionToolCall :: Text.Text -> Text.Text -> Text.Text -> ToolCall
+functionToolCall functionCallId functionName functionArguments = ToolCall
+    { callId = functionCallId
+    , name = functionName
+    , arguments = functionArguments
+    , callKind = FunctionCallKind
+    , argumentsEncrypted = False
+    }
+
 functionCallAdded :: Text.Text -> Text.Text -> Text.Text -> ResponseStreamEvent
 functionCallAdded functionItemId functionCallId functionName =
     ResponseOutputItemAddedEvent
@@ -456,6 +522,30 @@ functionCallAdded functionItemId functionCallId functionName =
 
         }
 
+functionCallDone
+    :: Text.Text
+    -> Text.Text
+    -> Text.Text
+    -> Text.Text
+    -> ResponseStreamEvent
+functionCallDone functionItemId functionCallId functionName functionArguments =
+    ResponseOutputItemDoneEvent
+        { item = FunctionCallItem FunctionCall
+            { itemId = Just functionItemId
+            , callId = functionCallId
+            , name = functionName
+            , namespace = Nothing
+            , provider = Nothing
+            , arguments = functionArguments
+            , encryptedFunctionArgs = Nothing
+            , status = Nothing
+
+            }
+        , outputIndex = Just 0
+        , sequenceNumber = Just 2
+
+        }
+
 customToolCallAdded :: Text.Text -> Text.Text -> Text.Text -> ResponseStreamEvent
 customToolCallAdded customItemId customCallId customName =
     ResponseOutputItemAddedEvent
@@ -470,6 +560,28 @@ customToolCallAdded customItemId customCallId customName =
             }
         , outputIndex = Just 0
         , sequenceNumber = Just 1
+
+        }
+
+customToolCallDone
+    :: Text.Text
+    -> Text.Text
+    -> Text.Text
+    -> Text.Text
+    -> ResponseStreamEvent
+customToolCallDone customItemId customCallId customName customInput =
+    ResponseOutputItemDoneEvent
+        { item = CustomToolCallItem CustomToolCall
+            { itemId = Just customItemId
+            , callId = customCallId
+            , name = customName
+            , namespace = Nothing
+            , input = customInput
+            , status = Nothing
+
+            }
+        , outputIndex = Just 0
+        , sequenceNumber = Just 2
 
         }
 

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -381,6 +381,16 @@ reduceLoop event state = case event of
                 , uiToolCalls = Map.empty
                 }
     ToolStarted call
+        | Map.member call.callId state.uiToolCalls ->
+            -- A streaming backend may announce the call before execution;
+            -- the core loop announces it again once the response is complete.
+            -- Refresh the canonical metadata without adding another block.
+            updateToolCall call
+                state
+                    { uiRunning = True
+                    , uiGenerating = False
+                    , uiAwaitingInput = False
+                    }
         | isTodoTool call.name ->
             state
                 { uiRunning = True

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -332,6 +332,27 @@ spec = describe "fullscreen UI reducer" do
         Foldable.toList state.uiToolCalls
             `shouldBe` [(0, canonical)]
 
+    it "makes repeated tool starts idempotent by call id" do
+        let early = functionToolCall "c1" "Task" "{}"
+            canonical =
+                functionToolCall
+                    "c1"
+                    "Agent"
+                    "{\"description\":\"review the patch\"}"
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted early)
+                    , UiLoop (ToolStarted canonical)
+                    ]
+        case Foldable.toList state.uiBlocks of
+            [block] -> do
+                block.blockTitle `shouldBe` "Agent"
+                block.blockState `shouldBe` BlockRunning
+            _ -> expectationFailure "expected one updated tool block"
+        Foldable.toList state.uiToolCalls
+            `shouldBe` [(0, canonical)]
+
     it "retracts a tool and repairs later tool positions" do
         let first = functionToolCall "c1" "Task" "{}"
             second = functionToolCall "c2" "Read" "{\"file_path\":\"README.md\"}"


### PR DESCRIPTION
## Summary

- surface Responses function and custom tool calls as soon as `output_item.added` arrives
- update early tool blocks in place with canonical arguments and deduplicate the later execution start
- preserve useful append-only output by printing canonical tool metadata once after an empty streamed placeholder
- add projection, reducer, and renderer regression coverage

## Validation

- `nix develop -c cabal test agent-responses:test:agent-responses-test agent-tui:test:agent-tui-test --test-show-details=direct`
  - agent-responses: 65 examples, 0 failures
  - agent-tui: 188 examples, 0 failures
- multi-package `cabal repl` loaded all 275 modules
- live tmux smoke test launched the TUI and captured the shell tool block while the status still read `Writing shell_command call…`
- `git diff --check`

## Known test-suite blocker

The new `Agent.CLI.RenderSpec` compiles. The aggregate `agent-cli-test` target does not complete because existing `DatabaseSpec` and `LearnedSkillsSpec` fixtures fail to typecheck against the current typed database/learned-skill interfaces; those errors are unrelated to this diff.
