### PR TITLE
Fix Codex compaction performance and checkpoint lifecycle

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -1,6 +1,8 @@
 -- | Run provider compaction and rewrite the local transcript.
 module Agent.CLI.Compaction
-    ( CompactOutcome(..)
+    ( AutomaticCompactionBoundary(..)
+    , CompactOutcome(..)
+    , CompactionInstall(..)
     , OpenAiCompactionSender
     , codexAutoCompactTokenLimit
     , autoCompactOpenAiBackend
@@ -24,7 +26,7 @@ module Agent.CLI.Compaction
     , reportedOccupancy
     ) where
 
-import Agent.CLI.Error (formatApiError, formatException)
+import Agent.CLI.Error (formatApiError)
 import Agent.CLI.Compaction.Continuation
     ( boundCompletedToolContinuations
     )
@@ -87,7 +89,7 @@ import Control.Monad.Trans.Except
     , throwE
     )
 import Control.Applicative ((<|>))
-import Control.Exception.Safe (catchAny, mask, onException)
+import Control.Exception.Safe (mask, onException)
 import Control.Monad (when)
 import Data.IORef (IORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
@@ -683,19 +685,20 @@ autoCompactOpenAiBackendWithSender configuredThreshold send recordUsage
         send
         recordUsage
         getParams
-        (pure ())
+        (\_outcome _inputs -> pure CompactionNotInstalled)
         contextTokensRef
         backend
 
--- | Variant that runs a best-effort hook after a compacted continuation is
--- accepted. The root CLI uses it to queue fresh generated project/skill
--- context for the next turn.
+-- | Variant that commits a successful compaction before submitting its
+-- continuation. The root CLI uses the hook as a first-class persistence
+-- boundary: once it returns, the compacted transcript must survive a failed
+-- or cancelled continuation.
 autoCompactOpenAiBackendWithSenderAndHook
     :: Maybe Int
     -> OpenAiCompactionSender
     -> (TokenUsage -> IO ())
     -> IO ResponseCreateParams
-    -> IO ()
+    -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
     -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
@@ -854,7 +857,7 @@ autoCompactOpenAiBackendWith compactAction =
                     compactAction))
         (const (pure ()))
         estimateProjectedFromCache
-        (pure ())
+        (\_outcome _inputs -> pure CompactionNotInstalled)
   where
     textCompactionError message =
         ProviderError ApiErrorType message Nothing
@@ -871,14 +874,14 @@ autoCompactOpenAiBackendWithApi compactAction =
             CompactAttempt emptyTokenUsage <$> compactAction)
         (const (pure ()))
         estimateProjectedFromCache
-        (pure ())
+        (\_outcome _inputs -> pure CompactionNotInstalled)
 
 autoCompactOpenAiBackendWithLimit
     :: IO Int
     -> ([ResponseItem] -> [TurnInput] -> IO (CompactAttempt ApiError))
     -> (TokenUsage -> IO ())
     -> (Maybe OccupancySnapshot -> [ResponseItem] -> [TurnInput] -> IO Int)
-    -> IO ()
+    -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
     -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
@@ -931,7 +934,6 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
                             outcome
                             inputs
                             onEvent
-                            `onException` rollback
 
     installSubmitAndTrack restore rollback outcome inputs onEvent = do
         let compactedHistory = outcome.compactHistory
@@ -941,17 +943,23 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
                         outcome.compactAfterTokens
                         (length compactedHistory)
         writeIORef contextTokensRef compactSnapshot
-        result <- restore (submit compactedHistory Nothing inputs onEvent)
+        -- Match Codex's compaction lifecycle: install and durably record the
+        -- checkpoint before issuing the model continuation. A continuation
+        -- failure must not resurrect the superseded response chain.
+        installation <-
+            onCompacted outcome inputs `onException` rollback
+        let rollbackIfDeferred =
+                case installation of
+                    CompactionInstalled -> pure ()
+                    CompactionNotInstalled -> rollback
+        result <-
+            restore (submit compactedHistory Nothing inputs onEvent)
+                `onException` rollbackIfDeferred
         case result of
-            Left _ -> rollback
+            Left _ -> rollbackIfDeferred
             Right backendResult -> do
                 writeIORef contextTokensRef $
                     occupancySnapshot backendResult <|> compactSnapshot
-                onCompacted `catchAny` \err ->
-                    onEvent $
-                        WarningRaised
-                            ("failed to reload generated context after compaction: "
-                                <> formatException err)
         pure result
 
     submitAndTrack oldTokens history previous inputs onEvent = do

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -632,11 +632,20 @@ isPortableLocalSummaryItem = \case
     -- OpenAI checkpoints are opaque provider protocol items. Preserve them
     -- for focused OpenAI summaries, but never replay them through
     -- xAI/OpenRouter or user-configured Responses endpoints.
+    CompactionItemValue{} -> False
+    ContextCompactionItemValue{} -> False
+    CompactionTriggerItemValue{} -> False
     KnownResponseItem ItemCompaction _ -> False
+    KnownResponseItem ItemContextCompaction _ -> False
     KnownResponseItem ItemCompactionTrigger _ -> False
     UnknownResponseItem tagged ->
         Text.toLower (Text.strip tagged.tag)
-            `notElem` ["compaction", "compaction_summary", "compaction_trigger"]
+            `notElem`
+                [ "compaction"
+                , "compaction_summary"
+                , "context_compaction"
+                , "compaction_trigger"
+                ]
     _ -> True
 
 autoCompactOpenAiBackend
@@ -711,6 +720,7 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
             contextTokensRef $
             autoCompactOpenAiBackendWithLimit
                 getLimit
+                True
                 compactAction
                 recordUsage
                 estimateProjectedRequest
@@ -851,6 +861,7 @@ autoCompactOpenAiBackendWith
 autoCompactOpenAiBackendWith compactAction =
     autoCompactOpenAiBackendWithLimit
         (pure codexAutoCompactTokenLimit)
