### PR TITLE
Supervise concurrent native tasks

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -260,6 +260,7 @@ foreign-library haskell-agent-bridge
     other-modules:    Agent.CLI.MacOS.Bridge
                     , Agent.CLI.MacOS.EngineMailbox
                     , Agent.CLI.MacOS.NativeLoopEvent
+                    , Agent.CLI.MacOS.TaskScheduler
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     includes:         HaskellAgentBridge.h
@@ -360,6 +361,8 @@ test-suite agent-cli-test
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
                     , Agent.CLI.MacOS.BridgeFFISpec
+                    , Agent.CLI.MacOS.TaskScheduler
+                    , Agent.CLI.MacOS.TaskSchedulerSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec
@@ -473,6 +476,7 @@ test-suite agent-cli-test
     if os(darwin)
         c-sources:    test/cbits/HaskellAgentBridgeBrowserSmoke.c
                     , test/cbits/HaskellAgentBridgeImageSmoke.c
+                    , test/cbits/HaskellAgentBridgeTaskSmoke.c
                     , cbits/HaskellAgentBridgeRuntime.c
         other-modules: Agent.CLI.MacOS.Bridge
 

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -67,6 +67,10 @@ import Agent.CLI.MacOS.EngineMailbox
     , newEngineMailboxIO
     , readEngineCommand
     )
