### PR TITLE
Render Claude Code tool calls and interim text faithfully

### DIFF
--- a/packages/agent-claude/agent-claude.cabal
+++ b/packages/agent-claude/agent-claude.cabal
@@ -72,6 +72,7 @@ test-suite agent-claude-test
     build-depends:    base >= 4.14 && < 5
                     , agent-claude
                     , agent-core
+                    , agent-json
                     , agent-responses
                     , agent-responses-types
                     , claude-agent-sdk-haskell

--- a/packages/agent-claude/package.nix
+++ b/packages/agent-claude/package.nix
@@ -13,9 +13,9 @@ mkDerivation {
     filepath hermes-json process safe-exceptions text uuid-types
   ];
   testHaskellDepends = [
-    agent-core agent-responses agent-responses-types base bytestring
-    claude-agent-sdk-haskell directory filepath hspec safe-exceptions
-    text unix
+    agent-core agent-json agent-responses agent-responses-types base
+    bytestring claude-agent-sdk-haskell directory filepath hspec
+    safe-exceptions text unix
   ];
   description = "Claude Code subscription adapter for Agent.Loop";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
+++ b/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
@@ -2,6 +2,7 @@
 -- provider-neutral events expected by the harness.
 module Agent.Claude.Internal.Messages
     ( CompletedClaudeTurn(..)
+    , ClaudeLiveEvent(..)
     , ClaudeEventState
     , emptyClaudeEventState
     , claudeEventStateHasActivity
@@ -9,6 +10,7 @@ module Agent.Claude.Internal.Messages
     , streamClaudeProgress
     , streamClaudeMessage
     , remainingClaudeEvents
+    , assistantMessageItem
     ) where
 
 import Agent.Loop (LoopEvent(..))
@@ -23,7 +25,11 @@ import Agent.Responses.Types
     ( FunctionCall(..)
     , FunctionCallOutput(..)
     , ItemStatus(..)
+    , MessageContent(..)
+    , ResponseContentPart(..)
     , ResponseItem(..)
+    , ResponseMessage(..)
+    , ResponseRole(..)
     )
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -61,11 +67,24 @@ import qualified Data.Text.Encoding as TextEncoding
 data CompletedClaudeTurn = CompletedClaudeTurn
     { sessionId :: !Text
     , assistantText :: !(Maybe Text)
-    , events :: ![LoopEvent]
+    -- | Every canonical top-level record in wire order. Completion replays
+    -- whatever 'streamClaudeMessage' has not already exposed.
+    , liveEvents :: ![ClaudeLiveEvent]
     , tokenUsage :: !Usage
     , cumulativeModelUsage :: !(Maybe Usage)
-    , toolItems :: ![ResponseItem]
+    -- | Host transcript items for this turn in wire order: assistant text
+    -- interleaved with tool calls and outputs, always ending in at least
+    -- one assistant message.
+    , turnItems :: ![ResponseItem]
     } deriving (Eq, Show)
+
+-- | Kind of the most recent streamed delta since the last tool start. The
+-- renderer extends the current block for consecutive deltas of one kind, so
+-- separate wire blocks need an explicit paragraph break between them.
+data LiveDeltaKind
+    = LiveTextDelta
+    | LiveThinkingDelta
+    deriving (Eq, Show)
 
 data ClaudeEventState = ClaudeEventState
     { startedToolCalls :: !(Set Text)
@@ -74,31 +93,53 @@ data ClaudeEventState = ClaudeEventState
     , toolMessageIds :: !(Map.Map Text [Text])
     , warnedUnknownTypes :: !(Set Text)
     , nativeAgentCalls :: !(Map.Map Text ToolCall)
+    -- | Wire UUIDs of assistant records whose text or thinking is already
+    -- displayed.
+    , streamedMessageIds :: !(Set Text)
+    , lastDelta :: !(Maybe LiveDeltaKind)
+    -- | Set after displayed text was retracted: the attempt has been
+    -- discarded, so nothing more is exposed live and completion replays the
+    -- surviving records in order.
+    , replayAtCompletion :: !Bool
     } deriving (Eq, Show)
 
 emptyClaudeEventState :: ClaudeEventState
 emptyClaudeEventState =
     ClaudeEventState
-        Set.empty Map.empty Set.empty Map.empty Set.empty Map.empty
+        { startedToolCalls = Set.empty
+        , startedToolDetails = Map.empty
+        , finishedToolCalls = Set.empty
+        , toolMessageIds = Map.empty
+        , warnedUnknownTypes = Set.empty
+        , nativeAgentCalls = Map.empty
+        , streamedMessageIds = Set.empty
+        , lastDelta = Nothing
+        , replayAtCompletion = False
+        }
 
 claudeEventStateHasActivity :: ClaudeEventState -> Bool
 claudeEventStateHasActivity state =
     not (Set.null state.startedToolCalls)
 
--- | Expose completed top-level tool messages as soon as Claude Code emits
--- them. In particular, its @Task@ tool remains in flight while a native
--- subagent runs, so buffering this event until the final result leaves the UI
--- blank for the entire child-agent lifetime.
+-- | Expose completed top-level records as soon as Claude Code emits them.
+-- Claude Code writes one assistant record per content block and its final
+-- @result@ carries only the last text block, so text and thinking must be
+-- shown as they arrive or everything the model said before its last tool
+-- call is lost. Tools are exposed incrementally by stable call id; in
+-- particular the @Task@ tool remains in flight while a native subagent runs,
+-- so buffering it until the final result leaves the UI blank for the entire
+-- child-agent lifetime.
 streamClaudeMessage
     :: ClaudeEventState
     -> Message
     -> (ClaudeEventState, [LoopEvent])
 streamClaudeMessage state message
     | messageHasParentToolUseId message = (state, [])
+    | state.replayAtCompletion = (state, [])
     | otherwise =
-        let toolEvents = messageToolEvents message
+        let toolEvents = messageLiveEvents message
             (nextState, events) =
-                advanceToolEvents state toolEvents
+                advanceLiveEvents state toolEvents
             messageIds =
                 maybe [] (\identifier -> [identifier]) (messageUuid message)
             withIds =
@@ -129,10 +170,20 @@ streamClaudeProgress
 streamClaudeProgress state = \case
     QueryMessageObserved QueryTopLevel message ->
         let (next, events) = streamClaudeMessage state message
-        in (next, events <> nativeLifecycleEvents state events)
+        in (next, events <> nativeLifecycleEvents next.startedToolDetails events)
     QueryMessageObserved (QueryNested parent) message ->
         nestedNativeEvents state parent message
     QueryMessagesRetracted scope identifiers
