### PR TITLE
fix: keep delegated model switches session-local

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -1,7 +1,8 @@
 -- | Project-scoped settings under @<project>/.haskell-agent/settings.json@,
 -- plus the user-level last model under @~/.haskell-agent/settings.json@.
 module Agent.CLI.Project
-    ( ProjectAccount(..)
+    ( ModelSwitchScope(..)
+    , ProjectAccount(..)
     , ProjectModel(..)
     , ProjectSettings(..)
     , defaultProjectSettings
@@ -17,7 +18,7 @@ module Agent.CLI.Project
     , saveProjectMaxConcurrentAgents
     , saveProjectAccount
     , saveProjectModel
-    , saveRememberedModel
+    , persistModelSwitch
     , userSettingsPath
     , withInheritedLastModel
     ) where
@@ -307,16 +308,26 @@ saveProjectModel projectRoot target =
                 { projectModelTarget = target }
             }
 
--- | Persist the selected model on the current checkout and as the user-level
--- default so the next freshly created worktree can inherit it.
-saveRememberedModel
-    :: OsPath
+-- | Whether a live model/provider switch may update inherited settings.
+-- Startup and resume targets are not switch events and must not be persisted;
+-- delegated/background transitions use 'SessionLocalSwitch'.
+data ModelSwitchScope
+    = TopLevelSwitch
+    | SessionLocalSwitch
+    deriving (Eq, Show)
+
+-- | Persist a top-level switch on the current checkout and as the user-level
+-- default. Session-local switches retain their target only in session state.
+persistModelSwitch
+    :: ModelSwitchScope
+    -> OsPath
     -- ^ User home (@~/.haskell-agent/settings.json@).
     -> OsPath
     -- ^ Checkout root.
     -> ModelTarget
     -> IO ()
-saveRememberedModel home projectRoot target = do
+persistModelSwitch SessionLocalSwitch _ _ _ = pure ()
+persistModelSwitch TopLevelSwitch home projectRoot target = do
     saveProjectModel projectRoot target
     saveProjectModel home target
 

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -49,11 +49,12 @@ import Agent.CLI.Models
     , resolveModelOptionDialect
     )
 import Agent.CLI.Project
