### PR TITLE
Own raw Hermes bytes and tolerate null optional fields

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/Types.hs
@@ -36,7 +36,6 @@ import Data.Aeson ((.=))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString as BS
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -158,9 +157,9 @@ grokDocumentDecoder = Hermes.object do
     direct <- grokFieldsFieldsDecoder
     nested <- Hermes.liftObjectDecoder $
         Hermes.objectFold Nothing \_ found ->
-            Hermes.withRawJsonByteString \raw ->
+            Hermes.withOwnedRawJson \raw ->
                 pure $ found <|> validGrokFields
-                    (Hermes.decodeEither grokFieldsDecoder (BS.copy raw))
+                    (Hermes.decodeEither grokFieldsDecoder raw)
     case validFields direct <|> nested of
         Just fields -> pure fields
         Nothing -> fail "authentication object has no access token"
@@ -175,10 +174,10 @@ validFields fields
 
 timestampDecoder :: Hermes.Decoder UTCTime
 timestampDecoder =
-    Hermes.withRawJsonByteString \raw ->
-        case Hermes.decodeEither Hermes.utcTime (BS.copy raw) of
+    Hermes.withOwnedRawJson \raw ->
+        case Hermes.decodeEither Hermes.utcTime raw of
             Right value -> pure value
-            Left _ -> case Hermes.decodeEither Hermes.scientific (BS.copy raw) of
+            Left _ -> case Hermes.decodeEither Hermes.scientific raw of
                 Right seconds ->
                     pure (posixSecondsToUTCTime (realToFrac seconds))
                 Left _ -> fail "expected an ISO timestamp or epoch seconds"
@@ -361,12 +360,12 @@ grokEmailDocumentDecoder =
         fields <- grokFieldsFieldsDecoder
         nested <- Hermes.liftObjectDecoder $
             Hermes.objectFold Nothing \_ found ->
-                Hermes.withRawJsonByteString \raw ->
+                Hermes.withOwnedRawJson \raw ->
                     pure $ found <|>
                         either (const Nothing) id
                             (Hermes.decodeEither
                                 grokEmailDocumentDecoder
-                                (BS.copy raw))
+                                raw)
         pure $
             fields.grokFieldEmail
                 <|> (fields.grokFieldIdToken >>= XAIAuth.emailFromToken)

--- a/packages/agent-cli/src/Agent/CLI/Lsp/Formatting.hs
+++ b/packages/agent-cli/src/Agent/CLI/Lsp/Formatting.hs
@@ -15,7 +15,6 @@ import Agent.Json.Decode
     )
 import Agent.Json.Decode qualified as Hermes
 import Control.Applicative ((<|>))
-import qualified Data.ByteString as BS
 import Data.Maybe (fromMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -93,12 +92,12 @@ hoverDecoder =
         Hermes.VArray ->
             Text.intercalate "\n\n" <$> Hermes.list hoverDecoder
         Hermes.VObject ->
-            Hermes.withRawJsonByteString \bytes ->
+            Hermes.withOwnedRawJson \bytes ->
                 pure $
                     either
                         (const (Text.decodeUtf8With lenientDecode bytes))
                         (fromMaybe (Text.decodeUtf8With lenientDecode bytes))
-                        (decodeEither hoverObjectDecoder (BS.copy bytes))
+                        (decodeEither hoverObjectDecoder bytes)
         _ ->
             rawTextDecoder
 
@@ -149,7 +148,7 @@ symbolLinesDecoder depth =
 
 rawTextDecoder :: Hermes.Decoder Text
 rawTextDecoder =
-    Hermes.withRawJsonByteString $
+    Hermes.withOwnedRawJson $
         pure . Text.decodeUtf8With lenientDecode
 
 decodeRawJson :: Hermes.Decoder a -> RawJson -> Either Text a

--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -44,7 +44,6 @@ import Data.Aeson
     , (.=)
     )
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
@@ -205,9 +204,9 @@ projectSettingsDecoder = Hermes.object do
 
 lenient :: Hermes.Decoder a -> Hermes.Decoder (Maybe a)
 lenient decoder =
-    Hermes.withRawJsonByteString \raw ->
+    Hermes.withOwnedRawJson \raw ->
         pure $ either (const Nothing) Just
