### PR TITLE
Render shell commands while arguments stream

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -500,6 +500,8 @@ updateManagedActivity event state =
                 }
         ToolUpdated _ ->
             state
+        ToolArgumentsUpdated _ ->
+            state
         ToolRetracted _ ->
             state
         ResponseAttemptDiscarded ->

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -502,6 +502,10 @@ renderEventUnlocked config = \case
                             call
                 unless (Text.null extra) do
                     putTextLn config.renderStderr extra
+    -- Partial arguments can be repainted by the retained fullscreen UI, but
+    -- cannot be updated safely in append-only terminal scrollback.
+    ToolArgumentsUpdated _ ->
+        pure ()
     ToolRetracted _ ->
         pure ()
     ResponseAttemptDiscarded ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -294,6 +294,7 @@ handleEvent event = do
         ReasoningDelta{} -> True
         ActivityUpdated{} -> True
         ToolUpdated{} -> True
+        ToolArgumentsUpdated{} -> True
         ToolOutputUpdated{} -> True
         NativeAgentOutput{} -> True
         _ -> False

--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -319,6 +319,7 @@ eventWeight = \case
     TurnFinished _ -> 1
     ToolStarted call -> Text.length call.callId
     ToolUpdated call -> Text.length call.callId
+    ToolArgumentsUpdated call -> Text.length call.callId
     ToolRetracted callId -> Text.length callId
     ResponseAttemptDiscarded -> 1
     NativeAgentStarted identifier parent label model ->

--- a/packages/agent-core/src/Agent/JsonText.hs
+++ b/packages/agent-core/src/Agent/JsonText.hs
@@ -2,10 +2,15 @@
 module Agent.JsonText
     ( jsonTextField
     , jsonTextFieldDefault
+    , jsonTextFieldPartial
     ) where
 
 import qualified Agent.Json.Decode as Json
+import Control.Applicative ((<|>))
+import Control.Monad (guard)
+import Data.Char (isHexDigit, isSpace)
 import Data.Text (Text)
+import qualified Data.Text as Text
 
 -- | Read a string field from a JSON object encoded as 'Text'.
 jsonTextField :: Text -> Text -> Maybe Text
@@ -17,3 +22,45 @@ jsonTextField key arguments =
 jsonTextFieldDefault :: Text -> Text -> Text
 jsonTextFieldDefault key arguments =
     maybe "" id (jsonTextField key arguments)
+
+-- | Read a string field from a JSON object that may still be streaming.
+--
+-- Complete JSON takes the normal decoder path. For an incomplete object, this
+-- locates the requested string value and decodes the complete JSON escapes
+-- received so far. A trailing incomplete escape is omitted until its remaining
+-- characters arrive.
+jsonTextFieldPartial :: Text -> Text -> Maybe Text
+jsonTextFieldPartial key arguments =
+    jsonTextField key arguments <|> do
+        let marker = "\"" <> key <> "\""
+            (_, marked) = Text.breakOn marker arguments
+        guard (not (Text.null marked))
+        let afterKey = Text.dropWhile isSpace (Text.drop (Text.length marker) marked)
+        (':', afterColon) <- Text.uncons afterKey
+        ('"', bodyStart) <- Text.uncons (Text.dropWhile isSpace afterColon)
+        let encodedBody = completeEscapePrefix (takeStringBody bodyStart)
+        either (const Nothing) Just $
+            Json.decodeText Json.text ("\"" <> encodedBody <> "\"")
+
+takeStringBody :: Text -> Text
+takeStringBody = Text.pack . go False . Text.unpack
+  where
+    go _ [] = []
+    go escaped (char : rest)
+        | char == '"' && not escaped = []
+        | char == '\\' && not escaped = char : go True rest
+        | otherwise = char : go False rest
+
+completeEscapePrefix :: Text -> Text
+completeEscapePrefix body
+    | odd (Text.length trailingSlashes) = Text.dropEnd 1 body
+    | otherwise =
+        case Text.breakOnEnd "\\u" body of
+            ("", _) -> body
+            (_throughMarker, suffix)
+                | Text.length suffix < 4
+                , Text.all isHexDigit suffix ->
+                    Text.dropEnd (2 + Text.length suffix) body
+                | otherwise -> body
+  where
+    trailingSlashes = Text.takeWhileEnd (== '\\') body

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -278,6 +278,10 @@ data LoopEvent
     -- | Replace the metadata for an already-visible in-flight tool call.
     -- Providers may learn canonical arguments after an early live start.
     | ToolUpdated ToolCall
