### PR TITLE
Expose current usage windows to native account UIs

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -16,9 +16,13 @@ import Agent.CLI.MacOS.NativeLoopEvent
 import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.Login
     ( AccountBilling(..)
+    , AccountUsage(..)
     , LoginAccount(..)
+    , UsageState(..)
+    , UsageWindow(..)
     , discoverLoginAccounts
     , loginAccountSelectionId
+    , refreshLoginAccount
     , storeConnectedCredential
     )
 import Agent.CLI.CredentialStore
@@ -92,6 +96,7 @@ import Control.Concurrent (forkFinally, forkIO)
 import Control.Concurrent.Async
     ( Async
     , cancel
+    , mapConcurrently
     , waitCatchSTM
     , withAsync
     )
@@ -153,6 +158,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (addUTCTime, getCurrentTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Word (Word8, Word64)
 import Foreign
     ( FunPtr
@@ -168,7 +174,7 @@ import Foreign
     , nullPtr
     )
 import Foreign.C.String (CString)
-import Foreign.C.Types (CInt(..), CSize(..))
+import Foreign.C.Types (CInt(..), CLLong(..), CSize(..))
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
     ( IOMode(WriteMode)
@@ -206,6 +212,10 @@ type AccountListCallback =
     -> CString -> CSize -> CString -> CSize -> CString -> CSize
     -> CInt -> CInt -> CString -> CSize -> IO ()
 
+type AccountUsageWindowCallback =
+    Ptr () -> CString -> CSize -> CString -> CSize
+    -> CInt -> CLLong -> CLLong -> IO ()
+
 type AccountResultCallback =
     Ptr () -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
 
@@ -220,6 +230,10 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeAccountListCallback
         :: FunPtr AccountListCallback -> AccountListCallback
+
+foreign import ccall "dynamic"
+    invokeAccountUsageWindowCallback
+        :: FunPtr AccountUsageWindowCallback -> AccountUsageWindowCallback
 
 foreign import ccall "dynamic"
     invokeAccountResultCallback
@@ -419,7 +433,8 @@ foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
 
 foreign export ccall ha_accounts_list
-    :: FunPtr AccountListCallback -> Ptr () -> IO CInt
+    :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback
+    -> Ptr () -> IO CInt
 
 foreign export ccall ha_account_oauth_start
     :: Ptr Word8 -> CSize -> FunPtr AccountOAuthStartCallback -> Ptr () -> IO CInt
@@ -440,12 +455,16 @@ foreign export ccall ha_account_set_enabled
 foreign export ccall ha_account_delete
     :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
 
-ha_accounts_list :: FunPtr AccountListCallback -> Ptr () -> IO CInt
-ha_accounts_list callback context
-    | callback == nullFunPtr = pure 1
+ha_accounts_list
+    :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback
+    -> Ptr () -> IO CInt
+ha_accounts_list callback usageCallback context
+    | callback == nullFunPtr || usageCallback == nullFunPtr = pure 1
     | otherwise = do
         _ <- forkIO do
-            tryAny discoverLoginAccounts >>= \case
+            tryAny
+                (discoverLoginAccounts >>= mapConcurrently refreshLoginAccount)
+                >>= \case
                 Left exception ->
                     withText (Text.pack (show exception)) $ \errorPtr errorLength ->
                         invokeAccountListCallback callback context (-1)
@@ -453,9 +472,10 @@ ha_accounts_list callback context
                             nullPtr 0 nullPtr 0 nullPtr 0
                             0 0 errorPtr errorLength
                 Right accounts -> do
-                    forM_ accounts \account ->
+                    forM_ accounts \account -> do
                         withAccountStrings account $
                             invokeAccountListCallback callback context 0
+                        invokeAccountUsageWindows usageCallback context account
                     invokeAccountListCallback callback context 1
                         nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
                         nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
@@ -586,7 +606,9 @@ withAccountStrings account action =
     withText account.loginAccountId $ \accountId accountIdLength ->
     withText account.loginLabel $ \label labelLength ->
     withText account.loginSource $ \source sourceLength ->
-        withText account.loginSource $ \detail detailLength ->
+        withText
+            (accountUsageSummary account)
+            $ \detail detailLength ->
         withOptionalText account.loginManagedId $ \managedId managedLength ->
         action provider providerLength billing billingLength
             selection selectionLength accountId accountIdLength label labelLength
@@ -599,6 +621,40 @@ billingText :: AccountBilling -> Text
 billingText = \case
     SubscriptionBilling _ -> "subscription"
     ApiCreditsBilling -> "api"
+
+accountUsageSummary :: LoginAccount -> Text
+accountUsageSummary account =
+    Text.intercalate " · " $
+        billing <> case account.loginUsage of
+            UsageNotChecked -> []
+            UsageUnavailable _ -> ["usage unavailable"]
+            UsageAvailable usage ->
+                maybeToList usage.usagePlan
+                    <> maybeToList
+                        (("credits " <>) <$> usage.creditsRemaining)
+                    <> maybeToList
+                        (("used " <>) <$> usage.creditsUsed)
+  where
+    billing = case account.loginBilling of
+        ApiCreditsBilling -> ["API credits"]
+        SubscriptionBilling plan ->
+            maybe ["subscription"] (\value -> ["subscription", value]) plan
+    maybeToList = maybe [] pure
+
+invokeAccountUsageWindows
+    :: FunPtr AccountUsageWindowCallback -> Ptr () -> LoginAccount -> IO ()
+invokeAccountUsageWindows callback context account =
+    case account.loginUsage of
+        UsageAvailable usage ->
+            forM_ usage.usageWindows \window ->
+                withText (loginAccountSelectionId account) $ \selection selectionLength ->
+                withText window.windowName $ \name nameLength ->
+                    invokeAccountUsageWindowCallback callback context
+                        selection selectionLength name nameLength
+                        (fromIntegral window.usedPercent)
+                        (fromIntegral window.windowSeconds)
+                        (round (utcTimeToPOSIXSeconds window.resetsAt))
+        _ -> pure ()
 
 parseChallenge :: Aeson.Value
     -> Maybe (Text, Text, Maybe Text, Maybe Text, Int, Int)

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -47,6 +47,19 @@ typedef void (*ha_account_list_callback)(
 );
 
 /*
+ * Usage-window callbacks are emitted after their corresponding account item.
+ * reset_at_unix is an absolute UTC Unix timestamp in seconds.
+ */
+typedef void (*ha_account_usage_window_callback)(
+    void *context,
+    const uint8_t *selection_id, size_t selection_id_length,
+    const uint8_t *name, size_t name_length,
+    int32_t used_percent,
+    int64_t window_seconds,
+    int64_t reset_at_unix
+);
+
+/*
  * Result callbacks use status 0 for success, 1 when OAuth polling remains
  * pending, and -1 for an error.
  */
@@ -100,7 +113,11 @@ void ha_engine_destroy(void *engine);
  * during the callback and must be copied by the caller. All functions return
  * 0 when accepted, or a nonzero error before starting the worker.
  */
-int32_t ha_accounts_list(ha_account_list_callback callback, void *context);
+int32_t ha_accounts_list(
+    ha_account_list_callback callback,
+    ha_account_usage_window_callback usage_callback,
+    void *context
+);
 int32_t ha_account_oauth_start(
     const uint8_t *provider,
     size_t provider_length,


### PR DESCRIPTION
## Summary
- refresh discovered accounts concurrently before returning them to native clients
- add a typed usage-window callback to the C ABI
- expose window name, percentage used, duration, and absolute reset time
- retain concise plan and credit metadata in the account detail

## Validation
- `nix develop -c cabal build agent-cli:flib:haskell-agent-bridge`
- integrated macOS build passes through the sibling flake override

Consumer PR: https://github.com/digitallyinduced/haskell-agent-macos/pull/23