### PR TITLE
Type Responses metadata and shell environment

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
@@ -13,10 +13,7 @@ import Agent.Tools.Types
     ( appToolHandlers
     )
 import Agent.ToolDispatch (dispatchToolCall)
-import Agent.Json (rawJsonFromEncoding)
 import Control.Exception.Safe (displayException)
-import Data.Aeson (object, (.=))
-import qualified Data.Aeson as Aeson
 import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -30,8 +27,7 @@ spec = do
             let env = testEnv
                     { databaseRunQuery = \scope sql -> do
                         writeIORef seen (Just (scope, sql))
-                        pure (Right (rawJsonFromEncoding (Aeson.toEncoding
-                            (object ["rows" .= [object ["title" .= ("test" :: Text)]]]))))
+                        pure (Right "row 1:\n  title: test\n\ntruncated: no")
                     }
             result <- dispatchToolCall dispatchConfig
                 (appToolHandlers (databaseTools env))
@@ -39,14 +35,14 @@ spec = do
                     "{\"scope\":\"user\",\"sql\":\"select * from todos\"}")
             readIORef seen `shouldReturn`
                 Just (DatabaseUserScope, "select * from todos")
-            result.output `shouldContainText` "\"rows\""
+            result.output `shouldContainText` "title: test"
 
         it "rejects empty mutating SQL before calling storage" do
             called <- newIORef False
             let env = testEnv
                     { databaseRunExecute = \_ _ _ -> do
                         writeIORef called True
-                        pure (Right (object []))
+                        pure (Right "ok")
                     }
             result <- dispatchToolCall dispatchConfig
                 (appToolHandlers (databaseTools env))
@@ -137,10 +133,9 @@ spec = do
 
 testEnv :: DatabaseToolsEnv
 testEnv = DatabaseToolsEnv
-    { databaseDescribeScope = \_ -> pure (Right (object []))
-    , databaseRunQuery = \_ _ ->
-        pure (Right (rawJsonFromEncoding (Aeson.toEncoding (object []))))
-    , databaseRunExecute = \_ _ _ -> pure (Right (object []))
+    { databaseDescribeScope = \_ -> pure (Right "ok")
+    , databaseRunQuery = \_ _ -> pure (Right "(no rows)")
+    , databaseRunExecute = \_ _ _ -> pure (Right "ok")
     , databaseSearchConversations = \_ _ ->
         pure (Right [])
     }

--- a/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
@@ -33,7 +33,6 @@ import Agent.Tools.Types
     , appToolHandlers
     )
 import Control.Exception.Safe (displayException)
-import Data.Aeson (object, (.=))
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -79,10 +78,10 @@ spec = do
             let env = testEnv
                     { learnedSkillSearch = \query limit -> do
                         writeIORef searchSeen (Just (query, limit))
-                        pure (Right (object ["matches" .= ([] :: [Text])]))
+                        pure (Right testSearchResponse)
                     , learnedSkillCreate = \request -> do
                         writeIORef createSeen (Just request)
-                        pure (Right (object ["status" .= ("applied" :: Text)]))
+                        pure (Right testMutationResponse)
                     }
             searchResult <- dispatchToolCall dispatchConfig
                 (appToolHandlers (learnedSkillTools invocationsRef env))
@@ -103,8 +102,8 @@ spec = do
                 Just ("postgres session", 4)
             fmap (.createRequestSlug) <$> readIORef createSeen
                 `shouldReturn` Just "postgres-session"
-            searchResult.output `shouldContainText` "\"matches\""
-            createResult.output `shouldContainText` "\"applied\""
+            searchResult.output `shouldContainText` "no matching learned skills"
+            createResult.output `shouldContainText` "status: applied"
 
         it "views filesystem and learned skills through one lazy-loading tool" do
             learnedSeen <- newIORef Nothing
@@ -113,9 +112,7 @@ spec = do
             let env = testEnv
                     { learnedSkillRead = \scope slug revision -> do
                         writeIORef learnedSeen (Just (scope, slug, revision))
-                        pure (Right (object
-                            [ "instructions" .= ("Learned body" :: Text)
-                            ]))
+                        pure (Right testLearnedSkillView)
                     }
                 handlers =
                     appToolHandlers (learnedSkillTools invocationsRef env)
@@ -127,12 +124,12 @@ spec = do
                     "{\"name\":\"postgres-session\",\
                     \\"scope\":\"repository\",\
                     \\"revision\":2}")
