### PR TITLE
Add show_image tool for inline image display in the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ The built-in `ask_secret` tool reads secrets through a masked prompt and gives
 the model only a private temporary-file path, keeping values out of chat and
 tool arguments. Files are removed when the tool runtime closes.
 
+### Inline images
+
+The built-in `show_image` tool displays an image file (PNG, JPEG, GIF, BMP,
+TIFF) inline in the conversation next to the tool call: Kitty, Ghostty,
+WezTerm, and iTerm2 draw the bitmap natively, other terminals get a
+true-colour text approximation. The image is shown to the user only; it is
+not added to the model context.
+
 ## Ideas and direction
 
 Why an independent harness matters, why code and Haskell are useful

--- a/packages/agent-cli/src/Agent/CLI/Dialects.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dialects.hs
@@ -55,6 +55,7 @@ import Agent.Tools.Secret
     , closeSecretStore
     , newSecretStore
     )
+import Agent.Tools.ShowImage (ImageDisplayHooks, showImageTool)
 import Agent.Tools.Types (AppTool(..), ToolEnv(..))
 import Control.Exception.Safe (finally, onException)
 import Data.IORef (newIORef)
@@ -85,23 +86,28 @@ codingToolsFor
     -> ToolEnv
     -> Maybe PlanModeHooks
     -> Maybe SecretPromptHooks
+    -> Maybe ImageDisplayHooks
     -> Maybe MultiAgentContext
     -> IO CodingTools
-codingToolsFor dialect env planHooks secretHooks multi = do
+codingToolsFor dialect env planHooks secretHooks imageHooks multi = do
     typesRef <- newIORef Map.empty
     codingToolsForWithTypes
-        dialect env planHooks secretHooks multi typesRef
+        dialect env planHooks secretHooks imageHooks multi typesRef
 
+-- | Host-presented tools (@ask_secret@, @show_image@) are registered only
+-- when the host supplies the matching hooks, so headless and child sessions
+-- never advertise capabilities they cannot fulfil.
 codingToolsForWithTypes
     :: Dialect
     -> ToolEnv
     -> Maybe PlanModeHooks
     -> Maybe SecretPromptHooks
+    -> Maybe ImageDisplayHooks
     -> Maybe MultiAgentContext
     -> GrokSubagentSpecs
     -> IO CodingTools
 codingToolsForWithTypes
-        dialect env planHooks secretHooks multi typesRef = do
+        dialect env planHooks secretHooks imageHooks multi typesRef = do
     secretStore <- traverse (newSecretStore env) secretHooks
     let closeSecrets = mapM_ closeSecretStore secretStore
         analysisSpawner =
@@ -128,6 +134,7 @@ codingToolsForWithTypes
                             (Just "none")
                 _ -> Nothing
         secretTools = maybe [] (pure . askSecretTool) secretStore
+        imageTools = maybe [] (pure . showImageTool env) imageHooks
         finish tools includeArtifacts plan suspendGhci close agentTypes grokRuntime =
             CodingTools
                 { codingAppTools =
@@ -136,6 +143,7 @@ codingToolsForWithTypes
                             then artifactTools env analysisSpawner
                             else [])
                         <> secretTools
+                        <> imageTools
                 , codingPlanMode = plan
                 , codingSuspendGhci = suspendGhci
                 , codingClose = close `finally` closeSecrets

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Prompt
     , codexEnvironmentContext
     , mcpInstructionsGuidance
     , secretInputGuidance
+    , imageDisplayGuidance
     , subscriptionSubagentModelGuidance
     , sessionTempGuidance
     , systemPrompt
@@ -96,6 +97,7 @@ systemPromptForTools
             [ base
             , sessionTempGuidance sessionTmp
             , secretInputGuidance available
+            , imageDisplayGuidance available
             , learnedSkillGuidance available
             , ghciGuidanceForTools dialect available
             , timeContextGuidance
@@ -141,6 +143,7 @@ systemPromptForCatalogModel dialect info toolNames sessionTmp =
                 (renderModelInstructions ModelPersonalityDefault info)
             , sessionTempGuidance sessionTmp
             , secretInputGuidance available
+            , imageDisplayGuidance available
             , learnedSkillGuidance available
             , ghciGuidanceForTools dialect available
             , timeContextGuidance
@@ -204,6 +207,18 @@ secretInputGuidance available
             , "- Use ask_secret to request sensitive values. It returns a private temporary file path, never the secret value."
             , "- Pass that path to a consumer that supports file input and delete the file promptly after use."
             , "- Never read, print, summarize, or otherwise expose the secret file contents."
+            ]
+
+-- | Point the model at inline image display when the host can present one.
+imageDisplayGuidance :: Set Text -> Text
+imageDisplayGuidance available
+    | "show_image" `Set.notMember` available = ""
+    | otherwise =
+        Text.unlines
+            [ "Image display:"
+            , "- Use show_image to present an image file (PNG, JPEG, GIF, BMP, TIFF) inline to the user, for example screenshots, rendered previews, charts, or icons."
+            , "- Convert other formats such as SVG or PDF to PNG first."
+            , "- The user sees the image; it is not added to your own context."
             ]
 
 -- | Natural-language guidance advertised by MCP servers, appended verbatim

--- a/packages/agent-cli/src/Agent/CLI/PromptHooks.hs
+++ b/packages/agent-cli/src/Agent/CLI/PromptHooks.hs
@@ -1,6 +1,8 @@
--- | Adapt plan-mode and secret prompts to the currently active fullscreen UI.
+-- | Adapt plan-mode, secret, and image-display hooks to the currently active
+-- fullscreen UI.
 module Agent.CLI.PromptHooks
