### PR TITLE
Fix code mode freeform tool arguments

### DIFF
--- a/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
@@ -282,27 +282,34 @@ runNestedTool invoke nextInvocation nested codeName arguments =
     case Map.lookup codeName nested of
         Nothing -> pure (Left
             ("tool is not available in this cell: " <> codeName))
-        Just tool -> do
-            invocation <- atomicModifyIORef' nextInvocation
-                \current ->
-                    let next = current + 1
-                    in (next, next)
-            let call = ToolCall
-                    { callId =
-                        "code-mode:"
-                            <> Text.pack (show invocation)
-                            <> ":"
-                            <> codeName
-                    , name = tool.nestedRuntimeName
-                    , arguments =
-                        TextEncoding.decodeUtf8 . LBS.toStrict $
-                            encode arguments
-                    , callKind = tool.nestedCallKind
-                    , argumentsEncrypted = False
-                    }
-            invoke call >>= \case
-                Left err -> pure (Left err)
-                Right output -> pure (Right (String output))
+        Just tool -> either (pure . Left) (invokeTool tool)
+            (nestedToolArguments tool.nestedCallKind arguments)
+  where
+    invokeTool :: NestedTool -> Text -> IO (Either Text Value)
+    invokeTool tool callArguments = do
+        invocation <- atomicModifyIORef' nextInvocation
+            \current ->
+                let next = current + 1
+                in (next, next)
+        result <- invoke ToolCall
+            { callId =
+                "code-mode:"
+                    <> Text.pack (show invocation)
+                    <> ":"
+                    <> codeName
+            , name = tool.nestedRuntimeName
+            , arguments = callArguments
+            , callKind = tool.nestedCallKind
+            , argumentsEncrypted = False
+            }
+        pure (String <$> result)
+
+nestedToolArguments :: ToolCallKind -> Value -> Either Text Text
+nestedToolArguments CustomCallKind = \case
+    String input -> Right input
+    _ -> Left "freeform tool calls require a string input"
+nestedToolArguments _ =
+    Right . TextEncoding.decodeUtf8 . LBS.toStrict . encode
 
 newtype ExecArgs = ExecArgs { source :: Text }
 

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -5,10 +5,12 @@ import qualified Agent.Json.Decode as Json
 import Agent.ToolArgs (objectArgsExact, reqInt)
 import Agent.ToolDispatch
     ( ToolCall(..)
+    , ToolCallKind(..)
     , ToolCallResult(..)
     , ToolHandler
     , customToolCall
     , dispatchToolCall
+    , textTool
     , typedTool
     )
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
@@ -19,6 +21,7 @@ import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
     , ToolExecutionPolicy(..)
+    , freeformApplyPatchAppToolWithExecution
     , jsonAppToolWithExecution
     )
 import Control.Concurrent
@@ -595,6 +598,41 @@ spec = describe "code-mode Bun host" do
             "text(await tools.double({\"value\": 21}));"
         result `shouldSatisfy` Text.isInfixOf "42"
         readIORef approvals `shouldReturn` 1
+        toolSet.closeCodeModeToolSet
+
+    it "passes freeform nested tool input without JSON encoding" do
+        received <- newIORef Nothing
+        worker <- codeModeWorkerPath
+        let patch = "*** Begin Patch\n*** End Patch"
+            patchTool = freeformApplyPatchAppToolWithExecution
+                "apply_patch"
+                "Apply a patch."
+                AlwaysReadOnly
+                TurnSequential
+                (textTool "apply_patch" \input -> do
+                    writeIORef received (Just input)
+                    pure (Right "applied"))
+            invoke call = do
+                call.callKind `shouldBe` CustomCallKind
+                result <- dispatchToolCall
+                    defaultLoopDispatch
+                    [toolHandlerOf patchTool]
+                    call
+                pure (Right result.output)
+        created <- newCodeModeToolSet
+            CodeOnlyToolMode
+            ImageDetailVisible
+            worker
+            invoke
+            [plainNested patchTool]
+        toolSet <- either
+            (\err -> expectationFailure (show err) >> fail "unreachable")
+            pure
+            created
+        result <- runRegisteredExec toolSet
+            "text(await tools.apply_patch(\"*** Begin Patch\\n*** End Patch\"));"
+        result `shouldSatisfy` Text.isInfixOf "applied"
+        readIORef received `shouldReturn` Just patch
         toolSet.closeCodeModeToolSet
 
     it "expands nested declarations only in code-only mode" do


### PR DESCRIPTION
## Summary
- preserve raw string arguments when code mode invokes custom/freeform tools
- retain JSON encoding for ordinary function tools
- reject non-string inputs for freeform nested calls
- add an end-to-end regression test covering `exec` to `apply_patch` dispatch

## Root cause
The nested code-mode bridge JSON-encoded every tool argument. For a freeform tool, this turned patch text into a quoted JSON string, so `apply_patch` saw `"*** Begin Patch..."` instead of a patch beginning with `*** Begin Patch`.

## Testing
- `nix develop -c cabal test agent-core:agent-core-test` (483 examples, 0 failures)
- `git diff --check`