+    -- | Replace the live UI preview for an in-flight tool call while its
+    -- arguments are still streaming. Append-only renderers may ignore this;
+    -- retained renderers can repaint the existing tool block.
+    | ToolArgumentsUpdated ToolCall
     -- | Latest accumulated output snapshot for an in-flight tool call.
     | ToolOutputUpdated Text Text
     | ToolFinished ToolCallResult

--- a/packages/agent-core/test/Agent/JsonTextSpec.hs
+++ b/packages/agent-core/test/Agent/JsonTextSpec.hs
@@ -13,3 +13,17 @@ spec = describe "jsonTextField" do
         jsonTextField "command" "{\"description\":\"x\"}" `shouldBe` Nothing
         jsonTextFieldDefault "command" "not-json" `shouldBe` ""
         jsonTextField "n" "{\"n\":1}" `shouldBe` Nothing
+
+    it "reads a string field while its JSON value is still streaming" do
+        jsonTextFieldPartial "command" "{\"command\":\"git sta"
+            `shouldBe` Just "git sta"
+        jsonTextFieldPartial "command" "{\"command\": \"git status\"}"
+            `shouldBe` Just "git status"
+
+    it "drops an incomplete escape until the remaining JSON arrives" do
+        jsonTextFieldPartial "command" "{\"command\":\"printf foo\\"
+            `shouldBe` Just "printf foo"
+        jsonTextFieldPartial "command" "{\"command\":\"printf foo\\nbar"
+            `shouldBe` Just "printf foo\nbar"
+        jsonTextFieldPartial "command" "{\"command\":\"printf \\u26"
+            `shouldBe` Just "printf "

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -27,6 +27,8 @@ import Agent.InterAgentMessage
     , renderInterAgentMessage
     , renderInterAgentMessageHeader
     )
+import Agent.Json (rawJsonFromEncoding)
+import Agent.JsonText (jsonTextFieldPartial)
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
@@ -46,11 +48,11 @@ import Agent.Provider
     )
 import Agent.Responses.Request (stripReplayedItemStatus)
 import Agent.Responses.Types
-import Agent.Json (rawJsonFromEncoding)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
     , ToolCallResult(..)
+    , canonicalToolName
     )
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
@@ -647,12 +649,10 @@ codexRateLimitsWarning limits =
 -- | Stateful projection of one streamed response attempt into loop events.
 --
 -- On top of 'streamEventToLoopEventWithRawReasoning' this surfaces streamed
--- tool-call arguments as live activity. Argument deltas map to no visible
--- loop event on their own, so a model writing a large tool call — or stuck in
--- a degenerate repetition loop inside one (observed as multi-minute
--- 128k-output-token samples whose arguments repeat @\\u0000@ or a hallucinated
--- path segment) — previously looked like endless silent reasoning until the
--- provider's output-token cap ended the turn.
+-- shell arguments as a repaintable command preview and reports coarse activity
+-- for other tools. It also warns when a model gets stuck in a degenerate
+-- repetition loop inside one call (observed as multi-minute 128k-output-token
+-- samples whose arguments repeat @\\u0000@ or a hallucinated path segment).
 --
 -- Build one projector per response attempt so counters describe a single
 -- provider sample.
