### PR TITLE
Extract the loop event pump from Agent.Loop.Internal

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -91,7 +91,8 @@ library
                     , Agent.Tools.ShellReadOnly
                     , Agent.Tools.Types
                     , Agent.Transport.WebSocket
-    other-modules:    Agent.Loop.Internal
+    other-modules:    Agent.Loop.EventPump
+                    , Agent.Loop.Internal
                     , Agent.Subagents.Registry.Internal.Core
                     , Agent.Subagents.Registry.Internal.Operations
                     , Agent.Subagents.Registry.Internal.Types

--- a/packages/agent-core/src/Agent/Loop/EventPump.hs
+++ b/packages/agent-core/src/Agent/Loop/EventPump.hs
@@ -1,0 +1,277 @@
+-- | A bounded, single-consumer event pump with adjacent-event coalescing.
+--
+-- Producers may enqueue concurrently, but the sink is always invoked by one
+-- worker. A sink failure is published through STM so blocked producers wake
+-- up rather than waiting forever for queue capacity.
+module Agent.Loop.EventPump
+    ( EventPump
+    , EventPumpFailure(..)
+    , emitAppendedText
+    , emitEvent
+    , emitLatestText
+    , flushEventPump
+    , newEventPump
+    , runEventPump
+    , waitEventPumpFailure
+    ) where
+
+import Agent.TextBuffer
+    ( TextBuffer
+    , appendTextBuffer
+    , emptyTextBuffer
+    , textBufferToText
+    )
+import Control.Concurrent.Async (Async, race, waitCatch)
+import Control.Concurrent.STM
+    ( STM
+    , TBQueue
+    , TMVar
+    , TVar
+    , atomically
+    , modifyTVar'
+    , newEmptyTMVarIO
+    , newTBQueueIO
+    , newTVar
+    , orElse
+    , putTMVar
+    , readTBQueue
+    , readTMVar
+    , readTVar
+    , retry
+    , tryPutTMVar
+    , writeTBQueue
+    , writeTVar
+    )
+import Control.Exception (AsyncException, toException)
+import qualified Control.Exception as Exception
+import Control.Exception.Safe
+    ( SomeException
+    , catchAsync
+    , isAsyncException
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (void)
+import Data.Text (Text)
+
+data EventPumpCommand key event
+    = DeliverEvent !event
+    | DeliverCoalescedEvent !(CoalescedEvent key event)
+    | FlushEvents !(TMVar ())
+
+data CoalescedEvent key event
+    = AppendedEvent !key !(Text -> event) !(TVar TextBuffer)
+    | ReplacedEvent !key !(Text -> event) !(TVar Text)
+
+data EventPumpFailure
+    = EventPumpSyncFailure !SomeException
+    | EventPumpAsyncFailure !AsyncException
+
+data EventPump key event = EventPump
+    { eventPumpQueue :: !(TBQueue (EventPumpCommand key event))
+    , eventPumpFailure :: !(TMVar EventPumpFailure)
+    , eventPumpTail :: !(TVar (Maybe (CoalescedEvent key event)))
+    , eventPumpSink :: !(event -> IO ())
+    }
+
+eventQueueCapacity :: Int
+eventQueueCapacity = 256
+
+newEventPump :: (event -> IO ()) -> IO (EventPump key event)
+newEventPump sink = do
+    queue <- newTBQueueIO (fromIntegral eventQueueCapacity)
+    failure <- newEmptyTMVarIO
+    tailEvent <- atomically (newTVar Nothing)
+    pure EventPump
+        { eventPumpQueue = queue
+        , eventPumpFailure = failure
+        , eventPumpTail = tailEvent
+        , eventPumpSink = sink
+        }
+
+runEventPump :: Eq key => EventPump key event -> IO ()
+runEventPump pump = go
+  where
+    go =
+        atomically (readTBQueue pump.eventPumpQueue) >>= \case
+            DeliverEvent event ->
+                deliver event
+            DeliverCoalescedEvent pending -> do
+                event <- atomically do
+                    current <- readTVar pump.eventPumpTail
+                    whenSTM (sameCoalescedEvent current pending) $
+                        writeTVar pump.eventPumpTail Nothing
+                    materializeCoalescedEvent pending
+                deliver event
+            FlushEvents flushed -> do
+                atomically (putTMVar flushed ())
+                go
+    deliver event = do
+        (tryAny (pump.eventPumpSink event) >>= \case
+            Right () -> go
+            Left exception -> do
+                atomically $
+                    recordEventPumpFailure
+                        pump
+                        (EventPumpSyncFailure exception)
+                atomically retry)
+            `catchAsync` \(exception :: AsyncException) -> do
+                atomically $
+                    recordEventPumpFailure
+                        pump
+                        (EventPumpAsyncFailure exception)
+                Exception.throwIO exception
+
+-- | Enqueue an event that forms a coalescing boundary.
+emitEvent :: EventPump key event -> event -> IO ()
+emitEvent pump event =
+    enqueueEventPumpCommand pump (DeliverEvent event)
+
+flushEventPump
+    :: EventPump key event
+    -> IO (Either EventPumpFailure ())
+flushEventPump pump = do
+    flushed <- newEmptyTMVarIO
+    tryAny (enqueueEventPumpCommand pump (FlushEvents flushed)) >>= \case
+        Left exception
+            | isAsyncException exception ->
+                Exception.throwIO exception
+            | otherwise ->
+                pure (Left (EventPumpSyncFailure exception))
+        Right () ->
+            atomically $
+                (Left <$> readTMVar pump.eventPumpFailure)
+                    `orElse`
+                (readTMVar flushed >> pure (Right ()))
+
+enqueueEventPumpCommand
+    :: EventPump key event
+    -> EventPumpCommand key event
+    -> IO ()
+enqueueEventPumpCommand pump command =
+    atomically
+        ( (Left <$> readTMVar pump.eventPumpFailure)
+            `orElse`
+          (do
+            clearEventPumpTail pump
+            writeTBQueue pump.eventPumpQueue command
+            pure (Right ()))
+        ) >>= either throwEventPumpFailure pure
+
+-- | Enqueue text, appending it to an adjacent event with the same key.
+emitAppendedText
+    :: Eq key
+    => EventPump key event
+    -> key
+    -> (Text -> event)
+    -> Text
+    -> IO ()
+emitAppendedText pump key build text =
+    atomically
+        ( (Left <$> readTMVar pump.eventPumpFailure)
+            `orElse`
+          (do
+            current <- readTVar pump.eventPumpTail
+            case current of
+                Just (AppendedEvent currentKey _ buffer)
+                    | currentKey == key -> do
+                        modifyTVar' buffer (appendTextBuffer text)
+                        pure (Right ())
+                _ -> do
+                    buffer <- newTVar
+                        (appendTextBuffer text emptyTextBuffer)
+                    let pending = AppendedEvent key build buffer
+                    writeTVar pump.eventPumpTail (Just pending)
+                    writeTBQueue pump.eventPumpQueue
+                        (DeliverCoalescedEvent pending)
+                    pure (Right ()))
+        ) >>= either throwEventPumpFailure pure
+
+-- | Enqueue text, replacing an adjacent snapshot with the same key.
+emitLatestText
+    :: Eq key
+    => EventPump key event
+    -> key
+    -> (Text -> event)
+    -> Text
+    -> IO ()
+emitLatestText pump key build text =
+    atomically
+        ( (Left <$> readTMVar pump.eventPumpFailure)
+            `orElse`
+          (do
+            current <- readTVar pump.eventPumpTail
+            case current of
+                Just (ReplacedEvent currentKey _ snapshot)
+                    | currentKey == key -> do
+                        writeTVar snapshot text
+                        pure (Right ())
+                _ -> do
+                    snapshot <- newTVar text
+                    let pending = ReplacedEvent key build snapshot
+                    writeTVar pump.eventPumpTail (Just pending)
+                    writeTBQueue pump.eventPumpQueue
+                        (DeliverCoalescedEvent pending)
+                    pure (Right ()))
+        ) >>= either throwEventPumpFailure pure
+
+sameCoalescedEvent
+    :: Eq key
+    => Maybe (CoalescedEvent key event)
+    -> CoalescedEvent key event
+    -> Bool
+sameCoalescedEvent current pending =
+    case (current, pending) of
+        ( Just (AppendedEvent leftKey _ leftBuffer)
+          , AppendedEvent rightKey _ rightBuffer
+          ) ->
+            leftKey == rightKey && leftBuffer == rightBuffer
+        ( Just (ReplacedEvent leftKey _ leftSnapshot)
+          , ReplacedEvent rightKey _ rightSnapshot
+          ) ->
+            leftKey == rightKey && leftSnapshot == rightSnapshot
+        _ -> False
+
+materializeCoalescedEvent :: CoalescedEvent key event -> STM event
+materializeCoalescedEvent = \case
+    AppendedEvent _ build buffer ->
+        build . textBufferToText <$> readTVar buffer
+    ReplacedEvent _ build snapshot ->
+        build <$> readTVar snapshot
+
+clearEventPumpTail :: EventPump key event -> STM ()
+clearEventPumpTail pump =
+    readTVar pump.eventPumpTail >>= \case
+        Nothing -> pure ()
+        Just _ -> writeTVar pump.eventPumpTail Nothing
+
+whenSTM :: Bool -> STM () -> STM ()
+whenSTM True action = action
+whenSTM False _ = pure ()
+
+waitEventPumpFailure
+    :: Async ()
+    -> EventPump key event
+    -> IO EventPumpFailure
+waitEventPumpFailure worker pump =
+    race
+        (atomically (readTMVar pump.eventPumpFailure))
+        (waitCatch worker) >>= \case
+            Left failure -> pure failure
+            Right (Left exception)
+                | isAsyncException exception ->
+                    Exception.throwIO exception
+                | otherwise ->
+                    pure (EventPumpSyncFailure exception)
+            Right (Right ()) ->
+                pure . EventPumpSyncFailure . toException $
+                    userError "event pump stopped unexpectedly"
+
+throwEventPumpFailure :: EventPumpFailure -> IO a
+throwEventPumpFailure = \case
+    EventPumpSyncFailure exception -> throwIO exception
+    EventPumpAsyncFailure exception -> Exception.throwIO exception
+
+recordEventPumpFailure :: EventPump key event -> EventPumpFailure -> STM ()
+recordEventPumpFailure pump failure =
+    void (tryPutTMVar pump.eventPumpFailure failure)

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -4,13 +4,18 @@ import Agent.Cancel (CancelFlag, isCancelled, waitCancel)
 import qualified Agent.Json.Decode as Json
 import Agent.Error (ApiError)
 import Agent.InterAgentMessage (InterAgentMessage)
-import Agent.Responses.Types (ResponseItem)
-import Agent.TextBuffer
-    ( TextBuffer
-    , appendTextBuffer
-    , emptyTextBuffer
-    , textBufferToText
+import Agent.Loop.EventPump
+    ( EventPump
+    , EventPumpFailure(..)
+    , emitAppendedText
+    , emitEvent
+    , emitLatestText
+    , flushEventPump
+    , newEventPump
+    , runEventPump
+    , waitEventPumpFailure
     )
+import Agent.Responses.Types (ResponseItem)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallResult(..)
@@ -26,44 +31,17 @@ import Agent.Tools.Types
     , toolSchedulingPlanFor
     )
 import Control.Concurrent.Async
-    ( Async
-    , mapConcurrently
+    ( mapConcurrently
     , race
-    , waitCatch
     , withAsync
     )
-import Control.Concurrent.STM
-    ( TBQueue
-    , TMVar
-    , STM
-    , TVar
-    , atomically
-    , newEmptyTMVarIO
-    , newTVar
-    , newTBQueueIO
-    , modifyTVar'
-    , orElse
-    , putTMVar
-    , readTBQueue
-    , readTMVar
-    , readTVar
-    , retry
-    , tryPutTMVar
-    , writeTVar
-    , writeTBQueue
-    )
-import Control.Exception (AsyncException, toException)
 import qualified Control.Exception as Exception
 import Control.Exception.Safe
     ( SomeException
-    , catchAsync
     , displayException
-    , isAsyncException
     , mask
-    , throwIO
     , tryAny
     )
-import Control.Monad (void)
 import Data.Aeson (ToJSON(..), object, (.=))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
@@ -461,12 +439,12 @@ runLoopInputsUnsafe
     -> [TurnInput]
     -> IO LoopExecution
 runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
-    eventPump <- newLoopEventPump config0.loopOnEvent
+    eventPump <- newEventPump config0.loopOnEvent
     progressRef <- newIORef (initialState, NoResponseCommitted)
     uncommittedTextRef <- newIORef ([], [])
     initialSteering <- config0.loopReadSteering
     pendingRef <- newIORef (firstInputs <> initialSteering)
-    withAsync (runLoopEventPump eventPump) \eventWorker -> do
+    withAsync (runEventPump eventPump) \eventWorker -> do
         let recordVisible event =
                 modifyIORef' uncommittedTextRef \(finished, current) ->
                     case event of
@@ -671,13 +649,13 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                     , cursorTokenUsage = emptyTokenUsage
                     , cursorEmptyContinuations = 0
                     }
-        raced <- race (waitLoopEventFailure eventWorker eventPump) run
+        raced <- race (waitEventPumpFailure eventWorker eventPump) run
         execution <- case raced of
             Left failure -> do
                 (state, progress) <- readIORef progressRef
                 handleLoopEventFailure unexpected state progress failure
             Right completed -> pure completed
-        flushLoopEvents eventPump >>= \case
+        flushEventPump eventPump >>= \case
             Left failure ->
                 handleLoopEventFailure
                     unexpected
@@ -686,232 +664,40 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                     failure
             Right () -> pure execution
 
-data LoopEventCommand
-    = DeliverLoopEvent !LoopEvent
-    | DeliverCoalescedLoopEvent !CoalescedLoopEvent
-    | FlushLoopEvents !(TMVar ())
+data LoopEventCoalescingKey
+    = AssistantTextDelta
+    | AssistantReasoningDelta
+    | ToolOutputSnapshot !Text
+    deriving (Eq)
 
-data CoalescedLoopEvent
-    = CoalescedTextDelta !(TVar TextBuffer)
-    | CoalescedReasoningDelta !(TVar TextBuffer)
-    | CoalescedToolOutput !Text !(TVar Text)
-
-data LoopEventFailure
-    = LoopEventSyncFailure !SomeException
-    | LoopEventAsyncFailure !AsyncException
-
-data LoopEventPump = LoopEventPump
-    { eventPumpQueue :: !(TBQueue LoopEventCommand)
-    , eventPumpFailure :: !(TMVar LoopEventFailure)
-    , eventPumpTail :: !(TVar (Maybe CoalescedLoopEvent))
-    , eventPumpSink :: !(LoopEvent -> IO ())
-    }
-
-loopEventQueueCapacity :: Int
-loopEventQueueCapacity = 256
-
-newLoopEventPump :: (LoopEvent -> IO ()) -> IO LoopEventPump
-newLoopEventPump sink = do
-    queue <- newTBQueueIO (fromIntegral loopEventQueueCapacity)
-    failure <- newEmptyTMVarIO
-    tailEvent <- atomically (newTVar Nothing)
-    pure LoopEventPump
-        { eventPumpQueue = queue
-        , eventPumpFailure = failure
-        , eventPumpTail = tailEvent
-        , eventPumpSink = sink
-        }
-
-runLoopEventPump :: LoopEventPump -> IO ()
-runLoopEventPump pump = go
-  where
-    go =
-        atomically (readTBQueue pump.eventPumpQueue) >>= \case
-            DeliverLoopEvent event ->
-                deliver event
-            DeliverCoalescedLoopEvent pending -> do
-                event <- atomically do
-                    current <- readTVar pump.eventPumpTail
-                    whenSTM (sameCoalescedEvent current pending) $
-                        writeTVar pump.eventPumpTail Nothing
-                    materializeCoalescedEvent pending
-                deliver event
-            FlushLoopEvents flushed -> do
-                atomically (putTMVar flushed ())
-                go
-    deliver event = do
-        (tryAny (pump.eventPumpSink event) >>= \case
-            Right () -> go
-            Left exception -> do
-                atomically $
-                    recordLoopEventFailure
-                        pump
-                        (LoopEventSyncFailure exception)
-                atomically retry)
-            `catchAsync` \(exception :: AsyncException) -> do
-                atomically $
-                    recordLoopEventFailure
-                        pump
-                        (LoopEventAsyncFailure exception)
-                Exception.throwIO exception
+type LoopEventPump = EventPump LoopEventCoalescingKey LoopEvent
 
 emitLoopEvent :: LoopEventPump -> LoopEvent -> IO ()
 emitLoopEvent pump = \case
     TextDelta text ->
-        enqueueTextDelta pump False text
+        emitAppendedText pump AssistantTextDelta TextDelta text
     ReasoningDelta text ->
-        enqueueTextDelta pump True text
+        emitAppendedText pump AssistantReasoningDelta ReasoningDelta text
     ToolOutputUpdated callId output ->
-        enqueueToolOutput pump callId output
+        emitLatestText
+            pump
+            (ToolOutputSnapshot callId)
+            (ToolOutputUpdated callId)
+            output
     event ->
-        enqueueLoopEventCommand pump (DeliverLoopEvent event)
-
-flushLoopEvents :: LoopEventPump -> IO (Either LoopEventFailure ())
-flushLoopEvents pump = do
-    flushed <- newEmptyTMVarIO
-    tryAny (enqueueLoopEventCommand pump (FlushLoopEvents flushed)) >>= \case
-        Left exception
-            | isAsyncException exception ->
-                Exception.throwIO exception
-            | otherwise ->
-                pure (Left (LoopEventSyncFailure exception))
-        Right () ->
-            atomically $
-                (Left <$> readTMVar pump.eventPumpFailure)
-                    `orElse`
-                (readTMVar flushed >> pure (Right ()))
-
-enqueueLoopEventCommand :: LoopEventPump -> LoopEventCommand -> IO ()
-enqueueLoopEventCommand pump command =
-    atomically
-        ( (Left <$> readTMVar pump.eventPumpFailure)
-            `orElse`
-          (do
-            clearEventPumpTail pump
-            writeTBQueue pump.eventPumpQueue command
-            pure (Right ()))
-        ) >>= either throwLoopEventFailure pure
-
-enqueueTextDelta :: LoopEventPump -> Bool -> Text -> IO ()
-enqueueTextDelta pump reasoning text =
-    atomically
-        ( (Left <$> readTMVar pump.eventPumpFailure)
-            `orElse`
-          (do
-            current <- readTVar pump.eventPumpTail
-            case current of
-                Just (CoalescedTextDelta buffer)
-                    | not reasoning -> do
-                        modifyTVar' buffer (appendTextBuffer text)
-                        pure (Right ())
-                Just (CoalescedReasoningDelta buffer)
-                    | reasoning -> do
-                        modifyTVar' buffer (appendTextBuffer text)
-                        pure (Right ())
-                _ -> do
-                    buffer <- newTVar
-                        (appendTextBuffer text emptyTextBuffer)
-                    let pending =
-                            if reasoning
-                                then CoalescedReasoningDelta buffer
-                                else CoalescedTextDelta buffer
-                    writeTVar pump.eventPumpTail (Just pending)
-                    writeTBQueue pump.eventPumpQueue
-                        (DeliverCoalescedLoopEvent pending)
-                    pure (Right ()))
-        ) >>= either throwLoopEventFailure pure
-
-enqueueToolOutput :: LoopEventPump -> Text -> Text -> IO ()
-enqueueToolOutput pump callId output =
-    atomically
-        ( (Left <$> readTMVar pump.eventPumpFailure)
-            `orElse`
-          (do
-            current <- readTVar pump.eventPumpTail
-            case current of
-                Just (CoalescedToolOutput currentId snapshot)
-                    | currentId == callId -> do
-                        writeTVar snapshot output
-                        pure (Right ())
-                _ -> do
-                    snapshot <- newTVar output
-                    let pending = CoalescedToolOutput callId snapshot
-                    writeTVar pump.eventPumpTail (Just pending)
-                    writeTBQueue pump.eventPumpQueue
-                        (DeliverCoalescedLoopEvent pending)
-                    pure (Right ()))
-        ) >>= either throwLoopEventFailure pure
-
-sameCoalescedEvent
-    :: Maybe CoalescedLoopEvent
-    -> CoalescedLoopEvent
-    -> Bool
-sameCoalescedEvent current pending =
-    case (current, pending) of
-        (Just (CoalescedTextDelta left), CoalescedTextDelta right) ->
-            left == right
-        (Just (CoalescedReasoningDelta left), CoalescedReasoningDelta right) ->
-            left == right
-        ( Just (CoalescedToolOutput leftId left)
-          , CoalescedToolOutput rightId right
-          ) ->
-            leftId == rightId && left == right
-        _ -> False
-
-materializeCoalescedEvent :: CoalescedLoopEvent -> STM LoopEvent
-materializeCoalescedEvent = \case
-    CoalescedTextDelta buffer ->
-        TextDelta . textBufferToText <$> readTVar buffer
-    CoalescedReasoningDelta buffer ->
-        ReasoningDelta . textBufferToText <$> readTVar buffer
-    CoalescedToolOutput callId snapshot ->
-        ToolOutputUpdated callId <$> readTVar snapshot
-
-clearEventPumpTail :: LoopEventPump -> STM ()
-clearEventPumpTail pump =
-    readTVar pump.eventPumpTail >>= \case
-        Nothing -> pure ()
-        Just _ -> writeTVar pump.eventPumpTail Nothing
-
-whenSTM :: Bool -> STM () -> STM ()
-whenSTM True action = action
-whenSTM False _ = pure ()
-
-waitLoopEventFailure :: Async () -> LoopEventPump -> IO LoopEventFailure
-waitLoopEventFailure worker pump =
-    race
-        (atomically (readTMVar pump.eventPumpFailure))
-        (waitCatch worker) >>= \case
-            Left failure -> pure failure
-            Right (Left exception)
-                | isAsyncException exception ->
-                    Exception.throwIO exception
-                | otherwise ->
-                    pure (LoopEventSyncFailure exception)
-            Right (Right ()) ->
-                pure . LoopEventSyncFailure . toException $
-                    userError "loop event pump stopped unexpectedly"
-
-throwLoopEventFailure :: LoopEventFailure -> IO a
-throwLoopEventFailure = \case
-    LoopEventSyncFailure exception -> throwIO exception
-    LoopEventAsyncFailure exception -> Exception.throwIO exception
+        emitEvent pump event
 
 handleLoopEventFailure
     :: ([ResponseItem] -> LoopProgress -> SomeException -> IO LoopExecution)
     -> [ResponseItem]
     -> LoopProgress
-    -> LoopEventFailure
+    -> EventPumpFailure
     -> IO LoopExecution
 handleLoopEventFailure unexpected state progress = \case
-    LoopEventSyncFailure exception ->
+    EventPumpSyncFailure exception ->
         unexpected state progress exception
-    LoopEventAsyncFailure exception ->
+    EventPumpAsyncFailure exception ->
         Exception.throwIO exception
-
-recordLoopEventFailure :: LoopEventPump -> LoopEventFailure -> STM ()
-recordLoopEventFailure pump failure =
-    void (tryPutTMVar pump.eventPumpFailure failure)
 
 -- | Preserve model order between conflicting calls while allowing independent
 -- calls from the same model turn to overlap. Results are returned in model

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -257,6 +257,42 @@ spec = describe "runLoop" do
                 , tokenUsage = emptyTokenUsage
                 }
 