-            (Hermes.decodeEither decoder (BS.copy raw))
+            (Hermes.decodeEither decoder raw)
 
 -- | Settings root for the checkout that contains @cwd@.
 -- Uses @git rev-parse --show-toplevel@ so a linked worktree stays in that

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -354,7 +354,7 @@ propertyNames tool =
         Hermes.atKey "properties" $
             Hermes.objectFold []
                 (\key names ->
-                    (key : names) <$ Hermes.withRawJsonByteString (const (pure ()))))
+                    (key : names) <$ Hermes.withOwnedRawJson (const (pure ()))))
 
 propertyDescription :: Text -> FunctionTool -> Maybe Text
 propertyDescription propertyName tool =

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -471,7 +471,7 @@ intOrString = Json.withType \case
 
 firstPresentText :: [Text] -> Json.FieldsDecoder Text
 firstPresentText keys = do
-    values <- traverse (`Json.atKeyOptional` Json.text) keys
+    values <- traverse (`Json.optionalKey` Json.text) keys
     case [value | Just value <- values] of
         value : _ -> pure value
         [] -> fail "missing patch text"

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
@@ -49,8 +49,8 @@ data TaskOutputArgs = TaskOutputArgs
 
 taskOutputArgsDecoder :: Json.Decoder TaskOutputArgs
 taskOutputArgsDecoder = Json.object do
-        canonicalIds <- Json.atKeyOptional "task_ids" textList
-        legacyIds <- Json.atKeyOptional "task_id" textList
+        canonicalIds <- Json.optionalKey "task_ids" textList
+        legacyIds <- Json.optionalKey "task_id" textList
         taskIds <- maybe (maybe (fail "Missing parameter: task_ids") pure legacyIds) pure canonicalIds
         canonicalTimeout <- optionalInt "timeout_ms"
         legacyTimeout <- optionalInt "timeout"

--- a/packages/agent-json/src/Agent/Json/Decode.hs
+++ b/packages/agent-json/src/Agent/Json/Decode.hs
@@ -16,6 +16,7 @@ module Agent.Json.Decode
     , defaultKey
     , discriminatedObject
     , validateRawJson
+    , withOwnedRawJson
     ) where
 
 import Agent.Json (RawJson)
@@ -23,7 +24,12 @@ import Agent.Json.Internal (RawJson(..))
 import Control.Exception.Safe (tryAny)
 import Control.Monad (join)
 import qualified Data.ByteString as BS
-import Data.Hermes as Hermes hiding (decodeEither)
+import Data.Hermes as Hermes hiding
+    ( decodeEither
+    , withRawByteString
+    , withRawJsonByteString
+    )
+import qualified Data.Hermes as HermesRaw (withRawJsonByteString)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -108,6 +114,23 @@ validateRawJson bytes = do
     () <- decodeEither validateValue bytes
     let owned = BS.copy bytes
     owned `seq` pure (RawJson owned)
+
+-- | Run a decoder continuation with an owned copy of the current value's
+-- complete JSON bytes.
+--
+-- Hermes hands out a zero-copy view into simdjson's padded input buffer, and
+-- that buffer is released as soon as the enclosing parse returns. A result
+-- that captures the view lazily and is forced later therefore reads freed
+-- memory. Copying before the continuation runs keeps every downstream use
+-- valid, including re-decoding the bytes with 'decodeEither'. The aliasing
+-- Hermes combinators are deliberately not re-exported from this module.
+withOwnedRawJson
+    :: (BS.ByteString -> Hermes.Decoder a)
+    -> Hermes.Decoder a
+withOwnedRawJson continuation =
+    HermesRaw.withRawJsonByteString \view ->
+        let owned = BS.copy view
+        in owned `seq` continuation owned
 
 validateValue :: Hermes.Decoder ()
 validateValue =

--- a/packages/agent-json/test/Spec.hs
+++ b/packages/agent-json/test/Spec.hs
@@ -5,8 +5,10 @@ import qualified Agent.Json.Decode as Json
 import Control.Concurrent.Async (concurrently)
 import qualified Data.Aeson.Encoding.Internal as Aeson
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
 import Test.Hspec
 
 data Person = Person
@@ -55,6 +57,33 @@ main = hspec do
             Json.decodeEither optionalPersonDecoder
                 "{\"nickname\":null,\"score\":null}"
                 `shouldBe` Right (Nothing, 0)
