### PR TITLE
Extract a pure tool approval decision engine

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -46,6 +46,7 @@ library
     other-modules:    Agent.CLI.AccountPicker
                     , Agent.CLI.AgentSessions.Render
                     , Agent.CLI.AgentViewport.Status
+                    , Agent.CLI.Approval.Decision
                     , Agent.CLI.Auth.Grok
                     , Agent.CLI.Auth.OpenAI
                     , Agent.CLI.Auth.Types

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -1,42 +1,48 @@
 -- | Parent and child tool-approval policy for interactive CLI sessions.
 module Agent.CLI.Approval
-    ( ApprovalNotice(..)
+    ( ApprovalAction(..)
+    , ApprovalFacts(..)
+    , ApprovalNotice(..)
+    , ApprovalPlan(..)
     , approveToolDecision
     , approveToolDecisionWith
     , approveToolDecisionWithReporter
     , approveToolDecisionWithReporterAndPersistence
     , childApprove
+    , planApproval
+    , resolveApprovalPrompt
     , toggleAlwaysApprove
     ) where
 
+import Agent.CLI.Approval.Decision
+    ( ApprovalAction(..)
+    , ApprovalFacts(..)
+    , ApprovalNotice(..)
+    , ApprovalPlan(..)
+    , planApproval
+    , resolveApprovalPrompt
+    )
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Permission
-    ( PermissionChoice(..)
+    ( PermissionChoice
     , promptPermission
     )
-import System.OsPath (OsPath)
 import Agent.CLI.Project (saveProjectAutoApprove)
 import Agent.CLI.Render (putTextLn)
 import Agent.CLI.Style
-    ( glyphOk
-    , glyphWarn
-    , roleSuccess
+    ( roleSuccess
     , roleWarn
     )
 import Agent.CLI.Terminal (resolveColor)
-import Agent.JsonText (jsonTextFieldDefault)
-import Agent.OsPath (fromText, toText)
+import Agent.OsPath (toText)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , canonicalToolName
     )
-import Agent.Tools.Dangerous (shellCommandBlocked)
 import Agent.Tools.PlanMode
     ( PlanModeEnv
-    , isPlanFileEditTarget
     , isPlanModeActive
     , planFilePath
-    , planModeBlockedEditMessage
     )
 import Agent.Tools.Types
     ( ToolRegistry
@@ -52,13 +58,8 @@ import Data.IORef
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
-import qualified Data.Text as Text
 import System.IO (stderr)
-
-data ApprovalNotice
-    = ApprovalWarning !Text
-    | ApprovalSuccess !Text
-    deriving (Eq, Show)
+import System.OsPath (OsPath)
 
 approveToolDecision
     :: IORef ApprovalPolicy
@@ -129,102 +130,53 @@ approveToolDecisionWithReporterAndPersistence
     -> PlanModeEnv
     -> ToolCall
     -> IO (Either Text Bool)
-approveToolDecisionWithReporterAndPersistence requestPermission report persistAlwaysApprove policyRef allowedToolsRef tools planMode call = do
+approveToolDecisionWithReporterAndPersistence
+        requestPermission report persistAlwaysApprove
+        policyRef allowedToolsRef tools planMode call = do
     policy <- readIORef policyRef
     planActive <- isPlanModeActive planMode
     planPath <- planFilePath planMode
-    let toolName = canonicalToolName call.name
-    -- Hard deny for catastrophic shell deletes, even under ApproveAll / yolo.
-    case shellCommandBlocked toolName call.arguments of
-        Just msg -> do
-            report (ApprovalWarning (glyphWarn <> msg))
-            pure (Left msg)
-        Nothing -> do
+    let initialFacts = ApprovalFacts
+            { policy
+            , planActive
+            , planPath
+            , readOnly = Nothing
+            , allowedForSession = Nothing
+            , call
+            }
+    interpret initialFacts (planApproval initialFacts)
+  where
+    interpret facts = \case
+        CompleteApproval result actions -> do
+            mapM_ runAction actions
+            pure result
+        NeedReadOnlyClassification -> do
             readOnly <- case lookupRegisteredTool call.name tools of
                 Nothing -> pure False
                 Just tool -> toolAllowsWithoutPrompt tool call
-            -- Plan mode hard-denies writes even under yolo. The dedicated
-            -- write_plan tool and Grok's path-locked plan.md edit are the only
-            -- mutations allowed. Shell tools are blocked entirely because an
-            -- arbitrary shell script cannot be proven read-only.
-            if planModeBlocksCall planActive planPath readOnly call
-                then do
-                    let msg = planModeBlockedEditMessage planPath
-                    report (ApprovalWarning msg)
-                    pure (Left msg)
-                else do
-                    -- plan.md edits are auto-approved while plan mode is active.
-                    if isPlanFileWrite planActive planPath call
-                        then pure (Right True)
-                        else do
-                            allowed <- readIORef allowedToolsRef
-                            if Set.member toolName allowed
-                                then pure (Right True)
-                                else case policy of
-                                    ApproveAll -> pure (Right True)
-                                    DenyMutating -> pure (Right readOnly)
-                                    PromptMutating
-                                        | readOnly -> pure (Right True)
-                                        | otherwise -> do
-                                            requestPermission call >>= \case
-                                                Nothing -> pure (Right False)
-                                                Just PermissionAllowOnce ->
-                                                    pure (Right True)
-                                                Just PermissionAllowAll -> do
-                                                    atomicModifyIORef' policyRef $
-                                                        const (ApproveAll, ())
-                                                    persistAlwaysApprove
-                                                    report $
-                                                        ApprovalSuccess
-                                                            (glyphOk
-                                                                <> "auto-approve on \
-                                                                   \(saved for project)")
-                                                    pure (Right True)
-                                                Just PermissionAllowTool -> do
-                                                    modifyIORef' allowedToolsRef
-                                                        (Set.insert toolName)
-                                                    report $
-                                                        ApprovalSuccess
-                                                            (glyphOk
-                                                                <> "always allow "
-                                                                <> call.name
-                                                                <> " this session")
-                                                    pure (Right True)
-                                                Just PermissionDeny ->
-                                                    pure (Right False)
+            let nextFacts = facts { readOnly = Just readOnly }
+            interpret nextFacts (planApproval nextFacts)
+        NeedSessionAllowance -> do
+            allowed <- readIORef allowedToolsRef
+            let toolName = canonicalToolName call.name
+                nextFacts = facts
+                    { allowedForSession =
+                        Just (Set.member toolName allowed)
+                    }
+            interpret nextFacts (planApproval nextFacts)
+        NeedPermissionPrompt -> do
+            choice <- requestPermission call
+            interpret facts (resolveApprovalPrompt call choice)
 
-planModeBlocksCall :: Bool -> OsPath -> Bool -> ToolCall -> Bool
-planModeBlocksCall active planPath readOnly call
-    | not active = False
-    | name == "apply_patch" = True
-    | name == "write_plan" = False
-    | name == "exit_plan_mode" = False
-    | name == "search_replace" =
-        let target = jsonTextFieldDefault "file_path" call.arguments
-        in Text.null target
-            || not (isPlanFileEditTarget planPath (fromText target))
-    | name `elem` ["shell_command", "run_terminal_cmd"] =
-        True
-    | name == "write_stdin" = True
-    | name `elem`
-        [ "spawn_agent", "followup_task", "create_agent_session"
-        , "send_agent_session_message"
-        ] = True
-    | otherwise = not readOnly
-  where
-    name = canonicalToolName call.name
-
-isPlanFileWrite :: Bool -> OsPath -> ToolCall -> Bool
-isPlanFileWrite active planPath call
-    | not active = False
-    | name == "write_plan" = True
-    | name == "search_replace" =
-        let target = jsonTextFieldDefault "file_path" call.arguments
-        in not (Text.null target)
-            && isPlanFileEditTarget planPath (fromText target)
-    | otherwise = False
-  where
-    name = canonicalToolName call.name
+    runAction = \case
+        SetApprovalPolicy next ->
+            atomicModifyIORef' policyRef (const (next, ()))
+        PersistProjectAutoApprove ->
+            persistAlwaysApprove
+        RememberToolForSession toolName ->
+            modifyIORef' allowedToolsRef (Set.insert toolName)
+        ReportApprovalNotice notice ->
+            report notice
 
 toggleAlwaysApprove :: IORef ApprovalPolicy -> OsPath -> IO Text
 toggleAlwaysApprove policyRef projectRoot = do

--- a/packages/agent-cli/src/Agent/CLI/Approval/Decision.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval/Decision.hs
@@ -1,0 +1,178 @@
+-- | Pure planning for parent tool approval.
+--
+-- Approval facts are acquired in stages so hard denials run before dynamic
+-- read-only classifiers, and plan-mode restrictions run before remembered or
+-- policy-based approval. 'ApprovalPlan' tells the IO interpreter which fact or
+-- effect is needed next.
+module Agent.CLI.Approval.Decision
+    ( ApprovalAction(..)
+    , ApprovalFacts(..)
+    , ApprovalNotice(..)
+    , ApprovalPlan(..)
+    , planApproval
+    , resolveApprovalPrompt
+    ) where
+
+import Agent.CLI.Options (ApprovalPolicy(..))
+import Agent.CLI.Permission (PermissionChoice(..))
+import Agent.CLI.Style (glyphOk, glyphWarn)
+import Agent.JsonText (jsonTextFieldDefault)
+import Agent.OsPath (fromText)
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , canonicalToolName
+    )
+import Agent.Tools.Dangerous (shellCommandBlocked)
+import Agent.Tools.PlanMode
+    ( isPlanFileEditTarget
+    , planModeBlockedEditMessage
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.OsPath (OsPath)
+
+data ApprovalNotice
+    = ApprovalWarning !Text
+    | ApprovalSuccess !Text
+    deriving (Eq, Show)
+
+-- | Effects requested by a completed approval plan.
+--
+-- The interpreter runs these from left to right before returning the result.
+data ApprovalAction
+    = SetApprovalPolicy !ApprovalPolicy
+    | PersistProjectAutoApprove
+    | RememberToolForSession !Text
+    | ReportApprovalNotice !ApprovalNotice
+    deriving (Eq, Show)
+
+-- | A staged approval decision.
+--
+-- Read-only classification and the session allow-list are deliberately
+-- requested separately. This preserves the security-sensitive precedence:
+--
+-- 1. catastrophic shell hard-deny
+-- 2. dynamic read-only classification
+-- 3. plan-mode restrictions
+-- 4. plan-file exception
+-- 5. remembered tool approval
+-- 6. session policy or user prompt
+data ApprovalPlan
+    = CompleteApproval !(Either Text Bool) ![ApprovalAction]
+    | NeedReadOnlyClassification
+    | NeedSessionAllowance
+    | NeedPermissionPrompt
+    deriving (Eq, Show)
+
+-- | Snapshot inputs and facts discovered so far.
+--
+-- 'Nothing' means the interpreter has not acquired that fact yet. Calls to
+-- 'planApproval' request facts only after all higher-precedence checks pass.
+data ApprovalFacts = ApprovalFacts
+    { policy :: !ApprovalPolicy
+    , planActive :: !Bool
+    , planPath :: !OsPath
+    , readOnly :: !(Maybe Bool)
+    , allowedForSession :: !(Maybe Bool)
+    , call :: !ToolCall
+    }
+    deriving (Eq, Show)
+
+planApproval :: ApprovalFacts -> ApprovalPlan
+planApproval facts =
+    case shellCommandBlocked toolName facts.call.arguments of
+        Just message ->
+            CompleteApproval
+                (Left message)
+                [ReportApprovalNotice
+                    (ApprovalWarning (glyphWarn <> message))]
+        Nothing -> case facts.readOnly of
+            Nothing -> NeedReadOnlyClassification
+            Just readOnly
+                | planModeBlocksCall
+                    facts.planActive facts.planPath readOnly facts.call ->
+                        let message =
+                                planModeBlockedEditMessage facts.planPath
+                        in CompleteApproval
+                            (Left message)
+                            [ReportApprovalNotice
+                                (ApprovalWarning message)]
+                | isPlanFileWrite
+                    facts.planActive facts.planPath facts.call ->
+                        approved
+                | otherwise -> case facts.allowedForSession of
+                    Nothing -> NeedSessionAllowance
+                    Just True -> approved
+                    Just False -> policyPlan facts.policy readOnly
+  where
+    toolName = canonicalToolName facts.call.name
+    approved = CompleteApproval (Right True) []
+
+resolveApprovalPrompt :: ToolCall -> Maybe PermissionChoice -> ApprovalPlan
+resolveApprovalPrompt call = \case
+    Nothing -> denied
+    Just PermissionDeny -> denied
+    Just PermissionAllowOnce -> approved
+    Just PermissionAllowAll ->
+        CompleteApproval
+            (Right True)
+            [ SetApprovalPolicy ApproveAll
+            , PersistProjectAutoApprove
+            , ReportApprovalNotice
+                (ApprovalSuccess
+                    (glyphOk <> "auto-approve on (saved for project)"))
+            ]
+    Just PermissionAllowTool ->
+        CompleteApproval
+            (Right True)
+            [ RememberToolForSession (canonicalToolName call.name)
+            , ReportApprovalNotice
+                (ApprovalSuccess
+                    (glyphOk
+                        <> "always allow "
+                        <> call.name
+                        <> " this session"))
+            ]
+  where
+    approved = CompleteApproval (Right True) []
+    denied = CompleteApproval (Right False) []
+
+policyPlan :: ApprovalPolicy -> Bool -> ApprovalPlan
+policyPlan policy readOnly = case policy of
+    ApproveAll -> CompleteApproval (Right True) []
+    DenyMutating -> CompleteApproval (Right readOnly) []
+    PromptMutating
+        | readOnly -> CompleteApproval (Right True) []
+        | otherwise -> NeedPermissionPrompt
+
+planModeBlocksCall :: Bool -> OsPath -> Bool -> ToolCall -> Bool
+planModeBlocksCall active planPath readOnly call
+    | not active = False
+    | name == "apply_patch" = True
+    | name == "write_plan" = False
+    | name == "exit_plan_mode" = False
+    | name == "search_replace" =
+        let target = jsonTextFieldDefault "file_path" call.arguments
+        in Text.null target
+            || not (isPlanFileEditTarget planPath (fromText target))
+    | name `elem` ["shell_command", "run_terminal_cmd"] = True
+    | name == "write_stdin" = True
+    | name `elem`
+        [ "spawn_agent", "followup_task", "create_agent_session"
+        , "send_agent_session_message"
+        ] = True
+    | otherwise = not readOnly
+  where
+    name = canonicalToolName call.name
+
+isPlanFileWrite :: Bool -> OsPath -> ToolCall -> Bool
+isPlanFileWrite active planPath call
+    | not active = False
+    | name == "write_plan" = True
+    | name == "search_replace" =
+        let target = jsonTextFieldDefault "file_path" call.arguments
+        in not (Text.null target)
+            && isPlanFileEditTarget planPath (fromText target)
+    | otherwise = False
+  where
+    name = canonicalToolName call.name

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -1,10 +1,15 @@
 module Agent.CLI.ApprovalSpec (spec) where
 
 import Agent.CLI.Approval
-    ( ApprovalNotice(..)
+    ( ApprovalAction(..)
+    , ApprovalFacts(..)
+    , ApprovalNotice(..)
+    , ApprovalPlan(..)
     , approveToolDecisionWithReporter
     , approveToolDecisionWithReporterAndPersistence
     , childApprove
+    , planApproval
+    , resolveApprovalPrompt
     )
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Permission (PermissionChoice(..))
@@ -37,7 +42,200 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "planApproval" do
+        it "hard-denies catastrophic shell calls before requesting classification" do
+            let call = functionToolCall
+                    "call-shell"
+                    "shell_command"
+                    "{\"command\":\"rm -rf /\"}"
+                facts = (approvalFacts call)
+                    { policy = ApproveAll
+                    , allowedForSession = Just True
+                    }
+            planApproval facts
+                `shouldSatisfy` \case
+                    CompleteApproval
+                        (Left message)
+                        [ReportApprovalNotice (ApprovalWarning notice)] ->
+                            "Blocked dangerous shell command"
+                                `Text.isInfixOf` message
+                                && message `Text.isInfixOf` notice
+                    _ -> False
+
+        it "requests facts in security-precedence order" do
+            let initial = approvalFacts mutatingCall
+                classified = initial { readOnly = Just False }
+            planApproval initial `shouldBe` NeedReadOnlyClassification
+            planApproval classified `shouldBe` NeedSessionAllowance
+            planApproval (classified { allowedForSession = Just False })
+                `shouldBe` NeedPermissionPrompt
+
+        it "cannot bypass plan mode with remembered approval or yolo" do
+            let facts = (approvalFacts mutatingCall)
+                    { policy = ApproveAll
+                    , planActive = True
+                    , readOnly = Just False
+                    , allowedForSession = Just True
+                    }
+            planApproval facts `shouldSatisfy` \case
+                CompleteApproval
+                    (Left message)
+                    [ReportApprovalNotice (ApprovalWarning notice)] ->
+                        "file edits are not allowed in plan mode"
+                            `Text.isInfixOf` message
+                            && notice == message
+                _ -> False
+
+        it "auto-approves only the dedicated plan-file exception" do
+            let planWrite = functionToolCall
+                    "call-write-plan"
+                    "write_plan"
+                    "{\"content\":\"# Plan\"}"
+                facts = (approvalFacts planWrite)
+                    { policy = PromptMutating
+                    , planActive = True
+                    , readOnly = Just False
+                    }
+            planApproval facts
+                `shouldBe` CompleteApproval (Right True) []
+
+        it "allows the path-locked plan edit but rejects another target" do
+            let searchReplace target = functionToolCall
+                    "call-search-replace"
+                    "search_replace"
+                    ("{\"file_path\":\"" <> target <> "\"}")
+                facts call = (approvalFacts call)
+                    { policy = ApproveAll
+                    , planActive = True
+                    , readOnly = Just False
+                    , allowedForSession = Just True
+                    }
+            planApproval (facts (searchReplace "plan.md"))
+                `shouldBe` CompleteApproval (Right True) []
+            planApproval (facts (searchReplace "src/Main.hs"))
+                `shouldSatisfy` \case
+                    CompleteApproval (Left _) [_] -> True
+                    _ -> False
+
+        it "blocks collaboration writes in plan mode even if marked read-only" do
+            let call = functionToolCall
+                    "call-spawn"
+                    "collaboration.spawn_agent"
+                    "{}"
+                facts = (approvalFacts call)
+                    { policy = ApproveAll
+                    , planActive = True
+                    , readOnly = Just True
+                    , allowedForSession = Just True
+                    }
+            planApproval facts `shouldSatisfy` \case
+                CompleteApproval (Left _) [_] -> True
+                _ -> False
+
+        it "applies the session policy after remembered-tool approval" do
+            let classified = (approvalFacts mutatingCall)
+                    { readOnly = Just False
+                    }
+            planApproval (classified { allowedForSession = Just True })
+                `shouldBe` CompleteApproval (Right True) []
+            planApproval (classified
+                { policy = ApproveAll
+                , allowedForSession = Just False
+                })
+                `shouldBe` CompleteApproval (Right True) []
+            planApproval (classified
+                { policy = DenyMutating
+                , allowedForSession = Just False
+                })
+                `shouldBe` CompleteApproval (Right False) []
+
+        it "auto-approves read-only calls under restrictive policies" do
+            let facts policy = (approvalFacts readOnlyCall)
+                    { policy
+                    , readOnly = Just True
+                    , allowedForSession = Just False
+                    }
+            planApproval (facts DenyMutating)
+                `shouldBe` CompleteApproval (Right True) []
+            planApproval (facts PromptMutating)
+                `shouldBe` CompleteApproval (Right True) []
+
+    describe "resolveApprovalPrompt" do
+        it "maps cancellation and explicit denial to an in-band denial" do
+            resolveApprovalPrompt mutatingCall Nothing
+                `shouldBe` CompleteApproval (Right False) []
+            resolveApprovalPrompt mutatingCall (Just PermissionDeny)
+                `shouldBe` CompleteApproval (Right False) []
+
+        it "allows once without changing approval state" do
+            resolveApprovalPrompt mutatingCall (Just PermissionAllowOnce)
+                `shouldBe` CompleteApproval (Right True) []
+
+        it "plans project persistence after enabling auto-approval" do
+            resolveApprovalPrompt mutatingCall (Just PermissionAllowAll)
+                `shouldBe` CompleteApproval
+                    (Right True)
+                    [ SetApprovalPolicy ApproveAll
+                    , PersistProjectAutoApprove
+                    , ReportApprovalNotice
+                        (ApprovalSuccess
+                            "✓ auto-approve on (saved for project)")
+                    ]
+
+        it "canonicalizes remembered aliases but reports the requested name" do
+            let call = functionToolCall
+                    "call-shell"
+                    "run_terminal_command"
+                    "{\"command\":\"git status\"}"
+            resolveApprovalPrompt call (Just PermissionAllowTool)
+                `shouldBe` CompleteApproval
+                    (Right True)
+                    [ RememberToolForSession "run_terminal_cmd"
+                    , ReportApprovalNotice
+                        (ApprovalSuccess
+                            "✓ always allow run_terminal_command this session")
+                    ]
+
     describe "approveToolDecisionWith" do
+        it "does not classify, prompt, or persist a catastrophic shell call" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            classifications <- newIORef (0 :: Int)
+            permissionRequests <- newIORef (0 :: Int)
+            persistenceCalls <- newIORef (0 :: Int)
+            notices <- newIORef []
+            let call = functionToolCall
+                    "call-shell"
+                    "shell_command"
+                    "{\"command\":\"rm -rf /\"}"
+                shellTool = tool "shell_command" $
+                    ClassifyReadOnly \_ -> do
+                        modifyIORef' classifications (+ 1)
+                        pure True
+
+            result <- approveToolDecisionWithReporterAndPersistence
+                (\_ -> modifyIORef' permissionRequests (+ 1)
+                    >> pure (Just PermissionAllowOnce))
+                (\notice -> modifyIORef' notices (<> [notice]))
+                (modifyIORef' persistenceCalls (+ 1))
+                policy allowed (registry [shellTool]) plan call
+
+            result `shouldSatisfy` either
+                (Text.isInfixOf "Blocked dangerous shell command")
+                (const False)
+            readIORef classifications `shouldReturn` 0
+            readIORef permissionRequests `shouldReturn` 0
+            readIORef persistenceCalls `shouldReturn` 0
+            readIORef policy `shouldReturn` PromptMutating
+            readIORef allowed `shouldReturn` Set.empty
+            recordedNotices <- readIORef notices
+            recordedNotices `shouldSatisfy` \case
+                [ApprovalWarning message] ->
+                    "Blocked dangerous shell command"
+                        `Text.isInfixOf` message
+                _ -> False
+
         it "reports plan-mode denials without requiring terminal output" do
             policy <- newIORef ApproveAll
             allowed <- newIORef Set.empty
@@ -198,7 +396,10 @@ spec = do
             let request _ = do
                     modifyIORef' permissionRequests (+ 1)
                     pure (Just PermissionAllowTool)
-                report notice = modifyIORef' notices (<> [notice])
+                report notice = do
+                    readIORef allowed
+                        `shouldReturn` Set.singleton "write"
+                    modifyIORef' notices (<> [notice])
 
             approveToolDecisionWithReporter
                 request report policy allowed
@@ -220,11 +421,20 @@ spec = do
             plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
             notices <- newIORef []
             persisted <- newIORef (0 :: Int)
+            events <- newIORef ([] :: [Text])
+            let persist = do
+                    readIORef policy `shouldReturn` ApproveAll
+                    modifyIORef' persisted (+ 1)
+                    modifyIORef' events (<> ["persist"])
+                report notice = do
+                    readIORef events `shouldReturn` ["persist"]
+                    modifyIORef' events (<> ["report"])
+                    modifyIORef' notices (<> [notice])
 
             approveToolDecisionWithReporterAndPersistence
                 (\_ -> pure (Just PermissionAllowAll))
-                (\notice -> modifyIORef' notices (<> [notice]))
-                (modifyIORef' persisted (+ 1))
+                report
+                persist
                 policy allowed (registry [mutatingTool]) plan mutatingCall
                 `shouldReturn` Right True
 
@@ -232,6 +442,26 @@ spec = do
             readIORef persisted `shouldReturn` 1
             readIORef notices `shouldReturn`
                 [ApprovalSuccess "✓ auto-approve on (saved for project)"]
+            readIORef events `shouldReturn` ["persist", "report"]
+
+        it "does not mutate or report when a prompt is denied" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            notices <- newIORef []
+            persisted <- newIORef (0 :: Int)
+
+            approveToolDecisionWithReporterAndPersistence
+                (\_ -> pure (Just PermissionDeny))
+                (\notice -> modifyIORef' notices (<> [notice]))
+                (modifyIORef' persisted (+ 1))
+                policy allowed (registry [mutatingTool]) plan mutatingCall
+                `shouldReturn` Right False
+
+            readIORef policy `shouldReturn` PromptMutating
+            readIORef allowed `shouldReturn` Set.empty
+            readIORef notices `shouldReturn` []
+            readIORef persisted `shouldReturn` 0
 
         it "shares remembered approval across public and internal Grok aliases" do
             policy <- newIORef PromptMutating
@@ -325,3 +555,13 @@ tool name approval =
 
 registry :: [AppTool] -> ToolRegistry
 registry = either (error . Text.unpack) id . mkToolRegistry
+
+approvalFacts :: ToolCall -> ApprovalFacts
+approvalFacts call = ApprovalFacts
+    { policy = PromptMutating
+    , planActive = False
+    , planPath = unsafeEncodeUtf "/tmp/approval-test/plan.md"
+    , readOnly = Nothing
+    , allowedForSession = Nothing
+    , call
+    }


### PR DESCRIPTION
## Summary

- extract parent tool-approval precedence into a staged pure `ApprovalFacts -> ApprovalPlan` engine
- keep `Approval.hs` as a small IO interpreter for classification, allow-list reads, prompts, persistence, and reporting
- model prompt outcomes as ordered effects so policy/allow-list mutations, persistence, and notices are directly testable

## Security and compatibility

This is intended to be behavior-preserving. The planner makes the existing precedence explicit:

1. catastrophic shell hard-deny
2. dynamic read-only classification
3. plan-mode restrictions
4. the dedicated plan-file write exception
5. remembered per-tool approval
6. session policy or user prompt

Facts are requested in stages rather than collected eagerly, so a dynamic classifier still cannot run before the shell hard-deny. Plan-mode restrictions still precede both remembered approval and `ApproveAll`. Prompt effects retain their existing order (`set policy -> persist -> report` and `remember tool -> report`), including exception behavior.

## Validation

- `nix develop -c cabal repl agent-cli:lib:agent-cli --offline` — all 195 library modules loaded
- focused test REPL invocation for `planApproval`, `resolveApprovalPrompt`, and `approveToolDecisionWith` — 25 examples, 0 failures
- `nix develop -c cabal check` — passes; only the package's existing distribution warnings
- regenerated `packages/agent-cli/package.nix` with `cabal2nix` and confirmed it is unchanged
- independent parity review found no definite behavior or security regression

### Live tmux smoke

Ran the agent from the library REPL in a real tmux TTY with `--no-yolo --minimal --max-turns 1` and requested one shell write to `/tmp/haskell-agent-approval-smoke.txt`. The four-choice approval dialog rendered correctly. Sending `n` produced `Tool call rejected by user`, and the target file did not exist afterward.