+    it "wakes a producer blocked on a full queue when the sink fails" do
+        sinkStarted <- newEmptyMVar
+        releaseSink <- newEmptyMVar
+        backendStarted <- newEmptyMVar
+        backendFinished <- newEmptyMVar
+        let backend = Backend \_state _prev _inputs onEvent -> do
+                putMVar backendStarted ()
+                mapM_ (const (onEvent (WarningRaised "queued")))
+                    [1 .. 300 :: Int]
+                putMVar backendFinished ()
+                pure $ Right BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "resp-1" [] (Just "done")
+                    , backendState = []
+                    }
+            onEvent = \case
+                TurnStarted -> do
+                    putMVar sinkStarted ()
+                    takeMVar releaseSink
+                    Exception.throwIO (userError "renderer exploded")
+                _ -> pure ()
+        config0 <- testConfig backend
+        let config = config0 { loopOnEvent = onEvent }
+        withAsync (runLoop config Nothing "go") \running -> do
+            takeMVar sinkStarted
+            takeMVar backendStarted
+            timeout 100000 (takeMVar backendFinished)
+                `shouldReturn` Nothing
+            putMVar releaseSink ()
+            timeout 1000000 (wait running)
+                `shouldReturn`
+                    Just
+                        (Left
+                            (LoopUnexpected
+                                "user error (renderer exploded)"))
+
     it "coalesces adjacent deltas while preserving event boundaries" do
         sinkStarted <- newEmptyMVar
         releaseSink <- newEmptyMVar


