### PR TITLE
Decode Claude tool results with array content

### DIFF
--- a/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
+++ b/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
@@ -40,11 +40,11 @@ library
     exposed-modules:  Claude.Agent.SDK
                     , Claude.Agent.SDK.Client
                     , Claude.Agent.SDK.Errors
+                    , Claude.Agent.SDK.Internal.MessageParser
                     , Claude.Agent.SDK.Query
                     , Claude.Agent.SDK.Transport
                     , Claude.Agent.SDK.Types
     other-modules:    Claude.Agent.SDK.Internal.Client.Usage
-                    , Claude.Agent.SDK.Internal.MessageParser
                     , Claude.Agent.SDK.Internal.Process
                     , Claude.Agent.SDK.Internal.Query
                     , Claude.Agent.SDK.Internal.Transport.SubprocessCLI
@@ -71,6 +71,7 @@ test-suite claude-agent-sdk-haskell-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Claude.Agent.SDK.ClientSpec
+                    , Claude.Agent.SDK.MessageParserSpec
                     , Claude.Agent.SDK.QuerySpec
                     , Claude.Agent.SDK.TestSupport
     ghc-options:      -threaded

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
@@ -5,6 +5,7 @@ module Claude.Agent.SDK.Internal.MessageParser
 
 import Agent.Json
     ( RawJson
+    , rawJsonBytes
     , rawJsonDecoder
     , rawJsonFromEncoding
     )
@@ -13,6 +14,7 @@ import Claude.Agent.SDK.Errors (ClaudeSDKError(..))
 import Claude.Agent.SDK.Types
 import qualified Data.Aeson.Encoding as Aeson
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe)
@@ -286,22 +288,51 @@ contentBlockDecoder = Json.withType \case
                     <$> Json.liftObjectDecoder rawJsonDecoder
     _ -> fail "content block must be a JSON object"
 
+-- | Capture the complete @content@ value once, then render the retained
+-- bytes in a separate decode pass.
+--
+-- Hermes values are forward-only simdjson On-Demand iterators. Capturing the
+-- raw bytes of an array or object consumes it, so a second decoder must not
+-- run on the same value; iterating the consumed array reads past its tape and
+-- fails with an opaque SIMD error. Scalars tolerate a re-read, which is why
+-- string content never exhibited the problem.
 toolResultContentDecoder :: Json.Decoder ToolResultContent
-toolResultContentDecoder =
-    ToolResultContent <$> rawJsonDecoder <*> renderedToolResultDecoder
+toolResultContentDecoder = do
+    raw <- rawJsonDecoder
+    pure ToolResultContent
+        { raw
+        , renderedText = renderToolResultBytes (rawJsonBytes raw)
+        }
 
+renderToolResultBytes :: ByteString -> Text
+renderToolResultBytes bytes =
+    either
+        (const (displayBytes bytes))
+        id
+        (Json.decodeEither renderedToolResultDecoder bytes)
+
+-- | Render tool result content as text. Arrays join their rendered elements,
+-- objects use their @text@ field when present, and anything else falls back
+-- to the raw JSON. Every branch consumes the current value exactly once.
 renderedToolResultDecoder :: Json.Decoder Text
 renderedToolResultDecoder =
