### PR TITLE
Cache startup account usage metadata

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -269,6 +269,7 @@ foreign-library haskell-agent-bridge
                     , safe-exceptions
                     , stm
                     , text >= 2.0 && < 2.2
+                    , time
 
 executable eval-ghci-vs-bash
     import:           common-options

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -44,6 +44,7 @@ library
     hs-source-dirs:   src
     autogen-modules:  Paths_agent_cli
     other-modules:    Agent.CLI.AccountPicker
+                    , Agent.CLI.AccountUsageCache
                     , Agent.CLI.Auth.Grok
                     , Agent.CLI.Auth.OpenAI
                     , Agent.CLI.Auth.Types

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE FieldSelectors #-}
 
 module Agent.CLI.MacOS.Bridge () where
 
@@ -59,6 +60,11 @@ import Agent.Store.Postgres
     , closeStore
     , openStore
     , trustedPool
+    )
+import Agent.Store.Postgres.UsageCache
+    ( AccountUsageCacheEntry(..)
+    , loadAccountUsageCache
+    , upsertAccountUsageCache
     )
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
@@ -127,6 +133,8 @@ import qualified Data.Set as Set
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Time.Clock (addUTCTime, getCurrentTime)
 import Data.Word (Word8)
 import Foreign
     ( FunPtr
@@ -939,7 +947,8 @@ handleRequest config store root request = do
                             (const (successEvent current.requestId True))
                             changed
             "accounts.list" -> do
-                accounts <- accountSummariesJSON
+                activeStore <- acquireStore config store
+                accounts <- cachedAccountSummaries activeStore
                 pure $ successEvent current.requestId
                     accounts
             "turn.agents" ->
@@ -962,6 +971,48 @@ handleRequest config store root request = do
             method ->
                 pure $ failureEvent current.requestId
                     ("unknown method: " <> method)
+
+cachedAccountSummaries :: Store -> IO [Aeson.Value]
+cachedAccountSummaries store = do
+    let pool = trustedPool store
+    cached <- loadAccountUsageCache pool accountCacheProvider accountCacheKey
+    now <- getCurrentTime
+    case cached of
+        Right (Just entry)
+            | Just accounts <- decodeAccountCache entry.accountUsageCachePayload -> do
+                if entry.accountUsageCacheExpiresAt <= now
+                    then void $ forkFinally
+                        (refreshAccountCache store)
+                        (const (pure ()))
+                    else pure ()
+                pure accounts
+        _ -> refreshAccountCache store
+
+refreshAccountCache :: Store -> IO [Aeson.Value]
+refreshAccountCache store = do
+    accounts <- accountSummariesJSON
+    fetchedAt <- getCurrentTime
+    let payload = TextEncoding.decodeUtf8 $
+            LBS.toStrict (Aeson.encode accounts)
+        entry = AccountUsageCacheEntry
+            { accountUsageCacheProvider = accountCacheProvider
+            , accountUsageCacheAccountId = accountCacheKey
+            , accountUsageCachePayload = payload
+            , accountUsageCacheFetchedAt = fetchedAt
+            , accountUsageCacheExpiresAt = addUTCTime 300 fetchedAt
+            }
+    void $ upsertAccountUsageCache (trustedPool store) entry
+    pure accounts
+
+decodeAccountCache :: Text -> Maybe [Aeson.Value]
+decodeAccountCache =
+    Aeson.decodeStrict' . TextEncoding.encodeUtf8
+
+accountCacheProvider :: Text
+accountCacheProvider = "macos-bridge"
+
+accountCacheKey :: Text
+accountCacheKey = "account-summaries-v1"
 
 loadNativeModelCatalog
     :: Store

--- a/packages/agent-cli/src/Agent/CLI/AccountPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountPicker.hs
@@ -5,8 +5,10 @@ module Agent.CLI.AccountPicker
     , accountPickerRow
     , formatLoginUsageSummary
     , loadAllAccountPickerOptions
+    , loadAllAccountPickerOptionsCached
     ) where
 
+import Agent.CLI.AccountUsageCache (refreshLoginAccountCached)
 import Agent.CLI.Login
     ( AccountBilling(..)
     , AccountUsage(..)
@@ -28,6 +30,7 @@ import Agent.Provider
     , providerSlug
     )
 import Control.Concurrent.Async (mapConcurrently)
