### PR TITLE
Reconnect and resubmit after a Codex socket dies mid-response

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Connectivity.hs
+++ b/packages/agent-cli/src/Agent/CLI/Connectivity.hs
@@ -69,6 +69,10 @@ withConnectionRecoveryUsing waitMicros (Backend submit) =
                 streamed <- newIORef False
                 result <- submit state previous inputs \event -> do
                     when (isStreamOutput event) (writeIORef streamed True)
+                    -- A lower layer already closed the interrupted attempt
+                    -- with its own boundary; only output streamed afterwards
+                    -- needs another one before the next replay.
+                    when (isRestartBoundary event) (writeIORef streamed False)
                     onEvent event
                 didStream <- readIORef streamed
                 case result of
@@ -121,6 +125,12 @@ isStreamOutput = \case
     -- boundary that text output gets.
     ToolStarted _ -> True
     ToolUpdated _ -> True
+    _ -> False
+
+isRestartBoundary :: LoopEvent -> Bool
+isRestartBoundary = \case
+    ResponseRestarted _ -> True
+    ResponseAttemptDiscarded -> True
     _ -> False
 
 connectionWaitingMessage :: Int -> Text

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/OpenAI.hs
@@ -10,9 +10,9 @@ import Agent.OpenAI.WebSocketClient
     ( CodexTurnState
     , newCodexTurnState
     , sendWsRequestWithEvents
-    , withCodexWsRetryingUsingTurnState
+    , withCodexWsCredentialUsingTurnState
     )
-import Agent.Provider (TokenProvider)
+import Agent.Provider (TokenProvider, runWithTokenProvider)
 import Agent.Responses.Types (ResponseCreateParams)
 
 -- | Each submission is its own logical turn with disposable connections.
@@ -34,11 +34,16 @@ freshOpenAiBackendWithTurnState
     :: Bool -> CodexTurnState -> TokenProvider
     -> IO ResponseCreateParams -> Backend
 freshOpenAiBackendWithTurnState showRawReasoning turnState provider getParams =
-    openAiBackendWithReasoningVisibility
-        showRawReasoning
-        (\request previousResponseId onStreamEvent ->
-            withCodexWsRetryingUsingTurnState provider turnState
-                \conn _credential ->
-                    sendWsRequestWithEvents conn request
-                        previousResponseId onStreamEvent)
-        getParams
+    Backend \state previous inputs onEvent ->
+        runWithTokenProvider provider \credential ->
+            let Backend submit =
+                    openAiBackendWithReasoningVisibility
+                        showRawReasoning
+                        (\request previousResponseId onStreamEvent ->
+                            withCodexWsCredentialUsingTurnState
+                                credential turnState
+                                \conn _activeCredential ->
+                                    sendWsRequestWithEvents conn request
+                                        previousResponseId onStreamEvent)
+                        getParams
+            in submit state previous inputs onEvent

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/OpenAI.hs
@@ -5,41 +5,40 @@ module Agent.CLI.Subagents.Runtime.OpenAI
     ) where
 
 import Agent.Loop (Backend(..))
-import Agent.OpenAI.LoopBackend
-    ( openAiBackendWithRawReasoning
-    , openAiBackendWithReasoningVisibility
-    )
+import Agent.OpenAI.LoopBackend (openAiBackendWithReasoningVisibility)
 import Agent.OpenAI.WebSocketClient
     ( CodexTurnState
+    , newCodexTurnState
     , sendWsRequestWithEvents
-    , withCodexWsRetrying
     , withCodexWsRetryingUsingTurnState
     )
 import Agent.Provider (TokenProvider)
 import Agent.Responses.Types (ResponseCreateParams)
 
+-- | Each submission is its own logical turn with disposable connections.
 freshOpenAiBackend
     :: Bool -> TokenProvider -> IO ResponseCreateParams -> Backend
 freshOpenAiBackend showRawReasoning provider getParams =
-    Backend \state previous inputs onEvent ->
-        withCodexWsRetrying provider \conn _credential ->
-            let Backend submit =
-                    openAiBackendWithRawReasoning
-                        showRawReasoning conn getParams
-            in submit state previous inputs onEvent
+    Backend \state previous inputs onEvent -> do
+        turnState <- newCodexTurnState
+        let Backend submit =
+                freshOpenAiBackendWithTurnState
+                    showRawReasoning turnState provider getParams
+        submit state previous inputs onEvent
 
+-- | Every request dials its own connection attached to the shared logical
+-- turn. That includes the resubmission after a socket died mid-response: the
+-- backend's reconnect policy simply calls the sender again, and a request that
+-- reused the dead connection would fail immediately instead of recovering.
 freshOpenAiBackendWithTurnState
     :: Bool -> CodexTurnState -> TokenProvider
     -> IO ResponseCreateParams -> Backend
 freshOpenAiBackendWithTurnState showRawReasoning turnState provider getParams =
