### PR TITLE
Expose model reasoning effort capabilities

### DIFF
--- a/packages/agent-cli/config/models.default.json
+++ b/packages/agent-cli/config/models.default.json
@@ -24,6 +24,8 @@
       "connection": "openai",
       "dialect": "codex",
       "label": "default · frontier",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "low",
       "default": true,
       "fallback_priority": 0
     },
@@ -31,13 +33,17 @@
       "id": "gpt-5.6-terra",
       "connection": "openai",
       "dialect": "codex",
-      "label": "balanced"
+      "label": "balanced",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "medium"
     },
     {
       "id": "gpt-5.6-luna",
       "connection": "openai",
       "dialect": "codex",
-      "label": "fast · low cost"
+      "label": "fast · low cost",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "medium"
     },
     {
       "id": "grok-4.6",
@@ -45,6 +51,8 @@
       "dialect": "grok-build",
       "context_window": 500000,
       "label": "default",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh"],
+      "default_reasoning_effort": "high",
       "default": true,
       "fallback_priority": 10
     },
@@ -62,19 +70,25 @@
       "connection": "claude-code",
       "dialect": "claude-code",
       "label": "default · subscription",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "xhigh",
       "default": true
     },
     {
       "id": "opus",
       "connection": "claude-code",
       "dialect": "claude-code",
-      "label": "previous frontier · subscription"
+      "label": "previous frontier · subscription",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "xhigh"
     },
     {
       "id": "fable",
       "connection": "claude-code",
       "dialect": "claude-code",
-      "label": "frontier · subscription"
+      "label": "frontier · subscription",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "xhigh"
     }
   ]
 }

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -59,7 +59,12 @@ import qualified Agent.OpenAI.Auth as OpenAIAuth
 import qualified Agent.OpenAI.Auth.Types as OpenAIAuthTypes
 import qualified Agent.XAI.Auth as XAIAuth
 import qualified Agent.OpenRouter.Usage as OpenRouter
-import Agent.CLI.ModelConfig (loadModelCatalogAt)
+import Agent.CLI.ModelConfig
+    ( CatalogModel(..)
+    , ModelCatalog
+    , catalogModelById
+    , loadModelCatalogAt
+    )
 import Agent.CLI.Database.Store
     ( applicableDatabaseScopes
     , deriveDatabaseScopes
@@ -1785,9 +1790,10 @@ loadNativeModelCatalog store root request = do
                                 target.targetDialect
                             pure $ Right $ Aeson.object
                                 [ "options" Aeson..=
-                                    map modelOptionJSON picker.pickerAll
+                                    map (modelOptionJSON catalog)
+                                        picker.pickerAll
                                 , "current" Aeson..=
-                                    fmap modelOptionJSON
+                                    fmap (modelOptionJSON catalog)
                                         (selectedOption picker)
                                 ]
 
@@ -1821,9 +1827,11 @@ sessionModelTarget meta =
         , targetDialect = meta.metaDialect
         }
 
-modelOptionJSON :: ModelOption -> Aeson.Value
-modelOptionJSON option =
+modelOptionJSON :: ModelCatalog -> ModelOption -> Aeson.Value
+modelOptionJSON catalog option =
     let target = option.modelTarget
+        configured =
+            catalogModelById catalog target.targetModelId
     in Aeson.object
         [ "id" Aeson..= target.targetModelId
         , "provider" Aeson..= providerSlug target.targetProvider
@@ -1831,6 +1839,10 @@ modelOptionJSON option =
         , "wireModel" Aeson..= target.targetWireModelId
         , "dialect" Aeson..= dialectSlug target.targetDialect
         , "label" Aeson..= option.modelLabel
+        , "supportedReasoningEfforts" Aeson..=
+            (configured >>= (.catalogModelReasoningEfforts))
+        , "defaultReasoningEffort" Aeson..=
+            (configured >>= (.catalogModelDefaultReasoningEffort))
         ]
 
 parseParams :: Aeson.FromJSON value => BridgeRequest -> Either Text value

--- a/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
@@ -47,7 +47,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlpha, isAlphaNum, isSpace)
 import Data.Foldable (traverse_)
