### PR TITLE
Add live OpenRouter model selector

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -1,6 +1,7 @@
 -- | Interactive TTY model picker for bare @/model@.
 module Agent.CLI.ModelPicker
     ( pickModel
+    , pickModelWithOptions
     , formatCatalogListing
     , renderPickerFrame
     , decodePickerKey
@@ -8,7 +9,7 @@ module Agent.CLI.ModelPicker
 
 import Agent.CLI.Models
 import Agent.CLI.ModelConfig (ModelCatalog)
-import Agent.CLI.Picker (PickerKey(..), runOverlay)
+import Agent.CLI.Picker (PickerKey(..), runOverlayWithDecoder)
 import qualified Agent.CLI.Picker as Picker
 import Agent.Dialect (DialectId, dialectSlug)
 import Agent.CLI.Style
@@ -20,6 +21,7 @@ import Agent.CLI.Style
     )
 import Agent.Provider (Provider)
 import Control.Monad (join)
+import Data.Char (isPrint)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -27,7 +29,13 @@ import System.IO (hFlush, hIsTerminalDevice, stderr, stdin)
 
 -- | Decode one keypress (including CSI arrow sequences) into a picker event.
 decodePickerKey :: String -> Maybe PickerEvent
-decodePickerKey raw = toEvent <$> Picker.decodePickerKey raw
+decodePickerKey raw = toEvent <$> decodeModelPickerKey raw
+
+decodeModelPickerKey :: String -> Maybe PickerKey
+decodeModelPickerKey raw = case raw of
+    [c]
+        | isPrint c -> Just (PickerKeyChar c)
+    _ -> Picker.decodePickerKey raw
 
 toEvent :: PickerKey -> PickerEvent
 toEvent = \case
@@ -50,10 +58,32 @@ pickModel
     -> DialectId
     -> IO (Maybe ModelOption)
 pickModel catalog color connectionId provider current currentDialect = do
+    pickModelWithOptions
+        catalog
+        []
+        color
+        connectionId
+        provider
+        current
+        currentDialect
+
+-- | Open the picker with extra runtime-discovered entries appended to the
+-- configured catalog.
+pickModelWithOptions
+    :: ModelCatalog
+    -> [ModelOption]
+    -> Bool
+    -> Text
+    -> Provider
+    -> Text
+    -> DialectId
+    -> IO (Maybe ModelOption)
+pickModelWithOptions
+        catalog discovered color connectionId provider current currentDialect = do
     isTty <- hIsTerminalDevice stdin
     state0 <-
-        initialPickerStateResolved
-            catalog connectionId provider current currentDialect
+        initialPickerStateResolvedWith
+            catalog discovered connectionId provider current currentDialect
     if not isTty
         then do
             Text.hPutStrLn stderr
@@ -62,7 +92,12 @@ pickModel catalog color connectionId provider current currentDialect = do
             hFlush stderr
             pure Nothing
         else do
-            result <- runOverlay (renderPickerFrame color) step state0
+            result <-
+                runOverlayWithDecoder
+                    decodeModelPickerKey
+                    (renderPickerFrame color)
+                    step
+                    state0
             pure (join result)
   where
     step key state = applyPickerEvent (toEvent key) state
@@ -124,6 +159,13 @@ renderPickerFrame color state =
     let visible = visibleOptions state
         n = length visible
         idx = if n == 0 then 0 else min state.pickerIndex (n - 1)
+        windowStart =
+            max 0
+                $ min
+                    (max 0 (n - pickerViewportSize))
+                    (idx - pickerViewportSize `div` 2)
+        window =
+            take pickerViewportSize (drop windowStart visible)
         header =
             rolePrompt color "model"
                 <> roleMuted color
@@ -139,19 +181,31 @@ renderPickerFrame color state =
                     <> roleWarn color state.pickerFilter
         body = case visible of
             [] -> [roleMuted color "(no matches)"]
-            opts ->
+            _ ->
                 zipWith
                     (\i opt -> renderRow color (i == idx)
                         state.pickerConnectionId
                         state.pickerCurrent
                         state.pickerCurrentDialect
                         opt)
-                    [0 ..]
-                    opts
+                    [windowStart ..]
+                    window
+        position
+            | n == 0 = roleMuted color "0 models"
+            | otherwise =
+                roleMuted color
+                    (Text.pack (show (idx + 1))
+                        <> "/"
+                        <> Text.pack (show n)
+                        <> " models")
         footer =
             roleMuted color
-                "↑↓/jk or scroll · click/enter · esc/q · type to filter"
-    in Text.intercalate "\n" (header : filterLine : body <> [footer])
+                "↑↓ or scroll · click/enter · esc · type to filter"
+    in Text.intercalate "\n"
+        (header : filterLine : body <> [position, footer])
+
+pickerViewportSize :: Int
+pickerViewportSize = 12
 
 renderRow
     :: Bool

--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -16,6 +16,7 @@ module Agent.CLI.Models
     , ensureCurrentInList
     , initialPickerState
     , initialPickerStateResolved
+    , initialPickerStateResolvedWith
     , visibleOptions
     , selectedOption
     , applyPickerEvent
@@ -41,7 +42,8 @@ import Agent.Dialect
 import qualified Agent.OpenRouter.Options as OpenRouter
 import qualified Agent.OpenRouter.Request as OpenRouter
 import Agent.Provider (Provider(..))
-import Data.List (findIndex)
+import Data.Char (isPrint)
+import Data.List (findIndex, nubBy)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -198,12 +200,45 @@ initialPickerStateResolved
     -> DialectId
     -> IO PickerState
 initialPickerStateResolved
-        catalog connectionId provider current currentDialect = do
-    resolved <- traverse resolveModelOptionDialect
-        (prioritizeCurrentConnection connectionId (modelCatalog catalog))
+        catalog connectionId provider current currentDialect =
+    initialPickerStateResolvedWith
+        catalog
+        []
+        connectionId
+        provider
+        current
+        currentDialect
+
+-- | Build picker state with additional, runtime-discovered models. Configured
+-- entries win when the same connection/model pair also appears in the live
+-- catalog, preserving custom labels and wire-model overrides.
+initialPickerStateResolvedWith
+    :: ModelCatalog
+    -> [ModelOption]
+    -> Text
+    -> Provider
+    -> Text
+    -> DialectId
+    -> IO PickerState
+initialPickerStateResolvedWith
+        catalog discovered connectionId provider current currentDialect = do
+    let options =
+            prioritizeCurrentConnection connectionId
+                $ deduplicateOptions
+                    (modelCatalog catalog <> discovered)
+    resolved <- resolveModelOptionsDialects options
     pure $
         pickerStateFromOptions
             connectionId provider current currentDialect resolved
+
+deduplicateOptions :: [ModelOption] -> [ModelOption]
+deduplicateOptions = nubBy sameIdentity
+  where
+    sameIdentity left right =
+        left.modelTarget.targetConnectionId
+            == right.modelTarget.targetConnectionId
+            && left.modelTarget.targetModelId
+                == right.modelTarget.targetModelId
 
 prioritizeCurrentConnection :: Text -> [ModelOption] -> [ModelOption]
 prioritizeCurrentConnection current options =
