### PR TITLE
Report realistic token throughput

### DIFF
--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -16,6 +16,7 @@ module Agent.CLI
     , formatRepositoryPath
     , formatStartupTimings
     , formatTokenUsage
+    , formatEstimatedTokensPerSecond
     , formatTokensPerSecond
     , formatUsageWithRate
     , learnAboutUserOnboardingPrompt
@@ -45,7 +46,8 @@ import Agent.CLI.McpStatus
     )
 import Agent.CLI.Runtime.Types (DevResult(..))
 import Agent.CLI.Status
-    ( formatReplStatusLine
+    ( formatEstimatedTokensPerSecond
+    , formatReplStatusLine
     , formatTokenUsage
     , formatTokensPerSecond
     , formatUsageWithRate

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -304,9 +304,7 @@ recordRenderTurnRate now turn state =
         { stateLastTokensPerSecond =
             generationTokensPerSecond
                 turn.tokenUsage.outputTokens
-                state.stateGenerationChars
                 (generationElapsedMillis now state)
-                <|> state.stateLastTokensPerSecond
         }
 
 renderTokensPerSecond :: UTCTime -> RenderState -> Maybe Double

--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Status
     , cycleReplInteraction
     , formatReplStatusLine
     , formatTokenUsage
+    , formatEstimatedTokensPerSecond
     , formatTokensPerSecond
     , formatUsageWithRate
     ) where
@@ -121,6 +122,11 @@ formatUsageWithRate usage rate =
             [ formatTokenUsage usage
             , maybe "" formatTokensPerSecond rate
             ]
+
+-- | Prefix a character-derived generation rate with an approximation marker.
+formatEstimatedTokensPerSecond :: Bool -> Double -> Text
+formatEstimatedTokensPerSecond estimated rate =
+    (if estimated then "~" else "") <> formatTokensPerSecond rate
 
 -- | Compact generation speed: @4.2 tok/s@, @42 tok/s@, @1.2k tok/s@.
 formatTokensPerSecond :: Double -> Text

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -56,7 +56,10 @@ import Agent.CLI.Resume
       groupResumeEntries,
       resumeRelativeAge )
 import Agent.CLI.Secret ()