-            filesystemResult.output `shouldContainText` "\"kind\":\"filesystem\""
+            filesystemResult.output `shouldContainText` "kind: filesystem"
             filesystemResult.output `shouldContainText`
-                "\"instructions\":\"Deploy carefully.\""
+                "instructions:\n  Deploy carefully."
             readIORef learnedSeen `shouldReturn`
                 Just (DatabaseRepositoryScope, "postgres-session", Just 2)
-            learnedResult.output `shouldContainText` "\"Learned body\""
+            learnedResult.output `shouldContainText` "Learned body"
 
         it "rejects invalid mutations before calling storage" do
             called <- newIORef False
@@ -140,10 +137,10 @@ spec = do
             let env = testEnv
                     { learnedSkillCreate = \_ -> do
                         writeIORef called True
-                        pure (Right (object []))
+                        pure (Right testMutationResponse)
                     , learnedSkillUpdate = \_ -> do
                         writeIORef called True
-                        pure (Right (object []))
+                        pure (Right testMutationResponse)
                     }
             badSlug <- dispatchToolCall dispatchConfig
                 (appToolHandlers (learnedSkillTools invocationsRef env))
@@ -271,13 +268,54 @@ spec = do
 
 testEnv :: LearnedSkillToolsEnv
 testEnv = LearnedSkillToolsEnv
