### PR TITLE
Document native image attachment pointer nullability

### DIFF
--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -483,12 +483,18 @@ void ha_runtime_exit(void);
 void *ha_engine_create(ha_event_callback callback, void *context);
 /*
  * Stage an ordered image batch for a turn before its turn.start request.
- * A later call for the same turn replaces the previous batch. Passing zero
- * images discards that turn's batch, which callers should do if they abandon
- * the request. Staging is also discarded when a request envelope or turn.start
- * parameters are rejected, and is consumed by the matching valid turn.start.
- * Returns 0 when accepted, 1 for a null engine, 2 for an invalid turn ID, 3
- * for an internal failure, and 4 for an invalid image array or UTF-8 MIME.
+ * A later call for the same turn replaces the previous batch. turn_id is
+ * required, must be non-null even when turn_id_length is zero, and must have
+ * a non-zero length; a null or empty turn ID returns 2. Invalid UTF-8 returns
+ * 4. images may be null only when image_count is zero. Passing zero images
+ * discards that turn's batch, which callers should do if they abandon the
+ * request. For every image, mime and bytes are required, non-null, and have
+ * non-zero lengths; violating those requirements returns 4. All pointers are
+ * borrowed for this call and the runtime copies accepted data before return.
+ * Staging is also discarded when a request envelope or turn.start parameters
+ * are rejected, and is consumed by the matching valid turn.start. Returns 0
+ * when accepted, 1 for a null engine, 2 for a null or empty turn ID, 3 for an
+ * internal failure, and 4 for invalid image fields or UTF-8.
  */
 int32_t ha_engine_stage_turn_images(
     void *engine,


### PR DESCRIPTION
## Summary

- document the exact nullability contract for the staged turn ID, image array, MIME, and byte buffers
- identify the status returned for null, empty, or invalid UTF-8 inputs
- state that accepted attachment data is copied before the call returns

This follows up the native image staging bridge in #731 and addresses the pointer-contract review feedback on the macOS client attachment PR.

## Validation

- `nix develop --command cabal v2-test agent-cli:test:agent-cli-test --test-option=--match --test-option="native image attachment"` (2 examples, 0 failures)

## Dependency

- Stacked on #750, which fixes unrelated baseline storage-migration failures in the native bridge branch.