### PR TITLE
Add removal controls for pending images

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -46,6 +46,7 @@ data ReplAction
     | ReplPaste !Bool !Text
     | ReplClearAttachments
     | ReplShowAttachments
+    | ReplRemoveAttachment !Int
     | ReplCopyLast
     | ReplCopyCode Int
     | ReplCopyDiff

--- a/packages/agent-cli/src/Agent/CLI/Input/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Types.hs
@@ -28,6 +28,7 @@ data ReplLine
     | ReplChooseModel Text
     | ReplChooseEffort Text
     | ReplChooseAccount Text
+    | ReplRemovePendingImage !Text !Int
     | ReplQuitInterrupt
     deriving (Eq, Show)
 

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -235,6 +235,8 @@ readChangeNotes interrupt color = do
             readChangeNotes interrupt color
         ReplChooseAccount _ ->
             readChangeNotes interrupt color
+        ReplRemovePendingImage _ _ ->
+            readChangeNotes interrupt color
         ReplText text
             | Text.null (Text.strip text) -> pure "(no notes)"
             | otherwise -> pure (Text.strip text)
@@ -277,6 +279,8 @@ askQuestion interrupt resolveColor question options = do
                         ReplChooseEffort _ ->
                             askQuestion interrupt resolveColor question []
                         ReplChooseAccount _ ->
+                            askQuestion interrupt resolveColor question []
+                        ReplRemovePendingImage _ _ ->
                             askQuestion interrupt resolveColor question []
                         ReplText text
                             | Text.null (Text.strip text) -> pure Nothing

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
@@ -8,7 +8,8 @@ import Agent.CLI.Clipboard
     ( formatImageSize, loadImagesFromPastedText, nonEmptyClipboardImages,
       readClipboardImagesForPaste, readClipboardImagesImageFirst )
 import Agent.CLI.Command
-    ( ReplAction(ReplPaste, ReplShowAttachments, ReplClearAttachments) )
+    ( ReplAction(ReplPaste, ReplShowAttachments, ReplClearAttachments,
+                 ReplRemoveAttachment) )
 import Agent.CLI.Input
     ( ReplLine(ReplClipboardPaste, ReplClipboardPasteOrText) )
 import Agent.CLI.ProviderTransition ( TurnResult )
@@ -16,6 +17,7 @@ import Agent.CLI.Render ( resetRenderPrintedText )
 import Agent.CLI.Runtime.Types ( RunResult )
 import Agent.CLI.Session.Attachments
     ( putImagePreview, queueAttachedImages, queueClipboardImages )
+import Agent.CLI.SessionState (removeImageAttachmentAt)
 import Agent.CLI.Session.History
     ( modifyLiveAttachments, readLiveAttachments )
 import Agent.CLI.SessionEnv ( SessionEnv(..) )
@@ -226,6 +228,19 @@ handleAttachmentAction
             Text.putStrLn
                 (roleMuted color
                     (glyphOk <> "attachments cleared"))
+        continue
+    ReplRemoveAttachment index -> do
+        removed <- modifyLiveAttachments conversationRef
+            (removeImageAttachmentAt index)
+        syncFullscreenImagePreviews
+        color <- resolveColor stdout
+        let message =
+                if removed
+                    then "attachment removed"
+                    else "attachment is no longer available"
+        displayInfo message $
+            Text.putStrLn
+                (roleMuted color (glyphOk <> message))
         continue
     _ -> error "handleAttachmentAction: unsupported action"
   where

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -21,6 +21,7 @@ import Agent.CLI.Command
       ReplAction(ReplCommandError, ReplQuit, ReplReload, ReplPrompt,
                  ReplExpandedPrompt, ReplInvokeSkill, ReplSkills, ReplShowShell,
                  ReplSetShell, ReplPaste, ReplShowAttachments, ReplClearAttachments,
+                 ReplRemoveAttachment,
                  ReplShowAgentLimit, ReplSetAgentLimit, ReplAgents, ReplMcp,
                  ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
                  ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopyLast,
@@ -48,7 +49,8 @@ import Agent.CLI.Input
       submissionPromptText,
       ReplLine(ReplText, ReplEof, ReplQuitInterrupt, ReplCycleMode,
                ReplClipboardPaste, ReplClipboardPasteOrText, ReplChooseModel,
-               ReplChooseEffort, ReplChooseAccount, ReplPasted) )
+               ReplChooseEffort, ReplChooseAccount, ReplRemovePendingImage,
+               ReplPasted) )
 import Agent.CLI.Interrupt ()
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
@@ -316,6 +318,12 @@ handleReplLine
         handleSelectionInput env (continueWith keptDraft) action
     action@(ReplChooseAccount keptDraft) ->
         handleSelectionInput env (continueWith keptDraft) action
