### PR TITLE
Allow running sessions to be renamed and archived

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -1085,29 +1085,14 @@ renameSession
 renameSession pool root sessionId rawTitle = runExceptT do
     let title = Text.unwords (Text.words (Text.strip rawTitle))
     when (Text.null title) (throwE "session title cannot be empty")
-    meta <- lift (loadSessionMeta pool root sessionId) >>= except
-    dir <- except (sessionDirForId root sessionId)
-    exists <- lift (doesDirectoryExist dir)
-    lock <- if exists
-        then lift (acquireSessionLock dir sessionId) >>= \case
-            Left _ -> throwE "cannot rename a running session"
-            Right lock -> pure (Just lock)
-        else pure Nothing
-    let updated = meta
-            { metaTitle = title
-            , metaTitleIsManual = True
-            , metaTitleRefreshIndex = 2
-            }
+    _ <- except (sessionDirForId root sessionId)
+    now <- lift getCurrentTime
     renamed <- lift $
-        Store.replaceSessionMetadata
-            pool
-            "session.renamed"
-            (toStoredMetadata updated)
-            `finally` maybe (pure ()) releaseSessionLock lock
+        Store.setSessionTitle pool sessionId title True 2 now
     case renamed of
         Left err -> throwE (renderStoreError err)
         Right False -> throwE ("session not found: " <> sessionId)
-        Right True -> pure updated
+        Right True -> lift (loadSessionMeta pool root sessionId) >>= except
 
 setSessionArchived
     :: StorePool
@@ -1116,20 +1101,10 @@ setSessionArchived
     -> Bool
     -> IO (Either Text ())
 setSessionArchived pool root sessionId archived = runExceptT do
-    dir <- except (sessionDirForId root sessionId)
-    exists <- lift (doesDirectoryExist dir)
-    lock <- if exists
-        then lift (acquireSessionLock dir sessionId) >>= \case
-            Left _ -> throwE $
-                if archived
-                    then "cannot archive a running session"
-                    else "cannot restore a running session"
-            Right lock -> pure (Just lock)
-        else pure Nothing
+    _ <- except (sessionDirForId root sessionId)
     now <- lift getCurrentTime
     changed <- lift $
         Store.setSessionArchived pool sessionId archived now
-            `finally` maybe (pure ()) releaseSessionLock lock
     case changed of
         Left err -> throwE (renderStoreError err)
         Right False -> throwE ("session not found: " <> sessionId)
@@ -1199,7 +1174,34 @@ sessionTitleFromPrompt prompt =
 setGeneratedSessionTitle :: Int -> Text -> SessionHandle -> IO SessionHandle
 setGeneratedSessionTitle refreshIndex rawTitle handle
     | handle.sessionMeta.metaTitleIsManual = pure handle
-    | otherwise = writeTitle False refreshIndex rawTitle handle
+    | otherwise = do
+        let title = Text.unwords (Text.words (Text.strip rawTitle))
+        now <- getCurrentTime
+        Store.setGeneratedSessionTitle
+            handle.sessionPool
+            handle.sessionMeta.metaId
+            title
+            (fromIntegral refreshIndex)
+            now >>= \case
+                Left err ->
+                    fail
+                        ("could not update PostgreSQL session title: "
+                            <> Text.unpack (renderStoreError err))
+                Right True ->
+                    pure handle
+                        { sessionMeta = handle.sessionMeta
+                            { metaTitle = title
+                            , metaTitleIsManual = False
+                            , metaTitleRefreshIndex = refreshIndex
+                            }
+                        }
+                Right False ->
+                    loadSessionMeta
+                        handle.sessionPool
+                        handle.sessionDir
+                        handle.sessionMeta.metaId >>= \case
+                            Left err -> fail (Text.unpack err)
+                            Right meta -> pure handle { sessionMeta = meta }
 
 setManualSessionTitle :: Text -> SessionHandle -> IO SessionHandle
 setManualSessionTitle = writeTitle True 2
@@ -1212,8 +1214,21 @@ writeTitle manual refreshIndex rawTitle handle = do
             , metaTitleIsManual = manual
             , metaTitleRefreshIndex = refreshIndex
             }
-    writeSessionMeta handle.sessionPool handle.sessionMetaPath meta
-    pure handle { sessionMeta = meta }
+    now <- getCurrentTime
+    Store.setSessionTitle
+        handle.sessionPool
+        handle.sessionMeta.metaId
+        title
+        manual
+        (fromIntegral refreshIndex)
+        now >>= \case
+            Left err ->
+                fail
+                    ("could not update PostgreSQL session title: "
+                        <> Text.unpack (renderStoreError err))
+            Right False ->
+                fail ("session not found: " <> Text.unpack handle.sessionMeta.metaId)
+            Right True -> pure handle { sessionMeta = meta }
 
 resetSessionTitleToAuto :: SessionHandle -> IO SessionHandle
 resetSessionTitleToAuto handle = do
