### PR TITLE
refactor(cli): extract agent viewport runtime

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -140,6 +140,7 @@ library
                     , Agent.CLI.AccountSelection
                     , Agent.CLI.AgentSessions
                     , Agent.CLI.AgentViewport
+                    , Agent.CLI.AgentViewport.Runtime
                     , Agent.CLI.Approval
                     , Agent.CLI.Artifact
                     , Agent.CLI.Afk
@@ -393,6 +394,7 @@ test-suite agent-cli-test
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec
                     , Agent.CLI.AgentViewportSpec
+                    , Agent.CLI.AgentViewportRuntimeSpec
                     , Agent.CLI.EnvironmentSpec
                     , Agent.CLI.AuthSpec
                     , Agent.CLI.BtwSpec

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport/Runtime.hs
@@ -1,0 +1,368 @@
+-- | State and lifecycle for a live agent viewport.
+module Agent.CLI.AgentViewport.Runtime
+    ( AgentStepCache(..)
+    , AgentChildListing(..)
+    , AgentChildSource(..)
+    , AgentViewportRuntime
+    , AgentViewportRuntimeConfig(..)
+    , agentViewportEnvironment
+    , loadAgentSnapshot
+    , newAgentViewportRuntime
+    , recordAgentViewportEvent
+    , resetAgentViewport
+    , selectAgentViewport
+    ) where
+
+import Agent.CLI.AgentViewport
+    ( AgentEntry(..)
+    , AgentStep
+    , AgentTarget(..)
+    , AgentViewportEnv(..)
+    , agentStepsForStatusRelative
+    , formatAgentStatus
+    , responseItemPreviewLines
+    , responseItemStepPreviewsRelative
+    , responseItemsToUiStateRelative
+    )
+import Agent.CLI.NativeAgents
+    ( NativeAgentView(..)
+    , applyNativeAgentEvent
+    , nativeAgentEntries
+    , restoreNativeAgents
+    )
+import qualified Agent.CLI.TUI.Bridge as TuiBridge
+import Agent.Concurrent (mapConcurrentlyBounded)
+import Agent.Loop (LoopEvent)
+import Agent.Responses.Types (ResponseItem)
+import Agent.Subagents
+    ( SubagentId
+    , SubagentStatus(..)
+    )
+import Agent.TUI.Model
+    ( BlockState(..)
+    , UiEvent(..)
+    , UiState(..)
+    , initialUiState
+    , reduceUi
+    )
+import Control.Monad (when)
+import Data.IORef
+    ( atomicModifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Mem.StableName (StableName, makeStableName)
+
+data AgentStepCache = AgentStepCache
+    { cachedTranscript :: !(StableName [ResponseItem])
+    , cachedVariant :: !(Maybe SubagentStatus)
+    , cachedSteps :: ![AgentStep]
+    }
+
+-- | Registry metadata needed to render one host-managed child agent.
+data AgentChildListing = AgentChildListing
+    { childListingPath :: !Text
+    , childListingId :: !SubagentId
+    , childListingStatus :: !SubagentStatus
+    }
+
+-- | Resident session data for a child agent.
+--
+-- The transcript remains an action so snapshots can read child transcripts
+-- concurrently after taking one coherent snapshot of the resident-session map.
+data AgentChildSource = AgentChildSource
+    { childSourceModel :: !Text
+    , childSourceTranscript :: !(IO [ResponseItem])
+    }
+
+-- | External capabilities used by the viewport runtime.
+--
+-- Child selection and release stay injected because they own persistence and
+-- hydration concerns outside of the viewport itself.
+data AgentViewportRuntimeConfig = AgentViewportRuntimeConfig
+    { viewportConfigShowRawReasoning :: !Bool
+    , viewportConfigWorkspace :: !Text
+    , viewportConfigReadRootTranscript :: !(IO [ResponseItem])
+    , viewportConfigListChildren :: !(IO [AgentChildListing])
+    , viewportConfigReadChildSources
+        :: !(IO (Map.Map SubagentId AgentChildSource))
+    , viewportConfigSelectChild :: !(SubagentId -> IO ())
+    , viewportConfigReleaseChild :: !(SubagentId -> IO ())
+    }
+
+data AgentViewportRuntime = AgentViewportRuntime
+    { runtimeEnvironment :: !AgentViewportEnv
+    , runtimeLoadSnapshot :: !(Bool -> IO (AgentTarget, [AgentEntry]))
+    , runtimeRecordEvent :: !(LoopEvent -> IO ())
+    , runtimeReset :: !(IO ())
+    }
+
+newAgentViewportRuntime
+    :: AgentViewportRuntimeConfig
+    -> IO AgentViewportRuntime
+newAgentViewportRuntime config = do
+    selectedAgent <- newIORef AgentRoot
+    nativeAgents <- newIORef (Map.empty :: Map.Map Text NativeAgentView)
+    stepCache <-
+        newIORef (Map.empty :: Map.Map AgentTarget AgentStepCache)
+    let cachedAgentSteps target variant items build = do
+            transcriptName <- makeStableName items
+            cache <- readIORef stepCache
+            case Map.lookup target cache of
+                Just cached
+                    | cached.cachedTranscript == transcriptName
+                    , cached.cachedVariant == variant ->
+                        pure cached.cachedSteps
+                _ -> do
+                    let steps = build items
+                    atomicModifyIORef' stepCache \current ->
+                        ( Map.insert target (AgentStepCache
+                            { cachedTranscript = transcriptName
+                            , cachedVariant = variant
+                            , cachedSteps = steps
+                            })
+                            current
+                        , ()
+                        )
+                    pure steps
+        loadSnapshot includeSummaries = do
+            rootItems <- config.viewportConfigReadRootTranscript
+            native <-
+                atomicModifyIORef' nativeAgents \current ->
+                    let restored = restoreNativeAgents rootItems current
+                    in (restored, restored)
+            children <- config.viewportConfigListChildren
+            let availableTargets =
+                    AgentRoot
+                        : map
+                            (AgentChild . (.childListingId))
+                            children
+                        <> map
+                            (AgentNative . (.nativeAgentId))
+                            (Map.elems native)
+            selected <-
+                atomicModifyIORef' selectedAgent \current ->
+                    let reconciled =
+                            TuiBridge.reconcileAgentSelection
+                                availableTargets
+                                current
+                    in (reconciled, reconciled)
+            childSources <- config.viewportConfigReadChildSources
+            let transcriptLines target items
+                    | null children = []
+                    | target == selected = case target of
+                        AgentRoot ->
+                            responseItemPreviewLines 12 items
+                        AgentChild _
+                            | includeSummaries ->
+                                responseItemPreviewLines 12 items
+                            | otherwise ->
+                                []
+                        AgentNative nativeId ->
+                            maybe [] (.nativeAgentTranscript)
+                                (Map.lookup nativeId native)
+                    | includeSummaries =
+                        responseItemPreviewLines 0 items
+                    | otherwise = []
+                conversationFor target status items
+                    | includeSummaries = initialUiState
+                    | target /= selected = initialUiState
+                    | target == AgentRoot = initialUiState
+                    | AgentNative nativeId <- target =
+                        maybe initialUiState (.nativeAgentConversation)
+                            (Map.lookup nativeId native)
+                    | otherwise =
+                        settleConversation items status $
+                            responseItemsToUiStateRelative
+                                config.viewportConfigShowRawReasoning
+                                config.viewportConfigWorkspace
+                                items
+            rootSteps <-
+                if null children
+                    then pure []
+                    else cachedAgentSteps
+                        AgentRoot
+                        Nothing
+                        rootItems
+                        (responseItemStepPreviewsRelative
+                            config.viewportConfigWorkspace
+                            2)
+            let rootEntry = AgentEntry
+                    { agentTarget = AgentRoot
+                    , agentPath = "/root"
+                    , agentStatus = "active"
+                    , agentModel = Nothing
+                    , agentSteps = rootSteps
+                    , agentTranscript =
+                        transcriptLines AgentRoot rootItems
+                    , agentConversation = initialUiState
+                    }
+            childEntries <- mapConcurrentlyBounded 8
+                (materializeChild
+                    config.viewportConfigWorkspace
+                    cachedAgentSteps
+                    transcriptLines
+                    conversationFor
+                    childSources)
+                children
+            pure
+                ( selected
+                , rootEntry : childEntries <> nativeAgentEntries native
+                )
+        selectAgent target = do
+            previous <- readIORef selectedAgent
+            when (previous /= target) $
+                releaseAgent config previous
+            case target of
+                AgentRoot -> pure ()
+                AgentNative _ -> pure ()
+                AgentChild agentId ->
+                    config.viewportConfigSelectChild agentId
+            writeIORef selectedAgent target
+        environment = AgentViewportEnv
+            { viewportSelected = selectedAgent
+            , viewportSelect = selectAgent
+            , viewportEntries = snd <$> loadSnapshot True
+            }
+        recordEvent event =
+            atomicModifyIORef' nativeAgents \current ->
+                (applyNativeAgentEvent event current, ())
+        reset = do
+            writeIORef selectedAgent AgentRoot
+            writeIORef stepCache Map.empty
+    pure AgentViewportRuntime
+        { runtimeEnvironment = environment
+        , runtimeLoadSnapshot = loadSnapshot
+        , runtimeRecordEvent = recordEvent
+        , runtimeReset = reset
+        }
+
+agentViewportEnvironment :: AgentViewportRuntime -> AgentViewportEnv
+agentViewportEnvironment = (.runtimeEnvironment)
+
+loadAgentSnapshot
+    :: AgentViewportRuntime
+    -> Bool
+    -> IO (AgentTarget, [AgentEntry])
+loadAgentSnapshot runtime = runtime.runtimeLoadSnapshot
+
+recordAgentViewportEvent :: AgentViewportRuntime -> LoopEvent -> IO ()
+recordAgentViewportEvent runtime = runtime.runtimeRecordEvent
+
+selectAgentViewport
+    :: AgentViewportRuntime
+    -> AgentTarget
+    -> IO ()
+selectAgentViewport runtime =
+    runtime.runtimeEnvironment.viewportSelect
+
+-- | Reset selection and derived step previews for a fresh conversation.
+--
+-- Native-agent views remain event-owned, matching the existing session reset
+-- semantics.
+resetAgentViewport :: AgentViewportRuntime -> IO ()
+resetAgentViewport = (.runtimeReset)
+
+releaseAgent :: AgentViewportRuntimeConfig -> AgentTarget -> IO ()
+releaseAgent config = \case
+    AgentRoot -> pure ()
+    AgentNative _ -> pure ()
+    AgentChild agentId ->
+        config.viewportConfigReleaseChild agentId
+
+materializeChild
+    :: Text
+    -> ( AgentTarget
+        -> Maybe SubagentStatus
+        -> [ResponseItem]
+        -> ([ResponseItem] -> [AgentStep])
+        -> IO [AgentStep]
+       )
+    -> (AgentTarget -> [ResponseItem] -> [Text])
+    -> (AgentTarget -> SubagentStatus -> [ResponseItem] -> UiState)
+    -> Map.Map SubagentId AgentChildSource
+    -> AgentChildListing
+    -> IO AgentEntry
+materializeChild
+        workspace
+        cachedAgentSteps
+        transcriptLines
+        conversationFor
+        childSources
+        child = do
+    let agentId = child.childListingId
+        target = AgentChild agentId
+        maybeSource = Map.lookup agentId childSources
+    items <- maybe (pure []) (.childSourceTranscript) maybeSource
+    steps <- cachedAgentSteps
+        target
+        (Just child.childListingStatus)
+        items
+        (agentStepsForStatusRelative
+            workspace
+            2
+            child.childListingStatus)
+    let transcript =
+            transcriptLines target items
+                <> case child.childListingStatus of
+                    Completed (Just result)
+                        | null items
+                        , not (Text.null (Text.strip result)) ->
+                            ["assistant: " <> Text.strip result]
+                    Errored message ->
+                        ["error: " <> Text.strip message]
+                    _ -> []
+    pure AgentEntry
+        { agentTarget = target
+        , agentPath = child.childListingPath
+        , agentStatus = formatAgentStatus child.childListingStatus
+        , agentModel = (.childSourceModel) <$> maybeSource
+        , agentSteps = steps
+        , agentTranscript = transcript
+        , agentConversation =
+            conversationFor target child.childListingStatus items
+        }
+
+settleConversation
+    :: [ResponseItem]
+    -> SubagentStatus
+    -> UiState
+    -> UiState
+settleConversation items status conversation =
+    case status of
+        Pending -> conversation
+        Running -> conversation
+        Completed result ->
+            let settled = finalizeAll BlockComplete conversation
+            in case result of
+                Just text
+                    | null items
+                    , not (Text.null (Text.strip text)) ->
+                        reduceUi
+                            (UiAssistantHistory (Text.strip text))
+                            settled
+                _ -> settled
+        Errored message ->
+            reduceUi
+                (UiErrorMessage
+                    (if Text.null (Text.strip message)
+                        then "Agent failed."
+                        else Text.strip message))
+                (finalizeAll BlockFailed conversation)
+        Interrupted ->
+            finalizeAll BlockCancelled conversation
+        Closed ->
+            finalizeAll BlockComplete conversation
+        NotFound ->
+            reduceUi
+                (UiErrorMessage "Agent transcript is unavailable.")
+                (finalizeAll BlockFailed conversation)
+  where
+    finalizeAll terminal ui =
+        reduceUi
+            (UiTurnEnded terminal)
+            ui { uiTurnStartBlock = 0 }

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -12,14 +12,10 @@ import Agent.CLI.Compaction
     )
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.CLI.Session.Runner.Types
-    ( AgentStepCache(..)
-    , SessionRunnerContinuation(..)
-    )
-import Agent.CLI.AgentViewport
-import Agent.CLI.NativeAgents
+    ( SessionRunnerContinuation(..) )
+import Agent.CLI.AgentViewport.Runtime
 import Agent.Tools.OutputArtifact
 import Agent.CLI.SessionTitle