+    ReplRemovePendingImage keptDraft index ->
+        handleAttachmentAction
+            env
+            finishTurn
+            (continueWith keptDraft)
+            (ReplRemoveAttachment index)
     ReplPasted pasted ->
         submitLine slashCatalog skillInvocations
             continue stdoutColor True pasted
@@ -451,6 +459,7 @@ handleReplLine
                     action@ReplPaste{} -> handleAttachmentAction env finishTurn continue action
                     action@ReplShowAttachments -> handleAttachmentAction env finishTurn continue action
                     action@ReplClearAttachments -> handleAttachmentAction env finishTurn continue action
+                    action@ReplRemoveAttachment{} -> handleAttachmentAction env finishTurn continue action
                     ReplShowAgentLimit -> do
                         limit <- env.sessionConcurrentLimit
                         let message =

--- a/packages/agent-cli/src/Agent/CLI/SessionState.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionState.hs
@@ -2,10 +2,12 @@
 module Agent.CLI.SessionState
     ( SessionState(..)
     , newSessionState
+    , removeImageAttachmentAt
     ) where
 
 import Agent.CLI.Session.ConversationStore (newConversationStore)
 import Agent.CLI.Session.History (LiveConversation)
+import Agent.Loop (ImageAttachment)
 import Data.IORef (IORef, newIORef)
 import Data.Text (Text)
 
@@ -29,3 +31,15 @@ newSessionState = do
         , sessionConversation = conversation
         , sessionPreviewId = previewId
         }
+
+-- | Remove one pending attachment by its stable zero-based composer index.
+removeImageAttachmentAt
+    :: Int
+    -> [ImageAttachment]
+    -> ([ImageAttachment], Bool)
+removeImageAttachmentAt index pending
+    | index < 0 = (pending, False)
+    | otherwise =
+        case splitAt index pending of
+            (before, _ : after) -> (before <> after, True)
+            _ -> (pending, False)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -651,6 +651,8 @@ handleEventInner event = case event of
                                 Composer.handleControlMouseDown ComposerMode
                             (ComposerAccount, V.BLeft) ->
                                 Composer.handleControlMouseDown ComposerAccount
+                            (name@ComposerImageRemove{}, V.BLeft) ->
+                                Composer.handleControlMouseDown name
                             (name, V.BLeft)
                                 | isQuickStartControl name ->
                                     Composer.handleControlMouseDown name

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -464,6 +464,10 @@ activateControl = \case
         Composer.handlePromptControlClick
             applyLocalUiEventWith
             ReplChooseAccount
+    ComposerImageRemove index ->
+        Composer.handlePromptControlClick
+            applyLocalUiEventWith
+            (\draft -> ReplRemovePendingImage draft index)
     QuickStartWorktree ->
         activateQuickStartCommand "/worktree"
     QuickStartResume ->
@@ -499,6 +503,7 @@ isInteractiveControl = \case
     ComposerEffort -> True
     ComposerMode -> True
     ComposerAccount -> True
