### PR TITLE
Refactor inline editor key handling into a pure reducer

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -170,6 +170,7 @@ library
                     , Agent.CLI.Input
                     , Agent.CLI.Input.Types
                     , Agent.CLI.Input.Display
+                    , Agent.CLI.Input.Editor
                     , Agent.CLI.Input.Paste
                     , Agent.CLI.Input.History
                     , Agent.CLI.Input.KeyDecoder

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -43,10 +43,10 @@ import Agent.CLI.Command
     , SlashSuggestion(..)
     , defaultSlashCatalog
     , slashCatalogWithSkills
-    , slashMenuForCatalog
     )
 import Agent.CLI.Input.Display
 import Agent.CLI.Input.Approval
+import Agent.CLI.Input.Editor
 import Agent.CLI.Input.History
 import Agent.CLI.Input.KeyDecoder
 import Agent.CLI.Input.Paste
@@ -65,10 +65,6 @@ import Agent.CLI.Terminal
     , kittyKeyboardPop
     , stripAnsi
     )
-import Agent.TUI.TextWidth
-    ( nextGraphemeBoundary
-    , previousGraphemeBoundary
-    )
 import Control.Exception.Safe
     ( bracket
     , bracket_
@@ -78,11 +74,7 @@ import Control.Exception.Safe
     , tryIO
     )
 import Control.Monad (unless, when)
-import Data.Char
-    ( isSpace
-    )
 import Data.List (isPrefixOf)
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -227,115 +219,42 @@ readInlineEditor
                     \() -> do
                         history <- readHistory historyPath `catchIO` \_ -> pure emptyHistory
                         let entries = map Text.pack (historyLines history)
-                            state = EditorState
-                                { editorText = initial
-                                , editorCursor = Text.length initial
-                                , editorSelected = 0
-                                , editorHistoryIndex = Nothing
-                                , editorHistoryDraft = initial
-                                , editorKillBuffer = ""
-                                , editorPasted = False
-                                , editorSlashEnabled = slashEnabled
-                                , editorSlashDismissed = False
-                                , editorSlashCatalog = catalog
-                                }
+                            state =
+                                initialEditorState catalog slashEnabled initial
                         redrawEditor prompt state
                         editorLoop history entries state
   where
     editorLoop history entries state = do
         key <- readEditorKey
-        let menu = currentMenu state
-        case key of
-            EditorEnter ->
-                case selectedSuggestion state menu of
-                    Just suggestion
-                        | not (exactCommandSelected state suggestion) -> do
-                            let accepted = acceptSuggestion state menu suggestion
-                            if suggestion.slashSuggestionTakesArguments
-                                then redrawEditor prompt accepted
-                                    >> editorLoop history entries accepted
-                                else finish history accepted
-                    _ -> finish history state
-            EditorCycleMode -> do
-                finishEditorLine prompt state
-                pure (ReplCycleMode state.editorText)
-            EditorClipboardPaste images -> do
-                finishEditorLine prompt state
-                pure (ReplClipboardPaste state.editorText images)
-            EditorInterrupt ->
+        let EditorStep
+                { editorStepState = next
+                , editorStepEffect = requested
+                } = reduceEditorKey entries state key
+        case requested of
+            RedrawEditor -> do
+                redrawEditor prompt next
+                editorLoop history entries next
+            SubmitEditor ->
+                finish history next
+            ReturnEditor line -> do
+                finishEditorLine prompt next
+                pure line
+            CheckEditorInterrupt ->
                 noteIdleCtrlC interrupt >>= \case
                     ContinuePrompt -> do
-                        finishEditorLine prompt state
+                        finishEditorLine prompt next
                         Text.putStrLn "^C"
-                        redrawEditor prompt state
-                        editorLoop history entries state
+                        redrawEditor prompt next
+                        editorLoop history entries next
                     QuitProcess -> do
-                        finishEditorLine prompt state
+                        finishEditorLine prompt next
                         pure ReplQuitInterrupt