+import Agent.Store.Postgres.Connection (StorePool)
 import Data.List (sortOn)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -44,9 +47,20 @@ data AccountPickerOption
     | AccountPickerConnect !Provider
 
 loadAllAccountPickerOptions :: Provider -> IO [AccountPickerOption]
-loadAllAccountPickerOptions currentProvider = do
+loadAllAccountPickerOptions = loadAllAccountPickerOptionsWith refreshLoginAccount
+
+loadAllAccountPickerOptionsCached
+    :: StorePool -> Provider -> IO [AccountPickerOption]
+loadAllAccountPickerOptionsCached pool =
+    loadAllAccountPickerOptionsWith (refreshLoginAccountCached pool)
+
+loadAllAccountPickerOptionsWith
+    :: (LoginAccount -> IO LoginAccount)
+    -> Provider
+    -> IO [AccountPickerOption]
+loadAllAccountPickerOptionsWith refresh currentProvider = do
     discovered <- discoverSelectableLoginAccounts
-    refreshed <- mapConcurrently refreshLoginAccount discovered
+    refreshed <- mapConcurrently refresh discovered
     claudeAuth <- loadClaudeCodeAuth
     now <- getCurrentTime
     let providerAccounts =

--- a/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
@@ -7,8 +7,10 @@ module Agent.CLI.AccountSelection
     , selectCandidates
     , selectAccount
     , selectProviderAccount
+    , selectProviderAccountCached
     ) where
 
+import Agent.CLI.AccountUsageCache (refreshLoginAccountCached)
 import Agent.CLI.Login
     ( AccountBilling(..)
     , AccountUsage(..)
@@ -33,6 +35,7 @@ import Agent.Provider
     , providerSlug
     )
 import Control.Concurrent.Async (mapConcurrently)
+import Agent.Store.Postgres.Connection (StorePool)
 import Data.List (find, sortOn)
 import Data.Ord (Down(..))
 import Data.Text (Text)
@@ -78,7 +81,24 @@ selectProviderAccount
     -> Maybe BillingMode
     -> Maybe (Text, Text)
     -> IO (Either Text SelectedAccount)
-selectProviderAccount provider requiredBilling remembered = do
+selectProviderAccount = selectProviderAccountWith refreshLoginAccount
+
+selectProviderAccountCached
+    :: StorePool
+    -> Provider
+    -> Maybe BillingMode
+    -> Maybe (Text, Text)
+    -> IO (Either Text SelectedAccount)
+selectProviderAccountCached pool =
+    selectProviderAccountWith (refreshLoginAccountCached pool)
+
+selectProviderAccountWith
+    :: (LoginAccount -> IO LoginAccount)
+    -> Provider
+    -> Maybe BillingMode
+    -> Maybe (Text, Text)
+    -> IO (Either Text SelectedAccount)
+selectProviderAccountWith refresh provider requiredBilling remembered = do
     providerAccounts <-
         filter
             ((== provider) . (.loginProvider))
@@ -94,7 +114,9 @@ selectProviderAccount provider requiredBilling remembered = do
                                 . billingMode . (.loginBilling))
                             providerAccounts
                 in if null subscription then providerAccounts else subscription
-    checked <- mapConcurrently refreshSelectableAccount billingAccounts
+    checked <- mapConcurrently
+        (refreshSelectableAccountWith refresh)
+        billingAccounts
     pure $ case selectAccount remembered checked of
         Just selected -> Right selected
         Nothing -> Left $
@@ -187,13 +209,16 @@ parseAmount :: Text -> Maybe Double
 parseAmount =
     readMaybe . Text.unpack . Text.dropWhile (`elem` ("$ " :: String))
 
-refreshSelectableAccount :: LoginAccount -> IO LoginAccount
-refreshSelectableAccount account =
+refreshSelectableAccountWith
+    :: (LoginAccount -> IO LoginAccount)
+    -> LoginAccount
+    -> IO LoginAccount
+refreshSelectableAccountWith refresh account =
     refreshCredential account >>= \case
         Left err ->
             pure account { loginUsage = UsageUnavailable err }
         Right refreshed ->
