### PR TITLE
Use icons for token usage status

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -32,7 +32,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 
 -- | Idle prompt chrome: model, reasoning effort, interaction mode, and active
--- account on the left; session token totals and last tok/s right-aligned
+-- account on the left; session token totals and last generation rate right-aligned
 -- when possible.
 formatReplStatusLine
     :: Bool
@@ -97,24 +97,24 @@ cycleReplInteraction :: PlanModeState -> ApprovalPolicy -> ReplMode
 cycleReplInteraction planState policy =
     cycleReplMode (replModeFromState planState policy)
 
--- | Compact session totals: @1.2k in · 340 out@. Cached tokens are shown
+-- | Compact session totals: @1.2k ↓ · 340 ↑@. Cached tokens are shown
 -- only when the provider reported a non-zero cache hit.
 formatTokenUsage :: TokenUsage -> Text
 formatTokenUsage usage
     | usage == emptyTokenUsage = ""
     | otherwise =
         formatTokenCount usage.inputTokens
-            <> " in · "
+            <> " ↓ · "
             <> formatTokenCount usage.outputTokens
-            <> " out"
+            <> " ↑"
             <> cachedSuffix
   where
     cachedSuffix
         | usage.cachedTokens > 0 =
-            " · " <> formatTokenCount usage.cachedTokens <> " cached"
+            " · " <> formatTokenCount usage.cachedTokens <> " ↻"
         | otherwise = ""
 
--- | Session totals plus a generation rate: @1.2k in · 340 out · 42 tok/s@.
+-- | Session totals plus a generation rate: @1.2k ↓ · 340 ↑ · 42 ◈/s@.
 formatUsageWithRate :: TokenUsage -> Maybe Double -> Text
 formatUsageWithRate usage rate =
     Text.intercalate " · " $
@@ -128,17 +128,17 @@ formatEstimatedTokensPerSecond :: Bool -> Double -> Text
 formatEstimatedTokensPerSecond estimated rate =
     (if estimated then "~" else "") <> formatTokensPerSecond rate
 
--- | Compact generation speed: @4.2 tok/s@, @42 tok/s@, @1.2k tok/s@.
+-- | Compact generation speed: @4.2 ◈/s@, @42 ◈/s@, @1.2k ◈/s@.
 formatTokensPerSecond :: Double -> Text
 formatTokensPerSecond rate
-    | rate < 0.05 = "<0.1 tok/s"
+    | rate < 0.05 = "<0.1 ◈/s"
     | rate < 9.95 =
         let tenths = round (rate * 10) :: Int
             whole = tenths `div` 10
             frac = tenths `mod` 10
-        in Text.pack (show whole <> "." <> show frac <> " tok/s")
+        in Text.pack (show whole <> "." <> show frac <> " ◈/s")
     | otherwise =
-        formatTokenCount (round rate) <> " tok/s"
+        formatTokenCount (round rate) <> " ◈/s"
 
 formatTokenCount :: Int -> Text
 formatTokenCount n

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -286,7 +286,7 @@ spec = do
             formatActivityLine False "⠋" "Thinking…" 1.2 Nothing
                 `shouldBe` "⠋ Thinking…  1.2s"
             formatActivityLine False "⠋" "Writing…" 1.2 (Just 42)
-                `shouldBe` "⠋ Writing…  1.2s · 42 tok/s"
+                `shouldBe` "⠋ Writing…  1.2s · 42 ◈/s"
 
     describe "formatToolStarted" do
         it "renders English verbs for known tools" do

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -208,19 +208,19 @@ spec = do
             formatReplStatusLine False Nothing "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
                 Nothing
-                `shouldBe` "  grok-4.6 · high · ask  1.2k in · 340 out"
+                `shouldBe` "  grok-4.6 · high · ask  1.2k ↓ · 340 ↑"
 
         it "appends last generation speed next to usage" do
             formatReplStatusLine False Nothing "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
                 (Just 42)
