### PR TITLE
Add native account management bridge

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -260,6 +260,9 @@ foreign-library haskell-agent-bridge
     build-depends:    agent-cli
                     , agent-core >= 0.1 && < 0.2
                     , agent-store >= 0.1 && < 0.2
+                    , agent-openai >= 0.1 && < 0.2
+                    , agent-xai >= 0.1 && < 0.2
+                    , agent-openrouter >= 0.1 && < 0.2
                     , aeson >= 2.0
                     , async
                     , base >= 4.17 && < 5

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -470,21 +470,25 @@ ha_account_oauth_start providerBytes (CSize providerLength) callback context
     | otherwise = do
         provider <- decodeInput providerBytes providerLength
         _ <- forkIO do
-            startAccountOAuth AccountProviderRequest
-                { accountProvider = provider } >>= \case
-                    Left err -> withText err $ \errorPtr errorLength ->
-                        invokeAccountOAuthStartCallback callback context
-                            (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 0 0
-                            errorPtr errorLength
-                    Right value -> case parseChallenge value of
-                        Nothing -> withText "invalid OAuth challenge"
-                            (\errorPtr errorLength ->
-                                invokeAccountOAuthStartCallback callback context
-                                    (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-                                    0 0 errorPtr errorLength)
-                        Just challenge ->
-                            withChallengeStrings challenge
-                                (invokeAccountOAuthStartCallback callback context 0)
+            tryAny (startAccountOAuth AccountProviderRequest
+                { accountProvider = provider }) >>= \case
+                Left exception -> withText (Text.pack (show exception)) $ \errorPtr errorLength ->
+                    invokeAccountOAuthStartCallback callback context
+                        (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 0 0
+                        errorPtr errorLength
+                Right (Left err) -> withText err $ \errorPtr errorLength ->
+                    invokeAccountOAuthStartCallback callback context
+                        (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 0 0
+                        errorPtr errorLength
+                Right (Right value) -> case parseChallenge value of
+                    Nothing -> withText "invalid OAuth challenge"
+                        (\errorPtr errorLength ->
+                            invokeAccountOAuthStartCallback callback context
+                                (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                                0 0 errorPtr errorLength)
+                    Just challenge ->
+                        withChallengeStrings challenge
+                            (invokeAccountOAuthStartCallback callback context 0)
         pure 0
 
 ha_account_oauth_poll
@@ -509,7 +513,7 @@ ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLe
         authId <- decodeInput authIdBytes authIdLength
         device <- decodeInput deviceBytes deviceLength
         _ <- forkIO do
-            pollAccountOAuth AccountOAuthPollRequest
+            tryAny (pollAccountOAuth AccountOAuthPollRequest
                 { oauthPollProvider = provider
                 , oauthPollVerificationUrl = nonEmptyText url
                 , oauthPollUserCode = nonEmptyText user
@@ -517,7 +521,9 @@ ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLe
                 , oauthPollDeviceCode = nonEmptyText device
                 , oauthPollIntervalSeconds = Just (fromIntegral pollInterval)
                 , oauthPollExpiresInSeconds = Just (fromIntegral expires)
-                } >>= invokeResult callback context
+                }) >>= \case
+                    Left exception -> invokeExceptionResult callback context exception
+                    Right result -> invokeResult callback context result
         pure 0
 
 ha_account_api_key_connect
@@ -531,9 +537,11 @@ ha_account_api_key_connect providerBytes (CSize providerLength) keyBytes (CSize 
         provider <- decodeInput providerBytes providerLength
         key <- decodeInput keyBytes keyLength
         _ <- forkIO do
-            connectAccountAPIKey AccountAPIKeyRequest
+            tryAny (connectAccountAPIKey AccountAPIKeyRequest
                 { accountAPIKeyProvider = provider, accountAPIKey = key }
-                >>= invokeResult callback context
+                ) >>= \case
+                    Left exception -> invokeExceptionResult callback context exception
+                    Right result -> invokeResult callback context result
         pure 0
 
 ha_account_set_enabled
@@ -544,8 +552,10 @@ ha_account_set_enabled idBytes (CSize idLength) enabled callback context
     | otherwise = do
         managedId <- decodeInput idBytes idLength
         _ <- forkIO do
-            setManagedCredentialEnabled managedId (enabled /= 0)
-                >>= invokeStoreResult callback context
+            tryAny (setManagedCredentialEnabled managedId (enabled /= 0))
+                >>= \case
+                    Left exception -> invokeExceptionResult callback context exception
+                    Right result -> invokeStoreResult callback context result
         pure 0
 
 ha_account_delete
@@ -556,8 +566,9 @@ ha_account_delete idBytes (CSize idLength) callback context
     | otherwise = do
         managedId <- decodeInput idBytes idLength
         _ <- forkIO do
-            deleteManagedCredential managedId
-                >>= invokeStoreResult callback context
+            tryAny (deleteManagedCredential managedId) >>= \case
+                Left exception -> invokeExceptionResult callback context exception
+                Right result -> invokeStoreResult callback context result
         pure 0
 
 anyNonEmptyNull :: [(Ptr Word8, Word64)] -> Bool
@@ -638,6 +649,13 @@ invokeStoreResult callback context result = case result of
         invokeAccountResultCallback callback context (-1)
             nullPtr 0 errorPtr errorLength
     Right () -> invokeAccountResultCallback callback context 0 nullPtr 0 nullPtr 0
+
+invokeExceptionResult :: FunPtr AccountResultCallback -> Ptr ()
+    -> SomeException -> IO ()
+invokeExceptionResult callback context exception =
+    withText (Text.pack (show exception)) $ \errorPtr errorLength ->
+        invokeAccountResultCallback callback context (-1)
+            nullPtr 0 errorPtr errorLength
 
 ha_engine_create :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
 ha_engine_create callback context

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE FieldSelectors #-}
 
 module Agent.CLI.MacOS.Bridge () where
 
@@ -71,8 +70,7 @@ import Agent.CLI.Session
     , sessionsRoot
     )
 import Agent.CLI.SessionAdmin
-    ( accountSummariesJSON
-    , loadSessionPageJSON
+    ( loadSessionPageJSON
     , managedPostgresConfigForHome
     , sessionSummaryWithStatusJSON
     )
@@ -85,11 +83,6 @@ import Agent.Store.Postgres
     , closeStore
     , openStore
     , trustedPool
-    )
-import Agent.Store.Postgres.UsageCache
-    ( AccountUsageCacheEntry(..)
-    , loadAccountUsageCache
-    , upsertAccountUsageCache
     )
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
@@ -373,10 +366,6 @@ data AccountProviderRequest = AccountProviderRequest
     { accountProvider :: !Text
     }
 
-instance Aeson.FromJSON AccountProviderRequest where
-    parseJSON = Aeson.withObject "AccountProviderRequest" \object ->
-        AccountProviderRequest <$> object .: "provider"
-
 data AccountOAuthPollRequest = AccountOAuthPollRequest
     { oauthPollProvider :: !Text
     , oauthPollVerificationUrl :: !(Maybe Text)
@@ -387,46 +376,10 @@ data AccountOAuthPollRequest = AccountOAuthPollRequest
     , oauthPollExpiresInSeconds :: !(Maybe Int)
     }
 
-instance Aeson.FromJSON AccountOAuthPollRequest where
-    parseJSON = Aeson.withObject "AccountOAuthPollRequest" \object ->
-        AccountOAuthPollRequest
-            <$> object .: "provider"
-            <*> object .:? "verificationUrl"
-            <*> object .:? "userCode"
-            <*> object .:? "deviceAuthId"
-            <*> object .:? "deviceCode"
-            <*> object .:? "pollIntervalSeconds"
-            <*> object .:? "expiresInSeconds"
-
 data AccountAPIKeyRequest = AccountAPIKeyRequest
     { accountAPIKeyProvider :: !Text
     , accountAPIKey :: !Text
     }
-
-instance Aeson.FromJSON AccountAPIKeyRequest where
-    parseJSON = Aeson.withObject "AccountAPIKeyRequest" \object ->
-        AccountAPIKeyRequest
-            <$> object .: "provider"
-            <*> object .: "apiKey"
-
-data AccountEnabledRequest = AccountEnabledRequest
-    { accountEnabledManagedId :: !Text
-    , accountEnabledEnabled :: !Bool
-    }
-
-instance Aeson.FromJSON AccountEnabledRequest where
-    parseJSON = Aeson.withObject "AccountEnabledRequest" \object ->
-        AccountEnabledRequest
-            <$> object .: "managedID"
-            <*> object .: "enabled"
-
-data AccountDeleteRequest = AccountDeleteRequest
-    { accountDeleteManagedId :: !Text
-    }
-
-instance Aeson.FromJSON AccountDeleteRequest where
-    parseJSON = Aeson.withObject "AccountDeleteRequest" \object ->
-        AccountDeleteRequest <$> object .: "managedID"
 
 data EngineCommand
     = EngineRequest !BridgeRequest
@@ -579,7 +532,7 @@ ha_account_set_enabled
 ha_account_set_enabled idBytes (CSize idLength) enabled callback context
     | callback == nullFunPtr = pure 1
     | otherwise = do
-        managedId <- decodeInput idBytes (CSize idLength)
+        managedId <- decodeInput idBytes idLength
         _ <- forkIO do
             setManagedCredentialEnabled managedId (enabled /= 0)
                 >>= invokeStoreResult callback context
@@ -590,7 +543,7 @@ ha_account_delete
 ha_account_delete idBytes (CSize idLength) callback context
     | callback == nullFunPtr = pure 1
     | otherwise = do
-        managedId <- decodeInput idBytes (CSize idLength)
+        managedId <- decodeInput idBytes idLength
         _ <- forkIO do
             deleteManagedCredential managedId
                 >>= invokeStoreResult callback context
@@ -1281,53 +1234,6 @@ handleRequest config store root request = do
                             (failureEvent current.requestId)
                             (const (successEvent current.requestId True))
                             changed
-            "accounts.list" -> do
-                activeStore <- acquireStore config store
-                accounts <- cachedAccountSummaries activeStore
-                pure $ successEvent current.requestId
-                    accounts
-            "accounts.oauth.start" ->
-                case (parseParams current :: Either Text AccountProviderRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request ->
-                        startAccountOAuth request >>= either
-                            (pure . failureEvent current.requestId)
-                            (pure . successEvent current.requestId)
-            "accounts.oauth.poll" ->
-                case (parseParams current :: Either Text AccountOAuthPollRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request ->
-                        pollAccountOAuth request >>= either
-                            (pure . failureEvent current.requestId)
-                            (pure . successEvent current.requestId)
-            "accounts.apiKey.connect" ->
-                case (parseParams current :: Either Text AccountAPIKeyRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request ->
-                        connectAccountAPIKey request >>= either
-                            (pure . failureEvent current.requestId)
-                            (pure . successEvent current.requestId)
-            "accounts.setEnabled" ->
-                case (parseParams current :: Either Text AccountEnabledRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request -> do
-                        result <- setManagedCredentialEnabled
-                            request.accountEnabledManagedId
-                            request.accountEnabledEnabled
-                        pure $ either
-                            (failureEvent current.requestId)
-                            (const (successEvent current.requestId True))
-                            result
-            "accounts.delete" ->
-                case (parseParams current :: Either Text AccountDeleteRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request -> do
-                        result <- deleteManagedCredential
-                            request.accountDeleteManagedId
-                        pure $ either
-                            (failureEvent current.requestId)
-                            (const (successEvent current.requestId True))
-                            result
             "turn.agents" ->
                 pure $ successEvent current.requestId ([] :: [Aeson.Value])
             "models.list" ->
@@ -1348,48 +1254,6 @@ handleRequest config store root request = do
             method ->
                 pure $ failureEvent current.requestId
                     ("unknown method: " <> method)
-
-cachedAccountSummaries :: Store -> IO [Aeson.Value]
-cachedAccountSummaries store = do
-    let pool = trustedPool store
-    cached <- loadAccountUsageCache pool accountCacheProvider accountCacheKey
-    now <- getCurrentTime
-    case cached of
-        Right (Just entry)
-            | Just accounts <- decodeAccountCache entry.accountUsageCachePayload -> do
-                if entry.accountUsageCacheExpiresAt <= now
-                    then void $ forkFinally
-                        (refreshAccountCache store)
-                        (const (pure ()))
-                    else pure ()
-                pure accounts
-        _ -> refreshAccountCache store
-
-refreshAccountCache :: Store -> IO [Aeson.Value]
-refreshAccountCache store = do
-    accounts <- accountSummariesJSON
-    fetchedAt <- getCurrentTime
-    let payload = TextEncoding.decodeUtf8 $
-            LBS.toStrict (Aeson.encode accounts)
-        entry = AccountUsageCacheEntry
-            { accountUsageCacheProvider = accountCacheProvider
-            , accountUsageCacheAccountId = accountCacheKey
-            , accountUsageCachePayload = payload
-            , accountUsageCacheFetchedAt = fetchedAt
-            , accountUsageCacheExpiresAt = addUTCTime 300 fetchedAt
-            }
-    void $ upsertAccountUsageCache (trustedPool store) entry
-    pure accounts
-
-decodeAccountCache :: Text -> Maybe [Aeson.Value]
-decodeAccountCache =
-    Aeson.decodeStrict' . TextEncoding.encodeUtf8
-
-accountCacheProvider :: Text
-accountCacheProvider = "macos-bridge"
-
-accountCacheKey :: Text
-accountCacheKey = "account-summaries-v1"
 
 loadNativeModelCatalog
     :: Store

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -495,6 +495,13 @@ ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLe
     userBytes (CSize userLength) authIdBytes (CSize authIdLength)
     deviceBytes (CSize deviceLength) pollInterval expires callback context
     | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull
+        [ (providerBytes, providerLength)
+        , (urlBytes, urlLength)
+        , (userBytes, userLength)
+        , (authIdBytes, authIdLength)
+        , (deviceBytes, deviceLength)
+        ] = pure 2
     | otherwise = do
         provider <- decodeInput providerBytes providerLength
         url <- decodeInput urlBytes urlLength
@@ -518,6 +525,8 @@ ha_account_api_key_connect
     -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
 ha_account_api_key_connect providerBytes (CSize providerLength) keyBytes (CSize keyLength) callback context
     | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull
+        [ (providerBytes, providerLength), (keyBytes, keyLength) ] = pure 2
     | otherwise = do
         provider <- decodeInput providerBytes providerLength
         key <- decodeInput keyBytes keyLength
@@ -531,6 +540,7 @@ ha_account_set_enabled
     :: Ptr Word8 -> CSize -> CInt -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
 ha_account_set_enabled idBytes (CSize idLength) enabled callback context
     | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull [(idBytes, idLength)] = pure 2
     | otherwise = do
         managedId <- decodeInput idBytes idLength
         _ <- forkIO do
@@ -542,12 +552,17 @@ ha_account_delete
     :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
 ha_account_delete idBytes (CSize idLength) callback context
     | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull [(idBytes, idLength)] = pure 2
     | otherwise = do
         managedId <- decodeInput idBytes idLength
         _ <- forkIO do
             deleteManagedCredential managedId
                 >>= invokeStoreResult callback context
         pure 0
+
+anyNonEmptyNull :: [(Ptr Word8, Word64)] -> Bool
+anyNonEmptyNull = any \(pointer, length) ->
+    pointer == nullPtr && length > 0
 
 withAccountStrings :: LoginAccount -> (CString -> CSize -> CString -> CSize
     -> CString -> CSize -> CString -> CSize -> CString -> CSize

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -14,6 +14,26 @@ import Agent.CLI.NativeRuntime
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     )
+import Agent.CLI.Environment (lookupNonEmpty)
+import Agent.CLI.Login
+    ( storeConnectedCredential )
+import Agent.CLI.CredentialStore
+    ( ManagedAuthKind(..)
+    , deleteManagedCredential
+    , setManagedCredentialEnabled
+    )
+import Agent.CLI.Auth
+    ( GrokAuthState(..)
+    , grokAuthStateToJson
+    , openAIOAuthClientId
+    , openaiAuthStateFromJson
+    , xaiOAuthClientId
+    )
+import qualified Agent.OpenAI.Login as OpenAILogin
+import qualified Agent.OpenAI.Auth as OpenAIAuth
+import qualified Agent.OpenAI.Auth.Types as OpenAIAuthTypes
+import qualified Agent.XAI.Auth as XAIAuth
+import qualified Agent.OpenRouter.Usage as OpenRouter
 import Agent.CLI.ModelConfig (loadModelCatalogAt)
 import Agent.CLI.Models
     ( ModelOption(..)
@@ -53,7 +73,7 @@ import Agent.CLI.SessionAdmin
     )
 import Agent.Loop (LoopEvent(..))
 import Agent.Dialect (dialectSlug)
-import Agent.Provider (Provider(..), providerSlug)
+import Agent.Provider (Provider(..), providerSlug, parseProvider, BillingMode(..))
 import Agent.Store.Postgres
     ( ManagedPostgresConfig
     , Store
@@ -298,6 +318,65 @@ instance Aeson.FromJSON ModelsListRequest where
         ModelsListRequest
             <$> object .: "cwd"
             <*> object .:? "sessionId"
+
+data AccountProviderRequest = AccountProviderRequest
+    { accountProvider :: !Text
+    }
+
+instance Aeson.FromJSON AccountProviderRequest where
+    parseJSON = Aeson.withObject "AccountProviderRequest" \object ->
+        AccountProviderRequest <$> object .: "provider"
+
+data AccountOAuthPollRequest = AccountOAuthPollRequest
+    { oauthPollProvider :: !Text
+    , oauthPollVerificationUrl :: !(Maybe Text)
+    , oauthPollUserCode :: !(Maybe Text)
+    , oauthPollDeviceAuthId :: !(Maybe Text)
+    , oauthPollDeviceCode :: !(Maybe Text)
+    , oauthPollIntervalSeconds :: !(Maybe Int)
+    , oauthPollExpiresInSeconds :: !(Maybe Int)
+    }
+
+instance Aeson.FromJSON AccountOAuthPollRequest where
+    parseJSON = Aeson.withObject "AccountOAuthPollRequest" \object ->
+        AccountOAuthPollRequest
+            <$> object .: "provider"
+            <*> object .:? "verificationUrl"
+            <*> object .:? "userCode"
+            <*> object .:? "deviceAuthId"
+            <*> object .:? "deviceCode"
+            <*> object .:? "pollIntervalSeconds"
+            <*> object .:? "expiresInSeconds"
+
+data AccountAPIKeyRequest = AccountAPIKeyRequest
+    { accountAPIKeyProvider :: !Text
+    , accountAPIKey :: !Text
+    }
+
+instance Aeson.FromJSON AccountAPIKeyRequest where
+    parseJSON = Aeson.withObject "AccountAPIKeyRequest" \object ->
+        AccountAPIKeyRequest
+            <$> object .: "provider"
+            <*> object .: "apiKey"
+
+data AccountEnabledRequest = AccountEnabledRequest
+    { accountEnabledManagedId :: !Text
+    , accountEnabledEnabled :: !Bool
+    }
+
+instance Aeson.FromJSON AccountEnabledRequest where
+    parseJSON = Aeson.withObject "AccountEnabledRequest" \object ->
+        AccountEnabledRequest
+            <$> object .: "managedID"
+            <*> object .: "enabled"
+
+data AccountDeleteRequest = AccountDeleteRequest
+    { accountDeleteManagedId :: !Text
+    }
+
+instance Aeson.FromJSON AccountDeleteRequest where
+    parseJSON = Aeson.withObject "AccountDeleteRequest" \object ->
+        AccountDeleteRequest <$> object .: "managedID"
 
 data EngineCommand
     = EngineRequest !BridgeRequest
@@ -951,6 +1030,48 @@ handleRequest config store root request = do
                 accounts <- cachedAccountSummaries activeStore
                 pure $ successEvent current.requestId
                     accounts
+            "accounts.oauth.start" ->
+                case (parseParams current :: Either Text AccountProviderRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request ->
+                        startAccountOAuth request >>= either
+                            (pure . failureEvent current.requestId)
+                            (pure . successEvent current.requestId)
+            "accounts.oauth.poll" ->
+                case (parseParams current :: Either Text AccountOAuthPollRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request ->
+                        pollAccountOAuth request >>= either
+                            (pure . failureEvent current.requestId)
+                            (pure . successEvent current.requestId)
+            "accounts.apiKey.connect" ->
+                case (parseParams current :: Either Text AccountAPIKeyRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request ->
+                        connectAccountAPIKey request >>= either
+                            (pure . failureEvent current.requestId)
+                            (pure . successEvent current.requestId)
+            "accounts.setEnabled" ->
+                case (parseParams current :: Either Text AccountEnabledRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request -> do
+                        result <- setManagedCredentialEnabled
+                            request.accountEnabledManagedId
+                            request.accountEnabledEnabled
+                        pure $ either
+                            (failureEvent current.requestId)
+                            (const (successEvent current.requestId True))
+                            result
+            "accounts.delete" ->
+                case (parseParams current :: Either Text AccountDeleteRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request -> do
+                        result <- deleteManagedCredential
+                            request.accountDeleteManagedId
+                        pure $ either
+                            (failureEvent current.requestId)
+                            (const (successEvent current.requestId True))
+                            result
             "turn.agents" ->
                 pure $ successEvent current.requestId ([] :: [Aeson.Value])
             "models.list" ->
@@ -1108,6 +1229,174 @@ parseParams request =
     case Aeson.parseEither Aeson.parseJSON request.requestParams of
         Left err -> Left (Text.pack err)
         Right value -> Right value
+
+startAccountOAuth
+    :: AccountProviderRequest
+    -> IO (Either Text Aeson.Value)
+startAccountOAuth request =
+    case parseProvider request.accountProvider of
+        Just OpenAIProvider -> do
+            clientId <- openAIOAuthClientId <$> lookupNonEmpty
+                "OPENAI_OAUTH_CLIENT_ID"
+            OpenAILogin.requestDeviceCode
+                (OpenAILogin.defaultLoginOptions clientId) >>= \case
+                    Left err -> pure (Left err)
+                    Right code -> pure $ Right (Aeson.object
+                        [ "provider" Aeson..= ("openai" :: Text)
+                        , "verificationUrl" Aeson..= code.verificationUrl
+                        , "userCode" Aeson..= code.userCode
+                        , "deviceAuthId" Aeson..= code.deviceAuthId
+                        , "pollIntervalSeconds" Aeson..=
+                            code.pollIntervalSeconds
+                        ])
+        Just XAIProvider -> do
+            clientId <- xaiOAuthClientId <$> lookupNonEmpty
+                "XAI_OAUTH_CLIENT_ID"
+            XAIAuth.requestDeviceAuthorization
+                (XAIAuth.defaultOAuthOptions clientId) >>= \case
+                    Left err -> pure (Left err)
+                    Right code -> pure $ Right (Aeson.object
+                        [ "provider" Aeson..= ("xai" :: Text)
+                        , "verificationUrl" Aeson..= code.verificationUrl
+                        , "userCode" Aeson..= code.userCode
+                        , "deviceCode" Aeson..= code.deviceCode
+                        , "pollIntervalSeconds" Aeson..=
+                            code.pollIntervalSeconds
+                        , "expiresInSeconds" Aeson..=
+                            code.expiresInSeconds
+                        ])
+        _ -> pure (Left "OAuth account connection is not supported for this provider")
+
+pollAccountOAuth
+    :: AccountOAuthPollRequest
+    -> IO (Either Text Aeson.Value)
+pollAccountOAuth request =
+    case parseProvider request.oauthPollProvider of
+        Just OpenAIProvider -> case
+            (request.oauthPollVerificationUrl, request.oauthPollUserCode,
+                request.oauthPollDeviceAuthId) of
+            (Just url, Just userCode, Just authId) ->
+                do
+                    clientId <- openAIOAuthClientId <$> lookupNonEmpty
+                        "OPENAI_OAUTH_CLIENT_ID"
+                    OpenAILogin.pollDeviceCode
+                        (OpenAILogin.defaultLoginOptions clientId)
+                        OpenAILogin.DeviceCode
+                            { OpenAILogin.verificationUrl = Text.unpack url
+                            , OpenAILogin.userCode = userCode
+                            , OpenAILogin.deviceAuthId = authId
+                            , OpenAILogin.pollIntervalSeconds =
+                                fromMaybe 5 request.oauthPollIntervalSeconds
+                            } >>= \case
+                            Left err -> pure (Left err)
+                            Right Nothing -> pure $ Right
+                                (Aeson.object ["status" Aeson..= ("pending" :: Text)])
+                            Right (Just authJson) -> do
+                                now <- getCurrentTime
+                                case openaiAuthStateFromJson now
+                                    (Aeson.encode authJson) of
+                                    Nothing -> pure (Left
+                                        "OpenAI returned invalid account data")
+                                    Just auth -> do
+                                        let accountId =
+                                                case auth of
+                                                    OpenAIAuthTypes.AuthState
+                                                        _ _ value _ _ -> value
+                                        stored <- storeConnectedCredential
+                                            False OpenAIProvider
+                                                accountId
+                                            "ChatGPT" SubscriptionBilled
+                                            ManagedOpenAIAuthJson
+                                            (TextEncoding.decodeUtf8
+                                                (LBS.toStrict
+                                                    (Aeson.encode authJson)))
+                                        pure $ if stored
+                                            then Right (Aeson.object
+                                                [ "status" Aeson..=
+                                                    ("connected" :: Text)
+                                                , "accountID" Aeson..=
+                                                    auth.accountId
+                                                ])
+                                            else Left "could not store account"
+            _ -> pure (Left "OAuth challenge is missing required fields")
+        Just XAIProvider -> case
+            (request.oauthPollUserCode, request.oauthPollDeviceCode) of
+            (Just _, Just deviceCode) -> do
+                clientId <- xaiOAuthClientId <$> lookupNonEmpty
+                    "XAI_OAUTH_CLIENT_ID"
+                let challenge = XAIAuth.DeviceAuthorization
+                        { XAIAuth.deviceCode = deviceCode
+                        , XAIAuth.userCode = fromMaybe "" request.oauthPollUserCode
+                        , XAIAuth.verificationUrl =
+                            fromMaybe "" request.oauthPollVerificationUrl
+                        , XAIAuth.pollIntervalSeconds =
+                            fromMaybe 5 request.oauthPollIntervalSeconds
+                        , XAIAuth.expiresInSeconds =
+                            request.oauthPollExpiresInSeconds
+                        }
+                XAIAuth.pollDeviceAuthorization
+                    (XAIAuth.defaultOAuthOptions clientId) challenge >>= \case
+                        Left err -> pure (Left err)
+                        Right Nothing -> pure $ Right
+                            (Aeson.object ["status" Aeson..= ("pending" :: Text)])
+                        Right (Just tokens) -> do
+                            now <- getCurrentTime
+                            let accountId = fromMaybe "grok"
+                                    (XAIAuth.accountIdFromAccessToken
+                                        tokens.accessToken)
+                                label = fromMaybe "Grok" $
+                                    (tokens.idToken >>= XAIAuth.emailFromToken)
+                                    <|> XAIAuth.emailFromToken tokens.accessToken
+                                authJson = grokAuthStateToJson GrokAuthState
+                                    { grokAccessToken = tokens.accessToken
+                                    , grokRefreshToken = tokens.refreshToken
+                                    , grokIdToken = tokens.idToken
+                                    , grokExpiresAt =
+                                        ((`addUTCTime` now) . fromIntegral
+                                            <$> tokens.expiresInSeconds)
+                                    }
+                            case tokens.refreshToken of
+                                Nothing -> pure (Left
+                                    "Grok login did not return a refresh token")
+                                Just _ -> do
+                                    stored <- storeConnectedCredential
+                                        False XAIProvider accountId label
+                                        SubscriptionBilled ManagedGrokAuthJson
+                                        (TextEncoding.decodeUtf8
+                                            (LBS.toStrict
+                                                (Aeson.encode authJson)))
+                                    pure $ if stored
+                                        then Right (Aeson.object
+                                            [ "status" Aeson..=
+                                                ("connected" :: Text)
+                                            , "accountID" Aeson..= accountId
+                                            ])
+                                        else Left "could not store account"
+            _ -> pure (Left "OAuth challenge is missing required fields")
+        _ -> pure (Left "OAuth account connection is not supported for this provider")
+
+connectAccountAPIKey
+    :: AccountAPIKeyRequest
+    -> IO (Either Text Aeson.Value)
+connectAccountAPIKey request =
+    case parseProvider request.accountAPIKeyProvider of
+        Just OpenRouterProvider
+            | not (Text.null (Text.strip request.accountAPIKey)) ->
+                OpenRouter.fetchOpenRouterUsage request.accountAPIKey >>= \case
+                    Left err -> pure (Left ("OpenRouter rejected the key: " <> err))
+                    Right usage -> do
+                        let accountId = fromMaybe "openrouter" usage.keyLabel
+                            label = fromMaybe "OpenRouter" usage.keyLabel
+                        stored <- storeConnectedCredential
+                            False OpenRouterProvider accountId label ApiBilled
+                            ManagedBearerToken request.accountAPIKey
+                        pure $ if stored
+                            then Right (Aeson.object
+                                [ "status" Aeson..= ("connected" :: Text)
+                                , "accountID" Aeson..= accountId
+                                ])
+                            else Left "could not store account"
+        _ -> pure (Left "API-key connections are supported for OpenRouter")
 
 acquireStore :: ManagedPostgresConfig -> MVar (Maybe Store) -> IO Store
 acquireStore config state =

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -16,7 +16,12 @@ import Agent.CLI.MacOS.NativeLoopEvent
     )
 import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.Login
-    ( storeConnectedCredential )
+    ( AccountBilling(..)
+    , LoginAccount(..)
+    , discoverLoginAccounts
+    , loginAccountSelectionId
+    , storeConnectedCredential
+    )
 import Agent.CLI.CredentialStore
     ( ManagedAuthKind(..)
     , deleteManagedCredential
@@ -90,7 +95,7 @@ import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
     )
-import Control.Concurrent (forkFinally)
+import Control.Concurrent (forkFinally, forkIO)
 import Control.Concurrent.Async
     ( Async
     , cancel
@@ -169,6 +174,7 @@ import Foreign
     , nullFunPtr
     , nullPtr
     )
+import Foreign.C.String (CString, withCStringLen)
 import Foreign.C.Types (CInt(..), CSize(..))
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
@@ -181,10 +187,54 @@ import System.OsPath
     , unsafeEncodeUtf
     )
 
+decodeInput :: Ptr Word8 -> CSize -> IO Text
+decodeInput pointer (CSize length)
+    | pointer == nullPtr || length == 0 = pure ""
+    | otherwise = TextEncoding.decodeUtf8 <$> BS.packCStringLen
+        (castPtr pointer, fromIntegral length)
+
+nonEmptyText :: Text -> Maybe Text
+nonEmptyText value
+    | Text.null value = Nothing
+    | otherwise = Just value
+
+withText :: Text -> (CString -> CSize -> IO a) -> IO a
+withText value action = withCStringLen (Text.unpack value) \(pointer, length) ->
+    action pointer (fromIntegral length)
+
+withOptionalText :: Maybe Text -> (CString -> CSize -> IO a) -> IO a
+withOptionalText value action = withText (fromMaybe "" value) action
+
 type EventCallback = Ptr () -> Ptr Word8 -> CSize -> IO ()
+
+type AccountListCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CInt -> CString -> CSize -> IO ()
+
+type AccountResultCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
+type AccountOAuthStartCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CInt -> CInt
+    -> CString -> CSize -> IO ()
 
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
+
+foreign import ccall "dynamic"
+    invokeAccountListCallback
+        :: FunPtr AccountListCallback -> AccountListCallback
+
+foreign import ccall "dynamic"
+    invokeAccountResultCallback
+        :: FunPtr AccountResultCallback -> AccountResultCallback
+
+foreign import ccall "dynamic"
+    invokeAccountOAuthStartCallback
+        :: FunPtr AccountOAuthStartCallback -> AccountOAuthStartCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -414,6 +464,212 @@ foreign export ccall ha_engine_send_json
 
 foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
+
+foreign export ccall ha_accounts_list
+    :: FunPtr AccountListCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_oauth_start
+    :: Ptr Word8 -> CSize -> FunPtr AccountOAuthStartCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_oauth_poll
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt -> CInt
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_api_key_connect
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_set_enabled
+    :: Ptr Word8 -> CSize -> CInt
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_delete
+    :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+ha_accounts_list :: FunPtr AccountListCallback -> Ptr () -> IO CInt
+ha_accounts_list callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        _ <- forkIO do
+            tryAny discoverLoginAccounts >>= \case
+                Left exception ->
+                    withText (Text.pack (show exception)) $ \errorPtr errorLength ->
+                        invokeAccountListCallback callback context (-1)
+                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                            nullPtr 0 nullPtr 0 nullPtr 0
+                            0 0 errorPtr errorLength
+                Right accounts -> do
+                    forM_ accounts \account ->
+                        withAccountStrings account $
+                            invokeAccountListCallback callback context 0
+                    invokeAccountListCallback callback context 1
+                        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                        0 0 nullPtr 0
+        pure 0
+
+ha_account_oauth_start
+    :: Ptr Word8 -> CSize -> FunPtr AccountOAuthStartCallback -> Ptr () -> IO CInt
+ha_account_oauth_start providerBytes (CSize providerLength) callback context
+    | callback == nullFunPtr = pure 1
+    | providerBytes == nullPtr && providerLength > 0 = pure 2
+    | otherwise = do
+        provider <- decodeInput providerBytes (CSize providerLength)
+        _ <- forkIO do
+            startAccountOAuth AccountProviderRequest
+                { accountProvider = provider } >>= \case
+                    Left err -> withText err $ \errorPtr errorLength ->
+                        invokeAccountOAuthStartCallback callback context
+                            (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 0 0
+                            errorPtr errorLength
+                    Right value -> case parseChallenge value of
+                        Nothing -> withText "invalid OAuth challenge"
+                            (\errorPtr errorLength ->
+                                invokeAccountOAuthStartCallback callback context
+                                    (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                                    0 0 errorPtr errorLength)
+                        Just challenge ->
+                            withChallengeStrings challenge
+                                (invokeAccountOAuthStartCallback callback context 0)
+        pure 0
+
+ha_account_oauth_poll
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt -> CInt
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLength)
+    userBytes (CSize userLength) authIdBytes (CSize authIdLength)
+    deviceBytes (CSize deviceLength) pollInterval expires callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        provider <- decodeInput providerBytes (CSize providerLength)
+        url <- decodeInput urlBytes (CSize urlLength)
+        user <- decodeInput userBytes (CSize userLength)
+        authId <- decodeInput authIdBytes (CSize authIdLength)
+        device <- decodeInput deviceBytes (CSize deviceLength)
+        _ <- forkIO do
+            pollAccountOAuth AccountOAuthPollRequest
+                { oauthPollProvider = provider
+                , oauthPollVerificationUrl = nonEmptyText url
+                , oauthPollUserCode = nonEmptyText user
+                , oauthPollDeviceAuthId = nonEmptyText authId
+                , oauthPollDeviceCode = nonEmptyText device
+                , oauthPollIntervalSeconds = Just (fromIntegral pollInterval)
+                , oauthPollExpiresInSeconds = Just (fromIntegral expires)
+                } >>= invokeResult callback context
+        pure 0
+
+ha_account_api_key_connect
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+ha_account_api_key_connect providerBytes (CSize providerLength) keyBytes (CSize keyLength) callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        provider <- decodeInput providerBytes (CSize providerLength)
+        key <- decodeInput keyBytes (CSize keyLength)
+        _ <- forkIO do
+            connectAccountAPIKey AccountAPIKeyRequest
+                { accountAPIKeyProvider = provider, accountAPIKey = key }
+                >>= invokeResult callback context
+        pure 0
+
+ha_account_set_enabled
+    :: Ptr Word8 -> CSize -> CInt -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+ha_account_set_enabled idBytes (CSize idLength) enabled callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        managedId <- decodeInput idBytes (CSize idLength)
+        _ <- forkIO do
+            setManagedCredentialEnabled managedId (enabled /= 0)
+                >>= invokeStoreResult callback context
+        pure 0
+
+ha_account_delete
+    :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+ha_account_delete idBytes (CSize idLength) callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        managedId <- decodeInput idBytes (CSize idLength)
+        _ <- forkIO do
+            deleteManagedCredential managedId
+                >>= invokeStoreResult callback context
+        pure 0
+
+withAccountStrings :: LoginAccount -> (CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CInt -> CString -> CSize -> IO a) -> IO a
+withAccountStrings account action =
+    withText (providerSlug account.loginProvider) $ \provider providerLength ->
+    withText (billingText account.loginBilling) $ \billing billingLength ->
+    withText (loginAccountSelectionId account) $ \selection selectionLength ->
+    withText account.loginAccountId $ \accountId accountIdLength ->
+    withText account.loginLabel $ \label labelLength ->
+    withText account.loginSource $ \source sourceLength ->
+        withText account.loginSource $ \detail detailLength ->
+        withOptionalText account.loginManagedId $ \managedId managedLength ->
+        action provider providerLength billing billingLength
+            selection selectionLength accountId accountIdLength label labelLength
+            detail detailLength managedId managedLength source sourceLength
+            (if account.loginEnabled then 1 else 0)
+            (if account.loginManagedId == Nothing then 0 else 1)
+            nullPtr 0
+
+billingText :: AccountBilling -> Text
+billingText = \case
+    SubscriptionBilling _ -> "subscription"
+    ApiCreditsBilling -> "api"
+
+parseChallenge :: Aeson.Value
+    -> Maybe (Text, Text, Maybe Text, Maybe Text, Int, Int)
+parseChallenge = Aeson.parseMaybe $ Aeson.withObject "challenge" \object ->
+    (,,,,,)
+        <$> object Aeson..: "verificationUrl"
+        <*> object Aeson..: "userCode"
+        <*> object Aeson..:? "deviceAuthId"
+        <*> object Aeson..:? "deviceCode"
+        <*> (object Aeson..:? "pollIntervalSeconds" Aeson..!= 5)
+        <*> (object Aeson..:? "expiresInSeconds" Aeson..!= 0)
+
+withChallengeStrings
+    :: (Text, Text, Maybe Text, Maybe Text, Int, Int)
+    -> (CString -> CSize -> CString -> CSize -> CString -> CSize -> CString -> CSize
+        -> CInt -> CInt -> CString -> CSize -> IO a)
+    -> IO a
+withChallengeStrings (url, user, authId, device, interval, expires) action =
+    withText url $ \urlPtr urlLength ->
+    withText user $ \userPtr userLength ->
+    withOptionalText authId $ \authPtr authLength ->
+    withOptionalText device $ \devicePtr deviceLength ->
+        action urlPtr urlLength userPtr userLength authPtr authLength
+            devicePtr deviceLength (fromIntegral interval) (fromIntegral expires)
+            nullPtr 0
+
+invokeResult :: FunPtr AccountResultCallback -> Ptr ()
+    -> Either Text Aeson.Value -> IO ()
+invokeResult callback context result = case result of
+    Left errorText -> withText errorText $ \errorPtr errorLength ->
+        invokeAccountResultCallback callback context (-1)
+            nullPtr 0 errorPtr errorLength
+    Right value ->
+        let status = Aeson.parseMaybe (Aeson.withObject "result"
+                (\object -> object Aeson..: "status")) value
+            accountId = Aeson.parseMaybe (Aeson.withObject "result"
+                (\object -> object Aeson..:? "accountID")) value >>= id
+        in case status of
+            Just ("pending" :: Text) ->
+                invokeAccountResultCallback callback context 1 nullPtr 0 nullPtr 0
+            _ -> withOptionalText accountId $ \idPtr idLength ->
+                invokeAccountResultCallback callback context 0 idPtr idLength nullPtr 0
+
+invokeStoreResult :: FunPtr AccountResultCallback -> Ptr ()
+    -> Either Text () -> IO ()
+invokeStoreResult callback context result = case result of
+    Left errorText -> withText errorText $ \errorPtr errorLength ->
+        invokeAccountResultCallback callback context (-1)
+            nullPtr 0 errorPtr errorLength
+    Right () -> invokeAccountResultCallback callback context 0 nullPtr 0 nullPtr 0
 
 ha_engine_create :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
 ha_engine_create callback context

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -167,7 +167,7 @@ import Foreign
     , nullFunPtr
     , nullPtr
     )
-import Foreign.C.String (CString, withCStringLen)
+import Foreign.C.String (CString)
 import Foreign.C.Types (CInt(..), CSize(..))
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
@@ -192,7 +192,7 @@ nonEmptyText value
     | otherwise = Just value
 
 withText :: Text -> (CString -> CSize -> IO a) -> IO a
-withText value action = withCStringLen (Text.unpack value) \(pointer, length) ->
+withText value action = BS.useAsCStringLen (TextEncoding.encodeUtf8 value) \(pointer, length) ->
     action pointer (fromIntegral length)
 
 withOptionalText :: Maybe Text -> (CString -> CSize -> IO a) -> IO a

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -160,7 +160,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (addUTCTime, getCurrentTime)
-import Data.Word (Word8)
+import Data.Word (Word8, Word64)
 import Foreign
     ( FunPtr
     , Ptr
@@ -187,8 +187,8 @@ import System.OsPath
     , unsafeEncodeUtf
     )
 
-decodeInput :: Ptr Word8 -> CSize -> IO Text
-decodeInput pointer (CSize length)
+decodeInput :: Ptr Word8 -> Word64 -> IO Text
+decodeInput pointer length
     | pointer == nullPtr || length == 0 = pure ""
     | otherwise = TextEncoding.decodeUtf8 <$> BS.packCStringLen
         (castPtr pointer, fromIntegral length)
@@ -515,7 +515,7 @@ ha_account_oauth_start providerBytes (CSize providerLength) callback context
     | callback == nullFunPtr = pure 1
     | providerBytes == nullPtr && providerLength > 0 = pure 2
     | otherwise = do
-        provider <- decodeInput providerBytes (CSize providerLength)
+        provider <- decodeInput providerBytes providerLength
         _ <- forkIO do
             startAccountOAuth AccountProviderRequest
                 { accountProvider = provider } >>= \case
@@ -543,11 +543,11 @@ ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLe
     deviceBytes (CSize deviceLength) pollInterval expires callback context
     | callback == nullFunPtr = pure 1
     | otherwise = do
-        provider <- decodeInput providerBytes (CSize providerLength)
-        url <- decodeInput urlBytes (CSize urlLength)
-        user <- decodeInput userBytes (CSize userLength)
-        authId <- decodeInput authIdBytes (CSize authIdLength)
-        device <- decodeInput deviceBytes (CSize deviceLength)
+        provider <- decodeInput providerBytes providerLength
+        url <- decodeInput urlBytes urlLength
+        user <- decodeInput userBytes userLength
+        authId <- decodeInput authIdBytes authIdLength
+        device <- decodeInput deviceBytes deviceLength
         _ <- forkIO do
             pollAccountOAuth AccountOAuthPollRequest
                 { oauthPollProvider = provider
@@ -566,8 +566,8 @@ ha_account_api_key_connect
 ha_account_api_key_connect providerBytes (CSize providerLength) keyBytes (CSize keyLength) callback context
     | callback == nullFunPtr = pure 1
     | otherwise = do
-        provider <- decodeInput providerBytes (CSize providerLength)
-        key <- decodeInput keyBytes (CSize keyLength)
+        provider <- decodeInput providerBytes providerLength
+        key <- decodeInput keyBytes keyLength
         _ <- forkIO do
             connectAccountAPIKey AccountAPIKeyRequest
                 { accountAPIKeyProvider = provider, accountAPIKey = key }

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -25,6 +25,11 @@ typedef void (*ha_event_callback)(
     size_t length
 );
 
+/*
+ * Account list callbacks use status 0 for an item, 1 for end-of-list, and
+ * -1 for an error. Item strings include disabled managed credentials and
+ * externally discovered accounts.
+ */
 typedef void (*ha_account_list_callback)(
     void *context,
     int32_t status,
@@ -41,6 +46,10 @@ typedef void (*ha_account_list_callback)(
     const uint8_t *error, size_t error_length
 );
 
+/*
+ * Result callbacks use status 0 for success, 1 when OAuth polling remains
+ * pending, and -1 for an error.
+ */
 typedef void (*ha_account_result_callback)(
     void *context,
     int32_t status,
@@ -50,6 +59,7 @@ typedef void (*ha_account_result_callback)(
     size_t error_length
 );
 
+/* OAuth start callbacks use status 0 for a challenge and -1 for an error. */
 typedef void (*ha_account_oauth_start_callback)(
     void *context,
     int32_t status,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -25,6 +25,48 @@ typedef void (*ha_event_callback)(
     size_t length
 );
 
+typedef void (*ha_account_list_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *provider, size_t provider_length,
+    const uint8_t *billing, size_t billing_length,
+    const uint8_t *selection_id, size_t selection_id_length,
+    const uint8_t *account_id, size_t account_id_length,
+    const uint8_t *label, size_t label_length,
+    const uint8_t *detail, size_t detail_length,
+    const uint8_t *managed_id, size_t managed_id_length,
+    const uint8_t *source, size_t source_length,
+    int32_t enabled,
+    int32_t can_manage,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_account_result_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *account_id,
+    size_t account_id_length,
+    const uint8_t *error,
+    size_t error_length
+);
+
+typedef void (*ha_account_oauth_start_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *verification_url,
+    size_t verification_url_length,
+    const uint8_t *user_code,
+    size_t user_code_length,
+    const uint8_t *device_auth_id,
+    size_t device_auth_id_length,
+    const uint8_t *device_code,
+    size_t device_code_length,
+    int32_t poll_interval_seconds,
+    int32_t expires_in_seconds,
+    const uint8_t *error,
+    size_t error_length
+);
+
 /* Runtime calls are process-global and reference counted. */
 int32_t ha_runtime_init(void);
 void ha_runtime_exit(void);
@@ -42,6 +84,56 @@ int32_t ha_engine_send_json(
     size_t length
 );
 void ha_engine_destroy(void *engine);
+
+/*
+ * Account operations use typed callbacks. Callback buffers are valid only
+ * during the callback and must be copied by the caller. All functions return
+ * 0 when accepted, or a nonzero error before starting the worker.
+ */
+int32_t ha_accounts_list(ha_account_list_callback callback, void *context);
+int32_t ha_account_oauth_start(
+    const uint8_t *provider,
+    size_t provider_length,
+    ha_account_oauth_start_callback callback,
+    void *context
+);
+int32_t ha_account_oauth_poll(
+    const uint8_t *provider,
+    size_t provider_length,
+    const uint8_t *verification_url,
+    size_t verification_url_length,
+    const uint8_t *user_code,
+    size_t user_code_length,
+    const uint8_t *device_auth_id,
+    size_t device_auth_id_length,
+    const uint8_t *device_code,
+    size_t device_code_length,
+    int32_t poll_interval_seconds,
+    int32_t expires_in_seconds,
+    ha_account_result_callback callback,
+    void *context
+);
+int32_t ha_account_api_key_connect(
+    const uint8_t *provider,
+    size_t provider_length,
+    const uint8_t *api_key,
+    size_t api_key_length,
+    ha_account_result_callback callback,
+    void *context
+);
+int32_t ha_account_set_enabled(
+    const uint8_t *managed_id,
+    size_t managed_id_length,
+    int32_t enabled,
+    ha_account_result_callback callback,
+    void *context
+);
+int32_t ha_account_delete(
+    const uint8_t *managed_id,
+    size_t managed_id_length,
+    ha_account_result_callback callback,
+    void *context
+);
 
 #ifdef __cplusplus
 }

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -17,6 +17,7 @@ module Agent.CLI.Login
     , refreshLoginAccount
     , renderLoginFrame
     , runLoginManager
+    , storeConnectedCredential
     ) where
 
 import Agent.CLI.Auth

--- a/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
@@ -16,9 +16,11 @@ import Agent.CLI.Database.Storage
     ( postgresStorageCommandEnv
     , runStorageCommand
     )
-import Agent.CLI.AccountPicker
-    ( AccountPickerOption(..)
-    , loadAllAccountPickerOptions
+import Agent.CLI.Login
+    ( AccountBilling(..)
+    , LoginAccount(..)
+    , discoverLoginAccounts
+    , loginAccountSelectionId
     )
 import Agent.CLI.Options
     ( SessionOutputFormat(..)
@@ -47,7 +49,7 @@ import Agent.CLI.SessionLock
     , sessionLockPath
     )
 import Agent.OsPath (unsafeToFilePath)
-import Agent.Provider (BillingMode(..), Provider(..), providerSlug)
+import Agent.Provider (providerSlug)
 import Agent.Responses.Types
     ( CustomToolCall(..)
     , CustomToolCallOutput(..)
@@ -258,29 +260,22 @@ sessionSummaryJSONWithState running locked archived meta =
         ]
 
 accountSummariesJSON :: IO [Aeson.Value]
-accountSummariesJSON = do
-    options <- loadAllAccountPickerOptions OpenAIProvider
-    pure (mapMaybe accountOptionJSON options)
+accountSummariesJSON = map accountJSON <$> discoverLoginAccounts
   where
-    accountOptionJSON = \case
-        AccountPickerAccount
-            provider
-            billing
-            selectionId
-            accountId
-            label
-            detail ->
-                Just $ Aeson.object
-                    [ "provider" Aeson..= providerSlug provider
-                    , "billing" Aeson..= case billing of
-                        SubscriptionBilled -> ("subscription" :: Text)
-                        ApiBilled -> "api"
-                    , "selectionID" Aeson..= selectionId
-                    , "accountID" Aeson..= accountId
-                    , "label" Aeson..= label
-                    , "detail" Aeson..= detail
-                    ]
-        AccountPickerConnect _ -> Nothing
+    accountJSON account = Aeson.object
+        [ "provider" Aeson..= providerSlug account.loginProvider
+        , "billing" Aeson..= case account.loginBilling of
+            SubscriptionBilling _ -> ("subscription" :: Text)
+            ApiCreditsBilling -> "api"
+        , "selectionID" Aeson..= loginAccountSelectionId account
+        , "accountID" Aeson..= account.loginAccountId
+        , "label" Aeson..= account.loginLabel
+        , "detail" Aeson..= account.loginSource
+        , "managedID" Aeson..= account.loginManagedId
+        , "source" Aeson..= account.loginSource
+        , "enabled" Aeson..= account.loginEnabled
+        , "canManage" Aeson..= maybe False (const True) account.loginManagedId
+        ]
 
 -- Keep native transcript hydration independent from provider response items.
 -- Those can contain large tool payloads that this view does not render.


### PR DESCRIPTION
## Summary
- expose typed async C ABI functions for account list, OAuth start/poll, OpenRouter API key connection, enable/disable, and deletion
- pass UTF-8 fields through callback-scoped pointer/length pairs with documented status semantics
- remove account operations from the generic JSON request dispatcher
- preserve generic JSON only for unrelated engine protocol methods
- validate input buffers and report worker failures through callbacks

## Testing
- `nix develop --command cabal build flib:haskell-agent-bridge --disable-optimization -j1`
- consumed by the macOS package build and typed account-list runtime smoke test