### PR TITLE
Make code mode opt-in

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -351,6 +351,10 @@ parseSlash catalog raw line = case Text.words line of
                 ["reload"] -> ReplSkills True
                 _ -> ReplCommandError "usage: /skills [reload]"
             "shell" -> parseShellCommand args
+            "codemod" ->
+                if null args
+                    then ReplEnableCodeMode
+                    else ReplCommandError "usage: /codemod"
             "always-approve" ->
                 if null args
                     then ReplToggleAlwaysApprove

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -45,6 +45,7 @@ slashCommands =
     , grokToolCmd "workflow" "deep-research" [] "/deep-research <query>" "Run bounded background research, cross-check evidence, and write a cited report" True
     , cmd "skills" [] "/skills [reload]" "List discovered skills or reload them from disk" True
     , cmd "shell" [] "/shell [ghci|bash|both|none]" "Show or select the allowed shell tools" True
+    , cmd "codemod" ["code-mode"] "/codemod" "Enable JavaScript code mode for this session" False
     , cmd "always-approve" ["yolo"] "/always-approve" "Toggle project auto-approve (or Shift+Tab)" False
     , cmd "quit" ["exit"] "/quit" "Exit the current session" False
     ]

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -26,6 +26,7 @@ data ReplAction
     | ReplToggleFast
     | ReplShowModel
     | ReplSetModel Text
+    | ReplEnableCodeMode
     | ReplToggleAlwaysApprove
     | ReplPlan (Maybe Text)
     -- ^ Enter plan mode. @Just@ starts a turn with that description.

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -132,6 +132,8 @@ data CliOptions = CliOptions
       -- ^ Expose the provider's explicit shell execution tool (default: True).
     , optComputerUse :: !Bool
       -- ^ Allow the model to control the local macOS desktop (default: False).
+    , optCodeMode :: !Bool
+      -- ^ Honor catalog-selected JavaScript code mode (default: False).
     , optScreenMode :: !ScreenMode
     , optMotionMode :: !MotionMode
     } deriving (Eq, Show)
@@ -160,6 +162,7 @@ defaultCliOptions = CliOptions
     , optGhci = False
     , optBash = True
     , optComputerUse = False
+    , optCodeMode = False
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
     }
@@ -396,6 +399,10 @@ optionUpdateParser = asum
         (\value options -> options { optComputerUse = value })
     , boolFlagUpdate "no-computer-use" False "Disable local computer use"
         (\value options -> options { optComputerUse = value })
+    , boolFlagUpdate "code-mode" True "Enable catalog-selected code mode"
+        (\value options -> options { optCodeMode = value })
+    , boolFlagUpdate "no-code-mode" False "Use conventional tool calling"
+        (\value options -> options { optCodeMode = value })
     , screenFlagUpdate "fullscreen" ScreenFullscreen
         "Use the retained full-screen TUI"
     , screenFlagUpdate "minimal" ScreenMinimal

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -42,7 +42,7 @@ import Agent.CLI.Options
     ( isOneShot,
       CliOptions(optMotionMode, optManagedTurnFile, optScreenMode,
                  optProvider, optModel, optWorktree, optEffort, optPrompt,
-                 optPromptFile, optResume, optCwd),
+                 optPromptFile, optResume, optCwd, optCodeMode),
       ScreenMode(ScreenMinimal) )
 import Agent.CLI.PendingInputs ()
 import Agent.CLI.Plan ()
@@ -286,6 +286,11 @@ runAgentWithRuntime processRuntime runMode options = do
                 go fullscreenInputs sessionState
                     (restartSessionOptions current sessionId)
                     Nothing
+            RunEnableCodeMode sessionId ->
+                let nextOptions =
+                        (restartSessionOptions current sessionId)
+                            { optCodeMode = True }
+                in go fullscreenInputs sessionState nextOptions Nothing
             RunProviderStartFailed apiError ->
                 case transition of
                     Just failed

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Restart.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Restart.hs
@@ -3,7 +3,7 @@ module Agent.CLI.Runtime.Orchestration.Restart
     , runFullscreenRestartLoop
     ) where
 
