### PR TITLE
Add Codex image generation support

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -345,13 +345,12 @@ collectTurnInputs inputs = do
             [userText]
         UserMultimodalFiles{userText} ->
             [userText]
-        CompletedTool
-            (ToolDispatch.ToolCallResult resultCallId resultOutput _) ->
+        CompletedTool result ->
             pure $
                 "Host tool result for "
-                    <> resultCallId
+                    <> result.callId
                     <> ":\n"
-                    <> resultOutput
+                    <> result.output
     inputImages = \case
         UserMultimodal{userImages} -> userImages
         UserMultimodalFiles{userImages} -> userImages

--- a/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
@@ -17,6 +17,8 @@ module Agent.CLI.CodeModeRuntime
     , codexCatalogDefaultEffort
     , projectCodeModeTools
     , codeModeSessionRuntimeFor
+    , imageGenerationCodeModeRuntimeFor
+    , imageGenerationCodeModeProjection
     ) where
 
 import Agent.CLI.Models (modelsCacheFilePath)
@@ -241,6 +243,45 @@ codeModeSessionRuntimeFor maybeInfo tools =
                         info
                         CodeOnlyToolMode
                         (projectCodeModeTools CodeOnlyToolMode tools)
+
+-- | Catalog @code_mode_only@ models reserve @image_gen.imagegen@ but expect it
+-- behind the @exec@ surface. When the user has not enabled full code mode,
+-- project only image generation through @exec@ and leave every other tool
+-- directly provider-visible.
+imageGenerationCodeModeRuntimeFor
+    :: Maybe ModelInfo
+    -> [AppTool]
+    -> IO (Either Text (Maybe CodeModeSessionRuntime))
+imageGenerationCodeModeRuntimeFor maybeInfo tools =
+    case maybeInfo of
+        Just info
+            | Just projection <-
+                imageGenerationCodeModeProjection
+                    (toolModeForInfo ConventionalToolMode info)
+                    tools ->
+                buildRuntime
+                    info
+                    CodeOnlyToolMode
+                    projection
+        _ -> pure (Right Nothing)
+
+imageGenerationCodeModeProjection
+    :: ToolMode
+    -> [AppTool]
+    -> Maybe CodeModeToolProjection
+imageGenerationCodeModeProjection mode tools
+    | mode == CodeOnlyToolMode
+    , any isImageGenerationTool tools =
+        Just CodeModeToolProjection
+            { directCodeModeTools =
+                filter (not . isImageGenerationTool) tools
+            , nestedCodeModeTools =
+                filter isImageGenerationTool tools
+            }
+    | otherwise = Nothing
+  where
+    isImageGenerationTool tool =
+        tool.appToolName == imageGenerationToolName
 
 buildRuntime
     :: ModelInfo

--- a/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
@@ -25,6 +25,11 @@ import Agent.Dialect
     , PromptStyle(..)
     , dialectPromptStyle
     )
+import Agent.OpenAI.ImageGeneration
+    ( imageGenerationNamespace
+    , imageGenerationNamespaceDescription
+    , imageGenerationToolName
+    )
 import Agent.OpenAI.Models
     ( ModelInfo(..)
     , ModelsClientConfig(..)
@@ -49,7 +54,7 @@ import Agent.Provider
     , getNextToken
     , tokenProviderBillingMode
     )
-import Agent.ToolDispatch (ToolCall(..))
+import Agent.ToolDispatch (ToolCall(..), ToolCallResult)
 import Agent.Tools.CodeMode.Host
     ( ImageDetailVisibility(..)
     , codeModeWorkerPath
@@ -78,7 +83,8 @@ import System.OsPath (OsPath)
 
 -- | Late-bound nested dispatcher for code-mode tool calls.
 newtype CodeModeNestedSlot =
-    CodeModeNestedSlot (IORef (ToolCall -> IO (Either Text Text)))
+    CodeModeNestedSlot
+        (IORef (ToolCall -> IO (Either Text ToolCallResult)))
 
 newCodeModeNestedSlot :: IO CodeModeNestedSlot
 newCodeModeNestedSlot =
@@ -88,14 +94,14 @@ newCodeModeNestedSlot =
 
 setCodeModeNestedInvoke
     :: CodeModeNestedSlot
-    -> (ToolCall -> IO (Either Text Text))
+    -> (ToolCall -> IO (Either Text ToolCallResult))
     -> IO ()
 setCodeModeNestedInvoke (CodeModeNestedSlot ref) = writeIORef ref
 
 invokeThroughSlot
     :: CodeModeNestedSlot
     -> ToolCall
-    -> IO (Either Text Text)
+    -> IO (Either Text ToolCallResult)
 invokeThroughSlot (CodeModeNestedSlot ref) call = do
     invoke <- readIORef ref
     invoke call
@@ -267,11 +273,16 @@ nestedSpecFor :: AppTool -> CodeModeNestedSpec
 nestedSpecFor tool = CodeModeNestedSpec
     { nestedSpecTool = tool
     , nestedSpecNamespace =
-        if tool.appToolName `elem` multiAgentToolNames
+        if tool.appToolName == imageGenerationToolName
             then Just CodeModeNamespace
+                { namespaceName = imageGenerationNamespace
+                , namespaceDescription = imageGenerationNamespaceDescription
+                }
+            else if tool.appToolName `elem` multiAgentToolNames
+                then Just CodeModeNamespace
                 { namespaceName = multiAgentNamespace
                 , namespaceDescription =
                     "Tools for spawning and managing sub-agents."
                 }
-            else Nothing
+                else Nothing
     }

--- a/packages/agent-cli/src/Agent/CLI/Compaction/Continuation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction/Continuation.hs
@@ -16,7 +16,10 @@ import Agent.OpenAI.Compaction
     )
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types
-import Agent.ToolDispatch (ToolCallResult(..))
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , toolCallResultImages
+    )
 import Control.Applicative ((<|>))
 import Data.IORef (IORef, readIORef)
 import Data.List (partition)
@@ -156,14 +159,24 @@ fitCompletedToolOutputsToLimit limit requestTokens inputs
 capCompletedToolOutputs :: Int -> [TurnInput] -> [TurnInput]
 capCompletedToolOutputs maximumCharacters =
     map \case
-        CompletedTool result ->
-            CompletedTool ToolCallResult
+        CompletedTool result -> CompletedTool (capToolResult result)
+        input -> input
+  where
+    capToolResult result =
+        let cappedOutput =
+                capToolOutput maximumCharacters result.output
+        in case toolCallResultImages result of
+            [] -> ToolCallResult
                 { callId = result.callId
-                , output =
-                    capToolOutput maximumCharacters result.output
+                , output = cappedOutput
                 , callKind = result.callKind
                 }
