### PR TITLE
Label Claude tool references and images in tool results

### DIFF
--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
@@ -12,6 +12,7 @@ import Agent.Json
 import qualified Agent.Json.Decode as Json
 import Claude.Agent.SDK.Errors (ClaudeSDKError(..))
 import Claude.Agent.SDK.Types
+import Control.Monad (join)
 import qualified Data.Aeson.Encoding as Aeson
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
@@ -312,8 +313,8 @@ renderToolResultBytes bytes =
         (Json.decodeEither renderedToolResultDecoder bytes)
 
 -- | Render tool result content as text. Arrays join their rendered elements,
--- objects use their @text@ field when present, and anything else falls back
--- to the raw JSON. Every branch consumes the current value exactly once.
+-- objects render as structured blocks, and anything else falls back to the
+-- raw JSON. Every branch consumes the current value exactly once.
 renderedToolResultDecoder :: Json.Decoder Text
 renderedToolResultDecoder =
     Json.withType \case
@@ -321,18 +322,43 @@ renderedToolResultDecoder =
         Json.VArray ->
             Text.intercalate "\n" <$> Json.list renderedToolResultDecoder
         Json.VObject ->
-            Json.withRawJsonByteString \raw ->
-                pure (renderToolResultObjectBytes raw)
+            Json.withRawJsonByteString (strictly . renderToolResultBlock)
         Json.VNull -> pure ""
-        _ -> Json.withRawJsonByteString (pure . displayBytes)
+        _ -> Json.withRawJsonByteString (strictly . displayBytes)
+  where
+    -- The raw bytes alias the parser's input buffer; force the projection
+    -- before the decoder returns.
+    strictly rendered = rendered `seq` pure rendered
 
-renderToolResultObjectBytes :: ByteString -> Text
-renderToolResultObjectBytes raw =
-    case Json.decodeEither (Json.object (optionalText "text")) owned of
-        Right (Just textValue) -> textValue
+-- | Render one structured tool-result block. Text blocks contribute their
+-- text, tool references and images get compact labels, and anything else
+-- falls back to its raw JSON.
+renderToolResultBlock :: ByteString -> Text
+renderToolResultBlock raw =
+    case Json.decodeEither toolResultBlockDecoder owned of
+        Right (Just rendered) -> rendered
         _ -> displayBytes owned
   where
     owned = ByteString.copy raw
+
+toolResultBlockDecoder :: Json.Decoder (Maybe Text)
+toolResultBlockDecoder = Json.object do
+    blockType <- optionalText "type"
+    textValue <- optionalText "text"
+    toolName <- optionalNonEmptyText "tool_name"
+    mediaType <- join <$> optionalTyped "source" imageSourceMediaTypeDecoder
+    pure case (blockType, textValue) of
+        (_, Just text) -> Just text
+        (Just "tool_reference", Nothing) ->
+            ("Tool reference: " <>) <$> toolName
+        (Just "image", Nothing) ->
+            Just ("[image" <> maybe "" (" " <>) mediaType <> "]")
+        _ -> Nothing
+
+imageSourceMediaTypeDecoder :: Json.Decoder (Maybe Text)
+imageSourceMediaTypeDecoder = Json.withType \case
+    Json.VObject -> Json.object (optionalNonEmptyText "media_type")
+    _ -> pure Nothing
 
 usageDecoder :: Json.Decoder Usage
 usageDecoder = Json.object do

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/MessageParserSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/MessageParserSpec.hs
@@ -28,15 +28,24 @@ spec = describe "decodeMessageLine" do
                     "[{\"type\":\"text\",\"text\":\"first\"},\
                     \{\"type\":\"text\",\"text\":\"second\"}]"
 
-        it "renders objects without text as raw JSON" do
-            -- Claude Code answers ToolSearch with tool_reference blocks.
+        it "labels tool references and images" do
+            -- Claude Code answers ToolSearch with tool_reference blocks and
+            -- image reads with base64 image blocks.
             block <- decodeToolResult
                 "[{\"type\":\"tool_reference\",\"tool_name\":\"WebFetch\"},\
-                \{\"type\":\"tool_reference\",\"tool_name\":\"WebSearch\"}]"
+                \{\"type\":\"tool_reference\",\"tool_name\":\"WebSearch\"},\
+                \{\"type\":\"image\",\"source\":{\"type\":\"base64\",\
+                \\"media_type\":\"image/png\",\"data\":\"iVBORw0KGgo=\"}}]"
             renderedTextOf block `shouldBe`
                 Just
-                    "{\"type\":\"tool_reference\",\"tool_name\":\"WebFetch\"}\n\
-                    \{\"type\":\"tool_reference\",\"tool_name\":\"WebSearch\"}"
+                    "Tool reference: WebFetch\nTool reference: WebSearch\n\
+                    \[image image/png]"
+
+        it "renders objects without text as raw JSON" do
+            block <- decodeToolResult
+                "[{\"type\":\"mystery\",\"value\":2}]"
+            renderedTextOf block `shouldBe`
+                Just "{\"type\":\"mystery\",\"value\":2}"
 
         it "renders mixed arrays including scalars and nested arrays" do
             block <- decodeToolResult

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
@@ -12,6 +12,7 @@ import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 import Test.Hspec
 
 spec :: Spec
@@ -46,6 +47,46 @@ spec = describe "query" do
                 ]
         messages `shouldSatisfy` any hasCanonicalAssistant
         messages `shouldSatisfy` all (not . hasRetractedContent)