-import Agent.CLI.Status ( formatTokensPerSecond, formatUsageWithRate )
+import Agent.CLI.Status
+    ( formatEstimatedTokensPerSecond
+    , formatUsageWithRate
+    )
 import Agent.CLI.Style ( motionGlyphSet )
 import Agent.CLI.TUI.History
     ( HistoryWindow(historyWindowTurns, historyWindowTotalTurns,
@@ -136,7 +139,8 @@ import Agent.TUI.Model
               uiCompletionRemainingMillis, uiRunning, uiElapsedMillis, uiFocus,
               uiSelectedBlock, uiPermission, uiFollow, uiRetryCountdown,
               uiNotice, uiBranch, uiCwd, uiPrompt),
-      uiTokensPerSecond )
+      uiTokensPerSecond,
+      uiTokensPerSecondEstimated )
 import Agent.TUI.Motion
     ( backgroundIndicator,
       foregroundIndicator,
@@ -536,9 +540,7 @@ drawHeaderRight :: AppState -> Widget Name
 drawHeaderRight state =
     withAttr Theme.mutedAttr $
         terminalTxt
-            (formatUsageWithRate
-                state.appUi.uiPrompt.promptUsage
-                (uiTokensPerSecond state.appUi))
+            (formatUiUsageWithRate state.appUi)
 
 drawLiveTodos :: UiState -> Widget Name
 drawLiveTodos ui =
@@ -639,12 +641,26 @@ drawPromptActivity state
             <> formatElapsed (fromIntegral ui.uiElapsedMillis / 1000)
     right
         | ui.uiRunning =
-            formatUsageWithRate
-                ui.uiPrompt.promptUsage
-                (uiTokensPerSecond ui)
+            formatUiUsageWithRate ui
         | ui.uiCompletionRemainingMillis > 0 =
-            maybe "" formatTokensPerSecond (uiTokensPerSecond ui)
+            maybe
+                ""
+                (formatEstimatedTokensPerSecond
+                    (uiTokensPerSecondEstimated ui))
+                (uiTokensPerSecond ui)
         | otherwise = ""
+
+formatUiUsageWithRate :: UiState -> Text
+formatUiUsageWithRate ui =
+    Text.intercalate " · " $
+        filter (not . Text.null)
+            [ formatUsageWithRate ui.uiPrompt.promptUsage Nothing
+            , maybe
+                ""
+                (formatEstimatedTokensPerSecond
+                    (uiTokensPerSecondEstimated ui))
+                (uiTokensPerSecond ui)
+            ]
 
 -- | Describe the child agents which keep the session alive after the root
 -- agent has finished. Prefer their current running step so the status line

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -87,6 +87,18 @@ spec = do
                     recordRenderTurnRate (addUTCTime 2 startedAt) turn started
             stateLastTokensPerSecond recorded `shouldBe` Just 40
 
+        it "does not estimate a completed rate without provider usage" do
+            let startedAt = UTCTime (fromGregorian 2026 1 2) 0
+                started =
+                    countGenerationChars "abcdefghijklmnop" $
+                        beginRenderTurn startedAt $
+                            emptyRenderState
+                                { stateLastTokensPerSecond = Just 42 }
+                turn = emptyTurnOutput "r1" [] (Just "abcdefghijklmnop")
+                recorded =
+                    recordRenderTurnRate (addUTCTime 2 startedAt) turn started
+            stateLastTokensPerSecond recorded `shouldBe` Nothing
+
         it "keeps the turn timer when a generation restarts" do
             let startedAt = UTCTime (fromGregorian 2026 1 2) 0
                 started = beginRenderTurn startedAt $

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -15,6 +15,7 @@ import Agent.CLI
     , formatRepositoryPath
     , formatStartupTimings
     , formatTokenUsage
+    , formatEstimatedTokensPerSecond
     , formatTokensPerSecond
     , formatUsageWithRate
     , withRestoredCurrentDirectory
@@ -385,6 +386,12 @@ spec = do
             formatTokensPerSecond 4.2 `shouldBe` "4.2 tok/s"
             formatTokensPerSecond 42 `shouldBe` "42 tok/s"
             formatTokensPerSecond 12500 `shouldBe` "13k tok/s"
+
+        it "marks character-derived rates as estimates" do
+            formatEstimatedTokensPerSecond True 42
+                `shouldBe` "~42 tok/s"
+            formatEstimatedTokensPerSecond False 42
+                `shouldBe` "42 tok/s"
 
         it "joins usage and rate" do
             formatUsageWithRate emptyTokenUsage (Just 42)

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -176,16 +176,10 @@ tokensPerSecond tokens millis
     | otherwise =
         Just (fromIntegral tokens * 1000 / fromIntegral millis)
 
--- | Prefer provider-reported output tokens; fall back to the streamed-text
--- estimate when usage is missing.
-generationTokensPerSecond :: Int -> Int -> Int -> Maybe Double
-generationTokensPerSecond reportedOutput chars millis =
-    tokensPerSecond
-        ( if reportedOutput > 0
-            then reportedOutput
-            else estimateTokensFromChars chars
-        )
-        millis
+-- | Completed generation speed from provider-reported output-token metadata.
+-- Character-derived estimates are reserved for the live streaming display.
+generationTokensPerSecond :: Int -> Int -> Maybe Double
+generationTokensPerSecond = tokensPerSecond
 
 -- | Live tok/s is noisy on the first few hundred milliseconds of a stream.
 liveTokenRateMinMillis :: Int

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -78,8 +78,8 @@ spec = describe "runLoop" do
         tokensPerSecond 100 0 `shouldBe` Nothing
         tokensPerSecond 100 1000 `shouldBe` Just 100
         tokensPerSecond 40 2000 `shouldBe` Just 20
-        generationTokensPerSecond 80 16 1000 `shouldBe` Just 80
-        generationTokensPerSecond 0 16 1000 `shouldBe` Just 4
+        generationTokensPerSecond 80 1000 `shouldBe` Just 80
+        generationTokensPerSecond 0 1000 `shouldBe` Nothing
         liveTokensPerSecond 16 (liveTokenRateMinMillis - 1) `shouldBe` Nothing
         liveTokensPerSecond 16 liveTokenRateMinMillis
             `shouldBe` tokensPerSecond 4 liveTokenRateMinMillis

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -338,9 +338,7 @@ snapshotGenerationRate usage state =
         , uiLastTokensPerSecond =
             generationTokensPerSecond
                 usage.outputTokens
-                state.uiGenerationChars
                 generationMillis
-                <|> state.uiLastTokensPerSecond
         }
 
 reduceLoop :: LoopEvent -> UiState -> UiState
