### PR TITLE
Stage image attachments through the native macOS bridge

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -343,11 +343,14 @@ test-suite agent-cli-test
     hs-source-dirs:   test ffi
     main-is:          Spec.hs
     c-sources:        test/cbits/HaskellAgentBridgeImageSmoke.c
+                    , cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     other-modules:    Agent.CLI.AccountSelectionSpec
                     , Agent.CLI.MacOS.NativeLoopEventSpec
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
+                    , Agent.CLI.MacOS.BridgeFFISpec
+                    , Agent.CLI.MacOS.Bridge
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -342,9 +342,12 @@ test-suite agent-cli-test
     ghc-options:      -threaded
     hs-source-dirs:   test ffi
     main-is:          Spec.hs
+    c-sources:        test/cbits/HaskellAgentBridgeImageSmoke.c
+    include-dirs:     include
     other-modules:    Agent.CLI.AccountSelectionSpec
                     , Agent.CLI.MacOS.NativeLoopEventSpec
                     , Agent.CLI.MacOS.NativeLoopEvent
+                    , Agent.CLI.MacOS.BridgeHeaderSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -342,15 +342,12 @@ test-suite agent-cli-test
     ghc-options:      -threaded
     hs-source-dirs:   test ffi
     main-is:          Spec.hs
-    c-sources:        test/cbits/HaskellAgentBridgeImageSmoke.c
-                    , cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     other-modules:    Agent.CLI.AccountSelectionSpec
                     , Agent.CLI.MacOS.NativeLoopEventSpec
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
                     , Agent.CLI.MacOS.BridgeFFISpec
-                    , Agent.CLI.MacOS.Bridge
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec
@@ -456,6 +453,10 @@ test-suite agent-cli-test
                     , transformers
                     , unix
                     , vty >= 6.4 && < 7
+    if os(darwin)
+        c-sources:    test/cbits/HaskellAgentBridgeImageSmoke.c
+                    , cbits/HaskellAgentBridgeRuntime.c
+        other-modules: Agent.CLI.MacOS.Bridge
 
 benchmark image-preview-latency-bench
     import:           common-options

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -247,6 +247,8 @@ executable agent-cli
 
 foreign-library haskell-agent-bridge
     import:           common-options
+    if !os(darwin)
+        buildable:    False
     type:             native-shared
     options:          standalone
     hs-source-dirs:   ffi

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -14,6 +14,11 @@ import Agent.Store.Postgres.Session
     ( NativeConversationSearchResult(..)
     , searchNativeConversations
     )
+import Agent.CLI.ManagedTurn
+    ( ManagedTurnMedia(..)
+    , managedTurnRequestWithImages
+    , renderManagedTurnPrompt
+    )
 import Data.Bifunctor (first)
 import Agent.Store.Postgres.Scope (Scope(..), scopeKindText)
 import Agent.Store.Postgres.Skill
@@ -21,11 +26,6 @@ import Agent.Store.Postgres.Skill
     , learnedSkillActivationText
     , learnedSkillStatusText
     , listAllLearnedSkills
-    )
-import Agent.CLI.ManagedTurn
-    ( ManagedTurnMedia(..)
-    , managedTurnRequestWithImages
-    , renderManagedTurnPrompt
     )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
@@ -908,7 +908,9 @@ ha_engine_send_json pointer bytes (CSize length)
                 (castPtr bytes, fromIntegral length)
             case (Aeson.eitherDecodeStrict' payload
                 :: Either String BridgeRequest) of