-        input -> input
+            images -> ToolCallResultWithImages
+                { callId = result.callId
+                , output = cappedOutput
+                , callKind = result.callKind
+                , toolResultImages = images
+                }
 
 capToolOutput :: Int -> Text -> Text
 capToolOutput maximumCharacters text

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -97,6 +97,7 @@ import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
     ( SessionRequest(codexCatalogSession, SessionRequest, catalog, modelInfo,
                      connectionId, options, provider, dialect, policy, allTools,
+                     recordImageGenerationInputs, clearImageGenerationHistory,
                      suspendGhci, grokRuntime, mcpRegistrations, mcpWarnings,
                      mcpInstructions, mcpFleet,
                      ghciEnabledRef, bashEnabledRef, toolEnv, planMode, startup,
@@ -233,6 +234,8 @@ runAgentSession
     activeSelectionRef
     agentTypesRef
     allTools
+    recordImageGenerationInputs
+    clearImageGenerationHistory
     bashEnabledRef
     catalog
     checkStartupUsageInBackground
@@ -543,6 +546,8 @@ runAgentSession
                                 , dialect
                                 , policy
                                 , allTools = registryTools
+                                , recordImageGenerationInputs
+                                , clearImageGenerationHistory
                                 , suspendGhci = coding.codingSuspendGhci
                                 , grokRuntime = coding.codingGrokRuntime
                                 , mcpRegistrations =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -14,6 +14,7 @@ import Agent.CLI.CodeModeRuntime
     ( CodeModeSessionRuntime(..),
       CodexCatalogSession(..),
       codeModeSessionRuntimeFor,
+      imageGenerationCodeModeRuntimeFor,
       loadCodexCatalogModelInfo )
 import Agent.CLI.Command ()
 import Agent.CLI.Compaction
@@ -155,6 +156,7 @@ import Agent.GrokBuild.Dialect.Task ()
 import Agent.GrokBuild.Dialect.Workflow ()
 import Agent.Loop ( addTokenUsage, emptyTokenUsage )
 import Agent.OpenAI.Compaction ()
+import Agent.OpenAI.ImageGeneration ( imageGenerationToolName )
 import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient ()
 import Agent.OpenRouter.LoopBackend ()
@@ -324,10 +326,11 @@ runAgentSession
                 Nothing -> pure ()
         today <- utctDay <$> getCurrentTime
         mcpInstructions <- MCP.mcpFleetInstructions mcpFleet
-        -- Catalog models provide the per-model instructions template. Code
-        -- mode is opt-in even when the catalog selects code_mode_only; normal
-        -- provider tool calling remains the default. The offline lookup never
-        -- blocks startup on the network.
+        -- Catalog models provide the per-model instructions template. Full
+        -- code mode remains opt-in, but code_mode_only models still route the
+        -- reserved image-generation tool through exec because Responses Lite
+        -- rejects its direct namespace. The offline lookup never blocks
+        -- startup on the network.
         codexModelInfo <-
             loadCodexCatalogModelInfo
                 stateDirectory
@@ -335,18 +338,33 @@ runAgentSession
                 dialect
                 (Just loaded.loadedTokenProvider)
                 model
-        codeModeRuntime <- if options.optCodeMode
-            then codeModeSessionRuntimeFor codexModelInfo tools >>= \case
+        let initializeCodeMode =
+                if options.optCodeMode
+                    then codeModeSessionRuntimeFor codexModelInfo tools
+                    else imageGenerationCodeModeRuntimeFor codexModelInfo tools
+            codeModeFallbackWarning
+                | options.optCodeMode =
+                    "code mode unavailable; falling back to compatible \
+                    \direct tools: "
+                | otherwise =
+                    "image generation code mode unavailable; \
+                    \disabling image generation: "
+        (codeModeRuntime, suppressDirectImageGeneration) <-
+            initializeCodeMode >>= \case
                 Left err -> do
                     reportStartupWarning startup
-                        ("code mode unavailable; falling back to direct tools: "
-                            <> err)
-                    pure Nothing
-                Right runtime -> pure runtime
-            else pure Nothing
+                        (codeModeFallbackWarning <> err)
+                    pure (Nothing, True)
+                Right runtime -> pure (runtime, False)
         writeIORef codeModeCloseRef
             (maybe (pure ()) (.codeModeClose) codeModeRuntime)
-        let catalogSession = codexModelInfo <&> \info ->
+        let providerTools
+                | suppressDirectImageGeneration =
+                    filter
+                        ((/= imageGenerationToolName) . (.appToolName))
+                        tools
+                | otherwise = tools
+            catalogSession = codexModelInfo <&> \info ->
                 CodexCatalogSession
                     { catalogInstructionsFor = \toolNames sessionTmpDir ->
                         systemPromptForCatalogModel
@@ -361,12 +379,12 @@ runAgentSession
                 appendMcpInstructions mcpInstructions case catalogSession of
                     Just catalog ->
                         catalog.catalogInstructionsFor
-                            (map (.appToolName) tools)
+                            (map (.appToolName) providerTools)
                             (Just sessionTmp)
                     Nothing ->
                         systemPromptForTools
                             dialect
-                            (map (.appToolName) tools)
+                            (map (.appToolName) providerTools)
                             cwd
                             (Just sessionTmp)
                             today
@@ -378,7 +396,7 @@ runAgentSession
                         ( codeMode.codeModeWireTools
                             <> codeMode.codeModeDirectTools
                         )
-                Nothing -> schemasFromAppTools dialect tools
+                Nothing -> schemasFromAppTools dialect providerTools
             environmentContextBlock =
                 (.catalogEnvironmentContext) <$> catalogSession
             registryTools =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -119,7 +119,7 @@ import Agent.CLI.Session
       SessionTurn(turnAssistantText) )
 import Agent.CLI.Session.Attachments ( putImagePreview )
 import Agent.CLI.Session.Choices ()
-import Agent.CLI.Session.History ()
+import Agent.CLI.Session.History (foldSessionItems)
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
     ( StartupRuntime(startupFullscreen, startupBackground,
@@ -163,7 +163,10 @@ import Agent.CLI.Worktree
     ( createWorktree, removeWorktree, worktreeRoot )
 import Agent.Cancel ()
 import Agent.Claude ()
-import Agent.Dialect ( dialectForId, DialectId(GrokBuildDialect) )
+import Agent.Dialect
+    ( dialectForId
+    , DialectId(CodexDialect, GrokBuildDialect)
+    )
 import Agent.Error ()
 import Agent.GrokBuild.Dialect.Goal ()
 import Agent.GrokBuild.Dialect.Runtime ()
@@ -173,13 +176,21 @@ import Agent.Loop
     ( TurnInput(UserMessage, AgentMessage),
       LoopError(LoopNoResponseId) )
 import Agent.OpenAI.Compaction ()
+import Agent.OpenAI.ImageGeneration
+    ( clearImageGenerationHistory
+    , imageGenerationTool
+    , newImageGenerationHistory
+    , recordImageGenerationImages
+    , recordImageGenerationResponseItems
+    )
 import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient ()
 import Agent.OpenRouter.LoopBackend ()
 import Agent.OsPath ( unsafeToFilePath )
 import Agent.Provider
-    ( Provider(XAIProvider, OpenRouterProvider, OpenAIProvider),
-      tokenProviderBillingMode )
+    ( Provider(XAIProvider, OpenRouterProvider, OpenAIProvider)
+    , tokenProviderBillingMode
+    )
 import Agent.ReasoningEffort
     ( parseReasoningEffort, reasoningEffortText )
 import Agent.Responses.GenericBackend ()
@@ -597,6 +608,11 @@ runAgentTools
                 (sessionId, tempDir) <- allocateSessionTemp root
                 pure (tempDir, Just sessionId)
     setToolSessionTmp baseToolEnv (Just sessionTmp)
+    imageGenerationHistory <- newImageGenerationHistory
+    forM_ resumed \(_, turns) ->
+        recordImageGenerationResponseItems
+            imageGenerationHistory
+            (foldSessionItems turns)
     home <- getHomeDirectory
     let cleanupScratch = do
             cleanupPendingPersistence persist
@@ -846,6 +862,17 @@ runAgentTools
             learnedSkillTools skillInvocationsRef learnedSkillToolsEnv
         computerTools =
             [ComputerUse.computerUseTool | options.optComputerUse, provider == OpenAIProvider]
+        imageGenerationTools =
+            [ imageGenerationTool
+                tokenProvider
+                toolEnv
+                imageGenerationHistory
+                imageHooks
+            | provider == OpenAIProvider
+            , dialectId == CodexDialect
+            , inferredTarget.targetConnectionId
+                == builtinConnectionId OpenAIProvider
+            ]
         allTools =
             coding.codingAppTools
                 ++ extraTools
@@ -854,7 +881,7 @@ runAgentTools
                 ++ gatewayTools
                 ++ databaseAppTools
                 ++ learnedSkillAppTools
-                ++ computerTools
+                ++ imageGenerationTools
                 ++ computerTools
         tools =
             filterGhciTools options.optGhci
@@ -865,6 +892,7 @@ runAgentTools
                 ++ gatewayTools
                 ++ databaseAppTools
                 ++ learnedSkillAppTools
+                ++ imageGenerationTools
         planMode = coding.codingPlanMode
         resumedPlanPending =
             case resumed of
@@ -909,6 +937,8 @@ runAgentTools
         activeSelectionRef
         agentTypesRef
         allTools
+        (recordImageGenerationImages imageGenerationHistory)
+        (clearImageGenerationHistory imageGenerationHistory)
         bashEnabledRef
         catalog
         checkStartupUsageInBackground

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -494,6 +494,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 resetBackendState
                 conversationRef
                 planMode
+            clearImageGenerationHistory
             writeIORef usageRef emptyTokenUsage
             modifyIORef' renderStateRef clearRenderTokenRate
             writeIORef lastAssistantRef Nothing
@@ -832,7 +833,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                             toolRegistry
                             call
                         emitLoop (ToolFinished result)
-                        pure (Right result.output)
+                        pure (Right result)
     btwRequests <- newChan
     recapRequests <- newChan
     let
@@ -905,6 +906,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionConnection = connectionId
             , sessionModelCatalog = catalog
             , sessionDialect = dialect
+            , sessionRecordImageGenerationInputs =
+                recordImageGenerationInputs
             , sessionUnavailableProviders = unavailableProvidersRef
             , sessionStartupUnavailable = startupUnavailableRef
             , sessionConversation = conversationRef

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -51,6 +51,7 @@ import Agent.GrokBuild.Dialect.Runtime (GrokRuntimeControl)
 import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
 import Agent.Loop
     ( Backend
+    , ImageAttachment
     , TokenUsage
     , TurnInput
     )
@@ -105,6 +106,8 @@ data SessionRequest = SessionRequest
     , dialect :: !Dialect
     , policy :: !ApprovalPolicy
     , allTools :: ![AppTool]
+    , recordImageGenerationInputs :: !([ImageAttachment] -> IO ())
+    , clearImageGenerationHistory :: !(IO ())
     , suspendGhci :: !(IO ())
     , grokRuntime :: !(Maybe GrokRuntimeControl)
     , mcpRegistrations :: ![MCP.McpToolRegistration]

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -23,7 +23,7 @@ import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.Dialect (Dialect)
 import Agent.Error (ApiError)
 import Agent.GrokBuild.Dialect.Runtime (GrokRuntimeControl)
-import Agent.Loop (LoopConfig, TokenUsage)
+import Agent.Loop (ImageAttachment, LoopConfig, TokenUsage)
 import Agent.MCP (McpFleet, McpToolRegistration)
 import qualified Agent.OpenAI.Auth as OpenAI
 import Agent.Responses.Types (ResponseCreateParams)
@@ -51,6 +51,7 @@ data SessionEnv = SessionEnv
     , sessionConnection :: !Text
     , sessionModelCatalog :: !ModelCatalog
     , sessionDialect :: !Dialect
+    , sessionRecordImageGenerationInputs :: !([ImageAttachment] -> IO ())
     , sessionUnavailableProviders :: !(IORef (Set Provider))
     , sessionStartupUnavailable :: !(IORef (Maybe (STM ApiError)))
     , sessionConversation :: !(IORef LiveConversation)

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -25,6 +25,11 @@ import Agent.Dialect
     , grokBuildPublicToolName
     )
 import Agent.OpenAI.ToolDSL (buildGrokTool, buildTool)
+import Agent.OpenAI.ImageGeneration
+    ( imageGenerationNamespace
+    , imageGenerationNamespaceDescription
+    , imageGenerationToolName
+    )
 import Agent.ToolDSL (PropertySchema(..), parametersObjectLoose)
 import Agent.ToolDispatch (canonicalToolName)
 import Agent.Codex.Dialect.ApplyPatch (applyPatchGrammar)
@@ -91,12 +96,20 @@ hostedSearchToolCollisions =
 schemasFromAppTools :: Dialect -> [AppTool] -> [ResponseTool]
 schemasFromAppTools dialect tools = case dialectToolLayout dialect of
     CollaborationNamespaceLayout ->
-        let (multi, rest) = partition isMultiAgentTool tools
+        let (multi, nonMulti) = partition isMultiAgentTool tools
+            (imageGeneration, rest) =
+                partition isImageGenerationTool nonMulti
             base = hostedSearchTools dialect
                 ++ mapMaybe (schemaFromAppTool dialect) rest
-        in if null multi
-            then base
-            else base ++ [multiAgentNamespaceTool multi]
+            imageNamespaces =
+                [ imageGenerationNamespaceTool imageGeneration
+                | not (null imageGeneration)
+                ]
+            collaborationNamespaces =
+                [ multiAgentNamespaceTool multi
+                | not (null multi)
+                ]
+        in base ++ imageNamespaces ++ collaborationNamespaces
     FlatToolLayout ->
         hostedSearchTools dialect ++ mapMaybe (schemaFromAppTool dialect) tools
     NoHostToolLayout ->
@@ -104,6 +117,10 @@ schemasFromAppTools dialect tools = case dialectToolLayout dialect of
 
 isMultiAgentTool :: AppTool -> Bool
 isMultiAgentTool tool = tool.appToolName `elem` multiAgentToolNames
+
+isImageGenerationTool :: AppTool -> Bool
+isImageGenerationTool tool =
+    tool.appToolName == imageGenerationToolName
 
 schemaFromAppTool :: Dialect -> AppTool -> Maybe ResponseTool
 schemaFromAppTool dialect tool
@@ -189,9 +206,22 @@ grokPublicText =
 -- | Codex collaboration namespace: nested non-strict function tools.
 multiAgentNamespaceTool :: [AppTool] -> ResponseTool
 multiAgentNamespaceTool tools =
+    namespaceTool
+        multiAgentNamespace
+        "Tools for spawning and managing sub-agents."
+        tools
+
+imageGenerationNamespaceTool :: [AppTool] -> ResponseTool
+imageGenerationNamespaceTool =
+    namespaceTool
+        imageGenerationNamespace
+        imageGenerationNamespaceDescription
+
+namespaceTool :: Text -> Text -> [AppTool] -> ResponseTool
+namespaceTool namespaceName namespaceDescription tools =
     NamespaceToolValue NamespaceTool
-        { name = multiAgentNamespace
-        , description = Just "Tools for spawning and managing sub-agents."
+        { name = namespaceName
+        , description = Just namespaceDescription
         , tools = map nestedFunction tools
         }
   where
@@ -201,21 +231,20 @@ multiAgentNamespaceTool tools =
             , description = Just tool.appToolDescription
             , strict = Just False
             , parameters = Just . rawJsonFromEncoding . Aeson.toEncoding $
-                namespaceParameters (appToolJsonParameters tool)
+                namespaceParameters tool
             }
 
-    namespaceParameters parameters = case parametersObjectLoose parameters of
+    namespaceParameters tool = case parametersValue tool of
         Aeson.Object schema
             | Just (Aeson.Array required) <- KeyMap.lookup "required" schema
             , null required -> Aeson.Object (KeyMap.delete "required" schema)
         schema -> schema
 
-appToolJsonParameters :: AppTool -> [PropertySchema]
-appToolJsonParameters tool = case tool.appToolSchema of
-    JsonFunctionSchema parameters -> parameters
-    RawJsonFunctionSchema _ -> []
-    FreeformApplyPatchSchema -> []
-    FreeformGrammarSchema _ _ -> []
+    parametersValue tool = case tool.appToolSchema of
+        JsonFunctionSchema parameters -> parametersObjectLoose parameters
+        RawJsonFunctionSchema parameters -> parameters
+        FreeformApplyPatchSchema -> Aeson.object []
+        FreeformGrammarSchema _ _ -> Aeson.object []
 
 -- | Codex registers apply_patch as a Responses custom tool with a Lark grammar.
 applyPatchCustomTool :: Text -> Text -> ResponseTool

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -115,6 +115,7 @@ import Agent.Loop
     , LoopError(..)
     , LoopProgress(..)
     , LoopResult(..)
+    , ImageAttachment
     , TurnCompletion(..)
     , TurnInput(..)
     , TurnOutput(..)
@@ -172,6 +173,12 @@ runOneTurn = runOneTurnWithContext True
 -- be generated again.
 retryCheckpointedTurn :: SessionEnv -> IO TurnResult
 retryCheckpointedTurn env = runOneTurnWithContext False env "" []
+
+turnInputImages :: TurnInput -> [ImageAttachment]
+turnInputImages = \case
+    UserMultimodal{userImages} -> userImages
+    UserMultimodalFiles{userImages} -> userImages
+    _ -> []
 
 runOneTurnWithContext
     :: Bool
@@ -266,6 +273,9 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                                     <> handle.sessionMeta.metaId))
         PersistenceDisabled -> pure ()
     prev <- readLivePreviousResponseId conversationRef
+    when includeTurnContext $
+        env.sessionRecordImageGenerationInputs
+            (concatMap turnInputImages inputs)
     pendingStartup <-
         if includeTurnContext
             then atomicModifyIORef' startupContext \pendingCtx ->

--- a/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
@@ -395,5 +395,6 @@ shouldNotContainText actual expected =
 approvalLabel :: ApprovalRule -> Text
 approvalLabel = \case
     AlwaysReadOnly -> "read-only"
+    AlwaysAllowed -> "always-allowed"
     AlwaysPrompt -> "prompt"
     ClassifyReadOnly _ -> "classified"

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -253,6 +253,36 @@ spec = describe "schemasFromAppTools" do
                 namespace.name `shouldBe` "collaboration"
             other -> expectationFailure ("expected namespace tool, got " <> show other)
 
+    it "emits imagegen in the reserved image_gen namespace with its raw schema" do
+        let parameters = Aeson.object
+                [ "type" Aeson..= ("object" :: Text)
+                , "properties" Aeson..= Aeson.object
+                    [ "prompt" Aeson..= Aeson.object
+                        ["type" Aeson..= ("string" :: Text)]
+                    ]
+                , "required" Aeson..= (["prompt"] :: [Text])
+                , "additionalProperties" Aeson..= False
+                ]
+            imagegen = rawJsonAppTool
+                "imagegen"
+                "Generate an image."
+                parameters
+                AlwaysAllowed
+                (noArgsTool "imagegen" (pure (Right "ok")))
+        case schemasFromAppTools codexDialect [imagegen] of
+            [_, NamespaceToolValue namespace] -> do
+                namespace.name `shouldBe` "image_gen"
+                case namespace.tools of
+                    [FunctionToolValue tool] -> do
+                        tool.name `shouldBe` "imagegen"
+                        tool.strict `shouldBe` Just False
+                        tool.parameters `shouldBe`
+                            Just (rawJsonValue parameters)
+                    other -> expectationFailure
+                        ("expected one imagegen function, got " <> show other)
+            other -> expectationFailure
+                ("expected image_gen namespace, got " <> show other)
+
     it "omits an empty required list from reserved collaboration schemas" do
         let wait = jsonAppTool "wait_agent" "Wait."
                 [ PropertySchema "timeout_ms" PropertyNumber False Nothing ]

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.ToolsSpec (spec) where
 import Agent.CLI.Tools
 import Agent.CLI.CodeModeRuntime
     ( CodeModeToolProjection(..)
+    , imageGenerationCodeModeProjection
     , projectCodeModeTools
     )
 import Agent.Dialect
@@ -65,6 +66,21 @@ spec = describe "schemasFromAppTools" do
             `shouldBe` ["shell_command", "write_stdin"]
         map (.appToolName) projection.nestedCodeModeTools
             `shouldBe` ["read_file", "shell_command", "write_stdin", "apply_patch"]
+    it "nests only imagegen for code-only models when full code mode is off" do
+        let tools = map testTool ["read_file", "imagegen", "shell_command"]
+        case imageGenerationCodeModeProjection CodeOnlyToolMode tools of
+            Just projection -> do
+                map (.appToolName) projection.directCodeModeTools
+                    `shouldBe` ["read_file", "shell_command"]
+                map (.appToolName) projection.nestedCodeModeTools
+                    `shouldBe` ["imagegen"]
+            Nothing ->
+                expectationFailure "expected an image-generation projection"
+        case imageGenerationCodeModeProjection ConventionalToolMode tools of
+            Nothing -> pure ()
+            Just _ ->
+                expectationFailure
+                    "conventional models should keep imagegen direct"
     it "enables built-in web_search ahead of app tools" do
         case schemasFromAppTools codexDialect [jsonTool] of
             KnownResponseTool ToolWebSearch : _ -> pure ()

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -4,13 +4,19 @@ module Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
     , ToolCallResult(..)
+    , ToolResultImage(..)
+    , ToolHandlerResult(..)
+    , toolCallResultImages
     , ToolDispatchConfig(..)
     , ToolHandler
     , typedTool
     , typedToolWithCall
+    , typedRichToolWithCall
     , typedStreamingTool
+    , typedStreamingRichTool
     , textTool
     , streamingTextTool
+    , streamingRichTextTool
     , noArgsTool
     , functionToolCall
     , customToolCall
@@ -70,12 +76,62 @@ instance Show ToolCall where
             | call.argumentsEncrypted = "<redacted>"
             | otherwise = show call.arguments
 
--- | Provider-neutral result ready for a transport adapter to encode.
-data ToolCallResult = ToolCallResult
-    { callId :: !Text
-    , output :: !Text
-    , callKind :: !ToolCallKind
+-- | An image returned alongside a tool's short textual output. Keeping image
+-- data out of 'output' prevents large data URLs from being truncated, logged,
+-- or fed back to the model as ordinary text.
+data ToolResultImage = ToolResultImage
+    { imageUrl :: !Text
+    , imageDetail :: !(Maybe Text)
+    } deriving (Eq)
+
+instance Show ToolResultImage where
+    show image =
+        "ToolResultImage { imageUrl = <redacted>, imageDetail = "
+            <> show image.imageDetail
+            <> " }"
+
+-- | Rich result produced by the small number of tools that return media.
+-- Ordinary tool constructors continue to accept @Either Text Text@.
+data ToolHandlerResult = ToolHandlerResult
+    { resultText :: !Text
+    , resultImages :: ![ToolResultImage]
     } deriving (Eq, Show)
+
+-- | Provider-neutral result ready for a transport adapter to encode.
+--
+-- The original constructor stays unchanged for ordinary text tools. The rich
+-- constructor avoids a source-compatible API break for callers that build or
+-- pattern-match three-field results.
+data ToolCallResult
+    = ToolCallResult
+        { callId :: !Text
+        , output :: !Text
+        , callKind :: !ToolCallKind
+        }
+    | ToolCallResultWithImages
+        { callId :: !Text
+        , output :: !Text
+        , callKind :: !ToolCallKind
+        , toolResultImages :: ![ToolResultImage]
+        }
+    deriving (Eq)
+
+instance Show ToolCallResult where
+    show result =
+        "ToolCallResult { callId = " <> show result.callId
+            <> ", output = " <> show result.output
+            <> ", callKind = " <> show result.callKind
+            <> imageSummary
+            <> " }"
+      where
+        imageSummary = case toolCallResultImages result of
+            [] -> ""
+            images -> ", images = <" <> show (length images) <> ">"
+
+toolCallResultImages :: ToolCallResult -> [ToolResultImage]
+toolCallResultImages = \case
+    ToolCallResult{} -> []
+    ToolCallResultWithImages{toolResultImages} -> toolResultImages
 
 functionToolCall :: Text -> Text -> Text -> ToolCall
 functionToolCall callId name arguments = ToolCall
@@ -107,9 +163,12 @@ data ToolDispatchConfig = ToolDispatchConfig
 data ToolHandler
     = forall args. TypedTool Text (Decoder args) (args -> IO (Either Text Text))
     | forall args. TypedToolWithCall Text (Decoder args) (ToolCall -> args -> IO (Either Text Text))
+    | forall args. TypedRichToolWithCall Text (Decoder args) (ToolCall -> args -> IO (Either Text ToolHandlerResult))
     | forall args. TypedStreamingTool Text (Decoder args) ((Text -> IO ()) -> args -> IO (Either Text Text))
+    | forall args. TypedStreamingRichTool Text (Decoder args) ((Text -> IO ()) -> args -> IO (Either Text ToolHandlerResult))
     | TextTool Text (Text -> IO (Either Text Text))
     | StreamingTextTool Text ((Text -> IO ()) -> Text -> IO (Either Text Text))
+    | StreamingRichTextTool Text ((Text -> IO ()) -> Text -> IO (Either Text ToolHandlerResult))
     | NoArgsTool Text (IO (Either Text Text))
 
 typedTool :: Text -> Decoder args -> (args -> IO (Either Text Text)) -> ToolHandler
@@ -117,6 +176,13 @@ typedTool = TypedTool
 
 typedToolWithCall :: Text -> Decoder args -> (ToolCall -> args -> IO (Either Text Text)) -> ToolHandler
 typedToolWithCall = TypedToolWithCall
+
+typedRichToolWithCall
+    :: Text
+    -> Decoder args
+    -> (ToolCall -> args -> IO (Either Text ToolHandlerResult))
+    -> ToolHandler
+typedRichToolWithCall = TypedRichToolWithCall
 
 -- | A typed tool that can publish accumulated output snapshots while running.
 -- The final result remains authoritative.
@@ -126,6 +192,13 @@ typedStreamingTool
     -> ((Text -> IO ()) -> args -> IO (Either Text Text))
     -> ToolHandler
 typedStreamingTool = TypedStreamingTool
+
+typedStreamingRichTool
+    :: Text
+    -> Decoder args
+    -> ((Text -> IO ()) -> args -> IO (Either Text ToolHandlerResult))
+    -> ToolHandler
+typedStreamingRichTool = TypedStreamingRichTool
 
 -- | A freeform tool whose input is plain text rather than JSON.
 textTool
@@ -141,6 +214,12 @@ streamingTextTool
     -> ((Text -> IO ()) -> Text -> IO (Either Text Text))
     -> ToolHandler
 streamingTextTool = StreamingTextTool
+
+streamingRichTextTool
+    :: Text
+    -> ((Text -> IO ()) -> Text -> IO (Either Text ToolHandlerResult))
+    -> ToolHandler
+streamingRichTextTool = StreamingRichTextTool
 
 noArgsTool :: Text -> IO (Either Text Text) -> ToolHandler
 noArgsTool = NoArgsTool
@@ -168,26 +247,34 @@ dispatchToolHandler config maybeHandler call = do
                     handler
             Nothing -> pure (Left (config.toolDispatchUnknownTool callName))
     result <- tryAny runTool
-    resultOutput <- case result of
-        Right toolResult ->
-            pure (config.toolDispatchFormatResult toolResult)
+    (resultOutput, resultImages) <- case result of
+        Right (Right toolResult) ->
+            pure
+                ( config.toolDispatchFormatResult (Right toolResult.resultText)
+                , toolResult.resultImages
+                )
+        Right (Left err) ->
+            pure (config.toolDispatchFormatResult (Left err), [])
         Left exception -> do
             -- Diagnostics must not replace the original tool failure with a
             -- second exception. 'tryAny' still lets asynchronous cancellation
             -- propagate.
             _ <- tryAny (config.toolDispatchOnException callName exception)
-            pure (config.toolDispatchFormatException callName exception)
+            pure (config.toolDispatchFormatException callName exception, [])
     finalizedOutput <-
         tryAny (config.toolDispatchFinalizeOutput call resultOutput) >>= \case
             Right output -> pure output
             Left exception -> do
                 _ <- tryAny (config.toolDispatchOnException callName exception)
                 pure resultOutput
-    pure ToolCallResult
-        { callId = call.callId
-        , output = finalizedOutput
-        , callKind = call.callKind
-        }
+    pure $
+        if null resultImages
+            then ToolCallResult call.callId finalizedOutput call.callKind
+            else ToolCallResultWithImages
+                call.callId
+                finalizedOutput
+                call.callKind
+                resultImages
 
 toolArgumentsValue :: Text -> Text
 toolArgumentsValue = id
@@ -218,6 +305,9 @@ canonicalToolName :: Text -> Text
 canonicalToolName name
     | grokName /= name = grokName
     | claudeName /= name = claudeName
+    | name == "image_gen__imagegen" = "imagegen"
+    | Just rest <- Text.stripPrefix "image_gen." name
+    , rest == "imagegen" = "imagegen"
     | Just rest <- Text.stripPrefix "collaboration." name =
         canonicalToolName rest
     | Just rest <- Text.stripPrefix "collaboration" name
@@ -257,9 +347,12 @@ handlerName :: ToolHandler -> Text
 handlerName = \case
     TypedTool name _ _ -> name
     TypedToolWithCall name _ _ -> name
+    TypedRichToolWithCall name _ _ -> name
     TypedStreamingTool name _ _ -> name
+    TypedStreamingRichTool name _ _ -> name
     TextTool name _ -> name
     StreamingTextTool name _ -> name
+    StreamingRichTextTool name _ -> name
     NoArgsTool name _ -> name
 
 runHandler
@@ -267,20 +360,30 @@ runHandler
     -> ToolCall
     -> Text
     -> ToolHandler
-    -> IO (Either Text Text)
+    -> IO (Either Text ToolHandlerResult)
 runHandler emitOutput call value = \case
-    TypedTool _ decoder run -> decodeAndRun decoder value run
-    TypedToolWithCall _ decoder run -> decodeAndRun decoder value (run call)
-    TypedStreamingTool _ decoder run -> decodeAndRun decoder value (run emitOutput)
-    TextTool _ run -> run value
-    StreamingTextTool _ run -> run emitOutput value
+    TypedTool _ decoder run ->
+        plainResult <$> decodeAndRun decoder value run
+    TypedToolWithCall _ decoder run ->
+        plainResult <$> decodeAndRun decoder value (run call)
+    TypedRichToolWithCall _ decoder run ->
+        decodeAndRun decoder value (run call)
+    TypedStreamingTool _ decoder run ->
+        plainResult <$> decodeAndRun decoder value (run emitOutput)
+    TypedStreamingRichTool _ decoder run ->
+        decodeAndRun decoder value (run emitOutput)
+    TextTool _ run -> plainResult <$> run value
+    StreamingTextTool _ run -> plainResult <$> run emitOutput value
+    StreamingRichTextTool _ run -> run emitOutput value
     NoArgsTool _ run ->
-        run
+        plainResult <$> run
+  where
+    plainResult = fmap \text -> ToolHandlerResult text []
 
 decodeAndRun
     :: Decoder args
     -> Text
-    -> (args -> IO (Either Text Text))
-    -> IO (Either Text Text)
+    -> (args -> IO (Either Text result))
+    -> IO (Either Text result)
 decodeAndRun decoder value run =
     either (pure . Left) run (decodeToolArguments decoder value)

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
@@ -36,8 +36,12 @@ import Agent.ToolDSL
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
-    , streamingTextTool
-    , typedStreamingTool
+    , ToolCallResult(..)
+    , ToolHandlerResult(..)
+    , ToolResultImage(..)
+    , streamingRichTextTool
+    , toolCallResultImages
+    , typedStreamingRichTool
     )
 import Agent.Tools.CodeMode.Host
     ( CodeModeConfig(..)
@@ -75,7 +79,7 @@ import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.List (sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -93,8 +97,9 @@ data ToolMode
 
 -- | Run one nested tool call through the host application's registry,
 -- authorization, and dispatch. 'Left' rejects the nested JavaScript promise
--- with the given message; 'Right' resolves it with the tool output text.
-type CodeModeNestedInvoke = ToolCall -> IO (Either Text Text)
+-- with the given message; 'Right' resolves it with the tool output and any
+-- supplemental media.
+type CodeModeNestedInvoke = ToolCall -> IO (Either Text ToolCallResult)
 
 -- | A namespaced nested-tool group, mirroring provider tool namespaces such
 -- as @collaboration@.
@@ -302,7 +307,18 @@ runNestedTool invoke nextInvocation nested codeName arguments =
             , callKind = tool.nestedCallKind
             , argumentsEncrypted = False
             }
-        pure (String <$> result)
+        pure (nestedResultValue <$> result)
+
+nestedResultValue :: ToolCallResult -> Value
+nestedResultValue result =
+    case toolCallResultImages result of
+        [] -> String result.output
+        image : _ ->
+            Object . KeyMap.fromList $
+                [ ("image_url", String image.imageUrl) ]
+                    <> [ ("output_hint", String result.output)
+                       | not (Text.null (Text.strip result.output))
+                       ]
 
 nestedToolArguments :: ToolCallKind -> Value -> Either Text Text
 nestedToolArguments CustomCallKind = \case
@@ -346,14 +362,14 @@ execTool host nestedTools description =
         -- wrapper as an exclusive call; concurrency requested inside the
         -- cell remains explicit in the JavaScript (for example Promise.all).
         TurnSequential
-        (streamingTextTool "exec" \_emit source ->
+        (streamingRichTextTool "exec" \_emit source ->
             runExec host nestedTools (ExecArgs source))
 
 runExec
     :: CodeModeHost
     -> [CodeModeToolMetadata]
     -> ExecArgs
-    -> IO (Either Text Text)
+    -> IO (Either Text ToolHandlerResult)
 runExec host nestedTools args =
     case parseExecSource args.source of
         Left err -> pure (Left err)
@@ -381,10 +397,12 @@ runExec host nestedTools args =
                     (resolveYieldTimeoutMs
                         (fromMaybe defaultExecYieldTimeMs pragma.yieldTimeMs))
                 finished <- getCurrentTime
-                pure $ renderCodeModeResult
-                    pragma.maxOutputTokens
-                    (elapsedSeconds started finished)
-                    result
+                pure $
+                    withResultImages result
+                        <$> renderCodeModeResult
+                            pragma.maxOutputTokens
+                            (elapsedSeconds started finished)
+                            result
 
 -- | Codex grants a one-second grace period on top of yields of ten seconds or
 -- more, so a script that finishes just past its yield window still returns a
@@ -460,9 +478,9 @@ waitTool host =
         ]
         AlwaysReadOnly
         ParallelSafe
-        (typedStreamingTool "wait" waitArgsDecoder (\_emit -> runWait host))
+        (typedStreamingRichTool "wait" waitArgsDecoder (\_emit -> runWait host))
 
-runWait :: CodeModeHost -> WaitArgs -> IO (Either Text Text)
+runWait :: CodeModeHost -> WaitArgs -> IO (Either Text ToolHandlerResult)
 runWait host args
     | maybe False (< 0) args.yieldTimeMs =
         pure (Left "yield_time_ms must be non-negative")
@@ -477,10 +495,48 @@ runWait host args
                     (resolveYieldTimeoutMs
                         (fromMaybe defaultWaitYieldTimeMs args.yieldTimeMs))
         finished <- getCurrentTime
-        pure $ renderCodeModeResult
-            args.maxTokens
-            (elapsedSeconds started finished)
-            result
+        pure $
+            withResultImages result
+                <$> renderCodeModeResult
+                    args.maxTokens
+                    (elapsedSeconds started finished)
+                    result
+
+withResultImages
+    :: Either CodeModeError CodeModeResult
+    -> Text
+    -> ToolHandlerResult
+withResultImages result text =
+    ToolHandlerResult
+        { resultText = text
+        , resultImages = codeModeResultImages result
+        }
+
+codeModeResultImages
+    :: Either CodeModeError CodeModeResult
+    -> [ToolResultImage]
+codeModeResultImages = \case
+    Right CodeModeRunning { cellOutput } -> valueImages cellOutput
+    Right CodeModeTerminated { cellValue } -> valueImages cellValue
+    Right CodeModeFinished { cellValue } -> valueImages cellValue
+    Right CodeModeFailed { cellValue } -> valueImages cellValue
+    Left _ -> []
+  where
+    valueImages (Object result)
+        | Just (Array content) <- KeyMap.lookup "content" result =
+            mapMaybe contentImage (Vector.toList content)
+    valueImages _ = []
+
+    contentImage (Object content)
+        | Just (String "image") <- KeyMap.lookup "type" content
+        , Just (String imageUrl) <- KeyMap.lookup "image_url" content =
+            Just ToolResultImage
+                { imageUrl
+                , imageDetail = case KeyMap.lookup "detail" content of
+                    Just (String detail) -> Just detail
+                    _ -> Nothing
+                }
+    contentImage _ = Nothing
 
 renderCodeModeResult
     :: Maybe Int

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -75,6 +75,9 @@ data ToolSchema
 -- | Whether a call may run without generic user approval.
 data ApprovalRule
     = AlwaysReadOnly
+    -- | Host-authorized effect that is intentionally exempt from the generic
+    -- mutation prompt (for example a paid provider capability).
+    | AlwaysAllowed
     | AlwaysPrompt
     | ClassifyReadOnly !(ToolCall -> IO Bool)
 
@@ -391,5 +394,6 @@ appToolHandlers = map (.appToolHandler)
 toolAllowsWithoutPrompt :: AppTool -> ToolCall -> IO Bool
 toolAllowsWithoutPrompt tool call = case tool.appToolApproval of
     AlwaysReadOnly -> pure True
+    AlwaysAllowed -> pure True
     AlwaysPrompt -> pure False
     ClassifyReadOnly classify -> classify call

--- a/packages/agent-core/test/Agent/ToolDispatchSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDispatchSpec.hs
@@ -110,6 +110,28 @@ spec = describe "dispatchToolCall" do
             (functionToolCall "call-1" "echo" "{\"message\":\"hello\"}")
         result `shouldBe` functionResult "call-1" "call-1:hello"
 
+    it "preserves rich image results without exposing image data in Show" do
+        let secretDataUrl = "data:image/png;base64,c2VjcmV0"
+        result <- dispatchToolCall testConfig
+            [ typedRichToolWithCall "echo" echoArgsDecoder
+                \_call (EchoArgs message) ->
+                    pure $ Right ToolHandlerResult
+                        { resultText = "echo:" <> message
+                        , resultImages =
+                            [ ToolResultImage
+                                { imageUrl = secretDataUrl
+                                , imageDetail = Just "high"
+                                }
+                            ]
+                        }
+            ]
+            (functionToolCall "call-1" "echo" "{\"message\":\"hello\"}")
+        result.output `shouldBe` "echo:hello"
+        toolCallResultImages result `shouldBe`
+            [ToolResultImage secretDataUrl (Just "high")]
+        show result `shouldContain` "images = <1>"
+        show result `shouldNotContain` "c2VjcmV0"
+
     it "turns typed decode failures into formatted tool output" do
         result <- dispatchToolCall testConfig
             [ typedTool "echo" echoArgsDecoder \(EchoArgs message) ->

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -608,7 +608,7 @@ spec = describe "code-mode Bun host" do
                     defaultLoopDispatch
                     [toolHandlerOf doubleTool]
                     call
-                pure (Right result.output)
+                pure (Right result)
         created <- newCodeModeToolSet
             CodeOnlyToolMode
             ImageDetailVisible
@@ -644,7 +644,7 @@ spec = describe "code-mode Bun host" do
                     defaultLoopDispatch
                     [toolHandlerOf patchTool]
                     call
-                pure (Right result.output)
+                pure (Right result)
         created <- newCodeModeToolSet
             CodeOnlyToolMode
             ImageDetailVisible
@@ -670,7 +670,8 @@ spec = describe "code-mode Bun host" do
                 AlwaysReadOnly
                 ParallelSafe
                 (typedTool "lookup" emptyObjectDecoder \() -> pure (Right "value"))
-            invoke _ = pure (Right "value")
+            invoke _ = pure
+                (Right (ToolCallResult "nested" "value" FunctionCallKind))
         codeOnly <- newCodeModeToolSet
             CodeOnlyToolMode ImageDetailVisible worker invoke
             [plainNested lookupTool]
@@ -697,7 +698,8 @@ spec = describe "code-mode Bun host" do
             (not . Text.isInfixOf "### `lookup`")
 
     it "fails closed before advertising a missing worker" do
-        let invoke _ = pure (Right "value")
+        let invoke _ = pure
+                (Right (ToolCallResult "nested" "value" FunctionCallKind))
         unavailable <- newCodeModeToolSet
             CodeOnlyToolMode
             ImageDetailVisible
@@ -728,7 +730,7 @@ spec = describe "code-mode Bun host" do
                     defaultLoopDispatch
                     [toolHandlerOf (mkTool "look-up"), toolHandlerOf (mkTool "look_up")]
                     call
-                pure (Right result.output)
+                pure (Right result)
         created <- newCodeModeToolSet
             CodeOnlyToolMode ImageDetailVisible worker invoke
             [plainNested (mkTool "look-up"), plainNested (mkTool "look_up")]
@@ -758,7 +760,7 @@ spec = describe "code-mode Bun host" do
                     defaultLoopDispatch
                     [toolHandlerOf lookupTool]
                     call
-                pure (Right result.output)
+                pure (Right result)
         created <- newCodeModeToolSet
             CodeOnlyToolMode ImageDetailVisible worker invoke
             [ CodeModeNestedSpec

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -72,6 +72,7 @@ library
                     , Agent.OpenAI.CompactClient
                     , Agent.OpenAI.Compaction
                     , Agent.OpenAI.ToolDSL
+                    , Agent.OpenAI.ImageGeneration
     other-modules:    Agent.OpenAI.Compaction.Commands
                     , Agent.OpenAI.Compaction.Request
                     , Agent.OpenAI.Models.Types.Enums
@@ -85,6 +86,7 @@ library
                     , agent-responses-types >= 0.1 && < 0.2
                     , text
                     , bytestring
+                    , base64-bytestring
                     , aeson                 >= 2.0
                     , http-client
                     , http-conduit
@@ -127,6 +129,7 @@ test-suite agent-openai-test
                     , Agent.OpenAI.CredentialSpec
                     , Agent.OpenAI.ErrorSpec
                     , Agent.OpenAI.FunctionalSpec
+                    , Agent.OpenAI.ImageGenerationSpec
                     , Agent.OpenAI.LoginSpec
                     , Agent.OpenAI.LoopBackendSpec
                     , Agent.OpenAI.ModelsClientSpec

--- a/packages/agent-openai/package.nix
+++ b/packages/agent-openai/package.nix
@@ -14,10 +14,10 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson agent-core agent-json agent-responses agent-responses-types
-    base bytestring containers directory exceptions filepath HsOpenSSL
-    http-client http-conduit http-streams io-streams network-uri retry
-    safe-exceptions scientific template-haskell text time unix vector
-    websockets wuss
+    base base64-bytestring bytestring containers directory exceptions
+    filepath HsOpenSSL http-client http-conduit http-streams io-streams
+    network-uri retry safe-exceptions scientific template-haskell text
+    time unix vector websockets wuss
   ];
   executableHaskellDepends = [
     agent-core base directory filepath text

--- a/packages/agent-openai/src/Agent/OpenAI/ImageGeneration.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/ImageGeneration.hs
@@ -1,0 +1,730 @@
+-- | OpenAI Codex image generation and editing.
+--
+-- This mirrors the image generation extension shipped by the upstream Codex
+-- client: new images use @images/generations@, edits use @images/edits@, and
+-- the result is returned as structured image content rather than a very large
+-- textual data URL.
+module Agent.OpenAI.ImageGeneration
+    ( ImageGenerationHistory
+    , newImageGenerationHistory
+    , recordImageGenerationImages
+    , recordImageGenerationResponseItems
+    , clearImageGenerationHistory
+    , imageGenerationTool
+    , imageGenerationToolAt
+    , imageGenerationToolName
+    , imageGenerationNamespace
+    , imageGenerationNamespaceDescription
+    , imageGenerationDescription
+    ) where
+
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Json (RawJson, rawJsonBytes, rawJsonDecoder)
+import Agent.Loop (ImageAttachment(..))
+import Agent.OpenAI.Client (defaultCodexBaseUrl)
+import Agent.OpenAI.Error (classifyHttpFailure)
+import Agent.OpenAI.Http (postCodexJson)
+import Agent.OsPath (fromText, unsafeToFilePath)
+import Agent.Provider
+    ( Credential(..)
+    , Provider(..)
+    , TokenProvider
+    , runWithTokenProvider
+    )
+import Agent.Responses.Types
+    ( ImageGenerationCall(..)
+    , ResponseItem(..)
+    )
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , ToolHandlerResult(..)
+    , ToolResultImage(..)
+    , typedRichToolWithCall
+    )
+import Agent.Tools.FileSystem (resolveForRead, resolveUnderCwd)
+import Agent.Tools.ShowImage
+    ( ImageDisplayHooks(..)
+    , ImageDisplayRequest(..)
+    , maxShowImageBytes
+    , sniffImageMime
+    )
+import Agent.Tools.Types
+    ( AppTool
+    , ApprovalRule(AlwaysAllowed)
+    , ToolEnv
+    , ToolExecutionPolicy(TurnSequential)
+    , rawJsonAppToolWithExecution
+    )
+import Control.Applicative ((<|>))
+import Control.Exception.Safe
+    ( bracketOnError
+    , finally
+    , tryAny
+    )
+import Control.Monad (unless)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Aeson.KeyMap as AesonKeyMap
+import qualified Data.Aeson.Types as AesonTypes
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as Base64
+import Data.Char (isAlphaNum)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text
+import Network.Http.Client
+    ( RequestBuilder
+    , Response
+    , getStatusCode
+    , setHeader
+    )
+import qualified System.IO.Streams as Streams
+import System.Directory.OsPath
+    ( createDirectory
+    , doesDirectoryExist
+    , doesFileExist
+    , doesPathExist
+    , getFileSize
+    , pathIsSymbolicLink
+    )
+import System.IO (hClose)
+import System.OsPath
+    ( OsPath
+    , isAbsolute
+    , takeDirectory
+    , (</>)
+    )
+import System.Posix.IO
+    ( OpenFileFlags(..)
+    , OpenMode(WriteOnly)
+    , closeFd
+    , defaultFileFlags
+    , fdToHandle
+    , openFd
+    )
+
+imageGenerationToolName :: Text
+imageGenerationToolName = "imagegen"
+
+imageGenerationNamespace :: Text
+imageGenerationNamespace = "image_gen"
+
+imageGenerationNamespaceDescription :: Text
+imageGenerationNamespaceDescription = "Tools in the image_gen namespace."
+
+imageGenerationDescription :: Text
+imageGenerationDescription =
+    "The `image_gen.imagegen` tool enables image generation from descriptions and editing of existing images based on specific instructions. Use it when:\n\
+    \\n\
+    \- The user requests an image based on a scene description, such as a diagram, portrait, comic, meme, or any other visual.\n\
+    \- The user wants to modify an attached or previously generated image with specific changes, including adding or removing elements, altering colors, improving quality/resolution, or transforming the style (e.g., cartoon, oil painting).\n\
+    \\n\
+    \Guidelines:\n\
+    \- imagegen needs a few minutes to finish. In code-mode, use the first-line @exec directive to give the initial call 120 seconds and the same yield for any waits that follow. Once it finishes, return the image with generatedImage(result).\n\
+    \- Omit both `referenced_image_paths` and `num_last_images_to_include` when generating a brand new image.\n\
+    \- For edits, use `referenced_image_paths` when every target image has a local file path.\n\
+    \- If you have not seen a local image yet, use `show_image` to inspect it before editing.\n\
+    \- Use `num_last_images_to_include` only when at least one target image has no local file path.\n\
+    \- Set `num_last_images_to_include` to the smallest number of recent conversation images that includes every target image, up to 5.\n\
+    \- Never provide both `referenced_image_paths` and `num_last_images_to_include`.\n\
+    \- If neither mechanism can include every target image, ask the user to attach the missing images again.\n\
+    \- Directly generate the image without reconfirmation or clarification unless required images must be attached again.\n\
+    \- Always use this tool for image editing unless the user explicitly requests otherwise. Do not use the `python` tool for image editing unless specifically instructed."
+
+-- | Session-local chronological image history. Only the five images that can
+-- be selected by the public tool contract need to be retained.
+newtype ImageGenerationHistory = ImageGenerationHistory
+    { recentImages :: IORef [ImageAttachment]
+    }
+
+newImageGenerationHistory :: IO ImageGenerationHistory
+newImageGenerationHistory =
+    ImageGenerationHistory <$> newIORef []
+
+recordImageGenerationImages
+    :: ImageGenerationHistory
+    -> [ImageAttachment]
+    -> IO ()
+recordImageGenerationImages _ [] = pure ()
+recordImageGenerationImages history images =
+    atomicModifyIORef' history.recentImages \previous ->
+        let combined = previous <> images
+            retained = drop (max 0 (length combined - maxSelectableImages)) combined
+        in (retained, ())
+
+-- | Rehydrate recent images from a persisted provider transcript. Rich tool
+-- outputs and user messages both encode images as @input_image@ content; the
+-- provider-native image-generation item stores bare PNG base64 instead.
+recordImageGenerationResponseItems
+    :: ImageGenerationHistory
+    -> [ResponseItem]
+    -> IO ()
+recordImageGenerationResponseItems history items =
+    recordImageGenerationImages history $
+        reverse
+            (take maxSelectableImages
+                (mapMaybe decodeImageDataUrl newestFirstUrls))
+  where
+    newestFirstUrls =
+        concatMap (reverse . responseItemImageUrls) (reverse items)
+
+clearImageGenerationHistory :: ImageGenerationHistory -> IO ()
+clearImageGenerationHistory history =
+    writeIORef history.recentImages []
+
+imageGenerationTool
+    :: TokenProvider
+    -> ToolEnv
+    -> ImageGenerationHistory
+    -> Maybe ImageDisplayHooks
+    -> AppTool
+imageGenerationTool =
+    imageGenerationToolAt defaultCodexBaseUrl
+
+imageGenerationToolAt
+    :: Text
+    -> TokenProvider
+    -> ToolEnv
+    -> ImageGenerationHistory
+    -> Maybe ImageDisplayHooks
+    -> AppTool
+imageGenerationToolAt baseUrl tokenProvider env history displayHooks =
+    rawJsonAppToolWithExecution
+        imageGenerationToolName
+        imageGenerationDescription
+        imageGenerationSchema
+        AlwaysAllowed
+        TurnSequential
+        (typedRichToolWithCall
+            imageGenerationToolName
+            rawJsonDecoder
+            (runImageGeneration
+                baseUrl
+                tokenProvider
+                env
+                history
+                displayHooks))
+
+data ImageGenerationArgs = ImageGenerationArgs
+    { prompt :: !Text
+    , referencedImagePaths :: !(Maybe [Text])
+    , numLastImagesToInclude :: !(Maybe Int)
+    }
+    deriving (Eq, Show)
+
+instance Aeson.FromJSON ImageGenerationArgs where
+    parseJSON = Aeson.withObject "imagegen arguments" \object -> do
+        let allowed =
+                [ "prompt"
+                , "referenced_image_paths"
+                , "num_last_images_to_include"
+                ]
+            unknown =
+                filter (`notElem` allowed)
+                    (map AesonKey.toText (AesonKeyMap.keys object))
+        unless (null unknown) $
+            fail ("unknown field(s): " <> Text.unpack (Text.intercalate ", " unknown))
+        ImageGenerationArgs
+            <$> object Aeson..: "prompt"
+            <*> object Aeson..:? "referenced_image_paths"
+            <*> object Aeson..:? "num_last_images_to_include"
+
+imageGenerationSchema :: Aeson.Value
+imageGenerationSchema = Aeson.object
+    [ "type" Aeson..= ("object" :: Text)
+    , "additionalProperties" Aeson..= False
+    , "required" Aeson..= ["prompt" :: Text]
+    , "properties" Aeson..= Aeson.object
+        [ "prompt" Aeson..= Aeson.object
+            [ "type" Aeson..= ("string" :: Text)
+            ]
+        , "referenced_image_paths" Aeson..= Aeson.object
+            [ "type" Aeson..= ["array" :: Text, "null"]
+            , "items" Aeson..= Aeson.object
+                [ "type" Aeson..= ("string" :: Text)
+                , "description" Aeson..=
+                    ("Absolute path to a local image to edit." :: Text)
+                ]
+            , "maxItems" Aeson..= maxSelectableImages
+            ]
+        , "num_last_images_to_include" Aeson..= Aeson.object
+            [ "type" Aeson..= ["integer" :: Text, "null"]
+            , "format" Aeson..= ("uint" :: Text)
+            , "minimum" Aeson..= (1 :: Int)
+            , "maximum" Aeson..= maxSelectableImages
+            ]
+        ]
+    ]
+
+runImageGeneration
+    :: Text
+    -> TokenProvider
+    -> ToolEnv
+    -> ImageGenerationHistory
+    -> Maybe ImageDisplayHooks
+    -> ToolCall
+    -> RawJson
+    -> IO (Either Text ToolHandlerResult)
+runImageGeneration baseUrl tokenProvider env history displayHooks call raw =
+    case Aeson.eitherDecodeStrict' (rawJsonBytes raw) of
+        Left err ->
+            pure (Left ("invalid imagegen arguments: " <> Text.pack err))
+        Right args ->
+            validateArgs args >>= \case
+                Left err -> pure (Left err)
+                Right () ->
+                    selectReferenceImages env history args >>= \case
+                        Left err -> pure (Left err)
+                        Right references -> do
+                            let (endpoint, requestBody) =
+                                    imageRequest args.prompt references
+                            response <- runWithTokenProvider tokenProvider \credential ->
+                                if credential.provider /= OpenAIProvider
+                                    then pure $ Left $ ProviderError
+                                        InvalidRequestError
+                                        "Image generation requires an OpenAI credential."
+                                        Nothing
+                                    else postCodexJson
+                                        baseUrl
+                                        endpoint
+                                        credential.accessToken
+                                        credential.accountId
+                                        (imageRequestHeaders call.callId)
+                                        requestBody
+                                        imageResponseHandler
+                            case response of
+                                Left err -> pure (Left (renderApiError err))
+                                Right encoded ->
+                                    finishGeneratedImage
+                                        env
+                                        history
+                                        displayHooks
+                                        call
+                                        encoded
+
+validateArgs :: ImageGenerationArgs -> IO (Either Text ())
+validateArgs args
+    | maybe False ((> maxSelectableImages) . length) args.referencedImagePaths =
+        pure $ Left "`referenced_image_paths` must contain at most 5 paths"
+    | maybe False (\count -> count < 1 || count > maxSelectableImages)
+            args.numLastImagesToInclude =
+        pure $ Left
+            "`num_last_images_to_include` must be between 1 and 5"
+    | maybe False (not . null) args.referencedImagePaths
+        && maybe False (const True) args.numLastImagesToInclude =
+            pure $ Left
+                "provide only one of `referenced_image_paths` or `num_last_images_to_include`"
+    | otherwise = pure (Right ())
+
+selectReferenceImages
+    :: ToolEnv
+    -> ImageGenerationHistory
+    -> ImageGenerationArgs
+    -> IO (Either Text [ImageAttachment])
+selectReferenceImages env history args =
+    case args.referencedImagePaths of
+        Just paths | not (null paths) ->
+            loadReferencedImages env paths
+        _ -> case args.numLastImagesToInclude of
+            Nothing -> pure (Right [])
+            Just count -> do
+                available <- readIORef history.recentImages
+                let selected = drop (length available - count) available
+                if length selected == count
+                    then pure (Right selected)
+                    else pure $ Left $
+                        "requested the last "
+                            <> Text.pack (show count)
+                            <> " conversation images, but only "
+                            <> Text.pack (show (length available))
+                            <> " were available"
+
+loadReferencedImages
+    :: ToolEnv
+    -> [Text]
+    -> IO (Either Text [ImageAttachment])
+loadReferencedImages env = go []
+  where
+    go reversed = \case
+        [] -> pure (Right (reverse reversed))
+        pathText : rest ->
+            let requested = fromText pathText
+            in if not (isAbsolute requested)
+                then pure $ Left $
+                    "`referenced_image_paths` entries must be absolute paths: "
+                        <> pathText
+                else resolveForRead env requested >>= \case
+                    Left err -> pure (Left err)
+                    Right path ->
+                        readReferencedImage pathText path >>= \case
+                            Left err -> pure (Left err)
+                            Right image -> go (image : reversed) rest
+
+readReferencedImage
+    :: Text
+    -> OsPath
+    -> IO (Either Text ImageAttachment)
+readReferencedImage display path =
+    tryAny readImage >>= \case
+        Left err ->
+            pure $ Left $
+                "failed to read referenced image "
+                    <> display
+                    <> ": "
+                    <> Text.pack (show err)
+        Right result -> pure result
+  where
+    readImage = do
+        exists <- doesFileExist path
+        if not exists
+            then pure (Left ("referenced image not found: " <> display))
+            else do
+                size <- getFileSize path
+                if size > toInteger maxDecodedImageBytes
+                    then pure $ Left $
+                        "referenced image exceeds the 32 MiB limit: " <> display
+                    else do
+                        bytes <- BS.readFile (unsafeToFilePath path)
+                        pure $
+                            if BS.length bytes > maxDecodedImageBytes
+                                then Left $
+                                    "referenced image exceeds the 32 MiB limit: "
+                                        <> display
+                                else case sniffEditableImageMime bytes of
+                                    Nothing -> Left $
+                                        "unsupported referenced image format: "
+                                            <> display
+                                    Just mime -> Right ImageAttachment
+                                        { imageMime = mime
+                                        , imageBytes = bytes
+                                        }
+
+imageRequest
+    :: Text
+    -> [ImageAttachment]
+    -> (Text, Aeson.Value)
+imageRequest prompt references
+    | null references =
+        ( "/images/generations"
+        , Aeson.object
+            [ "prompt" Aeson..= prompt
+            , "background" Aeson..= ("auto" :: Text)
+            , "model" Aeson..= ("gpt-image-2" :: Text)
+            , "quality" Aeson..= ("auto" :: Text)
+            , "size" Aeson..= ("auto" :: Text)
+            ]
+        )
+    | otherwise =
+        ( "/images/edits"
+        , Aeson.object
+            [ "images" Aeson..= map imageUrlObject references
+            , "prompt" Aeson..= prompt
+            , "background" Aeson..= ("auto" :: Text)
+            , "model" Aeson..= ("gpt-image-2" :: Text)
+            , "quality" Aeson..= ("auto" :: Text)
+            , "size" Aeson..= ("auto" :: Text)
+            ]
+        )
+  where
+    imageUrlObject image = Aeson.object
+        [ "image_url" Aeson..= attachmentDataUrl image
+        ]
+
+imageRequestHeaders :: Text -> RequestBuilder () -> RequestBuilder ()
+imageRequestHeaders callId request = do
+    request
+    setHeader "Accept" "application/json"
+    setHeader "x-codex-image-turn-id" (Text.encodeUtf8 callId)
+    setHeader "originator" "haskell-agent"
+
+newtype ImageResponse = ImageResponse
+    { responseImages :: [ImageResponseData]
+    }
+
+newtype ImageResponseData = ImageResponseData
+    { responseBase64 :: Text
+    }
+
+instance Aeson.FromJSON ImageResponse where
+    parseJSON = Aeson.withObject "image response" \object -> do
+        created <- object Aeson..: "created" :: AesonTypes.Parser Integer
+        images <- object Aeson..: "data"
+        created `seq` pure (ImageResponse images)
+
+instance Aeson.FromJSON ImageResponseData where
+    parseJSON = Aeson.withObject "image response data" \object ->
+        ImageResponseData <$> object Aeson..: "b64_json"
+
+imageResponseHandler
+    :: Response
+    -> Streams.InputStream BS.ByteString
+    -> IO (Either ApiError Text)
+imageResponseHandler response stream =
+    readBoundedResponseBody stream >>= \case
+        Left err -> pure (Left err)
+        Right body -> do
+            let status = getStatusCode response
+                bodyText = Text.decodeUtf8With Text.lenientDecode body
+            if status < 200 || status >= 300
+                then pure (Left (classifyHttpFailure status bodyText))
+                else pure $ case Aeson.eitherDecodeStrict' body of
+                    Left err -> Left $ JsonDecodeError
+                        (Text.pack err)
+                        (Text.take 2000 bodyText)
+                    Right ImageResponse{responseImages = []} ->
+                        Left $ JsonDecodeError
+                            "image response contained no images"
+                            (Text.take 2000 bodyText)
+                    Right ImageResponse{responseImages = image : _} ->
+                        Right image.responseBase64
+
+readBoundedResponseBody
+    :: Streams.InputStream BS.ByteString
+    -> IO (Either ApiError BS.ByteString)
+readBoundedResponseBody = go 0 []
+  where
+    go total reversed stream =
+        Streams.read stream >>= \case
+            Nothing -> pure (Right (BS.concat (reverse reversed)))
+            Just chunk ->
+                let nextTotal = total + BS.length chunk
+                in if nextTotal > maxImageResponseBytes
+                    then pure $ Left $ ProviderError
+                        PayloadTooLargeError
+                        "Image generation response exceeded the 48 MiB limit."
+                        Nothing
+                    else go nextTotal (chunk : reversed) stream
+
+finishGeneratedImage
+    :: ToolEnv
+    -> ImageGenerationHistory
+    -> Maybe ImageDisplayHooks
+    -> ToolCall
+    -> Text
+    -> IO (Either Text ToolHandlerResult)
+finishGeneratedImage env history displayHooks call encodedText = do
+    let stripped = Text.strip encodedText
+        encoded = Text.encodeUtf8 stripped
+    if BS.length encoded > maxEncodedImageBytes
+        then pure $ Left "generated image exceeded the encoded size limit"
+        else case Base64.decode encoded of
+            Left err ->
+                pure $ Left $
+                    "image service returned invalid base64 data: " <> Text.pack err
+            Right bytes
+                | BS.length bytes > maxDecodedImageBytes ->
+                    pure $ Left "generated image exceeded the 32 MiB limit"
+                | otherwise -> do
+                    let image = ImageAttachment
+                            { imageMime = "image/png"
+                            , imageBytes = bytes
+                            }
+                        fileName = generatedImageFileName call.callId
+                        displayPath = "generated_images/" <> fileName
+                        dataUrl = "data:image/png;base64," <> stripped
+                    saveResult <- saveGeneratedImage env fileName bytes
+                    recordImageGenerationImages history [image]
+                    displayGeneratedImage
+                        displayHooks
+                        call.callId
+                        displayPath
+                        image
+                    let hint = case saveResult of
+                            Right () ->
+                                imageOutputHint "generated_images" displayPath
+                            Left _ -> ""
+                    pure $ Right ToolHandlerResult
+                        { resultText = hint
+                        , resultImages =
+                            [ ToolResultImage
+                                { imageUrl = dataUrl
+                                , imageDetail = Just "high"
+                                }
+                            ]
+                        }
+
+saveGeneratedImage
+    :: ToolEnv
+    -> Text
+    -> BS.ByteString
+    -> IO (Either Text ())
+saveGeneratedImage env fileName bytes = do
+    let relativeDirectory = fromText "generated_images"
+        relativePath = relativeDirectory </> fromText fileName
+    resolveUnderCwd env relativePath >>= \case
+        Left err -> pure (Left err)
+        Right destination ->
+            tryAny (writeDestination destination) >>= \case
+                Left err ->
+                    pure $ Left $
+                        "failed to save generated image: "
+                            <> Text.pack (show err)
+                Right result -> pure result
+  where
+    writeDestination destination = do
+        let directory = takeDirectory destination
+        directoryExists <- doesPathExist directory
+        unless directoryExists (createDirectory directory)
+        directoryIsLink <- pathIsSymbolicLink directory
+        directoryIsDirectory <- doesDirectoryExist directory
+        if directoryIsLink || not directoryIsDirectory
+            then pure $ Left
+                "generated_images exists but is not a regular directory"
+            else do
+                destinationExists <- doesPathExist destination
+                if destinationExists
+                    then pure $ Left
+                        "generated image destination already exists"
+                    else do
+                        handle <- bracketOnError
+                            (openFd
+                                (unsafeToFilePath destination)
+                                WriteOnly
+                                defaultFileFlags
+                                    { creat = Just 0o600
+                                    , exclusive = True
+                                    , nofollow = True
+                                    , cloexec = True
+                                    })
+                            closeFd
+                            fdToHandle
+                        BS.hPut handle bytes `finally` hClose handle
+                        pure (Right ())
+
+displayGeneratedImage
+    :: Maybe ImageDisplayHooks
+    -> Text
+    -> Text
+    -> ImageAttachment
+    -> IO ()
+displayGeneratedImage Nothing _ _ _ = pure ()
+displayGeneratedImage (Just hooks) callId displayPath image
+    | BS.length image.imageBytes > maxShowImageBytes = pure ()
+    | otherwise = do
+        _ <- tryAny $ hooks.showImage ImageDisplayRequest
+            { displayCallId = callId
+            , displayPath
+            , displayCaption = Nothing
+            , displayImage = image
+            }
+        pure ()
+
+imageOutputHint :: Text -> Text -> Text
+imageOutputHint outputDirectory outputPath =
+    "Generated images are saved to "
+        <> outputDirectory
+        <> " as "
+        <> outputPath
+        <> " by default.\n\
+        \If you need to use a generated image at another path, copy it and leave the original in place unless the user explicitly asks you to delete it.\n\
+        \The generated image is already displayed to the user. There is no need to render it in the final response as a Markdown image or file link."
+
+attachmentDataUrl :: ImageAttachment -> Text
+attachmentDataUrl image =
+    "data:"
+        <> image.imageMime
+        <> ";base64,"
+        <> Text.decodeUtf8 (Base64.encode image.imageBytes)
+
+responseItemImageUrls :: ResponseItem -> [Text]
+responseItemImageUrls item =
+    imageUrlsInValue (Aeson.toJSON item)
+        <> case item of
+            ImageGenerationCallItem ImageGenerationCall{result = Just encoded} ->
+                ["data:image/png;base64," <> encoded]
+            _ -> []
+
+imageUrlsInValue :: Aeson.Value -> [Text]
+imageUrlsInValue = \case
+    Aeson.Array values ->
+        concatMap imageUrlsInValue values
+    Aeson.Object object
+        | Just (Aeson.String contentType) <- AesonKeyMap.lookup "type" object
+        , contentType `elem` ["input_image", "computer_screenshot"]
+        , Just (Aeson.String imageUrl) <- AesonKeyMap.lookup "image_url" object ->
+            [imageUrl]
+        | otherwise ->
+            concatMap imageUrlsInValue (AesonKeyMap.elems object)
+    _ -> []
+
+decodeImageDataUrl :: Text -> Maybe ImageAttachment
+decodeImageDataUrl dataUrl = do
+    encodedWithMime <- Text.stripPrefix "data:" dataUrl
+    let (declaredMime, encodedWithSeparator) =
+            Text.breakOn ";base64," encodedWithMime
+    encodedText <- Text.stripPrefix ";base64," encodedWithSeparator
+    let encoded = Text.encodeUtf8 encodedText
+    if Text.isPrefixOf "image/" declaredMime
+            && BS.length encoded <= maxEncodedImageBytes
+        then case Base64.decode encoded of
+            Right bytes
+                | BS.length bytes <= maxDecodedImageBytes
+                , Just mime <- sniffEditableImageMime bytes ->
+                    Just ImageAttachment
+                        { imageMime = mime
+                        , imageBytes = bytes
+                        }
+            _ -> Nothing
+        else Nothing
+
+sniffEditableImageMime :: BS.ByteString -> Maybe Text
+sniffEditableImageMime bytes =
+    sniffImageMime bytes
+        <|> if isWebP bytes then Just "image/webp" else Nothing
+  where
+    isWebP value =
+        BS.length value >= 12
+            && BS.take 4 value == "RIFF"
+            && BS.take 4 (BS.drop 8 value) == "WEBP"
+
+generatedImageFileName :: Text -> Text
+generatedImageFileName callId =
+    let sanitized = Text.map sanitizeCharacter callId
+        stem
+            | Text.null sanitized = "image"
+            | otherwise = sanitized
+    in stem <> ".png"
+  where
+    sanitizeCharacter character
+        | isAlphaNum character || character == '-' || character == '_' =
+            character
+        | otherwise = '_'
+
+renderApiError :: ApiError -> Text
+renderApiError = \case
+    HttpError status body ->
+        "Image generation request failed (HTTP "
+            <> Text.pack (show status)
+            <> "): "
+            <> Text.take 2000 body
+    JsonDecodeError err _ ->
+        "Image generation response was invalid: " <> err
+    ProviderError _ message _ -> message
+    CredentialError message -> message
+    ConnectionError message ->
+        "Image generation connection failed: " <> message
+    CredentialsExhausted{} ->
+        "No eligible OpenAI subscription credential is currently available."
+
+maxSelectableImages :: Int
+maxSelectableImages = 5
+
+maxDecodedImageBytes :: Int
+maxDecodedImageBytes = 32 * 1024 * 1024
+
+-- Upstream checks this before decoding so a maliciously padded string cannot
+-- allocate far past the 32 MiB decoded limit.
+maxEncodedImageBytes :: Int
+maxEncodedImageBytes = 44_739_244
+
+maxImageResponseBytes :: Int
+maxImageResponseBytes = 48 * 1024 * 1024

--- a/packages/agent-openai/src/Agent/OpenAI/ImageGeneration.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/ImageGeneration.hs
@@ -132,13 +132,13 @@ imageGenerationDescription =
     \- imagegen needs a few minutes to finish. In code-mode, use the first-line @exec directive to give the initial call 120 seconds and the same yield for any waits that follow. Once it finishes, return the image with generatedImage(result).\n\
     \- Omit both `referenced_image_paths` and `num_last_images_to_include` when generating a brand new image.\n\
     \- For edits, use `referenced_image_paths` when every target image has a local file path.\n\
-    \- If you have not seen a local image yet, use `show_image` to inspect it before editing.\n\
+    \- If you have not seen a local image yet, use `view_image` to inspect it before editing.\n\
     \- Use `num_last_images_to_include` only when at least one target image has no local file path.\n\
     \- Set `num_last_images_to_include` to the smallest number of recent conversation images that includes every target image, up to 5.\n\
     \- Never provide both `referenced_image_paths` and `num_last_images_to_include`.\n\
     \- If neither mechanism can include every target image, ask the user to attach the missing images again.\n\
     \- Directly generate the image without reconfirmation or clarification unless required images must be attached again.\n\
-    \- Always use this tool for image editing unless the user explicitly requests otherwise. Do not use the `python` tool for image editing unless specifically instructed."
+    \- Always use this tool for image editing unless the user explicitly requests otherwise. Do not use the `python` tool for image editing unless specifically instructed.\n"
 
 -- | Session-local chronological image history. Only the five images that can
 -- be selected by the public tool contract need to be retained.
@@ -252,7 +252,7 @@ imageGenerationSchema = Aeson.object
             , "items" Aeson..= Aeson.object
                 [ "type" Aeson..= ("string" :: Text)
                 , "description" Aeson..=
-                    ("Absolute path to a local image to edit." :: Text)
+                    ("A path that is guaranteed to be absolute and normalized (though it is not guaranteed to be canonicalized or exist on the filesystem).\n\nIMPORTANT: When deserializing an `AbsolutePathBuf`, a base path must be set using [AbsolutePathBufGuard::new]. If no base path is set, the deserialization will fail unless the path being deserialized is already absolute." :: Text)
                 ]
             , "maxItems" Aeson..= maxSelectableImages
             ]

--- a/packages/agent-openai/test/Agent/OpenAI/ImageGenerationSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ImageGenerationSpec.hs
@@ -1,0 +1,282 @@
+module Agent.OpenAI.ImageGenerationSpec (spec) where
+
+import Agent.Loop
+    ( ImageAttachment(..)
+    , defaultLoopDispatch
+    )
+import Agent.OpenAI.ImageGeneration
+    ( imageGenerationToolAt
+    , newImageGenerationHistory
+    , recordImageGenerationResponseItems
+    )
+import Agent.OsPath (fromText)
+import Agent.Provider
+    ( BillingMode(SubscriptionBilled)
+    , Credential(..)
+    , Provider(OpenAIProvider)
+    , tokenProvider
+    )
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolResultImage(..)
+    , dispatchToolCall
+    , functionToolCall
+    , toolCallResultImages
+    )
+import Agent.Responses.Types
+    ( MessageContent(..)
+    , ResponseContentPart(..)
+    , ResponseItem(..)
+    , ResponseMessage(..)
+    , ResponseRole(RoleUser)
+    )
+import Agent.Tools.ShowImage
+    ( ImageDisplayHooks(..)
+    , ImageDisplayRequest(..)
+    )
+import Agent.Tools.Types
+    ( appToolHandlers
+    , defaultToolEnv
+    )
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as Base64
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    , readIORef
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Network.HTTP.Types as HTTP
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+data RecordedRequest = RecordedRequest
+    { requestMethod :: !HTTP.Method
+    , requestPath :: !Text
+    , requestHeaders :: !HTTP.RequestHeaders
+    , requestBody :: !Aeson.Value
+    }
+
+spec :: Spec
+spec = describe "image generation tool" do
+    it "generates an image, returns rich model content, saves it, and displays it" do
+        withSystemTempDirectory "agent-imagegen" \cwd -> do
+            recorded <- newIORef []
+            displayed <- newIORef []
+            withImageServer recorded generatedPng \baseUrl -> do
+                env <- defaultToolEnv (fromText (Text.pack cwd))
+                history <- newImageGenerationHistory
+                let hooks = ImageDisplayHooks \request -> do
+                        atomicModifyIORef' displayed \requests ->
+                            (requests <> [request], ())
+                        pure (Right ())
+                    tool = imageGenerationToolAt
+                        baseUrl
+                        openAiProvider
+                        env
+                        history
+                        (Just hooks)
+                result <- dispatchToolCall
+                    defaultLoopDispatch
+                    (appToolHandlers [tool])
+                    (functionToolCall
+                        "call-1"
+                        "image_gen.imagegen"
+                        "{\"prompt\":\"paint a moonlit lake\"}")
+
+                result.output `shouldSatisfy`
+                    Text.isInfixOf "generated_images/call-1.png"
+                toolCallResultImages result `shouldBe`
+                    [ ToolResultImage
+                        { imageUrl = pngDataUrl generatedPng
+                        , imageDetail = Just "high"
+                        }
+                    ]
+                BS.readFile (cwd </> "generated_images" </> "call-1.png")
+                    `shouldReturn` generatedPng
+                readIORef displayed `shouldReturn`
+                    [ ImageDisplayRequest
+                        { displayCallId = "call-1"
+                        , displayPath = "generated_images/call-1.png"
+                        , displayCaption = Nothing
+                        , displayImage = ImageAttachment "image/png" generatedPng
+                        }
+                    ]
+
+            [request] <- readIORef recorded
+            request.requestMethod `shouldBe` HTTP.methodPost
+            request.requestPath `shouldBe` "/images/generations"
+            lookup "authorization" request.requestHeaders
+                `shouldBe` Just "Bearer test-token"
+            lookup "chatgpt-account-id" request.requestHeaders
+                `shouldBe` Just "account-1"
+            lookup "x-codex-image-turn-id" request.requestHeaders
+                `shouldBe` Just "call-1"
+            lookup "originator" request.requestHeaders
+                `shouldBe` Just "haskell-agent"
+            request.requestBody `shouldBe` Aeson.object
+                [ "prompt" .= ("paint a moonlit lake" :: Text)
+                , "background" .= ("auto" :: Text)
+                , "model" .= ("gpt-image-2" :: Text)
+                , "quality" .= ("auto" :: Text)
+                , "size" .= ("auto" :: Text)
+                ]
+
+    it "edits the requested number of recent images in chronological order" do
+        withSystemTempDirectory "agent-imagegen-edit" \cwd -> do
+            recorded <- newIORef []
+            withImageServer recorded generatedPng \baseUrl -> do
+                env <- defaultToolEnv (fromText (Text.pack cwd))
+                history <- newImageGenerationHistory
+                let first = ImageAttachment "image/png" generatedPng
+                    second = ImageAttachment "image/jpeg" jpegBytes
+                    persistedMessage = MessageItem ResponseMessage
+                        { messageId = Nothing
+                        , content = MessageContentParts
+                            [ inputImagePart first
+                            , inputImagePart second
+                            ]
+                        , role = RoleUser
+                        , status = Nothing
+                        , phase = Nothing
+                        , passthrough = Nothing
+                        }
+                recordImageGenerationResponseItems history [persistedMessage]
+                let tool = imageGenerationToolAt
+                        baseUrl
+                        openAiProvider
+                        env
+                        history
+                        Nothing
+                _ <- dispatchToolCall
+                    defaultLoopDispatch
+                    (appToolHandlers [tool])
+                    (functionToolCall
+                        "edit-1"
+                        "imagegen"
+                        "{\"prompt\":\"change the lighting\",\
+                        \\"num_last_images_to_include\":2}")
+                pure ()
+
+            [request] <- readIORef recorded
+            request.requestPath `shouldBe` "/images/edits"
+            request.requestBody `shouldBe` Aeson.object
+                [ "images" .=
+                    [ Aeson.object ["image_url" .= attachmentDataUrl
+                        (ImageAttachment "image/png" generatedPng)]
+                    , Aeson.object ["image_url" .= attachmentDataUrl
+                        (ImageAttachment "image/jpeg" jpegBytes)]
+                    ]
+                , "prompt" .= ("change the lighting" :: Text)
+                , "background" .= ("auto" :: Text)
+                , "model" .= ("gpt-image-2" :: Text)
+                , "quality" .= ("auto" :: Text)
+                , "size" .= ("auto" :: Text)
+                ]
+
+    it "rejects conflicting image selectors before making a request" do
+        withSystemTempDirectory "agent-imagegen-invalid" \cwd -> do
+            env <- defaultToolEnv (fromText (Text.pack cwd))
+            history <- newImageGenerationHistory
+            let tool = imageGenerationToolAt
+                    "http://127.0.0.1:1"
+                    openAiProvider
+                    env
+                    history
+                    Nothing
+            result <- dispatchToolCall
+                defaultLoopDispatch
+                (appToolHandlers [tool])
+                (functionToolCall
+                    "invalid-1"
+                    "imagegen"
+                    "{\"prompt\":\"edit\",\
+                    \\"referenced_image_paths\":[\"/tmp/a.png\"],\
+                    \\"num_last_images_to_include\":1}")
+            result.output `shouldSatisfy`
+                Text.isInfixOf
+                    "provide only one of `referenced_image_paths` or `num_last_images_to_include`"
+            toolCallResultImages result `shouldBe` []
+
+openAiProvider =
+    tokenProvider SubscriptionBilled \_ ->
+        pure $ Right Credential
+            { accessToken = "test-token"
+            , accountId = "account-1"
+            , leaseId = Nothing
+            , provider = OpenAIProvider
+            }
+
+withImageServer
+    :: IORef [RecordedRequest]
+    -> BS.ByteString
+    -> (Text -> IO a)
+    -> IO a
+withImageServer recorded imageBytes action =
+    Warp.testWithApplication (pure app) \port ->
+        action ("http://127.0.0.1:" <> Text.pack (show port))
+  where
+    app request respond = do
+        body <- Wai.strictRequestBody request
+        let decoded = case Aeson.eitherDecode body of
+                Right value -> value
+                Left _ -> Aeson.Null
+            captured = RecordedRequest
+                { requestMethod = Wai.requestMethod request
+                , requestPath = Text.decodeUtf8 (Wai.rawPathInfo request)
+                , requestHeaders = Wai.requestHeaders request
+                , requestBody = decoded
+                }
+        atomicModifyIORef' recorded \requests ->
+            (requests <> [captured], ())
+        respond $ Wai.responseLBS
+            HTTP.status200
+            [("Content-Type", "application/json")]
+            (Aeson.encode (Aeson.object
+                [ "created" .= (1 :: Int)
+                , "data" .=
+                    [ Aeson.object
+                        [ "b64_json" .=
+                            Text.decodeUtf8 (Base64.encode imageBytes)
+                        ]
+                    ]
+                ]))
+
+attachmentDataUrl :: ImageAttachment -> Text
+attachmentDataUrl image =
+    "data:"
+        <> image.imageMime
+        <> ";base64,"
+        <> Text.decodeUtf8 (Base64.encode image.imageBytes)
+
+inputImagePart :: ImageAttachment -> ResponseContentPart
+inputImagePart image =
+    InputImagePart
+        { detail = Nothing
+        , fileId = Nothing
+        , imageUrl = Just (attachmentDataUrl image)
+        , promptCacheBreakpoint = Nothing
+        }
+
+pngDataUrl :: BS.ByteString -> Text
+pngDataUrl bytes =
+    "data:image/png;base64," <> Text.decodeUtf8 (Base64.encode bytes)
+
+generatedPng :: BS.ByteString
+generatedPng =
+    BS.pack
+        [ 0x89, 0x50, 0x4e, 0x47
+        , 0x0d, 0x0a, 0x1a, 0x0a
+        , 0x00, 0x00, 0x00, 0x00
+        ]
+
+jpegBytes :: BS.ByteString
+jpegBytes = BS.pack [0xff, 0xd8, 0xff, 0x00]

--- a/packages/agent-openai/test/Spec.hs
+++ b/packages/agent-openai/test/Spec.hs
@@ -7,6 +7,7 @@ import qualified Agent.OpenAI.ClientSpec as ClientSpec
 import qualified Agent.OpenAI.CredentialSpec as CredentialSpec
 import qualified Agent.OpenAI.ErrorSpec as ErrorSpec
 import qualified Agent.OpenAI.FunctionalSpec as FunctionalSpec
+import qualified Agent.OpenAI.ImageGenerationSpec as ImageGenerationSpec
 import qualified Agent.OpenAI.LoginSpec as LoginSpec
 import qualified Agent.OpenAI.LoopBackendSpec as LoopBackendSpec
 import qualified Agent.OpenAI.ModelsClientSpec as ModelsClientSpec
@@ -24,6 +25,7 @@ main = hspec do
     CredentialSpec.spec
     ErrorSpec.spec
     FunctionalSpec.spec
+    ImageGenerationSpec.spec
     LoginSpec.spec
     LoopBackendSpec.spec
     ModelsClientSpec.spec

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -27,7 +27,7 @@ import Agent.InterAgentMessage
     , renderInterAgentMessage
     , renderInterAgentMessageHeader
     )
