### PR TITLE
Request access to external directories

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -9,6 +9,7 @@ module Agent.CLI.GatewayBridge
     , managedGatewayTools
     , newManagedLoopEventPublisher
     , requestManagedApproval
+    , requestManagedRootAccess
     , managedBridgeRequestsDirectory
     , managedBridgeResponsesDirectory
     , managedBridgeActivityPath
@@ -20,7 +21,7 @@ import Agent.CLI.ManagedTurn (ManagedTurnRequest(..))
 import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.Loop (LoopEvent(..))
-import Agent.OsPath (unsafeToFilePath)
+import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.TextBuffer
     ( TextBuffer
     , appendTextBuffer
@@ -389,6 +390,20 @@ requestManagedApproval request call =
                 Right "deny" -> pure (Just PermissionDeny)
                 _ -> pure Nothing
             _ -> pure Nothing
+
+requestManagedRootAccess :: ManagedTurnRequest -> OsPath -> IO Bool
+requestManagedRootAccess request root =
+    performBridgeRequest
+        request
+        "filesystem-access"
+        "filesystem_access"
+        (object ["path" .= toText root])
+        (30 * 60 * 1_000_000) >>= \case
+            Right raw ->
+                case Hermes.decodeEither Hermes.text (rawJsonBytes raw) of
+                    Right "allow" -> pure True
+                    _ -> pure False
+            Left _ -> pure False
 
 data ManagedActivityAccumulator = ManagedActivityAccumulator
     { accumulatorKind :: !Text

--- a/packages/agent-cli/src/Agent/CLI/Permission.hs
+++ b/packages/agent-cli/src/Agent/CLI/Permission.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Permission
     , applyPermissionKey
     , initialPermissionState
     , promptPermission
+    , promptRootAccess
     , renderPermissionFrame
     ) where
 
@@ -22,6 +23,8 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.IO (hIsTerminalDevice, stderr, stdin)
+import System.OsPath (OsPath)
+import Agent.OsPath (toText)
 
 data PermissionChoice
     = PermissionAllowOnce
@@ -113,6 +116,38 @@ promptPermission color workspace call = do
                     applyPermissionKey
                     (initialPermissionState summary)
             pure (Just (fromMaybe PermissionDeny result))
+
+-- | Ask whether an additional directory may be used for this session.
+-- This is intentionally separate from tool permission: granting a directory
+-- never enables a tool or persists beyond the current session.
+promptRootAccess :: Bool -> OsPath -> IO Bool
+promptRootAccess color root = do
+    isTty <- hIsTerminalDevice stdin
+    let summary = "Allow filesystem access to " <> toText root <> " for this session?"
+        labels = ["Allow directory for this session", "Deny"]
+        render state =
+            let rows = zipWith
+                    (\i label -> renderRow color (i == state) label)
+                    [0 ..] labels
+            in Text.intercalate "\n"
+                (roleWarn color (glyphWarn <> summary) : rows
+                    <> [roleMuted color "↑↓/jk or scroll · enter/click · y allow · n/esc deny"])
+        step key state = case key of
+            PickerKeyCancel -> Left False
+            PickerKeyConfirm -> Left (state == 0)
+            PickerKeyUp -> Right ((state - 1) `mod` length labels)
+            PickerKeyDown -> Right ((state + 1) `mod` length labels)
+            PickerKeyChar c
+                | Text.toLower (Text.singleton c) == "y" -> Left True
+                | Text.toLower (Text.singleton c) == "n" -> Left False
+            _ -> Right state
+    if not isTty
+        then readApprovalLine (roleWarn color (glyphWarn <> summary <> " [y/N] ")) >>= \case
+            Just raw -> pure (Text.toLower (Text.strip raw) `elem` ["y", "yes"])
+            Nothing -> pure False
+        else do
+            notifyAttention stderr PermissionRequested
+            fromMaybe False <$> runOverlay render step 0
 
 cooked :: Bool -> Text -> IO (Maybe PermissionChoice)
 cooked color summary = do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -125,6 +125,7 @@ import Agent.CLI.Subagents.Runtime
     ( SubagentRuntime(subagentOpenAiChild, SubagentRuntime,
                       subagentOptions, subagentGhciEnabled, subagentBashEnabled,
                       subagentPolicy, subagentPlanHooks, subagentSkillRoots,
+                      subagentAllowedRoots, subagentRootAccessRequest,
                       subagentParams, subagentMcpTools, subagentRegistry,
                       subagentSessions, subagentStoreRoot, subagentTypes,
                       subagentLegacyTarget, subagentConnection, subagentMapModel,
@@ -414,6 +415,8 @@ runAgentSession
                 , subagentPolicy = policy
                 , subagentPlanHooks = planHooks
                 , subagentSkillRoots = toolEnv.toolSkillRoots
+                , subagentAllowedRoots = toolEnv.toolAllowedRoots
+                , subagentRootAccessRequest = toolEnv.toolRootAccessRequest
                 , subagentParams = paramsRef
                 , subagentMcpTools = mcpTools
                 , subagentRegistry = registry

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -173,7 +173,9 @@ import Agent.Tools.MultiAgents
 import Agent.Tools.PlanMode ()
 import Agent.Tools.Secret ()
 import Agent.Tools.Types
-    ( AppTool(appToolName), ToolEnv(toolSkillRoots, toolSessionTmp) )
+    ( AppTool(appToolName)
+    , ToolEnv(toolAllowedRoots, toolRootAccessRequest, toolSkillRoots, toolSessionTmp)
+    )
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ()
 import Control.Concurrent.Async ( waitSTM, withAsync )

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -23,6 +23,7 @@ import Agent.Concurrent
 import Agent.CLI.ManagedTurn
 import Agent.CLI.GatewayBridge
 import Agent.CLI.Approval
+import Agent.CLI.Permission (promptRootAccess)
 import Agent.CLI.Recap
 import Agent.CLI.CancelWatch
 import Agent.CLI.Clipboard
@@ -105,6 +106,26 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
               Just runtime -> setFullscreenWindowTitle runtime title
               Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
       withIoLock action = withMVar ioLock (const action)
+      requestRootAccess root =
+          withMVar ioLock \_ ->
+              case promptRequest of
+                  Just request
+                      | isJust request.managedTurnBridgeDirectory ->
+                          requestManagedRootAccess request root
+                  _ -> case fullscreen of
+                      Just runtime ->
+                          maybe False (== 0)
+                              <$> requestFullscreenChoiceWithBody
+                                  runtime
+                                  "Filesystem access requested"
+                                  ("Allow access to " <> toText root
+                                      <> " for this session?")
+                                  0
+                                  [ ("Allow directory for this session", "")
+                                  , ("Deny", "")
+                                  ]
+                      Nothing ->
+                          withStdinPaused escPaused (promptRootAccess useColor root)
       reportSessionError message =
           case fullscreen of
               Just runtime ->
@@ -118,6 +139,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
       startupWindowTitle
       withIoLock
       writeWindowTitle
+  setToolRootAccessRequest toolEnv (Just requestRootAccess)
   let setWindowTitle = windowTitle.windowTitleSet
       beginWindowTitleBusy = windowTitle.windowTitleBeginBusy
       endWindowTitleBusy = windowTitle.windowTitleEndBusy

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -715,7 +715,12 @@ prepareChild
     -> IO PreparedChild
 prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoot = do
     parentParams <- readIORef runtime.subagentParams
-    childEnv <- defaultToolEnv env.subCwd
+    childEnv <- do
+        freshEnv <- defaultToolEnv env.subCwd
+        pure freshEnv
+            { toolAllowedRoots = runtime.subagentAllowedRoots
+            , toolRootAccessRequest = runtime.subagentRootAccessRequest
+            }
     skillRoots <- readIORef runtime.subagentSkillRoots
     writeIORef childEnv.toolSkillRoots skillRoots
     sessionTmp <- readIORef runtime.subagentSessionTmp

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
@@ -45,6 +45,8 @@ data SubagentRuntime = SubagentRuntime
     , subagentPolicy :: !ApprovalPolicy
     , subagentPlanHooks :: !PlanModeHooks
     , subagentSkillRoots :: !(IORef [OsPath])
+    , subagentAllowedRoots :: !(IORef [OsPath])
+    , subagentRootAccessRequest :: !(IORef (Maybe (OsPath -> IO Bool)))
     , subagentSessionTmp :: !(IORef (Maybe OsPath))
     , subagentMcpTools :: ![AppTool]
     , subagentParams :: !(IORef ResponseCreateParams)

--- a/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayBridgeSpec.hs
@@ -6,6 +6,7 @@ import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.Loop (LoopEvent(..), defaultLoopDispatch)
 import Agent.Json.Decode qualified as Hermes
 import Agent.OsPath (unsafeToFilePath)
+import Agent.Json (rawJsonBytes)
 import Agent.ToolDispatch
     ( ToolCallResult(..)
     , dispatchToolCall
@@ -25,6 +26,7 @@ import System.Directory
     , removePathForcibly
     )
 import System.FilePath ((</>), takeExtension)
+import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
@@ -78,6 +80,26 @@ spec = describe "Agent.CLI.GatewayBridge" do
                     , bridgeResponseError = Nothing
                     }
                 wait running `shouldReturn` Just PermissionAllowOnce
+
+    it "uses the bridge for filesystem root access choices" $
+        withBridgeRequest \request -> do
+            let root = "/tmp/agent-root"
+            withAsync
+                (requestManagedRootAccess request (unsafeEncodeUtf root))
+                \running -> do
+                    bridgeRequest <- waitForBridgeRequest request
+                    bridgeRequest.bridgeRequestKind
+                        `shouldBe` "filesystem_access"
+                    rawJsonBytes bridgeRequest.bridgeRequestPayload
+                        `shouldBe` "{\"path\":\"/tmp/agent-root\"}"
+                    writeManagedBridgeResponse request ManagedBridgeResponse
+                        { bridgeResponseVersion = 1
+                        , bridgeResponseId = bridgeRequest.bridgeRequestId
+                        , bridgeResponseOk = True
+                        , bridgeResponseResult = Just (String "allow")
+                        , bridgeResponseError = Nothing
+                        }
+                    wait running `shouldReturn` True
 
     it "publishes accumulated reasoning summaries and response text" $
         withBridgeRequest \request -> do

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -14,11 +14,11 @@ import Agent.FileRetry (retryOnFileBusy)
 import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.OsPath (relativeDisplayPath, toText, unsafeToFilePath)
 import Agent.Tools.Types (ToolEnv(..))
-import Control.Exception.Safe (SomeException, try, tryIO)
+import Control.Exception.Safe (SomeException, try, tryAny, tryIO)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
-import Data.IORef (readIORef)
+import Data.IORef (atomicModifyIORef', readIORef)
 import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Directory.OsPath
@@ -65,6 +65,41 @@ resolveWithRoots
     -> [OsPath]
     -> IO (Either Text OsPath)
 resolveWithRoots env requested extraRoots = do
+    resolveWithRootsAttempt env requested extraRoots >>= \case
+        Right resolved -> pure (Right resolved)
+        Left (OutsideAllowedRoots resolved) ->
+            readIORef env.toolRootAccessRequest >>= \case
+                Nothing -> pure $ Left (outsideRootsMessage requested)
+                Just requestAccess -> do
+                    root <- nearestExistingDirectory resolved
+                    case root of
+                        Nothing -> pure $ Left (outsideRootsMessage requested)
+                        Just requestedRoot ->
+                            tryAny (requestAccess requestedRoot) >>= \case
+                                Left exception ->
+                                    pure $ Left
+                                        ("Filesystem access request failed: "
+                                            <> Text.pack (show exception))
+                                Right False ->
+                                    pure $ Left (outsideRootsMessage requested)
+                                Right True -> do
+                                    addAllowedRoot env requestedRoot
+                                    resolveWithRootsAttempt env requested extraRoots >>= \case
+                                        Right value -> pure (Right value)
+                                        Left _ -> pure $
+                                            Left (outsideRootsMessage requested)
+        Left (ResolverFailure err) -> pure (Left err)
+
+data ResolveFailure
+    = OutsideAllowedRoots !OsPath
+    | ResolverFailure !Text
+
+resolveWithRootsAttempt
+    :: ToolEnv
+    -> OsPath
+    -> [OsPath]
+    -> IO (Either ResolveFailure OsPath)
+resolveWithRootsAttempt env requested extraRoots = do
     configuredRoots <- readIORef env.toolAllowedRoots
     sessionTmp <- readIORef env.toolSessionTmp
     canonicalRoots <-
@@ -83,12 +118,38 @@ resolveWithRoots env requested extraRoots = do
         then Right <$> canonicalizePath combined
         else resolveMissing combined
     pure $ case resolvedResult of
-        Left err -> Left err
+        Left err -> Left (ResolverFailure err)
         Right resolved
             | any (`isInside` resolved) (absCwd : allowedRoots) ->
                 Right resolved
-            | otherwise -> Left $
-                "Path escapes the allowed filesystem roots: " <> toText requested
+            | otherwise -> Left (OutsideAllowedRoots resolved)
+
+outsideRootsMessage :: OsPath -> Text
+outsideRootsMessage requested =
+    "Path escapes the allowed filesystem roots: " <> toText requested
+
+-- | Return the nearest existing directory containing a requested path. This
+-- keeps grants useful for new files while avoiding a grant for a nonexistent
+-- path that cannot be canonicalized yet.
+nearestExistingDirectory :: OsPath -> IO (Maybe OsPath)
+nearestExistingDirectory path = do
+    doesDirectoryExist path >>= \case
+        True -> Just <$> canonicalizePath path
+        False -> go (takeDirectory path)
+  where
+    go directory = do
+        doesDirectoryExist directory >>= \case
+            True -> Just <$> canonicalizePath directory
+            False ->
+                let parent = takeDirectory directory
+                in if equalFilePath parent directory
+                    then pure Nothing
+                    else go parent
+
+addAllowedRoot :: ToolEnv -> OsPath -> IO ()
+addAllowedRoot env root =
+    atomicModifyIORef' env.toolAllowedRoots \roots ->
+        (if any (equalFilePath root) roots then roots else roots <> [root], ())
 
 resolveMissing :: OsPath -> IO (Either Text OsPath)
 resolveMissing path = do

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -13,12 +13,12 @@ module Agent.Tools.FileSystem
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.OsPath (relativeDisplayPath, toText, unsafeToFilePath)
-import Agent.Tools.Types (ToolEnv(..))
+import Agent.Tools.Types (ToolEnv(..), addToolAllowedRoot)
 import Control.Exception.Safe (SomeException, try, tryAny, tryIO)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
-import Data.IORef (atomicModifyIORef', readIORef)
+import Data.IORef (readIORef)
 import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Directory.OsPath
@@ -83,7 +83,7 @@ resolveWithRoots env requested extraRoots = do
                                 Right False ->
                                     pure $ Left (outsideRootsMessage requested)
                                 Right True -> do
-                                    addAllowedRoot env requestedRoot
+                                    addToolAllowedRoot env requestedRoot
                                     resolveWithRootsAttempt env requested extraRoots >>= \case
                                         Right value -> pure (Right value)
                                         Left _ -> pure $
@@ -145,11 +145,6 @@ nearestExistingDirectory path = do
                 in if equalFilePath parent directory
                     then pure Nothing
                     else go parent
-
-addAllowedRoot :: ToolEnv -> OsPath -> IO ()
-addAllowedRoot env root =
-    atomicModifyIORef' env.toolAllowedRoots \roots ->
-        (if any (equalFilePath root) roots then roots else roots <> [root], ())
 
 resolveMissing :: OsPath -> IO (Either Text OsPath)
 resolveMissing path = do

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -6,6 +6,7 @@ module Agent.Tools.Types
     , ToolRegistry
     , ToolEnv(..)
     , defaultToolEnv
+    , setToolRootAccessRequest
     , setToolSkillRoots
     , setToolSessionTmp
     , jsonTool
@@ -107,6 +108,10 @@ data ToolEnv = ToolEnv
     , toolAllowedRoots :: !(IORef [OsPath])
       -- | Additional non-session filesystem roots. The current
       -- 'toolSessionTmp' is always allowed implicitly.
+    , toolRootAccessRequest :: !(IORef (Maybe (OsPath -> IO Bool)))
+      -- | Optional session-local callback used when a path falls outside
+      -- the configured roots. An approved path is added to
+      -- 'toolAllowedRoots' by the filesystem resolver.
     , toolSkillRoots :: !(IORef [OsPath])
       -- | Directories belonging to the currently discovered skill catalog.
       -- Kept separate so catalog refreshes can replace them without
@@ -124,11 +129,13 @@ defaultToolEnv :: OsPath -> IO ToolEnv
 defaultToolEnv cwd = do
     cancel <- newCancelFlag
     allowedRoots <- newIORef []
+    rootAccessRequest <- newIORef Nothing
     skillRoots <- newIORef []
     sessionTmp <- newIORef Nothing
     pure ToolEnv
         { toolCwd = dropTrailingPathSeparator cwd
         , toolAllowedRoots = allowedRoots
+        , toolRootAccessRequest = rootAccessRequest
         , toolSkillRoots = skillRoots
         , toolSessionTmp = sessionTmp
         , toolOutputInlineCap = 50 * 1024
@@ -137,6 +144,12 @@ defaultToolEnv cwd = do
         , toolStdoutCap = 16 * 1024
         , toolCancel = cancel
         }
+
+-- | Install the session-local callback used to request access to an
+-- additional filesystem root. The callback should perform any human-facing
+-- approval and return whether the requested root may be added.
+setToolRootAccessRequest :: ToolEnv -> Maybe (OsPath -> IO Bool) -> IO ()
+setToolRootAccessRequest env = writeIORef env.toolRootAccessRequest
 
 -- | Replace the directories exposed for the current skill catalog.
 setToolSkillRoots :: ToolEnv -> [OsPath] -> IO ()

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -5,6 +5,7 @@ module Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , ToolRegistry
     , ToolEnv(..)
+    , addToolAllowedRoot
     , defaultToolEnv
     , setToolRootAccessRequest
     , setToolSkillRoots
@@ -49,11 +50,15 @@ import Agent.Tools.Scheduling
 import Control.Exception.Safe (tryAny)
 import Control.Monad (foldM)
 import Data.Aeson (Value)
-import Data.IORef (IORef, newIORef, writeIORef)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, writeIORef)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.OsPath (OsPath, dropTrailingPathSeparator)
+import System.OsPath
+    ( OsPath
+    , dropTrailingPathSeparator
+    , equalFilePath
+    )
 
 -- | Provider-facing schema. The sum prevents freeform tools from carrying
 -- meaningless JSON parameters.
@@ -150,6 +155,13 @@ defaultToolEnv cwd = do
 -- approval and return whether the requested root may be added.
 setToolRootAccessRequest :: ToolEnv -> Maybe (OsPath -> IO Bool) -> IO ()
 setToolRootAccessRequest env = writeIORef env.toolRootAccessRequest
+
+-- | Add a canonical directory to the roots available for this session.
+-- Duplicate roots are ignored so repeated approvals remain idempotent.
+addToolAllowedRoot :: ToolEnv -> OsPath -> IO ()
+addToolAllowedRoot env root =
+    atomicModifyIORef' env.toolAllowedRoots \roots ->
+        (if any (equalFilePath root) roots then roots else roots <> [root], ())
 
 -- | Replace the directories exposed for the current skill catalog.
 setToolSkillRoots :: ToolEnv -> [OsPath] -> IO ()

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -6,7 +6,7 @@ import Agent.FileRetry
     , retryOnFileBusy
     , writeLazyFileAtomically
     )
-import System.OsPath (unsafeEncodeUtf)
+import System.OsPath (equalFilePath, unsafeEncodeUtf)
 import Agent.Tools.IO
     ( CommandResult(..)
     , RunningCommand(..)
@@ -28,7 +28,12 @@ import Agent.Tools.OutputArtifact
     ( OutputArtifact(..)
     , readOutputArtifact
     )
-import Agent.Tools.Types (ToolEnv(..), defaultToolEnv, setToolSessionTmp)
+import Agent.Tools.Types
+    ( ToolEnv(..)
+    , defaultToolEnv
+    , setToolRootAccessRequest
+    , setToolSessionTmp
+    )
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.MVar (readMVar)
 import Control.Exception.Safe (bracket, tryIO)
@@ -213,6 +218,45 @@ spec = describe "Agent.Tools.IO" do
             resolveUnderCwd env
                 (fromFilePath (dir </> "unrelated" </> "file.txt"))
                 >>= (`shouldSatisfy` isLeft)
+
+    it "requests and remembers approval for an escaped filesystem root" do
+        withTempDir \dir -> do
+            let workspace = dir </> "workspace"
+                outside = dir </> "outside"
+                target = outside </> "file.txt"
+            createDirectory workspace
+            createDirectory outside
+            writeFile target "approved"
+            env <- defaultToolEnv (fromFilePath workspace)
+            requests <- newIORef []
+            setToolRootAccessRequest env $ Just \root -> do
+                modifyIORef' requests (<> [root])
+                pure True
+            resolveUnderCwd env (fromFilePath target)
+                `shouldReturn` Right (fromFilePath target)
+            readIORef requests `shouldReturn` [fromFilePath outside]
+            roots <- readIORef env.toolAllowedRoots
+            roots `shouldSatisfy` any (equalFilePath (fromFilePath outside))
+            resolveUnderCwd env (fromFilePath target)
+                `shouldReturn` Right (fromFilePath target)
+            readIORef requests `shouldReturn` [fromFilePath outside]
+
+    it "keeps rejecting an escaped root when access is denied" do
+        withTempDir \dir -> do
+            let workspace = dir </> "workspace"
+                outside = dir </> "outside"
+                target = outside </> "file.txt"
+            createDirectory workspace
+            createDirectory outside
+            writeFile target "denied"
+            env <- defaultToolEnv (fromFilePath workspace)
+            requests <- newIORef []
+            setToolRootAccessRequest env $ Just \root -> do
+                modifyIORef' requests (<> [root])
+                pure False
+            result <- resolveUnderCwd env (fromFilePath target)
+            result `shouldSatisfy` isLeft
+            readIORef requests `shouldReturn` [fromFilePath outside]
 
     it "rejects symlink escapes from an additional filesystem root" do
         withTempDir \dir -> do

--- a/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
@@ -122,6 +122,14 @@ approvalRequestDecoder = Hermes.object $
         <$> Hermes.atKey "tool_name" Hermes.text
         <*> Hermes.atKey "arguments" Hermes.text
 
+data FilesystemAccessRequest = FilesystemAccessRequest
+    { filesystemAccessPath :: !Text
+    }
+
+filesystemAccessRequestDecoder :: Hermes.Decoder FilesystemAccessRequest
+filesystemAccessRequestDecoder = Hermes.object $
+    FilesystemAccessRequest <$> Hermes.atKey "path" Hermes.text
+
 data AllowlistRequest = AllowlistRequest
     { allowlistQuery :: !(Maybe Text)
     , allowlistUserId :: !(Maybe Integer)
@@ -294,6 +302,14 @@ processBridgeRequest env request =
                         [ ("Allow once", "allow_once")
                         , ("Always this tool", "allow_tool")
                         , ("Allow all", "allow_all")
+                        , ("Deny", "deny")
+                        ]
+            "filesystem_access" ->
+                withPayload filesystemAccessRequestDecoder current \payload ->
+                    registerChoice env current
+                        ("Allow access to " <> payload.filesystemAccessPath
+                            <> " for this session?")
+                        [ ("Allow directory for this session", "allow")
                         , ("Deny", "deny")
                         ]
             "allow_user" ->


### PR DESCRIPTION
## Summary
- prompt the human when a structured filesystem operation targets a canonical directory outside the worktree or session temp roots
- remember approved directories for the current session only
- route approval through terminal, fullscreen, and managed Telegram flows
- cover allow, deny, session-memory, and managed bridge behavior with tests

## Testing
- agent-core test suite via GHCi: 481 examples, 0 failures
- Agent.CLI.GatewayBridgeSpec via GHCi: 5 examples, 0 failures
- agent-cli library via GHCi: all 194 modules loaded
- agent-telegram library via GHCi: all 21 modules loaded
- live terminal prompt smoke-tested in tmux
- git diff --check

## Scope
This enforces roots for structured filesystem tools and shell working-directory resolution. Shell command strings are not OS-sandboxed, so commands such as `cat /etc/passwd` can still access arbitrary paths; full arbitrary-shell enforcement should be handled separately with an OS-level sandbox.