-                Left _ -> pure False
+                Left _ -> do
+                    atomically $ writeTVar engine.engineStagedImages Map.empty
+                    pure False
                 Right request -> do
                     atomically
                         (writeTQueue
@@ -965,8 +967,10 @@ ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
                 [0 .. fromIntegral imageCount - 1]
             case (turnIDText, sequence imageResults) of
                 (Right turnIDValue, Just images) -> do
-                    atomically $ modifyTVar' engine.engineStagedImages
-                        (Map.insertWith (flip (<>)) turnIDValue images)
+                    atomically $ modifyTVar' engine.engineStagedImages $
+                        if null images
+                            then Map.delete turnIDValue
+                            else Map.insert turnIDValue images
                     pure True
                 _ -> pure False
         pure $ case accepted of
@@ -1065,6 +1069,8 @@ idleLoop callback context config store root processRuntime commands stagedImages
                 case (parseParams request
                     :: Either Text TurnStart) of
                     Left err -> do
+                        atomically $ modifyTVar' stagedImages
+                            (Map.delete request.requestId)
                         sendEvent callback context
                             (failureEvent request.requestId err)
                         continue

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -992,6 +992,7 @@ ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
             (mimePointer == nullPtr && mimeLength > 0)
                 || (bytesPointer == nullPtr && bytesLength > 0)
                 || mimeLength == 0
+                || bytesLength == 0
         then pure Nothing
         else do
             mimeBytes <- BS.packCStringLen

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -22,6 +22,11 @@ import Agent.Store.Postgres.Skill
     , learnedSkillStatusText
     , listAllLearnedSkills
     )
+import Agent.CLI.ManagedTurn
+    ( ManagedTurnMedia(..)
+    , managedTurnRequestWithImages
+    , renderManagedTurnPrompt
+    )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     )
@@ -94,7 +99,7 @@ import Agent.CLI.SessionAdmin
     , managedPostgresConfigForHome
     , sessionSummaryWithStatusJSON
     )
-import Agent.Loop (LoopEvent(..))
+import Agent.Loop (ImageAttachment(..), LoopEvent(..))
 import Agent.Dialect (dialectSlug)
 import Agent.Provider (Provider(..), providerSlug, parseProvider, BillingMode(..))
 import Agent.Store.Postgres
@@ -189,12 +194,21 @@ import Foreign
     , newStablePtr
     , nullFunPtr
     , nullPtr
+    , plusPtr
+    , peekByteOff
+    , sizeOf
     )
 import Foreign.C.String (CString)
 import Foreign.C.Types (CDouble(..), CInt(..), CLLong(..), CSize(..))
+import System.Directory
+    ( getTemporaryDirectory
+    , removeFile
+    )
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
     ( IOMode(WriteMode)
+    , hClose
+    , openBinaryTempFile
     , withFile
     )
 import System.OsPath
@@ -452,6 +466,7 @@ data EngineCommand
 data Engine = Engine
     { engineCommands :: !(TQueue EngineCommand)
     , engineDone :: !(MVar ())
+    , engineStagedImages :: !(TVar (Map Text [ImageAttachment]))
     }
 
 data TurnControl = TurnControl
@@ -478,6 +493,9 @@ foreign export ccall ha_engine_create
 
 foreign export ccall ha_engine_send_json
     :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
+
+foreign export ccall ha_engine_stage_turn_images
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize -> IO CInt
 
 foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
@@ -855,17 +873,20 @@ ha_engine_create callback context
             config <- managedPostgresConfigForHome home
             commands <- newTQueueIO
             done <- newEmptyMVar
+            stagedImages <- newTVarIO Map.empty
             _ <- forkFinally
                 (workerLifecycle
                     callback
                     context
                     config
                     (sessionsRoot home)
-                    commands)
+                    commands
+                    stagedImages)
                 (const (putMVar done ()))
             stable <- newStablePtr Engine
                 { engineCommands = commands
                 , engineDone = done
+                , engineStagedImages = stagedImages
                 }
             pure (castStablePtrToPtr stable)
         case created of
@@ -926,6 +947,60 @@ ha_engine_search_conversations pointer bytes (CSize length) rawLimit callback co
             Right False -> 2
             Right True -> 0
 