+    ComposerImageRemove _ -> True
     QuickStartWorktree -> True
     QuickStartResume -> True
     QuickStartCommands -> True

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -100,7 +100,7 @@ import Agent.CLI.TUI.Types
       Name(ChoiceRow, ConversationViewport, ConversationViewportExtent,
            ConversationImage, AgentRow, AgentPane,
            AgentPopover, ConversationChunkCache, ConversationReserve,
-           QuickStartWorktree, QuickStartResume, QuickStartCommands,
+           ComposerImageRemove, QuickStartWorktree, QuickStartResume, QuickStartCommands,
            QuickStartModel, CodeBlockCache, ConversationBlock,
            ConversationBlockCache, ConversationBodyCache, CodeCopy, PermissionRow, ResumeViewport,
            ResumeSearchCursor, ResumeRow, OverlayViewport, MarkdownLink,
@@ -438,14 +438,14 @@ padImageBottom attr width amount image
 
 imagePreviewLayers :: Bool -> [TuiImagePreview] -> [Widget Name]
 imagePreviewLayers native previews =
-    case takeLast 3 previews of
+    case takeLast 3 (zip [0 ..] previews) of
         [] -> []
         shown -> [centerLayer (drawImagePreviews native shown)]
   where
     takeLast count values =
         drop (max 0 (length values - count)) values
 
-drawImagePreviews :: Bool -> [TuiImagePreview] -> Widget Name
+drawImagePreviews :: Bool -> [(Int, TuiImagePreview)] -> Widget Name
 drawImagePreviews native previews =
     Widget Fixed Fixed do
         context <- getContext
@@ -472,17 +472,18 @@ drawImagePreviews native previews =
   where
     previewGap = 2
 
-    drawPreview maxWidth maxHeight preview =
+    drawPreview maxWidth maxHeight (index, preview) =
         hLimit maxWidth $
             vBox
                 [ hCenter $
                     if native
                         then nativeImagePlaceholder maxWidth maxHeight preview
                         else renderTuiImagePreview maxWidth maxHeight preview
-                , hCenter $
-                    withAttr Theme.mutedAttr $
-                        terminalTxt $
-                            "[image] "
+                , clickable (ComposerImageRemove index) $
+                    hCenter $
+                        withAttr Theme.mutedAttr $
+                            terminalTxt $
+                                "[image] "
                                 <> preview.previewMime
                                 <> " · "
                                 <> Text.pack (show preview.previewSourceWidth)
@@ -490,6 +491,7 @@ drawImagePreviews native previews =
                                 <> Text.pack (show preview.previewSourceHeight)
                                 <> " · "
                                 <> formatImageSize preview.previewBytes
+                                <> "  [× remove]"
                 ]
 
     nativeImagePlaceholder maxWidth maxHeight preview =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -92,6 +92,7 @@ data Name
     | ComposerEffort
     | ComposerMode
     | ComposerAccount
+    | ComposerImageRemove !Int
     | QuickStartWorktree
     | QuickStartResume
     | QuickStartCommands

--- a/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
@@ -24,6 +24,19 @@ spec =
             readLiveAttachments state.sessionConversation `shouldReturn` [image]
             readIORef state.sessionPreviewId `shouldReturn` 42
 
+        it "removes only the selected pending image" do
+            let first = ImageAttachment "image/png" "first"
+                second = ImageAttachment "image/jpeg" "second"
+                pending = [first, second]
+            removeImageAttachmentAt 0 pending
+                `shouldBe` ([second], True)
+            removeImageAttachmentAt 1 pending
+                `shouldBe` ([first], True)
+            removeImageAttachmentAt (-1) pending
+                `shouldBe` (pending, False)
+            removeImageAttachmentAt 2 pending
+                `shouldBe` (pending, False)
+
         it "starts a new user session with empty composer state" do
             state <- newSessionState
             readIORef state.sessionDraft `shouldReturn` ""


### PR DESCRIPTION
## Summary
- show a clickable `× remove` action on each pending image preview
- route removal through the session attachment state so the preview and submitted payload stay in sync
- preserve the current composer draft while removing an image
- cover selected and invalid attachment indexes

## Validation
- loaded `agent-cli:lib:agent-cli` successfully in GHCi
- exercised removal index cases in GHCi
- verified paste, visible remove control, mouse activation, preview removal, and composer attachment-count update in a live tmux TTY

## Test-suite status
The full `agent-cli-test` REPL currently stops on pre-existing type mismatches in `DatabaseSpec` and `LearnedSkillsSpec`; the changed library and focused removal checks pass.
