### PR TITLE
Add native learned-memory listing bridge

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -145,6 +145,7 @@ import Control.Concurrent.STM
 import Control.Applicative ((<|>))
 import Control.Exception.Safe
     ( SomeException
+    , bracket
     , finally
     , tryAny
     )
@@ -518,24 +519,15 @@ ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
             tryAny (listLearnedSkillsFor (Text.unpack cwd)) >>= \case
                 Left exception ->
                     withText (Text.pack (show exception)) $ \errorPtr errorLength ->
-                        invokeLearnedSkillsListCallback callback context (-1)
-                            nullPtr 0 nullPtr 0 0
-                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-                            nullPtr 0 nullPtr 0 nullPtr 0 0 errorPtr errorLength
+                        learnedSkillsTerminal callback context (-1) errorPtr errorLength
                 Right (Left err) ->
                     withText err $ \errorPtr errorLength ->
-                        invokeLearnedSkillsListCallback callback context (-1)
-                            nullPtr 0 nullPtr 0 0
-                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-                            nullPtr 0 nullPtr 0 nullPtr 0 0 errorPtr errorLength
+                        learnedSkillsTerminal callback context (-1) errorPtr errorLength
                 Right (Right skills) -> do
                     forM_ skills \skill ->
                         withLearnedSkillStrings skill $
                             invokeLearnedSkillsListCallback callback context 0
-                    invokeLearnedSkillsListCallback callback context 1
-                        nullPtr 0 nullPtr 0 0
-                        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-                        nullPtr 0 nullPtr 0 nullPtr 0 0 nullPtr 0 nullPtr 0
+                    learnedSkillsTerminal callback context 1 nullPtr 0
         pure 0
   where
     listLearnedSkillsFor cwd = do
@@ -550,12 +542,12 @@ ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
                 store <- openStore =<< managedPostgresConfigForHome home
                 case store of
                     Left err -> pure (Left (renderStoreError err))
-                    Right opened -> do
-                        result <- listAllLearnedSkills
-                            (trustedPool opened)
-                            (applicableDatabaseScopes databaseScopes)
-                        closeStore opened
-                        pure (first renderStoreError result)
+                    Right opened ->
+                        bracket (pure opened) closeStore \store ->
+                            first renderStoreError
+                                <$> listAllLearnedSkills
+                                    (trustedPool store)
+                                    (applicableDatabaseScopes databaseScopes)
 
 type LearnedSkillItemCallback =
     CString -> CSize -> CString -> CSize -> CLLong
@@ -581,6 +573,16 @@ withLearnedSkillStrings skill action =
             activation activationLength status statusLength
             (fromIntegral skill.learnedSkillPriority) updated updatedLength
             nullPtr 0
+
+learnedSkillsTerminal
+    :: FunPtr LearnedSkillsListCallback
+    -> Ptr () -> CInt -> CString -> CSize -> IO ()
+learnedSkillsTerminal callback context status errorPtr errorLength =
+    invokeLearnedSkillsListCallback callback context status
+        nullPtr 0 nullPtr 0 0
+        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+        nullPtr 0 nullPtr 0 nullPtr 0
+        0 nullPtr 0 errorPtr errorLength
 
 ha_accounts_list
     :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -14,6 +14,14 @@ import Agent.Store.Postgres.Session
     ( NativeConversationSearchResult(..)
     , searchNativeConversations
     )
+import Data.Bifunctor (first)
+import Agent.Store.Postgres.Scope (scopeKindText)
+import Agent.Store.Postgres.Skill
+    ( LearnedSkill(..)
+    , learnedSkillActivationText
+    , learnedSkillStatusText
+    , listAllLearnedSkills
+    )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     )
@@ -47,6 +55,10 @@ import qualified Agent.OpenAI.Auth.Types as OpenAIAuthTypes
 import qualified Agent.XAI.Auth as XAIAuth
 import qualified Agent.OpenRouter.Usage as OpenRouter
 import Agent.CLI.ModelConfig (loadModelCatalogAt)
+import Agent.CLI.Database.Store
+    ( applicableDatabaseScopes
+    , deriveDatabaseScopes
+    )
 import Agent.CLI.Models
     ( ModelOption(..)
     , ModelTarget(..)
@@ -186,6 +198,7 @@ import System.IO
     )
 import System.OsPath
     ( OsPath
+    , decodeFS
     , takeDirectory
     , unsafeEncodeUtf
     )
