### PR TITLE
test: add QuickCheck coverage and fix path traversal

### DIFF
--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -173,9 +173,22 @@ isInside root path
     | otherwise =
         let relative = makeRelative root path
         in not (isAbsolute relative)
-            && case splitDirectories relative of
-                (first : _) | first == unsafeEncodeUtf ".." -> False
-                _ -> True
+            && staysWithinRoot (splitDirectories relative)
+  where
+    parent = unsafeEncodeUtf ".."
+    current = unsafeEncodeUtf "."
+
+    -- A missing path is intentionally kept lexical by 'resolveMissing'.
+    -- Track directory depth instead of checking only the first component:
+    -- e.g. @nested/../../outside@ escapes even though it starts safely.
+    staysWithinRoot = go (0 :: Int)
+      where
+        go _ [] = True
+        go depth (component : rest)
+            | component == current = go depth rest
+            | component == parent =
+                depth > 0 && go (depth - 1) rest
+            | otherwise = go (depth + 1) rest
 
 -- | Present a resolved filesystem path relative to the tool workspace.
 displayPathInWorkspace :: ToolEnv -> OsPath -> IO Text

--- a/packages/agent-core/test/Agent/TextBufferSpec.hs
+++ b/packages/agent-core/test/Agent/TextBufferSpec.hs
@@ -3,6 +3,20 @@ module Agent.TextBufferSpec (spec) where
 import Agent.TextBuffer
 import qualified Data.Text as Text
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck (Arbitrary(..), listOf, resize, (===), (.&&.))
+
+newtype ChunkText = ChunkText Text.Text
+    deriving (Show)
+
+instance Arbitrary ChunkText where
+    arbitrary = ChunkText . Text.pack <$> resize 32 (listOf arbitrary)
+
+newtype ChunkList = ChunkList [ChunkText]
+    deriving (Show)
+
+instance Arbitrary ChunkList where
+    arbitrary = ChunkList <$> resize 20 (listOf arbitrary)
 
 spec :: Spec
 spec = describe "TextBuffer" do
@@ -24,3 +38,19 @@ spec = describe "TextBuffer" do
         textBufferNull buffered `shouldBe` False
         compactTextBuffer buffered `shouldBe` textBufferFromText "first second"
         textBufferNull (appendTextBuffer "" emptyTextBuffer) `shouldBe` True
+
+    modifyMaxSuccess (const 300) $
+        prop "preserves chunk order for arbitrary streams" $
+            \(ChunkList chunks) ->
+                let texts = [text | ChunkText text <- chunks]
+                    buffered = foldl' (flip appendTextBuffer) emptyTextBuffer texts
+                in textBufferToText buffered === Text.concat texts
+
+    modifyMaxSuccess (const 300) $
+        prop "compaction preserves content and is idempotent" $
+            \(ChunkList chunks) ->
+                let texts = [text | ChunkText text <- chunks]
+                    buffered = foldl' (flip appendTextBuffer) emptyTextBuffer texts
+                    compacted = compactTextBuffer buffered
+                in textBufferToText compacted === textBufferToText buffered
+                    .&&. compactTextBuffer compacted === compacted

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -185,6 +185,15 @@ spec = describe "Agent.Tools.IO" do
                 (fromFilePath ("link" </> "missing" </> "file.txt"))
             result `shouldSatisfy` isLeft
 
+    it "rejects missing paths whose traversal is hidden after a safe segment" do
+        withTempDir \dir -> do
+            let workspace = dir </> "workspace"
+            createDirectory workspace
+            env <- defaultToolEnv (fromFilePath workspace)
+            result <- resolveUnderCwd env
+                (fromFilePath ("nested" </> ".." </> ".." </> "outside.txt"))
+            result `shouldSatisfy` isLeft
+
     it "preserves parent-segment semantics after a directory symlink" do
         withTempDir \dir -> do
             let workspace = dir </> "workspace"

--- a/packages/agent-responses/test/Agent/Responses/ResponseMergeSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/ResponseMergeSpec.hs
@@ -5,10 +5,28 @@ import Agent.Responses.ResponseMerge
 import Agent.Responses.Types
 import qualified Data.ByteString.Char8 as BS
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(..)
+    , chooseInt
+    , counterexample
+    , listOf
+    , (===)
+    )
 
 spec :: Spec
 spec = describe "typed response merging" do
+    modifyMaxSuccess (const 500) $
+        prop "merging streamed function calls is idempotent" $
+            \(FunctionCallStream items) ->
+                let once = mergeCompletedResponseOutput items baseResponse
+                    twice = mergeCompletedResponseOutput items once
+                in counterexample
+                    ("streamed items: " <> show items)
+                    (twice === once)
+
     it "fills empty terminal output from streamed items" do
         let call = functionCall "call-1"
             merged = mergeCompletedResponseOutput [call] baseResponse
@@ -73,6 +91,20 @@ functionCall callId = FunctionCallItem FunctionCall
     , encryptedFunctionArgs = Nothing
     , status = Nothing
     }
+
+newtype FunctionCallStream = FunctionCallStream [ResponseItem]
+    deriving (Show)
+
+instance Arbitrary FunctionCallStream where
+    arbitrary = do
+        identifiers <- listOf (chooseInt (-10, 10))
+        pure
+            (FunctionCallStream
+                [ functionCall ("call-" <> Text.pack (show identifier))
+                | identifier <- identifiers
+                ])
+
+    shrink _ = []
 
 withOutput :: [ResponseItem] -> Response -> Response
 withOutput value response = response { output = value }


### PR DESCRIPTION
## Summary

- add QuickCheck coverage for streamed text buffering and response merging
- fix workspace containment for missing paths with nested `..` traversal
- add a regression test for `nested/../../outside.txt`

## Validation

- `nix develop -c cabal test --offline agent-core:agent-core-test --test-show-details=direct`
- `nix develop -c cabal test --offline agent-responses:agent-responses-test --test-show-details=direct`
- `git diff --check`

Both test suites pass with zero failures.
