### PR TITLE
Fetch upstream by default for managed worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,23 +142,24 @@ Start in an isolated Git worktree:
 agent-cli --worktree
 ```
 
-By default the worktree branches from the current local `HEAD`. To always fetch
-and branch from the selected remote's latest default branch, add this to
-`~/.haskell-agent/config.json`:
+By default, managed worktrees fetch and branch from the selected remote's latest
+default commit. Repositories without remotes instead branch from the current
+local `HEAD`. To disable fetching, add this to `~/.haskell-agent/config.json`:
 
 ```json
 {
   "version": 1,
   "worktree": {
-    "fetchLatestUpstream": true
+    "fetchLatestUpstream": false
   }
 }
 ```
 
 This policy applies to `--worktree`, `/worktree`, and subagent worktrees. The
 remote is selected from the current branch's configured remote, then
-`upstream`, `origin`, or the repository's sole remote. A fetch failure aborts
-worktree creation rather than falling back to a stale commit.
+`upstream`, `origin`, or the repository's sole remote. When a remote exists, a
+fetch failure aborts worktree creation rather than falling back to a stale
+commit.
 
 Use `--provider openai`, `--provider xai`, `--provider openrouter`, or
 `--provider claude-code` to override automatic provider detection. Claude Code

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -171,8 +171,8 @@ data LspConfig = LspConfig
     }
     deriving (Eq, Show)
 
--- | Managed worktree creation policy. Fetching is opt-in so worktree creation
--- remains available in offline repositories by default.
+-- | Managed worktree creation policy. Repositories with remotes fetch by
+-- default, while local-only repositories continue to branch from @HEAD@.
 data WorktreeConfig = WorktreeConfig
     { worktreeFetchLatestUpstream :: !Bool
     }
@@ -327,7 +327,7 @@ defaultHarnessConfig = HarnessConfig
         , lspServers = Map.empty
         }
     , configWorktree = WorktreeConfig
-        { worktreeFetchLatestUpstream = False
+        { worktreeFetchLatestUpstream = True
         }
     , configMaxConcurrentAgents = Nothing
     }
@@ -432,7 +432,7 @@ worktreeConfigDecoder :: Hermes.Decoder WorktreeConfig
 worktreeConfigDecoder =
     Hermes.object $
         WorktreeConfig
-            <$> defaultKey False "fetchLatestUpstream" Hermes.bool
+            <$> defaultKey True "fetchLatestUpstream" Hermes.bool
 
 harnessConfigDecoder :: Hermes.Decoder HarnessConfig
 harnessConfigDecoder =

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -85,7 +85,7 @@ createWorktreeWithFetch fetchLatest source root = runExceptT do
     repoName <- gitRepositoryName repo
     base <-
         if fetchLatest
-            then Just <$> fetchLatestUpstream repo
+            then fetchLatestUpstream repo
             else pure Nothing
     now <- lift getCurrentTime
     let day = utctDay now
@@ -184,16 +184,21 @@ gitRepositoryName repo = do
             else takeFileName path
 
 -- | Fetch and return the commit at the selected remote's advertised default
--- branch. The current branch's configured remote wins, followed by conventional
--- @upstream@ and @origin@ names, then a sole remaining remote.
-fetchLatestUpstream :: OsPath -> ExceptT Text IO Text
+-- branch, or use the local @HEAD@ when the repository has no remotes. The
+-- current branch's configured remote wins, followed by conventional @upstream@
+-- and @origin@ names, then a sole remaining remote.
+fetchLatestUpstream :: OsPath -> ExceptT Text IO (Maybe Text)
 fetchLatestUpstream repo = do
-    remote <- selectUpstreamRemote repo
-    remoteHead <- remoteDefaultBranch repo remote
-    localRef <- lift freshFetchRef
-    ExceptT $
-        runExceptT (fetchIntoRef repo remote remoteHead localRef)
-            `finally` cleanupFetchRef repo localRef
+    selectUpstreamRemote repo >>= \case
+        Nothing -> pure Nothing
+        Just remote -> do
+            remoteHead <- remoteDefaultBranch repo remote
+            localRef <- lift freshFetchRef
+            commit <-
+                ExceptT $
+                    runExceptT (fetchIntoRef repo remote remoteHead localRef)
+                        `finally` cleanupFetchRef repo localRef
+            pure (Just commit)
 
 fetchIntoRef :: OsPath -> Text -> Text -> Text -> ExceptT Text IO Text
 fetchIntoRef repo remote remoteHead localRef = do
@@ -241,7 +246,7 @@ cleanupFetchRef repo localRef =
         tryAny $
             git repo ["update-ref", "-d", Text.unpack localRef]
 
-selectUpstreamRemote :: OsPath -> ExceptT Text IO Text
+selectUpstreamRemote :: OsPath -> ExceptT Text IO (Maybe Text)
 selectUpstreamRemote repo = do
     output <- ExceptT (git repo ["remote"])
     let remotes = filter (not . Text.null) (map Text.strip (Text.lines output))
@@ -256,11 +261,9 @@ selectUpstreamRemote repo = do
             [remote] -> Just remote
             _ -> Nothing
       of
-        Just remote -> pure remote
+        Just remote -> pure (Just remote)
         Nothing
-            | null remotes ->
-                throwE
-                    "worktree.fetchLatestUpstream requires a git remote"
+            | null remotes -> pure Nothing
             | otherwise ->
                 throwE
                     ( "could not choose an upstream git remote; configure the "

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -164,14 +164,24 @@ spec = describe "Agent.CLI.Config" do
             fmap (.configMaxConcurrentAgents) result
                 `shouldBe` Right (Just 48)
 
-    it "loads the managed worktree fetch policy" $
+    it "fetches the latest upstream for managed worktrees by default" $
         withTempDir "agent-config-" \home -> do
             writeConfig home
-                "{\"worktree\":{\"fetchLatestUpstream\":true}}"
+                "{\"worktree\":{}}"
             result <- loadHarnessConfig home
             fmap (.configWorktree) result
                 `shouldBe` Right WorktreeConfig
                     { worktreeFetchLatestUpstream = True
+                    }
+
+    it "loads the managed worktree fetch opt-out" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home
+                "{\"worktree\":{\"fetchLatestUpstream\":false}}"
+            result <- loadHarnessConfig home
+            fmap (.configWorktree) result
+                `shouldBe` Right WorktreeConfig
+                    { worktreeFetchLatestUpstream = False
                     }
 
     it "decodes LSP maps and retains opaque JSON options" $

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -87,29 +87,36 @@ spec = describe "Agent.CLI.Worktree" do
                         expectationFailure ("expected failure, got " <> toFilePath path)
                 doesDirectoryExist root `shouldReturn` False
 
-        it "fails closed when latest-upstream mode has no remote" $
+        it "uses local HEAD when default fetching has no remote" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do
+                sourceHead <- git repo ["rev-parse", "HEAD"]
+                path <- expectRight =<< createManagedWorktree home repo
+                git path ["rev-parse", "HEAD"] `shouldReturn` sourceHead
+
+        it "fails closed when a configured remote cannot be fetched" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                _ <- git repo
+                    [ "remote"
+                    , "add"
+                    , "origin"
+                    , toFilePath (repo </> fromFilePath "missing.git")
+                    ]
                 let root = worktreeRoot home
                 result <- createWorktreeWithFetch True repo root
                 result `shouldSatisfy` \case
                     Left err ->
-                        "requires a git remote" `Text.isInfixOf` err
+                        "failed to inspect git remote" `Text.isInfixOf` err
                     Right _ -> False
                 doesDirectoryExist root `shouldReturn` False
 
-        it "fetches and branches from the remote's latest default commit" $
+        it "fetches and branches from the remote's latest default commit by default" $
             withTempRemoteRepo \repo updater ->
             withTempDir "agent-home-" \home -> do
                 stale <- git repo ["rev-parse", "refs/remotes/origin/master"]
                 latest <- git updater ["rev-parse", "HEAD"]
                 stale `shouldNotBe` latest
-                let config = defaultHarnessConfig
-                        { configWorktree = WorktreeConfig
-                            { worktreeFetchLatestUpstream = True
-                            }
-                        }
-                saveHarnessConfig home config `shouldReturn` Right ()
 
                 path <- expectRight =<< createManagedWorktree home repo
 
@@ -123,6 +130,25 @@ spec = describe "Agent.CLI.Worktree" do
                 git path ["rev-parse", "--abbrev-ref", "HEAD"]
                     `shouldReturn` toFilePath (takeFileName path)
                 temporaryFetchRefs repo `shouldReturn` ""
+
+        it "uses local HEAD when latest-upstream fetching is disabled" $
+            withTempRemoteRepo \repo updater ->
+            withTempDir "agent-home-" \home -> do
+                local <- git repo ["rev-parse", "HEAD"]
+                latest <- git updater ["rev-parse", "HEAD"]
+                local `shouldNotBe` latest
+                let config = defaultHarnessConfig
+                        { configWorktree = WorktreeConfig
+                            { worktreeFetchLatestUpstream = False
+                            }
+                        }
+                saveHarnessConfig home config `shouldReturn` Right ()
+
+                path <- expectRight =<< createManagedWorktree home repo
+
+                git path ["rev-parse", "HEAD"] `shouldReturn` local
+                doesFileExist (path </> fromFilePath "LOCAL")
+                    `shouldReturn` True
 
         it "uses isolated fetch refs for concurrent worktree creation" $
             withTempRemoteRepo \repo updater ->


### PR DESCRIPTION
## Summary
- enable `worktree.fetchLatestUpstream` by default
- keep repositories without remotes working from local `HEAD`, while still failing when an existing remote cannot be fetched
- preserve `fetchLatestUpstream: false` as an explicit offline opt-out and document the new default
- add regression coverage for default fetching, local-only fallback, strict fetch failures, and the opt-out

Follow-up to #738.

## Testing
- focused `ConfigSpec` and `WorktreeSpec` run in GHCi: 38 examples, 0 failures
- `git diff --check`