-            refreshLoginAccount refreshed
+            refresh refreshed
   where
     refreshCredential candidate = case candidate.loginProvider of
         OpenAIProvider ->

--- a/packages/agent-cli/src/Agent/CLI/AccountUsageCache.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountUsageCache.hs
@@ -1,0 +1,139 @@
+-- | PostgreSQL-backed cache for credential-safe account usage metadata.
+module Agent.CLI.AccountUsageCache
+    ( refreshLoginAccountCached
+    ) where
+
+import Agent.CLI.Login
+    ( AccountBilling(..)
+    , AccountUsage(..)
+    , LoginAccount(..)
+    , UsageState(..)
+    , UsageWindow(..)
+    , refreshLoginAccount
+    )
+import Agent.Provider (providerSlug)
+import Agent.Store.Postgres.Connection (StorePool)
+import Agent.Store.Postgres.UsageCache
+    ( AccountUsageCacheEntry(..)
+    , loadAccountUsageCache
+    , upsertAccountUsageCache
+    )
+import Control.Monad (void)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.:), (.:?), (.=))
+import Data.Aeson.Types (Parser)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import Data.Time.Clock (addUTCTime, getCurrentTime)
+
+data CachedAccountUsage = CachedAccountUsage
+    { cachedLabel :: !Text
+    , cachedBilling :: !AccountBilling
+    , cachedUsage :: !AccountUsage
+    }
+
+instance Aeson.ToJSON CachedAccountUsage where
+    toJSON cached = Aeson.object
+        [ "label" .= cached.cachedLabel
+        , "billing" .= billingJSON cached.cachedBilling
+        , "usage" .= usageJSON cached.cachedUsage
+        ]
+
+instance Aeson.FromJSON CachedAccountUsage where
+    parseJSON = Aeson.withObject "cached account usage" \object ->
+        CachedAccountUsage
+            <$> object .: "label"
+            <*> (object .: "billing" >>= parseBilling)
+            <*> (object .: "usage" >>= parseUsage)
+
+-- | Use a fresh cached usage result when possible. Cache payloads contain only
+-- display metadata; credentials and managed-secret payloads are never stored.
+refreshLoginAccountCached :: StorePool -> LoginAccount -> IO LoginAccount
+refreshLoginAccountCached pool account = do
+    now <- getCurrentTime
+    loadAccountUsageCache pool cacheProvider account.loginAccountId >>= \case
+        Right (Just entry)
+            | entry.accountUsageCacheExpiresAt > now
+            , Just cached <- decodeCached entry.accountUsageCachePayload ->
+                pure (applyCached cached account)
+        _ -> refreshAndStore now
+  where
+    cacheProvider = "tui:" <> providerSlug account.loginProvider
+    refreshAndStore now = do
+        refreshed <- refreshLoginAccount account
+        case refreshed.loginUsage of
+            UsageAvailable usage -> void $ upsertAccountUsageCache pool
+                AccountUsageCacheEntry
+                    { accountUsageCacheProvider = cacheProvider
+                    , accountUsageCacheAccountId = account.loginAccountId
+                    , accountUsageCachePayload = encodeCached CachedAccountUsage
+                        { cachedLabel = refreshed.loginLabel
+                        , cachedBilling = refreshed.loginBilling
+                        , cachedUsage = usage
+                        }
+                    , accountUsageCacheFetchedAt = now
+                    , accountUsageCacheExpiresAt = addUTCTime 300 now
+                    }
+            _ -> pure ()
+        pure refreshed
+
+applyCached :: CachedAccountUsage -> LoginAccount -> LoginAccount
+applyCached cached account = account
+    { loginLabel = cached.cachedLabel
+    , loginBilling = cached.cachedBilling
+    , loginUsage = UsageAvailable cached.cachedUsage
+    }
+
+encodeCached :: CachedAccountUsage -> Text
+encodeCached = Text.decodeUtf8 . LBS.toStrict . Aeson.encode
+
+decodeCached :: Text -> Maybe CachedAccountUsage
+decodeCached = Aeson.decodeStrict' . Text.encodeUtf8
+
+billingJSON :: AccountBilling -> Aeson.Value
+billingJSON = \case
+    ApiCreditsBilling -> Aeson.object ["kind" .= ("api" :: Text)]
+    SubscriptionBilling plan -> Aeson.object
+        [ "kind" .= ("subscription" :: Text)
+        , "plan" .= plan
+        ]
+
+parseBilling :: Aeson.Value -> Parser AccountBilling
+parseBilling = Aeson.withObject "cached billing" \object ->
+    object .: "kind" >>= \case
+        ("api" :: Text) -> pure ApiCreditsBilling
+        "subscription" -> SubscriptionBilling <$> object .:? "plan"
+        _ -> fail "unknown cached billing kind"
+
+usageJSON :: AccountUsage -> Aeson.Value
+usageJSON usage = Aeson.object
+    [ "plan" .= usage.usagePlan
+    , "windows" .= map windowJSON usage.usageWindows
+    , "creditsRemaining" .= usage.creditsRemaining
+    , "creditsUsed" .= usage.creditsUsed
+    ]
+
+parseUsage :: Aeson.Value -> Parser AccountUsage
+parseUsage = Aeson.withObject "cached usage" \object ->
+    AccountUsage
+        <$> object .:? "plan"
+        <*> (object .: "windows" >>= traverse parseWindow)
+        <*> object .:? "creditsRemaining"
+        <*> object .:? "creditsUsed"
+
+windowJSON :: UsageWindow -> Aeson.Value
+windowJSON window = Aeson.object
+    [ "name" .= window.windowName
+    , "usedPercent" .= window.usedPercent
+    , "windowSeconds" .= window.windowSeconds
+    , "resetsAt" .= window.resetsAt
+    ]
+
+parseWindow :: Aeson.Value -> Parser UsageWindow
+parseWindow = Aeson.withObject "cached usage window" \object ->
+    UsageWindow
+        <$> object .: "name"
+        <*> object .: "usedPercent"
+        <*> object .: "windowSeconds"
+        <*> object .: "resetsAt"

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -8,7 +8,7 @@ import Agent.CLI.AccountPicker ()
 import Agent.CLI.AccountSelection
     ( SelectedAccount(..),
       providerSupportsUsageAccountSelection,
-      selectProviderAccount )
+      selectProviderAccountCached )
 import Agent.CLI.Afk ()
 import Agent.CLI.AgentSessions
     ( AgentSessionToolsEnv(..),
@@ -1241,7 +1241,8 @@ runAgentInitializedWithLock
                             , account.projectAccountId
                             ))
                         (projectAccountFor provider projectSettings)