-            EditorEof
-                | Text.null state.editorText -> do
-                    finishEditorLine prompt state
-                    pure ReplEof
-                | otherwise ->
-                    continue history entries (deleteAtCursor state)
-            EditorUp
-                | menuHasRows menu ->
-                    continue history entries (moveMenuSelection (-1) menu state)
-                | otherwise ->
-                    continue history entries (historyMove (-1) entries state)
-            EditorDown
-                | menuHasRows menu ->
-                    continue history entries (moveMenuSelection 1 menu state)
-                | otherwise ->
-                    continue history entries (historyMove 1 entries state)
-            EditorTab ->
-                case selectedSuggestion state menu of
-                    Nothing -> editorLoop history entries state
-                    Just suggestion ->
-                        continue history entries (acceptSuggestion state menu suggestion)
-            EditorEscape
-                | menuHasRows menu ->
-                    continue history entries state
-                        { editorSelected = 0
-                        , editorSlashDismissed = True
-                        }
-                | otherwise ->
-                    editorLoop history entries state
-            EditorBackspace -> continue history entries (backspace state)
-            EditorDelete -> continue history entries (deleteAtCursor state)
-            EditorLeft -> continue history entries state
-                { editorCursor =
-                    previousGraphemeBoundary
-                        state.editorText
-                        state.editorCursor
-                , editorSelected = 0
-                , editorSlashDismissed = False
-                }
-            EditorRight -> continue history entries state
-                { editorCursor =
-                    nextGraphemeBoundary
-                        state.editorText
-                        state.editorCursor
-                , editorSelected = 0
-                , editorSlashDismissed = False
-                }
-            EditorHome -> continue history entries state
-                { editorCursor = 0, editorSelected = 0, editorSlashDismissed = False }
-            EditorEnd -> continue history entries state
-                { editorCursor = Text.length state.editorText
-                , editorSelected = 0
-                , editorSlashDismissed = False
-                }
-            EditorKillStart -> continue history entries (killStart state)
-            EditorKillEnd -> continue history entries (killEnd state)
-            EditorKillWord -> continue history entries (killWord state)
-            EditorYank -> continue history entries (insertText state.editorKillBuffer state)
-            EditorClearScreen -> do
+            ClearEditorScreen -> do
                 Text.hPutStr stdout "\ESC[2J\ESC[H"
-                redrawEditor prompt state
-                editorLoop history entries state
-            EditorDictate -> do
-                finishEditorLine prompt state
+                redrawEditor prompt next
+                editorLoop history entries next
+            DictateIntoEditor -> do
+                finishEditorLine prompt next
                 result <- tryAny dictate
                 case result of
                     Left err ->
@@ -344,14 +263,14 @@ readInlineEditor
                     Right _ ->
                         Text.putStrLn "Dictation inserted."
                 let state' = case result of
-                        Left _ -> state
+                        Left _ -> next
                         Right transcript ->
                             let (text, cursor) =
                                     insertDictation
-                                        state.editorText
-                                        state.editorCursor
+                                        next.editorText
+                                        next.editorCursor
                                         transcript
-                            in state
+                            in next
                                 { editorText = text
                                 , editorCursor = cursor
                                 , editorHistoryIndex = Nothing
@@ -360,28 +279,14 @@ readInlineEditor
                                 }
                 redrawEditor prompt state'
                 editorLoop history entries state'
-            EditorPaste pasted -> do
-                finishEditorLine prompt state
-                let pastedState =
-                        (insertText pasted state) { editorPasted = True }
-                pure $ ReplClipboardPasteOrText
-                    state.editorText
-                    pasted
-                    pastedState.editorText
-            EditorInputError message -> do
-                finishEditorLine prompt state
+            ReportEditorError message -> do
+                finishEditorLine prompt next
                 Text.putStrLn ("input ignored: " <> message)
-                redrawEditor prompt state
-                editorLoop history entries state
-            EditorChar char ->
-                continue history entries (insertText (Text.singleton char) state)
-            EditorIgnore -> editorLoop history entries state
+                redrawEditor prompt next
+                editorLoop history entries next
+            IgnoreEditorInput ->
+                editorLoop history entries next
       where
-        continue history' entries' state' = do
-            let normalized = normalizeSelection state'
-            redrawEditor prompt normalized
-            editorLoop history' entries' normalized
-
         finish history' state' = do
             finishEditorLine prompt state'
             let text = state'.editorText
@@ -392,205 +297,6 @@ readInlineEditor
                 if state'.editorPasted
                     then ReplPasted text
                     else ReplText text
