### PR TITLE
Encode native loop events as binary frames

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -250,6 +250,7 @@ foreign-library haskell-agent-bridge
     options:          standalone
     hs-source-dirs:   ffi
     other-modules:    Agent.CLI.MacOS.Bridge
+                    , Agent.CLI.MacOS.NativeLoopEvent
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     includes:         HaskellAgentBridge.h
@@ -334,9 +335,11 @@ test-suite agent-cli-test
     import:           common-options
     type:             exitcode-stdio-1.0
     ghc-options:      -threaded
-    hs-source-dirs:   test
+    hs-source-dirs:   test ffi
     main-is:          Spec.hs
     other-modules:    Agent.CLI.AccountSelectionSpec
+                    , Agent.CLI.MacOS.NativeLoopEventSpec
+                    , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -10,6 +10,9 @@ import Agent.CLI.NativeRuntime
     , newNativeProcessRuntime
     , runNativeAgent
     )
+import Agent.CLI.MacOS.NativeLoopEvent
+    ( encodeNativeLoopEvent
+    )
 import Agent.CLI.ModelConfig (loadModelCatalogAt)
 import Agent.CLI.Models
     ( ModelOption(..)
@@ -60,7 +63,6 @@ import Agent.Store.Postgres
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
-    , ToolCallResult(..)
     )
 import Control.Concurrent (forkFinally)
 import Control.Concurrent.Async
@@ -555,8 +557,11 @@ runNativeTurn callback context processRuntime control start = do
                 case event of
                     TurnFinished _ -> writeIORef completedRef True
                     _ -> pure ()
-                forM_ (nativeLoopEvent control.turnControlId event)
-                    (sendEvent callback context)
+                case encodeNativeLoopEvent control.turnControlId event of
+                    Just bytes -> sendBinaryEvent callback context bytes
+                    Nothing ->
+                        forM_ (nativeLoopEvent control.turnControlId event)
+                            (sendEvent callback context)
             , nativeOnSessionId = \sessionId -> do
                 writeIORef sessionIdRef (Just sessionId)
                 sendEvent callback context $
@@ -803,53 +808,9 @@ finishTurnEvent callback context turnId = \case
 
 nativeLoopEvent :: Text -> LoopEvent -> Maybe Aeson.Value
 nativeLoopEvent turnId = \case
-    ReasoningDelta text ->
-        Just $ Aeson.object
-            [ "event" Aeson..= ("turn.reasoning_delta" :: Text)
-            , "turnId" Aeson..= turnId
-            , "text" Aeson..= text
-            ]
-    TextDelta text ->
-        Just $ Aeson.object
-            [ "event" Aeson..= ("turn.text_delta" :: Text)
-            , "turnId" Aeson..= turnId
-            , "text" Aeson..= text
-            ]
-    ToolStarted call ->
-        let (arguments, truncated) =
-                boundedEventText
-                    (if call.argumentsEncrypted then "" else call.arguments)
-        in Just $ Aeson.object
-            [ "event" Aeson..= ("turn.tool" :: Text)
-            , "turnId" Aeson..= turnId
-            , "tool" Aeson..= Aeson.object
-                [ "type" Aeson..= ("tool_started" :: Text)
-                , "callId" Aeson..= call.callId
-                , "name" Aeson..= call.name
-                , "summary" Aeson..= summarizeToolCall call
-                , "arguments" Aeson..= arguments
-                , "argumentsEncrypted" Aeson..= call.argumentsEncrypted
-                , "truncated" Aeson..= truncated
-                ]
-            ]
-    ToolFinished result ->
-        let (output, truncated) = boundedEventText result.output
-        in Just $ Aeson.object
-            [ "event" Aeson..= ("turn.tool" :: Text)
-            , "turnId" Aeson..= turnId
-            , "tool" Aeson..= Aeson.object
-                [ "type" Aeson..= ("tool_finished" :: Text)
-                , "callId" Aeson..= result.callId
-                , "output" Aeson..= output
-                , "truncated" Aeson..= truncated
-                ]
-            ]
-    ActivityUpdated status ->
-        Just $ turnStatusEvent turnId status
-    WarningRaised warning ->
-        Just $ turnStatusEvent turnId warning
-    ResponseRestarted message ->
-        Just $ turnStatusEvent turnId message
+    ActivityUpdated status -> Just $ turnStatusEvent turnId status
+    WarningRaised warning -> Just $ turnStatusEvent turnId warning
+    ResponseRestarted message -> Just $ turnStatusEvent turnId message
     _ -> Nothing
 
 turnStatusEvent :: Text -> Text -> Aeson.Value
@@ -896,7 +857,7 @@ handleRequest config store root request = do
                 pure $ successEvent current.requestId $
                     Aeson.object
                         [ "runtime" Aeson..= ("haskell" :: Text)
-                        , "protocol" Aeson..= (3 :: Int)
+                        , "protocol" Aeson..= (4 :: Int)
                         ]
             "sessions.list" -> do
                 activeStore <- acquireStore config store
