### PR TITLE
Decouple MCP progress callbacks from fleet state

### DIFF
--- a/packages/agent-mcp/src/Agent/MCP/Fleet.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Fleet.hs
@@ -21,6 +21,7 @@ import Agent.ToolDispatch (ToolCall(..), typedTool)
 import Agent.Concurrent (forConcurrentlyBounded_)
 import Control.Concurrent.Async
     ( asyncWithUnmask
+    , concurrently
     , mapConcurrently
     , poll
     )
@@ -40,9 +41,12 @@ import Control.Concurrent.STM
     , TVar
     , atomically
     , modifyTVar'
+    , newTQueueIO
     , newTVarIO
+    , readTQueue
     , readTVar
     , readTVarIO
+    , writeTQueue
     , writeTVar
     )
 import Control.Exception.Safe
@@ -227,9 +231,13 @@ startMcpFleetWithProgressHooks hooks reportActive configs = mask \restore -> do
     activeServers <- newMVar Set.empty
     results <-
         restore
-            (mapConcurrently
-                (startServerTracked ownedClients activeServers)
-                configs)
+            (withProgressReporter reportActive \publishActive ->
+                mapConcurrently
+                    (startServerTracked
+                        ownedClients
+                        activeServers
+                        publishActive)
+                    configs)
             `onException` closeOwnedClients ownedClients
     let (clients, registrations, warnings, failures) =
             foldr collectServerResult ([], [], [], Map.empty) results
@@ -275,8 +283,15 @@ startMcpFleetWithProgressHooks hooks reportActive configs = mask \restore -> do
     forM_ clients (attachFleetEvents fleet)
     pure fleet
   where
-    startServerTracked ownedClients activeServers config = mask \restore -> do
-        updateActive activeServers (Set.insert config.mcpServerName)
+    startServerTracked
+        ownedClients
+        activeServers
+        publishActive
+        config = mask \restore -> do
+        updateActive
+            activeServers
+            publishActive
+            (Set.insert config.mcpServerName)
         (do
             attempt <- tryAny (restore (startServer config))
             case attempt of
@@ -294,12 +309,16 @@ startMcpFleetWithProgressHooks hooks reportActive configs = mask \restore -> do
                     atomicModifyIORef' ownedClients \clients ->
                         (client : clients, ())
                     pure (Right result))
-            `finally` updateActive activeServers (Set.delete config.mcpServerName)
+            `finally`
+                updateActive
+                    activeServers
+                    publishActive
+                    (Set.delete config.mcpServerName)
 
-    updateActive activeServers update =
+    updateActive activeServers publishActive update =
         modifyMVar_ activeServers \current -> do
             let active = update current
-            reportActive (Set.toAscList active)
+            publishActive (Set.toAscList active)
             pure active
 
     closeOwnedClients ownedClients =
@@ -355,6 +374,25 @@ startMcpFleetWithProgressHooks hooks reportActive configs = mask \restore -> do
             <> config.mcpServerName
             <> " failed to start: "
             <> err
+
+-- | Deliver progress updates in state-transition order without running the
+-- callback under the state lock or blocking server startup on callback work.
+withProgressReporter
+    :: (a -> IO ())
+    -> ((a -> IO ()) -> IO b)
+    -> IO b
+withProgressReporter report action = do
+    updates <- newTQueueIO
+    fst <$> concurrently
+        ( action (atomically . writeTQueue updates . Just)
+            `finally` atomically (writeTQueue updates Nothing)
+        )
+        (reportUpdates updates)
+  where
+    reportUpdates updates =
+        atomically (readTQueue updates) >>= \case
+            Nothing -> pure ()
+            Just update -> report update >> reportUpdates updates
 
 validateServerNames :: [McpServerConfig] -> IO ()
 validateServerNames = go Set.empty

--- a/packages/agent-mcp/src/Agent/MCP/Fleet.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Fleet.hs
@@ -376,7 +376,8 @@ startMcpFleetWithProgressHooks hooks reportActive configs = mask \restore -> do
             <> err
 
 -- | Deliver progress updates in state-transition order without running the
--- callback under the state lock or blocking server startup on callback work.
+-- callback under the state lock or blocking individual server workers.
+-- The enclosing startup still waits for queued callbacks to drain.
 withProgressReporter
     :: (a -> IO ())
     -> ((a -> IO ()) -> IO b)

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -57,6 +57,7 @@ import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
     , getTemporaryDirectory
+    , listDirectory
     , removeDirectoryRecursive
     , removeFile
     , withCurrentDirectory
@@ -272,6 +273,23 @@ spec = describe "Agent.MCP" do
                 updates <- readIORef progress
                 updates `shouldContain` [["first", "second"]]
                 last updates `shouldBe` []
+
+    it "starts other servers while a progress callback is stalled" $
+        withConcurrentFakeServer \script barrier -> do
+            started <- timeout 5000000 $
+                startMcpFleetWithProgress
+                    (\case
+                        [_] -> waitForConcurrentStarts barrier
+                        _ -> pure ())
+                    [ concurrentConfig script barrier "first"
+                    , concurrentConfig script barrier "second"
+                    ]
+            case started of
+                Nothing ->
+                    expectationFailure
+                        "fleet startup deadlocked behind the progress callback"
+                Just fleet ->
+                    bracket (pure fleet) closeMcpFleet \_ -> pure ()
 
     it "reports failed configured servers without hiding healthy ones" $
         withFakeServer \script -> do
@@ -767,6 +785,18 @@ waitForCatalogEntry fleet name = go (300 :: Int)
     go remaining = do
         entries <- readTVarIO fleet.mcpFleetCatalog
         if Map.member name entries
+            then pure ()
+            else threadDelay 10000 >> go (remaining - 1)
+
+waitForConcurrentStarts :: FilePath -> IO ()
+waitForConcurrentStarts barrier = go (300 :: Int)
+  where
+    go 0 =
+        expectationFailure
+            "other MCP servers did not start while progress reporting was blocked"
+    go remaining = do
+        starts <- listDirectory barrier
+        if length starts >= 2
             then pure ()
             else threadDelay 10000 >> go (remaining - 1)
 


### PR DESCRIPTION
## Summary

- move MCP active-server progress callbacks out of the `activeServers` `MVar`
- queue state snapshots under the lock, then deliver them in transition order from a scoped reporter
- preserve serialized callback delivery while allowing other servers to continue starting when UI/reporting work pauses
- add a regression test where the first progress callback waits for both fake servers to enter initialization

## Concurrency reasoning

Previously, `reportActive` ran inside `modifyMVar_ activeServers`. If a callback stalled or waited for another server to make progress, that server could not update the same `MVar`, so startup deadlocked before either server launched.

The new publisher only performs a non-blocking `TQueue` write while holding the state lock. A reporter owned by `concurrently` drains snapshots and invokes user code outside the lock. This keeps snapshot/callback order deterministic, avoids concurrent callback races, and ensures the reporter and startup workers are cancelled and joined together on failure. Startup still waits for queued reporting to drain before returning, preserving the synchronous callback contract.

## Tests

- `nix develop -c cabal repl agent-mcp:test:agent-mcp-test`, then `:main` — 82 examples, 0 failures
- new stalled-callback regression repeated 10 times — 10/10 passed
- regression verified against the pre-change `Fleet.hs` — fails because the callback prevents the peer server from starting
- `git diff --check`
