### PR TITLE
Preserve streamed output when cancelling turns

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -352,8 +352,12 @@ runOneTurnBusy includeTurnContext env@SessionEnv
             Nothing -> extra
             Just t0 -> extra <> " · " <> formatElapsed (realToFrac (diffUTCTime finishedAt t0))
         persistIncomplete
-            :: [ResponseItem] -> Text -> Maybe TurnOutput -> IO ()
-        persistIncomplete retainedItems errorText maybeTurn = case persist of
+            :: [ResponseItem]
+            -> Text
+            -> Maybe TurnOutput
+            -> Maybe Text
+            -> IO ()
+        persistIncomplete retainedItems errorText maybeTurn displayAssistant = case persist of
             PersistenceDisabled -> pure ()
             PersistenceEnabled slotRef -> do
                 now <- getCurrentTime
@@ -363,7 +367,10 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                 let turn = SessionTurn
                         { turnAt = now
                         , turnUserText = promptText
-                        , turnAssistantText = maybeTurn >>= (.assistantText)
+                        , turnAssistantText =
+                            case displayAssistant of
+                                Just text -> Just text
+                                Nothing -> maybeTurn >>= (.assistantText)
                         , turnError = Just errorText
                         , turnResponseId = (.responseId) <$> maybeTurn
                         , turnEffect = TranscriptAppend
@@ -421,10 +428,14 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                         (formatLoopErrorColored color cancelled)
                     putTextLn stderrHandle
                         (formatTurnStatus color "cancelled" (elapsedDetail model))
+            let partialAssistant =
+                    fmap stripBracketedTimestamps
+                        execution.executionVisibleAssistantText
             persistIncomplete
                 (inputOnlyTurnItems committedPrepared)
                 "cancelled"
                 Nothing
+                partialAssistant
             pure TurnCancelled
         (Nothing, Left err) -> do
             abortSubagentTurn rootTurnId
@@ -489,6 +500,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                     persistIncomplete (inputOnlyTurnItems committedPrepared)
                         (formatLoopErrorPersistedAt finishedAt err)
                         maybeIncompleteTurn
+                        Nothing
                     planState <- readIORef planMode.planStateRef
                     pure $ TurnFailed PendingTurn
                         { pendingPromptText = promptText

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -358,6 +358,22 @@ spec = describe "bounded fullscreen history window" do
             `shouldSatisfy`
                 all (not . Text.isInfixOf "Don't mention skills")
 
+    it "preserves partial assistant output in a cancelled durable turn" do
+        let turnValue =
+                (sessionTurn TranscriptAppend "stop here"
+                    [userMessage "stop here"])
+                    { turnAssistantText = Just "already visible"
+                    , turnError = Just "cancelled"
+                    }
+            blocks = toList $
+                (sessionHistoryTurn (19 :: Int) turnValue).historyTurnBlocks
+        map (\block -> (block.blockKind, block.blockBody, block.blockState)) blocks
+            `shouldBe`
+                [ (BlockUser, "stop here", BlockComplete)
+                , (BlockAssistant, "already visible", BlockComplete)
+                , (BlockError, "cancelled", BlockFailed)
+                ]
+
     it "does not rematerialise the compacted prefix of replacement turns" do
         let projected =
                 sessionHistoryTurn

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -67,7 +67,7 @@ import Control.Monad (void)
 import Data.Aeson (ToJSON(..), object, (.=))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
-import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntSet as IntSet
@@ -220,6 +220,10 @@ data LoopProgress
 data LoopExecution = LoopExecution
     { executionState :: ![ResponseItem]
     , executionProgress :: !LoopProgress
+    -- | Assistant text exposed by streaming events during this execution.
+    -- This is display metadata only: callers must not add it to backend state
+    -- when a submission did not commit.
+    , executionVisibleAssistantText :: !(Maybe Text)
     , executionResult :: !(Either LoopError LoopResult)
     } deriving (Eq, Show)
 
@@ -393,16 +397,43 @@ runLoopInputsUnsafe
 runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
     eventPump <- newLoopEventPump config0.loopOnEvent
     progressRef <- newIORef (initialState, NoResponseCommitted)
+    visibleTextRef <- newIORef ([], [])
     initialSteering <- config0.loopReadSteering
     withAsync (runLoopEventPump eventPump) \eventWorker -> do
-        let config = config0
-                { loopOnEvent = emitLoopEvent eventPump
+        let recordVisible event =
+                modifyIORef' visibleTextRef \(finished, current) ->
+                    case event of
+                        TextDelta delta -> (finished, delta : current)
+                        ResponseRestarted _ -> finishCurrent finished current
+                        TurnFinished turn ->
+                            finishCurrent finished
+                                (if null current
+                                    then maybe [] pure turn.assistantText
+                                    else current)
+                        ResponseAttemptDiscarded -> (finished, [])
+                        _ -> (finished, current)
+            finishCurrent finished current
+                | null current = (finished, [])
+                | otherwise = (current : finished, [])
+            config = config0
+                { loopOnEvent = \event -> do
+                    recordVisible event
+                    emitLoopEvent eventPump event
                 }
             finish state progress result = do
                 writeIORef progressRef (state, progress)
+                (finishedChunks, currentChunks) <- readIORef visibleTextRef
+                let visibleText = Text.intercalate "\n\n" $
+                        filter (not . Text.null) $
+                            map (Text.concat . reverse)
+                                (reverse finishedChunks <> [currentChunks])
                 pure LoopExecution
                     { executionState = state
                     , executionProgress = progress
+                    , executionVisibleAssistantText =
+                        if Text.null visibleText
+                            then Nothing
+                            else Just visibleText
                     , executionResult = result
                     }
             unexpected state progress exception =

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1246,6 +1246,23 @@ spec = describe "runLoop" do
         result <- runLoop config0 Nothing "go"
         result `shouldBe` Left (LoopCancelled [])
 
+    it "retains assistant text streamed before submitTurn is cancelled" do
+        started <- newEmptyMVar
+        config0 <- testConfig $ Backend \_state _prev _inputs onEvent -> do
+            onEvent (TextDelta "visible ")
+            onEvent (TextDelta "partial")
+            putMVar started ()
+            threadDelay 2000000
+            error "cancel should stop the backend"
+        let cancelFlag = config0.loopCancel
+        _ <- forkIO do
+            takeMVar started
+            requestCancel cancelFlag
+        execution <- runLoopInputsDetailed config0 Nothing [UserMessage "go"]
+        execution.executionResult `shouldBe` Left (LoopCancelled [])
+        execution.executionVisibleAssistantText
+            `shouldBe` Just "visible partial"
+
     it "does not clear a cancel requested before the loop starts" do
         submissions <- newIORef []
         backend <- scriptedBackend submissions


### PR DESCRIPTION
## Summary
- retain assistant text that was exposed through streaming before a turn is cancelled
- persist that text as display-only cancellation metadata while keeping the model transcript at its safe input-only checkpoint
- preserve retry boundaries and discard provider-retracted response attempts
- accumulate streamed chunks without repeated strict `Text` append

## Regression coverage
- core loop test proves text streamed before an in-flight submission is cancelled remains available on `LoopExecution`
- fullscreen history test proves a cancelled durable turn projects its partial assistant output

## Validation
- loaded the combined `agent-core` and `agent-cli` test targets in GHCi (111 modules)
- focused core regression: 1 example, 0 failures
- focused fullscreen-history regression: 1 example, 0 failures
- live tmux smoke test: streamed `ESC-PRESERVE-MARKER` lines, pressed Esc during generation, and confirmed the visible prefix remained after cancellation/history commit