@@ -312,23 +347,43 @@ resolvePersistedDialect storedDialect storedTransportModel inferred =
 
 resolveModelOptionDialect :: ModelOption -> IO ModelOption
 resolveModelOptionDialect option
-    | option.modelTarget.targetConnectionId
-        == builtinConnectionId OpenRouterProvider = do
+    | isBuiltinOpenRouter option = do
         options <- OpenRouter.clientOptionsFromEnv
+        pure (resolveModelOptionDialectWith options option)
+    | otherwise = pure option
+
+resolveModelOptionsDialects :: [ModelOption] -> IO [ModelOption]
+resolveModelOptionsDialects options
+    | any isBuiltinOpenRouter options = do
+        clientOptions <- OpenRouter.clientOptionsFromEnv
+        pure (map (resolveModelOptionDialectWith clientOptions) options)
+    | otherwise = pure options
+
+resolveModelOptionDialectWith
+    :: OpenRouter.ClientOptions
+    -> ModelOption
+    -> ModelOption
+resolveModelOptionDialectWith options option
+    | isBuiltinOpenRouter option =
         let transportedModel
                 | option.modelTarget.targetWireModelId
                     /= option.modelTarget.targetModelId =
                         option.modelTarget.targetWireModelId
                 | otherwise =
                     OpenRouter.mapModel options option.modelTarget.targetModelId
-        pure option
+        in option
             { modelTarget = option.modelTarget
                 { targetWireModelId = transportedModel
                 , targetDialect =
                     dialectIdForModel OpenRouterProvider transportedModel
                 }
             }
-    | otherwise = pure option
+    | otherwise = option
+
+isBuiltinOpenRouter :: ModelOption -> Bool
+isBuiltinOpenRouter option =
+    option.modelTarget.targetConnectionId
+        == builtinConnectionId OpenRouterProvider
 
 move :: Int -> PickerState -> PickerState
 move delta state =
@@ -353,11 +408,7 @@ clampIndex n i
     | otherwise = i
 
 isFilterChar :: Char -> Bool
-isFilterChar c =
-    c == '-' || c == '/' || c == '.' || c == '_'
-        || (c >= 'a' && c <= 'z')
-        || (c >= 'A' && c <= 'Z')
-        || (c >= '0' && c <= '9')
+isFilterChar = isPrint
 
 isCurrent :: Text -> Text -> DialectId -> ModelOption -> Bool
 isCurrent connectionId current dialect option =

--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Picker
     , decodeMouseEvent
     , mouseKeysForFrame
     , runOverlay
+    , runOverlayWithDecoder
     , runOverlayWithUpdates
     , withRawTty
     ) where
@@ -182,8 +183,19 @@ safeLast xs = Just (last xs)
 
 -- | Draw @render@, then feed keys through @step@ until it returns @Left@.
 runOverlay :: (state -> Text) -> (PickerKey -> state -> Either result state) -> state -> IO (Maybe result)
-runOverlay render step state =
-    fmap (fmap fst) (runOverlayInternal render step Nothing state)
+runOverlay = runOverlayWithDecoder decodePickerKey
+
+-- | Run an overlay with a caller-specific keyboard decoder. This is useful
+-- for searchable overlays where printable @j@, @k@, or @q@ must remain text
+-- rather than the default navigation shortcuts.
+runOverlayWithDecoder
+    :: (String -> Maybe PickerKey)
+    -> (state -> Text)
+    -> (PickerKey -> state -> Either result state)
+    -> state
+    -> IO (Maybe result)
+runOverlayWithDecoder decode render step state =
+    fmap (fmap fst) (runOverlayInternal decode render step Nothing state)
 
 -- | Like 'runOverlay', but also redraw when an external update arrives.
 runOverlayWithUpdates
@@ -194,15 +206,20 @@ runOverlayWithUpdates
     -> state
     -> IO (Maybe (result, state))
 runOverlayWithUpdates render step awaitUpdate applyUpdate =
-    runOverlayInternal render step (Just (awaitUpdate, applyUpdate))
+    runOverlayInternal
+        decodePickerKey
+        render
+        step
+        (Just (awaitUpdate, applyUpdate))
 
 runOverlayInternal
-    :: (state -> Text)
+    :: (String -> Maybe PickerKey)
+    -> (state -> Text)
     -> (PickerKey -> state -> Either result state)
     -> Maybe (IO update, update -> state -> state)
     -> state
     -> IO (Maybe (result, state))
-runOverlayInternal render step updates state0 =
+runOverlayInternal decodeKey render step updates state0 =
     withRawTty do
         terminal <- detectTerminalCapabilities stderr
         let frame0 = render state0
@@ -222,7 +239,7 @@ runOverlayInternal render step updates state0 =
             Left (Just raw) ->
                 let keys = case decodeMouseEvent raw of
                         Just mouse -> mouseKeysForFrame top frame mouse
-                        Nothing -> maybe [] pure (decodePickerKey raw)
+                        Nothing -> maybe [] pure (decodeKey raw)
                 in applyKeys terminal h state drawnLines frame top keys
             Right update -> case updates of
                 Nothing -> loop terminal h state drawnLines frame top

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -8,13 +8,17 @@ module Agent.CLI.Session.Choices
     ) where
 
 import Agent.CLI.Error (formatApiErrorInlineAt)
-import Agent.CLI.ModelConfig (ModelCatalog)
-import Agent.CLI.ModelPicker (pickModel)
+import Agent.CLI.ModelConfig
+    ( ModelCatalog
+    , builtinConnectionId
+    )
+import Agent.CLI.ModelPicker (pickModelWithOptions)
 import Agent.CLI.Models
     ( ModelOption(..)
     , ModelTarget(..)
     , PickerState(..)
-    , initialPickerStateResolved
+    , initialPickerStateResolvedWith
+    , rawModelOption
     )
 import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.ReasoningEffort
