### PR TITLE
Auto-approve filesystem roots in yolo mode

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Approval
     , approveToolDecisionWith
     , approveToolDecisionWithReporter
     , approveToolDecisionWithReporterAndPersistence
+    , approveFilesystemRootAccess
     , childApprove
     , planApproval
     , resolveApprovalPrompt
@@ -60,6 +61,15 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import System.IO (stderr)
 import System.OsPath (OsPath)
+
+-- | Auto-approve access to additional filesystem roots while yolo mode is
+-- active. Read the live policy so toggling yolo during a session takes effect
+-- for subsequent root requests.
+approveFilesystemRootAccess :: IORef ApprovalPolicy -> IO Bool -> IO Bool
+approveFilesystemRootAccess policyRef requestAccess =
+    readIORef policyRef >>= \case
+        ApproveAll -> pure True
+        _ -> requestAccess
 
 approveToolDecision
     :: IORef ApprovalPolicy

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -89,6 +89,7 @@ runSession
 runSession callbacks SessionRequest{..} SessionBackend{..} = do
   initialPrevious <- readLivePreviousResponseId conversationRef
   ioLock <- newMVar ()
+  policyRef <- newIORef policy
   let fullscreen = startup.startupFullscreen
       terminal = startup.startupTerminal
       stdoutHandle = startup.startupStdout
@@ -102,26 +103,28 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
               Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
       withIoLock action = withMVar ioLock (const action)
       requestRootAccess root =
-          withMVar ioLock \_ ->
-              case promptRequest of
-                  Just request
-                      | isJust request.managedTurnBridgeDirectory ->
-                          requestManagedRootAccess request root
-                  _ -> case fullscreen of
-                      Just runtime -> do
-                          notifyAttention stderrHandle PermissionRequested
-                          maybe False (== 0)
-                              <$> requestFullscreenChoiceWithBody
-                                  runtime
-                                  "Filesystem access requested"
-                                  ("Allow access to " <> toText root
-                                      <> " for this session?")
-                                  0
-                                  [ ("Allow directory for this session", "")
-                                  , ("Deny", "")
-                                  ]
-                      Nothing ->
-                          withStdinPaused escPaused (promptRootAccess useColor root)
+          approveFilesystemRootAccess policyRef $
+              withMVar ioLock \_ ->
+                  case promptRequest of
+                      Just request
+                          | isJust request.managedTurnBridgeDirectory ->
+                              requestManagedRootAccess request root
+                      _ -> case fullscreen of
+                          Just runtime -> do
+                              notifyAttention stderrHandle PermissionRequested
+                              maybe False (== 0)
+                                  <$> requestFullscreenChoiceWithBody
+                                      runtime
+                                      "Filesystem access requested"
+                                      ("Allow access to " <> toText root
+                                          <> " for this session?")
+                                      0
+                                      [ ("Allow directory for this session", "")
+                                      , ("Deny", "")
+                                      ]
+                          Nothing ->
+                              withStdinPaused escPaused
+                                  (promptRootAccess useColor root)
       reportSessionError message =
           case fullscreen of
               Just runtime ->
@@ -404,7 +407,6 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     when (omitted > 0) $
                         emitUiEvent runtime
                             (UiSystemMessage (formatSkillOmission omitted))
-    policyRef <- newIORef policy
     managedLoopPublisher <-
         maybe
             (pure (const (pure ())))

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.Approval
     , ApprovalFacts(..)
     , ApprovalNotice(..)
     , ApprovalPlan(..)
+    , approveFilesystemRootAccess
     , approveToolDecisionWithReporter
     , approveToolDecisionWithReporterAndPersistence
     , childApprove
@@ -33,6 +34,7 @@ import Data.IORef
     ( modifyIORef'
     , newIORef
     , readIORef
+    , writeIORef
     )
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -195,6 +197,21 @@ spec = do
                         (ApprovalSuccess
                             "✓ always allow run_terminal_command this session")
                     ]
+
+    describe "approveFilesystemRootAccess" do
+        it "bypasses the prompt whenever the live policy is yolo" do
+            policy <- newIORef PromptMutating
+            requests <- newIORef (0 :: Int)
+            let request = modifyIORef' requests (+ 1) >> pure False
+
+            approveFilesystemRootAccess policy request
+                `shouldReturn` False
+            readIORef requests `shouldReturn` 1
+
+            writeIORef policy ApproveAll
+            approveFilesystemRootAccess policy request
+                `shouldReturn` True
+            readIORef requests `shouldReturn` 1
 
     describe "approveToolDecisionWith" do
         it "does not classify, prompt, or persist a catastrophic shell call" do


### PR DESCRIPTION
## Summary
- route additional filesystem-root access through the live session approval policy
- auto-approve out-of-root read and write access while YOLO mode is active
- preserve existing prompts outside YOLO and honor runtime `/yolo` toggles

## Validation
- `nix develop -c cabal repl -v0 agent-cli:test:agent-cli-test --repl-no-load` (focused `Agent.CLI.ApprovalSpec`: 31 examples, 0 failures)
- tmux smoke test: YOLO session read and wrote files outside the working root with zero filesystem permission dialogs
- `git diff --check`
