### PR TITLE
Add Muse Spark 1.2 via Meta and OpenRouter

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -1,6 +1,7 @@
 # Model catalog and local models
 
-The model picker merges the shipped OpenAI, xAI, and OpenRouter catalog with:
+The model picker merges the shipped OpenAI, xAI, OpenRouter, and Meta catalog
+with:
 
 ```text
 ~/.haskell-agent/models.json
@@ -10,6 +11,11 @@ User entries with the same `id` replace shipped entries; new entries are
 appended. The `id` is accepted by `/model` and `--model`. Secrets are not
 stored in this file: connections name an environment variable containing the
 API key.
+
+The shipped Meta connection calls Meta Model API directly. Export
+`MODEL_API_KEY`, then select `muse-spark-1.2` with
+`agent-cli --model muse-spark-1.2` or from `/model`. The separate
+`meta/muse-spark-1.2` entry uses OpenRouter.
 
 For example, an unauthenticated local server exposing the streaming OpenAI
 Responses API at `POST /v1/responses` can be configured as:
@@ -53,8 +59,9 @@ Supported dialects are:
 - `generic-responses` for portable Responses-compatible models
 
 Custom connections are selected manually and are not considered for automatic
-billing fallback. Built-in connection names (`openai`, `xai`, and
-`openrouter`) are reserved. Invalid catalogs are reported at startup.
+billing fallback. Shipped connection names (`openai`, `xai`, `openrouter`,
+`meta`, and `claude-code`) are reserved. Invalid catalogs are reported at
+startup.
 
 The built-in `add-model` skill handles requests such as “use the model running
 at this URL”, “add this OpenRouter model”, or “OpenAI released a new model”.

--- a/packages/agent-cli/config/models.default.json
+++ b/packages/agent-cli/config/models.default.json
@@ -13,6 +13,11 @@
       "api": "builtin",
       "provider": "openrouter"
     },
+    "meta": {
+      "api": "responses",
+      "base_url": "https://api.meta.ai/v1",
+      "api_key_env": "MODEL_API_KEY"
+    },
     "claude-code": {
       "api": "builtin",
       "provider": "claude-code"
@@ -56,6 +61,20 @@
       "label": "default · frontier · free · coding · 1M context",
       "default": true,
       "fallback_priority": 20
+    },
+    {
+      "id": "meta/muse-spark-1.2",
+      "connection": "openrouter",
+      "dialect": "generic-responses",
+      "context_window": 1048576,
+      "label": "reasoning · agentic · 1M context"
+    },
+    {
+      "id": "muse-spark-1.2",
+      "connection": "meta",
+      "dialect": "generic-responses",
+      "context_window": 1048576,
+      "label": "direct · reasoning · agentic · 1M context"
     },
     {
       "id": "sonnet",

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -54,7 +54,8 @@ spec = do
                     , "gpt-5.6-luna"
                     ]
             modelIdsFor XAIProvider `shouldBe` ["grok-4.6"]
-            modelIdsFor OpenRouterProvider `shouldBe` ["stealth/ox-alpha"]
+            modelIdsFor OpenRouterProvider
+                `shouldBe` ["stealth/ox-alpha", "meta/muse-spark-1.2"]
             modelIdsFor ClaudeCodeProvider
                 `shouldBe` ["sonnet", "opus", "fable"]
 


### PR DESCRIPTION
## Summary

- add `meta/muse-spark-1.2` to the shipped OpenRouter catalog
- add a direct Meta Responses connection for `muse-spark-1.2` using `MODEL_API_KEY`
- document how to select either route

## Validation

- `jq empty packages/agent-cli/config/models.default.json`
- `git diff --check`
- live tmux `/model` smoke confirmed both `openrouter · meta/muse-spark-1.2` and `meta · muse-spark-1.2`

No billable inference request was sent.