+ha_engine_stage_turn_images
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize -> IO CInt
+ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
+    | pointer == nullPtr = pure 1
+    | turnID == nullPtr || turnIDLength == 0 = pure 2
+    | imagePointer == nullPtr && imageCount > 0 = pure 4
+    | toInteger imageCount > toInteger (maxBound :: Int) = pure 4
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            turnIDBytes <- BS.packCStringLen
+                (castPtr turnID, fromIntegral turnIDLength)
+            turnIDText <- either (const (fail "invalid turn ID UTF-8")) pure
+                (TextEncoding.decodeUtf8' turnIDBytes)
+            images <- mapM peekImage
+                [0 .. fromIntegral imageCount - 1]
+            atomically $ modifyTVar' engine.engineStagedImages
+                (Map.insertWith (flip (<>)) turnIDText images)
+        pure $ case accepted of
+            Left _ -> 4
+            Right () -> 0
+  where
+    pointerSize = sizeOf (nullPtr :: Ptr ())
+    sizeSize = sizeOf (undefined :: CSize)
+    imageSize = pointerSize + sizeSize + pointerSize + sizeSize
+
+    peekImage index = do
+        let base = castPtr imagePointer `plusPtr` (index * imageSize)
+            readPointer offset =
+                peekByteOff base offset :: IO (Ptr Word8)
+            readLength offset =
+                peekByteOff base offset :: IO CSize
+        mimePointer <- readPointer 0
+        mimeLength <- readLength pointerSize
+        bytesPointer <- readPointer (pointerSize + sizeSize)
+        bytesLength <- readLength (pointerSize + sizeSize + pointerSize)
+        if
+            (mimePointer == nullPtr && mimeLength > 0)
+                || (bytesPointer == nullPtr && bytesLength > 0)
+                || mimeLength == 0
+        then fail "invalid image attachment"
+        else do
+            mimeBytes <- BS.packCStringLen
+                (castPtr mimePointer, fromIntegral mimeLength)
+            mime <- either (const (fail "invalid MIME UTF-8")) pure
+                (TextEncoding.decodeUtf8' mimeBytes)
+            bytes <- BS.packCStringLen
+                (castPtr bytesPointer, fromIntegral bytesLength)
+            pure ImageAttachment
+                { imageMime = mime
+                , imageBytes = bytes
+                }
+
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer
     | pointer == nullPtr = pure ()
@@ -943,8 +1018,9 @@ workerLifecycle
     -> ManagedPostgresConfig
     -> OsPath
     -> TQueue EngineCommand
+    -> TVar (Map Text [ImageAttachment])
     -> IO ()
-workerLifecycle callback context config root commands = do
+workerLifecycle callback context config root commands stagedImages = do
     store <- newMVar Nothing
     processRuntime <- newNativeProcessRuntime root
     let cleanup =
@@ -958,6 +1034,7 @@ workerLifecycle callback context config root commands = do
         root
         processRuntime
         commands
+        stagedImages
         `finally` cleanup
 
 idleLoop
@@ -968,8 +1045,9 @@ idleLoop
     -> OsPath
     -> NativeProcessRuntime
     -> TQueue EngineCommand
+    -> TVar (Map Text [ImageAttachment])
     -> IO ()
-idleLoop callback context config store root processRuntime commands =
+idleLoop callback context config store root processRuntime commands stagedImages =
     atomically (readTQueue commands) >>= \case
         EngineStop -> pure ()
         EngineSearch query limit searchCallback searchContext -> do
@@ -985,6 +1063,11 @@ idleLoop callback context config store root processRuntime commands =
                             (failureEvent request.requestId err)
                         continue
                     Right start -> do
+                        images <- atomically $ do
+                            staged <- readTVar stagedImages
+                            writeTVar stagedImages
+                                (Map.delete start.turnStartId staged)
+                            pure (Map.findWithDefault [] start.turnStartId staged)
                         control <- newTurnControl start.turnStartId
                         sendEvent callback context $
                             successEvent request.requestId $
@@ -1004,7 +1087,8 @@ idleLoop callback context config store root processRuntime commands =
                                 context
                                 processRuntime
                                 control
-                                start)
+                                start
+                                images)
                             \running ->
                                 activeLoop
                                     callback
@@ -1030,7 +1114,15 @@ idleLoop callback context config store root processRuntime commands =
                 continue
   where
     continue =
-        idleLoop callback context config store root processRuntime commands
+        idleLoop
+            callback
+            context
+            config
+            store
+            root
+            processRuntime
+            commands
+            stagedImages
 
 activeLoop
     :: FunPtr EventCallback