+        | scope == Nothing || scope == Just QueryTopLevel
+        , any (`Set.member` state.streamedMessageIds) identifiers ->
+            -- Displayed text has no per-block retraction event. Discard the
+            -- whole attempt and replay the surviving records at completion.
+            ( emptyClaudeEventState
+                { warnedUnknownTypes = state.warnedUnknownTypes
+                , replayAtCompletion = True
+                }
+            , [ResponseAttemptDiscarded]
+            )
         | scope == Nothing || scope == Just QueryTopLevel ->
             let calls =
                     [ callId
@@ -161,8 +212,11 @@ streamClaudeProgress state = \case
     QueryMessagesRetracted _ _ ->
         (state, [])
 
-nativeLifecycleEvents :: ClaudeEventState -> [LoopEvent] -> [LoopEvent]
-nativeLifecycleEvents state = concatMap \case
+nativeLifecycleEvents
+    :: Map.Map Text ToolCall
+    -> [LoopEvent]
+    -> [LoopEvent]
+nativeLifecycleEvents startedToolDetails = concatMap \case
     ToolStarted call
         | isNativeAgentName call.name ->
             [NativeAgentStarted
@@ -171,7 +225,7 @@ nativeLifecycleEvents state = concatMap \case
                 (nativeAgentLabel call)
                 (nativeAgentModel call)]
     ToolFinished result
-        | Just call <- Map.lookup result.callId state.startedToolDetails
+        | Just call <- Map.lookup result.callId startedToolDetails
         , isNativeAgentName call.name ->
             [NativeAgentFinished
                 result.callId
@@ -190,7 +244,7 @@ nestedNativeEvents state parent message =
     case parent of
         Nothing -> (state, [])
         Just identifier ->
-            let tools = messageToolEvents message
+            let tools = messageLiveEvents message
                 (nextState, childLifecycle) =
                     foldl' (\(current, events) -> \case
                     ClaudeToolStarted call
@@ -308,41 +362,31 @@ unknownToolLikeType = \case
             ]
     _ -> Nothing
 
--- | Emit anything not already exposed by 'streamClaudeMessage'. Assistant
--- text remains completion-buffered because the SDK can supersede messages;
--- tool lifecycle events are safe to expose incrementally by stable call id.
+-- | Emit anything not already exposed by 'streamClaudeMessage', in wire
+-- order. After a discarded attempt this replays the whole surviving turn.
+-- When Claude Code produced no text blocks at all, the result record's text
+-- is the only reply and is exposed here.
 remainingClaudeEvents
     :: ClaudeEventState
     -> CompletedClaudeTurn
     -> [LoopEvent]
 remainingClaudeEvents state completed =
-    reverse eventsRev <> textEvents
+    events
+        <> nativeLifecycleEvents next.startedToolDetails events
+        <> resultText
   where
-    (_, eventsRev) = foldl' step (state, []) completed.events
-    textEvents =
-        [event | event@TextDelta{} <- completed.events]
-    step (current, events) event = case event of
-        ToolStarted call
-            | Set.member call.callId current.startedToolCalls ->
-                (current, events)
-            | otherwise ->
-                ( current
-                    { startedToolCalls =
-                        Set.insert call.callId current.startedToolCalls
-                    }
-                , event : events
-                )
-        ToolFinished result
-            | Set.member result.callId current.finishedToolCalls ->
-                (current, events)
-            | otherwise ->
-                ( current
-                    { finishedToolCalls =
-                        Set.insert result.callId current.finishedToolCalls
-                    }
-                , event : events
-                )
-        _ -> (current, events)
+    (next, events) =
+        advanceLiveEvents
+            state { replayAtCompletion = False }
+            completed.liveEvents
+    resultText =
+        [ TextDelta text
+        | not (any isTextEvent completed.liveEvents)
+        , Just text <- [completed.assistantText]
+        ]
+    isTextEvent = \case
+        ClaudeText{} -> True
+        _ -> False
 
 interpretClaudeTurn
     :: [Message]
@@ -353,25 +397,21 @@ interpretClaudeTurn messages result = do
             filter (not . messageHasParentToolUseId) messages
     validateSubscriptionSource visibleMessages
     let
-        bufferedAssistantText =
-            Text.concat
-                [ text
-                | MessageAssistant assistant <- visibleMessages
-                , assistant.error == Nothing
-                , TextBlock{text} <- assistant.content
-                ]
+        liveEvents = concatMap messageLiveEvents visibleMessages
+        -- Claude Code's result text is only the last text block; the
+        -- canonical records carry everything the model said this turn.
         assistantText =
             firstNonEmptyText
-                [ maybe "" id result.result
-                , bufferedAssistantText
+                [ Text.intercalate
+                    "\n\n"
+                    [text | ClaudeText _ text <- liveEvents]
+                , fromMaybe "" result.result
                 ]
-        toolEvents =
-            canonicalToolEvents
-                (concatMap messageToolEvents visibleMessages)
-        toolItems = canonicalToolItems visibleMessages
-        events =
-            toolEvents
-                <> maybe [] (pure . TextDelta) assistantText
+        canonicalItems = canonicalTurnItems visibleMessages
+        turnItems
+            | any isAssistantItem canonicalItems = canonicalItems
+            | otherwise =
+                canonicalItems <> [assistantMessageItem assistantText]
         cumulative =
             case Map.elems result.modelUsage of
                 [] -> Nothing
@@ -381,10 +421,10 @@ interpretClaudeTurn messages result = do
     pure CompletedClaudeTurn
         { sessionId = result.sessionId
         , assistantText
-        , events
+        , liveEvents
         , tokenUsage = result.usage
         , cumulativeModelUsage = cumulative
-        , toolItems
+        , turnItems
         }
 
 validateSubscriptionSource :: [Message] -> Either Text ()
@@ -419,15 +459,21 @@ validateSubscriptionSource messages =
                     Nothing -> found)
             Nothing
 
-data ClaudeToolEvent
+-- | One displayable unit of a canonical Claude record. Text and thinking
+-- carry their record's wire UUID so completion can skip records that were
+-- already streamed live.
+data ClaudeLiveEvent
     = ClaudeToolStarted !ToolCall
     | ClaudeToolFinished !ToolCallResult
+    | ClaudeText !(Maybe Text) !Text
+    | ClaudeThinking !(Maybe Text) !Text
+    deriving (Eq, Show)
 
-messageToolEvents :: Message -> [ClaudeToolEvent]
-messageToolEvents = \case
+messageLiveEvents :: Message -> [ClaudeLiveEvent]
+messageLiveEvents = \case
     MessageAssistant assistant
         | assistant.error == Nothing ->
-            concatMap assistantBlockEvents assistant.content
+            concatMap (assistantBlockEvents assistant.uuid) assistant.content
     MessageUser user ->
         concatMap userBlockEvents user.content
     MessageStreamEvent stream ->
@@ -435,40 +481,81 @@ messageToolEvents = \case
     _ ->
         []
 
-messageToolItems :: Message -> [ResponseItem]
-messageToolItems = \case
+-- | One transcript-relevant unit of a canonical record.
+data TurnUnit
+    = TurnText !Text
+    | TurnItem !ResponseItem
+
+messageTurnUnits :: Message -> [TurnUnit]
+messageTurnUnits = \case
     MessageAssistant assistant
         | assistant.error == Nothing ->
-            concatMap assistantBlockItems assistant.content
+            concatMap assistantBlockUnits assistant.content
     MessageUser user ->
-        concatMap userBlockItems user.content
+        concatMap userBlockUnits user.content
     _ -> []
   where
-    assistantBlockItems = \case
+    assistantBlockUnits = \case
+        TextBlock{text}
+            | Text.null (Text.strip text) -> []
+            | otherwise -> [TurnText text]
         ToolUseBlock{toolUseId, name, input} ->
-            [functionCallItem toolUseId name input]
+            [TurnItem (functionCallItem toolUseId name input)]
         ServerToolUseBlock{toolUseId, name, input} ->
-            [functionCallItem toolUseId name input]
+            [TurnItem (functionCallItem toolUseId name input)]
         _ -> []
-    userBlockItems = \case
+    userBlockUnits = \case
         ToolResultBlock{toolUseId, content, isError} ->
-            [functionOutputItem toolUseId content isError]
+            [TurnItem (functionOutputItem toolUseId content isError)]
         ServerToolResultBlock{toolUseId, content} ->
-            [functionOutputItem toolUseId content Nothing]
+            [TurnItem (functionOutputItem toolUseId content Nothing)]
         _ -> []
 
-canonicalToolItems :: [Message] -> [ResponseItem]
-canonicalToolItems messages =
-    filter keepItem items
+-- | Transcript items in wire order. Text between tool calls becomes its own
+-- assistant message so a replayed transcript keeps the order the user saw
+-- live; consecutive text blocks merge with the same paragraph break the
+-- live view inserts. Outputs without a visible call are dropped.
+canonicalTurnItems :: [Message] -> [ResponseItem]
+canonicalTurnItems messages =
+    go Nothing (filter keepUnit units)
   where
-    items = concatMap messageToolItems messages
+    units = concatMap messageTurnUnits messages
     started =
         Set.fromList
-            [call.callId | FunctionCallItem call <- items]
-    keepItem = \case
-        FunctionCallOutputItem output ->
+            [call.callId | TurnItem (FunctionCallItem call) <- units]
+    keepUnit = \case
+        TurnItem (FunctionCallOutputItem output) ->
             Set.member output.callId started
         _ -> True
+    go pending [] = flush pending []
+    go pending (TurnText text : rest) =
+        go (Just (maybe text (\previous -> previous <> "\n\n" <> text) pending)) rest
+    go pending (TurnItem item : rest) =
+        flush pending (item : go Nothing rest)
+    flush pending rest =
+        maybe rest (\text -> assistantMessageItem (Just text) : rest) pending
+
+isAssistantItem :: ResponseItem -> Bool
+isAssistantItem = \case
+    MessageItem message -> message.role == RoleAssistant
+    _ -> False
+
+assistantMessageItem :: Maybe Text -> ResponseItem
+assistantMessageItem assistantText =
+    MessageItem ResponseMessage
+        { messageId = Nothing
+        , content = MessageContentParts
+            [ OutputTextPart
+                { text = fromMaybe "" assistantText
+                , annotations = Nothing
+                , logprobs = Nothing
+                }
+            ]
+        , role = RoleAssistant
+        , status = Just ItemCompleted
+        , phase = Nothing
+        , passthrough = Nothing
+        }
 
 functionCallItem :: Text -> Text -> RawJson -> ResponseItem
 functionCallItem callId name input =
@@ -483,6 +570,10 @@ functionCallItem callId name input =
         , status = Just ItemCompleted
         }
 
