### PR TITLE
Notify on fullscreen permission requests

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -141,6 +141,10 @@ import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Monad (forever, unless, void, when, (>=>))
 import Control.Concurrent.STM ( STM , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
+import Agent.CLI.Notification
+    ( AttentionRequest(PermissionRequested)
+    , notifyAttention
+    )
 import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoRecapRetryInterval )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
@@ -168,7 +172,7 @@ import qualified Graphics.Vty as V
 import qualified Graphics.Vty.CrossPlatform as Vty
 import System.Environment (lookupEnv)
 import System.Info (os)
-import System.IO (stdout)
+import System.IO (stderr, stdout)
 import System.Posix.Process (getProcessID)
 import System.Process (callProcess)
 
@@ -803,6 +807,7 @@ requestFullscreenPermission
 requestFullscreenPermission runtime workspace call = do
     reply <- newEmptyTMVarIO
     let summary = permissionToolCallPromptRelative workspace call
+    notifyAttention stderr PermissionRequested
     enqueueAppEvent runtime (AppAskPermission summary reply)
     atomically (readTMVar reply)
 


### PR DESCRIPTION
## Summary
- emit the existing OSC 9 permission notification before fullscreen approval prompts
- cover folder-access requests and other tool approvals in the fullscreen TUI

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli`
- `nix develop -c cabal test agent-cli-test --test-options="--match attentionNotificationSequence"`
- live agent startup and prompt smoke-tested in tmux