### PR TITLE
Make shell command workdir optional

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -23,11 +23,17 @@ import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.ToolDispatch (noArgsTool)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.Codex.Dialect.ApplyPatch (applyPatchGrammar)
+import Agent.Codex.Dialect.Runtime
+    ( CodexCodingTools(..)
+    , newCodexCodingTools
+    )
 import Agent.Tools.MultiAgents (MultiAgentContext(..), multiAgentTools)
 import Agent.Tools.CodeMode.Tool (ToolMode(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
+    , ToolSchema(..)
+    , defaultToolEnv
     , freeformApplyPatchAppTool
     , jsonAppTool
     , rawJsonAppTool
@@ -70,6 +76,48 @@ spec = describe "schemasFromAppTools" do
                 tool.name `shouldBe` "read_file"
                 tool.strict `shouldBe` Just True
             other -> expectationFailure ("expected function tool, got " <> show other)
+
+    it "keeps shell_command workdir optional in direct and code-only mode" do
+        env <- defaultToolEnv (unsafeEncodeUtf "/tmp")
+        bracket
+            (newCodexCodingTools env Nothing Nothing)
+            (.codexClose)
+            \coding ->
+                case
+                    [ tool
+                    | tool <- coding.codexAppTools
+                    , tool.appToolName == "shell_command"
+                    ] of
+                    [shell] -> do
+                        shell.appToolSchema `shouldSatisfy` \case
+                            RawJsonFunctionSchema _ -> True
+                            _ -> False
+
+                        assertOptionalShellSchema $
+                            schemasFromAppTools
+                                codexDialect
+                                coding.codexAppTools
+
+                        let projection =
+                                projectCodeModeTools
+                                    CodeOnlyToolMode
+                                    coding.codexAppTools
+                            projectedSchemas tools =
+                                [ tool.appToolSchema
+                                | tool <- tools
+                                , tool.appToolName == "shell_command"
+                                ]
+                        projectedSchemas projection.directCodeModeTools
+                            `shouldBe` [shell.appToolSchema]
+                        projectedSchemas projection.nestedCodeModeTools
+                            `shouldBe` [shell.appToolSchema]
+                        assertOptionalShellSchema $
+                            schemasFromAppToolsCodeMode
+                                codexDialect
+                                projection.directCodeModeTools
+                    other -> expectationFailure
+                        ("expected one shell_command app tool, got "
+                            <> show (map (.appToolName) other))
 
     it "does not advertise harness tools to the Claude Code subprocess" do
         schemasFromAppTools claudeCodeDialect [jsonTool, patchTool]
@@ -385,3 +433,17 @@ decodeRaw decoder =
 
 rawJsonValue :: Aeson.ToJSON value => value -> RawJson
 rawJsonValue = rawJsonFromEncoding . Aeson.toEncoding
+
+assertOptionalShellSchema :: [ResponseTool] -> Expectation
+assertOptionalShellSchema tools =
+    case functionToolsNamed "shell_command" tools of
+        [shell] -> do
+            shell.strict `shouldBe` Just False
+            required_ shell `shouldBe` Just ["command"]
+            shell.description `shouldSatisfy`
+                maybe False (Text.isInfixOf "`workdir` is optional")
+            propertyNames shell `shouldMatchList`
+                ["command", "workdir", "timeout_ms", "yield_time_ms"]
+            propertyType "workdir" shell `shouldBe` Just "string"
+        other -> expectationFailure
+            ("expected one shell_command function schema, got " <> show other)

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Prompt.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Prompt.hs
@@ -17,7 +17,7 @@ codexSystemPrompt cwd today =
         , "Today's date is " <> formattedToday <> "."
         , ""
         , "Use these tools:"
-        , "- Inspect files with read_file, grep, and list_dir. Outside Plan Mode, shell_command is also available; always set workdir."
+        , "- Inspect files with read_file, grep, and list_dir. Outside Plan Mode, shell_command is also available; omit workdir to use the turn cwd."
         , "- Edit files with apply_patch. Never call applypatch or apply-patch."
         , "- For every multi-step task, call update_plan before starting (unavailable in Plan Mode)."
         , "- Keep the checklist current: mark steps completed immediately after verification, keep exactly one step in_progress, and leave unfinished work pending or remove it rather than claiming completion."
@@ -54,7 +54,7 @@ codexSystemPromptForTools available cwd today =
         , "Use the registered tools:"
         ]
             <> toolLine "shell_command"
-                "- Inspect the repo and run system commands with shell_command. Always set workdir."
+                "- Inspect the repo and run system commands with shell_command. Omit workdir to use the turn cwd."
             <> toolLine "apply_patch"
                 "- Edit files with apply_patch. Never call applypatch or apply-patch."
             <> toolLine "update_plan"

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -14,6 +14,7 @@ import qualified Agent.Json.Decode as Json
 import Agent.ToolDSL
     ( PropertySchema(..)
     , PropertyType(..)
+    , parametersObjectLoose
     )
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -67,6 +68,7 @@ import Agent.Tools.Types
     , freeformApplyPatchAppToolWithExecution
     , jsonAppToolWithExecution
     , jsonTool
+    , rawJsonAppToolWithExecution
     , withToolResourceClaims
     )
 import Data.Maybe (fromMaybe)