@@ -1137,7 +1098,22 @@ sendEvent :: FunPtr EventCallback -> Ptr () -> Aeson.Value -> IO ()
 sendEvent callback context event =
     void $ tryAny $
         BS.useAsCStringLen (LBS.toStrict (Aeson.encode event)) \(bytes, length) ->
-            invokeEventCallback callback
-                context
-                (castPtr bytes)
-                (fromIntegral length)
+            sendCallbackBytes callback context (castPtr bytes) length
+
+sendBinaryEvent :: FunPtr EventCallback -> Ptr () -> BS.ByteString -> IO ()
+sendBinaryEvent callback context bytes =
+    void $ tryAny $
+        BS.useAsCStringLen bytes \ (pointer, length) ->
+            sendCallbackBytes callback context (castPtr pointer) length
+
+sendCallbackBytes
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> Ptr Word8
+    -> Int
+    -> IO ()
+sendCallbackBytes callback context bytes length =
+    invokeEventCallback callback
+        context
+        (castPtr bytes)
+        (fromIntegral length)

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE GHC2021 #-}
+
+module Agent.CLI.MacOS.NativeLoopEvent
+    ( encodeNativeLoopEvent
+    ) where
+
+import Agent.CLI.Render (summarizeToolCall)
+import Agent.Loop (LoopEvent(..))
+import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word16, Word8)
+
+-- | Binary events are framed individually by the C callback.  HAEV version 1
+-- uses a common header followed by a turn id and kind-specific length-prefixed
+-- UTF-8 fields:
+--
+--   magic (4), version (1), kind (1), flags (u16 BE),
+--   turn-id length (u32 BE), fields...
+--
+-- A field length of maxBound denotes an absent optional field.  The callback
+-- already supplies the complete frame length, so no outer payload length is
+-- needed.
+encodeNativeLoopEvent :: Text -> LoopEvent -> Maybe BS.ByteString
+encodeNativeLoopEvent turnId event =
+    case event of
+        ReasoningDelta text -> textEvent 1 turnId text
+        TextDelta text -> textEvent 2 turnId text
+        ActivityUpdated status -> textEvent 3 turnId status
+        WarningRaised warning -> textEvent 3 turnId warning
+        ResponseRestarted message -> textEvent 3 turnId message
+        ToolStarted call ->
+            toolEvent 4 flags startedFields
+          where
+            (arguments, truncated) =
+                boundedEventText
+                    (if call.argumentsEncrypted then "" else call.arguments)
+            flags =
+                (if call.argumentsEncrypted then 1 else 0)
+                    + (if truncated then 2 else 0)
+            startedFields =
+                [ Just call.callId
+                , Just call.name
+                , Just (summarizeToolCall call)
+                , Just arguments
+                ]
+        ToolFinished result ->
+            toolEvent 5 flags finishedFields
+          where
+            (output, truncated) = boundedEventText result.output
+            flags = if truncated then 2 else 0
+            finishedFields = [Just result.callId, Just output]
+        _ -> Nothing
+  where
+    textEvent kind id text = frame kind 0 id [Just text]
+    toolEvent kind flags fields = frame kind flags turnId fields
+
+frame :: Word8 -> Word16 -> Text -> [Maybe Text] -> Maybe BS.ByteString
+frame kind flags turnId fields =
+    fmap
+        (LBS.toStrict . Builder.toLazyByteString)
+        ( do
+            turnIdField <- field (Just turnId)
+            fields' <- traverse field fields
+            pure $
+                Builder.byteString "HAEV"
+                    <> Builder.word8 1
+                    <> Builder.word8 kind
+                    <> Builder.word16BE flags
+                    <> turnIdField
+                    <> foldMap id fields'
+        )
+
+maxNativeFieldBytes :: Int
+-- Keep malformed callback frames from requesting unbounded allocations in
+-- consumers, while leaving room for bounded tool output and future fields.
+maxNativeFieldBytes = 16 * 1024 * 1024
+
+field :: Maybe Text -> Maybe Builder.Builder
+field Nothing = Just (Builder.word32BE maxBound)
+field (Just value) =
+    let bytes = TextEncoding.encodeUtf8 value
+    in if BS.length bytes > maxNativeFieldBytes
+        then Nothing
+        else Just $
+            Builder.word32BE (fromIntegral (BS.length bytes))
+                <> Builder.byteString bytes
+
+boundedEventText :: Text -> (Text, Bool)
+boundedEventText value =
+    let (visible, remainder) = Text.splitAt 8192 value
+    in (visible, not (Text.null remainder))

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -10,7 +10,17 @@ extern "C" {
 
 typedef void (*ha_event_callback)(
     void *context,
-    /* Valid only for the duration of this callback; copy before returning. */
+    /*
+     * Events are normally UTF-8 JSON. Native loop events use a versioned
+     * binary HAEV frame:
+     *   magic "HAEV" (4), version (u8), kind (u8), flags (u16 BE),
+     *   turn-id and kind-specific fields as u32-BE length-prefixed UTF-8.
+     * Kind 1 is reasoning text, 2 text, 3 status, 4 tool-start, and 5
+     * tool-finish. Tool-start flags use bit 0 for encrypted arguments and
+     * bit 1 for truncation; tool-finish uses bit 1 for truncation.
+     * The bytes are valid only for the duration of this callback; copy before
+     * returning.
+     */
     const uint8_t *bytes,
     size_t length
 );

--- a/packages/agent-cli/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
@@ -1,0 +1,79 @@
+module Agent.CLI.MacOS.NativeLoopEventSpec (spec) where
+
+import Agent.CLI.MacOS.NativeLoopEvent (encodeNativeLoopEvent)
+import Agent.Loop (LoopEvent(..))
+import Agent.ToolDispatch (ToolCall(..), ToolCallKind(..), ToolCallResult(..))
+import qualified Data.ByteString as BS
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word8, Word32)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "native loop event binary encoding" do
+    it "encodes text deltas with a versioned HAEV frame" do
+        encodeNativeLoopEvent "turn" (TextDelta "hé")
+            `shouldBe` Just (frame 2 0 ["turn", "hé"])
+
+    it "encodes reasoning and status events as distinct kinds" do
+        encodeNativeLoopEvent "turn" (ReasoningDelta "checking")
+            `shouldSatisfy` hasKind 1
+        encodeNativeLoopEvent "turn" (ActivityUpdated "working")
+            `shouldSatisfy` hasKind 3
+
+    it "preserves tool flags and fields" do
+        let call = ToolCall
+                { callId = "call-1"
+                , name = "read_file"
+                , arguments = "{\"path\":\"/tmp/a\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = True
+                }
+        case encodeNativeLoopEvent "turn" (ToolStarted call) of
+            Nothing -> expectationFailure "native tool event failed to encode"
+            Just encoded -> do
+                BS.take 8 encoded `shouldBe` header 4 1
+                BS.isInfixOf "call-1" encoded `shouldBe` True
+                BS.isInfixOf "read_file" encoded `shouldBe` True
+                BS.index encoded 7 `shouldBe` 1
+
+    it "encodes truncated tool output with its flag" do
+        let result = ToolCallResult
+                { callId = "call-1"
+                , output = Text.replicate 8193 "x"
+                , callKind = FunctionCallKind
+                }
+        case encodeNativeLoopEvent "turn" (ToolFinished result) of
+            Nothing -> expectationFailure "native tool event failed to encode"
+            Just encoded -> BS.take 8 encoded `shouldBe` header 5 2
+
+    it "does not encode lifecycle events as native loop frames" do
+        encodeNativeLoopEvent "turn" TurnStarted `shouldBe` Nothing
+
+frame :: Word8 -> Word8 -> [String] -> BS.ByteString
+frame kind flags fields =
+    header kind flags
+        <> BS.concat
+            [ field (TextEncoding.encodeUtf8 (Text.pack value))
+            | value <- fields
+            ]
+
+header :: Word8 -> Word8 -> BS.ByteString
+header kind flags =
+    "HAEV" <> BS.pack [1, kind, 0, flags]
+
+field :: BS.ByteString -> BS.ByteString
+field bytes = word32BE (fromIntegral (BS.length bytes)) <> bytes
+
+word32BE :: Word32 -> BS.ByteString
+word32BE value = BS.pack
+    [ fromIntegral (value `div` 16777216)
+    , fromIntegral (value `div` 65536)
+    , fromIntegral (value `div` 256)
+    , fromIntegral value
+    ]
+
+hasKind :: Word8 -> Maybe BS.ByteString -> Bool
+hasKind kind (Just encoded) =
+    BS.take 8 encoded == header kind 0
+hasKind _ Nothing = False

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -27,6 +27,7 @@ import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
+import qualified Agent.CLI.MacOS.NativeLoopEventSpec as NativeLoopEventSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
@@ -101,6 +102,7 @@ main = hspec do
     InterruptSpec.spec
     LoginSpec.spec
     LearnedSkillsSpec.spec
+    NativeLoopEventSpec.spec
     MarkdownSpec.spec
     McpManagerSpec.spec
     ModelConfigSpec.spec


### PR DESCRIPTION
## Summary
- encode transient native loop events in a versioned `HAEV` binary frame
- preserve JSON framing for requests, responses, approvals, and lifecycle events
- document the mixed callback framing and bump the embedded protocol to version 4
- add golden coverage for text, reasoning, status, tool, flag, UTF-8, and lifecycle behavior

## Validation
- native codec Hspec: 6 examples, 0 failures
- native bridge Cabal build
- coordinated sibling `nix build --override-input haskell-agent "path:$(realpath ../haskell-agent)" .#agent-macos` passed before the protocol-version-only bump; the repeat compiled but local output copying failed because the Nix store ran out of space
- matching Swift decoder benchmark: 10,000 events decoded in 7.146 ms binary vs 15.614 ms JSON; 417,890 bytes vs 797,890 bytes
- `git diff --check`