+-- | Persist the text projection rather than the wire JSON: structured
+-- results (tool references, image reads carrying base64 payloads) are
+-- replayed into the transcript view and imported into later prompts as
+-- plain text.
 functionOutputItem
     :: Text
     -> Maybe ToolResultContent
@@ -498,7 +589,7 @@ functionOutputItem callId content isError =
         , output =
             maybe
                 (rawJsonFromEncoding Aeson.null_)
-                (.raw)
+                (rawJsonFromEncoding . Aeson.text . renderResultContent)
                 content
         , status =
             Just $
@@ -507,7 +598,7 @@ functionOutputItem callId content isError =
                     else ItemCompleted
         }
 
-streamEventToolEvents :: StreamEvent -> [ClaudeToolEvent]
+streamEventToolEvents :: StreamEvent -> [ClaudeLiveEvent]
 streamEventToolEvents StreamEvent{streamToolUse = Just toolUse} =
     [ ClaudeToolStarted ToolCall
         { callId = toolUse.toolUseId
@@ -519,8 +610,14 @@ streamEventToolEvents StreamEvent{streamToolUse = Just toolUse} =
     ]
 streamEventToolEvents _ = []
 
-assistantBlockEvents :: ContentBlock -> [ClaudeToolEvent]
-assistantBlockEvents = \case
+assistantBlockEvents :: Maybe Text -> ContentBlock -> [ClaudeLiveEvent]
+assistantBlockEvents messageId = \case
+    TextBlock{text}
+        | Text.null (Text.strip text) -> []
+        | otherwise -> [ClaudeText messageId text]
+    ThinkingBlock{thinking}
+        | Text.null (Text.strip thinking) -> []
+        | otherwise -> [ClaudeThinking messageId thinking]
     ToolUseBlock{toolUseId, name, input} ->
         [ ClaudeToolStarted ToolCall
             { callId = toolUseId
@@ -542,7 +639,7 @@ assistantBlockEvents = \case
     _ ->
         []
 
-userBlockEvents :: ContentBlock -> [ClaudeToolEvent]
+userBlockEvents :: ContentBlock -> [ClaudeLiveEvent]
 userBlockEvents = \case
     ToolResultBlock{toolUseId, content, isError} ->
         let rawOutput = maybe "" renderResultContent content
@@ -568,26 +665,58 @@ userBlockEvents = \case
     _ ->
         []
 
-canonicalToolEvents :: [ClaudeToolEvent] -> [LoopEvent]
-canonicalToolEvents toolEvents =
-    events
-  where
-    (_, events) = advanceToolEvents emptyClaudeEventState toolEvents
-
-advanceToolEvents
+-- | Project a batch of live events (one record while streaming, the whole
+-- turn at completion) onto loop events, skipping what is already displayed.
+-- Text and thinking are skipped per record, judged against the state before
+-- the batch, so every block of a multi-block record is emitted together.
+advanceLiveEvents
     :: ClaudeEventState
-    -> [ClaudeToolEvent]
+    -> [ClaudeLiveEvent]
     -> (ClaudeEventState, [LoopEvent])
-advanceToolEvents initialState toolEvents =
+advanceLiveEvents initialState toolEvents =
     let (state, eventsRev) =
             foldl' step (initialState, []) toolEvents
     in (state, reverse eventsRev)
   where
+    alreadyStreamed :: Maybe Text -> Bool
+    alreadyStreamed =
+        maybe False (`Set.member` initialState.streamedMessageIds)
+
+    markStreamed :: Maybe Text -> ClaudeEventState -> ClaudeEventState
+    markStreamed messageId state =
+        case messageId of
+            Nothing -> state
+            Just identifier ->
+                state
+                    { streamedMessageIds =
+                        Set.insert identifier state.streamedMessageIds
+                    }
+
+    paragraph :: LiveDeltaKind -> ClaudeEventState -> Text -> Text
+    paragraph kind state text
+        | state.lastDelta == Just kind = "\n\n" <> text
+        | otherwise = text
+
     step
         :: (ClaudeEventState, [LoopEvent])
-        -> ClaudeToolEvent
+        -> ClaudeLiveEvent
         -> (ClaudeEventState, [LoopEvent])
     step (state, events) = \case
+        ClaudeText messageId text
+            | alreadyStreamed messageId -> (state, events)
+            | otherwise ->
+                ( (markStreamed messageId state)
+                    { lastDelta = Just LiveTextDelta }
+                , TextDelta (paragraph LiveTextDelta state text) : events
+                )
+        ClaudeThinking messageId thinking
+            | alreadyStreamed messageId -> (state, events)
+            | otherwise ->
+                ( (markStreamed messageId state)
+                    { lastDelta = Just LiveThinkingDelta }
+                , ReasoningDelta (paragraph LiveThinkingDelta state thinking)
+                    : events
+                )
         ClaudeToolStarted call
             | Just previous <- Map.lookup
                 call.callId
@@ -613,6 +742,7 @@ advanceToolEvents initialState toolEvents =
                             call.callId
                             call
                             state.startedToolDetails
+                    , lastDelta = Nothing
                     }
                 , ToolStarted call : events
                 )

--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -14,6 +14,7 @@ import Agent.Claude.Options
 import Agent.Claude.Internal.Messages
     ( ClaudeEventState
     , CompletedClaudeTurn(..)
+    , assistantMessageItem
     , claudeEventStateHasActivity
     , emptyClaudeEventState
     , interpretClaudeTurn
@@ -319,8 +320,7 @@ submitClaudeCodeTurn
                     transcript
                     completed.sessionId
                     inputs
-                    completed.toolItems
-                    completed.assistantText
+                    completed.turnItems
         mapM_ onEvent (remainingClaudeEvents eventState completed)
         pure (Right (output, commit))
 
@@ -615,16 +615,14 @@ commitHostTranscript
     -> Text
     -> [TurnInput]
     -> [ResponseItem]
-    -> Maybe Text
     -> IO ()
 commitHostTranscript
     checkpoint
     transcript
     sessionId
     inputs
-    toolItems
-    assistantText = do
-    appendHostTranscriptRef transcript inputs toolItems assistantText
+    turnItems = do
+    appendHostTranscriptRef transcript inputs turnItems
     -- Read and enter the exact object installed in the IORef before taking its
     -- StableName. Otherwise the lazy append thunk can later be entered by the
     -- CLI, changing the StableName despite no host-side transcript change.
@@ -649,37 +647,20 @@ appendHostTranscript history inputs assistantText =
         <> turnInputsToItems inputs
         <> [assistantMessageItem assistantText]
 
+-- | Append one completed turn: its inputs followed by the turn's transcript
+-- items, which already end in an assistant message.
 appendHostTranscriptRef
     :: IORef [ResponseItem]
     -> [TurnInput]
     -> [ResponseItem]
-    -> Maybe Text
     -> IO ()
-appendHostTranscriptRef transcript inputs toolItems assistantText =
+appendHostTranscriptRef transcript inputs turnItems =
     atomicModifyIORef' transcript \history ->
         ( history
             <> turnInputsToItems inputs
-            <> toolItems
-            <> [assistantMessageItem assistantText]
+            <> turnItems
         , ()
         )
-
-assistantMessageItem :: Maybe Text -> ResponseItem
-assistantMessageItem assistantText =
-    MessageItem ResponseMessage
-        { messageId = Nothing
-        , content = MessageContentParts
-            [ OutputTextPart
-                { text = fromMaybe "" assistantText
-                , annotations = Nothing
-                , logprobs = Nothing
-                }
-            ]
-        , role = RoleAssistant
-        , status = Just ItemCompleted
-        , phase = Nothing
-        , passthrough = Nothing
-        }
 
 sdkErrorToApiError :: ClaudeSDKError -> ApiError
 sdkErrorToApiError = \case

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -11,6 +11,7 @@ import Agent.Claude.Options
     , defaultClaudeCodeOptions
     )
 import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Json (rawJsonBytes)
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
@@ -31,6 +32,7 @@ import Agent.Responses.Types
     , ResponseCreateParams(..)
     , ResponseItem(..)
     , ResponseMessage(..)
+    , ResponseRole(..)
     , defaultResponseCreateParams
     )
 import Agent.ToolDispatch