-import Agent.Json (rawJsonFromEncoding)
+import Agent.Json (RawJson, rawJsonFromEncoding)
 import Agent.JsonText (jsonTextFieldPartial)
 import Agent.Loop
     ( Backend(..)
@@ -52,7 +52,9 @@ import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
     , ToolCallResult(..)
+    , ToolResultImage(..)
     , canonicalToolName
+    , toolCallResultImages
     )
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
@@ -380,7 +382,7 @@ toolResultToItem result = case result.callKind of
         , name = Nothing
         , namespace = Nothing
         , provider = Nothing
-        , output = rawJsonFromEncoding (Aeson.toEncoding result.output)
+        , output = toolResultOutput result
         , status = Nothing
 
         }
@@ -388,7 +390,7 @@ toolResultToItem result = case result.callKind of
         { itemId = Nothing
         , callId = result.callId
         , name = Nothing
-        , output = rawJsonFromEncoding (Aeson.toEncoding result.output)
+        , output = toolResultOutput result
         , status = Nothing
         }
     ComputerCallKind -> case Hermes.decodeEither computerCallOutputDecoder
@@ -402,6 +404,25 @@ toolResultToItem result = case result.callKind of
             , acknowledgedChecks = []
             , computerOutputStatus = Nothing
             , computerOutputExtra = KeyMap.empty
