### PR TITLE
Harden fullscreen recovery after hidden terminal tabs

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -218,6 +218,7 @@ handleEvent event = do
     stateAfterMotionSync <- get
     when
         ( stateAfterMotionSync.appTerminalFocus == TerminalUnfocused
+            && not (eventRequiresUnfocusedRedraw event)
             && not
                 (completionRequiresRedraw
                     stateBeforeEvent.appUi
@@ -227,6 +228,12 @@ handleEvent event = do
         ) $
         continueWithoutRedraw
   where
+    -- Durable history replacement must reach the terminal backing screen even
+    -- if a terminal tab omits focus gain.
+    eventRequiresUnfocusedRedraw = \case
+        AppEvent (AppHistoryCommitted _ _ _) -> True
+        _ -> False
+
     isMotionTick = \case
         AppEvent AppMotionTick -> True
         _ -> False

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -194,6 +194,19 @@ handleEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleEvent event = do
     advanceAppClockNow
     stateBeforeEvent <- get
+    imagePreviewRevisionBefore <-
+        liftIO $
+            readIORef
+                stateBeforeEvent.appRuntime.runtimeImagePreviewRevision
+    when
+        ( stateBeforeEvent.appTerminalFocus == TerminalUnfocused
+            && terminalInteractionImpliesFocus event
+        ) do
+        -- A key, paste, or pointer event can only come from the active
+        -- terminal. Recover when a tab transition omitted EvGainedFocus;
+        -- otherwise every interaction would keep mutating state invisibly.
+        noteTerminalFocusGained
+        resolveConversationFollow
     when (isMotionTick event) refreshNativeProgressKeepalive
     handleEventInner event
     when (eventMayExposeSyntax event) requestVisibleSyntaxLanguages
@@ -216,9 +229,21 @@ handleEvent event = do
                 (+ 1)
     syncMotionDemand
     stateAfterMotionSync <- get
+    imagePreviewRevisionAfter <-
+        liftIO $
+            readIORef
+                stateAfterMotionSync.appRuntime.runtimeImagePreviewRevision
     when
         ( stateAfterMotionSync.appTerminalFocus == TerminalUnfocused
-            && not (eventRequiresUnfocusedRedraw event)
+            && eventMaySkipUnfocusedRedraw event
+            && imagePreviewRevisionBefore == imagePreviewRevisionAfter
+            && not
+                (userActionPending stateBeforeEvent
+                    /= userActionPending stateAfterMotionSync)
+            && not
+                (agentStructureRequiresUnfocusedRedraw
+                    stateBeforeEvent
+                    stateAfterMotionSync)
             && not
                 (completionRequiresRedraw
                     stateBeforeEvent.appUi
@@ -228,10 +253,75 @@ handleEvent event = do
         ) $
         continueWithoutRedraw
   where
-    -- Durable history replacement must reach the terminal backing screen even
-    -- if a terminal tab omits focus gain.
-    eventRequiresUnfocusedRedraw = \case
-        AppEvent (AppHistoryCommitted _ _ _) -> True
+    -- Suppression is deliberately opt-in. continueWithoutRedraw is Brick's
+    -- final EventM action, so applying it to an unknown event can overwrite a
+    -- halt/suspend request or hide a new blocking/structural UI state. Only
+    -- known high-frequency and cosmetic events are safe to throttle.
+    eventMaySkipUnfocusedRedraw = \case
+        AppEvent appEvent ->
+            appEventMaySkipUnfocusedRedraw appEvent
+        VtyEvent V.EvLostFocus -> True
+        VtyEvent V.EvResize{} -> True
+        -- The patched backend represents pointer motion as a no-button mouse
+        -- release; it is not proof that the hidden terminal regained focus.
+        VtyEvent (V.EvMouseUp _ _ Nothing) -> True
+        MouseUp _ Nothing _ -> True
+        _ -> False
+
+    appEventMaySkipUnfocusedRedraw = \case
+        AppUi uiEvent ->
+            uiEventMaySkipUnfocusedRedraw uiEvent
+        AppUiBatch uiEvents ->
+            all uiEventMaySkipUnfocusedRedraw uiEvents
+        AppDictationPartial{} -> True
+        AppAgentSnapshot{} -> True
+        AppSetWindowTitle{} -> True
+        AppSyntaxHighlighterChanged -> True
+        AppHistoryLiveStarted -> True
+        AppConversationReflow -> True
+        AppSyncSubmittedImagePlacements -> True
+        AppMotionTick -> True
+        AppRecapPoll -> True
+        _ -> False
+
+    uiEventMaySkipUnfocusedRedraw = \case
+        UiLoop loopEvent ->
+            loopEventMaySkipUnfocusedRedraw loopEvent
+        _ -> False
+
+    loopEventMaySkipUnfocusedRedraw = \case
+        TextDelta{} -> True
+        ReasoningDelta{} -> True
+        ActivityUpdated{} -> True
+        ToolUpdated{} -> True
+        ToolOutputUpdated{} -> True
+        NativeAgentOutput{} -> True
+        _ -> False
+
+    agentStructureRequiresUnfocusedRedraw previous next =
+        previous.appAgentSelected /= next.appAgentSelected
+            || agentChromeSignature previous.appAgentEntries
+                /= agentChromeSignature next.appAgentEntries
+
+    -- Snapshot steps and conversations can update at streaming cadence. The
+    -- sorted chrome fields change only for low-rate lifecycle/layout updates.
+    agentChromeSignature entries =
+        sortOn id
+            [ ( entry.agentTarget
+              , entry.agentPath
+              , entry.agentStatus
+              , entry.agentModel
+              )
+            | entry <- entries
+            ]
+
+    terminalInteractionImpliesFocus = \case
+        MouseDown{} -> True
+        MouseUp _ (Just _) _ -> True
+        VtyEvent V.EvKey{} -> True
+        VtyEvent V.EvMouseDown{} -> True
+        VtyEvent (V.EvMouseUp _ _ (Just _)) -> True
+        VtyEvent V.EvPaste{} -> True
         _ -> False
 
     isMotionTick = \case
@@ -419,6 +509,7 @@ handleEventInner event = case event of
     AppEvent (AppHistoryReset page) -> do
         modify' (resetHistoryPage page)
         invalidateCache
+        resolveConversationFollow
         queueConversationReflow
     AppEvent (AppHistoryLoaded request result) -> do
         state <- get

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -81,6 +81,7 @@ import Brick
     , VScrollbarRenderer(..)
     , Widget
     , customMain
+    , halt
     , hLimit
     , renderWidget
     , txt
@@ -773,6 +774,11 @@ spec = do
                 (replacementLeavesDurableTailVisible ReplaceWhileHidden)
                 `shouldReturn` Just True
 
+        it "shows the durable tail without relying on a focus-gained event" do
+            timeout 2_000_000
+                (replacementLeavesDurableTailVisible ReplaceWhileHiddenNoFocus)
+                `shouldReturn` Just True
+
     describe "motion demand" do
         it "distinguishes foreground, waiting, background, and static modes" do
             let idle =
@@ -1100,10 +1106,12 @@ spec = do
 data FullscreenScriptEvent
     = FullscreenScriptApp !AppEvent
     | FullscreenScriptVty !V.Event
+    | FullscreenScriptHalt
 
 data ReplacementScenario
     = ReplaceWhileFocused
     | ReplaceWhileHidden
+    | ReplaceWhileHiddenNoFocus
 
 replacementLeavesDurableTailVisible :: ReplacementScenario -> IO Bool
 replacementLeavesDurableTailVisible scenario = do
@@ -1155,6 +1163,8 @@ replacementLeavesDurableTailVisible scenario = do
                     fullscreenApp.appHandleEvent (AppEvent event)
                 AppEvent (FullscreenScriptVty event) ->
                     fullscreenApp.appHandleEvent (VtyEvent event)
+                AppEvent FullscreenScriptHalt ->
+                    halt
                 VtyEvent event ->
                     fullscreenApp.appHandleEvent (VtyEvent event)
                 MouseDown name button modifiers location ->
@@ -1193,6 +1203,14 @@ replacementLeavesDurableTailVisible scenario = do
                 , FullscreenScriptApp AppConversationReflow
                 , FullscreenScriptVty V.EvGainedFocus
                 , FullscreenScriptApp AppStop
+                ]
+            ReplaceWhileHiddenNoFocus ->
+                [ FullscreenScriptVty V.EvLostFocus
+                , commit
+                -- Some terminal tabs omit focus gain; the durable replacement
+                -- must still reach the terminal's backing screen.
+                , FullscreenScriptApp AppConversationReflow
+                , FullscreenScriptHalt
                 ]
     mapM_ (writeBChan events) script
 

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -56,6 +56,7 @@ import Agent.CLI.TUI.App
 import Agent.CLI.WindowTitle (oscWindowTitleBytes)
 import Agent.CLI.TUI.Types
     ( AppEvent(..)
+    , AppState
     , ChoiceOverlay(..)
     , ChoicePresentation(..)
     , FullscreenRuntime(..)
@@ -67,7 +68,9 @@ import Agent.CLI.TUI.Types
     )
 import Agent.CLI.TUI.History
     ( HistoryCursor(..)
+    , HistoryDirection(..)
     , HistoryGeneration(..)
+    , HistoryPage(..)
     , HistoryTurn(..)
     )
 import Agent.CLI.Terminal
@@ -102,7 +105,12 @@ import Agent.TUI.Presentation
     , TodoDisplayStatus(..)
     )
 import Agent.TUI.Motion