@@ -29,6 +33,7 @@ import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.TUI.App
     ( FullscreenRuntime
     , requestFullscreenChoice
+    , requestFullscreenFilterChoice
     )
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
@@ -45,6 +50,7 @@ import Agent.Dialect
     )
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.OpenAI.Usage (fetchUsage)
+import qualified Agent.OpenRouter.Models as OpenRouterModels
 import Agent.Provider
     ( Credential(..)
     , Provider(..)
@@ -54,6 +60,7 @@ import Agent.Provider
 import Data.List (elemIndex)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Clock (getCurrentTime)
 import System.IO (stdout)
@@ -69,36 +76,89 @@ modelChoice
     -> IO (Maybe ModelOption)
 modelChoice
         catalog fullscreen color connectionId provider current currentDialect =
-    case fullscreen of
-    Nothing ->
-        pickModel
-            catalog color connectionId provider current currentDialect
-    Just runtime -> do
-        picker <-
-            initialPickerStateResolved
-                catalog connectionId provider current currentDialect
-        let options = picker.pickerAll
-            rows =
-                [ ( option.modelTarget.targetConnectionId
-                        <> " · "
-                        <> option.modelTarget.targetModelId
-                        <> " · "
-                        <> dialectSlug option.modelTarget.targetDialect
-                  , fromMaybe "" option.modelLabel
-                  )
-                | option <- options
-                ]
-        requestFullscreenChoice
-            runtime
-            "Model"
-            picker.pickerIndex
-            rows
-            >>= \case
-                Just index
-                    | index >= 0
-                    , index < length options ->
-                        pure (Just (options !! index))
-                _ -> pure Nothing
+    discoverModelOptions connectionId provider >>= \(title, discovered) ->
+        case fullscreen of
+            Nothing ->
+                pickModelWithOptions
+                    catalog discovered color connectionId provider current
+                    currentDialect
+            Just runtime -> do
+                picker <-
+                    initialPickerStateResolvedWith
+                        catalog
+                        discovered
+                        connectionId
+                        provider
+                        current
+                        currentDialect
+                let options = picker.pickerAll
+                    rows =
+                        [ ( option.modelTarget.targetConnectionId
+                                <> " · "
+                                <> option.modelTarget.targetModelId
+                                <> " · "
+                                <> dialectSlug option.modelTarget.targetDialect
+                          , fromMaybe "" option.modelLabel
+                          )
+                        | option <- options
+                        ]
+                requestFullscreenFilterChoice
+                    runtime
+                    title
+                    picker.pickerIndex
+                    rows
+                    >>= \case
+                        Just index
+                            | index >= 0
+                            , index < length options ->
+                                pure (Just (options !! index))
+                        _ -> pure Nothing
+
+discoverModelOptions :: Text -> Provider -> IO (Text, [ModelOption])
+discoverModelOptions connectionId provider
+    | provider == OpenRouterProvider
+    , connectionId == builtinConnectionId OpenRouterProvider =
+        OpenRouterModels.fetchOpenRouterModels >>= \case
+            Left _ -> pure ("Model · configured only", [])
+            Right models ->
+                pure
+                    ( "Model · OpenRouter live"
+                    , map openRouterModelOption models
+                    )
+    | otherwise = pure ("Model", [])
+
+openRouterModelOption :: OpenRouterModels.OpenRouterModel -> ModelOption
+openRouterModelOption model =
+    (rawModelOption OpenRouterProvider model.modelId)
+        { modelLabel = Just $
+            Text.intercalate
+                " · "
+                ( [model.modelDisplayName]
+                    <> maybe
+                        []
+                        (pure . formatContextLength)
+                        model.modelContextLength
+                    <> [ if model.modelSupportsTools
+                            then "tools"
+                            else "no tools"
+                       , "OpenRouter live"
+                       ]
+                )
+        }
+
+formatContextLength :: Int -> Text
+formatContextLength contextLength
+    | contextLength >= 1000000 =
+        let tenths = contextLength `div` 100000
+            whole = tenths `div` 10
+            fraction = tenths `mod` 10
+            amount
+                | fraction == 0 = show whole
+                | otherwise = show whole <> "." <> show fraction
+        in Text.pack amount <> "M context"
+    | contextLength >= 1000 =
+        Text.pack (show (contextLength `div` 1000)) <> "k context"
+    | otherwise = Text.pack (show contextLength) <> " context"
 
 effortChoice
     :: Maybe FullscreenRuntime

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -49,6 +49,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
+    , requestFullscreenFilterChoice
     , requestFullscreenOnboarding
     , requestFullscreenResume
     , requestFullscreenSecret

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -677,6 +677,28 @@ handleEventInner event = case event of
                     , choiceIndex =
                         max 0 (min (max 0 (length rows - 1)) initial)
                     , choiceRows = rows
+                    , choiceSearch = False
+                    , choiceQuery = ""
+                    , choiceCloseOnTurnEnd = False
+                    }
+                , appChoiceReply = Just (atomically . putTMVar reply)
+                , appAgentHover = Nothing
+                }
+        vScrollToBeginning (viewportScroll OverlayViewport)
+    AppEvent (AppAskFilterChoice title initial rows reply) -> do
+        state <- get
+        liftIO (state.appRuntime.runtimeNativeProgress False)
+        modify' \state ->
+            state
+                { appChoice = Just ChoiceOverlay
+                    { choicePresentation = ChoiceDialog
+                    , choiceTitle = title
+                    , choiceBody = ""
+                    , choiceIndex =
+                        max 0 (min (max 0 (length rows - 1)) initial)
+                    , choiceRows = rows
+                    , choiceSearch = True
+                    , choiceQuery = ""
                     , choiceCloseOnTurnEnd = False
                     }
                 , appChoiceReply = Just (atomically . putTMVar reply)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -143,7 +143,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
 import Control.Exception.Safe (finally, mask, onException, throwIO, tryAny)
 import Control.Exception (AsyncException(UserInterrupt))
-import Data.Char (isControl, isSpace)
+import Data.Char (isControl, isPrint, isSpace)
 import Data.Foldable (toList)
 import Data.IORef ( atomicModifyIORef' , modifyIORef' , newIORef , readIORef , writeIORef )
 import Data.List ( find , findIndex , intersperse , nub , sort , sortOn )
@@ -394,7 +394,15 @@ confirmResumeId sessionId = do
                     resolveResume True
 
 handleChoiceKey :: V.Event -> EventM Name AppState ()
-handleChoiceKey = \case
+handleChoiceKey event = do
+    state <- get
+    case state.appChoice of
+        Just choice
+            | choice.choiceSearch -> handleFilterChoiceKey event
+        _ -> handleStaticChoiceKey event
+
+handleStaticChoiceKey :: V.Event -> EventM Name AppState ()
+handleStaticChoiceKey = \case
     V.EvKey V.KUp [] -> moveChoice (-1)
     V.EvKey V.KDown [] -> moveChoice 1
     V.EvKey V.KBackTab [] -> moveChoice (-1)
@@ -432,10 +440,86 @@ handleChoiceKey = \case
                         <$> state.appChoice
                 }
 
+handleFilterChoiceKey :: V.Event -> EventM Name AppState ()
+handleFilterChoiceKey event = case event of
+    V.EvKey V.KUp [] -> moveFilteredChoice (-1)
+    V.EvKey V.KDown [] -> moveFilteredChoice 1
+    V.EvKey V.KBackTab [] -> moveFilteredChoice (-1)
+    V.EvKey (V.KChar '\t') [] -> moveFilteredChoice 1
+    V.EvKey V.KPageUp [] ->
+        vScrollPage (viewportScroll OverlayViewport) Up
+    V.EvKey V.KPageDown [] ->
+        vScrollPage (viewportScroll OverlayViewport) Down
+    V.EvMouseDown _ _ V.BScrollUp _ ->
+        vScrollBy (viewportScroll OverlayViewport) (-mouseScrollLines)
+    V.EvMouseDown _ _ V.BScrollDown _ ->
+        vScrollBy (viewportScroll OverlayViewport) mouseScrollLines
+    V.EvKey V.KEnter [] -> resolveChoice True
+    V.EvKey V.KEsc [] -> resolveChoice False
+    V.EvKey V.KBS [] -> updateChoiceQuery (Text.dropEnd 1)
+    V.EvKey (V.KChar char) []
+        | isPrint char ->
+            updateChoiceQuery (`Text.snoc` char)
+    V.EvPaste bytes ->
+        updateChoiceQuery
+            (<> Text.filter isPrint (Composer.decodePaste bytes))
+    V.EvKey (V.KChar 'c') modifiers
+        | V.MCtrl `elem` modifiers -> do
+            state <- get
+            _ <- handleCtrlC
+            when state.appUi.uiRunning (resolveChoice False)
+    _ -> pure ()
+  where
+    moveFilteredChoice delta = do
+        modify' \state ->
+            state
+                { appChoice =
+                    (\choice ->
+                        let count = length (choiceVisibleRows choice)
+                        in choice
+                            { choiceIndex =
+                                if count == 0
+                                    then 0
+                                    else
+                                        (choice.choiceIndex + delta)
+                                            `mod` count
+                            })
+                        <$> state.appChoice
+                }
+
+    updateChoiceQuery update = do
+        modify' \state ->
+            state
+                { appChoice =
+                    (\choice ->
+                        choice
+                            { choiceQuery = update choice.choiceQuery
+                            , choiceIndex = 0
+                            })
+                        <$> state.appChoice
+                }
+        vScrollToBeginning (viewportScroll OverlayViewport)
+
 confirmChoiceAt :: Int -> EventM Name AppState ()
 confirmChoiceAt index = do
     state <- get
     case state.appChoice of
