### PR TITLE
Notify for fullscreen filesystem access prompts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -22,6 +22,10 @@ import Agent.CLI.SessionTitle
 import Agent.Concurrent
 import Agent.CLI.ManagedTurn
 import Agent.CLI.GatewayBridge
+import Agent.CLI.Notification
+    ( AttentionRequest(PermissionRequested)
+    , notifyAttention
+    )
 import Agent.CLI.Approval
 import Agent.CLI.Permission (promptRootAccess)
 import Agent.CLI.Recap
@@ -113,7 +117,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                       | isJust request.managedTurnBridgeDirectory ->
                           requestManagedRootAccess request root
                   _ -> case fullscreen of
-                      Just runtime ->
+                      Just runtime -> do
+                          notifyAttention stderrHandle PermissionRequested
                           maybe False (== 0)
                               <$> requestFullscreenChoiceWithBody
                                   runtime


### PR DESCRIPTION
## Summary
- emit the existing permission-required terminal notification before showing the fullscreen filesystem access dialog
- keep generic fullscreen pickers unchanged so user-initiated menus do not generate attention notifications

## Validation
- loaded `Agent.CLI.Session.Runner.Execution` in the `agent-cli` GHCi repl
- ran focused `attentionNotificationSequence` specs: 3 examples, 0 failures
- reproduced the filesystem access dialog in a live fullscreen agent under tmux
- confirmed raw pane output contains the tmux-wrapped OSC 9 `Haskell Agent: permission required` notification
- `git diff --check`