-import Data.List (find)
+import Data.List (find, nub)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
@@ -86,6 +86,8 @@ data CatalogModel = CatalogModel
     , catalogModelDialect :: !DialectId
     , catalogModelContextWindow :: !(Maybe Int)
     , catalogModelLabel :: !(Maybe Text)
+    , catalogModelReasoningEfforts :: !(Maybe [Text])
+    , catalogModelDefaultReasoningEffort :: !(Maybe Text)
     , catalogModelDefault :: !Bool
     , catalogModelFallbackPriority :: !(Maybe Int)
     }
@@ -121,6 +123,8 @@ data ModelFile = ModelFile
     , modelFileDialect :: !Text
     , modelFileContextWindow :: !(Maybe Int)
     , modelFileLabel :: !(Maybe Text)
+    , modelFileReasoningEfforts :: !(Maybe [Text])
+    , modelFileDefaultReasoningEffort :: !(Maybe Text)
     , modelFileDefault :: !Bool
     , modelFileFallbackPriority :: !(Maybe Int)
     }
@@ -152,6 +156,8 @@ instance FromJSON ModelFile where
             <*> object .: "dialect"
             <*> object .:? "context_window"
             <*> object .:? "label"
+            <*> object .:? "reasoning_efforts"
+            <*> object .:? "default_reasoning_effort"
             <*> object .:? "default" .!= False
             <*> object .:? "fallback_priority"
 
@@ -432,6 +438,12 @@ validateConfig source config = do
         let modelId = Text.strip raw.modelFileId
             connectionId = Text.strip raw.modelFileConnection
             wireId = Text.strip (fromMaybe modelId raw.modelFileWireId)
+            reasoningEfforts = fmap
+                (map (Text.toLower . Text.strip))
+                raw.modelFileReasoningEfforts
+            defaultReasoningEffort =
+                Text.toLower . Text.strip
+                    <$> raw.modelFileDefaultReasoningEffort
         when (Text.null modelId || Text.any isSpace modelId) $
             Left ("model id must be nonempty and contain no whitespace: "
                 <> raw.modelFileId)
@@ -474,6 +486,37 @@ validateConfig source config = do
                 Left ("model " <> modelId
                     <> " context_window must be positive"))
             raw.modelFileContextWindow
+        unless
+            ( maybe True
+                (all (`elem` supportedReasoningEfforts))
+                reasoningEfforts
+            ) $
+            Left
+                ( "model " <> modelId
+                    <> " has unsupported reasoning_efforts; expected "
+                    <> Text.intercalate ", " supportedReasoningEfforts
+                )
+        traverse_
+            (\efforts -> do
+                when (null efforts) $
+                    Left
+                        ( "model " <> modelId
+                            <> " reasoning_efforts must not be empty"
+                        )
+                when (length efforts /= length (nub efforts)) $
+                    Left
+                        ( "model " <> modelId
+                            <> " reasoning_efforts must not contain duplicates"
+                        ))
+            reasoningEfforts
+        traverse_
+            (\effort -> unless (maybe False (effort `elem`) reasoningEfforts) $
+                Left
+                    ( "model " <> modelId
+                        <> " default_reasoning_effort must be listed in "
+                        <> "reasoning_efforts"
+                    ))
+            defaultReasoningEffort
         pure CatalogModel
             { catalogModelId = modelId
             , catalogModelConnectionId = connectionId
@@ -483,10 +526,17 @@ validateConfig source config = do
                 raw.modelFileContextWindow
             , catalogModelLabel =
                 nonEmptyText =<< raw.modelFileLabel
+            , catalogModelReasoningEfforts = reasoningEfforts
+            , catalogModelDefaultReasoningEffort =
+                defaultReasoningEffort
             , catalogModelDefault = raw.modelFileDefault
             , catalogModelFallbackPriority =
                 raw.modelFileFallbackPriority
             }
+
+supportedReasoningEfforts :: [Text]
+supportedReasoningEfforts =
+    ["none", "low", "medium", "high", "xhigh", "max"]
 
 validateBuiltinDefault :: [CatalogModel] -> Provider -> Either Text ()
 validateBuiltinDefault models provider =