+        Just choice
+            | choice.choiceSearch ->
+                case findIndex
+                        ((== index) . fst)
+                        (choiceVisibleRows choice) of
+                    Just visibleIndex -> do
+                        modify' \current ->
+                            current
+                                { appChoice =
+                                    (\overlay ->
+                                        overlay
+                                            { choiceIndex = visibleIndex })
+                                        <$> current.appChoice
+                                }
+                        resolveChoice True
+                    Nothing -> pure ()
         Just choice
             | index >= 0
             , index < length choice.choiceRows -> do
@@ -601,7 +685,7 @@ resolveChoice confirmed = do
         Just reply ->
             liftIO $ reply $
                 if confirmed
-                    then (.choiceIndex) <$> state.appChoice
+                    then state.appChoice >>= selectedChoiceIndex
                     else Nothing
     modify' \current ->
         current

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -850,6 +850,21 @@ requestFullscreenChoiceWithBody runtime title body initial rows = do
         (AppAskChoice ChoiceDialog title body initial rows reply)
     atomically (readTMVar reply)
 
+-- | Open a choice overlay whose rows can be narrowed by typing. The returned
+-- index always refers to the original row list, even while the visible rows
+-- are filtered.
+requestFullscreenFilterChoice
+    :: FullscreenRuntime
+    -> Text
+    -> Int
+    -> [(Text, Text)]
+    -> IO (Maybe Int)
+requestFullscreenFilterChoice runtime title initial rows = do
+    reply <- newEmptyTMVarIO
+    enqueueAppEvent runtime
+        (AppAskFilterChoice title initial rows reply)
+    atomically (readTMVar reply)
+
 requestFullscreenOnboarding
     :: FullscreenRuntime
     -> Text

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -212,6 +212,8 @@ handleEffortControlClick applyUiEvent = do
                                 "Changing effort will restart the current turn."
                             , choiceIndex = initial
                             , choiceRows = [(effort, "") | effort <- efforts]
+                            , choiceSearch = False
+                            , choiceQuery = ""
                             , choiceCloseOnTurnEnd = True
                             }
                         , appChoiceReply = Just choose

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -79,7 +79,8 @@ import Agent.CLI.TUI.Types
                   textTitle),
       ResumeOverlay(resumeOverlayBrowser),
       ChoiceOverlay(choicePresentation, choiceIndex, choiceRows,
-                    choiceTitle, choiceBody),
+                    choiceTitle, choiceBody, choiceSearch, choiceQuery),
+      choiceVisibleRows,
       ChoicePresentation(ChoiceOnboarding, ChoiceDialog),
       AgentHover(agentHoverTarget, agentHoverPaneUpperLeft,
                  agentHoverPaneWidth, agentHoverUpperLeft),
@@ -354,6 +355,9 @@ drawFooter state =
             if state.appUi.uiRunning
                 then "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc close  │  Ctrl+C cancel turn"
                 else "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc cancel"
+        (_, Nothing, Just choice, _)
+            | choice.choiceSearch ->
+                "type to filter  │  ↑↓ navigate  │  Enter choose  │  Esc cancel"
         (_, Nothing, Just _, _) ->
             if state.appUi.uiRunning
                 then "↑↓ select  │  Enter choose  │  Esc close  │  Ctrl+C cancel turn"
@@ -604,9 +608,70 @@ resumeFooter browser =
                     )
 
 drawChoice :: AppState -> ChoiceOverlay -> Widget Name
-drawChoice appState choice = case choice.choicePresentation of
-    ChoiceDialog -> drawDialogChoice appState choice
-    ChoiceOnboarding -> drawOnboardingChoice appState choice
+drawChoice appState choice
+    | choice.choiceSearch = drawFilterChoice appState choice
+    | otherwise = case choice.choicePresentation of
+        ChoiceDialog -> drawDialogChoice appState choice
+        ChoiceOnboarding -> drawOnboardingChoice appState choice
+
+drawFilterChoice :: AppState -> ChoiceOverlay -> Widget Name
+drawFilterChoice appState choice =
+    centerLayer $
+        hLimitPercent 82 $
+            vLimitPercent 78 $
+                overrideAttr Border.borderAttr Theme.borderActiveAttr $
+                    withBorderStyle unicodeRounded $
+                        borderWithLabel
+                            (waitingOverlayLabel appState choice.choiceTitle) $
+                            padAll 1 $
+                                vBox
+                                    [ filterChoiceQuery choice
+                                    , Border.hBorder
+                                    , filterChoiceRows appState choice
+                                    , Border.hBorder
+                                    , withAttr Theme.footerAttr $
+                                        terminalTxt
+                                            "type to filter  │  ↑↓ navigate  │  Enter choose  │  Esc cancel"
+                                    ]
+
+filterChoiceQuery :: ChoiceOverlay -> Widget Name
+filterChoiceQuery choice =
+    let prefix = "search: "
+        query = if Text.null choice.choiceQuery
+            then withAttr Theme.mutedAttr (txt "(type to filter)")
+            else terminalTxt choice.choiceQuery
+        content = hBox
+            [ terminalTxt prefix
+            , query
+            , terminalTxt " "
+            ]
+        cursorColumn =
+            terminalTextWidth prefix
+                + terminalTextWidth choice.choiceQuery
+    in showCursor OverlayCursor (Location (cursorColumn, 0)) content
+
+filterChoiceRows :: AppState -> ChoiceOverlay -> Widget Name
+filterChoiceRows appState choice =
+    case visible of
+        [] ->
+            padTop (Pad 1) $
+                withAttr Theme.mutedAttr (txt "  No matches")
+        _ ->
+            vBox $
+                [ choiceRow
+                    appState
+                    choice.choiceIndex
+                    visibleIndex
+                    originalIndex
+                    row
+                | (visibleIndex, (originalIndex, row)) <-
+                    zip [start ..] rows
+                ]
+  where
+    visible = choiceVisibleRows choice
+    count = length visible
+    start = max 0 (min choice.choiceIndex (max 0 (count - 14)))
+    rows = take 14 (drop start visible)
 
 drawDialogChoice :: AppState -> ChoiceOverlay -> Widget Name
 drawDialogChoice appState choice =
@@ -628,18 +693,22 @@ drawDialogChoice appState choice =
                                                         MarkdownLink
                                                         choice.choiceBody
                                     , vBox $