-import Agent.CLI.Options ( CliOptions )
+import Agent.CLI.Options ( CliOptions(optCodeMode) )
 import Agent.CLI.ProviderTransition
     ( ProviderTransition(..), TransitionCause(AutomaticFallback) )
 import Agent.CLI.Runtime.Types ( PreparedAgent(..), RunResult(..) )
@@ -59,6 +59,11 @@ runFullscreenRestartLoop callbacks runtime =
             Right result -> case result of
                 RunRestart sessionId -> do
                     let nextOptions = callbacks.restartOptions options sessionId
+                    retryStartup nextOptions Nothing
+                RunEnableCodeMode sessionId -> do
+                    let nextOptions =
+                            (callbacks.restartOptions options sessionId)
+                                { optCodeMode = True }
                     retryStartup nextOptions Nothing
                 RunSwitchProvider next -> do
                     let nextOptions =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -37,7 +37,9 @@ import Agent.CLI.McpStatus ()
 import Agent.CLI.ModelConfig ( catalogContextWindowForTransport )
 import Agent.CLI.Models ()
 import Agent.CLI.Options
-    ( isOneShot, CliOptions(optShowRawReasoning, optCompactThreshold) )
+    ( isOneShot
+    , CliOptions(optCodeMode, optShowRawReasoning, optCompactThreshold)
+    )
 import Agent.CLI.PendingInputs ()
 import Agent.CLI.Plan ()
 import Agent.CLI.Project ()
@@ -319,9 +321,10 @@ runAgentSession
                 Nothing -> pure ()
         today <- utctDay <$> getCurrentTime
         mcpInstructions <- MCP.mcpFleetInstructions mcpFleet
-        -- Catalog models: per-model instructions template and, when the
-        -- catalog selects code_mode_only, the exec/wait tool surface. The
-        -- offline lookup never blocks startup on the network.
+        -- Catalog models provide the per-model instructions template. Code
+        -- mode is opt-in even when the catalog selects code_mode_only; normal
+        -- provider tool calling remains the default. The offline lookup never
+        -- blocks startup on the network.
         codexModelInfo <-
             loadCodexCatalogModelInfo
                 stateDirectory
@@ -329,14 +332,15 @@ runAgentSession
                 dialect
                 (Just loaded.loadedTokenProvider)
                 model
-        codeModeRuntime <-
-            codeModeSessionRuntimeFor codexModelInfo tools >>= \case
+        codeModeRuntime <- if options.optCodeMode
+            then codeModeSessionRuntimeFor codexModelInfo tools >>= \case
                 Left err -> do
                     reportStartupWarning startup
                         ("code mode unavailable; falling back to direct tools: "
                             <> err)
                     pure Nothing
                 Right runtime -> pure runtime
+            else pure Nothing
         writeIORef codeModeCloseRef
             (maybe (pure ()) (.codeModeClose) codeModeRuntime)
         let catalogSession = codexModelInfo <&> \info ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -27,7 +27,8 @@ import Agent.CLI.Command
                  ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopyLast,
                  ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
                  ReplShowTerminal, ReplShowEffort, ReplSetEffort, ReplShowModel,
-                 ReplSetModel, ReplToggleFast, ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
+                 ReplSetModel, ReplToggleFast, ReplEnableCodeMode,
+                 ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
                  ReplBtw, ReplRecap, ReplRetry, ReplResume, ReplSearch, ReplClear, ReplNew,
                  ReplShowSession, ReplShowSessionInfo, ReplAfk, ReplWorktree,
                  ReplRename, ReplRenameAuto, ReplLogin, ReplUsage, ReplReloadAuth,
@@ -100,7 +101,8 @@ import Agent.CLI.Runtime.Repl.Selection
 import Agent.CLI.Runtime.Repl.Session ( handleSessionAction )
 import Agent.CLI.Runtime.Repl.Workflow ( handleWorkflowAction )
 import Agent.CLI.Runtime.Types