-                selectProviderAccount
+                selectProviderAccountCached
+                    (trustedPool startup.startupDatabaseStore)
                     provider
                     Nothing
                     rememberedIds >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -8,7 +8,7 @@ import Agent.CLI.AccountPicker
     ( AccountPickerOption(..),
       accountPickerMatches,
       accountPickerRow,
-      loadAllAccountPickerOptions )
+      loadAllAccountPickerOptionsCached )
 import Agent.CLI.AccountSelection ()
 import Agent.CLI.Afk ()
 import Agent.CLI.AgentSessions ()
@@ -203,6 +203,7 @@ handleSelection
             , sessionDialect = dialect
             , sessionParams = paramsRef
             , sessionPersist = persist
+            , sessionDatabasePool = databasePool
             , sessionProjectRoot = projectRoot
             , sessionDraft = draftRef
             , sessionAccountId = accountIdRef
@@ -352,7 +353,7 @@ handleSelection
                 currentAccountId <- readIORef accountIdRef
                 options <- withReplActivity
                     "Loading account usage…"
-                    (loadAllAccountPickerOptions provider)
+                    (loadAllAccountPickerOptionsCached databasePool provider)
                 let initial =
                         fromMaybe 0 $
                             findIndex
@@ -414,7 +415,8 @@ handleSelection
                                             Nothing -> next
                                             Just selectedAccountId -> do
                                                 refreshed <-
