### PR TITLE
Add native conversation search bridge

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -10,6 +10,10 @@ import Agent.CLI.NativeRuntime
     , newNativeProcessRuntime
     , runNativeAgent
     )
+import Agent.Store.Postgres.Session
+    ( NativeConversationSearchResult(..)
+    , searchNativeConversations
+    )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     )
@@ -152,7 +156,8 @@ import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
-import Data.Time.Clock (addUTCTime, getCurrentTime)
+import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Word (Word8, Word64)
 import Foreign
     ( FunPtr
@@ -168,7 +173,7 @@ import Foreign
     , nullPtr
     )
 import Foreign.C.String (CString)
-import Foreign.C.Types (CInt(..), CSize(..))
+import Foreign.C.Types (CDouble(..), CInt(..), CSize(..))
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
     ( IOMode(WriteMode)
@@ -214,6 +219,23 @@ type AccountOAuthStartCallback =
     -> CString -> CSize -> CString -> CSize -> CInt -> CInt
     -> CString -> CSize -> IO ()
 
+-- Status is 0 for a result, 1 for completion, and -1 for failure. Every
+-- pointer is callback-scoped UTF-8. A turn index of -1 denotes a metadata hit;
+-- role is 0 (metadata), 1 (user), or 2 (assistant).
+type SearchCallback =
+    Ptr () -> CInt
+    -> Ptr Word8 -> CSize -- session id
+    -> Ptr Word8 -> CSize -- title
+    -> Ptr Word8 -> CSize -- cwd
+    -> Ptr Word8 -> CSize -- provider
+    -> Ptr Word8 -> CSize -- model
+    -> Int64 -> CInt -> Int64 -> Int64 -> CInt
+    -> Ptr Word8 -> CSize -- user
+    -> Ptr Word8 -> CSize -- assistant
+    -> CDouble
+    -> Ptr Word8 -> CSize -- error
+    -> IO ()
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -228,6 +250,9 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeAccountOAuthStartCallback
         :: FunPtr AccountOAuthStartCallback -> AccountOAuthStartCallback
+
+foreign import ccall "dynamic"
+    invokeSearchCallback :: FunPtr SearchCallback -> SearchCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -383,6 +408,7 @@ data AccountAPIKeyRequest = AccountAPIKeyRequest
 
 data EngineCommand
     = EngineRequest !BridgeRequest
+    | EngineSearch !Text !Int !(FunPtr SearchCallback) !(Ptr ())
     | EngineStop
 
 data Engine = Engine
@@ -657,6 +683,10 @@ invokeExceptionResult callback context exception =
         invokeAccountResultCallback callback context (-1)
             nullPtr 0 errorPtr errorLength
 
+foreign export ccall ha_engine_search_conversations
+    :: Ptr () -> Ptr Word8 -> CSize -> CSize
+    -> FunPtr SearchCallback -> Ptr () -> IO CInt
+
 ha_engine_create :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
 ha_engine_create callback context
     | callback == nullFunPtr = pure nullPtr
@@ -710,6 +740,33 @@ ha_engine_send_json pointer bytes (CSize length)
             Right False -> 4
             Right True -> 0
 
+ha_engine_search_conversations
+    :: Ptr () -> Ptr Word8 -> CSize -> CSize
+    -> FunPtr SearchCallback -> Ptr () -> IO CInt
+ha_engine_search_conversations pointer bytes (CSize length) rawLimit callback context
+    | pointer == nullPtr = pure 1
+    | callback == nullFunPtr = pure 2
+    | bytes == nullPtr || length == 0 = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            payload <- BS.packCStringLen (castPtr bytes, fromIntegral length)
+            case TextEncoding.decodeUtf8' payload of
+                Left _ -> pure False
+                Right query
+                    | Text.null (Text.strip query) -> pure False
+                    | otherwise -> do
+                        let requested = fromIntegral rawLimit :: Integer
+                            limit = fromInteger (max 1 (min 100 requested))
+                        atomically $ writeTQueue engine.engineCommands
+                            (EngineSearch query limit callback context)
+                        pure True
+        pure $ case accepted of
+            Left _ -> 3
+            Right False -> 2
+            Right True -> 0
+
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer
     | pointer == nullPtr = pure ()
@@ -756,6 +813,10 @@ idleLoop
 idleLoop callback context config store root processRuntime commands =
     atomically (readTQueue commands) >>= \case
         EngineStop -> pure ()
+        EngineSearch query limit searchCallback searchContext -> do
+            runConversationSearch
+                config store query limit searchCallback searchContext
+            continue
         EngineRequest request
             | request.requestMethod == "turn.start" ->
                 case (parseParams request
@@ -833,6 +894,11 @@ activeLoop callback context config store root commands control running =
             cancelTurn control
             cancel running
             pure ActiveStop
+        Left (EngineSearch query limit searchCallback searchContext) -> do
+            runConversationSearch
+                config store query limit searchCallback searchContext
+            activeLoop
+                callback context config store root commands control running
         Left (EngineRequest request) -> do
             if request.requestMethod == "turn.cancel"
               then
@@ -870,6 +936,90 @@ activeLoop callback context config store root commands control running =
                 commands
                 control
                 running
+
+runConversationSearch
+    :: ManagedPostgresConfig
+    -> MVar (Maybe Store)
+    -> Text
+    -> Int
+    -> FunPtr SearchCallback
+    -> Ptr ()
+    -> IO ()
+runConversationSearch config store query limit callback context = do
+    outcome <- tryAny do
+        activeStore <- acquireStore config store
+        searchNativeConversations (trustedPool activeStore) query limit
+    case outcome of
+        Left exception ->
+            sendSearchFailure callback context (Text.pack (show exception))
+        Right (Left err) ->
+            sendSearchFailure callback context (renderStoreError err)
+        Right (Right results) -> do
+            forM_ results (sendSearchResult callback context)
+            invokeSearchCallback callback context
+                1 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                0 0 (-1) 0 0 nullPtr 0 nullPtr 0 0 nullPtr 0
+
+sendSearchFailure :: FunPtr SearchCallback -> Ptr () -> Text -> IO ()
+sendSearchFailure callback context message =
+    withTextBytes message \errorPointer errorLength ->
+        invokeSearchCallback callback context
+            (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            0 0 (-1) 0 0 nullPtr 0 nullPtr 0 0
+            errorPointer errorLength
+
+sendSearchResult
+    :: FunPtr SearchCallback
+    -> Ptr ()
+    -> NativeConversationSearchResult
+    -> IO ()
+sendSearchResult callback context result =
+    withTextBytes result.nativeSearchSessionId \sessionPointer sessionLength ->
+    withTextBytes result.nativeSearchTitle \titlePointer titleLength ->
+    withTextBytes result.nativeSearchCwd \cwdPointer cwdLength ->
+    withTextBytes result.nativeSearchProvider \providerPointer providerLength ->
+    withTextBytes result.nativeSearchModel \modelPointer modelLength ->
+    withMaybeTextBytes result.nativeSearchUserText \userPointer userLength ->
+    withMaybeTextBytes result.nativeSearchAssistantText
+        \assistantPointer assistantLength ->
+            invokeSearchCallback callback context
+                0
+                sessionPointer sessionLength
+                titlePointer titleLength
+                cwdPointer cwdLength
+                providerPointer providerLength
+                modelPointer modelLength
+                (epochMilliseconds result.nativeSearchUpdatedAt)
+                (if result.nativeSearchArchived then 1 else 0)
+                (fromMaybe (-1) result.nativeSearchTurnIndex)
+                (maybe 0 epochMilliseconds result.nativeSearchOccurredAt)
+                (searchRoleCode result.nativeSearchRole)
+                userPointer userLength
+                assistantPointer assistantLength
+                (realToFrac result.nativeSearchRank)
+                nullPtr 0
+
+withTextBytes :: Text -> (Ptr Word8 -> CSize -> IO a) -> IO a
+withTextBytes value action =
+    BS.useAsCStringLen (TextEncoding.encodeUtf8 value) \(pointer, length) ->
+        action (castPtr pointer) (fromIntegral length)
+
+withMaybeTextBytes
+    :: Maybe Text
+    -> (Ptr Word8 -> CSize -> IO a)
+    -> IO a
+withMaybeTextBytes Nothing action = action nullPtr 0
+withMaybeTextBytes (Just value) action = withTextBytes value action
+
+epochMilliseconds :: UTCTime -> Int64
+epochMilliseconds =
+    floor . (* 1000) . utcTimeToPOSIXSeconds
+
+searchRoleCode :: Maybe Text -> CInt
+searchRoleCode = \case
+    Just "user" -> 1
+    Just "assistant" -> 2
+    _ -> 0
 
 runNativeTurn
     :: FunPtr EventCallback

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -26,6 +26,37 @@ typedef void (*ha_event_callback)(
 );
 
 /*
+ * A conversation-search callback. status is 0 for a result, 1 for terminal
+ * success, and -1 for terminal failure (with error populated). All UTF-8
+ * buffers are valid only during the callback and must be copied before it
+ * returns. A result has error == NULL. Completion has no result fields.
+ *
+ * turn_index is -1 for a metadata hit. occurred_at_ms is 0 when absent. role
+ * is 0 for metadata, 1 for user, and 2 for assistant. Timestamps are
+ * milliseconds since the Unix epoch. Callbacks run serially on the engine
+ * worker thread, not the caller or main thread. An accepted request receives
+ * exactly one terminal callback unless engine destruction has begun.
+ */
+typedef void (*ha_conversation_search_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *session_id, size_t session_id_length,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *cwd, size_t cwd_length,
+    const uint8_t *provider, size_t provider_length,
+    const uint8_t *model, size_t model_length,
+    int64_t updated_at_ms,
+    int32_t archived,
+    int64_t turn_index,
+    int64_t occurred_at_ms,
+    int32_t role,
+    const uint8_t *user_text, size_t user_text_length,
+    const uint8_t *assistant_text, size_t assistant_text_length,
+    double rank,
+    const uint8_t *error, size_t error_length
+);
+
+/*
  * Account list callbacks use status 0 for an item, 1 for end-of-list, and
  * -1 for an error. Item strings include disabled managed credentials and
  * externally discovered accounts.
@@ -92,6 +123,20 @@ int32_t ha_engine_send_json(
     void *engine,
     const uint8_t *bytes,
     size_t length
+);
+/*
+ * Search active and archived (but not deleted) conversations. The query is
+ * copied before return and limit is clamped to 1...100. Returns 0 when
+ * accepted, 1 for a null engine, 2 for invalid query/callback, and 3 for an
+ * internal failure. Calls must be serialized with ha_engine_destroy.
+ */
+int32_t ha_engine_search_conversations(
+    void *engine,
+    const uint8_t *query,
+    size_t query_length,
+    size_t limit,
+    ha_conversation_search_callback callback,
+    void *context
 );
 void ha_engine_destroy(void *engine);
 

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -20,6 +20,7 @@ module Agent.Store.Postgres.Session
     , StoredTurn(..)
     , LegacySession(..)
     , ConversationSearchResult(..)
+    , NativeConversationSearchResult(..)
     , sessionSchemaStatements
     , createSession
     , replaceSessionMetadata
@@ -42,6 +43,7 @@ module Agent.Store.Postgres.Session
     , listSessionArchiveKeys
     , setSessionArchived
     , searchConversationTurns
+    , searchNativeConversations
     , deleteSession
     , importLegacySession
     , withSessionAdvisoryLock
@@ -79,6 +81,23 @@ data SessionLegacyTarget = SessionLegacyTarget
     , sessionLegacyConnection :: !Text
     , sessionLegacyEffectiveModel :: !Text
     , sessionLegacyDialect :: !Text
+    }
+    deriving (Eq, Show)
+
+data NativeConversationSearchResult = NativeConversationSearchResult
+    { nativeSearchSessionId :: !Text
+    , nativeSearchTitle :: !Text
+    , nativeSearchCwd :: !Text
+    , nativeSearchProvider :: !Text
+    , nativeSearchModel :: !Text
+    , nativeSearchUpdatedAt :: !UTCTime
+    , nativeSearchArchived :: !Bool
+    , nativeSearchTurnIndex :: !(Maybe Int64)
+    , nativeSearchOccurredAt :: !(Maybe UTCTime)
+    , nativeSearchRole :: !(Maybe Text)
+    , nativeSearchUserText :: !(Maybe Text)
+    , nativeSearchAssistantText :: !(Maybe Text)
+    , nativeSearchRank :: !Double
     }
     deriving (Eq, Show)
 
@@ -727,6 +746,15 @@ searchConversationTurns pool query limit =
         HasqlSession.statement
             (query, fromIntegral (max 1 (min 100 limit)))
             searchTurnsStatement
+
+searchNativeConversations
+    :: StorePool -> Text -> Int
+    -> IO (Either StoreError [NativeConversationSearchResult])
+searchNativeConversations pool query limit =
+    withSession pool $
+        HasqlSession.statement
+            (query, fromIntegral (max 1 (min 100 limit)))
+            searchNativeConversationsStatement
 
 deleteSession
     :: StorePool
@@ -1460,6 +1488,52 @@ searchTurnsStatement = mkStatement
             <*> Decoders.column (Decoders.nonNullable Decoders.int8)
             <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
             <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.float8))