-    ( fullscreenAwarePlanHooks
+    ( fullscreenAwareImageHooks
+    , fullscreenAwarePlanHooks
     , fullscreenAwareSecretHooks
     ) where
 
@@ -10,6 +12,7 @@ import Agent.CLI.TUI.App
     , requestFullscreenChoiceWithBody
     , requestFullscreenSecret
     , requestFullscreenText
+    , showFullscreenToolImage
     )
 import Agent.Tools.PlanMode
     ( PlanDecision(..)
@@ -18,6 +21,10 @@ import Agent.Tools.PlanMode
 import Agent.Tools.Secret
     ( SecretPrompt(..)
     , SecretPromptHooks(..)
+    )
+import Agent.Tools.ShowImage
+    ( ImageDisplayHooks(..)
+    , ImageDisplayRequest(..)
     )
 import Data.IORef (IORef, readIORef)
 import Data.Maybe (fromMaybe)
@@ -101,6 +108,22 @@ fullscreenAwareSecretHooks runtimeRef hooks =
                     runtime
                     "Secret requested by agent"
                     (secretRequestBody request)
+
+-- | Attach agent-displayed images to the fullscreen transcript while it is
+-- active; otherwise fall back to the plain-terminal presentation.
+fullscreenAwareImageHooks
+    :: IORef (Maybe FullscreenRuntime)
+    -> ImageDisplayHooks
+    -> ImageDisplayHooks
+fullscreenAwareImageHooks runtimeRef hooks =
+    ImageDisplayHooks \request ->
+        withCurrentFullscreen runtimeRef
+            (hooks.showImage request)
+            \runtime ->
+                showFullscreenToolImage
+                    runtime
+                    request.displayCallId
+                    request.displayImage
 
 secretRequestBody :: SecretPrompt -> Text
 secretRequestBody request =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -80,7 +80,7 @@ import Agent.CLI.Plan
 import Agent.CLI.Project ( saveRememberedModel )
 import Agent.CLI.Prompt ( subscriptionSubagentModelGuidance )
 import Agent.CLI.PromptHooks
-    ( fullscreenAwarePlanHooks, fullscreenAwareSecretHooks )
+    ( fullscreenAwareImageHooks, fullscreenAwarePlanHooks, fullscreenAwareSecretHooks )
 import Agent.CLI.Provider.OpenAI ()
 import Agent.CLI.Provider.Switch ()
 import Agent.CLI.ProviderAvailability ()
@@ -118,13 +118,14 @@ import Agent.CLI.Session
       SessionMeta(metaId, metaTransportModel, metaProvider,
                   metaConnection, metaModel, metaDialect, metaEffort),
       SessionTurn(turnAssistantText) )
-import Agent.CLI.Session.Attachments ()
+import Agent.CLI.Session.Attachments ( putImagePreview )
 import Agent.CLI.Session.Choices ()
 import Agent.CLI.Session.History ()
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
     ( StartupRuntime(startupFullscreen, startupBackground,
-                     startupFinished, startupDatabaseStore) )
+                     startupFinished, startupDatabaseStore,
+                     startupSessionState) )
 import Agent.CLI.Session.Selection
     ( currentSessionId, loadPrompt, reservedSessionId )
 import Agent.CLI.SessionAdmin ()
@@ -134,7 +135,7 @@ import Agent.CLI.SessionLock
       releaseSessionLock,
       sessionLockFilePath,
       sessionLockPath )
-import Agent.CLI.SessionState ()
+import Agent.CLI.SessionState ( SessionState(sessionPreviewId) )
 import Agent.CLI.SessionTitle ()
 import Agent.CLI.Skills ()
 import Agent.CLI.Startup.Auth
@@ -212,6 +213,8 @@ import Agent.Tools.PlanMode
       PlanDecision(PlanCancel) )
 import Agent.Tools.Secret
     ( SecretPrompt(..), SecretPromptHooks(..) )
+import Agent.Tools.ShowImage
+    ( ImageDisplayHooks(..), ImageDisplayRequest(..) )
 import Agent.Tools.Types ( setToolSessionTmp )
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ( (<|>) )
@@ -342,6 +345,19 @@ runAgentTools
             | isOneShot options || not isTty = Nothing
             | otherwise =
                 Just (fullscreenAwareSecretHooks uiRuntimeRef baseSecretHooks)
+        -- Outside the retained TUI, agent-displayed images print inline with
+        -- the same graphics path as pasted attachments.
+        baseImageHooks = ImageDisplayHooks \request -> do
+            color <- resolveColor stderrHandle
+            putImagePreview
+                startup.startupSessionState.sessionPreviewId
+                color
+                [request.displayImage]
+            pure (Right ())
+        imageHooks
+            | not isTty = Nothing
+            | otherwise =
+                Just (fullscreenAwareImageHooks uiRuntimeRef baseImageHooks)
         provider = loaded.loadedProvider
         fallbackModel =
             fromMaybe
@@ -687,6 +703,7 @@ runAgentTools
             toolEnv
             (Just planHooks)
             secretHooks
+            imageHooks
             multiCtx
             agentTypesRef
             `onException`

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -442,6 +442,7 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                         prepared.preparedToolEnv
                         (Just runtime.subagentPlanHooks)
                         Nothing
+                        Nothing
                         (Just prepared.preparedMultiContext)
                 syncStoreRootFromPlan
                     runtime.subagentStoreRoot
@@ -608,6 +609,7 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                         childDialect
                         prepared.preparedToolEnv
                         (Just runtime.subagentPlanHooks)
+                        Nothing
                         Nothing
                         (Just prepared.preparedMultiContext)
                 flip finally coding.codingClose do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -69,6 +69,8 @@ module Agent.CLI.TUI.App
     , withTrackedVtyBuilder
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle
+    , showFullscreenToolImage
+    , toolImageBlockId
     , applyStoredFullscreenWindowTitle
     , turnCompletionRequiresRedraw
     , syntaxLanguagesForBlocks

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -454,6 +454,24 @@ handleEventInner event = case event of
                 , appSubmittedImagePreviews = submitted
                 }
         queueConversationReflow