+            }
+
+toolResultOutput :: ToolCallResult -> RawJson
+toolResultOutput result =
+    case toolCallResultImages result of
+        [] -> rawJsonFromEncoding (Aeson.toEncoding result.output)
+        images ->
+            rawJsonFromEncoding . Aeson.toEncoding $
+                map imagePart images
+                    <> [ InputTextPart result.output Nothing
+                       | not (Text.null (Text.strip result.output))
+                       ]
+  where
+    imagePart image =
+        InputImagePart
+            { detail = image.imageDetail
+            , fileId = Nothing
+            , imageUrl = Just image.imageUrl
+            , promptCacheBreakpoint = Nothing
             }
 
 transparentPixelDataUrl :: Text

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -57,7 +57,12 @@ import Data.IORef
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
-import Agent.ToolDispatch (ToolCall(..), ToolCallKind(..), ToolCallResult(..))
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , ToolCallKind(..)
+    , ToolCallResult(..)
+    , ToolResultImage(..)
+    )
 import Test.Hspec
 
 spec :: Spec
@@ -118,6 +123,34 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                             any isInputFile ps && any isInputImage ps
                     _ -> expectationFailure "expected multimodal message parts"
             other -> expectationFailure ("unexpected items: " <> show other)
+
+    it "encodes rich function outputs as image content followed by the hint" do
+        case toolResultToItem ToolCallResultWithImages
+                { callId = "image-call"
+                , output = "saved under generated_images"
+                , callKind = FunctionCallKind
+                , toolResultImages =
+                    [ ToolResultImage
+                        { imageUrl = "data:image/png;base64,AA=="
+                        , imageDetail = Just "high"
+                        }
+                    ]
+                } of
+            FunctionCallOutputItem output ->
+                Aeson.toJSON output.output `shouldBe` Aeson.toJSON
+                    [ InputImagePart
+                        { detail = Just "high"
+                        , fileId = Nothing
+                        , imageUrl = Just "data:image/png;base64,AA=="
+                        , promptCacheBreakpoint = Nothing
+                        }
+                    , InputTextPart
+                        { text = "saved under generated_images"
+                        , promptCacheBreakpoint = Nothing
+                        }
+                    ]
+            other -> expectationFailure
+                ("expected function output, got " <> show other)
 
     it "reacquires a credential after an authentication rejection" do
         attempts <- newIORef []