-import Control.Concurrent.STM (atomically, newTChanIO, retry)
+import Control.Concurrent.STM
+    ( atomically
+    , newEmptyTMVarIO
+    , newTChanIO
+    , retry
+    )
 import qualified Data.ByteString as ByteString
 import Data.Foldable (find, toList)
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
@@ -779,6 +787,35 @@ spec = do
                 (replacementLeavesDurableTailVisible ReplaceWhileHiddenNoFocus)
                 `shouldReturn` Just True
 
+    describe "unfocused terminal recovery" do
+        it "treats paste input as proof that focus returned" do
+            timeout 2_000_000 unfocusedPasteRendersDraft
+                `shouldReturn` Just True
+
+        it "renders a blocking text prompt without a focus-gained event" do
+            timeout 2_000_000 unfocusedTextPromptIsVisible
+                `shouldReturn` Just True
+
+        it "renders a submitted prompt without a focus-gained event" do
+            timeout 2_000_000 unfocusedSubmissionIsVisible
+                `shouldReturn` Just True
+
+        it "renders reset durable history without a focus-gained event" do
+            timeout 2_000_000 unfocusedHistoryResetIsVisible
+                `shouldReturn` Just True
+
+        it "halts when the worker stops while unfocused" do
+            timeout 2_000_000 unfocusedStopHalts
+                `shouldReturn` Just ()
+
+        it "runs a suspension requested while unfocused" do
+            timeout 2_000_000 unfocusedSuspendRuns
+                `shouldReturn` Just True
+
+        it "keeps high-frequency streaming redraws throttled" do
+            timeout 2_000_000 unfocusedStreamingRemainsThrottled
+                `shouldReturn` Just True
+
     describe "motion demand" do
         it "distinguishes foreground, waiting, background, and static modes" do
             let idle =