+    True
+
+searchNativeConversationsStatement
+    :: Statement (Text, Int64) [NativeConversationSearchResult]
+searchNativeConversationsStatement = mkStatement
+    "WITH query AS (SELECT websearch_to_tsquery('english', $1) AS ts,\
+    \ lower(btrim($1)) AS needle), candidates AS (\
+    \ SELECT s.session_key,s.title,s.cwd,s.provider,s.model_id,s.updated_at,\
+    \ s.archived_at IS NOT NULL,NULL::bigint,NULL::timestamptz,NULL::text,\
+    \ NULL::text,NULL::text,CASE WHEN lower(s.title)=query.needle THEN 1000::float8\
+    \ WHEN lower(s.title) LIKE query.needle || '%' THEN 800::float8\
+    \ WHEN s.title ILIKE '%' || $1 || '%' THEN 600::float8\
+    \ WHEN s.cwd ILIKE '%' || $1 || '%' THEN 400::float8 ELSE 300::float8 END\
+    \ FROM harness.sessions s CROSS JOIN query WHERE s.deleted_at IS NULL AND (\
+    \ s.title ILIKE '%' || $1 || '%' OR s.cwd ILIKE '%' || $1 || '%' OR\
+    \ s.provider ILIKE '%' || $1 || '%' OR s.model_id ILIKE '%' || $1 || '%')\
+    \ UNION ALL\
+    \ SELECT s.session_key,s.title,s.cwd,s.provider,s.model_id,s.updated_at,\
+    \ s.archived_at IS NOT NULL,t.turn_index,t.occurred_at,\
+    \ CASE WHEN t.user_text ILIKE '%' || $1 || '%' OR\
+    \ to_tsvector('english',coalesce(t.user_text,'')) @@ query.ts\
+    \ THEN 'user' ELSE 'assistant' END,\
+    \ t.user_text,t.assistant_text,\
+    \ (100 + ts_rank_cd(t.search_vector,query.ts)*100)::float8\
+    \ FROM harness.session_turns t JOIN harness.sessions s ON s.session_id=t.session_id\
+    \ CROSS JOIN query WHERE s.deleted_at IS NULL AND (\
+    \ t.search_vector @@ query.ts OR t.user_text ILIKE '%' || $1 || '%' OR\
+    \ coalesce(t.assistant_text,'') ILIKE '%' || $1 || '%'))\
+    \ SELECT * FROM candidates ORDER BY 13 DESC,6 DESC,9 DESC NULLS LAST LIMIT $2"
+    ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.int8)) )
+    (Decoders.rowList $
+        NativeConversationSearchResult
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+            <*> Decoders.column (Decoders.nonNullable Decoders.bool)
+            <*> Decoders.column (Decoders.nullable Decoders.int8)
+            <*> Decoders.column (Decoders.nullable Decoders.timestamptz)
+            <*> Decoders.column (Decoders.nullable Decoders.text)
+            <*> Decoders.column (Decoders.nullable Decoders.text)
             <*> Decoders.column (Decoders.nullable Decoders.text)
             <*> Decoders.column (Decoders.nonNullable Decoders.float8))
     True

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -161,6 +161,28 @@ spec = describe "PostgreSQL session schema" do
                                 other ->
                                     expectationFailure
                                         ("unexpected conversation search: " <> show other)