### PR DESCRIPTION
## Summary

- extract the bounded, single-consumer loop event queue into the internal `Agent.Loop.EventPump` module
- leave `LoopEvent` policy in `Agent.Loop.Internal`: text/reasoning deltas append by distinct keys, tool output keeps the latest adjacent snapshot per call, and all other events form ordering boundaries
- keep the public `Agent.Loop` API unchanged while reducing `Agent.Loop.Internal` from 1,096 to 882 lines
- add a regression proving a sink failure wakes a backend producer blocked by full-queue backpressure instead of deadlocking

## Preserved invariants

- queue capacity remains 256
- event sinks remain serialized on one structured worker
- direct events preserve FIFO ordering and terminate adjacent coalescing
- text/reasoning deltas still append only to the same adjacent stream
- tool output still retains only the latest adjacent snapshot for the same call id
- completion still flushes all accepted events before returning
- synchronous sink failures remain in-band `LoopUnexpected` failures
- asynchronous sink cancellation is recorded and rethrown
- the worker remains scoped by `withAsync`; no detached concurrency was introduced
- reconnect handling from #725 remains intact: `ResponseAttemptDiscarded` clears the visible-output marker before subsequent transport classification

## Validation

Rebased onto `167abf81` (`origin/master`) and reran:

- `printf ':quit\n' | nix develop -c cabal repl agent-core:lib:agent-core --offline`
  - 62 library modules loaded successfully
- `printf ':set args --match runLoop\nmain\n:quit\n' | nix develop -c cabal repl agent-core:test:agent-core-test --offline`
  - 68 examples, 0 failures, including reconnect discard and event-pump backpressure regressions
- new full-queue/sink-failure regression repeated 10 times in the test-suite repl before the rebase
  - 10/10 passes
- `printf 'main\n:quit\n' | nix develop -c cabal repl agent-core:test:agent-core-test --offline`
  - 430 examples, 0 failures
- regenerated the `agent-core` cabal2nix expression and compared it with `package.nix`
  - no change
- `git diff --check origin/master...HEAD`
  - clean