-                                        zipWith
-                                            (choiceRow
-                                                appState
-                                                choice.choiceIndex)
-                                            [start ..]
-                                            rows
+                                        [ choiceRow
+                                            appState
+                                            choice.choiceIndex
+                                            visibleIndex
+                                            originalIndex
+                                            row
+                                        | (visibleIndex, (originalIndex, row)) <-
+                                            zip [start ..] rows
+                                        ]
                                     ]
   where
-    count = length choice.choiceRows
+    visible = choiceVisibleRows choice
+    count = length visible
     start =
         max 0 (min choice.choiceIndex (max 0 (count - 14)))
-    rows = take 14 (drop start choice.choiceRows)
+    rows = take 14 (drop start visible)
 
 drawOnboardingChoice :: AppState -> ChoiceOverlay -> Widget Name
 drawOnboardingChoice appState choice =
@@ -830,10 +899,16 @@ normalizeTextOverlayInsertion = \case
     TextInputSecret -> Text.takeWhile \character ->
         character /= '\n' && character /= '\r'
 
-choiceRow :: AppState -> Int -> Int -> (Text, Text) -> Widget Name
-choiceRow appState selected index (label, detail) =
-    let prefix = if selected == index then "› " else "  "
-        name = ChoiceRow index
+choiceRow
+    :: AppState
+    -> Int
+    -> Int
+    -> Int
+    -> (Text, Text)
+    -> Widget Name
+choiceRow appState selected visibleIndex originalIndex (label, detail) =
+    let prefix = if selected == visibleIndex then "› " else "  "
+        name = ChoiceRow originalIndex
         row =
             Widget Greedy Fixed do
                 context <- getContext
@@ -850,7 +925,7 @@ choiceRow appState selected index (label, detail) =
                             (terminalTxt shownDetail)
                         ]
         styled =
-            if selected == index
+            if selected == visibleIndex
                 then withAttr Theme.selectedAttr row
                 else row
         interactive = case Composer.controlInteractionAttr appState name of

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -8,6 +8,8 @@ module Agent.CLI.TUI.Types
     , DictationSession(..)
     , ChoicePresentation(..)
     , ChoiceOverlay(..)
+    , choiceVisibleRows
+    , selectedChoiceIndex
     , FullscreenInput(..)
     , FullscreenInputBuffer(..)
     , FullscreenHistorySource(..)
@@ -58,6 +60,7 @@ import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import qualified Data.Set as Set
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Clock (NominalDiffTime)
 import Data.Word (Word64)
 import qualified Graphics.Vty as V
@@ -116,6 +119,11 @@ data AppEvent
     | AppAskChoice
         !ChoicePresentation
         !Text
+        !Text
+        !Int
+        ![(Text, Text)]
+        !(TMVar (Maybe Int))
+    | AppAskFilterChoice
         !Text
         !Int
         ![(Text, Text)]
@@ -360,8 +368,42 @@ data ChoiceOverlay = ChoiceOverlay
     , choiceBody :: !Text
     , choiceIndex :: !Int
     , choiceRows :: ![(Text, Text)]
+    , choiceSearch :: !Bool
+    , choiceQuery :: !Text
     , choiceCloseOnTurnEnd :: !Bool
     }
+
+-- | Rows currently visible in a choice overlay.  Searchable overlays retain
+-- each row's source index so callers can return the original choice even
+-- after filtering; ordinary overlays expose the identity mapping.
+choiceVisibleRows :: ChoiceOverlay -> [(Int, (Text, Text))]
+choiceVisibleRows choice
+    | not choice.choiceSearch = zip [0 ..] choice.choiceRows
+    | otherwise =
+        filter (matches choice.choiceQuery . snd)
+            (zip [0 ..] choice.choiceRows)
+  where
+    matches query (label, detail)
+        | Text.null needle = True
+        | otherwise =
+            needle `Text.isInfixOf` Text.toCaseFold label
+                || needle `Text.isInfixOf` Text.toCaseFold detail
+      where
+        needle = Text.toCaseFold query
+
+-- | Resolve the selected row to its source index.  Empty searchable results
+-- have no selection; static choices retain their historical index behavior.
+selectedChoiceIndex :: ChoiceOverlay -> Maybe Int
+selectedChoiceIndex choice
+    | not choice.choiceSearch = Just choice.choiceIndex
+    | otherwise =
+        fst <$> listAt choice.choiceIndex (choiceVisibleRows choice)
+  where
+    listAt index values
+        | index < 0 = Nothing
+        | otherwise = case drop index values of
+            value : _ -> Just value
+            [] -> Nothing
 
 data ResumeOverlay = ResumeOverlay
     { resumeOverlayBrowser :: !ResumeBrowser

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -19,20 +19,21 @@ spec :: Spec
 spec = do
     catalog <- runIO readPackagedCatalog
     describe "decodePickerKey" do
-        it "maps arrows and vim keys" do
+        it "maps arrows while keeping printable keys available to search" do
             decodePickerKey "\ESC[A" `shouldBe` Just PickerUp
             decodePickerKey "\ESC[B" `shouldBe` Just PickerDown
-            decodePickerKey "k" `shouldBe` Just PickerUp
-            decodePickerKey "j" `shouldBe` Just PickerDown
+            decodePickerKey "k" `shouldBe` Just (PickerType 'k')
+            decodePickerKey "j" `shouldBe` Just (PickerType 'j')
 
         it "maps confirm and cancel" do
             decodePickerKey "\n" `shouldBe` Just PickerConfirm
             decodePickerKey "\r" `shouldBe` Just PickerConfirm
             decodePickerKey "\ESC" `shouldBe` Just PickerCancel
-            decodePickerKey "q" `shouldBe` Just PickerCancel
+            decodePickerKey "q" `shouldBe` Just (PickerType 'q')
 
         it "maps filter editing" do
             decodePickerKey "\DEL" `shouldBe` Just PickerBackspace
+            decodePickerKey [toEnum 127] `shouldBe` Just PickerBackspace
             decodePickerKey "g" `shouldBe` Just (PickerType 'g')
 
     describe "renderPickerFrame" do
@@ -54,6 +55,28 @@ spec = do
             frame `shouldSatisfy` Text.isInfixOf "grok-4.6"
             frame `shouldSatisfy` Text.isInfixOf "enter"
             frame `shouldSatisfy` Text.isInfixOf "filter"
+
+        it "keeps large live catalogs inside a scrolling viewport" do
+            let options =
+                    [ rawModelOption
+                        OpenRouterProvider
+                        ("vendor/model-" <> Text.pack (show index))
+                    | index <- [0 .. 29 :: Int]
+                    ]
+                state =
+                    (initialPickerState
+                        catalog
+                        "openrouter"
+                        OpenRouterProvider
+                        "vendor/model-20"
+                        GenericResponsesDialect)
+                        { pickerAll = options
+                        , pickerIndex = 20
+                        }
+                frame = renderPickerFrame False state
+            length (Text.lines frame) `shouldBe` 16
+            frame `shouldSatisfy` Text.isInfixOf "vendor/model-20"
+            frame `shouldNotSatisfy` Text.isInfixOf "vendor/model-0 "
 
     describe "formatCatalogListing" do
         it "lists the current model and entries from every provider" do

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -98,6 +98,34 @@ spec = do
                     , ClaudeCodeProvider
                     ]
 