+
+    it "renders structured tool_result content and retains its raw JSON" do
+        (result, messages) <- runQueryLines
+            [ structuredToolResultUser
+            , successResult testSessionId
+            ]
+
+        _ <- expectRight result
+        let toolResults =
+                [ (toolUseId, rawJsonBytes content.raw, content.renderedText)
+                | MessageUser UserMessage{content = blocks} <- messages
+                , ToolResultBlock{toolUseId, content = Just content} <- blocks
+                ]
+        toolResults `shouldBe`
+            [ ( "tool-references"
+              , toolReferenceContent
+              , "Tool reference: WebSearch\nTool reference: WebFetch"
+              )
+            , ( "tool-text-blocks"
+              , "[{\"type\":\"text\",\"text\":\"first\"},\
+                \{\"type\":\"text\",\"text\":\"second\"}]"
+              , "first\nsecond"
+              )
+            , ( "tool-image"
+              , imageContent
+              , "[image image/png]"
+              )
+            , ( "tool-object"
+              , "{\"custom\":1}"
+              , "{\"custom\":1}"
+              )
+            , ( "tool-unknown-block"
+              , "[{\"type\":\"mystery\",\"value\":2}]"
+              , "{\"type\":\"mystery\",\"value\":2}"
+              )
+            , ( "tool-plain"
+              , "\"plain output\""
+              , "plain output"
+              )
+            ]
 
     it "retains unknown message and content variants for forward compatibility" do
         (result, messages) <- runQueryLines
@@ -205,9 +246,7 @@ spec = describe "query" do
                 } <- messages
             ]
             `shouldBe`
-                [ "{\"type\":\"tool_reference\",\"tool_name\":\"WebFetch\"}\n\
-                  \loaded"
-                ]
+                [ "Tool reference: WebFetch\nloaded" ]
 
     it "ignores autonomous results and keeps waiting for the human result" do
         (result, messages) <- runQueryLines
@@ -727,6 +766,49 @@ assistantWithUnknownBlock =
     \\"session_id\":\"123e4567-e89b-42d3-a456-426614174000\",\
     \\"message\":{\"content\":[{\"type\":\"future_block\",\
     \\"value\":1}]}}"
+
+-- | A ToolSearch-style user record: structured tool_result content plus the
+-- top-level @tool_use_result@ summary Claude Code attaches to it.
+structuredToolResultUser :: Text
+structuredToolResultUser =
+    "{\"type\":\"user\",\"uuid\":\"structured-tool-results\",\
+    \\"session_id\":\""
+        <> testSessionId
+        <> "\",\"parent_tool_use_id\":null,\
+           \\"message\":{\"role\":\"user\",\"content\":["
+        <> Text.intercalate
+            ","
+            [ toolResult "tool-references" (Text.decodeUtf8 toolReferenceContent)
+            , toolResult
+                "tool-text-blocks"
+                "[{\"type\":\"text\",\"text\":\"first\"},\
+                \{\"type\":\"text\",\"text\":\"second\"}]"
+            , toolResult "tool-image" (Text.decodeUtf8 imageContent)
+            , toolResult "tool-object" "{\"custom\":1}"
+            , toolResult
+                "tool-unknown-block"
+                "[{\"type\":\"mystery\",\"value\":2}]"
+            , toolResult "tool-plain" "\"plain output\""
+            ]
+        <> "]},\"tool_use_result\":{\"matches\":[\"WebFetch\",\"WebSearch\"],\
+           \\"query\":\"select:WebFetch,WebSearch\",\"total_deferred_tools\":15}}"
+  where
+    toolResult toolUseId content =
+        "{\"type\":\"tool_result\",\"tool_use_id\":\""
+            <> toolUseId
+            <> "\",\"content\":"
+            <> content
+            <> "}"
+
+toolReferenceContent :: ByteString.ByteString
+toolReferenceContent =
+    "[{\"type\":\"tool_reference\",\"tool_name\":\"WebSearch\"},\
+    \{\"type\":\"tool_reference\",\"tool_name\":\"WebFetch\"}]"
+
+imageContent :: ByteString.ByteString
+imageContent =
+    "[{\"type\":\"image\",\"source\":{\"type\":\"base64\",\
+    \\"media_type\":\"image/png\",\"data\":\"iVBORw0KGgo=\"}}]"
 
 successResult :: Text -> Text
 successResult sessionId =


### PR DESCRIPTION
## Summary
Builds on #684 (merged), which fixed the Hermes double-decode that made every array-shaped `tool_result.content` fail. This PR finishes the rendering side:
- `tool_reference` blocks (what ToolSearch returns) render as `Tool reference: WebFetch` instead of raw JSON, and base64 `image` blocks render as `[image image/png]` instead of dumping the payload. Unknown blocks keep the raw-JSON fallback; `text` blocks are unchanged.
- Each block projection is forced before the `withRawJsonByteString` decoder returns, since the raw slice aliases the parser input buffer.
- Tests: the unit spec's ToolSearch case now asserts the labels (plus an image block), a separate case keeps the raw-JSON fallback for unknown objects, and a query-spec case covers the real ToolSearch record shape (including the top-level `tool_use_result`) end to end, asserting both retained raw JSON and rendered text.

## Test plan
- [x] `cabal test claude-agent-sdk-haskell` (59 examples, 0 failures)
- [x] `cabal test agent-claude` (33 examples, 0 failures)
- CI: `nix flake check` currently fails on every PR at `agent-cli-functional-xai-hello-world` (`no xai account has verified available usage`) before reaching the Haskell suites; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)