+
+        it "keeps owned raw JSON valid after the parse buffer is released" do
+            -- Hermes exposes a view into simdjson's padded input, which is
+            -- freed when the parse returns. Decode lazily, churn the
+            -- allocator with same-sized documents, then force the result.
+            let document = "{\"k\":\"" <> BS.replicate 300 0x41 <> "\"}"
+                churn = "{\"k\":\"" <> BS.replicate 300 0x42 <> "\"}"
+                lazyRaw =
+                    Json.withOwnedRawJson (pure . Text.decodeUtf8)
+                        :: Json.Decoder Text
+                result = Json.decodeEither lazyRaw document
+            either (expectationFailure . show) (const (pure ())) result
+            mapM_
+                (\_ ->
+                    Json.decodeEither
+                        (Json.withOwnedRawJson (pure . BS.length))
+                        churn
+                        `shouldBe` Right (BS.length churn))
+                [1 .. 20 :: Int]
+            fmap Text.encodeUtf8 result `shouldBe` Right document
+
+        it "re-decodes owned raw JSON captured inside a decoder" do
+            let nested = Json.object $
+                    Json.atKey "items" $ Json.withOwnedRawJson \raw ->
+                        pure (Json.decodeEither (Json.list Json.int) raw)
+            Json.decodeEither nested "{\"items\":[1,2,3]}"
+                `shouldBe` Right (Right [1, 2, 3])
 
         it "rejects malformed and trailing input" do
             Json.decodeEither personDecoder

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/Refresh.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/Refresh.hs
@@ -1,4 +1,8 @@
-module Agent.OpenAI.Auth.Refresh (refreshAccessTokenHTTP) where
+module Agent.OpenAI.Auth.Refresh
+    ( RefreshResponse(..)
+    , decodeRefreshResponse
+    , refreshAccessTokenHTTP
+    ) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
 import qualified Agent.Json.Decode as Json
@@ -52,13 +56,8 @@ refreshAccessTokenHTTP oauthClientId state = do
                         <> Text.decodeUtf8With Text.lenientDecode
                             (LBS.toStrict (LBS.take 500 (getResponseBody response))))
                     Nothing
-                else case Json.decodeEither refreshResponseDecoder
-                        (LBS.toStrict (getResponseBody response)) of
-                    Left err ->
-                        pure $ Left $ ProviderError AuthenticationError
-                            ("Failed to parse token refresh response: "
-                                <> Json.jsonErrorMessage err)
-                            Nothing
+                else case decodeRefreshResponse (getResponseBody response) of
+                    Left err -> pure (Left err)
                     Right RefreshResponse{..} -> do
                         let newRefreshToken =
                                 fromMaybe state.refreshToken refreshToken
@@ -78,11 +77,23 @@ data RefreshResponse = RefreshResponse
     { accessToken :: !Text
     , refreshToken :: !(Maybe Text)
     , idToken :: !(Maybe Text)
-    }
+    } deriving (Eq, Show)
+
+-- | Parse a token endpoint body. The optional tokens may be absent or an
+-- explicit @null@; either keeps the previously stored value.
+decodeRefreshResponse :: LBS.ByteString -> Either ApiError RefreshResponse
+decodeRefreshResponse body =
+    case Json.decodeEither refreshResponseDecoder (LBS.toStrict body) of
+        Left err ->
+            Left $ ProviderError AuthenticationError
+                ("Failed to parse token refresh response: "
+                    <> Json.jsonErrorMessage err)
+                Nothing
+        Right response -> Right response
 
 refreshResponseDecoder :: Json.Decoder RefreshResponse
 refreshResponseDecoder = Json.object $
     RefreshResponse
         <$> Json.atKey "access_token" Json.text
-        <*> Json.atKeyOptional "refresh_token" Json.text
-        <*> Json.atKeyOptional "id_token" Json.text
+        <*> Json.optionalKey "refresh_token" Json.text
+        <*> Json.optionalKey "id_token" Json.text

--- a/packages/agent-openai/src/Agent/OpenAI/Usage.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Usage.hs
@@ -50,10 +50,10 @@ usageSnapshotDecoder :: Json.Decoder UsageSnapshot
 usageSnapshotDecoder = Json.object do
     planType <- Json.atKey "plan_type" Json.text
     rateLimit <- optionalNullable "rate_limit" usageLimitDecoder