-import Agent.Concurrent
 import Agent.CLI.ManagedTurn
 import Agent.CLI.GatewayBridge
 import Agent.CLI.Notification
@@ -42,7 +38,6 @@ import Agent.CLI.Interrupt
 import Agent.Store.Postgres
 import Agent.CLI.Project
 import Agent.CLI.Prompt
-import Agent.CLI.ProviderTransition
 import Agent.CLI.SessionState
 import Agent.CLI.Render
 import Agent.CLI.Session
@@ -60,7 +55,6 @@ import Agent.CLI.Tools
 import Agent.CLI.Error
 import Agent.CLI.Dialects
 import Agent.CLI.TUI.App
-import qualified Agent.CLI.TUI.Bridge as TuiBridge
 import Agent.TUI.Model
 import Agent.TUI.Motion
 import Agent.CLI.WindowTitle
@@ -69,7 +63,6 @@ import Agent.Cancel
 import Agent.Loop
 import Agent.Dialect
 import Agent.Skills
-import Agent.Responses.Types
 import Agent.Subagents
 import Agent.Subagents.TaskPath
 import Agent.ToolDispatch
@@ -85,11 +78,9 @@ import Control.Monad (forM_, unless, void, when)
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust, isNothing)
-import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Set as Set
 import Data.Time.Clock (getCurrentTime, utctDay)