-
-menuHasRows :: Maybe SlashMenu -> Bool
-menuHasRows = maybe False (not . null . (.slashMenuSuggestions))
-
-currentMenu :: EditorState -> Maybe SlashMenu
-currentMenu state
-    | not state.editorSlashEnabled = Nothing
-    | state.editorSlashDismissed = Nothing
-    | otherwise =
-        slashMenuForCatalog
-            state.editorSlashCatalog
-            state.editorText
-            state.editorCursor
-
-normalizeSelection :: EditorState -> EditorState
-normalizeSelection state =
-    case currentMenu state of
-        Nothing -> state { editorSelected = 0 }
-        Just menu ->
-            let count = length menu.slashMenuSuggestions
-            in state
-                { editorSelected =
-                    if count == 0 then 0 else state.editorSelected `mod` count
-                }
-
-moveMenuSelection :: Int -> Maybe SlashMenu -> EditorState -> EditorState
-moveMenuSelection delta menu state =
-    case menu of
-        Nothing -> state
-        Just SlashMenu{slashMenuSuggestions}
-            | null slashMenuSuggestions -> state
-            | otherwise ->
-                let count = length slashMenuSuggestions
-                    selected = (state.editorSelected + delta) `mod` count
-                in state { editorSelected = selected }
-
-selectedSuggestion :: EditorState -> Maybe SlashMenu -> Maybe SlashSuggestion
-selectedSuggestion state menu = do
-    SlashMenu{slashMenuSuggestions} <- menu
-    if null slashMenuSuggestions
-        then Nothing
-        else Just (slashMenuSuggestions !! (state.editorSelected `mod` length slashMenuSuggestions))
-
-exactCommandSelected :: EditorState -> SlashSuggestion -> Bool
-exactCommandSelected state suggestion =
-    Text.strip state.editorText == suggestion.slashSuggestionDisplay
-
-acceptSuggestion
-    :: EditorState
-    -> Maybe SlashMenu
-    -> SlashSuggestion
-    -> EditorState
-acceptSuggestion state menu suggestion =
-    case menu of
-        Nothing -> state
-        Just SlashMenu{slashMenuReplaceStart, slashMenuReplaceEnd} ->
-            let (before, rest) = Text.splitAt slashMenuReplaceStart state.editorText
-                (_, after) = Text.splitAt
-                    (slashMenuReplaceEnd - slashMenuReplaceStart)
-                    rest
-                replacement = suggestion.slashSuggestionReplacement
-                text = before <> replacement <> after
-            in state
-                { editorText = text
-                , editorCursor = slashMenuReplaceStart + Text.length replacement
-                , editorSelected = 0
-                , editorHistoryIndex = Nothing
-                , editorHistoryDraft = text
-                , editorSlashDismissed = False
-                }
-
-insertText :: Text -> EditorState -> EditorState
-insertText inserted state =
-    let (before, after) = Text.splitAt state.editorCursor state.editorText
-        text = before <> inserted <> after
-    in state
-        { editorText = text
-        , editorCursor = state.editorCursor + Text.length inserted
-        , editorSelected = 0
-        , editorHistoryIndex = Nothing
-        , editorHistoryDraft = text
-        , editorSlashDismissed = False
-        }
-
-backspace :: EditorState -> EditorState
-backspace state
-    | state.editorCursor <= 0 = state
-    | otherwise =
-        let start =
-                previousGraphemeBoundary
-                    state.editorText
-                    state.editorCursor
-            (before, rest) = Text.splitAt start state.editorText
-            (_, after) =
-                Text.splitAt (state.editorCursor - start) rest
-            text = before <> after
-        in state
-            { editorText = text
-            , editorCursor = start
-            , editorSelected = 0
-            , editorHistoryIndex = Nothing
-            , editorHistoryDraft = text
-            , editorSlashDismissed = False
-            }
-
-deleteAtCursor :: EditorState -> EditorState
-deleteAtCursor state
-    | state.editorCursor >= Text.length state.editorText = state
-    | otherwise =
-        let (before, rest) = Text.splitAt state.editorCursor state.editorText
-            end =
-                nextGraphemeBoundary
-                    state.editorText
-                    state.editorCursor
-            (_, after) = Text.splitAt (end - state.editorCursor) rest
-            text = before <> after
-        in state
-            { editorText = text
-            , editorSelected = 0
-            , editorHistoryIndex = Nothing
-            , editorHistoryDraft = text
-            , editorSlashDismissed = False
-            }
-
-killStart :: EditorState -> EditorState
-killStart state =
-    let (killed, after) = Text.splitAt state.editorCursor state.editorText
-    in state
-        { editorText = after
-        , editorCursor = 0
-        , editorSelected = 0
-        , editorHistoryIndex = Nothing
-        , editorHistoryDraft = after
-        , editorKillBuffer = killed
-        , editorSlashDismissed = False
-        }
-
-killEnd :: EditorState -> EditorState
-killEnd state =
-    let (before, killed) = Text.splitAt state.editorCursor state.editorText
-    in state
-        { editorText = before
-        , editorSelected = 0
-        , editorHistoryIndex = Nothing
-        , editorHistoryDraft = before
-        , editorKillBuffer = killed
-        , editorSlashDismissed = False
-        }
-
-killWord :: EditorState -> EditorState
-killWord state
-    | state.editorCursor <= 0 = state
-    | otherwise =
-        let before = Text.take state.editorCursor state.editorText
-            trailingSpaces = Text.length (Text.takeWhileEnd isSpace before)
-            withoutSpaces = Text.dropEnd trailingSpaces before
-            wordLength = Text.length (Text.takeWhileEnd (not . isSpace) withoutSpaces)
-            start = state.editorCursor - trailingSpaces - wordLength
-            killed = Text.take (state.editorCursor - start) (Text.drop start state.editorText)
-            text = Text.take start state.editorText <> Text.drop state.editorCursor state.editorText
-        in state
-            { editorText = text
-            , editorCursor = start
-            , editorSelected = 0
-            , editorHistoryIndex = Nothing
-            , editorHistoryDraft = text
-            , editorKillBuffer = killed
-            , editorSlashDismissed = False
-            }
-
-historyMove :: Int -> [Text] -> EditorState -> EditorState
-historyMove delta entries state
-    | null entries = state
-    | otherwise =
-        let current = fromMaybe (-1) state.editorHistoryIndex
-            next = current - delta
-        in if next < 0
-            then state
-                { editorText = state.editorHistoryDraft
-                , editorCursor = Text.length state.editorHistoryDraft
-                , editorHistoryIndex = Nothing
-                , editorSelected = 0
-                , editorSlashDismissed = False
-                }
-            else if next >= length entries
-                then state
-                else
-                    let text = entries !! next
-                        draft = case state.editorHistoryIndex of
-                            Nothing -> state.editorText
-                            Just _ -> state.editorHistoryDraft
-                    in state
-                        { editorText = text
-                        , editorCursor = Text.length text
-                        , editorHistoryIndex = Just next
-                        , editorHistoryDraft = draft
-                        , editorSelected = 0
-                        , editorSlashDismissed = False
-                        }
 
 readEditorKey :: IO EditorKey
 readEditorKey = do

