### PR TITLE
Temporarily skip live Grok CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,6 @@ jobs:
 
           credential_source_home="$HOME"
           if [[ ! -f "$credential_source_home/.codex/auth.json" \
-            && ! -f "$credential_source_home/.grok/auth.json" \
             && ! -d "$credential_source_home/.haskell-agent/credentials" \
             && -d "$account_home" ]]; then
             credential_source_home="$account_home"
@@ -69,14 +68,6 @@ jobs:
               "$credential_home/.codex/auth.json"
           else
             echo "::error title=Missing OpenAI credentials::the CI runner must provide .codex/auth.json"
-            exit 1
-          fi
-          if [[ -f "$credential_source_home/.grok/auth.json" ]]; then
-            mkdir -p "$credential_home/.grok"
-            install -m 600 "$credential_source_home/.grok/auth.json" \
-              "$credential_home/.grok/auth.json"
-          else
-            echo "::error title=Missing xAI credentials::the CI runner must provide .grok/auth.json"
             exit 1
           fi
           if [[ -d "$credential_source_home/.haskell-agent/credentials" ]]; then

--- a/flake.nix
+++ b/flake.nix
@@ -752,9 +752,11 @@
                     agent-cli-functional-openai-hello-world =
                         agentCliHelloWorldFunctional "openai"
                             (functionalTestModel "OPENAI" "gpt-5.6-terra");
-                    agent-cli-functional-xai-hello-world =
-                        agentCliHelloWorldFunctional "xai"
-                            (functionalTestModel "XAI" "grok-4.6");
+                    # Temporarily disabled while the CI Grok account has no
+                    # verified available usage. Keep package/unit checks enabled.
+                    # agent-cli-functional-xai-hello-world =
+                    #     agentCliHelloWorldFunctional "xai"
+                    #         (functionalTestModel "XAI" "grok-4.6");
                 };
 
                 formatter = pkgs.nixfmt-rfc-style;


### PR DESCRIPTION
## Summary

- temporarily disable the live xAI/Grok hello-world flake check
- stop requiring and staging Grok credentials in the CI workflow while that check is disabled
- keep the Grok dialect and xAI package/unit checks enabled

The live check is currently failing because the CI Grok account reports `no xai account has verified available usage`. The commented flake check remains next to the OpenAI functional check for straightforward re-enablement.

## Validation

- `git diff --check`
- `nix flake show --no-write-lock-file`
- evaluated Linux CI check names with functional tests enabled and confirmed only `agent-cli-functional-openai-hello-world` remains