-    additionalRateLimits <-
-        maybe [] id <$> Json.atKeyOptional
-            "additional_rate_limits"
-            (Json.list additionalUsageLimitDecoder)
+    additionalRateLimits <- Json.defaultKey
+        []
+        "additional_rate_limits"
+        (Json.list additionalUsageLimitDecoder)
     pure UsageSnapshot{..}
 
 usageLimitDecoder :: Json.Decoder UsageLimit

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -1,6 +1,7 @@
 module Agent.OpenAI.AuthSpec (spec) where
 
 import Agent.OpenAI.Auth
+import Agent.OpenAI.Auth.Refresh (RefreshResponse(RefreshResponse), decodeRefreshResponse)
 import Agent.Error
     ( ApiError(..)
     , CredentialExhaustionReason(..)
@@ -30,6 +31,23 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "decodeRefreshResponse" do
+        it "keeps optional tokens when they are absent or null" do
+            decodeRefreshResponse "{\"access_token\":\"a\"}"
+                `shouldBe` Right (RefreshResponse "a" Nothing Nothing)
+            decodeRefreshResponse
+                "{\"access_token\":\"a\",\"refresh_token\":null,\"id_token\":null}"
+                `shouldBe` Right (RefreshResponse "a" Nothing Nothing)
+            decodeRefreshResponse
+                "{\"access_token\":\"a\",\"refresh_token\":\"r\",\"id_token\":\"i\"}"
+                `shouldBe` Right (RefreshResponse "a" (Just "r") (Just "i"))
+
+        it "reports an authentication error for unreadable bodies" do
+            decodeRefreshResponse "{\"refresh_token\":\"r\"}"
+                `shouldSatisfy` \case
+                    Left (ProviderError AuthenticationError _ Nothing) -> True
+                    _ -> False
+
     describe "Show" do
         it "redacts every token while retaining account metadata" do
             let auth = AuthState

--- a/packages/agent-openai/test/Agent/OpenAI/UsageSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/UsageSpec.hs
@@ -26,9 +26,13 @@ spec = describe "decodeUsageResponse" do
                 map (.meteredFeature) usage.additionalRateLimits `shouldBe` ["codex_review"]
 
     it "accepts null and absent optional limit data" do
-        decodeUsageResponse (LBS.pack "{\"plan_type\":\"free\",\"rate_limit\":null}")
-            `shouldBe` Right UsageSnapshot
+        let expected = UsageSnapshot
                 { planType = "free"
                 , rateLimit = Nothing
                 , additionalRateLimits = []
                 }
+        decodeUsageResponse (LBS.pack "{\"plan_type\":\"free\",\"rate_limit\":null}")
+            `shouldBe` Right expected
+        decodeUsageResponse
+            (LBS.pack "{\"plan_type\":\"free\",\"rate_limit\":null,\"additional_rate_limits\":null}")
+            `shouldBe` Right expected

--- a/packages/agent-xai/test/Agent/XAI/FunctionalSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/FunctionalSpec.hs
@@ -207,11 +207,11 @@ accessTokenFromAuthJson raw =
 
     maybeTextValue = Json.withType \case
         Json.VString -> Just <$> Json.text
-        _ -> Json.withRawJsonByteString (const (pure Nothing))
+        _ -> Json.withOwnedRawJson (const (pure Nothing))
 
     nestedTokenValue = Json.withType \case
         Json.VObject -> authObjectTokenDecoder
-        _ -> Json.withRawJsonByteString (const (pure Nothing))
+        _ -> Json.withOwnedRawJson (const (pure Nothing))
 
     chooseToken (direct, nested) = direct `orElse` nested
     nonEmpty (Just value) | not (Text.null value) = Just value

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
@@ -15,7 +15,6 @@ import Claude.Agent.SDK.Types
 import Control.Monad (join)
 import qualified Data.Aeson.Encoding as Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as ByteString
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe)
@@ -322,24 +321,18 @@ renderedToolResultDecoder =
         Json.VArray ->
             Text.intercalate "\n" <$> Json.list renderedToolResultDecoder
         Json.VObject ->