@@ -120,19 +122,26 @@ shellCommandArgsDecoder = Json.object $
 shellCommandTool :: ToolEnv -> CodexShellSession -> AppTool
 shellCommandTool env session =
     withToolResourceClaims (shellCommandResourceClaims env) $
-    jsonTool "shell_command" shellDescription
-    [ PropertySchema "command" PropertyString True $ Just
-        "Shell script to run in the user's default shell."
-    , PropertySchema "workdir" PropertyString False $ Just
-        "Working directory for the command. Defaults to the turn cwd."
-    , PropertySchema "timeout_ms" PropertyInteger False $ Just
-        "Maximum foreground command runtime. Defaults to 10000 ms. Mutually exclusive with yield_time_ms."
-    , PropertySchema "yield_time_ms" PropertyInteger False $ Just
-        "Return a session_id if the command is still running after this many milliseconds. Mutually exclusive with timeout_ms."
-    ]
-    False
-    TurnSequential
-    (typedStreamingTool "shell_command" shellCommandArgsDecoder (runShell env session))
+    -- Strict OpenAI schemas require every declared property on the wire.
+    -- shell_command instead mirrors Codex's non-strict schema so workdir and
+    -- the timing controls can actually be omitted.
+    rawJsonAppToolWithExecution "shell_command" shellDescription
+        (parametersObjectLoose
+            [ PropertySchema "command" PropertyString True $ Just
+                "Shell script to run in the user's default shell."
+            , PropertySchema "workdir" PropertyString False $ Just
+                "Working directory for the command. Defaults to the turn cwd."
+            , PropertySchema "timeout_ms" PropertyInteger False $ Just
+                "Maximum foreground command runtime. Defaults to 10000 ms. Mutually exclusive with yield_time_ms."
+            , PropertySchema "yield_time_ms" PropertyInteger False $ Just
+                "Return a session_id if the command is still running after this many milliseconds. Mutually exclusive with timeout_ms."
+            ])
+        AlwaysPrompt
+        TurnSequential
+        (typedStreamingTool
+            "shell_command"
+            shellCommandArgsDecoder
+            (runShell env session))
 
 shellCommandResourceClaims
     :: ToolEnv
@@ -159,7 +168,7 @@ shellCommandResourceClaims env call =
 shellDescription :: Text
 shellDescription =
     "Runs a shell command and returns its output.\n\
-    \- Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary.\n\
+    \- `workdir` is optional; omit it to use the turn cwd. Do not use `cd` unless absolutely necessary.\n\
     \- For a long-running command, set `yield_time_ms`; if it is still running, use `write_stdin` with the returned session_id to poll or send input."
 
 runShell

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -2,17 +2,27 @@ module Agent.Codex.DialectSpec (spec) where
 
 import Agent.Codex.Dialect.ApplyPatch (applyPatch)
 import Agent.Codex.Dialect.ProjectInstructions (formatCodexAgentsMd)
