### PR TITLE
Support remote MCP URLs in Telegram NixOS module

### DIFF
--- a/nix/modules/telegram.nix
+++ b/nix/modules/telegram.nix
@@ -15,6 +15,7 @@ let
     mkIf
     mkOption
     nameValuePair
+    optionalAttrs
     types
     ;
 
@@ -26,7 +27,7 @@ let
   isAbsoluteEnvironmentFile =
     path: hasPrefix "/" path || (hasPrefix "-/" path && builtins.stringLength path > 2);
 
-  mcpServerType = types.submodule {
+  mcpServerType = types.addCheck (types.submodule {
     options = {
       enabled = mkOption {
         type = types.bool;
@@ -34,8 +35,14 @@ let
         description = "Whether this MCP server is enabled.";
       };
       command = mkOption {
-        type = types.str;
-        description = "Executable used to start the stdio MCP server.";
+        type = types.nullOr types.str;
+        default = null;
+        description = "Executable used to start a stdio MCP server.";
+      };
+      url = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "URL of a remote Streamable HTTP MCP server.";
       };
       args = mkOption {
         type = types.listOf types.str;
@@ -66,7 +73,7 @@ let
         description = "Maximum time allowed for one MCP request.";
       };
     };
-  };
+  }) (server: (server.command != null) != (server.url != null));
 
   instanceType = types.submodule (
     { name, config, ... }:
@@ -271,17 +278,20 @@ let
     pkgs.writeText "haskell-agent-telegram-${name}-mcp.json" (
       builtins.toJSON {
         mcpInitStrategy = instance.mcpInitStrategy;
-        mcpServers = lib.mapAttrs (_: server: {
-          inherit (server)
-            args
-            command
-            cwd
-            enabled
-            requestTimeoutSeconds
-            startupTimeoutSeconds
-            ;
-          env = server.environment;
-        }) instance.mcpServers;
+        mcpServers = lib.mapAttrs (_: server:
+          {
+            inherit (server)
+              args
+              cwd
+              enabled
+              requestTimeoutSeconds
+              startupTimeoutSeconds
+              ;
+            env = server.environment;
+          }
+          // optionalAttrs (server.command != null) { inherit (server) command; }
+          // optionalAttrs (server.url != null) { inherit (server) url; }
+        ) instance.mcpServers;
       }
     );
 

--- a/nix/tests/telegram-module.nix
+++ b/nix/tests/telegram-module.nix
@@ -52,6 +52,10 @@ let
           startupTimeoutSeconds = 12;
           requestTimeoutSeconds = 34;
         };
+        mcpServers.remote = {
+          url = "https://example.test/mcp";
+          startupTimeoutSeconds = 20;
+        };
       };
 
       secondary = {
@@ -224,6 +228,15 @@ pkgs.runCommand "haskell-agent-telegram-module-test"
             env: { CREDENTIAL_FILE: "/run/keys/example" },
             requestTimeoutSeconds: 34,
             startupTimeoutSeconds: 12
+          },
+          remote: {
+            args: [],
+            cwd: null,
+            enabled: true,
+            env: {},
+            requestTimeoutSeconds: 60,
+            startupTimeoutSeconds: 20,
+            url: "https://example.test/mcp"
           }
         }
       }


### PR DESCRIPTION
## Summary
- allow each declarative Telegram MCP server to specify exactly one of `command` or `url`
- omit the unused transport field from generated harness JSON
- cover remote Streamable HTTP output in the NixOS module test

## Validation
- `nix build .#checks.aarch64-linux.nixos-module --no-link`
- `git diff --check`