--- a/packages/agent-cli/src/Agent/CLI/Input/Editor.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Editor.hs
@@ -1,0 +1,394 @@
+-- | Pure state transitions for the first-party inline editor.
+--
+-- Terminal reads, redraws, dictation, interrupts, and history persistence stay
+-- in "Agent.CLI.Input"; this module decides what the next editor state and
+-- effect should be for each decoded key.
+module Agent.CLI.Input.Editor
+    ( EditorEffect(..)
+    , EditorStep(..)
+    , currentMenu
+    , initialEditorState
+    , reduceEditorKey
+    ) where
+
+import Agent.CLI.Command
+    ( SlashCatalog
+    , SlashMenu(..)
+    , SlashSuggestion(..)
+    , slashMenuForCatalog
+    )
+import Agent.CLI.Input.Types
+    ( EditorKey(..)
+    , EditorState(..)
+    , ReplLine(..)
+    )
+import Agent.TUI.TextWidth
+    ( nextGraphemeBoundary
+    , previousGraphemeBoundary
+    )
+import Data.Char (isSpace)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | The side effect requested by one pure editor transition.
+data EditorEffect
+    = RedrawEditor
+    | SubmitEditor
+    | ReturnEditor !ReplLine
+    | CheckEditorInterrupt
+    | ClearEditorScreen
+    | DictateIntoEditor
+    | ReportEditorError !Text
+    | IgnoreEditorInput
+    deriving (Eq, Show)
+
+-- | The state and effect produced by reducing one decoded key.
+data EditorStep = EditorStep
+    { editorStepState :: !EditorState
+    , editorStepEffect :: !EditorEffect
+    }
+    deriving (Eq, Show)
+
+initialEditorState :: SlashCatalog -> Bool -> Text -> EditorState
+initialEditorState catalog slashEnabled initial =
+    EditorState
+        { editorText = initial
+        , editorCursor = Text.length initial
+        , editorSelected = 0
+        , editorHistoryIndex = Nothing
+        , editorHistoryDraft = initial
+        , editorKillBuffer = ""
+        , editorPasted = False
+        , editorSlashEnabled = slashEnabled
+        , editorSlashDismissed = False
+        , editorSlashCatalog = catalog
+        }
+
+-- | Decide the next editor state and requested effect for a decoded key.
+--
+-- History is passed newest-first, matching Haskeline's 'historyLines'.
+reduceEditorKey :: [Text] -> EditorState -> EditorKey -> EditorStep
+reduceEditorKey entries state key =
+    case key of
+        EditorEnter ->
+            case selectedSuggestion state menu of
+                Just suggestion
+                    | not (exactCommandSelected state suggestion) ->
+                        let accepted = acceptSuggestion state menu suggestion
+                        in if suggestion.slashSuggestionTakesArguments
+                            then redraw accepted
+                            else effect accepted SubmitEditor
+                _ -> effect state SubmitEditor
+        EditorCycleMode ->
+            effect state (ReturnEditor (ReplCycleMode state.editorText))
+        EditorClipboardPaste images ->
+            effect state $
+                ReturnEditor (ReplClipboardPaste state.editorText images)
+        EditorInterrupt ->
+            effect state CheckEditorInterrupt
+        EditorEof
+            | Text.null state.editorText ->
+                effect state (ReturnEditor ReplEof)
+            | otherwise ->
+                redraw (deleteAtCursor state)
+        EditorUp
+            | menuHasRows menu ->
+                redraw (moveMenuSelection (-1) menu state)
+            | otherwise ->
+                redraw (historyMove (-1) entries state)
+        EditorDown
+            | menuHasRows menu ->
+                redraw (moveMenuSelection 1 menu state)
+            | otherwise ->
+                redraw (historyMove 1 entries state)
+        EditorTab ->
+            case selectedSuggestion state menu of
+                Nothing -> effect state IgnoreEditorInput
+                Just suggestion ->
+                    redraw (acceptSuggestion state menu suggestion)
+        EditorEscape
+            | menuHasRows menu ->
+                redraw state
+                    { editorSelected = 0
+                    , editorSlashDismissed = True
+                    }
+            | otherwise ->
+                effect state IgnoreEditorInput
+        EditorBackspace -> redraw (backspace state)
+        EditorDelete -> redraw (deleteAtCursor state)
+        EditorLeft -> redraw state
+            { editorCursor =
+                previousGraphemeBoundary
+                    state.editorText
+                    state.editorCursor
+            , editorSelected = 0
+            , editorSlashDismissed = False
+            }
+        EditorRight -> redraw state
+            { editorCursor =
+                nextGraphemeBoundary
+                    state.editorText
+                    state.editorCursor
+            , editorSelected = 0
+            , editorSlashDismissed = False
+            }
+        EditorHome -> redraw state
+            { editorCursor = 0
+            , editorSelected = 0
+            , editorSlashDismissed = False
+            }
+        EditorEnd -> redraw state
+            { editorCursor = Text.length state.editorText
+            , editorSelected = 0
+            , editorSlashDismissed = False
+            }
+        EditorKillStart -> redraw (killStart state)
+        EditorKillEnd -> redraw (killEnd state)
+        EditorKillWord -> redraw (killWord state)
+        EditorYank -> redraw (insertText state.editorKillBuffer state)
+        EditorClearScreen -> effect state ClearEditorScreen
+        EditorDictate -> effect state DictateIntoEditor
+        EditorPaste pasted ->
+            let pastedState =
+                    (insertText pasted state) { editorPasted = True }
+            in effect state $
+                ReturnEditor
+                    (ReplClipboardPasteOrText
+                        state.editorText
+                        pasted
+                        pastedState.editorText)
+        EditorInputError message ->
+            effect state (ReportEditorError message)
+        EditorChar char ->
+            redraw (insertText (Text.singleton char) state)
+        EditorIgnore ->
+            effect state IgnoreEditorInput
+  where
+    menu = currentMenu state
+    effect next requested = EditorStep
+        { editorStepState = next
+        , editorStepEffect = requested
+        }
+    redraw = flip effect RedrawEditor . normalizeSelection
+
+menuHasRows :: Maybe SlashMenu -> Bool
+menuHasRows = maybe False (not . null . (.slashMenuSuggestions))
+
+currentMenu :: EditorState -> Maybe SlashMenu
+currentMenu state
+    | not state.editorSlashEnabled = Nothing
+    | state.editorSlashDismissed = Nothing
+    | otherwise =
+        slashMenuForCatalog
+            state.editorSlashCatalog
+            state.editorText
+            state.editorCursor
+
+normalizeSelection :: EditorState -> EditorState
+normalizeSelection state =
+    case currentMenu state of
+        Nothing -> state { editorSelected = 0 }
+        Just menu ->
+            let count = length menu.slashMenuSuggestions
+            in state
+                { editorSelected =
+                    if count == 0 then 0 else state.editorSelected `mod` count
+                }
+
+moveMenuSelection :: Int -> Maybe SlashMenu -> EditorState -> EditorState
+moveMenuSelection delta menu state =
+    case menu of
+        Nothing -> state
+        Just SlashMenu{slashMenuSuggestions}
+            | null slashMenuSuggestions -> state
+            | otherwise ->
+                let count = length slashMenuSuggestions
+                    selected = (state.editorSelected + delta) `mod` count
+                in state { editorSelected = selected }
+
+selectedSuggestion
+    :: EditorState
+    -> Maybe SlashMenu
+    -> Maybe SlashSuggestion
+selectedSuggestion state menu = do
+    SlashMenu{slashMenuSuggestions} <- menu
+    if null slashMenuSuggestions
+        then Nothing
+        else
+            Just $
+                slashMenuSuggestions
+                    !! (state.editorSelected `mod` length slashMenuSuggestions)
+
+exactCommandSelected :: EditorState -> SlashSuggestion -> Bool
+exactCommandSelected state suggestion =
+    Text.strip state.editorText == suggestion.slashSuggestionDisplay
+
+acceptSuggestion
+    :: EditorState
+    -> Maybe SlashMenu
+    -> SlashSuggestion
+    -> EditorState
+acceptSuggestion state menu suggestion =
+    case menu of
+        Nothing -> state
+        Just SlashMenu{slashMenuReplaceStart, slashMenuReplaceEnd} ->
+            let (before, rest) =
+                    Text.splitAt slashMenuReplaceStart state.editorText
+                (_, after) =
+                    Text.splitAt
+                        (slashMenuReplaceEnd - slashMenuReplaceStart)
+                        rest
+                replacement = suggestion.slashSuggestionReplacement
+                text = before <> replacement <> after
+            in state
+                { editorText = text
+                , editorCursor =
+                    slashMenuReplaceStart + Text.length replacement
+                , editorSelected = 0
+                , editorHistoryIndex = Nothing
+                , editorHistoryDraft = text
+                , editorSlashDismissed = False
+                }
+
+insertText :: Text -> EditorState -> EditorState
+insertText inserted state =
+    let (before, after) =
+            Text.splitAt state.editorCursor state.editorText
+        text = before <> inserted <> after
+    in state
+        { editorText = text
+        , editorCursor = state.editorCursor + Text.length inserted
+        , editorSelected = 0
+        , editorHistoryIndex = Nothing
+        , editorHistoryDraft = text
+        , editorSlashDismissed = False
+        }
+
+backspace :: EditorState -> EditorState
+backspace state
+    | state.editorCursor <= 0 = state
+    | otherwise =
+        let start =
+                previousGraphemeBoundary
+                    state.editorText
+                    state.editorCursor
+            (before, rest) = Text.splitAt start state.editorText
+            (_, after) =
+                Text.splitAt (state.editorCursor - start) rest
+            text = before <> after
+        in state
+            { editorText = text
+            , editorCursor = start
+            , editorSelected = 0
+            , editorHistoryIndex = Nothing
+            , editorHistoryDraft = text
+            , editorSlashDismissed = False
+            }
+
+deleteAtCursor :: EditorState -> EditorState
+deleteAtCursor state
+    | state.editorCursor >= Text.length state.editorText = state
+    | otherwise =
+        let (before, rest) =
+                Text.splitAt state.editorCursor state.editorText
+            end =
+                nextGraphemeBoundary
+                    state.editorText
+                    state.editorCursor
+            (_, after) =
+                Text.splitAt (end - state.editorCursor) rest
+            text = before <> after
+        in state
+            { editorText = text
+            , editorSelected = 0
+            , editorHistoryIndex = Nothing
+            , editorHistoryDraft = text
+            , editorSlashDismissed = False
+            }
+
+killStart :: EditorState -> EditorState
+killStart state =
+    let (killed, after) =
+            Text.splitAt state.editorCursor state.editorText
+    in state
+        { editorText = after
+        , editorCursor = 0
+        , editorSelected = 0
+        , editorHistoryIndex = Nothing
+        , editorHistoryDraft = after
+        , editorKillBuffer = killed
+        , editorSlashDismissed = False
+        }
+
+killEnd :: EditorState -> EditorState
+killEnd state =
+    let (before, killed) =
+            Text.splitAt state.editorCursor state.editorText
+    in state
+        { editorText = before
+        , editorSelected = 0
+        , editorHistoryIndex = Nothing
+        , editorHistoryDraft = before
+        , editorKillBuffer = killed
+        , editorSlashDismissed = False
+        }
+
+killWord :: EditorState -> EditorState
+killWord state
+    | state.editorCursor <= 0 = state
+    | otherwise =
+        let before = Text.take state.editorCursor state.editorText
+            trailingSpaces =
+                Text.length (Text.takeWhileEnd isSpace before)
+            withoutSpaces = Text.dropEnd trailingSpaces before
+            wordLength =
+                Text.length (Text.takeWhileEnd (not . isSpace) withoutSpaces)
+            start = state.editorCursor - trailingSpaces - wordLength
+            killed =
+                Text.take
+                    (state.editorCursor - start)
+                    (Text.drop start state.editorText)
+            text =
+                Text.take start state.editorText
+                    <> Text.drop state.editorCursor state.editorText
+        in state
+            { editorText = text
+            , editorCursor = start
+            , editorSelected = 0
+            , editorHistoryIndex = Nothing
+            , editorHistoryDraft = text
+            , editorKillBuffer = killed
+            , editorSlashDismissed = False
+            }
+
+historyMove :: Int -> [Text] -> EditorState -> EditorState
+historyMove delta entries state
+    | null entries = state
+    | otherwise =
+        let current = fromMaybe (-1) state.editorHistoryIndex
+            next = current - delta
+        in if next < 0
+            then state
+                { editorText = state.editorHistoryDraft
+                , editorCursor = Text.length state.editorHistoryDraft
+                , editorHistoryIndex = Nothing
+                , editorSelected = 0
+                , editorSlashDismissed = False
+                }
+            else if next >= length entries
+                then state
+                else
+                    let text = entries !! next
+                        draft =
+                            case state.editorHistoryIndex of
+                                Nothing -> state.editorText
+                                Just _ -> state.editorHistoryDraft
+                    in state
+                        { editorText = text
+                        , editorCursor = Text.length text
+                        , editorHistoryIndex = Just next
+                        , editorHistoryDraft = draft
+                        , editorSelected = 0
+                        , editorSlashDismissed = False
+                        }