-            Json.withRawJsonByteString (strictly . renderToolResultBlock)
+            Json.withOwnedRawJson (pure . renderToolResultBlock)
         Json.VNull -> pure ""
-        _ -> Json.withRawJsonByteString (strictly . displayBytes)
-  where
-    -- The raw bytes alias the parser's input buffer; force the projection
-    -- before the decoder returns.
-    strictly rendered = rendered `seq` pure rendered
+        _ -> Json.withOwnedRawJson (pure . displayBytes)
 
 -- | Render one structured tool-result block. Text blocks contribute their
 -- text, tool references and images get compact labels, and anything else
 -- falls back to its raw JSON.
 renderToolResultBlock :: ByteString -> Text
 renderToolResultBlock raw =
-    case Json.decodeEither toolResultBlockDecoder owned of
+    case Json.decodeEither toolResultBlockDecoder raw of
         Right (Just rendered) -> rendered
-        _ -> displayBytes owned
-  where
-    owned = ByteString.copy raw
+        _ -> displayBytes raw
 
 toolResultBlockDecoder :: Json.Decoder (Maybe Text)
 toolResultBlockDecoder = Json.object do


### PR DESCRIPTION
## Summary

Follow-up to #684 (Hermes double-consumption). Auditing the rest of the Hermes decoding logic turned up two more issues rooted in the same simdjson semantics, plus a null-handling regression from the Aeson → Hermes migration.

### 1. Raw-bytes views escaping the parse (use-after-free)

`Hermes.withRawJsonByteString` hands out an `unsafePackCStringLen` view into simdjson's `padded_string`, which hermes deletes as soon as the parse returns. Any lazily-forced result that captured the view therefore reads freed memory. Reproduced in GHCi: a `pure . decodeUtf8` continuation followed by 20 same-sized decodes yields garbage (`��0���� 4…`) instead of the input.

Sites with this shape (all forced later than the parse in some evaluation path):
- `Agent.CLI.Lsp.Formatting` — hover object branch and `rawTextDecoder`
- `Agent.CLI.Project.lenient` — the `BS.copy` ran *inside* the escaping thunk, i.e. after the free; a corrupted copy silently drops `lastModel` / `lastAccounts`
- `Agent.CLI.Auth.Types` — `grokDocumentDecoder`, `timestampDecoder`, `grokEmailDocumentDecoder`
- `Claude.Agent.SDK.Internal.MessageParser` — tool-result renderer (#685 added a local `seq` workaround; replaced here)

Fix: `Agent.Json.Decode.withOwnedRawJson` copies and forces the bytes before running the continuation. The aliasing Hermes combinators (`withRawJsonByteString`, `withRawByteString`) are no longer re-exported from `Agent.Json.Decode`, so the safe variant is the only one reachable from repository decoders. Every site is migrated; the per-site `BS.copy` calls go away.

### 2. Optional fields rejecting explicit `null`

Aeson's `.:?` treats `null` as absent; bare `Hermes.atKeyOptional` does not. The migration left these strict:
- `Agent.OpenAI.Auth.Refresh` — `"refresh_token": null` / `"id_token": null` failed the whole token refresh (previously `jsonTextMaybe`, tolerant). The decoder is now exposed as `decodeRefreshResponse` for testing.
- `Agent.OpenAI.Usage` — `"additional_rate_limits": null` failed the usage snapshot (previously `.:? … .!= []`).
- `Agent.Codex.Dialect.Tools.firstPresentText`, `Agent.GrokBuild.Dialect.TaskControl` — model-facing optional arguments.

### Tests
- `agent-json`: owned raw bytes stay valid after the parse buffer is released (decode lazily → churn allocator → force), and can be re-decoded.
- `agent-openai`: refresh response with absent/null/present optional tokens; unreadable body → `AuthenticationError`; usage snapshot with `additional_rate_limits: null`.

Ran `cabal test` for agent-json, agent-openai, agent-cli, claude-agent-sdk-haskell, agent-codex-dialect, agent-grok-build-dialect, agent-xai.

Audit notes (no change needed): every other raw/`list`/`objectFold`/`<|>` composition was checked in GHCi for the double-consumption pattern — stream-event double key read, `liftObjectDecoder rawJsonDecoder`, unknown blocks, `objectAsKeyValues`, hermes `<|>` array/object resets — all behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