@@ -1221,8 +1236,21 @@ resetSessionTitleToAuto handle = do
             { metaTitleIsManual = False
             , metaTitleRefreshIndex = 0
             }
-    writeSessionMeta handle.sessionPool handle.sessionMetaPath meta
-    pure handle { sessionMeta = meta }
+    now <- getCurrentTime
+    Store.setSessionTitle
+        handle.sessionPool
+        handle.sessionMeta.metaId
+        meta.metaTitle
+        False
+        0
+        now >>= \case
+            Left err ->
+                fail
+                    ("could not reset PostgreSQL session title: "
+                        <> Text.unpack (renderStoreError err))
+            Right False ->
+                fail ("session not found: " <> Text.unpack handle.sessionMeta.metaId)
+            Right True -> pure handle { sessionMeta = meta }
 
 setSessionRecap :: Text -> Int -> SessionHandle -> IO SessionHandle
 setSessionRecap summary mainTurns handle = do

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -1,6 +1,10 @@
 module Agent.CLI.SessionSpec (spec) where
 
 import Agent.CLI.Session
+import Agent.CLI.SessionLock
+    ( acquireSessionLock
+    , releaseSessionLock
+    )
 import Agent.CLI.Session.StoreCodec
     ( fromStoredResponseItem
     , toStoredResponseItem
@@ -771,26 +775,43 @@ spec = describe "Agent.CLI.Session" do
 
                 listed <- listSessions pool root
                 map (.metaId) listed `shouldBe` [handle.sessionMeta.metaId]
-                renameSession
-                    pool
-                    root
-                    handle.sessionMeta.metaId
-                    "  Manual   title  " >>= \case
-                        Left err -> expectationFailure (Text.unpack err)
-                        Right renamed -> do
-                            renamed.metaTitle `shouldBe` "Manual title"
-                            renamed.metaTitleIsManual `shouldBe` True
+                bracket
+                    (acquireSessionLock
+                        handle.sessionDir
+                        handle.sessionMeta.metaId >>= \case
+                            Left err -> expectationFailure (Text.unpack err)
+                                >> fail "could not acquire session lock"
+                            Right lock -> pure lock)
+                    releaseSessionLock
+                    \_ -> do
+                        renameSession
+                            pool
+                            root
+                            handle.sessionMeta.metaId
+                            "  Manual   title  " >>= \case
+                                Left err ->
+                                    expectationFailure (Text.unpack err)
+                                Right renamed -> do
+                                    renamed.metaTitle `shouldBe` "Manual title"
+                                    renamed.metaTitleIsManual `shouldBe` True
+                        setSessionArchived
+                            pool
+                            root
+                            handle.sessionMeta.metaId
+                            True `shouldReturn` Right ()
                 loadSessionMeta pool root handle.sessionMeta.metaId >>= \case
                     Left err -> expectationFailure (Text.unpack err)
                     Right renamed ->
                         renamed.metaTitle `shouldBe` "Manual title"
-                setSessionArchived
-                    pool
-                    root
-                    handle.sessionMeta.metaId
-                    True `shouldReturn` Right ()
                 listArchivedSessionIds pool
                     `shouldReturn` Right [handle.sessionMeta.metaId]
+                _ <- appendTurn final normalTurn
+                _ <- setGeneratedSessionTitle 3 "Generated replacement" final
+                loadSessionMeta pool root handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right renamed -> do
+                        renamed.metaTitle `shouldBe` "Manual title"
+                        renamed.metaTitleIsManual `shouldBe` True
                 setSessionArchived
                     pool
                     root

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -24,6 +24,8 @@ module Agent.Store.Postgres.Session
     , sessionSchemaStatements
     , createSession
     , replaceSessionMetadata
+    , setSessionTitle
+    , setGeneratedSessionTitle
     , appendSessionTurn
     , appendSessionTurnIndexed
     , loadSession
@@ -83,6 +85,15 @@ data SessionLegacyTarget = SessionLegacyTarget
     , sessionLegacyDialect :: !Text
     }
     deriving (Eq, Show)