+    AppEvent (AppToolImage callId preview) -> do
+        state <- get
+        case toolImageBlockId callId state.appUi of
+            Nothing -> pure ()
+            Just blockId -> do
+                modify' \current ->
+                    current
+                        { appSubmittedImagePreviews =
+                            Map.insertWith
+                                (flip (<>))
+                                blockId
+                                [preview]
+                                current.appSubmittedImagePreviews
+                        }
+                -- Running tool bodies are cached while empty; the new image
+                -- section must not be served from that entry.
+                invalidateCache
+                queueConversationReflow
     AppEvent (AppDictationPartial text) -> do
         state <- get
         when (isJust state.appDictation) $

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -660,3 +660,34 @@ conversationBlocks target state =
             maybe [] (toList . (.uiBlocks)) (conversationUiForTarget target state)
         AgentNative _ ->
             maybe [] (toList . (.uiBlocks)) (conversationUiForTarget target state)
+
+-- | Resolve the transcript block that carries an agent-displayed image.
+-- Nested code-mode calls run under synthetic @code-mode:@ call ids that never
+-- own a block, so they attach to the newest in-flight tool block: the exec
+-- cell that invoked them.
+toolImageBlockId :: Text -> UiState -> Maybe BlockId
+toolImageBlockId callId ui =
+    case blockForCall callId of
+        Just block -> Just block.blockId
+        Nothing ->
+            case Seq.findIndexR ((== Just callId) . (.blockCallId)) ui.uiBlocks of
+                Just index -> (.blockId) <$> Seq.lookup index ui.uiBlocks
+                Nothing -> newestRunningTool
+  where
+    blockForCall wanted = do
+        (blockIndex, _) <- Map.lookup wanted ui.uiToolCalls
+        block <- Seq.lookup blockIndex ui.uiBlocks
+        if block.blockCallId == Just wanted
+            then Just block
+            else Nothing
+    newestRunningTool =
+        case
+            [ block.blockId
+            | (active, _) <- Map.toList ui.uiToolCalls
+            , Just block <- [blockForCall active]
+            , block.blockState == BlockRunning
+            , block.blockKind `elem` [BlockTool, BlockShell]
+            ]
+        of
+            [] -> Nothing
+            candidates -> Just (maximum candidates)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -575,6 +575,23 @@ commitFullscreenImagePreviews runtime images = do
     -- terminals retain the encoded attachment for a viewport-aware placement.
     enqueueAppEvent runtime (AppCommitImagePreviews prepared)
 
+-- | Attach an agent-displayed image to the tool block that produced it. The
+-- preview is prepared on the calling tool thread: ANSI previews force the
+-- sampled bitmap here so the Brick draw thread never decodes an image.
+showFullscreenToolImage
+    :: FullscreenRuntime
+    -> Text
+    -> ImageAttachment
+    -> IO (Either Text ())
+showFullscreenToolImage runtime callId image =
+    case prepareTuiImagePreview image of
+        Left err -> pure (Left ("cannot decode image: " <> err))
+        Right preview -> do
+            unless runtime.runtimeNativeImagePreviews $
+                void $ pure $! pixelAt preview.previewSample 0 0
+            enqueueAppEvent runtime (AppToolImage callId preview)
+            pure (Right ())
+
 prepareFullscreenImagePreviews
     :: FullscreenRuntime
     -> [ImageAttachment]

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -355,7 +355,7 @@ drawBlock state target ui block =
                     (blockStateGlyph state target block <> block.blockTitle)
                     (visibleBody block)
             BlockTool ->
-                accentBlock
+                accentBlockWithSections
                     state
                     target
                     ui
@@ -365,7 +365,8 @@ drawBlock state target ui block =
                     (blockStateGlyph state target block
                         <> block.blockTitle
                         <> detailSuffix block)
-                    (visibleBody block)
+                    (bodySections (visibleBody block)
+                        <> toolImageSections state target block)
             BlockTodo ->
                 accentBlockWithSections
                     state
@@ -388,6 +389,7 @@ drawBlock state target ui block =
                     (blockStateGlyph state target block <> block.blockTitle)
                     block.blockDetail
                     (visibleShellBody block)
+                    (toolImageSections state target block)
             BlockEdit ->
                 accentBlock
                     state
@@ -468,7 +470,7 @@ submittedUserMessage state target block =
             vBox $
                 nativePlaceholder index preview
                     <> [ withAttr Theme.userMutedAttr $
-                            terminalTxt (imageSummary preview)
+                            terminalTxt (imagePreviewSummary preview)
                        ]
 
     nativePlaceholder index preview
@@ -481,15 +483,71 @@ submittedUserMessage state target block =
                         vLimit rows (fill ' ')
                ]
 
-    imageSummary preview =
-        "[image] "
-            <> preview.previewMime
-            <> " · "
-            <> Text.pack (show preview.previewSourceWidth)
-            <> "×"
-            <> Text.pack (show preview.previewSourceHeight)
-            <> " · "
-            <> formatImageSize preview.previewBytes
+imagePreviewSummary :: TuiImagePreview -> Text
+imagePreviewSummary preview =
+    "[image] "
+        <> preview.previewMime
+        <> " · "
+        <> Text.pack (show preview.previewSourceWidth)
+        <> "×"
+        <> Text.pack (show preview.previewSourceHeight)
+        <> " · "
+        <> formatImageSize preview.previewBytes
+
+-- | Images the agent displayed with @show_image@ while this tool call ran.
+-- Only the root conversation carries previews; child viewports show the
+-- textual tool result alone. Native terminals get a placeholder extent that
+-- the Kitty placement sync fills after each reflow; other terminals draw the
+-- sampled bitmap directly.
+toolImageSections :: AppState -> AgentTarget -> UiBlock -> [Widget Name]
+toolImageSections state target block =
+    case target of
+        AgentRoot ->
+            zipWith toolImage [0 ..] $
+                Map.findWithDefault
+                    []
+                    block.blockId
+                    state.appSubmittedImagePreviews
+        AgentChild _ -> []
+        AgentNative _ -> []
+  where
+    toolImage index preview =
+        vBox
+            [ imageWidget index preview
+            , withAttr Theme.mutedAttr $
+                terminalTxt (imagePreviewSummary preview)
+            ]
+
+    imageWidget index preview =
+        Widget Fixed Fixed do
+            context <- getContext
+            let maxColumns =
+                    max 1 (min toolImageMaxColumns context.availWidth)
+            render $
+                if state.appRuntime.runtimeNativeImagePreviews
+                    then
+                        let (columns, rows) =
+                                previewCellSize
+                                    maxColumns
+                                    toolImageMaxRows
+                                    preview
+                        in reportExtent
+                            (ConversationImage block.blockId index) $
+                            hLimit columns $
+                                vLimit rows (fill ' ')
+                    else
+                        renderTuiImagePreview
+                            maxColumns
+                            toolImageMaxRows
+                            preview
+
+-- | Agent-displayed images are the point of the call, so they get a larger
+-- canvas than the thumbnail attached to a submitted prompt.
+toolImageMaxColumns :: Int
+toolImageMaxColumns = 72
+
+toolImageMaxRows :: Int
+toolImageMaxRows = 24
 
 timestampedMessage :: AttrName -> Text -> Widget Name -> Widget Name
 timestampedMessage timestampAttr timestamp body