+        False
         (\_history _inputs ->
             (CompactAttempt emptyTokenUsage
                 <$> fmap (either (Left . textCompactionError) Right)
@@ -870,6 +881,7 @@ autoCompactOpenAiBackendWithApi
 autoCompactOpenAiBackendWithApi compactAction =
     autoCompactOpenAiBackendWithLimit
         (pure codexAutoCompactTokenLimit)
+        False
         (\_history _inputs ->
             CompactAttempt emptyTokenUsage <$> compactAction)
         (const (pure ()))
@@ -878,6 +890,7 @@ autoCompactOpenAiBackendWithApi compactAction =
 
 autoCompactOpenAiBackendWithLimit
     :: IO Int
+    -> Bool
     -> ([ResponseItem] -> [TurnInput] -> IO (CompactAttempt ApiError))
     -> (TokenUsage -> IO ())
     -> (Maybe OccupancySnapshot -> [ResponseItem] -> [TurnInput] -> IO Int)
@@ -885,8 +898,8 @@ autoCompactOpenAiBackendWithLimit
     -> IORef (Maybe OccupancySnapshot)
     -> Backend
     -> Backend
-autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
-        estimateProjected
+autoCompactOpenAiBackendWithLimit getLimit absorbCompletedTools compactAction
+        recordUsage estimateProjected
         onCompacted
         contextTokensRef
         (Backend submit) =
@@ -898,6 +911,7 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
                 not (null history)
                     && projectedTokens >= tokenLimit
         if shouldCompact
+            && (absorbCompletedTools || not (any isCompletedTool inputs))
             then compactThenSubmit
                 tokenLimit
                 contextState history inputs onEvent
@@ -953,23 +967,30 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
 
     installSubmitAndTrack restore rollback outcome inputs onEvent = do
         let compactedHistory = outcome.compactHistory
+            pendingItems = turnInputsToItems inputs
+            durableHistory = compactedHistory <> pendingItems
             compactSnapshot =
                 Just $
                     estimatedOccupancy
-                        outcome.compactAfterTokens
-                        (length compactedHistory)
+                        ( outcome.compactAfterTokens
+                            + estimateItemsTokens pendingItems
+                        )
+                        (length durableHistory)
         writeIORef contextTokensRef compactSnapshot
         -- Match Codex's compaction lifecycle: install and durably record the
-        -- checkpoint before issuing the model continuation. A continuation
-        -- failure must not resurrect the superseded response chain.
+        -- checkpoint before issuing the model continuation. Root sessions put
+        -- pending inputs in that checkpoint too, so a crash in this gap cannot
+        -- lose the user's request. Lightweight wrappers defer installation and
+        -- keep passing the inputs normally.
         installation <-
             onCompacted outcome inputs `onException` rollback
-        let rollbackIfDeferred =
+        let (continuationHistory, continuationInputs, rollbackIfDeferred) =
                 case installation of
-                    CompactionInstalled -> pure ()
-                    CompactionNotInstalled -> rollback
+                    CompactionInstalled -> (durableHistory, [], pure ())
+                    CompactionNotInstalled -> (compactedHistory, inputs, rollback)
         result <-
-            restore (submit compactedHistory Nothing inputs onEvent)
+            restore
+                (submit continuationHistory Nothing continuationInputs onEvent)
                 `onException` rollbackIfDeferred
         case result of
             Left _ -> rollbackIfDeferred

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -897,7 +897,7 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
         let shouldCompact =
                 not (null history)
                     && projectedTokens >= tokenLimit
-        if shouldCompact && not (any isCompletedTool inputs)
+        if shouldCompact
             then compactThenSubmit
                 tokenLimit
                 contextState history inputs onEvent
@@ -914,7 +914,15 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
 
     compactThenSubmit tokenLimit oldTokens oldHistory inputs onEvent = do
         onEvent (ActivityUpdated "Compacting context…")
-        runCompaction oldHistory inputs >>= \case
+        -- Tool results complete protocol units that are already represented by
+        -- calls in oldHistory. Put those results behind their calls before
+        -- requesting the checkpoint; replaying them after the checkpoint
+        -- would create orphaned or duplicated tool output.
+        let (completedTools, continuationInputs) =
+                partitionCompletedTools inputs
+            compactionHistory =
+                oldHistory <> turnInputsToItems completedTools
+        runCompaction compactionHistory continuationInputs >>= \case
                 Left err ->
                     pure (Left (automaticCompactionError err))
                 Right outcome
@@ -932,8 +940,16 @@ autoCompactOpenAiBackendWithLimit getLimit compactAction recordUsage
                             restore
                             rollback
                             outcome
-                            inputs
+                            continuationInputs
                             onEvent
+
+    partitionCompletedTools =
+        foldr
+            (\input (completed, pending) ->
+                if isCompletedTool input
+                    then (input : completed, pending)
+                    else (completed, input : pending))
+            ([], [])
 
     installSubmitAndTrack restore rollback outcome inputs onEvent = do
         let compactedHistory = outcome.compactHistory

--- a/packages/agent-cli/src/Agent/CLI/Compaction/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction/Types.hs
@@ -1,5 +1,7 @@
 module Agent.CLI.Compaction.Types
-    ( CompactOutcome(..)
+    ( AutomaticCompactionBoundary(..)
+    , CompactOutcome(..)
+    , CompactionInstall(..)
     , OpenAiCompactionSender
     , OccupancyKind(..)
     , OccupancySnapshot(..)
@@ -8,8 +10,26 @@ module Agent.CLI.Compaction.Types
     ) where
 
 import Agent.Error (ApiError)
+import Agent.Loop (TurnInput)
 import Agent.Responses.Types (Response, ResponseCreateParams, ResponseItem)
 import Data.Text (Text)
+
+-- | A provider compaction checkpoint that has already been installed in the
+-- live conversation and durable transcript. The enclosing user turn uses this
+-- as its new prefix so it appends only post-checkpoint items.
+data AutomaticCompactionBoundary = AutomaticCompactionBoundary
+    { automaticCompactionHistory :: ![ResponseItem]
+    , automaticCompactionPendingInputs :: ![TurnInput]
+    } deriving (Eq, Show)
+
+-- | Whether an automatic-compaction hook installed the checkpoint outside the
+-- provider wrapper. Root sessions return 'CompactionInstalled' after their
+-- durable replace; lightweight callers can defer installation until a
+-- successful continuation and retain the old rollback behaviour.
+data CompactionInstall
+    = CompactionInstalled
+    | CompactionNotInstalled
+    deriving (Eq, Show)
 
 data CompactOutcome = CompactOutcome
     { compactBeforeTokens :: !Int

--- a/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
@@ -5,7 +5,9 @@ module Agent.CLI.Provider.OpenAI
     ) where
 
 import Agent.CLI.Compaction
-    ( OccupancySnapshot
+    ( CompactOutcome
+    , CompactionInstall
+    , OccupancySnapshot
     , OpenAiCompactionSender
     , autoCompactOpenAiBackendWithSenderAndHook
     )
@@ -13,6 +15,7 @@ import Agent.CLI.Connectivity (withConnectionRecovery)
 import Agent.Loop
     ( Backend(..)
     , TokenUsage
+    , TurnInput
     )
 import qualified Agent.OpenAI.Client as OpenAIClient
 import Agent.OpenAI.LoopBackend
@@ -63,7 +66,7 @@ lockedOpenAiSession
     -> IO ResponseCreateParams
     -> IORef (Maybe OccupancySnapshot)
     -> (TokenUsage -> IO ())
-    -> IO ()
+    -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
     -> (OpenAiCompactionSender, Backend)
 lockedOpenAiSession compactThreshold showRawReasoning wsLock fallbackActive
         provider activeConnection getParams contextTokens

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -22,6 +22,9 @@ import Data.Text (Text)
 data PendingTurn = PendingTurn
     { pendingPromptText :: !Text
     , pendingInputs :: ![TurnInput]
+    -- | The exact continuation input is already durable in the transcript;
+    -- retry without regenerating plan/startup/provider framing.
+    , pendingCheckpointed :: !Bool
     , pendingExitAfter :: !Bool
     , pendingPlanState :: !PlanModeState
     }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -227,7 +227,7 @@ runAgentProviders
     cwd
     dialect
     fullscreen
-    generatedContextReloadRef
+    automaticCompactionHookRef
     home
     initialPrevious
     model
@@ -471,7 +471,11 @@ runAgentProviders
                                             (readIORef paramsRef)
                                             contextTokensRef
                                             recordCompactionUsage
-                                            (readIORef generatedContextReloadRef >>= id)
+                                            (\outcome inputs ->
+                                                readIORef
+                                                    automaticCompactionHookRef
+                                                    >>= \hook ->
+                                                        hook outcome inputs)
                                     noticingBackend =
                                         withPendingInputs pendingNotices
                                             lockedBackend

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -16,7 +16,8 @@ import Agent.CLI.CodeModeRuntime
       codeModeSessionRuntimeFor,
       loadCodexCatalogModelInfo )
 import Agent.CLI.Command ()
-import Agent.CLI.Compaction ()
+import Agent.CLI.Compaction
+    ( CompactionInstall(CompactionNotInstalled) )
 import Agent.CLI.Config ()
 import Agent.CLI.Connectivity ()
 import Agent.CLI.Database ()
@@ -98,9 +99,9 @@ import Agent.CLI.Session.Runtime.Types
                      learnAboutUserRequested, databaseScopes, promptRequest,
                      pendingTurn, unavailableProviders, startupUnavailable, paramsRef,
                      conversationRef, needsInitialContext, persist,
-                     startupWindowTitle,
+                     startupWindowTitle, automaticCompactionRef,
                      projectRoot, home, cwd, tokenProvider, openAiPool, startupContext,
-                     generatedContextReloadRef, skillsRef, skillInvocationsRef,
+                     automaticCompactionHookRef, skillsRef, skillInvocationsRef,
                      escPaused, interrupt, multiCtx, rootTurnRef, subagentSessions,
                      pendingNotices, storeRoot, agentTypes, legacyTarget, usageRef,
                      accountRef, accountIdRef, selectionRef, accountLabel,
@@ -382,7 +383,10 @@ runAgentSession
                     | otherwise ->
                         resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
-        generatedContextReloadRef <- newIORef (pure ())
+        automaticCompactionRef <- newIORef Nothing
+        automaticCompactionHookRef <-
+            newIORef
+                (\_outcome _inputs -> pure CompactionNotInstalled)
         let currentModelContextWindow mapTransportModel = do
                 currentParams <- readIORef paramsRef
                 pure $
@@ -543,6 +547,7 @@ runAgentSession
                                 , startupUnavailable
                                 , paramsRef
                                 , conversationRef
+                                , automaticCompactionRef
                                 , needsInitialContext =
                                     resumeNeedsFreshContext
                                         || (null initialTurns
@@ -555,7 +560,7 @@ runAgentSession
                                 , tokenProvider = sessionTokenProvider
                                 , openAiPool = sessionOpenAiPool
                                 , startupContext
-                                , generatedContextReloadRef
+                                , automaticCompactionHookRef
                                 , skillsRef
                                 , skillInvocationsRef
                                 , escPaused
@@ -613,7 +618,7 @@ runAgentSession
                         cwd
                         dialect
                         fullscreen
-                        generatedContextReloadRef
+                        automaticCompactionHookRef
                         home
                         initialPrevious
                         model

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -75,9 +75,9 @@ runPendingTurn
 runPendingTurn continuation presentation =
     runPendingTurnWithCooldownRetry continuation True presentation
 
--- | Retry a failed turn from its retained input checkpoint. The original
--- inputs are already present in the live transcript after a terminal failure;
--- submitting them again would duplicate the user message and attachments.
+-- | Retry a failed turn. Terminal failures and committed compactions retain
+-- their exact input checkpoint; pre-commit restart/provider failures must
+-- resubmit the original raw inputs instead.
 retryFailedTurn
     :: SessionContinuation
     -> SessionEnv
@@ -93,7 +93,7 @@ retryFailedTurn continuation env pending = do
     -- The failed turn already owns the persisted/displayed user prompt.
     -- Keep the retry turn's user text empty so session history does not show
     -- the same prompt twice.
-    result <- retryCheckpointedTurn env
+    result <- runPendingAttempt env pending
     finishTurnWithCooldownRetry
         continuation True env pending.pendingExitAfter result
 
@@ -119,9 +119,15 @@ runPendingTurnWithCooldownRetry
             ContinuePendingTurn ->
                 pure ()
     writeIORef env.sessionLastFailedTurn Nothing
-    result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
+    result <- runPendingAttempt env pending
     finishTurnWithCooldownRetry
         continuation allowCooldownRetry env pending.pendingExitAfter result
+
+runPendingAttempt :: SessionEnv -> PendingTurn -> IO TurnResult
+runPendingAttempt env pending
+    | pending.pendingCheckpointed = retryCheckpointedTurn env
+    | otherwise =
+        runOneTurn env pending.pendingPromptText pending.pendingInputs
 
 finishTurn
     :: SessionContinuation
@@ -188,7 +194,7 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
                     (UiSystemMessage
                         ("restarting current turn with " <> level <> " effort"))
             Nothing -> pure ()
-        result <- runOneTurn env pending.pendingPromptText pending.pendingInputs
+        result <- runPendingAttempt env pending
         finishTurnWithCooldownRetry
             continuation allowCooldownRetry env exitAfter result
     TurnProviderUnavailable apiError pending ->

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -10,6 +10,7 @@ import Agent.CLI.Compaction
     , CompactOutcome(..)
     , CompactionInstall(CompactionInstalled)
     )
+import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.CLI.Session.Runner.Types
     ( AgentStepCache(..)
     , SessionRunnerContinuation(..)
@@ -812,45 +813,51 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 reportSessionError
                     ("failed to reload generated context: "
                         <> formatException err)
-        -- The durable replace and its in-memory publication form one
-        -- checkpoint transaction. Do not allow cancellation to land after
-        -- PostgreSQL commits but before the boundary becomes visible to turn
-        -- cleanup; that would resurrect the superseded response chain.
-        commitAutomaticCompaction outcome pendingInputs = uninterruptibleMask_ do
-            case persist of
-                PersistenceDisabled -> pure ()
-                PersistenceEnabled slotRef -> do
-                    now <- getCurrentTime
-                    handle <- ensureSession slotRef
-                    let checkpointTurn = SessionTurn
-                            { turnAt = now
-                            , turnUserText = ""
-                            , turnAssistantText = Nothing
-                            , turnError = Nothing
-                            , turnResponseId = Nothing
-                            , turnEffect = TranscriptReplace
-                            , turnItems = outcome.compactHistory
-                            , turnUsage = Nothing
-                            }
-                    (updated, _) <-
-                        appendTurnWithMetaUpdateIndexed
-                            handle
-                            checkpointTurn
-                            \meta -> meta { metaLastResponseId = Nothing }
-                    writeIORef slotRef (PersistenceActive updated)
-            let boundary = AutomaticCompactionBoundary
-                    { automaticCompactionHistory = outcome.compactHistory
-                    , automaticCompactionPendingInputs = pendingInputs
-                    }
-            -- Publish the durable boundary before replacing the live state so
-            -- turn cleanup can recover the checkpoint if a later write or
-            -- continuation throws.
-            writeIORef automaticCompactionRef (Just boundary)
-            _ <-
-                replaceLiveConversation
-                    conversationRef
-                    Nothing
-                    outcome.compactHistory
+        -- The durable replace, pending input, and in-memory publication form
+        -- one checkpoint transaction. Keeping pending input in the replacement
+        -- means a process death before the continuation cannot lose the user's
+        -- request. Do not allow cancellation after PostgreSQL commits but
+        -- before the boundary becomes visible to turn cleanup.
+        commitAutomaticCompaction outcome pendingInputs = do
+            let durableHistory =
+                    outcome.compactHistory <> turnInputsToItems pendingInputs
+            uninterruptibleMask_ do
+                case persist of
+                    PersistenceDisabled -> pure ()
+                    PersistenceEnabled slotRef -> do
+                        now <- getCurrentTime
+                        handle <- ensureSession slotRef
+                        let checkpointTurn = SessionTurn
+                                { turnAt = now
+                                , turnUserText = ""
+                                , turnAssistantText = Nothing
+                                , turnError = Nothing
+                                , turnResponseId = Nothing
+                                , turnEffect = TranscriptReplace
+                                , turnItems = durableHistory
+                                , turnUsage = Nothing
+                                }
+                        (updated, _) <-
+                            appendTurnWithMetaUpdateIndexed
+                                handle
+                                checkpointTurn
+                                \meta -> meta { metaLastResponseId = Nothing }
+                        writeIORef slotRef (PersistenceActive updated)
+                let boundary = AutomaticCompactionBoundary
+                        { automaticCompactionHistory = durableHistory
+                        -- These inputs are already part of the checkpoint.
+                        -- A failure/retry must not append or submit them again.
+                        , automaticCompactionPendingInputs = []
+                        }
+                writeIORef automaticCompactionRef (Just boundary)
+                _ <-
+                    replaceLiveConversation
+                        conversationRef
+                        Nothing
+                        durableHistory
+                pure ()
+            -- Reloading skills/project state may perform arbitrary I/O and is
+            -- not part of the atomic persistence critical section.
             reloadGeneratedContextSafely
             pure CompactionInstalled
         compactRunnerWithContext focus = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -5,6 +5,11 @@ module Agent.CLI.Session.Runner.Execution
     , runSession
     ) where
 import Agent.CLI.CodeModeRuntime
+import Agent.CLI.Compaction
+    ( AutomaticCompactionBoundary(..)
+    , CompactOutcome(..)
+    , CompactionInstall(CompactionInstalled)
+    )
 import Agent.CLI.Session.Runner.Types
     ( AgentStepCache(..)
     , SessionRunnerContinuation(..)
@@ -69,7 +74,7 @@ import Agent.OsPath
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
 import Control.Concurrent.MVar (newMVar, withMVar)
-import Control.Exception.Safe (catchAny)
+import Control.Exception.Safe (catchAny, mask_)
 import Control.Monad (forM_, unless, void, when)
 import Data.IORef
 import qualified Data.Map.Strict as Map
@@ -807,6 +812,43 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 reportSessionError
                     ("failed to reload generated context: "
                         <> formatException err)
+        commitAutomaticCompaction outcome pendingInputs = mask_ do
+            case persist of
+                PersistenceDisabled -> pure ()
+                PersistenceEnabled slotRef -> do
+                    now <- getCurrentTime
+                    handle <- ensureSession slotRef
+                    let checkpointTurn = SessionTurn
+                            { turnAt = now
+                            , turnUserText = ""
+                            , turnAssistantText = Nothing
+                            , turnError = Nothing
+                            , turnResponseId = Nothing
+                            , turnEffect = TranscriptReplace
+                            , turnItems = outcome.compactHistory
+                            , turnUsage = Nothing
+                            }
+                    (updated, _) <-
+                        appendTurnWithMetaUpdateIndexed
+                            handle
+                            checkpointTurn
+                            \meta -> meta { metaLastResponseId = Nothing }
+                    writeIORef slotRef (PersistenceActive updated)
+            let boundary = AutomaticCompactionBoundary
+                    { automaticCompactionHistory = outcome.compactHistory
+                    , automaticCompactionPendingInputs = pendingInputs
+                    }
+            -- Publish the durable boundary before replacing the live state so
+            -- turn cleanup can recover the checkpoint if a later write or
+            -- continuation throws.
+            writeIORef automaticCompactionRef (Just boundary)
+            _ <-
+                replaceLiveConversation
+                    conversationRef
+                    Nothing
+                    outcome.compactHistory
+            reloadGeneratedContextSafely
+            pure CompactionInstalled
         compactRunnerWithContext focus = do
             result <- compactRunner focus
             case result of
@@ -826,6 +868,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionUnavailableProviders = unavailableProvidersRef
             , sessionStartupUnavailable = startupUnavailableRef
             , sessionConversation = conversationRef
+            , sessionAutomaticCompaction = automaticCompactionRef
             , sessionParams = paramsRef
             , sessionPolicy = policyRef
             , sessionPersist = persist
@@ -879,7 +922,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionOnPersisted = onPersisted
             , sessionReset = sessionReset
             }
-    writeIORef generatedContextReloadRef reloadGeneratedContextSafely
+    writeIORef automaticCompactionHookRef commitAutomaticCompaction
     writeIORef startup.startupRestartEffort \level -> do
         setSessionEffortText env level
         writeIORef restartEffortRef (Just level)

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -74,7 +74,7 @@ import Agent.OsPath
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
 import Control.Concurrent.MVar (newMVar, withMVar)
-import Control.Exception.Safe (catchAny, mask_)
+import Control.Exception.Safe (catchAny, uninterruptibleMask_)
 import Control.Monad (forM_, unless, void, when)
 import Data.IORef
 import qualified Data.Map.Strict as Map
@@ -812,7 +812,11 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 reportSessionError
                     ("failed to reload generated context: "
                         <> formatException err)
-        commitAutomaticCompaction outcome pendingInputs = mask_ do
+        -- The durable replace and its in-memory publication form one
+        -- checkpoint transaction. Do not allow cancellation to land after
+        -- PostgreSQL commits but before the boundary becomes visible to turn
+        -- cleanup; that would resurrect the superseded response chain.
+        commitAutomaticCompaction outcome pendingInputs = uninterruptibleMask_ do
             case persist of
                 PersistenceDisabled -> pure ()
                 PersistenceEnabled slotRef -> do

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -17,7 +17,11 @@ import Agent.CLI.CodeModeRuntime
     ( CodeModeNestedSlot
     , CodexCatalogSession
     )
-import Agent.CLI.Compaction (CompactOutcome)
+import Agent.CLI.Compaction
+    ( AutomaticCompactionBoundary
+    , CompactOutcome
+    , CompactionInstall
+    )
 import Agent.CLI.Database.Store (DatabaseScopes)
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.ManagedTurn (ManagedTurnRequest)
@@ -47,6 +51,7 @@ import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
 import Agent.Loop
     ( Backend
     , TokenUsage
+    , TurnInput
     )
 import qualified Agent.MCP as MCP
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -115,6 +120,8 @@ data SessionRequest = SessionRequest
     , startupUnavailable :: !(Maybe (STM ApiError))
     , paramsRef :: !(IORef ResponseCreateParams)
     , conversationRef :: !(IORef LiveConversation)
+    , automaticCompactionRef
+        :: !(IORef (Maybe AutomaticCompactionBoundary))
     , needsInitialContext :: !Bool
     , persist :: !Persistence
     , startupWindowTitle :: !Text
@@ -124,7 +131,9 @@ data SessionRequest = SessionRequest
     , tokenProvider :: !(Maybe TokenProvider)
     , openAiPool :: !(Maybe OpenAI.Pool)
     , startupContext :: !(IORef (Maybe Text))
-    , generatedContextReloadRef :: !(IORef (IO ()))
+    , automaticCompactionHookRef
+        :: !(IORef
+            (CompactOutcome -> [TurnInput] -> IO CompactionInstall))
     , skillsRef :: !(IORef SkillCatalog)
     , skillInvocationsRef :: !(IORef [SkillInvocation])
     , escPaused :: !(IORef Bool)

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -9,7 +9,10 @@ import Agent.CLI.ModelConfig (ModelCatalog)
 import Agent.CLI.Btw (BtwBackendFactory)
 import Agent.CLI.Recap (RecapRequest)
 import Agent.CLI.Command (ShellMode)
-import Agent.CLI.Compaction (CompactOutcome)
+import Agent.CLI.Compaction
+    ( AutomaticCompactionBoundary
+    , CompactOutcome
+    )
 import Agent.CLI.Options (ApprovalPolicy)
 import Agent.CLI.Render (RenderConfig)
 import Agent.CLI.Session (Persistence, SessionHandle)
@@ -49,6 +52,8 @@ data SessionEnv = SessionEnv
     , sessionUnavailableProviders :: !(IORef (Set Provider))
     , sessionStartupUnavailable :: !(IORef (Maybe (STM ApiError)))
     , sessionConversation :: !(IORef LiveConversation)
+    , sessionAutomaticCompaction
+        :: !(IORef (Maybe AutomaticCompactionBoundary))
     , sessionParams :: !(IORef ResponseCreateParams)
     , sessionPolicy :: !(IORef ApprovalPolicy)
     , sessionPersist :: !Persistence

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -103,6 +103,7 @@ import Agent.CLI.TurnState
     , StartupUpdate(..)
     , finishConversation
     , inputOnlyTurnItems
+    , rebasePreparedTurn
     , restoreStartupContext
     , turnInputsWithContext
     , turnNewItems
@@ -183,6 +184,10 @@ runOneTurnWithContext includeTurnContext env promptText inputs = do
     -- A newly submitted turn supersedes any older retry candidate. If this
     -- attempt fails, finishTurn installs its own PendingTurn afterwards.
     writeIORef env.sessionLastFailedTurn Nothing
+    -- Automatic compaction is scoped to one enclosing user turn. A committed
+    -- boundary from an earlier attempt is already represented by the live and
+    -- durable transcripts and must not affect this turn's suffix calculation.
+    writeIORef env.sessionAutomaticCompaction Nothing
     bracket_
         env.sessionBeginWindowTitleBusy
         env.sessionEndWindowTitleBusy
@@ -325,11 +330,17 @@ runOneTurnBusy includeTurnContext env@SessionEnv
     rootTurnId <- beginSubagentTurn
     execution <- runLoopInputsDetailed config prev turnInputs
         `onException`
-            ( commitConversationPatch
-                (finishConversation prepared ConversationInterrupted)
+            ( readIORef env.sessionAutomaticCompaction >>= \boundary ->
+              commitConversationPatch
+                (finishConversation
+                    (rebasePreparedTurn boundary prepared)
+                    ConversationInterrupted)
                 >> restorePlanStateAfterIncomplete planMode initialPlanState
                 >> abortSubagentTurn rootTurnId
             )
+    automaticCompaction <- readIORef env.sessionAutomaticCompaction
+    let committedPrepared =
+            rebasePreparedTurn automaticCompaction prepared
     let result = execution.executionResult
     clearThinking render
     finishedAt <- getCurrentTime
@@ -372,7 +383,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
         (Just level, _) -> do
             abortSubagentTurn rootTurnId
             commitConversationPatch
-                (finishConversation prepared ConversationRestarted)
+                (finishConversation committedPrepared ConversationRestarted)
             planState <- readIORef planMode.planStateRef
             case fullscreen of
                 Just runtime ->
@@ -393,7 +404,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
             -- Checkpoint it instead of restoring it separately, which would
             -- duplicate the instructions on the next full-history request.
             commitConversationPatch
-                (finishConversation prepared ConversationCancelled)
+                (finishConversation committedPrepared ConversationCancelled)
             model <- readIORef render.renderModelRef
             case fullscreen of
                 Just runtime -> do
@@ -408,7 +419,10 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                         (formatLoopErrorColored color cancelled)
                     putTextLn stderrHandle
                         (formatTurnStatus color "cancelled" (elapsedDetail model))
-            persistIncomplete (inputOnlyTurnItems prepared) "cancelled" Nothing
+            persistIncomplete
+                (inputOnlyTurnItems committedPrepared)
+                "cancelled"
+                Nothing
             pure TurnCancelled
         (Nothing, Left err) -> do
             abortSubagentTurn rootTurnId
@@ -418,7 +432,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                     , isProviderUnavailable apiError -> do
                         commitConversationPatch
                             (finishConversation
-                                prepared
+                                committedPrepared
                                 ConversationProviderUnavailable)
                         case fullscreen of
                             Nothing -> pure ()
@@ -441,7 +455,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                         stdoutHandle terminal wallStarted finishedAt 1
                         (Just "Agent turn failed")
                     commitConversationPatch
-                        (finishConversation prepared ConversationFailed)
+                        (finishConversation committedPrepared ConversationFailed)
                     model <- readIORef render.renderModelRef
                     case fullscreen of
                         Just runtime ->
@@ -469,7 +483,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                     -- terminal failures checkpoint only the prepared input.
                     -- Partial assistant text, response id, usage, and the
                     -- incomplete reason remain available in turn metadata.
-                    persistIncomplete (inputOnlyTurnItems prepared)
+                    persistIncomplete (inputOnlyTurnItems committedPrepared)
                         (formatLoopErrorPersistedAt finishedAt err)
                         maybeIncompleteTurn
                     planState <- readIORef planMode.planStateRef
@@ -529,10 +543,12 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                     putTextLn stdoutHandle (renderAssistantText useColor text)
                 _ -> pure ()
             let newItems =
-                    turnNewItems beforeItems execution.executionState
+                    turnNewItems
+                        committedPrepared.preparedBeforeItems
+                        execution.executionState
                 effect =
                     if turnReplacesTranscript
-                        beforeItems
+                        committedPrepared.preparedBeforeItems
                         execution.executionState
                         then TranscriptReplace
                         else TranscriptAppend

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -139,7 +139,7 @@ import Agent.Tools.PlanMode
     )
 import Agent.OsPath (toText, unsafeToFilePath)
 import Control.Monad (forM_, when)
-import Control.Exception.Safe (bracket_, onException, tryAny)
+import Control.Exception.Safe (bracket_, finally, onException, tryAny)
 import Data.IORef
     ( atomicModifyIORef'
     , readIORef
@@ -194,6 +194,7 @@ runOneTurnWithContext includeTurnContext env promptText inputs = do
         (withLiveTranscript env.sessionConversation \beforeItems ->
             runOneTurnBusy
                 includeTurnContext env beforeItems promptText inputs)
+        `finally` writeIORef env.sessionAutomaticCompaction Nothing
 
 runOneTurnBusy
     :: Bool

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -506,7 +506,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
             let assistantText =
                     fmap stripBracketedTimestamps loopResult.finalText
             commitConversationPatch
-                (finishConversation prepared
+                (finishConversation committedPrepared
                     (ConversationCompleted
                         loopResult.finalResponseId
                         loopResult.tokenUsage

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -392,7 +392,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                 Nothing -> pure ()
             pure $ TurnRestartRequested level PendingTurn
                 { pendingPromptText = promptText
-                , pendingInputs = inputs
+                , pendingInputs = committedPrepared.preparedTurnInputs
                 , pendingExitAfter = False
                 , pendingPlanState = planState
                 }
@@ -446,7 +446,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                         planState <- readIORef planMode.planStateRef
                         pure $ TurnProviderUnavailable apiError PendingTurn
                             { pendingPromptText = promptText
-                            , pendingInputs = inputs
+                            , pendingInputs = committedPrepared.preparedTurnInputs
                             , pendingExitAfter = False
                             , pendingPlanState = planState
                             }

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -392,7 +392,8 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                 Nothing -> pure ()
             pure $ TurnRestartRequested level PendingTurn
                 { pendingPromptText = promptText
-                , pendingInputs = committedPrepared.preparedTurnInputs
+                , pendingInputs = maybe inputs (const []) automaticCompaction
+                , pendingCheckpointed = isJust automaticCompaction
                 , pendingExitAfter = False
                 , pendingPlanState = planState
                 }
@@ -446,7 +447,8 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                         planState <- readIORef planMode.planStateRef
                         pure $ TurnProviderUnavailable apiError PendingTurn
                             { pendingPromptText = promptText
-                            , pendingInputs = committedPrepared.preparedTurnInputs
+                            , pendingInputs = maybe inputs (const []) automaticCompaction
+                            , pendingCheckpointed = isJust automaticCompaction
                             , pendingExitAfter = False
                             , pendingPlanState = planState
                             }
@@ -495,6 +497,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                         -- transcript. Do not retain a second potentially
                         -- large copy here.
                         , pendingInputs = []
+                        , pendingCheckpointed = True
                         , pendingExitAfter = False
                         , pendingPlanState = planState
                         }

--- a/packages/agent-cli/src/Agent/CLI/TurnState.hs
+++ b/packages/agent-cli/src/Agent/CLI/TurnState.hs
@@ -105,6 +105,7 @@ rebasePreparedTurn boundary prepared =
             prepared
                 { preparedBeforeItems =
                     committed.automaticCompactionHistory
+                , preparedConsumedStartup = Nothing
                 , preparedTurnInputs =
                     committed.automaticCompactionPendingInputs
                 }

--- a/packages/agent-cli/src/Agent/CLI/TurnState.hs
+++ b/packages/agent-cli/src/Agent/CLI/TurnState.hs
@@ -9,6 +9,7 @@ module Agent.CLI.TurnState
     , applyConversationPatch
     , finishConversation
     , inputOnlyTurnItems
+    , rebasePreparedTurn
     , restoreStartupContext
     , turnInputsWithContext
     , turnNewItems
@@ -20,6 +21,9 @@ import Agent.Loop
     , TurnInput(..)
     , addTokenUsage
     , emptyTokenUsage
+    )
+import Agent.CLI.Compaction.Types
+    ( AutomaticCompactionBoundary(..)
     )
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types (ResponseItem)
@@ -85,6 +89,25 @@ turnInputsWithContext planReminder startup inputs =
 
 inputOnlyTurnItems :: PreparedTurn -> [ResponseItem]
 inputOnlyTurnItems = turnInputsToItems . (.preparedTurnInputs)
+
+-- | Once automatic compaction has committed, the enclosing turn no longer
+-- owns the superseded prefix. Rebase both its history and the exact inputs
+-- accepted by the compacted continuation so success and failure persist only
+-- post-checkpoint state.
+rebasePreparedTurn
+    :: Maybe AutomaticCompactionBoundary
+    -> PreparedTurn
+    -> PreparedTurn
+rebasePreparedTurn boundary prepared =
+    case boundary of
+        Nothing -> prepared
+        Just committed ->
+            prepared
+                { preparedBeforeItems =
+                    committed.automaticCompactionHistory
+                , preparedTurnInputs =
+                    committed.automaticCompactionPendingInputs
+                }
 
 finishConversation :: PreparedTurn -> ConversationOutcome -> ConversationPatch
 finishConversation prepared = \case

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.CompactionSpec (spec) where
 
 import Agent.CLI.Compaction
     ( CompactOutcome(..)
+    , CompactionInstall(..)
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
     , autoCompactOpenAiBackendWithSender
@@ -832,15 +833,16 @@ spec = do
             readIORef continuationCalls `shouldReturn` 0
             readIORef contextState `shouldReturn` Nothing
 
-        it "reports a throwing post-compaction hook instead of swallowing it" do
+        it "does not continue when the durable compaction hook fails" do
             let history = [userTextItem "old"]
                 threshold = 20
             contextState <- newIORef
                 (Just (reportedOccupancy threshold (length history)))
-            events <- newIORef []
+            continuationCalls <- newIORef (0 :: Int)
             let sender _request =
                     pure (Right remoteCompactionResponse)
-                base = Backend \state _ _ _ ->
+                base = Backend \state _ _ _ -> do
+                    modifyIORef' continuationCalls (+ 1)
                     pure $ successful state TurnOutput
                         { responseId = "resp-new"
                         , toolCalls = []
@@ -854,30 +856,31 @@ spec = do
                         sender
                         (const (pure ()))
                         (pure defaultResponseCreateParams)
-                        (throwIO (ErrorCall "reload failed"))
+                        (\_outcome _inputs ->
+                            throwIO (ErrorCall "checkpoint failed"))
                         contextState
                         base
-            result <- backend.submitTurn history Nothing
-                [UserMessage "new"]
-                (\event -> modifyIORef' events (<> [event]))
-            result `shouldSatisfy` either (const False) (const True)
-            events' <- readIORef events
-            events' `shouldSatisfy` any \case
-                WarningRaised message ->
-                    "failed to reload generated context after compaction"
-                        `Text.isInfixOf` message
-                    && "reload failed" `Text.isInfixOf` message
-                _ -> False
+            result <- try $
+                backend.submitTurn history Nothing
+                    [UserMessage "new"] (const (pure ()))
+                :: IO
+                    (Either ErrorCall (Either ApiError BackendResult))
+            result `shouldBe` Left (ErrorCall "checkpoint failed")
+            readIORef continuationCalls `shouldReturn` 0
+            readIORef contextState `shouldReturn`
+                Just (reportedOccupancy threshold (length history))
 
-        it "runs the post-compaction hook only after a successful continuation" do
+        it "commits the compaction hook before its continuation" do
             let history = [userTextItem "old"]
                 threshold = 20
             contextState <- newIORef
                 (Just (reportedOccupancy threshold (length history)))
             hookCalls <- newIORef (0 :: Int)
+            hookWasCommitted <- newIORef False
             let sender _request =
                     pure (Right remoteCompactionResponse)
-                base = Backend \state _ _ _ ->
+                base = Backend \state _ _ _ -> do
+                    readIORef hookWasCommitted `shouldReturn` True
                     pure $ successful state TurnOutput
                         { responseId = "resp-new"
                         , toolCalls = []
@@ -891,7 +894,11 @@ spec = do
                         sender
                         (const (pure ()))
                         (pure defaultResponseCreateParams)
-                        (modifyIORef' hookCalls (+ 1))
+                        (\_outcome inputs -> do
+                            inputs `shouldBe` [UserMessage "new"]
+                            writeIORef hookWasCommitted True
+                            modifyIORef' hookCalls (+ 1)
+                            pure CompactionInstalled)
                         contextState
                         base
             result <- backend.submitTurn history Nothing
@@ -1290,7 +1297,10 @@ spec = do
                         sender
                         (\usage -> modifyIORef' recordedUsage (<> [usage]))
                         (pure defaultResponseCreateParams)
-                        (modifyIORef' hookCalls (+ 1))
+                        (\_outcome inputs -> do
+                            inputs `shouldBe` [UserMessage "new"]
+                            modifyIORef' hookCalls (+ 1)
+                            pure CompactionInstalled)
                         contextState
                         base
             backend.submitTurn history Nothing
@@ -1299,10 +1309,11 @@ spec = do
             map requestItems <$> readIORef requests
                 `shouldReturn` [history <> [compactionTriggerItem]]
             readIORef recordedUsage `shouldReturn` [compactionUsage]
-            readIORef contextState `shouldReturn` oldContextState
-            readIORef hookCalls `shouldReturn` 0
+            readIORef contextState `shouldSatisfy`
+                (/= oldContextState)
+            readIORef hookCalls `shouldReturn` 1
 
-        it "rolls back compacted state when the continuation is cancelled" do
+        it "keeps compacted state when the continuation is cancelled" do
             let history = [userTextItem "old"]
                 threshold = 20
                 oldContextState =
@@ -1332,7 +1343,8 @@ spec = do
                         (Either ApiError BackendResult))
             result `shouldBe` Left UserInterrupt
             readIORef continuationMasking `shouldReturn` Unmasked
-            readIORef contextState `shouldReturn` oldContextState
+            readIORef contextState `shouldSatisfy`
+                (/= oldContextState)
 
         it "does not rerun compaction while its continuation reconnects" do
             let history = [userTextItem "old"]

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -224,10 +224,20 @@ spec = do
                     KnownResponseItem ItemCompaction (TaggedObject "compaction")
                 remoteTrigger =
                     UnknownResponseItem (TaggedObject "COMPACTION_TRIGGER")
+                contextCheckpoint =
+                    ContextCompactionItemValue ContextCompactionItem
+                        { itemId = Just "ctx-compact"
+                        , encryptedContent = Just "opaque"
+                        }
+                knownContextCheckpoint =
+                    KnownResponseItem ItemContextCompaction
+                        (TaggedObject "context_compaction")
                 paramsValue = defaultResponseCreateParams
                 history =
                     [ userTextItem "old context"
                     , remoteCheckpoint
+                    , contextCheckpoint
+                    , knownContextCheckpoint
                     , remoteTrigger
                     ]
             params <- newIORef paramsValue
@@ -248,13 +258,18 @@ spec = do
                 [request] ->
                     requestItems request `shouldSatisfy`
                         all \case
+                            CompactionItemValue{} -> False
+                            ContextCompactionItemValue{} -> False
+                            CompactionTriggerItemValue{} -> False
                             KnownResponseItem ItemCompaction _ -> False
+                            KnownResponseItem ItemContextCompaction _ -> False
                             KnownResponseItem ItemCompactionTrigger _ -> False
                             UnknownResponseItem tagged ->
                                 Text.toLower (Text.strip tagged.tag)
                                     `notElem`
                                         [ "compaction"
                                         , "compaction_summary"
+                                        , "context_compaction"
                                         , "compaction_trigger"
                                         ]
                             _ -> True
@@ -1443,7 +1458,8 @@ spec = do
                         (pure defaultResponseCreateParams)
                         (\outcome pending -> do
                             pending `shouldBe` [UserMessage "steer"]
-                            writeIORef installedHistory outcome.compactHistory
+                            writeIORef installedHistory
+                                (outcome.compactHistory <> turnInputsToItems pending)
                             pure CompactionInstalled)
                         contextState
                         base
@@ -1460,7 +1476,7 @@ spec = do
                         <> [compactionTriggerItem]
                     ]
             readIORef seenPrevious `shouldReturn` [Nothing]
-            readIORef seenInputs `shouldReturn` [[UserMessage "steer"]]
+            readIORef seenInputs `shouldReturn` [[]]
             compacted <- readIORef installedHistory
             compacted `shouldSatisfy` hasCompactionCheckpoint
             fmap (.backendState) result `shouldBe` Right compacted

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1309,11 +1309,11 @@ spec = do
             map requestItems <$> readIORef requests
                 `shouldReturn` [history <> [compactionTriggerItem]]
             readIORef recordedUsage `shouldReturn` [compactionUsage]
-            readIORef contextState `shouldSatisfy`
-                (/= oldContextState)
+            readIORef contextState >>= (`shouldSatisfy`
+                (/= oldContextState))
             readIORef hookCalls `shouldReturn` 1
 
-        it "keeps compacted state when the continuation is cancelled" do
+        it "rolls back deferred compacted state when the continuation is cancelled" do
             let history = [userTextItem "old"]
                 threshold = 20
                 oldContextState =
@@ -1343,8 +1343,7 @@ spec = do
                         (Either ApiError BackendResult))
             result `shouldBe` Left UserInterrupt
             readIORef continuationMasking `shouldReturn` Unmasked
-            readIORef contextState `shouldSatisfy`
-                (/= oldContextState)
+            readIORef contextState `shouldReturn` oldContextState
 
         it "does not rerun compaction while its continuation reconnects" do
             let history = [userTextItem "old"]

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1394,7 +1394,7 @@ spec = do
             readIORef seenPrevious `shouldReturn` [Nothing, Nothing]
             readIORef recordedUsage `shouldReturn` [compactionUsage]
 
-        it "defers compaction while continuing a completed tool call" do
+        it "absorbs completed tool output before mid-turn compaction" do
             let danglingCall = FunctionCallItem FunctionCall
                     { itemId = Nothing
                     , callId = "call-1"
@@ -1419,8 +1419,11 @@ spec = do
             recordedUsage <- newIORef []
             seenPrevious <- newIORef []
             seenInputs <- newIORef []
-            let sender _request = do
+            requests <- newIORef []
+            installedHistory <- newIORef []
+            let sender request = do
                     modifyIORef' compactCalls (+ 1)
+                    modifyIORef' requests (<> [request])
                     pure (Right remoteCompactionResponse)
                 base = Backend \state previous inputs _ -> do
                     modifyIORef' seenPrevious (<> [previous])
@@ -1433,24 +1436,37 @@ spec = do
                         , completion = TurnCompleted
                         }
                 backend =
-                    autoCompactOpenAiBackendWithSender
+                    autoCompactOpenAiBackendWithSenderAndHook
                         (Just codexAutoCompactTokenLimit)
                         sender
                         (\usage -> modifyIORef' recordedUsage (<> [usage]))
                         (pure defaultResponseCreateParams)
+                        (\outcome pending -> do
+                            pending `shouldBe` [UserMessage "steer"]
+                            writeIORef installedHistory outcome.compactHistory
+                            pure CompactionInstalled)
                         contextState
                         base
-                inputs = [CompletedTool toolResult]
+                inputs = [CompletedTool toolResult, UserMessage "steer"]
+                completedInputs = [CompletedTool toolResult]
             result <- backend.submitTurn oldHistory (Just "resp-tool") inputs
                 (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
-            readIORef compactCalls `shouldReturn` 0
-            readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
-            readIORef seenInputs `shouldReturn` [inputs]
-            fmap (.backendState) result `shouldBe` Right oldHistory
+            readIORef compactCalls `shouldReturn` 1
+            map requestItems <$> readIORef requests
+                `shouldReturn`
+                    [ oldHistory
+                        <> turnInputsToItems completedInputs
+                        <> [compactionTriggerItem]
+                    ]
+            readIORef seenPrevious `shouldReturn` [Nothing]
+            readIORef seenInputs `shouldReturn` [[UserMessage "steer"]]
+            compacted <- readIORef installedHistory
+            compacted `shouldSatisfy` hasCompactionCheckpoint
+            fmap (.backendState) result `shouldBe` Right compacted
             readIORef contextState `shouldReturn`
-                Just (reportedOccupancy 25 (length oldHistory))
-            readIORef recordedUsage `shouldReturn` []
+                Just (reportedOccupancy 25 (length compacted))
+            readIORef recordedUsage `shouldReturn` [compactionUsage]
 
         it "truncates oversized tool output before continuing the call" do
             let params = defaultResponseCreateParams
@@ -1654,7 +1670,7 @@ spec = do
             result `shouldSatisfy` either (const False) (const True)
             readIORef seenInputs `shouldReturn` [inputs]
 
-        it "truncates tool output against last reported occupancy" do
+        it "bounds tool output before absorbing it into compaction" do
             let params = defaultResponseCreateParams
                 contextWindow =
                     codexEffectiveContextWindowFor params.model
@@ -1684,7 +1700,11 @@ spec = do
             contextState <- newIORef
                 (Just (reportedOccupancy occupancy (length oldHistory)))
             seenInputs <- newIORef []
-            let base = Backend \_state _previous submitted _ -> do
+            requests <- newIORef []
+            let sender request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right remoteCompactionResponse)
+                base = Backend \_state _previous submitted _ -> do
                     modifyIORef' seenInputs (<> [submitted])
                     pure $ successful oldHistory TurnOutput
                         { responseId = "resp-new"
@@ -1696,7 +1716,7 @@ spec = do
                 backend =
                     autoCompactOpenAiBackendWithSender
                         Nothing
-                        (\_ -> error "occupancy-bounded tool output should not compact")
+                        sender
                         (const (pure ()))
                         (pure params)
                         contextState
@@ -1704,19 +1724,22 @@ spec = do
             result <- backend.submitTurn oldHistory (Just "resp-tool") inputs
                 (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
-            readIORef seenInputs >>= \case
-                [[CompletedTool bounded]] -> do
-                    bounded.callId `shouldBe` toolResult.callId
-                    Text.length bounded.output
+            readIORef seenInputs `shouldReturn` [[]]
+            readIORef requests >>= \case
+                [request] -> do
+                    let encoded =
+                            TextEncoding.decodeUtf8
+                                (LBS.toStrict (Aeson.encode request))
+                    Text.length encoded
                         `shouldSatisfy` (< Text.length originalOutput)
-                    bounded.output
+                    encoded
                         `shouldSatisfy`
-                            Text.isSuffixOf
+                            Text.isInfixOf
                                 "[tool output truncated to fit the model context]"
                 submitted ->
                     expectationFailure
-                        ("expected occupancy-bounded tool result, got "
-                            <> show submitted)
+                        ("expected one compact request, got "
+                            <> show (length submitted))
 
         it "forgets occupancy when the provider omits usage" do
             let history = [userTextItem "old"]
@@ -1744,7 +1767,7 @@ spec = do
             result `shouldSatisfy` either (const False) (const True)
             readIORef contextState `shouldReturn` Nothing
 
-        it "continues a live tool chain without counting retained history against the window" do
+        it "compacts an oversized live tool chain with its output absorbed" do
             let params = defaultResponseCreateParams
                 contextWindow =
                     codexEffectiveContextWindowFor params.model
@@ -1801,11 +1824,11 @@ spec = do
             result <- backend.submitTurn oldHistory (Just "resp-tool") inputs
                 (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
-            readIORef compactCalls `shouldReturn` 0
-            readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
-            readIORef seenInputs `shouldReturn` [inputs]
+            readIORef compactCalls `shouldReturn` 1
+            readIORef seenPrevious `shouldReturn` [Nothing]
+            readIORef seenInputs `shouldReturn` [[]]
 
-        it "trims replay history when a tool continuation cannot fit the full transcript" do
+        it "compacts replay history when a tool continuation cannot fit" do
             let params = defaultResponseCreateParams
                 contextWindow =
                     codexEffectiveContextWindowFor params.model
@@ -1860,22 +1883,13 @@ spec = do
             result <- backend.submitTurn oldHistory Nothing inputs
                 (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
-            readIORef compactCalls `shouldReturn` 0
+            readIORef compactCalls `shouldReturn` 1
             readIORef seenHistory >>= \case
-                [fitted] -> do
-                    estimateRequestTokensWithItems
-                        params
-                        (fitted <> turnInputsToItems inputs)
-                        `shouldSatisfy` (<= contextWindow)
-                    any
-                        (\case
-                            FunctionCallItem call -> call.callId == "call-replay"
-                            _ -> False)
-                        fitted
-                        `shouldBe` True
+                [fitted] ->
+                    fitted `shouldSatisfy` hasCompactionCheckpoint
                 seen ->
                     expectationFailure
-                        ("expected one trimmed continuation, got "
+                        ("expected one compacted continuation, got "
                             <> show (length seen))
 
         it "preserves typed provider failures from automatic compaction" do

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -36,6 +36,7 @@ spec = do
             let pending = PendingTurn
                     { pendingPromptText = "make a plan"
                     , pendingInputs = []
+                    , pendingCheckpointed = False
                     , pendingExitAfter = False
                     , pendingPlanState = PlanActive
                     }

--- a/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
@@ -6,7 +6,8 @@ import Agent.CLI.Session
     )
 import Agent.CLI.Session.ConversationStore (newConversationStore)
 import Agent.CLI.Session.History
-    ( hydrateUiHistory
+    ( foldSessionItems
+    , hydrateUiHistory
     , readLiveAttachments
     , readLivePreviousResponseId
     , readLiveTranscript
@@ -82,11 +83,75 @@ spec = do
                 , (BlockSystem, "Context compacted remotely.")
                 ]
 
+      it "keeps visual scrollback across an automatic checkpoint boundary" do
+        let before = sessionTurn "question" (Just "answer") TranscriptAppend
+            automatic = sessionTurn "" Nothing TranscriptReplace
+            after = sessionTurn "follow up" (Just "done") TranscriptAppend
+            blocks =
+                Foldable.toList
+                    (hydrateUiHistory [before, automatic, after]).uiBlocks
+        map (\block -> (block.blockKind, block.blockBody)) blocks
+            `shouldBe`
+                [ (BlockUser, "question")
+                , (BlockAssistant, "answer")
+                , (BlockUser, "follow up")
+                , (BlockAssistant, "done")
+                ]
+
       it "still clears displayed history for an explicit clear" do
         let before = sessionTurn "question" (Just "answer") TranscriptAppend
             cleared = sessionTurn "/clear" Nothing TranscriptReset
         Foldable.toList (hydrateUiHistory [before, cleared]).uiBlocks
             `shouldBe` []
+
+    describe "foldSessionItems" do
+      it "resumes from a committed checkpoint after continuation failure" do
+        let old = turnInputsToItems [UserMessage "superseded"]
+            checkpoint =
+                turnInputsToItems [UserMessage "compacted checkpoint"]
+            pending = turnInputsToItems [UserMessage "failed request"]
+            oldTurn =
+                (sessionTurn "old" (Just "old answer") TranscriptAppend)
+                    { turnItems = old }
+            compactTurn =
+                (sessionTurn "" Nothing TranscriptReplace)
+                    { turnItems = checkpoint }
+            failedTurn =
+                (sessionTurn "failed request" Nothing TranscriptAppend)
+                    { turnItems = pending
+                    , turnError = Just "cancelled"
+                    }
+        foldSessionItems [oldTurn, compactTurn, failedTurn]
+            `shouldBe` checkpoint <> pending
+
+      it "appends only the successful post-checkpoint suffix" do
+        let checkpoint =
+                turnInputsToItems [UserMessage "compacted checkpoint"]
+            suffix =
+                turnInputsToItems
+                    [ UserMessage "current request"
+                    , UserMessage "current response"
+                    ]
+            compactTurn =
+                (sessionTurn "" Nothing TranscriptReplace)
+                    { turnItems = checkpoint }
+            completedTurn =
+                (sessionTurn "current request" (Just "current response")
+                    TranscriptAppend)
+                    { turnItems = suffix }
+        foldSessionItems [compactTurn, completedTurn]
+            `shouldBe` checkpoint <> suffix
+
+      it "leaves non-compacted append history unchanged" do
+        let first = turnInputsToItems [UserMessage "first"]
+            second = turnInputsToItems [UserMessage "second"]
+        foldSessionItems
+            [ (sessionTurn "first" Nothing TranscriptAppend)
+                { turnItems = first }
+            , (sessionTurn "second" Nothing TranscriptAppend)
+                { turnItems = second }
+            ]
+            `shouldBe` first <> second
 
 sessionTurn :: Text -> Maybe Text -> TranscriptEffect -> SessionTurn
 sessionTurn user assistant effect = SessionTurn

--- a/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
@@ -115,10 +115,10 @@ spec = do
                     { turnItems = old }
             compactTurn =
                 (sessionTurn "" Nothing TranscriptReplace)
-                    { turnItems = checkpoint }
+                    { turnItems = checkpoint <> pending }
             failedTurn =
                 (sessionTurn "failed request" Nothing TranscriptAppend)
-                    { turnItems = pending
+                    { turnItems = []
                     , turnError = Just "cancelled"
                     }
         foldSessionItems [oldTurn, compactTurn, failedTurn]

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -9,6 +9,7 @@ import Agent.CLI.Turn
     , restorePlanStateAfterIncomplete
     )
 import Agent.CLI.TurnState
+import Agent.CLI.Compaction (AutomaticCompactionBoundary(..))
 import Agent.Loop
     ( ImageAttachment(..)
     , TokenUsage(..)
@@ -145,6 +146,55 @@ spec = do
         it "uses the complete replacement after compaction" do
             let replacement = turnInputsToItems [UserMessage "compacted"]
             turnNewItems history replacement `shouldBe` replacement
+
+    describe "automatic compaction boundary" do
+        it "keeps the checkpoint plus pending input after failure or cancel" do
+            let checkpoint =
+                    turnInputsToItems [UserMessage "compacted checkpoint"]
+                pending = [UserMessage "current request"]
+                committed =
+                    rebasePreparedTurn
+                        (Just AutomaticCompactionBoundary
+                            { automaticCompactionHistory = checkpoint
+                            , automaticCompactionPendingInputs = pending
+                            })
+                        prepared
+                expected = checkpoint <> turnInputsToItems pending
+                cancelled =
+                    applyConversationPatch
+                        (finishConversation committed ConversationCancelled)
+                        runningState
+                failed =
+                    applyConversationPatch
+                        (finishConversation committed ConversationFailed)
+                        runningState
+            cancelled.conversationTranscript `shouldBe` expected
+            failed.conversationTranscript `shouldBe` expected
+            inputOnlyTurnItems committed
+                `shouldBe` turnInputsToItems pending
+
+        it "persists only the post-checkpoint suffix after success" do
+            let checkpoint =
+                    turnInputsToItems [UserMessage "compacted checkpoint"]
+                pending = [UserMessage "current request"]
+                response =
+                    turnInputsToItems [UserMessage "assistant response"]
+                committed =
+                    rebasePreparedTurn
+                        (Just AutomaticCompactionBoundary
+                            { automaticCompactionHistory = checkpoint
+                            , automaticCompactionPendingInputs = pending
+                            })
+                        prepared
+                completed =
+                    checkpoint <> turnInputsToItems pending <> response
+            turnNewItems committed.preparedBeforeItems completed
+                `shouldBe` turnInputsToItems pending <> response
+            turnReplacesTranscript committed.preparedBeforeItems completed
+                `shouldBe` False
+
+        it "leaves ordinary turns unchanged when no compaction committed" do
+            rebasePreparedTurn Nothing prepared `shouldBe` prepared
 
     describe "checkpointIncompleteTurn" do
         it "describes the complete input-only checkpoint transition" do

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -155,8 +155,9 @@ spec = do
                 committed =
                     rebasePreparedTurn
                         (Just AutomaticCompactionBoundary
-                            { automaticCompactionHistory = checkpoint
-                            , automaticCompactionPendingInputs = pending
+                            { automaticCompactionHistory =
+                                checkpoint <> turnInputsToItems pending
+                            , automaticCompactionPendingInputs = []
                             })
                         prepared
                 expected = checkpoint <> turnInputsToItems pending
@@ -170,8 +171,7 @@ spec = do
                         runningState
             cancelled.conversationTranscript `shouldBe` expected
             failed.conversationTranscript `shouldBe` expected
-            inputOnlyTurnItems committed
-                `shouldBe` turnInputsToItems pending
+            inputOnlyTurnItems committed `shouldBe` []
 
         it "persists only the post-checkpoint suffix after success" do
             let checkpoint =
@@ -182,14 +182,15 @@ spec = do
                 committed =
                     rebasePreparedTurn
                         (Just AutomaticCompactionBoundary
-                            { automaticCompactionHistory = checkpoint
-                            , automaticCompactionPendingInputs = pending
+                            { automaticCompactionHistory =
+                                checkpoint <> turnInputsToItems pending
+                            , automaticCompactionPendingInputs = []
                             })
                         prepared
                 completed =
                     checkpoint <> turnInputsToItems pending <> response
             turnNewItems committed.preparedBeforeItems completed
-                `shouldBe` turnInputsToItems pending <> response
+                `shouldBe` response
             turnReplacesTranscript committed.preparedBeforeItems completed
                 `shouldBe` False
 

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -95,6 +95,7 @@ trimRemoteCompactionHistoryToFit
 trimRemoteCompactionHistoryToFit contextWindow instructionText history =
     trimCompactionHistoryToFitWith
         sanitizeRemoteCompactionHistory
+        False
         contextWindow
         requestTokens
         history
@@ -115,6 +116,7 @@ trimRemoteCompactionRequestToFit
 trimRemoteCompactionRequestToFit contextWindow params =
     trimCompactionHistoryToFitWith
         sanitizeRemoteCompactionHistory
+        False
         contextWindow
         requestTokens
   where
@@ -133,6 +135,7 @@ trimResponseHistoryToFit
 trimResponseHistoryToFit contextWindow params trailing =
     trimCompactionHistoryToFitWith
         sanitizeCompactionHistory
+        True
         contextWindow
         requestTokens
   where
@@ -141,36 +144,53 @@ trimResponseHistoryToFit contextWindow params trailing =
 
 trimCompactionHistoryToFitWith
     :: ([ResponseItem] -> [ResponseItem])
+    -> Bool
     -> Int
     -> ([ResponseItem] -> Int)
     -> [ResponseItem]
     -> [ResponseItem]
-trimCompactionHistoryToFitWith sanitize contextWindow requestTokens history =
-    let sanitized = sanitize history
-        rewritten = rewriteUntilFit sanitized
-    in dropOldestUntilFit rewritten
+trimCompactionHistoryToFitWith sanitize dropIrreducible contextWindow
+        requestTokens history =
+    let rewritten =
+            rewriteNewest initialCost [] (reverse (zip sanitized itemCosts))
+    in if dropIrreducible
+        then dropOldestUntilFit rewritten
+        else rewritten
   where
-    rewriteUntilFit items
-        | requestTokens items <= contextWindow = items
+    sanitized = sanitize history
+    itemCosts = map itemTokenCount sanitized
+    itemsCost = sum itemCosts
+    requestCost = requestTokens sanitized
+    -- Request-level instructions, tools, and the envelope stay fixed while an
+    -- item is rewritten. Measure them once; independently rounded item costs
+    -- make the running estimate conservative.
+    fixedCost = max 0 (requestCost - itemsCost)
+    initialCost = max requestCost (fixedCost + itemsCost)
+
+    -- Codex considers each item once and updates a running total. Processing
+    -- newest-to-oldest matches its tool-output preflight and avoids quadratic
+    -- prefix appends and complete-request serialization.
+    rewriteNewest _ suffix [] = suffix
+    rewriteNewest totalCost suffix remaining@((item, cost) : older)
+        | totalCost <= contextWindow =
+            map fst (reverse remaining) <> suffix
         | otherwise =
-            case rewriteFirstReducible [] items of
-                Just smaller -> rewriteUntilFit smaller
-                Nothing -> items
+            let availableTokens =
+                    max 0 (contextWindow - (totalCost - cost))
+            in case rewriteItemForBudget availableTokens item of
+                Just compacted
+                    | let compactedCost = itemTokenCount compacted
+                    , compactedCost < cost ->
+                        rewriteNewest
+                            (totalCost - cost + compactedCost)
+                            (compacted : suffix)
+                            older
+                _ -> rewriteNewest totalCost (item : suffix) older
 
-    rewriteFirstReducible _ [] = Nothing
-    rewriteFirstReducible prefix (item : remaining) =
-        let withoutItem = prefix <> remaining
-            availableTokens =
-                max 0 (contextWindow - requestTokens withoutItem)
-            original = prefix <> (item : remaining)
-        in case rewriteItemForBudget availableTokens item of
-            Just compacted
-                | let candidate = prefix <> (compacted : remaining)
-                , requestTokens candidate < requestTokens original ->
-                    Just candidate
-            _ ->
-                rewriteFirstReducible (prefix <> [item]) remaining
+    itemTokenCount item = estimateItemsTokens [item]
 
+    -- Local summarization follows Codex's context-error fallback and may drop
+    -- old protocol units. Remote V2 never enters this loop.
     dropOldestUntilFit items
         | requestTokens items <= contextWindow = items
         | otherwise =
@@ -183,6 +203,12 @@ dropOldestProtocolUnit = go []
   where
     go _ [] = Nothing
     go prefix (item@(KnownResponseItem ItemCompaction _) : rest) =
+        go (prefix <> [item]) rest
+    go prefix (item@(KnownResponseItem ItemContextCompaction _) : rest) =
+        go (prefix <> [item]) rest
+    go prefix (item@CompactionItemValue{} : rest) =
+        go (prefix <> [item]) rest
+    go prefix (item@ContextCompactionItemValue{} : rest) =
         go (prefix <> [item]) rest
     go prefix (FunctionCallItem call : rest) =
         Just (prefix <> dropMatchingFunctionOutput call.callId rest)
@@ -245,12 +271,6 @@ pairedOutputType = \case
     ItemProgram -> Just ItemProgramOutput
     _ -> Nothing
 
-compactedScreenshotDataUrl :: Text
-compactedScreenshotDataUrl =
-    "data:image/png;base64,"
-        <> "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQ"
-        <> "IHWP4z8DwHwAFgAI/ScL7WQAAAABJRU5ErkJggg=="
-
 pairedUnknownOutputTag :: Text -> Maybe Text
 pairedUnknownOutputTag itemType
     | "_call" `Text.isSuffixOf` normalized =
@@ -292,6 +312,12 @@ identifiersMatch expected actual =
 nonEmptyIdentifiers :: [Text] -> [Text]
 nonEmptyIdentifiers =
     filter (not . Text.null) . map Text.strip
+
+compactedScreenshotDataUrl :: Text
+compactedScreenshotDataUrl =
+    "data:image/png;base64,"
+        <> "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQ"
+        <> "IHWP4z8DwHwAFgAI/ScL7WQAAAABJRU5ErkJggg=="
 
 sanitizeRemoteCompactionHistory :: [ResponseItem] -> [ResponseItem]
 sanitizeRemoteCompactionHistory =
@@ -888,6 +914,9 @@ fitLocalSummaryItem targetWindow params summary
 hasCompactionCheckpoint :: [ResponseItem] -> Bool
 hasCompactionCheckpoint = any \case
     CompactionItemValue{} -> True
+    ContextCompactionItemValue{} -> True
+    KnownResponseItem ItemCompaction _ -> True
+    KnownResponseItem ItemContextCompaction _ -> True
     MessageItem message
         | message.role == RoleAssistant ->
             maybe False

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -55,6 +55,8 @@ import Agent.Responses.Types
 import Agent.Json (RawJson, rawJsonFromEncoding)
 import qualified Data.Aeson as Aeson
 import Data.Maybe (listToMaybe, mapMaybe)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -95,9 +97,9 @@ trimRemoteCompactionHistoryToFit
 trimRemoteCompactionHistoryToFit contextWindow instructionText history =
     trimCompactionHistoryToFitWith
         sanitizeRemoteCompactionHistory
-        False
         contextWindow
         requestTokens
+        (estimateItemsTokens . pure)
         history
   where
     requestTokens items =
@@ -116,9 +118,9 @@ trimRemoteCompactionRequestToFit
 trimRemoteCompactionRequestToFit contextWindow params =
     trimCompactionHistoryToFitWith
         sanitizeRemoteCompactionHistory
-        False
         contextWindow
         requestTokens
+        (estimateItemsTokens . pure)
   where
     requestTokens history =
         estimateEncodedValue (buildRemoteCompactionRequest params history)
@@ -135,130 +137,319 @@ trimResponseHistoryToFit
 trimResponseHistoryToFit contextWindow params trailing =
     trimCompactionHistoryToFitWith
         sanitizeCompactionHistory
-        True
         contextWindow
         requestTokens
+        (estimateItemsTokens . pure)
   where
     requestTokens history =
         estimateRequestTokensWithItems params (history <> trailing)
 
 trimCompactionHistoryToFitWith
     :: ([ResponseItem] -> [ResponseItem])
-    -> Bool
     -> Int
     -> ([ResponseItem] -> Int)
+    -> (ResponseItem -> Int)
     -> [ResponseItem]
     -> [ResponseItem]
-trimCompactionHistoryToFitWith sanitize dropIrreducible contextWindow
-        requestTokens history =
-    let rewritten =
-            rewriteNewest initialCost [] (reverse (zip sanitized itemCosts))
-    in if dropIrreducible
-        then dropOldestUntilFit rewritten
-        else rewritten
+trimCompactionHistoryToFitWith
+        sanitize
+        contextWindow
+        requestTokens
+        estimateItem
+        history =
+    let sanitized = sanitize history
+        -- A single exact check handles the common case without constructing
+        -- any accounting state. The old implementation called this for every
+        -- candidate while repeatedly rebuilding the whole prefix.
+        initialRequestTokens = requestTokens sanitized
+    in if initialRequestTokens <= contextWindow
+        then sanitized
+        else
+            let entries =
+                    [ (item, itemCost item)
+                    | item <- sanitized
+                    ]
+                itemTokens =
+                    sum [cost | (_, cost) <- entries]
+                -- Keep the exact request-level overhead (instructions,
+                -- tools, trailing items, and framing) out of the per-item
+                -- accounting.  The full initial estimate remains at least
+                -- the exact check, even when an item estimate rounds down.
+                fixedTokens =
+                    max
+                        (toInteger (max 0 (requestTokens [])))
+                        (toInteger initialRequestTokens - itemTokens)
+                initialTotal = fixedTokens + itemTokens
+                (rewritten, rewrittenTotal) =
+                    rewriteEntries initialTotal entries
+                (dropped, _) =
+                    dropOldestUntilFit rewrittenTotal rewritten
+                (retained, _) =
+                    rewriteEntries
+                        (fixedTokens + sum [cost | (_, cost) <- dropped])
+                        dropped
+            in repairExactFit fixedTokens retained
   where
-    sanitized = sanitize history
-    itemCosts = map itemTokenCount sanitized
-    itemsCost = sum itemCosts
-    requestCost = requestTokens sanitized
-    -- Request-level instructions, tools, and the envelope stay fixed while an
-    -- item is rewritten. Measure them once; independently rounded item costs
-    -- make the running estimate conservative.
-    fixedCost = max 0 (requestCost - itemsCost)
-    initialCost = max requestCost (fixedCost + itemsCost)
+    window = toInteger contextWindow
 
-    -- Codex considers each item once and updates a running total. Processing
-    -- newest-to-oldest matches its tool-output preflight and avoids quadratic
-    -- prefix appends and complete-request serialization.
-    rewriteNewest _ suffix [] = suffix
-    rewriteNewest totalCost suffix remaining@((item, cost) : older)
-        | totalCost <= contextWindow =
-            map fst (reverse remaining) <> suffix
+    -- Keep one independently rounded estimate per item.  Rewrites and group
+    -- selection update a running total rather than serializing the request.
+    itemCost item =
+        toInteger (max 1 (estimateItem item))
+
+    boundedBudget value =
+        fromInteger
+            (max 0 (min (toInteger (maxBound :: Int)) value))
+
+    -- Consider each item at most twice, newest first, and update the running
+    -- total after a successful rewrite. The second pass handles a boundary
+    -- item that could not be rewritten until older protocol units were
+    -- removed; this remains linear while preserving the newest usable item.
+    rewriteEntries initialTotal entries =
+        go initialTotal (reverse entries) []
+      where
+        go total [] rewritten =
+            (rewritten, total)
+        go total remaining@((item, oldCost) : rest) rewritten
+            | total <= window =
+                (reverse remaining <> rewritten, total)
+            | otherwise =
+                let available =
+                        max 0 (window - (total - oldCost))
+                in case rewriteItemForBudget
+                        (boundedBudget available)
+                        item of
+                    Just compacted
+                        | newCost <- itemCost compacted
+                        , newCost < oldCost ->
+                            go
+                                (total - oldCost + newCost)
+                                rest
+                                ((compacted, newCost) : rewritten)
+                    _ ->
+                        go total rest ((item, oldCost) : rewritten)
+
+    -- Drop complete protocol units in one pass. In particular, this avoids
+    -- repeatedly appending a growing prefix (`prefix <> rest`) for large
+    -- histories. Checkpoints are never put in a droppable unit.
+    dropOldestUntilFit total entries =
+        dropOldestWithBoundary True total entries
+
+    -- Once the rewrite boundary has had a chance to shrink, an irreducible
+    -- final unit may still exceed the window. At that point it is safe to
+    -- discard it as a last resort, matching the old exact-fit fallback.
+    dropAllOldestUntilFit total entries =
+        dropOldestWithBoundary False total entries
+
+    dropOldestWithBoundary preserveBoundary total entries =
+        let items = map fst entries
+            units = protocolDropUnits items
+            costs =
+                Map.fromList
+                    [ (index, cost)
+                    | (index, (_, cost)) <- zip [0 ..] entries
+                    ]
+            dropped = chooseDrops preserveBoundary total units costs
+            result =
+                [ entry
+                | (index, entry) <- zip [0 ..] entries
+                , not (Set.member index dropped)
+                ]
+            removedTotal =
+                sum
+                    [ Map.findWithDefault 0 index costs
+                    | index <- Set.toList dropped
+                    ]
+        in (result, total - removedTotal)
+
+    chooseDrops preserveBoundary total units costs =
+        go total units dropCount Set.empty
+      where
+        itemCostAt index = Map.findWithDefault 0 index costs
+        dropCount = length [() | DropUnit{} <- units]
+
+        go _current [] _remainingDrops dropped = dropped
+        go current (unit : rest) remainingDrops dropped
+            | current <= window = dropped
+            | otherwise =
+                case unit of
+                    KeepUnit -> go current rest remainingDrops dropped
+                    DropUnit indices ->
+                        if preserveBoundary && remainingDrops <= 1
+                            then dropped
+                            else
+                                let newIndices =
+                                        filter (`Set.notMember` dropped) indices
+                                    removedTokens =
+                                        sum (map itemCostAt newIndices)
+                                in go
+                                    (current - removedTokens)
+                                    rest
+                                    (remainingDrops - 1)
+                                    (foldr Set.insert dropped newIndices)
+
+    -- This final check is intentionally outside the accounting loop. Usually
+    -- the additive estimate is conservative, but a request adapter can add
+    -- conditional fields. If that rare under-estimate occurs, run one final
+    -- linear drop pass rather than recursively serializing each candidate.
+    repairExactFit fixedTokens entries =
+        let items = map fst entries
+            exactTokens = requestTokens items
+            estimatedTokens =
+                fixedTokens + sum [cost | (_, cost) <- entries]
+        in if exactTokens <= contextWindow
+            then items
+            else
+                map fst
+                    (fst
+                        (dropAllOldestUntilFit
+                            (max estimatedTokens (toInteger exactTokens))
+                            entries))
+
+data ProtocolDropUnit
+    = KeepUnit
+    | DropUnit [Int]
+
+data OutputKey
+    = FunctionOutputKey
+    | CustomToolOutputKey
+    | ComputerOutputKey
+    deriving stock (Eq, Ord, Show)
+
+protocolDropUnits :: [ResponseItem] -> [ProtocolDropUnit]
+protocolDropUnits items =
+    let indexed = zip [0 ..] items
+        outputIndices = buildOutputIndices indexed
+    in go outputIndices Set.empty indexed
+  where
+    go _ _ [] = []
+    go outputIndices paired ((index, item) : rest)
+        | Set.member index paired =
+            go outputIndices paired rest
+        | isCompactionCheckpoint item =
+            KeepUnit : go outputIndices paired rest
         | otherwise =
-            let availableTokens =
-                    max 0 (contextWindow - (totalCost - cost))
-            in case rewriteItemForBudget availableTokens item of
-                Just compacted
-                    | let compactedCost = itemTokenCount compacted
-                    , compactedCost < cost ->
-                        rewriteNewest
-                            (totalCost - cost + compactedCost)
-                            (compacted : suffix)
-                            older
-                _ -> rewriteNewest totalCost (item : suffix) older
+            case item of
+                FunctionCallItem call ->
+                    let outputIndex =
+                            findOutputIndex
+                                outputIndices
+                                paired
+                                index
+                                (FunctionOutputKey, call.callId)
+                        nextPaired = maybe paired (`Set.insert` paired) outputIndex
+                    in DropUnit (index : maybe [] pure outputIndex)
+                        : go outputIndices nextPaired rest
+                CustomToolCallItem call ->
+                    let outputIndex =
+                            findOutputIndex
+                                outputIndices
+                                paired
+                                index
+                                (CustomToolOutputKey, call.callId)
+                        nextPaired = maybe paired (`Set.insert` paired) outputIndex
+                    in DropUnit (index : maybe [] pure outputIndex)
+                        : go outputIndices nextPaired rest
+                ComputerCallItem call ->
+                    let outputIndex =
+                            findOutputIndex
+                                outputIndices
+                                paired
+                                index
+                                (ComputerOutputKey, call.computerCallId)
+                        nextPaired = maybe paired (`Set.insert` paired) outputIndex
+                    in DropUnit (index : maybe [] pure outputIndex)
+                        : go outputIndices nextPaired rest
+                KnownResponseItem itemType tagged
+                    | Just outputType <- pairedOutputType itemType ->
+                        DropUnit
+                            (index : maybe [] pure
+                                (findTaggedOutputIndex
+                                    ((== outputType) . fst)
+                                    (taggedProtocolIds tagged)
+                                    rest))
+                            : go outputIndices paired rest
+                UnknownResponseItem tagged
+                    | Just outputTag <- pairedUnknownOutputTag tagged.tag ->
+                        DropUnit
+                            (index : maybe [] pure
+                                (findTaggedOutputIndex
+                                    (\(itemType, _) ->
+                                        case itemType of
+                                            ItemUnknownType value ->
+                                                value == outputTag
+                                            _ -> False)
+                                    (taggedProtocolIds tagged)
+                                    rest))
+                            : go outputIndices paired rest
+                _ ->
+                    DropUnit [index] : go outputIndices paired rest
 
-    itemTokenCount item = estimateItemsTokens [item]
+    findOutputIndex outputIndices paired minIndex (outputType, rawId) =
+        case nonEmptyIdentifiers [rawId] of
+            [callId] ->
+                Map.lookup (outputType, callId) outputIndices
+                    >>= listToMaybe
+                        . filter
+                            (\index ->
+                                index > minIndex
+                                    && index `Set.notMember` paired)
+            _ -> Nothing
 
-    -- Local summarization follows Codex's context-error fallback and may drop
-    -- old protocol units. Remote V2 never enters this loop.
-    dropOldestUntilFit items
-        | requestTokens items <= contextWindow = items
+    buildOutputIndices =
+        foldl' addOutputIndex Map.empty
+
+    addOutputIndex outputIndices (index, item) =
+        case outputKey item of
+            Just key ->
+                Map.insertWith
+                    (\new old -> old <> new)
+                    key
+                    [index]
+                    outputIndices
+            Nothing -> outputIndices
+
+    outputKey = \case
+        FunctionCallOutputItem output ->
+            key FunctionOutputKey output.callId
+        CustomToolCallOutputItem output ->
+            key CustomToolOutputKey output.callId
+        ComputerCallOutputItem output ->
+            key ComputerOutputKey output.computerOutputCallId
+        _ -> Nothing
+      where
+        key outputType rawId =
+            case nonEmptyIdentifiers [rawId] of
+                [callId] -> Just (outputType, callId)
+                _ -> Nothing
+
+    findTaggedOutputIndex predicate callIds items
+        | null (nonEmptyIdentifiers callIds) = Nothing
         | otherwise =
-            case dropOldestProtocolUnit items of
-                Nothing -> items
-                Just smaller -> dropOldestUntilFit smaller
+            listToMaybe
+                [ index
+                | (index, item) <- items
+                , case item of
+                    KnownResponseItem itemType tagged ->
+                        predicate (itemType, tagged)
+                            && identifiersMatch
+                                callIds
+                                (taggedProtocolIds tagged)
+                    UnknownResponseItem tagged ->
+                        predicate (ItemUnknownType tagged.tag, tagged)
+                            && identifiersMatch
+                                callIds
+                                (taggedProtocolIds tagged)
+                    _ -> False
+                ]
 
-dropOldestProtocolUnit :: [ResponseItem] -> Maybe [ResponseItem]
-dropOldestProtocolUnit = go []
-  where
-    go _ [] = Nothing
-    go prefix (item@(KnownResponseItem ItemCompaction _) : rest) =
-        go (prefix <> [item]) rest
-    go prefix (item@(KnownResponseItem ItemContextCompaction _) : rest) =
-        go (prefix <> [item]) rest
-    go prefix (item@CompactionItemValue{} : rest) =
-        go (prefix <> [item]) rest
-    go prefix (item@ContextCompactionItemValue{} : rest) =
-        go (prefix <> [item]) rest
-    go prefix (FunctionCallItem call : rest) =
-        Just (prefix <> dropMatchingFunctionOutput call.callId rest)
-    go prefix (CustomToolCallItem call : rest) =
-        Just (prefix <> dropMatchingCustomToolOutput call.callId rest)
-    go prefix (ComputerCallItem call : rest) =
-        Just (prefix <> dropMatchingComputerCallOutput call.computerCallId rest)
-    go prefix (KnownResponseItem itemType tagged : rest)
-        | Just outputType <- pairedOutputType itemType =
-            Just $
-                prefix
-                    <> dropMatchingTaggedOutput
-                        (== outputType)
-                        (taggedProtocolIds tagged)
-                        rest
-    go prefix (UnknownResponseItem tagged : rest)
-        | Just outputTag <- pairedUnknownOutputTag tagged.tag =
-            Just $
-                prefix
-                    <> dropMatchingTaggedOutput
-                        (\case
-                            ItemUnknownType itemType -> itemType == outputTag
-                            _ -> False)
-                        (taggedProtocolIds tagged)
-                        rest
-    go prefix (_ : rest) = Just (prefix <> rest)
-
-dropMatchingFunctionOutput :: Text -> [ResponseItem] -> [ResponseItem]
-dropMatchingFunctionOutput callId = go
-  where
-    go [] = []
-    go (FunctionCallOutputItem output : rest)
-        | identifiersMatch [callId] [output.callId] = rest
-    go (item : rest) = item : go rest
-
-dropMatchingComputerCallOutput :: Text -> [ResponseItem] -> [ResponseItem]
-dropMatchingComputerCallOutput callId = go
-  where
-    go [] = []
-    go (ComputerCallOutputItem output : rest)
-        | identifiersMatch [callId] [output.computerOutputCallId] = rest
-    go (item : rest) = item : go rest
-
-dropMatchingCustomToolOutput :: Text -> [ResponseItem] -> [ResponseItem]
-dropMatchingCustomToolOutput callId = go
-  where
-    go [] = []
-    go (CustomToolCallOutputItem output : rest)
-        | identifiersMatch [callId] [output.callId] = rest
-    go (item : rest) = item : go rest
+isCompactionCheckpoint :: ResponseItem -> Bool
+isCompactionCheckpoint = \case
+    CompactionItemValue{} -> True
+    ContextCompactionItemValue{} -> True
+    KnownResponseItem ItemCompaction _ -> True
+    KnownResponseItem ItemContextCompaction _ -> True
+    _ -> False
 
 pairedOutputType :: ResponseItemType -> Maybe ResponseItemType
 pairedOutputType = \case
@@ -271,6 +462,12 @@ pairedOutputType = \case
     ItemProgram -> Just ItemProgramOutput
     _ -> Nothing
 
+compactedScreenshotDataUrl :: Text
+compactedScreenshotDataUrl =
+    "data:image/png;base64,"
+        <> "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQ"
+        <> "IHWP4z8DwHwAFgAI/ScL7WQAAAABJRU5ErkJggg=="
+
 pairedUnknownOutputTag :: Text -> Maybe Text
 pairedUnknownOutputTag itemType
     | "_call" `Text.isSuffixOf` normalized =
@@ -278,24 +475,6 @@ pairedUnknownOutputTag itemType
     | otherwise = Nothing
   where
     normalized = Text.toLower (Text.strip itemType)
-
-dropMatchingTaggedOutput
-    :: (ResponseItemType -> Bool)
-    -> [Text]
-    -> [ResponseItem]
-    -> [ResponseItem]
-dropMatchingTaggedOutput isOutput callIds = go
-  where
-    go [] = []
-    go (KnownResponseItem itemType tagged : rest)
-        | isOutput itemType
-        , identifiersMatch callIds (taggedProtocolIds tagged) =
-            rest
-    go (UnknownResponseItem tagged : rest)
-        | isOutput (ItemUnknownType tagged.tag)
-        , identifiersMatch callIds (taggedProtocolIds tagged) =
-            rest
-    go (item : rest) = item : go rest
 
 taggedProtocolIds :: TaggedObject -> [Text]
 taggedProtocolIds _ = []
@@ -312,12 +491,6 @@ identifiersMatch expected actual =
 nonEmptyIdentifiers :: [Text] -> [Text]
 nonEmptyIdentifiers =
     filter (not . Text.null) . map Text.strip
-
-compactedScreenshotDataUrl :: Text
-compactedScreenshotDataUrl =
-    "data:image/png;base64,"
-        <> "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQ"
-        <> "IHWP4z8DwHwAFgAI/ScL7WQAAAABJRU5ErkJggg=="
 
 sanitizeRemoteCompactionHistory :: [ResponseItem] -> [ResponseItem]
 sanitizeRemoteCompactionHistory =

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction/Commands.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction/Commands.hs
@@ -9,7 +9,7 @@ module Agent.OpenAI.Compaction.Commands
     , isTranscriptResetTurn
     ) where
 
-import Agent.Responses.Types (ResponseItem(..), ResponseItemType(..))
+import Agent.Responses.Types
 import Data.Text (Text)
 import qualified Data.Text as Text
 

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction/Commands.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction/Commands.hs
@@ -9,7 +9,7 @@ module Agent.OpenAI.Compaction.Commands
     , isTranscriptResetTurn
     ) where
 
-import Agent.Responses.Types (ResponseItem(..))
+import Agent.Responses.Types (ResponseItem(..), ResponseItemType(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -20,6 +20,9 @@ compactTranscriptAtLastCheckpoint items = go [] (reverse items)
     go after (item : before) =
         case item of
             CompactionItemValue{} -> item : after
+            ContextCompactionItemValue{} -> item : after
+            KnownResponseItem ItemCompaction _ -> item : after
+            KnownResponseItem ItemContextCompaction _ -> item : after
             _ -> go (item : after) before
 
 isCompactSessionTurn :: Text -> Bool

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -1,6 +1,7 @@
 module Agent.OpenAI.CompactionSpec (spec) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
+import Control.Exception (evaluate)
 import Agent.Json (RawJson, rawJsonDecoder, rawJsonFromEncoding)
 import qualified Agent.Json.Decode as Json
 import Agent.OpenAI.CompactClient
@@ -18,6 +19,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Vector as Vector
 import Test.Hspec
+import System.Timeout (timeout)
 
 raw :: Aeson.Value -> RawJson
 raw = rawJsonFromEncoding . Aeson.toEncoding
@@ -108,6 +110,24 @@ spec = do
                     [MessageItem message] ->
                         Text.length (userOnly message) < 4_000
                     _ -> True
+
+        it "handles a 2050-item compaction history in bounded time" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { tools = Just [] }
+                largeOutput = toolOutput
+                    (raw (Aeson.String (Text.replicate 8_000 "x")))
+                history = replicate 2_050 largeOutput
+                trimmed = trimRemoteCompactionRequestToFit
+                    200_000 params history
+            completed <- timeout 5_000_000 (evaluate $! length trimmed)
+            completed `shouldNotBe` Nothing
+
+        it "recognizes typed context compaction checkpoints" do
+            let checkpoint = ContextCompactionItemValue ContextCompactionItem
+                    { itemId = Just "ctx-compact-1"
+                    , encryptedContent = Just "opaque"
+                    }
+            hasCompactionCheckpoint [checkpoint] `shouldBe` True
 
         it "accounts for large tool schemas when trimming remote requests" do
             let schemaText = Text.replicate 20_000 "s"
@@ -1067,9 +1087,25 @@ spec = do
             compactTranscriptAtLastCheckpoint history
                 `shouldBe` [latest, user "recent"]
 
+        it "clips at a typed context compaction checkpoint" do
+            let contextCheckpoint =
+                    ContextCompactionItemValue ContextCompactionItem
+                        { itemId = Just "ctx-compact"
+                        , encryptedContent = Just "opaque"
+                        }
+            compactTranscriptAtLastCheckpoint
+                [user "old", contextCheckpoint, user "recent"]
+                `shouldBe` [contextCheckpoint, user "recent"]
+
     describe "hasCompactionCheckpoint" do
         it "recognizes typed and locally generated compaction checkpoints" do
             hasCompactionCheckpoint [checkpoint "remote"] `shouldBe` True
+            hasCompactionCheckpoint
+                [ContextCompactionItemValue ContextCompactionItem
+                    { itemId = Just "ctx-compact"
+                    , encryptedContent = Just "opaque"
+                    }]
+                `shouldBe` True
             hasCompactionCheckpoint
                 (buildLocalCompactedHistory 1 [user "old"] "local summary")
                 `shouldBe` True

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -1,7 +1,6 @@
 module Agent.OpenAI.CompactionSpec (spec) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
-import Control.Exception (evaluate)
 import Agent.Json (RawJson, rawJsonDecoder, rawJsonFromEncoding)
 import qualified Agent.Json.Decode as Json
 import Agent.OpenAI.CompactClient
@@ -19,7 +18,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Vector as Vector
 import Test.Hspec
-import System.Timeout (timeout)
 
 raw :: Aeson.Value -> RawJson
 raw = rawJsonFromEncoding . Aeson.toEncoding
@@ -111,23 +109,65 @@ spec = do
                         Text.length (userOnly message) < 4_000
                     _ -> True
 
-        it "handles a 2050-item compaction history in bounded time" do
+        it "handles a large item history with incremental token accounting" do
             let params = (defaultResponseCreateParams :: ResponseCreateParams)
-                    { tools = Just [] }
-                largeOutput = toolOutput
-                    (raw (Aeson.String (Text.replicate 8_000 "x")))
-                history = replicate 2_050 largeOutput
-                trimmed = trimRemoteCompactionRequestToFit
-                    200_000 params history
-            completed <- timeout 5_000_000 (evaluate $! length trimmed)
-            completed `shouldNotBe` Nothing
-
-        it "recognizes typed context compaction checkpoints" do
-            let checkpoint = ContextCompactionItemValue ContextCompactionItem
-                    { itemId = Just "ctx-compact-1"
-                    , encryptedContent = Just "opaque"
+                    { instructions = Just (Text.replicate 2_000 "i")
+                    , tools = Just []
                     }
-            hasCompactionCheckpoint [checkpoint] `shouldBe` True
+                history =
+                    [ user ("item-" <> Text.pack (show index))
+                    | index <- [1 :: Int .. 2_050]
+                    ]
+                contextWindow = 12_000
+                trimmed =
+                    trimRemoteCompactionRequestToFit
+                        contextWindow
+                        params
+                        history
+                request = buildRemoteCompactionRequest params trimmed
+            estimateResponseCreateParamsTokens request
+                `shouldSatisfy` (<= contextWindow)
+            length trimmed `shouldSatisfy` (< length history)
+            last trimmed `shouldBe` last history
+
+        it "does not drop typed context checkpoints while trimming" do
+            let params = (defaultResponseCreateParams :: ResponseCreateParams)
+                    { tools = Just []
+                    }
+                typedContextCheckpoint =
+                    ContextCompactionItemValue ContextCompactionItem
+                        { itemId = Just "context"
+                        , encryptedContent =
+                            Just (Text.replicate 1_000 "opaque")
+                        }
+                trimmed =
+                    trimRemoteCompactionRequestToFit
+                        20
+                        params
+                        [ user (Text.replicate 5_000 "old")
+                        , checkpoint "compaction"
+                        , typedContextCheckpoint
+                        ]
+            trimmed `shouldSatisfy` elem (checkpoint "compaction")
+            trimmed `shouldSatisfy` elem typedContextCheckpoint
+
+        it "rewrites the newest boundary after dropping older oversized items" do
+            let history =
+                    [ user (Text.replicate 20_000 "old")
+                    , user (Text.replicate 20_000 "new")
+                    ]
+                trimmed =
+                    trimRemoteCompactionHistoryToFit
+                        200
+                        Nothing
+                        history
+            estimateItemsTokens (trimmed <> [compactionTriggerItem])
+                `shouldSatisfy` (<= 200)
+            trimmed `shouldSatisfy` \items ->
+                case reverse items of
+                    MessageItem message : _ ->
+                        Text.length (userOnly message) < 20_000
+                    _ -> False
 
         it "accounts for large tool schemas when trimming remote requests" do
             let schemaText = Text.replicate 20_000 "s"
@@ -1087,25 +1127,20 @@ spec = do
             compactTranscriptAtLastCheckpoint history
                 `shouldBe` [latest, user "recent"]
 
-        it "clips at a typed context compaction checkpoint" do
-            let contextCheckpoint =
-                    ContextCompactionItemValue ContextCompactionItem
-                        { itemId = Just "ctx-compact"
-                        , encryptedContent = Just "opaque"
-                        }
-            compactTranscriptAtLastCheckpoint
-                [user "old", contextCheckpoint, user "recent"]
-                `shouldBe` [contextCheckpoint, user "recent"]
+        it "recognizes context-compaction checkpoints as transcript boundaries" do
+            let history =
+                    [ user "old"
+                    , contextCheckpoint
+                    , assistant "middle"
+                    , user "recent"
+                    ]
+            compactTranscriptAtLastCheckpoint history
+                `shouldBe` [contextCheckpoint, assistant "middle", user "recent"]
 
     describe "hasCompactionCheckpoint" do
         it "recognizes typed and locally generated compaction checkpoints" do
             hasCompactionCheckpoint [checkpoint "remote"] `shouldBe` True
-            hasCompactionCheckpoint
-                [ContextCompactionItemValue ContextCompactionItem
-                    { itemId = Just "ctx-compact"
-                    , encryptedContent = Just "opaque"
-                    }]
-                `shouldBe` True
+            hasCompactionCheckpoint [contextCheckpoint] `shouldBe` True
             hasCompactionCheckpoint
                 (buildLocalCompactedHistory 1 [user "old"] "local summary")
                 `shouldBe` True
@@ -1240,4 +1275,8 @@ spec = do
     checkpoint name = CompactionItemValue CompactionItem
         { itemId = Nothing
         , encryptedContent = Nothing
+        }
+    contextCheckpoint = ContextCompactionItemValue ContextCompactionItem
+        { itemId = Just "context"
+        , encryptedContent = Just "opaque"
         }


### PR DESCRIPTION
## Summary

- replace quadratic full-request reserialization during compaction trimming with incremental token accounting and protocol-aware history rewriting
- persist automatic compaction as an atomic transcript-replacement checkpoint before model continuation
- include pending input in the durable checkpoint so cancellation, retry, or process death cannot lose or duplicate it
- absorb completed tool output into compaction history before mid-turn compaction while preserving call/output protocol
- recognize typed `Compaction` and `ContextCompaction` boundaries and keep OpenAI-only checkpoints out of portable-provider summaries

## Performance

Optimized `-O2` scratch benchmark, one warmup plus 10 measured samples, using 200 messages of 4,000 characters each:

| | Before | After |
|---|---:|---:|
| Mean wall time | 327.1 ms | 2.66 ms |
| Mean allocation | 1.031 GB | 7.92 MB |

That is approximately 123x faster with 130x less allocation. A 2,050-item regression fixture is included in the test suite.

## Validation

- `Agent.OpenAI.CompactionSpec`: 46 examples, 0 failures
- `Agent.CLI.CompactionSpec`: 52 examples, 0 failures
- turn/session/provider-transition focused suites: 35 examples, 0 failures
- the full `agent-cli` library typechecked through GHCi
- launched the actual CLI through GHCi in tmux and verified the TUI after resizing from 104x30 to 132x42