+
+data TitleUpdate = TitleUpdate
+    { titleUpdateKey :: !Text
+    , titleUpdateTitle :: !Text
+    , titleUpdateManual :: !Bool
+    , titleUpdateRefreshIndex :: !Int32
+    , titleUpdateOccurredAt :: !UTCTime
+    , titleUpdateOnlyWhenAutomatic :: !Bool
+    }
 
 data NativeConversationSearchResult = NativeConversationSearchResult
     { nativeSearchSessionId :: !Text
@@ -379,6 +390,66 @@ createSession pool metadata =
                             , eventInsertKind = "session.created"
                             , eventInsertOccurredAt =
                                 metadata.sessionMetadataCreatedAt
+                            }
+                        insertEventStatement
+                    pure True
+
+setSessionTitle
+    :: StorePool
+    -> Text
+    -> Text
+    -> Bool
+    -> Int32
+    -> UTCTime
+    -> IO (Either StoreError Bool)
+setSessionTitle pool sessionKey title manual refreshIndex occurredAt =
+    updateSessionTitle pool TitleUpdate
+        { titleUpdateKey = sessionKey
+        , titleUpdateTitle = title
+        , titleUpdateManual = manual
+        , titleUpdateRefreshIndex = refreshIndex
+        , titleUpdateOccurredAt = occurredAt
+        , titleUpdateOnlyWhenAutomatic = False
+        }
+
+setGeneratedSessionTitle
+    :: StorePool
+    -> Text
+    -> Text
+    -> Int32
+    -> UTCTime
+    -> IO (Either StoreError Bool)
+setGeneratedSessionTitle pool sessionKey title refreshIndex occurredAt =
+    updateSessionTitle pool TitleUpdate
+        { titleUpdateKey = sessionKey
+        , titleUpdateTitle = title
+        , titleUpdateManual = False
+        , titleUpdateRefreshIndex = refreshIndex
+        , titleUpdateOccurredAt = occurredAt
+        , titleUpdateOnlyWhenAutomatic = True
+        }
+
+updateSessionTitle
+    :: StorePool
+    -> TitleUpdate
+    -> IO (Either StoreError Bool)
+updateSessionTitle pool update =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write do
+            _ <- Transaction.statement
+                update.titleUpdateKey
+                blockingAdvisoryLockStatement
+            changed <- Transaction.statement update setTitleProjectionStatement
+            case changed of
+                Nothing -> pure False
+                Just (sessionId, sequence) -> do
+                    _ <- Transaction.statement
+                        EventInsert
+                            { eventInsertSessionId = sessionId
+                            , eventInsertSequence = sequence
+                            , eventInsertKind = "session.title_updated"
+                            , eventInsertOccurredAt =
+                                update.titleUpdateOccurredAt
                             }
                         insertEventStatement
                     pure True
@@ -1056,11 +1127,44 @@ metadataUpdateSql =
     \ transport_model_id = $8, dialect = $9,\
     \ legacy_target_provider = $10, legacy_target_connection = $11,\
     \ legacy_target_effective_model = $12, legacy_target_dialect = $13,\
-    \ cwd = $14, effort = $15, title = $16, title_is_manual = $17,\
-    \ title_refresh_index = $18, title_user_turns = $19,\
+    \ cwd = $14, effort = $15,\
+    \ title = CASE WHEN title_is_manual THEN title ELSE $16 END,\
+    \ title_is_manual = CASE\
+    \   WHEN title_is_manual THEN title_is_manual ELSE $17 END,\
+    \ title_refresh_index = CASE\
+    \   WHEN title_is_manual THEN title_refresh_index ELSE $18 END,\
+    \ title_user_turns = $19,\
     \ last_response_id = $20, input_tokens = $21, output_tokens = $22,\
     \ cached_tokens = $23, last_recap = $24, last_turn_summary = $25,\
     \ last_recap_main_turns = $26"
+
+setTitleProjectionStatement
+    :: Statement TitleUpdate (Maybe (Text, Int64))
+setTitleProjectionStatement = mkStatement
+    "UPDATE harness.sessions SET\
+    \ title = $2, title_is_manual = $3, title_refresh_index = $4,\
+    \ updated_at = $5, next_event_sequence = next_event_sequence + 1\
+    \ WHERE session_key = $1 AND deleted_at IS NULL\
+    \ AND (NOT $6 OR NOT title_is_manual)\
+    \ RETURNING session_id::text, next_event_sequence - 1"
+    ( ((.titleUpdateKey)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.titleUpdateTitle)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.titleUpdateManual)
+            >$< Encoders.param (Encoders.nonNullable Encoders.bool))
+        <> ((.titleUpdateRefreshIndex)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int4))
+        <> ((.titleUpdateOccurredAt)
+            >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
+        <> ((.titleUpdateOnlyWhenAutomatic)
+            >$< Encoders.param (Encoders.nonNullable Encoders.bool))
+    )
+    (Decoders.rowMaybe $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.int8))
+    True
 
 insertEventStatement :: Statement EventInsert Text
 insertEventStatement = mkStatement


### PR DESCRIPTION
## Summary
- update session titles and archive state without taking the running-session filesystem lock
- preserve manual titles against stale running handles and automatic title generation
- cover rename and archive operations while a session lock is held

## Testing
- `nix develop -c cabal build --offline agent-store:lib:agent-store agent-cli:lib:agent-cli agent-cli:test:agent-cli-test`
- focused `Agent.CLI.Session` PostgreSQL persistence regression (1 example, 0 failures)