@@ -683,6 +683,9 @@ runawayToolArgumentWarningChars = 100000
 
 data ToolArgumentStreamState = ToolArgumentStreamState
     { toolNamesById :: !(Map Text Text)
+    , toolCallsById :: !(Map Text ToolCall)
+    , currentToolCall :: !(Maybe ToolCall)
+    , shellPreviewsByCallId :: !(Map Text Text)
     , currentToolName :: !(Maybe Text)
     , streamedArgumentChars :: !Int
     , announcedArgumentChars :: !Int
@@ -692,6 +695,9 @@ data ToolArgumentStreamState = ToolArgumentStreamState
 emptyToolArgumentStreamState :: ToolArgumentStreamState
 emptyToolArgumentStreamState = ToolArgumentStreamState
     { toolNamesById = Map.empty
+    , toolCallsById = Map.empty
+    , currentToolCall = Nothing
+    , shellPreviewsByCallId = Map.empty
     , currentToolName = Nothing
     , streamedArgumentChars = 0
     , announcedArgumentChars = 0
@@ -704,40 +710,55 @@ toolArgumentStreamStep
     -> (ToolArgumentStreamState, [LoopEvent])
 toolArgumentStreamStep event state = case event of
     ResponseOutputItemAddedEvent { item = FunctionCallItem call } ->
-        announceToolCall (namespacedToolName call.namespace call.name)
+        announceToolCall
+            (responseItemToToolCall (FunctionCallItem call))
+            (namespacedToolName call.namespace call.name)
             (maybeToList call.itemId <> [call.callId])
             state
     ResponseOutputItemAddedEvent { item = CustomToolCallItem call } ->
-        announceToolCall (namespacedToolName call.namespace call.name)
+        announceToolCall
+            (responseItemToToolCall (CustomToolCallItem call))
+            (namespacedToolName call.namespace call.name)
             (maybeToList call.itemId <> [call.callId])
             state
     ResponseFunctionCallArgumentsDeltaEvent { delta = Just deltaText, streamItemId } ->
-        countToolArgumentChars
-            (resolveToolName [streamItemId] state)
-            (Text.length deltaText)
+        updateToolArguments
+            [streamItemId]
+            deltaText
             state
     ResponseCustomToolInputDeltaEvent
         { delta = Just deltaText, streamItemId, streamCallId } ->
-            countToolArgumentChars
-                (resolveToolName [streamItemId, streamCallId] state)
-                (Text.length deltaText)
+            updateToolArguments
+                [streamItemId, streamCallId]
+                deltaText
                 state
     _ -> (state, [])
 
 announceToolCall
-    :: Text
+    :: Maybe ToolCall
+    -> Text
     -> [Text]
     -> ToolArgumentStreamState
     -> (ToolArgumentStreamState, [LoopEvent])
-announceToolCall name identities state =
+announceToolCall maybeCall name identities state =
     ( state
         { toolNamesById =
             foldr (\identity -> Map.insert identity name)
                 state.toolNamesById
                 identities
+        , toolCallsById =
+            case maybeCall of
+                Nothing -> state.toolCallsById
+                Just call ->
+                    foldr (\identity -> Map.insert identity call)
+                        state.toolCallsById
+                        identities
+        , currentToolCall = maybeCall <|> state.currentToolCall
         , currentToolName = Just name
         }
-    , [ActivityUpdated (writingToolCallActivity name Nothing)]
+    , [ ActivityUpdated (writingToolCallActivity name Nothing)
+      | not (isLiveShellTool name)
+      ]
     )
 
 resolveToolName :: [Maybe Text] -> ToolArgumentStreamState -> Text
@@ -749,6 +770,102 @@ resolveToolName identities state =
             ]
   where
     firstJust = foldr (<|>) Nothing
+
+resolveToolCall
+    :: [Maybe Text]
+    -> ToolArgumentStreamState
+    -> Maybe ToolCall
+resolveToolCall identities state =
+    firstJust
+        [ Map.lookup identity state.toolCallsById
+        | Just identity <- identities
+        ]
+        <|> state.currentToolCall
+  where
+    firstJust = foldr (<|>) Nothing
+
+-- Keep enough raw arguments to render a useful one-line shell preview without
+-- accumulating an unbounded repeated strict Text value for runaway calls.
+liveToolArgumentPrefixChars :: Int
+liveToolArgumentPrefixChars = 4096
+
+updateToolArguments
+    :: [Maybe Text]
+    -> Text
+    -> ToolArgumentStreamState
+    -> (ToolArgumentStreamState, [LoopEvent])
+updateToolArguments identities delta state =
+    let name = resolveToolName identities state
+        maybeCall = resolveToolCall identities state
+        (withDraft, previewEvents) = case maybeCall of
+            Just call
+                | isLiveShellTool call.name ->
+                    updateLiveShellCall call delta state
+            _ -> (state, [])
+        (counted, activityEvents) =
+            countToolArgumentChars name (Text.length delta) withDraft
+    in (counted, previewEvents <> activityEvents)
+
+updateLiveShellCall
+    :: ToolCall
+    -> Text
+    -> ToolArgumentStreamState
+    -> (ToolArgumentStreamState, [LoopEvent])
+updateLiveShellCall call delta state =
+    let rawArguments =
+            Text.take liveToolArgumentPrefixChars (call.arguments <> delta)
+        updatedCall = withToolArguments call rawArguments
+        updatedCalls =
+            Map.map
+                (\known ->
+                    if known.callId == call.callId then updatedCall else known)
+                state.toolCallsById
+        maybeCommand = jsonTextFieldPartial "command" rawArguments
+        preview = Text.takeWhile (/= '\n') <$> maybeCommand
+        previousPreview = Map.lookup call.callId state.shellPreviewsByCallId
+        changed = maybe False
+            (\value -> not (Text.null value) && Just value /= previousPreview)
+            preview
+        displayCall command =
+            withToolArguments updatedCall $
+                Text.decodeUtf8
+                    (LBS.toStrict
+                        (Aeson.encode (Aeson.object ["command" Aeson..= command])))
+        next = state
+            { toolCallsById = updatedCalls
+            , currentToolCall = Just updatedCall
+            , shellPreviewsByCallId =
+                maybe state.shellPreviewsByCallId
+                    (\value -> Map.insert call.callId value
+                        state.shellPreviewsByCallId)
+                    preview
+            }
+    in
+    ( next
+    , [ToolArgumentsUpdated (displayCall command)
+      | changed
+      , command <- maybeToList preview
+      ]
+    )
+
+isLiveShellTool :: Text -> Bool
+isLiveShellTool name =
+    canonicalToolName name `elem` ["shell_command", "run_terminal_cmd"]
+
+withToolArguments :: ToolCall -> Text -> ToolCall
+withToolArguments ToolCall
+    { callId
+    , name
+    , callKind
+    , argumentsEncrypted
+    } arguments =
+        ToolCall
+            { callId
+            , name
+            , arguments
+            , callKind
+            , argumentsEncrypted
+            }
 
 countToolArgumentChars
     :: Text
@@ -773,6 +890,7 @@ countToolArgumentChars name deltaChars state =
         }
     , [ ActivityUpdated (writingToolCallActivity name (Just total))
       | announce
+      , not (isLiveShellTool name)
       ]
         <> [ WarningRaised (runawayToolArgumentWarning name total)
            | warn

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -461,11 +461,9 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
         map encodedField (requestInputItems request) !! 1
             `shouldBe` Just (Aeson.String "opaque")
 
--- | Streamed tool calls are announced immediately, while argument deltas map
--- to activity updates at coarse boundaries. Without the projected activity
--- below, a model writing a large call — or degenerating into a repetition
--- loop inside one — looks like endless silent reasoning until the provider's
--- output-token cap fails the turn.
+-- | Streamed tool calls are announced immediately. Shell argument deltas
+-- repaint that call with the partial command, while other tools retain coarse
+-- activity updates.
 streamProjectionSpec :: Spec
 streamProjectionSpec = describe "newStreamEventToLoopEvents" do
     it "publishes a streamed function call immediately" do
@@ -474,7 +472,27 @@ streamProjectionSpec = describe "newStreamEventToLoopEvents" do
         events `shouldBe`
             [ ToolStarted
                 (functionToolCall "call-1" "shell_command" "")
-            , ActivityUpdated "Writing shell_command call…"
+            ]
+
+    it "repaints a streamed shell call with its partial command" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent (functionCallAdded "fc-1" "call-1" "shell_command")
+        first <- projectEvent
+            (argumentsDelta "fc-1" "{\"command\":\"git sta")
+        first `shouldBe`
+            [ ToolArgumentsUpdated
+                (functionToolCall
+                    "call-1"
+                    "shell_command"
+                    "{\"command\":\"git sta\"}")
+            ]
+        second <- projectEvent (argumentsDelta "fc-1" "tus\"}")
+        second `shouldBe`
+            [ ToolArgumentsUpdated
+                (functionToolCall
+                    "call-1"
+                    "shell_command"
+                    "{\"command\":\"git status\"}")
             ]
 
     it "replaces streamed tool metadata with the canonical done item" do
@@ -529,7 +547,7 @@ streamProjectionSpec = describe "newStreamEventToLoopEvents" do
                 }
             ]
 