@@ -272,6 +274,137 @@ spec = do
                         history <- readIORef transcript
                         [call | FunctionCallItem call <- history]
                             `shouldBe` []
+
+        it "streams interim text and thinking live and persists the whole reply" $
+            withFakeClaude \fake ->
+                withEnvironmentVariables
+                    [("FAKE_CLAUDE_INTERIM", Just "1")]
+                    do
+                        transcript <- newIORef []
+                        events <- newIORef []
+                        result <- timeout 5_000_000 $
+                            withClaudeCodeBackend
+                                (defaultClaudeCodeOptions
+                                    fake.executable
+                                    fake.workingDirectory)
+                                Nothing
+                                (pure defaultResponseCreateParams)
+                                transcript
+                                \backend ->
+                                    submitBackend backend
+                                        Nothing
+                                        [UserMessage "read it"]
+                                        (\event ->
+                                            modifyIORef' events (<> [event]))
+                        turn <- case result of
+                            Just (Right value) -> pure value
+                            other -> do
+                                expectationFailure
+                                    ("unexpected turn: " <> show other)
+                                fail "unreachable"
+                        observed <- readIORef events
+                        observed `shouldBe`
+                            [ ReasoningDelta "weighing options"
+                            , TextDelta "Let me read it."
+                            , ToolStarted expectedFakeToolCall
+                            , ToolFinished expectedFakeToolResult
+                            , TextDelta "fake response"
+                            ]
+                        -- Claude Code's result record only carries the last
+                        -- text block; the turn keeps everything, and the
+                        -- host transcript preserves the order seen live.
+                        turn.assistantText
+                            `shouldBe` Just "Let me read it.\n\nfake response"
+                        history <- readIORef transcript
+                        map historyTag history
+                            `shouldBe`
+                                [ "user:read it"
+                                , "assistant:Let me read it."
+                                , "call:fake-tool"
+                                , "output:fake-tool"
+                                , "assistant:fake response"
+                                ]
+
+        it "discards the attempt when displayed text is retracted and replays survivors" $
+            withFakeClaude \fake ->
+                withEnvironmentVariables
+                    [ ("FAKE_CLAUDE_INTERIM", Just "1")
+                    , ("FAKE_CLAUDE_RETRACT_TEXT", Just "1")
+                    ]
+                    do
+                        transcript <- newIORef []
+                        events <- newIORef []
+                        result <- timeout 5_000_000 $
+                            withClaudeCodeBackend
+                                (defaultClaudeCodeOptions
+                                    fake.executable
+                                    fake.workingDirectory)
+                                Nothing
+                                (pure defaultResponseCreateParams)
+                                transcript
+                                \backend ->
+                                    submitBackend backend
+                                        Nothing
+                                        [UserMessage "read it"]
+                                        (\event ->
+                                            modifyIORef' events (<> [event]))
+                        turn <- case result of
+                            Just (Right value) -> pure value
+                            other -> do
+                                expectationFailure
+                                    ("unexpected turn: " <> show other)
+                                fail "unreachable"
+                        observed <- readIORef events
+                        observed `shouldBe`
+                            [ ReasoningDelta "weighing options"
+                            , TextDelta "Let me read it."
+                            , ToolStarted expectedFakeToolCall
+                            , ResponseAttemptDiscarded
+                            , ReasoningDelta "weighing options"
+                            , ToolStarted expectedFakeToolCall
+                            , ToolFinished expectedFakeToolResult
+                            , TextDelta "fake response"
+                            ]
+                        turn.assistantText `shouldBe` Just "fake response"
+                        history <- readIORef transcript
+                        map responseMessageText
+                            [message | MessageItem message <- history]
+                            `shouldBe` ["read it", "fake response"]
+
+        it "renders and persists structured tool results as text" $
+            withFakeClaude \fake ->
+                withEnvironmentVariables
+                    [("FAKE_CLAUDE_STRUCTURED_RESULT", Just "1")]
+                    do
+                        transcript <- newIORef []
+                        events <- newIORef []
+                        result <- timeout 5_000_000 $
+                            withClaudeCodeBackend
+                                (defaultClaudeCodeOptions
+                                    fake.executable
+                                    fake.workingDirectory)
+                                Nothing
+                                (pure defaultResponseCreateParams)
+                                transcript
+                                \backend ->
+                                    submitBackend backend
+                                        Nothing
+                                        [UserMessage "search tools"]
+                                        (\event ->
+                                            modifyIORef' events (<> [event]))
+                        result `shouldSatisfy` \case
+                            Just (Right _) -> True
+                            _ -> False
+                        observed <- readIORef events
+                        observed `shouldContain`
+                            [ ToolFinished expectedFakeToolResult
+                                { output = "Tool reference: WebFetch\nloaded" }
+                            ]
+                        history <- readIORef transcript
+                        [ rawJsonBytes output.output
+                            | FunctionCallOutputItem output <- history
+                            ]
+                            `shouldBe` ["\"Tool reference: WebFetch\\nloaded\""]
 
         it "starts from partial tool records and enriches canonical arguments" $
             withFakeClaude \fake ->
@@ -679,9 +812,12 @@ spec = do
                                         && "was active"
                                             `Text.isInfixOf` message
                             _ -> False
+                        -- Text is exposed as it arrives; the failed turn
+                        -- discards the whole displayed attempt.
                         readIORef events `shouldReturn`
                             [ ToolStarted expectedFakeToolCall
                             , ToolFinished expectedFakeToolResult
+                            , TextDelta "fake response"
                             , ResponseAttemptDiscarded
                             ]
 
@@ -1293,13 +1429,24 @@ fakeClaudeScript promptLog startLog argumentLog =
         , "  if [ \"$FAKE_CLAUDE_PARTIAL_TOOL\" = 1 ]; then"
         , "    printf '{\"type\":\"stream_event\",\"uuid\":\"partial-tool-%s\",\"session_id\":\"%s\",\"event\":{\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"fake-tool\",\"name\":\"Read\",\"input\":{}}}}\\n' \"$turn\" \"$session_id\""
         , "  fi"
+        , "  if [ \"$FAKE_CLAUDE_INTERIM\" = 1 ]; then"
+        , "    printf '{\"type\":\"assistant\",\"uuid\":\"thinking-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"thinking\",\"thinking\":\"weighing options\",\"signature\":\"sig\"}]}}\\n' \"$turn\" \"$session_id\""
+        , "    printf '{\"type\":\"assistant\",\"uuid\":\"interim-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Let me read it.\"}]}}\\n' \"$turn\" \"$session_id\""
+        , "  fi"
         , "  tool_name=${FAKE_CLAUDE_TOOL_NAME:-Read}"
         , "  printf '{\"type\":\"assistant\",\"uuid\":\"tool-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"fake-tool\",\"name\":\"%s\",\"input\":{\"file_path\":\"README.md\"}}]}}\\n' \"$turn\" \"$session_id\" \"$tool_name\""
         , "  if [ \"$FAKE_CLAUDE_RETRACT_TOOL\" = 1 ]; then"
         , "    printf '{\"type\":\"system\",\"subtype\":\"model_refusal_fallback\",\"uuid\":\"retract-%s\",\"session_id\":\"%s\",\"retracted_message_uuids\":[\"tool-%s\"]}\\n' \"$turn\" \"$session_id\" \"$turn\""
         , "  fi"
+        , "  if [ \"$FAKE_CLAUDE_RETRACT_TEXT\" = 1 ]; then"
+        , "    printf '{\"type\":\"system\",\"subtype\":\"model_refusal_fallback\",\"uuid\":\"retract-text-%s\",\"session_id\":\"%s\",\"retracted_message_uuids\":[\"interim-%s\"]}\\n' \"$turn\" \"$session_id\" \"$turn\""
+        , "  fi"
         , "  if [ \"$FAKE_CLAUDE_PAUSE_AFTER_TOOL\" = 1 ]; then sleep 1; fi"
-        , "  printf '{\"type\":\"user\",\"uuid\":\"tool-result-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"fake-tool\",\"content\":\"fake contents\"}]}}\\n' \"$turn\" \"$session_id\""
+        , "  if [ \"$FAKE_CLAUDE_STRUCTURED_RESULT\" = 1 ]; then"
+        , "    printf '{\"type\":\"user\",\"uuid\":\"tool-result-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"fake-tool\",\"content\":[{\"type\":\"tool_reference\",\"tool_name\":\"WebFetch\"},{\"type\":\"text\",\"text\":\"loaded\"}]}]}}\\n' \"$turn\" \"$session_id\""
+        , "  else"
+        , "    printf '{\"type\":\"user\",\"uuid\":\"tool-result-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"fake-tool\",\"content\":\"fake contents\"}]}}\\n' \"$turn\" \"$session_id\""
+        , "  fi"
         , "  printf '{\"type\":\"assistant\",\"uuid\":\"assistant-%s\",\"session_id\":\"%s\",\"message\":{\"id\":\"message-%s\",\"content\":[{\"type\":\"text\",\"text\":\"fake response\"}]}}\\n' \"$turn\" \"$session_id\" \"$turn\""
         , "  result_session_id=${FAKE_CLAUDE_RESULT_SESSION_ID:-$session_id}"
         , "  if [ -n \"$FAKE_CLAUDE_RESULT_MARKER\" ]; then : > \"$FAKE_CLAUDE_RESULT_MARKER\"; fi"
@@ -1354,6 +1501,16 @@ expectedFakeToolResult = ToolCallResult
     , output = "fake contents"
     , callKind = FunctionCallKind
     }
+
+historyTag :: ResponseItem -> Text
+historyTag = \case
+    MessageItem message
+        | message.role == RoleAssistant ->
+            "assistant:" <> responseMessageText message
+        | otherwise -> "user:" <> responseMessageText message
+    FunctionCallItem call -> "call:" <> call.callId
+    FunctionCallOutputItem output -> "output:" <> output.callId
+    _ -> "other"
 
 eventTag :: LoopEvent -> Text
 eventTag = \case

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -121,7 +121,9 @@ import Agent.TUI.Presentation
     , parseSearchReplaceDiff
     , summarizeToolCall
     , summarizeToolCallRelative
+    , toolCallDiff
     , toolDetail
+    , toolVerb
     , workspaceRelativeDisplayPath
     )
 import Agent.ToolDispatch
@@ -828,7 +830,21 @@ toolChrome name = case canonicalToolName name of
     "skill_update" -> ToolChrome "Updated skill" ToolDetailMuted
     "skill_archive" -> ToolChrome "Archived skill" ToolDetailMuted
     "skill_rollback" -> ToolChrome "Restored skill" ToolDetailMuted
-    _ -> ToolChrome name ToolDetailMuted
+    "Write" -> ToolChrome "Wrote" ToolDetailPath
+    "Glob" -> ToolChrome "Globbed" ToolDetailMuted
+    "WebFetch" -> ToolChrome "Fetched" ToolDetailMuted
+    "WebSearch" -> ToolChrome "Searched web" ToolDetailMuted
+    "ToolSearch" -> ToolChrome "Searched tools" ToolDetailMuted
+    "Agent" -> ToolChrome "Spawned agent" ToolDetailMuted
+    "Task" -> ToolChrome "Spawned agent" ToolDetailMuted
+    "NotebookEdit" -> ToolChrome "Edited" ToolDetailPath
+    "Monitor" -> ToolChrome "Monitored" ToolDetailCommand
+    "Skill" -> ToolChrome "Ran skill" ToolDetailMuted
+    "EnterWorktree" -> ToolChrome "Entered worktree" ToolDetailMuted
+    "ExitWorktree" -> ToolChrome "Exited worktree" ToolDetailMuted
+    "SendMessage" -> ToolChrome "Sent message to" ToolDetailMuted
+    "ListAgents" -> ToolChrome "Listed agents" ToolDetailMuted
+    _ -> ToolChrome (toolVerb name) ToolDetailMuted
 
 isTodoTool :: Text -> Bool
 isTodoTool name =
@@ -839,10 +855,8 @@ formatToolBody color = formatToolBodyRelative color ""
 
 formatToolBodyRelative :: Bool -> Text -> ToolCall -> Text
 formatToolBodyRelative color workspace call = case canonicalToolName call.name of
-    "search_replace" ->
-        formatSearchReplaceDiffRelative color workspace call.arguments
     "exec" -> roleToolCommand color call.arguments
-    _ -> ""
+    _ -> maybe "" (paintDiffRelative color workspace) (toolCallDiff call)
 
 -- | Compact unified-diff preview for @search_replace@ arguments.
 formatSearchReplaceDiff :: Bool -> Text -> Text
@@ -850,8 +864,12 @@ formatSearchReplaceDiff color = formatSearchReplaceDiffRelative color ""
 
 formatSearchReplaceDiffRelative :: Bool -> Text -> Text -> Text
 formatSearchReplaceDiffRelative color workspace arguments =
+    paintDiffRelative color workspace (parseSearchReplaceDiff arguments)
+
+paintDiffRelative :: Bool -> Text -> SearchReplaceDiff -> Text
+paintDiffRelative color workspace diff =
     let SearchReplaceDiff { diffPath, diffAction, diffLines, diffHiddenLines } =
-            parseSearchReplaceDiff arguments
+            diff
         header = case diffAction of
             Just SearchReplaceCreate ->
                 roleMuted color "  create "
@@ -859,7 +877,10 @@ formatSearchReplaceDiffRelative color workspace arguments =
             Just SearchReplaceDelete ->
                 roleMuted color "  delete "
                     <> renderToolPath color workspace diffPath
-            _ -> ""
+            Just SearchReplaceWrite ->
+                roleMuted color "  write "
+                    <> renderToolPath color workspace diffPath
+            Nothing -> ""
         shown = map paintLine diffLines
         more =
             if diffHiddenLines == 0

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -270,6 +270,26 @@ spec = do
             formatToolStarted False (functionToolCall "c5" "custom_tool" "{\"x\":1}")
                 `shouldBe` "◆ custom_tool"
 
+        it "renders Claude Code built-ins with host chrome" do
+            formatToolStarted False (functionToolCall "c10" "Bash" "{\"command\":\"git status\"}")
+                `shouldBe` "◆ $ git status"
+            formatToolStarted False (functionToolCall "c11" "Read" "{\"file_path\":\"src/A.hs\"}")
+                `shouldBe` "◆ Read src/A.hs"
+            formatToolStarted False (functionToolCall "c12" "Edit" "{\"file_path\":\"src/A.hs\"}")
+                `shouldBe` "◆ Edited src/A.hs"
+            formatToolStarted False
+                (functionToolCall "c13" "Write" "{\"file_path\":\"src/B.hs\",\"content\":\"x\"}")
+                `shouldBe` "◆ Wrote src/B.hs"
+            formatToolStarted False
+                (functionToolCall "c14" "WebFetch" "{\"url\":\"https://example.com\"}")
+                `shouldBe` "◆ Fetched https://example.com"
+            formatToolStarted False
+                (functionToolCall "c15" "mcp__playwright__browser_click" "{}")
+                `shouldBe` "◆ playwright: browser_click"
+            formatToolBody False
+                (functionToolCall "c13" "Write" "{\"file_path\":\"src/B.hs\",\"content\":\"x\"}")
+                `shouldBe` "  write src/B.hs\n  +x"
+
         it "keeps todo_write and update_plan on their wire names" do
             formatToolStarted False
                 (functionToolCall

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -207,7 +207,7 @@ spec = describe "requestParams" do
         let params :: ResponseCreateParams
             params =
                 (requestParams OpenAIProvider "gpt-generic"
-                    "instructions" [] "high")
+                    "instructions" [] "high" :: ResponseCreateParams)
                     { serviceTier = Just "priority" }
         setRequestModel OpenAIProvider "gpt-5.6-terra" params
             `shouldSatisfy` \result -> result.serviceTier == Nothing

--- a/packages/agent-core/src/Agent/Dialect.hs
+++ b/packages/agent-core/src/Agent/Dialect.hs
@@ -31,6 +31,7 @@ module Agent.Dialect
     , providerSupportsDialect
     , grokBuildPublicToolName
     , grokBuildCanonicalToolName
+    , claudeCodeCanonicalToolName
     , dialectSlug
     , parseDialect
     ) where