@@ -245,6 +258,13 @@ type SearchCallback =
     -> Ptr Word8 -> CSize -- error
     -> IO ()
 
+type LearnedSkillsListCallback =
+    Ptr () -> CInt
+    -> CString -> CSize -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -266,6 +286,10 @@ foreign import ccall "dynamic"
 
 foreign import ccall "dynamic"
     invokeSearchCallback :: FunPtr SearchCallback -> SearchCallback
+
+foreign import ccall "dynamic"
+    invokeLearnedSkillsListCallback
+        :: FunPtr LearnedSkillsListCallback -> LearnedSkillsListCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -479,6 +503,84 @@ foreign export ccall ha_account_set_enabled
 
 foreign export ccall ha_account_delete
     :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_learned_skills_list
+    :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
+
+ha_learned_skills_list
+    :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
+ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
+    | callback == nullFunPtr = pure 1
+    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
+    | otherwise = do
+        cwd <- decodeInput cwdBytes cwdLength
+        _ <- forkIO do
+            tryAny (listLearnedSkillsFor (Text.unpack cwd)) >>= \case
+                Left exception ->
+                    withText (Text.pack (show exception)) $ \errorPtr errorLength ->
+                        invokeLearnedSkillsListCallback callback context (-1)
+                            nullPtr 0 nullPtr 0 0
+                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                            nullPtr 0 nullPtr 0 nullPtr 0 0 errorPtr errorLength
+                Right (Left err) ->
+                    withText err $ \errorPtr errorLength ->
+                        invokeLearnedSkillsListCallback callback context (-1)
+                            nullPtr 0 nullPtr 0 0
+                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                            nullPtr 0 nullPtr 0 nullPtr 0 0 errorPtr errorLength
+                Right (Right skills) -> do
+                    forM_ skills \skill ->
+                        withLearnedSkillStrings skill $
+                            invokeLearnedSkillsListCallback callback context 0
+                    invokeLearnedSkillsListCallback callback context 1
+                        nullPtr 0 nullPtr 0 0
+                        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                        nullPtr 0 nullPtr 0 nullPtr 0 0 nullPtr 0 nullPtr 0
+        pure 0
+  where
+    listLearnedSkillsFor cwd = do
+        home <- getHomeDirectory
+        projectRoot <- resolveProjectRoot (unsafeEncodeUtf cwd)
+        stateDirectory <- decodeFS (takeDirectory (sessionsRoot home))
+        projectRootPath <- decodeFS projectRoot
+        scopes <- deriveDatabaseScopes stateDirectory projectRootPath
+        case scopes of
+            Left err -> pure (Left err)
+            Right databaseScopes -> do
+                store <- openStore =<< managedPostgresConfigForHome home
+                case store of
+                    Left err -> pure (Left (renderStoreError err))
+                    Right opened -> do
+                        result <- listAllLearnedSkills
+                            (trustedPool opened)
+                            (applicableDatabaseScopes databaseScopes)
+                        closeStore opened
+                        pure (first renderStoreError result)
+
+type LearnedSkillItemCallback =
+    CString -> CSize -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
+withLearnedSkillStrings :: LearnedSkill -> LearnedSkillItemCallback -> IO ()
+withLearnedSkillStrings skill action =
+    withText (scopeKindText skill.learnedSkillScope.scopeKind) $ \scope scopeLength ->
+    withText skill.learnedSkillSlug $ \slug slugLength ->
+    withText skill.learnedSkillTitle $ \title titleLength ->
+    withText skill.learnedSkillDescription $ \description descriptionLength ->
+    withText skill.learnedSkillAppliesWhen $ \applies appliesLength ->
+    withText skill.learnedSkillInstructions $ \instructions instructionsLength ->
+    withText (learnedSkillActivationText skill.learnedSkillActivation) $ \activation activationLength ->
+    withText (learnedSkillStatusText skill.learnedSkillStatus) $ \status statusLength ->
+    withText (Text.pack (show skill.learnedSkillUpdatedAt)) $ \updated updatedLength ->
+        action scope scopeLength slug slugLength
+            (fromIntegral skill.learnedSkillRevision)
+            title titleLength description descriptionLength
+            applies appliesLength instructions instructionsLength
+            activation activationLength status statusLength
+            (fromIntegral skill.learnedSkillPriority) updated updatedLength
+            nullPtr 0
 
 ha_accounts_list
     :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -15,7 +15,7 @@ import Agent.Store.Postgres.Session
     , searchNativeConversations
     )
 import Data.Bifunctor (first)