### PR DESCRIPTION
## Summary

- add the upstream Codex-style `image_gen.imagegen` namespace tool for OpenAI/Codex sessions
- support generation and edits through the Images API, local/recent image references, secure artifact saving, and inline display
- preserve rich image tool outputs across Responses transport, code mode, compaction, reset, and resumed-session history
- route image generation through `exec` automatically for catalog `code_mode_only` models, matching Codex Responses Lite behavior while leaving other tools direct
- add integration and transport tests for schemas, request payloads, rich outputs, saving, display, validation, and model-specific projection

The implementation follows OpenAI Codex commit `b8c86376a258e55efc8e5ecfbabc21c16c07d814`.

## Validation

- real end-to-end generation in the live GHCi CLI under tmux: `gpt-5.6-sol` invoked nested `image_gen.imagegen`, `gpt-image-2` completed in 12.1s, and the harness saved/displayed a verified 1024×1024 RGBA PNG (85,417 bytes)
- normal no-flag `gpt-5.6-sol` control request returned `READY` with the automatic bridge and no reserved-schema rejection
- `nix develop -c cabal test --offline agent-openai:test:agent-openai-test --test-options=--match=image` (13 examples, 0 failures)
- `nix develop -c cabal test --offline agent-core:test:agent-core-test --test-options=--match=preserves` (14 examples, 0 failures)
- `nix develop -c cabal test --offline agent-responses:test:agent-responses-test --test-options=--match=rich` (1 example, 0 failures)
- `nix develop -c cabal test --offline agent-cli:test:agent-cli-test --test-options=--match=imagegen` (2 examples, 0 failures)
- loaded `Agent.CLI.Runtime.Orchestration.Tools` in `cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code` (187 modules)
- `git diff --check`