-                `shouldBe` "  grok-4.6 · high · ask  1.2k in · 340 out · 42 tok/s"
+                `shouldBe` "  grok-4.6 · high · ask  1.2k ↓ · 340 ↑ · 42 ◈/s"
 
         it "right-aligns session usage when the TTY is wide enough" do
             formatReplStatusLine False (Just 48) "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
                 Nothing
-                `shouldBe` "  grok-4.6 · high · ask        1.2k in · 340 out"
+                `shouldBe` "  grok-4.6 · high · ask           1.2k ↓ · 340 ↑"
 
         it "drops usage rather than wrapping when only the state fits" do
             formatReplStatusLine False (Just 24) "grok-4.6" "high" ReplModeNormal ""
@@ -359,43 +359,43 @@ spec = do
         it "omits empty totals" do
             formatTokenUsage emptyTokenUsage `shouldBe` ""
 
-        it "formats compact in/out counts" do
+        it "formats compact input/output counts with arrows" do
             formatTokenUsage TokenUsage
                 { inputTokens = 42
                 , outputTokens = 7
                 , cachedTokens = 0
-                } `shouldBe` "42 in · 7 out"
+                } `shouldBe` "42 ↓ · 7 ↑"
 
         it "includes cached tokens when present" do
             formatTokenUsage TokenUsage
                 { inputTokens = 1500
                 , outputTokens = 80
                 , cachedTokens = 1200
-                } `shouldBe` "1.5k in · 80 out · 1.2k cached"
+                } `shouldBe` "1.5k ↓ · 80 ↑ · 1.2k ↻"
 
         it "uses k/M suffixes" do
             formatTokenUsage TokenUsage
                 { inputTokens = 12500
                 , outputTokens = 1500000
                 , cachedTokens = 0
-                } `shouldBe` "13k in · 1.5M out"
+                } `shouldBe` "13k ↓ · 1.5M ↑"
 
     describe "formatTokensPerSecond" do
         it "uses one decimal below 10 and compact counts above" do
-            formatTokensPerSecond 0.04 `shouldBe` "<0.1 tok/s"
-            formatTokensPerSecond 4.2 `shouldBe` "4.2 tok/s"
-            formatTokensPerSecond 42 `shouldBe` "42 tok/s"
-            formatTokensPerSecond 12500 `shouldBe` "13k tok/s"
+            formatTokensPerSecond 0.04 `shouldBe` "<0.1 ◈/s"
+            formatTokensPerSecond 4.2 `shouldBe` "4.2 ◈/s"
+            formatTokensPerSecond 42 `shouldBe` "42 ◈/s"
+            formatTokensPerSecond 12500 `shouldBe` "13k ◈/s"
 
         it "marks character-derived rates as estimates" do
             formatEstimatedTokensPerSecond True 42
-                `shouldBe` "~42 tok/s"
+                `shouldBe` "~42 ◈/s"
             formatEstimatedTokensPerSecond False 42
-                `shouldBe` "42 tok/s"
+                `shouldBe` "42 ◈/s"
 
         it "joins usage and rate" do
             formatUsageWithRate emptyTokenUsage (Just 42)
-                `shouldBe` "42 tok/s"
+                `shouldBe` "42 ◈/s"
             formatUsageWithRate
                 TokenUsage
                     { inputTokens = 1200
@@ -403,7 +403,7 @@ spec = do
                     , cachedTokens = 0
                     }
                 (Just 42)
-                `shouldBe` "1.2k in · 340 out · 42 tok/s"
+                `shouldBe` "1.2k ↓ · 340 ↑ · 42 ◈/s"
 
 withTempDir :: String -> (FilePath -> IO a) -> IO a
 withTempDir prefix action = do


### PR DESCRIPTION
## Summary
- replace input/output labels with down/up arrows
- use a reuse icon for cached tokens
- display generation rate as a token icon per second
- keep idle and active status lines consistent

## Testing
- [x] focused `agent-cli` status formatter tests
- [x] tmux live CLI smoke test