-    Json.withRawJsonByteString \raw ->
-        Json.withType \case
-            Json.VString -> Json.text
-            Json.VArray ->
-                Text.intercalate "\n" <$> Json.list renderedToolResultDecoder
-            Json.VObject -> Json.object do
-                textValue <- optionalText "text"
-                pure (fromMaybe (displayBytes raw) textValue)
-            Json.VNull -> pure ""
-            _ -> pure (displayBytes raw)
+    Json.withType \case
+        Json.VString -> Json.text
+        Json.VArray ->
+            Text.intercalate "\n" <$> Json.list renderedToolResultDecoder
+        Json.VObject ->
+            Json.withRawJsonByteString \raw ->
+                pure (renderToolResultObjectBytes raw)
+        Json.VNull -> pure ""
+        _ -> Json.withRawJsonByteString (pure . displayBytes)
+
+renderToolResultObjectBytes :: ByteString -> Text
+renderToolResultObjectBytes raw =
+    case Json.decodeEither (Json.object (optionalText "text")) owned of
+        Right (Just textValue) -> textValue
+        _ -> displayBytes owned
+  where
+    owned = ByteString.copy raw
 
 usageDecoder :: Json.Decoder Usage
 usageDecoder = Json.object do

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/MessageParserSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/MessageParserSpec.hs
@@ -1,0 +1,109 @@
+module Claude.Agent.SDK.MessageParserSpec (spec) where
+
+import Agent.Json (rawJsonBytes)
+import Claude.Agent.SDK.Internal.MessageParser (decodeMessageLine)
+import Claude.Agent.SDK.Types
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "decodeMessageLine" do
+    describe "tool_result content" do
+        it "keeps string content" do
+            block <- decodeToolResult "\"hello\""
+            block.content `shouldSatisfy` \case
+                Just ToolResultContent{raw, renderedText} ->
+                    rawJsonBytes raw == "\"hello\""
+                        && renderedText == "hello"
+                Nothing -> False
+
+        it "joins text blocks from array content" do
+            block <- decodeToolResult
+                "[{\"type\":\"text\",\"text\":\"first\"},\
+                \{\"type\":\"text\",\"text\":\"second\"}]"
+            renderedTextOf block `shouldBe` Just "first\nsecond"
+            rawBytesOf block `shouldBe`
+                Just
+                    "[{\"type\":\"text\",\"text\":\"first\"},\
+                    \{\"type\":\"text\",\"text\":\"second\"}]"
+
+        it "renders objects without text as raw JSON" do
+            -- Claude Code answers ToolSearch with tool_reference blocks.
+            block <- decodeToolResult
+                "[{\"type\":\"tool_reference\",\"tool_name\":\"WebFetch\"},\
+                \{\"type\":\"tool_reference\",\"tool_name\":\"WebSearch\"}]"
+            renderedTextOf block `shouldBe`
+                Just
+                    "{\"type\":\"tool_reference\",\"tool_name\":\"WebFetch\"}\n\
+                    \{\"type\":\"tool_reference\",\"tool_name\":\"WebSearch\"}"
+
+        it "renders mixed arrays including scalars and nested arrays" do
+            block <- decodeToolResult
+                "[\"plain\",7,true,null,[{\"type\":\"text\",\"text\":\"deep\"}]]"
+            renderedTextOf block `shouldBe` Just "plain\n7\ntrue\n\ndeep"
+
+        it "renders a single object with text" do
+            block <- decodeToolResult
+                "{\"type\":\"text\",\"text\":\"only\"}"
+            renderedTextOf block `shouldBe` Just "only"
+
+        it "treats null content as absent" do
+            block <- decodeToolResult "null"
+            block.content `shouldBe` Nothing
+
+        it "continues decoding sibling fields after array content" do
+            block <- decodeToolResult
+                "[{\"type\":\"text\",\"text\":\"failed\"}]"
+            block.isError `shouldBe` Just True
+            block.toolUseId `shouldBe` "tool-1"
+
+        it "decodes array content inside assistant advisor results" do
+            let line =
+                    "{\"type\":\"assistant\",\"uuid\":\"advisor\",\
+                    \\"message\":{\"content\":[{\"type\":\"advisor_tool_result\",\
+                    \\"tool_use_id\":\"advisor-1\",\"content\":[{\"type\":\"text\",\
+                    \\"text\":\"advice\"}]}]}}"
+            case decodeMessageLine line of
+                Right
+                    (MessageAssistant
+                        AssistantMessage
+                            { content =
+                                [ ServerToolResultBlock
+                                    { content = Just ToolResultContent{renderedText}
+                                    }
+                                ]
+                            }) ->
+                    renderedText `shouldBe` "advice"
+                other ->
+                    expectationFailure ("unexpected decode: " <> show other)
+
+decodeToolResult :: ByteString -> IO ContentBlock
+decodeToolResult content =
+    case decodeMessageLine (userToolResultLine content) of
+        Right (MessageUser UserMessage{content = [block@ToolResultBlock{}]}) ->
+            pure block
+        other -> do
+            expectationFailure ("unexpected decode: " <> show other)
+            fail "unreachable"
+
+userToolResultLine :: ByteString -> ByteString
+userToolResultLine content =
+    "{\"type\":\"user\",\"uuid\":\"tool-result\",\
+    \\"session_id\":\"123e4567-e89b-42d3-a456-426614174000\",\
+    \\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\
+    \\"tool_use_id\":\"tool-1\",\"content\":"
+        <> content
+        <> ",\"is_error\":true}]}}"
+
+renderedTextOf :: ContentBlock -> Maybe Text
+renderedTextOf = \case
+    ToolResultBlock{content = Just ToolResultContent{renderedText}} ->
+        Just renderedText
+    _ -> Nothing
+
+rawBytesOf :: ContentBlock -> Maybe ByteString
+rawBytesOf = \case
+    ToolResultBlock{content = Just ToolResultContent{raw}} ->
+        Just (rawJsonBytes raw)
+    _ -> Nothing

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
@@ -173,6 +173,42 @@ spec = describe "query" do
                    \\"retracted_message_uuids\":\"visible-before-error\"}"
             ]
 