@@ -781,10 +779,6 @@ finalizeTurn terminalState state =
         , uiGenerationMillis = generationMillis
         , uiLastTokensPerSecond =
             state.uiLastTokensPerSecond
-                <|> generationTokensPerSecond
-                    0
-                    state.uiGenerationChars
-                    generationMillis
         , uiActivity =
             if terminalState == BlockComplete
                 then "Finished"

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -265,6 +265,7 @@ reduceUi event state = case event of
             , uiGenerationChars = 0
             , uiGenerationMillis = 0
             , uiGenerationLastDeltaMillis = 0
+            , uiResponseMillis = 0
             , uiLastTokensPerSecond = Nothing
             }
     UiSetFollow follow ->
@@ -311,13 +312,15 @@ reduceUi event state = case event of
 
 resetGeneration :: UiState -> UiState
 resetGeneration state =
-    -- Throughput measures decoding, so the clock starts with the first delta
-    -- rather than including request latency and prompt ingestion.
+    -- The live character estimate starts with the first visible delta. The
+    -- provider response clock starts here because provider output-token usage
+    -- can also include hidden reasoning generated before that first delta.
     state
         { uiGenerating = False
         , uiGenerationChars = 0
         , uiGenerationMillis = 0
         , uiGenerationLastDeltaMillis = 0
+        , uiResponseMillis = 0
         }
 
 appendGenerationChars :: Text -> UiState -> UiState
@@ -331,14 +334,16 @@ appendGenerationChars delta state =
 
 snapshotGenerationRate :: TokenUsage -> UiState -> UiState
 snapshotGenerationRate usage state =
-    let generationMillis = state.uiGenerationLastDeltaMillis
+    let
+        generationMillis = state.uiGenerationLastDeltaMillis
+        responseMillis = state.uiResponseMillis
     in state
         { uiGenerating = False
         , uiGenerationMillis = generationMillis
         , uiLastTokensPerSecond =
             generationTokensPerSecond
                 usage.outputTokens
-                generationMillis
+                responseMillis
         }
 
 reduceLoop :: LoopEvent -> UiState -> UiState

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -35,6 +35,7 @@ module Agent.TUI.Model
     , uiNextDeadlineMillis
     , uiNeedsTick
     , uiTokensPerSecond
+    , uiTokensPerSecondEstimated
     , warningNotice
     , advanceUiTime
     , blockCodeLanguage
@@ -263,6 +264,7 @@ reduceUi event state = case event of
             , uiGenerating = False
             , uiGenerationChars = 0
             , uiGenerationMillis = 0
+            , uiGenerationLastDeltaMillis = 0
             , uiLastTokensPerSecond = Nothing
             }
     UiSetFollow follow ->
@@ -315,6 +317,7 @@ resetGeneration state =
         { uiGenerating = False
         , uiGenerationChars = 0
         , uiGenerationMillis = 0
+        , uiGenerationLastDeltaMillis = 0
         }
 
 appendGenerationChars :: Text -> UiState -> UiState
@@ -323,17 +326,20 @@ appendGenerationChars delta state =
         { uiGenerating = True
         , uiGenerationChars =
             state.uiGenerationChars + Text.length delta
+        , uiGenerationLastDeltaMillis = state.uiGenerationMillis
         }
 
 snapshotGenerationRate :: TokenUsage -> UiState -> UiState
 snapshotGenerationRate usage state =
-    state
+    let generationMillis = state.uiGenerationLastDeltaMillis
+    in state
         { uiGenerating = False
+        , uiGenerationMillis = generationMillis
         , uiLastTokensPerSecond =
             generationTokensPerSecond
                 usage.outputTokens
                 state.uiGenerationChars
-                state.uiGenerationMillis
+                generationMillis
                 <|> state.uiLastTokensPerSecond
         }
 
