### PR TITLE
Gate mutating MCP tools through normal approvals

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -30,11 +30,14 @@ Environment variable values are never displayed.
 servers progressively for interactive sessions so the prompt is immediately
 available, while one-shot commands wait for MCP initialization.
 
-Enabled servers are shared with subagents. Only tools explicitly annotated
-`readOnlyHint: true` are exposed. Blocking startup publishes them as
-`server__tool`. Progressive startup exposes `mcp_search` and `mcp_call` while
-servers connect, then publishes each server's read-only catalog. Failed stdio
-transports are restarted once before a progressive call is retried.
+Enabled servers are shared with subagents. Tools explicitly annotated
+`readOnlyHint: true` run without generic mutation approval. All other tools are
+exposed as mutations and follow the session's normal approval policy; Telegram
+uses its scoped inline approval buttons, while `--deny-mutations` blocks them.
+Blocking startup publishes tools as `server__tool`. Progressive startup exposes
+`mcp_search` and `mcp_call` while servers connect, then publishes each server's
+catalog. Failed stdio transports are restarted and retried only for read-only
+calls, because retrying a mutation could duplicate its side effect.
 
 ## Remote Streamable HTTP servers
 

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -417,29 +417,9 @@ discoverMcpTools client = go Nothing [] []
                 case parsePage result of
                     Left err -> ioError (userError ("invalid tools/list response: " <> Text.unpack err))
                     Right (pageTools, nextCursor) -> do
-                        let (readOnlyTools, skipped) =
-                                foldr classify ([], []) pageTools
-                            skippedWarnings =
-                                [ "MCP server "
-                                    <> client.clientConfig.mcpServerName
-                                    <> " skipped non-read-only tool "
-                                    <> tool.discoveredName
-                                | tool <- skipped
-                                ]
                         if isJust nextCursor
-                            then go nextCursor
-                                (tools <> readOnlyTools)
-                                (warnings <> skippedWarnings)
-                            else pure
-                                (tools <> readOnlyTools, warnings <> skippedWarnings)
-
-    classify
-        :: McpTool
-        -> ([McpTool], [McpTool])
-        -> ([McpTool], [McpTool])
-    classify tool (allowed, skipped)
-        | tool.discoveredReadOnly = (tool : allowed, skipped)
-        | otherwise = (allowed, tool : skipped)
+                            then go nextCursor (tools <> pageTools) warnings
+                            else pure (tools <> pageTools, warnings)
 
     parsePage :: RawJson -> Either Text ([McpTool], Maybe RawJson)
     parsePage raw =
@@ -558,8 +538,10 @@ appToolFor client tool = AppTool
     , appToolHandler =
         typedTool qualifiedName rawObjectDecoder \arguments -> do
             callDiscoveredTool client tool arguments
-    , appToolApproval = AlwaysReadOnly
-    , appToolExecution = ParallelSafe
+    , appToolApproval =
+        if tool.discoveredReadOnly then AlwaysReadOnly else AlwaysPrompt
+    , appToolExecution =
+        if tool.discoveredReadOnly then ParallelSafe else TurnSequential
     , appToolResourceClaims = Nothing
     }
   where

--- a/packages/agent-core/src/Agent/MCP/Fleet.hs
+++ b/packages/agent-core/src/Agent/MCP/Fleet.hs
@@ -15,7 +15,7 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , ToolSchema(..)
     )
