### PR TITLE
Add catalog-driven Codex fast mode

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -75,22 +75,25 @@ import qualified Data.Text as Text
 -- callers with a live session should use 'mkSlashCatalog'.
 defaultSlashCatalog :: SlashCatalog
 defaultSlashCatalog =
-    mkSlashCatalog CodexDialect [] [] []
+    mkSlashCatalog False CodexDialect [] [] []
 
 mkSlashCatalog
-    :: DialectId
+    :: Bool
+    -> DialectId
     -> [Text]
     -> [SkillCommand]
     -> [Text]
     -> SlashCatalog
-mkSlashCatalog dialect toolNames skills modelIds =
+mkSlashCatalog fastMode dialect toolNames skills modelIds =
     let tools =
             Set.fromList
                 (map (Text.toLower . Text.strip) toolNames)
         commands =
             filter
-                (commandAvailable dialect tools)
-                (map (commandForDialect dialect) slashCommands)
+                (\command -> command.slashName /= "fast" || fastMode)
+                (filter
+                    (commandAvailable dialect tools)
+                    (map (commandForDialect dialect) slashCommands))
     in SlashCatalog
         { slashCatalogDialect = dialect
         , slashCatalogToolNames = tools
@@ -210,6 +213,10 @@ parseSlash catalog raw line = case Text.words line of
         Just spec -> case spec.slashName of
             "help" -> parseHelpCommand catalog args
             "effort" -> parseEffortCommand args
+            "fast" ->
+                if null args
+                    then ReplToggleFast
+                    else ReplCommandError "usage: /fast"
             "model" -> parseModelCommand args
             "plan" ->
                 let description =

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -10,6 +10,7 @@ slashCommands =
     [ cmd "help" [] "/help [NAME]" "List slash commands, or describe one" True
     , cmd "model" ["m"] "/model [NAME]" "Open the model picker, or set a model" True
     , cmd "effort" [] "/effort [none|low|medium|high|xhigh|max]" "Show or set reasoning effort" True
+    , codexCmd "fast" [] "/fast" "Toggle the Fast service tier" False
     , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)" True
     , cmd "btw" [] "/btw <QUESTION>" "Ask a side question without changing the conversation" True
     , cmd "recap" ["summarize"] "/recap" "Summarize the session so far" False
@@ -63,3 +64,6 @@ slashCommands =
             { slashDialects = Just [GrokBuildDialect]
             , slashRequiredTools = [requiredTool]
             }
+    codexCmd name aliases usage summary takesArguments =
+        (cmd name aliases usage summary takesArguments)
+            { slashDialects = Just [CodexDialect] }

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -23,6 +23,7 @@ data ReplAction
       -- ^ Original user-visible text and the model-visible expansion.
     | ReplShowEffort
     | ReplSetEffort ReasoningEffort
+    | ReplToggleFast
     | ReplShowModel
     | ReplSetModel Text
     | ReplToggleAlwaysApprove

--- a/packages/agent-cli/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli/src/Agent/CLI/Request.hs
@@ -81,7 +81,10 @@ setRequestModel
     -> ResponseCreateParams
 setRequestModel provider modelName params
     | oldLite == newLite =
-        setModelField modelName params
+        setModelField modelName
+            (if params.model == Just modelName
+                then params
+                else clearServiceTier params)
     | newLite =
         let instructionText = fromMaybe "" params.instructions
             toolSchemas = fromMaybe [] params.tools
@@ -97,6 +100,10 @@ setRequestModel provider modelName params
                     , reasoning = setReasoningContext
                         (Just "all_turns")
                         reasoning
+                    , serviceTier =
+                        if params.model == Just modelName
+                            then serviceTier
+                            else Nothing
                     , text = Just (toResponsesLiteTextConfig text)
                     , tools = Nothing
                     , ..
@@ -115,6 +122,10 @@ setRequestModel provider modelName params
                             else Just (ResponseInputItems suffix)
                     , parallelToolCalls = Just True
                     , reasoning = setReasoningContext Nothing reasoning
+                    , serviceTier =
+                        if params.model == Just modelName
+                            then serviceTier
+                            else Nothing
                     , text = fromResponsesLiteTextConfig text
                     , tools = Just toolSchemas
                     , ..
@@ -353,6 +364,10 @@ responseInputItems = \case
 setModelField :: Text -> ResponseCreateParams -> ResponseCreateParams
 setModelField modelName ResponseCreateParams{..} =
     ResponseCreateParams { model = Just modelName, .. }
+
+clearServiceTier :: ResponseCreateParams -> ResponseCreateParams
+clearServiceTier ResponseCreateParams{..} =
+    ResponseCreateParams { serviceTier = Nothing, .. }
 
 setReasoningContext
     :: Maybe Text

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -91,7 +91,7 @@ import Agent.CLI.Session.History
       replaceLiveConversation )
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
-    ( SessionRequest(codexCatalogSession, SessionRequest, catalog,
+    ( SessionRequest(codexCatalogSession, SessionRequest, catalog, modelInfo,
                      connectionId, options, provider, dialect, policy, allTools,
                      suspendGhci, grokRuntime, mcpRegistrations, mcpWarnings,
                      ghciEnabledRef, bashEnabledRef, toolEnv, planMode, startup,
@@ -518,6 +518,7 @@ runAgentSession
                         sessionCompactRunner =
                             SessionRequest
                                 { catalog
+                                , modelInfo = codexModelInfo
                                 , connectionId =
                                     inferredTarget.targetConnectionId
                                 , options

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -39,6 +39,7 @@ import Agent.CLI.ManagedTurn ()
 import Agent.CLI.McpManager ()
 import Agent.CLI.McpStatus ()
 import Agent.CLI.ModelConfig ()
+import Agent.OpenAI.Models.Types (ModelInfo(..), modelServiceTierForRequest)
 import Agent.CLI.Models ( catalogModelIds )
 import Agent.CLI.Options ()
 import Agent.CLI.PendingInputs ()
@@ -250,17 +251,20 @@ replWithDraft env@SessionEnv
             map skillInvocationCommand
                 (filter (.invocationSkill.skillUserInvocable) skillInvocations)
     activeToolNames <- readActiveToolNames
+    params <- readIORef paramsRef
     let slashCatalog =
             mkSlashCatalog
-                (dialectId dialect)
-                activeToolNames
-                skillCommands
+                (maybe False (\info ->
+                    info.slug == currentModel params
+                        && modelServiceTierForRequest info (Just "priority")
+                            == Just "priority")
+                    env.sessionModelInfo)
+                (dialectId dialect) activeToolNames skillCommands
                 (catalogModelIds catalog)
     stdoutColor <- resolveColor stdout
     planState <- readIORef planMode.planStateRef
     let planActive = planState == PlanActive
         planPending = planState == PlanPending
-    params <- readIORef paramsRef
     policy <- readIORef policyRef
     pendingAttachments <- readLiveAttachments conversationRef
     let idleMode = replModeFromState planState policy

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -26,7 +26,7 @@ import Agent.CLI.Command
                  ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopyLast,
                  ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
                  ReplShowTerminal, ReplShowEffort, ReplSetEffort, ReplShowModel,
-                 ReplSetModel, ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
+                 ReplSetModel, ReplToggleFast, ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
                  ReplBtw, ReplRecap, ReplRetry, ReplResume, ReplSearch, ReplClear, ReplNew,
                  ReplShowSession, ReplShowSessionInfo, ReplAfk, ReplWorktree,
                  ReplRename, ReplRenameAuto, ReplLogin, ReplUsage, ReplReloadAuth,
@@ -544,6 +544,7 @@ handleReplLine
                         continue
                     action@ReplShowEffort -> handleSelectionAction env continue action
                     action@ReplSetEffort{} -> handleSelectionAction env continue action
+                    action@ReplToggleFast -> handleSelectionAction env continue action
                     action@ReplShowModel -> handleSelectionAction env continue action
                     action@ReplSetModel{} -> handleSelectionAction env continue action
                     ReplToggleAlwaysApprove

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -20,7 +20,7 @@ import Agent.CLI.Clipboard ()
 import Agent.CLI.Command
     ( currentEffort,
       currentModel,
-      ReplAction(ReplSetModel, ReplShowEffort, ReplSetEffort,
+      ReplAction(ReplSetModel, ReplShowEffort, ReplSetEffort, ReplToggleFast,
                  ReplShowModel) )
 import Agent.CLI.Compaction ()
 import Agent.CLI.Config ()
@@ -121,6 +121,7 @@ import Agent.Loop ( LoopEvent(ActivityUpdated) )
 import Agent.OpenAI.Compaction ()
 import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient ()
+import Agent.OpenAI.Models.Types (ModelInfo(..), modelServiceTierForRequest)
 import Agent.OpenRouter.LoopBackend ()
 import Agent.OsPath ()
 import Agent.Provider
@@ -130,7 +131,7 @@ import Agent.Provider
 import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Responses.GenericBackend ()
 import Agent.Responses.GenericClient ()
-import Agent.Responses.Types ()
+import Agent.Responses.Types (ResponseCreateParams(..))
 import Agent.Skills ()
 import Agent.Store.Postgres ()
 import Agent.Store.Types ()
@@ -239,6 +240,32 @@ handleSelection
         continue
     Right (ReplSetEffort level) -> do
         setEffort level
+        continue
+    Right ReplToggleFast -> do
+        color <- resolveColor stdout
+        params <- readIORef paramsRef
+        let enabled = params.serviceTier == Just "priority"
+            supported = maybe False
+                (\info ->
+                    let ModelInfo { slug = infoSlug } = info
+                    in infoSlug == currentModel params
+                        && modelServiceTierForRequest info (Just "priority")
+                            == Just "priority")
+                env.sessionModelInfo
+        if not supported
+            then do
+                let message = "fast mode is not available for the active model"
+                displayError message $
+                    Text.hPutStrLn stderr (roleError color message)
+            else do
+                let next = not enabled
+                    message =
+                        if next then "fast mode enabled"
+                        else "fast mode disabled"
+                writeIORef paramsRef
+                    params { serviceTier = if next then Just "priority" else Nothing }
+                displayInfo message $
+                    Text.putStrLn (roleMuted color (glyphOk <> message))
         continue
     Right ReplShowModel -> do
         chooseModel continue

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -815,6 +815,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             pure result
         env = SessionEnv
             { sessionLoop = config
+            , sessionModelInfo = modelInfo
             , sessionBtwBackend = btwBackend
             , sessionQueueRecap = writeChan recapRequests
             , sessionCompact = compactRunnerWithContext

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -22,6 +22,7 @@ import Agent.CLI.Database.Store (DatabaseScopes)
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.ManagedTurn (ManagedTurnRequest)
 import Agent.CLI.ModelConfig (ModelCatalog)
+import Agent.OpenAI.Models.Types (ModelInfo)
 import Agent.CLI.Options
     ( ApprovalPolicy
     , CliOptions
@@ -92,6 +93,7 @@ data SessionBackend = SessionBackend
 
 data SessionRequest = SessionRequest
     { catalog :: !ModelCatalog
+    , modelInfo :: !(Maybe ModelInfo)
     , connectionId :: !Text
     , options :: !CliOptions
     , provider :: !Provider

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -24,6 +24,7 @@ import Agent.Loop (LoopConfig, TokenUsage)
 import Agent.MCP (McpToolRegistration)
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Responses.Types (ResponseCreateParams)
+import Agent.OpenAI.Models.Types (ModelInfo)
 import System.OsPath (OsPath)
 import Agent.Provider (Credential, Provider, TokenProvider)
 import Agent.CLI.ProviderTransition (PendingTurn)
@@ -38,6 +39,7 @@ import Control.Concurrent.STM (STM)
 
 data SessionEnv = SessionEnv
     { sessionLoop :: !LoopConfig
+    , sessionModelInfo :: !(Maybe ModelInfo)
     , sessionBtwBackend :: !BtwBackendFactory
     , sessionQueueRecap :: !(RecapRequest -> IO ())
     , sessionCompact :: !(Maybe Text -> IO (Either Text CompactOutcome))

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -52,6 +52,15 @@ spec = do
             parseReplLine "/effort" `shouldBe` ReplShowEffort
             parseReplLine "  /Effort  " `shouldBe` ReplShowEffort
 
+        it "toggles Fast mode with /fast" do
+            let catalog = mkSlashCatalog True CodexDialect [] [] []
+            parseReplLineWithCatalog catalog "/fast"
+                `shouldBe` ReplToggleFast
+            parseReplLineWithCatalog catalog "/FAST"
+                `shouldBe` ReplToggleFast
+            parseReplLineWithCatalog catalog "/fast on"
+                `shouldBe` ReplCommandError "usage: /fast"
+
         it "sets a valid effort level" do
             parseReplLine "/effort none" `shouldBe` ReplSetEffort EffortNone
             parseReplLine "/effort high" `shouldBe` ReplSetEffort EffortHigh
@@ -357,7 +366,7 @@ spec = do
             slashCompletionCandidates "troffe/" "h" `shouldBe` ["high"]
             slashCompletionCandidates "troffe/" "m" `shouldBe` ["medium", "max"]
             slashCompletionCandidates "troffe/" "n" `shouldBe` ["none"]
-            let grokCatalog = mkSlashCatalog GrokBuildDialect [] [] []
+            let grokCatalog = mkSlashCatalog False GrokBuildDialect [] [] []
             slashCompletionCandidatesWithCatalog
                 grokCatalog
                 "troffe/"
@@ -442,8 +451,18 @@ spec = do
                     ("/effort [none|low|medium|high|xhigh|max]" `isInfixOf`)
 
     describe "capability-gated slash catalog" do
+        it "only exposes Fast mode for models advertising priority" do
+            let unavailable = mkSlashCatalog False CodexDialect [] [] []
+                available = mkSlashCatalog True CodexDialect [] [] []
+            lookupSlashCommandIn unavailable "/fast" `shouldBe` Nothing
+            lookupSlashCommandIn available "/fast"
+                `shouldSatisfy` maybe False (const True)
+            parseReplLineWithCatalog unavailable "/fast"
+                `shouldBe` ReplCommandError
+                    "unknown command: /fast (try /help)"
+
         let grokCatalog tools =
-                mkSlashCatalog GrokBuildDialect tools [] ["grok-4.6"]
+                mkSlashCatalog False GrokBuildDialect tools [] ["grok-4.6"]
             allCoreTools =
                 [ "scheduler_create"
                 , "update_goal"
@@ -457,7 +476,7 @@ spec = do
                     ReplCommandError "unknown command: /loop (try /help)"
             parseReplLineWithCatalog
                 (mkSlashCatalog
-                    CodexDialect allCoreTools [] [])
+                    False CodexDialect allCoreTools [] [])
                 "/loop 5m check ci"
                 `shouldBe`
                     ReplCommandError "unknown command: /loop (try /help)"

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -179,6 +179,14 @@ spec = describe "requestParams" do
             (genericText { verbosity = Nothing })
         restored.input `shouldBe` Just (ResponseInputItems [pending])
 
+    it "clears Fast mode when switching models" do
+        let params =
+                (requestParams OpenAIProvider "gpt-generic"
+                    "instructions" [] "high")
+                    { serviceTier = Just "priority" }
+        setRequestModel OpenAIProvider "gpt-5.6-terra" params
+            `shouldSatisfy` \result -> result.serviceTier == Nothing
+
 isAdditionalTools :: ResponseItem -> Bool
 isAdditionalTools = \case
     AdditionalToolsItemValue{} -> True


### PR DESCRIPTION
## Summary
- add a Codex-only `/fast` command gated by the active model catalog's `priority` service tier
- toggle `service_tier` between `priority` and the default tier for subsequent turns
- clear a selected service tier when switching models so Fast mode cannot leak to unsupported models
- retain the active Codex model metadata in session state for command availability and runtime validation

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options='-fno-code'` (all 193 modules loaded)
- live tmux smoke test: `/fast` displayed `fast mode enabled`, then `fast mode disabled`
- `git diff --check`

## Test-suite note
A focused `cabal test agent-cli:test:agent-cli-test` invocation compiled the changed library and the new `CommandSpec`, but the overall test executable is currently blocked by unrelated existing type errors in `DatabaseSpec` and `LearnedSkillsSpec`.