-    ( ProjectAccount(..)
+    ( ModelSwitchScope(..)
+    , ProjectAccount(..)
     , loadProjectSettings
     , projectAccountFor
     , resolveProjectRoot
-    , saveRememberedModel
+    , persistModelSwitch
     )
 import Agent.CLI.Request (setRequestModel)
 import Agent.CLI.ProviderAvailability
@@ -229,7 +230,7 @@ applyModelChange
         paramsRef render previous persist = do
     modifyIORef' paramsRef (setRequestModel provider name)
     writeIORef render.renderModelRef name
-    saveRememberedModel home projectRoot ModelTarget
+    persistModelSwitch TopLevelSwitch home projectRoot ModelTarget
         { targetProvider = provider
         , targetConnectionId = connection
         , targetModelId = name
@@ -791,14 +792,15 @@ ensureTransitionSessionId (PersistenceEnabled slotRef) = do
     pure (Just handle.sessionMeta.metaId)
 
 commitProviderTransition
-    :: OsPath
+    :: ModelSwitchScope
+    -> OsPath
     -> OsPath
     -> Maybe ProviderTransition
     -> Persistence
     -> IO ()
-commitProviderTransition _ _ Nothing _ = pure ()
-commitProviderTransition home projectRoot (Just transition) persist = do
-    saveRememberedModel home projectRoot transition.transitionTarget
+commitProviderTransition _ _ _ Nothing _ = pure ()
+commitProviderTransition scope home projectRoot (Just transition) persist = do
+    persistModelSwitch scope home projectRoot transition.transitionTarget
     case persist of
         PersistenceDisabled -> pure ()
         PersistenceEnabled slotRef -> do
@@ -835,32 +837,35 @@ commitProviderTransition home projectRoot (Just transition) persist = do
                         (PersistenceActive handle { sessionMeta = meta })
 
 prepareTransitionBackend
-    :: OsPath
+    :: ModelSwitchScope
+    -> OsPath
     -> OsPath
     -> Maybe ProviderTransition
     -> Persistence
     -> Backend
     -> IO Backend
-prepareTransitionBackend _ _ Nothing _ backend = pure backend
-prepareTransitionBackend home projectRoot (Just transition) persist backend
+prepareTransitionBackend _ _ _ Nothing _ backend = pure backend
+prepareTransitionBackend scope home projectRoot (Just transition) persist backend
     | transitionCommitsImmediately transition = do
-        commitProviderTransition home projectRoot (Just transition) persist
+        commitProviderTransition scope home projectRoot (Just transition) persist
         pure backend
     | otherwise = do
         committed <- newIORef False
         pure $
             commitBackendOnSuccess
-                home projectRoot committed transition persist backend
+                scope home projectRoot committed transition persist backend
 
 commitBackendOnSuccess
-    :: OsPath
+    :: ModelSwitchScope
+    -> OsPath
     -> OsPath
     -> IORef Bool
     -> ProviderTransition
     -> Persistence
     -> Backend
     -> Backend
-commitBackendOnSuccess home projectRoot committed transition persist (Backend submit) =
+commitBackendOnSuccess
+        scope home projectRoot committed transition persist (Backend submit) =
     Backend \state previous inputs onEvent -> do
         result <- submit state previous inputs onEvent
         case result of
@@ -869,7 +874,7 @@ commitBackendOnSuccess home projectRoot committed transition persist (Backend su
                     (True, not done)
                 when shouldCommit $
                     commitProviderTransition
-                        home projectRoot (Just transition) persist
+                        scope home projectRoot (Just transition) persist
             Left _ -> pure ()
         pure result
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -212,6 +212,7 @@ import qualified Agent.XAI.Request as XAIRequest ( mapModel )
 import qualified Agent.XAI.Usage as XAIUsage ()
 
 runAgentProviders
+    modelSwitchScope
     loaded
     sessionRequest
     activeAccountIdRef
@@ -513,7 +514,8 @@ runAgentProviders
                                                 resetCodexTurnState turnState
                                 activeBackend <-
                                     prepareTransitionBackend
-                                        home projectRoot transition persist noticingBackend
+                                        modelSwitchScope home projectRoot
+                                        transition persist noticingBackend
                                 withAsync switchLoop \switchWorker -> do
                                     link switchWorker
                                     runSession
@@ -623,7 +625,8 @@ runAgentProviders
                                     focus
                         activeBackend <-
                             prepareTransitionBackend
-                                home projectRoot transition persist backend
+                                modelSwitchScope home projectRoot
+                                transition persist backend
                         runSession
                             (sessionRequest
                                 startupUnavailable
@@ -697,7 +700,8 @@ runAgentProviders
                             \backend -> do
                                 activeBackend <-
                                     prepareTransitionBackend
-                                        home projectRoot transition persist backend
+                                        modelSwitchScope home projectRoot
+                                        transition persist backend
                                 result <- runSession
                                     (sessionRequest
                                         startupUnavailable
@@ -809,7 +813,8 @@ runAgentProviders
                                     focus
                         activeBackend <-
                             prepareTransitionBackend
-                                home projectRoot transition persist backend
+                                modelSwitchScope home projectRoot
+                                transition persist backend
                         runSession
                             (sessionRequest
                                 startupUnavailable

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -40,7 +40,7 @@ import Agent.CLI.Options
     ( isOneShot, CliOptions(optShowRawReasoning, optCompactThreshold) )
 import Agent.CLI.PendingInputs ()
 import Agent.CLI.Plan ()
-import Agent.CLI.Project ()
+import Agent.CLI.Project ( ModelSwitchScope(..) )
 import Agent.CLI.Prompt
     ( codexEnvironmentContext,
       subscriptionSubagentModelGuidance,
@@ -615,6 +615,9 @@ runAgentSession
                         | otherwise = action Nothing
                 withStartupAvailability \startupUnavailable ->
                     runAgentProviders
+                        (if startup.startupBackground
+                            then SessionLocalSwitch
+                            else TopLevelSwitch)
                         loaded
                         sessionRequest
                         activeAccountIdRef

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -77,7 +77,6 @@ import Agent.CLI.Plan
     ( cliPlanHooks
     , resumedPlanNeedsApproval
     )
-import Agent.CLI.Project ( saveRememberedModel )
 import Agent.CLI.Prompt ( subscriptionSubagentModelGuidance )
 import Agent.CLI.PromptHooks
     ( fullscreenAwareImageHooks, fullscreenAwarePlanHooks, fullscreenAwareSecretHooks )
@@ -480,11 +479,9 @@ runAgentTools
     -- is durable in the session transcript. Reconstruct the approval phase
     -- before entering the REPL so a resumed Codex session cannot interpret
     -- the user's approval as ordinary steering input.
-    -- Provider transitions commit their selection separately: manual switches
-    -- immediately, automatic fallbacks only after the replacement succeeds.
-    when (isNothing transition) $
-        saveRememberedModel home projectRoot
-            inferredTarget { targetDialect = dialectId }
+    -- Keep inferred startup, resume, and delegated-agent targets session-local.
+    -- Live top-level model/provider switches persist their selection in
+    -- Agent.CLI.Provider.Switch instead.
     activeSessionLock <- newIORef resumeLock
     persistSlotRef <- newIORef PersistenceDisabled
     -- Per-subagent transcripts / previous ids, shared across send_input / task.

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -153,12 +153,12 @@ spec = describe "Agent.CLI.Project" do
                 projectModelFor OpenAIProvider updated
                     `shouldBe` Just "gpt-project"
 
-        it "writes the last model to both the checkout and user home" $
+        it "writes a top-level model switch to the checkout and user home" $
             withTempDir "agent-project-" \project ->
                 withTempDir "agent-home-" \home -> do
                     saveProjectAutoApprove home True
                     saveProjectAutoApprove project False
-                    saveRememberedModel home project
+                    persistModelSwitch TopLevelSwitch home project
                         (target XAIProvider "xai"
                             "grok-4.6" "grok-4.6" GrokBuildDialect)
 
@@ -174,6 +174,18 @@ spec = describe "Agent.CLI.Project" do
                     userSettings.settingsLastModel
                         `shouldBe` projectSettings.settingsLastModel
                     userSettingsPath home `shouldBe` projectSettingsPath home
+
+        it "keeps a delegated model switch out of checkout and user settings" $
+            withTempDir "agent-project-" \project ->
+                withTempDir "agent-home-" \home -> do
+                    persistModelSwitch SessionLocalSwitch home project
+                        (target OpenAIProvider "openai"
+                            "gpt-5.6-luna" "gpt-5.6-luna" CodexDialect)
+
+                    doesFileExist (projectSettingsPath project)
+                        `shouldReturn` False
+                    doesFileExist (userSettingsPath home)
+                        `shouldReturn` False
 
         it "replaces the remembered provider/model without resetting approval" $
             withTempDir "agent-project-" \root -> do


### PR DESCRIPTION
## Summary

- stop startup, resume, and delegated-agent model targets from updating remembered project/user settings
- make the persistence boundary explicit with top-level and session-local switch scopes
- keep delegated/background provider transitions in session metadata without changing inherited settings
- add regression coverage proving session-local Luna switches create neither settings file

## Root cause

The common runtime startup path persisted its inferred model target. A delegated session launched with a `gpt-5.6-luna` override could therefore overwrite both the checkout and user-level remembered model, making a later top-level `gpt-5.6-sol` session appear to switch models without user input.

## Testing

- loaded the affected CLI runtime/provider modules in GHCi
- ran `Agent.CLI.ProjectSpec` through `nix develop -c cabal repl agent-cli:test:agent-cli-test`
- 21 examples, 0 failures
- rebased onto current `origin/master` before the post-rebase test run