--- a/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
@@ -45,6 +45,25 @@ spec = describe "Agent.CLI.ModelConfig" do
                 , "gpt-5.6-terra"
                 , "gpt-5.6-luna"
                 ]
+        let modelById modelId =
+                findModel modelId catalog.catalogModels
+        fmap (.catalogModelReasoningEfforts)
+            (modelById "gpt-5.6-sol")
+            `shouldBe`
+                Just (Just ["low", "medium", "high", "xhigh", "max"])
+        fmap (.catalogModelDefaultReasoningEffort)
+            (modelById "gpt-5.6-sol")
+            `shouldBe` Just (Just "low")
+        fmap (.catalogModelReasoningEfforts)
+            (modelById "grok-4.6")
+            `shouldBe`
+                Just (Just ["low", "medium", "high", "xhigh"])
+        fmap (.catalogModelDefaultReasoningEffort)
+            (modelById "grok-4.6")
+            `shouldBe` Just (Just "high")
+        fmap (.catalogModelReasoningEfforts)
+            (modelById "stealth/ox-alpha")
+            `shouldBe` Just Nothing
 
     it "adds a custom Responses connection and model" do
         defaults <- readPackagedDefaults
@@ -187,6 +206,41 @@ spec = describe "Agent.CLI.ModelConfig" do
             (Just ("models.json", overlay))
             `shouldSatisfy` leftContains "context_window must be positive"
 
+    it "rejects invalid or duplicate reasoning efforts" do
+        defaults <- readPackagedDefaults
+        let invalid effortFields =
+                LBS.pack $
+                    "{\"version\":1,\"models\":[{\"id\":\"gpt-5.6-sol\","
+                    <> "\"connection\":\"openai\",\"dialect\":\"codex\","
+                    <> "\"default\":true,"
+                    <> effortFields
+                    <> "}]}"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just
+                ( "models.json"
+                , invalid "\"reasoning_efforts\":[\"medium\",\"turbo\"]"
+                ))
+            `shouldSatisfy` leftContains "unsupported reasoning_efforts"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just
+                ( "models.json"
+                , invalid "\"reasoning_efforts\":[\"high\",\"high\"]"
+                ))
+            `shouldSatisfy` leftContains "must not contain duplicates"
+
+    it "requires a model reasoning default to be advertised" do
+        defaults <- readPackagedDefaults
+        let overlay =
+                "{\"version\":1,\"models\":[{\"id\":\"gpt-5.6-sol\",\"connection\":\"openai\",\"dialect\":\"codex\",\"reasoning_efforts\":[\"low\",\"medium\"],\"default_reasoning_effort\":\"high\",\"default\":true}]}"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just ("models.json", overlay))
+            `shouldSatisfy`
+                leftContains
+                    "default_reasoning_effort must be listed"
+
     it "loads ~/.haskell-agent/models.json over an explicit default path" $
         withTempDirectory "agent-model-config-" \root -> do
             defaults <- readPackagedDefaults
@@ -209,6 +263,15 @@ leftContains :: Text -> Either Text value -> Bool
 leftContains needle = \case
     Left err -> needle `Text.isInfixOf` err
     Right _ -> False
+
+findModel :: Text -> [CatalogModel] -> Maybe CatalogModel
+findModel modelId = go
+  where
+    go = \case
+        [] -> Nothing
+        model : rest
+            | model.catalogModelId == modelId -> Just model
+            | otherwise -> go rest
 
 expectRight :: Either Text value -> IO value
 expectRight = \case


### PR DESCRIPTION
## Summary
- add optional supported and default reasoning efforts to model catalog entries
- validate effort capability metadata during catalog loading
- expose model-specific effort metadata through the native macOS bridge

## Validation
- `nix develop -c cabal test --offline agent-cli:agent-cli-test --test-options='--match Agent.CLI.ModelConfig'`
- `nix develop -c cabal build --offline agent-cli:flib:haskell-agent-bridge`
- JSON parse and `git diff --check`