+                            setSessionArchived pool "session-2" True now
+                                `shouldReturn` Right True
+                            searchNativeConversations pool "second" 10 >>= \case
+                                Right [match] -> do
+                                    match.nativeSearchSessionId
+                                        `shouldBe` "session-2"
+                                    match.nativeSearchArchived `shouldBe` True
+                                    match.nativeSearchTurnIndex `shouldBe` Nothing
+                                other ->
+                                    expectationFailure
+                                        ("unexpected native metadata search: "
+                                            <> show other)
+                            searchNativeConversations pool "batch" 10 >>= \case
+                                Right [match] -> do
+                                    match.nativeSearchSessionId
+                                        `shouldBe` "session-2"
+                                    match.nativeSearchTurnIndex `shouldBe` Just 0
+                                    match.nativeSearchRole `shouldBe` Just "user"
+                                other ->
+                                    expectationFailure
+                                        ("unexpected native turn search: "
+                                            <> show other)
                             deleteSession pool "session-1" now
                                 `shouldReturn` Right True
                             events <- loadSessionEvents pool "session-1"


### PR DESCRIPTION
## Summary
- add ranked native conversation search across metadata and stored turns
- expose results through a typed asynchronous C callback ABI
- service searches while the native engine is idle or running a turn
- include archived sessions while excluding deleted conversations

## Validation
- `TMPDIR=/tmp nix develop -c cabal test --offline agent-store:agent-store-test` (30/33 pass; three pre-existing legacy migration fixtures fail because migration 11 indexes `harness.sessions` after fixtures remove it)
- `nix develop -c cabal build --offline agent-cli:lib:agent-cli`
- `nix build --fallback path:.#agent-native-bridge`