-    ( RunResult(RunRestart, RunSwitchProvider, RunReload, RunQuit) )
+    ( RunResult(RunEnableCodeMode, RunRestart, RunSwitchProvider, RunReload,
+                RunQuit) )
 import Agent.CLI.Secret ()
 import Agent.CLI.Session
     ( TranscriptEffect(TranscriptReplace),
@@ -572,6 +574,8 @@ handleReplLine
                     action@ReplToggleFast -> handleSelectionAction env continue action
                     action@ReplShowModel -> handleSelectionAction env continue action
                     action@ReplSetModel{} -> handleSelectionAction env continue action
+                    ReplEnableCodeMode ->
+                        requestCodeModeRestart fullscreen persist
                     ReplToggleAlwaysApprove
                         | provider == ClaudeCodeProvider -> do
                             let message =
@@ -860,6 +864,28 @@ requestMcpRestart fullscreen persist = do
             handle <- ensureSession slotRef
             report "restarting MCP servers…"
             pure (RunRestart handle.sessionMeta.metaId)
+
+requestCodeModeRestart
+    :: Maybe FullscreenRuntime
+    -> Persistence
+    -> IO RunResult
+requestCodeModeRestart fullscreen persist = do
+    color <- resolveColor stderr
+    let report message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
+    case persist of
+        PersistenceDisabled -> do
+            report "code mode requires a persisted REPL session"
+            pure RunQuit
+        PersistenceEnabled slotRef -> do
+            handle <- ensureSession slotRef
+            report "enabling code mode…"
+            pure (RunEnableCodeMode handle.sessionMeta.metaId)
 
 enterPlanFromSlash :: SessionEnv -> Maybe Text -> IO (Maybe ProviderTransition)
 enterPlanFromSlash env@SessionEnv

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
@@ -31,6 +31,7 @@ data DevResult
 data RunResult
     = RunQuit
     | RunRestart Text
+    | RunEnableCodeMode Text
     | RunReload Text
     | RunSwitchProvider ProviderTransition
     | RunProviderStartFailed ApiError

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -85,6 +85,12 @@ spec = do
                 `shouldBe` ReplCommandError
                     "usage: /shell [ghci|bash|both|none]"
 
+        it "parses runtime code-mode enablement" do
+            parseReplLine "/codemod" `shouldBe` ReplEnableCodeMode
+            parseReplLine "/code-mode" `shouldBe` ReplEnableCodeMode
+            parseReplLine "/codemod now"
+                `shouldBe` ReplCommandError "usage: /codemod"
+
         it "rejects extra args on /always-approve" do
             parseReplLine "/always-approve now"
                 `shouldBe` ReplCommandError "usage: /always-approve"

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -267,6 +267,15 @@ spec = do
                 `shouldBe` Right (RunAgent defaultCliOptions
                     { optComputerUse = False })
 
+        it "uses conventional tool calling by default" do
+            defaultCliOptions.optCodeMode `shouldBe` False
+            parseArgs ["--code-mode"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optCodeMode = True })
+            parseArgs ["--code-mode", "--no-code-mode"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optCodeMode = False })
+
         it "keeps ghci disabled by default and enables it explicitly" do
             parseArgs []
                 `shouldBe` Right (RunAgent defaultCliOptions)


### PR DESCRIPTION
## Summary
- default agent sessions to conventional provider tool calling
- make catalog-selected JavaScript code mode opt-in with `--code-mode`
- add `--no-code-mode` and parser coverage for the default and overrides
- allow an active persisted REPL session to enable code mode with `/codemod` (alias `/code-mode`), restarting the same session with the code-mode tool surface

## Testing
- `printf '\:main --match "conventional tool calling"\n\:q\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test` (1 example, 0 failures)
- `nix develop -c cabal test agent-cli-test --test-options='--match "runtime code-mode enablement"'` (1 example, 0 failures)
- `printf '\:quit\n' | nix develop -c cabal repl agent-cli` (271 modules loaded)
- live tmux smoke test: entered `/codemod`, observed `enabling code mode…`, and confirmed the same session resumed
- `git diff --check`

## Full-suite note
The earlier full GHCi suite compiled and ran 1,180 examples. Its 26 PostgreSQL-backed failures were caused by the generated Unix socket directory exceeding macOS's path-length limit in this deep worktree; all non-PostgreSQL tests, including the focused tests above, passed.