--- a/packages/agent-cli/src/Agent/CLI/Input/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Types.hs
@@ -52,6 +52,7 @@ data EditorState = EditorState
     , editorSlashDismissed :: !Bool
     , editorSlashCatalog :: !SlashCatalog
     }
+    deriving (Eq, Show)
 
 data DisplayCell = DisplayCell
     { displayCellText :: !Text

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -1,5 +1,6 @@
 module Agent.CLI.InputSpec (spec) where
 
+import Agent.CLI.Command (defaultSlashCatalog)
 import Agent.CLI.Input
     ( ChoiceKey(..)
     , approvalKeyText
@@ -18,10 +19,21 @@ import Agent.CLI.Input
     , truncateDisplayText
     , visibleEditorText
     )
+import Agent.CLI.Input.Editor
+    ( EditorEffect(..)
+    , EditorStep(..)
+    , initialEditorState
+    , reduceEditorKey
+    )
 import Agent.CLI.Input.KeyDecoder (decodeKittyEditorKey)
-import Agent.CLI.Input.Types (EditorKey(..))
+import Agent.CLI.Input.Types
+    ( EditorKey(..)
+    , EditorState(..)
+    , ReplLine(..)
+    )
 import Data.Char (isControl)
 import Data.Either (isLeft)
+import Data.List (mapAccumL)
 import qualified Data.Text as Text
 import qualified Graphics.Vty as V
 import System.FilePath ((</>))
@@ -40,6 +52,9 @@ import Test.QuickCheck
     )
 
 data EditorViewportCase = EditorViewportCase !Int !Text.Text !Int
