### PR TITLE
Share Responses provider client wiring

### DIFF
--- a/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Client.hs
@@ -13,10 +13,10 @@ import Agent.Error
     , ErrorType(..)
     , isInlineRetryableProviderError
     )
-import Agent.Responses.Client
-    ( ResponsesClientConfig(..)
-    , performResponsesRequest
-    , retryStreamingResultWithPolicy
+import Agent.Responses.GenericClient
+    ( ProviderClientConfig(..)
+    , createResponseWithProviderPolicy
+    , retryTransientResultWithPolicy
     )
 import qualified Agent.Responses.HttpSSE as HttpSSE
 import Agent.Responses.Types
@@ -79,26 +79,11 @@ createResponseWithEventsPolicy policy options credential request onEvent
         "agent-openrouter requires an OpenRouter credential"
         Nothing
     | otherwise =
-        retryTransientOpenRouterResultWithPolicy policy performOnce onEvent
-  where
-    performOnce =
-        performResponsesRequest
-            ResponsesClientConfig
-                { clientExceptionPrefix = "OpenRouter request failed"
-                , clientBaseUrl = options.baseUrl
-                , clientTimeoutSeconds = options.requestTimeoutSeconds
-                , clientClassifyFailure = classifyFailure
-                , clientBuildResponse = buildResponse
-                }
-            (buildRequest options request)
-            configureRequest
-
-    configureRequest =
-        setRequestHeader "Authorization"
-            ["Bearer " <> Text.encodeUtf8 credential.accessToken]
-            . setRequestHeader "User-Agent" ["haskell-agent"]
-            . optionalHeader "HTTP-Referer" options.httpReferer
-            . optionalHeader "X-Title" options.appTitle
+        createResponseWithProviderPolicy
+            policy
+            (openRouterProviderConfig options credential)
+            request
+            (Just onEvent)
 
 -- | Retry transient failures while replay is safe. The callback marker is
 -- written before user code runs, so callback exceptions are never retried.
@@ -107,15 +92,30 @@ retryTransientOpenRouterResultWithPolicy
     -> ((event -> IO ()) -> IO (Either ApiError value))
     -> (event -> IO ())
     -> IO (Either ApiError value)
-retryTransientOpenRouterResultWithPolicy policy request onEvent =
-    retryStreamingResultWithPolicy
-        policy
-        isInlineRetryableProviderError
-        request
-        (Just onEvent)
+retryTransientOpenRouterResultWithPolicy = retryTransientResultWithPolicy
 
 transientResultPolicy :: RetryPolicyM IO
 transientResultPolicy = exponentialBackoff 1_000_000 <> limitRetries 3
+
+openRouterProviderConfig
+    :: ClientOptions
+    -> Credential
+    -> ProviderClientConfig
+openRouterProviderConfig options credential = ProviderClientConfig
+    { providerExceptionPrefix = "OpenRouter request failed"
+    , providerBaseUrl = options.baseUrl
+    , providerRequestTimeoutSeconds = options.requestTimeoutSeconds
+    , providerBuildRequest = buildRequest options
+    , providerConfigureRequest =
+        setRequestHeader "Authorization"
+            ["Bearer " <> Text.encodeUtf8 credential.accessToken]
+            . setRequestHeader "User-Agent" ["haskell-agent"]
+            . optionalHeader "HTTP-Referer" options.httpReferer
+            . optionalHeader "X-Title" options.appTitle
+    , providerClassifyFailure = classifyFailure
+    , providerBuildResponse = buildResponse
+    , providerRetryableFailure = isInlineRetryableProviderError
+    }
 
 optionalHeader :: HeaderName -> Maybe Text -> Request -> Request
 optionalHeader name value request = case nonEmptyText value of

--- a/packages/agent-openrouter/test/Agent/OpenRouter/ClientSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/ClientSpec.hs
@@ -45,6 +45,7 @@ spec = do
             [request] <- readIORef recorded
             request.path `shouldBe` "/v1/responses"
             lookup "Authorization" request.headers `shouldBe` Just "Bearer token-a"
+            lookup "User-Agent" request.headers `shouldBe` Just "haskell-agent"
             lookup "HTTP-Referer" request.headers `shouldBe` Just "https://example.com"
             lookup "X-Title" request.headers `shouldBe` Just "haskell-agent-test"
             requestModel request `shouldBe` Just "openai/gpt-5.1"

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -94,9 +94,13 @@ test-suite agent-responses-test
                     , bytestring
                     , containers
                     , hspec
+                    , http-conduit
+                    , http-types
                     , QuickCheck >= 2.14 && < 2.16
                     , retry
                     , text
+                    , wai
+                    , warp
 
 benchmark responses-json-bench
     import:           common-opts

--- a/packages/agent-responses/package.nix
+++ b/packages/agent-responses/package.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, agent-core, agent-json
 , agent-responses-types, base, base64-bytestring, bytestring
 , containers, hermes-json, hspec, http-client, http-client-tls
-, http-conduit, lib, QuickCheck, retry, safe-exceptions, scientific
-, text, vector
+, http-conduit, http-types, lib, QuickCheck, retry, safe-exceptions
+, scientific, text, vector, wai, warp
 }:
 mkDerivation {
   pname = "agent-responses";
@@ -16,7 +16,8 @@ mkDerivation {
   ];
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses-types base bytestring
-    containers hspec QuickCheck retry text
+    containers hspec http-conduit http-types QuickCheck retry text wai
+    warp
   ];
   benchmarkHaskellDepends = [
     aeson agent-json agent-responses-types base bytestring text

--- a/packages/agent-responses/src/Agent/Responses/GenericClient.hs
+++ b/packages/agent-responses/src/Agent/Responses/GenericClient.hs
@@ -2,10 +2,12 @@
 -- endpoints.
 module Agent.Responses.GenericClient
     ( GenericClientOptions(..)
+    , ProviderClientConfig(..)
     , buildRequest
     , createResponseWith
     , createResponseWithEvents
     , createResponseWithEventsPolicy
+    , createResponseWithProviderPolicy
     , retryTransientResultWithPolicy
     , classifyFailure
     , classifyStreamError
@@ -59,6 +61,25 @@ data GenericClientOptions = GenericClientOptions
       -- ^ Full streaming-response timeout.
     } deriving (Eq, Show)
 
+-- | Provider-specific hooks around the shared stateless Responses client.
+--
+-- Named providers retain their own option and credential types, request
+-- dialects, headers, error classification, and retry policy. This record only
+-- centralizes the transport/retry wiring common to those clients.
+data ProviderClientConfig = ProviderClientConfig
+    { providerExceptionPrefix :: !Text
+    , providerBaseUrl :: !String
+    , providerRequestTimeoutSeconds :: !Int
+    , providerBuildRequest
+        :: !(ResponseCreateParams -> ResponseCreateParams)
+    , providerConfigureRequest :: !(Request -> Request)
+    , providerClassifyFailure
+        :: !(Int -> Maybe Int -> Text -> ApiError)
+    , providerBuildResponse
+        :: !([ResponseStreamEvent] -> Either ApiError Response)
+    , providerRetryableFailure :: !(ApiError -> Bool)
+    }
+
 -- | Project canonical request parameters onto a stateless Responses endpoint.
 --
 -- Stateless endpoints receive the complete local transcript on every request,
@@ -91,29 +112,42 @@ createResponseWithEventsPolicy
     -> HttpSSE.StreamEventCallback
     -> IO (Either ApiError Response)
 createResponseWithEventsPolicy policy options request onEvent =
-    retryTransientResultWithPolicy policy performOnce onEvent
+    createResponseWithProviderPolicy
+        policy
+        (genericProviderConfig options)
+        request
+        (Just onEvent)
+
+-- | Execute a stateless Responses request through provider-specific hooks.
+--
+-- A missing callback means streamed events are intentionally discarded and
+-- therefore remain safe to replay. A present callback prevents retries after
+-- the first caller-visible event.
+createResponseWithProviderPolicy
+    :: RetryPolicyM IO
+    -> ProviderClientConfig
+    -> ResponseCreateParams
+    -> Maybe HttpSSE.StreamEventCallback
+    -> IO (Either ApiError Response)
+createResponseWithProviderPolicy policy config request onEvent =
+    retryStreamingResultWithPolicy
+        policy
+        config.providerRetryableFailure
+        performOnce
+        onEvent
   where
     performOnce =
         performResponsesRequest
             ResponsesClientConfig
-                { clientExceptionPrefix = "Responses request failed"
-                , clientBaseUrl = options.baseUrl
-                , clientTimeoutSeconds = options.requestTimeoutSeconds
-                , clientClassifyFailure = classifyFailure
-                , clientBuildResponse = buildResponse
+                { clientExceptionPrefix = config.providerExceptionPrefix
+                , clientBaseUrl = config.providerBaseUrl
+                , clientTimeoutSeconds =
+                    config.providerRequestTimeoutSeconds
+                , clientClassifyFailure = config.providerClassifyFailure
+                , clientBuildResponse = config.providerBuildResponse
                 }
-            (buildRequest options request)
-            configureRequest
-
-    configureRequest =
-        maybe
-            id
-            (\token ->
-                setRequestHeader
-                    "Authorization"
-                    ["Bearer " <> Text.encodeUtf8 token])
-            (nonEmptyText options.bearerToken)
-            . setRequestHeader "User-Agent" ["haskell-agent"]
+            (config.providerBuildRequest request)
+            config.providerConfigureRequest
 
 retryTransientResultWithPolicy
     :: RetryPolicyM IO
@@ -153,6 +187,26 @@ buildResponse = buildStreamResponse StreamAssemblyConfig
 
 transientResultPolicy :: RetryPolicyM IO
 transientResultPolicy = exponentialBackoff 1_000_000 <> limitRetries 3
+
+genericProviderConfig :: GenericClientOptions -> ProviderClientConfig
+genericProviderConfig options = ProviderClientConfig
+    { providerExceptionPrefix = "Responses request failed"
+    , providerBaseUrl = options.baseUrl
+    , providerRequestTimeoutSeconds = options.requestTimeoutSeconds
+    , providerBuildRequest = buildRequest options
+    , providerConfigureRequest =
+        maybe
+            id
+            (\token ->
+                setRequestHeader
+                    "Authorization"
+                    ["Bearer " <> Text.encodeUtf8 token])
+            (nonEmptyText options.bearerToken)
+            . setRequestHeader "User-Agent" ["haskell-agent"]
+    , providerClassifyFailure = classifyFailure
+    , providerBuildResponse = buildResponse
+    , providerRetryableFailure = isInlineRetryableProviderError
+    }
 
 nonEmptyText :: Maybe Text -> Maybe Text
 nonEmptyText (Just value)

--- a/packages/agent-responses/test/Agent/Responses/GenericClientSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/GenericClientSpec.hs
@@ -4,6 +4,7 @@ import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Json (rawJsonBytes, rawJsonFromEncoding)
 import qualified Agent.Responses.Codec as Codec
 import Agent.Responses.GenericClient
+import Agent.Responses.Request (setResponseModel)
 import Agent.Responses.Types
 import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
@@ -11,6 +12,11 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Char8 as BS
 import Data.IORef
 import Data.Text (Text)
+import qualified Data.Text as Text
+import Network.HTTP.Simple (setRequestHeader)
+import qualified Network.HTTP.Types as HTTP
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
 import Test.Hspec
 
 spec :: Spec
@@ -124,6 +130,27 @@ spec = do
             result `shouldBe` Left (ConnectionError "after output")
             readIORef attempts `shouldReturn` 1
             readIORef delivered `shouldReturn` [1]
+
+    describe "createResponseWithProviderPolicy" do
+        it "applies provider hooks through the shared transport and retry path" do
+            attempts <- newIORef (0 :: Int)
+            recordedModels <- newIORef []
+            recordedHeaders <- newIORef []
+            Warp.testWithApplication
+                (pure (providerHookApp attempts recordedModels recordedHeaders))
+                \port -> do
+                    let config = providerHookConfig port
+                    result <- createResponseWithProviderPolicy
+                        (constantDelay 0 <> limitRetries 2)
+                        config
+                        defaultResponseCreateParams
+                        Nothing
+                    response <- expectRight result
+                    response.responseId `shouldBe` "resp-provider-hook"
+            readIORef attempts `shouldReturn` 2
+            readIORef recordedModels
+                `shouldReturn` [Just "provider-model", Just "provider-model"]
+            readIORef recordedHeaders `shouldReturn` [True, True]
   where
     options = GenericClientOptions
         { baseUrl = "http://localhost:8000/v1"
@@ -131,6 +158,65 @@ spec = do
         , bearerToken = Nothing
         , requestTimeoutSeconds = 60
         }
+
+providerHookConfig :: Warp.Port -> ProviderClientConfig
+providerHookConfig port = ProviderClientConfig
+    { providerExceptionPrefix = "Provider hook request failed"
+    , providerBaseUrl = "http://127.0.0.1:" <> show port <> "/v1"
+    , providerRequestTimeoutSeconds = 10
+    , providerBuildRequest = setResponseModel "provider-model"
+    , providerConfigureRequest =
+        setRequestHeader "X-Provider-Hook" ["enabled"]
+    , providerClassifyFailure = \_status _retryAfter body ->
+        ConnectionError ("provider hook: " <> body)
+    , providerBuildResponse = buildResponse
+    , providerRetryableFailure = \case
+        ConnectionError message ->
+            "provider hook:" `Text.isPrefixOf` message
+        _ -> False
+    }
+
+providerHookApp attempts recordedModels recordedHeaders request respond = do
+    body <- Wai.strictRequestBody request
+    let decoded = Codec.decodeResponseCreateParams (LBS.toStrict body)
+        requestModel = either (const Nothing) (.model) decoded
+        hasProviderHeader =
+            lookup "X-Provider-Hook" (Wai.requestHeaders request)
+                == Just "enabled"
+    modifyIORef' recordedModels (<> [requestModel])
+    modifyIORef' recordedHeaders (<> [hasProviderHeader])
+    attempt <- atomicModifyIORef' attempts \current ->
+        let next = current + 1
+        in (next, next)
+    respond $
+        if attempt == 1
+            then Wai.responseLBS HTTP.status418
+                [("Content-Type", "text/plain")]
+                "try again"
+            else providerHookResponse
+
+providerHookResponse :: Wai.Response
+providerHookResponse = Wai.responseLBS HTTP.status200
+    [("Content-Type", "text/event-stream")]
+    ("event: response.completed\ndata: " <> Aeson.encode payload <> "\n\n")
+  where
+    payload = Aeson.object
+        [ "type" Aeson..= ("response.completed" :: Text)
+        , "response" Aeson..= Aeson.object
+            [ "id" Aeson..= ("resp-provider-hook" :: Text)
+            , "created_at" Aeson..= (0 :: Int)
+            , "model" Aeson..= ("provider-model" :: Text)
+            , "status" Aeson..= ("completed" :: Text)
+            , "output" Aeson..= ([] :: [Aeson.Value])
+            ]
+        ]
+
+expectRight :: Show error => Either error value -> IO value
+expectRight = \case
+    Left err ->
+        expectationFailure ("expected Right, got Left " <> show err)
+            >> fail "unreachable"
+    Right value -> pure value
 
 withTools :: [ResponseTool] -> ResponseCreateParams -> ResponseCreateParams
 withTools value request = request { tools = Just value }

--- a/packages/agent-xai/src/Agent/XAI/Client.hs
+++ b/packages/agent-xai/src/Agent/XAI/Client.hs
@@ -13,10 +13,9 @@ import Agent.Error
     ( ApiError(..)
     , ErrorType(..)
     )
-import Agent.Responses.Client
-    ( ResponsesClientConfig(..)
-    , performResponsesRequest
-    , retryStreamingResultWithPolicy
+import Agent.Responses.GenericClient
+    ( ProviderClientConfig(..)
+    , createResponseWithProviderPolicy
     )
 import qualified Agent.Responses.HttpSSE as HttpSSE
 import Agent.Responses.Types
@@ -114,25 +113,26 @@ createResponseWithMaybeEventsPolicy policy options credential request onEvent
         "agent-xai requires an xAI credential"
         Nothing
     | otherwise =
-        retryStreamingResultWithPolicy
+        createResponseWithProviderPolicy
             policy
-            isCapacityRetryable
-            performOnce
+            (xaiProviderConfig options credential)
+            request
             onEvent
-  where
-    performOnce =
-        performResponsesRequest
-            ResponsesClientConfig
-                { clientExceptionPrefix = "xAI request failed"
-                , clientBaseUrl = options.baseUrl
-                , clientTimeoutSeconds = options.requestTimeoutSeconds
-                , clientClassifyFailure = classifyFailure
-                , clientBuildResponse = buildResponse
-                }
-            (buildRequest options request)
-            configureRequest
 
-    configureRequest =
+defaultTransientPolicy :: RetryPolicyM IO
+defaultTransientPolicy =
+    constantDelay (capacityRetryAfterSeconds * 1_000_000) <> limitRetries 3
+
+xaiProviderConfig
+    :: ClientOptions
+    -> Credential
+    -> ProviderClientConfig
+xaiProviderConfig options credential = ProviderClientConfig
+    { providerExceptionPrefix = "xAI request failed"
+    , providerBaseUrl = options.baseUrl
+    , providerRequestTimeoutSeconds = options.requestTimeoutSeconds
+    , providerBuildRequest = buildRequest options
+    , providerConfigureRequest =
         setRequestHeader "Authorization"
             ["Bearer " <> Text.encodeUtf8 credential.accessToken]
             . setRequestHeader "X-XAI-Token-Auth"
@@ -146,10 +146,10 @@ createResponseWithMaybeEventsPolicy policy options credential request onEvent
             . setRequestHeader "x-grok-client-mode" ["interactive"]
             . setRequestHeader "User-Agent"
                 [Text.encodeUtf8 (grokUserAgent options.clientVersion)]
-
-defaultTransientPolicy :: RetryPolicyM IO
-defaultTransientPolicy =
-    constantDelay (capacityRetryAfterSeconds * 1_000_000) <> limitRetries 3
+    , providerClassifyFailure = classifyFailure
+    , providerBuildResponse = buildResponse
+    , providerRetryableFailure = isCapacityRetryable
+    }
 
 -- | Retry capacity / overload pressure and short-lived 5xx failures. Generic
 -- connection drops and quota errors are left to the caller. Production uses a

--- a/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
@@ -52,6 +52,8 @@ spec = do
                 `shouldBe` Just grokClientIdentifier
             lookup "x-grok-client-version" request.headers
                 `shouldBe` Just defaultGrokClientVersion
+            lookup "x-grok-client-mode" request.headers
+                `shouldBe` Just "interactive"
             lookup "User-Agent" request.headers
                 `shouldBe` Just (grokUserAgent defaultGrokClientVersion)
             requestModel request `shouldBe` Just "grok-4.6"


### PR DESCRIPTION
## Summary

- add `ProviderClientConfig` and `createResponseWithProviderPolicy` to make request projection, headers, failure/response classification, and retryability explicit provider hooks
- migrate the generic, OpenRouter, and xAI clients onto the shared transport/retry path while keeping their provider-named APIs intact
- preserve the callback replay boundary, including xAI's ability to retry discarded capacity-error streams while never replaying caller-visible events
- add an in-process HTTP regression covering the shared hooks and provider-specific header assertions; regenerate `agent-responses/package.nix`

## Motivation

The xAI and OpenRouter clients each rebuilt the same `ResponsesClientConfig` + `performResponsesRequest` + `retryStreamingResultWithPolicy` pipeline. Their genuine protocol differences should remain local, but the common execution wiring should not have to be copied for every Responses-compatible provider.

## Compatibility

No existing provider entry point changes signature. Request dialects, credential checks, headers, error assembly, retry predicates, delays, and callback semantics remain provider-owned.

## Testing

- multi-package GHCi load: `nix develop -c cabal repl agent-responses:lib:agent-responses agent-openrouter:lib:agent-openrouter agent-xai:lib:agent-xai` (31 modules loaded)
- `nix develop -c cabal test agent-responses:test:agent-responses-test agent-openrouter:test:agent-openrouter-test agent-xai:test:agent-xai-test --test-show-details=direct`
  - Responses: 68 examples, 0 failures
  - OpenRouter: 39 examples, 0 failures, 1 credential-gated live test pending
  - xAI: 57 examples, 0 failures, 1 credential-gated live test pending
