### PR TITLE
Cancel in-flight tools with agent turns

### DIFF
--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -831,26 +831,31 @@ runToolCalls config calls = do
                     (\scheduled ->
                         IntSet.notMember scheduled.index readyIndexes)
                     remaining
-        batchResults <-
-            mapConcurrently
+        raced <- race
+            (waitCancel config.loopCancel)
+            (mapConcurrently
                 (\scheduled -> do
                     result <-
                         runPreparedToolCall config scheduled.prepared
                     pure (fmap (\value -> (scheduled.index, value)) result))
-                ready
-        let completed' =
-                foldr
-                    (\result acc ->
-                        maybe
-                            acc
-                            (\(index, value) -> IntMap.insert index value acc)
-                            result)
-                    completed
-                    batchResults
-        cancelled <- isCancelled config.loopCancel
-        if cancelled
-            then pure (IntMap.elems completed')
-            else go pending completed'
+                ready)
+        case raced of
+            Left () ->
+                -- 'race' cancels and joins the structured concurrent batch,
+                -- so no tool handler survives the cancelled turn.
+                pure (IntMap.elems completed)
+            Right batchResults -> do
+                let completed' =
+                        foldr
+                            (\result acc ->
+                                maybe
+                                    acc
+                                    (\(index, value) ->
+                                        IntMap.insert index value acc)
+                                    result)
+                            completed
+                            batchResults
+                go pending completed'
 
 data IndexedPreparedToolCall = IndexedPreparedToolCall
     { index :: !Int

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
@@ -207,25 +207,35 @@ execCodeCellWithTools host source tools yieldMs = do
                                 then do
                                     stopCell cell
                                     pure (Left (activeCellLimitError host))
-                                else do
-                                    sent <- try @_ @SomeException $ sendLine cell $
-                                        encodeExecRequestWithStateAndImageDetail
-                                            "exec"
-                                            source
-                                            tools
-                                            storedValues
-                                            (host.hostConfig.imageDetailVisibility
-                                                == ImageDetailVisible)
-                                    case sent of
-                                        Left err -> do
-                                            void $ takeCell host identifier
-                                            stopCell cell
-                                            pure $ Left $ CodeModeProtocolError $
-                                                "failed to send execution request: "
-                                                    <> Text.pack
-                                                        (displayException err)
-                                        Right () ->
-                                            observeCell host cell yieldMs
+                                else
+                                    (do
+                                        sent <- try @_ @SomeException $ sendLine cell $
+                                            encodeExecRequestWithStateAndImageDetail
+                                                "exec"
+                                                source
+                                                tools
+                                                storedValues
+                                                (host.hostConfig.imageDetailVisibility
+                                                    == ImageDetailVisible)
+                                        case sent of
+                                            Left err -> do
+                                                void $ takeCell host identifier
+                                                stopCell cell
+                                                pure $ Left $ CodeModeProtocolError $
+                                                    "failed to send execution request: "
+                                                        <> Text.pack
+                                                            (displayException err)
+                                            Right () ->
+                                                observeCell host cell yieldMs)
+                                        `onException` abortCell host cell
+
+abortCell :: CodeModeHost -> Cell -> IO ()
+abortCell host cell =
+    takeCell host cell.cellIdentifier >>= \case
+        Nothing -> pure ()
+        Just ownedCell -> do
+            markCellClosed ownedCell
+            stopCell ownedCell
 
 activeCellLimit :: CodeModeHost -> Int
 activeCellLimit host = max 1 host.hostConfig.maxActiveCells

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1155,7 +1155,9 @@ spec = describe "runLoop" do
             ]
 
 
-    it "returns LoopCancelled when the cancel flag is set during tools" do
+    it "cancels an in-flight tool when the cancel flag is set" do
+        started <- newEmptyMVar
+        stopped <- newEmptyMVar
         submissions <- newIORef []
         backend <- scriptedBackend submissions
             [ Right $ emptyTurnOutput "resp-1"
@@ -1167,16 +1169,19 @@ spec = describe "runLoop" do
                 LoopConfig{loopCancel = c} -> c
             handlers =
                 [ noArgsTool "slow" do
-                    requestCancel cancel
-                    threadDelay 10000
-                    pure (Right "should-not-continue")
+                    Exception.finally
+                        (putMVar started ()
+                            >> threadDelay maxBound
+                            >> pure (Right "should-not-continue"))
+                        (putMVar stopped ())
                 ]
             config = config0 { loopTools = registryFromHandlers handlers }
-        result <- runLoop config Nothing "go"
-        case result of
-            Left (LoopCancelled results) ->
-                results `shouldNotBe` []
-            other -> expectationFailure ("expected LoopCancelled, got " <> show other)
+        withAsync (runLoop config Nothing "go") \running -> do
+            takeMVar started
+            requestCancel cancel
+            timeout 1000000 (wait running)
+                `shouldReturn` Just (Left (LoopCancelled []))
+            tryReadMVar stopped `shouldReturn` Just ()
 
     it "does not render a rejected tool when approval cancels the turn" do
         events <- newIORef []

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -27,8 +27,8 @@ import Control.Concurrent
     , readMVar
     , threadDelay
     )
-import Control.Concurrent.Async (async, wait)
-import Control.Exception.Safe (bracket)
+import Control.Concurrent.Async (async, cancel, wait, withAsync)
+import Control.Exception.Safe (bracket, finally)
 import Data.Aeson (Value(..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -38,6 +38,7 @@ import qualified Data.Text as Text
 import Data.Time.Clock (diffUTCTime, getCurrentTime)
 import System.Directory (doesFileExist)
 import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -125,6 +126,31 @@ spec = describe "code-mode Bun host" do
                         ]
                     ]
                 }
+
+    it "stops a cell and its nested tool when execution is cancelled" do
+        started <- newEmptyMVar
+        stopped <- newEmptyMVar
+        let handler _ _ =
+                finally
+                    (putMVar started () >> threadDelay maxBound >> pure (Right Null))
+                    (putMVar stopped ())
+            config = defaultCodeModeConfig
+                "data/code-mode/worker.mjs"
+                handler
+        host <- newCodeModeHost config
+        withAsync
+            (execCodeCell
+                host
+                "await tools.slow({});"
+                ["slow"]
+                60000)
+            \running -> do
+                readMVar started
+                cancel running
+                timeout 1000000 (readMVar stopped) `shouldReturn` Just ()
+                terminateCodeCell host "1" `shouldReturn`
+                    Left (CodeModeUnknownCell "1")
+        closeCodeModeHost host
 
     it "keeps JavaScript globals isolated when reusing a pooled worker" do
         let config = defaultCodeModeConfig


### PR DESCRIPTION
## Summary
- race active tool batches against turn cancellation so blocked handlers are interrupted and joined
- abort code-mode cells on cancellation, including nested calls such as `collaboration.wait_agent`
- add regressions proving both generic handlers and nested code-mode tools are stopped

## Testing
- `nix develop -c cabal repl agent-core:test:agent-core-test`
  - `:main --match "runLoop"` (58 examples, 0 failures)
  - `:main --match "code-mode Bun host"` (29 examples, 0 failures)
  - focused cancellation tests rerun after final cleanup (2 examples, 0 failures)
- `git diff --check`