@@ -581,10 +639,13 @@ accentBlock
     -> Text
     -> Widget Name
 accentBlock state target ui block waveElapsed accent title body =
-    accentBlockWithSections state target ui block waveElapsed accent title $
-        if Text.null (Text.strip body)
-            then []
-            else [terminalTxtWrap body]
+    accentBlockWithSections state target ui block waveElapsed accent title
+        (bodySections body)
+
+bodySections :: Text -> [Widget Name]
+bodySections body
+    | Text.null (Text.strip body) = []
+    | otherwise = [terminalTxtWrap body]
 
 accentMarkdownBlock
     :: AppState
@@ -616,6 +677,7 @@ accentCodeBlock
     -> Text
     -> Text
     -> Text
+    -> [Widget Name]
     -> Widget Name
 accentCodeBlock
     state
@@ -627,7 +689,8 @@ accentCodeBlock
     accent
     title
     code
-    body =
+    body
+    extraSections =
     accentBlockWithSections state target ui block waveElapsed accent title $
         [ codeWidgetWithSyntaxHighlighting
             syntaxHighlighter
@@ -635,9 +698,8 @@ accentCodeBlock
             code
         | not (Text.null (Text.strip code))
         ]
-            <> [ terminalTxtWrap body
-               | not (Text.null (Text.strip body))
-               ]
+            <> bodySections body
+            <> extraSections
 
 accentBlockWithSections
     :: AppState

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -141,6 +141,9 @@ data AppEvent
       -- ^ Legacy compatibility; prefer 'AppSetSlashCatalog'.
     | AppSetImagePreviews ![(ImageAttachment, TuiImagePreview)]
     | AppCommitImagePreviews ![(ImageAttachment, TuiImagePreview)]
+    | AppToolImage !Text !TuiImagePreview
+      -- ^ An image the agent displayed through @show_image@, keyed by the
+      -- originating tool call id.
     | AppDictationPartial !Text
     | AppDictationFinished !(Either Text Text)
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
@@ -303,6 +306,10 @@ data AppState = AppState
     , appDictation :: !(Maybe DictationSession)
     , appSlashCatalog :: !SlashCatalog
     , appImagePreviews :: ![TuiImagePreview]
+      -- | Previews attached to conversation blocks: images the user
+      -- submitted with a prompt and images the agent displayed from a tool
+      -- call. Native placements are synchronized from this map after each
+      -- reflow.
     , appSubmittedImagePreviews :: !(Map.Map BlockId [TuiImagePreview])
     , appAgentSelected :: !AgentTarget
     , appAgentEntries :: ![AgentEntry]

--- a/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
@@ -17,6 +17,7 @@ import Agent.Dialect
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
 import Agent.ToolDispatch (noArgsTool)
 import Agent.Tools.Secret (SecretPromptHooks(..))