-import Agent.ToolDispatch (typedTool)
+import Agent.ToolDispatch (ToolCall(..), typedTool)
 import Agent.Concurrent (forConcurrentlyBounded_)
 import Control.Concurrent.Async
     ( Async
@@ -677,17 +677,21 @@ callCatalogEntryWithReconnect fleet qualifiedName entry arguments =
     callDiscoveredTool entry.catalogClient entry.catalogTool arguments
         >>= \case
             Right result -> pure (Right result)
-            Left originalError -> do
-                failed <- readTVarIO entry.catalogClient.clientFailure
-                case failed of
-                    Nothing -> pure (Left originalError)
-                    Just _ ->
-                        -- Stable meta-tool handlers can transparently replace
-                        -- a failed stdio transport and retry the read-only
-                        -- call once. The per-server lock makes this
-                        -- single-flight across concurrent calls.
-                        reconnectCatalogEntry fleet qualifiedName entry
-                            >>= \case
+            Left originalError
+                | not entry.catalogTool.discoveredReadOnly ->
+                    -- A failed mutation may have reached the server. Retrying
+                    -- it after reconnect could duplicate the side effect.
+                    pure (Left originalError)
+                | otherwise -> do
+                    failed <- readTVarIO entry.catalogClient.clientFailure
+                    case failed of
+                        Nothing -> pure (Left originalError)
+                        Just _ ->
+                            -- Read-only calls are safe to retry once after a
+                            -- transport failure. The per-server lock makes
+                            -- this single-flight across concurrent calls.
+                            reconnectCatalogEntry fleet qualifiedName entry
+                                >>= \case
                                 Left reconnectError ->
                                     pure . Left $
                                         originalError
@@ -770,7 +774,7 @@ mcpCallTool :: McpFleet -> AppTool
 mcpCallTool fleet = AppTool
     { appToolName = "mcp_call"
     , appToolDescription =
-        "Call a currently available read-only MCP tool by its qualified server__tool name."
+        "Call a currently available MCP tool by its qualified server__tool name. Mutating tools require user approval."
     , appToolSchema = RawJsonFunctionSchema $ object
         [ "type" .= ("object" :: Text)
         , "properties" .= object
@@ -794,8 +798,9 @@ mcpCallTool fleet = AppTool
                                 then
                                     "MCP tool is not available yet; one or more servers are still connecting"
                                 else "Unknown MCP tool: " <> name
-    , appToolApproval = AlwaysReadOnly
-    , appToolExecution = ParallelSafe
+    , appToolApproval =
+        ClassifyReadOnly (catalogCallIsReadOnly fleet callArgumentsDecoder)
+    , appToolExecution = TurnSequential
     , appToolResourceClaims = Nothing
     }
 
@@ -833,10 +838,25 @@ grokUseTool fleet = AppTool
                                 then
                                     "MCP tool is not available yet; one or more servers are still connecting"
                                 else "Unknown MCP tool: " <> name
-    , appToolApproval = AlwaysReadOnly
-    , appToolExecution = ParallelSafe
+    , appToolApproval =
+        ClassifyReadOnly (catalogCallIsReadOnly fleet grokCallArgumentsDecoder)
+    , appToolExecution = TurnSequential
     , appToolResourceClaims = Nothing
     }
+
+catalogCallIsReadOnly
+    :: McpFleet
+    -> Json.Decoder (Text, RawJson)
+    -> ToolCall
+    -> IO Bool
+catalogCallIsReadOnly fleet decoder call =
+    case Json.decodeEither decoder (TextEncoding.encodeUtf8 call.arguments) of
+        Left _ -> pure False
+        Right (name, _) -> do
+            entries <- readTVarIO fleet.mcpFleetCatalog
+            pure $ maybe False
+                (.catalogTool.discoveredReadOnly)
+                (Map.lookup name entries)
 
 searchArgumentsDecoder :: Json.Decoder (Maybe Text, Maybe Text, Int)
 searchArgumentsDecoder = Json.object do

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -11,7 +11,9 @@ import Agent.ToolDispatch
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
     , appToolHandlers
+    , toolAllowsWithoutPrompt
     )
 import Control.Exception.Safe (bracket)
 import Control.Concurrent (threadDelay)
@@ -83,7 +85,7 @@ spec = describe "Agent.MCP" do
                     ])
                 `shouldBe` Left "denied"
 
-    it "initializes a stdio server, exposes only read-only tools, and calls one" $
+    it "exposes MCP mutations behind approval while reads stay unprompted" $
         withFakeServer \script -> do
             started <- newIORef []
             fleet <- startMcpFleetWithProgress
@@ -102,16 +104,23 @@ spec = describe "Agent.MCP" do
             bracket (pure fleet) closeMcpFleet \_ -> do
                 readIORef started `shouldReturn` [["fake"], []]
                 let tools = mcpFleetTools fleet
-                map (.appToolName) tools `shouldBe` ["fake__echo_read"]
-                fleet.mcpFleetWarnings `shouldBe`
-                    ["MCP server fake skipped non-read-only tool mutate"]
+                map (.appToolName) tools `shouldBe`
+                    ["fake__echo_read", "fake__mutate"]
+                fleet.mcpFleetWarnings `shouldBe` []
                 mcpFleetStatuses fleet `shouldReturn`
-                    [McpServerStatus "fake" McpReady 1]
-                Just tool <-
+                    [McpServerStatus "fake" McpReady 2]
+                Just readTool <-
                     pure (find ((== "fake__echo_read") . (.appToolName)) tools)
-                case tool.appToolApproval of
+                Just mutateTool <-
+                    pure (find ((== "fake__mutate") . (.appToolName)) tools)
+                case readTool.appToolApproval of
                     AlwaysReadOnly -> pure ()
                     _ -> expectationFailure "expected read-only approval"
+                readTool.appToolExecution `shouldBe` ParallelSafe
+                case mutateTool.appToolApproval of
+                    AlwaysPrompt -> pure ()
+                    _ -> expectationFailure "expected mutation approval"
+                mutateTool.appToolExecution `shouldBe` TurnSequential
                 let dispatch ident message = dispatchToolCall
                         defaultLoopDispatch
                         (appToolHandlers tools)
@@ -184,7 +193,7 @@ spec = describe "Agent.MCP" do
                     `shouldBe` ["missing", "healthy"]
                 case statuses of
                     [ McpServerStatus "missing" (McpFailed _) 0
-                        , McpServerStatus "healthy" McpReady 1
+                        , McpServerStatus "healthy" McpReady 2
                         ] -> pure ()
                     _ -> expectationFailure ("unexpected statuses: " <> show statuses)
 
@@ -238,6 +247,25 @@ spec = describe "Agent.MCP" do
                 called.output `shouldBe` "delayed response"
                 updates <- readIORef progress
                 updates `shouldSatisfy` (not . null)
