### PR TITLE
fix(cli): guard managed session cleanup by launch token

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -156,12 +156,13 @@ data SessionThreadManager = SessionThreadManager
     }
 
 data ManagedSessionProcess
-    = ManagedSessionStarting !(MVar ())
-    | ManagedSessionRunning !ProcessHandle
+    = ManagedSessionStarting !Int !(MVar ())
+    | ManagedSessionRunning !Int !ProcessHandle
 
 data SessionProcessState = SessionProcessState
     { sessionManagerLifecycle :: !SessionManagerLifecycle
     , sessionManagerProcesses :: !(Map Text ManagedSessionProcess)
+    , sessionManagerNextToken :: !Int
     }
 
 data SessionManagerLifecycle
@@ -337,6 +338,7 @@ newSessionProcessManagerWithLifetime lifetime root = do
     processes <- newMVar SessionProcessState
         { sessionManagerLifecycle = SessionManagerOpen
         , sessionManagerProcesses = Map.empty
+        , sessionManagerNextToken = 0
         }
     pure SessionProcessManager
         { managedRoot = root
@@ -392,34 +394,37 @@ launchSessionTurnInput
                 busy <- case Map.lookup sessionId state.sessionManagerProcesses of
                     Nothing -> pure False
                     Just ManagedSessionStarting{} -> pure True
-                    Just (ManagedSessionRunning managedHandle) ->
+                    Just (ManagedSessionRunning _ managedHandle) ->
                         (== Nothing) <$> getProcessExitCode managedHandle
                 if not (sessionManagerIsOpen state) || busy
-                    then pure (state, False)
-                    else pure
-                        ( state
-                            { sessionManagerProcesses =
-                                Map.insert
-                                    sessionId
-                                    (ManagedSessionStarting completion)
-                                    state.sessionManagerProcesses
-                            }
-                        , True
-                        )
-            if not reserved
-                then pure (Left ("session " <> sessionId
+                    then pure (state, Nothing)
+                    else
+                        let token = state.sessionManagerNextToken
+                        in pure
+                            ( state
+                                { sessionManagerProcesses =
+                                    Map.insert
+                                        sessionId
+                                        (ManagedSessionStarting token completion)
+                                        state.sessionManagerProcesses
+                                , sessionManagerNextToken = token + 1
+                                }
+                            , Just token
+                            )
+            case reserved of
+                Nothing -> pure (Left ("session " <> sessionId
                     <> " is already running or its process manager is closed"))
-                else (`finally` putMVar completion ()) do
+                Just token -> (`finally` putMVar completion ()) do
                     started <- try @_ @SomeException
                         (startManagedSession executable)
                     case started of
                         Left err -> do
-                            forgetSession manager sessionId
+                            forgetSession manager sessionId token
                             pure $ Left
                                 ("failed to start agent session: "
                                     <> formatException err)
                         Right (Left err) -> do
-                            forgetSession manager sessionId
+                            forgetSession manager sessionId token
                             pure (Left err)
                         Right (Right process) -> do
                             published <-
@@ -430,7 +435,7 @@ launchSessionTurnInput
                                             ( state
                                                 { sessionManagerProcesses =
                                                     Map.insert sessionId
-                                                        (ManagedSessionRunning process)
+                                                        (ManagedSessionRunning token process)
                                                         state.sessionManagerProcesses
                                                 }
                                             , True
@@ -457,7 +462,7 @@ launchSessionTurnInput
                                                                     "agent session timed out")
                                                             Just exitCode ->
                                                                 pure (Right exitCode)
-                                        forgetSession manager sessionId
+                                        forgetSession manager sessionId token
                                         pure case exitResult of
                                             Left err -> Left err
                                             Right ExitSuccess ->
@@ -598,13 +603,19 @@ launchManagedTurnBounded
         handle
         (ManagedRequestInput request)
 
-forgetSession :: SessionProcessManager -> Text -> IO ()
-forgetSession manager sessionId =
-    modifyMVar_ manager.managedProcesses
-        (\state -> pure state
-            { sessionManagerProcesses =
-                Map.delete sessionId state.sessionManagerProcesses
-            })
+forgetSession :: SessionProcessManager -> Text -> Int -> IO ()
+forgetSession manager sessionId token =
+    modifyMVar_ manager.managedProcesses \state ->
+        let matches = case Map.lookup sessionId state.sessionManagerProcesses of
+                Just (ManagedSessionStarting current _) -> current == token
+                Just (ManagedSessionRunning current _) -> current == token
+                Nothing -> False
+        in pure if matches
+            then state
+                { sessionManagerProcesses =
+                    Map.delete sessionId state.sessionManagerProcesses
+                }
+            else state
 
 gatewayOnlyEnv :: [String]
 gatewayOnlyEnv =
@@ -624,7 +635,7 @@ sessionProcessStatus manager sessionId =
                 pure (state, if locked then "running" else "idle")
             Just ManagedSessionStarting{} ->
                 pure (state, "running")
-            Just (ManagedSessionRunning managedHandle) ->
+            Just (ManagedSessionRunning _ managedHandle) ->
                 -- Keep the exited process record rather than deleting it on
                 -- read: getProcessExitCode returns a stable code once the
                 -- process has exited, so retaining the handle lets repeated
@@ -672,11 +683,11 @@ closeSessionProcessManager manager = do
   where
     closeProcesses processes = do
         let waitStarting = \case
-                ManagedSessionStarting completion -> readMVar completion
-                ManagedSessionRunning _ -> pure ()
+                ManagedSessionStarting _ completion -> readMVar completion
+                ManagedSessionRunning _ _ -> pure ()
             closeRunning = \case
                 ManagedSessionStarting{} -> pure ()
-                ManagedSessionRunning managedHandle ->
+                ManagedSessionRunning _ managedHandle ->
                     getProcessExitCode managedHandle >>= \case
                         Just _ ->
                             void $ try @_ @SomeException


### PR DESCRIPTION
## Summary
- prevent an older managed-session turn from deleting a newer restart's process entry
- assign each launch a generation token and make cleanup conditional on that token

## Bug
When a foreground turn exited and a rapid restart replaced its process record, the old turn's unconditional cleanup could erase the new process entry. Subsequent status checks reported idle and another launch could start a duplicate child.

## Validation
- `TMPDIR=/tmp nix develop -c cabal test agent-cli-test --test-options='--match "/Agent.CLI.AgentSessions/"'` (23 examples, 0 failures)