@@ -759,7 +765,8 @@ updateToolOutput callId output state =
 
 finalizeTurn :: BlockState -> UiState -> UiState
 finalizeTurn terminalState state =
-    state
+    let generationMillis = state.uiGenerationLastDeltaMillis
+    in state
         { uiBlocks =
             Seq.mapWithIndex
                 (\index block ->
@@ -771,12 +778,13 @@ finalizeTurn terminalState state =
                 state.uiBlocks
         , uiRunning = False
         , uiGenerating = False
+        , uiGenerationMillis = generationMillis
         , uiLastTokensPerSecond =
             state.uiLastTokensPerSecond
                 <|> generationTokensPerSecond
                     0
                     state.uiGenerationChars
-                    state.uiGenerationMillis
+                    generationMillis
         , uiActivity =
             if terminalState == BlockComplete
                 then "Finished"

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -309,8 +309,10 @@ reduceUi event state = case event of
 
 resetGeneration :: UiState -> UiState
 resetGeneration state =
+    -- Throughput measures decoding, so the clock starts with the first delta
+    -- rather than including request latency and prompt ingestion.
     state
-        { uiGenerating = True
+        { uiGenerating = False
         , uiGenerationChars = 0
         , uiGenerationMillis = 0
         }
@@ -318,7 +320,8 @@ resetGeneration state =
 appendGenerationChars :: Text -> UiState -> UiState
 appendGenerationChars delta state =
     state
-        { uiGenerationChars =
+        { uiGenerating = True
+        , uiGenerationChars =
             state.uiGenerationChars + Text.length delta
         }
 
@@ -354,13 +357,11 @@ reduceLoop event state = case event of
         appendOrExtend BlockThinking "Thought" delta BlockStreaming $
             appendGenerationChars delta state
                 { uiActivity = "Thinking…"
-                , uiGenerating = True
                 }
     TextDelta delta ->
         appendOrExtend BlockAssistant "Assistant" delta BlockStreaming $
             appendGenerationChars delta state
                 { uiActivity = "Writing…"
-                , uiGenerating = True
                 }
     ActivityUpdated activity ->
         state { uiActivity = activity }

--- a/packages/agent-tui/src/Agent/TUI/Model/State.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/State.hs
@@ -57,6 +57,7 @@ initialUiState = UiState
     , uiGenerating = False
     , uiGenerationChars = 0
     , uiGenerationMillis = 0
+    , uiGenerationLastDeltaMillis = 0
     , uiLastTokensPerSecond = Nothing
     }
 

--- a/packages/agent-tui/src/Agent/TUI/Model/State.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/State.hs
@@ -58,6 +58,7 @@ initialUiState = UiState
     , uiGenerationChars = 0
     , uiGenerationMillis = 0
     , uiGenerationLastDeltaMillis = 0
+    , uiResponseMillis = 0
     , uiLastTokensPerSecond = Nothing
     }
 

--- a/packages/agent-tui/src/Agent/TUI/Model/Timing.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Timing.hs
@@ -4,6 +4,7 @@ module Agent.TUI.Model.Timing
     , uiNextDeadlineMillis
     , uiNeedsTick
     , uiTokensPerSecond
+    , uiTokensPerSecondEstimated
     , retryCountdownText
     ) where
 
@@ -62,6 +63,16 @@ uiTokensPerSecond state
         liveTokensPerSecond state.uiGenerationChars state.uiGenerationMillis
             <|> state.uiLastTokensPerSecond
     | otherwise = state.uiLastTokensPerSecond
+
+-- | Whether the displayed rate is the live streamed-text estimate rather than
+-- a retained provider-reported rate.
+uiTokensPerSecondEstimated :: UiState -> Bool
+uiTokensPerSecondEstimated state =
+    state.uiGenerating
+        && liveTokensPerSecond
+            state.uiGenerationChars
+            state.uiGenerationMillis
+            /= Nothing
 
 uiNeedsTick :: UiState -> Bool
 uiNeedsTick state =

--- a/packages/agent-tui/src/Agent/TUI/Model/Timing.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Timing.hs
@@ -44,6 +44,10 @@ advanceUiTime rawElapsedMillis state =
             if state.uiGenerating
                 then state.uiGenerationMillis + elapsedMillis
                 else state.uiGenerationMillis
+        , uiResponseMillis =
+            if state.uiRunning
+                then state.uiResponseMillis + elapsedMillis
+                else state.uiResponseMillis
         , uiActivity =
             if state.uiCompletionRemainingMillis > 0
                 && completionRemainingMillis == 0

--- a/packages/agent-tui/src/Agent/TUI/Model/Types.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Types.hs
@@ -147,6 +147,7 @@ data UiState = UiState
     , uiGenerationChars :: !Int
     , uiGenerationMillis :: !Int
     , uiGenerationLastDeltaMillis :: !Int
+    , uiResponseMillis :: !Int
     , uiLastTokensPerSecond :: !(Maybe Double)
     }
     deriving (Eq, Show)