+import Agent.Tools.ShowImage (ImageDisplayHooks(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(AlwaysReadOnly)
@@ -69,7 +70,7 @@ spec = describe "Agent.CLI.Dialects" do
 
     it "does not allocate host tools for Claude Code" do
         env <- defaultToolEnv (unsafeEncodeUtf "/tmp")
-        coding <- codingToolsFor claudeCodeDialect env Nothing Nothing Nothing
+        coding <- codingToolsFor claudeCodeDialect env Nothing Nothing Nothing Nothing
         length coding.codingAppTools `shouldBe` 0
         coding.codingClose
 
@@ -77,7 +78,7 @@ spec = describe "Agent.CLI.Dialects" do
         withTempToolEnv \env ->
             forM_ [codexDialect, grokBuildDialect] \dialect -> do
                 withoutSecret <-
-                    codingToolsFor dialect env Nothing Nothing Nothing
+                    codingToolsFor dialect env Nothing Nothing Nothing Nothing
                 map (.appToolName) withoutSecret.codingAppTools
                     `shouldNotContain` ["ask_secret"]
                 withoutSecret.codingClose
@@ -85,15 +86,31 @@ spec = describe "Agent.CLI.Dialects" do
                 let hooks = SecretPromptHooks
                         (const (pure (Right Nothing)))
                 withSecret <-
-                    codingToolsFor dialect env Nothing (Just hooks) Nothing
+                    codingToolsFor dialect env Nothing (Just hooks) Nothing Nothing
                 (map (.appToolName) withSecret.codingAppTools
                     `shouldContain` ["ask_secret"])
                     `finally` withSecret.codingClose
 
+    it "registers show_image only when image display hooks are supplied" do
+        withTempToolEnv \env ->
+            forM_ [codexDialect, grokBuildDialect] \dialect -> do
+                withoutImages <-
+                    codingToolsFor dialect env Nothing Nothing Nothing Nothing
+                map (.appToolName) withoutImages.codingAppTools
+                    `shouldNotContain` ["show_image"]
+                withoutImages.codingClose
+
+                let hooks = ImageDisplayHooks (const (pure (Right ())))
+                withImages <-
+                    codingToolsFor dialect env Nothing Nothing (Just hooks) Nothing
+                (map (.appToolName) withImages.codingAppTools
+                    `shouldContain` ["show_image"])
+                    `finally` withImages.codingClose
+
     it "registers bounded artifact readers on coding tool surfaces" do
         withTempToolEnv \env ->
             forM_ [codexDialect, grokBuildDialect] \dialect -> do
-                coding <- codingToolsFor dialect env Nothing Nothing Nothing
+                coding <- codingToolsFor dialect env Nothing Nothing Nothing Nothing
                 let names = map (.appToolName) coding.codingAppTools
                 names `shouldContain`
                     ["read_tool_output", "search_tool_output"]

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -163,6 +163,29 @@ spec = describe "systemPrompt" do
             "Never read, print, summarize"
         withoutSecret `shouldNotSatisfy` Text.isInfixOf "Use ask_secret"
 
+    it "adds image display guidance only when show_image is registered" do
+        let withImages =
+                systemPromptForTools
+                    genericResponsesDialect
+                    ["read_file", "show_image"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+            withoutImages =
+                systemPromptForTools
+                    genericResponsesDialect
+                    ["read_file"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+        withImages `shouldSatisfy` Text.isInfixOf
+            "Use show_image to present an image file"
+        withImages `shouldSatisfy` Text.isInfixOf
+            "not added to your own context"
+        withoutImages `shouldNotSatisfy` Text.isInfixOf "show_image"
+
     it "adds reusable-memory guidance only when learned-skill tools are registered" do
         let withSkills =
                 systemPromptForTools

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -50,6 +50,7 @@ import Agent.CLI.TUI.App
     , setFullscreenWindowTitle
     , syntaxLanguagesForBlocks
     , textOverlayDisplayText
+    , toolImageBlockId
     , turnCompletionRequiresRedraw
     , uiEventRestartsMotionSchedule
     )
@@ -127,6 +128,41 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "toolImageBlockId" do
+        let started callId name =
+                reduceUi
+                    (UiLoop (ToolStarted (functionToolCall callId name "{}")))
+            finished callId =
+                reduceUi
+                    (UiLoop
+                        (ToolFinished
+                            (ToolCallResult callId "done" FunctionCallKind)))
+            firstBlock = BlockId initialUiState.uiNextBlockId
+            secondBlock = BlockId (initialUiState.uiNextBlockId + 1)
+
+        it "attaches to the block of the originating call" do
+            let ui =
+                    started "call-2" "show_image" $
+                        started "call-1" "shell_command" initialUiState
+            toolImageBlockId "call-1" ui `shouldBe` Just firstBlock
+            toolImageBlockId "call-2" ui `shouldBe` Just secondBlock
+
+        it "falls back to the newest running tool block for nested code-mode calls" do
+            let ui =
+                    started "exec-1" "exec" $
+                        finished "call-1" $
+                            started "call-1" "shell_command" initialUiState
+            toolImageBlockId "code-mode:1:show_image" ui
+                `shouldBe` Just secondBlock
+
+        it "ignores unknown calls once no tool is running" do
+            let ui =
+                    finished "call-1" $
+                        started "call-1" "shell_command" initialUiState
+            toolImageBlockId "code-mode:1:show_image" ui `shouldBe` Nothing
+            toolImageBlockId "code-mode:1:show_image" initialUiState
+                `shouldBe` Nothing
+
     describe "background activity status" do
         it "names a running agent and its current step" do
             backgroundActivityText

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -94,6 +94,7 @@ library
                     , Agent.Tools.PlanMode
                     , Agent.Tools.Secret
                     , Agent.Tools.Scheduling
+                    , Agent.Tools.ShowImage
                     , Agent.Tools.ShellReadOnly
                     , Agent.Tools.Types
                     , Agent.Transport.WebSocket
@@ -246,6 +247,7 @@ test-suite agent-core-test
                     , Agent.Tools.OutputArtifactSpec
                     , Agent.Tools.PlanModeSpec
                     , Agent.Tools.SecretSpec
+                    , Agent.Tools.ShowImageSpec
                     , Agent.ToolDSLSpec
                     , Agent.Transport.WebSocketSpec
     build-depends:    base >= 4.14 && < 5

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
@@ -533,7 +533,7 @@ renderCodeModeResult budget wallTime = \case
         , Just (String text) <- KeyMap.lookup "text" content =
             text
         | Just (String "image") <- KeyMap.lookup "type" content =
-            "[image output item]"
+            "[image output item; call tools.show_image to display an image to the user]"
         | Just (String "audio") <- KeyMap.lookup "type" content =
             "[audio output item]"
         | otherwise = renderValue value

--- a/packages/agent-core/src/Agent/Tools/ShowImage.hs
+++ b/packages/agent-core/src/Agent/Tools/ShowImage.hs
@@ -1,0 +1,213 @@
+-- | Host-mediated inline image display for model tool calls.
+--
+-- The model names an image file; the trusted host decides how to present it
+-- (Kitty/iTerm2 graphics, an ANSI approximation, a chat photo, …). The image
+-- is shown to the user only. It is never attached to the model context, so
+-- the tool result stays a short text summary.
+module Agent.Tools.ShowImage
+    ( ImageDisplayHooks(..)
+    , ImageDisplayRequest(..)
+    , showImageTool
+    , showImageToolName
+    , sniffImageMime
+    , maxShowImageBytes
+    ) where
+
+import Agent.Json.Decode (Decoder)
+import Agent.Loop (ImageAttachment(..))
+import Agent.OsPath (fromText, unsafeToFilePath)
+import Agent.ToolArgs (objectArgs, optText, reqText)
+import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , decodeToolArguments
+    , toolArgumentsValue
+    , typedToolWithCall
+    )
+import Agent.Tools.FileSystem (displayPathInWorkspace, resolveForRead)
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    )
+import Agent.Tools.Types
+    ( AppTool
+    , ToolEnv
+    , ToolExecutionPolicy(..)
+    , jsonTool
+    , withToolResourceClaims
+    )
+import Control.Exception.Safe (tryIO)
+import qualified Data.ByteString as BS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Directory.OsPath (doesFileExist, getFileSize)
+
+-- | One image the model asked the host to present.
+data ImageDisplayRequest = ImageDisplayRequest
+    { displayCallId :: !Text
+      -- ^ The originating tool call, so a transcript UI can attach the image
+      -- to the matching tool block.
+    , displayPath :: !Text
+      -- ^ Workspace-relative display path of the source file.
+    , displayCaption :: !(Maybe Text)
+    , displayImage :: !ImageAttachment
+    }
+    deriving (Eq, Show)
+
+-- | Host presentation used by 'showImageTool'. A 'Left' reports why the host
+-- could not present the image; the tool surfaces it to the model.
+newtype ImageDisplayHooks = ImageDisplayHooks
+    { showImage :: ImageDisplayRequest -> IO (Either Text ())
+    }
+
+showImageToolName :: Text
+showImageToolName = "show_image"
+
+-- | Larger files are rejected before they are read: terminal graphics
+-- protocols transfer the encoded image inline, so multi-megabyte files stall
+-- the UI without looking better.
+maxShowImageBytes :: Int
+maxShowImageBytes = 20 * 1024 * 1024
+
+data ShowImageArgs = ShowImageArgs
+    { path :: !Text
+    , caption :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+showImageArgsDecoder :: Decoder ShowImageArgs
+showImageArgsDecoder = objectArgs \object ->
+    ShowImageArgs
+        <$> reqText object "path"
+        <*> optText object "caption"
+
+showImageTool :: ToolEnv -> ImageDisplayHooks -> AppTool
+showImageTool env hooks =
+    withToolResourceClaims (showImageClaims env) $
+        jsonTool showImageToolName showImageDescription
+            [ PropertySchema "path" PropertyString True $ Just
+                "Path of the image file to display. Relative paths use the workspace; absolute paths may resolve within the workspace or session temp directory. PNG, JPEG, GIF, BMP, and TIFF are supported."
+            , PropertySchema "caption" PropertyString False $ Just
+                "Optional short caption shown with the image."
+            ]
+            True
+            ParallelSafe
+            (typedToolWithCall showImageToolName showImageArgsDecoder
+                (runShowImage env hooks))
+
+showImageDescription :: Text
+showImageDescription =
+    "Display an image file inline to the user in the conversation.\n\
+    \\n\
+    \- Use it to present screenshots, rendered previews, charts, icons, or other generated images\n\
+    \- Supported formats: PNG, JPEG, GIF, BMP, TIFF. Convert SVG, PDF, or WebP to PNG first (for example with rsvg-convert or ImageMagick)\n\
+    \- The image is shown to the user only; it is not added to your own context. Use read_file or the user's description when you need to inspect image contents yourself"
+
+showImageClaims
+    :: ToolEnv
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+showImageClaims env call =
+    case
+        decodeToolArguments showImageArgsDecoder (toolArgumentsValue call.arguments)
+            :: Either Text ShowImageArgs
+    of
+        Left err -> pure (Left err)
+        Right args ->
+            resolveForRead env (fromText args.path)
+                >>= pure . fmap
+                    (\path -> [ToolResourceClaim ToolRead (ToolPath path)])
+
+runShowImage
+    :: ToolEnv
+    -> ImageDisplayHooks
+    -> ToolCall
+    -> ShowImageArgs
+    -> IO (Either Text Text)
+runShowImage env hooks call args =
+    resolveForRead env (fromText args.path) >>= \case
+        Left err -> pure (Left err)
+        Right path -> do
+            display <- displayPathInWorkspace env path
+            exists <- doesFileExist path
+            if not exists
+                then pure (Left ("File not found: " <> display))
+                else do
+                    size <- getFileSize path
+                    if size > toInteger maxShowImageBytes
+                        then pure $ Left $
+                            "Image is too large to display ("
+                                <> formatByteCount (fromInteger size)
+                                <> "; the limit is "
+                                <> formatByteCount maxShowImageBytes
+                                <> "). Downscale it first."
+                        else readImage display path
+  where
+    readImage display path =
+        tryIO (BS.readFile (unsafeToFilePath path)) >>= \case
+            Left err ->
+                pure (Left ("Failed to read " <> display <> ": " <> Text.pack (show err)))
+            Right bytes ->
+                case sniffImageMime bytes of
+                    Nothing ->
+                        pure $ Left $
+                            display
+                                <> " is not a supported image. Supported formats: PNG, JPEG, GIF, BMP, TIFF. Convert other formats (SVG, PDF, WebP) to PNG first."
+                    Just mime -> do
+                        let caption = normalizeCaption args.caption
+                            request = ImageDisplayRequest
+                                { displayCallId = call.callId
+                                , displayPath = display
+                                , displayCaption = caption
+                                , displayImage = ImageAttachment
+                                    { imageMime = mime
+                                    , imageBytes = bytes
+                                    }
+                                }
+                        hooks.showImage request >>= \case
+                            Left err ->
+                                pure (Left ("Could not display " <> display <> ": " <> err))
+                            Right () ->
+                                pure $ Right $
+                                    Text.intercalate "\n" $
+                                        [ "Displayed "
+                                            <> display
+                                            <> " to the user ("
+                                            <> mime
+                                            <> ", "
+                                            <> formatByteCount (BS.length bytes)
+                                            <> ")."
+                                        ]
+                                            <> [ "Caption: " <> text
+                                               | Just text <- [caption]
+                                               ]
+                                            <> [ "The image is visible to the user only; it was not added to your context."
+                                               ]
+
+normalizeCaption :: Maybe Text -> Maybe Text
+normalizeCaption raw =
+    case Text.strip <$> raw of
+        Just text | not (Text.null text) -> Just text
+        _ -> Nothing
+
+-- | Detect the encoded format from its magic bytes. File extensions are
+-- ignored: models routinely write PNG data to @.jpg@ paths and vice versa.
+sniffImageMime :: BS.ByteString -> Maybe Text
+sniffImageMime bytes
+    | hasPrefix [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] = Just "image/png"
+    | hasPrefix [0xff, 0xd8, 0xff] = Just "image/jpeg"
+    | hasPrefix [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]
+        || hasPrefix [0x47, 0x49, 0x46, 0x38, 0x39, 0x61] = Just "image/gif"
+    | hasPrefix [0x42, 0x4d] && BS.length bytes >= 14 = Just "image/bmp"
+    | hasPrefix [0x49, 0x49, 0x2a, 0x00]
+        || hasPrefix [0x4d, 0x4d, 0x00, 0x2a] = Just "image/tiff"
+    | otherwise = Nothing
+  where
+    hasPrefix prefix = BS.pack prefix `BS.isPrefixOf` bytes
+
+formatByteCount :: Int -> Text
+formatByteCount n
+    | n < 1024 = Text.pack (show n) <> " B"
+    | n < 1024 * 1024 = Text.pack (show (n `div` 1024)) <> " KB"
+    | otherwise = Text.pack (show (n `div` (1024 * 1024))) <> " MB"

--- a/packages/agent-core/test/Agent/Tools/ShowImageSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/ShowImageSpec.hs
@@ -1,0 +1,176 @@
+module Agent.Tools.ShowImageSpec (spec) where
+
+import Agent.Loop (ImageAttachment(..))
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
+import Agent.ToolDSL (PropertySchema(..))
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    , ToolSchedulingPlan(..)
+    )
+import Agent.Tools.ShowImage
+import Agent.Tools.Types
+    ( AppTool(..)
+    , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
+    , defaultToolEnv
+    , jsonToolParameters
+    , mkToolRegistry
+    , setToolSessionTmp
+    , toolSchedulingPlanFor
+    )
+import Control.Exception.Safe (bracket)
+import qualified Data.ByteString as BS
+import Data.IORef
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Directory
+    ( canonicalizePath
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
+import System.FilePath ((</>))
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Tools.ShowImage" do
+    describe "sniffImageMime" do
+        it "recognizes common raster formats by magic bytes" do
+            sniffImageMime pngBytes `shouldBe` Just "image/png"
+            sniffImageMime (BS.pack [0xff, 0xd8, 0xff, 0xe0, 0, 0])
+                `shouldBe` Just "image/jpeg"
+            sniffImageMime "GIF89a\0\0" `shouldBe` Just "image/gif"
+            sniffImageMime ("BM" <> BS.replicate 20 0) `shouldBe` Just "image/bmp"
+            sniffImageMime (BS.pack [0x49, 0x49, 0x2a, 0x00, 1])
+                `shouldBe` Just "image/tiff"
+
+        it "rejects text and vector formats" do
+            sniffImageMime "<svg xmlns=\"http://www.w3.org/2000/svg\"/>"
+                `shouldBe` Nothing
+            sniffImageMime "" `shouldBe` Nothing
+
+    it "advertises a read-only, parallel-safe path tool" do
+        withTool (const (pure (Right ()))) \_ tool -> do
+            tool.appToolName `shouldBe` "show_image"
+            let parameters = fromMaybe [] (jsonToolParameters tool)
+            map (.propertyName) parameters `shouldBe` ["path", "caption"]
+            map (.required) parameters `shouldBe` [True, False]
+            case tool.appToolApproval of
+                AlwaysReadOnly -> pure ()
+                _ -> expectationFailure "show_image should not require approval"
+            tool.appToolExecution `shouldBe` ParallelSafe
+
+    it "hands the sniffed image and call id to the host hook" do
+        seen <- newIORef Nothing
+        withTool (\request -> writeIORef seen (Just request) >> pure (Right ())) \workspace tool -> do
+            BS.writeFile (workspace </> "preview.jpg") pngBytes
+            output <- runTool tool "{\"path\":\"preview.jpg\",\"caption\":\"  Blue icon \"}"
+            request <- readIORef seen
+            fmap (.displayCallId) request `shouldBe` Just "show-1"
+            fmap (.displayPath) request `shouldBe` Just "preview.jpg"
+            fmap (.displayCaption) request `shouldBe` Just (Just "Blue icon")
+            fmap (.displayImage) request
+                `shouldBe` Just (ImageAttachment "image/png" pngBytes)
+            output `shouldSatisfy` Text.isPrefixOf "Displayed preview.jpg to the user (image/png, "
+            output `shouldSatisfy` Text.isInfixOf "Caption: Blue icon"
+            output `shouldSatisfy` Text.isInfixOf "not added to your context"
+
+    it "omits the caption line when none was given" do
+        withTool (const (pure (Right ()))) \workspace tool -> do
+            BS.writeFile (workspace </> "shot.png") pngBytes
+            output <- runTool tool "{\"path\":\"shot.png\"}"
+            output `shouldNotSatisfy` Text.isInfixOf "Caption:"
+
+    it "reports files that are not raster images without calling the host" do
+        calls <- newIORef (0 :: Int)
+        withTool (\_ -> modifyIORef' calls (+ 1) >> pure (Right ())) \workspace tool -> do
+            writeFile (workspace </> "icon.svg") "<svg xmlns=\"http://www.w3.org/2000/svg\"/>"
+            output <- runTool tool "{\"path\":\"icon.svg\"}"
+            output `shouldSatisfy` Text.isInfixOf "not a supported image"
+            output `shouldSatisfy` Text.isInfixOf "Convert other formats"
+            readIORef calls `shouldReturn` 0
+
+    it "reports missing files" do
+        withTool (const (pure (Right ()))) \_ tool -> do
+            output <- runTool tool "{\"path\":\"missing.png\"}"
+            output `shouldSatisfy` Text.isInfixOf "File not found: missing.png"
+
+    it "refuses paths outside the workspace" do
+        withTool (const (pure (Right ()))) \_ tool -> do
+            output <- runTool tool "{\"path\":\"/etc/hosts\"}"
+            output `shouldNotSatisfy` Text.isPrefixOf "Displayed"
+
+    it "surfaces host presentation failures to the model" do
+        withTool (const (pure (Left "terminal has no graphics support"))) \workspace tool -> do
+            BS.writeFile (workspace </> "shot.png") pngBytes
+            output <- runTool tool "{\"path\":\"shot.png\"}"
+            output `shouldSatisfy`
+                Text.isInfixOf "Could not display shot.png: terminal has no graphics support"
+
+    it "claims a read on the resolved image path" do
+        withTool (const (pure (Right ()))) \workspace tool -> do
+            BS.writeFile (workspace </> "shot.png") pngBytes
+            registry <- either (fail . Text.unpack) pure (mkToolRegistry [tool])
+            plan <- toolSchedulingPlanFor registry
+                (functionToolCall "show-2" "show_image" "{\"path\":\"shot.png\"}")
+            canonical <- canonicalizePath (workspace </> "shot.png")
+            plan `shouldBe`
+                ToolResourceClaims
+                    [ ToolResourceClaim ToolRead
+                        (ToolPath (unsafeEncodeUtf canonical))
+                    ]
+
+-- | A minimal valid 1×1 PNG.
+pngBytes :: BS.ByteString
+pngBytes = BS.pack
+    [ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a
+    , 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52
+    , 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01
+    , 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde
+    , 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54
+    , 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00
+    , 0x03, 0x01, 0x01, 0x00, 0x18, 0xdd, 0x8d, 0xb0
+    , 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44
+    , 0xae, 0x42, 0x60, 0x82
+    ]
+
+withTool
+    :: (ImageDisplayRequest -> IO (Either Text ()))
+    -> (FilePath -> AppTool -> IO a)
+    -> IO a
+withTool hook action = do
+    root <- getTemporaryDirectory
+    bracket
+        (mkdtemp (root </> "agent-show-image-test-"))
+        removeDirectoryRecursive
+        \workspace -> do
+            temp <- mkdtemp (workspace </> "session-tmp-")
+            env <- defaultToolEnv (unsafeEncodeUtf workspace)
+            setToolSessionTmp env (Just (unsafeEncodeUtf temp))
+            action workspace (showImageTool env (ImageDisplayHooks hook))
+
+runTool :: AppTool -> Text -> IO Text
+runTool tool arguments = do
+    result <- dispatchToolCall testDispatchConfig
+        [tool.appToolHandler]
+        (functionToolCall "show-1" "show_image" arguments)
+    pure result.output
+
+testDispatchConfig :: ToolDispatchConfig
+testDispatchConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    , toolDispatchFinalizeOutput = \_ output -> pure output
+    }

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -34,6 +34,7 @@ import qualified Agent.Tools.MultiAgentsSpec as MultiAgentsSpec
 import qualified Agent.Tools.OutputArtifactSpec as OutputArtifactSpec
 import qualified Agent.Tools.PlanModeSpec as PlanModeSpec
 import qualified Agent.Tools.SecretSpec as SecretSpec
+import qualified Agent.Tools.ShowImageSpec as ShowImageSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
 import Test.Hspec (hspec)
 
@@ -70,6 +71,7 @@ main = hspec do
     OutputArtifactSpec.spec
     PlanModeSpec.spec
     SecretSpec.spec
+    ShowImageSpec.spec
     CodeModeHostSpec.spec
     CodeModeProtocolSpec.spec
     DangerousSpec.spec


### PR DESCRIPTION
## Summary

The agent had no way to show an image to the user: code-mode `image(...)` output collapsed to `[image output item]`. This adds a `show_image` tool and renders the result inline in the conversation.

- **agent-core** — new `Agent.Tools.ShowImage`: `show_image { path, caption? }` resolves the file inside the allowed roots, sniffs the raster format (PNG/JPEG/GIF/BMP/TIFF, 20 MiB cap), and hands the bytes plus the originating call id to a host-provided `ImageDisplayHooks` callback. Read-only, parallel-safe, with a read claim on the path. The image is shown to the user only; the model gets a short text result.
- **agent-cli** — the tool is registered next to `ask_secret` only when a TTY can present images (`codingToolsFor` gains a `Maybe ImageDisplayHooks` parameter; subagents pass `Nothing`). In the fullscreen TUI the image is attached to the originating tool block (Kitty placement via the existing native preview sync, ANSI half-block fallback elsewhere); plain mode prints it with the same path as pasted attachments. Nested code-mode calls (`tools.show_image(...)` inside `exec`) carry synthetic call ids, so they attach to the running exec block.
- Prompt guidance for `show_image`, README section, and a hint in the code-mode `[image output item]` placeholder.

## Testing

- `Agent.Tools.ShowImageSpec` (agent-core): schema/approval, hook payload, format rejection, missing/outside-workspace paths, host failure surfacing, resource claims.
- `toolImageBlockId` cases in `TUIAppSpec`, `show_image` registration in `DialectsSpec`, prompt guidance in `PromptSpec`.
- agent-cli library + test suite type-check in a multi-package `cabal repl`.
- tmux smoke check with the interpreted agent (`--fullscreen --yolo`, gpt-5.6-luna, code mode): asked it to display a 320×200 PNG. The model ran `tools.show_image({path:"gradient.png", caption:"Smoke test gradient"})` inside `exec`; the exec block showed the tool result text, a 72×23-cell half-block rendering of the image (47 distinct colours in the captured pane — 256-colour under tmux), and the `[image] image/png · 320×200 · 89 KB` summary line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)