@@ -1186,8 +1278,9 @@ runNativeTurn
     -> NativeProcessRuntime
     -> TurnControl
     -> TurnStart
+    -> [ImageAttachment]
     -> IO TurnOutcome
-runNativeTurn callback context processRuntime control start = do
+runNativeTurn callback context processRuntime control start images = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     let hooks = NativeRunHooks
@@ -1238,15 +1331,17 @@ runNativeTurn callback context processRuntime control start = do
                     []
                     (\effort -> ["--effort", Text.unpack effort])
                     start.turnStartEffort
-                <> ["--prompt", Text.unpack start.turnStartPrompt]
     result <- tryAny $
-        withFile "/dev/null" WriteMode \output ->
-            runNativeAgent
-                processRuntime
-                output
-                (unsafeEncodeUtf start.turnStartCwd)
-                hooks
-                args
+        withTurnImages start.turnStartPrompt images \managedFile ->
+            withFile "/dev/null" WriteMode \output ->
+                runNativeAgent
+                    processRuntime
+                    output
+                    (unsafeEncodeUtf start.turnStartCwd)
+                    hooks
+                    (args <> maybe ["--prompt", Text.unpack start.turnStartPrompt]
+                        (\path -> ["--managed-turn-file", path])
+                        managedFile)
     completed <- readIORef completedRef
     sessionId <- readIORef sessionIdRef
     pure TurnOutcome
@@ -1261,6 +1356,46 @@ runNativeTurn callback context processRuntime control start = do
                         Just
                             "turn ended without a completion event"
         }
+
+withTurnImages
+    :: Text
+    -> [ImageAttachment]
+    -> (Maybe FilePath -> IO a)
+    -> IO a
+withTurnImages _ [] action = action Nothing
+withTurnImages prompt images action = do
+    temporaryDirectory <- getTemporaryDirectory
+    withImageFiles temporaryDirectory images \paths -> do
+        let request = managedTurnRequestWithImages prompt
+                [ ManagedTurnMedia
+                    { managedTurnMediaPath = path
+                    , managedTurnMediaMime = image.imageMime
+                    , managedTurnMediaName = Nothing
+                    }
+                | (path, image) <- zip paths images
+                ]
+        bracket
+            (openBinaryTempFile temporaryDirectory "ha-native-turn-")
+            (\(path, handle) -> do
+                hClose handle
+                void (tryAny (removeFile path)))
+            \(path, handle) -> do
+                hClose handle
+                BS.writeFile path
+                    (TextEncoding.encodeUtf8 (renderManagedTurnPrompt request))
+                action (Just path)
+  where
+    withImageFiles _ [] action = action []
+    withImageFiles directory (image : rest) action =
+        bracket
+            (openBinaryTempFile directory "ha-native-image-")
+            (\(path, handle) -> do
+                hClose handle
+                void (tryAny (removeFile path)))
+            \(path, handle) -> do
+                hClose handle
+                BS.writeFile path image.imageBytes
+                withImageFiles directory rest (action . (path :))
 
 newTurnControl :: Text -> IO TurnControl
 newTurnControl turnId =

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -960,15 +960,19 @@ ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
             engine <- deRefStablePtr stable
             turnIDBytes <- BS.packCStringLen
                 (castPtr turnID, fromIntegral turnIDLength)