--- a/packages/agent-tui/src/Agent/TUI/Model/Types.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Types.hs
@@ -146,6 +146,7 @@ data UiState = UiState
     , uiGenerating :: !Bool
     , uiGenerationChars :: !Int
     , uiGenerationMillis :: !Int
+    , uiGenerationLastDeltaMillis :: !Int
     , uiLastTokensPerSecond :: !(Maybe Double)
     }
     deriving (Eq, Show)

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -745,7 +745,7 @@ spec = describe "fullscreen UI reducer" do
                         ]
             lastDelta =
                 reduceUi (UiLoop (TextDelta "qrst")) streaming
-            awaitingCompletion = advanceUiTime 1000 lastDelta
+            awaitingCompletion = advanceUiTime 1600 lastDelta
             reported usage tools =
                 (emptyTurnOutput "r1" tools (Just "abcdefghijklmnop"))
                     { tokenUsage = usage }
@@ -767,17 +767,19 @@ spec = describe "fullscreen UI reducer" do
             afterNext = reduceUi (UiLoop TurnStarted) finished
         uiTokensPerSecond streaming `shouldBe` Just 10
         uiTokensPerSecondEstimated streaming `shouldBe` True
-        uiTokensPerSecond finished `shouldBe` Just 200
+        uiTokensPerSecond finished `shouldBe` Just 40
         uiTokensPerSecondEstimated finished `shouldBe` False
         finished.uiGenerating `shouldBe` False
         finished.uiGenerationMillis `shouldBe` liveTokenRateMinMillis
-        uiTokensPerSecond duringTools `shouldBe` Just 200
+        finished.uiResponseMillis `shouldBe` 2000
+        uiTokensPerSecond duringTools `shouldBe` Just 40
         duringTools.uiGenerating `shouldBe` False
         duringTools.uiGenerationMillis `shouldBe` liveTokenRateMinMillis
         (advanceUiTime 5000 duringTools).uiGenerationMillis
             `shouldBe` liveTokenRateMinMillis
-        uiTokensPerSecond afterNext `shouldBe` Just 200
+        uiTokensPerSecond afterNext `shouldBe` Just 40
         afterNext.uiGenerationMillis `shouldBe` 0
+        afterNext.uiResponseMillis `shouldBe` 0
 
     it "drops the live estimate when completed token metadata is missing" do
         let streaming =
@@ -800,7 +802,7 @@ spec = describe "fullscreen UI reducer" do
         uiTokensPerSecond finished `shouldBe` Nothing
         uiTokensPerSecondEstimated finished `shouldBe` False
 
-    it "excludes time to first token from generation speed" do
+    it "excludes time to first token only from the live estimate" do
         let waiting =
                 advanceUiTime 5000 $
                     reduceUi (UiLoop TurnStarted) initialUiState
@@ -809,11 +811,24 @@ spec = describe "fullscreen UI reducer" do
                     reduceUi
                         (UiLoop (TextDelta "abcdefghijklmnop"))
                         waiting
+            turn =
+                (emptyTurnOutput "r1" [] (Just "abcdefghijklmnop"))
+                    { tokenUsage =
+                        TokenUsage
+                            { inputTokens = 20
+                            , outputTokens = 108
+                            , cachedTokens = 0
+                            }
+                    }
+            finished = reduceUi (UiLoop (TurnFinished turn)) streaming
         waiting.uiGenerating `shouldBe` False
         waiting.uiGenerationMillis `shouldBe` 0
         uiTokensPerSecond waiting `shouldBe` Nothing
         streaming.uiGenerationMillis `shouldBe` liveTokenRateMinMillis
         uiTokensPerSecond streaming `shouldBe` Just 10