@@ -261,6 +262,25 @@ grokBuildCanonicalToolName = \case
     "get_command_or_subagent_output" -> "get_task_output"
     "wait_commands_or_subagents" -> "wait_tasks"
     "kill_command_or_subagent" -> "kill_task"
+    name -> name
+
+-- | Resolve Claude Code's built-in tool names to the stable internal names
+-- whose argument shapes they share. Claude Code executes these tools itself;
+-- the mapping only lets host chrome (verbs, paths, diffs, todo panels) treat
+-- them like the equivalent host tools. Names without a compatible host tool
+-- (@Write@, @Glob@, @WebFetch@, @Agent@, …) stay on their wire names.
+claudeCodeCanonicalToolName :: Text -> Text
+claudeCodeCanonicalToolName = \case
+    "Bash" -> "run_terminal_cmd"
+    "Read" -> "read_file"
+    "Edit" -> "search_replace"
+    "Grep" -> "grep"
+    "TodoWrite" -> "todo_write"
+    "EnterPlanMode" -> "enter_plan_mode"
+    "ExitPlanMode" -> "exit_plan_mode"
+    "AskUserQuestion" -> "ask_user_question"
+    "TaskOutput" -> "get_task_output"
+    "TaskStop" -> "kill_task"
     name -> name
 
 dialectSlug :: DialectId -> Text

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -23,7 +23,10 @@ module Agent.ToolDispatch
     , decodeToolArguments
     ) where
 