+
+    it "classifies progressive MCP calls using the selected tool annotation" $
+        withFakeServer \script -> do
+            fleet <- startMcpFleetProgressive
+                (const (pure ()))
+                [baseConfig "fake" script]
+            bracket (pure fleet) closeMcpFleet \_ -> do
+                waitForServerReady fleet "fake"
+                let tools = mcpFleetMetaTools fleet
+                Just callTool <-
+                    pure (find ((== "mcp_call") . (.appToolName)) tools)
+                toolAllowsWithoutPrompt callTool
+                    (functionToolCall "read" "mcp_call"
+                        "{\"name\":\"fake__echo_read\",\"arguments\":{}}")
+                    `shouldReturn` True
+                toolAllowsWithoutPrompt callTool
+                    (functionToolCall "write" "mcp_call"
+                        "{\"name\":\"fake__mutate\",\"arguments\":{}}")
+                    `shouldReturn` False
 
     it "projects progressive MCP discovery through Grok search_tool and use_tool" $
         withDelayedFakeServer \script -> do
@@ -427,6 +455,24 @@ spec = describe "Agent.MCP" do
                     called.output `shouldBe` "reconnected response"
                     countStarts counter `shouldReturn` 2
 
+        it "does not reconnect and retry a mutation after transport loss" $
+            withCountingMutationServer \script counter -> do
+                fleet <- startMcpFleetProgressive
+                    (const (pure ()))
+                    [ (baseConfig "mutation" script)
+                        { mcpServerArgs = [counter]
+                        }
+                    ]
+                bracket (pure fleet) closeMcpFleet \_ -> do
+                    waitForServerReady fleet "mutation"
+                    let tools = mcpFleetMetaTools fleet
+                    _ <- dispatchToolCall
+                        defaultLoopDispatch
+                        (appToolHandlers tools)
+                        (functionToolCall "mutation-call" "mcp_call"
+                            "{\"name\":\"mutation__write\",\"arguments\":{}}")
+                    countStarts counter `shouldReturn` 1
+
         it "rebuilds an idle fleet whose transport failed" $
             withCountingFailingServer \script counter -> do
                 supervisor <- newMcpSupervisor
@@ -476,6 +522,9 @@ withCountingFailingServer = withCountingServer countingFailingServer
 
 withCountingReconnectServer :: (FilePath -> FilePath -> IO a) -> IO a
 withCountingReconnectServer = withCountingServer countingReconnectServer
+
+withCountingMutationServer :: (FilePath -> FilePath -> IO a) -> IO a
+withCountingMutationServer = withCountingServer countingMutationServer
 
 withCountingServer
     :: LBS.ByteString
@@ -630,7 +679,7 @@ fakeServer =
     \      ;;\n\
     \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
     \    *'\"method\":\"tools/list\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"echo_read\",\"description\":\"Echo.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}},\"required\":[\"message\"],\"additionalProperties\":false},\"annotations\":{\"readOnlyHint\":true}},{\"name\":\"mutate\",\"description\":\"Write.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":false}}]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"echo_read\",\"description\":\"Echo.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}},\"required\":[\"message\"],\"additionalProperties\":false},\"annotations\":{\"readOnlyHint\":true}},{\"name\":\"mutate\",\"description\":\"Write.\",\"inputSchema\":{\"type\":\"object\"}}]}}'\n\
     \      ;;\n\
     \    *'\"method\":\"tools/call\"'*)\n\
     \      if [ -z \"$first_call_seen\" ]; then\n\
@@ -688,6 +737,26 @@ countingReconnectServer =
     \      else\n\
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"reconnected response\"}]}}'\n\
     \      fi\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+countingMutationServer :: LBS.ByteString
+countingMutationServer =
+    "#!/bin/sh\n\
+    \counter=\"$1\"\n\
+    \printf 'started\\n' >> \"$counter\"\n\
+    \while IFS= read -r line; do\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"mutation\",\"version\":\"1\"}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"write\",\"description\":\"Write.\",\"inputSchema\":{\"type\":\"object\"}}]}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/call\"'*)\n\
+    \      exit 0\n\
     \      ;;\n\
     \  esac\n\
     \done\n"


### PR DESCRIPTION
## Summary
- expose the full MCP tool catalog instead of dropping every tool without `readOnlyHint: true`
- classify annotated read tools as `AlwaysReadOnly` and all other tools as `AlwaysPrompt`
- serialize mutating MCP calls while keeping annotated reads parallel-safe
- make progressive `mcp_call` / Grok `use_tool` classify the selected tool dynamically
- never reconnect and retry a failed mutation, avoiding duplicate side effects
- document Telegram inline approval and `--deny-mutations` behavior

## Why
The previous safety policy hid all unannotated or mutating MCP tools, even though the harness and Telegram gateway already have a general mutation approval mechanism. This made common MCP servers appear unavailable.

## Validation
- focused MCP suite: 23 examples, 0 failures
- full agent-core suite: 422 examples, 0 failures
- `git diff --check`