-    it "reports argument progress at chunk boundaries" do
+    it "does not replace a shell preview with coarse argument activity" do
         projectEvent <- newStreamEventToLoopEvents False
         _ <- projectEvent (functionCallAdded "fc-1" "call-1" "shell_command")
         quiet <- projectEvent
@@ -537,27 +555,23 @@ streamProjectionSpec = describe "newStreamEventToLoopEvents" do
         quiet `shouldBe` []
         loud <- projectEvent
             (argumentsDelta "fc-1" (Text.replicate 9900 "y"))
-        loud `shouldBe`
-            [ActivityUpdated "Writing shell_command call… (10k chars)"]
+        loud `shouldBe` []
 
     it "warns once per runaway argument window" do
         projectEvent <- newStreamEventToLoopEvents False
         _ <- projectEvent (functionCallAdded "fc-1" "call-1" "shell_command")
         let bigDelta = Text.replicate 60000 "z"
         first <- projectEvent (argumentsDelta "fc-1" bigDelta)
-        first `shouldBe`
-            [ActivityUpdated "Writing shell_command call… (60k chars)"]
+        first `shouldBe` []
         second <- projectEvent (argumentsDelta "fc-1" bigDelta)
         second `shouldBe`
-            [ ActivityUpdated "Writing shell_command call… (120k chars)"
-            , WarningRaised
+            [ WarningRaised
                 ("The model has streamed 120k chars of shell_command "
                     <> "arguments in one response; it may be stuck in a "
                     <> "repetition loop.")
             ]
         third <- projectEvent (argumentsDelta "fc-1" bigDelta)
-        third `shouldBe`
-            [ActivityUpdated "Writing shell_command call… (180k chars)"]
+        third `shouldBe` []
 
     it "counts custom tool input as argument streaming" do
         projectEvent <- newStreamEventToLoopEvents False

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -436,6 +436,8 @@ reduceLoop event state = case event of
                     }
     ToolUpdated call ->
         updateToolCall call state