-    Backend \state previous inputs onEvent ->
-        withCodexWsRetryingUsingTurnState provider turnState
-            \conn _credential ->
-                let Backend submit =
-                        openAiBackendWithReasoningVisibility
-                            showRawReasoning
-                            (\request previousResponseId onStreamEvent ->
-                                sendWsRequestWithEvents conn request
-                                    previousResponseId onStreamEvent)
-                            getParams
-                in submit state previous inputs onEvent
+    openAiBackendWithReasoningVisibility
+        showRawReasoning
+        (\request previousResponseId onStreamEvent ->
+            withCodexWsRetryingUsingTurnState provider turnState
+                \conn _credential ->
+                    sendWsRequestWithEvents conn request
+                        previousResponseId onStreamEvent)
+        getParams

--- a/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConnectivitySpec.hs
@@ -104,6 +104,44 @@ spec = describe "withConnectionRecovery" do
                 }
         readIORef attempts `shouldReturn` 2
 
+    it "does not repeat a restart boundary the backend already emitted" do
+        attempts <- newIORef (0 :: Int)
+        events <- newIORef []
+        let backend = withConnectionRecoveryUsing
+                (const (pure ()))
+                (Backend \state _ _ onEvent -> do
+                    attempt <- atomicModifyIORef' attempts
+                        \n -> (n + 1, n + 1)
+                    if attempt == 1
+                        then do
+                            onEvent (TextDelta "partial")
+                            onEvent (ResponseRestarted "inner restart")
+                            pure (Left (ConnectionError "dropped"))
+                        else
+                            pure (Right
+                                BackendResult
+                                    { backendOutput =
+                                        emptyTurnOutput
+                                            "response" [] (Just "done")
+                                    , backendState = state
+                                    }))
+        result <- backend.submitTurn [] Nothing []
+            (\event -> modifyIORef' events (<> [event]))
+        result `shouldBe`
+            Right BackendResult
+                { backendOutput =
+                    emptyTurnOutput "response" [] (Just "done")
+                , backendState = []
+                }
+        readIORef attempts `shouldReturn` 2
+        readIORef events `shouldReturn`
+            [ TextDelta "partial"
+            , ResponseRestarted "inner restart"
+            , ActivityUpdated
+                "Connection lost; waiting for internet. Retrying automatically in 1s (Esc or Ctrl-C to cancel)…"
+            , ActivityUpdated "Checking internet connection…"
+            ]
+
     it "restarts a submission after visible output streamed" do
         attempts <- newIORef (0 :: Int)
         waits <- newIORef []

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -552,6 +552,11 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                                         case event of
                                             TextDelta _ -> writeIORef outputSeen True
                                             ReasoningDelta _ -> writeIORef outputSeen True
+                                            -- The backend rolled that attempt back,
+                                            -- so a later failure no longer interrupts
+                                            -- visible output.
+                                            ResponseAttemptDiscarded ->
+                                                writeIORef outputSeen False
                                             _ -> pure ()
                                         config.loopOnEvent event
                                 -- Race the model call against cancel so Ctrl-C / Esc

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1074,6 +1074,15 @@ spec = describe "runLoop" do
         result `shouldBe`
             Left (LoopTransportAfterOutput (ConnectionError "down"))
 
+    it "treats a transport failure after a discarded attempt as pre-output" do
+        let backend = Backend \_state _prev _inputs onEvent -> do
+                onEvent (TextDelta "partial")
+                onEvent ResponseAttemptDiscarded
+                pure (Left (ConnectionError "down"))
+        config <- testConfig backend
+        result <- runLoop config Nothing "hello"
+        result `shouldBe` Left (LoopTransport (ConnectionError "down"))
+
     it "turns synchronous backend exceptions into a failed turn" do
         config <- testConfig $ Backend \_state _prev _inputs _onEvent ->
             Exception.throwIO (userError "backend exploded")

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -15,6 +15,8 @@ module Agent.OpenAI.LoopBackend
     , openAiBackendWith
     , openAiBackendWithReasoningVisibility
     , openAiBackendWithRetryPolicy
+    , openAiBackendWithRetryPolicies
+    , connectionReplayPolicy
     , openAiBackendWithConnectionRecovery
     , openAiBackendWithTransportFallback
     , withCodexTurnStateScope
@@ -471,12 +473,17 @@ isReplayUnsafeError = \case
     _ -> False
 
 -- | Prefer a WebSocket backend, then switch this agent session permanently to
--- a fallback transport when the socket dies before exposing model output.
+-- a fallback transport once the socket has failed.
 --
 -- Independent agent sessions need their own WebSocket connections. The Codex
 -- endpoint can accept the upgrade and then close a fresh connection before its
--- first response frame. Replaying the same logical turn over the stateless HTTP
--- backend is safe while no text or reasoning delta has reached the caller.
+-- first response frame, and a live socket can die mid-response after the
+-- WebSocket backend exhausted its own reconnect attempts. A dead socket commits
+-- nothing on the server, so the same logical turn is replayed over the
+-- stateless HTTP backend. Text or reasoning that already reached the caller is
+-- closed with a visible restart boundary first; an announced tool block that
+-- never ran is discarded. This mirrors Codex, which retries the sampling
+-- request over WebSocket and then falls back to HTTPS for the session.
 openAiBackendWithTransportFallback
     :: IORef Bool
     -> Backend
@@ -492,26 +499,35 @@ openAiBackendWithTransportFallback fallbackActive primary fallback =
     tryPrimary state previousResponseId inputs onEvent = do
         emittedModelOutput <- newIORef False
         announcedToolCall <- newIORef False
+        let resetAttempt = do
+                writeIORef emittedModelOutput False
+                writeIORef announcedToolCall False
         result <- primary.submitTurn state previousResponseId inputs \event -> do
-            when (isModelOutput event) $
-                writeIORef emittedModelOutput True
-            when (isToolAnnouncement event) $
-                writeIORef announcedToolCall True
+            case event of
+                -- The primary already closed that attempt; only activity from
+                -- its newest attempt still needs a boundary before a replay.
+                ResponseRestarted _ -> resetAttempt
+                ResponseAttemptDiscarded -> resetAttempt
+                _ -> do
+                    when (isModelOutput event) $
+                        writeIORef emittedModelOutput True
+                    when (isToolAnnouncement event) $
+                        writeIORef announcedToolCall True
             onEvent event
         case result of
             Left err
                 | isOpenAiWebSocketTransportFailure err -> do
                     writeIORef fallbackActive True
                     emitted <- readIORef emittedModelOutput
+                    announced <- readIORef announcedToolCall
                     if emitted
-                        then pure result
-                        else do
+                        then onEvent (ResponseRestarted fallbackRestartMessage)
+                        else
                             -- A tool block the dead socket announced must not
                             -- linger as running next to the replayed attempt.
-                            announced <- readIORef announcedToolCall
                             when announced (onEvent ResponseAttemptDiscarded)
-                            fallback.submitTurn
-                                state previousResponseId inputs onEvent
+                    fallback.submitTurn
+                        state previousResponseId inputs onEvent
             _ -> pure result
 
     isModelOutput = \case
@@ -581,9 +597,17 @@ openAiBackendWithReasoningVisibility showRawReasoning =
         showRawReasoning
         transientStreamingResultPolicy
 
--- | Streaming retries are replay-safe only until the loop has observed output.
--- Server error events themselves are not loop-visible, so transient Codex
--- failures can wait and retry without printing an error or duplicating output.
+-- | Transient server errors are retried only until the loop has observed
+-- output. Server error events themselves are not loop-visible, so transient
+-- Codex failures can wait and retry without printing an error or duplicating
+-- output.
+--
+-- A connection that dies mid-response is different: the dead socket committed
+-- nothing on either side, so the same request is resubmitted even after
+-- output streamed. Partial text or reasoning stays visible behind a restart
+-- boundary and hidden activity is discarded, then the transport (a
+-- reconnecting sender or a per-request dial) opens a fresh connection. Codex
+-- retries its sampling request the same way before falling back to HTTPS.
 openAiBackendWithRetryPolicy
     :: RetryPolicyM IO
     -> (ResponseCreateParams
@@ -592,8 +616,22 @@ openAiBackendWithRetryPolicy
         -> IO (Either ApiError Response))
     -> IO ResponseCreateParams
     -> Backend
-openAiBackendWithRetryPolicy =
-    openAiBackendWithRetryPolicyAndReasoningVisibility False
+openAiBackendWithRetryPolicy transientPolicy =
+    openAiBackendWithRetryPolicies transientPolicy connectionReplayPolicy
+
+-- | 'openAiBackendWithRetryPolicy' with an explicit reconnect policy for
+-- mid-response connection failures.
+openAiBackendWithRetryPolicies
+    :: RetryPolicyM IO
+    -> RetryPolicyM IO
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> Backend
+openAiBackendWithRetryPolicies =
+    openAiBackendWithRetryPoliciesAndReasoningVisibility False
 
 openAiBackendWithRetryPolicyAndReasoningVisibility
     :: Bool
@@ -605,7 +643,24 @@ openAiBackendWithRetryPolicyAndReasoningVisibility
     -> IO ResponseCreateParams
     -> Backend
 openAiBackendWithRetryPolicyAndReasoningVisibility
-        showRawReasoning retryPolicy send getParams =
+        showRawReasoning transientPolicy =
+    openAiBackendWithRetryPoliciesAndReasoningVisibility
+        showRawReasoning
+        transientPolicy
+        connectionReplayPolicy
+
+openAiBackendWithRetryPoliciesAndReasoningVisibility
+    :: Bool
+    -> RetryPolicyM IO
+    -> RetryPolicyM IO
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> Backend
+openAiBackendWithRetryPoliciesAndReasoningVisibility
+        showRawReasoning transientPolicy reconnectPolicy send getParams =
     Backend \history previousResponseId inputs onLoopEvent -> do
         baseParams <- sanitizeCodexRequest <$> getParams
         let newItems = turnInputsToItems inputs
@@ -639,9 +694,11 @@ openAiBackendWithRetryPolicyAndReasoningVisibility
     sendRetrying onLoopEvent request previousResponseId = do
         emittedRawOutput <- newIORef False
         emittedVisibleOutput <- newIORef False
-        go emittedRawOutput emittedVisibleOutput defaultRetryStatus
+        go emittedRawOutput emittedVisibleOutput
+            defaultRetryStatus defaultRetryStatus
       where
-        go emittedRawOutput emittedVisibleOutput retryStatus = do
+        go emittedRawOutput emittedVisibleOutput transientStatus
+                reconnectStatus = do
             -- One projector per attempt: argument-progress counters must
             -- describe a single provider sample, not the whole retry chain.
             projectEvent <-
@@ -658,9 +715,42 @@ openAiBackendWithRetryPolicyAndReasoningVisibility
             emitted <- readIORef emittedRawOutput
             case result of
                 Left apiError
+                    -- A pre-output connection failure is handled by the
+                    -- connection-recovery sender and the transport fallback;
+                    -- only a socket that died mid-response is retried here.
+                    | emitted
+                    , isReconnectableTransportFailure apiError ->
+                        applyPolicy reconnectPolicy reconnectStatus >>= \case
+                            Nothing -> settle apiError result
+                            Just nextStatus -> do
+                                visible <- readIORef emittedVisibleOutput
+                                let delayMicros =
+                                        fromMaybe 0 nextStatus.rsPreviousDelay
+                                    attempt = nextStatus.rsIterNumber
+                                onLoopEvent $ ActivityUpdated $
+                                    formatReconnectScheduled
+                                        apiError attempt delayMicros
+                                threadDelay delayMicros
+                                -- Close the interrupted attempt in every
+                                -- renderer before the replay streams. Visible
+                                -- partial output stays on screen marked as
+                                -- failed; hidden activity such as an announced
+                                -- tool call is removed.
+                                if visible
+                                    then onLoopEvent
+                                        (ResponseRestarted
+                                            connectionRestartMessage)
+                                    else onLoopEvent ResponseAttemptDiscarded
+                                onLoopEvent $ ActivityUpdated $
+                                    "Reconnecting to Codex (attempt "
+                                        <> Text.pack (show attempt) <> ")…"
+                                writeIORef emittedRawOutput False
+                                writeIORef emittedVisibleOutput False
+                                go emittedRawOutput emittedVisibleOutput
+                                    transientStatus nextStatus
                     | not emitted
                     , isInlineRetryableProviderResponseError apiError ->
-                        applyPolicy retryPolicy retryStatus >>= \case
+                        applyPolicy transientPolicy transientStatus >>= \case
                             Nothing -> pure result
                             Just nextStatus -> do
                                 let delayMicros =
@@ -672,30 +762,71 @@ openAiBackendWithRetryPolicyAndReasoningVisibility
                                 onLoopEvent $ ActivityUpdated $
                                     "Retrying Codex request (attempt "
                                         <> Text.pack (show attempt) <> ")…"
-                                go emittedRawOutput emittedVisibleOutput nextStatus
-                    | emitted -> do
-                        visible <- readIORef emittedVisibleOutput
-                        pure $ if visible || isConnectionFailure apiError
-                            then result
-                            else Left (replayUnsafeError "model output" apiError)
+                                go emittedRawOutput emittedVisibleOutput
+                                    nextStatus reconnectStatus
+                    | emitted -> settle apiError result
                 _ -> pure result
+          where
+            -- The transport fallback may still replay a dropped connection
+            -- after this backend gives up; every other failure after output
+            -- is terminal because the provider may have committed the sample.
+            settle apiError result = do
+                visible <- readIORef emittedVisibleOutput
+                pure $ if visible || isReconnectableTransportFailure apiError
+                    then result
+                    else Left (replayUnsafeError "model output" apiError)
 
     isVisibleModelOutput = \case
         TextDelta{} -> True
         ReasoningDelta{} -> True
         _ -> False
 
-    -- A dropped socket commits nothing on either side, so the connection
-    -- recovery wrapper may resubmit the request even when only hidden output
-    -- (a tool-call announcement, raw reasoning) had streamed. Codex likewise
-    -- reconnects and resends the same request instead of failing the turn.
-    isConnectionFailure = \case
-        ConnectionError{} -> True
-        _ -> False
-
 transientStreamingResultPolicy :: RetryPolicyM IO
 transientStreamingResultPolicy =
     exponentialBackoff 5_000_000 <> limitRetries 3
+
+-- | Reconnect attempts after a socket died mid-response: 200ms, 400ms, 800ms,
+-- 1.6s and 3.2s, matching Codex's @stream_max_retries@ default of five with
+-- its 200ms exponential backoff. The transport fallback takes over afterwards.
+connectionReplayPolicy :: RetryPolicyM IO
+connectionReplayPolicy =
+    exponentialBackoff 200_000 <> limitRetries 5
+
+-- | Failures that mean the current WebSocket is gone, not that the request was
+-- rejected. A dropped socket commits nothing on either side, so the request
+-- may be resubmitted on a fresh connection even after output streamed.
+isReconnectableTransportFailure :: ApiError -> Bool
+isReconnectableTransportFailure = \case
+    ConnectionError{} -> True
+    ProviderError WebSocketConnectionLimitReached _ _ -> True
+    _ -> False
+
+connectionRestartMessage :: Text
+connectionRestartMessage =
+    "Connection interrupted the response; restarting automatically. "
+        <> "The new attempt may repeat partial output shown above."
+
+fallbackRestartMessage :: Text
+fallbackRestartMessage =
+    "Connection interrupted the response; retrying over the HTTP transport. "
+        <> "The new attempt may repeat partial output shown above."
+
+formatReconnectScheduled :: ApiError -> Int -> Int -> Text
+formatReconnectScheduled apiError attempt delayMicros =
+    "Connection lost mid-response ("
+        <> transportFailureReason apiError
+        <> "); reconnecting in "
+        <> Text.pack (show (ceilingSeconds delayMicros))
+        <> "s (attempt "
+        <> Text.pack (show attempt)
+        <> ")…"
+
+transportFailureReason :: ApiError -> Text
+transportFailureReason = \case
+    ConnectionError reason -> reason
+    ProviderError WebSocketConnectionLimitReached _ _ ->
+        "Codex connection limit reached"
+    other -> Text.pack (show other)
 
 -- | OpenAI's default event projection: reasoning summaries are visible, while
 -- raw chain-of-thought deltas are suppressed.
@@ -718,18 +849,19 @@ formatRetryScheduled :: ApiError -> Int -> Int -> Text
 formatRetryScheduled apiError attempt delayMicros =
     retryReason apiError
         <> "; retrying in "
-        <> Text.pack (show delaySeconds)
+        <> Text.pack (show (ceilingSeconds delayMicros))
         <> "s (attempt "
         <> Text.pack (show attempt)
         <> ")…"
   where
-    delaySeconds
-        | delayMicros <= 0 = 0
-        | otherwise = (delayMicros + 999_999) `div` 1_000_000
-
     retryReason = \case
         ProviderError OverloadedError _ _ -> "Codex is overloaded"
         ProviderError ServiceUnavailableError _ _ -> "Codex is unavailable"
         ProviderError WebSocketConnectionLimitReached _ _ ->
             "Codex connection limit reached"
         _ -> "Codex server error"
+
+ceilingSeconds :: Int -> Int
+ceilingSeconds delayMicros
+    | delayMicros <= 0 = 0
+    | otherwise = (delayMicros + 999_999) `div` 1_000_000

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -2,6 +2,7 @@ module Agent.OpenAI.WebSocketClient
     ( withCodexWs
     , withCodexWsWithProvider
     , withCodexWsCredential
+    , withCodexWsCredentialUsingTurnState
     , withCodexWsRetrying
     , withCodexWsRetryingAfter
     , sendWsRequest
@@ -214,6 +215,18 @@ withCodexWsCredential credential action =
         (limitRetries 2 <> exponentialBackoff 500000)
         credential
         (\conn activeCredential -> Right <$> action conn activeCredential)
+
+-- | Open a disposable physical connection for an existing logical turn using
+-- one already-selected credential. Keeping credential selection outside this
+-- operation lets a streaming backend observe the completed attempt before
+-- deciding whether account failover may safely replay it.
+withCodexWsCredentialUsingTurnState
+    :: Credential
+    -> CodexTurnState
+    -> (CodexConn -> Credential -> IO (Either ApiError a))
+    -> IO (Either ApiError a)
+withCodexWsCredentialUsingTurnState =
+    runConnectionAttemptUsingTurnState
 
 -- | Run a replay-safe WebSocket action and automatically reacquire a
 -- credential after handshake or in-band account failures. The callback is

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -829,6 +829,36 @@ spec = do
             observedEvents <- readIORef events
             reverse observedEvents `shouldBe` [TextDelta "partial"]
 
+        it "blocks credential failover after hidden output was streamed" do
+            transcript <- newIORef []
+            events <- newIORef []
+            let exhausted = ProviderError UsageLimitReached
+                    "usage exhausted" (Just 120)
+                send _request _previous onEvent = do
+                    onEvent ResponseOutputItemAddedEvent
+                        { item = functionCallItem "fc-1" "shell" "{}"
+                        , outputIndex = Just 0
+                        , sequenceNumber = Nothing
+                        }
+                    pure (Left exhausted)
+                backend = openAiBackendWithRetryPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe` Left (ProviderError
+                (UnknownErrorType "replay_unsafe")
+                ( "provider failed after model output; refusing to replay: "
+                    <> Text.pack (show exhausted)
+                )
+                Nothing)
+            recorded <- reverse <$> readIORef events
+            [() | ToolStarted started <- recorded, started.callId == "fc-1"]
+                `shouldBe` [()]
+            filter (not . isToolStartedEvent) recorded `shouldBe`
+                [ActivityUpdated "Writing shell call…"]
+
         it "resubmits after a mid-response socket drop behind a restart boundary" do
             attempts <- newIORef (0 :: Int)
             transcript <- newIORef []

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -829,6 +829,125 @@ spec = do
             observedEvents <- readIORef events
             reverse observedEvents `shouldBe` [TextDelta "partial"]
 
+        it "resubmits after a mid-response socket drop behind a restart boundary" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    attempt <- readIORef attempts
+                    if attempt == 1
+                        then do
+                            onEvent (deltaEvent EventOutputTextDelta "partial")
+                            pure (Left (ConnectionError
+                                "WebSocket closed by server (1012): "))
+                        else do
+                            onEvent (deltaEvent EventOutputTextDelta "complete")
+                            pure (Right
+                                (testResponse "resp-replayed"
+                                    [assistantItem "complete"]))
+                backend = openAiBackendWithRetryPolicies
+                    (constantDelay 0 <> limitRetries 3)
+                    (constantDelay 0 <> limitRetries 5)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-replayed" [] (Just "complete"))
+            readIORef attempts `shouldReturn` 2
+            reverse <$> readIORef events `shouldReturn`
+                [ TextDelta "partial"
+                , ActivityUpdated
+                    "Connection lost mid-response (WebSocket closed by server (1012): ); reconnecting in 0s (attempt 1)…"
+                , ResponseRestarted
+                    "Connection interrupted the response; restarting automatically. The new attempt may repeat partial output shown above."
+                , ActivityUpdated "Reconnecting to Codex (attempt 1)…"
+                , TextDelta "complete"
+                ]
+
+        it "discards a hidden partial attempt before reconnecting" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    attempt <- readIORef attempts
+                    if attempt == 1
+                        then do
+                            onEvent ResponseOutputItemAddedEvent
+                                { item = functionCallItem "fc-1" "shell" "{}"
+                                , outputIndex = Just 0
+                                , sequenceNumber = Nothing
+                                }
+                            pure (Left (ProviderError
+                                WebSocketConnectionLimitReached
+                                "too many websocket connections"
+                                Nothing))
+                        else pure (Right
+                            (testResponse "resp-replayed" [assistantItem "ok"]))
+                backend = openAiBackendWithRetryPolicies
+                    (constantDelay 0 <> limitRetries 3)
+                    (constantDelay 0 <> limitRetries 5)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-replayed" [] (Just "ok"))
+            readIORef attempts `shouldReturn` 2
+            recorded <- reverse <$> readIORef events
+            [() | ToolStarted started <- recorded, started.callId == "fc-1"]
+                `shouldBe` [()]
+            filter (not . isToolStartedEvent) recorded `shouldBe`
+                [ ActivityUpdated "Writing shell call…"
+                , ActivityUpdated
+                    "Connection lost mid-response (Codex connection limit reached); reconnecting in 0s (attempt 1)…"
+                , ResponseAttemptDiscarded
+                , ActivityUpdated "Reconnecting to Codex (attempt 1)…"
+                ]
+
+        it "reports the transport failure once the reconnect policy is exhausted" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    onEvent (deltaEvent EventOutputTextDelta "partial")
+                    pure (Left (ConnectionError "socket closed"))
+                backend = openAiBackendWithRetryPolicies
+                    (constantDelay 0 <> limitRetries 3)
+                    (constantDelay 0 <> limitRetries 2)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            -- Not replay-unsafe: the transport fallback may still replay it.
+            result `shouldBe` Left (ConnectionError "socket closed")
+            readIORef attempts `shouldReturn` 3
+            recorded <- reverse <$> readIORef events
+            length (filter (== TextDelta "partial") recorded) `shouldBe` 3
+            length [() | ResponseRestarted _ <- recorded] `shouldBe` 2
+            last recorded `shouldBe` TextDelta "partial"
+
+        it "does not reconnect before any output streamed" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            let send _request _previous _onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    pure (Left (ConnectionError "socket closed"))
+                backend = openAiBackendWithRetryPolicies
+                    (constantDelay 0 <> limitRetries 3)
+                    (constantDelay 0 <> limitRetries 5)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (const (pure ()))
+            -- Pre-output failures belong to the connection-recovery sender and
+            -- the transport fallback, which replay without a boundary.
+            result `shouldBe` Left (ConnectionError "socket closed")
+            readIORef attempts `shouldReturn` 1
+
     describe "openAiBackendWithConnectionRecovery" do
         it "keeps auxiliary requests on the healthy reusable connection" do
             currentCalls <- newIORef (0 :: Int)
@@ -1067,7 +1186,7 @@ spec = do
             readIORef healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 1
 
-        it "does not replay after loop-visible output was already streamed" do
+        it "reconnects behind a restart boundary after loop-visible output streamed" do
             freshCalls <- newIORef (0 :: Int)
             healthy <- newIORef True
             transcript <- newIORef []
@@ -1082,10 +1201,20 @@ spec = do
                     healthy sendCurrent sendFresh (pure baseParams)
             result <- submitWithState transcript streamingBackend Nothing [UserMessage "one"]
                 (modifyIORef' events . (:))
-            result `shouldBe` Left (ConnectionError "socket closed")
-            reverse <$> readIORef events `shouldReturn` [TextDelta "partial"]
+            -- The dead socket committed nothing, so the backend closes the
+            -- partial attempt with a visible boundary and resubmits the same
+            -- request; the sender then dials a fresh connection.
+            result `shouldBe` Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
+            reverse <$> readIORef events `shouldReturn`
+                [ TextDelta "partial"
+                , ActivityUpdated
+                    "Connection lost mid-response (socket closed); reconnecting in 1s (attempt 1)…"
+                , ResponseRestarted
+                    "Connection interrupted the response; restarting automatically. The new attempt may repeat partial output shown above."
+                , ActivityUpdated "Reconnecting to Codex (attempt 1)…"
+                ]
             readIORef healthy `shouldReturn` False
-            readIORef freshCalls `shouldReturn` 0
+            readIORef freshCalls `shouldReturn` 1
 
         it "does not treat provider errors as a dead connection" do
             freshCalls <- newIORef (0 :: Int)
@@ -1247,15 +1376,46 @@ spec = do
             readIORef primaryCalls `shouldReturn` 1
             readIORef fallbackCalls `shouldReturn` 2
 
-        it "does not replay a failed turn after model output was exposed" do
+        it "replays over the fallback behind a restart boundary after visible output" do
             fallbackActive <- newIORef False
             fallbackCalls <- newIORef (0 :: Int)
             transcript <- newIORef []
+            events <- newIORef []
             let primary = Backend \_state _previous _inputs onEvent -> do
                     onEvent (TextDelta "partial")
                     pure (Left (ConnectionError "socket closed"))
-                fallback = Backend \state _previous _inputs _onEvent -> do
+                fallback = Backend \state _previous _inputs onEvent -> do
                     modifyIORef' fallbackCalls (+ 1)
+                    onEvent (TextDelta "replayed")
+                    pure $ Right BackendResult
+                        { backendOutput =
+                            emptyTurnOutput "resp-http" [] (Just "replayed")
+                        , backendState = state
+                        }
+                backend =
+                    openAiBackendWithTransportFallback
+                        fallbackActive primary fallback
+            result <- submitWithState transcript backend Nothing
+                [UserMessage "one"] (\event -> modifyIORef' events (<> [event]))
+            fmap (.assistantText) result `shouldBe` Right (Just "replayed")
+            readIORef fallbackActive `shouldReturn` True
+            readIORef fallbackCalls `shouldReturn` 1
+            readIORef events `shouldReturn`
+                [ TextDelta "partial"
+                , ResponseRestarted
+                    "Connection interrupted the response; retrying over the HTTP transport. The new attempt may repeat partial output shown above."
+                , TextDelta "replayed"
+                ]
+
+        it "does not repeat a restart boundary the primary already emitted" do
+            fallbackActive <- newIORef False
+            transcript <- newIORef []
+            events <- newIORef []
+            let primary = Backend \_state _previous _inputs onEvent -> do
+                    onEvent (TextDelta "partial")
+                    onEvent (ResponseRestarted "inner restart")
+                    pure (Left (ConnectionError "socket closed"))
+                fallback = Backend \state _previous _inputs _onEvent ->
                     pure $ Right BackendResult
                         { backendOutput =
                             emptyTurnOutput "resp-http" [] (Just "ok")
@@ -1265,10 +1425,10 @@ spec = do
                     openAiBackendWithTransportFallback
                         fallbackActive primary fallback
             result <- submitWithState transcript backend Nothing
-                [UserMessage "one"] (const (pure ()))
-            result `shouldBe` Left (ConnectionError "socket closed")
-            readIORef fallbackActive `shouldReturn` True
-            readIORef fallbackCalls `shouldReturn` 0
+                [UserMessage "one"] (\event -> modifyIORef' events (<> [event]))
+            fmap (.assistantText) result `shouldBe` Right (Just "ok")
+            readIORef events `shouldReturn`
+                [TextDelta "partial", ResponseRestarted "inner restart"]
 
         it "replays over the fallback transport after only hidden output streamed" do
             fallbackActive <- newIORef False
@@ -1285,8 +1445,9 @@ spec = do
                     modifyIORef' primaryCalls (+ 1)
                     onEvent outputEvent
                     pure (Left connectionFailure)
-                primary = openAiBackendWithRetryPolicy
+                primary = openAiBackendWithRetryPolicies
                     (constantDelay 0 <> limitRetries 3)
+                    (limitRetries 0)
                     sendPrimary
                     (pure baseParams)
                 fallback = Backend \state _previous _inputs _onEvent -> do
@@ -1320,8 +1481,9 @@ spec = do
                         , sequenceNumber = Nothing
                         }
                     pure (Left (ConnectionError "socket closed"))
-                primary = openAiBackendWithRetryPolicy
+                primary = openAiBackendWithRetryPolicies
                     (constantDelay 0 <> limitRetries 3)
+                    (limitRetries 0)
                     sendPrimary
                     (pure baseParams)
                 fallback = Backend \state _previous _inputs onEvent -> do
@@ -1430,6 +1592,11 @@ spec = do
 --------------------------------------------------------------------------------
 -- Fixtures
 --------------------------------------------------------------------------------
+
+isToolStartedEvent :: LoopEvent -> Bool
+isToolStartedEvent = \case
+    ToolStarted _ -> True
+    _ -> False
 
 submitWithState
     :: IORef [ResponseItem]


### PR DESCRIPTION
## Problem

Since the WebSocket transport stopped faking `incomplete: unknown` responses (#708), a Codex socket that dies **after** the model streamed output still ended the turn: the WebSocket backend refused to resubmit once any output had been observed, and the HTTP fallback only replayed before *visible* output. With gpt-5.6 a reasoning-summary delta arrives within seconds of every response, so practically every mid-response drop (`WebSocket receive error: ParseException "not enough bytes"`, a 1012 close, the 300 s receive idle timeout) surfaced as "Response interrupted after partial output" instead of continuing. The session store shows this class of failure many times per day.

Codex (`codex-rs/core/src/session/turn.rs`, `core/src/responses_retry.rs`) treats such a drop as a retryable stream error: it resubmits the sampling request up to `stream_max_retries` (5) with 200 ms exponential backoff, shows "Reconnecting... n/5", and only then switches the session to HTTPS. The dead socket committed nothing on either side, so the replay is safe; only the renderer needs a boundary for the partial attempt.

## Changes

- **`agent-openai` backend retry loop**: after a mid-response `ConnectionError` or connection-limit failure the same request is resubmitted even when output streamed, with `connectionReplayPolicy` (200 ms, 400 ms, 800 ms, 1.6 s, 3.2 s). Visible partial text/reasoning stays on screen behind `ResponseRestarted`; hidden activity such as an announced tool call is removed with `ResponseAttemptDiscarded`. The status line names the transport failure (`Connection lost mid-response (…); reconnecting in 1s (attempt 1)…`) so future incidents are diagnosable. Pre-output failures keep their existing fresh-connection and fallback handling. The resubmission goes through the reconnecting sender, which dials a fresh socket.
- **Transport fallback**: replays over HTTP after visible output too (behind a restart boundary) instead of returning the error, and does not repeat a boundary the primary already emitted.
- **Subagents**: OpenAI child backends dial a fresh connection per request, so the resubmission does not reuse the dead per-submission socket.
- **Core loop / CLI**: `ResponseAttemptDiscarded` resets the after-output classification; `withConnectionRecovery` does not emit a second boundary for an attempt a lower layer already closed.

## Tests

- `agent-openai`: reconnect after visible output, discard of a hidden partial attempt, exhaustion reporting the transport failure (not `replay_unsafe`), no reconnect before output, fallback replay after visible output, no duplicated boundary.
- `agent-core`: transport failure after a discarded attempt is classified as pre-output.
- `agent-cli`: connection recovery does not repeat an inner restart boundary.

Ran locally in `nix develop`: `agent-openai-test` (296 examples, 0 failures), `agent-core-test`, `agent-cli-test`. The only local failures are pre-existing and unrelated (`Agent.Tools.IO` `/tmp` vs `/private/tmp` on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