-import System.Mem.StableName (makeStableName)
 runSession
     :: SessionRunnerContinuation
     -> SessionRequest
@@ -198,183 +189,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
     restartEffortRef <- newIORef Nothing
     lastFailedTurnRef <- newIORef Nothing
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
-    selectedAgent <- newIORef AgentRoot
-    nativeAgentsRef <- newIORef (Map.empty :: Map.Map Text NativeAgentView)
-    agentStepCache <- newIORef (Map.empty :: Map.Map AgentTarget AgentStepCache)
-    let cachedAgentSteps target variant items build = do
-            transcriptName <- makeStableName items
-            cache <- readIORef agentStepCache
-            case Map.lookup target cache of
-                Just cached
-                    | cached.cachedTranscript == transcriptName
-                    , cached.cachedVariant == variant ->
-                        pure cached.cachedSteps
-                _ -> do
-                    let steps = build items
-                    atomicModifyIORef' agentStepCache \current ->
-                        ( Map.insert target (AgentStepCache
-                            { cachedTranscript = transcriptName
-                            , cachedVariant = variant
-                            , cachedSteps = steps
-                            })
-                            current
-                        , ()
-                        )
-                    pure steps
-        loadAgentSnapshot includeSummaries = do
-            rootItems <- readLiveTranscript conversationRef
-            nativeAgents <-
-                atomicModifyIORef' nativeAgentsRef \current ->
-                    let restored = restoreNativeAgents rootItems current
-                    in (restored, restored)
-            agents <- case multiCtx of
-                Nothing -> pure []
-                Just ctx -> listAgents ctx.multiRegistry Nothing
-            let availableTargets =
-                    AgentRoot
-                        : [ AgentChild agentId
-                          | (_, agentId, _) <- agents
-                          ]
-                        <> map (\view -> AgentNative view.nativeAgentId)
-                            (Map.elems nativeAgents)
-            selected <-
-                atomicModifyIORef' selectedAgent \current ->
-                    let reconciled =
-                            TuiBridge.reconcileAgentSelection
-                                availableTargets
-                                current
-                    in (reconciled, reconciled)
-            sessions <- readIORef subagentSessions
-            let transcriptLines target items
-                    | null agents = []
-                    | target == selected = case target of
-                        AgentRoot ->
-                            responseItemPreviewLines 12 items
-                        AgentChild _
-                            | includeSummaries ->
-                                responseItemPreviewLines 12 items
-                            | otherwise ->
-                                []
-                        AgentNative nativeId ->
-                            maybe [] (.nativeAgentTranscript)
-                                (Map.lookup nativeId nativeAgents)
-                    | includeSummaries =
-                        responseItemPreviewLines 0 items
-                    | otherwise = []
-                conversationFor target status items
-                    | includeSummaries = initialUiState
-                    | target /= selected = initialUiState
-                    | target == AgentRoot = initialUiState
-                    | AgentNative nativeId <- target =
-                        maybe initialUiState (.nativeAgentConversation)
-                            (Map.lookup nativeId nativeAgents)
-                    | otherwise =
-                        settleConversation items status $
-                            responseItemsToUiStateRelative
-                                options.optShowRawReasoning
-                                (toText cwd)
-                                items
-                settleConversation items status conversation =
-                    case status of
-                        Pending -> conversation
-                        Running -> conversation
-                        Completed result ->
-                            let settled =
-                                    finalizeAll BlockComplete conversation
-                            in case result of
-                                Just text
-                                    | null items
-                                    , not (Text.null (Text.strip text)) ->
-                                        reduceUi
-                                            (UiAssistantHistory
-                                                (Text.strip text))
-                                            settled
-                                _ -> settled
-                        Errored message ->
-                            reduceUi
-                                (UiErrorMessage
-                                    (if Text.null (Text.strip message)
-                                        then "Agent failed."
-                                        else Text.strip message))
-                                (finalizeAll BlockFailed conversation)
-                        Interrupted ->
-                            finalizeAll BlockCancelled conversation
-                        Closed ->
-                            finalizeAll BlockComplete conversation
-                        NotFound ->
-                            reduceUi
-                                (UiErrorMessage
-                                    "Agent transcript is unavailable.")
-                                (finalizeAll BlockFailed conversation)
-                  where
-                    finalizeAll terminal ui =
-                        reduceUi
-                            (UiTurnEnded terminal)
-                            ui { uiTurnStartBlock = 0 }
-            rootSteps <-
-                if null agents
-                    then pure []
-                    else cachedAgentSteps
-                        AgentRoot
-                        Nothing
-                        rootItems
-                        (responseItemStepPreviewsRelative (toText cwd) 2)
-            let rootEntry = AgentEntry
-                    { agentTarget = AgentRoot
-                    , agentPath = "/root"
-                    , agentStatus = "active"
-                    , agentModel = Nothing
-                    , agentSteps = rootSteps
-                    , agentTranscript =
-                        transcriptLines AgentRoot rootItems
-                    , agentConversation = initialUiState
-                    }
-            children <- mapConcurrentlyBounded 8
-                (materializeChild
-                    transcriptLines
-                    conversationFor
-                    sessions)
-                agents
-            let nativeEntries = nativeAgentEntries nativeAgents
-            pure (selected, rootEntry : children <> nativeEntries)
-          where
-            materializeChild
-                    transcriptLines
-                    conversationFor
-                    sessions
-                    (path, agentId, status) = do
-                let target = AgentChild agentId
-                items <- case Map.lookup agentId sessions of
-                    Nothing -> pure []
-                    Just session -> readIORef session.subSessionTranscript
-                steps <- cachedAgentSteps
-                    target
-                    (Just status)
-                    items
-                    (agentStepsForStatusRelative (toText cwd) 2 status)
-                let transcript =
-                        transcriptLines target items
-                            <> case status of
-                                Completed (Just result)
-                                    | null items
-                                    , not (Text.null (Text.strip result)) ->
-                                        ["assistant: " <> Text.strip result]
-                                Errored message ->
-                                    ["error: " <> Text.strip message]
-                                _ -> []
-                pure AgentEntry
-                    { agentTarget = target
-                    , agentPath = taskPathText path
-                    , agentStatus = formatAgentStatus status
-                    , agentModel =
-                        (.subSessionEffectiveModel)
-                            <$> Map.lookup agentId sessions
-                    , agentSteps = steps
-                    , agentTranscript = transcript
-                    , agentConversation =
-                        conversationFor target status items
-                    }
-        hydrateSelectedAgent agentId = do
+    let hydrateSelectedAgent agentId = do
             effectiveModel <- readIORef modelRef
             lookupOrCreateSubagentSession
                 subagentSessions
