### PR TITLE
Use icons for fresh-session token status

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -108,7 +108,7 @@ import Agent.CLI.Skills ()
 import Agent.CLI.Startup.Auth ()
 import Agent.CLI.Startup.Format ()
 import Agent.CLI.StartupContext ()
-import Agent.CLI.Status ( formatTokenUsage )
+import Agent.CLI.Status ( formatTokenUsageOrZero )
 import Agent.CLI.Style
     ( cliWindowTitle, glyphOk, glyphSession, roleError, roleMuted )
 import Agent.CLI.Subagents.Runtime ()
@@ -427,11 +427,7 @@ handleSessionAction
         let toolNames =
                 Set.toAscList
                     slashCatalog.slashCatalogToolNames
-            usageText =
-                let formatted = formatTokenUsage usage
-                in if Text.null formatted
-                    then "0 in · 0 out"
-                    else formatted
+            usageText = formatTokenUsageOrZero usage
             message = Text.unlines $
                 [ "session: "
                     <> fromMaybe "(not persisted)" sessionId

--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Status
     , cycleReplInteraction
     , formatReplStatusLine
     , formatTokenUsage
+    , formatTokenUsageOrZero
     , formatEstimatedTokensPerSecond
     , formatTokensPerSecond
     , formatUsageWithRate
@@ -113,6 +114,14 @@ formatTokenUsage usage
         | usage.cachedTokens > 0 =
             " · " <> formatTokenCount usage.cachedTokens <> " ↻"
         | otherwise = ""
+
+-- | Format token totals for contexts that must show fresh-session zeroes.
+formatTokenUsageOrZero :: TokenUsage -> Text
+formatTokenUsageOrZero usage =
+    let formatted = formatTokenUsage usage
+    in if Text.null formatted
+        then "0 ↓ · 0 ↑"
+        else formatted
 
 -- | Session totals plus a generation rate: @1.2k ↓ · 340 ↑ · 42 ◈/s@.
 formatUsageWithRate :: TokenUsage -> Maybe Double -> Text

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -23,6 +23,7 @@ import Agent.CLI
 import Agent.CLI.Command (setModel, setReasoningEffort)
 import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
+import Agent.CLI.Status (formatTokenUsageOrZero)
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , decodeModelConfig
@@ -358,6 +359,9 @@ spec = do
     describe "formatTokenUsage" do
         it "omits empty totals" do
             formatTokenUsage emptyTokenUsage `shouldBe` ""
+
+        it "formats fresh-session zeroes with arrows when required" do
+            formatTokenUsageOrZero emptyTokenUsage `shouldBe` "0 ↓ · 0 ↑"
 
         it "formats compact input/output counts with arrows" do
             formatTokenUsage TokenUsage


### PR DESCRIPTION
## Summary
- show arrow icons in the zero-usage `/status` fallback
- centralize the explicit-zero formatter and add regression coverage
- address the post-merge review feedback from #728

## Testing
- [x] focused `formatTokenUsage` tests
- [x] fresh `/new` then `/status` smoke test in tmux (`tokens: 0 ↓ · 0 ↑`)