@@ -1115,23 +1152,9 @@ data ReplacementScenario
 
 replacementLeavesDurableTailVisible :: ReplacementScenario -> IO Bool
 replacementLeavesDurableTailVisible scenario = do
-    input <- newFullscreenInputBuffer
     let liveTranscript =
             Text.unlines (replicate 200 "live transcript line")
-    runtime <- newFullscreenRuntime
-        input
-        (pure ())
-        (const (pure ()))
-        (pure WarnExit)
-        (const (pure True))
-        (const (pure ()))
-        (const (pure ()))
-        (pure (AgentRoot, []))
-        (const (pure ()))
-        (pure ())
-        (const (pure ()))
-        MotionFull
-        False
+    runtime <- newScriptRuntime
         (initialUiState { uiFollow = True })
     let
         durableTail = "FINAL DURABLE ANSWER"
@@ -1155,31 +1178,9 @@ replacementLeavesDurableTailVisible scenario = do
             }
         initialState =
             initialFullscreenAppState runtime [] AgentRoot [] 0
-        scriptedApp = App
-            { appDraw = fullscreenApp.appDraw
-            , appChooseCursor = fullscreenApp.appChooseCursor
-            , appHandleEvent = \case
-                AppEvent (FullscreenScriptApp event) ->
-                    fullscreenApp.appHandleEvent (AppEvent event)
-                AppEvent (FullscreenScriptVty event) ->
-                    fullscreenApp.appHandleEvent (VtyEvent event)
-                AppEvent FullscreenScriptHalt ->
-                    halt
-                VtyEvent event ->
-                    fullscreenApp.appHandleEvent (VtyEvent event)
-                MouseDown name button modifiers location ->
-                    fullscreenApp.appHandleEvent
-                        (MouseDown name button modifiers location)
-                MouseUp name button location ->
-                    fullscreenApp.appHandleEvent
-                        (MouseUp name button location)
-            , appStartEvent = fullscreenApp.appStartEvent
-            , appAttrMap = fullscreenApp.appAttrMap
-            }
 
     -- A single custom-event channel makes each focus/history sequence
     -- deterministic while still running the real Brick event handler.