-            turnIDText <- either (const (fail "invalid turn ID UTF-8")) pure
-                (TextEncoding.decodeUtf8' turnIDBytes)
-            images <- mapM peekImage
+            let turnIDText = TextEncoding.decodeUtf8' turnIDBytes
+            imageResults <- mapM peekImage
                 [0 .. fromIntegral imageCount - 1]
-            atomically $ modifyTVar' engine.engineStagedImages
-                (Map.insertWith (flip (<>)) turnIDText images)
+            case (turnIDText, sequence imageResults) of
+                (Right turnIDValue, Just images) -> do
+                    atomically $ modifyTVar' engine.engineStagedImages
+                        (Map.insertWith (flip (<>)) turnIDValue images)
+                    pure True
+                _ -> pure False
         pure $ case accepted of
-            Left _ -> 4
-            Right () -> 0
+            Left _ -> 3
+            Right False -> 4
+            Right True -> 0
   where
     pointerSize = sizeOf (nullPtr :: Ptr ())
     sizeSize = sizeOf (undefined :: CSize)
@@ -988,18 +992,19 @@ ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
             (mimePointer == nullPtr && mimeLength > 0)
                 || (bytesPointer == nullPtr && bytesLength > 0)
                 || mimeLength == 0
-        then fail "invalid image attachment"
+        then pure Nothing
         else do
             mimeBytes <- BS.packCStringLen
                 (castPtr mimePointer, fromIntegral mimeLength)
-            mime <- either (const (fail "invalid MIME UTF-8")) pure
-                (TextEncoding.decodeUtf8' mimeBytes)
+            let mime = TextEncoding.decodeUtf8' mimeBytes
             bytes <- BS.packCStringLen
                 (castPtr bytesPointer, fromIntegral bytesLength)
-            pure ImageAttachment
-                { imageMime = mime
-                , imageBytes = bytes
-                }
+            pure $ case mime of
+                Left _ -> Nothing
+                Right mimeValue -> Just ImageAttachment
+                    { imageMime = mimeValue
+                    , imageBytes = bytes
+                    }
 
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -146,6 +146,7 @@ typedef void (*ha_account_oauth_start_callback)(
     const uint8_t *error,
     size_t error_length
 );
+/*
  * An image submitted for a native turn. The runtime copies both buffers
  * before this call returns; the caller retains ownership of them.
  */

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -146,6 +146,15 @@ typedef void (*ha_account_oauth_start_callback)(
     const uint8_t *error,
     size_t error_length
 );
+ * An image submitted for a native turn. The runtime copies both buffers
+ * before this call returns; the caller retains ownership of them.
+ */
+typedef struct ha_image_attachment {
+    const uint8_t *mime;
+    size_t mime_length;
+    const uint8_t *bytes;
+    size_t bytes_length;
+} ha_image_attachment;
 
 /* Runtime calls are process-global and reference counted. */
 int32_t ha_runtime_init(void);
@@ -158,6 +167,19 @@ void ha_runtime_exit(void);
  * for an invalid request envelope.
  */
 void *ha_engine_create(ha_event_callback callback, void *context);
+/*
+ * Stage ordered images for a turn before its turn.start request. Staging is
+ * consumed by the matching turn.start. Returns 0 when accepted, 1 for a
+ * null engine, 2 for an invalid turn ID, 3 for an internal failure, and 4
+ * for an invalid image array or UTF-8 MIME.
+ */
+int32_t ha_engine_stage_turn_images(
+    void *engine,
+    const uint8_t *turn_id,
+    size_t turn_id_length,
+    const ha_image_attachment *images,
+    size_t image_count
+);
 int32_t ha_engine_send_json(
     void *engine,
     const uint8_t *bytes,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -169,10 +169,13 @@ void ha_runtime_exit(void);
  */
 void *ha_engine_create(ha_event_callback callback, void *context);
 /*
- * Stage ordered images for a turn before its turn.start request. Staging is
- * consumed by the matching turn.start. Returns 0 when accepted, 1 for a
- * null engine, 2 for an invalid turn ID, 3 for an internal failure, and 4
- * for an invalid image array or UTF-8 MIME.
+ * Stage an ordered image batch for a turn before its turn.start request.
+ * A later call for the same turn replaces the previous batch. Passing zero
+ * images discards that turn's batch, which callers should do if they abandon
+ * the request. Staging is also discarded when a request envelope or turn.start
+ * parameters are rejected, and is consumed by the matching valid turn.start.
+ * Returns 0 when accepted, 1 for a null engine, 2 for an invalid turn ID, 3
+ * for an internal failure, and 4 for an invalid image array or UTF-8 MIME.
  */
 int32_t ha_engine_stage_turn_images(
     void *engine,

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Agent.CLI.MacOS.BridgeFFISpec (spec) where
+
+import Foreign.C.Types (CInt(..))
+import Test.Hspec (Spec, describe, it, shouldReturn)
+
+foreign import ccall "ha_image_attachment_stage_smoke"
+    imageAttachmentStageSmoke :: IO CInt
+
+spec :: Spec
+spec = describe "native image attachment staging" do
+    it "accepts copied image buffers through the exported bridge" do
+        imageAttachmentStageSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -1,14 +1,23 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE CPP #-}
 
 module Agent.CLI.MacOS.BridgeFFISpec (spec) where
 
+#ifdef darwin_HOST_OS
 import Foreign.C.Types (CInt(..))
 import Test.Hspec (Spec, describe, it, shouldReturn)
 
 foreign import ccall "ha_image_attachment_stage_smoke"
     imageAttachmentStageSmoke :: IO CInt
+#else
+import Test.Hspec (Spec, describe, it, pendingWith)
+#endif
 
 spec :: Spec
 spec = describe "native image attachment staging" do
     it "accepts copied image buffers through the exported bridge" do
+#ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0
+#else
+        pendingWith "the native bridge smoke test only links on macOS"
+#endif

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Agent.CLI.MacOS.BridgeHeaderSpec (spec) where
+
+import Foreign.C.Types (CInt(..))
+import Test.Hspec (Spec, describe, it, shouldReturn)
+
+foreign import ccall "ha_image_attachment_abi_smoke"
+    imageAttachmentAbiSmoke :: IO CInt
+
+spec :: Spec
+spec = describe "native image attachment ABI" do
+    it "preserves the documented image struct layout and ordered buffers" do
+        imageAttachmentAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -28,6 +28,7 @@ import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
 import qualified Agent.CLI.MacOS.NativeLoopEventSpec as NativeLoopEventSpec
+import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
@@ -103,6 +104,7 @@ main = hspec do
     LoginSpec.spec
     LearnedSkillsSpec.spec
     NativeLoopEventSpec.spec
+    BridgeHeaderSpec.spec
     MarkdownSpec.spec
     McpManagerSpec.spec
     ModelConfigSpec.spec

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -29,6 +29,7 @@ import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
 import qualified Agent.CLI.MacOS.NativeLoopEventSpec as NativeLoopEventSpec
 import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
+import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
@@ -105,6 +106,7 @@ main = hspec do
     LearnedSkillsSpec.spec
     NativeLoopEventSpec.spec
     BridgeHeaderSpec.spec
+    BridgeFFISpec.spec
     MarkdownSpec.spec
     McpManagerSpec.spec
     ModelConfigSpec.spec

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -1,0 +1,73 @@
+#include "HaskellAgentBridge.h"
+
+#include <stddef.h>
+
+static void search_callback(
+    void *context,
+    int32_t status,
+    const uint8_t *session_id, size_t session_id_length,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *cwd, size_t cwd_length,
+    const uint8_t *provider, size_t provider_length,
+    const uint8_t *model, size_t model_length,
+    int64_t updated_at_ms, int32_t archived, int64_t turn_index,
+    int64_t occurred_at_ms, int32_t role,
+    const uint8_t *user_text, size_t user_text_length,
+    const uint8_t *assistant_text, size_t assistant_text_length,
+    double rank,
+    const uint8_t *error, size_t error_length
+) {
+    (void)context; (void)status; (void)session_id; (void)session_id_length;
+    (void)title; (void)title_length; (void)cwd; (void)cwd_length;
+    (void)provider; (void)provider_length; (void)model; (void)model_length;
+    (void)updated_at_ms; (void)archived; (void)turn_index;
+    (void)occurred_at_ms; (void)role; (void)user_text;
+    (void)user_text_length; (void)assistant_text;
+    (void)assistant_text_length; (void)rank; (void)error; (void)error_length;
+}
+
+/*
+ * Keep a native compile/run smoke check next to the public ABI. This catches
+ * accidental field reordering or type changes before the macOS client stages
+ * image buffers through the bridge.
+ */
+int ha_image_attachment_abi_smoke(void) {
+    ha_conversation_search_callback typed_search_callback = search_callback;
+    static const uint8_t first_mime[] = "image/png";
+    static const uint8_t first_bytes[] = {0x89, 0x50, 0x4e, 0x47};
+    static const uint8_t second_mime[] = "image/jpeg";
+    static const uint8_t second_bytes[] = {0xff, 0xd8, 0xff};
+    const ha_image_attachment images[] = {
+        {
+            .mime = first_mime,
+            .mime_length = sizeof(first_mime) - 1,
+            .bytes = first_bytes,
+            .bytes_length = sizeof(first_bytes),
+        },
+        {
+            .mime = second_mime,
+            .mime_length = sizeof(second_mime) - 1,
+            .bytes = second_bytes,
+            .bytes_length = sizeof(second_bytes),
+        },
+    };
+
+    if (typed_search_callback == NULL) {
+        return 3;
+    }
+    if (offsetof(ha_image_attachment, mime) != 0
+            || offsetof(ha_image_attachment, mime_length)
+                != sizeof(const uint8_t *)
+            || offsetof(ha_image_attachment, bytes)
+                != sizeof(const uint8_t *) + sizeof(size_t)
+            || offsetof(ha_image_attachment, bytes_length)
+                != 2 * sizeof(const uint8_t *) + sizeof(size_t)) {
+        return 1;
+    }
+    if (images[0].mime_length != 9 || images[1].mime_length != 10
+            || images[0].bytes_length != 4 || images[1].bytes_length != 3
+            || images[0].mime[0] != 'i' || images[1].mime[6] != 'j') {
+        return 2;
+    }
+    return 0;
+}

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -87,6 +87,14 @@ int ha_image_attachment_stage_smoke(void) {
     }
     int32_t status = ha_engine_stage_turn_images(
         engine, turn_id, sizeof(turn_id) - 1, images, 2);
+    if (status == 0) {
+        status = ha_engine_stage_turn_images(
+            engine, turn_id, sizeof(turn_id) - 1, images, 1);
+    }
+    if (status == 0) {
+        status = ha_engine_stage_turn_images(
+            engine, turn_id, sizeof(turn_id) - 1, NULL, 0);
+    }
     ha_engine_destroy(engine);
     ha_runtime_exit();
     return status;

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -2,37 +2,12 @@
 
 #include <stddef.h>
 
-static void search_callback(
-    void *context,
-    int32_t status,
-    const uint8_t *session_id, size_t session_id_length,
-    const uint8_t *title, size_t title_length,
-    const uint8_t *cwd, size_t cwd_length,
-    const uint8_t *provider, size_t provider_length,
-    const uint8_t *model, size_t model_length,
-    int64_t updated_at_ms, int32_t archived, int64_t turn_index,
-    int64_t occurred_at_ms, int32_t role,
-    const uint8_t *user_text, size_t user_text_length,
-    const uint8_t *assistant_text, size_t assistant_text_length,
-    double rank,
-    const uint8_t *error, size_t error_length
-) {
-    (void)context; (void)status; (void)session_id; (void)session_id_length;
-    (void)title; (void)title_length; (void)cwd; (void)cwd_length;
-    (void)provider; (void)provider_length; (void)model; (void)model_length;
-    (void)updated_at_ms; (void)archived; (void)turn_index;
-    (void)occurred_at_ms; (void)role; (void)user_text;
-    (void)user_text_length; (void)assistant_text;
-    (void)assistant_text_length; (void)rank; (void)error; (void)error_length;
-}
-
 /*
  * Keep a native compile/run smoke check next to the public ABI. This catches
  * accidental field reordering or type changes before the macOS client stages
  * image buffers through the bridge.
  */
 int ha_image_attachment_abi_smoke(void) {
-    ha_conversation_search_callback typed_search_callback = search_callback;
     static const uint8_t first_mime[] = "image/png";
     static const uint8_t first_bytes[] = {0x89, 0x50, 0x4e, 0x47};
     static const uint8_t second_mime[] = "image/jpeg";
@@ -52,9 +27,6 @@ int ha_image_attachment_abi_smoke(void) {
         },
     };
 
-    if (typed_search_callback == NULL) {
-        return 3;
-    }
     if (offsetof(ha_image_attachment, mime) != 0
             || offsetof(ha_image_attachment, mime_length)
                 != sizeof(const uint8_t *)

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -71,3 +71,41 @@ int ha_image_attachment_abi_smoke(void) {
     }
     return 0;
 }
+
+static void image_stage_callback(void *context, const uint8_t *bytes,
+                                 size_t length) {
+    (void)context;
+    (void)bytes;
+    (void)length;
+}
+
+/*
+ * Exercise the actual exported bridge entry points as a native caller would:
+ * initialize the runtime, create an engine, stage one image, and tear it down.
+ * The Haskell entry point copies the buffers before returning, so these
+ * stack-backed buffers are intentionally short-lived.
+ */
+int ha_image_attachment_stage_smoke(void) {
+    const uint8_t turn_id[] = "native-smoke-turn";
+    const uint8_t mime[] = "image/png";
+    const uint8_t bytes[] = {0x89, 0x50, 0x4e, 0x47};
+    const ha_image_attachment image = {
+        .mime = mime,
+        .mime_length = sizeof(mime) - 1,
+        .bytes = bytes,
+        .bytes_length = sizeof(bytes),
+    };
+    if (ha_runtime_init() != 0) {
+        return 10;
+    }
+    void *engine = ha_engine_create(image_stage_callback, NULL);
+    if (engine == NULL) {
+        ha_runtime_exit();
+        return 11;
+    }
+    int32_t status = ha_engine_stage_turn_images(
+        engine, turn_id, sizeof(turn_id) - 1, &image, 1);
+    ha_engine_destroy(engine);
+    ha_runtime_exit();
+    return status;
+}

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -59,13 +59,23 @@ static void image_stage_callback(void *context, const uint8_t *bytes,
  */
 int ha_image_attachment_stage_smoke(void) {
     const uint8_t turn_id[] = "native-smoke-turn";
-    const uint8_t mime[] = "image/png";
-    const uint8_t bytes[] = {0x89, 0x50, 0x4e, 0x47};
-    const ha_image_attachment image = {
-        .mime = mime,
-        .mime_length = sizeof(mime) - 1,
-        .bytes = bytes,
-        .bytes_length = sizeof(bytes),
+    const uint8_t first_mime[] = "image/png";
+    const uint8_t first_bytes[] = {0x89, 0x50, 0x4e, 0x47};
+    const uint8_t second_mime[] = "image/jpeg";
+    const uint8_t second_bytes[] = {0xff, 0xd8, 0xff};
+    const ha_image_attachment images[] = {
+        {
+            .mime = first_mime,
+            .mime_length = sizeof(first_mime) - 1,
+            .bytes = first_bytes,
+            .bytes_length = sizeof(first_bytes),
+        },
+        {
+            .mime = second_mime,
+            .mime_length = sizeof(second_mime) - 1,
+            .bytes = second_bytes,
+            .bytes_length = sizeof(second_bytes),
+        },
     };
     if (ha_runtime_init() != 0) {
         return 10;
@@ -76,7 +86,7 @@ int ha_image_attachment_stage_smoke(void) {
         return 11;
     }
     int32_t status = ha_engine_stage_turn_images(
-        engine, turn_id, sizeof(turn_id) - 1, &image, 1);
+        engine, turn_id, sizeof(turn_id) - 1, images, 2);
     ha_engine_destroy(engine);
     ha_runtime_exit();
     return status;


### PR DESCRIPTION
## Summary

- add a typed C ABI for staging ordered image attachments by turn ID
- copy staged buffers into the runtime and consume them when the matching turn starts
- route native images through the existing managed multimodal turn path
- add C ABI layout and live engine staging smoke tests

## Validation

- `nix develop --command cabal v2-test agent-cli:test:agent-cli-test --test-option=--match --test-option="native image attachment"`
- coordinated macOS Nix build and Swift tests in the companion app checkout