### PR TITLE
Read Claude Code output records with linear buffering

### DIFF
--- a/packages/claude-agent-sdk-haskell/benchmark/OutputBuffer.hs
+++ b/packages/claude-agent-sdk-haskell/benchmark/OutputBuffer.hs
@@ -1,0 +1,251 @@
+-- | Compare the chunked stdout record reader against the strict-append
+-- reader it replaced. Both run the same IO loop over the same in-memory
+-- stream, delivered in pipe-sized reads, with the production record cap.
+--
+-- Usage: output-buffer-bench IMPLEMENTATION RECORD_BYTES READ_BYTES RECORDS SAMPLES +RTS -T
+module Main (main) where
+
+import Claude.Agent.SDK.Internal.Transport.OutputBuffer
+    ( OutputReadResult(..)
+    , emptyOutputBuffer
+    , readOutputLine
+    )
+import Control.Exception (evaluate)
+import Control.Exception.Safe (IOException, try)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as ByteString8
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.List (sort)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.IO.Error (isEOFError)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Implementation
+    = Legacy
+    | Chunked
+
+data Sample = Sample
+    { wallMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+-- | The production default for 'maxBufferSizeBytes'.
+recordLimit :: Int
+recordLimit = 1_073_741_824
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    getArgs >>= \case
+        [implementationArg, sizeArg, readArg, recordsArg, samplesArg] -> do
+            implementation <- parseImplementation implementationArg
+            recordBytes <- parsePositive "record size" sizeArg
+            readBytes <- parsePositive "read size" readArg
+            recordCount <- parsePositive "record count" recordsArg
+            sampleCount <- parsePositive "sample count" samplesArg
+            if recordBytes < 2
+                then die "record size must be at least 2"
+                else pure ()
+            let stream = makeStream recordBytes recordCount
+            _ <- evaluate (ByteString.length stream)
+            samples <-
+                mapM
+                    (\_ ->
+                        measure
+                            (runSample
+                                implementation
+                                readBytes
+                                recordCount
+                                stream))
+                    [1 .. sampleCount]
+            let result = median samples
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d\n"
+                implementationArg
+                recordBytes
+                readBytes
+                recordCount
+                result.wallMillis
+                result.cpuMillis
+                result.allocatedBytes
+        _ ->
+            die $
+                "usage: output-buffer-bench IMPLEMENTATION RECORD_BYTES "
+                    <> "READ_BYTES RECORDS SAMPLES\n"
+                    <> "implementations: legacy, chunked"
+
+parseImplementation :: String -> IO Implementation
+parseImplementation = \case
+    "legacy" -> pure Legacy
+    "chunked" -> pure Chunked
+    other -> die ("unknown implementation: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+-- | @recordCount@ newline-terminated records of @recordBytes@ bytes each,
+-- with a varying first byte so records are distinguishable.
+makeStream :: Int -> Int -> ByteString
+makeStream recordBytes recordCount =
+    ByteString.concat
+        [ ByteString.cons
+            (fromIntegral (97 + seed `mod` 23))
+            (ByteString.replicate (recordBytes - 2) 120)
+            <> "\n"
+        | seed <- [1 .. recordCount]
+        ]
+
+-- | Read every record from @stream@, delivered in reads of at most
+-- @readBytes@, and return a checksum that forces each record.
+runSample :: Implementation -> Int -> Int -> ByteString -> IO Int
+runSample implementation readBytes expectedRecords stream = do
+    source <- newIORef stream
+    let readChunk size =
+            atomicModifyIORef' source \remaining ->
+                let (chunk, rest) =
+                        ByteString.splitAt (min size readBytes) remaining
+                 in (rest, chunk)
+    readLine <-
+        case implementation of
+            Legacy -> do
+                bufferRef <- newIORef ByteString.empty
+                pure (legacyReadLine bufferRef recordLimit readChunk)
+            Chunked -> do
+                bufferRef <- newIORef emptyOutputBuffer
+                pure (readOutputLine bufferRef recordLimit readChunk)
+    let loop !count !acc =
+            readLine >>= \case
+                OutputReadLine line ->
+                    loop (count + 1) (acc + checksum line)
+                OutputReadEnd
+                    | count == expectedRecords ->
+                        pure acc
+                    | otherwise ->
+                        die $
+                            "read "
+                                <> show count
+                                <> " records, expected "
+                                <> show expectedRecords
+                OutputReadTooLarge ->
+                    die "unexpected oversized record"
+                OutputReadFailure exception ->
+                    die (show exception)
+    loop (0 :: Int) 0
+
+checksum :: ByteString -> Int
+checksum bytes =
+    ByteString.length bytes
+        + fromIntegral (ByteString.head bytes)
+        + fromIntegral (ByteString.last bytes)
+
+-- | The strict-append reader this benchmark's baseline replaces: every read
+-- appends to the accumulated record and rescans it from the start, so a
+-- record spanning many reads costs quadratic copying.
+legacyReadLine
+    :: IORef ByteString
+    -> Int
+    -> (Int -> IO ByteString)
+    -> IO OutputReadResult
+legacyReadLine bufferRef maximumBytes readChunk =
+    go
+  where
+    go = do
+        buffered <- readIORef bufferRef
+        case ByteString8.elemIndex '\n' buffered of
+            Just newlineIndex -> do
+                let (line, withNewline) =
+                        ByteString.splitAt newlineIndex buffered
+                writeIORef bufferRef (ByteString.drop 1 withNewline)
+                pure
+                    if ByteString.length line > maximumBytes
+                        then OutputReadTooLarge
+                        else OutputReadLine line
+            Nothing
+                | ByteString.length buffered > maximumBytes ->
+                    pure OutputReadTooLarge
+                | otherwise -> do
+                    let readSize =
+                            min
+                                8_192
+                                (maximumBytes - ByteString.length buffered + 1)
+                    result <-
+                        try (readChunk readSize)
+                            :: IO (Either IOException ByteString)
+                    case result of
+                        Right chunk
+                            | ByteString.null chunk ->
+                                finish buffered
+                            | otherwise -> do
+                                writeIORef bufferRef (buffered <> chunk)
+                                go
+                        Left exception
+                            | isEOFError exception ->
+                                finish buffered
+                            | otherwise ->
+                                pure (OutputReadFailure exception)
+
+    finish buffered = do
+        writeIORef bufferRef ByteString.empty
+        pure
+            if ByteString.null buffered
+                then OutputReadEnd
+                else OutputReadLine buffered
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCPU <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    result <- action
+    _ <- evaluate result
+    afterWall <- getMonotonicTimeNSec
+    afterCPU <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
+    pure
+        Sample
+            { wallMillis =
+                fromIntegral (afterWall - beforeWall) / 1_000_000
+            , cpuMillis =
+                fromIntegral (afterCPU - beforeCPU) / 1_000_000_000
+            , allocatedBytes =
+                fromIntegral
+                    ( afterStats.allocated_bytes
+                        - beforeStats.allocated_bytes
+                    )
+            }
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { wallMillis = middle (sort (map (.wallMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
+++ b/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
@@ -40,6 +40,7 @@ library
     exposed-modules:  Claude.Agent.SDK
                     , Claude.Agent.SDK.Client
                     , Claude.Agent.SDK.Errors
+                    , Claude.Agent.SDK.Internal.Transport.OutputBuffer
                     , Claude.Agent.SDK.Internal.MessageParser
                     , Claude.Agent.SDK.Query
                     , Claude.Agent.SDK.Transport
@@ -65,12 +66,24 @@ library
                     , unix
                     , uuid-types
 
+benchmark output-buffer-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          OutputBuffer.hs
+    ghc-options:      -O2 -rtsopts
+    build-depends:    base >= 4.17 && < 5
+                    , claude-agent-sdk-haskell
+                    , bytestring
+                    , safe-exceptions
+
 test-suite claude-agent-sdk-haskell-test
     import:           common-opts
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Claude.Agent.SDK.ClientSpec
+                    , Claude.Agent.SDK.Internal.Transport.OutputBufferSpec
                     , Claude.Agent.SDK.MessageParserSpec
                     , Claude.Agent.SDK.QuerySpec
                     , Claude.Agent.SDK.TestSupport

--- a/packages/claude-agent-sdk-haskell/package.nix
+++ b/packages/claude-agent-sdk-haskell/package.nix
@@ -16,6 +16,7 @@ mkDerivation {
     agent-json base bytestring containers directory filepath hspec
     safe-exceptions text unix
   ];
+  benchmarkHaskellDepends = [ base bytestring safe-exceptions ];
   description = "Haskell SDK for the Claude Agent SDK stream protocol";
   license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/OutputBuffer.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/OutputBuffer.hs
@@ -1,0 +1,138 @@
+-- | Bounded newline-delimited record reader for Claude Code's stdout.
+module Claude.Agent.SDK.Internal.Transport.OutputBuffer
+    ( OutputBuffer
+    , OutputReadResult(..)
+    , emptyOutputBuffer
+    , readOutputLine
+    ) where
+
+import Control.Exception.Safe (IOException, try)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as ByteString8
+import qualified Data.ByteString.Unsafe as ByteStringUnsafe
+import Data.IORef (IORef, readIORef, writeIORef)
+import System.IO.Error (isEOFError)
+
+-- | Bytes received from stdout that have not been returned as a record yet.
+--
+-- Claude Code echoes every tool result as one NDJSON record, so a record can
+-- span thousands of pipe reads: an image @Read@ embeds the whole file as
+-- base64. The chunks of the current record are kept as a list and joined
+-- once when its newline arrives, so a record costs one copy rather than one
+-- copy per read. A record that arrives within a single read is returned as
+-- a slice of that read without copying.
+data OutputBuffer = OutputBuffer
+    { recordChunksReversed :: ![ByteString]
+    -- ^ Newline-free chunks of the current record, newest first.
+    , recordLength :: !Int
+    -- ^ Total size of 'recordChunksReversed'.
+    , unscanned :: !ByteString
+    -- ^ Bytes from the latest read that have not been scanned for a newline.
+    }
+
+emptyOutputBuffer :: OutputBuffer
+emptyOutputBuffer =
+    OutputBuffer
+        { recordChunksReversed = []
+        , recordLength = 0
+        , unscanned = ByteString.empty
+        }
+
+data OutputReadResult
+    = OutputReadLine !ByteString
+    | OutputReadEnd
+    | OutputReadTooLarge
+    | OutputReadFailure !IOException
+
+-- | Read one newline-terminated record of at most @maximumBytes@ bytes, not
+-- counting the newline. The final record may be terminated by end of input.
+--
+-- @readChunk size@ returns at most @size@ bytes, or an empty string at end
+-- of input, like 'ByteString.hGetSome'; an EOF exception is treated as an
+-- empty read. The buffer is persisted after every read, so an interrupted
+-- call never drops input, and a record is rejected as soon as it has been
+-- read past the limit rather than after it has been buffered in full.
+readOutputLine
+    :: IORef OutputBuffer
+    -> Int
+    -> (Int -> IO ByteString)
+    -> IO OutputReadResult
+readOutputLine bufferRef maximumBytes readChunk =
+    go
+  where
+    go = do
+        buffer <- readIORef bufferRef
+        case ByteString8.elemIndex '\n' buffer.unscanned of
+            Just newlineIndex -> do
+                -- The index is inside the scanned bytes, so both slices are
+                -- in bounds. Keep this branch strict: it runs once per
+                -- record and must not allocate more than the old reader.
+                let !recordEnd =
+                        ByteStringUnsafe.unsafeTake
+                            newlineIndex
+                            buffer.unscanned
+                    !remaining =
+                        ByteStringUnsafe.unsafeDrop
+                            (newlineIndex + 1)
+                            buffer.unscanned
+                writeIORef
+                    bufferRef
+                    (emptyOutputBuffer { unscanned = remaining })
+                if buffer.recordLength + newlineIndex > maximumBytes
+                    then pure OutputReadTooLarge
+                    else pure $! OutputReadLine (joinRecord buffer recordEnd)
+            Nothing -> do
+                let !pending = bufferScannedBytes buffer
+                if pending.recordLength > maximumBytes
+                    then pure OutputReadTooLarge
+                    else do
+                        let readSize =
+                                min
+                                    8_192
+                                    (maximumBytes - pending.recordLength + 1)
+                        result <- try (readChunk readSize)
+                        case result of
+                            Right chunk
+                                | ByteString.null chunk ->
+                                    finish pending
+                                | otherwise -> do
+                                    writeIORef
+                                        bufferRef
+                                        (pending { unscanned = chunk })
+                                    go
+                            Left exception
+                                | isEOFError exception ->
+                                    finish pending
+                                | otherwise ->
+                                    pure (OutputReadFailure exception)
+
+    finish pending = do
+        writeIORef bufferRef emptyOutputBuffer
+        if pending.recordLength == 0
+            then pure OutputReadEnd
+            else pure $! OutputReadLine (joinRecord pending ByteString.empty)
+
+-- | Move the newline-free 'unscanned' bytes into the current record.
+bufferScannedBytes :: OutputBuffer -> OutputBuffer
+bufferScannedBytes buffer
+    | ByteString.null buffer.unscanned =
+        buffer
+    | otherwise =
+        OutputBuffer
+            { recordChunksReversed =
+                buffer.unscanned : buffer.recordChunksReversed
+            , recordLength =
+                buffer.recordLength + ByteString.length buffer.unscanned
+            , unscanned = ByteString.empty
+            }
+
+-- | Assemble the current record from its buffered chunks and its final
+-- slice, copying only when the record spans more than one read.
+joinRecord :: OutputBuffer -> ByteString -> ByteString
+joinRecord buffer recordEnd =
+    case buffer.recordChunksReversed of
+        [] ->
+            recordEnd
+        chunks ->
+            ByteString.concat (reverse (recordEnd : chunks))

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/SubprocessCLI.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/Transport/SubprocessCLI.hs
@@ -10,6 +10,12 @@ import Claude.Agent.SDK.Errors
 import Claude.Agent.SDK.Internal.Process
     ( terminateProcessGroup
     )
+import Claude.Agent.SDK.Internal.Transport.OutputBuffer
+    ( OutputBuffer
+    , OutputReadResult(..)
+    , emptyOutputBuffer
+    , readOutputLine
+    )
 import Claude.Agent.SDK.Transport
     ( Transport(..)
     , TransportMode(..)
@@ -47,13 +53,11 @@ import Control.Exception.Safe
     , mask
     , onException
     , throwIO
-    , try
     , tryAny
     )
 import Control.Monad (void)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as ByteString
-import qualified Data.ByteString.Char8 as ByteString8
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
@@ -79,7 +83,7 @@ import System.IO
     , hSetBinaryMode
     , hSetBuffering
     )
-import System.IO.Error (isDoesNotExistError, isEOFError)
+import System.IO.Error (isDoesNotExistError)
 import System.Posix.Types (ProcessGroupID)
 import System.Process
     ( CreateProcess(..)
@@ -100,7 +104,7 @@ data RunningTransport = RunningTransport
     , processHandle :: !ProcessHandle
     , groupId :: !(Maybe ProcessGroupID)
     , diagnosticBytes :: !(IORef ByteString.ByteString)
-    , outputBytes :: !(IORef ByteString.ByteString)
+    , outputBytes :: !(IORef OutputBuffer)
     , outputReaderState :: !(MVar OutputReaderState)
     , inputWriterState :: !(MVar InputWriterState)
     , inputOpen :: !(IORef Bool)
@@ -239,7 +243,7 @@ startTransport options mode model effort =
                 [inputHandle, outputHandle, errorHandle])
             `onException` stopCreated processGroupId
         diagnosticRef <- newIORef ByteString.empty
-        outputRef <- newIORef ByteString.empty
+        outputRef <- newIORef emptyOutputBuffer
         outputReaderState <-
             newMVar OutputReaderState
                 { outputReaderClosing = False
@@ -493,79 +497,25 @@ readBoundedLine
     -> Int
     -> IO (Either ClaudeSDKError (Maybe ByteString.ByteString))
 readBoundedLine running maximumBytes =
-    go
+    readOutputLine
+        running.outputBytes
+        maximumBytes
+        (ByteString.hGetSome running.outputHandle)
+        >>= \case
+            OutputReadLine line ->
+                pure (Right (Just line))
+            OutputReadEnd ->
+                pure (Right Nothing)
+            OutputReadTooLarge ->
+                pure (Left oversizedRecordError)
+            OutputReadFailure exception ->
+                pure $
+                    Left $
+                        CLIConnectionError
+                            ( "Failed to read Claude Code output: "
+                                <> Text.pack (show exception)
+                            )
   where
-    go = do
-        buffered <- readIORef running.outputBytes
-        case ByteString8.elemIndex '\n' buffered of
-            Just newlineIndex -> do
-                let (line, withNewline) =
-                        ByteString.splitAt newlineIndex buffered
-                writeIORef
-                    running.outputBytes
-                    (ByteString.drop 1 withNewline)
-                if ByteString.length line > maximumBytes
-                    then pure (Left oversizedRecordError)
-                    else pure (Right (Just line))
-            Nothing
-                | ByteString.length buffered > maximumBytes ->
-                    pure (Left oversizedRecordError)
-                | otherwise -> do
-                    let remainingBytes =
-                            maximumBytes - ByteString.length buffered
-                        readSize =
-                            min 8_192 (remainingBytes + 1)
-                    result <-
-                        try
-                            (ByteString.hGetSome
-                                running.outputHandle
-                                readSize)
-                            :: IO
-                                (Either
-                                    IOException
-                                    ByteString.ByteString)
-                    case result of
-                        Right chunk
-                            | ByteString.null chunk ->
-                                if ByteString.null buffered
-                                    then pure (Right Nothing)
-                                    else do
-                                        writeIORef
-                                            running.outputBytes
-                                            ByteString.empty
-                                        if ByteString.length buffered
-                                                > maximumBytes
-                                            then
-                                                pure
-                                                    (Left
-                                                        oversizedRecordError)
-                                            else
-                                                pure
-                                                    (Right
-                                                        (Just buffered))
-                            | otherwise -> do
-                                writeIORef
-                                    running.outputBytes
-                                    (buffered <> chunk)
-                                go
-                        Left exception
-                            | isEOFError exception ->
-                                if ByteString.null buffered
-                                    then pure (Right Nothing)
-                                    else do
-                                        writeIORef
-                                            running.outputBytes
-                                            ByteString.empty
-                                        pure (Right (Just buffered))
-                            | otherwise ->
-                                pure $
-                                    Left $
-                                        CLIConnectionError
-                                            ( "Failed to read Claude Code output: "
-                                                <> Text.pack
-                                                    (show exception)
-                                            )
-
     oversizedRecordError =
         CLIProtocolError
             ( "Claude Code emitted a structured output record larger than "

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/Internal/Transport/OutputBufferSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/Internal/Transport/OutputBufferSpec.hs
@@ -1,0 +1,167 @@
+module Claude.Agent.SDK.Internal.Transport.OutputBufferSpec (spec) where
+
+import Claude.Agent.SDK.Internal.Transport.OutputBuffer
+    ( OutputReadResult(..)
+    , emptyOutputBuffer
+    , readOutputLine
+    )
+import Control.Exception.Safe (IOException, throwIO)
+import Control.Monad (replicateM)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
+import Data.IORef
+    ( atomicModifyIORef'
+    , modifyIORef'
+    , newIORef
+    , readIORef
+    )
+import System.IO.Error (eofErrorType, mkIOError)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "OutputBuffer" do
+    it "returns records that arrive in one read without reading again" do
+        reader <- scriptedReader [Deliver "a\nbb\nccc\n"]
+        outcomes <- readOutcomes 4 8_192 reader
+        outcomes `shouldBe` [Line "a", Line "bb", Line "ccc", End]
+        reader.requestedSizes `shouldReturn` [8_192, 8_192]
+
+    it "joins a record that spans several reads" do
+        reader <-
+            scriptedReader
+                [ Deliver "abc"
+                , Deliver "def"
+                , Deliver "g\nh"
+                , Deliver "i\n"
+                ]
+        outcomes <- readOutcomes 3 8_192 reader
+        outcomes `shouldBe` [Line "abcdefg", Line "hi", End]
+
+    it "handles newlines at read boundaries and a trailing record" do
+        reader <-
+            scriptedReader [Deliver "abc\n", Deliver "\n", Deliver "def"]
+        outcomes <- readOutcomes 5 8_192 reader
+        outcomes `shouldBe` [Line "abc", Line "", Line "def", End, End]
+
+    it "treats an EOF exception like an empty read" do
+        reader <- scriptedReader [Deliver "abc", Fail eofError]
+        outcomes <- readOutcomes 2 8_192 reader
+        outcomes `shouldBe` [Line "abc", End]
+
+    it "reports other read failures and keeps the buffered record" do
+        reader <-
+            scriptedReader
+                [Deliver "abc", Fail (userError "boom"), Deliver "def\n"]
+        outcomes <- readOutcomes 3 8_192 reader
+        outcomes
+            `shouldBe` [Failure "user error (boom)", Line "abcdef", End]
+
+    it "rejects a record as soon as it is read past the limit" do
+        reader <- scriptedReader [Deliver "abcdefgh\n"]
+        outcomes <- readOutcomes 1 4 reader
+        outcomes `shouldBe` [TooLarge]
+        reader.requestedSizes `shouldReturn` [5]
+
+    it "bounds every read to the remaining allowance plus one byte" do
+        reader <- scriptedReader [Deliver "abcd", Deliver "efghij"]
+        outcomes <- readOutcomes 1 10 reader
+        outcomes `shouldBe` [Line "abcdefghij"]
+        reader.requestedSizes `shouldReturn` [11, 7, 1]
+
+    it "rejects an oversized record delivered whole and resumes after it" do
+        reader <- scriptedReaderIgnoringSize [Deliver "abcdefgh\nok\n"]
+        outcomes <- readOutcomes 3 4 reader
+        outcomes `shouldBe` [TooLarge, Line "ok", End]
+
+    it "joins a large record spread over many reads in order" do
+        let record = ByteString.pack (take 1_000_003 (cycle [65 .. 90]))
+        reader <-
+            scriptedReader
+                (map Deliver (chunksOf 1_000 (record <> "\n")))
+        outcomes <- readOutcomes 2 2_000_000 reader
+        case outcomes of
+            [Line actual, End] ->
+                (ByteString.length actual, actual == record)
+                    `shouldBe` (ByteString.length record, True)
+            other ->
+                expectationFailure
+                    ("unexpected outcomes: " <> show (map summarize other))
+
+data Delivery
+    = Deliver ByteString
+    | Fail IOException
+
+data Outcome
+    = Line ByteString
+    | End
+    | TooLarge
+    | Failure String
+    deriving (Eq, Show)
+
+data Reader = Reader
+    { readChunk :: Int -> IO ByteString
+    , requestedSizes :: IO [Int]
+    }
+
+-- | Serve deliveries in order, honouring the requested read size like a pipe.
+scriptedReader :: [Delivery] -> IO Reader
+scriptedReader = makeReader True
+
+-- | Serve each delivery whole, even when it exceeds the requested size.
+scriptedReaderIgnoringSize :: [Delivery] -> IO Reader
+scriptedReaderIgnoringSize = makeReader False
+
+makeReader :: Bool -> [Delivery] -> IO Reader
+makeReader honorSize deliveries = do
+    queue <- newIORef deliveries
+    sizes <- newIORef []
+    let readChunk size = do
+            modifyIORef' sizes (size :)
+            next <-
+                atomicModifyIORef' queue \case
+                    [] ->
+                        ([], Right ByteString.empty)
+                    Deliver bytes : rest
+                        | honorSize && ByteString.length bytes > size ->
+                            let (served, remaining) =
+                                    ByteString.splitAt size bytes
+                             in (Deliver remaining : rest, Right served)
+                        | otherwise ->
+                            (rest, Right bytes)
+                    Fail exception : rest ->
+                        (rest, Left exception)
+            either throwIO pure next
+    pure
+        Reader
+            { readChunk
+            , requestedSizes = reverse <$> readIORef sizes
+            }
+
+readOutcomes :: Int -> Int -> Reader -> IO [Outcome]
+readOutcomes count maximumBytes reader = do
+    bufferRef <- newIORef emptyOutputBuffer
+    replicateM
+        count
+        (outcome <$> readOutputLine bufferRef maximumBytes reader.readChunk)
+
+outcome :: OutputReadResult -> Outcome
+outcome = \case
+    OutputReadLine line -> Line line
+    OutputReadEnd -> End
+    OutputReadTooLarge -> TooLarge
+    OutputReadFailure exception -> Failure (show exception)
+
+summarize :: Outcome -> Outcome
+summarize = \case
+    Line line -> Line (ByteString.take 32 line)
+    other -> other
+
+eofError :: IOException
+eofError = mkIOError eofErrorType "read" Nothing Nothing
+
+chunksOf :: Int -> ByteString -> [ByteString]
+chunksOf size bytes
+    | ByteString.null bytes = []
+    | otherwise =
+        let (chunk, rest) = ByteString.splitAt size bytes
+         in chunk : chunksOf size rest

--- a/packages/claude-agent-sdk-haskell/test/Spec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified Claude.Agent.SDK.ClientSpec as ClientSpec
+import qualified Claude.Agent.SDK.Internal.Transport.OutputBufferSpec as OutputBufferSpec
 import qualified Claude.Agent.SDK.MessageParserSpec as MessageParserSpec
 import qualified Claude.Agent.SDK.QuerySpec as QuerySpec
 import Control.Concurrent (threadDelay)
@@ -18,6 +19,7 @@ main =
         _ ->
             hspec do
                 ClientSpec.spec
+                OutputBufferSpec.spec
                 MessageParserSpec.spec
                 QuerySpec.spec
 


### PR DESCRIPTION
## Problem

Follow-up to #686, which raised `maxBufferSizeBytes` to 1 GiB. Codex flagged on that PR that `readBoundedLine` accumulates a record with `buffered <> chunk` for every 8 KiB pipe read, copying the whole record each time. With a 1 GiB cap that quadratic cost is now reachable by any large tool result Claude Code echoes on stdout (image `Read` as base64, large file reads): a 64 MiB record allocates 275 GB and burns 10 s of CPU before it can even be parsed.

## Change

- `Claude.Agent.SDK.Internal.Transport.OutputBuffer`: keep the chunks of the current record in a list with a running length, scan only the newly read bytes for a newline, and join the chunks once when the newline (or EOF) arrives. A record that arrives in one read is still returned as a slice without copying.
- `SubprocessCLI.readBoundedLine` delegates to it; oversize detection (`> maximumBytes`, checked as soon as the record is read past the limit), EOF/empty-read handling, `min 8192 (remaining + 1)` read sizing, non-EOF `IOException` reporting, and per-read persistence of buffered input are unchanged.
- Unit spec for the reader (single-read records, split records, newline at read boundaries, EOF exception, read failure keeps buffered input, oversize before/after newline, read-size bounding, 1 MB record over 1,000 reads).
- Benchmark `output-buffer-bench` running the old strict-append reader and the new one through the same IO loop and chunk source, with the production 1 GiB cap.

## Relation to #633 / #645

#633 was reverted in #645 because its chunked buffer had no common-path benefit and cost tens of ns per small record. Two things differ here: the 1 GiB cap turns the large-record case from a stress test into a real failure mode, and the per-record branch is kept strict so the single-read path is at parity (below).

## Benchmark

`nix develop -c cabal build --offline claude-agent-sdk-haskell:bench:output-buffer-bench` (`-O2`, GHC 9.10.3, aarch64-darwin), then `output-buffer-bench <legacy|chunked> RECORD_BYTES 8192 RECORDS SAMPLES +RTS -T`. Reads are capped at 8 KiB like `hGetSome` in production. Medians over 15 samples (≤ 64 KiB) / 7 (1 MiB) / 5 (16 MiB) / 3 (≥ 64 MiB); the 4 KiB and 1 MiB rows were run twice to check stability.

| Record | Records | Legacy wall | Chunked wall | Legacy alloc | Chunked alloc |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 256 B (one read) | 10,000 | 0.178 ms | 0.170 ms | 1.47 MB | 1.56 MB |
| 1 KiB (one read) | 10,000 | 0.382 ms | 0.412 ms | 2.02 MB | 2.17 MB |
| 4 KiB (one read) | 10,000 | 1.483 / 1.513 ms | 1.704 / 1.498 ms | 4.24 MB | 4.60 MB |
| 8 KiB (one read) | 5,000 | 1.393 ms | 1.285 ms | 3.60 MB | 3.92 MB |
| 16 KiB (2 reads) | 2,000 | 2.459 ms | 1.976 ms | 35.6 MB | 36.0 MB |
| 64 KiB (8 reads) | 500 | 6.385 ms | 1.948 ms | 146 MB | 35.7 MB |
| 1 MiB (128 reads) | 10 | 23.6 / 23.1 ms | 0.758 / 0.769 ms | 677 MB | 11.4 MB |
| 4 MiB | 4 | 142.6 ms | 1.116 ms | 4.30 GB | 18.2 MB |
| 16 MiB | 2 | 1,235.6 ms | 2.187 ms | 34.4 GB | 36.4 MB |
| 64 MiB | 1 | 9,985.9 ms | 5.904 ms | 275 GB | 72.8 MB |
| 256 MiB | 1 | not run | 23.6 ms | — | 291 MB |

Single-read records (the common Claude NDJSON case) are within noise on time and cost about one extra small record allocation per read (~+10–36 B per record). Everything spanning more than one read is faster and allocates less; the chunked reader scales linearly (≈0.09 ms and ≈1.1 MB allocated per MiB of record).

## Validation

- `cabal test claude-agent-sdk-haskell:test:claude-agent-sdk-haskell-test`: 66 examples, 0 failures (includes the 2 MiB end-to-end subprocess record test from #686).
- `git diff --check` clean; `package.nix` regenerated with `cabal2nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