+import Agent.CLI.MacOS.TaskScheduler
+    ( TaskIdentity(..)
+    , selectRunnableTasks
+    )
 import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.Login
     ( AccountBilling(..)
@@ -171,10 +175,10 @@ import Agent.Tools.Types (AppTool)
 import Control.Concurrent (forkFinally, forkIO)
 import Control.Concurrent.Async
     ( Async
+    , asyncWithUnmask
     , cancel
     , mapConcurrently
-    , waitCatchSTM
-    , withAsync
+    , waitCatch
     )
 import Control.Concurrent.MVar
     ( MVar
@@ -185,6 +189,7 @@ import Control.Concurrent.MVar
     , putMVar
     , readMVar
     , withMVar
+    , takeMVar
     )
 import Control.Concurrent.STM
     ( TMVar
@@ -193,7 +198,6 @@ import Control.Concurrent.STM
     , modifyTVar'
     , newEmptyTMVarIO
     , newTVarIO
-    , orElse
     , readTVar
     , readTVarIO
     , takeTMVar
@@ -205,10 +209,13 @@ import Control.Exception.Safe
     ( SomeException
     , bracket
     , finally
+    , mask
     , tryAny
     )
 import Control.Monad
-    ( forM_
+    ( foldM
+    , filterM
+    , forM_
     , void
     )
 import qualified Data.Aeson as Aeson
@@ -225,8 +232,12 @@ import Data.IORef
     , writeIORef
     )
 import Data.Int (Int64)
+import Data.Foldable (toList)
+import Data.List (partition)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
@@ -385,6 +396,16 @@ type McpServerFieldCallback =
 type McpResultCallback =
     Ptr () -> CInt -> Word64 -> CString -> CSize -> IO ()
 
+-- Status is 0 for an active task, 1 for completion, and -1 for failure.
+-- State is 0 for queued and 1 for running. Every pointer is callback-scoped.
+type TaskSnapshotCallback =
+    Ptr () -> CInt
+    -> Ptr Word8 -> CSize -- task id
+    -> Ptr Word8 -> CSize -- session id, optional
+    -> CInt
+    -> Ptr Word8 -> CSize -- error
+    -> IO ()
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -445,6 +466,10 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeMcpResultCallback
         :: FunPtr McpResultCallback -> McpResultCallback
+
+foreign import ccall "dynamic"
+    invokeTaskSnapshotCallback
+        :: FunPtr TaskSnapshotCallback -> TaskSnapshotCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -586,6 +611,11 @@ data EngineCommand
     | EngineSessionMutation
         !SessionMutation !(FunPtr SessionResultCallback) !(Ptr ())
     | EngineMcpRestart !Word64 !Text !(FunPtr McpResultCallback) !(Ptr ())
+    | EngineCancelTask !Text
+    | EngineTaskSnapshot !(FunPtr TaskSnapshotCallback) !(Ptr ())
+    | EngineSetTaskLimit !Int
+    | EngineTaskSession !Text !Text
+    | EngineTaskFinished !Text !TaskResult
     | EngineStop
 
 data SessionMutation
@@ -611,6 +641,8 @@ newtype BrowserHost = BrowserHost
 
 data TurnControl = TurnControl
     { turnControlId :: !Text
+    , turnControlSessionId :: !(TVar (Maybe Text))
+    , turnControlCancelled :: !(TVar Bool)
     , turnControlCancel :: !(TVar (IO ()))
     , turnControlApprovals
         :: !(TVar (Map Text (TMVar PermissionChoice)))
@@ -624,9 +656,29 @@ data TurnOutcome = TurnOutcome
     , turnOutcomeError :: !(Maybe Text)
     }
 
-data ActiveExit
-    = ActiveContinue
-    | ActiveStop
+data TaskResult
+    = TaskOutcome !TurnOutcome
+    | TaskFailure !Text
+
+data PendingTurn = PendingTurn
+    { pendingTurnStart :: !TurnStart
+    , pendingTurnImages :: ![ImageAttachment]
+    }
+
+data RunningTurn = RunningTurn
+    { runningTurnControl :: !TurnControl
+    , runningTurnWorker :: !(Async ())
+    }
+
+data TaskSupervisor = TaskSupervisor
+    { supervisorLimit :: !Int
+    , supervisorPending :: !(Seq PendingTurn)
+    , supervisorRunning :: !(Map Text RunningTurn)
+    , supervisorKnownTaskIds :: !(Set.Set Text)
+    }
+
+defaultTaskLimit :: Int
+defaultTaskLimit = 3
 
 foreign export ccall ha_engine_create
     :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
@@ -639,6 +691,15 @@ foreign export ccall ha_engine_stage_turn_images
 
 foreign export ccall ha_engine_set_browser_callback
     :: Ptr () -> FunPtr BrowserCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_cancel_task
+    :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
+
+foreign export ccall ha_engine_list_tasks
+    :: Ptr () -> FunPtr TaskSnapshotCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_set_task_limit
+    :: Ptr () -> CSize -> IO CInt
 
 foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
@@ -1801,6 +1862,66 @@ enqueueSessionMutation pointer mutation callback context
             Right False -> 3
             Right True -> 0
 
+ha_engine_cancel_task
+    :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
+ha_engine_cancel_task pointer taskID (CSize taskIDLength)
+    | pointer == nullPtr = pure 1
+    | taskID == nullPtr || taskIDLength == 0 = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            taskIDBytes <- BS.packCStringLen
+                (castPtr taskID, fromIntegral taskIDLength)
+            case TextEncoding.decodeUtf8' taskIDBytes of
+                Left _ -> pure Nothing
+                Right taskIDText
+                    | Text.null taskIDText -> pure Nothing
+                    | otherwise -> Just <$> atomically
+                        (acceptEngineCommand
+                            engine.engineCommands
+                            (EngineCancelTask taskIDText))
+        pure $ case accepted of
+            Left _ -> 3
+            Right Nothing -> 2
+            Right (Just False) -> 3
+            Right (Just True) -> 0
+
+ha_engine_list_tasks
+    :: Ptr () -> FunPtr TaskSnapshotCallback -> Ptr () -> IO CInt
+ha_engine_list_tasks pointer callback context
+    | pointer == nullPtr = pure 1
+    | callback == nullFunPtr = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            atomically $ acceptEngineCommand
+                engine.engineCommands
+                (EngineTaskSnapshot callback context)
+        pure $ case accepted of
+            Left _ -> 3
+            Right False -> 3
+            Right True -> 0
+
+ha_engine_set_task_limit :: Ptr () -> CSize -> IO CInt
+ha_engine_set_task_limit pointer rawLimit
+    | pointer == nullPtr = pure 1
+    | limit < 1 || limit > 32 = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            atomically $ acceptEngineCommand
+                engine.engineCommands
+                (EngineSetTaskLimit limit)
+        pure $ case accepted of
+            Left _ -> 3
+            Right False -> 3
+            Right True -> 0
+  where
+    limit = fromIntegral rawLimit
+
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer
     | pointer == nullPtr = pure ()
@@ -1826,10 +1947,12 @@ workerLifecycle callback context config root commands stagedImages browser =
     (do
         store <- newMVar Nothing
         processRuntime <- newNativeProcessRuntime root
+        workerRegistry <- newTVarIO Map.empty
         let cleanup =
-                closeNativeProcessRuntime processRuntime
+                shutdownRunningTurns workerRegistry
+                    `finally` closeNativeProcessRuntime processRuntime
                     `finally` closeEngineStore store
-        idleLoop
+        supervisorLoop
             callback
             context
             config
@@ -1839,6 +1962,13 @@ workerLifecycle callback context config root commands stagedImages browser =
             commands
             stagedImages
             browser
+            workerRegistry
+            TaskSupervisor
+                { supervisorLimit = defaultTaskLimit
+                , supervisorPending = Seq.empty
+                , supervisorRunning = Map.empty
+                , supervisorKnownTaskIds = Set.empty
+                }
             `finally` cleanup)
         `finally` cancelPendingMcpRestarts commands
 
@@ -1854,7 +1984,7 @@ cancelPendingMcpRestarts commands = do
                     invokeMcpResultCallback callback context (-1) expected
         _ -> pure ()
 
-idleLoop
+supervisorLoop
     :: FunPtr EventCallback
     -> Ptr ()
     -> ManagedPostgresConfig
@@ -1864,186 +1994,406 @@ idleLoop
     -> EngineMailbox EngineCommand
     -> TVar (Map Text [ImageAttachment])
     -> BrowserHost
+    -> TVar (Map Text RunningTurn)
+    -> TaskSupervisor
     -> IO ()
-idleLoop callback context config store root processRuntime commands stagedImages browser =
-    atomically (readEngineCommand commands) >>= \case
-        EngineStop -> pure ()
+supervisorLoop
+        callback context config store root processRuntime commands stagedImages browser
+        workerRegistry =
+    go
+  where
+    go supervisor0 = do
+        supervisor <- startRunnableTasks supervisor0
+        atomically (readEngineCommand commands) >>= handleCommand supervisor
+
+    handleCommand supervisor = \case
+        EngineStop ->
+            shutdownSupervisor supervisor
         EngineSearch query limit searchCallback searchContext -> do
             runConversationSearch
                 config store query limit searchCallback searchContext
-            continue
+            go supervisor
         EngineSessionMutation mutation resultCallback resultContext -> do
             runSessionMutation
                 config store root mutation resultCallback resultContext
-            continue
+            go supervisor
         EngineMcpRestart expected name resultCallback resultContext -> do
-            restarted <- tryAny do
-                home <- getHomeDirectory
-                mcpAdminTry
-                    (restartMcpAdminServer home expected name
-                        (restartNativeMcpRuntime processRuntime))
-            case restarted of
-                Left exception ->
-                    withText (Text.pack (show exception)) $
-                        invokeMcpResultCallback resultCallback
-                            resultContext (-1) expected
-                Right (Left err) ->
-                    emitMcpResult resultCallback resultContext
-                        (Left err
-                            :: Either McpAdminError (McpAdminSnapshot ()))
-                Right (Right snapshot) ->
-                    invokeMcpResultCallback resultCallback resultContext
-                        0 snapshot.mcpAdminRevision nullPtr 0
-            continue
-        EngineRequest request
-            | request.requestMethod == "turn.start" ->
-                case (parseParams request
-                    :: Either Text TurnStart) of
-                    Left err -> do
-                        atomically $ modifyTVar' stagedImages
-                            (Map.delete request.requestId)
-                        sendEvent callback context
-                            (failureEvent request.requestId err)
-                        continue
-                    Right start -> do
-                        images <- atomically $ do
-                            staged <- readTVar stagedImages
-                            writeTVar stagedImages
-                                (Map.delete start.turnStartId staged)
-                            pure (Map.findWithDefault [] start.turnStartId staged)
-                        nativeBrowserTools <- browserToolsWhenEnabled browser
-                        control <- newTurnControl start.turnStartId
-                        sendEvent callback context $
-                            successEvent request.requestId $
-                                Aeson.object
-                                    [ "turnId" Aeson..= start.turnStartId
-                                    ]
-                        sendTurnStatus
-                            callback
-                            context
-                            start.turnStartId
-                            (if start.turnStartWorktree
-                                then "Creating worktree…"
-                                else "Starting…")
-                        withAsync
-                            (runNativeTurn
-                                callback
-                                context
-                                processRuntime
-                                control
-                                nativeBrowserTools
-                                start
-                                images)
-                            \running ->
-                                activeLoop
-                                    callback
-                                    context
-                                    config
-                                    store
-                                    root
-                                    commands
-                                    control
-                                    running >>= \case
-                                        ActiveContinue -> continue
-                                        ActiveStop -> pure ()
-            | request.requestMethod `elem`
-                ["turn.cancel", "approval.resolve"] -> do
+            if Map.null supervisor.supervisorRunning
+                then do
+                    restarted <- tryAny do
+                        home <- getHomeDirectory
+                        mcpAdminTry
+                            (restartMcpAdminServer home expected name
+                                (restartNativeMcpRuntime processRuntime))
+                    case restarted of
+                        Left exception ->
+                            withText (Text.pack (show exception)) $
+                                invokeMcpResultCallback resultCallback
+                                    resultContext (-1) expected
+                        Right (Left err) ->
+                            emitMcpResult resultCallback resultContext
+                                (Left err
+                                    :: Either
+                                        McpAdminError
+                                        (McpAdminSnapshot ()))
+                        Right (Right snapshot) ->
+                            invokeMcpResultCallback
+                                resultCallback
+                                resultContext
+                                0
+                                snapshot.mcpAdminRevision
+                                nullPtr
+                                0
+                else
+                    withText "cannot restart MCP while tasks are active" $
+                        invokeMcpResultCallback resultCallback resultContext
+                            (-1) expected
+            go supervisor
+        EngineCancelTask taskId -> do
+            next <- cancelTaskById supervisor taskId
+            go next
+        EngineTaskSnapshot snapshotCallback snapshotContext -> do
+            sendTaskSnapshot snapshotCallback snapshotContext supervisor
+            go supervisor
+        EngineSetTaskLimit limit ->
+            go supervisor { supervisorLimit = limit }
+        EngineTaskSession taskId sessionId -> do
+            case Map.lookup taskId supervisor.supervisorRunning of
+                Nothing -> pure ()
+                Just running -> atomically $
+                    writeTVar
+                        running.runningTurnControl.turnControlSessionId
+                        (Just sessionId)
+            go supervisor
+        EngineTaskFinished taskId outcome -> do
+            case Map.lookup taskId supervisor.supervisorRunning of
+                Nothing -> pure ()
+                Just running -> do
+                    _ <- waitCatch running.runningTurnWorker
+                    sessionId <- readTVarIO
+                        running.runningTurnControl.turnControlSessionId
+                    cancelled <- readTVarIO
+                        running.runningTurnControl.turnControlCancelled
+                    if cancelled
+                        then do
+                            sendTaskState taskId sessionId "cancelled"
+                            sendEvent callback context $
+                                turnFailedEvent taskId "turn cancelled"
+                        else do
+                            sendTaskState
+                                taskId
+                                (taskResultSessionId sessionId outcome)
+                                (taskResultState outcome)
+                            finishTurnEvent callback context taskId outcome
+            atomically $ modifyTVar' workerRegistry (Map.delete taskId)
+            go supervisor
+                { supervisorRunning =
+                    Map.delete taskId supervisor.supervisorRunning
+                }
+        EngineRequest request ->
+            handleEngineRequest supervisor request >>= go
+
+    handleEngineRequest supervisor request
+        | request.requestMethod == "turn.start" =
+            enqueueTurn supervisor request
+        | request.requestMethod == "turn.cancel" =
+            case (parseParams request :: Either Text TurnReference) of
+                Left err -> do
+                    sendEvent callback context
+                        (failureEvent request.requestId err)
+                    pure supervisor
+                Right reference -> do
+                    let active =
+                            Map.member
+                                reference.turnReferenceId
+                                supervisor.supervisorRunning
+                        queued = any
+                            ((== reference.turnReferenceId)
+                                . (.turnStartId)
+                                . (.pendingTurnStart))
+                            supervisor.supervisorPending
+                    next <- cancelTaskById
+                        supervisor
+                        reference.turnReferenceId
                     sendEvent callback context $
-                        failureEvent
-                            request.requestId
-                            "there is no active turn"
-                    continue
-            | otherwise -> do
-                event <- handleRequest config store root request
-                sendEvent callback context event
-                continue
-  where
-    continue =
-        idleLoop
+                        if active || queued
+                            then successEvent request.requestId True
+                            else failureEvent
+                                request.requestId
+                                "turn id is not active"
+                    pure next
+        | request.requestMethod == "approval.resolve" =
+            case (parseParams request :: Either Text ApprovalResolution) of
+                Left err -> do
+                    sendEvent callback context
+                        (failureEvent request.requestId err)
+                    pure supervisor
+                Right resolution -> do
+                    matching <- filterM
+                        (approvalIsActive resolution.approvalResolutionId
+                            . (.runningTurnControl))
+                        (Map.elems supervisor.supervisorRunning)
+                    case matching of
+                        [running] ->
+                            resolveApproval running.runningTurnControl request
+                                >>= sendEvent callback context
+                        _ ->
+                            sendEvent callback context $
+                                failureEvent
+                                    request.requestId
+                                    "approval request is no longer active"
+                    pure supervisor
+        | request.requestMethod == "turn.agents" =
+            selectRunningTurn request.requestParams supervisor >>= \case
+                Left err -> do
+                    sendEvent callback context
+                        (failureEvent request.requestId err)
+                    pure supervisor
+                Right Nothing -> do
+                    sendEvent callback context $
+                        successEvent request.requestId ([] :: [Aeson.Value])
+                    pure supervisor
+                Right (Just running) ->
+                    activeAgentSnapshot running.runningTurnControl request
+                        >>= sendEvent callback context
+                        >> pure supervisor
+        | otherwise = do
+            event <- handleRequest config store root request
+            sendEvent callback context event
+            pure supervisor
+
+    selectRunningTurn params supervisor =
+        case Aeson.parseEither
+            (Aeson.withObject "turn reference" (.:? "turnId"))
+            params of
+            Left err -> pure (Left (Text.pack err))
+            Right (Just taskId) ->
+                pure $ maybe
+                    (Left "turn id is not active")
+                    (Right . Just)
+                    (Map.lookup taskId supervisor.supervisorRunning)
+            Right Nothing ->
+                pure $ case Map.elems supervisor.supervisorRunning of
+                    [running] -> Right (Just running)
+                    [] -> Right Nothing
+                    _ -> Left "turnId is required while multiple turns run"
+
+    approvalIsActive approvalId control =
+        Map.member approvalId
+            <$> readTVarIO control.turnControlApprovals
+
+    enqueueTurn supervisor request =
+        case (parseParams request :: Either Text TurnStart) of
+            Left err -> do
+                atomically $ modifyTVar' stagedImages
+                    (Map.delete request.requestId)
+                sendEvent callback context
+                    (failureEvent request.requestId err)
+                pure supervisor
+            Right start
+                | taskExists start.turnStartId supervisor -> do
+                    atomically $ modifyTVar' stagedImages
+                        (Map.delete start.turnStartId)
+                    sendEvent callback context $
+                        failureEvent request.requestId "turn id already exists"
+                    pure supervisor
+                | otherwise -> do
+                    images <- atomically $ do
+                        staged <- readTVar stagedImages
+                        writeTVar stagedImages
+                            (Map.delete start.turnStartId staged)
+                        pure
+                            (Map.findWithDefault
+                                []
+                                start.turnStartId
+                                staged)
+                    sendEvent callback context $
+                        successEvent request.requestId $
+                            Aeson.object
+                                [ "turnId" Aeson..= start.turnStartId
+                                , "state" Aeson..= ("queued" :: Text)
+                                ]
+                    sendTaskState start.turnStartId start.turnStartSessionId
+                        "queued"
+                    pure supervisor
+                        { supervisorPending =
+                            supervisor.supervisorPending
+                                Seq.|> PendingTurn start images
+                        , supervisorKnownTaskIds =
+                            Set.insert
+                                start.turnStartId
+                                supervisor.supervisorKnownTaskIds
+                        }
+
+    startRunnableTasks supervisor = do
+        sessionIds <- activeSessionIds supervisor
+        let available =
+                supervisor.supervisorLimit
+                    - Map.size supervisor.supervisorRunning
+            pending = toList supervisor.supervisorPending
+            candidates =
+                [ ( TaskIdentity
+                        pending.pendingTurnStart.turnStartId
+                        pending.pendingTurnStart.turnStartSessionId
+                  , pending
+                  )
+                | pending <- pending
+                ]
+            (selected, remaining) =
+                selectRunnableTasks available sessionIds candidates
+        running <- foldM
+            startTask
+            supervisor.supervisorRunning
+            (map snd selected)
+        pure supervisor
+            { supervisorPending = Seq.fromList (map snd remaining)
+            , supervisorRunning = running
+            }
+
+    startTask
+        :: Map Text RunningTurn
+        -> PendingTurn
+        -> IO (Map Text RunningTurn)
+    startTask running pending = do
+        let start = pending.pendingTurnStart
+        control <- newTurnControl
+            start.turnStartId
+            start.turnStartSessionId
+        sendTaskState start.turnStartId start.turnStartSessionId "running"
+        sendTurnStatus
             callback
             context
-            config
-            store
-            root
-            processRuntime
-            commands
-            stagedImages
-            browser
-
-activeLoop
-    :: FunPtr EventCallback
-    -> Ptr ()
-    -> ManagedPostgresConfig
-    -> MVar (Maybe Store)
-    -> OsPath
-    -> EngineMailbox EngineCommand
-    -> TurnControl
-    -> Async TurnOutcome
-    -> IO ActiveExit
-activeLoop callback context config store root commands control running =
-    atomically
-        ((Left <$> readEngineCommand commands)
-            `orElse` (Right <$> waitCatchSTM running)) >>= \case
-        Right outcome -> do
-            finishTurnEvent callback context control.turnControlId outcome
-            pure ActiveContinue
-        Left EngineStop -> do
-            cancelTurn control
-            cancel running
-            pure ActiveStop
-        Left (EngineSearch query limit searchCallback searchContext) -> do
-            runConversationSearch
-                config store query limit searchCallback searchContext
-            activeLoop
-                callback context config store root commands control running
-        Left (EngineSessionMutation mutation resultCallback resultContext) -> do
-            runSessionMutation
-                config store root mutation resultCallback resultContext
-            activeLoop
-                callback context config store root commands control running
-        Left (EngineMcpRestart expected _ resultCallback resultContext) -> do
-            withText "cannot restart MCP while a turn is active" $
-                invokeMcpResultCallback resultCallback resultContext (-1)
-                    expected
-            activeLoop
-                callback context config store root commands control running
-        Left (EngineRequest request) -> do
-            if request.requestMethod == "turn.cancel"
-              then
-                case (parseParams request
-                    :: Either Text TurnReference) of
-                    Right reference
-                        | reference.turnReferenceId == control.turnControlId -> do
-                            cancelTurn control
-                            cancel running
-                            sendEvent callback context $
-                                successEvent request.requestId True
-                    _ ->
-                        sendEvent callback context $
-                            failureEvent request.requestId "turn id is not active"
-              else if request.requestMethod == "approval.resolve"
-              then
-                resolveApproval control request >>= sendEvent callback context
-              else if request.requestMethod == "turn.agents"
-              then
-                activeAgentSnapshot control request
-                    >>= sendEvent callback context
-              else if request.requestMethod == "turn.start"
-              then
-                sendEvent callback context $
-                    failureEvent request.requestId "a turn is already running"
-              else
-                handleRequest config store root request
-                    >>= sendEvent callback context
-            activeLoop
+            start.turnStartId
+            (if start.turnStartWorktree
+                then "Creating worktree…"
+                else "Starting…")
+        nativeBrowserTools <- browserToolsWhenEnabled browser
+        worker <- launchTrackedWorker start.turnStartId do
+            runNativeTurn
                 callback
                 context
-                config
-                store
-                root
                 commands
+                processRuntime
                 control
-                running
+                nativeBrowserTools
+                start
+                pending.pendingTurnImages
+        let runningTurn =
+                RunningTurn
+                    { runningTurnControl = control
+                    , runningTurnWorker = worker
+                    }
+        atomically $ modifyTVar' workerRegistry $
+            Map.insert start.turnStartId runningTurn
+        pure $ Map.insert
+            start.turnStartId
+            runningTurn
+            running
+
+    launchTrackedWorker taskId action =
+        mask \_ -> do
+            gate <- newEmptyMVar
+            worker <- asyncWithUnmask \unmask -> do
+                takeMVar gate
+                outcome <- newIORef (TaskFailure "turn cancelled")
+                (tryAny (unmask action) >>= \case
+                    Left exception ->
+                        writeIORef outcome
+                            (TaskFailure (Text.pack (show exception)))
+                    Right value ->
+                        writeIORef outcome (TaskOutcome value))
+                    `finally` do
+                        result <- readIORef outcome
+                        void $ atomically $ acceptEngineCommand
+                            commands
+                            (EngineTaskFinished taskId result)
+            putMVar gate ()
+            pure worker
+
+    activeSessionIds supervisor = do
+        sessions <- mapM
+            (readTVarIO . (.turnControlSessionId) . (.runningTurnControl))
+            (Map.elems supervisor.supervisorRunning)
+        pure (Set.fromList [session | Just session <- sessions])
+
+    cancelTaskById supervisor taskId =
+        case Map.lookup taskId supervisor.supervisorRunning of
+            Just running -> do
+                cancelTurn running.runningTurnControl
+                cancel running.runningTurnWorker
+                pure supervisor
+            Nothing -> do
+                let (cancelled, retained) = partition
+                        ((== taskId)
+                            . (.turnStartId)
+                            . (.pendingTurnStart))
+                        (toList supervisor.supervisorPending)
+                forM_ cancelled \pending ->
+                    let start = pending.pendingTurnStart
+                    in do
+                        sendTaskState
+                            start.turnStartId
+                            start.turnStartSessionId
+                            "cancelled"
+                        sendEvent callback context $
+                            turnFailedEvent
+                                start.turnStartId
+                                "turn cancelled"
+                pure supervisor
+                    { supervisorPending = Seq.fromList retained }
+
+    taskExists taskId supervisor =
+        Set.member taskId supervisor.supervisorKnownTaskIds
+
+    shutdownSupervisor _ =
+        shutdownRunningTurns workerRegistry
+
+    sendTaskState :: Text -> Maybe Text -> Text -> IO ()
+    sendTaskState taskId sessionId state =
+        sendEvent callback context $
+            Aeson.object
+                [ "event" Aeson..= ("task.state" :: Text)
+                , "taskId" Aeson..= taskId
+                , "sessionId" Aeson..= sessionId
+                , "state" Aeson..= state
+                ]
+
+    sendTaskSnapshot snapshotCallback snapshotContext supervisor = do
+        forM_ supervisor.supervisorPending \pending ->
+            sendSnapshotItem
+                snapshotCallback
+                snapshotContext
+                pending.pendingTurnStart.turnStartId
+                pending.pendingTurnStart.turnStartSessionId
+                0
+        forM_ (Map.elems supervisor.supervisorRunning) \running -> do
+            sessionId <- readTVarIO
+                running.runningTurnControl.turnControlSessionId
+            sendSnapshotItem
+                snapshotCallback
+                snapshotContext
+                running.runningTurnControl.turnControlId
+                sessionId
+                1
+        invokeTaskSnapshotCallback snapshotCallback snapshotContext
+            1 nullPtr 0 nullPtr 0 0 nullPtr 0
+
+    sendSnapshotItem snapshotCallback snapshotContext taskId sessionId state =
+        withTextBytes taskId \taskPointer taskLength ->
+        withMaybeTextBytes sessionId \sessionPointer sessionLength ->
+            invokeTaskSnapshotCallback snapshotCallback snapshotContext
+                0 taskPointer taskLength sessionPointer sessionLength
+                state nullPtr 0
+
+shutdownRunningTurns :: TVar (Map Text RunningTurn) -> IO ()
+shutdownRunningTurns workerRegistry = do
+    running <- atomically do
+        current <- readTVar workerRegistry
+        writeTVar workerRegistry Map.empty
+        pure (Map.elems current)
+    forM_ running (cancelTurn . (.runningTurnControl))
+    mapM_ (cancel . (.runningTurnWorker)) running
+    mapM_ (waitCatch . (.runningTurnWorker)) running
 
 runSessionMutation
     :: ManagedPostgresConfig
@@ -2262,13 +2612,16 @@ browserStatusMessage = \case
 runNativeTurn
     :: FunPtr EventCallback
     -> Ptr ()
+    -> EngineMailbox EngineCommand
     -> NativeProcessRuntime
     -> TurnControl
     -> [AppTool]
     -> TurnStart
     -> [ImageAttachment]
     -> IO TurnOutcome
-runNativeTurn callback context processRuntime control nativeBrowserTools start images = do
+runNativeTurn
+        callback context commands processRuntime control nativeBrowserTools
+        start images = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     let hooks = NativeRunHooks
@@ -2283,6 +2636,9 @@ runNativeTurn callback context processRuntime control nativeBrowserTools start i
                             (sendEvent callback context)
             , nativeOnSessionId = \sessionId -> do
                 writeIORef sessionIdRef (Just sessionId)
+                void $ atomically $ acceptEngineCommand
+                    commands
+                    (EngineTaskSession control.turnControlId sessionId)
                 sendEvent callback context $
                     Aeson.object
                         [ "event" Aeson..= ("turn.session" :: Text)
@@ -2393,10 +2749,12 @@ withTurnImages prompt images action = do
                 BS.writeFile path image.imageBytes
                 withImageFiles directory rest (action . (path :))
 
-newTurnControl :: Text -> IO TurnControl
-newTurnControl turnId =
+newTurnControl :: Text -> Maybe Text -> IO TurnControl
+newTurnControl turnId sessionId =
     TurnControl turnId
-        <$> newTVarIO (pure ())
+        <$> newTVarIO sessionId
+        <*> newTVarIO False
+        <*> newTVarIO (pure ())
         <*> newTVarIO Map.empty
         <*> newTVarIO 0
         <*> newTVarIO Set.empty
@@ -2437,6 +2795,7 @@ agentStepStateText = \case
 
 cancelTurn :: TurnControl -> IO ()
 cancelTurn control = do
+    atomically $ writeTVar control.turnControlCancelled True
     cancelAction <- readTVarIO control.turnControlCancel
     cancelAction
     waiters <- atomically do
@@ -2558,13 +2917,13 @@ finishTurnEvent
     :: FunPtr EventCallback
     -> Ptr ()
     -> Text
-    -> Either SomeException TurnOutcome
+    -> TaskResult
     -> IO ()
 finishTurnEvent callback context turnId = \case
-    Left exception ->
+    TaskFailure message ->
         sendEvent callback context $
-            turnFailedEvent turnId (Text.pack (show exception))
-    Right outcome ->
+            turnFailedEvent turnId message
+    TaskOutcome outcome ->
         case outcome.turnOutcomeError of
             Just err ->
                 sendEvent callback context (turnFailedEvent turnId err)
@@ -2575,6 +2934,19 @@ finishTurnEvent callback context turnId = \case
                         , "turnId" Aeson..= turnId
                         , "sessionId" Aeson..= outcome.turnOutcomeSessionId
                         ]
+
+taskResultSessionId :: Maybe Text -> TaskResult -> Maybe Text
+taskResultSessionId fallback = \case
+    TaskFailure _ -> fallback
+    TaskOutcome outcome -> outcome.turnOutcomeSessionId <|> fallback
+
+taskResultState :: TaskResult -> Text
+taskResultState = \case
+    TaskFailure _ -> "failed"
+    TaskOutcome outcome ->
+        case outcome.turnOutcomeError of
+            Just _ -> "failed"
+            Nothing -> "succeeded"
 
 nativeLoopEvent :: Text -> LoopEvent -> Maybe Aeson.Value
 nativeLoopEvent turnId = \case

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/TaskScheduler.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/TaskScheduler.hs
@@ -1,0 +1,51 @@
+module Agent.CLI.MacOS.TaskScheduler
+    ( TaskIdentity(..)
+    , selectRunnableTasks
+    ) where
+
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+
+-- | Stable scheduling identity for one native task. A missing session id is a
+-- fresh session and therefore does not conflict with another queued task.
+data TaskIdentity = TaskIdentity
+    { taskIdentityId :: !Text
+    , taskIdentitySessionId :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+-- | Select at most @capacity@ tasks in queue order while leaving tasks for an
+-- already-active (or newly-selected) session queued. Skipping a blocked task
+-- lets unrelated sessions make progress without allowing a later turn for the
+-- same session to overtake it.
+selectRunnableTasks
+    :: Int
+    -> Set Text
+    -> [(TaskIdentity, task)]
+    -> ([(TaskIdentity, task)], [(TaskIdentity, task)])
+selectRunnableTasks rawCapacity activeSessions =
+    go (max 0 rawCapacity) activeSessions [] []
+  where
+    go _ _ selected deferred [] =
+        (reverse selected, reverse deferred)
+    go 0 _ selected deferred remaining =
+        (reverse selected, reverse deferred <> remaining)
+    go capacity sessions selected deferred (candidate@(identity, _) : rest) =
+        case identity.taskIdentitySessionId of
+            Just sessionId
+                | Set.member sessionId sessions ->
+                    go capacity sessions selected (candidate : deferred) rest
+                | otherwise ->
+                    go
+                        (capacity - 1)
+                        (Set.insert sessionId sessions)
+                        (candidate : selected)
+                        deferred
+                        rest
+            Nothing ->
+                go
+                    (capacity - 1)
+                    sessions
+                    (candidate : selected)
+                    deferred
+                    rest

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -18,8 +18,11 @@ typedef void (*ha_event_callback)(
      * Kind 1 is reasoning text, 2 text, 3 status, 4 tool-start, and 5
      * tool-finish. Tool-start flags use bit 0 for encrypted arguments and
      * bit 1 for truncation; tool-finish uses bit 1 for truncation.
-     * The bytes are valid only for the duration of this callback; copy before
-     * returning.
+     * Turn IDs are stable task IDs for the lifetime of an engine. Events for
+     * one task are delivered in order, but callbacks for different tasks may
+     * run concurrently on runtime worker threads. The callback must be
+     * thread-safe and return promptly. The bytes are valid only for the
+     * duration of this callback; copy before returning.
      */
     const uint8_t *bytes,
     size_t length
@@ -470,6 +473,26 @@ typedef struct ha_image_attachment {
     size_t bytes_length;
 } ha_image_attachment;
 
+/*
+ * Active-task snapshots emit status 0 for each task, status 1 exactly once on
+ * completion, and status -1 for failure. state is 0 for queued or 1 for
+ * running. session_id is NULL/zero until a new task creates its session; all
+ * other item pointers are non-NULL. Error is populated only for status -1.
+ * Buffers are callback-scoped UTF-8 and must be copied before returning.
+ * Callbacks run serially on the engine command worker, not the caller thread.
+ */
+typedef void (*ha_task_snapshot_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *task_id,
+    size_t task_id_length,
+    const uint8_t *session_id,
+    size_t session_id_length,
+    int32_t state,
+    const uint8_t *error,
+    size_t error_length
+);
+
 /* Runtime calls are process-global and reference counted. */
 int32_t ha_runtime_init(void);
 void ha_runtime_exit(void);
@@ -502,6 +525,35 @@ int32_t ha_engine_send_json(
     const uint8_t *bytes,
     size_t length
 );
+/*
+ * Queue cancellation for a copied, non-empty UTF-8 task ID. Return 0 means
+ * the command was accepted, not that the task necessarily still exists.
+ * Terminal task outcome continues through ha_event_callback. Returns 1 for a
+ * null engine, 2 for an invalid task ID, and 3 for an internal failure.
+ */
+int32_t ha_engine_cancel_task(
+    void *engine,
+    const uint8_t *task_id,
+    size_t task_id_length
+);
+/*
+ * List currently queued and running tasks. Returns 0 when accepted, 1 for a
+ * null engine, 2 for a null callback, and 3 for an internal failure. An
+ * accepted request receives exactly one terminal callback unless destruction
+ * has begun. Calls must be serialized with ha_engine_destroy.
+ */
+int32_t ha_engine_list_tasks(
+    void *engine,
+    ha_task_snapshot_callback callback,
+    void *context
+);
+/*
+ * Set the engine-wide cross-session concurrency limit for future scheduling.
+ * Existing tasks are not cancelled when lowering it. Valid limits are 1...32;
+ * the default is 3. Returns 0 when accepted, 1 for a null engine, 2 for an
+ * invalid limit, and 3 for an internal failure.
+ */
+int32_t ha_engine_set_task_limit(void *engine, size_t limit);
 /*
  * Search active and archived (but not deleted) conversations. The query is
  * copied before return and limit is clamped to 1...100. Returns 0 when

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -10,6 +10,8 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 foreign import ccall "ha_image_attachment_stage_smoke"
     imageAttachmentStageSmoke :: IO CInt
 
+foreign import ccall "ha_task_supervisor_abi_smoke"
+    taskSupervisorAbiSmoke :: IO CInt
 #else
 import Test.Hspec (Spec, describe, it, pendingWith)
 #endif
@@ -19,6 +21,13 @@ spec = describe "native engine lifecycle smoke" do
     it "stages copied images and completes restart before destroy returns" do
 #ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0
+#else
+        pendingWith "the native bridge smoke test only links on macOS"
+#endif
+
+    it "controls and snapshots native tasks through the exported bridge" do
+#ifdef darwin_HOST_OS
+        taskSupervisorAbiSmoke `shouldReturn` 0
 #else
         pendingWith "the native bridge smoke test only links on macOS"
 #endif

--- a/packages/agent-cli/test/Agent/CLI/MacOS/TaskSchedulerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/TaskSchedulerSpec.hs
@@ -1,0 +1,71 @@
+module Agent.CLI.MacOS.TaskSchedulerSpec (spec) where
+
+import Agent.CLI.MacOS.TaskScheduler
+    ( TaskIdentity(..)
+    , selectRunnableTasks
+    )
+import qualified Data.Set as Set
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+spec :: Spec
+spec = describe "native task scheduling" do
+    it "starts distinct sessions up to the available capacity" do
+        let queued =
+                [ task "first" (Just "session-a")
+                , task "second" (Just "session-b")
+                , task "third" (Just "session-c")
+                ]
+            (selected, remaining) =
+                selectRunnableTasks 2 Set.empty queued
+        map (identityId . fst) selected
+            `shouldBe` ["first", "second"]
+        map (identityId . fst) remaining
+            `shouldBe` ["third"]
+
+    it "keeps a same-session task queued while starting unrelated work" do
+        let queued =
+                [ task "blocked" (Just "session-a")
+                , task "runnable" (Just "session-b")
+                ]
+            (selected, remaining) =
+                selectRunnableTasks 2 (Set.singleton "session-a") queued
+        map (identityId . fst) selected
+            `shouldBe` ["runnable"]
+        map (identityId . fst) remaining
+            `shouldBe` ["blocked"]
+
+    it "does not overtake an earlier task for the same queued session" do
+        let queued =
+                [ task "first-a" (Just "session-a")
+                , task "second-a" (Just "session-a")
+                , task "first-b" (Just "session-b")
+                ]
+            (selected, remaining) =
+                selectRunnableTasks 3 Set.empty queued
+        map (identityId . fst) selected
+            `shouldBe` ["first-a", "first-b"]
+        map (identityId . fst) remaining
+            `shouldBe` ["second-a"]
+
+    it "treats fresh sessions as independent tasks" do
+        let queued = [task "first" Nothing, task "second" Nothing]
+            (selected, remaining) =
+                selectRunnableTasks 2 Set.empty queued
+        map (identityId . fst) selected
+            `shouldBe` ["first", "second"]
+        remaining `shouldBe` []
+  where
+    task taskId sessionId =
+        ( TaskIdentity
+            { taskIdentityId = taskId
+            , taskIdentitySessionId = sessionId
+            }
+        , ()
+        )
+
+    identityId (TaskIdentity taskId _) = taskId

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -37,6 +37,7 @@ import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
 import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
 import qualified Agent.CLI.MacOS.BrowserBridgeFFISpec as BrowserBridgeFFISpec
 import qualified Agent.CLI.MacOS.BridgeSpec as BridgeSpec
+import qualified Agent.CLI.MacOS.TaskSchedulerSpec as TaskSchedulerSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.McpAdminSpec as McpAdminSpec
@@ -122,6 +123,7 @@ main = hspec do
     BridgeFFISpec.spec
     BrowserBridgeFFISpec.spec
     BridgeSpec.spec
+    TaskSchedulerSpec.spec
     MarkdownSpec.spec
     McpAdminSpec.spec
     McpManagerSpec.spec

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeTaskSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeTaskSmoke.c
@@ -1,0 +1,90 @@
+#include "HaskellAgentBridge.h"
+
+#include <stddef.h>
+
+typedef struct task_snapshot_state {
+    int terminal_count;
+    int invalid_item;
+} task_snapshot_state;
+
+static void task_event_callback(void *context, const uint8_t *bytes,
+                                size_t length) {
+    (void)context;
+    (void)bytes;
+    (void)length;
+}
+
+static void task_snapshot_callback(void *raw_context, int32_t status,
+                                   const uint8_t *task_id,
+                                   size_t task_id_length,
+                                   const uint8_t *session_id,
+                                   size_t session_id_length,
+                                   int32_t state,
+                                   const uint8_t *error,
+                                   size_t error_length) {
+    task_snapshot_state *context = (task_snapshot_state *)raw_context;
+    (void)session_id;
+    (void)session_id_length;
+
+    if (status == 0) {
+        if (task_id == NULL || task_id_length == 0
+                || (state != 0 && state != 1)
+                || error != NULL || error_length != 0) {
+            context->invalid_item = 1;
+        }
+    } else if (status == 1) {
+        if (task_id != NULL || task_id_length != 0
+                || error != NULL || error_length != 0) {
+            context->invalid_item = 1;
+        }
+        context->terminal_count += 1;
+    } else {
+        context->invalid_item = 1;
+    }
+}
+
+/*
+ * Exercise the task-control ABI from a native caller. FIFO command handling
+ * guarantees the accepted snapshot finishes before destroy returns.
+ */
+int ha_task_supervisor_abi_smoke(void) {
+    const uint8_t missing_task[] = "missing-task";
+    task_snapshot_state state = {0, 0};
+
+    if (ha_runtime_init() != 0) {
+        return 10;
+    }
+    void *engine = ha_engine_create(task_event_callback, NULL);
+    if (engine == NULL) {
+        ha_runtime_exit();
+        return 11;
+    }
+    if (ha_engine_set_task_limit(engine, 0) != 2
+            || ha_engine_set_task_limit(engine, 33) != 2
+            || ha_engine_set_task_limit(engine, 2) != 0) {
+        ha_engine_destroy(engine);
+        ha_runtime_exit();
+        return 12;
+    }
+    if (ha_engine_cancel_task(
+            engine, missing_task, sizeof(missing_task) - 1) != 0) {
+        ha_engine_destroy(engine);
+        ha_runtime_exit();
+        return 13;
+    }
+    if (ha_engine_list_tasks(engine, task_snapshot_callback, &state) != 0) {
+        ha_engine_destroy(engine);
+        ha_runtime_exit();
+        return 14;
+    }
+    ha_engine_destroy(engine);
+    ha_runtime_exit();
+
+    if (state.invalid_item) {
+        return 15;
+    }
+    if (state.terminal_count != 1) {
+        return 16;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace the single-active-turn native loop with stable task handles
- run up to three sessions concurrently while preserving same-session FIFO order
- expose typed task cancellation, snapshots, limits, and lifecycle events through the C ABI
- keep legacy JSON cancellation, agent, and approval behavior compatible

## Safety and ownership
- task IDs are stable and never reused within an engine
- shutdown cancels and joins tracked workers
- callback concurrency, buffer ownership, and ambiguity behavior are documented in the header

## Validation
- `nix develop -c cabal build agent-cli:flib:haskell-agent-bridge -j4`
- focused scheduler and native FFI tests: 6 examples, 0 failures
- `cabal check`
- `git diff --check`

## Dependency
Stacked on #750 so CI includes the partial-schema migration fix. This PR does not add daemon persistence; that is a separate reviewable layer.