-import Agent.Dialect (grokBuildCanonicalToolName)
+import Agent.Dialect
+    ( claudeCodeCanonicalToolName
+    , grokBuildCanonicalToolName
+    )
 import Agent.Json.Decode (Decoder)
 import qualified Agent.Json.Decode as Json
 import Control.Applicative ((<|>))
@@ -214,6 +217,7 @@ findHandler name handlers =
 canonicalToolName :: Text -> Text
 canonicalToolName name
     | grokName /= name = grokName
+    | claudeName /= name = claudeName
     | Just rest <- Text.stripPrefix "collaboration." name =
         canonicalToolName rest
     | Just rest <- Text.stripPrefix "collaboration" name
@@ -227,6 +231,7 @@ canonicalToolName name
     | otherwise = name
   where
     grokName = grokBuildCanonicalToolName name
+    claudeName = claudeCodeCanonicalToolName name
 
 -- | Project current public Grok Build parameter names back onto the stable
 -- internal handler contract. Keep this beside 'canonicalToolName' so every

--- a/packages/agent-core/test/Agent/ToolDispatchSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDispatchSpec.hs
@@ -51,6 +51,35 @@ spec = describe "dispatchToolCall" do
             (functionToolCall "call-1" "run_terminal_command" "{}")
         result `shouldBe` functionResult "call-1" "ran"
 
+    it "canonicalizes Claude Code built-ins that share a host tool shape" do
+        map canonicalToolName
+            [ "Bash"
+            , "Read"
+            , "Edit"
+            , "Grep"
+            , "TodoWrite"
+            , "TaskOutput"
+            , "TaskStop"
+            , "EnterPlanMode"
+            , "ExitPlanMode"
+            , "AskUserQuestion"
+            ]
+            `shouldBe`
+                [ "run_terminal_cmd"
+                , "read_file"
+                , "search_replace"
+                , "grep"
+                , "todo_write"
+                , "get_task_output"
+                , "kill_task"
+                , "enter_plan_mode"
+                , "exit_plan_mode"
+                , "ask_user_question"
+                ]
+        -- Tools without a compatible host equivalent keep their wire names.
+        map canonicalToolName ["Write", "Glob", "WebFetch", "Agent", "Task"]
+            `shouldBe` ["Write", "Glob", "WebFetch", "Agent", "Task"]
+
     it "canonicalizes every current Grok Build public tool name" do
         map canonicalToolName
             [ "run_terminal_command"

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -41,8 +41,9 @@ module Agent.TUI.Model
     ) where
 
 import Agent.TUI.Presentation
-    ( formatSearchReplaceDiffRelative
+    ( formatToolDiffRelative
     , formatToolOutputRelative
+    , todoListFromToolArguments
     , todoListFromToolOutput
     , toolCallInput
     , toolCallTitleRelative
@@ -408,12 +409,7 @@ reduceLoop event state = case event of
                 kind = toolBlockKind call.name
                 title = toolCallTitleRelative state.uiWorkspaceRoot call
                 blockIndex = Seq.length state.uiBlocks
-                body = case canonicalToolName call.name of
-                    "search_replace" ->
-                        formatSearchReplaceDiffRelative
-                            state.uiWorkspaceRoot
-                            call.arguments
-                    _ -> ""
+                body = formatToolDiffRelative state.uiWorkspaceRoot call
                 detail = toolCallInput call
             in appendBlock kind title body detail
                 BlockRunning (Just call.callId)
@@ -449,7 +445,9 @@ reduceLoop event state = case event of
                     Just (_, call)
                         | isTodoTool call.name ->
                             fromMaybe state.uiTodos
-                                (todoListFromToolOutput result.output)
+                                (todoListFromToolOutput result.output
+                                    <|> todoListFromToolArguments
+                                        call.arguments)
                     _ -> state.uiTodos
             next =
                 state
@@ -671,12 +669,7 @@ updateToolCall call state =
         Just (blockIndex, previous) ->
             let title =
                     toolCallTitleRelative state.uiWorkspaceRoot call
-                body = case canonicalToolName call.name of
-                    "search_replace" ->
-                        formatSearchReplaceDiffRelative
-                            state.uiWorkspaceRoot
-                            call.arguments
-                    _ -> ""
+                body = formatToolDiffRelative state.uiWorkspaceRoot call
                 blocks
                     | isTodoTool previous.name = state.uiBlocks
                     | otherwise =
@@ -937,7 +930,7 @@ toolBlockKind :: Text -> BlockKind
 toolBlockKind rawName
     | name `elem` ["run_terminal_cmd", "shell_command", "write_stdin", "run_ghci", "exec"] =
         BlockShell
-    | name `elem` ["search_replace", "apply_patch"] =
+    | name `elem` ["search_replace", "apply_patch", "Write", "NotebookEdit"] =
         BlockEdit
     | name `elem` ["todo_write", "update_plan"] =
         BlockTodo

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -7,14 +7,17 @@ module Agent.TUI.Presentation
     , TodoDisplayStatus(..)
     , formatSearchReplaceDiff
     , formatSearchReplaceDiffRelative
+    , formatToolDiffRelative
     , formatTodoList
     , formatToolOutput
     , formatToolOutputRelative
     , liveTodoPanelLines
     , parseSearchReplaceDiff
+    , parseWriteFileDiff
     , parseTodoList
     , permissionToolCallPrompt
     , permissionToolCallPromptRelative
+    , todoListFromToolArguments
     , todoListFromToolOutput
     , summarizeToolCall
     , summarizeToolCallRelative
@@ -25,8 +28,10 @@ module Agent.TUI.Presentation
     , toolCallInput
     , toolCallTitle
     , toolCallTitleRelative
+    , toolCallDiff
     , toolDetail
     , toolPathArgument
+    , toolVerb
     , workspaceRelativeDisplayPath
     ) where
 
@@ -120,6 +125,8 @@ computerActionDetail _ = "computer action"
 data SearchReplaceAction
     = SearchReplaceCreate
     | SearchReplaceDelete
+    -- | Whole-file write where the previous contents are unknown.
+    | SearchReplaceWrite
     deriving (Eq, Show)
 
 data SearchReplaceLine
@@ -155,18 +162,51 @@ parseSearchReplaceDiff arguments =
         , diffHiddenLines = length raw - length shown
         }
 
