### PR TITLE
Fetch upstream before creating worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ Start in an isolated Git worktree:
 agent-cli --worktree
 ```
 
+By default the worktree branches from the current local `HEAD`. To always fetch
+and branch from the selected remote's latest default branch, add this to
+`~/.haskell-agent/config.json`:
+
+```json
+{
+  "version": 1,
+  "worktree": {
+    "fetchLatestUpstream": true
+  }
+}
+```
+
+This policy applies to `--worktree`, `/worktree`, and subagent worktrees. The
+remote is selected from the current branch's configured remote, then
+`upstream`, `origin`, or the repository's sole remote. A fetch failure aborts
+worktree creation rather than falling back to a stale commit.
+
 Use `--provider openai`, `--provider xai`, `--provider openrouter`, or
 `--provider claude-code` to override automatic provider detection. Claude Code
 is selected explicitly rather than by auto-detection.

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Config
     , McpInitStrategy(..)
     , McpOAuthConfig(..)
     , McpServerConfig(..)
+    , WorktreeConfig(..)
     , defaultHarnessConfig
     , harnessConfigPath
     , loadHarnessConfig
@@ -170,6 +171,13 @@ data LspConfig = LspConfig
     }
     deriving (Eq, Show)
 
+-- | Managed worktree creation policy. Fetching is opt-in so worktree creation
+-- remains available in offline repositories by default.
+data WorktreeConfig = WorktreeConfig
+    { worktreeFetchLatestUpstream :: !Bool
+    }
+    deriving (Eq, Show)
+
 -- | Resolve the configured MCP startup policy for the current invocation.
 -- Interactive sessions favor prompt availability, while one-shot commands
 -- preserve deterministic startup unless explicitly overridden.
@@ -272,12 +280,20 @@ instance Aeson.ToJSON LspConfig where
             , "servers" Aeson..= config.lspServers
             ]
 
+instance Aeson.ToJSON WorktreeConfig where
+    toJSON config =
+        Aeson.object
+            [ "fetchLatestUpstream"
+                Aeson..= config.worktreeFetchLatestUpstream
+            ]
+
 data HarnessConfig = HarnessConfig
     { configVersion :: !Int
     , configMcpInitStrategy :: !McpInitStrategy
     , configMcpServers :: !(Map Text McpServerConfig)
     , configWebFetch :: !WebFetchConfig
     , configLsp :: !LspConfig
+    , configWorktree :: !WorktreeConfig
     , configMaxConcurrentAgents :: !(Maybe Int)
     }
     deriving (Eq, Show)
@@ -290,6 +306,7 @@ instance Aeson.ToJSON HarnessConfig where
             , "mcpServers" Aeson..= config.configMcpServers
             , "webFetch" Aeson..= config.configWebFetch
             , "lsp" Aeson..= config.configLsp
+            , "worktree" Aeson..= config.configWorktree
             , "maxConcurrentAgents" Aeson..= config.configMaxConcurrentAgents
             ]
 
@@ -308,6 +325,9 @@ defaultHarnessConfig = HarnessConfig
     , configLsp = LspConfig
         { lspEnabled = False
         , lspServers = Map.empty
+        }
+    , configWorktree = WorktreeConfig
+        { worktreeFetchLatestUpstream = False
         }
     , configMaxConcurrentAgents = Nothing
     }
@@ -408,6 +428,12 @@ lspConfigDecoder =
             <*> defaultKey Map.empty "servers"
                 (Hermes.objectAsMap pure lspServerConfigDecoder)
 
+worktreeConfigDecoder :: Hermes.Decoder WorktreeConfig
+worktreeConfigDecoder =
+    Hermes.object $
+        WorktreeConfig
+            <$> defaultKey False "fetchLatestUpstream" Hermes.bool
+
 harnessConfigDecoder :: Hermes.Decoder HarnessConfig
 harnessConfigDecoder =
     Hermes.object $
@@ -421,6 +447,8 @@ harnessConfigDecoder =
                 "webFetch" webFetchConfigDecoder
             <*> defaultKey defaultHarnessConfig.configLsp
                 "lsp" lspConfigDecoder
+            <*> defaultKey defaultHarnessConfig.configWorktree
+                "worktree" worktreeConfigDecoder
             <*> optionalKey "maxConcurrentAgents" Hermes.int
 
 textMapDecoder :: Hermes.Decoder (Map Text Text)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -145,7 +145,7 @@ import Agent.CLI.Tools ()
 import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch ()
-import Agent.CLI.Worktree ( createWorktree, worktreeRoot )
+import Agent.CLI.Worktree ( createManagedWorktree )
 import Agent.Cancel ( requestCancel )
 import Agent.Claude ()
 import Agent.Dialect ()
@@ -704,7 +704,7 @@ prepareAgentIterationTracked
                                 Just _ -> pure ()
                                 Nothing ->
                                     putTextLn stderrHandle "Creating worktree…"
-                            createWorktree source (worktreeRoot home)
+                            createManagedWorktree home source
                                 >>= either
                                     (\err -> do
                                         mapM_ releaseSessionLock resumeLock

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -160,7 +160,7 @@ import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch
     ( closeWebFetchRuntime, newWebFetchRuntime, webFetchRuntimeTool )
 import Agent.CLI.Worktree
-    ( createWorktree, removeWorktree, worktreeRoot )
+    ( createManagedWorktree, removeWorktree )
 import Agent.Cancel ()
 import Agent.Claude ()
 import Agent.Dialect ( dialectForId, DialectId(GrokBuildDialect) )
@@ -521,7 +521,7 @@ runAgentTools
             enqueuePendingInput pendingNotices (AgentMessage message)
             pure (Right "queued")
         createSubagentWorktree source =
-            createWorktree source (worktreeRoot home) >>= \case
+            createManagedWorktree home source >>= \case
                 Left err -> pure (Left err)
                 Right path -> pure $ Right SubagentWorktree
                     { subagentWorktreePath = path

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -121,7 +121,7 @@ import Agent.CLI.Tools ()
 import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch ()
-import Agent.CLI.Worktree ( createWorktree, worktreeRoot )
+import Agent.CLI.Worktree ( createManagedWorktree )
 import Agent.Cancel ()
 import Agent.Claude ()
 import Agent.Dialect ( dialectId, dialectSlug )
@@ -513,7 +513,7 @@ handleSessionAction
                                                             finishAfk message
     ReplWorktree -> do
         result <- withReplActivity "Creating worktree…" $
-            createWorktree cwd (worktreeRoot env.sessionHome)
+            createManagedWorktree env.sessionHome cwd
         case result of
             Left err -> do
                 color <- resolveColor stderr

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -1,13 +1,21 @@
 -- | Create isolated git worktrees under @~/.haskell-agent/worktrees@.
 module Agent.CLI.Worktree
     ( createWorktree
+    , createWorktreeWithFetch
+    , createManagedWorktree
     , removeWorktree
     , isUnderWorktreeRoot
     , worktreePath
     , worktreeRoot
     ) where
 
+import Agent.CLI.Config
+    ( HarnessConfig(..)
+    , WorktreeConfig(..)
+    , loadHarnessConfig
+    )
 import Agent.OsPath (unsafeToFilePath)
+import Control.Applicative ((<|>))
 import Control.Exception.Safe (mask, onException, tryAny)
 import Control.Monad (void)
 import Control.Monad.Trans.Class (lift)
@@ -18,6 +26,7 @@ import Control.Monad.Trans.Except
     , withExceptT
     )
 import Data.List (isPrefixOf)
+import Data.Maybe (listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (Day)
@@ -59,17 +68,41 @@ worktreePath :: OsPath -> OsPath -> Day -> String -> OsPath
 worktreePath root repoName day hex8 =
     root </> repoName </> unsafeEncodeUtf (formatDay day <> "-" <> hex8)
 
--- | Add a new worktree of @source@ under @root@. @root@ is injected so tests
--- can use a temp directory instead of the real home.
+-- | Add a new worktree of @source@ under @root@ using the current @HEAD@.
+-- @root@ is injected so tests can use a temp directory instead of the real
+-- home.
 createWorktree :: OsPath -> OsPath -> IO (Either Text OsPath)
-createWorktree source root = runExceptT do
+createWorktree = createWorktreeWithFetch False
+
+-- | Add a new worktree, optionally fetching the selected remote's current
+-- default branch and using that commit as the base.
+createWorktreeWithFetch
+    :: Bool -> OsPath -> OsPath -> IO (Either Text OsPath)
+createWorktreeWithFetch fetchLatest source root = runExceptT do
     repo <- gitToplevel source
     repoName <- gitRepositoryName repo
+    base <-
+        if fetchLatest
+            then Just <$> fetchLatestUpstream repo
+            else pure Nothing
     now <- lift getCurrentTime
     let day = utctDay now
         start = posixMicros now
     lift (createDirectoryIfMissing True (root </> repoName))
-    addUnique repo root repoName day start 0
+    addUnique repo root repoName day start base 0
+
+-- | Create a worktree using the machine-wide policy under the supplied home.
+-- Configuration is read for every creation so startup, slash-command, and
+-- subagent worktrees all follow the same current setting.
+createManagedWorktree :: OsPath -> OsPath -> IO (Either Text OsPath)
+createManagedWorktree home source =
+    loadHarnessConfig home >>= \case
+        Left err -> pure (Left err)
+        Right config ->
+            createWorktreeWithFetch
+                config.configWorktree.worktreeFetchLatestUpstream
+                source
+                (worktreeRoot home)
 
 -- | Remove a managed worktree and the branch created for it.
 removeWorktree :: OsPath -> OsPath -> IO (Either Text ())
@@ -86,24 +119,34 @@ addUnique
     -> OsPath
     -> Day
     -> Integer
+    -> Maybe Text
     -> Int
     -> ExceptT Text IO OsPath
-addUnique repo root repoName day start attempt
+addUnique repo root repoName day start base attempt
     | attempt >= 32 =
         throwE "could not pick a unique worktree path"
     | otherwise = do
         let path = worktreePath root repoName day (hex8 (start + fromIntegral attempt))
         exists <- lift (doesPathExist path)
         if exists
-            then addUnique repo root repoName day start (attempt + 1)
+            then addUnique repo root repoName day start base (attempt + 1)
             else do
+                let branch = unsafeToFilePath (takeFileName path)
+                    addArgs = case base of
+                        Nothing ->
+                            ["worktree", "add", unsafeToFilePath path]
+                        Just commit ->
+                            [ "worktree", "add", "-b", branch
+                            , unsafeToFilePath path, Text.unpack commit
+                            ]
                 added <- lift $ mask \restore ->
-                    restore (git repo ["worktree", "add", unsafeToFilePath path])
+                    restore (git repo addArgs)
                         `onException` cleanupWorktreeCandidate repo path
                 case added of
                     Left err
                         | branchTaken err ->
-                            addUnique repo root repoName day start (attempt + 1)
+                            addUnique
+                                repo root repoName day start base (attempt + 1)
                         | otherwise -> do
                             lift (cleanupWorktreeCandidate repo path)
                             throwE err
@@ -137,6 +180,116 @@ gitRepositoryName repo = do
         if takeFileName path == unsafeEncodeUtf ".git"
             then takeFileName (takeDirectory path)
             else takeFileName path
+
+-- | Fetch and return the commit at the selected remote's advertised default
+-- branch. The current branch's configured remote wins, followed by conventional
+-- @upstream@ and @origin@ names, then a sole remaining remote.
+fetchLatestUpstream :: OsPath -> ExceptT Text IO Text
+fetchLatestUpstream repo = do
+    remote <- selectUpstreamRemote repo
+    remoteHead <- remoteDefaultBranch repo remote
+    let branch = Text.drop (Text.length headsPrefix) remoteHead
+        localRef = "refs/remotes/" <> remote <> "/" <> branch
+        refspec = "+" <> remoteHead <> ":" <> localRef
+        context action err =
+            "failed to " <> action <> " from git remote "
+                <> quote remote <> ": " <> Text.strip err
+    void $
+        withExceptT (context "fetch the latest default branch") $
+            ExceptT $
+                git repo
+                    [ "fetch"
+                    , "--no-tags"
+                    , Text.unpack remote
+                    , Text.unpack refspec
+                    ]
+    commit <-
+        withExceptT (context "resolve the fetched default branch") $
+            ExceptT $
+                git repo
+                    [ "rev-parse"
+                    , "--verify"
+                    , Text.unpack (localRef <> "^{commit}")
+                    ]
+    pure (Text.strip commit)
+  where
+    headsPrefix = "refs/heads/"
+
+selectUpstreamRemote :: OsPath -> ExceptT Text IO Text
+selectUpstreamRemote repo = do
+    output <- ExceptT (git repo ["remote"])
+    let remotes = filter (not . Text.null) (map Text.strip (Text.lines output))
+    configured <- lift (configuredBranchRemote repo)
+    case
+        listToMaybe
+            [ remote
+            | remote <- maybe [] pure configured <> ["upstream", "origin"]
+            , remote `elem` remotes
+            ]
+        <|> case remotes of
+            [remote] -> Just remote
+            _ -> Nothing
+      of
+        Just remote -> pure remote
+        Nothing
+            | null remotes ->
+                throwE
+                    "worktree.fetchLatestUpstream requires a git remote"
+            | otherwise ->
+                throwE
+                    ( "could not choose an upstream git remote; configure the "
+                        <> "current branch's remote or name one 'upstream' or 'origin'"
+                    )
+
+configuredBranchRemote :: OsPath -> IO (Maybe Text)
+configuredBranchRemote repo =
+    git repo ["branch", "--show-current"] >>= \case
+        Right rawBranch
+            | not (Text.null (Text.strip rawBranch)) ->
+                git repo
+                    [ "config"
+                    , "--get"
+                    , "branch." <> Text.unpack (Text.strip rawBranch) <> ".remote"
+                    ] >>= \case
+                        Right rawRemote ->
+                            let remote = Text.strip rawRemote
+                            in pure $
+                                if Text.null remote || remote == "."
+                                    then Nothing
+                                    else Just remote
+                        Left _ -> pure Nothing
+        _ -> pure Nothing
+
+remoteDefaultBranch :: OsPath -> Text -> ExceptT Text IO Text
+remoteDefaultBranch repo remote = do
+    output <-
+        withExceptT
+            (\err ->
+                "failed to inspect git remote " <> quote remote
+                    <> ": " <> Text.strip err)
+            (ExceptT
+                (git repo
+                    [ "ls-remote"
+                    , "--symref"
+                    , Text.unpack remote
+                    , "HEAD"
+                    ]))
+    case
+        [ ref
+        | line <- Text.lines output
+        , ["ref:", ref, "HEAD"] <- [Text.words line]
+        , "refs/heads/" `Text.isPrefixOf` ref
+        ]
+      of
+        ref : _ -> pure ref
+        [] ->
+            throwE
+                ( "git remote " <> quote remote
+                    <> " did not advertise a default branch"
+                )
+
+quote :: Text -> Text
+quote value = "'" <> value <> "'"
 
 git :: OsPath -> [String] -> IO (Either Text Text)
 git dir args = do

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -16,7 +16,7 @@ import Agent.CLI.Config
     )
 import Agent.OsPath (unsafeToFilePath)
 import Control.Applicative ((<|>))
-import Control.Exception.Safe (mask, onException, tryAny)
+import Control.Exception.Safe (finally, mask, onException, tryAny)
 import Control.Monad (void)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
@@ -25,6 +25,7 @@ import Control.Monad.Trans.Except
     , throwE
     , withExceptT
     )
+import qualified Data.ByteString as ByteString
 import Data.List (isPrefixOf)
 import Data.Maybe (listToMaybe)
 import Data.Text (Text)
@@ -39,6 +40,7 @@ import System.Directory.OsPath
     , doesPathExist
     , removePathForcibly
     )
+import System.Entropy (getEntropy)
 import System.Exit (ExitCode(..))
 import System.OsPath
     ( OsPath
@@ -188,18 +190,27 @@ fetchLatestUpstream :: OsPath -> ExceptT Text IO Text
 fetchLatestUpstream repo = do
     remote <- selectUpstreamRemote repo
     remoteHead <- remoteDefaultBranch repo remote
-    let branch = Text.drop (Text.length headsPrefix) remoteHead
-        localRef = "refs/remotes/" <> remote <> "/" <> branch
-        refspec = "+" <> remoteHead <> ":" <> localRef
+    localRef <- lift freshFetchRef
+    ExceptT $
+        runExceptT (fetchIntoRef repo remote remoteHead localRef)
+            `finally` cleanupFetchRef repo localRef
+
+fetchIntoRef :: OsPath -> Text -> Text -> Text -> ExceptT Text IO Text
+fetchIntoRef repo remote remoteHead localRef = do
+    let refspec = remoteHead <> ":" <> localRef
         context action err =
             "failed to " <> action <> " from git remote "
                 <> quote remote <> ": " <> Text.strip err
+    -- An empty refmap prevents Git from also updating the configured
+    -- remote-tracking ref, which would reintroduce a shared ref-lock race.
     void $
         withExceptT (context "fetch the latest default branch") $
             ExceptT $
                 git repo
                     [ "fetch"
                     , "--no-tags"
+                    , "--no-write-fetch-head"
+                    , "--refmap="
                     , Text.unpack remote
                     , Text.unpack refspec
                     ]
@@ -212,8 +223,23 @@ fetchLatestUpstream repo = do
                     , Text.unpack (localRef <> "^{commit}")
                     ]
     pure (Text.strip commit)
+
+freshFetchRef :: IO Text
+freshFetchRef = do
+    bytes <- ByteString.unpack <$> getEntropy 16
+    pure $
+        "refs/haskell-agent/worktree-fetches/"
+            <> Text.pack (concatMap hexByte bytes)
   where
-    headsPrefix = "refs/heads/"
+    hexByte byte =
+        let encoded = showHex byte ""
+        in replicate (2 - length encoded) '0' <> encoded
+
+cleanupFetchRef :: OsPath -> Text -> IO ()
+cleanupFetchRef repo localRef =
+    void $
+        tryAny $
+            git repo ["update-ref", "-d", Text.unpack localRef]
 
 selectUpstreamRemote :: OsPath -> ExceptT Text IO Text
 selectUpstreamRemote repo = do

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -164,6 +164,16 @@ spec = describe "Agent.CLI.Config" do
             fmap (.configMaxConcurrentAgents) result
                 `shouldBe` Right (Just 48)
 
+    it "loads the managed worktree fetch policy" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home
+                "{\"worktree\":{\"fetchLatestUpstream\":true}}"
+            result <- loadHarnessConfig home
+            fmap (.configWorktree) result
+                `shouldBe` Right WorktreeConfig
+                    { worktreeFetchLatestUpstream = True
+                    }
+
     it "decodes LSP maps and retains opaque JSON options" $
         withTempDir "agent-config-" \home -> do
             writeConfig home
@@ -274,6 +284,9 @@ spec = describe "Agent.CLI.Config" do
                     }
                 config = defaultHarnessConfig
                     { configMcpServers = Map.singleton "seo-mcp" server
+                    , configWorktree = WorktreeConfig
+                        { worktreeFetchLatestUpstream = True
+                        }
                     , configMaxConcurrentAgents = Just 48
                     }
             saveHarnessConfig home config `shouldReturn` Right ()

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -2,7 +2,7 @@ module Agent.CLI.WorktreeSpec (spec) where
 
 import Agent.CLI.Config
 import Agent.CLI.Worktree
-import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
+import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception.Safe (bracket)
 import Data.List (dropWhileEnd, isInfixOf)
 import Data.Text (Text)
@@ -12,7 +12,14 @@ import qualified System.Directory as Directory
 import System.Directory.OsPath (doesDirectoryExist, doesFileExist)
 import System.Exit (ExitCode(..))
 import qualified System.FilePath as FilePath
-import System.OsPath (addTrailingPathSeparator, takeFileName, (</>))
+import System.OsPath
+    ( OsPath
+    , addTrailingPathSeparator
+    , decodeUtf
+    , takeFileName
+    , unsafeEncodeUtf
+    , (</>)
+    )
 import System.Posix.Temp (mkdtemp)
 import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
 import Test.Hspec
@@ -108,13 +115,32 @@ spec = describe "Agent.CLI.Worktree" do
 
                 git path ["rev-parse", "HEAD"] `shouldReturn` latest
                 git repo ["rev-parse", "refs/remotes/origin/master"]
-                    `shouldReturn` latest
+                    `shouldReturn` stale
                 readFile (toFilePath (path </> fromFilePath "README"))
                     `shouldReturn` "latest\n"
                 doesFileExist (path </> fromFilePath "LOCAL")
                     `shouldReturn` False
                 git path ["rev-parse", "--abbrev-ref", "HEAD"]
                     `shouldReturn` toFilePath (takeFileName path)
+                temporaryFetchRefs repo `shouldReturn` ""
+
+        it "uses isolated fetch refs for concurrent worktree creation" $
+            withTempRemoteRepo \repo updater ->
+            withTempDir "agent-home-" \home -> do
+                latest <- git updater ["rev-parse", "HEAD"]
+                paths <-
+                    mapM expectRight
+                        =<< mapConcurrently
+                            (\_ ->
+                                createWorktreeWithFetch
+                                    True
+                                    repo
+                                    (worktreeRoot home))
+                            [1 :: Int .. 4]
+
+                mapM_ (\path ->
+                    git path ["rev-parse", "HEAD"] `shouldReturn` latest) paths
+                temporaryFetchRefs repo `shouldReturn` ""
 
         it "creates two distinct worktrees for the same repo" $
             withTempGitRepo \repo ->
@@ -198,6 +224,14 @@ configureGit repo = do
     _ <- git repo ["config", "user.name", "Test"]
     _ <- git repo ["config", "commit.gpgsign", "false"]
     pure ()
+
+temporaryFetchRefs :: OsPath -> IO String
+temporaryFetchRefs repo =
+    git repo
+        [ "for-each-ref"
+        , "--format=%(refname)"
+        , "refs/haskell-agent/worktree-fetches/"
+        ]
 
 withTempDir :: String -> (OsPath -> IO a) -> IO a
 withTempDir prefix action = do

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -1,14 +1,15 @@
 module Agent.CLI.WorktreeSpec (spec) where
 
+import Agent.CLI.Config
 import Agent.CLI.Worktree
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
-import Control.Exception (bracket)
+import Control.Exception.Safe (bracket)
 import Data.List (dropWhileEnd, isInfixOf)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import qualified System.Directory as Directory
-import System.Directory.OsPath (doesDirectoryExist)
+import System.Directory.OsPath (doesDirectoryExist, doesFileExist)
 import System.Exit (ExitCode(..))
 import qualified System.FilePath as FilePath
 import System.OsPath (addTrailingPathSeparator, takeFileName, (</>))
@@ -66,6 +67,8 @@ spec = describe "Agent.CLI.Worktree" do
                 worktreeBranch <- git path ["rev-parse", "--abbrev-ref", "HEAD"]
                 worktreeBranch `shouldNotBe` sourceBranch
                 worktreeBranch `shouldBe` toFilePath (takeFileName path)
+                sourceHead <- git repo ["rev-parse", "HEAD"]
+                git path ["rev-parse", "HEAD"] `shouldReturn` sourceHead
 
         it "rejects a directory that is not a git checkout" $
             withTempDir "agent-not-git-" \dir -> do
@@ -76,6 +79,42 @@ spec = describe "Agent.CLI.Worktree" do
                     Right path ->
                         expectationFailure ("expected failure, got " <> toFilePath path)
                 doesDirectoryExist root `shouldReturn` False
+
+        it "fails closed when latest-upstream mode has no remote" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                result <- createWorktreeWithFetch True repo root
+                result `shouldSatisfy` \case
+                    Left err ->
+                        "requires a git remote" `Text.isInfixOf` err
+                    Right _ -> False
+                doesDirectoryExist root `shouldReturn` False
+
+        it "fetches and branches from the remote's latest default commit" $
+            withTempRemoteRepo \repo updater ->
+            withTempDir "agent-home-" \home -> do
+                stale <- git repo ["rev-parse", "refs/remotes/origin/master"]
+                latest <- git updater ["rev-parse", "HEAD"]
+                stale `shouldNotBe` latest
+                let config = defaultHarnessConfig
+                        { configWorktree = WorktreeConfig
+                            { worktreeFetchLatestUpstream = True
+                            }
+                        }
+                saveHarnessConfig home config `shouldReturn` Right ()
+
+                path <- expectRight =<< createManagedWorktree home repo
+
+                git path ["rev-parse", "HEAD"] `shouldReturn` latest
+                git repo ["rev-parse", "refs/remotes/origin/master"]
+                    `shouldReturn` latest
+                readFile (toFilePath (path </> fromFilePath "README"))
+                    `shouldReturn` "latest\n"
+                doesFileExist (path </> fromFilePath "LOCAL")
+                    `shouldReturn` False
+                git path ["rev-parse", "--abbrev-ref", "HEAD"]
+                    `shouldReturn` toFilePath (takeFileName path)
 
         it "creates two distinct worktrees for the same repo" $
             withTempGitRepo \repo ->
@@ -122,6 +161,43 @@ withTempGitRepo action =
         _ <- git dir ["add", "README"]
         _ <- git dir ["commit", "-m", "init"]
         action dir
+
+withTempRemoteRepo :: (OsPath -> OsPath -> IO a) -> IO a
+withTempRemoteRepo action =
+    withTempDir "agent-remote-" \root -> do
+        let bare = root </> fromFilePath "origin.git"
+            repo = root </> fromFilePath "source"
+            updater = root </> fromFilePath "updater"
+        _ <- git root
+            [ "init", "--bare", "--initial-branch=master", toFilePath bare ]
+        Directory.createDirectory (toFilePath repo)
+        _ <- git repo ["init", "--initial-branch=master"]
+        configureGit repo
+        writeFile (toFilePath (repo </> fromFilePath "README")) "initial\n"
+        _ <- git repo ["add", "README"]
+        _ <- git repo ["commit", "-m", "initial"]
+        _ <- git repo ["remote", "add", "origin", toFilePath bare]
+        _ <- git repo ["push", "-u", "origin", "master"]
+
+        _ <- git root ["clone", toFilePath bare, toFilePath updater]
+        configureGit updater
+        writeFile (toFilePath (updater </> fromFilePath "README")) "latest\n"
+        _ <- git updater ["add", "README"]
+        _ <- git updater ["commit", "-m", "latest"]
+        _ <- git updater ["push", "origin", "master"]
+
+        _ <- git repo ["switch", "-c", "local-work"]
+        writeFile (toFilePath (repo </> fromFilePath "LOCAL")) "local\n"
+        _ <- git repo ["add", "LOCAL"]
+        _ <- git repo ["commit", "-m", "local"]
+        action repo updater
+
+configureGit :: OsPath -> IO ()
+configureGit repo = do
+    _ <- git repo ["config", "user.email", "test@example.com"]
+    _ <- git repo ["config", "user.name", "Test"]
+    _ <- git repo ["config", "commit.gpgsign", "false"]
+    pure ()
 
 withTempDir :: String -> (OsPath -> IO a) -> IO a
 withTempDir prefix action = do


### PR DESCRIPTION
## Summary

- add the opt-in `worktree.fetchLatestUpstream` configuration, defaulting to `false`
- fetch the selected remote's advertised default branch and base each generated worktree branch on the exact fetched commit
- apply the policy to `--worktree`, `/worktree`, and subagent worktrees, with documentation and fail-closed integration coverage

## Testing

- `nix develop -c cabal repl --repl-no-load agent-cli:test:agent-cli-test`
  - loaded `Agent.CLI.ConfigSpec` and `Agent.CLI.WorktreeSpec`
  - 34 examples, 0 failures
- `git diff --check origin/master...HEAD`