-import Agent.Store.Postgres.Scope (scopeKindText)
+import Agent.Store.Postgres.Scope (Scope(..), scopeKindText)
 import Agent.Store.Postgres.Skill
     ( LearnedSkill(..)
     , learnedSkillActivationText
@@ -581,7 +581,7 @@ learnedSkillsTerminal callback context status errorPtr errorLength =
     invokeLearnedSkillsListCallback callback context status
         nullPtr 0 nullPtr 0 0
         nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-        nullPtr 0 nullPtr 0 nullPtr 0
+        nullPtr 0 nullPtr 0
         0 nullPtr 0 errorPtr errorLength
 
 ha_accounts_list

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -57,6 +57,32 @@ typedef void (*ha_conversation_search_callback)(
 );
 
 /*
+ * Learned-skill list callbacks emit current rows from all applicable scopes,
+ * including archived skills. Status is 0 for an item, 1 for end-of-list, and
+ * -1 for an error. UTF-8 buffers are callback-scoped and must be copied.
+ */
+typedef void (*ha_learned_skills_list_callback)(
+    void *context, int32_t status,
+    const uint8_t *scope, size_t scope_length,
+    const uint8_t *slug, size_t slug_length,
+    int64_t revision,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *description, size_t description_length,
+    const uint8_t *applies_when, size_t applies_when_length,
+    const uint8_t *instructions, size_t instructions_length,
+    const uint8_t *activation, size_t activation_length,
+    const uint8_t *status_text, size_t status_text_length,
+    int32_t priority,
+    const uint8_t *updated_at, size_t updated_at_length,
+    const uint8_t *error, size_t error_length
+);
+
+int32_t ha_learned_skills_list(
+    const uint8_t *cwd, size_t cwd_length,
+    ha_learned_skills_list_callback callback, void *context
+);
+
+/*
  * Account list callbacks use status 0 for an item, 1 for end-of-list, and
  * -1 for an error. Item strings include disabled managed credentials and
  * externally discovered accounts.

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill.hs
@@ -34,6 +34,7 @@ module Agent.Store.Postgres.Skill
     , readLearnedSkill
     , searchLearnedSkills
     , listApplicableLearnedSkills
+    , listAllLearnedSkills
     , listLearnedSkillRevisions
     , listLearnedSkillSources
     ) where
@@ -506,6 +507,18 @@ listApplicableLearnedSkills pool scopes =
                 (HasqlSession.statement applicable listSkillsStatement)
                 >>= pure . decodeSkillListResult
 
+listAllLearnedSkills
+    :: StorePool
+    -> [Scope]
+    -> IO (Either StoreError [LearnedSkill])
+listAllLearnedSkills pool scopes =
+    case applicableScopes scopes of
+        Left err -> pure (Left (StoreDataError err))
+        Right applicable ->
+            withSession pool
+                (HasqlSession.statement applicable listAllSkillsStatement)
+                >>= pure . decodeSkillListResult
+
 listLearnedSkillRevisions
     :: StorePool
     -> Scope
@@ -818,6 +831,15 @@ insertSkillStatement = mkStatement
         <> ((.learnedSkillCreateAt) >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
     )
     (Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.text)))
+    True
+
+listAllSkillsStatement :: Statement ApplicableScopes [SkillRow]
+listAllSkillsStatement = mkStatement
+    (skillSelectSql
+        <> applicableWhereSql
+        <> " ORDER BY scope_kind, title, slug")
+    applicableScopesEncoder
+    (Decoders.rowList skillRowDecoder)
     True
 
 updateSkillStatement :: Statement LearnedSkill ()


### PR DESCRIPTION
## Summary
- add a typed native callback API for listing learned skills
- include active and archived skills from applicable user, repository, and checkout scopes
- expose the store query needed by the macOS memory viewer

## Validation
- `nix develop -c cabal build agent-cli:flib:haskell-agent-bridge --offline`
- authoritative C header syntax check
- full downstream macOS Nix package build using this checkout