+    deriving (Show)
+
+newtype EditorKeySequence = EditorKeySequence [EditorKey]
     deriving (Show)
 
 spec :: Spec
@@ -225,6 +240,131 @@ spec = do
             isShiftEnterCsiBody "13;2u" `shouldBe` True
             isShiftEnterCsiBody "13u" `shouldBe` False
 
+    describe "inline editor reducer" do
+        it "reduces common editing keys without performing IO" do
+            let initial = editorState "a界b" 2
+                cases =
+                    [ ( EditorLeft
+                      , "a界b"
+                      , 1
+                      )
+                    , ( EditorRight
+                      , "a界b"
+                      , 3
+                      )
+                    , ( EditorBackspace
+                      , "ab"
+                      , 1
+                      )
+                    , ( EditorDelete
+                      , "a界"
+                      , 2
+                      )
+                    , ( EditorChar '!'
+                      , "a界!b"
+                      , 3
+                      )
+                    ]
+            mapM_
+                (\(key, expectedText, expectedCursor) -> do
+                    let step = reduceEditorKey [] initial key
+                    step.editorStepEffect `shouldBe` RedrawEditor
+                    step.editorStepState.editorText `shouldBe` expectedText
+                    step.editorStepState.editorCursor
+                        `shouldBe` expectedCursor)
+                cases
+
+        it "moves through history and restores the in-progress draft" do
+            let initial = editorState "draft" 5
+                newest = reduceEditorKey ["new", "old"] initial EditorUp
+                older =
+                    reduceEditorKey
+                        ["new", "old"]
+                        newest.editorStepState
+                        EditorUp
+                restored =
+                    reduceEditorKey
+                        ["new", "old"]
+                        newest.editorStepState
+                        EditorDown
+            newest.editorStepState.editorText `shouldBe` "new"
+            newest.editorStepState.editorHistoryIndex `shouldBe` Just 0
+            older.editorStepState.editorText `shouldBe` "old"
+            older.editorStepState.editorHistoryIndex `shouldBe` Just 1
+            restored.editorStepState.editorText `shouldBe` "draft"
+            restored.editorStepState.editorHistoryIndex `shouldBe` Nothing
+
+        it "turns effectful keys into explicit requests" do
+            let initial = editorState "draft" 5
+                eofStep =
+                    reduceEditorKey [] (editorState "" 0) EditorEof
+                effects =
+                    [ (EditorEnter, SubmitEditor)
+                    , (EditorCycleMode, ReturnEditor (ReplCycleMode "draft"))
+                    , ( EditorClipboardPaste Nothing
+                      , ReturnEditor (ReplClipboardPaste "draft" Nothing)
+                      )
+                    , (EditorInterrupt, CheckEditorInterrupt)
+                    , (EditorClearScreen, ClearEditorScreen)
+                    , (EditorDictate, DictateIntoEditor)
+                    , (EditorInputError "bad key", ReportEditorError "bad key")
+                    , (EditorIgnore, IgnoreEditorInput)
+                    ]
+            mapM_
+                (\(key, expected) ->
+                    (reduceEditorKey [] initial key).editorStepEffect
+                        `shouldBe` expected)
+                effects
+            eofStep.editorStepEffect
+                `shouldBe` ReturnEditor ReplEof
+
+        it "preserves kill and yank behavior at text boundaries" do
+            let initial = editorState "one  two" 8
+                killed = reduceEditorKey [] initial EditorKillWord
+                yanked =
+                    reduceEditorKey [] killed.editorStepState EditorYank
+                start = editorState "draft" 0
+                end = editorState "draft" 5
+            killed.editorStepState.editorText `shouldBe` "one  "
+            killed.editorStepState.editorCursor `shouldBe` 5
+            killed.editorStepState.editorKillBuffer `shouldBe` "two"
+            yanked.editorStepState.editorText `shouldBe` "one  two"
+            yanked.editorStepState.editorCursor `shouldBe` 8
+            (reduceEditorKey [] start EditorBackspace).editorStepState
+                `shouldBe` start
+            (reduceEditorKey [] end EditorDelete).editorStepState
+                `shouldBe` end
+
+        it "returns paste classification without mutating the live draft" do
+            let initial = editorState "ac" 1
+                step = reduceEditorKey [] initial (EditorPaste "b")
+            step.editorStepState `shouldBe` initial
+            step.editorStepEffect
+                `shouldBe`
+                    ReturnEditor (ReplClipboardPasteOrText "ac" "b" "abc")
+
+        it "keeps slash completion decisions in the pure layer" do
+            let helpDraft =
+                    initialEditorState defaultSlashCatalog True "/he"
+                accepted =
+                    reduceEditorKey [] helpDraft EditorEnter
+                quitDraft =
+                    initialEditorState defaultSlashCatalog True "/qu"
+                submitted =
+                    reduceEditorKey [] quitDraft EditorEnter
+                dismissed =
+                    reduceEditorKey [] helpDraft EditorEscape
+            accepted.editorStepEffect `shouldBe` RedrawEditor
+            accepted.editorStepState.editorText `shouldBe` "/help "
+            submitted.editorStepEffect `shouldBe` SubmitEditor
+            submitted.editorStepState.editorText `shouldBe` "/quit"
+            dismissed.editorStepEffect `shouldBe` RedrawEditor
+            dismissed.editorStepState.editorSlashDismissed `shouldBe` True
+
+        modifyMaxSuccess (const 1000) $
+            prop "keeps the cursor in bounds across generated transitions" $
+                editorReducerCursorProperty
+
 editorViewportProperty :: EditorViewportCase -> Property
 editorViewportProperty (EditorViewportCase available raw requestedCursor) =
     conjoin