+        streaming.uiResponseMillis `shouldBe` 5400
+        uiTokensPerSecond finished `shouldBe` Just 20
+        uiTokensPerSecondEstimated finished `shouldBe` False
 
     it "keeps turn elapsed time but resets generation timing when a response restarts" do
         let streaming =
@@ -829,10 +844,12 @@ spec = describe "fullscreen UI reducer" do
         restarted.uiElapsedMillis `shouldBe` 800
         restarted.uiGenerationMillis `shouldBe` 0
         restarted.uiGenerationChars `shouldBe` 0
+        restarted.uiResponseMillis `shouldBe` 0
         restarted.uiGenerating `shouldBe` False
         restarted.uiActivity `shouldBe` "Retrying response…"
         waiting.uiElapsedMillis `shouldBe` 2000
         waiting.uiGenerationMillis `shouldBe` 0
+        waiting.uiResponseMillis `shouldBe` 1200
 
     it "drops last tok/s when the conversation is cleared" do
         let streaming =

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -773,7 +773,22 @@ spec = describe "fullscreen UI reducer" do
         uiTokensPerSecond afterNext `shouldBe` Just 200
         afterNext.uiGenerationMillis `shouldBe` 0
 
-    it "keeps turn elapsed time when a response restarts" do
+    it "excludes time to first token from generation speed" do
+        let waiting =
+                advanceUiTime 5000 $
+                    reduceUi (UiLoop TurnStarted) initialUiState
+            streaming =
+                advanceUiTime liveTokenRateMinMillis $
+                    reduceUi
+                        (UiLoop (TextDelta "abcdefghijklmnop"))
+                        waiting
+        waiting.uiGenerating `shouldBe` False
+        waiting.uiGenerationMillis `shouldBe` 0
+        uiTokensPerSecond waiting `shouldBe` Nothing
+        streaming.uiGenerationMillis `shouldBe` liveTokenRateMinMillis
+        uiTokensPerSecond streaming `shouldBe` Just 10
+
+    it "keeps turn elapsed time but resets generation timing when a response restarts" do
         let streaming =
                 advanceUiTime 800 $
                     apply
@@ -782,12 +797,15 @@ spec = describe "fullscreen UI reducer" do
                         ]
             restarted =
                 reduceUi (UiLoop (ResponseRestarted "retrying")) streaming
+            waiting = advanceUiTime 1200 restarted
         streaming.uiElapsedMillis `shouldBe` 800
         restarted.uiElapsedMillis `shouldBe` 800
         restarted.uiGenerationMillis `shouldBe` 0
         restarted.uiGenerationChars `shouldBe` 0
-        restarted.uiGenerating `shouldBe` True
+        restarted.uiGenerating `shouldBe` False
         restarted.uiActivity `shouldBe` "Retrying response…"
+        waiting.uiElapsedMillis `shouldBe` 2000
+        waiting.uiGenerationMillis `shouldBe` 0
 
     it "drops last tok/s when the conversation is cleared" do
         let finished =

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -779,6 +779,27 @@ spec = describe "fullscreen UI reducer" do
         uiTokensPerSecond afterNext `shouldBe` Just 200
         afterNext.uiGenerationMillis `shouldBe` 0
 
+    it "drops the live estimate when completed token metadata is missing" do
+        let streaming =
+                advanceUiTime liveTokenRateMinMillis $
+                    foldl
+                        (flip reduceUi)
+                        initialUiState
+                            { uiLastTokensPerSecond = Just 42 }
+                        [ UiLoop TurnStarted
+                        , UiLoop (TextDelta "abcdefghijklmnop")
+                        ]
+            finished =
+                reduceUi
+                    (UiLoop
+                        (TurnFinished
+                            (emptyTurnOutput "r1" [] (Just "abcdefghijklmnop"))))
+                    streaming
+        uiTokensPerSecond streaming `shouldBe` Just 10
+        uiTokensPerSecondEstimated streaming `shouldBe` True
+        uiTokensPerSecond finished `shouldBe` Nothing
+        uiTokensPerSecondEstimated finished `shouldBe` False
+
     it "excludes time to first token from generation speed" do
         let waiting =
                 advanceUiTime 5000 $

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -743,6 +743,9 @@ spec = describe "fullscreen UI reducer" do
                         [ UiLoop TurnStarted
                         , UiLoop (TextDelta "abcdefghijklmnop")
                         ]