+    it "delivers tool results whose content is an array of blocks" do
+        (result, messages) <- runQueryLines
+            [ "{\"type\":\"assistant\",\"uuid\":\"tool-search\",\
+              \\"session_id\":\""
+                <> testSessionId
+                <> "\",\"message\":{\"content\":[{\"type\":\"tool_use\",\
+                   \\"id\":\"search-1\",\"name\":\"ToolSearch\",\
+                   \\"input\":{\"query\":\"select:WebFetch\"}}]}}"
+            , "{\"type\":\"user\",\"uuid\":\"tool-search-result\",\
+              \\"session_id\":\""
+                <> testSessionId
+                <> "\",\"message\":{\"role\":\"user\",\"content\":[{\
+                   \\"type\":\"tool_result\",\"tool_use_id\":\"search-1\",\
+                   \\"content\":[{\"type\":\"tool_reference\",\
+                   \\"tool_name\":\"WebFetch\"},{\"type\":\"text\",\
+                   \\"text\":\"loaded\"}]}]}}"
+            , successResult testSessionId
+            ]
+
+        completed <- expectRight result
+        completed.result `shouldBe` Just "ok"
+        [ renderedText
+            | MessageUser UserMessage
+                { content =
+                    [ ToolResultBlock
+                        { toolUseId = "search-1"
+                        , content = Just ToolResultContent{renderedText}
+                        }
+                    ]
+                } <- messages
+            ]
+            `shouldBe`
+                [ "{\"type\":\"tool_reference\",\"tool_name\":\"WebFetch\"}\n\
+                  \loaded"
+                ]
+
     it "ignores autonomous results and keeps waiting for the human result" do
         (result, messages) <- runQueryLines
             [ assistantLine "human-before-background" "human text"

--- a/packages/claude-agent-sdk-haskell/test/Spec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified Claude.Agent.SDK.ClientSpec as ClientSpec
+import qualified Claude.Agent.SDK.MessageParserSpec as MessageParserSpec
 import qualified Claude.Agent.SDK.QuerySpec as QuerySpec
 import Control.Concurrent (threadDelay)
 import qualified System.Posix.IO.ByteString as PosixByteString
@@ -17,6 +18,7 @@ main =
         _ ->
             hspec do
                 ClientSpec.spec
+                MessageParserSpec.spec
                 QuerySpec.spec
 
 holdStdinOpen :: FilePath -> IO ()


### PR DESCRIPTION
## Summary

Fixes "Provider returned an unreadable response." on Claude Code whenever a tool returns array content: `ToolSearch`, image/PDF `Read`, `WebFetch`/`WebSearch`, and MCP tools that return multiple blocks.

**Root cause.** `toolResultContentDecoder` captured the raw bytes of `content` with `rawJsonDecoder` and then ran `renderedToolResultDecoder` on the *same* Hermes value. Hermes wraps simdjson On-Demand, whose values are forward-only iterators: capturing an array or object consumes it, so the second pass iterated past the consumed tape and failed with `unknown int for Value type` (`hermes/SIMDJSON/Types.hs:138`). That surfaced as `MessageParseError` → `JsonDecodeError` → the generic "unreadable response" message. String content survived because scalars tolerate a re-read, which is all the existing tests covered. Regressed in 396043e8 (Hermes migration).

**Fix.** Capture the `content` bytes once and render the retained copy in a separate `decodeEither` pass (the same pattern `Project.hs`, `Auth/Types.hs`, and `Lsp/Formatting.hs` already use). The object branch of the renderer likewise re-decodes its captured bytes instead of reopening a consumed object.

## Verification

- New `MessageParserSpec` covers string, array-of-text, `tool_reference` objects, mixed scalar/nested arrays, single object, null, sibling fields after array content, and `advisor_tool_result`.
- New `QuerySpec` example delivers a ToolSearch-style `tool_reference` result through the query loop.
- `cabal test claude-agent-sdk-haskell:test:claude-agent-sdk-haskell-test agent-claude:test:agent-claude-test` — both pass.
- Replayed the actual stream-json captured from the failing prompt (`take a look at teh current mcp spec…`) through `decodeMessageLine`: the `ToolSearch` record that previously failed now decodes.
- `package.nix` regenerated with `cabal2nix`; no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