@@ -264,4 +404,54 @@ genEditorAtom =
         , Text.pack ['\x1f1fa', '\x1f1f8']
         , Text.pack ['\x1f44d', '\x1f3fd']
         , Text.pack ['1', '\xfe0f', '\x20e3']
+        ]
+
+editorState :: Text.Text -> Int -> EditorState
+editorState text cursor =
+    (initialEditorState defaultSlashCatalog False text)
+        { editorCursor = cursor
+        }
+
+editorReducerCursorProperty :: EditorKeySequence -> Property
+editorReducerCursorProperty (EditorKeySequence keys) =
+    conjoin $
+        zipWith cursorProperty [0 :: Int ..] states
+  where
+    initial = editorState "界e\x0301🙂" 4
+    (_, states) = mapAccumL reduce initial keys
+    reduce state key =
+        let next = (reduceEditorKey [] state key).editorStepState
+        in (next, next)
+    cursorProperty index state =
+        counterexample
+            ("transition " <> show index <> " produced " <> show state)
+            ( (state.editorCursor >= 0
+                && state.editorCursor <= Text.length state.editorText)
+                === True
+            )
+
+instance Arbitrary EditorKeySequence where
+    arbitrary = do
+        count <- chooseInt (0, 200)
+        EditorKeySequence <$> vectorOf count genPureEditorKey
+
+genPureEditorKey :: Gen EditorKey
+genPureEditorKey =
+    elements
+        [ EditorChar 'a'
+        , EditorChar '界'
+        , EditorChar '\x0301'
+        , EditorChar '🙂'
+        , EditorBackspace
+        , EditorDelete
+        , EditorLeft
+        , EditorRight
+        , EditorHome
+        , EditorEnd
+        , EditorKillStart
+        , EditorKillEnd
+        , EditorKillWord
+        , EditorYank
+        , EditorEof
+        , EditorIgnore
         ]