-    events <- newBChan 8
     let commit = FullscreenScriptApp
             (AppHistoryCommitted
                 (HistoryGeneration 0)
@@ -1212,8 +1213,187 @@ replacementLeavesDurableTailVisible scenario = do
                 , FullscreenScriptApp AppConversationReflow
                 , FullscreenScriptHalt
                 ]
-    mapM_ (writeBChan events) script
+    rendered <- runFullscreenScript initialState script
+    pure $ encoded durableTail `ByteString.isInfixOf` rendered
 
+unfocusedPasteRendersDraft :: IO Bool
+unfocusedPasteRendersDraft = do
+    runtime <- newScriptRuntime initialUiState
+    let marker = "IMPLICIT_FOCUS_DRAFT"
+        initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+        script =
+            [ FullscreenScriptVty V.EvLostFocus
+            , FullscreenScriptVty (V.EvPaste (encoded marker))
+            , FullscreenScriptHalt
+            ]
+    rendered <- runFullscreenScript initialState script
+    pure $ encoded marker `ByteString.isInfixOf` rendered
+
+unfocusedTextPromptIsVisible :: IO Bool
+unfocusedTextPromptIsVisible = do
+    runtime <- newScriptRuntime initialUiState
+    reply <- newEmptyTMVarIO
+    let marker = "HIDDEN_TEXT_PROMPT_MARKER"
+        initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+        script =
+            [ FullscreenScriptVty V.EvLostFocus
+            , FullscreenScriptApp
+                (AppAskText
+                    TextInputPlain
+                    "Hidden text prompt"
+                    marker
+                    ""
+                    reply)
+            , FullscreenScriptHalt
+            ]
+    rendered <- runFullscreenScript initialState script
+    pure $ encoded marker `ByteString.isInfixOf` rendered
+
+unfocusedSubmissionIsVisible :: IO Bool
+unfocusedSubmissionIsVisible = do
+    runtime <- newScriptRuntime initialUiState
+    let marker = "HIDDEN_SUBMITTED_PROMPT"
+        initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+        script =
+            [ FullscreenScriptVty V.EvLostFocus
+            , FullscreenScriptApp (AppUi (UiUserSubmitted marker))
+            , FullscreenScriptHalt
+            ]
+    rendered <- runFullscreenScript initialState script
+    pure $ encoded marker `ByteString.isInfixOf` rendered
+
+unfocusedHistoryResetIsVisible :: IO Bool
+unfocusedHistoryResetIsVisible = do
+    runtime <- newScriptRuntime (initialUiState { uiFollow = True })
+    let marker = "HIDDEN_RESET_HISTORY"
+        liveTranscript =
+            Text.unlines (replicate 200 "reset live transcript line")
+        generation = HistoryGeneration 1
+        cursor = HistoryCursor 0
+        durableTurn = HistoryTurn
+            { historyTurnCursor = cursor
+            , historyTurnBlocks =
+                Seq.singleton
+                    (markerBlock
+                        (BlockId 1001)
+                        (Text.unlines
+                            (replicate 35 "reset durable transcript line"
+                                <> [marker])))
+            }
+        page = HistoryPage
+            { historyPageGeneration = generation
+            , historyPageDirection = HistoryNewer
+            , historyPageTurns = Seq.singleton durableTurn
+            , historyPageGenerationStart = cursor
+            , historyPageTotalTurns = 1
+            , historyPageHasOlder = False
+            , historyPageHasNewer = False
+            }
+        initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+        script =
+            [ FullscreenScriptApp
+                (AppUi (UiAssistantHistory liveTranscript))
+            , FullscreenScriptVty V.EvLostFocus
+            , FullscreenScriptApp (AppHistoryReset page)
+            , FullscreenScriptApp AppConversationReflow
+            , FullscreenScriptHalt
+            ]
+    rendered <- runFullscreenScript initialState script
+    pure $ encoded marker `ByteString.isInfixOf` rendered
+
+unfocusedStopHalts :: IO ()
+unfocusedStopHalts = do
+    runtime <- newScriptRuntime initialUiState
+    let initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+    _ <- runFullscreenScript
+        initialState
+        [ FullscreenScriptVty V.EvLostFocus
+        , FullscreenScriptApp AppStop
+        ]
+    pure ()
+
+unfocusedSuspendRuns :: IO Bool
+unfocusedSuspendRuns = do
+    runtime <- newScriptRuntime initialUiState
+    actionRan <- newIORef False
+    reply <- newEmptyTMVarIO
+    let initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+    _ <- runFullscreenScript
+        initialState
+        [ FullscreenScriptVty V.EvLostFocus
+        , FullscreenScriptApp
+            (AppSuspend (writeIORef actionRan True) reply)
+        , FullscreenScriptApp AppStop
+        ]
+    readIORef actionRan
+
+unfocusedStreamingRemainsThrottled :: IO Bool
+unfocusedStreamingRemainsThrottled = do
+    runtime <- newScriptRuntime initialUiState
+    let marker = "HIDDEN_STREAMING_DELTA"
+        initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+        script =
+            [ FullscreenScriptVty V.EvLostFocus
+            , FullscreenScriptApp (AppUi (UiLoop (TextDelta marker)))
+            , FullscreenScriptHalt
+            ]
+    rendered <- runFullscreenScript initialState script
+    pure $ not (encoded marker `ByteString.isInfixOf` rendered)
+
+newScriptRuntime :: UiState -> IO FullscreenRuntime
+newScriptRuntime ui = do
+    input <- newFullscreenInputBuffer
+    newFullscreenRuntime
+        input
+        (pure ())
+        (const (pure ()))
+        (pure WarnExit)
+        (const (pure True))
+        (const (pure ()))
+        (const (pure ()))
+        (pure (AgentRoot, []))
+        (const (pure ()))
+        (pure ())
+        (const (pure ()))
+        MotionFull
+        False
+        ui
+
+runFullscreenScript
+    :: AppState
+    -> [FullscreenScriptEvent]
+    -> IO ByteString.ByteString
+runFullscreenScript initialState script = do
+    let scriptedApp = App
+            { appDraw = fullscreenApp.appDraw
+            , appChooseCursor = fullscreenApp.appChooseCursor
+            , appHandleEvent = \case
+                AppEvent (FullscreenScriptApp event) ->
+                    fullscreenApp.appHandleEvent (AppEvent event)
+                AppEvent (FullscreenScriptVty event) ->
+                    fullscreenApp.appHandleEvent (VtyEvent event)
+                AppEvent FullscreenScriptHalt ->
+                    halt
+                VtyEvent event ->
+                    fullscreenApp.appHandleEvent (VtyEvent event)
+                MouseDown name button modifiers location ->
+                    fullscreenApp.appHandleEvent
+                        (MouseDown name button modifiers location)
+                MouseUp name button location ->
+                    fullscreenApp.appHandleEvent
+                        (MouseUp name button location)
+            , appStartEvent = fullscreenApp.appStartEvent
+            , appAttrMap = fullscreenApp.appAttrMap
+            }
+    events <- newBChan (max 1 (length script))
+    mapM_ (writeBChan events) script
     let bounds = (80, 24)
     (_, mockOutput) <- VMock.mockTerminal bounds
     outputBytes <- newIORef ByteString.empty