+        it "merges live models without replacing configured metadata" do
+            let duplicate =
+                    (rawModelOption OpenRouterProvider "stealth/ox-alpha")
+                        { modelLabel = Just "live duplicate" }
+                discovered =
+                    (rawModelOption OpenRouterProvider "qwen/example-new")
+                        { modelLabel = Just "OpenRouter live" }
+            state <-
+                initialPickerStateResolvedWith
+                    catalog
+                    [duplicate, discovered]
+                    "openrouter"
+                    OpenRouterProvider
+                    "stealth/ox-alpha"
+                    GenericResponsesDialect
+            let matching model =
+                    filter
+                        ((== model) . (.modelTarget.targetModelId))
+                        state.pickerAll
+            length (matching "stealth/ox-alpha") `shouldBe` 1
+            fmap (.modelLabel) (listToMaybe (matching "stealth/ox-alpha"))
+                `shouldBe`
+                    Just
+                        (Just
+                            "default · frontier · free · coding · 1M context")
+            fmap (.modelLabel) (listToMaybe (matching "qwen/example-new"))
+                `shouldBe` Just (Just "OpenRouter live")
+
     describe "modelTargetRequiresRebuild" do
         let sameDialect =
                 testOption OpenRouterProvider "openrouter"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -60,6 +60,8 @@ import Agent.CLI.TUI.Types
     , AppState(appConversationReflowQueued)
     , ChoiceOverlay(..)
     , ChoicePresentation(..)
+    , choiceVisibleRows
+    , selectedChoiceIndex
     , FullscreenRuntime(..)
     , HistoryCommit(..)
     , Name(..)
@@ -378,6 +380,29 @@ spec = do
                 continuing
                 (choiceOverlay True)
                 `shouldBe` False
+
+    describe "searchable choice rows" do
+        let searchable = (choiceOverlay False)
+                { choiceSearch = True
+                , choiceQuery = "claude"
+                , choiceRows =
+                    [ ("gpt-5.6", "Vendor: OpenAI")
+                    , ("anthropic/claude-sonnet", "Anthropic")
+                    , ("google/gemini", "Google")
+                    ]
+                }
+        it "matches title and detail case-insensitively" do
+            choiceVisibleRows searchable
+                `shouldBe` [(1, ("anthropic/claude-sonnet", "Anthropic"))]
+            choiceVisibleRows searchable { choiceQuery = "VENDOR" }
+                `shouldBe` [(0, ("gpt-5.6", "Vendor: OpenAI"))]
+        it "returns the source index after filtering" do
+            selectedChoiceIndex searchable
+                `shouldBe` Just 1
+        it "returns no selection when a query has no matches" do
+            selectedChoiceIndex
+                searchable { choiceQuery = "missing" }
+                `shouldBe` Nothing
 
     describe "prompt model refresh" do
         it "preserves the live draft and cursor across a provider restart" do
@@ -1521,6 +1546,8 @@ choiceOverlay closeOnTurnEnd = ChoiceOverlay
     , choiceBody = ""
     , choiceIndex = 0
     , choiceRows = [("one", "")]
+    , choiceSearch = False
+    , choiceQuery = ""
     , choiceCloseOnTurnEnd = closeOnTurnEnd
     }
 

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -610,6 +610,8 @@ applyAction action harness =
                                 , choiceBody = body
                                 , choiceIndex = index
                                 , choiceRows = rows
+                                , choiceSearch = False
+                                , choiceQuery = ""
                                 , choiceCloseOnTurnEnd = False
                                 }
                         , appTextPrompt = Nothing

--- a/packages/agent-openrouter/agent-openrouter.cabal
+++ b/packages/agent-openrouter/agent-openrouter.cabal
@@ -43,6 +43,7 @@ library
                     , Agent.OpenRouter.Credential
                     , Agent.OpenRouter.Error
                     , Agent.OpenRouter.LoopBackend
+                    , Agent.OpenRouter.Models
                     , Agent.OpenRouter.Options
                     , Agent.OpenRouter.Request
                     , Agent.OpenRouter.Stream
@@ -74,6 +75,7 @@ test-suite agent-openrouter-test
                     , Agent.OpenRouter.CredentialSpec
                     , Agent.OpenRouter.ErrorSpec
                     , Agent.OpenRouter.FunctionalSpec
+                    , Agent.OpenRouter.ModelsSpec
                     , Agent.OpenRouter.RequestSpec
                     , Agent.OpenRouter.UsageSpec
     ghc-options:      -threaded

--- a/packages/agent-openrouter/src/Agent/OpenRouter.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter.hs
@@ -3,6 +3,7 @@ module Agent.OpenRouter
     ( module Agent.OpenRouter.Client
     , module Agent.OpenRouter.Credential
     , module Agent.OpenRouter.LoopBackend
+    , module Agent.OpenRouter.Models
     , module Agent.OpenRouter.Options
     , module Agent.OpenRouter.Request
     ) where
@@ -10,5 +11,6 @@ module Agent.OpenRouter
 import Agent.OpenRouter.Client
 import Agent.OpenRouter.Credential
 import Agent.OpenRouter.LoopBackend
+import Agent.OpenRouter.Models
 import Agent.OpenRouter.Options
 import Agent.OpenRouter.Request

