### PR TITLE
Stream reasoning summaries through the native bridge

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -803,6 +803,12 @@ finishTurnEvent callback context turnId = \case
 
 nativeLoopEvent :: Text -> LoopEvent -> Maybe Aeson.Value
 nativeLoopEvent turnId = \case
+    ReasoningDelta text ->
+        Just $ Aeson.object
+            [ "event" Aeson..= ("turn.reasoning_delta" :: Text)
+            , "turnId" Aeson..= turnId
+            , "text" Aeson..= text
+            ]
     TextDelta text ->
         Just $ Aeson.object
             [ "event" Aeson..= ("turn.text_delta" :: Text)


### PR DESCRIPTION
## Summary
- forward provider reasoning-summary deltas through the macOS native event bridge
- emit additive `turn.reasoning_delta` events with the active turn ID

## Validation
- built as part of the coordinated macOS app derivation with the sibling checkout override
- `git diff --check`