+-- | Preview for Claude Code's @Write@ tool: the new file contents as added
+-- lines. Whether the path already exists is unknown here, so the header
+-- says @write@ rather than @create@.
+parseWriteFileDiff :: Text -> SearchReplaceDiff
+parseWriteFileDiff arguments =
+    let path = jsonTextFieldDefault "file_path" arguments
+        content = jsonTextFieldDefault "content" arguments
+        raw = map SearchReplaceAdded (Text.lines content)
+        shown = take 20 raw
+    in SearchReplaceDiff
+        { diffPath = path
+        , diffAction = Just SearchReplaceWrite
+        , diffLines = shown
+        , diffHiddenLines = length raw - length shown
+        }
+
+-- | Diff preview carried by a tool call's arguments, when the tool has one.
+toolCallDiff :: ToolCall -> Maybe SearchReplaceDiff
+toolCallDiff call = case canonicalToolName call.name of
+    "search_replace" -> Just (parseSearchReplaceDiff call.arguments)
+    "Write" -> Just (parseWriteFileDiff call.arguments)
+    _ -> Nothing
+
 formatSearchReplaceDiff :: Text -> Text
 formatSearchReplaceDiff = formatSearchReplaceDiffRelative ""
 
 formatSearchReplaceDiffRelative :: Text -> Text -> Text
 formatSearchReplaceDiffRelative workspace arguments =
+    formatDiffRelative workspace (parseSearchReplaceDiff arguments)
+
+-- | Diff body for a tool block; empty when the tool carries no diff.
+formatToolDiffRelative :: Text -> ToolCall -> Text
+formatToolDiffRelative workspace call =
+    maybe "" (formatDiffRelative workspace) (toolCallDiff call)
+
+formatDiffRelative :: Text -> SearchReplaceDiff -> Text
+formatDiffRelative workspace diff =
     let SearchReplaceDiff { diffPath, diffAction, diffLines, diffHiddenLines } =
-            parseSearchReplaceDiff arguments
+            diff
         displayedPath = workspaceRelativeDisplayPath workspace diffPath
         header = case diffAction of
             Just SearchReplaceCreate -> "  create " <> displayedPath
             Just SearchReplaceDelete -> "  delete " <> displayedPath
-            _ -> ""
+            Just SearchReplaceWrite -> "  write " <> displayedPath
+            Nothing -> ""
         shown = map formatLine diffLines
         more
             | diffHiddenLines == 0 = []
@@ -246,10 +286,12 @@ workspaceRelativeDisplayPath workspace path =
 toolPathArgument :: ToolCall -> Maybe Text
 toolPathArgument call =
     nonEmptyPath $ case canonicalToolName call.name of
-        "read_file" -> jsonTextFieldDefault "target_file" call.arguments
+        "read_file" -> readFilePath call.arguments
         "list_dir" -> jsonTextFieldDefault "target_directory" call.arguments
         "search_replace" -> jsonTextFieldDefault "file_path" call.arguments
         "apply_patch" -> fromMaybe "" (firstPatchPath call.arguments)
+        "Write" -> jsonTextFieldDefault "file_path" call.arguments
+        "NotebookEdit" -> jsonTextFieldDefault "notebook_path" call.arguments
         _ -> ""
   where
     nonEmptyPath text =
@@ -316,6 +358,36 @@ todoListFromToolOutput output =
     in if stripped == "No tasks currently tracked."
         then Just []
         else if null parsed then Nothing else Just parsed
+
+-- | Checklist carried by a @todo_write@-shaped argument payload. Claude
+-- Code's @TodoWrite@ answers with prose, so its list is only visible here.
+todoListFromToolArguments :: Text -> Maybe [TodoDisplayLine]
+todoListFromToolArguments arguments =
+    case decodeMaybe todosDecoder arguments of
+        Just (Just todos) -> Just (mapMaybe id todos)
+        _ -> Nothing
+  where
+    todosDecoder =
+        Hermes.object $
+            Hermes.atKeyOptional "todos" (Hermes.list todoDecoder)
+    todoDecoder =
+        Hermes.getType >>= \case
+            Hermes.VObject ->
+                Hermes.object do
+                    content <- Hermes.atKeyOptional "content" Hermes.text
+                    status <- Hermes.atKeyOptional "status" Hermes.text
+                    pure do
+                        text <- Text.strip <$> content
+                        if Text.null text
+                            then Nothing
+                            else Just TodoDisplayLine
+                                { todoLineStatus =
+                                    fromMaybe
+                                        TodoDisplayPending
+                                        (status >>= parseTodoStatusMarker)
+                                , todoLineText = text
+                                }
+            _ -> pure Nothing
 
 parseTodoList :: Text -> [TodoDisplayLine]
 parseTodoList output =
@@ -483,12 +555,40 @@ toolVerb name = case canonicalToolName name of
     "skill_archive" -> "Archived skill"
     "skill_rollback" -> "Restored skill"
     "conversation_search" -> "Searched conversations"
-    other -> other
+    -- Claude Code built-ins without a host equivalent keep their wire names
+    -- as identity; the equivalents are mapped by 'canonicalToolName'.
+    "Write" -> "Wrote"
+    "Glob" -> "Globbed"
+    "WebFetch" -> "Fetched"
+    "WebSearch" -> "Searched web"
+    "ToolSearch" -> "Searched tools"
+    "Agent" -> "Spawned agent"
+    "Task" -> "Spawned agent"
+    "NotebookEdit" -> "Edited"
+    "Monitor" -> "Monitored"
+    "Skill" -> "Ran skill"
+    "EnterWorktree" -> "Entered worktree"
+    "ExitWorktree" -> "Exited worktree"
+    "SendMessage" -> "Sent message to"
+    "ListAgents" -> "Listed agents"
+    other -> mcpToolDisplayName other
+
+-- | Claude Code names MCP tools @mcp__server__tool@; show @server: tool@.
+mcpToolDisplayName :: Text -> Text
+mcpToolDisplayName name =
+    case Text.stripPrefix "mcp__" name of
+        Just rest
+            | (server, tool) <- Text.breakOn "__" rest
+            , not (Text.null server)
+            , Just toolName <- Text.stripPrefix "__" tool
+            , not (Text.null toolName) ->
+                server <> ": " <> toolName
+        _ -> name
 
 toolDetail :: ToolCall -> Text
 toolDetail call = case canonicalToolName call.name of
     "computer" -> computerActionDetail call.arguments
-    "read_file" -> jsonTextFieldDefault "target_file" call.arguments
+    "read_file" -> readFilePath call.arguments
     "list_dir" -> jsonTextFieldDefault "target_directory" call.arguments
     "search_replace" -> jsonTextFieldDefault "file_path" call.arguments
     "grep" -> jsonTextFieldDefault "pattern" call.arguments
@@ -529,7 +629,28 @@ toolDetail call = case canonicalToolName call.name of
     "skill_rollback" -> skillIdentity call.arguments
     "conversation_search" ->
         firstLine (jsonTextFieldDefault "query" call.arguments)
+    "get_task_output" -> jsonTextFieldDefault "task_id" call.arguments
+    "kill_task" -> jsonTextFieldDefault "task_id" call.arguments
+    "Write" -> jsonTextFieldDefault "file_path" call.arguments
+    "Glob" -> jsonTextFieldDefault "pattern" call.arguments
+    "WebFetch" -> jsonTextFieldDefault "url" call.arguments
+    "WebSearch" -> firstLine (jsonTextFieldDefault "query" call.arguments)
+    "ToolSearch" -> firstLine (jsonTextFieldDefault "query" call.arguments)
+    "Agent" -> firstLine (jsonTextFieldDefault "description" call.arguments)
+    "Task" -> firstLine (jsonTextFieldDefault "description" call.arguments)
+    "NotebookEdit" -> jsonTextFieldDefault "notebook_path" call.arguments
+    "Monitor" -> firstLine (jsonTextFieldDefault "command" call.arguments)
+    "Skill" -> firstLine (jsonTextFieldDefault "skill" call.arguments)
+    "SendMessage" -> jsonTextFieldDefault "to" call.arguments
     _ -> ""