-    { learnedSkillSearch = \_ _ -> pure (Right (object []))
-    , learnedSkillRead = \_ _ _ -> pure (Right (object []))
-    , learnedSkillCreate = \_ -> pure (Right (object []))
-    , learnedSkillUpdate = \_ -> pure (Right (object []))
-    , learnedSkillArchive = \_ -> pure (Right (object []))
-    , learnedSkillRollback = \_ -> pure (Right (object []))
+    { learnedSkillSearch = \_ _ -> pure (Right testSearchResponse)
+    , learnedSkillRead = \_ _ _ -> pure (Right testLearnedSkillView)
+    , learnedSkillCreate = \_ -> pure (Right testMutationResponse)
+    , learnedSkillUpdate = \_ -> pure (Right testMutationResponse)
+    , learnedSkillArchive = \_ -> pure (Right testMutationResponse)
+    , learnedSkillRollback = \_ -> pure (Right testMutationResponse)
     }
+
+testSearchResponse :: LearnedSkillSearchResponse
+testSearchResponse = LearnedSkillSearchResponse []
+
+testMutationResponse :: LearnedSkillMutationResponse
+testMutationResponse = LearnedSkillMutationResponse "applied" testSkillDetails
+
+testLearnedSkillView :: LearnedSkillView
+testLearnedSkillView = LearnedSkillView
+    testSkillDetails
+    testRevisionDetails
+    []
+    []
+
+testSkillDetails :: LearnedSkillDetails
+testSkillDetails = LearnedSkillDetails
+    "repository"
+    "postgres-session"
+    "Postgres sessions"
+    "Use typed durable tables"
+    "Changing session persistence"
+    "Learned body"
+    "relevant"
+    0
+    "active"
+    2
+    timestamp
+    timestamp
+
+testRevisionDetails :: LearnedSkillRevisionDetails
+testRevisionDetails = LearnedSkillRevisionDetails
+    2
+    "Postgres sessions"
+    "Use typed durable tables"
+    "Changing session persistence"
+    "Learned body"
+    "relevant"
+    0
+    "active"
+    "Updated lesson"
+    timestamp
 
 dispatchConfig :: ToolDispatchConfig
 dispatchConfig = ToolDispatchConfig

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -8,11 +8,15 @@ import Agent.CLI.Request
 import Agent.CLI.Tools (webSearchTool)
 import Agent.Provider (Provider(..))
 import Agent.Responses.Types
+import Agent.Responses.Types.Items (responseItemDecoder)
+import Agent.Json.Decode qualified as Hermes
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Foldable (toList)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
 import Test.Hspec
 
 spec :: Spec
@@ -42,6 +46,26 @@ spec = describe "requestParams" do
                 reasoning.generateSummary `shouldBe` Nothing
                 reasoning.reasoningMode `shouldBe` Nothing
                 reasoning.summary `shouldBe` Just "auto"
+
+    it "decodes Responses metadata as a string map" do
+        let decoded = Hermes.decodeEither responseCreateParamsDecoder $
+                Text.encodeUtf8
+                    "{\"metadata\":{\"team\":\"agent\"}}"
+        fmap (.metadata) decoded `shouldBe`
+            Right (Just (ResponseMetadata (Map.fromList [("team", "agent")])))
+
+    it "decodes local-shell environment variables as a string map" do
+        let decoded = Hermes.decodeEither responseItemDecoder $ Text.encodeUtf8
+                "{\"type\":\"local_shell_call\",\"action\":{\"type\":\"exec\",\"command\":[\"env\"],\"env\":{\"LANG\":\"C\"}}}"
+        case decoded of
+            Right (LocalShellCallItem LocalShellCall
+                { action = Just LocalShellExec{env} }) ->
+                    env `shouldBe` Just
+                        (EnvironmentVariables (Map.fromList [("LANG", "C")]))
+            Right item -> expectationFailure
+                ("unexpected decoded item: " <> show item)
+            Left err -> expectationFailure
+                ("could not decode local shell item: " <> show err)
 
     it "leaves reasoning summaries provider-controlled outside OpenAI" do
         let params =

--- a/packages/agent-responses-types/agent-responses-types.cabal
+++ b/packages/agent-responses-types/agent-responses-types.cabal
@@ -57,5 +57,6 @@ library
                     , agent-json >= 0.1 && < 0.2
                     , aeson      >= 2.0
                     , hermes-json
+                    , containers
                     , scientific
                     , text

--- a/packages/agent-responses-types/package.nix
+++ b/packages/agent-responses-types/package.nix
@@ -1,12 +1,12 @@
-{ mkDerivation, aeson, agent-json, base, hermes-json, lib
-, scientific, text
+{ mkDerivation, aeson, agent-json, base, containers, hermes-json
+, lib, scientific, text
 }:
 mkDerivation {
   pname = "agent-responses-types";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson agent-json base hermes-json scientific text
+    aeson agent-json base containers hermes-json scientific text
   ];
   description = "Canonical wire types for Responses-compatible APIs";
   license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";

--- a/packages/agent-responses-types/src/Agent/Responses/Types.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types.hs
@@ -55,6 +55,8 @@ module Agent.Responses.Types
     , ReasoningSummaryPart(..)
     , ItemReference(..)
     , TaggedObject(..)
+    , ResponseMetadata(..)
+    , EnvironmentVariables(..)
 
       -- * Tools
     , ResponseTool(..)

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Common.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Common.hs
@@ -8,6 +8,10 @@ module Agent.Responses.Types.Common
     , optionalAtKey
     , RawJson
     , rawJsonDecoder
+    , ResponseMetadata(..)
+    , responseMetadataDecoder
+    , EnvironmentVariables(..)
+    , environmentVariablesDecoder
     ) where
 
 import Control.Monad (join)
@@ -16,6 +20,8 @@ import Data.Aeson hiding (TaggedObject)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Key as Key
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
 import qualified Data.Hermes as Hermes
 import Data.Text (Text)
@@ -55,3 +61,29 @@ optionalAtKey
     -> Hermes.FieldsDecoder (Maybe value)
 optionalAtKey key decoder =
     join <$> Hermes.atKeyOptional key (Hermes.nullable decoder)
+
+-- | Responses metadata: string keys mapped to string values.
+newtype ResponseMetadata = ResponseMetadata
+    { unResponseMetadata :: Map Text Text
+    } deriving stock (Eq, Show)
+
+instance ToJSON ResponseMetadata where
+    toJSON (ResponseMetadata entries) = toJSON entries
+
+responseMetadataDecoder :: Hermes.Decoder ResponseMetadata
+responseMetadataDecoder = ResponseMetadata <$> textMapDecoder
+
+-- | Environment variables supplied to a local shell action.
+newtype EnvironmentVariables = EnvironmentVariables
+    { unEnvironmentVariables :: Map Text Text
+    } deriving stock (Eq, Show)
+
+instance ToJSON EnvironmentVariables where
+    toJSON (EnvironmentVariables entries) = toJSON entries
+
+environmentVariablesDecoder :: Hermes.Decoder EnvironmentVariables
+environmentVariablesDecoder = EnvironmentVariables <$> textMapDecoder
+
+textMapDecoder :: Hermes.Decoder (Map Text Text)
+textMapDecoder = Map.fromList
+    <$> Hermes.objectAsKeyValues pure Hermes.text

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Items.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Items.hs
@@ -361,7 +361,7 @@ data LocalShellAction
         { command           :: ![Text]
         , timeoutMs         :: !(Maybe Integer)
         , workingDirectory  :: !(Maybe Text)
-        , env               :: !(Maybe RawJson)
+        , env               :: !(Maybe EnvironmentVariables)
         , user              :: !(Maybe Text)
 
         }
@@ -833,7 +833,7 @@ localShellActionDecoder =
                     (Hermes.list Hermes.text))
                 <*> optionalAtKey "timeout_ms" integerDecoder
                 <*> optionalAtKey "working_directory" Hermes.text