### PR DESCRIPTION
## Summary

- extract inline editor key/state decisions into the pure `Agent.CLI.Input.Editor` reducer
- keep `Agent.CLI.Input` focused on interpreting effects for redraw, history persistence, dictation, interrupts, and returns
- add table and property coverage for edits, history, slash completion, paste, effect requests, graphemes, and cursor bounds

No user-visible behavior is intentionally changed. The fullscreen TUI composer is deliberately out of scope so this remains a narrow refactor.

## Validation

- `nix develop -c cabal repl agent-cli:lib:agent-cli --offline` — loaded all 195 library modules
- `printf ':main --match "inline editor reducer"\n:quit\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test --offline` — 7 examples, 0 failures; QuickCheck passed 1,000 generated transition sequences
- `cabal2nix packages/agent-cli` — output matches `packages/agent-cli/package.nix`
- `git diff --check origin/master...HEAD`
- independent behavior-parity review against the pre-refactor implementation found no issues

## TTY smoke test

In a 110x32 tmux session, loaded the CLI in GHCi and launched the real minimal inline prompt with:

```haskell
:module +Agent.CLI
import System.Environment (withArgs)
withArgs ["--minimal", "--provider", "openai", "--model", "gpt-5.6-sol", "--yolo"] run
```

Verified these live interactions:

1. typed `/he` and saw the `/help` suggestion
2. pressed Tab and saw `/help ` accepted with its argument menu
3. pressed Down and Up and observed selection movement
4. pressed Ctrl-U, then Ctrl-Y, and observed kill/yank restore `/help `
5. pressed Esc and observed completion dismiss without losing the draft
6. entered `/quit` and returned cleanly to the GHCi prompt