-                                                    loadAllAccountPickerOptions
+                                                    loadAllAccountPickerOptionsCached
+                                                        databasePool
                                                         provider
                                                 case listToMaybe
                                                         [ account

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -47,6 +47,7 @@ library
                     , Agent.Store.Postgres.Scope
                     , Agent.Store.Postgres.Session
                     , Agent.Store.Postgres.Skill
+                    , Agent.Store.Postgres.UsageCache
     other-modules:    Agent.Store.Custom.QueryResult
                     , Agent.Store.Postgres.Custom.Sql
                     , Agent.Store.Postgres.Hasql

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -35,6 +35,9 @@ import Agent.Store.Postgres.Skill
     ( learnedSkillRuntimeGrantStatements
     , learnedSkillSchemaStatements
     )
+import Agent.Store.Postgres.UsageCache
+    ( accountUsageCacheSchemaStatements
+    )
 import Agent.Store.Types
 
 data Migration = Migration
@@ -162,6 +165,15 @@ coreMigrations =
               \ ON harness.sessions (archived_at DESC)\
               \ WHERE deleted_at IS NULL AND archived_at IS NOT NULL"
             ]
+        }
+    , Migration
+        { migrationVersion = 12
+        , migrationName = "account usage cache"
+        , migrationStatements =
+            accountUsageCacheSchemaStatements
+            <> [ "GRANT SELECT, INSERT, UPDATE\
+                \ ON harness.account_usage_cache TO ha_runtime"
+               ]
         }
     ]
 

--- a/packages/agent-store/src/Agent/Store/Postgres/UsageCache.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/UsageCache.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FieldSelectors #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Durable, provider-agnostic cache entries for account usage snapshots.
+--
+-- The payload is deliberately opaque text. Provider packages own the JSON
+-- schema and decode it at the boundary; the store never receives credentials
+-- or provider-specific types.
+module Agent.Store.Postgres.UsageCache
+    ( AccountUsageCacheEntry(..)
+    , accountUsageCacheSchemaStatements
+    , loadAccountUsageCache
+    , upsertAccountUsageCache
+    ) where
+
+import Data.ByteString (ByteString)
+import Data.Functor.Contravariant ((>$<))
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Session as Session
+import Hasql.Statement (Statement)
+
+import Agent.Store.Postgres.Connection
+    ( StorePool
+    , withSession
+    )
+import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Types (StoreError)
+
+-- | A cached provider response.  'accountUsageCacheFetchedAt' and
+-- 'accountUsageCacheExpiresAt' are both retained so callers can show stale
+-- data while an asynchronous refresh is in flight.
+data AccountUsageCacheEntry = AccountUsageCacheEntry
+    { accountUsageCacheProvider :: !Text
+    , accountUsageCacheAccountId :: !Text
+    , accountUsageCachePayload :: !Text
+    , accountUsageCacheFetchedAt :: !UTCTime
+    , accountUsageCacheExpiresAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+-- | DDL is kept with the cache API so migration and schema tests cannot drift.
+accountUsageCacheSchemaStatements :: [ByteString]
+accountUsageCacheSchemaStatements =
+    [ "CREATE TABLE IF NOT EXISTS harness.account_usage_cache (\
+      \ provider text NOT NULL,\
+      \ account_id text NOT NULL,\
+      \ payload_text text NOT NULL,\
+      \ fetched_at timestamptz NOT NULL,\
+      \ expires_at timestamptz NOT NULL,\
+      \ PRIMARY KEY (provider, account_id)\
+      \ )"
+    ]
+
+loadAccountUsageCache
+    :: StorePool
+    -> Text
+    -> Text
+    -> IO (Either StoreError (Maybe AccountUsageCacheEntry))
+loadAccountUsageCache pool provider accountId =
+    withSession pool (Session.statement
+        (provider, accountId)
+        loadAccountUsageCacheStatement)
+
+upsertAccountUsageCache
+    :: StorePool
+    -> AccountUsageCacheEntry
+    -> IO (Either StoreError ())
+upsertAccountUsageCache pool entry =
+    withSession pool (Session.statement entry upsertAccountUsageCacheStatement)
+
+loadAccountUsageCacheStatement
+    :: Statement (Text, Text) (Maybe AccountUsageCacheEntry)
+loadAccountUsageCacheStatement = mkStatement
+    "SELECT provider, account_id, payload_text, fetched_at, expires_at\
+    \ FROM harness.account_usage_cache\
+    \ WHERE provider = $1 AND account_id = $2"
+    cacheKeyParams
+    (Decoders.rowMaybe $
+        AccountUsageCacheEntry
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+            <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz))
+    True
+
+upsertAccountUsageCacheStatement
+    :: Statement AccountUsageCacheEntry ()
+upsertAccountUsageCacheStatement = mkStatement
+    "INSERT INTO harness.account_usage_cache\
+    \ (provider, account_id, payload_text, fetched_at, expires_at)\
+    \ VALUES ($1, $2, $3, $4, $5)\
+    \ ON CONFLICT (provider, account_id) DO UPDATE SET\
+    \ payload_text = EXCLUDED.payload_text,\
+    \ fetched_at = EXCLUDED.fetched_at,\
+    \ expires_at = EXCLUDED.expires_at"
+    ( ((.accountUsageCacheProvider)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.accountUsageCacheAccountId)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.accountUsageCachePayload)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.accountUsageCacheFetchedAt)
+            >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
+        <> ((.accountUsageCacheExpiresAt)
+            >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
+    )
+    Decoders.noResult
+    True
+
+cacheKeyParams :: Encoders.Params (Text, Text)
+cacheKeyParams =
+    ((fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.text)))