@@ -386,56 +201,74 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 effectiveModel
                 (dialectId dialect)
                 agentId
-        selectAgent target = do
-            previous <- readIORef selectedAgent
-            when (previous /= target) $
-                releaseSelectedAgent previous
-            case target of
-                AgentRoot -> pure ()
-                AgentNative _ -> pure ()
-                AgentChild agentId -> do
-                    session <-
-                        (Just <$>
-                            hydrateSelectedAgent agentId)
-                            `catchAny` \err -> do
-                                reportSessionError
-                                    ("failed to load selected agent: "
-                                        <> formatException err)
-                                pure Nothing
-                    forM_ session \selectedSession -> do
-                        withMVar selectedSession.subSessionHydrated \_ ->
-                            writeIORef selectedSession.subSessionPinned True
-                        void
-                            (hydrateSelectedAgent agentId)
-                            `catchAny` \err ->
-                                reportSessionError
-                                    ("failed to pin selected agent: "
-                                        <> formatException err)
-            writeIORef selectedAgent target
-        releaseSelectedAgent = \case
-            AgentRoot -> pure ()
-            AgentNative _ -> pure ()
-            AgentChild agentId -> do
-                sessions <- readIORef subagentSessions
-                forM_ (Map.lookup agentId sessions) \session -> do
-                    withMVar session.subSessionHydrated \_ ->
-                        writeIORef session.subSessionPinned False
-                    case multiCtx of
-                        Nothing -> pure ()
-                        Just ctx -> do
-                            status <- getStatus ctx.multiRegistry agentId
-                            void $
-                                persistAndEvictSubagentSessionWithStatus
-                                    storeRoot ctx.multiRegistry agentTypes
-                                    agentId status session
-        agentViewport = AgentViewportEnv
-            { viewportSelected = selectedAgent
-            , viewportSelect = selectAgent
-            , viewportEntries = snd <$> loadAgentSnapshot True
+        selectChild agentId = do
+            session <-
+                (Just <$> hydrateSelectedAgent agentId)
+                    `catchAny` \err -> do
+                        reportSessionError
+                            ("failed to load selected agent: "
+                                <> formatException err)
+                        pure Nothing
+            forM_ session \selectedSession -> do
+                withMVar selectedSession.subSessionHydrated \_ ->
+                    writeIORef selectedSession.subSessionPinned True
+                void
+                    (hydrateSelectedAgent agentId)
+                    `catchAny` \err ->
+                        reportSessionError
+                            ("failed to pin selected agent: "
+                                <> formatException err)
+        releaseChild agentId = do
+            sessions <- readIORef subagentSessions
+            forM_ (Map.lookup agentId sessions) \session -> do
+                withMVar session.subSessionHydrated \_ ->
+                    writeIORef session.subSessionPinned False
+                case multiCtx of
+                    Nothing -> pure ()
+                    Just ctx -> do
+                        status <- getStatus ctx.multiRegistry agentId
+                        void $
+                            persistAndEvictSubagentSessionWithStatus
+                                storeRoot ctx.multiRegistry agentTypes
+                                agentId status session
+        listChildAgents =
+            case multiCtx of
+                Nothing -> pure []
+                Just ctx ->
+                    map
+                        (\(path, agentId, status) -> AgentChildListing
+                            { childListingPath = taskPathText path
+                            , childListingId = agentId
+                            , childListingStatus = status
+                            })
+                        <$> listAgents ctx.multiRegistry Nothing
+        readChildSources =
+            Map.map
+                (\session -> AgentChildSource
+                    { childSourceModel =
+                        session.subSessionEffectiveModel
+                    , childSourceTranscript =
+                        readIORef session.subSessionTranscript
+                    })
+                <$> readIORef subagentSessions
+    agentViewportRuntime <-
+        newAgentViewportRuntime AgentViewportRuntimeConfig
+            { viewportConfigShowRawReasoning =
+                options.optShowRawReasoning
+            , viewportConfigWorkspace = toText cwd
+            , viewportConfigReadRootTranscript =
+                readLiveTranscript conversationRef
+            , viewportConfigListChildren = listChildAgents
+            , viewportConfigReadChildSources = readChildSources
+            , viewportConfigSelectChild = selectChild
+            , viewportConfigReleaseChild = releaseChild
             }
+    let agentViewport =
+            agentViewportEnvironment agentViewportRuntime
     writeIORef startup.startupAgentSnapshot
-        (loadAgentSnapshot False)
-    writeIORef startup.startupAgentSelect selectAgent
+        (loadAgentSnapshot agentViewportRuntime False)
+    writeIORef startup.startupAgentSelect
+        (selectAgentViewport agentViewportRuntime)
     let installSkills context queueContext skills = do
             before <- readIORef context
             installSkillToolRoots toolEnv skills
@@ -498,8 +331,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             modifyIORef' renderStateRef clearRenderTokenRate
             writeIORef lastAssistantRef Nothing
             writeIORef subagentSessions Map.empty
-            writeIORef selectedAgent AgentRoot
-            writeIORef agentStepCache Map.empty
+            resetAgentViewport agentViewportRuntime
             case multiCtx of
                 Just ctx -> resetSubagentRegistry ctx.multiRegistry
                 Nothing -> pure ()
@@ -602,8 +434,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , renderWorkspace = toText cwd
             }
         emitLoop event = do
