### PR TITLE
Fix update_plan prompt assertion

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -57,7 +57,9 @@ spec = describe "systemPrompt" do
         openai `shouldSatisfy` Text.isInfixOf "apply_patch"
         openai `shouldSatisfy` Text.isInfixOf "update_plan"
         openai `shouldSatisfy` Text.isInfixOf "call update_plan before starting"
-        openai `shouldSatisfy` Text.isInfixOf "Before your final response, update_plan"
+        openai `shouldSatisfy` Text.isInfixOf
+            "Before your final response, when update_plan is available"
+        openai `shouldSatisfy` Text.isInfixOf "left pending/removed"
         openai `shouldSatisfy` Text.isInfixOf "web_search"
         openai `shouldSatisfy` Text.isInfixOf "enter_plan_mode"
         openai `shouldSatisfy` Text.isInfixOf "write_plan"


### PR DESCRIPTION
## Summary
- update the stale `systemPrompt` assertion to match the current conditional `update_plan` guidance
- retain coverage that the final-response guidance requires no items be left pending or removed

Follow-up to #716 after CI run [33261070559](https://github.com/digitallyinduced/haskell-agent/actions/runs/33261070559) exposed the stale expectation.

## Validation
- focused `agent-cli-test` example in GHCi: 1 example, 0 failures
- `git diff --check`