--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FieldSelectors #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -8,6 +9,7 @@ import Control.Exception.Safe (finally)
 import Data.ByteString (ByteString)
 import Data.Either (isLeft, isRight)
 import Data.Text (Text)
+import Data.Time.Clock (addUTCTime, getCurrentTime)
 import qualified Hasql.Decoders as Decoders
 import qualified Hasql.Encoders as Encoders
 import qualified Hasql.Session as Session
@@ -33,6 +35,11 @@ import Agent.Store.Postgres.Migrations
     , runMigrations
     )
 import Agent.Store.Postgres.Scope (customSchemaStatements)
+import Agent.Store.Postgres.UsageCache
+    ( AccountUsageCacheEntry(..)
+    , loadAccountUsageCache
+    , upsertAccountUsageCache
+    )
 
 spec :: Spec
 spec =
@@ -63,6 +70,22 @@ spec =
                         (Session.script
                             "CREATE SCHEMA runtime_must_not_create")
                     forbiddenResult `shouldSatisfy` isLeft
+                    fetchedAt <- getCurrentTime
+                    let usageEntry = AccountUsageCacheEntry
+                            { accountUsageCacheProvider = "openai"
+                            , accountUsageCacheAccountId = "account-1"
+                            , accountUsageCachePayload = "{\"remaining\":42}"
+                            , accountUsageCacheFetchedAt = fetchedAt
+                            , accountUsageCacheExpiresAt =
+                                addUTCTime 300 fetchedAt
+                            }
+                    upsertAccountUsageCache (trustedPool store) usageEntry
+                        `shouldReturn` Right ()
+                    loadAccountUsageCache
+                        (trustedPool store)
+                        "openai"
+                        "account-1"
+                        `shouldReturn` Right (Just usageEntry)
                     ) >>= \case
                         Left err ->
                             expectationFailure


### PR DESCRIPTION
## Summary
- add a versioned PostgreSQL cache for credential-safe account/usage display metadata
- serve cached native account summaries immediately and refresh expired data in the background
- use the same cache for synchronous TUI startup account ranking and the fullscreen Accounts picker
- keep tokens and provider credentials out of every cached payload
- add migration/grant and Hasql round-trip coverage

## Validation
- `nix develop -c cabal build agent-cli`
- `nix develop -c cabal test agent-cli-test --test-options='--match=account'` (43 examples passed)
- `TMPDIR=/tmp nix develop -c sh -c '\"$(cabal list-bin agent-store-test)\" --match \"starts on a private socket and applies the harness migrations\"'`
- downstream macOS app: `nix build --fallback path:.#agent-macos`

## Notes
- a cold lookup still performs the provider request and populates the cache
- the normal remembered-account fullscreen path already renders before its availability probe; this change targets the synchronous ranking/picker paths
- the full managed-store suite has three pre-existing legacy-fixture failures at migration v11 when `harness.sessions` is absent