### PR TITLE
Implement MCP 2026-07-28: dual-era client, elicitation, tasks, subscriptions, OAuth conformance

### DIFF
--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -1,0 +1,126 @@
+# MCP OAuth authorization
+
+Remote Streamable HTTP MCP servers can require OAuth 2.1 authorization. The
+harness implements the client side of the MCP authorization specification
+(revision 2026-07-28): protected resource metadata discovery, authorization
+server metadata discovery with issuer validation, PKCE, client registration,
+scope selection, RFC 8707 resource indicators, and RFC 9207 issuer validation
+of the authorization response.
+
+## Logging in
+
+```
+agent-cli mcp login https://example.com/mcp
+agent-cli mcp logout https://example.com/mcp
+```
+
+`mcp login` runs the interactive browser flow:
+
+1. An unauthenticated JSON-RPC request is sent to the MCP endpoint. The
+   `WWW-Authenticate: Bearer ...` challenge of the `401` response supplies the
+   `resource_metadata` URL and the `scope` the server requires.
+2. Protected resource metadata (RFC 9728) is fetched from the challenge URL.
+   Without a challenge the well-known URIs are tried in order: the path-aware
+   `https://host/.well-known/oauth-protected-resource/<path>` and then the root
+   `https://host/.well-known/oauth-protected-resource`. A document whose
+   `resource` names a different server is rejected.
+3. Authorization server metadata is discovered for the first advertised
+   authorization server (or the one used by a previous login). For issuers
+   with a path component the candidates are
+   `/.well-known/oauth-authorization-server/<path>`,
+   `/.well-known/openid-configuration/<path>`, and
+   `/<path>/.well-known/openid-configuration`; without a path they are
+   `/.well-known/oauth-authorization-server` and
+   `/.well-known/openid-configuration`. The document's `issuer` must be
+   byte-identical to the issuer used to build the URL.
+4. The login refuses to proceed unless `code_challenge_methods_supported`
+   contains `S256`.
+5. A `client_id` is obtained using the first available mechanism:
+   pre-registered credentials from the config, a Client ID Metadata Document
+   URL when the authorization server advertises
+   `client_id_metadata_document_supported`, a dynamic registration reused
+   from the previous login for the same issuer and redirect URI, or a new
+   Dynamic Client Registration (RFC 7591) as a native public client. If none
+   is available the login fails with instructions to configure
+   `oauth.clientId` or `oauth.clientIdMetadataUrl`.
+6. Scopes are selected from the challenge `scope`, else the protected
+   resource metadata `scopes_supported`, else the configured `oauth.scopes`.
+   Previously granted scopes for the same issuer and any additional scopes
+   requested for step-up authorization are unioned in. `offline_access` is
+   added only when the authorization server advertises it.
+7. The browser is opened with `code_challenge`, `state`, `scope`, and the
+   canonical server URI as `resource`. On callback the `iss` parameter is
+   validated against the recorded issuer before anything else is inspected,
+   then `state` is verified and the code is exchanged (again with
+   `resource`, and `client_secret` for confidential pre-registered clients).
+
+The token record is written atomically with mode `0600` to
+`~/.haskell-agent/credentials/mcp/<hex(url)>.json` and is picked up by
+configured remote servers automatically. The wire client refreshes expired
+tokens with the stored `resource` and `client_secret`.
+
+## Configuration
+
+Remote servers accept an optional `oauth` object. Every key is optional:
+
+```json
+{
+  "mcpServers": {
+    "remote": {
+      "url": "https://example.com/mcp",
+      "oauth": {
+        "clientId": "pre-registered-client-id",
+        "clientSecret": "only-for-confidential-clients",
+        "clientIdMetadataUrl": "https://app.example.com/oauth/client-metadata.json",
+        "scopes": ["files:read"]
+      }
+    }
+  }
+}
+```
+
+- `clientId` / `clientSecret`: credentials from a pre-registration with the
+  authorization server. They take precedence over every other mechanism. The
+  secret is never printed; it is stored in the private token record so token
+  refreshes can present it.
+- `clientIdMetadataUrl`: an `https` URL with a path that serves a Client ID
+  Metadata Document. It is used verbatim as the `client_id` when the
+  authorization server supports the mechanism.
+- `scopes`: fallback scopes when neither the challenge nor the protected
+  resource metadata names any.
+
+## Token record
+
+```json
+{
+  "client_id": "...",
+  "token_endpoint": "https://auth.example.com/token",
+  "access_token": "...",
+  "refresh_token": "...",
+  "expires_at": 1790000000,
+  "issuer": "https://auth.example.com",
+  "scope": "files:read offline_access",
+  "resource": "https://example.com/mcp",
+  "client_id_source": "dynamic_registration",
+  "client_id_metadata_url": null,
+  "client_secret": null,
+  "redirect_uri": "http://127.0.0.1:43127/callback"
+}
+```
+
+The first five keys are the compatibility record used by the wire client;
+records written before the remaining keys existed still load. Credentials are
+bound to `issuer`: when a later login discovers a different authorization
+server the stored client registration and scopes are not reused.
+
+## Library API
+
+`Agent.MCP.OAuth` exposes the pure building blocks so the wire client and
+tests share one implementation: `parseWwwAuthenticate` / `challengeScopes`,
+`canonicalResourceUri`, `protectedResourceMetadataUrls`,
+`authorizationServerMetadataUrls`, `validateIssuer`, `checkPkceSupport`,
+`selectClientRegistration`, `selectScopes` / `planScopes`, and
+`validateAuthorizationResponseIssuer`, plus the IO discovery and token
+endpoint helpers built on them.
+
+TODO: link this page from docs/mcp.md once the wire client rewrite lands.

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -11,8 +11,14 @@ of the authorization response.
 
 ```
 agent-cli mcp login https://example.com/mcp
+agent-cli mcp login https://example.com/mcp --scope files:write
 agent-cli mcp logout https://example.com/mcp
 ```
+
+`--scope` (repeatable) requests additional scopes for step-up authorization;
+they are unioned with the scopes already granted for the same issuer. A `403`
+with `insufficient_scope` during a session names the missing scope in its
+error message.
 
 `mcp login` runs the interactive browser flow:
 
@@ -122,5 +128,3 @@ tests share one implementation: `parseWwwAuthenticate` / `challengeScopes`,
 `selectClientRegistration`, `selectScopes` / `planScopes`, and
 `validateAuthorizationResponseIssuer`, plus the IO discovery and token
 endpoint helpers built on them.
-
-TODO: link this page from docs/mcp.md once the wire client rewrite lands.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,8 @@
-# Local MCP servers
+# MCP servers
 
-Configure local stdio MCP servers in `~/.haskell-agent/config.json`:
+The harness is an MCP client for the current specification revision
+(`2026-07-28`) and for the earlier `initialize`-based revisions
+(`2025-11-25` and before). Configure servers in `~/.haskell-agent/config.json`:
 
 ```json
 {
@@ -14,14 +16,15 @@ Configure local stdio MCP servers in `~/.haskell-agent/config.json`:
         "GOOGLE_APPLICATION_CREDENTIALS": "/absolute/path/to/credentials.json"
       },
       "startupTimeoutSeconds": 120,
-      "requestTimeoutSeconds": 60
+      "requestTimeoutSeconds": 60,
+      "protocol": "auto"
     }
   }
 }
 ```
 
-In an interactive session, `/mcp` opens the local-server manager. Use the
-arrow keys or `j`/`k` to navigate, Enter to inspect tools, `a` to add a server,
+In an interactive session, `/mcp` opens the server manager. Use the arrow
+keys or `j`/`k` to navigate, Enter to inspect tools, `a` to add a server,
 Space to enable or disable it, `x` to remove it, and `r` to restart the MCP
 runtime. Saved changes restart the runtime while preserving the session.
 Environment variable values are never displayed.
@@ -36,8 +39,76 @@ exposed as mutations and follow the session's normal approval policy; Telegram
 uses its scoped inline approval buttons, while `--deny-mutations` blocks them.
 Blocking startup publishes tools as `server__tool`. Progressive startup exposes
 `mcp_search` and `mcp_call` while servers connect, then publishes each server's
-catalog. Failed stdio transports are restarted and retried only for read-only
-calls, because retrying a mutation could duplicate its side effect.
+catalog. Every mode also exposes `mcp_list_resources` and `mcp_read_resource`
+for browsing server resources and following `resource_link` results.
+
+## Protocol negotiation
+
+`protocol` selects how a server is contacted:
+
+- `auto` (default) sends `server/discover` first. A modern server answers with
+  its supported versions and capabilities; a server that returns any other
+  error, an HTTP error without a modern JSON-RPC body, or nothing within five
+  seconds is treated as legacy and initialized with the `initialize`
+  handshake (requesting `2025-11-25`). The era is remembered across
+  reconnects.
+- `modern` requires `server/discover` to succeed.
+- `legacy` skips the probe and starts with `initialize`.
+
+With a modern server every request carries the protocol version, client
+identity, and client capabilities in `_meta`. Over Streamable HTTP the client
+also sends the `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` headers,
+mirrors `x-mcp-header` tool parameters into `Mcp-Param-*` headers (tools with
+invalid annotations are dropped with a warning), and treats an
+`UnsupportedProtocolVersion` error as a request to retry with an advertised
+version. Legacy HTTP servers keep their `Mcp-Session-Id`, which is terminated
+with `DELETE` on shutdown.
+
+## Requests, progress, and cancellation
+
+Tool calls, prompt resolution, and resource reads follow the multi round-trip
+pattern: an `input_required` result is answered with the requested input and
+retried with the server's opaque `requestState`, for up to eight rounds. Task
+results (`resultType: "task"`, extension `io.modelcontextprotocol/tasks`) are
+polled with `tasks/get` at the server's suggested interval; `input_required`
+tasks are answered through `tasks/update`, and the task is cancelled when the
+call gives up.
+
+`requestTimeoutSeconds` is an idle timeout. Progress notifications
+(`notifications/progress`) extend it, up to ten times the configured value,
+and are shown as live output on the running tool. A stdio request that times
+out is cancelled with `notifications/cancelled`; over HTTP the response
+stream is closed. Server `ping` requests are answered on every transport.
+
+## Elicitation
+
+Servers may ask the user for input while a tool runs. Form-mode requests are
+rendered field by field with the restricted schema the specification allows
+(text, numbers, booleans, single and multi-select enums), validated locally,
+and reviewed before they are sent. URL-mode requests show the full URL and
+its host and only open the browser after explicit consent; the page is never
+loaded by the agent. Decline and cancel are always available. Non-interactive
+runs do not declare the `elicitation` capability and cancel any request that
+arrives anyway.
+
+## Catalog changes and subscriptions
+
+Modern servers that advertise `listChanged` receive a `subscriptions/listen`
+stream for tool, prompt, and resource list changes; legacy servers deliver
+the same notifications unsolicited. A `notifications/tools/list_changed`
+re-lists the server's tools and updates the catalog used by `mcp_search`,
+`mcp_call`, and the `/mcp` manager. Statically registered `server__tool`
+handlers keep working as long as the server still offers the tool.
+
+## Server instructions, prompts, and resources
+
+Instructions advertised by a server are appended to the system prompt under an
+"MCP server instructions" heading. In progressive mode they are delivered as a
+system reminder once the servers settle.
+
+`/mcp prompt <server> <name> [key=value ...]` resolves a server prompt
+template and submits its messages as the next turn. Resources are available to
+the model through `mcp_list_resources` and `mcp_read_resource`.
 
 ## Remote Streamable HTTP servers
 
@@ -54,11 +125,13 @@ Remote MCP endpoints use `url` instead of `command`:
 }
 ```
 
-The client preserves the `Mcp-Session-Id` returned by initialization. OAuth
-protected-resource discovery, authorization-server discovery, dynamic client
-registration, and refresh-token exchange are available in the MCP OAuth layer.
-Until the interactive PKCE login UI is wired in, an access token can be supplied
-as the redacted `MCP_ACCESS_TOKEN` environment entry.
+Responses are consumed as they stream: request-scoped notifications are
+processed as they arrive and the response ends the stream. Authorization uses
+the OAuth 2.1 flow described in [MCP OAuth](mcp-oauth.md): run
+`agent mcp login <url>` to authorize, or supply an access token through the
+redacted `MCP_ACCESS_TOKEN` environment entry. A `401` or `403` response
+surfaces the server's `WWW-Authenticate` challenge, including the scopes it
+requires.
 
 ### OAuth token refresh
 
@@ -81,3 +154,13 @@ the record, exchanges its refresh token, atomically persists the new access
 and rotated refresh tokens with mode `0600`, and retries the MCP request once.
 A failed refresh returns an actionable error instead of repeatedly attempting
 the authorization flow.
+
+## Not implemented
+
+- Sampling, roots, and logging (`logging/setLevel`) are deprecated in
+  `2026-07-28` and are not offered; a server that requests them receives a
+  method-not-found error.
+- Image and audio content blocks are described to the model but their bytes
+  are not forwarded.
+- Task identifiers are not persisted across restarts.
+- Skills-over-MCP metadata is discovered but not yet activated by the CLI.

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -182,6 +182,7 @@ library
                     , Agent.CLI.Lsp
                     , Agent.CLI.Markdown
                     , Agent.CLI.ModelPicker
+                    , Agent.CLI.McpElicitation
                     , Agent.CLI.McpManager
                     , Agent.CLI.ModelConfig
                     , Agent.CLI.Models

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -327,10 +327,13 @@ parseSlash catalog raw line = case Text.words line of
                     then ReplShowTerminal
                     else ReplCommandError "usage: /terminal"
             "agents" -> parseAgentsCommand args
-            "mcp" ->
-                if null args
-                    then ReplMcp
-                    else ReplCommandError "usage: /mcp"
+            "mcp" -> case args of
+                [] -> ReplMcp
+                ("prompt" : server : name : rest) ->
+                    ReplMcpPrompt server name (map parsePromptArgument rest)
+                _ ->
+                    ReplCommandError
+                        "usage: /mcp [prompt <server> <prompt> [key=value ...]]"
             "loop" ->
                 parseLoopCommand raw
                     (Text.strip (Text.drop (Text.length command) line))
@@ -998,3 +1001,10 @@ subsequencePositions needle haystack =
     go index wanted@(n:ns) (h:hs)
         | n == h = (index :) <$> go (index + 1) ns hs
         | otherwise = go (index + 1) wanted hs
+
+-- | Split a @key=value@ prompt argument; a bare word is a key with an empty
+-- value.
+parsePromptArgument :: Text -> (Text, Text)
+parsePromptArgument argument =
+    let (key, value) = Text.breakOn "=" argument
+    in (key, Text.drop 1 value)

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -38,7 +38,7 @@ slashCommands =
     , cmd "copy-session" [] "/copy-session" "Copy the current session id" False
     , cmd "terminal" ["ghostty"] "/terminal" "Show detected terminal capabilities" False
     , cmd "agents" ["a"] "/agents [limit [N]]" "Browse agents, or show/set the concurrent subagent cap" True
-    , cmd "mcp" ["mcps"] "/mcp" "Manage local MCP servers" False
+    , cmd "mcp" ["mcps"] "/mcp [prompt <server> <name> [key=value…]]" "Manage MCP servers or run a server prompt" False
     , grokToolCmd "scheduler_create" "loop" [] "/loop [interval] <prompt>" "Run a prompt on a recurring interval" True
     , grokToolCmd "update_goal" "goal" [] "/goal <objective> [--budget N] | status | pause | resume | clear" "Set, manage, or check an autonomous goal" True
     , grokToolCmd "workflow" "workflow" [] "/workflow runs | <name> [input]" "Launch a named workflow or list workflow runs" True

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -58,6 +58,7 @@ data ReplAction
     | ReplShowAgentLimit
     | ReplSetAgentLimit Int
     | ReplMcp
+    | ReplMcpPrompt Text Text [(Text, Text)]
     | ReplGoalStatus
     | ReplGoalPause
     | ReplGoalResume

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -17,6 +17,7 @@ module Agent.CLI.Config
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.CLI.Json (decodeLazy)
+import Agent.MCP (McpProtocolPreference(..))
 import Agent.MCP.OAuth (validateClientIdMetadataUrl)
 import Agent.Json (RawJson, rawJsonDecoder)
 import Agent.Json.Decode (defaultKey, optionalKey)
@@ -71,6 +72,9 @@ data McpServerConfig = McpServerConfig
     , mcpStartupTimeoutSeconds :: !Int
     , mcpRequestTimeoutSeconds :: !Int
     , mcpOAuth :: !(Maybe McpOAuthConfig)
+    , mcpProtocol :: !McpProtocolPreference
+    -- ^ @auto@ probes for the 2026-07-28 protocol and falls back to the
+    -- legacy @initialize@ handshake; @modern@ and @legacy@ skip the probe.
     }
     deriving (Eq)
 
@@ -212,6 +216,8 @@ instance Show McpServerConfig where
             <> show server.mcpRequestTimeoutSeconds
             <> ", mcpOAuth = "
             <> show server.mcpOAuth
+            <> ", mcpProtocol = "
+            <> show server.mcpProtocol
             <> " }"
 
 instance Aeson.ToJSON McpServerConfig where
@@ -228,6 +234,7 @@ instance Aeson.ToJSON McpServerConfig where
             , "requestTimeoutSeconds"
                 Aeson..= server.mcpRequestTimeoutSeconds
             , "oauth" Aeson..= server.mcpOAuth
+            , "protocol" Aeson..= protocolPreferenceText server.mcpProtocol
             ]
 
 instance Aeson.ToJSON WebFetchConfig where
@@ -320,6 +327,26 @@ mcpServerConfigDecoder =
             <*> defaultKey defaultMcpRequestTimeoutSeconds
                 "requestTimeoutSeconds" Hermes.int
             <*> optionalKey "oauth" mcpOAuthConfigDecoder
+            <*> defaultKey McpProtocolAuto "protocol" protocolPreferenceDecoder
+
+protocolPreferenceDecoder :: Hermes.Decoder McpProtocolPreference
+protocolPreferenceDecoder =
+    Hermes.text >>= \case
+        "auto" -> pure McpProtocolAuto
+        "modern" -> pure McpProtocolModern
+        "legacy" -> pure McpProtocolLegacy
+        other ->
+            fail
+                (Text.unpack
+                    ("unknown MCP protocol preference: "
+                        <> other
+                        <> " (expected auto, modern, or legacy)"))
+
+protocolPreferenceText :: McpProtocolPreference -> Text
+protocolPreferenceText = \case
+    McpProtocolAuto -> "auto"
+    McpProtocolModern -> "modern"
+    McpProtocolLegacy -> "legacy"
 
 mcpOAuthConfigDecoder :: Hermes.Decoder McpOAuthConfig
 mcpOAuthConfigDecoder =

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Config
     , LspConfig(..)
     , LspServerConfig(..)
     , McpInitStrategy(..)
+    , McpOAuthConfig(..)
     , McpServerConfig(..)
     , defaultHarnessConfig
     , harnessConfigPath
@@ -16,16 +17,18 @@ module Agent.CLI.Config
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.CLI.Json (decodeLazy)
+import Agent.MCP.OAuth (validateClientIdMetadataUrl)
 import Agent.Json (RawJson, rawJsonDecoder)
 import Agent.Json.Decode (defaultKey, optionalKey)
 import Agent.Json.Decode qualified as Hermes
 import Agent.OsPath (unsafeToFilePath)
 import Control.Exception.Safe (displayException, tryIO)
-import Control.Monad (unless, when)
+import Control.Monad (forM_, unless, when)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
+import Data.Maybe (isJust, isNothing)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath (createDirectoryIfMissing, doesFileExist)
@@ -67,8 +70,41 @@ data McpServerConfig = McpServerConfig
     , mcpEnv :: !(Map Text Text)
     , mcpStartupTimeoutSeconds :: !Int
     , mcpRequestTimeoutSeconds :: !Int
+    , mcpOAuth :: !(Maybe McpOAuthConfig)
     }
     deriving (Eq)
+
+-- | Optional OAuth client settings for a remote MCP server: pre-registered
+-- credentials, a Client ID Metadata Document URL, and default scopes. The
+-- client secret is redacted from 'Show' and must never be printed.
+data McpOAuthConfig = McpOAuthConfig
+    { mcpOAuthClientId :: !(Maybe Text)
+    , mcpOAuthClientSecret :: !(Maybe Text)
+    , mcpOAuthClientIdMetadataUrl :: !(Maybe Text)
+    , mcpOAuthScopes :: ![Text]
+    }
+    deriving (Eq)
+
+instance Show McpOAuthConfig where
+    show oauth =
+        "McpOAuthConfig { mcpOAuthClientId = "
+            <> show oauth.mcpOAuthClientId
+            <> ", mcpOAuthClientSecret = "
+            <> (if isJust oauth.mcpOAuthClientSecret then "<redacted>" else "Nothing")
+            <> ", mcpOAuthClientIdMetadataUrl = "
+            <> show oauth.mcpOAuthClientIdMetadataUrl
+            <> ", mcpOAuthScopes = "
+            <> show oauth.mcpOAuthScopes
+            <> " }"
+
+instance Aeson.ToJSON McpOAuthConfig where
+    toJSON oauth =
+        Aeson.object
+            [ "clientId" Aeson..= oauth.mcpOAuthClientId
+            , "clientSecret" Aeson..= oauth.mcpOAuthClientSecret
+            , "clientIdMetadataUrl" Aeson..= oauth.mcpOAuthClientIdMetadataUrl
+            , "scopes" Aeson..= oauth.mcpOAuthScopes
+            ]
 
 data McpInitStrategy
     = McpInitAuto
@@ -174,6 +210,8 @@ instance Show McpServerConfig where
             <> show server.mcpStartupTimeoutSeconds
             <> ", mcpRequestTimeoutSeconds = "
             <> show server.mcpRequestTimeoutSeconds
+            <> ", mcpOAuth = "
+            <> show server.mcpOAuth
             <> " }"
 
 instance Aeson.ToJSON McpServerConfig where
@@ -189,6 +227,7 @@ instance Aeson.ToJSON McpServerConfig where
                 Aeson..= server.mcpStartupTimeoutSeconds
             , "requestTimeoutSeconds"
                 Aeson..= server.mcpRequestTimeoutSeconds
+            , "oauth" Aeson..= server.mcpOAuth
             ]
 
 instance Aeson.ToJSON WebFetchConfig where
@@ -280,6 +319,16 @@ mcpServerConfigDecoder =
                 "startupTimeoutSeconds" Hermes.int
             <*> defaultKey defaultMcpRequestTimeoutSeconds
                 "requestTimeoutSeconds" Hermes.int
+            <*> optionalKey "oauth" mcpOAuthConfigDecoder
+
+mcpOAuthConfigDecoder :: Hermes.Decoder McpOAuthConfig
+mcpOAuthConfigDecoder =
+    Hermes.object $
+        McpOAuthConfig
+            <$> optionalKey "clientId" Hermes.text
+            <*> optionalKey "clientSecret" Hermes.text
+            <*> optionalKey "clientIdMetadataUrl" Hermes.text
+            <*> defaultKey [] "scopes" (Hermes.list Hermes.text)
 
 webFetchConfigDecoder :: Hermes.Decoder WebFetchConfig
 webFetchConfigDecoder =
@@ -460,7 +509,35 @@ validateHarnessConfig config = do
                     <> quote label
                     <> " requestTimeoutSeconds must be positive"
                 )
+        forM_ server.mcpOAuth (validateOAuth label hasUrl)
         pure server
+
+    validateOAuth label hasUrl oauth = do
+        unless hasUrl $
+            Left ("MCP server " <> quote label <> " oauth requires url")
+        when (maybe False (Text.null . Text.strip) oauth.mcpOAuthClientId) $
+            Left ("MCP server " <> quote label <> " oauth.clientId must not be empty")
+        when (isJust oauth.mcpOAuthClientSecret && isNothing oauth.mcpOAuthClientId) $
+            Left
+                ( "MCP server "
+                    <> quote label
+                    <> " oauth.clientSecret requires oauth.clientId"
+                )
+        forM_ oauth.mcpOAuthClientIdMetadataUrl \url ->
+            case validateClientIdMetadataUrl url of
+                Left _ ->
+                    Left
+                        ( "MCP server "
+                            <> quote label
+                            <> " oauth.clientIdMetadataUrl must be an https URL with a path"
+                        )
+                Right () -> Right ()
+        when (any (Text.null . Text.strip) oauth.mcpOAuthScopes) $
+            Left
+                ( "MCP server "
+                    <> quote label
+                    <> " oauth.scopes must not contain empty entries"
+                )
 
     validateMaxConcurrentAgents = \case
         Nothing -> pure ()

--- a/packages/agent-cli/src/Agent/CLI/McpElicitation.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpElicitation.hs
@@ -1,0 +1,310 @@
+-- | Interactive handling of MCP elicitation requests: form-mode input
+-- collected field by field, and URL-mode consent before opening a browser.
+--
+-- Both the line-oriented prompt and the fullscreen UI make clear which
+-- server is asking, let the user review answers before sending, and offer
+-- explicit decline and cancel choices.
+module Agent.CLI.McpElicitation
+    ( cliMcpElicitation
+    , elicitationHost
+    , renderElicitationHeader
+    ) where
+
+import Agent.CLI.CancelWatch (withStdinPaused)
+import Agent.CLI.Input (readApprovalLine)
+import Agent.CLI.Notification
+    ( AttentionRequest(InputRequested)
+    , notifyAttention
+    )
+import Agent.CLI.TUI.App
+    ( FullscreenRuntime
+    , requestFullscreenChoiceWithBody
+    , requestFullscreenText
+    )
+import Agent.MCP
+    ( McpElicitMode(..)
+    , McpElicitRequest(..)
+    , McpElicitResult(..)
+    )
+import Agent.MCP.Elicitation
+    ( McpFieldKind(..)
+    , McpFormField(..)
+    , McpEnumOption(..)
+    , describeFieldKind
+    , encodeFormContent
+    , fieldDefaultText
+    , parseElicitForm
+    , parseFieldAnswer
+    )
+import Control.Exception.Safe (tryAny, tryIO)
+import Control.Monad (forM_)
+import Data.Aeson (Value(..))
+import Data.Char (isControl)
+import Data.IORef (IORef, readIORef)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.Exit (ExitCode(..))
+import System.IO
+    ( hFlush
+    , hIsTerminalDevice
+    , stderr
+    , stdin
+    )
+import System.Process (rawSystem)
+
+-- | Elicitation hook for the CLI. Uses the fullscreen UI when one is active
+-- and the terminal otherwise; without a terminal the request is cancelled.
+cliMcpElicitation
+    :: IORef Bool
+    -> IORef (Maybe FullscreenRuntime)
+    -> McpElicitRequest
+    -> IO McpElicitResult
+cliMcpElicitation escPaused runtimeRef request = do
+    runtime <- readIORef runtimeRef
+    case runtime of
+        Just active -> fullscreenElicitation active request
+        Nothing -> lineElicitation escPaused request
+
+-- | The host component of a URL, shown prominently so users can judge where
+-- a URL-mode elicitation leads.
+elicitationHost :: Text -> Text
+elicitationHost url =
+    let afterScheme = case Text.breakOn "://" url of
+            (_, rest) | not (Text.null rest) -> Text.drop 3 rest
+            _ -> url
+    in Text.takeWhile (\character -> character /= '/' && character /= '?' && character /= '#') afterScheme
+
+renderElicitationHeader :: McpElicitRequest -> Text
+renderElicitationHeader request =
+    "MCP server \"" <> sanitize request.elicitServerName <> "\" requests input"
+        <> (if Text.null (Text.strip request.elicitMessage)
+            then ""
+            else "\n" <> sanitize (Text.strip request.elicitMessage))
+
+sanitize :: Text -> Text
+sanitize = Text.map (\character -> if isControl character && character /= '\n' then ' ' else character)
+
+-- * Line mode
+
+lineElicitation :: IORef Bool -> McpElicitRequest -> IO McpElicitResult
+lineElicitation escPaused request =
+    withStdinPaused escPaused do
+        tty <- hIsTerminalDevice stdin
+        if not tty
+            then pure McpElicitCancel
+            else do
+                notifyAttention stderr InputRequested
+                Text.hPutStrLn stderr ""
+                Text.hPutStrLn stderr (renderElicitationHeader request)
+                case request.elicitMode of
+                    McpElicitUrl url -> lineUrlConsent url
+                    McpElicitForm schema ->
+                        case parseElicitForm schema of
+                            Left err -> do
+                                Text.hPutStrLn stderr
+                                    ("Cannot render the requested form: " <> err)
+                                pure McpElicitCancel
+                            Right fields -> lineForm fields
+
+lineUrlConsent :: Text -> IO McpElicitResult
+lineUrlConsent url = do
+    Text.hPutStrLn stderr ("URL: " <> sanitize url)
+    Text.hPutStrLn stderr ("Host: " <> elicitationHost url)
+    Text.hPutStrLn stderr
+        "The page opens in your browser; nothing you enter there is visible to the agent."
+    answer <- readApprovalLine "Open it? [y]es / [n]o (decline) / [c]ancel: "
+    case fmap (Text.toLower . Text.strip) answer of
+        Just value
+            | value `elem` ["y", "yes"] -> do
+                opened <- openBrowser url
+                if opened
+                    then pure (McpElicitAccept Nothing)
+                    else do
+                        Text.hPutStrLn stderr
+                            "Could not open a browser; open the URL manually, then continue."
+                        pure (McpElicitAccept Nothing)
+            | value `elem` ["n", "no", "d", "decline"] -> pure McpElicitDecline
+        _ -> pure McpElicitCancel
+
+lineForm :: [McpFormField] -> IO McpElicitResult
+lineForm fields = do
+    Text.hPutStrLn stderr
+        "Answer each field (Enter keeps the default or skips an optional field; type !decline or !cancel to stop)."
+    collect fields [] >>= \case
+        Left result -> pure result
+        Right answers -> do
+            Text.hPutStrLn stderr "Answers to send:"
+            forM_ answers \(name, value) ->
+                Text.hPutStrLn stderr ("  " <> name <> ": " <> renderValue value)
+            confirmation <- readApprovalLine "Send these answers? [y]es / [n]o (decline) / [c]ancel: "
+            case fmap (Text.toLower . Text.strip) confirmation of
+                Just value
+                    | value `elem` ["y", "yes"] ->
+                        pure (McpElicitAccept (Just (encodeFormContent answers)))
+                    | value `elem` ["n", "no", "d", "decline"] -> pure McpElicitDecline
+                _ -> pure McpElicitCancel
+  where
+    collect [] answers = pure (Right (reverse answers))
+    collect (field : rest) answers = askField field (3 :: Int) >>= \case
+        Left result -> pure (Left result)
+        Right Nothing -> collect rest answers
+        Right (Just value) -> collect rest ((field.fieldName, value) : answers)
+
+    askField field attempts = do
+        Text.hPutStrLn stderr ""
+        Text.hPutStrLn stderr (fieldHeading field)
+        forM_ field.fieldDescription \description ->
+            Text.hPutStrLn stderr ("  " <> sanitize description)
+        Text.hPutStrLn stderr ("  expects: " <> describeFieldKind field)
+        case field.fieldKind of
+            McpEnumField options _ _ _ ->
+                forM_ (zip [1 :: Int ..] options) \(index, option) ->
+                    Text.hPutStrLn stderr
+                        ("    " <> Text.pack (show index) <> ") "
+                            <> (if option.optionTitle == option.optionValue
+                                then option.optionValue
+                                else option.optionTitle <> " (" <> option.optionValue <> ")"))
+            _ -> pure ()
+        Text.hPutStr stderr
+            ("  " <> field.fieldName
+                <> maybe "" (\value -> " [" <> value <> "]") (fieldDefaultText field)
+                <> "> ")
+        hFlush stderr
+        line <- tryIO Text.getLine
+        case line of
+            Left _ -> pure (Left McpElicitCancel)
+            Right raw
+                | Text.strip raw == "!cancel" -> pure (Left McpElicitCancel)
+                | Text.strip raw == "!decline" -> pure (Left McpElicitDecline)
+                | otherwise ->
+                    case parseFieldAnswer field raw of
+                        Right value -> pure (Right value)
+                        Left err
+                            | attempts <= 1 -> do
+                                Text.hPutStrLn stderr ("  " <> err <> "; cancelling")
+                                pure (Left McpElicitCancel)
+                            | otherwise -> do
+                                Text.hPutStrLn stderr ("  " <> err)
+                                askField field (attempts - 1)
+
+fieldHeading :: McpFormField -> Text
+fieldHeading field =
+    "* " <> sanitize (fromMaybe field.fieldName field.fieldTitle)
+        <> (if field.fieldRequired then " (required)" else " (optional)")
+
+renderValue :: Value -> Text
+renderValue = \case
+    String text -> text
+    Number number -> Text.pack (show number)
+    Bool flag -> if flag then "yes" else "no"
+    Array values -> Text.intercalate ", " (map renderValue (foldr (:) [] values))
+    Null -> "null"
+    Object _ -> "{…}"
+
+-- * Fullscreen mode
+
+fullscreenElicitation :: FullscreenRuntime -> McpElicitRequest -> IO McpElicitResult
+fullscreenElicitation runtime request =
+    case request.elicitMode of
+        McpElicitUrl url -> do
+            choice <-
+                requestFullscreenChoiceWithBody
+                    runtime
+                    "MCP server requests a URL visit"
+                    (renderElicitationHeader request
+                        <> "\n\nURL: " <> sanitize url
+                        <> "\nHost: " <> elicitationHost url
+                        <> "\n\nThe page opens in your browser; nothing you enter there is visible to the agent.")
+                    1
+                    [ ("Open in browser", "Consent and open the URL")
+                    , ("Decline", "Tell the server you will not visit the URL")
+                    , ("Cancel", "Dismiss without answering")
+                    ]
+            case choice of
+                Just 0 -> do
+                    _ <- openBrowser url
+                    pure (McpElicitAccept Nothing)
+                Just 1 -> pure McpElicitDecline
+                _ -> pure McpElicitCancel
+        McpElicitForm schema ->
+            case parseElicitForm schema of
+                Left _ -> pure McpElicitCancel
+                Right fields -> collect fields [] >>= \case
+                    Left result -> pure result
+                    Right answers -> do
+                        choice <-
+                            requestFullscreenChoiceWithBody
+                                runtime
+                                ("Send answers to " <> sanitize request.elicitServerName <> "?")
+                                (Text.unlines
+                                    [ name <> ": " <> renderValue value
+                                    | (name, value) <- answers
+                                    ])
+                                0
+                                [ ("Send", "Return these answers to the server")
+                                , ("Decline", "Refuse the request")
+                                , ("Cancel", "Dismiss without answering")
+                                ]
+                        pure case choice of
+                            Just 0 -> McpElicitAccept (Just (encodeFormContent answers))
+                            Just 1 -> McpElicitDecline
+                            _ -> McpElicitCancel
+  where
+    collect [] answers = pure (Right (reverse answers))
+    collect (field : rest) answers = askField field Nothing (3 :: Int) >>= \case
+        Left result -> pure (Left result)
+        Right Nothing -> collect rest answers
+        Right (Just value) -> collect rest ((field.fieldName, value) : answers)
+
+    askField field problem attempts = do
+        let body =
+                Text.intercalate "\n" $
+                    filter (not . Text.null)
+                        [ renderElicitationHeader request
+                        , ""
+                        , fieldHeading field
+                        , maybe "" sanitize field.fieldDescription
+                        , "Expects: " <> describeFieldKind field
+                        , maybe "" ("Problem: " <>) problem
+                        ]
+        answer <- case field.fieldKind of
+            McpEnumField options False _ _ | not (null options) -> do
+                let rows =
+                        [ (option.optionTitle, if option.optionTitle == option.optionValue then "" else option.optionValue)
+                        | option <- options
+                        ]
+                        <> [("Skip", "Leave this field empty") | not field.fieldRequired]
+                        <> [("Cancel", "Dismiss the request")]
+                choice <- requestFullscreenChoiceWithBody runtime (fieldHeading field) body 0 rows
+                pure $ case choice of
+                    Just index
+                        | index < length options -> Just (options !! index).optionValue
+                        | not field.fieldRequired && index == length options -> Just ""
+                    _ -> Nothing
+            McpBooleanField -> do
+                choice <- requestFullscreenChoiceWithBody runtime (fieldHeading field) body 0
+                    [("Yes", ""), ("No", ""), ("Cancel", "Dismiss the request")]
+                pure $ case choice of
+                    Just 0 -> Just "yes"
+                    Just 1 -> Just "no"
+                    _ -> Nothing
+            _ -> requestFullscreenText runtime (fieldHeading field) body
+                    (fromMaybe "" (fieldDefaultText field))
+        case answer of
+            Nothing -> pure (Left McpElicitCancel)
+            Just text -> case parseFieldAnswer field text of
+                Right value -> pure (Right value)
+                Left err
+                    | attempts <= 1 -> pure (Left McpElicitCancel)
+                    | otherwise -> askField field (Just err) (attempts - 1)
+
+openBrowser :: Text -> IO Bool
+openBrowser url = do
+    result <- tryAny (rawSystem "open" [Text.unpack url])
+    case result of
+        Right ExitSuccess -> pure True
+        _ -> do
+            fallback <- tryAny (rawSystem "xdg-open" [Text.unpack url])
+            pure (case fallback of Right ExitSuccess -> True; _ -> False)

--- a/packages/agent-cli/src/Agent/CLI/McpManager.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager.hs
@@ -32,6 +32,7 @@ import Agent.CLI.Style
     )
 import Agent.MCP (McpToolRegistration(..))
 import Agent.Tools.Types (AppTool(..))
+import Agent.MCP (McpProtocolPreference(..))
 import Data.Char (isAlphaNum, isSpace, toLower)
 import Data.List (find)
 import qualified Data.Map.Strict as Map
@@ -321,6 +322,7 @@ promptNewServer config =
                                         , mcpStartupTimeoutSeconds = 30
                                         , mcpRequestTimeoutSeconds = 60
                                         , mcpOAuth = Nothing
+                                        , mcpProtocol = McpProtocolAuto
                                         }
                                     )
 

--- a/packages/agent-cli/src/Agent/CLI/McpManager.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager.hs
@@ -320,6 +320,7 @@ promptNewServer config =
                                         , mcpEnv = Map.empty
                                         , mcpStartupTimeoutSeconds = 30
                                         , mcpRequestTimeoutSeconds = 60
+                                        , mcpOAuth = Nothing
                                         }
                                     )
 

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -1,19 +1,33 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+-- | Interactive OAuth 2.1 login for remote MCP servers following the MCP
+-- authorization specification (revision 2026-07-28): unauthenticated probe
+-- for the @WWW-Authenticate@ challenge, protected resource and authorization
+-- server metadata discovery with issuer validation, PKCE gate, client
+-- registration selection, scope selection, RFC 8707 resource indicators, and
+-- RFC 9207 issuer validation of the authorization response.
 module Agent.CLI.McpOAuth
-    ( loginMcp
+    ( LoginOptions(..)
+    , defaultLoginOptions
+    , loginMcp
+    , loginMcpWith
     , logoutMcp
+    , lookupServerOAuthConfig
     ) where
 
-import Agent.CLI.McpOAuthStore (mcpOAuthStorePath, saveMcpOAuth)
+import Agent.CLI.Config (HarnessConfig(..), McpOAuthConfig(..), McpServerConfig(..), loadHarnessConfig)
+import Agent.CLI.McpOAuthStore (loadMcpOAuthRecord, mcpOAuthStorePath, saveMcpOAuthRecord)
 import qualified Agent.MCP.OAuth as OAuth
+import Control.Exception.Safe (bracket, bracketOnError, tryAny)
+import Control.Monad (forM_, when)
 import Crypto.Hash (Digest, SHA256, hash)
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Base64.URL as Base64
 import qualified Data.ByteString.Lazy as LBS
-import Data.Maybe (fromMaybe)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
@@ -31,55 +45,185 @@ import qualified System.Entropy
 import System.Exit (ExitCode(..))
 import System.Process (rawSystem)
 import System.Timeout (timeout)
-import Control.Exception.Safe (bracket, tryAny)
-import Control.Monad (when)
+
+data LoginOptions = LoginOptions
+    { loginAdditionalScopes :: [Text]
+    -- ^ Extra scopes to request on top of the selected and previously
+    -- granted ones (step-up authorization).
+    }
+    deriving (Eq, Show)
+
+defaultLoginOptions :: LoginOptions
+defaultLoginOptions = LoginOptions { loginAdditionalScopes = [] }
 
 loginMcp :: Text -> IO ()
-loginMcp serverUrl = do
+loginMcp = loginMcpWith defaultLoginOptions
+
+-- | The @client_id@ chosen for this login and how it was obtained.
+data ResolvedClient = ResolvedClient
+    { resolvedClientId :: Text
+    , resolvedClientSecret :: Maybe Text
+    , resolvedSource :: OAuth.ClientIdSource
+    , resolvedMetadataUrl :: Maybe Text
+    }
+
+loginMcpWith :: LoginOptions -> Text -> IO ()
+loginMcpWith options serverUrl = do
+    home <- Dir.getHomeDirectory
+    harness <- loadHarnessConfig home >>= either failText pure
+    let oauthConfig = lookupServerOAuthConfig serverUrl harness
+        resourceUri = OAuth.canonicalResourceUri serverUrl
     manager <- newTlsManager
-    resource <- OAuth.discoverProtectedResource manager serverUrl >>= either failText pure
-    authIssuer <- case resource.authorizationServers of
-        issuer : _ -> pure issuer
-        [] -> failText "MCP OAuth metadata did not advertise an authorization server"
-    metadata <- OAuth.discoverAuthorizationServer manager authIssuer >>= either failText pure
-    bracket (openCallbackSocket) close $ \listener -> do
+    challenge <- OAuth.probeAuthorizationChallenge manager serverUrl >>= \case
+        Left err -> do
+            putStrLn ("Warning: " <> Text.unpack err <> "; falling back to well-known discovery.")
+            pure Nothing
+        Right probe -> do
+            when (probe.probeStatus /= 401 && probe.probeStatus /= 403) $
+                putStrLn ("Note: the MCP server answered the unauthenticated probe with HTTP "
+                    <> show probe.probeStatus <> "; continuing with discovery.")
+            pure probe.probeChallenge
+    resource <- OAuth.discoverProtectedResourceMetadata manager serverUrl
+        (challenge >>= (.challengeResourceMetadata)) >>= either failText pure
+    stored <- loadMcpOAuthRecord serverUrl >>= \case
+        Left err -> do
+            putStrLn ("Warning: ignoring unreadable MCP OAuth record: " <> Text.unpack err)
+            pure Nothing
+        Right record -> pure record
+    let storedIssuer = stored >>= (.extraIssuer) . snd
+    issuer <- case resource.authorizationServers of
+        [] -> failText "MCP protected resource metadata did not advertise an authorization server"
+        first : _ -> pure case storedIssuer of
+            Just previous | previous `elem` resource.authorizationServers -> previous
+            _ -> first
+    metadata <- OAuth.discoverAuthorizationServerMetadata manager issuer >>= either failText pure
+    either failText pure (OAuth.checkPkceSupport metadata)
+    let recordedIssuer = fromMaybe issuer metadata.issuer
+        sameIssuer = storedIssuer == Just recordedIssuer
+        previous = if sameIssuer then stored else Nothing
+    when (isJust stored && not sameIssuer) $
+        putStrLn ("Note: the authorization server changed to " <> Text.unpack recordedIssuer
+            <> "; the previous client registration and granted scopes will not be reused.")
+    let preferredPort = previous >>= (.extraRedirectUri) . snd >>= OAuth.loopbackRedirectPort
+    bracket (openCallbackSocket preferredPort) close $ \listener -> do
         port <- callbackPort listener
         let redirect = "http://127.0.0.1:" <> Text.pack (show port) <> "/callback"
-        registration <- case metadata.registrationEndpoint of
-            Nothing -> pure (OAuth.ClientRegistration "mcp-client" Nothing)
-            Just endpoint ->
-                OAuth.registerClient manager endpoint [redirect] metadata.scopesSupportedByServer
-                    >>= either failText pure
+            scopes = OAuth.planScopes OAuth.ScopePlan
+                { scopeSources = OAuth.ScopeSources
+                    { scopeChallenge = maybe [] OAuth.challengeScopes challenge
+                    , scopeResourceMetadata = resource.scopesSupported
+                    , scopeConfigured = maybe [] (.mcpOAuthScopes) oauthConfig
+                    }
+                , scopePreviouslyGranted = maybe [] Text.words (previous >>= (.extraScope) . snd)
+                , scopeAdditional = options.loginAdditionalScopes
+                , scopeAuthorizationServerSupported = metadata.scopesSupportedByServer
+                }
+            registrationOptions = OAuth.RegistrationOptions
+                { registrationPreRegistered = oauthConfig >>= \config ->
+                    (\clientId -> OAuth.PreRegisteredClient clientId config.mcpOAuthClientSecret)
+                        <$> config.mcpOAuthClientId
+                , registrationClientIdMetadataUrl = oauthConfig >>= (.mcpOAuthClientIdMetadataUrl)
+                , registrationStored = previous >>= \(file, extra) ->
+                    OAuth.StoredClient
+                        <$> extra.extraIssuer
+                        <*> pure file.tokenClientId
+                        <*> extra.extraClientIdSource
+                        <*> pure extra.extraRedirectUri
+                , registrationRedirectUri = redirect
+                }
+        plan <- either failText pure (OAuth.selectClientRegistration registrationOptions metadata)
+        client <- case plan of
+            OAuth.UsePreRegisteredClient pre -> do
+                putStrLn "Using the pre-registered OAuth client from ~/.haskell-agent/config.json."
+                pure ResolvedClient
+                    { resolvedClientId = pre.preRegisteredClientId
+                    , resolvedClientSecret = pre.preRegisteredClientSecret
+                    , resolvedSource = OAuth.ClientIdPreRegistered
+                    , resolvedMetadataUrl = Nothing
+                    }
+            OAuth.UseClientIdMetadataDocument url -> do
+                putStrLn ("Using the Client ID Metadata Document " <> Text.unpack url <> " as client_id.")
+                pure ResolvedClient
+                    { resolvedClientId = url
+                    , resolvedClientSecret = Nothing
+                    , resolvedSource = OAuth.ClientIdMetadataDocument
+                    , resolvedMetadataUrl = Just url
+                    }
+            OAuth.ReuseDynamicRegistration clientId -> do
+                putStrLn "Reusing the dynamic client registration from the previous login."
+                pure ResolvedClient
+                    { resolvedClientId = clientId
+                    , resolvedClientSecret = Nothing
+                    , resolvedSource = OAuth.ClientIdDynamicRegistration
+                    , resolvedMetadataUrl = Nothing
+                    }
+            OAuth.UseDynamicRegistration endpoint -> do
+                registration <- OAuth.registerClientWith manager endpoint OAuth.ClientRegistrationRequest
+                    { registrationClientName = "Haskell Agent"
+                    , registrationRedirectUris = [redirect]
+                    , registrationScopes = scopes
+                    } >>= either failText pure
+                pure ResolvedClient
+                    { resolvedClientId = registration.clientId
+                    , resolvedClientSecret = registration.clientSecret
+                    , resolvedSource = OAuth.ClientIdDynamicRegistration
+                    , resolvedMetadataUrl = Nothing
+                    }
         verifier <- randomUrlBytes 32
         state <- randomUrlBytes 24
-        let challenge = Base64.encodeUnpadded (BA.convert (hash (Encoding.encodeUtf8 verifier) :: Digest SHA256))
-            scope = Text.unwords metadata.scopesSupportedByServer
-            resourceUrl = fromMaybe serverUrl resource.resource
-            authUrl = metadata.authorizationEndpoint
-                <> "?response_type=code&client_id=" <> encode registration.clientId
+        let codeChallenge = Base64.encodeUnpadded (BA.convert (hash (Encoding.encodeUtf8 verifier) :: Digest SHA256))
+            scopeText = Text.unwords scopes
+            separator = if "?" `Text.isInfixOf` metadata.authorizationEndpoint then "&" else "?"
+            authUrl = metadata.authorizationEndpoint <> separator
+                <> "response_type=code&client_id=" <> encode client.resolvedClientId
                 <> "&redirect_uri=" <> encode redirect
-                <> "&code_challenge=" <> Encoding.decodeUtf8 challenge
+                <> "&code_challenge=" <> Encoding.decodeUtf8 codeChallenge
                 <> "&code_challenge_method=S256&state=" <> encode state
-                <> (if Text.null scope then "" else "&scope=" <> encode scope)
-                <> "&resource=" <> encode resourceUrl
+                <> (if Text.null scopeText then "" else "&scope=" <> encode scopeText)
+                <> "&resource=" <> encode resourceUri
         putStrLn ("Opening browser for MCP authorization: " <> Text.unpack authUrl)
         _ <- openBrowser authUrl
         callback <- timeout (5 * 60 * 1000000) (receiveCallback listener)
             >>= maybe (failText "Timed out waiting for MCP OAuth callback") pure
-        when (callback.state /= Just state) (failText "MCP OAuth callback state mismatch")
-        code <- maybe (failText "MCP OAuth callback did not contain an authorization code") pure callback.code
-        OAuth.exchangeAuthorizationCode manager metadata.tokenEndpoint registration.clientId code redirect verifier (Just resourceUrl)
-            >>= \case
+        -- RFC 9207: validate the issuer before acting on any other parameter,
+        -- including error responses.
+        either failText pure $ OAuth.validateAuthorizationResponseIssuer
+            metadata.authorizationResponseIssParameterSupported recordedIssuer callback.callbackIss
+        when (callback.callbackState /= Just state) (failText "MCP OAuth callback state mismatch")
+        forM_ callback.callbackError \err ->
+            failText ("MCP authorization was not granted: " <> err
+                <> maybe "" (\description -> " (" <> description <> ")") callback.callbackErrorDescription)
+        code <- maybe (failText "MCP OAuth callback did not contain an authorization code") pure callback.callbackCode
+        OAuth.exchangeAuthorizationCodeWith manager OAuth.TokenExchange
+            { exchangeEndpoint = metadata.tokenEndpoint
+            , exchangeClientId = client.resolvedClientId
+            , exchangeClientSecret = client.resolvedClientSecret
+            , exchangeCode = code
+            , exchangeRedirectUri = redirect
+            , exchangeCodeVerifier = verifier
+            , exchangeResource = Just resourceUri
+            } >>= \case
                 OAuth.OAuthTokenFailure err -> failText err
                 OAuth.OAuthTokenSuccess tokens -> do
-                    now <- round <$> getPOSIXTime
+                    now :: Int <- round <$> getPOSIXTime
                     let tokenFile = OAuth.OAuthTokenFile
-                            registration.clientId metadata.tokenEndpoint tokens.accessToken
+                            client.resolvedClientId metadata.tokenEndpoint tokens.accessToken
                             (fromMaybe "" tokens.refreshToken)
-                            (fmap (\seconds -> now + seconds) tokens.expiresIn)
+                            (fmap (now +) tokens.expiresIn)
+                        granted = fromMaybe scopeText tokens.scope
+                        extra = OAuth.OAuthTokenFileExtra
+                            { extraIssuer = Just recordedIssuer
+                            , extraScope = if Text.null (Text.strip granted) then Nothing else Just granted
+                            , extraResource = Just resourceUri
+                            , extraClientIdSource = Just client.resolvedSource
+                            , extraClientIdMetadataUrl = client.resolvedMetadataUrl
+                            , extraClientSecret = client.resolvedClientSecret
+                            , extraRedirectUri = Just redirect
+                            }
                     when (Text.null tokenFile.tokenRefreshToken) $
                         putStrLn "Warning: MCP provider returned no refresh token; reauthorization may be required."
-                    saveMcpOAuth serverUrl tokenFile >>= either failText (const (putStrLn "MCP authorization saved."))
+                    saveMcpOAuthRecord serverUrl tokenFile extra
+                        >>= either failText (const (putStrLn "MCP authorization saved."))
 
 logoutMcp :: Text -> IO ()
 logoutMcp server = do
@@ -88,16 +232,43 @@ logoutMcp server = do
     exists <- Dir.doesFileExist path
     when exists (Dir.removeFile path)
 
-data Callback = Callback { code :: Maybe Text, state :: Maybe Text }
+-- | The @oauth@ block of the configured remote server whose URL identifies the
+-- same MCP server as the login URL.
+lookupServerOAuthConfig :: Text -> HarnessConfig -> Maybe McpOAuthConfig
+lookupServerOAuthConfig serverUrl harness =
+    case [server | server <- Map.elems harness.configMcpServers, matches server] of
+        server : _ -> server.mcpOAuth
+        [] -> Nothing
+  where
+    canonical = OAuth.canonicalResourceUri serverUrl
+    matches server = maybe False ((== canonical) . OAuth.canonicalResourceUri) server.mcpUrl
 
-openCallbackSocket :: IO Socket
-openCallbackSocket = do
-    addr : _ <- getAddrInfo (Just defaultHints { addrSocketType = Stream }) (Just "127.0.0.1") (Just "0")
-    sock <- socket (addrFamily addr) Stream defaultProtocol
-    setSocketOption sock ReuseAddr 1
-    bind sock (addrAddress addr)
-    listen sock 1
-    pure sock
+data Callback = Callback
+    { callbackCode :: Maybe Text
+    , callbackState :: Maybe Text
+    , callbackIss :: Maybe Text
+    , callbackError :: Maybe Text
+    , callbackErrorDescription :: Maybe Text
+    }
+
+-- | Listen on the loopback interface, preferring the port used by the
+-- previous login so a stored dynamic registration's redirect URI can be
+-- reproduced exactly.
+openCallbackSocket :: Maybe Int -> IO Socket
+openCallbackSocket preferred = do
+    preferredSocket <- case preferred of
+        Nothing -> pure Nothing
+        Just port -> either (const Nothing) Just <$> tryAny (bindLoopback (show port))
+    maybe (bindLoopback "0") pure preferredSocket
+
+bindLoopback :: String -> IO Socket
+bindLoopback service = do
+    addr : _ <- getAddrInfo (Just defaultHints { addrSocketType = Stream }) (Just "127.0.0.1") (Just service)
+    bracketOnError (socket (addrFamily addr) Stream defaultProtocol) close \sock -> do
+        setSocketOption sock ReuseAddr 1
+        bind sock (addrAddress addr)
+        listen sock 1
+        pure sock
 
 callbackPort :: Socket -> IO Int
 callbackPort sock = do
@@ -115,7 +286,13 @@ receiveCallback listener = bracket (fst <$> accept listener) close $ \sock -> do
             <> Encoding.encodeUtf8 (Text.pack (show (LBS.length OAuth.oauthCallbackSuccessPage)))
             <> "\r\nConnection: close\r\n\r\n" <> LBS.toStrict OAuth.oauthCallbackSuccessPage
     Socket.sendAll sock response
-    pure Callback { code = lookup "code" params, state = lookup "state" params }
+    pure Callback
+        { callbackCode = lookup "code" params
+        , callbackState = lookup "state" params
+        , callbackIss = lookup "iss" params
+        , callbackError = lookup "error" params
+        , callbackErrorDescription = lookup "error_description" params
+        }
 
 parseQuery :: BS.ByteString -> [(Text, Text)]
 parseQuery raw = map parsePair (filter (not . BS.null) (BS.split 38 raw))

--- a/packages/agent-cli/src/Agent/CLI/McpOAuthStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuthStore.hs
@@ -1,16 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Agent.CLI.McpOAuthStore
-    ( loadMcpOAuth, mcpOAuthStorePath, saveMcpOAuth
+    ( loadMcpOAuth, loadMcpOAuthRecord, mcpOAuthStorePath
+    , saveMcpOAuth, saveMcpOAuthRecord
     , withMcpOAuthRefreshLock
     ) where
 
 import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Agent.FileRetry (writeLazyFileAtomically)
-import Agent.MCP.OAuth (OAuthTokenFile)
+import Agent.MCP.OAuth
+    ( OAuthTokenFile, OAuthTokenFileExtra, decodeOAuthTokenRecord
+    , emptyOAuthTokenFileExtra, encodeOAuthTokenRecord
+    )
 import Agent.OsPath (unsafeToFilePath)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception.Safe (tryAny)
-import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (ord)
 import Data.Text (Text)
@@ -29,7 +32,12 @@ mcpOAuthStorePath home server = home </> unsafeEncodeUtf ".haskell-agent"
     hexName = Text.unpack . Text.concatMap (Text.pack . (`showHex` "") . ord)
 
 loadMcpOAuth :: Text -> IO (Either Text (Maybe OAuthTokenFile))
-loadMcpOAuth server = do
+loadMcpOAuth server = fmap (fmap fst) <$> loadMcpOAuthRecord server
+
+-- | Load the token record together with the issuer, scope, resource, and
+-- client binding fields persisted alongside it.
+loadMcpOAuthRecord :: Text -> IO (Either Text (Maybe (OAuthTokenFile, OAuthTokenFileExtra)))
+loadMcpOAuthRecord server = do
     home <- getHomeDirectory
     let path = mcpOAuthStorePath home server
     exists <- doesFileExist path
@@ -37,16 +45,20 @@ loadMcpOAuth server = do
         result <- tryAny (LBS.readFile (unsafeToFilePath path))
         pure $ case result of
             Left exception -> Left (Text.pack (show exception))
-            Right bytes -> either (Left . Text.pack) (Right . Just) (Aeson.eitherDecode bytes)
+            Right bytes -> Just <$> decodeOAuthTokenRecord bytes
 
 saveMcpOAuth :: Text -> OAuthTokenFile -> IO (Either Text ())
-saveMcpOAuth server record = do
+saveMcpOAuth server record = saveMcpOAuthRecord server record emptyOAuthTokenFileExtra
+
+-- | Atomically persist a private (mode @0600@) token record.
+saveMcpOAuthRecord :: Text -> OAuthTokenFile -> OAuthTokenFileExtra -> IO (Either Text ())
+saveMcpOAuthRecord server record extra = do
     home <- getHomeDirectory
     let path = mcpOAuthStorePath home server
     result <- tryAny do
         createDirectoryIfMissing True (takeDirectory path)
         setFileMode (unsafeToFilePath (takeDirectory path)) 0o700
-        writeLazyFileAtomically path 0o600 (Aeson.encode record)
+        writeLazyFileAtomically path 0o600 (encodeOAuthTokenRecord record extra)
     pure $ either (Left . Text.pack . show) Right result
 
 withMcpOAuthRefreshLock :: Text -> IO a -> IO a

--- a/packages/agent-cli/src/Agent/CLI/McpStatus.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpStatus.hs
@@ -1,5 +1,6 @@
 module Agent.CLI.McpStatus
-    ( formatMcpModelNotice
+    ( formatMcpInstructionsNotice
+    , formatMcpModelNotice
     , formatMcpModelNoticeFor
     , formatMcpProgress
     , summarizeMcpStatuses
@@ -50,6 +51,18 @@ formatMcpProgress statuses =
                 <> " connecting, "
                 <> Text.pack (show ready)
                 <> " ready"
+
+-- | Server-provided usage guidance, delivered once servers settle when the
+-- system prompt was rendered before they were ready.
+formatMcpInstructionsNotice :: [(Text, Text)] -> Text
+formatMcpInstructionsNotice [] = ""
+formatMcpInstructionsNotice instructions =
+    "\n<system-reminder>MCP server instructions:\n"
+        <> Text.intercalate "\n\n"
+            [ "## " <> name <> "\n" <> body
+            | (name, body) <- instructions
+            ]
+        <> "</system-reminder>"
 
 formatMcpModelNotice :: [MCP.McpServerStatus] -> Text
 formatMcpModelNotice =

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -51,7 +51,7 @@ data Command
     deriving (Eq, Show)
 
 data McpCommand
-    = McpLogin Text
+    = McpLogin Text [Text]
     | McpLogout Text
     deriving (Eq, Show)
 
@@ -300,7 +300,14 @@ mcpParser :: Options.Parser Command
 mcpParser = Mcp <$> Options.hsubparser
     ( Options.command "login"
         (Options.info
-            (McpLogin . Text.pack <$> Options.argument Options.str (Options.metavar "URL"))
+            (McpLogin
+                <$> (Text.pack <$> Options.argument Options.str (Options.metavar "URL"))
+                <*> Options.many
+                    (Text.pack
+                        <$> Options.strOption
+                            (Options.long "scope"
+                                <> Options.metavar "SCOPE"
+                                <> Options.help "Additional OAuth scope to request (repeatable; unioned with granted scopes)")))
             (Options.progDesc "Authorize an MCP server with OAuth PKCE"))
     <> Options.command "logout"
         (Options.info
@@ -530,7 +537,7 @@ usage = unlines
     , "       agent-cli login"
     , "       agent-cli sessions [list]"
     , "       agent-cli sessions show <session-id>"
-    , "       agent-cli mcp login <url>"
+    , "       agent-cli mcp login <url> [--scope SCOPE]..."
     , "       agent-cli mcp logout <url>"
     , "       agent-cli storage <status|start|stop|migrate|doctor>"
     , ""

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -1,6 +1,8 @@
 -- | Dialect-specific system prompt closed over by the transport backend.
 module Agent.CLI.Prompt
-    ( codexEnvironmentContext
+    ( appendMcpInstructions
+    , codexEnvironmentContext
+    , mcpInstructionsGuidance
     , secretInputGuidance
     , subscriptionSubagentModelGuidance
     , sessionTempGuidance
@@ -203,6 +205,22 @@ secretInputGuidance available
             , "- Pass that path to a consumer that supports file input and delete the file promptly after use."
             , "- Never read, print, summarize, or otherwise expose the secret file contents."
             ]
+
+-- | Natural-language guidance advertised by MCP servers, appended verbatim
+-- under a heading per server.
+mcpInstructionsGuidance :: [(Text, Text)] -> Text
+mcpInstructionsGuidance [] = ""
+mcpInstructionsGuidance instructions =
+    Text.intercalate "\n\n" $
+        "MCP server instructions:"
+            : [ "## " <> name <> "\n" <> body
+              | (name, body) <- instructions
+              ]
+
+appendMcpInstructions :: [(Text, Text)] -> Text -> Text
+appendMcpInstructions [] base = base
+appendMcpInstructions instructions base =
+    base <> "\n\n" <> mcpInstructionsGuidance instructions
 
 learnedSkillGuidance :: Set Text -> Text
 learnedSkillGuidance available

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -27,7 +27,12 @@ import Agent.CLI.AgentSessions
     ( closeSessionThreadManager, newSessionThreadManager )
 import Agent.CLI.Interrupt ( catchUserInterrupt )
 import Agent.CLI.Login ( runLoginManager )
-import Agent.CLI.McpOAuth (loginMcp, logoutMcp)
+import Agent.CLI.McpOAuth
+    ( LoginOptions(..)
+    , defaultLoginOptions
+    , loginMcpWith
+    , logoutMcp
+    )
 import Agent.CLI.McpStatus
     ( formatMcpModelNotice
     , formatMcpModelNoticeFor
@@ -136,7 +141,7 @@ devMainResume resumeId = do
             color <- resolveColor stderr
             runLoginManager color
             pure DevQuit
-        Right (Mcp (McpLogin url)) -> loginMcp url >> pure DevQuit
+        Right (Mcp (McpLogin url scopes)) -> loginMcpWithScopes scopes url >> pure DevQuit
         Right (Mcp (McpLogout url)) -> logoutMcp url >> pure DevQuit
         Right ListSessions -> runListSessions >> pure DevQuit
         Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
@@ -160,7 +165,7 @@ run = do
         Right Login -> do
             color <- resolveColor stderr
             runLoginManager color
-        Right (Mcp (McpLogin url)) -> loginMcp url
+        Right (Mcp (McpLogin url scopes)) -> loginMcpWithScopes scopes url
         Right (Mcp (McpLogout url)) -> logoutMcp url
         Right ListSessions -> runListSessions
         Right (ShowSession sessionId) -> runShowSession sessionId
@@ -202,3 +207,7 @@ runAgentWithRestarts options =
                     (closeSessionThreadManager sessionThreads
                         `finally` MCP.closeMcpSupervisor mcpSupervisor))
         (pure DevQuit)
+
+loginMcpWithScopes :: [Text] -> Text -> IO ()
+loginMcpWithScopes scopes =
+    loginMcpWith defaultLoginOptions { loginAdditionalScopes = scopes }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -77,6 +77,7 @@ import System.Exit ( die )
 import System.IO ( stderr )
 
 import qualified Agent.MCP as MCP
+import Data.IORef (newIORef, readIORef)
 import qualified Data.Text as Text
 
 -- | GHCi @:cmd@ helper: on 'DevReload', reload modules and resume that exact
@@ -182,13 +183,18 @@ runAgentWithRestarts options =
         (do
             home <- getHomeDirectory
             let root = sessionsRoot home
-            mcpSupervisor <- MCP.newMcpSupervisor
+            elicitationRef <- newIORef Nothing
+            mcpSupervisor <-
+                MCP.newMcpSupervisorWith
+                    MCP.defaultMcpHostHooks
+                        { MCP.mcpHostElicit = readIORef elicitationRef }
             sessionThreads <-
                 newSessionThreadManager root
                     `onException` MCP.closeMcpSupervisor mcpSupervisor
             let processRuntime = AgentProcessRuntime
                     { processMcpSupervisor = mcpSupervisor
                     , processSessionThreads = sessionThreads
+                    , processMcpElicitation = elicitationRef
                     }
             withRestoredCurrentDirectory
                 (runAgentWithRuntime processRuntime foregroundRunMode options)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -91,7 +91,7 @@ import Agent.CLI.Runtime.Orchestration.Tools ( runAgentTools )
 import Agent.CLI.Runtime.Orchestration.Types
     ( ActiveHttpAuth(activeHttpGeneration, ActiveHttpAuth,
                      activeHttpAccountId, activeHttpProvider, activeHttpResolveLabel),
-      AgentProcessRuntime(processSessionThreads, processMcpSupervisor),
+      AgentProcessRuntime(processSessionThreads, processMcpSupervisor, processMcpElicitation),
       AgentRunMode )
 import Agent.CLI.Runtime.Persistence ()
 import Agent.CLI.Runtime.Recap ()

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -44,6 +44,7 @@ import Agent.CLI.Project ()
 import Agent.CLI.Prompt
     ( codexEnvironmentContext,
       subscriptionSubagentModelGuidance,
+      appendMcpInstructions,
       systemPromptForCatalogModel,
       systemPromptForTools )
 import Agent.CLI.PromptHooks ()
@@ -95,6 +96,7 @@ import Agent.CLI.Session.Runtime.Types
     ( SessionRequest(codexCatalogSession, SessionRequest, catalog, modelInfo,
                      connectionId, options, provider, dialect, policy, allTools,
                      suspendGhci, grokRuntime, mcpRegistrations, mcpWarnings,
+                     mcpInstructions, mcpFleet,
                      ghciEnabledRef, bashEnabledRef, toolEnv, planMode, startup,
                      learnAboutUserRequested, databaseScopes, promptRequest,
                      pendingTurn, unavailableProviders, startupUnavailable, paramsRef,
@@ -201,7 +203,7 @@ import System.OsPath ()
 import qualified Data.ByteString as BS ()
 import qualified Agent.Responses.GenericClient as GenericResponses
     ()
-import qualified Agent.MCP as MCP ()
+import qualified Agent.MCP as MCP
 import qualified Data.Map.Strict as Map ()
 import qualified Agent.OpenAI.Auth as OpenAI ()
 import qualified Agent.OpenRouter as OpenRouter ()
@@ -313,6 +315,7 @@ runAgentSession
                         ("Failed to initialize MCP tools: " <> Text.unpack err)
                 Nothing -> pure ()
         today <- utctDay <$> getCurrentTime
+        mcpInstructions <- MCP.mcpFleetInstructions mcpFleet
         -- Catalog models: per-model instructions template and, when the
         -- catalog selects code_mode_only, the exec/wait tool surface. The
         -- offline lookup never blocks startup on the network.
@@ -344,19 +347,20 @@ runAgentSession
                     , catalogEnvironmentContext =
                         codexEnvironmentContext cwd today Nothing Nothing
                     }
-            instructions = case catalogSession of
-                Just catalog ->
-                    catalog.catalogInstructionsFor
-                        (map (.appToolName) tools)
-                        (Just sessionTmp)
-                Nothing ->
-                    systemPromptForTools
-                        dialect
-                        (map (.appToolName) tools)
-                        cwd
-                        (Just sessionTmp)
-                        today
-                        (isOneShot options)
+            instructions =
+                appendMcpInstructions mcpInstructions case catalogSession of
+                    Just catalog ->
+                        catalog.catalogInstructionsFor
+                            (map (.appToolName) tools)
+                            (Just sessionTmp)
+                    Nothing ->
+                        systemPromptForTools
+                            dialect
+                            (map (.appToolName) tools)
+                            cwd
+                            (Just sessionTmp)
+                            today
+                            (isOneShot options)
             wireSchemas = case codeModeRuntime of
                 Just codeMode ->
                     schemasFromAppToolsCodeMode
@@ -535,6 +539,8 @@ runAgentSession
                                 , mcpRegistrations =
                                     mcpFleet.mcpFleetRegistrations
                                 , mcpWarnings = mcpFleet.mcpFleetWarnings
+                                , mcpInstructions
+                                , mcpFleet = Just mcpFleet
                                 , ghciEnabledRef
                                 , bashEnabledRef
                                 , toolEnv

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -49,8 +49,10 @@ import Agent.CLI.Lsp
 import Agent.CLI.ManagedTurn ( ManagedTurnRequest(..) )
 import Agent.CLI.McpManager ()
 import Agent.CLI.McpOAuthStore (mcpOAuthStorePath)
+import Agent.CLI.McpElicitation (cliMcpElicitation)
 import Agent.CLI.McpStatus
-    ( formatMcpModelNoticeFor,
+    ( formatMcpInstructionsNotice,
+      formatMcpModelNoticeFor,
       formatMcpProgress,
       summarizeMcpStatuses )
 import Agent.CLI.ModelConfig ( builtinConnectionId )
@@ -99,7 +101,7 @@ import Agent.CLI.Runtime.Orchestration.Restart ()
 import Agent.CLI.Runtime.Orchestration.Session ( runAgentSession )
 import Agent.CLI.Runtime.Orchestration.Startup
     ( reportStartupWarning )
-import Agent.CLI.Runtime.Orchestration.Types ()
+import Agent.CLI.Runtime.Orchestration.Types (AgentProcessRuntime(..))
 import Agent.CLI.Runtime.Persistence ( preparePersistence )
 import Agent.CLI.Runtime.Recap ()
 import Agent.CLI.Runtime.Repl ()
@@ -242,14 +244,16 @@ import qualified Agent.MCP as MCP
     ( acquireMcpFleetProgressive,
       acquireMcpFleetWithProgress,
       mcpFleetGrokMetaTools,
+      mcpFleetInstructions,
       mcpFleetMetaTools,
+      mcpFleetResourceTools,
       mcpFleetTools,
       releaseMcpFleetLease,
       McpFleet(mcpFleetRegistrations, mcpFleetWarnings),
       McpFleetLease(mcpLeaseFleet),
       McpServerConfig(mcpServerRequestTimeoutSeconds, McpServerConfig,
                       mcpServerName, mcpServerUrl, mcpServerCommand, mcpServerArgs, mcpServerCwd,
-                      mcpServerEnv, mcpServerStartupTimeoutSeconds) )
+                      mcpServerEnv, mcpServerStartupTimeoutSeconds, mcpServerProtocol) )
 import qualified Data.Map.Strict as Map
     ( toAscList, empty, lookup, notMember )
 import qualified Agent.OpenAI.Auth as OpenAI ()
@@ -608,6 +612,7 @@ runAgentTools
                     config.mcpStartupTimeoutSeconds
                 , MCP.mcpServerRequestTimeoutSeconds =
                     config.mcpRequestTimeoutSeconds
+                , MCP.mcpServerProtocol = config.mcpProtocol
                 }
             | (label, config) <-
                 Map.toAscList harnessConfig.configMcpServers
@@ -618,6 +623,11 @@ runAgentTools
                 harnessConfig.configMcpInitStrategy
                 (isOneShot options)
     mcpStatusPhaseRef <- newIORef (Nothing :: Maybe Bool)
+    mcpFleetRef <- newIORef (Nothing :: Maybe MCP.McpFleet)
+    writeIORef processRuntime.processMcpElicitation
+        (if isOneShot options || not isTty
+            then Nothing
+            else Just (cliMcpElicitation escPaused uiRuntimeRef))
     let reportProgressiveMcp statuses = do
             finished <- readIORef startup.startupFinished
             unless finished do
@@ -634,9 +644,14 @@ runAgentTools
             settled <-
                 atomicModifyIORef' mcpStatusPhaseRef \previous ->
                     (Just isConnecting, previous == Just True && not isConnecting)
-            when (settled && not (null statuses)) $
+            when (settled && not (null statuses)) do
+                instructions <-
+                    readIORef mcpFleetRef
+                        >>= maybe (pure []) MCP.mcpFleetInstructions
                 enqueuePendingInput pendingNotices
-                    (UserMessage (formatMcpModelNoticeFor dialectId statuses))
+                    (UserMessage
+                        (formatMcpModelNoticeFor dialectId statuses
+                            <> formatMcpInstructionsNotice instructions))
     mcpLease <-
         try @_ @SomeException
             (if progressiveMcp
@@ -663,6 +678,7 @@ runAgentTools
                     ("Failed to initialize MCP tools: " <> show exception)
             Right lease -> pure lease
     let mcpFleet = mcpLease.mcpLeaseFleet
+    writeIORef mcpFleetRef (Just mcpFleet)
     mapM_ (reportStartupWarning startup) mcpFleet.mcpFleetWarnings
     setStartupNotice startup.startupFullscreen "Loading built-in tools…"
     coding <-
@@ -792,11 +808,13 @@ runAgentTools
         mcpTools =
             if null mcpServerConfigs
                 then []
-                else if dialectId == GrokBuildDialect
-                    then MCP.mcpFleetGrokMetaTools mcpFleet
-                    else if progressiveMcp
-                        then MCP.mcpFleetMetaTools mcpFleet
-                        else MCP.mcpFleetTools mcpFleet
+                else
+                    (if dialectId == GrokBuildDialect
+                        then MCP.mcpFleetGrokMetaTools mcpFleet
+                        else if progressiveMcp
+                            then MCP.mcpFleetMetaTools mcpFleet
+                            else MCP.mcpFleetTools mcpFleet)
+                        <> MCP.mcpFleetResourceTools mcpFleet
         databaseToolsEnv =
             databaseToolsEnvForStore
                 startup.startupDatabaseStore

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -16,6 +16,7 @@ import System.IO ( Handle, stderr, stdout )
 import System.OsPath ( OsPath )
 
 import qualified Agent.MCP as MCP
+import Data.IORef (IORef)
 
 data ActiveHttpAuth = ActiveHttpAuth
     { activeHttpGeneration :: !Int
@@ -30,6 +31,10 @@ data AccountSwitchRequest
 data AgentProcessRuntime = AgentProcessRuntime
     { processMcpSupervisor :: !MCP.McpSupervisor
     , processSessionThreads :: !SessionThreadManager
+    , processMcpElicitation
+        :: !(IORef (Maybe (MCP.McpElicitRequest -> IO MCP.McpElicitResult)))
+    -- ^ Interactive elicitation UI installed by the active session, shared by
+    -- every MCP fleet the supervisor starts.
     }
 
 data AgentRunMode = AgentRunMode

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -22,7 +22,7 @@ import Agent.CLI.Command
                  ReplExpandedPrompt, ReplInvokeSkill, ReplSkills, ReplShowShell,
                  ReplSetShell, ReplPaste, ReplShowAttachments, ReplClearAttachments,
                  ReplRemoveAttachment,
-                 ReplShowAgentLimit, ReplSetAgentLimit, ReplAgents, ReplMcp,
+                 ReplShowAgentLimit, ReplSetAgentLimit, ReplAgents, ReplMcp, ReplMcpPrompt,
                  ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
                  ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopyLast,
                  ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
@@ -218,7 +218,7 @@ import System.OsPath ()
 import System.Posix.Files ()
 import qualified Agent.Responses.GenericClient as GenericResponses
     ()
-import qualified Agent.MCP as MCP ()
+import qualified Agent.MCP as MCP
 import qualified Data.Map.Strict as Map ()
 import qualified Agent.OpenAI.Auth as OpenAI ()
 import qualified Agent.OpenRouter as OpenRouter ()
@@ -503,6 +503,22 @@ handleReplLine
                             then requestMcpRestart
                                 fullscreen persist
                             else continue
+                    ReplMcpPrompt server name arguments -> do
+                        outcome <- case env.sessionMcpFleet of
+                            Nothing -> pure (Left "no MCP servers are configured")
+                            Just fleet ->
+                                MCP.mcpFleetGetPrompt fleet server name arguments
+                        case outcome of
+                            Left err -> do
+                                displayError err $
+                                    Text.hPutStrLn stderr (roleError color err)
+                                continue
+                            Right result ->
+                                submitExpandedTurn
+                                    continue
+                                    color
+                                    ("/mcp prompt " <> server <> " " <> name)
+                                    (MCP.renderMcpPromptResult result)
                     action@ReplGoalStatus -> handleWorkflowAction env submitExpandedTurn color continue action
                     action@ReplGoalPause -> handleWorkflowAction env submitExpandedTurn color continue action
                     action@ReplGoalResume -> handleWorkflowAction env submitExpandedTurn color continue action

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -745,18 +745,19 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 today <- utctDay <$> getCurrentTime
                 let enabledTools = activeShellTools ghciEnabled bashEnabled
                     enabledNames = map (.appToolName) enabledTools
-                    instructionText = case codexCatalogSession of
-                        Just catalog ->
-                            catalog.catalogInstructionsFor
-                                enabledNames sessionTmp
-                        Nothing ->
-                            systemPromptForTools
-                                dialect
-                                enabledNames
-                                cwd
-                                sessionTmp
-                                today
-                                (isOneShot options)
+                    instructionText =
+                        appendMcpInstructions mcpInstructions case codexCatalogSession of
+                            Just catalog ->
+                                catalog.catalogInstructionsFor
+                                    enabledNames sessionTmp
+                            Nothing ->
+                                systemPromptForTools
+                                    dialect
+                                    enabledNames
+                                    cwd
+                                    sessionTmp
+                                    today
+                                    (isOneShot options)
                     toolSchemas = schemasFromAppTools dialect enabledTools
                 modifyIORef' paramsRef
                     (setRequestInstructionsAndTools
@@ -894,6 +895,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionHome = home
             , sessionMcpRegistrations = mcpRegistrations
             , sessionMcpWarnings = mcpWarnings
+            , sessionMcpFleet = mcpFleet
             , sessionSetTempDir = setSessionTempDir
             , sessionTokenProvider = tokenProvider
             , sessionOpenAiPool = openAiPool

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -109,6 +109,8 @@ data SessionRequest = SessionRequest
     , grokRuntime :: !(Maybe GrokRuntimeControl)
     , mcpRegistrations :: ![MCP.McpToolRegistration]
     , mcpWarnings :: ![Text]
+    , mcpInstructions :: ![(Text, Text)]
+    , mcpFleet :: !(Maybe MCP.McpFleet)
     , ghciEnabledRef :: !(IORef Bool)
     , bashEnabledRef :: !(IORef Bool)
     , toolEnv :: !ToolEnv

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -24,7 +24,7 @@ import Agent.Dialect (Dialect)
 import Agent.Error (ApiError)
 import Agent.GrokBuild.Dialect.Runtime (GrokRuntimeControl)
 import Agent.Loop (LoopConfig, TokenUsage)
-import Agent.MCP (McpToolRegistration)
+import Agent.MCP (McpFleet, McpToolRegistration)
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Responses.Types (ResponseCreateParams)
 import Agent.OpenAI.Models.Types (ModelInfo)
@@ -68,6 +68,7 @@ data SessionEnv = SessionEnv
     , sessionHome :: !OsPath
     , sessionMcpRegistrations :: ![McpToolRegistration]
     , sessionMcpWarnings :: ![Text]
+    , sessionMcpFleet :: !(Maybe McpFleet)
     , sessionSetTempDir :: !(OsPath -> IO ())
     , sessionTokenProvider :: !(Maybe TokenProvider)
     , sessionOpenAiPool :: !(Maybe OpenAI.Pool)

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -229,7 +229,7 @@ spec = do
             parseReplLine "/MCP" `shouldBe` ReplMcp
             parseReplLine "/mcps" `shouldBe` ReplMcp
             parseReplLine "/mcp now"
-                `shouldBe` ReplCommandError "usage: /mcp"
+                `shouldBe` ReplCommandError "usage: /mcp [prompt <server> <prompt> [key=value ...]]"
 
         it "lists slash commands with /help" do
             parseReplLine "/help" `shouldBe` ReplHelp Nothing
@@ -295,6 +295,7 @@ spec = do
                     [ "help"
                     , "model"
                     , "effort"
+                    , "fast"
                     , "plan"
                     , "btw"
                     , "recap"

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -66,6 +66,7 @@ spec = describe "Agent.CLI.Config" do
                             , mcpEnv = Map.fromList [("TOKEN", "secret")]
                             , mcpStartupTimeoutSeconds = 12
                             , mcpRequestTimeoutSeconds = 34
+                            , mcpOAuth = Nothing
                             }
                     Map.lookup "zeta" config.configMcpServers
                         `shouldBe` Just McpServerConfig
@@ -77,6 +78,7 @@ spec = describe "Agent.CLI.Config" do
                             , mcpEnv = Map.empty
                             , mcpStartupTimeoutSeconds = 30
                             , mcpRequestTimeoutSeconds = 60
+                            , mcpOAuth = Nothing
                             }
 
     it "loads remote MCP servers by URL" $
@@ -88,6 +90,61 @@ spec = describe "Agent.CLI.Config" do
                 `shouldSatisfy` \case
                     Right (Just server) -> server.mcpUrl == Just "https://example.test/mcp"
                     _ -> False
+
+    it "loads the optional per-server oauth object" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home
+                "{\"mcpServers\":{\"remote\":{\"url\":\"https://example.test/mcp\",\"oauth\":{\"clientId\":\"cid\",\"clientSecret\":\"top-secret\",\"clientIdMetadataUrl\":\"https://app.example/client.json\",\"scopes\":[\"files:read\"]}}}}"
+            result <- loadHarnessConfig home
+            case result of
+                Left err -> expectationFailure (Text.unpack err)
+                Right config -> do
+                    let oauth = Map.lookup "remote" config.configMcpServers >>= (.mcpOAuth)
+                    oauth `shouldBe` Just McpOAuthConfig
+                        { mcpOAuthClientId = Just "cid"
+                        , mcpOAuthClientSecret = Just "top-secret"
+                        , mcpOAuthClientIdMetadataUrl = Just "https://app.example/client.json"
+                        , mcpOAuthScopes = ["files:read"]
+                        }
+                    show oauth `shouldSatisfy` (not . Text.isInfixOf "top-secret" . Text.pack)
+                    show config `shouldSatisfy` (not . Text.isInfixOf "top-secret" . Text.pack)
+                    saveHarnessConfig home config `shouldReturn` Right ()
+                    loadHarnessConfig home `shouldReturn` Right config
+
+    it "treats a missing oauth object and partial oauth keys as optional" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home
+                "{\"mcpServers\":{\"remote\":{\"url\":\"https://example.test/mcp\",\"oauth\":{\"scopes\":[\"a\",\"b\"]}}}}"
+            result <- loadHarnessConfig home
+            fmap (\config -> Map.lookup "remote" config.configMcpServers >>= (.mcpOAuth)) result
+                `shouldBe` Right (Just (McpOAuthConfig Nothing Nothing Nothing ["a", "b"]))
+
+    it "validates the oauth object" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home
+                "{\"mcpServers\":{\"remote\":{\"url\":\"https://example.test/mcp\",\"oauth\":{\"clientSecret\":\"s\"}}}}"
+            loadHarnessConfig home
+                `shouldReturn` Left "MCP server 'remote' oauth.clientSecret requires oauth.clientId"
+
+            writeConfig home
+                "{\"mcpServers\":{\"remote\":{\"url\":\"https://example.test/mcp\",\"oauth\":{\"clientIdMetadataUrl\":\"http://app.example/client.json\"}}}}"
+            loadHarnessConfig home
+                `shouldReturn` Left "MCP server 'remote' oauth.clientIdMetadataUrl must be an https URL with a path"
+
+            writeConfig home
+                "{\"mcpServers\":{\"remote\":{\"url\":\"https://example.test/mcp\",\"oauth\":{\"clientIdMetadataUrl\":\"https://app.example\"}}}}"
+            loadHarnessConfig home
+                `shouldReturn` Left "MCP server 'remote' oauth.clientIdMetadataUrl must be an https URL with a path"
+
+            writeConfig home
+                "{\"mcpServers\":{\"local\":{\"command\":\"srv\",\"oauth\":{\"clientId\":\"c\"}}}}"
+            loadHarnessConfig home
+                `shouldReturn` Left "MCP server 'local' oauth requires url"
+
+            writeConfig home
+                "{\"mcpServers\":{\"remote\":{\"url\":\"https://example.test/mcp\",\"oauth\":{\"clientId\":\" \"}}}}"
+            loadHarnessConfig home
+                `shouldReturn` Left "MCP server 'remote' oauth.clientId must not be empty"
 
     it "loads the MCP initialization strategy" $
         withTempDir "agent-config-" \home -> do
@@ -209,6 +266,7 @@ spec = describe "Agent.CLI.Config" do
                     , mcpEnv = Map.fromList [("TOKEN", "secret")]
                     , mcpStartupTimeoutSeconds = 90
                     , mcpRequestTimeoutSeconds = 45
+                    , mcpOAuth = Nothing
                     }
                 config = defaultHarnessConfig
                     { configMcpServers = Map.singleton "seo-mcp" server
@@ -232,6 +290,7 @@ spec = describe "Agent.CLI.Config" do
                             , mcpEnv = Map.empty
                             , mcpStartupTimeoutSeconds = 30
                             , mcpRequestTimeoutSeconds = 60
+                            , mcpOAuth = Nothing
                             }
                     }
             saveHarnessConfig home broken

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.ConfigSpec (spec) where
 
 import Agent.CLI.Config
 import Control.Exception.Safe (bracket)
+import Agent.MCP (McpProtocolPreference(..))
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust)
@@ -67,6 +68,7 @@ spec = describe "Agent.CLI.Config" do
                             , mcpStartupTimeoutSeconds = 12
                             , mcpRequestTimeoutSeconds = 34
                             , mcpOAuth = Nothing
+                            , mcpProtocol = McpProtocolAuto
                             }
                     Map.lookup "zeta" config.configMcpServers
                         `shouldBe` Just McpServerConfig
@@ -79,6 +81,7 @@ spec = describe "Agent.CLI.Config" do
                             , mcpStartupTimeoutSeconds = 30
                             , mcpRequestTimeoutSeconds = 60
                             , mcpOAuth = Nothing
+                            , mcpProtocol = McpProtocolAuto
                             }
 
     it "loads remote MCP servers by URL" $
@@ -267,6 +270,7 @@ spec = describe "Agent.CLI.Config" do
                     , mcpStartupTimeoutSeconds = 90
                     , mcpRequestTimeoutSeconds = 45
                     , mcpOAuth = Nothing
+                    , mcpProtocol = McpProtocolAuto
                     }
                 config = defaultHarnessConfig
                     { configMcpServers = Map.singleton "seo-mcp" server
@@ -291,6 +295,7 @@ spec = describe "Agent.CLI.Config" do
                             , mcpStartupTimeoutSeconds = 30
                             , mcpRequestTimeoutSeconds = 60
                             , mcpOAuth = Nothing
+                            , mcpProtocol = McpProtocolAuto
                             }
                     }
             saveHarnessConfig home broken

--- a/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.McpManagerSpec (spec) where
 import Agent.CLI.Config
 import Agent.CLI.McpManager
 import Agent.CLI.Picker (PickerKey(..))
+import Agent.MCP (McpProtocolPreference(..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -115,4 +116,5 @@ server enabled command = McpServerConfig
     , mcpStartupTimeoutSeconds = 30
     , mcpRequestTimeoutSeconds = 60
     , mcpOAuth = Nothing
+    , mcpProtocol = McpProtocolAuto
     }

--- a/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
@@ -114,4 +114,5 @@ server enabled command = McpServerConfig
     , mcpEnv = Map.empty
     , mcpStartupTimeoutSeconds = 30
     , mcpRequestTimeoutSeconds = 60
+    , mcpOAuth = Nothing
     }

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -204,7 +204,8 @@ spec = describe "requestParams" do
         restored.input `shouldBe` Just (ResponseInputItems [pending])
 
     it "clears Fast mode when switching models" do
-        let params =
+        let params :: ResponseCreateParams
+            params =
                 (requestParams OpenAIProvider "gpt-generic"
                     "instructions" [] "high")
                     { serviceTier = Just "priority" }

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -50,6 +50,10 @@ library
                     , Agent.ReasoningEffort
                     , Agent.Loop
                     , Agent.MCP
+                    , Agent.MCP.Client
+                    , Agent.MCP.Fleet
+                    , Agent.MCP.Supervisor
+                    , Agent.MCP.Types
                     , Agent.MCP.OAuth
                     , Agent.JsonText
                     , Agent.OsPath
@@ -93,10 +97,6 @@ library
                     , Agent.Tools.Types
                     , Agent.Transport.WebSocket
     other-modules:    Agent.Loop.Internal
-                    , Agent.MCP.Client
-                    , Agent.MCP.Fleet
-                    , Agent.MCP.Supervisor
-                    , Agent.MCP.Types
                     , Agent.Subagents.Registry.Internal.Core
                     , Agent.Subagents.Registry.Internal.Operations
                     , Agent.Subagents.Registry.Internal.Types

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -51,6 +51,7 @@ library
                     , Agent.Loop
                     , Agent.MCP
                     , Agent.MCP.Client
+                    , Agent.MCP.Elicitation
                     , Agent.MCP.Fleet
                     , Agent.MCP.Supervisor
                     , Agent.MCP.Types

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -222,6 +222,7 @@ test-suite agent-core-test
                     , Agent.Http.HeaderSpec
                     , Agent.LoopSpec
                     , Agent.MCPSpec
+                    , Agent.MCP.OAuthSpec
                     , Agent.OsPathSpec
                     , Agent.JsonTextSpec
                     , Agent.ProjectInstructionsSpec

--- a/packages/agent-core/benchmark/McpStartup.hs
+++ b/packages/agent-core/benchmark/McpStartup.hs
@@ -5,6 +5,7 @@ import Agent.MCP
     , McpFleetLease(..)
     , McpInitState(..)
     , McpServerConfig(..)
+    , McpProtocolPreference(..)
     , McpServerStatus(..)
     , acquireMcpFleet
     , closeMcpFleet
@@ -185,6 +186,7 @@ fakeConfig script delayMillis index = McpServerConfig
     , mcpServerEnv = []
     , mcpServerStartupTimeoutSeconds = 30
     , mcpServerRequestTimeoutSeconds = 30
+    , mcpServerProtocol = McpProtocolAuto
     }
 
 withFakeServer :: (FilePath -> IO a) -> IO a

--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -1,11 +1,24 @@
--- | Local Model Context Protocol clients over the stdio transport.
+-- | Model Context Protocol clients over stdio and Streamable HTTP.
 --
--- Each configured server is started once, initialized, and queried for its
--- read-only tools and (when negotiated) Skills-over-MCP metadata. The
--- returned handlers share the retained client; 'closeMcpFleet' must run
--- after all loops and subagents using those handlers have stopped.
+-- Each configured server is started once, its protocol era negotiated
+-- (@server/discover@ for revision 2026-07-28, the @initialize@ handshake for
+-- earlier revisions), and queried for its tools and (when negotiated)
+-- Skills-over-MCP metadata. The returned handlers share the retained client;
+-- 'closeMcpFleet' must run after all loops and subagents using those handlers
+-- have stopped.
 module Agent.MCP
     ( McpServerConfig(..)
+    , McpProtocolPreference(..)
+    , McpProtocolEra(..)
+    , McpServerInfo(..)
+    , McpServerCapabilities(..)
+    , McpListCapability(..)
+    , McpResourcesCapability(..)
+    , McpHostHooks(..)
+    , defaultMcpHostHooks
+    , McpElicitRequest(..)
+    , McpElicitMode(..)
+    , McpElicitResult(..)
     , McpInitState(..)
     , McpServerStatus(..)
     , McpToolRegistration(..)
@@ -15,10 +28,22 @@ module Agent.MCP
     , McpSkillResources(..)
     , McpSkillResource(..)
     , McpResourceContent(..)
+    , McpResource(..)
+    , McpResourceTemplate(..)
+    , McpPrompt(..)
+    , McpPromptArgument(..)
+    , McpPromptMessage(..)
+    , McpPromptResult(..)
+    , McpCompletion(..)
+    , McpCompletionRef(..)
+    , McpProgress(..)
+    , McpError(..)
+    , renderMcpError
     , McpFleet(..)
     , McpSupervisor
     , McpFleetLease(..)
     , newMcpSupervisor
+    , newMcpSupervisorWith
     , acquireMcpFleet
     , acquireMcpFleetWithProgress
     , acquireMcpFleetProgressive
@@ -26,32 +51,60 @@ module Agent.MCP
     , closeMcpSupervisor
     , startMcpFleet
     , startMcpFleetWithProgress
+    , startMcpFleetWithProgressHooks
     , startMcpFleetProgressive
+    , startMcpFleetProgressiveHooks
     , closeMcpFleet
     , mcpFleetTools
     , mcpFleetMetaTools
     , mcpFleetGrokMetaTools
+    , mcpFleetResourceTools
     , mcpFleetStatuses
+    , mcpFleetServerInfos
+    , mcpFleetInstructions
     , mcpFleetSkillRegistrations
     , mcpFleetGetSkill
     , mcpFleetReadResource
+    , mcpFleetListResources
+    , mcpFleetListResourceTemplates
+    , mcpFleetListPrompts
+    , mcpFleetGetPrompt
+    , mcpFleetComplete
     , normalizeMcpToolResult
     , decodeHttpMcpResponse
+    , modernProtocolVersion
+    , supportedLegacyVersions
     ) where
 
-import Agent.MCP.Client (decodeHttpMcpResponse, normalizeMcpToolResult)
+import Agent.MCP.Client
+    ( McpCompletionRef(..)
+    , decodeHttpMcpResponse
+    , modernProtocolVersion
+    , normalizeMcpToolResult
+    , supportedLegacyVersions
+    )
 import Agent.MCP.Fleet
     ( closeMcpFleet
-    , mcpFleetGrokMetaTools
-    , mcpFleetMetaTools
-    , mcpFleetStatuses
-    , mcpFleetSkillRegistrations
+    , mcpFleetComplete
+    , mcpFleetGetPrompt
     , mcpFleetGetSkill
+    , mcpFleetGrokMetaTools
+    , mcpFleetInstructions
+    , mcpFleetListPrompts
+    , mcpFleetListResourceTemplates
+    , mcpFleetListResources
+    , mcpFleetMetaTools
     , mcpFleetReadResource
+    , mcpFleetResourceTools
+    , mcpFleetServerInfos
+    , mcpFleetSkillRegistrations
+    , mcpFleetStatuses
     , mcpFleetTools
     , startMcpFleet
     , startMcpFleetProgressive
+    , startMcpFleetProgressiveHooks
     , startMcpFleetWithProgress
+    , startMcpFleetWithProgressHooks
     )
 import Agent.MCP.Supervisor
     ( acquireMcpFleet
@@ -59,20 +112,42 @@ import Agent.MCP.Supervisor
     , acquireMcpFleetWithProgress
     , closeMcpSupervisor
     , newMcpSupervisor
+    , newMcpSupervisorWith
     , releaseMcpFleetLease
     )
 import Agent.MCP.Types
-    ( McpFleet(..)
+    ( McpCompletion(..)
+    , McpElicitMode(..)
+    , McpElicitRequest(..)
+    , McpElicitResult(..)
+    , McpError(..)
+    , McpFleet(..)
     , McpFleetLease(..)
+    , McpHostHooks(..)
     , McpInitState(..)
+    , McpListCapability(..)
+    , McpProgress(..)
+    , McpPrompt(..)
+    , McpPromptArgument(..)
+    , McpPromptMessage(..)
+    , McpPromptResult(..)
+    , McpProtocolEra(..)
+    , McpProtocolPreference(..)
+    , McpResource(..)
+    , McpResourceContent(..)
+    , McpResourceTemplate(..)
+    , McpResourcesCapability(..)
+    , McpServerCapabilities(..)
     , McpServerConfig(..)
+    , McpServerInfo(..)
     , McpServerStatus(..)
+    , McpSkillEntry(..)
+    , McpSkillRegistration(..)
+    , McpSkillResource(..)
+    , McpSkillResources(..)
+    , McpSkillsCapability(..)
     , McpSupervisor
     , McpToolRegistration(..)
-    , McpSkillsCapability(..)
-    , McpSkillRegistration(..)
-    , McpSkillEntry(..)
-    , McpSkillResources(..)
-    , McpSkillResource(..)
-    , McpResourceContent(..)
+    , defaultMcpHostHooks
+    , renderMcpError
     )

--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -71,6 +71,7 @@ module Agent.MCP
     , mcpFleetGetPrompt
     , mcpFleetComplete
     , normalizeMcpToolResult
+    , renderMcpPromptResult
     , decodeHttpMcpResponse
     , modernProtocolVersion
     , supportedLegacyVersions
@@ -81,6 +82,7 @@ import Agent.MCP.Client
     , decodeHttpMcpResponse
     , modernProtocolVersion
     , normalizeMcpToolResult
+    , renderMcpPromptResult
     , supportedLegacyVersions
     )
 import Agent.MCP.Fleet

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -525,9 +525,10 @@ selectFromVersions client supported
 -- | The @initialize@ handshake of protocol revisions up to @2025-11-25@.
 legacyInitialize :: McpClient -> Text -> IO ()
 legacyInitialize client requestedVersion = do
+    elicitEnabled <- isJust <$> client.clientHooks.mcpHostElicit
     let parameters =
             "protocolVersion" .= requestedVersion
-                <> "capabilities" .= legacyClientCapabilities client.clientHooks
+                <> "capabilities" .= legacyClientCapabilities elicitEnabled
                 <> "clientInfo" .= clientInfoValue client.clientHooks
     result <-
         requestMcpFull client
@@ -579,10 +580,10 @@ clientInfoValue hooks = object
     ]
 
 -- | Capabilities declared to modern servers on every request.
-clientCapabilitiesValue :: McpHostHooks -> Value
-clientCapabilitiesValue hooks = object $
+clientCapabilitiesValue :: Bool -> Value
+clientCapabilitiesValue elicitEnabled = object $
     [ "elicitation" .= object ["form" .= object [], "url" .= object []]
-    | isJust hooks.mcpHostElicit
+    | elicitEnabled
     ]
     <> [ "extensions" .= object
             [ "io.modelcontextprotocol/tasks" .= object []
@@ -591,10 +592,10 @@ clientCapabilitiesValue hooks = object $
        ]
 
 -- | Capabilities declared to legacy servers during @initialize@.
-legacyClientCapabilities :: McpHostHooks -> Value
-legacyClientCapabilities hooks = object $
+legacyClientCapabilities :: Bool -> Value
+legacyClientCapabilities elicitEnabled = object $
     [ "elicitation" .= object ["form" .= object [], "url" .= object []]
-    | isJust hooks.mcpHostElicit
+    | elicitEnabled
     ]
 
 startupFailure :: McpClient -> Text -> IO a
@@ -924,6 +925,27 @@ normalizeMcpToolResult result =
                     | otherwise = compactRawJson result
             in if isError then Left output else Right output
 
+-- | Flatten a resolved prompt into one user turn. Assistant-authored
+-- messages are labelled so the model can tell the two roles apart.
+renderMcpPromptResult :: McpPromptResult -> Text
+renderMcpPromptResult result =
+    Text.intercalate "\n\n" $
+        filter (not . Text.null) $
+            maybe [] (\description -> ["# " <> description]) result.promptResultDescription
+                <> map renderMessage result.promptResultMessages
+  where
+    renderMessage :: McpPromptMessage -> Text
+    renderMessage message =
+        let blocks = projectRawOr [] blocksDecoder message.promptMessageContent
+            body = Text.intercalate "\n" (mapMaybe renderContentBlock blocks)
+        in if message.promptMessageRole == "assistant"
+            then "[assistant]\n" <> body
+            else body
+    blocksDecoder =
+        Json.getType >>= \case
+            Json.VArray -> Json.list contentBlockDecoder
+            _ -> pure <$> contentBlockDecoder
+
 data McpContentBlock
     = McpTextBlock !Text
     | McpImageBlock !(Maybe Text) !Int
@@ -1188,7 +1210,11 @@ requestMcpFull client request = do
             pending <- newPendingRequest request
             atomically $
                 modifyTVar' client.clientPending (IntMap.insert requestId pending)
-            let meta = metaSeries client era request requestId
+            elicitEnabled <-
+                if request.requestMeta && era == Just McpEraModern
+                    then isJust <$> client.clientHooks.mcpHostElicit
+                    else pure False
+            let meta = metaSeries client era request requestId elicitEnabled
                 message = requestEnvelope (Just requestId) request.requestMethod
                     (request.requestParams <> meta)
             case client.clientConfig.mcpServerUrl of
@@ -1227,8 +1253,8 @@ requestEnvelope requestId method parameters =
 
 -- | Per-request metadata. Modern servers require the protocol version and
 -- client capabilities on every request; every era accepts a progress token.
-metaSeries :: McpClient -> Maybe McpProtocolEra -> McpRequest -> Int -> Series
-metaSeries client era request requestId
+metaSeries :: McpClient -> Maybe McpProtocolEra -> McpRequest -> Int -> Bool -> Series
+metaSeries client era request requestId elicitEnabled
     | not request.requestMeta = mempty
     | otherwise = "_meta" .= object (progress <> modern)
   where
@@ -1238,7 +1264,7 @@ metaSeries client era request requestId
             [ "io.modelcontextprotocol/protocolVersion" .= modernProtocolVersion
             , "io.modelcontextprotocol/clientInfo" .= clientInfoValue client.clientHooks
             , "io.modelcontextprotocol/clientCapabilities"
-                .= clientCapabilitiesValue client.clientHooks
+                .= clientCapabilitiesValue elicitEnabled
             ]
         _ -> []
 
@@ -1387,7 +1413,7 @@ fulfilInputRequests client = go []
 -- cancel; a crashing host hook also cancels rather than failing the call.
 runElicitation :: McpClient -> Maybe RawJson -> IO McpElicitResult
 runElicitation client params =
-    case client.clientHooks.mcpHostElicit of
+    client.clientHooks.mcpHostElicit >>= \case
         Nothing -> pure McpElicitCancel
         Just hook ->
             case params >>= decodeElicitRequest client.clientConfig.mcpServerName of
@@ -1945,16 +1971,25 @@ decodeErrorBody bytes =
 authorizationError :: Int -> [Header] -> McpError
 authorizationError status headers =
     McpHttpStatus status $
-        case lookup "WWW-Authenticate" headers of
-            Just challenge ->
-                (if status == 401
-                    then "MCP server requires OAuth authorization"
-                    else "MCP server denied the request (insufficient scope?)")
-                    <> "; challenge: "
-                    <> TextEncoding.decodeUtf8With lenientDecode challenge
+        case lookup "WWW-Authenticate" headers >>= OAuth.parseWwwAuthenticate of
+            Just challenge
+                | status == 403 || challenge.challengeError == Just "insufficient_scope" ->
+                    "MCP server requires additional authorization"
+                        <> scopeHint challenge
+                        <> "; run `agent mcp login <url> --scope <scope>` to re-authorize"
+                | otherwise ->
+                    "MCP server requires OAuth authorization"
+                        <> scopeHint challenge
+                        <> "; run `agent mcp login <url>`"
             Nothing
-                | status == 401 -> "MCP server requires OAuth authorization; run `/mcp login <url>` or configure MCP OAuth credentials"
+                | status == 401 -> "MCP server requires OAuth authorization; run `agent mcp login <url>` or configure MCP OAuth credentials"
                 | otherwise -> "MCP server denied the request"
+  where
+    scopeHint challenge =
+        (case OAuth.challengeScopes challenge of
+            [] -> ""
+            scopes -> " (scope: " <> Text.unwords scopes <> ")")
+            <> maybe "" (\description -> ": " <> description) challenge.challengeErrorDescription
 
 -- | Consume a Server-Sent Events response stream, routing every event
 -- through 'handleInbound' until the awaited response arrives or the stream

--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -1,5 +1,7 @@
+-- | One MCP client connection: transport, protocol negotiation, request
+-- routing, and the request/response patterns of the specification (multi
+-- round-trip input, tasks, subscriptions).
 module Agent.MCP.Client where
-
 
 import Agent.Json
     ( RawJson
@@ -9,6 +11,8 @@ import Agent.Json
     , rawJsonFromEncoding
     )
 import qualified Agent.Json.Decode as Json
+import Agent.MCP.Types
+import qualified Agent.MCP.OAuth as OAuth
 import Agent.Tools.IO (terminateProcessGroup)
 import Agent.Tools.Types
     ( AppTool(..)
@@ -16,25 +20,20 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , ToolSchema(..)
     )
-import Agent.ToolDispatch (typedTool)
-import Agent.Concurrent (forConcurrentlyBounded_)
+import Agent.ToolDispatch (typedStreamingTool)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
     , cancel
-    , mapConcurrently
+    , poll
     , waitCatch
-    )
-import Control.Concurrent.QSem
-    ( newQSem
-    , signalQSem
-    , waitQSem
     )
 import Control.Concurrent.MVar
     ( MVar
-    , modifyMVar
     , modifyMVar_
     , newMVar
+    , readMVar
     , withMVar
     )
 import Control.Concurrent.STM
@@ -42,6 +41,7 @@ import Control.Concurrent.STM
     , TMVar
     , TVar
     , atomically
+    , isEmptyTMVar
     , modifyTVar'
     , newEmptyTMVar
     , newEmptyTMVarIO
@@ -51,39 +51,36 @@ import Control.Concurrent.STM
     , readTVarIO
     , takeTMVar
     , tryPutTMVar
+    , tryReadTMVar
     , writeTVar
     )
 import Control.Exception.Safe
     ( SomeException
     , displayException
-    , bracket_
     , finally
     , mask
+    , mask_
     , onException
-    , throwIO
     , tryAny
     )
 import Control.Monad (forM, forM_, unless, void, when)
 import Data.Aeson
-    ( ToJSON(toJSON)
-    , Value
+    ( Series
+    , ToJSON(toJSON)
+    , Value(..)
     , object
-    , withObject
-    , (.:)
-    , (.:?)
-    , (.!=)
     , (.=)
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encoding as AesonEncoding
 import qualified Data.Aeson.Encoding.Internal as AesonEncodingInternal
+import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Aeson.Types as AesonTypes
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
-import Data.Bifunctor (first)
-import Data.Char (isAlphaNum)
+import Data.Char (isAlphaNum, isAscii, ord)
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
@@ -92,21 +89,32 @@ import Data.IORef
     , writeIORef
     )
 import qualified Data.IntMap.Strict as IntMap
+import Data.List (find, foldl')
 import qualified Data.Map.Strict as Map
-import Data.List (find, sortOn)
-import Data.Maybe (catMaybes, isJust, mapMaybe)
-import Data.Ord (Down(..))
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, mapMaybe)
 import Data.Scientific (floatingOrInteger)
-import qualified Data.Set as Set
+import Data.String (fromString)
 import Data.Text (Text)
-import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
-import qualified Data.Vector as Vector
 import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
+import Network.HTTP.Client
+    ( Manager
+    , RequestBody(..)
+    , brRead
+    , parseRequest
+    , responseBody
+    , responseHeaders
+    , responseStatus
+    , withResponse
+    )
+import qualified Network.HTTP.Client as HC
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Types (Header, statusCode)
 import System.Environment (getEnvironment)
-import System.Directory (getCurrentDirectory)
 import System.IO
     ( BufferMode(..)
     , Handle
@@ -115,6 +123,7 @@ import System.IO
     , hSetBinaryMode
     , hSetBuffering
     )
+import System.IO.Unsafe (unsafePerformIO)
 import System.Posix.Types (ProcessGroupID)
 import System.Process
     ( CreateProcess(..)
@@ -125,16 +134,47 @@ import System.Process
     , proc
     )
 import System.Timeout (timeout)
-import System.IO.Unsafe (unsafePerformIO)
-import Agent.MCP.Types
-import qualified Agent.MCP.OAuth as OAuth
-import Network.HTTP.Client (Manager, RequestBody(..), httpLbs, parseRequest, responseBody, responseHeaders, responseStatus)
-import qualified Network.HTTP.Client as HC
-import Network.HTTP.Client.TLS (newTlsManager)
-import Network.HTTP.Types (statusCode)
+
+-- * Protocol constants
+
+-- | The modern protocol revision this client implements.
+modernProtocolVersion :: Text
+modernProtocolVersion = "2026-07-28"
+
+-- | Legacy revisions that this client can drive through the @initialize@
+-- handshake, most preferred first.
+supportedLegacyVersions :: [Text]
+supportedLegacyVersions = ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]
+
+preferredLegacyVersion :: Text
+preferredLegacyVersion = "2025-11-25"
+
+-- | How long the @server/discover@ era probe waits before treating a silent
+-- server as legacy.
+discoverProbeTimeoutSeconds :: Int
+discoverProbeTimeoutSeconds = 5
+
+-- | Upper bound on input rounds for one multi round-trip request.
+maxInputRounds :: Int
+maxInputRounds = 8
+
+-- | A request whose server keeps reporting progress may run this many times
+-- longer than the configured request timeout.
+hardTimeoutMultiplier :: Int
+hardTimeoutMultiplier = 10
+
+-- * Client construction
+
 startMcpClient :: McpServerConfig -> IO McpClient
-startMcpClient config = case config.mcpServerUrl of
-    Just url -> startMcpHttpClient config url
+startMcpClient = startMcpClientWith defaultMcpHostHooks Nothing
+
+startMcpClientWith
+    :: McpHostHooks
+    -> Maybe McpProtocolEra
+    -> McpServerConfig
+    -> IO McpClient
+startMcpClientWith hooks eraHint config = case config.mcpServerUrl of
+    Just _ -> startMcpHttpClient hooks eraHint config
     Nothing -> mask \_ -> do
         processEnvironment <- mergedEnvironment config.mcpServerEnv
         let processSpec =
@@ -154,41 +194,18 @@ startMcpClient config = case config.mcpServerUrl of
                 hSetBinaryMode output True
                 hSetBinaryMode errOutput True
                 hSetBuffering input LineBuffering
-                nextId <- newIORef 1
-                pending <- newTVarIO IntMap.empty
-                failure <- newTVarIO Nothing
-                writeLock <- newMVar ()
-                stderrRef <- newIORef emptyCapturedStderr
-                closed <- newMVar False
-                lifecycle <- newTVarIO ClientPending
-                skillsCapability <- newTVarIO Nothing
-                discoveredSkills <- newTVarIO []
-                reader <- asyncWithUnmask \unmask ->
-                    unmask (readerLoop output pending failure)
-                        `finally` void (tryAny (hClose output))
+                client <-
+                    newClientRecord hooks eraHint config
+                        (Just input) (Just processHandle) groupId
                 stderrReader <- asyncWithUnmask \unmask ->
-                    unmask (stderrLoop errOutput stderrRef)
+                    unmask (stderrLoop errOutput client.clientStderr)
                         `finally` void (tryAny (hClose errOutput))
-                session <- newIORef Nothing
-                let client = McpClient
-                        { clientConfig = config
-                        , clientHttpSession = session
-                        , clientInput = Just input
-                        , clientProcess = Just processHandle
-                        , clientGroupId = groupId
-                        , clientNextId = nextId
-                        , clientPending = pending
-                        , clientFailure = failure
-                        , clientWriteLock = writeLock
-                        , clientStderr = stderrRef
-                        , clientReader = Just reader
-                        , clientStderrReader = Just stderrReader
-                        , clientClosed = closed
-                        , clientLifecycle = lifecycle
-                        , clientSkillsCapability = skillsCapability
-                        , clientDiscoveredSkills = discoveredSkills
-                        }
-                pure client
+                let withStderr = client { clientStderrReader = Just stderrReader }
+                reader <- asyncWithUnmask \unmask ->
+                    unmask (readerLoop withStderr output)
+                        `finally` void (tryAny (hClose output))
+                writeIORef withStderr.clientReader (Just reader)
+                pure withStderr
             _ -> do
                 let (_, _, _, processHandle) = created
                 groupId <- getPid processHandle
@@ -200,8 +217,25 @@ mcpHttpManager :: Manager
 mcpHttpManager = unsafePerformIO newTlsManager
 {-# NOINLINE mcpHttpManager #-}
 
-startMcpHttpClient :: McpServerConfig -> Text -> IO McpClient
-startMcpHttpClient config _url = mask $ \_ -> do
+startMcpHttpClient
+    :: McpHostHooks
+    -> Maybe McpProtocolEra
+    -> McpServerConfig
+    -> IO McpClient
+startMcpHttpClient hooks eraHint config =
+    -- HTTP has no subprocess or background reader.  Its lifecycle is driven
+    -- by requestMcp and closeMcpClient below.
+    newClientRecord hooks eraHint config Nothing Nothing Nothing
+
+newClientRecord
+    :: McpHostHooks
+    -> Maybe McpProtocolEra
+    -> McpServerConfig
+    -> Maybe Handle
+    -> Maybe ProcessHandle
+    -> Maybe ProcessGroupID
+    -> IO McpClient
+newClientRecord hooks eraHint config input processHandle groupId = do
     nextId <- newIORef 1
     pending <- newTVarIO IntMap.empty
     failure <- newTVarIO Nothing
@@ -209,21 +243,48 @@ startMcpHttpClient config _url = mask $ \_ -> do
     stderrRef <- newIORef emptyCapturedStderr
     closed <- newMVar False
     lifecycle <- newTVarIO ClientPending
-    skillsCapability <- newTVarIO Nothing
+    serverInfo <- newTVarIO Nothing
     discoveredSkills <- newTVarIO []
     session <- newIORef Nothing
-    -- HTTP has no subprocess or background reader.  Its lifecycle is driven
-    -- by requestMcp and closeMcpClient below.
+    reader <- newIORef Nothing
+    workers <- newTVarIO []
+    eventHandler <- newIORef (const (pure ()))
     pure McpClient
-        { clientConfig = config, clientHttpSession = session
-        , clientInput = Nothing, clientProcess = Nothing
-        , clientGroupId = Nothing, clientNextId = nextId
-        , clientPending = pending, clientFailure = failure
-        , clientWriteLock = writeLock, clientStderr = stderrRef
-        , clientReader = Nothing, clientStderrReader = Nothing
-        , clientClosed = closed, clientLifecycle = lifecycle
-        , clientSkillsCapability = skillsCapability
-        , clientDiscoveredSkills = discoveredSkills }
+        { clientConfig = config
+        , clientHooks = hooks
+        , clientHttpSession = session
+        , clientInput = input
+        , clientProcess = processHandle
+        , clientGroupId = groupId
+        , clientNextId = nextId
+        , clientPending = pending
+        , clientFailure = failure
+        , clientWriteLock = writeLock
+        , clientStderr = stderrRef
+        , clientReader = reader
+        , clientStderrReader = Nothing
+        , clientWorkers = workers
+        , clientClosed = closed
+        , clientLifecycle = lifecycle
+        , clientServerInfo = serverInfo
+        , clientDiscoveredSkills = discoveredSkills
+        , clientEventHandler = eventHandler
+        , clientEraHint = eraHint
+        }
+
+-- | Replace the handler invoked for server-initiated notifications. The
+-- handler runs on the transport reader thread and must not block.
+setMcpClientEventHandler :: McpClient -> (McpServerEvent -> IO ()) -> IO ()
+setMcpClientEventHandler client = writeIORef client.clientEventHandler
+
+-- | Era negotiated with the server, if initialization has completed.
+mcpClientEra :: McpClient -> IO (Maybe McpProtocolEra)
+mcpClientEra client = fmap (.serverInfoEra) <$> readTVarIO client.clientServerInfo
+
+mcpClientServerInfo :: McpClient -> IO (Maybe McpServerInfo)
+mcpClientServerInfo client = readTVarIO client.clientServerInfo
+
+-- * Initialization
 
 data InitializeRole
     = InitializeLeader
@@ -281,9 +342,10 @@ ensureMcpClientReadyWith publishReady client = mask \restore -> do
                                 (Left "MCP initialization cancelled")
                     closeMcpClient client
                 initialize = do
-                    initializeClient client
+                    negotiateProtocol client
                     (tools, warnings) <- discoverMcpTools client
                     skillWarnings <- discoverMcpSkills client
+                    startSubscriptions client
                     pure (tools, warnings <> skillWarnings)
             outcome <-
                 restore (tryAny initialize)
@@ -333,65 +395,207 @@ mcpClientStatus client = do
             _ -> 0
         }
 
-initializeClient :: McpClient -> IO ()
-initializeClient client = do
-    let timeoutMicros =
-            secondsToMicros client.clientConfig.mcpServerStartupTimeoutSeconds
-        parameters = object
-            [ "protocolVersion" .= ("2026-07-28" :: Text)
-            , "capabilities" .= object []
-            , "clientInfo" .= object
-                [ "name" .= ("haskell-agent" :: Text)
-                , "version" .= ("0.1.0" :: Text)
-                ]
-            ]
-    result <- requestMcp client timeoutMicros "initialize"
-        (Aeson.toEncoding parameters)
-    case result of
-        Left err -> startupFailure client err
-        Right response -> do
-            case parseSkillsCapability response of
-                Left err -> startupFailure client ("invalid initialize response: " <> err)
-                Right capability ->
-                    atomically $
-                        writeTVar client.clientSkillsCapability capability
-            sendNotification client "notifications/initialized"
-                (Aeson.toEncoding (object []))
-                >>= either (startupFailure client) pure
+-- | Decide which protocol era the server speaks and complete the handshake
+-- that era requires.
+negotiateProtocol :: McpClient -> IO ()
+negotiateProtocol client =
+    case (client.clientConfig.mcpServerProtocol, client.clientEraHint) of
+        (McpProtocolLegacy, _) -> legacyInitialize client preferredLegacyVersion
+        (McpProtocolAuto, Just McpEraLegacy) ->
+            legacyInitialize client preferredLegacyVersion
+        (preference, _) -> do
+            outcome <- probeDiscover client
+            case classifyProbe outcome of
+                ProbeModern raw -> applyDiscoverResult client raw
+                ProbeVersions supported -> selectFromVersions client supported
+                ProbeLegacy reason
+                    | preference == McpProtocolModern ->
+                        startupFailure client
+                            ("server did not answer server/discover as a modern MCP server ("
+                                <> reason
+                                <> "); set \"protocol\": \"legacy\" to use the initialize handshake")
+                    | otherwise -> legacyInitialize client preferredLegacyVersion
+                ProbeFailure err -> startupFailure client err
 
-parseSkillsCapability :: RawJson -> Either Text (Maybe McpSkillsCapability)
-parseSkillsCapability raw =
-    case Json.decodeEither capabilitiesDecoder (rawJsonBytes raw) of
-        Left err -> Left err.jsonErrorMessage
-        Right capabilities ->
-            case capabilities of
-                Nothing -> Right Nothing
-                Just value -> decodeExtensions value
+probeDiscover :: McpClient -> IO (Either McpError RawJson)
+probeDiscover client =
+    requestMcpFull client
+        (clientRequest client "server/discover" mempty)
+            { requestEra = Just McpEraModern
+            , requestTimeoutMicros =
+                secondsToMicros
+                    (min discoverProbeTimeoutSeconds
+                        client.clientConfig.mcpServerStartupTimeoutSeconds)
+            }
+
+data ProbeOutcome
+    = ProbeModern !RawJson
+    | ProbeVersions ![Text]
+    | ProbeLegacy !Text
+    | ProbeFailure !Text
+    deriving (Eq, Show)
+
+-- | Interpret the outcome of a @server/discover@ probe. A recognized modern
+-- error identifies a modern server; anything else identifies a legacy one
+-- (legacy servers answer unknown pre-@initialize@ requests with
+-- implementation-defined errors, or not at all).
+classifyProbe :: Either McpError RawJson -> ProbeOutcome
+classifyProbe = \case
+    Right raw -> ProbeModern raw
+    Left (McpRpcError code message payload)
+        | code == errorCodeUnsupportedProtocolVersion ->
+            ProbeVersions (maybe [] supportedVersionsOf payload)
+        | code == errorCodeHeaderMismatch
+            || code == errorCodeMissingClientCapability ->
+            ProbeFailure (renderMcpError (McpRpcError code message payload))
+        | otherwise ->
+            ProbeLegacy ("error " <> Text.pack (show code))
+    Left (McpTimeout _) -> ProbeLegacy "no response"
+    Left (McpHttpStatus status _) -> ProbeLegacy ("HTTP " <> Text.pack (show status))
+    Left (McpTransportError message) -> ProbeFailure message
   where
-    capabilitiesDecoder =
-        Json.object (Json.optionalKey "capabilities" rawJsonDecoder)
-    decodeExtensions capabilities =
-        case Json.decodeEither extensionsDecoder (rawJsonBytes capabilities) of
-            Left err -> Left err.jsonErrorMessage
-            Right extensions -> case extensions of
-                Nothing -> Right Nothing
-                Just value -> decodeSkills value
-    extensionsDecoder =
-        Json.object (Json.optionalKey "extensions" rawJsonDecoder)
-    decodeSkills extensions =
-        case Json.decodeEither skillsDecoder (rawJsonBytes extensions) of
-            Left err -> Left err.jsonErrorMessage
-            Right Nothing -> Right Nothing
-            Right (Just raw) ->
-                case Json.decodeEither directoryDecoder (rawJsonBytes raw) of
-                    Left err -> Left err.jsonErrorMessage
-                    Right directoryRead ->
-                        Right (Just McpSkillsCapability{mcpSkillsDirectoryRead = directoryRead})
-    skillsDecoder =
-        Json.object
-            (Json.atKeyOptional "io.modelcontextprotocol/skills" rawJsonDecoder)
-    directoryDecoder =
-        Json.object (Json.defaultKey False "directoryRead" Json.bool)
+    supportedVersionsOf payload =
+        projectRawOr []
+            (Json.object (Json.defaultKey [] "supported" (Json.list Json.text)))
+            payload
+
+applyDiscoverResult :: McpClient -> RawJson -> IO ()
+applyDiscoverResult client raw =
+    case Json.decodeEither discoverDecoder (rawJsonBytes raw) of
+        Left err ->
+            startupFailure client
+                ("invalid server/discover response: " <> err.jsonErrorMessage)
+        Right (supported, capabilities, instructions, identity)
+            | null supported || modernProtocolVersion `elem` supported -> do
+                let (name, version, title) = identity
+                atomically $ writeTVar client.clientServerInfo $ Just McpServerInfo
+                    { serverInfoEra = McpEraModern
+                    , serverInfoProtocolVersion = modernProtocolVersion
+                    , serverInfoName = name
+                    , serverInfoVersion = version
+                    , serverInfoTitle = title
+                    , serverInfoInstructions = instructions
+                    , serverInfoCapabilities = capabilities
+                    }
+            | otherwise -> selectFromVersions client supported
+  where
+    discoverDecoder = Json.object do
+        supported <- Json.defaultKey [] "supportedVersions" (Json.list Json.text)
+        capabilities <-
+            fromMaybe emptyServerCapabilities
+                <$> Json.optionalKey "capabilities" serverCapabilitiesDecoder
+        instructions <- Json.optionalKey "instructions" Json.text
+        meta <- Json.optionalKey "_meta" rawJsonDecoder
+        let identity =
+                maybe (Nothing, Nothing, Nothing)
+                    (projectRawOr (Nothing, Nothing, Nothing) metaServerInfoDecoder)
+                    meta
+        pure (supported, capabilities, instructions, identity)
+    metaServerInfoDecoder = Json.object do
+        info <-
+            Json.optionalKey "io.modelcontextprotocol/serverInfo"
+                implementationDecoder
+        pure (fromMaybe (Nothing, Nothing, Nothing) info)
+
+implementationDecoder :: Json.Decoder (Maybe Text, Maybe Text, Maybe Text)
+implementationDecoder = Json.object do
+    name <- Json.optionalKey "name" Json.text
+    version <- Json.optionalKey "version" Json.text
+    title <- Json.optionalKey "title" Json.text
+    pure (name, version, title)
+
+-- | Pick a mutually supported version from a server's advertised list.
+selectFromVersions :: McpClient -> [Text] -> IO ()
+selectFromVersions client supported
+    | modernProtocolVersion `elem` supported =
+        -- The server advertises our modern version but rejected the probe;
+        -- retry the probe once so a transient rejection does not strand us.
+        probeDiscover client >>= \case
+            Right raw -> applyDiscoverResult client raw
+            Left err -> startupFailure client (renderMcpError err)
+    | Just legacy <- find (`elem` supported) supportedLegacyVersions =
+        legacyInitialize client legacy
+    | otherwise =
+        startupFailure client
+            ("server supports protocol versions "
+                <> Text.intercalate ", " supported
+                <> "; this client supports "
+                <> Text.intercalate ", " (modernProtocolVersion : supportedLegacyVersions))
+
+-- | The @initialize@ handshake of protocol revisions up to @2025-11-25@.
+legacyInitialize :: McpClient -> Text -> IO ()
+legacyInitialize client requestedVersion = do
+    let parameters =
+            "protocolVersion" .= requestedVersion
+                <> "capabilities" .= legacyClientCapabilities client.clientHooks
+                <> "clientInfo" .= clientInfoValue client.clientHooks
+    result <-
+        requestMcpFull client
+            (clientRequest client "initialize" parameters)
+                { requestEra = Nothing
+                , requestMeta = False
+                , requestTimeoutMicros =
+                    secondsToMicros client.clientConfig.mcpServerStartupTimeoutSeconds
+                }
+    case result of
+        Left err -> startupFailure client (renderMcpError err)
+        Right response ->
+            case Json.decodeEither initializeDecoder (rawJsonBytes response) of
+                Left err ->
+                    startupFailure client
+                        ("invalid initialize response: " <> err.jsonErrorMessage)
+                Right (version, capabilities, instructions, (name, serverVersion, title))
+                    | version `notElem` supportedLegacyVersions ->
+                        startupFailure client
+                            ("server negotiated unsupported protocol version " <> version)
+                    | otherwise -> do
+                        atomically $ writeTVar client.clientServerInfo $ Just McpServerInfo
+                            { serverInfoEra = McpEraLegacy
+                            , serverInfoProtocolVersion = version
+                            , serverInfoName = name
+                            , serverInfoVersion = serverVersion
+                            , serverInfoTitle = title
+                            , serverInfoInstructions = instructions
+                            , serverInfoCapabilities = capabilities
+                            }
+                        sendNotification client "notifications/initialized" mempty
+                            >>= either (startupFailure client . renderMcpError) pure
+  where
+    initializeDecoder = Json.object do
+        version <- Json.defaultKey "" "protocolVersion" Json.text
+        capabilities <-
+            fromMaybe emptyServerCapabilities
+                <$> Json.optionalKey "capabilities" serverCapabilitiesDecoder
+        instructions <- Json.optionalKey "instructions" Json.text
+        identity <-
+            fromMaybe (Nothing, Nothing, Nothing)
+                <$> Json.optionalKey "serverInfo" implementationDecoder
+        pure (version, capabilities, instructions, identity)
+
+clientInfoValue :: McpHostHooks -> Value
+clientInfoValue hooks = object
+    [ "name" .= hooks.mcpHostClientName
+    , "version" .= hooks.mcpHostClientVersion
+    ]
+
+-- | Capabilities declared to modern servers on every request.
+clientCapabilitiesValue :: McpHostHooks -> Value
+clientCapabilitiesValue hooks = object $
+    [ "elicitation" .= object ["form" .= object [], "url" .= object []]
+    | isJust hooks.mcpHostElicit
+    ]
+    <> [ "extensions" .= object
+            [ "io.modelcontextprotocol/tasks" .= object []
+            , "io.modelcontextprotocol/skills" .= object []
+            ]
+       ]
+
+-- | Capabilities declared to legacy servers during @initialize@.
+legacyClientCapabilities :: McpHostHooks -> Value
+legacyClientCapabilities hooks = object $
+    [ "elicitation" .= object ["form" .= object [], "url" .= object []]
+    | isJust hooks.mcpHostElicit
+    ]
 
 startupFailure :: McpClient -> Text -> IO a
 startupFailure client err = do
@@ -400,37 +604,53 @@ startupFailure client err = do
         redactConfiguredValues client.clientConfig
             (err <> if Text.null stderrText then "" else "\nstderr:\n" <> stderrText)
 
-discoverMcpTools :: McpClient -> IO ([McpTool], [Text])
-discoverMcpTools client = go Nothing [] []
-  where
-    go cursor tools warnings = do
-        let parameters = maybe
-                (Aeson.toEncoding (object []))
-                (\value ->
-                    Aeson.pairs
-                        (AesonEncoding.pair "cursor" (rawJsonEncoding value)))
-                cursor
-            timeoutMicros =
-                secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds
-        requestMcp client timeoutMicros "tools/list" parameters >>= \case
-            Left err -> ioError (userError (Text.unpack err))
-            Right result ->
-                case parsePage result of
-                    Left err -> ioError (userError ("invalid tools/list response: " <> Text.unpack err))
-                    Right (pageTools, nextCursor) -> do
-                        if isJust nextCursor
-                            then go nextCursor (tools <> pageTools) warnings
-                            else pure (tools <> pageTools, warnings)
+-- * Discovery
 
-    parsePage :: RawJson -> Either Text ([McpTool], Maybe RawJson)
-    parsePage raw =
-        case Json.decodeEither pageDecoder (rawJsonBytes raw) of
-            Left err -> Left err.jsonErrorMessage
-            Right page -> Right page
+discoverMcpTools :: McpClient -> IO ([McpTool], [Text])
+discoverMcpTools client = do
+    tools <- paginate client "tools/list" "tools" mcpToolDecoder
+        >>= either (ioError . userError . Text.unpack . renderMcpError) pure
+    let isHttp = isJust client.clientConfig.mcpServerUrl
+        annotated =
+            [ (tool.discoveredName, annotateHeaderParams isHttp tool)
+            | tool <- tools
+            ]
+        accepted = [tool | (_, Right tool) <- annotated]
+        warnings =
+            [ "MCP server " <> client.clientConfig.mcpServerName
+                <> " tool " <> name <> " was rejected: " <> reason
+            | (name, Left reason) <- annotated
+            ]
+    pure (accepted, warnings)
+
+-- | Fetch every page of a list request.
+paginate
+    :: McpClient
+    -> Text
+    -> Text
+    -> Json.Decoder a
+    -> IO (Either McpError [a])
+paginate client method key itemDecoder = go Nothing []
+  where
+    go cursor collected = do
+        let parameters = maybe mempty
+                (\value -> AesonEncoding.pair "cursor" (rawJsonEncoding value))
+                cursor
+        requestMcpFull client (clientRequest client method parameters) >>= \case
+            Left err -> pure (Left err)
+            Right result ->
+                case Json.decodeEither pageDecoder (rawJsonBytes result) of
+                    Left err ->
+                        pure . Left . McpTransportError $
+                            "invalid " <> method <> " response: " <> err.jsonErrorMessage
+                    Right (items, nextCursor) ->
+                        case nextCursor of
+                            Just next -> go (Just next) (collected <> items)
+                            Nothing -> pure (Right (collected <> items))
 
     pageDecoder = Json.object $
         (,)
-            <$> Json.defaultKey [] "tools" (Json.list mcpToolDecoder)
+            <$> Json.defaultKey [] key (Json.list itemDecoder)
             <*> Json.optionalKey "nextCursor" rawJsonDecoder
 
 -- | Enumerate skill metadata only.  Skill resources are intentionally not
@@ -438,27 +658,23 @@ discoverMcpTools client = go Nothing [] []
 -- skill.
 discoverMcpSkills :: McpClient -> IO [Text]
 discoverMcpSkills client = do
-    capability <- readTVarIO client.clientSkillsCapability
+    capability <- clientSkillsCapability client
     case capability of
         Nothing -> pure []
         Just _ -> go Nothing []
   where
     go cursor warnings = do
-        let parameters = maybe
-                (Aeson.toEncoding (object []))
-                (\value -> Aeson.pairs
-                    (AesonEncoding.pair "cursor" (rawJsonEncoding value)))
+        let parameters = maybe mempty
+                (\value -> AesonEncoding.pair "cursor" (rawJsonEncoding value))
                 cursor
-        requestMcp client
-            (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
-            "skills/list" parameters >>= \case
+        requestMcpFull client (clientRequest client "skills/list" parameters) >>= \case
             Left err -> pure ["MCP server " <> client.clientConfig.mcpServerName
-                <> " skills/list failed: " <> err]
+                <> " skills/list failed: " <> renderMcpError err]
             Right result ->
-                case parseSkillPage result of
+                case Json.decodeEither pageDecoder (rawJsonBytes result) of
                     Left err -> pure ["MCP server "
                         <> client.clientConfig.mcpServerName
-                        <> " returned invalid skills/list response: " <> err]
+                        <> " returned invalid skills/list response: " <> err.jsonErrorMessage]
                     Right (rawSkills, nextCursor) -> do
                         let skills = mapMaybe decodeSkill rawSkills
                             invalid = length skills /= length rawSkills
@@ -473,10 +689,6 @@ discoverMcpSkills client = do
                             Nothing -> pure (warnings <> pageWarnings)
                             Just next -> go (Just next) (warnings <> pageWarnings)
 
-    parseSkillPage raw =
-        case Json.decodeEither pageDecoder (rawJsonBytes raw) of
-            Left err -> Left err.jsonErrorMessage
-            Right page -> Right page
     pageDecoder = Json.object $
         (,) <$> Json.defaultKey [] "skills" (Json.list rawJsonDecoder)
             <*> Json.optionalKey "nextCursor" rawJsonDecoder
@@ -485,21 +697,23 @@ discoverMcpSkills client = do
             Left _ -> Nothing
             Right skill -> Just skill
 
+clientSkillsCapability :: McpClient -> IO (Maybe McpSkillsCapability)
+clientSkillsCapability client =
+    (>>= (.serverInfoCapabilities.capabilitySkills))
+        <$> readTVarIO client.clientServerInfo
+
 -- | Retrieve one skill manifest by URI.  Unlike 'skills/list', this also
 -- supports servers whose catalog is not enumerable.
 getMcpSkill :: McpClient -> Text -> IO (Either Text McpSkillEntry)
 getMcpSkill client uri = do
-    capability <- readTVarIO client.clientSkillsCapability
+    capability <- clientSkillsCapability client
     case capability of
         Nothing -> pure (Left ("MCP server "
             <> client.clientConfig.mcpServerName
             <> " does not support io.modelcontextprotocol/skills"))
-        Just _ -> do
-            let parameters = Aeson.toEncoding (object ["uri" .= uri])
-            requestMcp client
-                (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
-                "skills/get" parameters >>= \case
-                Left err -> pure (Left err)
+        Just _ ->
+            requestMcpFull client (clientRequest client "skills/get" ("uri" .= uri)) >>= \case
+                Left err -> pure (Left (renderMcpError err))
                 Right result ->
                     case Json.decodeEither
                             (Json.object (Json.atKey "skill" mcpSkillEntryDecoder))
@@ -512,12 +726,12 @@ getMcpSkill client uri = do
 -- method.  This does not activate a skill; callers must perform their own
 -- approval, frontmatter, and manifest verification.
 readMcpResource :: McpClient -> Text -> IO (Either Text [McpResourceContent])
-readMcpResource client uri = do
-    let parameters = Aeson.toEncoding (object ["uri" .= uri])
-    requestMcp client
-        (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
-        "resources/read" parameters >>= \case
-        Left err -> pure (Left err)
+readMcpResource client uri =
+    invokeWithInputRounds client
+        (clientRequest client "resources/read" ("uri" .= uri))
+            { requestName = Just uri }
+        >>= \case
+        Left err -> pure (Left (renderMcpError err))
         Right result ->
             case Json.decodeEither
                     (Json.object
@@ -528,17 +742,95 @@ readMcpResource client uri = do
                     <> err.jsonErrorMessage))
                 Right contents -> pure (Right contents)
 
+listMcpResources :: McpClient -> IO (Either McpError [McpResource])
+listMcpResources client =
+    paginate client "resources/list" "resources" mcpResourceDecoder
+
+listMcpResourceTemplates :: McpClient -> IO (Either McpError [McpResourceTemplate])
+listMcpResourceTemplates client =
+    paginate client "resources/templates/list" "resourceTemplates"
+        mcpResourceTemplateDecoder
+
+listMcpPrompts :: McpClient -> IO (Either McpError [McpPrompt])
+listMcpPrompts client =
+    paginate client "prompts/list" "prompts" mcpPromptDecoder
+
+-- | Resolve a prompt template. Servers may ask for additional input first.
+getMcpPrompt
+    :: McpClient
+    -> Text
+    -> [(Text, Text)]
+    -> IO (Either McpError McpPromptResult)
+getMcpPrompt client name arguments =
+    invokeWithInputRounds client
+        (clientRequest client "prompts/get"
+            ("name" .= name
+                <> "arguments" .= object [Key.fromText key .= value | (key, value) <- arguments]))
+            { requestName = Just name }
+        >>= \case
+        Left err -> pure (Left err)
+        Right result ->
+            pure . either
+                (\err -> Left (McpTransportError ("invalid prompts/get response: " <> err.jsonErrorMessage)))
+                Right $
+                Json.decodeEither mcpPromptResultDecoder (rawJsonBytes result)
+
+data McpCompletionRef
+    = McpCompletePrompt !Text
+    | McpCompleteResource !Text
+    deriving (Eq, Show)
+
+-- | Request argument completions for a prompt or resource template.
+completeMcpArgument
+    :: McpClient
+    -> McpCompletionRef
+    -> Text
+    -> Text
+    -> [(Text, Text)]
+    -> IO (Either McpError McpCompletion)
+completeMcpArgument client ref argumentName partial context = do
+    let refValue = case ref of
+            McpCompletePrompt name ->
+                object ["type" .= ("ref/prompt" :: Text), "name" .= name]
+            McpCompleteResource uri ->
+                object ["type" .= ("ref/resource" :: Text), "uri" .= uri]
+        parameters =
+            "ref" .= refValue
+                <> "argument" .= object ["name" .= argumentName, "value" .= partial]
+                <> (if null context
+                        then mempty
+                        else "context" .= object
+                            [ "arguments" .= object
+                                [Key.fromText key .= value | (key, value) <- context]
+                            ])
+    requestMcpFull client (clientRequest client "completion/complete" parameters) >>= \case
+        Left err -> pure (Left err)
+        Right result ->
+            pure . either
+                (\err -> Left (McpTransportError ("invalid completion/complete response: " <> err.jsonErrorMessage)))
+                Right $
+                Json.decodeEither mcpCompletionDecoder (rawJsonBytes result)
+
+-- * Tools
+
 appToolFor :: McpClient -> McpTool -> AppTool
 appToolFor client tool = AppTool
     { appToolName = qualifiedName
-    , appToolDescription = tool.discoveredDescription
+    , appToolDescription = describeTool tool
     -- Tool schemas enter the legacy Aeson-valued tool API here. Their wire
     -- decode and storage remain RawJson.
     , appToolSchema =
         RawJsonFunctionSchema (toJSON tool.discoveredInputSchema)
     , appToolHandler =
-        typedTool qualifiedName rawObjectDecoder \arguments -> do
-            callDiscoveredTool client tool arguments
+        typedStreamingTool qualifiedName rawObjectDecoder \publish arguments -> do
+            -- Snapshots accumulate: each progress line is appended to the
+            -- text already shown for this call.
+            shown <- newIORef Text.empty
+            callDiscoveredToolWith client tool arguments $ Just \progress -> do
+                snapshot <- atomicModifyIORef' shown \current ->
+                    let next = current <> formatProgress progress
+                    in (next, next)
+                publish snapshot
     , appToolApproval =
         if tool.discoveredReadOnly then AlwaysReadOnly else AlwaysPrompt
     , appToolExecution =
@@ -549,6 +841,35 @@ appToolFor client tool = AppTool
     qualifiedName = qualifiedMcpToolName
         client.clientConfig.mcpServerName
         tool.discoveredName
+
+-- | Description shown to the model: the server's description, with the
+-- human-readable title as a prefix when the server provides one.
+describeTool :: McpTool -> Text
+describeTool tool =
+    case tool.discoveredTitle of
+        Just title
+            | not (Text.null (Text.strip title))
+            , Text.strip title /= tool.discoveredName ->
+                Text.strip title
+                    <> (if Text.null tool.discoveredDescription
+                        then ""
+                        else ": " <> tool.discoveredDescription)
+        _ -> tool.discoveredDescription
+
+formatProgress :: McpProgress -> Text
+formatProgress progress =
+    Text.intercalate " "
+        (catMaybes
+            [ Just ("progress " <> showNumber progress.progressValue
+                <> maybe "" (\total -> "/" <> showNumber total) progress.progressTotal)
+            , progress.progressMessage
+            ])
+        <> "\n"
+  where
+    showNumber value
+        | value == fromIntegral (round value :: Integer) =
+            Text.pack (show (round value :: Integer))
+        | otherwise = Text.pack (show value)
 
 rawObjectDecoder :: Json.Decoder RawJson
 rawObjectDecoder =
@@ -565,56 +886,113 @@ qualifiedMcpToolName serverName toolName =
             . Text.replace "%" "%25"
 
 callDiscoveredTool :: McpClient -> McpTool -> RawJson -> IO (Either Text Text)
-callDiscoveredTool client tool arguments = do
-    let encodedParameters = Aeson.pairs $
+callDiscoveredTool client tool arguments =
+    callDiscoveredToolWith client tool arguments Nothing
+
+callDiscoveredToolWith
+    :: McpClient
+    -> McpTool
+    -> RawJson
+    -> Maybe (McpProgress -> IO ())
+    -> IO (Either Text Text)
+callDiscoveredToolWith client tool arguments onProgress = do
+    let parameters =
             "name" .= tool.discoveredName
-                <> AesonEncoding.pair
-                    "arguments"
-                    (rawJsonEncoding arguments)
-        timeoutMicros =
-            secondsToMicros
-                client.clientConfig.mcpServerRequestTimeoutSeconds
-    requestMcp client timeoutMicros "tools/call" encodedParameters >>= \case
-        Left err -> pure (Left err)
+                <> AesonEncoding.pair "arguments" (rawJsonEncoding arguments)
+    invokeWithInputRounds client
+        (clientRequest client "tools/call" parameters)
+            { requestName = Just tool.discoveredName
+            , requestHeaderParams = headerParamValues tool arguments
+            , requestOnProgress = onProgress
+            }
+        >>= \case
+        Left err -> pure (Left (renderMcpError err))
         Right result -> pure (normalizeMcpToolResult result)
 
+-- | Render a @CallToolResult@ for the model.
 normalizeMcpToolResult :: RawJson -> Either Text Text
 normalizeMcpToolResult result =
     case Json.decodeEither mcpToolResultDecoder (rawJsonBytes result) of
         Left _ -> Right (compactRawJson result)
-        Right (isError, structured, textParts) ->
-            let output
-                    | isJust structured && not (null textParts) =
+        Right (isError, structured, blocks) ->
+            let rendered = mapMaybe renderContentBlock blocks
+                output
+                    | isJust structured && not (null rendered) =
                         compactRawJson result
                     | Just value <- structured = compactRawJson value
-                    | not (null textParts) = Text.intercalate "\n" textParts
+                    | not (null rendered) = Text.intercalate "\n" rendered
                     | otherwise = compactRawJson result
             in if isError then Left output else Right output
 
+data McpContentBlock
+    = McpTextBlock !Text
+    | McpImageBlock !(Maybe Text) !Int
+    | McpAudioBlock !(Maybe Text) !Int
+    | McpResourceLinkBlock !Text !(Maybe Text) !(Maybe Text) !(Maybe Text)
+    | McpEmbeddedResourceBlock !McpResourceContent
+    | McpUnknownBlock !Text
+    deriving (Eq, Show)
+
+renderContentBlock :: McpContentBlock -> Maybe Text
+renderContentBlock = \case
+    McpTextBlock text -> Just text
+    McpImageBlock mimeType size ->
+        Just ("[image " <> fromMaybe "image" mimeType <> ", "
+            <> Text.pack (show size) <> " base64 bytes; binary content is not shown]")
+    McpAudioBlock mimeType size ->
+        Just ("[audio " <> fromMaybe "audio" mimeType <> ", "
+            <> Text.pack (show size) <> " base64 bytes; binary content is not shown]")
+    McpResourceLinkBlock uri name description mimeType ->
+        Just ("[resource_link] " <> uri
+            <> maybe "" (\value -> " (" <> value <> ")") name
+            <> maybe "" (\value -> " [" <> value <> "]") mimeType
+            <> maybe "" (": " <>) description)
+    McpEmbeddedResourceBlock content ->
+        Just $ case (content.mcpResourceText, content.mcpResourceBlob) of
+            (Just text, _) ->
+                "[resource " <> content.mcpResourceUri
+                    <> maybe "" (\value -> " (" <> value <> ")") content.mcpResourceMimeType
+                    <> "]\n" <> text
+            (Nothing, Just blob) ->
+                "[resource " <> content.mcpResourceUri
+                    <> maybe "" (\value -> " (" <> value <> ")") content.mcpResourceMimeType
+                    <> ": " <> Text.pack (show (Text.length blob))
+                    <> " base64 bytes; binary content is not shown]"
+            (Nothing, Nothing) -> "[resource " <> content.mcpResourceUri <> "]"
+    McpUnknownBlock _ -> Nothing
+
 mcpToolResultDecoder
-    :: Json.Decoder (Bool, Maybe RawJson, [Text])
+    :: Json.Decoder (Bool, Maybe RawJson, [McpContentBlock])
 mcpToolResultDecoder = Json.object do
     rawError <- Json.optionalKey "isError" rawJsonDecoder
     structured <- Json.optionalKey "structuredContent" rawJsonDecoder
     rawContent <- Json.optionalKey "content" rawJsonDecoder
-    let isError = maybe False (projectOr False Json.bool) rawError
-        textParts =
-            maybe [] (projectOr [] contentTextPartsDecoder) rawContent
-    pure (isError, structured, textParts)
-  where
-    projectOr fallback decoder value =
-        either (const fallback) id $
-            Json.decodeEither decoder (rawJsonBytes value)
+    let isError = maybe False (projectRawOr False Json.bool) rawError
+        blocks = maybe [] (projectRawOr [] (Json.list contentBlockDecoder)) rawContent
+    pure (isError, structured, blocks)
 
-    contentTextPartsDecoder =
-        catMaybes <$> Json.list contentTextDecoder
-
-    contentTextDecoder = Json.object do
-        contentType <- Json.optionalKey "type" Json.text
-        text <- Json.optionalKey "text" Json.text
-        pure $ case (contentType, text) of
-            (Just "text", Just value) -> Just value
-            _ -> Nothing
+contentBlockDecoder :: Json.Decoder McpContentBlock
+contentBlockDecoder = Json.object do
+    contentType <- Json.defaultKey "" "type" Json.text
+    case contentType of
+        "text" -> McpTextBlock <$> Json.defaultKey "" "text" Json.text
+        "image" ->
+            McpImageBlock
+                <$> Json.optionalKey "mimeType" Json.text
+                <*> (maybe 0 Text.length <$> Json.optionalKey "data" Json.text)
+        "audio" ->
+            McpAudioBlock
+                <$> Json.optionalKey "mimeType" Json.text
+                <*> (maybe 0 Text.length <$> Json.optionalKey "data" Json.text)
+        "resource_link" ->
+            McpResourceLinkBlock
+                <$> Json.defaultKey "" "uri" Json.text
+                <*> Json.optionalKey "name" Json.text
+                <*> Json.optionalKey "description" Json.text
+                <*> Json.optionalKey "mimeType" Json.text
+        "resource" ->
+            McpEmbeddedResourceBlock <$> Json.atKey "resource" mcpResourceContentDecoder
+        other -> pure (McpUnknownBlock other)
 
 compactJson :: Value -> Text
 compactJson = TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode
@@ -622,146 +1000,601 @@ compactJson = TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode
 compactRawJson :: RawJson -> Text
 compactRawJson = TextEncoding.decodeUtf8 . rawJsonBytes
 
+-- * Header mirroring (@x-mcp-header@)
+
+-- | Resolve the @x-mcp-header@ annotations of a tool's input schema. Stdio
+-- transports ignore the annotations entirely; HTTP transports reject tools
+-- whose annotations violate the specification's constraints.
+annotateHeaderParams :: Bool -> McpTool -> Either Text McpTool
+annotateHeaderParams isHttp tool
+    | not isHttp = Right tool { discoveredHeaderParams = [] }
+    | otherwise =
+        case Aeson.decodeStrict (rawJsonBytes tool.discoveredInputSchema) of
+            Nothing -> Right tool { discoveredHeaderParams = [] }
+            Just schema -> do
+                params <- collectHeaderParams schema
+                validateHeaderNames params
+                pure tool { discoveredHeaderParams = params }
+
+collectHeaderParams :: Value -> Either Text [McpHeaderParam]
+collectHeaderParams root = case root of
+    Object fields
+        | KeyMap.member "x-mcp-header" fields ->
+            Left "x-mcp-header must annotate a property, not the schema root"
+        | otherwise -> walkObject [] fields
+    _ -> Right []
+  where
+    walkObject path fields =
+        concat <$> forM (KeyMap.toList fields) \(key, value) ->
+            if Key.toText key == "properties"
+                then case value of
+                    Object properties ->
+                        concat <$> forM (KeyMap.toList properties) \(name, property) ->
+                            walkProperty (path <> [Key.toText name]) property
+                    _ -> Right []
+                else if containsHeaderAnnotation value
+                    then Left ("x-mcp-header under \"" <> Key.toText key
+                        <> "\" is not statically reachable from the schema root")
+                    else Right []
+
+    walkProperty path property = case property of
+        Object fields -> do
+            here <- case KeyMap.lookup "x-mcp-header" fields of
+                Nothing -> Right []
+                Just (String name) -> do
+                    case KeyMap.lookup "type" fields of
+                        Just (String kind)
+                            | kind `elem` ["string", "integer", "boolean"] -> Right ()
+                        _ -> Left ("x-mcp-header on \"" <> Text.intercalate "." path
+                            <> "\" requires a string, integer, or boolean type")
+                    Right [McpHeaderParam path name]
+                Just _ -> Left ("x-mcp-header on \"" <> Text.intercalate "." path
+                    <> "\" must be a string")
+            nested <- walkObject path (KeyMap.delete "x-mcp-header" fields)
+            Right (here <> nested)
+        _ -> Right []
+
+containsHeaderAnnotation :: Value -> Bool
+containsHeaderAnnotation = \case
+    Object fields ->
+        KeyMap.member "x-mcp-header" fields
+            || any containsHeaderAnnotation (KeyMap.elems fields)
+    Array values -> any containsHeaderAnnotation values
+    _ -> False
+
+validateHeaderNames :: [McpHeaderParam] -> Either Text ()
+validateHeaderNames params = go [] params
+  where
+    go :: [Text] -> [McpHeaderParam] -> Either Text ()
+    go _ [] = Right ()
+    go seen (param : rest)
+        | Text.null param.headerParamName = Left "x-mcp-header must not be empty"
+        | not (Text.all isToken param.headerParamName) =
+            Left ("x-mcp-header \"" <> param.headerParamName
+                <> "\" is not a valid HTTP field name")
+        | Text.toLower param.headerParamName `elem` seen =
+            Left ("x-mcp-header \"" <> param.headerParamName
+                <> "\" is not unique within the tool")
+        | otherwise = go (Text.toLower param.headerParamName : seen) rest
+    isToken character =
+        isAscii character
+            && (isAlphaNum character || character `elem` ("!#$%&'*+-.^_`|~" :: String))
+
+-- | Compute the @Mcp-Param-{name}@ headers for one call.
+headerParamValues :: McpTool -> RawJson -> [(Text, Text)]
+headerParamValues tool arguments
+    | null tool.discoveredHeaderParams = []
+    | otherwise =
+        case Aeson.decodeStrict (rawJsonBytes arguments) of
+            Nothing -> []
+            Just value -> mapMaybe (paramHeader value) tool.discoveredHeaderParams
+  where
+    paramHeader :: Value -> McpHeaderParam -> Maybe (Text, Text)
+    paramHeader value param = do
+        leaf <- lookupPath param.headerParamPath value
+        rendered <- renderHeaderValue leaf
+        pure ("Mcp-Param-" <> param.headerParamName, encodeHeaderValue rendered)
+    lookupPath [] value = Just value
+    lookupPath (key : rest) value = case value of
+        Object fields -> KeyMap.lookup (Key.fromText key) fields >>= lookupPath rest
+        _ -> Nothing
+    renderHeaderValue = \case
+        String text -> Just text
+        Bool flag -> Just (if flag then "true" else "false")
+        Number number -> case floatingOrInteger number of
+            Right integer -> Just (Text.pack (show (integer :: Integer)))
+            Left _ -> Nothing
+        _ -> Nothing
+
+-- | Encode a header value per the Streamable HTTP value-encoding rules: plain
+-- ASCII passes through, anything else is carried as a Base64 sentinel.
+encodeHeaderValue :: Text -> Text
+encodeHeaderValue value
+    | safe = value
+    | otherwise =
+        "=?base64?"
+            <> TextEncoding.decodeUtf8 (Base64.encode (TextEncoding.encodeUtf8 value))
+            <> "?="
+  where
+    safe =
+        not (Text.null value)
+            && Text.all visibleAscii value
+            && not (isSpaceLike (Text.head value))
+            && not (isSpaceLike (Text.last value))
+            && not (looksLikeSentinel value)
+    visibleAscii character =
+        let code = ord character
+        in (code >= 0x21 && code <= 0x7E) || code == 0x20 || code == 0x09
+    isSpaceLike character = character == ' ' || character == '\t'
+    looksLikeSentinel text =
+        "=?base64?" `Text.isPrefixOf` text && "?=" `Text.isSuffixOf` text
+
+-- * Requests
+
+-- | One outbound JSON-RPC request.
+data McpRequest = McpRequest
+    { requestMethod :: !Text
+    , requestParams :: !Series
+    , requestName :: !(Maybe Text)
+    -- ^ Value mirrored into the @Mcp-Name@ header on Streamable HTTP.
+    , requestHeaderParams :: ![(Text, Text)]
+    -- ^ Already encoded @Mcp-Param-*@ headers.
+    , requestTimeoutMicros :: !Int
+    -- ^ Idle timeout. Non-positive waits indefinitely (subscriptions).
+    , requestEra :: !(Maybe McpProtocolEra)
+    -- ^ Era override. 'Nothing' uses the negotiated era.
+    , requestMeta :: !Bool
+    -- ^ Whether to attach @_meta@ at all (@initialize@ carries none).
+    , requestOnProgress :: !(Maybe (McpProgress -> IO ()))
+    }
+
+clientRequest :: McpClient -> Text -> Series -> McpRequest
+clientRequest client method parameters = McpRequest
+    { requestMethod = method
+    , requestParams = parameters
+    , requestName = Nothing
+    , requestHeaderParams = []
+    , requestTimeoutMicros =
+        secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds
+    , requestEra = Nothing
+    , requestMeta = True
+    , requestOnProgress = Nothing
+    }
+
+-- | Compatibility entry point: one request, rendered error.
 requestMcp
     :: McpClient
     -> Int
     -> Text
-    -> Aeson.Encoding
+    -> Series
     -> IO (Either Text RawJson)
-requestMcp client timeoutMicros method parameters = do
+requestMcp client timeoutMicros method parameters =
+    either (Left . renderMcpError) Right
+        <$> requestMcpFull client
+            (clientRequest client method parameters)
+                { requestTimeoutMicros = timeoutMicros }
+
+requestMcpFull :: McpClient -> McpRequest -> IO (Either McpError RawJson)
+requestMcpFull client request = do
     failed <- readTVarIO client.clientFailure
-    case (failed, client.clientConfig.mcpServerUrl) of
-        (Just err, _) -> pure (Left err)
-        (Nothing, Just url) -> httpRequestMcp client timeoutMicros url method parameters
-        (Nothing, Nothing) -> do
+    case failed of
+        Just err -> pure (Left (McpTransportError err))
+        Nothing -> do
+            era <- case request.requestEra of
+                Just era -> pure (Just era)
+                Nothing -> mcpClientEra client
             requestId <- atomicModifyIORef' client.clientNextId \current ->
                 (current + 1, current)
-            response <- newEmptyTMVarIO
+            pending <- newPendingRequest request
             atomically $
-                modifyTVar' client.clientPending (IntMap.insert requestId response)
-            let message = Aeson.pairs $
-                    "jsonrpc" .= ("2.0" :: Text)
-                        <> "id" .= requestId
-                        <> "method" .= method
-                        <> AesonEncoding.pair "params" parameters
-            sendMessage client message >>= \case
-                Left err -> do
-                    atomically $
-                        modifyTVar' client.clientPending (IntMap.delete requestId)
-                    pure (Left err)
-                Right () -> do
-                    timed <- timeout (max 1 timeoutMicros)
-                        (atomically (takeTMVar response))
-                    case timed of
-                        Just value -> pure value
-                        Nothing -> do
-                            atomically $
-                                modifyTVar' client.clientPending
-                                    (IntMap.delete requestId)
-                            pure . Left $
-                                "MCP request "
-                                    <> method
-                                    <> " timed out after "
-                                    <> Text.pack
-                                        (show
-                                            ((timeoutMicros + 999999) `div` 1000000))
-                                    <> " seconds"
+                modifyTVar' client.clientPending (IntMap.insert requestId pending)
+            let meta = metaSeries client era request requestId
+                message = requestEnvelope (Just requestId) request.requestMethod
+                    (request.requestParams <> meta)
+            case client.clientConfig.mcpServerUrl of
+                Just url ->
+                    httpExchange client url era request (Just (requestId, pending)) message
+                        `finally` unregister requestId
+                Nothing ->
+                    sendMessage client message >>= \case
+                        Left err -> do
+                            unregister requestId
+                            pure (Left (McpTransportError err))
+                        Right () ->
+                            awaitResponse client requestId pending request
+                                `finally` unregister requestId
+  where
+    unregister requestId =
+        atomically $ modifyTVar' client.clientPending (IntMap.delete requestId)
 
-httpRequestMcp :: McpClient -> Int -> Text -> Text -> Aeson.Encoding -> IO (Either Text RawJson)
-httpRequestMcp client timeoutMicros url method parameters = do
-    requestId <- atomicModifyIORef' client.clientNextId (\current -> (current + 1, current))
-    httpRequestMcpWithId client timeoutMicros url method parameters (Just requestId)
+newPendingRequest :: McpRequest -> IO PendingRequest
+newPendingRequest request = do
+    response <- newEmptyTMVarIO
+    activity <- newTVarIO 0
+    pure PendingRequest
+        { pendingResponse = response
+        , pendingActivity = activity
+        , pendingOnProgress = fromMaybe (const (pure ())) request.requestOnProgress
+        }
 
-httpNotificationMcp :: McpClient -> Int -> Text -> Text -> Aeson.Encoding -> IO (Either Text ())
-httpNotificationMcp client timeoutMicros url method parameters =
-    fmap (fmap (const ())) $
-        httpRequestMcpWithId client timeoutMicros url method parameters Nothing
+requestEnvelope :: Maybe Int -> Text -> Series -> Aeson.Encoding
+requestEnvelope requestId method parameters =
+    Aeson.pairs $
+        "jsonrpc" .= ("2.0" :: Text)
+            <> maybe mempty ("id" .=) requestId
+            <> "method" .= method
+            <> AesonEncoding.pair "params" (Aeson.pairs parameters)
 
-httpRequestMcpWithId
-    :: McpClient -> Int -> Text -> Text -> Aeson.Encoding -> Maybe Int
-    -> IO (Either Text RawJson)
-httpRequestMcpWithId client timeoutMicros url method parameters requestId = do
-    request <- parseRequest (Text.unpack url)
-    session <- readIORef client.clientHttpSession
-    fileResult <- case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
-        Nothing -> pure (Right Nothing)
-        Just path -> OAuth.loadOAuthTokenFile path >>= \case
+-- | Per-request metadata. Modern servers require the protocol version and
+-- client capabilities on every request; every era accepts a progress token.
+metaSeries :: McpClient -> Maybe McpProtocolEra -> McpRequest -> Int -> Series
+metaSeries client era request requestId
+    | not request.requestMeta = mempty
+    | otherwise = "_meta" .= object (progress <> modern)
+  where
+    progress = ["progressToken" .= requestId]
+    modern = case era of
+        Just McpEraModern ->
+            [ "io.modelcontextprotocol/protocolVersion" .= modernProtocolVersion
+            , "io.modelcontextprotocol/clientInfo" .= clientInfoValue client.clientHooks
+            , "io.modelcontextprotocol/clientCapabilities"
+                .= clientCapabilitiesValue client.clientHooks
+            ]
+        _ -> []
+
+-- | Wait for a stdio response. Progress notifications extend the wait up to
+-- a hard limit; a timeout cancels the request.
+awaitResponse
+    :: McpClient
+    -> Int
+    -> PendingRequest
+    -> McpRequest
+    -> IO (Either McpError RawJson)
+awaitResponse client requestId pending request
+    | request.requestTimeoutMicros <= 0 =
+        atomically (takeTMVar pending.pendingResponse)
+    | otherwise = do
+        start <- getMonotonicTimeNSec
+        go start 0
+  where
+    slice = max 1 request.requestTimeoutMicros
+    go start seen = do
+        timed <- timeout slice (atomically (takeTMVar pending.pendingResponse))
+        case timed of
+            Just value -> pure value
+            Nothing -> do
+                now <- getMonotonicTimeNSec
+                activity <- readTVarIO pending.pendingActivity
+                if activity /= seen && not (pastHardDeadline start now slice)
+                    then go start activity
+                    else do
+                        _ <- sendNotification client "notifications/cancelled"
+                            ("requestId" .= requestId
+                                <> "reason" .= ("timeout" :: Text))
+                        pure (Left (timeoutError request.requestMethod slice))
+
+pastHardDeadline :: Word64 -> Word64 -> Int -> Bool
+pastHardDeadline start now sliceMicros =
+    now - start
+        >= fromIntegral sliceMicros * fromIntegral hardTimeoutMultiplier * 1000
+
+timeoutError :: Text -> Int -> McpError
+timeoutError method sliceMicros =
+    McpTimeout $
+        "MCP request "
+            <> method
+            <> " timed out after "
+            <> Text.pack (show ((sliceMicros + 999999) `div` 1000000))
+            <> " seconds"
+
+-- * Multi round-trip requests and tasks
+
+data ResultKind
+    = ResultComplete
+    | ResultInputRequired
+    | ResultTask
+    | ResultUnknown !Text
+    deriving (Eq, Show)
+
+resultKind :: RawJson -> ResultKind
+resultKind raw =
+    case projectRawOr Nothing (Json.object (Json.optionalKey "resultType" Json.text)) raw of
+        Nothing -> ResultComplete
+        Just "complete" -> ResultComplete
+        Just "input_required" -> ResultInputRequired
+        Just "task" -> ResultTask
+        Just other -> ResultUnknown other
+
+-- | Issue a request that may return @input_required@ or @task@ results and
+-- drive it to completion.
+invokeWithInputRounds :: McpClient -> McpRequest -> IO (Either McpError RawJson)
+invokeWithInputRounds client request = go (0 :: Int) mempty
+  where
+    go rounds extra =
+        requestMcpFull client request { requestParams = request.requestParams <> extra }
+            >>= \case
             Left err -> pure (Left err)
-            Right (OAuth.OAuthTokenFile _ _ token _ expiresAt) -> do
-                now <- round <$> getPOSIXTime
-                if maybe False (<= now + 60) expiresAt
-                    then OAuth.refreshOAuthTokenFile mcpHttpManager path >>= \case
-                        Left err -> pure (Left err)
-                        Right (OAuth.OAuthTokenFile _ _ refreshed _ _) -> pure (Right (Just refreshed))
-                    else pure (Right (Just token))
-    let configuredToken = case fileResult of
-            Right (Just token) -> Just token
-            _ -> fmap Text.pack (lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv)
-        body = AesonEncodingInternal.encodingToLazyByteString $ Aeson.pairs $
-            "jsonrpc" .= ("2.0" :: Text)
-                <> maybe mempty ("id" .=) requestId
-                <> "method" .= method
-                <> AesonEncoding.pair "params" parameters
+            Right raw -> case resultKind raw of
+                ResultComplete -> pure (Right raw)
+                ResultTask -> awaitTask client request raw
+                ResultUnknown kind ->
+                    pure (Left (McpTransportError ("unrecognized resultType \"" <> kind <> "\"")))
+                ResultInputRequired
+                    | rounds >= maxInputRounds ->
+                        pure (Left (McpTransportError
+                            ("MCP server kept requesting input after "
+                                <> Text.pack (show maxInputRounds) <> " rounds")))
+                    | otherwise ->
+                        case Json.decodeEither inputRequiredDecoder (rawJsonBytes raw) of
+                            Left err ->
+                                pure (Left (McpTransportError
+                                    ("invalid input_required result: " <> err.jsonErrorMessage)))
+                            Right (requests, requestState) ->
+                                fulfilInputRequests client requests >>= \case
+                                    Left err -> pure (Left err)
+                                    Right responses ->
+                                        go (rounds + 1)
+                                            (inputResponsesSeries responses
+                                                <> maybe mempty
+                                                    (\state -> AesonEncoding.pair "requestState" (rawJsonEncoding state))
+                                                    requestState)
 
-        perform token = do
-            let headers = [("Content-Type", "application/json"), ("Accept", "application/json, text/event-stream")]
-                    <> maybe [] (\value -> [("Authorization", "Bearer " <> TextEncoding.encodeUtf8 value)]) token
-                    <> maybe [] (\value -> [("Mcp-Session-Id", TextEncoding.encodeUtf8 value)]) session
-                request' = request { HC.method = "POST", HC.requestBody = RequestBodyLBS body, HC.requestHeaders = headers }
-            tryAny (timeout (max 1 timeoutMicros) (httpLbs request' mcpHttpManager))
-        decodeResponse response
-            | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 =
-                pure (Left ("MCP HTTP request failed with status " <> Text.pack (show (statusCode (responseStatus response)))))
-            | otherwise = do
-                forM_ (lookup "Mcp-Session-Id" (responseHeaders response)) (writeIORef client.clientHttpSession . Just . TextEncoding.decodeUtf8)
-                let bytes = LBS.toStrict (responseBody response)
-                if BS.null bytes
-                    then pure (Right (rawJsonFromEncoding (Aeson.toEncoding (object []))))
-                    else case decodeHttpMcpResponse bytes of
-                        Right value -> pure (Right value)
-                        Left jsonError -> case find (BS8.isPrefixOf "data: ") (BS8.lines bytes) of
-                            Just eventData -> pure $
-                                first ("Invalid MCP SSE response: " <>)
-                                    (decodeHttpMcpResponse (BS8.drop 6 eventData))
-                            Nothing -> pure (Left ("Invalid MCP HTTP response: " <> jsonError))
-    perform configuredToken >>= \case
-        Left exception -> pure (Left ("MCP HTTP request failed: " <> exceptionSummary exception))
-        Right Nothing -> pure (Left ("MCP request " <> method <> " timed out"))
-        Right (Just response)
-            | statusCode (responseStatus response) == 401 -> case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
-                Nothing -> pure (Left "MCP server requires OAuth authorization; configure MCP OAuth credentials")
-                Just path -> OAuth.refreshOAuthTokenFile mcpHttpManager path >>= \case
-                    Left err -> pure (Left ("MCP OAuth refresh failed: " <> err))
-                    Right (OAuth.OAuthTokenFile _ _ token _ _) -> perform (Just token) >>= \case
-                        Right (Just retryResponse) -> decodeResponse retryResponse
-                        Right Nothing -> pure (Left ("MCP request " <> method <> " timed out"))
-                        Left retryException -> pure (Left ("MCP HTTP request failed: " <> exceptionSummary retryException))
-            | otherwise -> decodeResponse response
+inputResponsesSeries :: [(Text, RawJson)] -> Series
+inputResponsesSeries responses =
+    AesonEncoding.pair "inputResponses" $ Aeson.pairs $ mconcat
+        [ AesonEncoding.pair (Key.fromText key) (rawJsonEncoding value)
+        | (key, value) <- responses
+        ]
 
-decodeHttpMcpResponse :: BS.ByteString -> Either Text RawJson
-decodeHttpMcpResponse bytes = do
-    envelope <- first (.jsonErrorMessage) $
-        Json.decodeEither responseEnvelopeDecoder bytes
-    case envelope.envelopeError of
-        Just err -> Left ("MCP error: " <> compactRawJson err)
-        Nothing -> case envelope.envelopeResult of
-            Just result -> Right result
-            Nothing -> Left "MCP response omitted result"
+-- | Decode @inputRequests@ (key → method, params) and the opaque
+-- @requestState@.
+inputRequiredDecoder :: Json.Decoder ([(Text, Text, Maybe RawJson)], Maybe RawJson)
+inputRequiredDecoder = Json.object do
+    requests <-
+        Json.optionalKey "inputRequests"
+            (Json.objectAsMap pure inputRequestDecoder)
+    requestState <- Json.optionalKey "requestState" rawJsonDecoder
+    pure
+        ( [ (key, method, params)
+          | (key, (method, params)) <- maybe [] Map.toList requests
+          ]
+        , requestState
+        )
+  where
+    inputRequestDecoder = Json.object do
+        method <- Json.defaultKey "" "method" Json.text
+        params <- Json.optionalKey "params" rawJsonDecoder
+        pure (method, params)
+
+fulfilInputRequests
+    :: McpClient
+    -> [(Text, Text, Maybe RawJson)]
+    -> IO (Either McpError [(Text, RawJson)])
+fulfilInputRequests client = go []
+  where
+    go collected [] = pure (Right (reverse collected))
+    go collected ((key, method, params) : rest) =
+        case method of
+            "elicitation/create" -> do
+                result <- runElicitation client params
+                go ((key, encodeElicitResult result) : collected) rest
+            other ->
+                pure (Left (McpTransportError
+                    ("MCP server requested " <> other
+                        <> ", which this client does not support")))
+
+-- | Ask the host for the requested input. Hosts without an elicitation UI
+-- cancel; a crashing host hook also cancels rather than failing the call.
+runElicitation :: McpClient -> Maybe RawJson -> IO McpElicitResult
+runElicitation client params =
+    case client.clientHooks.mcpHostElicit of
+        Nothing -> pure McpElicitCancel
+        Just hook ->
+            case params >>= decodeElicitRequest client.clientConfig.mcpServerName of
+                Nothing -> pure McpElicitCancel
+                Just request ->
+                    tryAny (hook request) >>= \case
+                        Left _ -> pure McpElicitCancel
+                        Right result -> pure result
+
+decodeElicitRequest :: Text -> RawJson -> Maybe McpElicitRequest
+decodeElicitRequest serverName raw =
+    either (const Nothing) Just (Json.decodeEither decoder (rawJsonBytes raw))
+  where
+    decoder = Json.object do
+        mode <- Json.defaultKey "form" "mode" Json.text
+        message <- Json.defaultKey "" "message" Json.text
+        schema <- Json.optionalKey "requestedSchema" rawJsonDecoder
+        url <- Json.optionalKey "url" Json.text
+        elicitMode <- case mode of
+            "url" -> maybe (fail "url mode requires a url") (pure . McpElicitUrl) url
+            _ -> pure (McpElicitForm (fromMaybe emptyInputSchema schema))
+        pure McpElicitRequest
+            { elicitServerName = serverName
+            , elicitMessage = message
+            , elicitMode
+            }
+
+-- | Poll a task returned by a task-augmented request until it settles.
+awaitTask :: McpClient -> McpRequest -> RawJson -> IO (Either McpError RawJson)
+awaitTask client request raw =
+    case Json.decodeEither taskDecoder (rawJsonBytes raw) of
+        Left err ->
+            pure (Left (McpTransportError ("invalid task result: " <> err.jsonErrorMessage)))
+        Right task -> do
+            start <- getMonotonicTimeNSec
+            report 0 task
+            poll' start (1 :: Int) task.taskPollIntervalMs
+  where
+    slice = max 1 request.requestTimeoutMicros
+    report :: Int -> TaskState -> IO ()
+    report count task =
+        forM_ request.requestOnProgress \onProgress ->
+            onProgress McpProgress
+                { progressValue = fromIntegral (count :: Int)
+                , progressTotal = Nothing
+                , progressMessage =
+                    Just ("task " <> task.taskStatus
+                        <> maybe "" (": " <>) task.taskStatusMessage)
+                }
+    poll' start count intervalMs = do
+        threadDelay (max 100 intervalMs * 1000)
+        now <- getMonotonicTimeNSec
+        if request.requestTimeoutMicros > 0 && pastHardDeadline start now slice
+            then do
+                _ <- requestMcpFull client
+                    (clientRequest client "tasks/cancel" ("taskId" .= taskIdOf))
+                pure (Left (timeoutError (request.requestMethod <> " task") slice))
+            else
+                requestMcpFull client
+                    (clientRequest client "tasks/get" ("taskId" .= taskIdOf))
+                    >>= \case
+                    Left err -> pure (Left err)
+                    Right state ->
+                        case Json.decodeEither taskDecoder (rawJsonBytes state) of
+                            Left err ->
+                                pure (Left (McpTransportError
+                                    ("invalid tasks/get result: " <> err.jsonErrorMessage)))
+                            Right task -> do
+                                report count task
+                                case task.taskStatus of
+                                    "completed" -> case task.taskResult of
+                                        Just result -> pure (Right result)
+                                        Nothing -> legacyTaskResult
+                                    "failed" ->
+                                        pure . Left $ fromMaybe
+                                            (McpTransportError "MCP task failed")
+                                            (task.taskError >>= decodeRpcError)
+                                    "cancelled" ->
+                                        pure (Left (McpTransportError "MCP task was cancelled"))
+                                    "input_required" ->
+                                        fulfilInputRequests client task.taskInputRequests
+                                            >>= \case
+                                            Left err -> pure (Left err)
+                                            Right responses -> do
+                                                _ <- requestMcpFull client
+                                                    (clientRequest client "tasks/update"
+                                                        ("taskId" .= taskIdOf
+                                                            <> inputResponsesSeries responses))
+                                                poll' start (count + 1) task.taskPollIntervalMs
+                                    _ -> poll' start (count + 1) task.taskPollIntervalMs
+      where
+        taskIdOf = initialTaskId
+    initialTaskId =
+        projectRawOr "" (Json.object (Json.defaultKey "" "taskId" Json.text)) raw
+    legacyTaskResult =
+        requestMcpFull client
+            (clientRequest client "tasks/result" ("taskId" .= initialTaskId))
+
+data TaskState = TaskState
+    { taskStatus :: !Text
+    , taskStatusMessage :: !(Maybe Text)
+    , taskPollIntervalMs :: !Int
+    , taskResult :: !(Maybe RawJson)
+    , taskError :: !(Maybe RawJson)
+    , taskInputRequests :: ![(Text, Text, Maybe RawJson)]
+    }
+
+taskDecoder :: Json.Decoder TaskState
+taskDecoder = Json.object do
+    taskStatus <- Json.defaultKey "working" "status" Json.text
+    taskStatusMessage <- Json.optionalKey "statusMessage" Json.text
+    pollMs <- Json.optionalKey "pollIntervalMs" Json.int
+    pollLegacy <- Json.optionalKey "pollInterval" Json.int
+    taskResult <- Json.optionalKey "result" rawJsonDecoder
+    taskError <- Json.optionalKey "error" rawJsonDecoder
+    requests <-
+        Json.optionalKey "inputRequests"
+            (Json.objectAsMap pure inputRequestDecoder)
+    pure TaskState
+        { taskStatus
+        , taskStatusMessage
+        , taskPollIntervalMs = fromMaybe 1000 (maybe pollLegacy Just pollMs)
+        , taskResult
+        , taskError
+        , taskInputRequests =
+            [ (key, method, params)
+            | (key, (method, params)) <- maybe [] Map.toList requests
+            ]
+        }
+  where
+    inputRequestDecoder = Json.object do
+        method <- Json.defaultKey "" "method" Json.text
+        params <- Json.optionalKey "params" rawJsonDecoder
+        pure (method, params)
+
+decodeRpcError :: RawJson -> Maybe McpError
+decodeRpcError raw =
+    either (const Nothing) Just $
+        Json.decodeEither
+            (Json.object do
+                code <- Json.defaultKey errorCodeInternal "code" Json.int
+                message <- Json.defaultKey "" "message" Json.text
+                payload <- Json.optionalKey "data" rawJsonDecoder
+                pure (McpRpcError code message payload))
+            (rawJsonBytes raw)
+
+-- * Subscriptions
+
+-- | Open a @subscriptions/listen@ stream for the list-change notifications
+-- the server can emit. Legacy servers deliver list changes unsolicited.
+startSubscriptions :: McpClient -> IO ()
+startSubscriptions client = do
+    info <- readTVarIO client.clientServerInfo
+    case info of
+        Just McpServerInfo{serverInfoEra = McpEraModern, serverInfoCapabilities = capabilities} -> do
+            let wanted =
+                    [ "toolsListChanged" .= True
+                    | maybe False (.listChanged) capabilities.capabilityTools
+                    ]
+                    <> [ "promptsListChanged" .= True
+                       | maybe False (.listChanged) capabilities.capabilityPrompts
+                       ]
+                    <> [ "resourcesListChanged" .= True
+                       | maybe False (.resourcesListChanged) capabilities.capabilityResources
+                       ]
+            unless (null wanted) $
+                spawnClientWorker client (subscriptionLoop client (mconcat wanted))
+        _ -> pure ()
+
+subscriptionLoop :: McpClient -> Series -> IO ()
+subscriptionLoop client filterSeries = go (1 :: Int)
+  where
+    go delaySeconds = do
+        outcome <-
+            requestMcpFull client
+                (clientRequest client "subscriptions/listen"
+                    (AesonEncoding.pair "notifications" (Aeson.pairs filterSeries)))
+                    { requestTimeoutMicros = 0 }
+        closed <- readMVar client.clientClosed
+        failed <- readTVarIO client.clientFailure
+        case outcome of
+            Left (McpRpcError _ _ _) -> pure ()
+            _ | closed || isJust failed -> pure ()
+              | otherwise -> do
+                    -- The server closed the stream gracefully or the
+                    -- connection dropped; re-establish with backoff.
+                    threadDelay (delaySeconds * 1000000)
+                    go (min 30 (delaySeconds * 2))
+
+-- * Transport: stdio
 
 sendNotification
     :: McpClient
     -> Text
-    -> Aeson.Encoding
-    -> IO (Either Text ())
+    -> Series
+    -> IO (Either McpError ())
 sendNotification client method parameters =
     case client.clientConfig.mcpServerUrl of
-        Just url -> httpNotificationMcp client
-                (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
-                url method parameters
-        Nothing -> sendMessage client . Aeson.pairs $
-            "jsonrpc" .= ("2.0" :: Text)
-                <> "method" .= method
-                <> AesonEncoding.pair "params" parameters
+        Just url -> do
+            era <- mcpClientEra client
+            void <$> httpExchange client url era
+                (clientRequest client method parameters)
+                Nothing
+                (requestEnvelope Nothing method parameters)
+        Nothing ->
+            either (Left . McpTransportError) Right
+                <$> sendMessage client (requestEnvelope Nothing method parameters)
 
 sendMessage :: McpClient -> Aeson.Encoding -> IO (Either Text ())
 sendMessage client message =
@@ -775,66 +1608,457 @@ sendMessage client message =
         >>= \case
             Left exception -> do
                 let err = "MCP write failed: " <> exceptionSummary exception
-                failClient client.clientPending client.clientFailure err
+                failPending client.clientPending client.clientFailure err
                 pure (Left err)
             Right () -> pure (Right ())
 
-readerLoop
-    :: Handle
-    -> TVar (IntMap.IntMap (TMVar (Either Text RawJson)))
-    -> TVar (Maybe Text)
-    -> IO ()
-readerLoop output pending failure =
-    loop `finally` failPending pending failure "MCP server stdout closed"
+readerLoop :: McpClient -> Handle -> IO ()
+readerLoop client output =
+    loop `finally`
+        failPending client.clientPending client.clientFailure
+            "MCP server stdout closed"
   where
     loop = do
         line <- BS8.hGetLine output
-        unless (BS.null line) $
-            case Json.decodeEither responseEnvelopeDecoder line of
+        unless (BS.null (BS8.strip line)) $
+            case Json.decodeEither inboundDecoder line of
                 Left err ->
-                    failPending pending failure
-                        ("Invalid MCP JSON response: " <> err.jsonErrorMessage)
-                Right response ->
-                    routeResponse pending response
+                    failPending client.clientPending client.clientFailure
+                        ("Invalid MCP JSON message: " <> err.jsonErrorMessage)
+                Right inbound ->
+                    handleInbound client inbound
         loop
 
-data ResponseEnvelope = ResponseEnvelope
-    { envelopeId :: !(Maybe Int)
-    , envelopeError :: !(Maybe RawJson)
-    , envelopeResult :: !(Maybe RawJson)
+-- | Any JSON-RPC message received from the server.
+data McpInbound = McpInbound
+    { inboundRawId :: !(Maybe RawJson)
+    , inboundMethod :: !(Maybe Text)
+    , inboundParams :: !(Maybe RawJson)
+    , inboundResult :: !(Maybe RawJson)
+    , inboundError :: !(Maybe RawJson)
     }
 
-responseEnvelopeDecoder :: Json.Decoder ResponseEnvelope
-responseEnvelopeDecoder = Json.object do
-    rawId <- Json.optionalKey "id" rawJsonDecoder
-    envelopeError <- Json.optionalKey "error" rawJsonDecoder
-    envelopeResult <- Json.optionalKey "result" rawJsonDecoder
-    let envelopeId = rawId >>= \value ->
-            either (const Nothing) Just $
-                Json.decodeEither Json.int (rawJsonBytes value)
-    pure ResponseEnvelope{..}
+inboundDecoder :: Json.Decoder McpInbound
+inboundDecoder = Json.object do
+    inboundRawId <- Json.optionalKey "id" rawJsonDecoder
+    inboundMethod <- Json.optionalKey "method" Json.text
+    inboundParams <- Json.optionalKey "params" rawJsonDecoder
+    inboundResult <- Json.optionalKey "result" rawJsonDecoder
+    inboundError <- Json.optionalKey "error" rawJsonDecoder
+    pure McpInbound{..}
 
-routeResponse
-    :: TVar (IntMap.IntMap (TMVar (Either Text RawJson)))
-    -> ResponseEnvelope
-    -> IO ()
-routeResponse pending envelope =
-    case envelope.envelopeId of
+-- | Route one inbound message: response, server request, or notification.
+handleInbound :: McpClient -> McpInbound -> IO ()
+handleInbound client inbound =
+    case inbound.inboundMethod of
+        Just method -> case inbound.inboundRawId of
+            Just requestId -> handleServerRequest client requestId method inbound.inboundParams
+            Nothing -> handleNotification client method inbound.inboundParams
+        Nothing -> routeResponse client inbound
+
+routeResponse :: McpClient -> McpInbound -> IO ()
+routeResponse client inbound =
+    case inbound.inboundRawId >>= decodeIntId of
         Nothing -> pure ()
         Just ident -> do
             destination <- atomically do
-                current <- readTVar pending
-                writeTVar pending (IntMap.delete ident current)
+                current <- readTVar client.clientPending
+                writeTVar client.clientPending (IntMap.delete ident current)
                 pure (IntMap.lookup ident current)
-            case destination of
-                Nothing -> pure ()
-                Just response ->
-                    atomically . void . tryPutTMVar response $
-                        case envelope.envelopeError of
-                            Just err -> Left ("MCP error: " <> compactRawJson err)
-                            Nothing -> case envelope.envelopeResult of
-                                Just result -> Right result
-                                Nothing -> Left "MCP response omitted result"
+            forM_ destination \pending ->
+                atomically . void . tryPutTMVar pending.pendingResponse $
+                    case inbound.inboundError of
+                        Just err ->
+                            Left (fromMaybe
+                                (McpTransportError ("MCP error: " <> compactRawJson err))
+                                (decodeRpcError err))
+                        Nothing -> case inbound.inboundResult of
+                            Just result -> Right result
+                            Nothing -> Left (McpTransportError "MCP response omitted result")
+
+decodeIntId :: RawJson -> Maybe Int
+decodeIntId value =
+    either (const Nothing) Just (Json.decodeEither Json.int (rawJsonBytes value))
+
+-- | Answer a server-initiated request. Only @ping@ and legacy
+-- @elicitation/create@ are supported; everything else is unknown.
+handleServerRequest :: McpClient -> RawJson -> Text -> Maybe RawJson -> IO ()
+handleServerRequest client requestId method params =
+    case method of
+        "ping" -> respondResult (Aeson.toEncoding (object []))
+        "elicitation/create" ->
+            spawnClientWorker client do
+                result <- runElicitation client params
+                respondResult (rawJsonEncoding (encodeElicitResult result))
+        _ ->
+            respondError errorCodeMethodNotFound ("Method not found: " <> method)
+  where
+    respondResult result =
+        void $ sendResponse client $
+            Aeson.pairs $
+                "jsonrpc" .= ("2.0" :: Text)
+                    <> AesonEncoding.pair "id" (rawJsonEncoding requestId)
+                    <> AesonEncoding.pair "result" result
+    respondError code message =
+        void $ sendResponse client $
+            Aeson.pairs $
+                "jsonrpc" .= ("2.0" :: Text)
+                    <> AesonEncoding.pair "id" (rawJsonEncoding requestId)
+                    <> "error" .= object ["code" .= code, "message" .= message]
+
+sendResponse :: McpClient -> Aeson.Encoding -> IO (Either McpError ())
+sendResponse client message =
+    case client.clientConfig.mcpServerUrl of
+        Just url -> do
+            era <- mcpClientEra client
+            void <$> httpExchange client url era
+                (clientRequest client "" mempty) Nothing message
+        Nothing ->
+            either (Left . McpTransportError) Right <$> sendMessage client message
+
+handleNotification :: McpClient -> Text -> Maybe RawJson -> IO ()
+handleNotification client method params =
+    case method of
+        "notifications/progress" ->
+            forM_ (params >>= decodeProgress) \(token, progress) -> do
+                pending <- IntMap.lookup token <$> readTVarIO client.clientPending
+                forM_ pending \entry -> do
+                    atomically $ modifyTVar' entry.pendingActivity (+ 1)
+                    void (tryAny (entry.pendingOnProgress progress))
+        "notifications/tools/list_changed" -> emit McpToolsListChanged
+        "notifications/prompts/list_changed" -> emit McpPromptsListChanged
+        "notifications/resources/list_changed" -> emit McpResourcesListChanged
+        "notifications/resources/updated" ->
+            forM_ (params >>= uriOf) (emit . McpResourceUpdated)
+        "notifications/message" ->
+            forM_ (params >>= decodeLogMessage) \(level, logger, payload) ->
+                emit (McpLogMessage level logger payload)
+        _ -> pure ()
+  where
+    emit event = do
+        handler <- readIORef client.clientEventHandler
+        void (tryAny (handler event))
+    uriOf raw =
+        projectRawOr Nothing (Json.object (Json.optionalKey "uri" Json.text)) raw
+    decodeLogMessage raw =
+        either (const Nothing) Just $
+            Json.decodeEither
+                (Json.object do
+                    level <- Json.defaultKey "info" "level" Json.text
+                    logger <- Json.optionalKey "logger" Json.text
+                    payload <- Json.defaultKey emptyObjectJson "data" rawJsonDecoder
+                    pure (level, logger, payload))
+                (rawJsonBytes raw)
+
+emptyObjectJson :: RawJson
+emptyObjectJson = rawJsonFromEncoding (Aeson.toEncoding (object []))
+
+decodeProgress :: RawJson -> Maybe (Int, McpProgress)
+decodeProgress raw =
+    either (const Nothing) Just $
+        Json.decodeEither
+            (Json.object do
+                token <- Json.atKey "progressToken" tokenDecoder
+                value <- Json.defaultKey 0 "progress" Json.double
+                total <- Json.optionalKey "total" Json.double
+                message <- Json.optionalKey "message" Json.text
+                pure (token, McpProgress value total message))
+            (rawJsonBytes raw)
+  where
+    tokenDecoder =
+        Json.getType >>= \case
+            Json.VNumber -> Json.int
+            Json.VString -> do
+                text <- Json.text
+                case reads (Text.unpack text) of
+                    [(number, "")] -> pure number
+                    _ -> fail "progress token is not an integer"
+            _ -> fail "unsupported progress token"
+
+-- | Run background work owned by the client. Finished workers are pruned on
+-- the next spawn; remaining ones are cancelled by 'closeMcpClient'.
+spawnClientWorker :: McpClient -> IO () -> IO ()
+spawnClientWorker client action = mask_ do
+    worker <- asyncWithUnmask \unmask -> unmask (void (tryAny action))
+    current <- readTVarIO client.clientWorkers
+    live <- fmap catMaybes $ forM current \existing ->
+        poll existing >>= \case
+            Nothing -> pure (Just existing)
+            Just _ -> pure Nothing
+    atomically $ writeTVar client.clientWorkers (worker : live)
+
+-- * Transport: Streamable HTTP
+
+data HttpOutcome
+    = HttpDelivered
+    -- ^ The message was accepted (2xx). Any response was routed to the
+    -- pending map.
+    | HttpUnauthorized !Int ![Header]
+    | HttpFailed !McpError
+
+-- | Perform one POST to the MCP endpoint. Responses (single JSON objects or
+-- SSE streams) are routed through 'handleInbound'; the pending entry, when
+-- present, then carries the result.
+httpExchange
+    :: McpClient
+    -> Text
+    -> Maybe McpProtocolEra
+    -> McpRequest
+    -> Maybe (Int, PendingRequest)
+    -> Aeson.Encoding
+    -> IO (Either McpError RawJson)
+httpExchange client url era request pending message = do
+    baseRequest <- parseRequest (Text.unpack url)
+    session <- readIORef client.clientHttpSession
+    negotiated <- readTVarIO client.clientServerInfo
+    tokenResult <- configuredAccessToken client
+    let body = AesonEncodingInternal.encodingToLazyByteString message
+        protocolHeader = case era of
+            Just McpEraModern -> [("MCP-Protocol-Version", TextEncoding.encodeUtf8 modernProtocolVersion)]
+            Just McpEraLegacy ->
+                [ ("MCP-Protocol-Version", TextEncoding.encodeUtf8 info.serverInfoProtocolVersion)
+                | Just info <- [negotiated]
+                ]
+            Nothing -> []
+        modernHeaders
+            | era == Just McpEraModern && not (Text.null request.requestMethod) =
+                [("Mcp-Method", TextEncoding.encodeUtf8 request.requestMethod)]
+                    <> [ ("Mcp-Name", TextEncoding.encodeUtf8 (encodeHeaderValue name))
+                       | Just name <- [request.requestName]
+                       ]
+                    <> [ (fromString (Text.unpack name), TextEncoding.encodeUtf8 value)
+                       | (name, value) <- request.requestHeaderParams
+                       ]
+            | otherwise = []
+        sessionHeader
+            | era == Just McpEraModern = []
+            | otherwise =
+                [ ("Mcp-Session-Id", TextEncoding.encodeUtf8 value)
+                | Just value <- [session]
+                ]
+        headersFor token =
+            [ ("Content-Type", "application/json")
+            , ("Accept", "application/json, text/event-stream")
+            ]
+                <> [ ("Authorization", "Bearer " <> TextEncoding.encodeUtf8 value)
+                   | Just value <- [token]
+                   ]
+                <> protocolHeader
+                <> modernHeaders
+                <> sessionHeader
+        slice = request.requestTimeoutMicros
+        perform token = do
+            let httpRequest = baseRequest
+                    { HC.method = "POST"
+                    , HC.requestBody = RequestBodyLBS body
+                    , HC.requestHeaders = headersFor token
+                    , HC.responseTimeout =
+                        if slice <= 0
+                            then HC.responseTimeoutNone
+                            else HC.responseTimeoutMicro slice
+                    }
+            tryAny (withResponse httpRequest mcpHttpManager (consume era))
+        consume responseEra response = do
+            let status = statusCode (responseStatus response)
+                headers = responseHeaders response
+            when (responseEra /= Just McpEraModern) $
+                forM_ (lookup "Mcp-Session-Id" headers)
+                    (writeIORef client.clientHttpSession . Just . TextEncoding.decodeUtf8)
+            if status == 401 || status == 403
+                then pure (HttpUnauthorized status headers)
+                else if status < 200 || status >= 300
+                    then do
+                        bytes <- readBounded (responseBody response)
+                        pure . HttpFailed $ fromMaybe
+                            (McpHttpStatus status
+                                (TextEncoding.decodeUtf8With lenientDecode bytes))
+                            (decodeErrorBody bytes)
+                    else if status == 202 || status == 204
+                        then pure HttpDelivered
+                        else if isEventStream headers
+                            then readSseStream client (responseBody response) pending request
+                            else do
+                                bytes <- readBounded (responseBody response)
+                                if BS.null (BS8.strip bytes)
+                                    then pure HttpDelivered
+                                    else case Json.decodeEither inboundDecoder bytes of
+                                        Left err ->
+                                            pure (HttpFailed (McpTransportError
+                                                ("Invalid MCP HTTP response: " <> err.jsonErrorMessage)))
+                                        Right inbound -> do
+                                            handleInbound client inbound
+                                            pure HttpDelivered
+        settle outcome = case outcome of
+            Left exception ->
+                pure (Left (McpTransportError
+                    ("MCP HTTP request failed: " <> exceptionSummary exception)))
+            Right (HttpFailed err) -> pure (Left err)
+            Right (HttpUnauthorized status headers) ->
+                pure (Left (authorizationError status headers))
+            Right HttpDelivered -> case pending of
+                Nothing -> pure (Right emptyObjectJson)
+                Just (_, entry) ->
+                    atomically (tryReadTMVar entry.pendingResponse) >>= \case
+                        Just value -> pure value
+                        Nothing ->
+                            pure (Left (McpTransportError
+                                "MCP HTTP response did not include a result for the request"))
+    case tokenResult of
+        Left err -> pure (Left (McpTransportError err))
+        Right configuredToken ->
+            perform configuredToken >>= \case
+                Right (HttpUnauthorized 401 _)
+                    | Just path <- lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv ->
+                        OAuth.refreshOAuthTokenFile mcpHttpManager path >>= \case
+                            Left err -> pure (Left (McpTransportError ("MCP OAuth refresh failed: " <> err)))
+                            Right (OAuth.OAuthTokenFile _ _ token _ _) ->
+                                perform (Just token) >>= settle
+                outcome -> settle outcome
+
+-- | Read a whole response body with a size cap.
+readBounded :: HC.BodyReader -> IO BS.ByteString
+readBounded reader = go [] 0
+  where
+    limit = 16 * 1024 * 1024 :: Int
+    go chunks total = do
+        chunk <- brRead reader
+        if BS.null chunk || total > limit
+            then pure (BS.concat (reverse chunks))
+            else go (chunk : chunks) (total + BS.length chunk)
+
+isEventStream :: [Header] -> Bool
+isEventStream headers =
+    case lookup "Content-Type" headers of
+        Just value -> "text/event-stream" `BS.isPrefixOf` BS8.map toLowerAscii value
+        Nothing -> False
+  where
+    toLowerAscii character
+        | character >= 'A' && character <= 'Z' = toEnum (fromEnum character + 32)
+        | otherwise = character
+
+decodeErrorBody :: BS.ByteString -> Maybe McpError
+decodeErrorBody bytes =
+    case Json.decodeEither inboundDecoder bytes of
+        Right inbound -> inbound.inboundError >>= decodeRpcError
+        Left _ -> Nothing
+
+authorizationError :: Int -> [Header] -> McpError
+authorizationError status headers =
+    McpHttpStatus status $
+        case lookup "WWW-Authenticate" headers of
+            Just challenge ->
+                (if status == 401
+                    then "MCP server requires OAuth authorization"
+                    else "MCP server denied the request (insufficient scope?)")
+                    <> "; challenge: "
+                    <> TextEncoding.decodeUtf8With lenientDecode challenge
+            Nothing
+                | status == 401 -> "MCP server requires OAuth authorization; run `/mcp login <url>` or configure MCP OAuth credentials"
+                | otherwise -> "MCP server denied the request"
+
+-- | Consume a Server-Sent Events response stream, routing every event
+-- through 'handleInbound' until the awaited response arrives or the stream
+-- ends. Idle periods are bounded by the request timeout, extended while the
+-- server reports progress.
+readSseStream
+    :: McpClient
+    -> HC.BodyReader
+    -> Maybe (Int, PendingRequest)
+    -> McpRequest
+    -> IO HttpOutcome
+readSseStream client reader pending request = do
+    start <- getMonotonicTimeNSec
+    go start 0 BS.empty []
+  where
+    slice = request.requestTimeoutMicros
+    settled = case pending of
+        Nothing -> pure False
+        Just (_, entry) -> not <$> atomically (isEmptyTMVar entry.pendingResponse)
+    go start seen buffer dataLines = do
+        done <- settled
+        if done
+            then pure HttpDelivered
+            else do
+                chunk <-
+                    if slice <= 0
+                        then Just <$> brRead reader
+                        else timeout (max 1 slice) (brRead reader)
+                case chunk of
+                    Nothing -> do
+                        now <- getMonotonicTimeNSec
+                        activity <- maybe (pure 0) (readTVarIO . (.pendingActivity) . snd) pending
+                        if activity /= seen && not (pastHardDeadline start now slice)
+                            then go start activity buffer dataLines
+                            else pure (HttpFailed (timeoutError request.requestMethod slice))
+                    Just bytes
+                        | BS.null bytes -> do
+                            -- End of stream: flush a trailing event without a blank line.
+                            dispatchEvent dataLines
+                            finished <- settled
+                            pure $ if finished || isNothing pending
+                                then HttpDelivered
+                                else HttpFailed (McpTransportError
+                                    "MCP SSE stream closed before the response arrived")
+                        | otherwise -> do
+                            let (complete, rest) = splitLines (buffer <> bytes)
+                            remaining <- foldLines dataLines complete
+                            go start seen rest remaining
+    foldLines dataLines [] = pure dataLines
+    foldLines dataLines (line : rest)
+        | BS.null line = dispatchEvent dataLines >> foldLines [] rest
+        | BS8.isPrefixOf ":" line = foldLines dataLines rest
+        | Just payload <- BS.stripPrefix "data:" line =
+            foldLines (dataLines <> [fromMaybe payload (BS.stripPrefix " " payload)]) rest
+        | otherwise = foldLines dataLines rest
+    dispatchEvent [] = pure ()
+    dispatchEvent dataLines =
+        case Json.decodeEither inboundDecoder (BS8.intercalate "\n" dataLines) of
+            Left _ -> pure ()
+            Right inbound -> handleInbound client inbound
+
+-- | Split a buffer into complete lines (without terminators) and the
+-- trailing partial line.
+splitLines :: BS.ByteString -> ([BS.ByteString], BS.ByteString)
+splitLines buffer =
+    let pieces = BS8.split '\n' buffer
+    in case reverse pieces of
+        [] -> ([], BS.empty)
+        partial : completeReversed ->
+            (map stripCarriage (reverse completeReversed), partial)
+  where
+    stripCarriage line = fromMaybe line (BS.stripSuffix "\r" line)
+
+configuredAccessToken :: McpClient -> IO (Either Text (Maybe Text))
+configuredAccessToken client =
+    case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
+        Nothing -> pure (Right envToken)
+        Just path -> OAuth.loadOAuthTokenFile path >>= \case
+            Left err
+                | isJust envToken -> pure (Right envToken)
+                | otherwise -> pure (Left err)
+            Right (OAuth.OAuthTokenFile _ _ token _ expiresAt) -> do
+                now <- round <$> getPOSIXTime
+                if maybe False (<= now + 60) expiresAt
+                    then OAuth.refreshOAuthTokenFile mcpHttpManager path >>= \case
+                        Left err -> pure (Left err)
+                        Right (OAuth.OAuthTokenFile _ _ refreshed _ _) -> pure (Right (Just refreshed))
+                    else pure (Right (Just token))
+  where
+    envToken = fmap Text.pack (lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv)
+
+-- | Compatibility helper for tests: decode a single JSON-RPC response body.
+decodeHttpMcpResponse :: BS.ByteString -> Either Text RawJson
+decodeHttpMcpResponse bytes = do
+    inbound <- either (Left . (.jsonErrorMessage)) Right $
+        Json.decodeEither inboundDecoder bytes
+    case inbound.inboundError of
+        Just err ->
+            Left (maybe ("MCP error: " <> compactRawJson err) renderMcpError (decodeRpcError err))
+        Nothing -> case inbound.inboundResult of
+            Just result -> Right result
+            Nothing -> Left "MCP response omitted result"
+
+-- * Stderr capture
 
 stderrLoop :: Handle -> IORef CapturedStderr -> IO ()
 stderrLoop handle captured =
@@ -870,15 +2094,17 @@ capturedStderrText captured =
                 <> " stderr bytes omitted ...]\n"
                 <> body
 
+-- * Failure and shutdown
+
 failClient
-    :: TVar (IntMap.IntMap (TMVar (Either Text RawJson)))
+    :: TVar (IntMap.IntMap PendingRequest)
     -> TVar (Maybe Text)
     -> Text
     -> IO ()
 failClient = failPending
 
 failPending
-    :: TVar (IntMap.IntMap (TMVar (Either Text RawJson)))
+    :: TVar (IntMap.IntMap PendingRequest)
     -> TVar (Maybe Text)
     -> Text
     -> IO ()
@@ -888,7 +2114,7 @@ failPending pending failure err =
         when (existing == Nothing) (writeTVar failure (Just err))
         requests <- readTVar pending
         writeTVar pending IntMap.empty
-        mapM_ (\response -> void (tryPutTMVar response (Left err)))
+        mapM_ (\entry -> void (tryPutTMVar entry.pendingResponse (Left (McpTransportError err))))
             (IntMap.elems requests)
 
 closeMcpClient :: McpClient -> IO ()
@@ -906,45 +2132,47 @@ closeMcpClient client =
                                     (Left "MCP server closed")
                         _ ->
                             writeTVar client.clientLifecycle ClientClosed
+                workers <- atomically do
+                    current <- readTVar client.clientWorkers
+                    writeTVar client.clientWorkers []
+                    pure current
+                mapM_ stopWorker workers
                 forM_ client.clientInput \input ->
                     void $ tryAny (hClose input)
                 forM_ client.clientProcess $ \processHandle ->
                     terminateProcessGroup client.clientGroupId processHandle
                 when (isJust client.clientConfig.mcpServerUrl) $
                     closeHttpSession client
-                forM_ client.clientReader stopWorker
+                readIORef client.clientReader >>= mapM_ stopWorker
                 forM_ client.clientStderrReader stopWorker
                 failClient client.clientPending client.clientFailure
                     "MCP server closed"
                 pure True
 
--- Streamable HTTP sessions are explicitly terminated with DELETE when the
--- server assigned a session id.  Failure is intentionally ignored during
+-- Legacy Streamable HTTP sessions are explicitly terminated with DELETE when
+-- the server assigned a session id.  Failure is intentionally ignored during
 -- shutdown: the local client is already being closed and the server may have
 -- expired the session independently.
 closeHttpSession :: McpClient -> IO ()
 closeHttpSession client = do
     session <- readIORef client.clientHttpSession
-    case (client.clientConfig.mcpServerUrl, session) of
-        (Just url, Just sessionId) -> void $ tryAny do
-            request <- parseRequest (Text.unpack url)
-            bearer <- case lookup "MCP_OAUTH_TOKEN_FILE" client.clientConfig.mcpServerEnv of
-                Just path -> either (const Nothing)
-                    (\(OAuth.OAuthTokenFile _ _ token _ _) -> Just token)
-                    <$> OAuth.loadOAuthTokenFile path
-                Nothing -> pure $ fmap Text.pack
-                    (lookup "MCP_ACCESS_TOKEN" client.clientConfig.mcpServerEnv)
-            let request' = request
-                    { HC.method = "DELETE"
-                    , HC.requestHeaders =
-                        [ ("Mcp-Session-Id", TextEncoding.encodeUtf8 sessionId)
-                        ]
-                        <> maybe [] (\token ->
-                            [ ("Authorization", "Bearer " <> TextEncoding.encodeUtf8 token) ])
-                            bearer
-                    }
-            void $ timeout (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
-                (httpLbs request' mcpHttpManager)
+    era <- mcpClientEra client
+    case (client.clientConfig.mcpServerUrl, session, era) of
+        (Just url, Just sessionId, era')
+            | era' /= Just McpEraModern -> void $ tryAny do
+                request <- parseRequest (Text.unpack url)
+                bearer <- either (const Nothing) id <$> configuredAccessToken client
+                let request' = request
+                        { HC.method = "DELETE"
+                        , HC.requestHeaders =
+                            [ ("Mcp-Session-Id", TextEncoding.encodeUtf8 sessionId)
+                            ]
+                            <> maybe [] (\token ->
+                                [ ("Authorization", "Bearer " <> TextEncoding.encodeUtf8 token) ])
+                                bearer
+                        }
+                void $ timeout (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
+                    (HC.httpNoBody request' mcpHttpManager)
         _ -> pure ()
 
 stopWorker :: Async () -> IO ()
@@ -963,7 +2191,7 @@ mergedEnvironment :: [(String, String)] -> IO [(String, String)]
 mergedEnvironment overrides = do
     inherited <- getEnvironment
     pure . Map.toList $
-        foldl
+        foldl'
             (\environment (name, value) -> Map.insert name value environment)
             (Map.fromList inherited)
             overrides
@@ -981,7 +2209,7 @@ exceptionSummary =
 
 redactConfiguredValues :: McpServerConfig -> Text -> Text
 redactConfiguredValues config input =
-    foldl redact input (map (Text.pack . snd) config.mcpServerEnv)
+    foldl' redact input (map (Text.pack . snd) config.mcpServerEnv)
   where
     redact current secret
         | Text.null secret = current

--- a/packages/agent-core/src/Agent/MCP/Elicitation.hs
+++ b/packages/agent-core/src/Agent/MCP/Elicitation.hs
@@ -1,0 +1,309 @@
+-- | Form-mode elicitation schemas.
+--
+-- Servers describe the input they need with a restricted JSON Schema: a flat
+-- object whose properties are strings, numbers, booleans, or (multi-)select
+-- enums. Hosts render those fields, validate the answers, and return the
+-- resulting object.
+module Agent.MCP.Elicitation
+    ( McpFormField(..)
+    , McpFieldKind(..)
+    , McpEnumOption(..)
+    , parseElicitForm
+    , parseFieldAnswer
+    , encodeFormContent
+    , describeFieldKind
+    , fieldDefaultText
+    ) where
+
+import Agent.Json (RawJson, rawJsonBytes, rawJsonFromEncoding)
+import Data.Aeson (Value(..))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Char (isSpace)
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Scientific (Scientific, floatingOrInteger, fromFloatDigits)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Read as TextRead
+import qualified Data.Vector as Vector
+
+data McpEnumOption = McpEnumOption
+    { optionValue :: !Text
+    , optionTitle :: !Text
+    } deriving (Eq, Show)
+
+data McpFieldKind
+    = McpStringField
+        { stringFormat :: !(Maybe Text)
+        , stringMinLength :: !(Maybe Int)
+        , stringMaxLength :: !(Maybe Int)
+        }
+    | McpNumberField
+        { numberInteger :: !Bool
+        , numberMinimum :: !(Maybe Scientific)
+        , numberMaximum :: !(Maybe Scientific)
+        }
+    | McpBooleanField
+    | McpEnumField
+        { enumOptions :: ![McpEnumOption]
+        , enumMultiple :: !Bool
+        , enumMinItems :: !(Maybe Int)
+        , enumMaxItems :: !(Maybe Int)
+        }
+    deriving (Eq, Show)
+
+data McpFormField = McpFormField
+    { fieldName :: !Text
+    , fieldTitle :: !(Maybe Text)
+    , fieldDescription :: !(Maybe Text)
+    , fieldRequired :: !Bool
+    , fieldDefault :: !(Maybe Value)
+    , fieldKind :: !McpFieldKind
+    } deriving (Eq, Show)
+
+-- | Interpret a @requestedSchema@. Unsupported constructs are rejected so
+-- the host never renders a form it cannot validate.
+parseElicitForm :: RawJson -> Either Text [McpFormField]
+parseElicitForm raw =
+    case Aeson.decodeStrict (rawJsonBytes raw) of
+        Nothing -> Left "requestedSchema is not valid JSON"
+        Just (Object root) -> do
+            let required =
+                    case KeyMap.lookup "required" root of
+                        Just (Array values) ->
+                            mapMaybe asText (Vector.toList values)
+                        _ -> []
+            properties <- case KeyMap.lookup "properties" root of
+                Just (Object fields) -> Right (KeyMap.toList fields)
+                Nothing -> Right []
+                Just _ -> Left "requestedSchema.properties must be an object"
+            mapM (parseField required) properties
+        Just _ -> Left "requestedSchema must be an object schema"
+  where
+    asText = \case
+        String text -> Just text
+        _ -> Nothing
+
+parseField :: [Text] -> (Key.Key, Value) -> Either Text McpFormField
+parseField required (key, schema) = case schema of
+    Object fields -> do
+        let name = Key.toText key
+            lookupText field = case KeyMap.lookup field fields of
+                Just (String text) -> Just text
+                _ -> Nothing
+            lookupInt field = case KeyMap.lookup field fields of
+                Just (Number number) ->
+                    either (const Nothing) Just (floatingOrInteger @Double number)
+                _ -> Nothing
+            lookupNumber field = case KeyMap.lookup field fields of
+                Just (Number number) -> Just number
+                _ -> Nothing
+            kindName = fromMaybe "" (lookupText "type")
+        kind <- case kindName of
+            "string"
+                | Just (Array values) <- KeyMap.lookup "enum" fields ->
+                    Right McpEnumField
+                        { enumOptions =
+                            [ McpEnumOption value value
+                            | String value <- Vector.toList values
+                            ]
+                        , enumMultiple = False
+                        , enumMinItems = Nothing
+                        , enumMaxItems = Nothing
+                        }
+                | Just (Array values) <- KeyMap.lookup "oneOf" fields ->
+                    Right McpEnumField
+                        { enumOptions = mapMaybe titledOption (Vector.toList values)
+                        , enumMultiple = False
+                        , enumMinItems = Nothing
+                        , enumMaxItems = Nothing
+                        }
+                | otherwise ->
+                    Right McpStringField
+                        { stringFormat = lookupText "format"
+                        , stringMinLength = lookupInt "minLength"
+                        , stringMaxLength = lookupInt "maxLength"
+                        }
+            "number" -> Right (numberField False lookupNumber)
+            "integer" -> Right (numberField True lookupNumber)
+            "boolean" -> Right McpBooleanField
+            "array" -> case KeyMap.lookup "items" fields of
+                Just (Object items)
+                    | Just (Array values) <- KeyMap.lookup "enum" items ->
+                        Right McpEnumField
+                            { enumOptions =
+                                [ McpEnumOption value value
+                                | String value <- Vector.toList values
+                                ]
+                            , enumMultiple = True
+                            , enumMinItems = lookupInt "minItems"
+                            , enumMaxItems = lookupInt "maxItems"
+                            }
+                    | Just (Array values) <- KeyMap.lookup "anyOf" items ->
+                        Right McpEnumField
+                            { enumOptions = mapMaybe titledOption (Vector.toList values)
+                            , enumMultiple = True
+                            , enumMinItems = lookupInt "minItems"
+                            , enumMaxItems = lookupInt "maxItems"
+                            }
+                _ -> Left ("field " <> name <> " uses an unsupported array schema")
+            other ->
+                Left ("field " <> name <> " has unsupported type \"" <> other <> "\"")
+        Right McpFormField
+            { fieldName = name
+            , fieldTitle = lookupText "title"
+            , fieldDescription = lookupText "description"
+            , fieldRequired = name `elem` required
+            , fieldDefault = KeyMap.lookup "default" fields
+            , fieldKind = kind
+            }
+    _ -> Left ("field " <> Key.toText key <> " is not an object schema")
+  where
+    numberField integer lookupNumber = McpNumberField
+        { numberInteger = integer
+        , numberMinimum = lookupNumber "minimum"
+        , numberMaximum = lookupNumber "maximum"
+        }
+    titledOption = \case
+        Object option
+            | Just (String value) <- KeyMap.lookup "const" option ->
+                Just McpEnumOption
+                    { optionValue = value
+                    , optionTitle = case KeyMap.lookup "title" option of
+                        Just (String title) -> title
+                        _ -> value
+                    }
+        _ -> Nothing
+
+-- | Human-readable description of what a field accepts.
+describeFieldKind :: McpFormField -> Text
+describeFieldKind field = case field.fieldKind of
+    McpStringField format minLength maxLength ->
+        Text.intercalate ", " $
+            ("text" <> maybe "" (\value -> " (" <> value <> ")") format)
+                : [ "at least " <> plural n "character" | Just n <- [minLength] ]
+                <> [ "at most " <> plural n "character" | Just n <- [maxLength] ]
+    McpNumberField integer minimum maximum ->
+        Text.intercalate ", " $
+            (if integer then "integer" else "number")
+                : [ "minimum " <> showScientific n | Just n <- [minimum] ]
+                <> [ "maximum " <> showScientific n | Just n <- [maximum] ]
+    McpBooleanField -> "yes or no"
+    McpEnumField options multiple minItems maxItems ->
+        (if multiple then "comma-separated choices from: " else "one of: ")
+            <> Text.intercalate ", "
+                [ if option.optionTitle == option.optionValue
+                    then option.optionValue
+                    else option.optionTitle <> " (" <> option.optionValue <> ")"
+                | option <- options
+                ]
+            <> mconcat [ "; at least " <> Text.pack (show n) | Just n <- [minItems] ]
+            <> mconcat [ "; at most " <> Text.pack (show n) | Just n <- [maxItems] ]
+
+-- | The field's default rendered the way a user would type it.
+fieldDefaultText :: McpFormField -> Maybe Text
+fieldDefaultText field = field.fieldDefault >>= \case
+    String text -> Just text
+    Number number -> Just (showScientific number)
+    Bool flag -> Just (if flag then "yes" else "no")
+    Array values ->
+        Just (Text.intercalate ", " [ value | String value <- Vector.toList values ])
+    _ -> Nothing
+
+-- | Validate one typed answer. An empty answer resolves to the default when
+-- there is one and to 'Nothing' when the field is optional.
+parseFieldAnswer :: McpFormField -> Text -> Either Text (Maybe Value)
+parseFieldAnswer field answer
+    | Text.null trimmed =
+        case field.fieldDefault of
+            Just value -> Right (Just value)
+            Nothing
+                | field.fieldRequired -> Left (label <> " is required")
+                | otherwise -> Right Nothing
+    | otherwise = Just <$> parseValue
+  where
+    trimmed = Text.strip answer
+    label = fromMaybe field.fieldName field.fieldTitle
+    parseValue = case field.fieldKind of
+        McpStringField format minLength maxLength -> do
+            checkLength minLength maxLength
+            checkFormat format
+            Right (String trimmed)
+        McpNumberField integer minimum maximum ->
+            case TextRead.signed TextRead.rational trimmed of
+                Right (value, rest) | Text.null rest -> do
+                    let number = fromFloatDigits (value :: Double)
+                    if integer && not (isInteger number)
+                        then Left (label <> " must be an integer")
+                        else do
+                            mapM_ (\bound -> if number < bound then Left (label <> " must be at least " <> showScientific bound) else Right ()) minimum
+                            mapM_ (\bound -> if number > bound then Left (label <> " must be at most " <> showScientific bound) else Right ()) maximum
+                            Right (Number number)
+                _ -> Left (label <> " must be a number")
+        McpBooleanField ->
+            case Text.toLower trimmed of
+                value | value `elem` ["y", "yes", "true", "1", "on"] -> Right (Bool True)
+                      | value `elem` ["n", "no", "false", "0", "off"] -> Right (Bool False)
+                _ -> Left (label <> " must be yes or no")
+        McpEnumField options multiple minItems maxItems
+            | multiple -> do
+                let parts = filter (not . Text.null) (map Text.strip (Text.splitOn "," trimmed))
+                values <- mapM (resolveOption options) parts
+                mapM_ (\n -> if length values < n then Left (label <> " needs at least " <> Text.pack (show n) <> " choices") else Right ()) minItems
+                mapM_ (\n -> if length values > n then Left (label <> " allows at most " <> Text.pack (show n) <> " choices") else Right ()) maxItems
+                Right (Array (Vector.fromList (map String values)))
+            | otherwise -> String <$> resolveOption options trimmed
+    checkLength minLength maxLength = do
+        mapM_ (\n -> if Text.length trimmed < n then Left (label <> " must have at least " <> Text.pack (show n) <> " characters") else Right ()) minLength
+        mapM_ (\n -> if Text.length trimmed > n then Left (label <> " must have at most " <> Text.pack (show n) <> " characters") else Right ()) maxLength
+    checkFormat = \case
+        Just "email"
+            | not ("@" `Text.isInfixOf` trimmed) || Text.any isSpace trimmed ->
+                Left (label <> " must be an email address")
+        Just "uri"
+            | not ("://" `Text.isInfixOf` trimmed) || Text.any isSpace trimmed ->
+                Left (label <> " must be a URI")
+        Just "date"
+            | not (isDate trimmed) -> Left (label <> " must be a date (YYYY-MM-DD)")
+        Just "date-time"
+            | not (isDate (Text.take 10 trimmed) && Text.length trimmed > 10) ->
+                Left (label <> " must be an ISO 8601 date-time")
+        _ -> Right ()
+    isDate text =
+        Text.length text == 10
+            && Text.all (\character -> character == '-' || character `elem` ['0' .. '9']) text
+            && Text.index text 4 == '-'
+            && Text.index text 7 == '-'
+    resolveOption :: [McpEnumOption] -> Text -> Either Text Text
+    resolveOption options input =
+        let lowered = Text.toLower input
+            matches :: McpEnumOption -> Bool
+            matches option =
+                Text.toLower option.optionValue == lowered
+                    || Text.toLower option.optionTitle == lowered
+            byIndex = case TextRead.decimal input of
+                Right (index, rest)
+                    | Text.null rest, index >= 1, index <= length options ->
+                        Just (options !! (index - 1))
+                _ -> Nothing
+        in case filter matches options of
+            option : _ -> Right option.optionValue
+            [] -> case byIndex of
+                Just option -> Right option.optionValue
+                Nothing -> Left (label <> ": \"" <> input <> "\" is not one of the choices")
+    isInteger number = either (const False) (const True) (floatingOrInteger @Double @Integer number)
+
+encodeFormContent :: [(Text, Value)] -> RawJson
+encodeFormContent answers =
+    rawJsonFromEncoding . Aeson.toEncoding $
+        Object (KeyMap.fromList [ (Key.fromText name, value) | (name, value) <- answers ])
+
+plural :: Int -> Text -> Text
+plural count noun =
+    Text.pack (show count) <> " " <> noun <> (if count == 1 then "" else "s")
+
+showScientific :: Scientific -> Text
+showScientific number = case floatingOrInteger @Double @Integer number of
+    Right integer -> Text.pack (show integer)
+    Left floating -> Text.pack (show floating)

--- a/packages/agent-core/src/Agent/MCP/Fleet.hs
+++ b/packages/agent-core/src/Agent/MCP/Fleet.hs
@@ -1,5 +1,6 @@
+-- | A fleet of MCP servers: concurrent startup, the tool catalog shared with
+-- the model, meta-tools for progressive discovery, and reconnection.
 module Agent.MCP.Fleet where
-
 
 import Agent.Json
     ( RawJson
@@ -8,7 +9,8 @@ import Agent.Json
     , rawJsonFromEncoding
     )
 import qualified Agent.Json.Decode as Json
-import Agent.Tools.IO (terminateProcessGroup)
+import Agent.MCP.Client
+import Agent.MCP.Types
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
@@ -18,11 +20,9 @@ import Agent.Tools.Types
 import Agent.ToolDispatch (ToolCall(..), typedTool)
 import Agent.Concurrent (forConcurrentlyBounded_)
 import Control.Concurrent.Async
-    ( Async
-    , asyncWithUnmask
-    , cancel
+    ( asyncWithUnmask
     , mapConcurrently
-    , waitCatch
+    , poll
     )
 import Control.Concurrent.QSem
     ( newQSem
@@ -30,89 +30,53 @@ import Control.Concurrent.QSem
     , waitQSem
     )
 import Control.Concurrent.MVar
-    ( MVar
-    , modifyMVar
+    ( modifyMVar
     , modifyMVar_
     , newMVar
     , withMVar
     )
 import Control.Concurrent.STM
     ( STM
-    , TMVar
     , TVar
     , atomically
     , modifyTVar'
-    , newEmptyTMVar
-    , newEmptyTMVarIO
     , newTVarIO
-    , readTMVar
     , readTVar
     , readTVarIO
-    , takeTMVar
-    , tryPutTMVar
     , writeTVar
     )
 import Control.Exception.Safe
-    ( SomeException
-    , displayException
-    , bracket_
+    ( bracket_
     , finally
     , mask
+    , mask_
     , onException
     , throwIO
     , tryAny
     )
-import Control.Monad (forM, unless, void, when)
+import Control.Monad (forM, forM_, unless, void, when)
 import Data.Aeson
     ( Value(..)
     , object
     , (.=)
     )
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlphaNum)
 import Data.IORef
-    ( IORef
-    , atomicModifyIORef'
+    ( atomicModifyIORef'
     , newIORef
     , readIORef
     )
-import qualified Data.IntMap.Strict as IntMap
+import Data.List (sortOn)
 import qualified Data.Map.Strict as Map
-import Data.List (find, sortOn)
 import Data.Maybe (catMaybes, isJust)
 import Data.Ord (Down(..))
-import Data.Scientific (floatingOrInteger)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
-import Data.Text.Encoding.Error (lenientDecode)
-import qualified Data.Vector as Vector
-import System.Environment (getEnvironment)
 import System.Directory (getCurrentDirectory)
-import System.IO
-    ( BufferMode(..)
-    , Handle
-    , hClose
-    , hFlush
-    , hSetBinaryMode
-    , hSetBuffering
-    )
-import System.Posix.Types (ProcessGroupID)
-import System.Process
-    ( CreateProcess(..)
-    , ProcessHandle
-    , StdStream(..)
-    , createProcess
-    , getPid
-    , proc
-    )
-import System.Timeout (timeout)
-import Agent.MCP.Types
-import Agent.MCP.Client hiding (rawObjectDecoder)
+
 resolveEffectiveCwds :: [McpServerConfig] -> IO [McpServerConfig]
 resolveEffectiveCwds configs = do
     current <- getCurrentDirectory
@@ -142,19 +106,77 @@ mcpFleetSkillRegistrations :: McpFleet -> IO [McpSkillRegistration]
 mcpFleetSkillRegistrations fleet = readTVarIO fleet.mcpFleetSkills
 
 mcpFleetGetSkill :: McpFleet -> Text -> Text -> IO (Either Text McpSkillEntry)
-mcpFleetGetSkill fleet server uri = do
-    clients <- readTVarIO fleet.mcpFleetClients
-    case Map.lookup server clients of
-        Nothing -> pure (Left ("unknown MCP server: " <> server))
-        Just client -> getMcpSkill client uri
+mcpFleetGetSkill fleet server uri =
+    withFleetClient fleet server \client -> getMcpSkill client uri
 
 mcpFleetReadResource
     :: McpFleet -> Text -> Text -> IO (Either Text [McpResourceContent])
-mcpFleetReadResource fleet server uri = do
+mcpFleetReadResource fleet server uri =
+    withFleetClient fleet server \client -> readMcpResource client uri
+
+mcpFleetListResources :: McpFleet -> Text -> IO (Either Text [McpResource])
+mcpFleetListResources fleet server =
+    withFleetClient fleet server \client ->
+        either (Left . renderMcpError) Right <$> listMcpResources client
+
+mcpFleetListResourceTemplates
+    :: McpFleet -> Text -> IO (Either Text [McpResourceTemplate])
+mcpFleetListResourceTemplates fleet server =
+    withFleetClient fleet server \client ->
+        either (Left . renderMcpError) Right <$> listMcpResourceTemplates client
+
+mcpFleetListPrompts :: McpFleet -> Text -> IO (Either Text [McpPrompt])
+mcpFleetListPrompts fleet server =
+    withFleetClient fleet server \client ->
+        either (Left . renderMcpError) Right <$> listMcpPrompts client
+
+mcpFleetGetPrompt
+    :: McpFleet -> Text -> Text -> [(Text, Text)] -> IO (Either Text McpPromptResult)
+mcpFleetGetPrompt fleet server name arguments =
+    withFleetClient fleet server \client ->
+        either (Left . renderMcpError) Right <$> getMcpPrompt client name arguments
+
+mcpFleetComplete
+    :: McpFleet
+    -> Text
+    -> McpCompletionRef
+    -> Text
+    -> Text
+    -> [(Text, Text)]
+    -> IO (Either Text McpCompletion)
+mcpFleetComplete fleet server ref argument partial context =
+    withFleetClient fleet server \client ->
+        either (Left . renderMcpError) Right
+            <$> completeMcpArgument client ref argument partial context
+
+-- | Identity, capabilities, and instructions of every initialized server.
+mcpFleetServerInfos :: McpFleet -> IO [(Text, McpServerInfo)]
+mcpFleetServerInfos fleet = do
+    clients <- readTVarIO fleet.mcpFleetClients
+    fmap catMaybes $ forM fleet.mcpFleetServerOrder \name ->
+        case Map.lookup name clients of
+            Nothing -> pure Nothing
+            Just client -> fmap (\info -> (name, info)) <$> mcpClientServerInfo client
+
+-- | Natural-language guidance servers provide for the model.
+mcpFleetInstructions :: McpFleet -> IO [(Text, Text)]
+mcpFleetInstructions fleet =
+    catMaybes . map instructionsOf <$> mcpFleetServerInfos fleet
+  where
+    instructionsOf :: (Text, McpServerInfo) -> Maybe (Text, Text)
+    instructionsOf (name, info) = case info.serverInfoInstructions of
+        Just instructions
+            | not (Text.null (Text.strip instructions)) ->
+                Just (name, Text.strip instructions)
+        _ -> Nothing
+
+withFleetClient
+    :: McpFleet -> Text -> (McpClient -> IO (Either Text a)) -> IO (Either Text a)
+withFleetClient fleet server action = do
     clients <- readTVarIO fleet.mcpFleetClients
     case Map.lookup server clients of
         Nothing -> pure (Left ("unknown MCP server: " <> server))
-        Just client -> readMcpResource client uri
+        Just client -> action client
 
 -- | Snapshot server status without triggering initialization or other I/O.
 mcpFleetStatuses :: McpFleet -> IO [McpServerStatus]
@@ -184,14 +206,21 @@ mcpFleetStatuses fleet = do
 startMcpFleet :: [McpServerConfig] -> IO McpFleet
 startMcpFleet = startMcpFleetWithProgress (const (pure ()))
 
--- | Start every server concurrently while reporting the configured names that
--- are still initializing. The callback is intended for startup UI and
--- deliberately receives no command arguments or environment values.
 startMcpFleetWithProgress
     :: ([Text] -> IO ())
     -> [McpServerConfig]
     -> IO McpFleet
-startMcpFleetWithProgress reportActive configs = mask \restore -> do
+startMcpFleetWithProgress = startMcpFleetWithProgressHooks defaultMcpHostHooks
+
+-- | Start every server concurrently while reporting the configured names that
+-- are still initializing. The callback is intended for startup UI and
+-- deliberately receives no command arguments or environment values.
+startMcpFleetWithProgressHooks
+    :: McpHostHooks
+    -> ([Text] -> IO ())
+    -> [McpServerConfig]
+    -> IO McpFleet
+startMcpFleetWithProgressHooks hooks reportActive configs = mask \restore -> do
     validateServerNames configs
     closed <- newMVar False
     ownedClients <- newIORef []
@@ -241,7 +270,9 @@ startMcpFleetWithProgress reportActive configs = mask \restore -> do
             , mcpFleetReconnects = reconnects
             , mcpFleetWorkers = workers
             , mcpFleetClosed = closed
+            , mcpFleetHooks = hooks
             }
+    forM_ clients (attachFleetEvents fleet)
     pure fleet
   where
     startServerTracked ownedClients activeServers config = mask \restore -> do
@@ -305,7 +336,7 @@ startMcpFleetWithProgress reportActive configs = mask \restore -> do
                 )
 
     startServer config = mask \restore -> do
-        client <- startMcpClient config
+        client <- startMcpClientWith hooks Nothing config
         flip onException (closeMcpClient client) $ restore do
             ensureMcpClientReady client >>= \case
                 Left err -> throwIO (userError (Text.unpack err))
@@ -337,14 +368,21 @@ validateServerNames = go Set.empty
         | otherwise =
             go (Set.insert config.mcpServerName seen) rest
 
--- | Spawn configured stdio clients with bounded concurrency, then initialize
--- and discover each server in tracked background workers. The fleet can be
--- used immediately through 'mcpFleetMetaTools'.
 startMcpFleetProgressive
     :: ([McpServerStatus] -> IO ())
     -> [McpServerConfig]
     -> IO McpFleet
-startMcpFleetProgressive reportStatuses configs = mask \restore -> do
+startMcpFleetProgressive = startMcpFleetProgressiveHooks defaultMcpHostHooks
+
+-- | Spawn configured stdio clients with bounded concurrency, then initialize
+-- and discover each server in tracked background workers. The fleet can be
+-- used immediately through 'mcpFleetMetaTools'.
+startMcpFleetProgressiveHooks
+    :: McpHostHooks
+    -> ([McpServerStatus] -> IO ())
+    -> [McpServerConfig]
+    -> IO McpFleet
+startMcpFleetProgressiveHooks hooks reportStatuses configs = mask \restore -> do
     validateServerNames configs
     closed <- newMVar False
     workers <- newMVar []
@@ -395,6 +433,7 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
             , mcpFleetReconnects = reconnects
             , mcpFleetWorkers = workers
             , mcpFleetClosed = closed
+            , mcpFleetHooks = hooks
             }
         initializeOne client = do
             void (reportFleetStatuses reportStatuses fleet)
@@ -417,6 +456,7 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
                 [ (client.clientConfig.mcpServerName, client)
                 | client <- clients
                 ]
+    forM_ clients (attachFleetEvents fleet)
     spawned <- newIORef []
     started <-
         (forM clients \client -> do
@@ -438,7 +478,7 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
             bracket_
                 (waitQSem semaphore)
                 (signalQSem semaphore)
-                (tryAny (restore (startMcpClient config)))
+                (tryAny (restore (startMcpClientWith hooks Nothing config)))
         case attempt of
             Left exception -> pure (Left exception)
             Right client -> do
@@ -450,18 +490,27 @@ startMcpFleetProgressive reportStatuses configs = mask \restore -> do
         atomicModifyIORef' ownedClients (\clients -> ([], clients))
             >>= mapM_ closeMcpClient
 
-    publishCatalogEntries catalog client tools =
-        modifyTVar' catalog \current ->
-            foldl
-                (\entries tool ->
-                    Map.insert
-                        (qualifiedMcpToolName
-                            client.clientConfig.mcpServerName
-                            tool.discoveredName)
-                        (McpCatalogEntry client tool)
-                        entries)
-                current
-                tools
+publishCatalogEntries
+    :: TVar (Map.Map Text McpCatalogEntry)
+    -> McpClient
+    -> [McpTool]
+    -> STM ()
+publishCatalogEntries catalog client tools =
+    modifyTVar' catalog \current ->
+        foldl'
+            (\entries tool ->
+                Map.insert
+                    (qualifiedMcpToolName
+                        client.clientConfig.mcpServerName
+                        tool.discoveredName)
+                    (McpCatalogEntry client tool)
+                    entries)
+            (withoutServer client.clientConfig.mcpServerName current)
+            tools
+
+withoutServer :: Text -> Map.Map Text McpCatalogEntry -> Map.Map Text McpCatalogEntry
+withoutServer serverName =
+    Map.filter ((/= serverName) . (.clientConfig.mcpServerName) . (.catalogClient))
 
 progressiveSpawnLimit :: Int
 progressiveSpawnLimit = 8
@@ -475,6 +524,56 @@ reportFleetStatuses report fleet = do
     void (tryAny (report statuses))
     pure statuses
 
+-- * Server events
+
+-- | Route a client's server-initiated notifications into fleet maintenance.
+-- Tool list changes refresh the catalog in a tracked worker.
+attachFleetEvents :: McpFleet -> McpClient -> IO ()
+attachFleetEvents fleet client =
+    setMcpClientEventHandler client \case
+        McpToolsListChanged ->
+            spawnFleetWorker fleet (refreshServerTools fleet client)
+        _ -> pure ()
+
+-- | Run fleet maintenance in the background. Finished workers are pruned on
+-- the next spawn; the rest are cancelled by 'closeMcpFleet'.
+spawnFleetWorker :: McpFleet -> IO () -> IO ()
+spawnFleetWorker fleet action =
+    withMVar fleet.mcpFleetClosed \closed ->
+        unless closed $ mask_ do
+            worker <- asyncWithUnmask \unmask -> unmask (void (tryAny action))
+            modifyMVar_ fleet.mcpFleetWorkers \current -> do
+                live <- fmap catMaybes $ forM current \existing ->
+                    poll existing >>= \case
+                        Nothing -> pure (Just existing)
+                        Just _ -> pure Nothing
+                pure (worker : live)
+
+-- | Re-list a server's tools after @notifications/tools/list_changed@ and
+-- replace its catalog entries. Statically registered tools keep working for
+-- as long as the server still offers them.
+refreshServerTools :: McpFleet -> McpClient -> IO ()
+refreshServerTools fleet client =
+    forM_ (Map.lookup serverName fleet.mcpFleetReconnects) \lock ->
+        withMVar lock \_ -> do
+            current <- Map.lookup serverName <$> readTVarIO fleet.mcpFleetClients
+            when (maybe False (sameClient client) current) do
+                tryAny (discoverMcpTools client) >>= \case
+                    Left _ -> pure ()
+                    Right (tools, warnings) -> atomically do
+                        publishCatalogEntries fleet.mcpFleetCatalog client tools
+                        readTVar client.clientLifecycle >>= \case
+                            ClientReady _ _ ->
+                                writeTVar client.clientLifecycle
+                                    (ClientReady tools warnings)
+                            _ -> pure ()
+  where
+    serverName = client.clientConfig.mcpServerName
+    sameClient :: McpClient -> McpClient -> Bool
+    sameClient left right = left.clientNextId == right.clientNextId
+
+-- * Meta-tools
+
 -- | Stable concise MCP tools backed by the fleet's background-populated
 -- catalog. These schemas do not change as servers become ready.
 mcpFleetMetaTools :: McpFleet -> [AppTool]
@@ -487,6 +586,15 @@ mcpFleetGrokMetaTools :: McpFleet -> [AppTool]
 mcpFleetGrokMetaTools fleet =
     [ grokSearchTool fleet
     , grokUseTool fleet
+    ]
+
+-- | Read-only tools for browsing and reading server resources. They are
+-- useful in every startup mode because resource links appear in tool
+-- results.
+mcpFleetResourceTools :: McpFleet -> [AppTool]
+mcpFleetResourceTools fleet =
+    [ mcpListResourcesTool fleet
+    , mcpReadResourceTool fleet
     ]
 
 mcpSearchTool :: McpFleet -> AppTool
@@ -519,7 +627,7 @@ mcpSearchTool fleet = AppTool
                             `Text.isInfixOf`
                                 Text.toCaseFold
                                     (name <> " "
-                                        <> entry.catalogTool.discoveredDescription))
+                                        <> describeTool entry.catalogTool))
                     query
                     && maybe True
                         (== entry.catalogClient.clientConfig.mcpServerName)
@@ -527,15 +635,18 @@ mcpSearchTool fleet = AppTool
             found = take limit (filter matches (Map.toAscList entries))
             payload = object
                 [ "tools" .=
-                    [ object
+                    [ object $
                         [ "name" .= name
                         , "server" .=
                             entry.catalogClient.clientConfig.mcpServerName
-                        , "description" .=
-                            entry.catalogTool.discoveredDescription
+                        , "description" .= describeTool entry.catalogTool
                         , "inputSchema" .=
                             entry.catalogTool.discoveredInputSchema
+                        , "readOnly" .= entry.catalogTool.discoveredReadOnly
                         ]
+                        <> [ "outputSchema" .= schema
+                           | Just schema <- [entry.catalogTool.discoveredOutputSchema]
+                           ]
                     | (name, entry) <- found
                     ]
                 , "servers" .= map statusJson statuses
@@ -584,7 +695,7 @@ grokSearchTool fleet = AppTool
                                     entry.catalogClient.clientConfig.mcpServerName
                             normalizedDescription =
                                 normalizeSearchText
-                                    entry.catalogTool.discoveredDescription
+                                    (describeTool entry.catalogTool)
                             haystack =
                                 normalizedName
                                     <> " "
@@ -621,7 +732,7 @@ grokSearchTool fleet = AppTool
                                         [ "tool_name" .= name
                                         , "description" .=
                                             truncateMcpDescription
-                                                entry.catalogTool.discoveredDescription
+                                                (describeTool entry.catalogTool)
                                         , "score" .= scoreEntry pair
                                         , "input_schema" .=
                                             entry.catalogTool.discoveredInputSchema
@@ -678,7 +789,7 @@ callCatalogEntryWithReconnect fleet qualifiedName entry arguments =
         >>= \case
             Right result -> pure (Right result)
             Left originalError
-                | not entry.catalogTool.discoveredReadOnly ->
+                | not (mcpToolRetrySafe entry.catalogTool) ->
                     -- A failed mutation may have reached the server. Retrying
                     -- it after reconnect could duplicate the side effect.
                     pure (Left originalError)
@@ -687,9 +798,10 @@ callCatalogEntryWithReconnect fleet qualifiedName entry arguments =
                     case failed of
                         Nothing -> pure (Left originalError)
                         Just _ ->
-                            -- Read-only calls are safe to retry once after a
-                            -- transport failure. The per-server lock makes
-                            -- this single-flight across concurrent calls.
+                            -- Read-only and idempotent calls are safe to retry
+                            -- once after a transport failure. The per-server
+                            -- lock makes this single-flight across concurrent
+                            -- calls.
                             reconnectCatalogEntry fleet qualifiedName entry
                                 >>= \case
                                 Left reconnectError ->
@@ -723,14 +835,15 @@ reconnectCatalogEntry fleet qualifiedName failedEntry =
                                     | replacement.catalogClient.clientFailure
                                         /= failedEntry.catalogClient.clientFailure ->
                                             pure (Right replacement)
-                                _ -> restart current
+                                _ -> restart
   where
     serverName =
         failedEntry.catalogClient.clientConfig.mcpServerName
     config = failedEntry.catalogClient.clientConfig
 
-    restart _ = do
-        started <- tryAny (startMcpClient config)
+    restart = do
+        eraHint <- mcpClientEra failedEntry.catalogClient
+        started <- tryAny (startMcpClientWith fleet.mcpFleetHooks eraHint config)
         case started of
             Left exception ->
                 pure . Left $
@@ -753,17 +866,12 @@ reconnectCatalogEntry fleet qualifiedName failedEntry =
                         previousClient <- atomically do
                             clients <- readTVar fleet.mcpFleetClients
                             currentCatalog <- readTVar fleet.mcpFleetCatalog
-                            let withoutServer =
-                                    Map.filter
-                                        ((/= serverName)
-                                            . (.clientConfig.mcpServerName)
-                                            . (.catalogClient))
-                                        currentCatalog
                             writeTVar fleet.mcpFleetClients
                                 (Map.insert serverName replacementClient clients)
                             writeTVar fleet.mcpFleetCatalog
-                                (replacementEntries <> withoutServer)
+                                (replacementEntries <> withoutServer serverName currentCatalog)
                             pure (Map.lookup serverName clients)
+                        attachFleetEvents fleet replacementClient
                         mapM_ closeMcpClient previousClient
                         case Map.lookup qualifiedName replacementEntries of
                             Nothing ->
@@ -843,6 +951,110 @@ grokUseTool fleet = AppTool
     , appToolExecution = TurnSequential
     , appToolResourceClaims = Nothing
     }
+
+mcpListResourcesTool :: McpFleet -> AppTool
+mcpListResourcesTool fleet = AppTool
+    { appToolName = "mcp_list_resources"
+    , appToolDescription =
+        "List the resources and resource templates an MCP server exposes. \
+        \Omit `server` to query every connected server."
+    , appToolSchema = RawJsonFunctionSchema $ object
+        [ "type" .= ("object" :: Text)
+        , "properties" .= object
+            [ "server" .= object ["type" .= ("string" :: Text)]
+            ]
+        , "additionalProperties" .= False
+        ]
+    , appToolHandler = typedTool "mcp_list_resources"
+        (Json.object (nonEmptyOptionalText "server"))
+        \server -> do
+            infos <- mcpFleetServerInfos fleet
+            let selected =
+                    [ name
+                    | (name, info) <- infos
+                    , maybe True (== name) server
+                    , isJust info.serverInfoCapabilities.capabilityResources
+                    ]
+            listings <- forM selected \name -> do
+                resources <- mcpFleetListResources fleet name
+                templates <- mcpFleetListResourceTemplates fleet name
+                pure $ object
+                    [ "server" .= name
+                    , "resources" .= either (const []) (map resourceJson) resources
+                    , "resourceTemplates" .=
+                        either (const []) (map templateJson) templates
+                    , "error" .= either Just (const Nothing) resources
+                    ]
+            pure (Right (compactJson (object ["servers" .= listings])))
+    , appToolApproval = AlwaysReadOnly
+    , appToolExecution = ParallelSafe
+    , appToolResourceClaims = Nothing
+    }
+  where
+    resourceJson :: McpResource -> Value
+    resourceJson resource = object
+        [ "uri" .= resource.resourceUri
+        , "name" .= resource.resourceName
+        , "title" .= resource.resourceTitle
+        , "description" .= resource.resourceDescription
+        , "mimeType" .= resource.resourceMimeType
+        , "size" .= resource.resourceSize
+        ]
+    templateJson :: McpResourceTemplate -> Value
+    templateJson template = object
+        [ "uriTemplate" .= template.templateUri
+        , "name" .= template.templateName
+        , "title" .= template.templateTitle
+        , "description" .= template.templateDescription
+        , "mimeType" .= template.templateMimeType
+        ]
+
+mcpReadResourceTool :: McpFleet -> AppTool
+mcpReadResourceTool fleet = AppTool
+    { appToolName = "mcp_read_resource"
+    , appToolDescription =
+        "Read a resource from an MCP server by URI, for example one returned \
+        \by mcp_list_resources or referenced as a resource_link in a tool result."
+    , appToolSchema = RawJsonFunctionSchema $ object
+        [ "type" .= ("object" :: Text)
+        , "properties" .= object
+            [ "server" .= object ["type" .= ("string" :: Text)]
+            , "uri" .= object ["type" .= ("string" :: Text)]
+            ]
+        , "required" .= (["server", "uri"] :: [Text])
+        , "additionalProperties" .= False
+        ]
+    , appToolHandler = typedTool "mcp_read_resource" readArgumentsDecoder
+        \(server, uri) ->
+            mcpFleetReadResource fleet server uri >>= \case
+                Left err -> pure (Left err)
+                Right contents ->
+                    pure . Right . Text.intercalate "\n" $
+                        map renderResourceContent contents
+    , appToolApproval = AlwaysReadOnly
+    , appToolExecution = ParallelSafe
+    , appToolResourceClaims = Nothing
+    }
+  where
+    readArgumentsDecoder = Json.object do
+        server <- Text.strip <$> Json.atKey "server" Json.text
+        uri <- Text.strip <$> Json.atKey "uri" Json.text
+        when (Text.null server || Text.null uri) $
+            fail "mcp_read_resource requires server and uri"
+        pure (server, uri)
+    renderResourceContent :: McpResourceContent -> Text
+    renderResourceContent content =
+        case (content.mcpResourceText, content.mcpResourceBlob) of
+            (Just text, _) ->
+                "[" <> content.mcpResourceUri
+                    <> maybe "" (\value -> " (" <> value <> ")") content.mcpResourceMimeType
+                    <> "]\n" <> text
+            (Nothing, Just blob) ->
+                "[" <> content.mcpResourceUri
+                    <> maybe "" (\value -> " (" <> value <> ")") content.mcpResourceMimeType
+                    <> ": " <> Text.pack (show (Text.length blob))
+                    <> " base64 bytes; binary content is not shown]"
+            (Nothing, Nothing) -> "[" <> content.mcpResourceUri <> "]"
 
 catalogCallIsReadOnly
     :: McpFleet
@@ -933,12 +1145,6 @@ grokCallArgumentsDecoder = Json.object do
             Right value -> pure value
             Left _ -> fail "use_tool tool_input must be an object"
     pure (name, arguments)
-
-rawObjectDecoder :: Json.Decoder RawJson
-rawObjectDecoder =
-    Json.getType >>= \case
-        Json.VObject -> rawJsonDecoder
-        _ -> fail "expected object"
 
 emptyObject :: RawJson
 emptyObject = rawJsonFromEncoding (Aeson.toEncoding (object []))

--- a/packages/agent-core/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-core/src/Agent/MCP/OAuth.hs
@@ -1,37 +1,115 @@
-{-# LANGUAGE OverloadedStrings #-}
+-- | OAuth 2.1 client support for remote MCP servers, following the MCP
+-- authorization specification (revision 2026-07-28):
+--
+-- * @WWW-Authenticate@ challenge parsing (RFC 6750)
+-- * Protected Resource Metadata discovery (RFC 9728)
+-- * Authorization Server Metadata discovery (RFC 8414 / OpenID Connect
+--   Discovery) with issuer validation
+-- * PKCE capability checks, client registration selection (pre-registered,
+--   Client ID Metadata Documents, Dynamic Client Registration)
+-- * Scope selection and step-up unions
+-- * Authorization response issuer validation (RFC 9207)
+-- * Resource indicators (RFC 8707) on authorization, token, and refresh
+--   requests
+--
+-- Secrets never appear in 'Show' output or error text produced here.
 module Agent.MCP.OAuth
-    ( OAuthTokens(..), OAuthTokenResponse(..), ProtectedResourceMetadata(..)
+    ( -- * Tokens and metadata
+      OAuthTokens(..), OAuthTokenResponse(..), ProtectedResourceMetadata(..)
     , AuthorizationServerMetadata(..), ClientRegistration(..)
-    , discoverProtectedResource, discoverAuthorizationServer, registerClient
-    , refreshAccessToken, exchangeAuthorizationCode, oauthCallbackSuccessPage
-    , OAuthTokenFile(..), loadOAuthTokenFile, refreshOAuthTokenFile
+      -- * WWW-Authenticate challenges
+    , WwwAuthenticateChallenge(..), parseWwwAuthenticate, challengeScopes
+    , AuthorizationProbe(..), probeAuthorizationChallenge
+      -- * Canonical resource URIs
+    , canonicalResourceUri, resourceOrigin, loopbackRedirectPort
+      -- * Protected resource metadata discovery
+    , protectedResourceMetadataUrls, discoverProtectedResourceMetadata
+    , validateResourceMetadata, discoverProtectedResource
+      -- * Authorization server metadata discovery
+    , authorizationServerMetadataUrls, discoverAuthorizationServerMetadata
+    , validateIssuer, discoverAuthorizationServer
+      -- * PKCE
+    , checkPkceSupport
+      -- * Client registration
+    , ClientIdSource(..), clientIdSourceText, parseClientIdSource
+    , PreRegisteredClient(..), StoredClient(..), RegistrationOptions(..)
+    , RegistrationPlan(..), selectClientRegistration, validateClientIdMetadataUrl
+    , ClientRegistrationRequest(..), clientRegistrationPayload
+    , registerClientWith, registerClient
+      -- * Scopes
+    , ScopeSources(..), selectScopes, unionScopes, ScopePlan(..), planScopes
+    , offlineAccessScope
+      -- * Authorization response validation
+    , validateAuthorizationResponseIssuer
+      -- * Token endpoint requests
+    , TokenExchange(..), exchangeAuthorizationCodeWith, exchangeAuthorizationCode
+    , RefreshRequest(..), refreshAccessTokenWith, refreshAccessToken
+    , oauthCallbackSuccessPage
+      -- * Persisted token records
+    , OAuthTokenFile(..), OAuthTokenFileExtra(..), emptyOAuthTokenFileExtra
+    , loadOAuthTokenFile, loadOAuthTokenFileExtra, loadOAuthTokenRecord
+    , decodeOAuthTokenRecord, encodeOAuthTokenRecord, refreshOAuthTokenFile
     ) where
 
 import Agent.FileRetry (writeLazyFileAtomically)
-import System.OsPath (unsafeEncodeUtf)
-import Data.Bits ((.|.))
+import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception.Safe (bracket, tryAny)
-import qualified System.FileLock as FileLock
-import System.Posix.IO (OpenFileFlags(..), OpenMode(ReadWrite), closeFd, defaultFileFlags, openFd)
+import Control.Monad (guard)
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as AesonTypes
+import Data.Bits ((.|.))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
-import System.Posix.Files (ownerReadMode, ownerWriteMode)
-import System.IO.Unsafe (unsafePerformIO)
-import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Char (isAlphaNum, isSpace, toLower)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Text (Text)
-import Data.Time.Clock.POSIX (getPOSIXTime)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
+import qualified Data.Text.Encoding.Error as EncodingError
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import Network.HTTP.Client (Manager, RequestBody(..), httpLbs, parseRequest, responseBody, responseStatus, urlEncodedBody)
 import qualified Network.HTTP.Client as HC
 import Network.HTTP.Types (statusCode)
+import qualified System.FileLock as FileLock
+import System.IO.Unsafe (unsafePerformIO)
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Files (ownerReadMode, ownerWriteMode)
+import System.Posix.IO (OpenFileFlags(..), OpenMode(ReadWrite), closeFd, defaultFileFlags, openFd)
 
-data OAuthTokens = OAuthTokens { accessToken :: !Text, refreshToken :: !(Maybe Text), expiresIn :: !(Maybe Int) } deriving (Eq)
+-- ---------------------------------------------------------------------------
+-- Tokens
+
+data OAuthTokens = OAuthTokens
+    { accessToken :: !Text
+    , refreshToken :: !(Maybe Text)
+    , expiresIn :: !(Maybe Int)
+    , scope :: !(Maybe Text)
+    -- ^ Granted scope reported by the token endpoint, when it differs from
+    -- (or simply restates) the requested scope.
+    } deriving (Eq)
+
 instance Show OAuthTokens where
-    show tokens = "OAuthTokens { accessToken = <redacted>, refreshToken = " <> show (maybe False (const True) tokens.refreshToken) <> " }"
+    show tokens = "OAuthTokens { accessToken = <redacted>, refreshToken = "
+        <> show (isJust tokens.refreshToken) <> ", scope = " <> show tokens.scope <> " }"
+
+instance Aeson.FromJSON OAuthTokens where
+    parseJSON = Aeson.withObject "OAuthTokens" $ \object ->
+        OAuthTokens
+            <$> object Aeson..: "access_token"
+            <*> object Aeson..:? "refresh_token"
+            <*> object Aeson..:? "expires_in"
+            <*> object Aeson..:? "scope"
+
 data OAuthTokenResponse = OAuthTokenSuccess !OAuthTokens | OAuthTokenFailure !Text deriving (Eq, Show)
 
+-- ---------------------------------------------------------------------------
+-- Persisted token records
+
+-- | Fields the wire client depends on positionally. The constructor arity is
+-- part of the compatibility contract; new persisted fields live in
+-- 'OAuthTokenFileExtra' and share the same JSON document.
 data OAuthTokenFile = OAuthTokenFile
     { tokenClientId :: !Text
     , tokenEndpoint :: !Text
@@ -50,37 +128,140 @@ instance Aeson.FromJSON OAuthTokenFile where
         <*> o Aeson..:? "expires_at"
 
 instance Aeson.ToJSON OAuthTokenFile where
-    toJSON t = Aeson.object
-        [ "client_id" Aeson..= t.tokenClientId
-        , "token_endpoint" Aeson..= t.tokenEndpoint
-        , "access_token" Aeson..= t.tokenAccessToken
-        , "refresh_token" Aeson..= t.tokenRefreshToken
-        , "expires_at" Aeson..= t.tokenExpiresAt
-        ]
+    toJSON = Aeson.object . tokenFilePairs
+
+tokenFilePairs :: OAuthTokenFile -> [AesonTypes.Pair]
+tokenFilePairs t =
+    [ "client_id" Aeson..= t.tokenClientId
+    , "token_endpoint" Aeson..= t.tokenEndpoint
+    , "access_token" Aeson..= t.tokenAccessToken
+    , "refresh_token" Aeson..= t.tokenRefreshToken
+    , "expires_at" Aeson..= t.tokenExpiresAt
+    ]
+
+-- | Where a @client_id@ came from. Credentials are bound to the issuer that
+-- produced them; the source decides whether they may be reused.
+data ClientIdSource
+    = ClientIdPreRegistered
+    | ClientIdMetadataDocument
+    | ClientIdDynamicRegistration
+    deriving (Eq, Show)
+
+clientIdSourceText :: ClientIdSource -> Text
+clientIdSourceText = \case
+    ClientIdPreRegistered -> "pre_registered"
+    ClientIdMetadataDocument -> "client_id_metadata_document"
+    ClientIdDynamicRegistration -> "dynamic_registration"
+
+parseClientIdSource :: Text -> Maybe ClientIdSource
+parseClientIdSource = \case
+    "pre_registered" -> Just ClientIdPreRegistered
+    "client_id_metadata_document" -> Just ClientIdMetadataDocument
+    "dynamic_registration" -> Just ClientIdDynamicRegistration
+    _ -> Nothing
+
+-- | Additional persisted state stored in the same JSON document as
+-- 'OAuthTokenFile'. Every key is optional so records written before these
+-- fields existed still load.
+data OAuthTokenFileExtra = OAuthTokenFileExtra
+    { extraIssuer :: !(Maybe Text)
+    -- ^ Validated @issuer@ of the authorization server that issued the tokens.
+    , extraScope :: !(Maybe Text)
+    -- ^ Space-separated scopes granted for the current tokens.
+    , extraResource :: !(Maybe Text)
+    -- ^ Canonical MCP server URI sent as the RFC 8707 @resource@.
+    , extraClientIdSource :: !(Maybe ClientIdSource)
+    , extraClientIdMetadataUrl :: !(Maybe Text)
+    , extraClientSecret :: !(Maybe Text)
+    -- ^ Pre-registered confidential client secret, sent as @client_secret@.
+    , extraRedirectUri :: !(Maybe Text)
+    -- ^ Redirect URI the dynamic registration was created with.
+    } deriving (Eq)
+
+instance Show OAuthTokenFileExtra where
+    show extra = "OAuthTokenFileExtra { extraIssuer = " <> show extra.extraIssuer
+        <> ", extraScope = " <> show extra.extraScope
+        <> ", extraResource = " <> show extra.extraResource
+        <> ", extraClientIdSource = " <> show extra.extraClientIdSource
+        <> ", extraClientIdMetadataUrl = " <> show extra.extraClientIdMetadataUrl
+        <> ", extraClientSecret = " <> (if isJust extra.extraClientSecret then "<redacted>" else "Nothing")
+        <> ", extraRedirectUri = " <> show extra.extraRedirectUri <> " }"
+
+emptyOAuthTokenFileExtra :: OAuthTokenFileExtra
+emptyOAuthTokenFileExtra = OAuthTokenFileExtra Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+
+instance Aeson.FromJSON OAuthTokenFileExtra where
+    parseJSON = Aeson.withObject "OAuthTokenFileExtra" $ \o -> do
+        source <- o Aeson..:? "client_id_source"
+        OAuthTokenFileExtra
+            <$> o Aeson..:? "issuer"
+            <*> o Aeson..:? "scope"
+            <*> o Aeson..:? "resource"
+            <*> pure (source >>= parseClientIdSource)
+            <*> o Aeson..:? "client_id_metadata_url"
+            <*> o Aeson..:? "client_secret"
+            <*> o Aeson..:? "redirect_uri"
+
+tokenExtraPairs :: OAuthTokenFileExtra -> [AesonTypes.Pair]
+tokenExtraPairs extra = mapMaybe id
+    [ ("issuer" Aeson..=) <$> extra.extraIssuer
+    , ("scope" Aeson..=) <$> extra.extraScope
+    , ("resource" Aeson..=) <$> extra.extraResource
+    , ("client_id_source" Aeson..=) . clientIdSourceText <$> extra.extraClientIdSource
+    , ("client_id_metadata_url" Aeson..=) <$> extra.extraClientIdMetadataUrl
+    , ("client_secret" Aeson..=) <$> extra.extraClientSecret
+    , ("redirect_uri" Aeson..=) <$> extra.extraRedirectUri
+    ]
+
+-- | Serialise the compatibility fields and the extra fields into one document.
+encodeOAuthTokenRecord :: OAuthTokenFile -> OAuthTokenFileExtra -> LBS.ByteString
+encodeOAuthTokenRecord file extra = Aeson.encode (Aeson.object (tokenFilePairs file <> tokenExtraPairs extra))
+
+decodeOAuthTokenRecord :: LBS.ByteString -> Either Text (OAuthTokenFile, OAuthTokenFileExtra)
+decodeOAuthTokenRecord bytes = do
+    file <- either (Left . Text.pack) Right (Aeson.eitherDecode bytes)
+    extra <- either (Left . Text.pack) Right (Aeson.eitherDecode bytes)
+    pure (file, extra)
 
 loadOAuthTokenFile :: FilePath -> IO (Either Text OAuthTokenFile)
-loadOAuthTokenFile path = do
+loadOAuthTokenFile path = fmap fst <$> loadOAuthTokenRecord path
+
+loadOAuthTokenFileExtra :: FilePath -> IO (Either Text OAuthTokenFileExtra)
+loadOAuthTokenFileExtra path = fmap snd <$> loadOAuthTokenRecord path
+
+loadOAuthTokenRecord :: FilePath -> IO (Either Text (OAuthTokenFile, OAuthTokenFileExtra))
+loadOAuthTokenRecord path = do
     result <- tryAny (LBS.readFile path)
     pure $ case result of
         Left exception -> Left ("MCP OAuth token file unavailable: " <> Text.pack (show exception))
-        Right bytes -> either (Left . Text.pack) Right (Aeson.eitherDecode bytes)
+        Right bytes -> decodeOAuthTokenRecord bytes
 
+-- | Exchange the stored refresh token and persist the rotated record. The
+-- RFC 8707 @resource@ and any pre-registered @client_secret@ recorded in the
+-- extra fields are included in the refresh request.
 refreshOAuthTokenFile :: Manager -> FilePath -> IO (Either Text OAuthTokenFile)
 refreshOAuthTokenFile manager path = withMVar oauthRefreshLock $ \_ ->
-    withOAuthFileLock path $ do
-    loadOAuthTokenFile path >>= \file -> case file of
+    withOAuthFileLock path $
+    loadOAuthTokenRecord path >>= \case
         Left err -> pure (Left err)
-        Right current -> refreshAccessToken manager current.tokenEndpoint current.tokenClientId current.tokenRefreshToken >>= \case
+        Right (current, extra) -> refreshAccessTokenWith manager RefreshRequest
+            { refreshEndpoint = current.tokenEndpoint
+            , refreshClientId = current.tokenClientId
+            , refreshClientSecret = extra.extraClientSecret
+            , refreshRefreshToken = current.tokenRefreshToken
+            , refreshResource = extra.extraResource
+            } >>= \case
             OAuthTokenFailure err -> pure (Left err)
             OAuthTokenSuccess tokens -> do
-                now <- round <$> getPOSIXTime
+                now :: Int <- round <$> getPOSIXTime
                 let updated = current
                         { tokenAccessToken = tokens.accessToken
-                        , tokenRefreshToken = maybe current.tokenRefreshToken id tokens.refreshToken
-                        , tokenExpiresAt = fmap (fromIntegral now +) tokens.expiresIn
-
+                        , tokenRefreshToken = fromMaybe current.tokenRefreshToken tokens.refreshToken
+                        , tokenExpiresAt = fmap (now +) tokens.expiresIn
                         }
-                writeLazyFileAtomically (unsafeEncodeUtf path) (ownerReadMode .|. ownerWriteMode) (Aeson.encode updated)
+                    updatedExtra = extra { extraScope = tokens.scope <|> extra.extraScope }
+                writeLazyFileAtomically (unsafeEncodeUtf path) (ownerReadMode .|. ownerWriteMode)
+                    (encodeOAuthTokenRecord updated updatedExtra)
                 pure (Right updated)
 
 withOAuthFileLock :: FilePath -> IO a -> IO a
@@ -95,71 +276,624 @@ oauthRefreshLock :: MVar ()
 oauthRefreshLock = unsafePerformIO (newMVar ())
 {-# NOINLINE oauthRefreshLock #-}
 
-data ProtectedResourceMetadata = ProtectedResourceMetadata { resource :: !(Maybe Text), authorizationServers :: ![Text], scopesSupported :: ![Text] } deriving (Eq, Show)
-instance Aeson.FromJSON ProtectedResourceMetadata where
-    parseJSON = Aeson.withObject "ProtectedResourceMetadata" $ \o -> ProtectedResourceMetadata <$> o Aeson..:? "resource" <*> o Aeson..:? "authorization_servers" Aeson..!= [] <*> o Aeson..:? "scopes_supported" Aeson..!= []
+-- ---------------------------------------------------------------------------
+-- WWW-Authenticate challenges (RFC 6750 section 3)
 
-data AuthorizationServerMetadata = AuthorizationServerMetadata { issuer :: !(Maybe Text), authorizationEndpoint :: !Text, tokenEndpoint :: !Text, registrationEndpoint :: !(Maybe Text), codeChallengeMethodsSupported :: ![Text], scopesSupportedByServer :: ![Text] } deriving (Eq, Show)
+data WwwAuthenticateChallenge = WwwAuthenticateChallenge
+    { challengeResourceMetadata :: !(Maybe Text)
+    , challengeScope :: !(Maybe Text)
+    , challengeError :: !(Maybe Text)
+    , challengeErrorDescription :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+-- | Parse the first @Bearer@ challenge of a @WWW-Authenticate@ header value.
+-- Parameter names are case-insensitive; values may be quoted strings (with
+-- backslash escapes) or bare tokens. Other schemes in the same header are
+-- skipped.
+parseWwwAuthenticate :: BS.ByteString -> Maybe WwwAuthenticateChallenge
+parseWwwAuthenticate header =
+    case [params | (scheme, params) <- challenges, BS8.map toLower scheme == "bearer"] of
+        params : _ -> Just WwwAuthenticateChallenge
+            { challengeResourceMetadata = param "resource_metadata" params
+            , challengeScope = param "scope" params
+            , challengeError = param "error" params
+            , challengeErrorDescription = param "error_description" params
+            }
+        [] -> Nothing
+  where
+    challenges = groupChallenges (lexChallenge header)
+    param name params = decodeLenient <$> lookup name [(BS8.map toLower key, value) | (key, value) <- params]
+
+challengeScopes :: WwwAuthenticateChallenge -> [Text]
+challengeScopes challenge = maybe [] Text.words challenge.challengeScope
+
+data ChallengeToken = SchemeToken !BS.ByteString | ParamToken !BS.ByteString !BS.ByteString
+
+lexChallenge :: BS.ByteString -> [ChallengeToken]
+lexChallenge input =
+    let rest = BS8.dropWhile (\c -> isSpace c || c == ',') input
+    in if BS.null rest then [] else
+        let (word, afterWord) = BS8.span isTokenChar rest
+            afterSpaces = BS8.dropWhile (\c -> c == ' ' || c == '\t') afterWord
+        in if BS.null word
+            then lexChallenge (BS.drop 1 rest)
+            else case BS8.uncons afterSpaces of
+                Just ('=', afterEquals) ->
+                    let (value, remaining) = lexValue (BS8.dropWhile (\c -> c == ' ' || c == '\t') afterEquals)
+                    in ParamToken word value : lexChallenge remaining
+                _ -> SchemeToken word : lexChallenge afterWord
+
+-- | Quoted strings honour backslash escapes; bare values extend to the next
+-- comma or whitespace so servers emitting unquoted URLs still parse.
+lexValue :: BS.ByteString -> (BS.ByteString, BS.ByteString)
+lexValue input = case BS8.uncons input of
+    Just ('"', quoted) -> quotedString quoted []
+    _ -> BS8.span (\c -> c /= ',' && not (isSpace c)) input
+  where
+    quotedString remaining acc = case BS8.uncons remaining of
+        Nothing -> (BS8.pack (reverse acc), BS.empty)
+        Just ('"', after) -> (BS8.pack (reverse acc), after)
+        Just ('\\', after) -> case BS8.uncons after of
+            Just (escaped, after') -> quotedString after' (escaped : acc)
+            Nothing -> (BS8.pack (reverse acc), BS.empty)
+        Just (c, after) -> quotedString after (c : acc)
+
+isTokenChar :: Char -> Bool
+isTokenChar c = isAlphaNum c || c `elem` ("!#$%&'*+-.^_`|~" :: String)
+
+groupChallenges :: [ChallengeToken] -> [(BS.ByteString, [(BS.ByteString, BS.ByteString)])]
+groupChallenges = reverse . map (fmap reverse) . foldl' step []
+  where
+    step acc (SchemeToken scheme) = (scheme, []) : acc
+    step ((scheme, params) : acc) (ParamToken key value) = (scheme, (key, value) : params) : acc
+    step [] (ParamToken _ _) = []
+
+decodeLenient :: BS.ByteString -> Text
+decodeLenient = Encoding.decodeUtf8With EncodingError.lenientDecode
+
+-- | Outcome of an unauthenticated request to the MCP endpoint.
+data AuthorizationProbe = AuthorizationProbe
+    { probeStatus :: !Int
+    , probeChallenge :: !(Maybe WwwAuthenticateChallenge)
+    } deriving (Eq, Show)
+
+-- | Send a minimal unauthenticated JSON-RPC request to the MCP endpoint and
+-- read the @WWW-Authenticate@ challenge from the response, if any.
+probeAuthorizationChallenge :: Manager -> Text -> IO (Either Text AuthorizationProbe)
+probeAuthorizationChallenge manager endpoint = do
+    result <- tryAny $ do
+        request <- parseRequest (Text.unpack endpoint)
+        let payload = Aeson.encode $ Aeson.object
+                [ "jsonrpc" Aeson..= ("2.0" :: Text)
+                , "id" Aeson..= (0 :: Int)
+                , "method" Aeson..= ("server/discover" :: Text)
+                , "params" Aeson..= Aeson.object []
+                ]
+            request' = request
+                { HC.method = "POST"
+                , HC.requestBody = RequestBodyLBS payload
+                , HC.requestHeaders =
+                    [ ("Content-Type", "application/json")
+                    , ("Accept", "application/json, text/event-stream")
+                    , ("MCP-Protocol-Version", "2026-07-28")
+                    ]
+                }
+        httpLbs request' manager
+    pure $ case result of
+        Left exception -> Left ("MCP authorization probe failed: " <> Text.pack (show exception))
+        Right response ->
+            let challenges = [value | (name, value) <- HC.responseHeaders response, name == "WWW-Authenticate"]
+            in Right AuthorizationProbe
+                { probeStatus = statusCode (responseStatus response)
+                , probeChallenge = case mapMaybe parseWwwAuthenticate challenges of
+                    challenge : _ -> Just challenge
+                    [] -> Nothing
+                }
+
+-- ---------------------------------------------------------------------------
+-- URL helpers
+
+data UrlParts = UrlParts
+    { urlScheme :: !Text
+    , urlAuthority :: !Text
+    , urlPath :: !Text
+    }
+
+parseUrlParts :: Text -> Maybe UrlParts
+parseUrlParts url = do
+    let (scheme, rest) = Text.breakOn "://" url
+    guard (not (Text.null scheme) && Text.all isSchemeChar scheme && not (Text.null rest))
+    let afterScheme = Text.drop 3 rest
+        (authority, pathQuery) = Text.break (\c -> c == '/' || c == '?' || c == '#') afterScheme
+    guard (not (Text.null authority))
+    let path = Text.takeWhile (\c -> c /= '?' && c /= '#') pathQuery
+    pure UrlParts
+        { urlScheme = Text.toLower scheme
+        , urlAuthority = Text.toLower authority
+        , urlPath = Text.dropWhileEnd (== '/') path
+        }
+  where
+    isSchemeChar c = isAlphaNum c || c == '+' || c == '-' || c == '.'
+
+urlPartsOrigin :: UrlParts -> Text
+urlPartsOrigin parts = parts.urlScheme <> "://" <> parts.urlAuthority
+
+-- | Canonical MCP server URI for RFC 8707 resource indicators: lowercase
+-- scheme and host, explicit port kept, path kept, no query, fragment, or
+-- trailing slash.
+canonicalResourceUri :: Text -> Text
+canonicalResourceUri url = case parseUrlParts url of
+    Just parts -> urlPartsOrigin parts <> parts.urlPath
+    Nothing -> Text.dropWhileEnd (== '/') (Text.takeWhile (\c -> c /= '#' && c /= '?') url)
+
+-- | @scheme://host[:port]@ of a URL.
+resourceOrigin :: Text -> Maybe Text
+resourceOrigin url = urlPartsOrigin <$> parseUrlParts url
+
+-- | Port of a loopback redirect URI such as @http://127.0.0.1:43127/callback@.
+loopbackRedirectPort :: Text -> Maybe Int
+loopbackRedirectPort url = do
+    parts <- parseUrlParts url
+    guard (parts.urlScheme == "http")
+    let (host, portText) = Text.breakOn ":" parts.urlAuthority
+    guard (host `elem` ["127.0.0.1", "localhost", "[::1]"])
+    digits <- Text.stripPrefix ":" portText
+    guard (not (Text.null digits) && Text.all (`elem` ['0' .. '9']) digits)
+    let port = read (Text.unpack digits)
+    guard (port > 0 && port < 65536)
+    pure port
+
+-- | Authorization server endpoints and metadata must be HTTPS; plain HTTP is
+-- tolerated only for loopback development servers.
+checkSecureUrl :: Text -> Text -> Either Text ()
+checkSecureUrl label url = case parseUrlParts url of
+    Nothing -> Left (label <> " is not an absolute URL: " <> url)
+    Just parts
+        | parts.urlScheme == "https" -> Right ()
+        | parts.urlScheme == "http" && isLoopback parts.urlAuthority -> Right ()
+        | otherwise -> Left (label <> " must use https: " <> url)
+  where
+    isLoopback authority =
+        let host = Text.takeWhile (/= ':') (Text.takeWhileEnd (/= '@') authority)
+        in host `elem` ["localhost", "127.0.0.1", "[::1]"]
+
+-- ---------------------------------------------------------------------------
+-- Protected resource metadata (RFC 9728)
+
+data ProtectedResourceMetadata = ProtectedResourceMetadata
+    { resource :: !(Maybe Text)
+    , authorizationServers :: ![Text]
+    , scopesSupported :: ![Text]
+    } deriving (Eq, Show)
+
+instance Aeson.FromJSON ProtectedResourceMetadata where
+    parseJSON = Aeson.withObject "ProtectedResourceMetadata" $ \o -> ProtectedResourceMetadata
+        <$> o Aeson..:? "resource"
+        <*> o Aeson..:? "authorization_servers" Aeson..!= []
+        <*> o Aeson..:? "scopes_supported" Aeson..!= []
+
+-- | Well-known candidate URLs for an MCP endpoint, path-aware first, then the
+-- host root.
+protectedResourceMetadataUrls :: Text -> [Text]
+protectedResourceMetadataUrls endpoint = case parseUrlParts endpoint of
+    Nothing -> []
+    Just parts ->
+        let root = urlPartsOrigin parts <> "/.well-known/oauth-protected-resource"
+        in if Text.null parts.urlPath then [root] else [root <> parts.urlPath, root]
+
+-- | Reject a metadata document whose @resource@ names a different server than
+-- the one being authorized. A document served for the host root may describe
+-- the origin of the endpoint.
+validateResourceMetadata :: Text -> ProtectedResourceMetadata -> Either Text ProtectedResourceMetadata
+validateResourceMetadata endpoint metadata = case metadata.resource of
+    Nothing -> Right metadata
+    Just declared
+        | canonicalResourceUri declared == canonical -> Right metadata
+        | Just (canonicalResourceUri declared) == resourceOrigin canonical -> Right metadata
+        | otherwise -> Left
+            ("Protected resource metadata resource " <> declared
+                <> " does not match the MCP server " <> canonical)
+  where
+    canonical = canonicalResourceUri endpoint
+
+-- | Discover protected resource metadata for an MCP endpoint, using the
+-- @resource_metadata@ URL from the challenge when present and probing the
+-- well-known URIs otherwise.
+discoverProtectedResourceMetadata :: Manager -> Text -> Maybe Text -> IO (Either Text ProtectedResourceMetadata)
+discoverProtectedResourceMetadata manager endpoint challengeUrl =
+    case challengeUrl of
+        Just url -> case checkSecureUrl "WWW-Authenticate resource_metadata" url of
+            Left err -> pure (Left err)
+            Right () -> attempt [url]
+        Nothing -> case protectedResourceMetadataUrls endpoint of
+            [] -> pure (Left ("MCP server URL is not an absolute URL: " <> endpoint))
+            urls -> attempt urls
+  where
+    attempt = tryCandidates "Protected resource metadata discovery failed"
+        (\url -> fmap (>>= validateResourceMetadata endpoint) (getJson manager url))
+
+-- | Compatibility wrapper: well-known discovery without a challenge URL.
+discoverProtectedResource :: Manager -> Text -> IO (Either Text ProtectedResourceMetadata)
+discoverProtectedResource manager resourceUrl = discoverProtectedResourceMetadata manager resourceUrl Nothing
+
+-- ---------------------------------------------------------------------------
+-- Authorization server metadata (RFC 8414 / OpenID Connect Discovery)
+
+data AuthorizationServerMetadata = AuthorizationServerMetadata
+    { issuer :: !(Maybe Text)
+    , authorizationEndpoint :: !Text
+    , tokenEndpoint :: !Text
+    , registrationEndpoint :: !(Maybe Text)
+    , codeChallengeMethodsSupported :: !(Maybe [Text])
+    -- ^ 'Nothing' when the field is absent, which means PKCE is unsupported.
+    , scopesSupportedByServer :: ![Text]
+    , clientIdMetadataDocumentSupported :: !Bool
+    , authorizationResponseIssParameterSupported :: !Bool
+    , grantTypesSupported :: ![Text]
+    } deriving (Eq, Show)
+
 instance Aeson.FromJSON AuthorizationServerMetadata where
-    parseJSON = Aeson.withObject "AuthorizationServerMetadata" $ \o -> AuthorizationServerMetadata <$> o Aeson..:? "issuer" <*> o Aeson..: "authorization_endpoint" <*> o Aeson..: "token_endpoint" <*> o Aeson..:? "registration_endpoint" <*> o Aeson..:? "code_challenge_methods_supported" Aeson..!= [] <*> o Aeson..:? "scopes_supported" Aeson..!= []
+    parseJSON = Aeson.withObject "AuthorizationServerMetadata" $ \o -> AuthorizationServerMetadata
+        <$> o Aeson..:? "issuer"
+        <*> o Aeson..: "authorization_endpoint"
+        <*> o Aeson..: "token_endpoint"
+        <*> o Aeson..:? "registration_endpoint"
+        <*> o Aeson..:? "code_challenge_methods_supported"
+        <*> o Aeson..:? "scopes_supported" Aeson..!= []
+        <*> o Aeson..:? "client_id_metadata_document_supported" Aeson..!= False
+        <*> o Aeson..:? "authorization_response_iss_parameter_supported" Aeson..!= False
+        <*> o Aeson..:? "grant_types_supported" Aeson..!= []
+
+-- | Candidate metadata URLs for an issuer in the order the MCP specification
+-- requires: RFC 8414 path insertion, OpenID path insertion, then OpenID path
+-- appending (the latter only for issuers with a path component).
+authorizationServerMetadataUrls :: Text -> [Text]
+authorizationServerMetadataUrls issuerUrl = case parseUrlParts issuerUrl of
+    Nothing -> []
+    Just parts ->
+        let origin = urlPartsOrigin parts
+            path = parts.urlPath
+        in if Text.null path
+            then
+                [ origin <> "/.well-known/oauth-authorization-server"
+                , origin <> "/.well-known/openid-configuration"
+                ]
+            else
+                [ origin <> "/.well-known/oauth-authorization-server" <> path
+                , origin <> "/.well-known/openid-configuration" <> path
+                , origin <> path <> "/.well-known/openid-configuration"
+                ]
+
+-- | RFC 8414 section 3.3: the document's @issuer@ must be identical to the
+-- issuer identifier used to build the well-known URL.
+validateIssuer :: Text -> AuthorizationServerMetadata -> Either Text AuthorizationServerMetadata
+validateIssuer expected metadata = case metadata.issuer of
+    Nothing -> Left ("Authorization server metadata for " <> expected <> " omits issuer")
+    Just actual
+        | actual == expected -> Right metadata
+        | otherwise -> Left
+            ("Authorization server metadata issuer " <> actual
+                <> " does not match the expected issuer " <> expected)
+
+discoverAuthorizationServerMetadata :: Manager -> Text -> IO (Either Text AuthorizationServerMetadata)
+discoverAuthorizationServerMetadata manager issuerUrl =
+    case checkSecureUrl "Authorization server issuer" issuerUrl of
+        Left err -> pure (Left err)
+        Right () -> case authorizationServerMetadataUrls issuerUrl of
+            [] -> pure (Left ("Authorization server issuer is not an absolute URL: " <> issuerUrl))
+            urls -> tryCandidates "Authorization server metadata discovery failed"
+                (\url -> fmap (>>= validateIssuer issuerUrl) (getJson manager url)) urls
+
+-- | Compatibility wrapper around 'discoverAuthorizationServerMetadata'.
+discoverAuthorizationServer :: Manager -> Text -> IO (Either Text AuthorizationServerMetadata)
+discoverAuthorizationServer = discoverAuthorizationServerMetadata
+
+-- ---------------------------------------------------------------------------
+-- PKCE
+
+-- | The authorization flow must not proceed unless the server advertises the
+-- @S256@ code challenge method.
+checkPkceSupport :: AuthorizationServerMetadata -> Either Text ()
+checkPkceSupport metadata = case metadata.codeChallengeMethodsSupported of
+    Nothing -> Left
+        "Authorization server metadata omits code_challenge_methods_supported; PKCE is required for MCP authorization"
+    Just methods
+        | "S256" `elem` methods -> Right ()
+        | otherwise -> Left
+            ("Authorization server does not support the S256 PKCE method (advertised: "
+                <> Text.intercalate ", " methods <> ")")
+
+-- ---------------------------------------------------------------------------
+-- Client registration
 
 data ClientRegistration = ClientRegistration { clientId :: !Text, clientSecret :: !(Maybe Text) } deriving (Eq)
 instance Show ClientRegistration where
-    show registration = "ClientRegistration { clientId = <redacted>, clientSecret = " <> show (maybe False (const True) registration.clientSecret) <> " }"
+    show registration = "ClientRegistration { clientId = <redacted>, clientSecret = " <> show (isJust registration.clientSecret) <> " }"
 instance Aeson.FromJSON ClientRegistration where
     parseJSON = Aeson.withObject "ClientRegistration" $ \o -> ClientRegistration <$> o Aeson..: "client_id" <*> o Aeson..:? "client_secret"
 
-discoverProtectedResource :: Manager -> Text -> IO (Either Text ProtectedResourceMetadata)
-discoverProtectedResource manager resourceUrl = getJson manager (metadataRoot resourceUrl <> "/.well-known/oauth-protected-resource")
+-- | Statically configured client credentials.
+data PreRegisteredClient = PreRegisteredClient
+    { preRegisteredClientId :: !Text
+    , preRegisteredClientSecret :: !(Maybe Text)
+    } deriving (Eq)
 
-discoverAuthorizationServer :: Manager -> Text -> IO (Either Text AuthorizationServerMetadata)
-discoverAuthorizationServer manager issuerUrl = getJson manager (trimTrailingSlash issuerUrl <> "/.well-known/oauth-authorization-server")
+instance Show PreRegisteredClient where
+    show client = "PreRegisteredClient { preRegisteredClientId = " <> show client.preRegisteredClientId
+        <> ", preRegisteredClientSecret = " <> (if isJust client.preRegisteredClientSecret then "<redacted>" else "Nothing") <> " }"
 
-registerClient :: Manager -> Text -> [Text] -> [Text] -> IO (Either Text ClientRegistration)
-registerClient manager registrationUrl redirectUris scopes = do
+-- | Client credentials persisted from an earlier login.
+data StoredClient = StoredClient
+    { storedIssuer :: !Text
+    , storedClientId :: !Text
+    , storedSource :: !ClientIdSource
+    , storedRedirectUri :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+data RegistrationOptions = RegistrationOptions
+    { registrationPreRegistered :: !(Maybe PreRegisteredClient)
+    , registrationClientIdMetadataUrl :: !(Maybe Text)
+    , registrationStored :: !(Maybe StoredClient)
+    , registrationRedirectUri :: !Text
+    } deriving (Eq, Show)
+
+data RegistrationPlan
+    = UsePreRegisteredClient !PreRegisteredClient
+    | UseClientIdMetadataDocument !Text
+    -- ^ The metadata document URL is the @client_id@.
+    | ReuseDynamicRegistration !Text
+    -- ^ Reuse a @client_id@ obtained earlier from the same issuer.
+    | UseDynamicRegistration !Text
+    -- ^ Register at the given registration endpoint.
+    deriving (Eq, Show)
+
+-- | Choose how to obtain a @client_id@, in the priority order the MCP
+-- specification defines: pre-registered credentials, Client ID Metadata
+-- Documents, then Dynamic Client Registration. Stored dynamic registrations
+-- are reused only when they were issued by the same issuer for the same
+-- redirect URI.
+selectClientRegistration :: RegistrationOptions -> AuthorizationServerMetadata -> Either Text RegistrationPlan
+selectClientRegistration options metadata
+    | Just pre <- options.registrationPreRegistered
+    , not (Text.null (Text.strip pre.preRegisteredClientId)) =
+        Right (UsePreRegisteredClient pre)
+    | Just url <- options.registrationClientIdMetadataUrl
+    , Left err <- validateClientIdMetadataUrl url =
+        Left err
+    | Just url <- options.registrationClientIdMetadataUrl
+    , metadata.clientIdMetadataDocumentSupported =
+        Right (UseClientIdMetadataDocument url)
+    | Just stored <- options.registrationStored
+    , stored.storedSource == ClientIdDynamicRegistration
+    , Just stored.storedIssuer == metadata.issuer
+    , stored.storedRedirectUri == Just options.registrationRedirectUri =
+        Right (ReuseDynamicRegistration stored.storedClientId)
+    | Just endpoint <- metadata.registrationEndpoint =
+        Right (UseDynamicRegistration endpoint)
+    | otherwise = Left $
+        "The authorization server offers neither Client ID Metadata Documents"
+            <> (if isJust options.registrationClientIdMetadataUrl then "" else " (no oauth.clientIdMetadataUrl is configured)")
+            <> " nor Dynamic Client Registration. Configure oauth.clientId (and oauth.clientSecret if the"
+            <> " authorization server issued one) or oauth.clientIdMetadataUrl for this server in"
+            <> " ~/.haskell-agent/config.json."
+
+-- | A Client ID Metadata Document URL must use https and carry a path.
+validateClientIdMetadataUrl :: Text -> Either Text ()
+validateClientIdMetadataUrl url = case parseUrlParts url of
+    Just parts | parts.urlScheme == "https", not (Text.null parts.urlPath) -> Right ()
+    _ -> Left ("oauth.clientIdMetadataUrl must be an https URL with a path component: " <> url)
+
+data ClientRegistrationRequest = ClientRegistrationRequest
+    { registrationClientName :: !Text
+    , registrationRedirectUris :: ![Text]
+    , registrationScopes :: ![Text]
+    } deriving (Eq, Show)
+
+-- | RFC 7591 registration request body for a native public client.
+clientRegistrationPayload :: ClientRegistrationRequest -> Aeson.Value
+clientRegistrationPayload request = Aeson.object $
+    [ "application_type" Aeson..= ("native" :: Text)
+    , "client_name" Aeson..= request.registrationClientName
+    , "redirect_uris" Aeson..= request.registrationRedirectUris
+    , "grant_types" Aeson..= ["authorization_code", "refresh_token" :: Text]
+    , "response_types" Aeson..= ["code" :: Text]
+    , "token_endpoint_auth_method" Aeson..= ("none" :: Text)
+    ] <> ["scope" Aeson..= Text.unwords request.registrationScopes | not (null request.registrationScopes)]
+
+registerClientWith :: Manager -> Text -> ClientRegistrationRequest -> IO (Either Text ClientRegistration)
+registerClientWith manager registrationUrl registration = do
     result <- tryAny $ do
         request <- parseRequest (Text.unpack registrationUrl)
-        let payload = Aeson.encode $ Aeson.object ["redirect_uris" Aeson..= redirectUris, "token_endpoint_auth_method" Aeson..= ("none" :: Text), "grant_types" Aeson..= ["authorization_code", "refresh_token" :: Text], "response_types" Aeson..= ["code" :: Text], "scope" Aeson..= Text.unwords scopes]
-            request' = request { HC.method = "POST", HC.requestBody = RequestBodyLBS payload, HC.requestHeaders = [("Content-Type", "application/json"), ("Accept", "application/json")] }
+        let request' = request
+                { HC.method = "POST"
+                , HC.requestBody = RequestBodyLBS (Aeson.encode (clientRegistrationPayload registration))
+                , HC.requestHeaders = [("Content-Type", "application/json"), ("Accept", "application/json")]
+                }
         httpLbs request' manager
     case result of
-        Left exception -> pure (Left (Text.pack (show exception)))
-        Right response | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (Left "OAuth client registration failed")
-                       | otherwise -> decodeBody response
-
-refreshAccessToken :: Manager -> Text -> Text -> Text -> IO OAuthTokenResponse
-refreshAccessToken manager endpoint clientId oldRefresh = do
-    result <- tryAny $ do
-        request <- parseRequest (Text.unpack endpoint)
-        let request' = urlEncodedBody [("grant_type", "refresh_token"), ("refresh_token", Encoding.encodeUtf8 oldRefresh), ("client_id", Encoding.encodeUtf8 clientId)] request { HC.method = "POST" }
-        httpLbs request' manager
-    case result of
-        Left e -> pure (OAuthTokenFailure (Text.pack (show e)))
-        Right response | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (OAuthTokenFailure "OAuth token request failed")
-                       | otherwise -> pure $ either (OAuthTokenFailure . Text.pack) OAuthTokenSuccess (Aeson.eitherDecode (responseBody response))
-
-exchangeAuthorizationCode :: Manager -> Text -> Text -> Text -> Text -> Text -> Maybe Text -> IO OAuthTokenResponse
-exchangeAuthorizationCode manager endpoint clientId code redirectUri verifier resource = do
-    result <- tryAny $ do
-        request <- parseRequest (Text.unpack endpoint)
-        let parameters =
-                [ ("grant_type", "authorization_code")
-                , ("code", Encoding.encodeUtf8 code)
-                , ("redirect_uri", Encoding.encodeUtf8 redirectUri)
-                , ("client_id", Encoding.encodeUtf8 clientId)
-                , ("code_verifier", Encoding.encodeUtf8 verifier)
-                ] <> maybe [] (\value -> [("resource", Encoding.encodeUtf8 value)]) resource
-            request' = urlEncodedBody parameters request { HC.method = "POST" }
-        httpLbs request' manager
-    case result of
-        Left e -> pure (OAuthTokenFailure (Text.pack (show e)))
+        Left exception -> pure (Left ("OAuth client registration failed: " <> Text.pack (show exception)))
         Right response
-            | statusCode (responseStatus response) < 200
-                || statusCode (responseStatus response) >= 300 ->
-                pure (OAuthTokenFailure "OAuth authorization-code exchange failed")
-            | otherwise ->
-                pure $ either (OAuthTokenFailure . Text.pack) OAuthTokenSuccess
-                    (Aeson.eitherDecode (responseBody response))
+            | not (isSuccess response) -> pure (Left
+                ("OAuth client registration failed with HTTP "
+                    <> Text.pack (show (statusCode (responseStatus response)))
+                    <> ": " <> responseBodyText response))
+            | otherwise -> decodeBody response
+
+-- | Compatibility wrapper using the default client name.
+registerClient :: Manager -> Text -> [Text] -> [Text] -> IO (Either Text ClientRegistration)
+registerClient manager registrationUrl redirectUris scopes =
+    registerClientWith manager registrationUrl ClientRegistrationRequest
+        { registrationClientName = "Haskell Agent"
+        , registrationRedirectUris = redirectUris
+        , registrationScopes = scopes
+        }
+
+-- ---------------------------------------------------------------------------
+-- Scopes
+
+data ScopeSources = ScopeSources
+    { scopeChallenge :: ![Text]
+    -- ^ @scope@ from the @WWW-Authenticate@ challenge.
+    , scopeResourceMetadata :: ![Text]
+    -- ^ @scopes_supported@ from the protected resource metadata.
+    , scopeConfigured :: ![Text]
+    -- ^ @oauth.scopes@ from the harness configuration.
+    } deriving (Eq, Show)
+
+-- | Initial scope selection: the challenge is authoritative, then the
+-- protected resource metadata, then the configured scopes; otherwise none.
+selectScopes :: ScopeSources -> [Text]
+selectScopes sources = case filter (not . null) [sources.scopeChallenge, sources.scopeResourceMetadata, sources.scopeConfigured] of
+    chosen : _ -> unionScopes chosen []
+    [] -> []
+
+-- | Order-preserving union without duplicates or blank entries.
+unionScopes :: [Text] -> [Text] -> [Text]
+unionScopes left right = foldl' add [] (left <> right)
+  where
+    add acc scope
+        | Text.null scope || scope `elem` acc = acc
+        | otherwise = acc <> [scope]
+
+offlineAccessScope :: Text
+offlineAccessScope = "offline_access"
+
+data ScopePlan = ScopePlan
+    { scopeSources :: !ScopeSources
+    , scopePreviouslyGranted :: ![Text]
+    -- ^ Scopes recorded with an earlier token for the same issuer.
+    , scopeAdditional :: ![Text]
+    -- ^ Extra scopes requested for step-up authorization.
+    , scopeAuthorizationServerSupported :: ![Text]
+    -- ^ @scopes_supported@ from the authorization server metadata.
+    } deriving (Eq, Show)
+
+-- | Scopes to request: the selected set unioned with previously granted and
+-- additional scopes. @offline_access@ is included only when the
+-- authorization server advertises it.
+planScopes :: ScopePlan -> [Text]
+planScopes plan =
+    let base = filter (/= offlineAccessScope) $
+            unionScopes (selectScopes plan.scopeSources) (unionScopes plan.scopePreviouslyGranted plan.scopeAdditional)
+        offline = [offlineAccessScope | offlineAccessScope `elem` plan.scopeAuthorizationServerSupported]
+    in base <> offline
+
+-- ---------------------------------------------------------------------------
+-- Authorization response validation (RFC 9207)
+
+-- | Apply the RFC 9207 section 2.4 table: when the server advertises
+-- @authorization_response_iss_parameter_supported@ the @iss@ parameter is
+-- mandatory; whenever it is present it must equal the recorded issuer by
+-- simple string comparison.
+validateAuthorizationResponseIssuer :: Bool -> Text -> Maybe Text -> Either Text ()
+validateAuthorizationResponseIssuer advertised recorded received = case received of
+    Just actual
+        | actual == recorded -> Right ()
+        | otherwise -> Left
+            ("Authorization response iss " <> actual
+                <> " does not match the recorded issuer " <> recorded <> "; discarding the response")
+    Nothing
+        | advertised -> Left
+            ("Authorization server " <> recorded
+                <> " advertises the iss response parameter but the authorization response omitted it; discarding the response")
+        | otherwise -> Right ()
+
+-- ---------------------------------------------------------------------------
+-- Token endpoint
+
+data TokenExchange = TokenExchange
+    { exchangeEndpoint :: !Text
+    , exchangeClientId :: !Text
+    , exchangeClientSecret :: !(Maybe Text)
+    , exchangeCode :: !Text
+    , exchangeRedirectUri :: !Text
+    , exchangeCodeVerifier :: !Text
+    , exchangeResource :: !(Maybe Text)
+    }
+
+exchangeAuthorizationCodeWith :: Manager -> TokenExchange -> IO OAuthTokenResponse
+exchangeAuthorizationCodeWith manager exchange =
+    tokenRequest manager "OAuth authorization-code exchange failed" exchange.exchangeEndpoint $
+        [ ("grant_type", "authorization_code")
+        , ("code", Encoding.encodeUtf8 exchange.exchangeCode)
+        , ("redirect_uri", Encoding.encodeUtf8 exchange.exchangeRedirectUri)
+        , ("client_id", Encoding.encodeUtf8 exchange.exchangeClientId)
+        , ("code_verifier", Encoding.encodeUtf8 exchange.exchangeCodeVerifier)
+        ]
+        <> optionalParam "client_secret" exchange.exchangeClientSecret
+        <> optionalParam "resource" exchange.exchangeResource
+
+-- | Compatibility wrapper for public clients.
+exchangeAuthorizationCode :: Manager -> Text -> Text -> Text -> Text -> Text -> Maybe Text -> IO OAuthTokenResponse
+exchangeAuthorizationCode manager endpoint clientId code redirectUri verifier resource =
+    exchangeAuthorizationCodeWith manager TokenExchange
+        { exchangeEndpoint = endpoint
+        , exchangeClientId = clientId
+        , exchangeClientSecret = Nothing
+        , exchangeCode = code
+        , exchangeRedirectUri = redirectUri
+        , exchangeCodeVerifier = verifier
+        , exchangeResource = resource
+        }
+
+data RefreshRequest = RefreshRequest
+    { refreshEndpoint :: !Text
+    , refreshClientId :: !Text
+    , refreshClientSecret :: !(Maybe Text)
+    , refreshRefreshToken :: !Text
+    , refreshResource :: !(Maybe Text)
+    }
+
+refreshAccessTokenWith :: Manager -> RefreshRequest -> IO OAuthTokenResponse
+refreshAccessTokenWith manager refresh =
+    tokenRequest manager "OAuth token refresh failed" refresh.refreshEndpoint $
+        [ ("grant_type", "refresh_token")
+        , ("refresh_token", Encoding.encodeUtf8 refresh.refreshRefreshToken)
+        , ("client_id", Encoding.encodeUtf8 refresh.refreshClientId)
+        ]
+        <> optionalParam "client_secret" refresh.refreshClientSecret
+        <> optionalParam "resource" refresh.refreshResource
+
+-- | Compatibility wrapper: refresh for a public client without a resource
+-- indicator.
+refreshAccessToken :: Manager -> Text -> Text -> Text -> IO OAuthTokenResponse
+refreshAccessToken manager endpoint clientId oldRefresh =
+    refreshAccessTokenWith manager RefreshRequest
+        { refreshEndpoint = endpoint
+        , refreshClientId = clientId
+        , refreshClientSecret = Nothing
+        , refreshRefreshToken = oldRefresh
+        , refreshResource = Nothing
+        }
+
+optionalParam :: BS.ByteString -> Maybe Text -> [(BS.ByteString, BS.ByteString)]
+optionalParam name = maybe [] (\value -> [(name, Encoding.encodeUtf8 value)])
+
+tokenRequest :: Manager -> Text -> Text -> [(BS.ByteString, BS.ByteString)] -> IO OAuthTokenResponse
+tokenRequest manager failure endpoint parameters = do
+    result <- tryAny $ do
+        request <- parseRequest (Text.unpack endpoint)
+        let request' = urlEncodedBody parameters request { HC.method = "POST" }
+        httpLbs request' { HC.requestHeaders = ("Accept", "application/json") : HC.requestHeaders request' } manager
+    case result of
+        Left e -> pure (OAuthTokenFailure (failure <> ": " <> Text.pack (show e)))
+        Right response
+            | not (isSuccess response) -> pure $ OAuthTokenFailure
+                (failure <> " with HTTP " <> Text.pack (show (statusCode (responseStatus response)))
+                    <> ": " <> responseBodyText response)
+            | otherwise -> pure $ either (OAuthTokenFailure . Text.pack) OAuthTokenSuccess
+                (Aeson.eitherDecode (responseBody response))
+
+-- ---------------------------------------------------------------------------
+-- HTTP helpers
+
+tryCandidates :: Text -> (Text -> IO (Either Text a)) -> [Text] -> IO (Either Text a)
+tryCandidates failure fetch = go []
+  where
+    go errors [] = pure (Left (failure <> ": " <> Text.intercalate "; " (reverse errors)))
+    go errors (url : rest) = fetch url >>= \case
+        Right value -> pure (Right value)
+        Left err -> go ((url <> ": " <> err) : errors) rest
 
 getJson :: Aeson.FromJSON value => Manager -> Text -> IO (Either Text value)
 getJson manager url = do
@@ -168,25 +902,25 @@ getJson manager url = do
         httpLbs request { HC.requestHeaders = [("Accept", "application/json")] } manager
     case result of
         Left exception -> pure (Left (Text.pack (show exception)))
-        Right response | statusCode (responseStatus response) < 200 || statusCode (responseStatus response) >= 300 -> pure (Left "OAuth metadata request failed")
-                       | otherwise -> decodeBody response
+        Right response
+            | not (isSuccess response) -> pure (Left ("HTTP " <> Text.pack (show (statusCode (responseStatus response)))))
+            | otherwise -> decodeBody response
 
 decodeBody :: Aeson.FromJSON value => HC.Response LBS.ByteString -> IO (Either Text value)
 decodeBody response = pure $ either (Left . Text.pack) Right (Aeson.eitherDecode (responseBody response))
-metadataRoot :: Text -> Text
-metadataRoot url = case Text.breakOn "://" url of
-    (scheme, rest) | Text.null rest -> trimTrailingSlash url
-                   | otherwise -> scheme <> "://" <> Text.takeWhile (/= '/') (Text.drop 3 rest)
-trimTrailingSlash :: Text -> Text
-trimTrailingSlash t = Text.dropWhileEnd (== '/') t
+
+isSuccess :: HC.Response body -> Bool
+isSuccess response =
+    let code = statusCode (responseStatus response)
+    in code >= 200 && code < 300
+
+-- | Error bodies from OAuth endpoints describe the failure and carry no
+-- credentials; keep them short for diagnostics.
+responseBodyText :: HC.Response LBS.ByteString -> Text
+responseBodyText response =
+    let body = Text.strip (decodeLenient (LBS.toStrict (LBS.take 2048 (responseBody response))))
+    in if Text.null body then "(empty response body)" else body
 
 -- | UTF-8 success page served by the interactive OAuth callback listener.
 oauthCallbackSuccessPage :: LBS.ByteString
 oauthCallbackSuccessPage = "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width\"><title>Connected</title><style>body{margin:0;min-height:100vh;display:grid;place-items:center;background:#0b1020;color:#e8ecf5;font:16px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}.card{max-width:430px;margin:24px;padding:36px;border:1px solid #28324a;border-radius:20px;background:#131a2d;box-shadow:0 24px 70px #0008;text-align:center}.check{display:grid;place-items:center;width:56px;height:56px;margin:0 auto 20px;border-radius:50%;background:#173d31;color:#6ee7b7;font-size:30px}h1{margin:0 0 10px;font-size:24px}p{margin:0;color:#aab4ca;line-height:1.55}</style></head><body><main class=\"card\"><div class=\"check\">&#10003;</div><h1>MCP connected</h1><p>Authorization completed successfully. You can close this tab and return to Haskell Agent.</p></main></body></html>"
-
-instance Aeson.FromJSON OAuthTokens where
-    parseJSON = Aeson.withObject "OAuthTokens" $ \object ->
-        OAuthTokens
-            <$> object Aeson..: "access_token"
-            <*> object Aeson..:? "refresh_token"
-            <*> object Aeson..:? "expires_in"

--- a/packages/agent-core/src/Agent/MCP/Supervisor.hs
+++ b/packages/agent-core/src/Agent/MCP/Supervisor.hs
@@ -1,120 +1,64 @@
 module Agent.MCP.Supervisor where
 
 
-import Agent.Tools.IO (terminateProcessGroup)
-import Agent.Tools.Types
-    ( AppTool(..)
-    , ApprovalRule(..)
-    , ToolExecutionPolicy(..)
-    , ToolSchema(..)
-    )
-import Agent.ToolDispatch (typedTool)
 import Agent.Concurrent (forConcurrentlyBounded_)
-import Control.Concurrent.Async
-    ( Async
-    , asyncWithUnmask
-    , cancel
-    , mapConcurrently
-    , waitCatch
-    )
-import Control.Concurrent.QSem
-    ( newQSem
-    , signalQSem
-    , waitQSem
-    )
-import Control.Concurrent.MVar
-    ( MVar
-    , modifyMVar
-    , modifyMVar_
-    , newMVar
-    , withMVar
-    )
-import Control.Concurrent.STM
-    ( STM
-    , TMVar
-    , TVar
-    , atomically
-    , modifyTVar'
-    , newEmptyTMVar
-    , newEmptyTMVarIO
-    , newTVarIO
-    , readTMVar
-    , readTVar
-    , readTVarIO
-    , takeTMVar
-    , tryPutTMVar
-    , writeTVar
-    )
-import Control.Exception.Safe
-    ( SomeException
-    , displayException
-    , bracket_
-    , finally
-    , mask
-    , onException
-    , throwIO
-    , tryAny
-    )
-import Control.Monad (forM, unless, void, when)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as LBS
-import Data.Char (isAlphaNum)
-import Data.IORef
-    ( IORef
-    , atomicModifyIORef'
-    , newIORef
-    , readIORef
-    )
-import qualified Data.IntMap.Strict as IntMap
-import qualified Data.Map.Strict as Map
-import Data.List (find, sortOn)
-import Data.Maybe (catMaybes, isJust)
-import Data.Ord (Down(..))
-import Data.Scientific (floatingOrInteger)
-import qualified Data.Set as Set
-import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as TextEncoding
-import Data.Text.Encoding.Error (lenientDecode)
-import qualified Data.Vector as Vector
-import System.Environment (getEnvironment)
-import System.Directory (getCurrentDirectory)
-import System.IO
-    ( BufferMode(..)
-    , Handle
-    , hClose
-    , hFlush
-    , hSetBinaryMode
-    , hSetBuffering
-    )
-import System.Posix.Types (ProcessGroupID)
-import System.Process
-    ( CreateProcess(..)
-    , ProcessHandle
-    , StdStream(..)
-    , createProcess
-    , getPid
-    , proc
-    )
-import System.Timeout (timeout)
-import Agent.MCP.Types
-import Agent.MCP.Client (exceptionSummary, mcpClientStatus)
+import Agent.MCP.Client (closeMcpClient, exceptionSummary)
 import Agent.MCP.Fleet
     ( closeMcpFleet
     , mcpFleetStatuses
     , resolveEffectiveCwds
     , sameServerConfigs
-    , startMcpFleetProgressive
-    , startMcpFleetWithProgress
+    , startMcpFleetProgressiveHooks
+    , startMcpFleetWithProgressHooks
     )
+import Agent.MCP.Types
+import Control.Concurrent.Async
+    ( asyncWithUnmask
+    , cancel
+    , waitCatch
+    )
+import Control.Concurrent.MVar
+    ( modifyMVar
+    , modifyMVar_
+    , newMVar
+    )
+import Control.Concurrent.STM
+    ( TMVar
+    , atomically
+    , newEmptyTMVarIO
+    , readTMVar
+    , tryPutTMVar
+    )
+import Control.Exception.Safe
+    ( mask
+    , onException
+    , tryAny
+    )
+import Control.Monad (unless, void)
+import Data.IORef
+    ( atomicModifyIORef'
+    , newIORef
+    )
+import Data.List (find)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
 newMcpSupervisor :: IO McpSupervisor
-newMcpSupervisor =
-    McpSupervisor <$> newMVar McpSupervisorState
+newMcpSupervisor = newMcpSupervisorWith defaultMcpHostHooks
+
+-- | A supervisor whose fleets share the given host hooks (elicitation UI,
+-- client identity).
+newMcpSupervisorWith :: McpHostHooks -> IO McpSupervisor
+newMcpSupervisorWith hooks = do
+    state <- newMVar McpSupervisorState
         { supervisorClosed = False
         , supervisorNextLeaseId = 1
         , supervisorEntries = []
         , supervisorPending = []
+        }
+    pure McpSupervisor
+        { supervisorState = state
+        , supervisorHooks = hooks
         }
 
 acquireMcpFleet
@@ -123,7 +67,7 @@ acquireMcpFleet
     -> IO McpFleetLease
 acquireMcpFleet supervisor configs =
     resolveEffectiveCwds configs >>= acquireMcpFleetWith supervisor False
-        (startMcpFleetWithProgress (const (pure ())))
+        (startMcpFleetWithProgressHooks supervisor.supervisorHooks (const (pure ())))
 
 acquireMcpFleetWithProgress
     :: McpSupervisor
@@ -132,7 +76,7 @@ acquireMcpFleetWithProgress
     -> IO McpFleetLease
 acquireMcpFleetWithProgress supervisor report configs =
     resolveEffectiveCwds configs >>= acquireMcpFleetWith supervisor False
-        (startMcpFleetWithProgress report)
+        (startMcpFleetWithProgressHooks supervisor.supervisorHooks report)
 
 acquireMcpFleetProgressive
     :: McpSupervisor
@@ -141,7 +85,7 @@ acquireMcpFleetProgressive
     -> IO McpFleetLease
 acquireMcpFleetProgressive supervisor report configs =
     resolveEffectiveCwds configs >>= acquireMcpFleetWith supervisor True
-        (startMcpFleetProgressive report)
+        (startMcpFleetProgressiveHooks supervisor.supervisorHooks report)
 
 acquireMcpFleetWith
     :: McpSupervisor

--- a/packages/agent-core/src/Agent/MCP/Types.hs
+++ b/packages/agent-core/src/Agent/MCP/Types.hs
@@ -1,5 +1,13 @@
+-- | Shared types for the Model Context Protocol client.
+--
+-- The client speaks both protocol eras defined by the specification:
+--
+-- * /modern/ revisions (@2026-07-28@ and later) are stateless. Every request
+--   carries the protocol version, client identity, and client capabilities in
+--   @_meta@, and servers are discovered through @server/discover@.
+-- * /legacy/ revisions (@2025-11-25@ and earlier) establish a session with an
+--   @initialize@ handshake and, over Streamable HTTP, an @Mcp-Session-Id@.
 module Agent.MCP.Types where
-
 
 import Agent.Json
     ( RawJson
@@ -8,105 +16,32 @@ import Agent.Json
     , rawJsonFromEncoding
     )
 import qualified Agent.Json.Decode as Json
-import Agent.Tools.IO (terminateProcessGroup)
-import Agent.Tools.Types
-    ( AppTool(..)
-    , ApprovalRule(..)
-    , ToolExecutionPolicy(..)
-    , ToolSchema(..)
-    )
-import Agent.ToolDispatch (typedTool)
-import Agent.Concurrent (forConcurrentlyBounded_)
-import Control.Concurrent.Async
-    ( Async
-    , asyncWithUnmask
-    , cancel
-    , mapConcurrently
-    , waitCatch
-    )
-import Control.Concurrent.QSem
-    ( newQSem
-    , signalQSem
-    , waitQSem
-    )
-import Control.Concurrent.MVar
-    ( MVar
-    , modifyMVar
-    , modifyMVar_
-    , newMVar
-    , withMVar
-    )
-import Control.Concurrent.STM
-    ( STM
-    , TMVar
-    , TVar
-    , atomically
-    , modifyTVar'
-    , newEmptyTMVar
-    , newEmptyTMVarIO
-    , newTVarIO
-    , readTMVar
-    , readTVar
-    , readTVarIO
-    , takeTMVar
-    , tryPutTMVar
-    , writeTVar
-    )
-import Control.Exception.Safe
-    ( SomeException
-    , displayException
-    , bracket_
-    , finally
-    , mask
-    , onException
-    , throwIO
-    , tryAny
-    )
-import Control.Monad (forM, unless, void, when)
+import Agent.Tools.Types (AppTool(..))
+import Control.Concurrent.Async (Async)
+import Control.Concurrent.MVar (MVar)
+import Control.Concurrent.STM (TMVar, TVar)
 import Data.Aeson (object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as LBS
-import Data.Char (isAlphaNum)
-import Data.IORef
-    ( IORef
-    , atomicModifyIORef'
-    , newIORef
-    , readIORef
-    )
+import Data.IORef (IORef)
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
-import Data.List (find, sortOn)
-import Data.Maybe (catMaybes, isJust)
-import Data.Ord (Down(..))
-import Data.Scientific (floatingOrInteger)
-import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
-import qualified Data.Vector as Vector
-import System.Environment (getEnvironment)
-import System.Directory (getCurrentDirectory)
-import System.IO
-    ( BufferMode(..)
-    , Handle
-    , hClose
-    , hFlush
-    , hSetBinaryMode
-    , hSetBuffering
-    )
+import System.IO (Handle)
 import System.Posix.Types (ProcessGroupID)
-import System.Process
-    ( CreateProcess(..)
-    , ProcessHandle
-    , StdStream(..)
-    , createProcess
-    , getPid
-    , proc
-    )
-import System.Timeout (timeout)
+import System.Process (ProcessHandle)
+
+-- | Which protocol era to use for a configured server. 'McpProtocolAuto'
+-- probes with @server/discover@ and falls back to the legacy @initialize@
+-- handshake; the explicit values skip the probe.
+data McpProtocolPreference
+    = McpProtocolAuto
+    | McpProtocolModern
+    | McpProtocolLegacy
+    deriving (Eq, Show)
 
 data McpServerConfig = McpServerConfig
     { mcpServerName :: !Text
@@ -117,6 +52,7 @@ data McpServerConfig = McpServerConfig
     , mcpServerEnv :: ![(String, String)]
     , mcpServerStartupTimeoutSeconds :: !Int
     , mcpServerRequestTimeoutSeconds :: !Int
+    , mcpServerProtocol :: !McpProtocolPreference
     } deriving (Eq)
 
 instance Show McpServerConfig where
@@ -133,7 +69,57 @@ instance Show McpServerConfig where
             <> show config.mcpServerStartupTimeoutSeconds
             <> ", mcpServerRequestTimeoutSeconds = "
             <> show config.mcpServerRequestTimeoutSeconds
+            <> ", mcpServerProtocol = "
+            <> show config.mcpServerProtocol
             <> " }"
+
+-- | Host-provided integration points shared by every server in a fleet.
+data McpHostHooks = McpHostHooks
+    { mcpHostElicit :: !(Maybe (McpElicitRequest -> IO McpElicitResult))
+    -- ^ Interactive elicitation. 'Nothing' means the host cannot ask the user
+    -- for input, so the @elicitation@ capability is not declared and any
+    -- request for input is cancelled.
+    , mcpHostClientName :: !Text
+    , mcpHostClientVersion :: !Text
+    }
+
+defaultMcpHostHooks :: McpHostHooks
+defaultMcpHostHooks = McpHostHooks
+    { mcpHostElicit = Nothing
+    , mcpHostClientName = "haskell-agent"
+    , mcpHostClientVersion = "0.1.0"
+    }
+
+-- | A server's request for user input, delivered either as a legacy
+-- server-initiated @elicitation/create@ request or inside a multi round-trip
+-- @input_required@ result.
+data McpElicitRequest = McpElicitRequest
+    { elicitServerName :: !Text
+    , elicitMessage :: !Text
+    , elicitMode :: !McpElicitMode
+    } deriving (Eq, Show)
+
+data McpElicitMode
+    = McpElicitForm !RawJson
+    -- ^ Form mode with the (restricted) JSON Schema of the requested object.
+    | McpElicitUrl !Text
+    -- ^ URL mode. The user must consent before the URL is opened.
+    deriving (Eq, Show)
+
+data McpElicitResult
+    = McpElicitAccept !(Maybe RawJson)
+    | McpElicitDecline
+    | McpElicitCancel
+    deriving (Eq, Show)
+
+encodeElicitResult :: McpElicitResult -> RawJson
+encodeElicitResult result = rawJsonFromEncoding . Aeson.toEncoding $ case result of
+    McpElicitAccept content ->
+        object
+            ("action" .= ("accept" :: Text)
+                : maybe [] (\value -> ["content" .= value]) content)
+    McpElicitDecline -> object ["action" .= ("decline" :: Text)]
+    McpElicitCancel -> object ["action" .= ("cancel" :: Text)]
 
 data McpToolRegistration = McpToolRegistration
     { mcpRegistrationServer :: !Text
@@ -160,6 +146,153 @@ data McpServerStatus = McpServerStatus
     , mcpStatusState :: !McpInitState
     , mcpStatusToolCount :: !Int
     } deriving (Eq, Show)
+
+-- | Protocol era negotiated with a server.
+data McpProtocolEra
+    = McpEraModern
+    | McpEraLegacy
+    deriving (Eq, Show)
+
+-- | Identity and capabilities learned from @server/discover@ or the legacy
+-- @initialize@ result.
+data McpServerInfo = McpServerInfo
+    { serverInfoEra :: !McpProtocolEra
+    , serverInfoProtocolVersion :: !Text
+    , serverInfoName :: !(Maybe Text)
+    , serverInfoVersion :: !(Maybe Text)
+    , serverInfoTitle :: !(Maybe Text)
+    , serverInfoInstructions :: !(Maybe Text)
+    , serverInfoCapabilities :: !McpServerCapabilities
+    } deriving (Eq, Show)
+
+data McpServerCapabilities = McpServerCapabilities
+    { capabilityTools :: !(Maybe McpListCapability)
+    , capabilityPrompts :: !(Maybe McpListCapability)
+    , capabilityResources :: !(Maybe McpResourcesCapability)
+    , capabilityCompletions :: !Bool
+    , capabilityLogging :: !Bool
+    , capabilityExtensions :: !(Map.Map Text RawJson)
+    , capabilitySkills :: !(Maybe McpSkillsCapability)
+    } deriving (Eq, Show)
+
+emptyServerCapabilities :: McpServerCapabilities
+emptyServerCapabilities = McpServerCapabilities
+    { capabilityTools = Nothing
+    , capabilityPrompts = Nothing
+    , capabilityResources = Nothing
+    , capabilityCompletions = False
+    , capabilityLogging = False
+    , capabilityExtensions = Map.empty
+    , capabilitySkills = Nothing
+    }
+
+newtype McpListCapability = McpListCapability
+    { listChanged :: Bool
+    } deriving (Eq, Show)
+
+data McpResourcesCapability = McpResourcesCapability
+    { resourcesListChanged :: !Bool
+    , resourcesSubscribe :: !Bool
+    } deriving (Eq, Show)
+
+serverCapabilitiesDecoder :: Json.Decoder McpServerCapabilities
+serverCapabilitiesDecoder = Json.object do
+    capabilityTools <- Json.optionalKey "tools" listCapabilityDecoder
+    capabilityPrompts <- Json.optionalKey "prompts" listCapabilityDecoder
+    capabilityResources <- Json.optionalKey "resources" resourcesCapabilityDecoder
+    completions <- Json.optionalKey "completions" rawJsonDecoder
+    logging <- Json.optionalKey "logging" rawJsonDecoder
+    extensions <-
+        Json.optionalKey "extensions"
+            (Json.objectAsMap pure rawJsonDecoder)
+    let capabilityExtensions = maybe Map.empty id extensions
+        capabilitySkills =
+            case Map.lookup "io.modelcontextprotocol/skills" capabilityExtensions of
+                Nothing -> Nothing
+                Just raw ->
+                    Just McpSkillsCapability
+                        { mcpSkillsDirectoryRead =
+                            projectRawOr False skillsDirectoryDecoder raw
+                        }
+    pure McpServerCapabilities
+        { capabilityTools
+        , capabilityPrompts
+        , capabilityResources
+        , capabilityCompletions = maybe False (const True) completions
+        , capabilityLogging = maybe False (const True) logging
+        , capabilityExtensions
+        , capabilitySkills
+        }
+  where
+    listCapabilityDecoder =
+        Json.object (McpListCapability <$> Json.defaultKey False "listChanged" Json.bool)
+    resourcesCapabilityDecoder = Json.object do
+        resourcesListChanged <- Json.defaultKey False "listChanged" Json.bool
+        resourcesSubscribe <- Json.defaultKey False "subscribe" Json.bool
+        pure McpResourcesCapability{..}
+    skillsDirectoryDecoder =
+        Json.object (Json.defaultKey False "directoryRead" Json.bool)
+
+-- | Failure of one MCP request.
+data McpError
+    = McpTransportError !Text
+    -- ^ The transport failed or the message could not be decoded.
+    | McpTimeout !Text
+    -- ^ No response arrived within the request timeout. The request was
+    -- cancelled.
+    | McpHttpStatus !Int !Text
+    -- ^ A non-2xx HTTP status whose body was not a JSON-RPC error.
+    | McpRpcError !Int !Text !(Maybe RawJson)
+    -- ^ A JSON-RPC error response: code, message, and optional data.
+    deriving (Eq, Show)
+
+renderMcpError :: McpError -> Text
+renderMcpError = \case
+    McpTransportError message -> message
+    McpTimeout message -> message
+    McpHttpStatus status body ->
+        "MCP HTTP request failed with status "
+            <> Text.pack (show status)
+            <> (if Text.null body then "" else ": " <> Text.take 500 body)
+    McpRpcError code message payload ->
+        "MCP error " <> Text.pack (show code) <> ": " <> message
+            <> maybe ""
+                (\value -> " " <> decodeUtf8Lenient (rawJsonBytes value))
+                payload
+
+-- Error codes reserved by the specification.
+errorCodeHeaderMismatch, errorCodeMissingClientCapability, errorCodeUnsupportedProtocolVersion, errorCodeMethodNotFound, errorCodeInvalidParams, errorCodeInternal :: Int
+errorCodeHeaderMismatch = -32020
+errorCodeMissingClientCapability = -32021
+errorCodeUnsupportedProtocolVersion = -32022
+errorCodeMethodNotFound = -32601
+errorCodeInvalidParams = -32602
+errorCodeInternal = -32603
+
+-- | Progress reported for an in-flight request.
+data McpProgress = McpProgress
+    { progressValue :: !Double
+    , progressTotal :: !(Maybe Double)
+    , progressMessage :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+-- | Server-initiated notifications that are not tied to a single request.
+data McpServerEvent
+    = McpToolsListChanged
+    | McpPromptsListChanged
+    | McpResourcesListChanged
+    | McpResourceUpdated !Text
+    | McpLogMessage !Text !(Maybe Text) !RawJson
+    -- ^ Level, logger, and data of a @notifications/message@.
+    deriving (Eq, Show)
+
+data PendingRequest = PendingRequest
+    { pendingResponse :: !(TMVar (Either McpError RawJson))
+    , pendingActivity :: !(TVar Int)
+    -- ^ Incremented for every progress notification so the waiter can extend
+    -- its timeout while the server is demonstrably working.
+    , pendingOnProgress :: !(McpProgress -> IO ())
+    }
 
 mcpSkillEntryDecoder :: Json.Decoder McpSkillEntry
 mcpSkillEntryDecoder = Json.object do
@@ -206,10 +339,12 @@ data McpFleet = McpFleet
     , mcpFleetReconnects :: !(Map.Map Text (MVar ()))
     , mcpFleetWorkers :: !(MVar [Async ()])
     , mcpFleetClosed :: !(MVar Bool)
+    , mcpFleetHooks :: !McpHostHooks
     }
 
 data McpSupervisor = McpSupervisor
     { supervisorState :: !(MVar McpSupervisorState)
+    , supervisorHooks :: !McpHostHooks
     }
 
 data McpSupervisorState = McpSupervisorState
@@ -250,30 +385,36 @@ data McpFleetLease = McpFleetLease
     , mcpLeaseRelease :: !(IO ())
     }
 
--- | A process-scoped cache of MCP fleets. Released leases remain warm for a
--- later provider/session rebuild; changed configurations replace idle fleets,
--- and 'closeMcpSupervisor' performs the final deterministic shutdown.
+-- | One connection to an MCP server over stdio or Streamable HTTP.
 data McpClient = McpClient
     { clientConfig :: !McpServerConfig
+    , clientHooks :: !McpHostHooks
     , clientHttpSession :: !(IORef (Maybe Text))
+    -- ^ Legacy Streamable HTTP session id. Modern servers never mint one.
     -- Stdio transports own a process and input pipe; remote HTTP transports
     -- leave these fields empty and perform requests synchronously.
     , clientInput :: !(Maybe Handle)
     , clientProcess :: !(Maybe ProcessHandle)
     , clientGroupId :: !(Maybe ProcessGroupID)
     , clientNextId :: !(IORef Int)
-    , clientPending :: !(TVar (IntMap.IntMap (TMVar (Either Text RawJson))))
+    , clientPending :: !(TVar (IntMap.IntMap PendingRequest))
     , clientFailure :: !(TVar (Maybe Text))
     , clientWriteLock :: !(MVar ())
     , clientStderr :: !(IORef CapturedStderr)
-    , clientReader :: !(Maybe (Async ()))
+    , clientReader :: !(IORef (Maybe (Async ())))
     , clientStderrReader :: !(Maybe (Async ()))
+    , clientWorkers :: !(TVar [Async ()])
+    -- ^ Background work owned by the client: handlers for server-initiated
+    -- requests and long-lived subscription streams.
     , clientClosed :: !(MVar Bool)
     , clientLifecycle :: !(TVar McpClientLifecycle)
-    -- Set after initialize.  A missing value means the server did not
-    -- negotiate the optional Skills over MCP extension.
-    , clientSkillsCapability :: !(TVar (Maybe McpSkillsCapability))
+    , clientServerInfo :: !(TVar (Maybe McpServerInfo))
+    -- ^ Set once the protocol era has been negotiated.
     , clientDiscoveredSkills :: !(TVar [McpSkillEntry])
+    , clientEventHandler :: !(IORef (McpServerEvent -> IO ()))
+    , clientEraHint :: !(Maybe McpProtocolEra)
+    -- ^ Era observed by a previous connection to the same server. Skips the
+    -- discovery probe after a reconnect.
     }
 
 data McpSkillsCapability = McpSkillsCapability
@@ -309,6 +450,109 @@ data McpResourceContent = McpResourceContent
     , mcpResourceBlob :: !(Maybe Text)
     } deriving (Eq, Show)
 
+-- | A resource advertised by @resources/list@.
+data McpResource = McpResource
+    { resourceUri :: !Text
+    , resourceName :: !Text
+    , resourceTitle :: !(Maybe Text)
+    , resourceDescription :: !(Maybe Text)
+    , resourceMimeType :: !(Maybe Text)
+    , resourceSize :: !(Maybe Int)
+    } deriving (Eq, Show)
+
+mcpResourceDecoder :: Json.Decoder McpResource
+mcpResourceDecoder = Json.object do
+    resourceUri <- Json.atKey "uri" Json.text
+    resourceName <- Json.defaultKey "" "name" Json.text
+    resourceTitle <- Json.optionalKey "title" Json.text
+    resourceDescription <- Json.optionalKey "description" Json.text
+    resourceMimeType <- Json.optionalKey "mimeType" Json.text
+    resourceSize <- Json.optionalKey "size" Json.int
+    pure McpResource{..}
+
+-- | A parameterized resource advertised by @resources/templates/list@.
+data McpResourceTemplate = McpResourceTemplate
+    { templateUri :: !Text
+    , templateName :: !Text
+    , templateTitle :: !(Maybe Text)
+    , templateDescription :: !(Maybe Text)
+    , templateMimeType :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+mcpResourceTemplateDecoder :: Json.Decoder McpResourceTemplate
+mcpResourceTemplateDecoder = Json.object do
+    templateUri <- Json.atKey "uriTemplate" Json.text
+    templateName <- Json.defaultKey "" "name" Json.text
+    templateTitle <- Json.optionalKey "title" Json.text
+    templateDescription <- Json.optionalKey "description" Json.text
+    templateMimeType <- Json.optionalKey "mimeType" Json.text
+    pure McpResourceTemplate{..}
+
+-- | A prompt template advertised by @prompts/list@.
+data McpPrompt = McpPrompt
+    { promptName :: !Text
+    , promptTitle :: !(Maybe Text)
+    , promptDescription :: !(Maybe Text)
+    , promptArguments :: ![McpPromptArgument]
+    } deriving (Eq, Show)
+
+data McpPromptArgument = McpPromptArgument
+    { promptArgumentName :: !Text
+    , promptArgumentDescription :: !(Maybe Text)
+    , promptArgumentRequired :: !Bool
+    } deriving (Eq, Show)
+
+mcpPromptDecoder :: Json.Decoder McpPrompt
+mcpPromptDecoder = Json.object do
+    promptName <- Json.atKey "name" Json.text
+    promptTitle <- Json.optionalKey "title" Json.text
+    promptDescription <- Json.optionalKey "description" Json.text
+    promptArguments <- Json.defaultKey [] "arguments" (Json.list argumentDecoder)
+    pure McpPrompt{..}
+  where
+    argumentDecoder = Json.object do
+        promptArgumentName <- Json.atKey "name" Json.text
+        promptArgumentDescription <- Json.optionalKey "description" Json.text
+        promptArgumentRequired <- Json.defaultKey False "required" Json.bool
+        pure McpPromptArgument{..}
+
+-- | One message of a resolved prompt. The content is kept as the wire JSON
+-- because prompt messages carry the same content blocks as tool results.
+data McpPromptMessage = McpPromptMessage
+    { promptMessageRole :: !Text
+    , promptMessageContent :: !RawJson
+    } deriving (Eq, Show)
+
+data McpPromptResult = McpPromptResult
+    { promptResultDescription :: !(Maybe Text)
+    , promptResultMessages :: ![McpPromptMessage]
+    } deriving (Eq, Show)
+
+mcpPromptResultDecoder :: Json.Decoder McpPromptResult
+mcpPromptResultDecoder = Json.object do
+    promptResultDescription <- Json.optionalKey "description" Json.text
+    promptResultMessages <- Json.defaultKey [] "messages" (Json.list messageDecoder)
+    pure McpPromptResult{..}
+  where
+    messageDecoder = Json.object do
+        promptMessageRole <- Json.defaultKey "user" "role" Json.text
+        promptMessageContent <- Json.atKey "content" rawJsonDecoder
+        pure McpPromptMessage{..}
+
+-- | Argument completion suggestions from @completion/complete@.
+data McpCompletion = McpCompletion
+    { completionValues :: ![Text]
+    , completionTotal :: !(Maybe Int)
+    , completionHasMore :: !Bool
+    } deriving (Eq, Show)
+
+mcpCompletionDecoder :: Json.Decoder McpCompletion
+mcpCompletionDecoder = Json.object $ Json.atKey "completion" $ Json.object do
+    completionValues <- Json.defaultKey [] "values" (Json.list Json.text)
+    completionTotal <- Json.optionalKey "total" Json.int
+    completionHasMore <- Json.defaultKey False "hasMore" Json.bool
+    pure McpCompletion{..}
+
 data McpClientLifecycle
     = ClientPending
     | ClientInitializing
@@ -328,29 +572,59 @@ emptyCapturedStderr = CapturedStderr BS.empty 0
 stderrLimit :: Int
 stderrLimit = 16 * 1024
 
+-- | A tool parameter mirrored into an HTTP header via @x-mcp-header@.
+data McpHeaderParam = McpHeaderParam
+    { headerParamPath :: ![Text]
+    -- ^ Chain of @properties@ keys from the schema root.
+    , headerParamName :: !Text
+    -- ^ The name portion of the resulting @Mcp-Param-{name}@ header.
+    } deriving (Eq, Show)
+
 data McpTool = McpTool
     { discoveredName :: !Text
+    , discoveredTitle :: !(Maybe Text)
     , discoveredDescription :: !Text
     , discoveredInputSchema :: !RawJson
+    , discoveredOutputSchema :: !(Maybe RawJson)
     , discoveredReadOnly :: !Bool
+    , discoveredDestructive :: !Bool
+    , discoveredIdempotent :: !Bool
+    , discoveredOpenWorld :: !Bool
+    , discoveredHeaderParams :: ![McpHeaderParam]
     }
+
+-- | Whether a failed call may be retried without risking a duplicated side
+-- effect. Annotations are only hints, so this remains conservative.
+mcpToolRetrySafe :: McpTool -> Bool
+mcpToolRetrySafe tool = tool.discoveredReadOnly || tool.discoveredIdempotent
 
 mcpToolDecoder :: Json.Decoder McpTool
 mcpToolDecoder = Json.object do
     discoveredName <- Json.atKey "name" Json.text
+    discoveredTitle <- Json.optionalKey "title" Json.text
     rawDescription <- Json.optionalKey "description" rawJsonDecoder
     let discoveredDescription =
             maybe "" (projectRawOr "" Json.text) rawDescription
     discoveredInputSchema <-
         maybe emptyInputSchema id
             <$> Json.atKeyOptional "inputSchema" rawJsonDecoder
+    discoveredOutputSchema <- Json.optionalKey "outputSchema" rawJsonDecoder
     rawAnnotations <- Json.optionalKey "annotations" rawJsonDecoder
-    let discoveredReadOnly =
-            maybe False (projectRawOr False annotationsDecoder) rawAnnotations
+    let annotations =
+            maybe defaultAnnotations (projectRawOr defaultAnnotations annotationsDecoder) rawAnnotations
+        (discoveredReadOnly, discoveredDestructive, discoveredIdempotent, discoveredOpenWorld) =
+            annotations
+        discoveredHeaderParams = []
     pure McpTool{..}
   where
-    annotationsDecoder =
-        Json.object (Json.defaultKey False "readOnlyHint" Json.bool)
+    -- Specification defaults: destructive and open-world unless stated.
+    defaultAnnotations = (False, True, False, True)
+    annotationsDecoder = Json.object do
+        readOnly <- Json.defaultKey False "readOnlyHint" Json.bool
+        destructive <- Json.defaultKey True "destructiveHint" Json.bool
+        idempotent <- Json.defaultKey False "idempotentHint" Json.bool
+        openWorld <- Json.defaultKey True "openWorldHint" Json.bool
+        pure (readOnly, destructive, idempotent, openWorld)
 
 projectRawOr :: a -> Json.Decoder a -> RawJson -> a
 projectRawOr fallback decoder value =
@@ -364,3 +638,6 @@ emptyInputSchema =
         , "properties" .= object []
         , "additionalProperties" .= False
         ]
+
+decodeUtf8Lenient :: BS.ByteString -> Text
+decodeUtf8Lenient = TextEncoding.decodeUtf8With lenientDecode . BS.take 2000

--- a/packages/agent-core/src/Agent/MCP/Types.hs
+++ b/packages/agent-core/src/Agent/MCP/Types.hs
@@ -75,17 +75,18 @@ instance Show McpServerConfig where
 
 -- | Host-provided integration points shared by every server in a fleet.
 data McpHostHooks = McpHostHooks
-    { mcpHostElicit :: !(Maybe (McpElicitRequest -> IO McpElicitResult))
-    -- ^ Interactive elicitation. 'Nothing' means the host cannot ask the user
-    -- for input, so the @elicitation@ capability is not declared and any
-    -- request for input is cancelled.
+    { mcpHostElicit :: !(IO (Maybe (McpElicitRequest -> IO McpElicitResult)))
+    -- ^ Interactive elicitation, resolved when a request is built so hosts
+    -- can install or remove their UI over the life of a process. 'Nothing'
+    -- means the host cannot ask the user for input, so the @elicitation@
+    -- capability is not declared and any request for input is cancelled.
     , mcpHostClientName :: !Text
     , mcpHostClientVersion :: !Text
     }
 
 defaultMcpHostHooks :: McpHostHooks
 defaultMcpHostHooks = McpHostHooks
-    { mcpHostElicit = Nothing
+    { mcpHostElicit = pure Nothing
     , mcpHostClientName = "haskell-agent"
     , mcpHostClientVersion = "0.1.0"
     }

--- a/packages/agent-core/test/Agent/MCP/OAuthSpec.hs
+++ b/packages/agent-core/test/Agent/MCP/OAuthSpec.hs
@@ -1,0 +1,380 @@
+module Agent.MCP.OAuthSpec (spec) where
+
+import Agent.MCP.OAuth
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Either (isLeft, isRight)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.MCP.OAuth" do
+    describe "parseWwwAuthenticate" do
+        it "parses quoted parameters" do
+            parseWwwAuthenticate
+                "Bearer resource_metadata=\"https://mcp.example.com/.well-known/oauth-protected-resource\", scope=\"files:read files:write\""
+                `shouldBe` Just WwwAuthenticateChallenge
+                    { challengeResourceMetadata = Just "https://mcp.example.com/.well-known/oauth-protected-resource"
+                    , challengeScope = Just "files:read files:write"
+                    , challengeError = Nothing
+                    , challengeErrorDescription = Nothing
+                    }
+
+        it "parses unquoted parameters and case-insensitive names" do
+            parseWwwAuthenticate "bearer Resource_Metadata=https://x.example/prm, SCOPE=files:read"
+                `shouldBe` Just WwwAuthenticateChallenge
+                    { challengeResourceMetadata = Just "https://x.example/prm"
+                    , challengeScope = Just "files:read"
+                    , challengeError = Nothing
+                    , challengeErrorDescription = Nothing
+                    }
+
+        it "parses insufficient_scope challenges with mixed quoting and escapes" do
+            parseWwwAuthenticate
+                "Bearer error=insufficient_scope, scope=\"files:write\", resource_metadata=\"https://mcp.example.com/.well-known/oauth-protected-resource\", error_description=\"File \\\"write\\\" permission required\""
+                `shouldBe` Just WwwAuthenticateChallenge
+                    { challengeResourceMetadata = Just "https://mcp.example.com/.well-known/oauth-protected-resource"
+                    , challengeScope = Just "files:write"
+                    , challengeError = Just "insufficient_scope"
+                    , challengeErrorDescription = Just "File \"write\" permission required"
+                    }
+
+        it "skips non-Bearer challenges and finds Bearer among several" do
+            parseWwwAuthenticate "Basic realm=\"mcp\"" `shouldBe` Nothing
+            parseWwwAuthenticate "Digest realm=\"x\", nonce=\"abc\", Bearer scope=\"a b\""
+                `shouldBe` Just WwwAuthenticateChallenge
+                    { challengeResourceMetadata = Nothing
+                    , challengeScope = Just "a b"
+                    , challengeError = Nothing
+                    , challengeErrorDescription = Nothing
+                    }
+
+        it "accepts a bare Bearer scheme and ignores unknown parameters" do
+            parseWwwAuthenticate "Bearer" `shouldBe` Just (WwwAuthenticateChallenge Nothing Nothing Nothing Nothing)
+            parseWwwAuthenticate "Bearer realm=\"mcp\", scope=\"tools\""
+                `shouldBe` Just (WwwAuthenticateChallenge Nothing (Just "tools") Nothing Nothing)
+            parseWwwAuthenticate "" `shouldBe` Nothing
+
+        it "splits scopes on whitespace" do
+            challengeScopes (WwwAuthenticateChallenge Nothing (Just "  files:read   files:write ") Nothing Nothing)
+                `shouldBe` ["files:read", "files:write"]
+            challengeScopes (WwwAuthenticateChallenge Nothing Nothing Nothing Nothing) `shouldBe` []
+
+    describe "canonicalResourceUri" do
+        it "strips fragments, queries, and trailing slashes while keeping port and path" do
+            canonicalResourceUri "https://mcp.example.com/mcp/" `shouldBe` "https://mcp.example.com/mcp"
+            canonicalResourceUri "https://mcp.example.com:8443/server/mcp#frag" `shouldBe` "https://mcp.example.com:8443/server/mcp"
+            canonicalResourceUri "https://mcp.example.com/mcp?x=1" `shouldBe` "https://mcp.example.com/mcp"
+            canonicalResourceUri "https://mcp.example.com/" `shouldBe` "https://mcp.example.com"
+
+        it "lowercases scheme and host only" do
+            canonicalResourceUri "HTTPS://MCP.Example.COM/Path/To" `shouldBe` "https://mcp.example.com/Path/To"
+
+        it "reports the origin" do
+            resourceOrigin "https://mcp.example.com:8443/server/mcp" `shouldBe` Just "https://mcp.example.com:8443"
+            resourceOrigin "not a url" `shouldBe` Nothing
+
+        it "extracts loopback redirect ports" do
+            loopbackRedirectPort "http://127.0.0.1:43127/callback" `shouldBe` Just 43127
+            loopbackRedirectPort "http://localhost:8080/callback" `shouldBe` Just 8080
+            loopbackRedirectPort "https://example.com:443/callback" `shouldBe` Nothing
+            loopbackRedirectPort "http://127.0.0.1/callback" `shouldBe` Nothing
+
+    describe "protectedResourceMetadataUrls" do
+        it "tries the path-aware well-known URI before the root" do
+            protectedResourceMetadataUrls "https://example.com/public/mcp"
+                `shouldBe`
+                    [ "https://example.com/.well-known/oauth-protected-resource/public/mcp"
+                    , "https://example.com/.well-known/oauth-protected-resource"
+                    ]
+
+        it "only tries the root for endpoints without a path" do
+            protectedResourceMetadataUrls "https://example.com"
+                `shouldBe` ["https://example.com/.well-known/oauth-protected-resource"]
+            protectedResourceMetadataUrls "https://example.com:8443/"
+                `shouldBe` ["https://example.com:8443/.well-known/oauth-protected-resource"]
+
+        it "returns nothing for relative URLs" do
+            protectedResourceMetadataUrls "example.com/mcp" `shouldBe` []
+
+    describe "validateResourceMetadata" do
+        let metadata resource = ProtectedResourceMetadata
+                { resource = resource
+                , authorizationServers = ["https://auth.example.com"]
+                , scopesSupported = []
+                }
+        it "accepts documents without a resource or with the canonical resource" do
+            validateResourceMetadata "https://mcp.example.com/mcp" (metadata Nothing) `shouldSatisfy` isRight
+            validateResourceMetadata "https://mcp.example.com/mcp/" (metadata (Just "https://mcp.example.com/mcp"))
+                `shouldSatisfy` isRight
+            validateResourceMetadata "https://mcp.example.com/mcp" (metadata (Just "https://MCP.example.com/mcp/"))
+                `shouldSatisfy` isRight
+
+        it "accepts a root document describing the endpoint origin" do
+            validateResourceMetadata "https://mcp.example.com/mcp" (metadata (Just "https://mcp.example.com/"))
+                `shouldSatisfy` isRight
+
+        it "rejects documents for other hosts or paths" do
+            validateResourceMetadata "https://mcp.example.com/mcp" (metadata (Just "https://attacker.example/mcp"))
+                `shouldSatisfy` isLeft
+            validateResourceMetadata "https://mcp.example.com/mcp" (metadata (Just "https://mcp.example.com/other"))
+                `shouldSatisfy` isLeft
+            validateResourceMetadata "https://mcp.example.com:8443/mcp" (metadata (Just "https://mcp.example.com/mcp"))
+                `shouldSatisfy` isLeft
+
+    describe "authorizationServerMetadataUrls" do
+        it "orders candidates for issuers with a path component" do
+            authorizationServerMetadataUrls "https://auth.example.com/tenant1"
+                `shouldBe`
+                    [ "https://auth.example.com/.well-known/oauth-authorization-server/tenant1"
+                    , "https://auth.example.com/.well-known/openid-configuration/tenant1"
+                    , "https://auth.example.com/tenant1/.well-known/openid-configuration"
+                    ]
+
+        it "orders candidates for issuers without a path component" do
+            authorizationServerMetadataUrls "https://auth.example.com"
+                `shouldBe`
+                    [ "https://auth.example.com/.well-known/oauth-authorization-server"
+                    , "https://auth.example.com/.well-known/openid-configuration"
+                    ]
+            authorizationServerMetadataUrls "https://auth.example.com/"
+                `shouldBe`
+                    [ "https://auth.example.com/.well-known/oauth-authorization-server"
+                    , "https://auth.example.com/.well-known/openid-configuration"
+                    ]
+
+    describe "validateIssuer" do
+        it "requires the issuer to be byte-identical" do
+            validateIssuer "https://auth.example.com" (asMetadata (Just "https://auth.example.com"))
+                `shouldSatisfy` isRight
+            validateIssuer "https://auth.example.com" (asMetadata (Just "https://auth.example.com/"))
+                `shouldSatisfy` isLeft
+            validateIssuer "https://attacker.example" (asMetadata (Just "https://honest.example"))
+                `shouldSatisfy` isLeft
+            validateIssuer "https://auth.example.com" (asMetadata Nothing) `shouldSatisfy` isLeft
+
+    describe "checkPkceSupport" do
+        it "refuses when code_challenge_methods_supported is absent" do
+            checkPkceSupport (asMetadata (Just "https://auth.example.com")) { codeChallengeMethodsSupported = Nothing }
+                `shouldSatisfy` isLeft
+
+        it "refuses when S256 is not advertised" do
+            checkPkceSupport (asMetadata (Just "https://auth.example.com")) { codeChallengeMethodsSupported = Just ["plain"] }
+                `shouldSatisfy` isLeft
+
+        it "accepts S256" do
+            checkPkceSupport (asMetadata (Just "https://auth.example.com")) { codeChallengeMethodsSupported = Just ["plain", "S256"] }
+                `shouldBe` Right ()
+
+    describe "AuthorizationServerMetadata decoding" do
+        it "parses the extended fields" do
+            let json = "{\"issuer\":\"https://auth.example.com\",\"authorization_endpoint\":\"https://auth.example.com/authorize\",\"token_endpoint\":\"https://auth.example.com/token\",\"registration_endpoint\":\"https://auth.example.com/register\",\"code_challenge_methods_supported\":[\"S256\"],\"client_id_metadata_document_supported\":true,\"authorization_response_iss_parameter_supported\":true,\"scopes_supported\":[\"files:read\",\"offline_access\"],\"grant_types_supported\":[\"authorization_code\",\"refresh_token\"]}"
+            Aeson.eitherDecode json `shouldBe` Right AuthorizationServerMetadata
+                { issuer = Just "https://auth.example.com"
+                , authorizationEndpoint = "https://auth.example.com/authorize"
+                , tokenEndpoint = "https://auth.example.com/token"
+                , registrationEndpoint = Just "https://auth.example.com/register"
+                , codeChallengeMethodsSupported = Just ["S256"]
+                , scopesSupportedByServer = ["files:read", "offline_access"]
+                , clientIdMetadataDocumentSupported = True
+                , authorizationResponseIssParameterSupported = True
+                , grantTypesSupported = ["authorization_code", "refresh_token"]
+                }
+
+        it "defaults the optional flags" do
+            let json = "{\"authorization_endpoint\":\"https://a/authorize\",\"token_endpoint\":\"https://a/token\"}"
+            Aeson.eitherDecode json `shouldBe` Right (asMetadata Nothing)
+                { authorizationEndpoint = "https://a/authorize"
+                , tokenEndpoint = "https://a/token"
+                , codeChallengeMethodsSupported = Nothing
+                }
+
+    describe "selectClientRegistration" do
+        let pre = PreRegisteredClient "configured-client" (Just "secret")
+            options = RegistrationOptions
+                { registrationPreRegistered = Nothing
+                , registrationClientIdMetadataUrl = Nothing
+                , registrationStored = Nothing
+                , registrationRedirectUri = "http://127.0.0.1:43127/callback"
+                }
+            metadata = (asMetadata (Just "https://auth.example.com"))
+                { registrationEndpoint = Just "https://auth.example.com/register"
+                , clientIdMetadataDocumentSupported = True
+                }
+
+        it "prefers pre-registered credentials" do
+            selectClientRegistration
+                options { registrationPreRegistered = Just pre, registrationClientIdMetadataUrl = Just "https://app.example/client.json" }
+                metadata
+                `shouldBe` Right (UsePreRegisteredClient pre)
+
+        it "uses the client ID metadata document when the server supports it" do
+            selectClientRegistration options { registrationClientIdMetadataUrl = Just "https://app.example/client.json" } metadata
+                `shouldBe` Right (UseClientIdMetadataDocument "https://app.example/client.json")
+
+        it "falls back to dynamic registration when metadata documents are unsupported" do
+            selectClientRegistration
+                options { registrationClientIdMetadataUrl = Just "https://app.example/client.json" }
+                metadata { clientIdMetadataDocumentSupported = False }
+                `shouldBe` Right (UseDynamicRegistration "https://auth.example.com/register")
+
+        it "rejects metadata document URLs that are not https with a path" do
+            selectClientRegistration options { registrationClientIdMetadataUrl = Just "http://app.example/client.json" } metadata
+                `shouldSatisfy` isLeft
+            selectClientRegistration options { registrationClientIdMetadataUrl = Just "https://app.example" } metadata
+                `shouldSatisfy` isLeft
+            validateClientIdMetadataUrl "https://app.example/client.json" `shouldBe` Right ()
+
+        it "uses dynamic registration without configuration" do
+            selectClientRegistration options metadata { clientIdMetadataDocumentSupported = False }
+                `shouldBe` Right (UseDynamicRegistration "https://auth.example.com/register")
+
+        it "reuses a stored dynamic registration only for the same issuer and redirect URI" do
+            let stored = StoredClient
+                    { storedIssuer = "https://auth.example.com"
+                    , storedClientId = "dyn-client"
+                    , storedSource = ClientIdDynamicRegistration
+                    , storedRedirectUri = Just "http://127.0.0.1:43127/callback"
+                    }
+                plain = metadata { clientIdMetadataDocumentSupported = False }
+            selectClientRegistration options { registrationStored = Just stored } plain
+                `shouldBe` Right (ReuseDynamicRegistration "dyn-client")
+            selectClientRegistration options { registrationStored = Just stored { storedIssuer = "https://other.example" } } plain
+                `shouldBe` Right (UseDynamicRegistration "https://auth.example.com/register")
+            selectClientRegistration options { registrationStored = Just stored { storedRedirectUri = Just "http://127.0.0.1:1/callback" } } plain
+                `shouldBe` Right (UseDynamicRegistration "https://auth.example.com/register")
+            selectClientRegistration options { registrationStored = Just stored { storedSource = ClientIdPreRegistered } } plain
+                `shouldBe` Right (UseDynamicRegistration "https://auth.example.com/register")
+
+        it "fails with an actionable error when no mechanism is available" do
+            case selectClientRegistration options (asMetadata (Just "https://auth.example.com")) of
+                Left err -> do
+                    err `shouldSatisfy` Text.isInfixOf "oauth.clientId"
+                    err `shouldSatisfy` Text.isInfixOf "oauth.clientIdMetadataUrl"
+                Right plan -> expectationFailure ("unexpected plan " <> show plan)
+
+        it "never selects a bogus fallback client id" do
+            selectClientRegistration options (asMetadata (Just "https://auth.example.com")) `shouldSatisfy` isLeft
+
+    describe "clientRegistrationPayload" do
+        it "describes a native public client" do
+            let payload = clientRegistrationPayload ClientRegistrationRequest
+                    { registrationClientName = "Haskell Agent"
+                    , registrationRedirectUris = ["http://127.0.0.1:43127/callback"]
+                    , registrationScopes = ["files:read", "offline_access"]
+                    }
+            field "application_type" payload `shouldBe` Just (Aeson.String "native")
+            field "client_name" payload `shouldBe` Just (Aeson.String "Haskell Agent")
+            field "redirect_uris" payload `shouldBe` Just (Aeson.toJSON ["http://127.0.0.1:43127/callback" :: Text.Text])
+            field "grant_types" payload `shouldBe` Just (Aeson.toJSON ["authorization_code", "refresh_token" :: Text.Text])
+            field "response_types" payload `shouldBe` Just (Aeson.toJSON ["code" :: Text.Text])
+            field "token_endpoint_auth_method" payload `shouldBe` Just (Aeson.String "none")
+            field "scope" payload `shouldBe` Just (Aeson.String "files:read offline_access")
+
+        it "omits scope when no scopes are requested" do
+            field "scope" (clientRegistrationPayload (ClientRegistrationRequest "x" [] [])) `shouldBe` Nothing
+
+    describe "scope selection" do
+        it "prefers the challenge, then resource metadata, then configuration" do
+            selectScopes (ScopeSources ["c"] ["m"] ["k"]) `shouldBe` ["c"]
+            selectScopes (ScopeSources [] ["m1", "m2"] ["k"]) `shouldBe` ["m1", "m2"]
+            selectScopes (ScopeSources [] [] ["k"]) `shouldBe` ["k"]
+            selectScopes (ScopeSources [] [] []) `shouldBe` []
+
+        it "unions scopes preserving order and dropping duplicates" do
+            unionScopes ["a", "b"] ["b", "c", "a", ""] `shouldBe` ["a", "b", "c"]
+
+        it "unions previously granted and additional scopes for step-up" do
+            planScopes ScopePlan
+                { scopeSources = ScopeSources ["files:write"] ["files:read"] []
+                , scopePreviouslyGranted = ["files:read", "profile"]
+                , scopeAdditional = ["admin"]
+                , scopeAuthorizationServerSupported = []
+                }
+                `shouldBe` ["files:write", "files:read", "profile", "admin"]
+
+        it "adds offline_access only when the authorization server advertises it" do
+            planScopes (ScopePlan (ScopeSources ["files:read"] [] []) [] [] ["files:read", "offline_access"])
+                `shouldBe` ["files:read", "offline_access"]
+            planScopes (ScopePlan (ScopeSources ["files:read"] [] []) ["offline_access"] [] ["files:read"])
+                `shouldBe` ["files:read"]
+            planScopes (ScopePlan (ScopeSources [] [] []) [] [] []) `shouldBe` []
+
+    describe "validateAuthorizationResponseIssuer" do
+        let recorded = "https://auth.example.com"
+        it "advertised and present: compares by simple string comparison" do
+            validateAuthorizationResponseIssuer True recorded (Just recorded) `shouldBe` Right ()
+            validateAuthorizationResponseIssuer True recorded (Just "https://attacker.example") `shouldSatisfy` isLeft
+
+        it "advertised and absent: rejects the response" do
+            validateAuthorizationResponseIssuer True recorded Nothing `shouldSatisfy` isLeft
+
+        it "not advertised and present: still compares" do
+            validateAuthorizationResponseIssuer False recorded (Just recorded) `shouldBe` Right ()
+            validateAuthorizationResponseIssuer False recorded (Just "https://attacker.example") `shouldSatisfy` isLeft
+
+        it "not advertised and absent: proceeds" do
+            validateAuthorizationResponseIssuer False recorded Nothing `shouldBe` Right ()
+
+        it "applies no normalization" do
+            validateAuthorizationResponseIssuer False recorded (Just "https://auth.example.com/") `shouldSatisfy` isLeft
+            validateAuthorizationResponseIssuer False recorded (Just "HTTPS://auth.example.com") `shouldSatisfy` isLeft
+            validateAuthorizationResponseIssuer False recorded (Just "https://auth.example.com:443") `shouldSatisfy` isLeft
+
+    describe "token records" do
+        it "loads records written before the extra fields existed" do
+            let legacy = "{\"client_id\":\"c\",\"token_endpoint\":\"https://a/token\",\"access_token\":\"at\",\"refresh_token\":\"rt\",\"expires_at\":null}"
+            decodeOAuthTokenRecord legacy
+                `shouldBe` Right (OAuthTokenFile "c" "https://a/token" "at" "rt" Nothing, emptyOAuthTokenFileExtra)
+
+        it "round-trips the extra fields and omits absent keys" do
+            let file = OAuthTokenFile "c" "https://a/token" "at" "rt" (Just 42)
+                extra = emptyOAuthTokenFileExtra
+                    { extraIssuer = Just "https://auth.example.com"
+                    , extraScope = Just "files:read offline_access"
+                    , extraResource = Just "https://mcp.example.com/mcp"
+                    , extraClientIdSource = Just ClientIdDynamicRegistration
+                    , extraRedirectUri = Just "http://127.0.0.1:43127/callback"
+                    }
+                encoded = encodeOAuthTokenRecord file extra
+            decodeOAuthTokenRecord encoded `shouldBe` Right (file, extra)
+            Aeson.eitherDecode encoded `shouldBe` Right file
+            let keys = maybe [] KeyMap.keys (Aeson.decode encoded :: Maybe (KeyMap.KeyMap Aeson.Value))
+            keys `shouldSatisfy` notElem "client_secret"
+            keys `shouldSatisfy` notElem "client_id_metadata_url"
+            keys `shouldSatisfy` elem "client_id_source"
+
+        it "keeps client secrets out of Show output" do
+            let extra = emptyOAuthTokenFileExtra { extraClientSecret = Just "top-secret" }
+            show extra `shouldSatisfy` notElem' "top-secret"
+            show (PreRegisteredClient "id" (Just "top-secret")) `shouldSatisfy` notElem' "top-secret"
+            show (OAuthTokens "tok-secret-value" (Just "refresh-secret-value") Nothing Nothing)
+                `shouldSatisfy` (\shown -> notElem' "tok-secret-value" shown && notElem' "refresh-secret-value" shown)
+            show (OAuthTokenFile "c" "https://a/token" "tok-secret-value" "refresh-secret-value" Nothing)
+                `shouldSatisfy` notElem' "secret-value"
+
+        it "maps client id sources to stable text" do
+            mapM_ (\source -> parseClientIdSource (clientIdSourceText source) `shouldBe` Just source)
+                [ClientIdPreRegistered, ClientIdMetadataDocument, ClientIdDynamicRegistration]
+            parseClientIdSource "unknown" `shouldBe` Nothing
+
+asMetadata :: Maybe Text.Text -> AuthorizationServerMetadata
+asMetadata issuer = AuthorizationServerMetadata
+    { issuer = issuer
+    , authorizationEndpoint = "https://auth.example.com/authorize"
+    , tokenEndpoint = "https://auth.example.com/token"
+    , registrationEndpoint = Nothing
+    , codeChallengeMethodsSupported = Just ["S256"]
+    , scopesSupportedByServer = []
+    , clientIdMetadataDocumentSupported = False
+    , authorizationResponseIssParameterSupported = False
+    , grantTypesSupported = []
+    }
+
+field :: Aeson.Key -> Aeson.Value -> Maybe Aeson.Value
+field key = \case
+    Aeson.Object object -> KeyMap.lookup key object
+    _ -> Nothing
+
+notElem' :: String -> String -> Bool
+notElem' needle haystack = not (Text.pack needle `Text.isInfixOf` Text.pack haystack)

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -2,7 +2,25 @@ module Agent.MCPSpec (spec) where
 
 import Agent.Loop (defaultLoopDispatch)
 import Agent.MCP
-import Agent.Json (rawJsonBytes, rawJsonFromEncoding)
+import Agent.MCP.Client
+    ( ProbeOutcome(..)
+    , annotateHeaderParams
+    , classifyProbe
+    , encodeHeaderValue
+    , headerParamValues
+    , splitLines
+    )
+import Agent.MCP.Types
+    ( McpHeaderParam(..)
+    , McpTool(..)
+    )
+import Agent.Json (RawJson, rawJsonBytes, rawJsonDecoder, rawJsonFromEncoding)
+import qualified Agent.Json.Decode as Json
+import Control.Concurrent.STM (readTVarIO)
+import qualified Data.Aeson.Types
+import Data.Either (isLeft)
+import Data.List (isInfixOf)
+import qualified Data.Map.Strict as Map
 import Agent.ToolDispatch
     ( ToolCallResult(..)
     , dispatchToolCall
@@ -49,6 +67,7 @@ spec = describe "Agent.MCP" do
                 , mcpServerEnv = [("API_TOKEN", "super-secret")]
                 , mcpServerStartupTimeoutSeconds = 5
                 , mcpServerRequestTimeoutSeconds = 5
+                , mcpServerProtocol = McpProtocolAuto
                 }
         rendered `shouldContain` "API_TOKEN"
         rendered `shouldContain` "<redacted>"
@@ -122,6 +141,7 @@ spec = describe "Agent.MCP" do
                     , mcpServerEnv = []
                     , mcpServerStartupTimeoutSeconds = 5
                     , mcpServerRequestTimeoutSeconds = 5
+                    , mcpServerProtocol = McpProtocolAuto
                     }
                 ]
             bracket (pure fleet) closeMcpFleet \_ -> do
@@ -371,6 +391,147 @@ spec = describe "Agent.MCP" do
                 [McpServerStatus "exits" (McpFailed _) 0] -> pure ()
                 _ -> expectationFailure ("unexpected statuses: " <> show statuses)
 
+
+    describe "protocol negotiation" do
+        it "classifies discovery probes by era" do
+            classifyProbe (Left (McpRpcError (-32601) "Method not found" Nothing))
+                `shouldBe` ProbeLegacy "error -32601"
+            classifyProbe (Left (McpTimeout "no response"))
+                `shouldBe` ProbeLegacy "no response"
+            classifyProbe (Left (McpHttpStatus 404 ""))
+                `shouldBe` ProbeLegacy "HTTP 404"
+            classifyProbe
+                (Left (McpRpcError (-32022) "Unsupported"
+                    (Just (raw "{\"supported\":[\"2025-11-25\"]}"))))
+                `shouldBe` ProbeVersions ["2025-11-25"]
+            classifyProbe (Left (McpRpcError (-32020) "Header mismatch" Nothing))
+                `shouldSatisfy` \case
+                    ProbeFailure _ -> True
+                    _ -> False
+            classifyProbe (Left (McpTransportError "boom"))
+                `shouldBe` ProbeFailure "boom"
+
+    describe "Streamable HTTP headers" do
+        it "encodes header values per the value-encoding rules" do
+            encodeHeaderValue "us-west1" `shouldBe` "us-west1"
+            encodeHeaderValue "Hello, 世界"
+                `shouldBe` "=?base64?SGVsbG8sIOS4lueVjA==?="
+            encodeHeaderValue " padded " `shouldBe` "=?base64?IHBhZGRlZCA=?="
+            encodeHeaderValue "line1\nline2"
+                `shouldBe` "=?base64?bGluZTEKbGluZTI=?="
+            encodeHeaderValue "=?base64?literal?="
+                `shouldBe` "=?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?="
+
+        it "accepts statically reachable x-mcp-header annotations and rejects the rest" do
+            let region =
+                    "region" .= object
+                        [ "type" .= ("string" :: Text.Text)
+                        , "x-mcp-header" .= ("Region" :: Text.Text)
+                        ]
+            fmap (.discoveredHeaderParams)
+                (annotateHeaderParams True (schemaTool [region]))
+                `shouldBe` Right [McpHeaderParam ["region"] "Region"]
+            fmap (.discoveredHeaderParams)
+                (annotateHeaderParams False (schemaTool [region]))
+                `shouldBe` Right []
+            isLeft (annotateHeaderParams True
+                (schemaTool
+                    [ "choice" .= object
+                        [ "oneOf" .=
+                            [ object
+                                [ "type" .= ("string" :: Text.Text)
+                                , "x-mcp-header" .= ("A" :: Text.Text)
+                                ]
+                            ]
+                        ]
+                    ]))
+                `shouldBe` True
+            isLeft (annotateHeaderParams True
+                (schemaTool
+                    [ "ratio" .= object
+                        [ "type" .= ("number" :: Text.Text)
+                        , "x-mcp-header" .= ("Ratio" :: Text.Text)
+                        ]
+                    ]))
+                `shouldBe` True
+            isLeft (annotateHeaderParams True
+                (schemaTool
+                    [ region
+                    , "other" .= object
+                        [ "type" .= ("string" :: Text.Text)
+                        , "x-mcp-header" .= ("region" :: Text.Text)
+                        ]
+                    ]))
+                `shouldBe` True
+            case annotateHeaderParams True (schemaTool [region]) of
+                Left err -> expectationFailure (Text.unpack err)
+                Right annotated ->
+                    headerParamValues annotated
+                        (raw "{\"region\":\"us-west1\",\"query\":\"SELECT 1\"}")
+                        `shouldBe` [("Mcp-Param-Region", "us-west1")]
+
+        it "splits SSE buffers into complete lines" do
+            splitLines "data: a\r\n\r\ndata: b"
+                `shouldBe` (["data: a", ""], "data: b")
+
+    it "renders resource links and binary content blocks" do
+        normalizeMcpToolResult
+            (raw "{\"content\":[{\"type\":\"resource_link\",\"uri\":\"file:///a.rs\",\"name\":\"a.rs\",\"mimeType\":\"text/x-rust\"},{\"type\":\"image\",\"data\":\"AAAA\",\"mimeType\":\"image/png\"}]}")
+            `shouldBe`
+                Right "[resource_link] file:///a.rs (a.rs) [text/x-rust]\n[image image/png, 4 base64 bytes; binary content is not shown]"
+
+    it "drives a modern server through discovery, elicitation, subscriptions, and tasks" $
+        withCountingServer modernFakeServer \script log -> do
+            elicited <- newIORef []
+            let hooks = defaultMcpHostHooks
+                    { mcpHostElicit = Just \request -> do
+                        modifyIORef' elicited (<> [request])
+                        pure (McpElicitAccept (Just (raw "{\"name\":\"octocat\"}")))
+                    }
+            fleet <- startMcpFleetWithProgressHooks hooks (const (pure ()))
+                [(baseConfig "modern" script) { mcpServerArgs = [log] }]
+            bracket (pure fleet) closeMcpFleet \_ -> do
+                fleet.mcpFleetWarnings `shouldBe` []
+                map (.appToolName) (mcpFleetTools fleet)
+                    `shouldBe` ["modern__greet", "modern__slow_task"]
+                map (.appToolDescription) (mcpFleetTools fleet)
+                    `shouldBe` ["Greeter: Greets.", "Slow."]
+                mcpFleetInstructions fleet `shouldReturn` [("modern", "Be nice.")]
+                infos <- mcpFleetServerInfos fleet
+                map (\(name, info) -> (name, info.serverInfoEra, info.serverInfoName)) infos
+                    `shouldBe` [("modern", McpEraModern, Just "modern")]
+                greet <- callFleetTool fleet "modern__greet" "{}"
+                greet.output `shouldBe` "hello octocat"
+                requests <- readIORef elicited
+                map (\request -> (request.elicitServerName, request.elicitMessage)) requests
+                    `shouldBe` [("modern", "Your name?")]
+                task <- callFleetTool fleet "modern__slow_task" "{}"
+                task.output `shouldBe` "task done"
+                waitForLog log "listen"
+
+    it "answers pings, extends timeouts on progress, refreshes changed tool lists, and cancels timeouts" $
+        withCountingServer legacyEventsServer \script log -> do
+            fleet <- startMcpFleet
+                [ (baseConfig "events" script)
+                    { mcpServerArgs = [log]
+                    , mcpServerRequestTimeoutSeconds = 1
+                    }
+                ]
+            bracket (pure fleet) closeMcpFleet \_ -> do
+                fleet.mcpFleetWarnings `shouldBe` []
+                let tools = mcpFleetTools fleet
+                Just slow <- pure (find ((== "events__slow") . (.appToolName)) tools)
+                slow.appToolDescription `shouldBe` "pong=1"
+                infos <- mcpFleetServerInfos fleet
+                map (\(_, info) -> (info.serverInfoEra, info.serverInfoProtocolVersion)) infos
+                    `shouldBe` [(McpEraLegacy, "2025-11-25")]
+                result <- callFleetTool fleet "events__slow" "{}"
+                result.output `shouldBe` "slow done"
+                waitForCatalogEntry fleet "events__late"
+                hung <- callFleetTool fleet "events__hang" "{}"
+                hung.output `shouldSatisfy` Text.isInfixOf "timed out"
+                waitForLog log "cancelled"
+
     describe "McpSupervisor" do
         it "single-flights concurrent acquisitions for the same configuration" $
             withCountingFakeServer \script counter -> do
@@ -511,6 +672,55 @@ spec = describe "Agent.MCP" do
                     releaseMcpFleetLease second
                     countStarts counter `shouldReturn` 2
 
+raw :: BS8.ByteString -> RawJson
+raw bytes =
+    either (error . show) id (Json.decodeEither rawJsonDecoder bytes)
+
+schemaTool :: [Data.Aeson.Types.Pair] -> McpTool
+schemaTool properties = McpTool
+    { discoveredName = "execute_sql"
+    , discoveredTitle = Nothing
+    , discoveredDescription = ""
+    , discoveredInputSchema =
+        rawJsonFromEncoding . Data.Aeson.toEncoding $ object
+            [ "type" .= ("object" :: Text.Text)
+            , "properties" .= object properties
+            ]
+    , discoveredOutputSchema = Nothing
+    , discoveredReadOnly = False
+    , discoveredDestructive = True
+    , discoveredIdempotent = False
+    , discoveredOpenWorld = True
+    , discoveredHeaderParams = []
+    }
+
+callFleetTool :: McpFleet -> Text.Text -> Text.Text -> IO ToolCallResult
+callFleetTool fleet name arguments =
+    dispatchToolCall
+        defaultLoopDispatch
+        (appToolHandlers (mcpFleetTools fleet))
+        (functionToolCall "call" name arguments)
+
+waitForLog :: FilePath -> String -> IO ()
+waitForLog path needle = go (300 :: Int)
+  where
+    go 0 = expectationFailure ("log never contained " <> needle)
+    go remaining = do
+        contents <- readFile path
+        if needle `isInfixOf` contents
+            then pure ()
+            else threadDelay 10000 >> go (remaining - 1)
+
+waitForCatalogEntry :: McpFleet -> Text.Text -> IO ()
+waitForCatalogEntry fleet name = go (300 :: Int)
+  where
+    go 0 = expectationFailure ("catalog never contained " <> Text.unpack name)
+    go remaining = do
+        entries <- readTVarIO fleet.mcpFleetCatalog
+        if Map.member name entries
+            then pure ()
+            else threadDelay 10000 >> go (remaining - 1)
+
 withFakeServer :: (FilePath -> IO a) -> IO a
 withFakeServer action = do
     temporary <- getTemporaryDirectory
@@ -605,6 +815,7 @@ concurrentConfig script barrier name = McpServerConfig
     , mcpServerEnv = []
     , mcpServerStartupTimeoutSeconds = 2
     , mcpServerRequestTimeoutSeconds = 2
+    , mcpServerProtocol = McpProtocolAuto
     }
 
 progressiveConfig :: FilePath -> String -> Text.Text -> McpServerConfig
@@ -623,6 +834,7 @@ baseConfig name command = McpServerConfig
     , mcpServerEnv = []
     , mcpServerStartupTimeoutSeconds = 2
     , mcpServerRequestTimeoutSeconds = 2
+    , mcpServerProtocol = McpProtocolAuto
     }
 
 withConcurrentFakeServer :: (FilePath -> FilePath -> IO a) -> IO a
@@ -696,20 +908,25 @@ fakeServer :: LBS.ByteString
 fakeServer =
     "#!/bin/sh\n\
     \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
     \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
     \    *'\"method\":\"initialize\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"fake\",\"version\":\"1\"}}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"fake\",\"version\":\"1\"}}}'\n\
     \      ;;\n\
     \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
     \    *'\"method\":\"tools/list\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"echo_read\",\"description\":\"Echo.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}},\"required\":[\"message\"],\"additionalProperties\":false},\"annotations\":{\"readOnlyHint\":true}},{\"name\":\"mutate\",\"description\":\"Write.\",\"inputSchema\":{\"type\":\"object\"}}]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[{\"name\":\"echo_read\",\"description\":\"Echo.\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}},\"required\":[\"message\"],\"additionalProperties\":false},\"annotations\":{\"readOnlyHint\":true}},{\"name\":\"mutate\",\"description\":\"Write.\",\"inputSchema\":{\"type\":\"object\"}}]}}'\n\
     \      ;;\n\
     \    *'\"method\":\"tools/call\"'*)\n\
     \      if [ -z \"$first_call_seen\" ]; then\n\
     \        first_call_seen=1\n\
+    \        first_id=$id\n\
     \      else\n\
-    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"second response\"}]}}'\n\
-    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"first response\"}]}}'\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"second response\"}]}}'\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$first_id\"',\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"first response\"}]}}'\n\
     \      fi\n\
     \      ;;\n\
     \  esac\n\
@@ -719,22 +936,25 @@ skillsFakeServer :: LBS.ByteString
 skillsFakeServer =
     "#!/bin/sh\n\
     \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
     \  case \"$line\" in\n\
-    \    *'\"method\":\"initialize\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2026-07-28\",\"capabilities\":{\"extensions\":{\"io.modelcontextprotocol/skills\":{}}},\"serverInfo\":{\"name\":\"skills\",\"version\":\"1\"}}}'\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"complete\",\"supportedVersions\":[\"2026-07-28\"],\"capabilities\":{\"tools\":{},\"extensions\":{\"io.modelcontextprotocol/skills\":{}}},\"instructions\":\"Use the demo skill.\",\"_meta\":{\"io.modelcontextprotocol/serverInfo\":{\"name\":\"skills\",\"version\":\"1\"}}}}'\n\
     \      ;;\n\
-    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"initialize is not supported; use server/discover\"}}'\n\
+    \      ;;\n\
     \    *'\"method\":\"tools/list\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[]}}'\n\
     \      ;;\n\
     \    *'\"method\":\"skills/list\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"resultType\":\"complete\",\"skills\":[{\"uri\":\"skill://demo/SKILL.md\",\"frontmatter\":{\"name\":\"demo\",\"description\":\"Demo skill\"},\"resources\":[{\"uri\":\"skill://demo/SKILL.md\",\"digest\":\"sha256:demo\",\"size\":42}]}]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"complete\",\"skills\":[{\"uri\":\"skill://demo/SKILL.md\",\"frontmatter\":{\"name\":\"demo\",\"description\":\"Demo skill\"},\"resources\":[{\"uri\":\"skill://demo/SKILL.md\",\"digest\":\"sha256:demo\",\"size\":42}]}]}}'\n\
     \      ;;\n\
     \    *'\"method\":\"skills/get\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":{\"resultType\":\"complete\",\"skill\":{\"uri\":\"skill://demo/SKILL.md\",\"frontmatter\":{\"name\":\"demo\",\"description\":\"Demo skill\"},\"resources\":[{\"uri\":\"skill://demo/SKILL.md\",\"digest\":\"sha256:demo\",\"size\":42}]}}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"complete\",\"skill\":{\"uri\":\"skill://demo/SKILL.md\",\"frontmatter\":{\"name\":\"demo\",\"description\":\"Demo skill\"},\"resources\":[{\"uri\":\"skill://demo/SKILL.md\",\"digest\":\"sha256:demo\",\"size\":42}]}}}'\n\
     \      ;;\n\
     \    *'\"method\":\"resources/read\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":5,\"result\":{\"contents\":[{\"uri\":\"skill://demo/SKILL.md\",\"mimeType\":\"text/markdown\",\"text\":\"---\\nname: demo\\n---\\n\"}]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"contents\":[{\"uri\":\"skill://demo/SKILL.md\",\"mimeType\":\"text/markdown\",\"text\":\"---\\nname: demo\\n---\\n\"}]}}'\n\
     \      ;;\n\
     \  esac\n\
     \done\n"
@@ -746,19 +966,23 @@ countingReconnectServer =
     \printf 'started\\n' >> \"$counter\"\n\
     \instance=\"$(wc -l < \"$counter\" | tr -d ' ')\"\n\
     \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
     \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
     \    *'\"method\":\"initialize\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"reconnect\",\"version\":\"1\"}}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"reconnect\",\"version\":\"1\"}}}'\n\
     \      ;;\n\
     \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
     \    *'\"method\":\"tools/list\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"read\",\"description\":\"Read.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[{\"name\":\"read\",\"description\":\"Read.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}}'\n\
     \      ;;\n\
     \    *'\"method\":\"tools/call\"'*)\n\
     \      if [ \"$instance\" -eq 1 ]; then\n\
     \        exit 0\n\
     \      else\n\
-    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"reconnected response\"}]}}'\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"reconnected response\"}]}}'\n\
     \      fi\n\
     \      ;;\n\
     \  esac\n\
@@ -770,13 +994,17 @@ countingMutationServer =
     \counter=\"$1\"\n\
     \printf 'started\\n' >> \"$counter\"\n\
     \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
     \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
     \    *'\"method\":\"initialize\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"mutation\",\"version\":\"1\"}}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"mutation\",\"version\":\"1\"}}}'\n\
     \      ;;\n\
     \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
     \    *'\"method\":\"tools/list\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"write\",\"description\":\"Write.\",\"inputSchema\":{\"type\":\"object\"}}]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[{\"name\":\"write\",\"description\":\"Write.\",\"inputSchema\":{\"type\":\"object\"}}]}}'\n\
     \      ;;\n\
     \    *'\"method\":\"tools/call\"'*)\n\
     \      exit 0\n\
@@ -791,14 +1019,18 @@ countingFakeServer =
     \delay=\"$2\"\n\
     \printf 'started\\n' >> \"$counter\"\n\
     \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
     \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
     \    *'\"method\":\"initialize\"'*)\n\
     \      if [ -n \"$delay\" ]; then sleep \"$delay\"; fi\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"counting\",\"version\":\"1\"}}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"counting\",\"version\":\"1\"}}}'\n\
     \      ;;\n\
     \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
     \    *'\"method\":\"tools/list\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[]}}'\n\
     \      ;;\n\
     \  esac\n\
     \done\n"
@@ -809,13 +1041,17 @@ countingFailingServer =
     \counter=\"$1\"\n\
     \printf 'started\\n' >> \"$counter\"\n\
     \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
     \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
     \    *'\"method\":\"initialize\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"failing\",\"version\":\"1\"}}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"failing\",\"version\":\"1\"}}}'\n\
     \      ;;\n\
     \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
     \    *'\"method\":\"tools/list\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[]}}'\n\
     \      exit 0\n\
     \      ;;\n\
     \  esac\n\
@@ -826,17 +1062,21 @@ delayedFakeServer =
     "#!/bin/sh\n\
     \delay=\"$1\"\n\
     \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
     \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
     \    *'\"method\":\"initialize\"'*)\n\
     \      sleep \"$delay\"\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"delayed\",\"version\":\"1\"}}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"delayed\",\"version\":\"1\"}}}'\n\
     \      ;;\n\
     \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
     \    *'\"method\":\"tools/list\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"delayed_read\",\"description\":\"Delayed read.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[{\"name\":\"delayed_read\",\"description\":\"Delayed read.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}}'\n\
     \      ;;\n\
     \    *'\"method\":\"tools/call\"'*)\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"delayed response\"}]}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"delayed response\"}]}}'\n\
     \      ;;\n\
     \  esac\n\
     \done\n"
@@ -847,17 +1087,138 @@ concurrentFakeServer =
     \barrier=\"$1\"\n\
     \name=\"$2\"\n\
     \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
     \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
     \    *'\"method\":\"initialize\"'*)\n\
     \      : > \"$barrier/$name\"\n\
     \      while [ \"$(find \"$barrier\" -type f | wc -l)\" -lt 2 ]; do\n\
     \        sleep 0.01\n\
     \      done\n\
-    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"fake\",\"version\":\"1\"}}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"fake\",\"version\":\"1\"}}}'\n\
     \      ;;\n\
     \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
     \    *'\"method\":\"tools/list\"'*)\n\
-    \      printf '%s\\n' \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":2,\\\"result\\\":{\\\"tools\\\":[{\\\"name\\\":\\\"shared_read\\\",\\\"description\\\":\\\"Read.\\\",\\\"inputSchema\\\":{\\\"type\\\":\\\"object\\\"},\\\"annotations\\\":{\\\"readOnlyHint\\\":true}}]}}\"\n\
+    \      printf '%s\\n' \"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"id\\\":$id,\\\"result\\\":{\\\"tools\\\":[{\\\"name\\\":\\\"shared_read\\\",\\\"description\\\":\\\"Read.\\\",\\\"inputSchema\\\":{\\\"type\\\":\\\"object\\\"},\\\"annotations\\\":{\\\"readOnlyHint\\\":true}}]}}\"\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+modernFakeServer :: LBS.ByteString
+modernFakeServer =
+    "#!/bin/sh\n\
+    \log=\"$1\"\n\
+    \polls=0\n\
+    \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      case \"$line\" in\n\
+    \        *'\"io.modelcontextprotocol/protocolVersion\":\"2026-07-28\"'*)\n\
+    \          printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"complete\",\"supportedVersions\":[\"2026-07-28\"],\"capabilities\":{\"tools\":{\"listChanged\":true}},\"instructions\":\"Be nice.\",\"_meta\":{\"io.modelcontextprotocol/serverInfo\":{\"name\":\"modern\",\"version\":\"2\"}}}}'\n\
+    \          ;;\n\
+    \        *)\n\
+    \          printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32602,\"message\":\"missing protocol version\"}}'\n\
+    \          ;;\n\
+    \      esac\n\
+    \      ;;\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      case \"$line\" in\n\
+    \        *'\"io.modelcontextprotocol/clientCapabilities\"'*)\n\
+    \          printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"complete\",\"tools\":[{\"name\":\"greet\",\"title\":\"Greeter\",\"description\":\"Greets.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}},{\"name\":\"slow_task\",\"description\":\"Slow.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}],\"ttlMs\":1000,\"cacheScope\":\"public\"}}'\n\
+    \          ;;\n\
+    \        *)\n\
+    \          printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32602,\"message\":\"missing client capabilities\"}}'\n\
+    \          ;;\n\
+    \      esac\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/call\"'*)\n\
+    \      case \"$line\" in\n\
+    \        *'\"name\":\"greet\"'*)\n\
+    \          case \"$line\" in\n\
+    \            *'\"octocat\"'*'\"requestState\":\"state-1\"'*|*'\"requestState\":\"state-1\"'*'\"octocat\"'*)\n\
+    \              printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"complete\",\"content\":[{\"type\":\"text\",\"text\":\"hello octocat\"}]}}'\n\
+    \              ;;\n\
+    \            *)\n\
+    \              printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"input_required\",\"inputRequests\":{\"who\":{\"method\":\"elicitation/create\",\"params\":{\"mode\":\"form\",\"message\":\"Your name?\",\"requestedSchema\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"]}}}},\"requestState\":\"state-1\"}}'\n\
+    \              ;;\n\
+    \          esac\n\
+    \          ;;\n\
+    \        *'\"name\":\"slow_task\"'*)\n\
+    \          printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"task\",\"taskId\":\"task-1\",\"status\":\"working\",\"ttlMs\":60000,\"pollIntervalMs\":50}}'\n\
+    \          ;;\n\
+    \      esac\n\
+    \      ;;\n\
+    \    *'\"method\":\"tasks/get\"'*)\n\
+    \      polls=$((polls+1))\n\
+    \      if [ \"$polls\" -lt 2 ]; then\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"complete\",\"taskId\":\"task-1\",\"status\":\"working\",\"statusMessage\":\"halfway\",\"pollIntervalMs\":50}}'\n\
+    \      else\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"complete\",\"taskId\":\"task-1\",\"status\":\"completed\",\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"task done\"}]}}}'\n\
+    \      fi\n\
+    \      ;;\n\
+    \    *'\"method\":\"subscriptions/listen\"'*)\n\
+    \      printf 'listen\\n' >> \"$log\"\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/subscriptions/acknowledged\",\"params\":{\"_meta\":{\"io.modelcontextprotocol/subscriptionId\":'\"$id\"'},\"notifications\":{\"toolsListChanged\":true}}}'\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+legacyEventsServer :: LBS.ByteString
+legacyEventsServer =
+    "#!/bin/sh\n\
+    \log=\"$1\"\n\
+    \lists=0\n\
+    \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{\"tools\":{\"listChanged\":true}},\"serverInfo\":{\"name\":\"events\",\"version\":\"1\"}}}'\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":\"srv-ping\",\"method\":\"ping\"}'\n\
+    \      ;;\n\
+    \    *'\"id\":\"srv-ping\"'*)\n\
+    \      pong=1\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"notifications/cancelled\"'*)\n\
+    \      printf 'cancelled\\n' >> \"$log\"\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      n=0\n\
+    \      while [ -z \"$pong\" ] && [ \"$n\" -lt 20 ]; do\n\
+    \        if IFS= read -r extra; then\n\
+    \          case \"$extra\" in\n\
+    \            *'\"id\":\"srv-ping\"'*) pong=1 ;;\n\
+    \          esac\n\
+    \        fi\n\
+    \        n=$((n+1))\n\
+    \      done\n\
+    \      lists=$((lists+1))\n\
+    \      extra_tool=''\n\
+    \      if [ \"$lists\" -ge 2 ]; then\n\
+    \        extra_tool=',{\"name\":\"late\",\"description\":\"Late.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}'\n\
+    \      fi\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[{\"name\":\"slow\",\"description\":\"pong='\"$pong\"'\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}},{\"name\":\"hang\",\"description\":\"Hang.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}'\"$extra_tool\"']}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/call\"'*)\n\
+    \      case \"$line\" in\n\
+    \        *'\"name\":\"slow\"'*)\n\
+    \          sleep 0.7\n\
+    \          printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{\"progressToken\":'\"$id\"',\"progress\":1,\"total\":2,\"message\":\"halfway\"}}'\n\
+    \          sleep 0.7\n\
+    \          printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"slow done\"}]}}'\n\
+    \          printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"method\":\"notifications/tools/list_changed\"}'\n\
+    \          ;;\n\
+    \        *'\"name\":\"hang\"'*) ;;\n\
+    \      esac\n\
     \      ;;\n\
     \  esac\n\
     \done\n"

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -484,7 +484,7 @@ spec = describe "Agent.MCP" do
         withCountingServer modernFakeServer \script log -> do
             elicited <- newIORef []
             let hooks = defaultMcpHostHooks
-                    { mcpHostElicit = Just \request -> do
+                    { mcpHostElicit = pure $ Just \request -> do
                         modifyIORef' elicited (<> [request])
                         pure (McpElicitAccept (Just (raw "{\"name\":\"octocat\"}")))
                     }

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Agent.Http.HeaderSpec as HttpHeaderSpec
 import qualified Agent.JsonTextSpec as JsonTextSpec
 import qualified Agent.LoopSpec as LoopSpec
 import qualified Agent.MCPSpec as MCPSpec
+import qualified Agent.MCP.OAuthSpec as MCPOAuthSpec
 import qualified Agent.OsPathSpec as OsPathSpec
 import qualified Agent.ProjectInstructionsSpec as ProjectInstructionsSpec
 import qualified Agent.Provider.OptionsSpec as ProviderOptionsSpec
@@ -47,6 +48,7 @@ main = hspec do
     JsonTextSpec.spec
     LoopSpec.spec
     MCPSpec.spec
+    MCPOAuthSpec.spec
     OsPathSpec.spec
     ProjectInstructionsSpec.spec
     ProviderOptionsSpec.spec


### PR DESCRIPTION
## Summary

Brings the MCP client up to specification revision **2026-07-28** while keeping legacy (`initialize`-based, ≤ 2025-11-25) servers working.

### Core protocol (`agent-core`, `Agent.MCP.*`)
- **Dual-era negotiation**: `server/discover` probe with per-request `_meta` (`protocolVersion`, `clientInfo`, `clientCapabilities`); recognized modern errors (`-32020/-32021/-32022`) keep the modern path, anything else falls back to the legacy `initialize` handshake. `UnsupportedProtocolVersion` selects a mutually supported version. Era is remembered across reconnects; `"protocol": auto|modern|legacy` overrides the probe.
- **Streamable HTTP**: `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name` (+ Base64 sentinel encoding), `Mcp-Param-*` from `x-mcp-header` (with constraint validation and tool rejection), streaming SSE consumption with request-scoped notifications, legacy `Mcp-Session-Id`/`DELETE` retained for legacy servers only.
- **Message router** (stdio + SSE): answers `ping`, handles legacy server-initiated `elicitation/create`, `notifications/progress` (extends the idle timeout up to 10× and streams progress into the tool block), `notifications/tools|prompts|resources/list_changed`, `resources/updated`, `notifications/message`; timeouts send `notifications/cancelled` (stdio) or close the stream (HTTP).
- **`resultType`** handling: `complete`, `input_required` (multi round-trip retry with `inputResponses` + opaque `requestState`, max 8 rounds), `task` (Tasks extension: `tasks/get` polling, `tasks/update` for input, `tasks/cancel` on give-up; `tasks/result` fallback for the older draft).
- **Subscriptions**: `subscriptions/listen` for modern servers advertising `listChanged`, with reconnect/backoff; list changes refresh the tool catalog.
- **Tool metadata**: `title`, `outputSchema`, `destructiveHint`/`idempotentHint`/`openWorldHint` (idempotent tools are retried after transport loss like read-only ones), content blocks (`resource_link`, embedded resources, image/audio described).
- **Prompts / resources / completion** client APIs, `mcp_list_resources` + `mcp_read_resource` tools, server `instructions` exposed.
- New `Agent.MCP.Elicitation`: restricted form-schema parsing/validation shared by hosts.

### OAuth (`Agent.MCP.OAuth`, `agent mcp login`)
- `WWW-Authenticate` parsing, path-aware Protected Resource Metadata discovery with `resource` validation, RFC 8414 + OIDC authorization-server discovery with issuer validation, PKCE `S256` gate, registration priority (pre-registered → Client ID Metadata Documents → Dynamic Client Registration with `application_type: native`), scope selection/step-up unions, RFC 9207 `iss` validation, `resource` on authorization/token/refresh requests, issuer-bound credential records (backward compatible on disk).
- Config: optional per-server `oauth` object (`clientId`, `clientSecret`, `clientIdMetadataUrl`, `scopes`). See `docs/mcp-oauth.md`.

### CLI (`agent-cli`)
- Elicitation UI (line mode and fullscreen): form fields with validation and review, URL consent showing host + full URL, decline/cancel; hooks are installed per session and the capability is only declared when a TTY is available.
- Server instructions appended to the system prompt (blocking mode) or delivered with the settle notice (progressive mode).
- `/mcp prompt <server> <name> [key=value …]` resolves a prompt template into the next turn.
- 401/403 responses surface the challenge scopes with a `agent mcp login` hint.

### Not in scope (documented in `docs/mcp.md`)
Sampling/roots/logging (deprecated in 2026-07-28), forwarding image/audio bytes to the model, persisting task IDs across restarts, activating Skills-over-MCP entries in the CLI.

## Testing
- `agent-core-test`: 479 examples, 0 failures — includes new stdio fixtures for a modern server (discover, `_meta` checks, MRTR elicitation, task polling, `subscriptions/listen`) and a legacy server (ping, progress-extended timeout, `list_changed` catalog refresh, cancellation), plus pure tests for probe classification, header encoding, `x-mcp-header` validation, SSE line splitting, content rendering, and the OAuth helpers (47 examples).
- `agent-cli-test`: 1168 examples, 0 failures (two pre-existing compile/expectation breakages in `RequestSpec`/`CommandSpec` fixed along the way).
- Live tmux smoke test against a stdio fake modern server: elicitation form answered interactively, task polling completed, instructions injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