@@ -1239,8 +1419,23 @@ replacementLeavesDurableTailVisible scenario = do
             , V.isShutdown = pure False
             }
     _ <- customMain vty (pure vty) (Just events) scriptedApp initialState
-    rendered <- readIORef outputBytes
-    pure $ TextEncoding.encodeUtf8 durableTail `ByteString.isInfixOf` rendered
+    readIORef outputBytes
+
+markerBlock :: BlockId -> Text -> UiBlock
+markerBlock blockId body = UiBlock
+    { blockId
+    , blockKind = BlockAssistant
+    , blockTitle = "Assistant"
+    , blockBody = body
+    , blockTimestamp = ""
+    , blockDetail = ""
+    , blockState = BlockComplete
+    , blockExpanded = False
+    , blockCallId = Nothing
+    }
+
+encoded :: Text -> ByteString.ByteString
+encoded = TextEncoding.encodeUtf8
 
 mockVty :: V.Output -> IO () -> IO Bool -> IO V.Vty
 mockVty output shutdownAction isShutdownAction = do


### PR DESCRIPTION
## Summary

- repaint durable and other low-rate semantic state changes while the terminal is unfocused
- recover terminal focus from real key, paste, and button-pointer input when a tab omits `EvGainedFocus`
- make hidden redraw suppression opt-in for known high-frequency events instead of suppressing unknown events by default
- preserve throttling for streaming deltas, activity updates, motion, reflow, and unchanged agent snapshots
- add real Brick/Vty regressions for hidden-tab history, input, blocking overlays, lifecycle actions, and streaming throttling