-import Agent.Codex.Dialect.Prompt (codexSystemPrompt)
+import Agent.Codex.Dialect.Prompt
+    ( codexSystemPrompt
+    , codexSystemPromptForTools
+    )
 import Agent.Codex.Dialect.Runtime
     ( CodexCodingTools(..)
     , newCodexCodingTools
     )
 import Agent.Codex.Dialect.Tools (shellCommandIsReadOnly)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
-import Agent.ToolDispatch (customToolCall, functionToolCall)
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , customToolCall
+    , dispatchToolCall
+    , functionToolCall
+    )
 import Agent.Tools.Scheduling (schedulingPlansConflict)
 import Agent.Tools.Types
     ( AppTool(..)
+    , appToolHandlers
     , defaultToolEnv
     , mkToolRegistry
     , toolSchedulingPlanFor
@@ -41,6 +51,20 @@ spec = describe "Codex dialect" do
         prompt `shouldSatisfy` Text.isInfixOf "shell_command"
         prompt `shouldSatisfy` Text.isInfixOf "apply_patch"
         prompt `shouldSatisfy` Text.isInfixOf "<proposed_plan>"
+        Text.toLower prompt
+            `shouldSatisfy` Text.isInfixOf "omit workdir"
+        Text.toLower prompt
+            `shouldNotSatisfy` Text.isInfixOf "always set workdir"
+
+        let dynamicPrompt =
+                codexSystemPromptForTools
+                    ["shell_command"]
+                    (unsafeEncodeUtf "/repo")
+                    (fromGregorian 2026 8 23)
+        Text.toLower dynamicPrompt
+            `shouldSatisfy` Text.isInfixOf "omit workdir"
+        Text.toLower dynamicPrompt
+            `shouldNotSatisfy` Text.isInfixOf "always set workdir"
 
     it "constructs only the Codex tool surface" do
         withTempDir \dir -> do
@@ -56,6 +80,24 @@ spec = describe "Codex dialect" do
                 `shouldBe` replicate 4 True
             names `shouldNotContain` ["run_terminal_cmd", "search_replace"]
             coding.codexClose
+
+    it "defaults shell_command to the turn cwd when workdir is omitted" do
+        withTempDir \dir -> do
+            Text.writeFile (dir </> "cwd-marker") "present"
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket
+                (newCodexCodingTools env Nothing Nothing)
+                (.codexClose)
+                \coding -> do
+                    result <- dispatchToolCall
+                        testDispatchConfig
+                        (appToolHandlers coding.codexAppTools)
+                        (functionToolCall
+                            "shell-default-cwd"
+                            "shell_command"
+                            "{\"command\":\"test -f cwd-marker && printf cwd-defaulted\"}")
+                    result.output
+                        `shouldSatisfy` Text.isInfixOf "cwd-defaulted"
 
     it "formats project instructions as a contextual user fragment" do
         let loaded = LoadedAgentsMd
@@ -243,3 +285,13 @@ withTempDir action = do
         (mkdtemp (tmp </> "agent-codex-dialect-XXXXXX"))
         removeDirectoryRecursive
         action
+
+testDispatchConfig :: ToolDispatchConfig
+testDispatchConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    , toolDispatchFinalizeOutput = \_call output -> pure output
+    }


### PR DESCRIPTION
## Summary

- advertise `shell_command` with a non-strict OpenAI schema so only `command` is required on the wire
- stop prompting models to always emit `workdir`; omitted workdirs continue to use the turn cwd
- retain the loose schema in conventional and code-only tool projections
- add regressions for wire requiredness, prompt text, and default-cwd execution

## Motivation

The generic strict-schema projection turns application-optional fields into required-but-nullable fields. Combined with the Codex prompt that always required `workdir`, this could trigger recursive, extremely large `workdir` arguments on `gpt-5.6-sol`. This makes the shell contract match its runtime behavior and the non-strict Codex-style schema.

## Testing

- `nix develop -c cabal test --offline agent-codex-dialect:test:agent-codex-dialect-test --test-options='--match "Codex dialect"'` (10 examples)
- `nix develop -c cabal test --offline agent-cli:test:agent-cli-test --test-options='--match "schemasFromAppTools"'` (15 examples)
- live tmux smoke test with `gpt-5.6-sol`: generated `Main.hs`, ran `runghc Main.hs`, and printed `Hello, world!` without argument runaway