-            atomicModifyIORef' nativeAgentsRef \current ->
-                (applyNativeAgentEvent event current, ())
+            recordAgentViewportEvent agentViewportRuntime event
             managedLoopPublisher event
             case fullscreen of
                 Nothing -> renderEvent render event

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Types.hs
@@ -4,7 +4,7 @@ module Agent.CLI.Session.Runner.Types
     , SessionRunnerContinuation(..)
     ) where
 
-import Agent.CLI.AgentViewport (AgentStep)
+import Agent.CLI.AgentViewport.Runtime (AgentStepCache(..))
 import Agent.CLI.ProviderTransition (TurnResult)
 import Agent.CLI.Recap (RecapKind)
 import Agent.CLI.Runtime.Types (PendingTurnPresentation, RunResult)
@@ -12,16 +12,7 @@ import Agent.CLI.SessionEnv (SessionEnv)
 import Agent.CLI.Session.Runtime.Types (StartupRuntime)
 import Agent.CLI.ProviderTransition (PendingTurn)
 import Agent.Loop (TurnInput)
-import Agent.Responses.Types (ResponseItem)
-import Agent.Subagents (SubagentStatus)
 import Data.Text (Text)
-import System.Mem.StableName (StableName)
-
-data AgentStepCache = AgentStepCache
-    { cachedTranscript :: !(StableName [ResponseItem])
-    , cachedVariant :: !(Maybe SubagentStatus)
-    , cachedSteps :: ![AgentStep]
-    }
 
 data SessionRunnerContinuation = SessionRunnerContinuation
     { runnerFinishStartup :: StartupRuntime -> IO ()

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportRuntimeSpec.hs
@@ -1,0 +1,136 @@
+module Agent.CLI.AgentViewportRuntimeSpec (spec) where
+
+import Agent.CLI.AgentViewport
+    ( AgentEntry(..)
+    , AgentTarget(..)
+    , AgentViewportEnv(..)
+    )
+import Agent.CLI.AgentViewport.Runtime
+import Agent.Loop
+    ( LoopEvent(..)
+    , NativeAgentStatus(..)
+    )
+import Agent.Subagents
+    ( SubagentId(..)
+    , SubagentStatus(..)
+    )
+import Data.IORef
+    ( modifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "agent viewport runtime" do
+        it "owns child selection and release transitions" do
+            let alpha = SubagentId "alpha"
+                beta = SubagentId "beta"
+                listings =
+                    [ AgentChildListing "/root/alpha" alpha Running
+                    , AgentChildListing
+                        "/root/beta"
+                        beta
+                        (Completed (Just "finished"))
+                    ]
+                sources = Map.fromList
+                    [ (alpha, AgentChildSource "model-a" (pure []))
+                    , (beta, AgentChildSource "model-b" (pure []))
+                    ]
+            actions <- newIORef ([] :: [Text])
+            runtime <- newAgentViewportRuntime AgentViewportRuntimeConfig
+                { viewportConfigShowRawReasoning = False
+                , viewportConfigWorkspace = "/workspace"
+                , viewportConfigReadRootTranscript = pure []
+                , viewportConfigListChildren = pure listings
+                , viewportConfigReadChildSources = pure sources
+                , viewportConfigSelectChild = \agentId ->
+                    modifyIORef' actions
+                        (<> ["select:" <> agentId.unSubagentId])
+                , viewportConfigReleaseChild = \agentId ->
+                    modifyIORef' actions
+                        (<> ["release:" <> agentId.unSubagentId])
+                }
+
+            (selected, entries) <- loadAgentSnapshot runtime False
+            selected `shouldBe` AgentRoot
+            map (.agentTarget) entries
+                `shouldBe`
+                    [ AgentRoot
+                    , AgentChild alpha
+                    , AgentChild beta
+                    ]
+            map (.agentModel) entries
+                `shouldBe` [Nothing, Just "model-a", Just "model-b"]
+            entries !! 2
+                `shouldSatisfy`
+                    \entry ->
+                        entry.agentTranscript == ["assistant: finished"]
+
+            selectAgentViewport runtime (AgentChild alpha)
+            selectAgentViewport runtime (AgentChild beta)
+            selectAgentViewport runtime AgentRoot
+            readIORef actions
+                `shouldReturn`
+                    [ "select:alpha"
+                    , "release:alpha"
+                    , "select:beta"
+                    , "release:beta"
+                    ]
+
+        it "reconciles vanished selections and resets derived state" do
+            let alpha = SubagentId "alpha"
+            listings <- newIORef
+                [AgentChildListing "/root/alpha" alpha Running]
+            runtime <- newAgentViewportRuntime AgentViewportRuntimeConfig
+                { viewportConfigShowRawReasoning = False
+                , viewportConfigWorkspace = "/workspace"
+                , viewportConfigReadRootTranscript = pure []
+                , viewportConfigListChildren = readIORef listings
+                , viewportConfigReadChildSources = pure Map.empty
+                , viewportConfigSelectChild = const (pure ())
+                , viewportConfigReleaseChild = const (pure ())
+                }
+            selectAgentViewport runtime (AgentChild alpha)
+            writeIORef listings []
+
+            (selected, _) <- loadAgentSnapshot runtime False
+            selected `shouldBe` AgentRoot
+            resetAgentViewport runtime
+            readIORef
+                (agentViewportEnvironment runtime).viewportSelected
+                `shouldReturn` AgentRoot
+
+        it "tracks provider-native agent events inside the runtime" do
+            runtime <- newAgentViewportRuntime AgentViewportRuntimeConfig
+                { viewportConfigShowRawReasoning = False
+                , viewportConfigWorkspace = "/workspace"
+                , viewportConfigReadRootTranscript = pure []
+                , viewportConfigListChildren = pure []
+                , viewportConfigReadChildSources = pure Map.empty
+                , viewportConfigSelectChild = const (pure ())
+                , viewportConfigReleaseChild = const (pure ())
+                }
+            recordAgentViewportEvent runtime
+                (NativeAgentStarted
+                    "native-1"
+                    Nothing
+                    "explore"
+                    (Just "claude-sonnet"))
+            recordAgentViewportEvent runtime
+                (NativeAgentFinished
+                    "native-1"
+                    NativeAgentCompleted)
+
+            (_, entries) <- loadAgentSnapshot runtime False
+            map (.agentTarget) entries
+                `shouldBe` [AgentRoot, AgentNative "native-1"]
+            entries !! 1
+                `shouldSatisfy`
+                    \entry ->
+                        entry.agentStatus == "done"
+                            && entry.agentModel == Just "claude-sonnet"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -5,6 +5,7 @@ import Test.Hspec (hspec)
 import qualified Agent.CLI.AccountSelectionSpec as AccountSelectionSpec
 import qualified Agent.CLI.AgentSessionsSpec as AgentSessionsSpec
 import qualified Agent.CLI.AgentViewportSpec as AgentViewportSpec
+import qualified Agent.CLI.AgentViewportRuntimeSpec as AgentViewportRuntimeSpec
 import qualified Agent.CLI.ApprovalSpec as ApprovalSpec
 import qualified Agent.CLI.ArtifactSpec as ArtifactSpec
 import qualified Agent.CLI.AuthSpec as AuthSpec
@@ -80,6 +81,7 @@ main :: IO ()
 main = hspec do
     AccountSelectionSpec.spec
     AgentViewportSpec.spec
+    AgentViewportRuntimeSpec.spec
     AgentSessionsSpec.spec
     ApprovalSpec.spec
     ArtifactSpec.spec


### PR DESCRIPTION
## Why

`Agent.CLI.Session.Runner.Execution.runSession` directly owned agent selection, provider-native views, derived-step caching, snapshot materialization, and selection lifecycle effects. That made the session constructor responsible for a separate mutable subsystem and obscured its reset/event boundaries.

## What changed

- add `Agent.CLI.AgentViewport.Runtime` to own viewport selection, native-agent state, step caching, snapshots, event updates, and reset behavior
- inject the existing child-session hydration/pinning and persistence/eviction actions as explicit capabilities
- keep snapshot ordering, bounded child materialization, cache keys, and native-agent reset semantics unchanged
- retain the existing `AgentStepCache` re-exports for compatibility
- reduce `Session.Runner.Execution` from 1,084 to 915 lines
- add focused runtime tests for child selection/release, stale-selection reconciliation/reset, and provider-native events

## Validation

- targeted runner load in GHCi:
  - `nix develop -c cabal repl agent-cli:lib:agent-cli --offline`
  - `:load Agent.CLI.Session.Runner.Execution` → `Ok, 141 modules loaded.`
- focused viewport/native regression specs in the test REPL: **33 examples, 0 failures**
- complete `agent-cli` Hspec suite via `cabal repl agent-cli:test:agent-cli-test --offline` + `:main`: **1,210 examples, 0 failures**
  - used a short symlink to the private session temp directory so PostgreSQL's Unix socket stayed below its path limit
- `cabal check`: passes with the package's existing `-O2` and missing-upper-bound warnings
- regenerated `packages/agent-cli/package.nix` to a temporary file and confirmed it is unchanged/current
- `git diff --check`

This is a behavior-preserving extraction; it does not change rendering or terminal interaction.
