### PR TITLE
Prevent MCP workers escaping client shutdown

### DIFF
--- a/packages/agent-mcp/src/Agent/MCP/Client.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client.hs
@@ -1807,14 +1807,18 @@ decodeProgress raw =
 -- | Run background work owned by the client. Finished workers are pruned on
 -- the next spawn; remaining ones are cancelled by 'closeMcpClient'.
 spawnClientWorker :: McpClient -> IO () -> IO ()
-spawnClientWorker client action = mask_ do
-    worker <- asyncWithUnmask \unmask -> unmask (void (tryAny action))
-    current <- readTVarIO client.clientWorkers
-    live <- fmap catMaybes $ forM current \existing ->
-        poll existing >>= \case
-            Nothing -> pure (Just existing)
-            Just _ -> pure Nothing
-    atomically $ writeTVar client.clientWorkers (worker : live)
+spawnClientWorker client action =
+    -- Share the close lock through registration: shutdown either observes the
+    -- worker and joins it, or completes first and prevents it from starting.
+    withMVar client.clientClosed \closed ->
+        unless closed $ mask_ do
+            worker <- asyncWithUnmask \unmask -> unmask (void (tryAny action))
+            current <- readTVarIO client.clientWorkers
+            live <- fmap catMaybes $ forM current \existing ->
+                poll existing >>= \case
+                    Nothing -> pure (Just existing)
+                    Just _ -> pure Nothing
+            atomically $ writeTVar client.clientWorkers (worker : live)
 
 -- * Transport: Streamable HTTP
 

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -5,18 +5,29 @@ import Agent.MCP
 import Agent.MCP.Client
     ( ProbeOutcome(..)
     , annotateHeaderParams
+    , closeMcpClient
     , classifyProbe
     , encodeHeaderValue
     , headerParamValues
+    , spawnClientWorker
     , splitLines
+    , startMcpClient
     )
 import Agent.MCP.Types
-    ( McpHeaderParam(..)
+    ( McpClient(..)
+    , McpHeaderParam(..)
     , McpTool(..)
     )
 import Agent.Json (RawJson, rawJsonBytes, rawJsonDecoder, rawJsonFromEncoding)
 import qualified Agent.Json.Decode as Json
-import Control.Concurrent.STM (readTVarIO)
+import Control.Concurrent.STM
+    ( TMVar
+    , atomically
+    , newEmptyTMVarIO
+    , readTMVar
+    , readTVarIO
+    , tryPutTMVar
+    )
 import qualified Data.Aeson.Types
 import Data.Either (isLeft)
 import Data.List (isInfixOf)
@@ -54,6 +65,17 @@ import System.IO (hClose, openTempFile)
 import System.Posix.Files (setFileMode)
 import System.Timeout (timeout)
 import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck
+    ( Arbitrary(arbitrary, shrink)
+    , counterexample
+    , elements
+    , ioProperty
+    , listOf
+    , resize
+    , shrinkList
+    , (===)
+    )
 
 spec :: Spec
 spec = describe "Agent.MCP" do
@@ -72,6 +94,33 @@ spec = describe "Agent.MCP" do
         rendered `shouldContain` "API_TOKEN"
         rendered `shouldContain` "<redacted>"
         rendered `shouldNotContain` "super-secret"
+
+    describe "client worker lifecycle" do
+        it "does not start owned workers after the client is closed" $
+            bracket (startMcpClient workerClientConfig) closeMcpClient \client -> do
+                closeMcpClient client
+                spawnClientWorker client (pure ())
+                (length <$> readTVarIO client.clientWorkers) `shouldReturn` 0
+
+        modifyMaxSuccess (const 200) $
+            prop "preserves worker ownership for arbitrary lifecycle traces" $
+                \(WorkerLifecycle operations) -> ioProperty $
+                    bracket (startMcpClient workerClientConfig) closeMcpClient \client -> do
+                        gate <- newEmptyTMVarIO
+                        mapM_ (applyWorkerOperation client gate) operations
+                        workers <- readTVarIO client.clientWorkers
+                        _ <- atomically (tryPutTMVar gate ())
+                        let expected
+                                | CloseWorkerClient `elem` operations = 0
+                                | otherwise =
+                                    length
+                                        [ ()
+                                        | SpawnWorker <- operations
+                                        ]
+                        pure $
+                            counterexample
+                                ("operations: " <> show operations)
+                                (length workers === expected)
 
     describe "decodeHttpMcpResponse" do
         it "unwraps the JSON-RPC result before MCP payload decoding" do
@@ -817,6 +866,36 @@ concurrentConfig script barrier name = McpServerConfig
     , mcpServerRequestTimeoutSeconds = 2
     , mcpServerProtocol = McpProtocolAuto
     }
+
+data WorkerLifecycleOperation
+    = SpawnWorker
+    | CloseWorkerClient
+    deriving (Eq, Show)
+
+newtype WorkerLifecycle = WorkerLifecycle [WorkerLifecycleOperation]
+    deriving (Show)
+
+instance Arbitrary WorkerLifecycle where
+    arbitrary =
+        WorkerLifecycle
+            <$> resize 20 (listOf (elements [SpawnWorker, CloseWorkerClient]))
+    shrink (WorkerLifecycle operations) =
+        WorkerLifecycle <$> shrinkList (const []) operations
+
+applyWorkerOperation
+    :: McpClient
+    -> TMVar ()
+    -> WorkerLifecycleOperation
+    -> IO ()
+applyWorkerOperation client gate = \case
+    SpawnWorker -> spawnClientWorker client (atomically (readTMVar gate))
+    CloseWorkerClient -> closeMcpClient client
+
+workerClientConfig :: McpServerConfig
+workerClientConfig =
+    (baseConfig "worker-lifecycle" "/unused")
+        { mcpServerUrl = Just "http://127.0.0.1:1/mcp"
+        }
 
 progressiveConfig :: FilePath -> String -> Text.Text -> McpServerConfig
 progressiveConfig script delay name =


### PR DESCRIPTION
## Summary
- serialize MCP client worker spawning with client shutdown
- reject worker creation after the client has closed
- add deterministic regression coverage and a 200-case QuickCheck lifecycle property

## Why
`spawnClientWorker` previously created and registered workers without sharing the `clientClosed` lock. A concurrent or already-completed `closeMcpClient` could clear the worker registry before a new worker was registered, allowing that worker to outlive its client.

## Validation
- `nix develop -c cabal repl agent-mcp:test:agent-mcp-test`
- `TMPDIR=/tmp nix develop -c cabal test agent-mcp-test`
  - 81 examples, 0 failures
  - worker lifecycle property passed 200 generated traces
- `git diff --check origin/master...HEAD`