--- a/packages/agent-openrouter/src/Agent/OpenRouter/Models.hs
+++ b/packages/agent-openrouter/src/Agent/OpenRouter/Models.hs
@@ -1,0 +1,192 @@
+-- | Small client for OpenRouter's public model catalog endpoint.
+--
+-- The catalog is deliberately kept separate from the Responses transport:
+-- listing models is useful before a model has been configured, and the
+-- endpoint is available with or without an API key.
+module Agent.OpenRouter.Models
+    ( OpenRouterModel(..)
+    , decodeModels
+    , fetchOpenRouterModels
+    , fetchOpenRouterModelsWith
+    , fetchOpenRouterModelsWithCredential
+    ) where
+
+import qualified Agent.Json.Decode as Json
+import Agent.OpenRouter.Credential (credentialFromEnv)
+import Agent.OpenRouter.Options
+    ( ClientOptions(..)
+    , clientOptionsFromEnv
+    )
+import Agent.Provider
+    ( Credential(..)
+    , Provider(..)
+    )
+import Control.Exception.Safe (tryAny)
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (sortOn)
+import Data.Maybe (fromMaybe)
+import Data.Ord (Down(..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Network.HTTP.Client as HttpClient
+import Network.HTTP.Simple
+import Network.HTTP.Types (HeaderName)
+
+-- | The subset of OpenRouter model metadata needed by the interactive
+-- selector.  OpenRouter's catalog has grown additional fields over time, so
+-- unknown fields are intentionally ignored by the decoder below.
+data OpenRouterModel = OpenRouterModel
+    { modelId :: !Text
+    , modelDisplayName :: !Text
+    , modelContextLength :: !(Maybe Int)
+    , modelCreated :: !(Maybe Int)
+    , modelSupportsTools :: !Bool
+    }
+    deriving (Eq, Show)
+
+data ModelsResponse = ModelsResponse
+    { models :: ![OpenRouterModel]
+    }
+
+modelsResponseDecoder :: Json.Decoder ModelsResponse
+modelsResponseDecoder = Json.object $
+    ModelsResponse
+        <$> Json.atKey "data" (Json.list modelDecoder)
+
+modelDecoder :: Json.Decoder OpenRouterModel
+modelDecoder = Json.object do
+    modelId <- Json.atKey "id" Json.text
+    modelName <- Json.optionalKey "name" Json.text
+    modelContextLength <- Json.optionalKey "context_length" Json.int
+    modelCreated <- Json.optionalKey "created" Json.int
+    supportedParameters <- fromMaybe []
+        <$> Json.optionalKey "supported_parameters" (Json.list Json.text)
+    pure OpenRouterModel
+        { modelId
+        , modelDisplayName = displayName modelId modelName
+        , modelContextLength
+        , modelCreated
+        , modelSupportsTools = "tools" `elem` supportedParameters
+        }
+
+displayName :: Text -> Maybe Text -> Text
+displayName modelId = \case
+    Just value
+        | not (Text.null (Text.strip value)) -> value
+    _ -> modelId
+
+-- | Decode a successful @GET /models@ response.
+decodeModels :: LBS.ByteString -> Either Text [OpenRouterModel]
+decodeModels body =
+    case Json.decodeEither modelsResponseDecoder (LBS.toStrict body) of
+        Left _ -> Left "OpenRouter returned an unreadable models response."
+        Right response -> Right (sortModels response.models)
+
+-- | Keep the API's order for models with equal timestamps. Models without a
+-- timestamp are retained after dated entries, also in their original order.
+sortModels :: [OpenRouterModel] -> [OpenRouterModel]
+sortModels = sortOn modelSortKey
+
+modelSortKey :: OpenRouterModel -> (Bool, Down Int)
+modelSortKey model = case model.modelCreated of
+    Just value -> (False, Down value)
+    Nothing -> (True, Down 0)
+
+-- | Fetch OpenRouter's public model catalog using environment-derived options
+-- and the optional @OPENROUTER_API_KEY@.
+fetchOpenRouterModels :: IO (Either Text [OpenRouterModel])
+fetchOpenRouterModels = do
+    options <- clientOptionsFromEnv
+    credential <- credentialFromEnv
+    fetchOpenRouterModelsWithCredentialMaybe options credential
+
+-- | Fetch the catalog using explicit transport options and an optional API
+-- key.  OpenRouter permits this endpoint without authentication; a key is
+-- still useful when the caller wants the request associated with its account.
+fetchOpenRouterModelsWith
+    :: ClientOptions
+    -> Maybe Text
+    -> IO (Either Text [OpenRouterModel])
+fetchOpenRouterModelsWith options apiKey =
+    fetchOpenRouterModelsAt options apiKey
+
+-- | Fetch the catalog using an already-selected OpenRouter credential.
+fetchOpenRouterModelsWithCredential
+    :: ClientOptions
+    -> Credential
+    -> IO (Either Text [OpenRouterModel])
+fetchOpenRouterModelsWithCredential options credential
+    | credential.provider /= OpenRouterProvider =
+        pure $ Left "OpenRouter model discovery requires an OpenRouter credential."
+    | otherwise =
+        fetchOpenRouterModelsAt options (Just credential.accessToken)
+
+fetchOpenRouterModelsWithCredentialMaybe
+    :: ClientOptions
+    -> Maybe Credential
+    -> IO (Either Text [OpenRouterModel])
+fetchOpenRouterModelsWithCredentialMaybe options credential =
+    case credential of
+        Nothing -> fetchOpenRouterModelsAt options Nothing
+        Just value -> fetchOpenRouterModelsWithCredential options value
+
+fetchOpenRouterModelsAt
+    :: ClientOptions
+    -> Maybe Text
+    -> IO (Either Text [OpenRouterModel])
+fetchOpenRouterModelsAt options apiKey = do
+    result <- tryAny requestModels
+    case result of
+        Left _ ->
+            pure $ Left
+                "Could not load OpenRouter models. Check your connection and retry."
+        Right response -> do
+            let status = getResponseStatusCode response
+            pure $
+                if status >= 200 && status < 300
+                    then decodeModels (getResponseBody response)
+                    else Left
+                        ( "OpenRouter models returned HTTP "
+                            <> Text.pack (show status)
+                        )
+  where
+    requestModels = do
+        baseRequest <- parseRequest options.baseUrl
+        let endpointPath =
+                BS8.dropWhileEnd (== '/') (HttpClient.path baseRequest)
+                    <> "/models"
+            request =
+                setRequestPath endpointPath baseRequest
+        httpLBS
+            $ configureRequest apiKey
+            $ setRequestResponseTimeout
+                (HttpClient.responseTimeoutMicro (5 * 1_000_000))
+            $ request
+
+    configureRequest key =
+        optionalAuthorization key
+            . optionalHeader "HTTP-Referer" options.httpReferer
+            . optionalHeader "X-Title" options.appTitle
+            . setRequestHeader "User-Agent" ["haskell-agent"]
+            . setRequestHeader "Accept" ["application/json"]
+
+optionalAuthorization :: Maybe Text -> Request -> Request
+optionalAuthorization key request = case nonEmptyText key of
+    Just value ->
+        setRequestHeader
+            "Authorization"
+            ["Bearer " <> Text.encodeUtf8 value]
+            request
+    Nothing -> request
+
+optionalHeader :: HeaderName -> Maybe Text -> Request -> Request
+optionalHeader name value request = case nonEmptyText value of
+    Just text -> setRequestHeader name [Text.encodeUtf8 text] request
+    Nothing -> request
+
+nonEmptyText :: Maybe Text -> Maybe Text
+nonEmptyText (Just value)
+    | not (Text.null (Text.strip value)) = Just value
+nonEmptyText _ = Nothing

--- a/packages/agent-openrouter/test/Agent/OpenRouter/ModelsSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/ModelsSpec.hs
@@ -1,0 +1,189 @@
+module Agent.OpenRouter.ModelsSpec (spec) where
+
+import Agent.OpenRouter.Models
+import Agent.OpenRouter.Options
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.CaseInsensitive as CI
+import Data.IORef (IORef, newIORef, readIORef, atomicModifyIORef')
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Network.HTTP.Types as HTTP
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "decodeModels" do
+        it "decodes model metadata and derives tool support" do
+            decodeModels (LBS.pack
+                "{\"data\":[{\"id\":\"openai/gpt-5.1\",\
+                \\"name\":\"OpenAI: GPT-5.1\",\"context_length\":400000,\
+                \\"created\":1720000000,\"supported_parameters\":\
+                \[\"tools\",\"temperature\"]}]}")
+                `shouldBe`
+                    Right
+                        [ OpenRouterModel
+                            { modelId = "openai/gpt-5.1"
+                            , modelDisplayName = "OpenAI: GPT-5.1"
+                            , modelContextLength = Just 400000
+                            , modelCreated = Just 1720000000
+                            , modelSupportsTools = True
+                            }
+                        ]
+
+        it "falls back to the id when optional metadata is absent" do
+            decodeModels (LBS.pack
+                "{\"data\":[{\"id\":\"vendor/model\",\
+                \\"name\":null,\"context_length\":null,\
+                \\"supported_parameters\":null}]}")
+                `shouldBe`
+                    Right
+                        [ OpenRouterModel
+                            { modelId = "vendor/model"
+                            , modelDisplayName = "vendor/model"
+                            , modelContextLength = Nothing
+                            , modelCreated = Nothing
+                            , modelSupportsTools = False
+                            }
+                        ]
+
+        it "sorts newest first while preserving ties and undated entries" do
+            let modelBody =
+                    "{\"data\":[\
+                    \{\"id\":\"old\",\"name\":\"Old\",\"created\":10},\
+                    \{\"id\":\"new-a\",\"name\":\"New A\",\"created\":30},\
+                    \{\"id\":\"tie-a\",\"name\":\"Tie A\",\"created\":20},\
+                    \{\"id\":\"tie-b\",\"name\":\"Tie B\",\"created\":20},\
+                    \{\"id\":\"undated-a\",\"name\":\"Undated A\"},\
+                    \{\"id\":\"undated-b\",\"name\":\"Undated B\"}]}"
+            fmap (map (.modelId)) (decodeModels (LBS.pack modelBody))
+                `shouldBe`
+                    Right
+                        [ "new-a"
+                        , "tie-a"
+                        , "tie-b"
+                        , "old"
+                        , "undated-a"
+                        , "undated-b"
+                        ]
+
+        it "returns a stable error for malformed responses" do
+            decodeModels "{\"data\":{}}"
+                `shouldBe`
+                    Left "OpenRouter returned an unreadable models response."
+
+    describe "fetchOpenRouterModelsWith" do
+        it "gets /models with the configured headers and decodes the body" do
+            requests <- newIORef []
+            withMockModels requests
+                (Wai.responseLBS HTTP.status200
+                    [("Content-Type", "application/json")]
+                    (LBS.pack
+                        "{\"data\":[{\"id\":\"vendor/model\",\
+                        \\"name\":\"Vendor Model\",\"context_length\":8192,\
+                        \\"created\":1720000000,\
+                        \\"supported_parameters\":[\"tools\"]}]}"))
+                \options -> do
+                    result <- fetchOpenRouterModelsWith options (Just "secret")
+                    result `shouldBe`
+                        Right
+                            [ OpenRouterModel
+                                { modelId = "vendor/model"
+                                , modelDisplayName = "Vendor Model"
+                                , modelContextLength = Just 8192
+                                , modelCreated = Just 1720000000
+                                , modelSupportsTools = True
+                                }
+                            ]
+
+            [request] <- readIORef requests
+            request.requestMethod `shouldBe` "GET"
+            request.requestPath `shouldBe` "/v1/models"
+            requestHeader "Authorization" request
+                `shouldBe` Just "Bearer secret"
+            requestHeader "Accept" request
+                `shouldBe` Just "application/json"
+            requestHeader "User-Agent" request
+                `shouldBe` Just "haskell-agent"
+            requestHeader "HTTP-Referer" request
+                `shouldBe` Just "https://example.com"
+            requestHeader "X-Title" request
+                `shouldBe` Just "haskell-agent-test"
+
+        it "allows public discovery without an authorization header" do
+            requests <- newIORef []
+            withMockModels requests
+                (Wai.responseLBS HTTP.status200
+                    [("Content-Type", "application/json")]
+                    "{\"data\":[]}")
+                \options -> do
+                    fetchOpenRouterModelsWith options Nothing
+                        `shouldReturn` Right []
+
+            [request] <- readIORef requests
+            requestHeader "Authorization" request `shouldBe` Nothing
+
+        it "reports HTTP failures without exposing response internals" do
+            requests <- newIORef []
+            withMockModels requests
+                (Wai.responseLBS HTTP.status503
+                    [("Content-Type", "text/plain")]
+                    "temporary backend detail")
+                \options -> do
+                    fetchOpenRouterModelsWith options Nothing
+                        `shouldReturn`
+                            Left "OpenRouter models returned HTTP 503"
+
+        it "reports malformed successful responses clearly" do
+            requests <- newIORef []
+            withMockModels requests
+                (Wai.responseLBS HTTP.status200
+                    [("Content-Type", "application/json")]
+                    "{\"not_data\":[]}")
+                \options -> do
+                    fetchOpenRouterModelsWith options Nothing
+                        `shouldReturn`
+                            Left
+                                "OpenRouter returned an unreadable models response."
+
+data RecordedRequest = RecordedRequest
+    { requestMethod :: !Text
+    , requestPath :: !Text
+    , requestHeaders :: ![(Text, Text)]
+    }
+    deriving (Eq, Show)
+
+withMockModels
+    :: IORef [RecordedRequest]
+    -> Wai.Response
+    -> (ClientOptions -> IO a)
+    -> IO a
+withMockModels requests response action =
+    Warp.testWithApplication (pure app) \port ->
+        action defaultClientOptions
+            { baseUrl = "http://127.0.0.1:" <> show port <> "/v1"
+            , requestTimeoutSeconds = 10
+            , httpReferer = Just "https://example.com"
+            , appTitle = Just "haskell-agent-test"
+            }
+  where
+    app request respond = do
+        let recorded = RecordedRequest
+                { requestMethod = Text.decodeUtf8 (Wai.requestMethod request)
+                , requestPath =
+                    "/" <> Text.intercalate "/" (Wai.pathInfo request)
+                , requestHeaders =
+                    [ ( Text.decodeUtf8 (CI.original name)
+                      , Text.decodeUtf8 value
+                      )
+                    | (name, value) <- Wai.requestHeaders request
+                    ]
+                }
+        atomicModifyIORef' requests \values -> (values <> [recorded], ())
+        respond response
+
+requestHeader :: Text -> RecordedRequest -> Maybe Text
+requestHeader name request =
+    lookup name request.requestHeaders

--- a/packages/agent-openrouter/test/Spec.hs
+++ b/packages/agent-openrouter/test/Spec.hs
@@ -6,6 +6,7 @@ import qualified Agent.OpenRouter.ClientSpec as ClientSpec
 import qualified Agent.OpenRouter.CredentialSpec as CredentialSpec
 import qualified Agent.OpenRouter.ErrorSpec as ErrorSpec
 import qualified Agent.OpenRouter.FunctionalSpec as FunctionalSpec
+import qualified Agent.OpenRouter.ModelsSpec as ModelsSpec
 import qualified Agent.OpenRouter.RequestSpec as RequestSpec
 import qualified Agent.OpenRouter.UsageSpec as UsageSpec
 
@@ -15,5 +16,6 @@ main = hspec do
     ErrorSpec.spec
     CredentialSpec.spec
     ClientSpec.spec
+    ModelsSpec.spec
     FunctionalSpec.spec
     UsageSpec.spec


### PR DESCRIPTION
## Summary
- fetch and merge OpenRouter's live model catalog into the model selector
- add searchable, bounded model pickers for fullscreen and compact TTY modes
- show model context/tool support and fall back to configured models when discovery fails

## Validation
- OpenRouter tests: 47 examples, 0 failures, 1 expected pending
- focused CLI tests: 109 examples, 0 failures
- input decoder regression tests: 6 examples, 0 failures
- multi-package GHCi: 204 modules loaded after rebase
- live tmux smoke test: loaded the OpenRouter catalog, filtered for `qwen`, navigated results, and canceled cleanly
- `git diff --check`
