### PR TITLE
Decode HTTP MCP JSON-RPC response envelopes

### DIFF
--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -36,9 +36,10 @@ module Agent.MCP
     , mcpFleetGetSkill
     , mcpFleetReadResource
     , normalizeMcpToolResult
+    , decodeHttpMcpResponse
     ) where
 
-import Agent.MCP.Client (normalizeMcpToolResult)
+import Agent.MCP.Client (decodeHttpMcpResponse, normalizeMcpToolResult)
 import Agent.MCP.Fleet
     ( closeMcpFleet
     , mcpFleetGrokMetaTools

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -82,6 +82,7 @@ import qualified Data.Aeson.Types as AesonTypes
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
+import Data.Bifunctor (first)
 import Data.Char (isAlphaNum)
 import Data.IORef
     ( IORef
@@ -716,11 +717,13 @@ httpRequestMcpWithId client timeoutMicros url method parameters requestId = do
                 let bytes = LBS.toStrict (responseBody response)
                 if BS.null bytes
                     then pure (Right (rawJsonFromEncoding (Aeson.toEncoding (object []))))
-                else case Json.decodeEither rawJsonDecoder bytes of
-                    Right value -> pure (Right value)
-                    Left jsonError -> case find (BS8.isPrefixOf "data: ") (BS8.lines bytes) of
-                        Just eventData -> pure (either (Left . ("Invalid MCP SSE response: " <>) . Text.pack . show) Right (Json.decodeEither rawJsonDecoder (BS8.drop 6 eventData)))
-                        Nothing -> pure (Left ("Invalid MCP HTTP response: " <> Text.pack (show jsonError)))
+                    else case decodeHttpMcpResponse bytes of
+                        Right value -> pure (Right value)
+                        Left jsonError -> case find (BS8.isPrefixOf "data: ") (BS8.lines bytes) of
+                            Just eventData -> pure $
+                                first ("Invalid MCP SSE response: " <>)
+                                    (decodeHttpMcpResponse (BS8.drop 6 eventData))
+                            Nothing -> pure (Left ("Invalid MCP HTTP response: " <> jsonError))
     perform configuredToken >>= \case
         Left exception -> pure (Left ("MCP HTTP request failed: " <> exceptionSummary exception))
         Right Nothing -> pure (Left ("MCP request " <> method <> " timed out"))
@@ -734,6 +737,16 @@ httpRequestMcpWithId client timeoutMicros url method parameters requestId = do
                         Right Nothing -> pure (Left ("MCP request " <> method <> " timed out"))
                         Left retryException -> pure (Left ("MCP HTTP request failed: " <> exceptionSummary retryException))
             | otherwise -> decodeResponse response
+
+decodeHttpMcpResponse :: BS.ByteString -> Either Text RawJson
+decodeHttpMcpResponse bytes = do
+    envelope <- first (.jsonErrorMessage) $
+        Json.decodeEither responseEnvelopeDecoder bytes
+    case envelope.envelopeError of
+        Just err -> Left ("MCP error: " <> compactRawJson err)
+        Nothing -> case envelope.envelopeResult of
+            Just result -> Right result
+            Nothing -> Left "MCP response omitted result"
 
 sendNotification
     :: McpClient

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -2,7 +2,7 @@ module Agent.MCPSpec (spec) where
 
 import Agent.Loop (defaultLoopDispatch)
 import Agent.MCP
-import Agent.Json (rawJsonFromEncoding)
+import Agent.Json (rawJsonBytes, rawJsonFromEncoding)
 import Agent.ToolDispatch
     ( ToolCallResult(..)
     , dispatchToolCall
@@ -20,6 +20,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (async, wait, waitCatch, withAsync)
 import Data.Aeson (object, (.=))
 import qualified Data.Aeson
+import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List (find)
@@ -52,6 +53,28 @@ spec = describe "Agent.MCP" do
         rendered `shouldContain` "API_TOKEN"
         rendered `shouldContain` "<redacted>"
         rendered `shouldNotContain` "super-secret"
+
+    describe "decodeHttpMcpResponse" do
+        it "unwraps the JSON-RPC result before MCP payload decoding" do
+            let response = BS8.pack
+                    "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"read\"}]}}"
+            case decodeHttpMcpResponse response of
+                Left err -> expectationFailure (Text.unpack err)
+                Right result ->
+                    Data.Aeson.decodeStrict (rawJsonBytes result)
+                        `shouldBe`
+                            Just (object
+                                [ "tools" .=
+                                    [object ["name" .= ("read" :: Text.Text)]]
+                                ])
+
+        it "surfaces JSON-RPC errors instead of treating them as payloads" do
+            decodeHttpMcpResponse
+                (BS8.pack
+                    "{\"jsonrpc\":\"2.0\",\"id\":2,\"error\":{\"code\":-1,\"message\":\"denied\"}}")
+                `shouldSatisfy` \case
+                    Left err -> "denied" `Text.isInfixOf` err
+                    Right _ -> False
 
     describe "normalizeMcpToolResult" do
         it "extracts successful text content" do


### PR DESCRIPTION
## Summary
- unwrap HTTP and SSE JSON-RPC response envelopes before MCP payload decoding
- surface JSON-RPC errors consistently with the stdio transport
- add regression coverage for result extraction and error propagation

## Root cause
The HTTP transport returned the full `{jsonrpc,id,result}` object to `initialize` and `tools/list` consumers. Decoders then looked for `capabilities` or `tools` at the envelope root, silently interpreting a valid remote server as a ready server with zero tools. The stdio reader already unwraps this correctly.

## Validation
- focused MCP suite: 25 examples, 0 failures
- full agent-core suite: 425 examples, 0 failures
- live TextContent reproduction before fix: endpoint returns 13 tools while haskell-agent reports ready/toolCount 0