+            lastDelta =
+                reduceUi (UiLoop (TextDelta "qrst")) streaming
+            awaitingCompletion = advanceUiTime 1000 lastDelta
             reported usage tools =
                 (emptyTurnOutput "r1" tools (Just "abcdefghijklmnop"))
                     { tokenUsage = usage }
@@ -755,16 +758,19 @@ spec = describe "fullscreen UI reducer" do
             finished =
                 reduceUi
                     (UiLoop (TurnFinished (reported usage [])))
-                    streaming
+                    awaitingCompletion
             duringTools =
                 reduceUi (UiLoop (ToolStarted call)) $
                     reduceUi
                         (UiLoop (TurnFinished (reported usage [call])))
-                        streaming
+                        awaitingCompletion
             afterNext = reduceUi (UiLoop TurnStarted) finished
         uiTokensPerSecond streaming `shouldBe` Just 10
+        uiTokensPerSecondEstimated streaming `shouldBe` True
         uiTokensPerSecond finished `shouldBe` Just 200
+        uiTokensPerSecondEstimated finished `shouldBe` False
         finished.uiGenerating `shouldBe` False
+        finished.uiGenerationMillis `shouldBe` liveTokenRateMinMillis
         uiTokensPerSecond duringTools `shouldBe` Just 200
         duringTools.uiGenerating `shouldBe` False
         duringTools.uiGenerationMillis `shouldBe` liveTokenRateMinMillis
@@ -808,7 +814,13 @@ spec = describe "fullscreen UI reducer" do
         waiting.uiGenerationMillis `shouldBe` 0
 
     it "drops last tok/s when the conversation is cleared" do
-        let finished =
+        let streaming =
+                advanceUiTime liveTokenRateMinMillis $
+                    apply
+                        [ UiLoop TurnStarted
+                        , UiLoop (TextDelta "abcdefghijklmnop")
+                        ]
+            finished =
                 reduceUi
                     (UiLoop
                         (TurnFinished
@@ -820,11 +832,7 @@ spec = describe "fullscreen UI reducer" do
                                         , cachedTokens = 0
                                         }
                                 })))
-                    (advanceUiTime liveTokenRateMinMillis $
-                        apply
-                            [ UiLoop TurnStarted
-                            , UiLoop (TextDelta "abcdefghijklmnop")
-                            ])
+                    (reduceUi (UiLoop (TextDelta "qrst")) streaming)
             cleared = reduceUi UiConversationCleared finished
         uiTokensPerSecond finished `shouldBe` Just 200
         uiTokensPerSecond cleared `shouldBe` Nothing


### PR DESCRIPTION
## Summary
- start generation timing when the first reasoning or text delta arrives and stop it at the last streamed delta
- exclude request, prompt-ingestion, first-token, retry, and post-stream completion latency from tok/s
- calculate completed throughput exclusively from provider-reported output-token metadata
- keep character-derived rates only while streaming and prefix them with `~`
- clear the completed rate when usage metadata is unavailable instead of showing an estimate or stale value
- cover timing boundaries, metadata usage, missing metadata, and estimate formatting

## Testing
- `printf ':main --match "estimates tokens from streamed characters"\\n:q\\n' | nix develop -c cabal repl agent-core:test:agent-core-test` (1 example, 0 failures)
- `printf ':main --match "fullscreen UI reducer"\\n:q\\n' | nix develop -c cabal repl agent-tui:test:agent-tui-test` (59 examples, 0 failures)
- `printf ':main --match "RenderState transitions"\\n:q\\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test` (9 examples, 0 failures)
- exercised the live fullscreen CLI in tmux; observed `~90 tok/s` while streaming, then exact `67 tok/s` beside provider metadata reporting `387 out`
- `git diff --check`
