### PR TITLE
Reduce OpenAI compaction branching

### DIFF
--- a/packages/agent-core/src/Agent/MCP/Client.hs
+++ b/packages/agent-core/src/Agent/MCP/Client.hs
@@ -1047,17 +1047,20 @@ collectHeaderParams root = case root of
     _ -> Right []
   where
     walkObject path fields =
-        concat <$> forM (KeyMap.toList fields) \(key, value) ->
-            if Key.toText key == "properties"
-                then case value of
-                    Object properties ->
-                        concat <$> forM (KeyMap.toList properties) \(name, property) ->
-                            walkProperty (path <> [Key.toText name]) property
-                    _ -> Right []
-                else if containsHeaderAnnotation value
-                    then Left ("x-mcp-header under \"" <> Key.toText key
-                        <> "\" is not statically reachable from the schema root")
-                    else Right []
+        concat <$> forM (KeyMap.toList fields) (walkField path)
+
+    walkField path (key, value)
+        | Key.toText key == "properties" = walkProperties path value
+        | containsHeaderAnnotation value =
+            Left ("x-mcp-header under \"" <> Key.toText key
+                <> "\" is not statically reachable from the schema root")
+        | otherwise = Right []
+
+    walkProperties path = \case
+        Object properties ->
+            concat <$> forM (KeyMap.toList properties) \(name, property) ->
+                walkProperty (path <> [Key.toText name]) property
+        _ -> Right []
 
     walkProperty path property = case property of
         Object fields -> do

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -331,35 +331,29 @@ protocolDropUnits items =
         | otherwise =
             case item of
                 FunctionCallItem call ->
-                    let outputIndex =
-                            findOutputIndex
-                                outputIndices
-                                paired
-                                index
-                                (FunctionOutputKey, call.callId)
-                        nextPaired = maybe paired (`Set.insert` paired) outputIndex
-                    in DropUnit (index : maybe [] pure outputIndex)
-                        : go outputIndices nextPaired rest
+                    dropCallUnit
+                        outputIndices
+                        paired
+                        index
+                        rest
+                        FunctionOutputKey
+                        call.callId
                 CustomToolCallItem call ->
-                    let outputIndex =
-                            findOutputIndex
-                                outputIndices
-                                paired
-                                index
-                                (CustomToolOutputKey, call.callId)
-                        nextPaired = maybe paired (`Set.insert` paired) outputIndex
-                    in DropUnit (index : maybe [] pure outputIndex)
-                        : go outputIndices nextPaired rest
+                    dropCallUnit
+                        outputIndices
+                        paired
+                        index
+                        rest
+                        CustomToolOutputKey
+                        call.callId
                 ComputerCallItem call ->
-                    let outputIndex =
-                            findOutputIndex
-                                outputIndices
-                                paired
-                                index
-                                (ComputerOutputKey, call.computerCallId)
-                        nextPaired = maybe paired (`Set.insert` paired) outputIndex
-                    in DropUnit (index : maybe [] pure outputIndex)
-                        : go outputIndices nextPaired rest
+                    dropCallUnit
+                        outputIndices
+                        paired
+                        index
+                        rest
+                        ComputerOutputKey
+                        call.computerCallId
                 KnownResponseItem itemType tagged
                     | Just outputType <- pairedOutputType itemType ->
                         DropUnit
@@ -384,6 +378,17 @@ protocolDropUnits items =
                             : go outputIndices paired rest
                 _ ->
                     DropUnit [index] : go outputIndices paired rest
+
+    dropCallUnit outputIndices paired index rest outputType rawId =
+        let outputIndex =
+                findOutputIndex
+                    outputIndices
+                    paired
+                    index
+                    (outputType, rawId)
+            nextPaired = maybe paired (`Set.insert` paired) outputIndex
+        in DropUnit (index : maybe [] pure outputIndex)
+            : go outputIndices nextPaired rest
 
     findOutputIndex outputIndices paired minIndex (outputType, rawId) =
         case nonEmptyIdentifiers [rawId] of


### PR DESCRIPTION
## Summary
- factor shared call/output pairing logic in `protocolDropUnits`
- reduce duplicated branches while preserving behavior

## Validation
- `git diff --check`
- `nix develop -c cabal test agent-openai:test:agent-openai-test --offline`