## Root cause

The fullscreen handler applied `continueWithoutRedraw` after almost every event while `TerminalUnfocused`. Some terminal tab transitions omit or delay `EvGainedFocus`, so the terminal backing screen could remain indefinitely stale.

The audit found that this was broader than durable history replacement:

- submitted prompts could update state after focus loss without being painted;
- permission/choice/text/resume requests could install a blocking overlay that remained invisible;
- `AppHistoryReset` and async history loads could replace visible history without updating the backing screen;
- subsequent key/paste/mouse input could mutate state invisibly because the app still believed it was unfocused;
- a trailing `continueWithoutRedraw` could overwrite Brick lifecycle/control actions such as a hidden `AppStop` halt;
- native-image placement and low-rate agent chrome changes could remain stale.

The new policy only suppresses events explicitly classified as safe high-frequency/cosmetic updates. Unknown, blocking, structural, and lifecycle events therefore get one frame by default. Agent streaming content and ordinary deltas remain throttled, while lifecycle/status changes, image revision changes, user-action transitions, and completed turns bypass the throttle.

`AppHistoryReset` also reapplies the retained follow policy so replacing long content with a shorter durable page cannot leave Brick's viewport beyond the new tail. Intentional paused scrollback remains preserved.

## Validation

- Red baseline for the new recovery group: **0/5 passed** before the broader fix; four markers were absent and hidden `AppStop` timed out.
- Focused real Brick/Vty tests after the fix:
  - `history replacement viewport`: **3/3 passed**
  - `unfocused terminal recovery`: **7/7 passed**
- Complete CLI suite with a short PostgreSQL socket root:
  - `TMPDIR=/tmp HASKELL_AGENT_TMPDIR=/tmp cabal test agent-cli-test`
  - **1,177 examples, 0 failures, 1 pending**
- GHCi: all **194** `agent-cli` modules loaded and reloaded successfully.
- Live fullscreen agent in isolated tmux:
  - injected focus loss without any focus-gained event;
  - typed a draft through the real TTY path;
  - draft repainted immediately via implicit focus recovery.
- `git diff --check origin/master...HEAD`

The previous CI failure was unrelated to this patch: compilation completed, then `agent-cli-functional-xai-hello-world` failed because no xAI account had verified available usage.