+    ToolArgumentsUpdated call ->
+        updateToolCall call state
     ToolOutputUpdated callId output ->
         updateToolOutput callId output state
     ToolFinished result ->

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -332,6 +332,29 @@ spec = describe "fullscreen UI reducer" do
         Foldable.toList state.uiToolCalls
             `shouldBe` [(0, canonical)]
 
+    it "repaints a running shell call as command arguments stream" do
+        let early = functionToolCall "c1" "shell_command" ""
+            preview =
+                functionToolCall
+                    "c1"
+                    "shell_command"
+                    "{\"command\":\"git status\"}"
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted early)
+                    , UiLoop (ToolArgumentsUpdated preview)
+                    ]
+        case Foldable.toList state.uiBlocks of
+            [block] -> do
+                block.blockKind `shouldBe` BlockShell
+                block.blockTitle `shouldBe` "$ git status"
+                block.blockState `shouldBe` BlockRunning
+                state.uiActivity `shouldBe` "$ git status"
+            _ -> expectationFailure "expected one updated shell block"
+        Foldable.toList state.uiToolCalls
+            `shouldBe` [(0, preview)]
+
     it "makes repeated tool starts idempotent by call id" do
         let early = functionToolCall "c1" "Task" "{}"
             canonical =


### PR DESCRIPTION
## Summary
- replace the generic `Writing shell_command call…` status with a repaintable live shell tool block
- decode partial streamed JSON command arguments, including incomplete escapes
- keep append-only renderers unchanged while the fullscreen TUI updates the existing call in place

## Verification
- multi-package GHCi typecheck: 371 modules loaded
- `agent-core` focused tests: 4 examples, 0 failures
- `agent-responses` focused tests: 9 examples, 0 failures
- `agent-tui` focused test: 1 example, 0 failures
- `git diff --check`
- live tmux smoke test: in-flight call rendered as `$ sleep 3; printf shell-preview-ok` instead of `Writing shell_command call…`