+
+-- | Host @read_file@ takes @target_file@; Claude Code's @Read@ shares the
+-- canonical name but passes @file_path@.
+readFilePath :: Text -> Text
+readFilePath arguments =
+    case nonEmptyJsonText "target_file" arguments of
+        Just path -> path
+        Nothing -> jsonTextFieldDefault "file_path" arguments
 
 skillIdentity :: Text -> Text
 skillIdentity arguments =

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -325,7 +325,7 @@ spec = describe "fullscreen UI reducer" do
                     ]
         case Foldable.toList state.uiBlocks of
             [block] -> do
-                block.blockTitle `shouldBe` "Agent"
+                block.blockTitle `shouldBe` "Spawned agent review the patch"
                 block.blockDetail `shouldBe` ""
                 block.blockState `shouldBe` BlockRunning
             _ -> expectationFailure "expected one updated tool block"
@@ -347,7 +347,7 @@ spec = describe "fullscreen UI reducer" do
                     ]
         case Foldable.toList state.uiBlocks of
             [block] -> do
-                block.blockTitle `shouldBe` "Agent"
+                block.blockTitle `shouldBe` "Spawned agent review the patch"
                 block.blockState `shouldBe` BlockRunning
             _ -> expectationFailure "expected one updated tool block"
         Foldable.toList state.uiToolCalls

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -78,6 +78,60 @@ spec = describe "tool presentation" do
         permissionToolCallPrompt call
             `shouldSatisfy` (not . Text.isInfixOf "password")
 
+    it "summarizes Claude Code built-in tools with host chrome" do
+        summarizeToolCall
+            (functionToolCall "b" "Bash"
+                "{\"command\":\"git status\\nls\",\"description\":\"Show status\"}")
+            `shouldBe` "$ git status"
+        summarizeToolCall
+            (functionToolCall "r" "Read" "{\"file_path\":\"src/Main.hs\"}")
+            `shouldBe` "Read src/Main.hs"
+        summarizeToolCall
+            (functionToolCall "e" "Edit"
+                "{\"file_path\":\"src/Main.hs\",\"old_string\":\"a\",\"new_string\":\"b\"}")
+            `shouldBe` "Edited src/Main.hs"
+        summarizeToolCall
+            (functionToolCall "w" "Write"
+                "{\"file_path\":\"src/New.hs\",\"content\":\"main = pure ()\"}")
+            `shouldBe` "Wrote src/New.hs"
+        summarizeToolCall
+            (functionToolCall "g" "Glob" "{\"pattern\":\"**/*.hs\"}")
+            `shouldBe` "Globbed **/*.hs"
+        summarizeToolCall
+            (functionToolCall "s" "Grep" "{\"pattern\":\"TODO\",\"path\":\"src\"}")
+            `shouldBe` "Searched TODO"
+        summarizeToolCall
+            (functionToolCall "f" "WebFetch"
+                "{\"url\":\"https://example.com\",\"prompt\":\"summarize\"}")
+            `shouldBe` "Fetched https://example.com"
+        summarizeToolCall
+            (functionToolCall "t" "ToolSearch" "{\"query\":\"select:WebFetch\"}")
+            `shouldBe` "Searched tools select:WebFetch"
+        summarizeToolCall
+            (functionToolCall "a" "Agent"
+                "{\"description\":\"Find flaky tests\",\"prompt\":\"...\"}")
+            `shouldBe` "Spawned agent Find flaky tests"
+        summarizeToolCall
+            (functionToolCall "m" "mcp__playwright__browser_click" "{}")
+            `shouldBe` "playwright: browser_click"
+        toolPathArgument
+            (functionToolCall "r" "Read" "{\"file_path\":\"/tmp/a.hs\"}")
+            `shouldBe` Just "/tmp/a.hs"
+        formatToolDiffRelative ""
+            (functionToolCall "w" "Write"
+                "{\"file_path\":\"src/New.hs\",\"content\":\"main = pure ()\\n\"}")
+            `shouldBe` "  write src/New.hs\n  +main = pure ()"
+        todoListFromToolArguments
+            "{\"todos\":[{\"content\":\"Find repos\",\"status\":\"in_progress\",\
+            \\"activeForm\":\"Finding repos\"},{\"content\":\"Fix\",\"status\":\"pending\"}]}"
+            `shouldBe`
+                Just
+                    [ TodoDisplayLine TodoDisplayInProgress "Find repos"
+                    , TodoDisplayLine TodoDisplayPending "Fix"
+                    ]
+        todoListFromToolArguments "{\"todos\":[]}" `shouldBe` Just []
+        todoListFromToolArguments "Todos have been modified" `shouldBe` Nothing
+
     it "extracts tool details from function and custom calls" do
         toolDetail
             (functionToolCall "read" "read_file"


### PR DESCRIPTION
## Summary
Follow-up to #684/#685. Auditing the Claude rendering path (SDK parser → `agent-claude` event projection → TUI/CLI chrome) against real Claude Code stream-json turned up three more bugs, all reproduced against the real `claude` binary:

- **Claude-native tool calls had no chrome.** `canonicalToolName` knew nothing about `Bash`, `Read`, `Edit`, `Write`, `Glob`, `Grep`, `WebFetch`, `ToolSearch`, `Agent`, … so every block rendered as the bare tool name with no command, path, or diff. Built-ins whose argument shapes match host tools now map onto the canonical names (`Bash → run_terminal_cmd`, `Edit → search_replace`, `Read → read_file`, `TodoWrite → todo_write`, `TaskOutput/TaskStop → get_task_output/kill_task`, plan-mode/ask-user); the rest get explicit verbs and details (`Wrote path`, `Globbed pattern`, `Fetched url`, `Searched tools query`, `Spawned agent description`, …). `Write` renders a whole-file diff preview, `Read` accepts `file_path` next to `read_file`'s `target_file`, `TodoWrite` arguments feed the todo panel (its output is prose), and MCP tools show as `server: tool`.
- **Interim assistant text and thinking were dropped.** Claude Code emits one assistant record per content block and its `result` record carries only the *last* text block; the backend only exposed that, so anything the model said before its final tool call — and all `thinking` — never reached the UI or the transcript (11 of 27 real turns sampled had such text). Text and thinking now stream live as their records arrive (`TextDelta`/`ReasoningDelta`), completion replays only what was not shown, and the host transcript persists the turn's items in wire order (text ↔ tool call ↔ output) so the durable projection keeps the live interleaving. If a displayed record is retracted, the attempt is discarded and the surviving records are replayed at completion in order.
- **Structured tool results were persisted as raw JSON.** `tool_reference` arrays and base64 image reads were stored verbatim and replayed into the transcript view / imported into later Claude prompts as JSON. The text projection is persisted instead.

Also fixes two test-suite breakages left by the fast-mode change (`RequestSpec` ambiguous record update, `CommandSpec` missing `fast`), so `agent-cli-test` builds and passes again.

## Test plan
- [x] `cabal test agent-core` (426), `agent-tui` (189), `agent-claude` (36), `agent-cli` (1166) — all green, including new cases: Claude name canonicalization, Claude tool summaries/diff/todo parsing, CLI chrome, live interim text + thinking ordering, retraction → discard + replay, structured-result persistence, interleaved host transcript order.
- [x] tmux smoke against the real `claude` binary (`--provider claude-code --model sonnet --yolo`): `✓ Read notes.txt`, `✓ Edited …`, `✓ Wrote …`, `✓ $ cat hello.txt`, `✓ Searched tools select:WebFetch` → `Tool reference: WebFetch`; "ALPHA → tool → BETA" keeps its order both live and after the turn completes.
- CI: `nix flake check` still fails first at the unrelated `agent-cli-functional-xai-hello-world` (`no xai account has verified available usage`).

## Not in this PR
The durable history projection (`SessionHistory.projectTurn`) starts from `initialUiState` without the workspace root, so replayed tool blocks show absolute paths for every provider while live blocks show workspace-relative ones. Pre-existing and provider-independent; worth a separate change that threads the workspace root through `sessionHistoryTurn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)