-                <*> optionalAtKey "env" rawJsonDecoder
+                <*> optionalAtKey "env" environmentVariablesDecoder
                 <*> optionalAtKey "user" Hermes.text
             _ -> pure $
                 LocalShellActionOther

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Request.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Request.hs
@@ -217,7 +217,7 @@ data ResponseCreateParams = ResponseCreateParams
     , instructions         :: !(Maybe Text)
     , maxOutputTokens      :: !(Maybe Int)
     , maxToolCalls         :: !(Maybe Int)
-    , metadata             :: !(Maybe RawJson)
+    , metadata             :: !(Maybe ResponseMetadata)
     , model                :: !(Maybe Text)
     , moderation           :: !(Maybe RawJson)
     , parallelToolCalls    :: !(Maybe Bool)
@@ -416,7 +416,7 @@ responseCreateParamsDecoder = Hermes.object $
         <*> optionalAtKey "instructions" Hermes.text
         <*> optionalAtKey "max_output_tokens" Hermes.int
         <*> optionalAtKey "max_tool_calls" Hermes.int
-        <*> optionalAtKey "metadata" rawJsonDecoder
+        <*> optionalAtKey "metadata" responseMetadataDecoder
         <*> optionalAtKey "model" Hermes.text
         <*> optionalAtKey "moderation" rawJsonDecoder
         <*> optionalAtKey "parallel_tool_calls" Hermes.bool

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Response.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Response.hs
@@ -15,6 +15,8 @@ import Agent.Responses.Types.Common
     , optionalAtKey
     , RawJson
     , rawJsonDecoder
+    , ResponseMetadata
+    , responseMetadataDecoder
     )
 import Agent.Responses.Types.Items
     ( ResponseInput
@@ -135,7 +137,7 @@ data Response = Response
     , error                :: !(Maybe ResponseError)
     , incompleteDetails    :: !(Maybe IncompleteDetails)
     , instructions         :: !(Maybe ResponseInput)
-    , metadata             :: !(Maybe RawJson)
+    , metadata             :: !(Maybe ResponseMetadata)
     , model                :: !Text
     , object               :: !Text
     , output               :: ![ResponseItem]
@@ -286,7 +288,7 @@ responseDecoder = Hermes.object $
         <*> optionalAtKey "error" responseErrorDecoder
         <*> optionalAtKey "incomplete_details" incompleteDetailsDecoder
         <*> optionalAtKey "instructions" responseInputDecoder
-        <*> optionalAtKey "metadata" rawJsonDecoder
+        <*> optionalAtKey "metadata" responseMetadataDecoder
         <*> (maybe "" id <$> optionalAtKey "model" Hermes.text)
         <*> (maybe "response" id <$> optionalAtKey "object" Hermes.text)
         <*> (maybe [] id <$> optionalAtKey


### PR DESCRIPTION
## Summary

- represent Responses metadata as a typed string-to-string map
- represent local-shell environment variables as a typed string-to-string map
- decode both maps directly with Hermes and preserve their wire encodings
- repair database and learned-skill tests that still used the pre-#665 JSON callback shapes

`additional_tools.tools` and `tool_search_output.tools` remain opaque for now: the current `ResponseTool` sum intentionally collapses hosted/unknown tool definitions to their type tag, so decoding those fields through it would lose provider fields.

## Validation

- `nix develop -c cabal repl agent-responses-types:lib:agent-responses-types --repl-options='-e :quit'`
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options='-e :quit'`
- targeted `requestParams`, `databaseTools`, and `learnedSkillTools` specs (17 examples)
- `git diff --check`

## Contract reference

Verified against the official OpenAI API reference: Responses metadata is `map[string]` and local-shell `env` is `map[string]`.
