### PR TITLE
feat: support OpenAI dictation with ChatGPT OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ have to be.
 - **Guided agent workflows:** use plan mode, reusable skills, and scoped learned
   guidance for repeatable tasks and project or user preferences.
 - **Multimodal input and live voice dictation:** attach images and files, or
-  press `Ctrl+R` on macOS to stream microphone audio to xAI and insert the live
-  transcript into the prompt.
+  press `Ctrl+R` on macOS to stream microphone audio to OpenAI or xAI and
+  insert the transcript into the prompt.
 - **Telegram access:** run a durable, allowlisted Telegram gateway with
   per-conversation sessions, multimodal messages, approvals, retries, and
   bounded concurrent processing.
@@ -209,9 +209,18 @@ Works with your Codex, Grok, and Claude subscriptions, plus provider API keys.
 
 Press `Ctrl+R` in the prompt composer, speak, and press `Enter` to stop
 (or `Esc` to cancel). Recording stays in the TUI; it does not suspend or close
-the session. On macOS, audio is streamed to xAI and the live transcript is
-inserted at the cursor. Dictation uses the configured xAI credentials; set
-`XAI_STT_LANGUAGE` to override the default `en`.
+the session. On macOS, the resulting transcript is inserted at the cursor.
+Dictation prefers OpenAI credentials. ChatGPT/Codex OAuth uses the
+subscription-backed streaming protocol used by the official desktop app and
+falls back to its buffered ChatGPT transcription route with the same recording
+if streaming fails. API keys use the public OpenAI Realtime API. Both paths can
+update the composer while recording. Subscription auth is preferred when both
+are configured. Credentials can come from
+`CODEX_ACCESS_TOKEN`, `CODEX_AUTH_JSON`, `$CODEX_HOME/auth.json` (defaulting to
+`~/.codex/auth.json`),
+`OPENAI_API_KEY`, `CODEX_API_KEY`, or a managed OpenAI account. Without an
+OpenAI credential, dictation falls back to the configured xAI credentials; set
+`XAI_STT_LANGUAGE` to override xAI's default `en`.
 
 ### Claude Code subscription
 

--- a/README.md
+++ b/README.md
@@ -210,17 +210,20 @@ Works with your Codex, Grok, and Claude subscriptions, plus provider API keys.
 Press `Ctrl+R` in the prompt composer, speak, and press `Enter` to stop
 (or `Esc` to cancel). Recording stays in the TUI; it does not suspend or close
 the session. On macOS, the resulting transcript is inserted at the cursor.
-Dictation prefers OpenAI credentials. ChatGPT/Codex OAuth uses the
-subscription-backed streaming protocol used by the official desktop app and
-falls back to its buffered ChatGPT transcription route with the same recording
-if streaming fails. API keys use the public OpenAI Realtime API. Both paths can
-update the composer while recording. Subscription auth is preferred when both
-are configured. Credentials can come from
+Dictation follows the active model provider: OpenAI models use OpenAI and Grok
+models use xAI. ChatGPT/Codex OAuth uses the subscription-backed streaming
+protocol used by the official desktop app and falls back to its buffered
+ChatGPT transcription route with the same recording if streaming fails. API
+keys use the public OpenAI Realtime API. Both OpenAI paths can update the
+composer while recording. Subscription auth is preferred when both OpenAI
+credential types are configured. OpenAI credentials can come from
 `CODEX_ACCESS_TOKEN`, `CODEX_AUTH_JSON`, `$CODEX_HOME/auth.json` (defaulting to
 `~/.codex/auth.json`),
-`OPENAI_API_KEY`, `CODEX_API_KEY`, or a managed OpenAI account. Without an
-OpenAI credential, dictation falls back to the configured xAI credentials; set
-`XAI_STT_LANGUAGE` to override xAI's default `en`.
+`OPENAI_API_KEY`, `CODEX_API_KEY`, or a managed OpenAI account.
+For Grok models, dictation uses the configured xAI subscription or API-key
+credential; set `XAI_STT_LANGUAGE` to override xAI's default `en`.
+Dictation is currently unavailable for providers without a speech-to-text
+integration.
 
 ### Claude Code subscription
 

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -16,6 +16,7 @@ module Agent.CLI.Auth
     , hasOpenAiAuth
     , loadAuth
     , loadAuthForAccount
+    , loadOpenAiDictationAuth
     , managedAuthSelectionId
     , managedGrokTokenProvider
     , ExternalGrokLoaded(..)
@@ -43,6 +44,7 @@ import Agent.CLI.Auth.Grok
     )
 import Agent.CLI.Auth.OpenAI
     ( loadOpenAi
+    , loadOpenAiDictationAuth
     , openAiAuthStateChanged
     , preferredOpenAiTokenProvider
     )
@@ -373,8 +375,14 @@ hasOpenAiAuth = do
     envJson <- lookupNonEmpty "CODEX_AUTH_JSON"
     envToken <- lookupNonEmpty "CODEX_ACCESS_TOKEN"
     home <- getHomeDirectory
+    configuredCodexHome <- lookupNonEmpty "CODEX_HOME"
+    let codexDirectory =
+            maybe
+                (home </> unsafeEncodeUtf ".codex")
+                (unsafeEncodeUtf . Text.unpack)
+                configuredCodexHome
     file <- doesFileExist
-        (home </> unsafeEncodeUtf ".codex" </> unsafeEncodeUtf "auth.json")
+        (codexDirectory </> unsafeEncodeUtf "auth.json")
     managed <- hasManagedProvider OpenAIProvider
     pure (isJust envJson || isJust envToken || file || managed)
 

--- a/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
@@ -1,5 +1,6 @@
 module Agent.CLI.Auth.OpenAI
     ( loadOpenAi
+    , loadOpenAiDictationAuth
     , openAiAuthStateChanged
     , preferredOpenAiTokenProvider
     ) where
@@ -8,6 +9,9 @@ import Agent.CLI.Auth.Types
     ( LoadedAuth(..)
     , authStateToJson
     , credentialAccountLabel
+    , credentialAccountLabelWith
+    , externalAuthSelectionId
+    , managedAuthSelectionId
     , nonEmptyText
     , openAIOAuthClientId
     , openaiAuthStateFromJson
@@ -41,8 +45,9 @@ import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Monad (when)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Except (ExceptT, throwE)
+import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
 import qualified Data.Aeson as Aeson
+import Data.Aeson ((.:?))
 import qualified Data.ByteString.Lazy as LBS
 import Data.Either (partitionEithers)
 import Data.IORef
@@ -53,7 +58,7 @@ import Data.IORef
     )
 import Data.Containers.ListUtils (nubOrdOn)
 import Data.List (find)
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -63,6 +68,21 @@ import System.Directory.OsPath
     , getHomeDirectory
     )
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+
+data OpenAiApiKeySource = OpenAiApiKeySource
+    { apiKeyAccessToken :: !Text
+    , apiKeyAccountId :: !Text
+    , apiKeyLabel :: !Text
+    , apiKeySelectionId :: !Text
+    }
+
+newtype CodexApiKey = CodexApiKey
+    { codexOpenAiApiKey :: Maybe Text
+    }
+
+instance Aeson.FromJSON CodexApiKey where
+    parseJSON = Aeson.withObject "Codex auth" \object ->
+        CodexApiKey <$> object .:? "OPENAI_API_KEY"
 
 -- | Pin normal checkouts to one OpenAI pool account until that credential is
 -- reported as failed. A failure for the selected credential clears the pin
@@ -110,6 +130,158 @@ preferredOpenAiTokenProvider preferredAccount pool fallback =
                     }
             Left err ->
                 pure (Left err)
+
+-- | Load the best OpenAI credential for dictation. ChatGPT OAuth is preferred
+-- because the official desktop client transcribes subscription audio through
+-- the ChatGPT backend. API keys remain available for the public Realtime API.
+loadOpenAiDictationAuth :: IO (Maybe LoadedAuth)
+loadOpenAiDictationAuth =
+    runExceptT loadOpenAi >>= \case
+        Right loaded
+            | tokenProviderBillingMode loaded.loadedTokenProvider
+                == SubscriptionBilled ->
+                pure (Just loaded)
+            | otherwise ->
+                loadExternalOpenAiApiKeyDictationAuth >>= \case
+                    Just external ->
+                        pure (Just external)
+                    Nothing ->
+                        pure (Just loaded)
+        Left _ ->
+            loadOpenAiApiKeyDictationAuth
+
+loadOpenAiApiKeyDictationAuth :: IO (Maybe LoadedAuth)
+loadOpenAiApiKeyDictationAuth =
+    loadOpenAiApiKeyDictationAuthWith True
+
+loadExternalOpenAiApiKeyDictationAuth :: IO (Maybe LoadedAuth)
+loadExternalOpenAiApiKeyDictationAuth =
+    loadOpenAiApiKeyDictationAuthWith False
+
+loadOpenAiApiKeyDictationAuthWith :: Bool -> IO (Maybe LoadedAuth)
+loadOpenAiApiKeyDictationAuthWith includeManaged =
+    fmap (fmap loadedAuthForApiKey) $
+        firstJustM
+            ( [ loadEnvironmentApiKey "OPENAI_API_KEY"
+              , loadEnvironmentApiKey "CODEX_API_KEY"
+              , loadCodexEnvironmentApiKey
+              , loadCodexFileApiKey
+              ]
+                <> if includeManaged
+                    then
+                        [managedApiKeySource <$> loadManagedCredentials]
+                    else []
+            )
+  where
+    loadEnvironmentApiKey variable = do
+        key <- (>>= nonEmptyText) <$> lookupNonEmpty variable
+        pure $
+            externalApiKeySource
+                (Text.pack variable)
+                "OpenAI API key"
+                <$> key
+    loadCodexEnvironmentApiKey = do
+        value <- lookupNonEmpty "CODEX_AUTH_JSON"
+        pure $
+            externalApiKeySource
+                "CODEX_AUTH_JSON"
+                "OpenAI API key"
+                <$> (value >>= codexApiKeyFromText)
+    loadCodexFileApiKey = do
+        codexHome <- lookupNonEmpty "CODEX_HOME"
+        codexDirectory <- case codexHome of
+            Just path ->
+                pure (unsafeEncodeUtf (Text.unpack path))
+            Nothing ->
+                (</> unsafeEncodeUtf ".codex") <$> getHomeDirectory
+        let filePath = codexDirectory </> unsafeEncodeUtf "auth.json"
+        fileExists <- doesFileExist filePath
+        fileBytes <- if fileExists
+            then
+                Just
+                    <$> retryOnFileBusy
+                        (LBS.readFile (unsafeToFilePath filePath))
+            else pure Nothing
+        pure $
+            externalApiKeySource
+                (Text.pack (unsafeToFilePath filePath))
+                "OpenAI API key"
+                <$> (fileBytes >>= codexApiKeyFromJson)
+
+firstJustM :: [IO (Maybe value)] -> IO (Maybe value)
+firstJustM = \case
+    [] ->
+        pure Nothing
+    action : remaining ->
+        action >>= \case
+            Just value ->
+                pure (Just value)
+            Nothing ->
+                firstJustM remaining
+
+externalApiKeySource :: Text -> Text -> Text -> OpenAiApiKeySource
+externalApiKeySource source label accessToken =
+    OpenAiApiKeySource
+        { apiKeyAccessToken = accessToken
+        , apiKeyAccountId = ""
+        , apiKeyLabel = label
+        , apiKeySelectionId =
+            externalAuthSelectionId OpenAIProvider source
+        }
+
+managedApiKeySource
+    :: Either Text [(ManagedCredential, ManagedSecret)]
+    -> Maybe OpenAiApiKeySource
+managedApiKeySource = \case
+    Left _ ->
+        Nothing
+    Right credentials ->
+        listToMaybe
+            [ OpenAiApiKeySource
+                { apiKeyAccessToken = accessToken
+                , apiKeyAccountId = metadata.managedAccountId
+                , apiKeyLabel = metadata.managedLabel
+                , apiKeySelectionId =
+                    managedAuthSelectionId metadata.managedId
+                }
+            | (metadata, secret) <- credentials
+            , metadata.managedEnabled
+            , metadata.managedProvider == OpenAIProvider
+            , metadata.managedBilling == ApiBilled
+            , metadata.managedAuthKind == ManagedBearerToken
+            , Just accessToken <- [nonEmptyText secret.secretPayload]
+            ]
+
+codexApiKeyFromText :: Text -> Maybe Text
+codexApiKeyFromText =
+    codexApiKeyFromJson . LBS.fromStrict . TextEncoding.encodeUtf8
+
+codexApiKeyFromJson :: LBS.ByteString -> Maybe Text
+codexApiKeyFromJson bytes = do
+    CodexApiKey{codexOpenAiApiKey} <- Aeson.decode bytes
+    codexOpenAiApiKey >>= nonEmptyText
+
+loadedAuthForApiKey :: OpenAiApiKeySource -> LoadedAuth
+loadedAuthForApiKey source =
+    LoadedAuth
+        { loadedProvider = OpenAIProvider
+        , loadedTokenProvider =
+            tokenProvider ApiBilled \case
+                Nothing ->
+                    pure $ Right Credential
+                        { accessToken = source.apiKeyAccessToken
+                        , accountId = source.apiKeyAccountId
+                        , leaseId = Nothing
+                        , provider = OpenAIProvider
+                        }
+                Just _ ->
+                    pure $ Left $ CredentialError
+                        "OpenAI API-key credential was rejected"
+        , loadedAccountLabel =
+            pure . credentialAccountLabelWith source.apiKeyLabel
+        , loadedSelectionId = Just source.apiKeySelectionId
+        , loadedOpenAiPool = Nothing
+        }
 
 loadOpenAi :: ExceptT Text IO LoadedAuth
 loadOpenAi = do
@@ -160,8 +332,13 @@ loadOpenAiAccounts = do
     fromEnvToken <- lookupNonEmpty "CODEX_ACCESS_TOKEN"
     fromEnvJson <- lookupNonEmpty "CODEX_AUTH_JSON"
     home <- getHomeDirectory
-    let filePath =
-            home </> unsafeEncodeUtf ".codex" </> unsafeEncodeUtf "auth.json"
+    configuredCodexHome <- lookupNonEmpty "CODEX_HOME"
+    let codexDirectory =
+            maybe
+                (home </> unsafeEncodeUtf ".codex")
+                (unsafeEncodeUtf . Text.unpack)
+                configuredCodexHome
+        filePath = codexDirectory </> unsafeEncodeUtf "auth.json"
     fileExists <- doesFileExist filePath
     fileBytes <- if fileExists
         then Just <$> retryOnFileBusy (LBS.readFile (unsafeToFilePath filePath))

--- a/packages/agent-cli/src/Agent/CLI/Dictation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation.hs
@@ -1,9 +1,12 @@
 -- | Terminal microphone recording and provider transcription.
 module Agent.CLI.Dictation
-    ( DictationControl(..)
+    ( DictationBackend(..)
+    , DictationControl(..)
     , DictationResult(..)
     , dictate
+    , dictateForProvider
     , dictateWith
+    , dictationBackendForProvider
     , insertDictation
     , transcribeAudio
     ) where
@@ -17,7 +20,10 @@ import Agent.OpenAI.Transcription
     ( openAITranscriptionSampleRate
     , transcribePcmWithOpenAI
     )
-import Agent.Provider (Provider(XAIProvider))
+import Agent.Provider
+    ( Provider(..)
+    , providerSlug
+    )
 import Agent.XAI.Transcription
     ( transcribeAudioWithXAI
     , transcribePcmWithXAI
@@ -77,13 +83,37 @@ data DictationResult
     | DictationFailed !Text
     deriving (Eq, Show)
 
--- | Stream the default microphone until Enter and return the transcript.
+data DictationBackend
+    = OpenAIDictation
+    | XAIDictation
+    deriving (Eq, Show)
+
+-- | Select dictation from the active model provider. Providers without a
+-- speech-to-text integration fail explicitly rather than spending credentials
+-- from an unrelated provider.
+dictationBackendForProvider :: Provider -> Either Text DictationBackend
+dictationBackendForProvider = \case
+    OpenAIProvider -> Right OpenAIDictation
+    XAIProvider -> Right XAIDictation
+    provider ->
+        Left $
+            "Dictation is not supported for "
+                <> providerSlug provider
+                <> " models"
+
+-- | Legacy standalone entry point. The inline model-aware REPL and fullscreen
+-- composer use 'dictateForProvider'; this preserves the original xAI default
+-- for callers that have no active model context.
 dictate :: IO Text
-dictate = do
+dictate = dictateForProvider XAIProvider
+
+-- | Stream the default microphone using the active model provider.
+dictateForProvider :: Provider -> IO Text
+dictateForProvider provider = do
     Text.hPutStrLn stderr "● Starting dictation…"
     hFlush stderr
     result <-
-        dictateWith
+        dictateWith provider
             DictationControl
                 { dictationWaitForStop = do
                     Text.hPutStr stderr "● Listening… press Enter to stop"
@@ -98,40 +128,47 @@ dictate = do
 
 -- | Record microphone audio until the caller signals stop. Providers that
 -- stream partial transcripts deliver them through the control callback.
-dictateWith :: DictationControl -> IO DictationResult
-dictateWith control =
+dictateWith :: Provider -> DictationControl -> IO DictationResult
+dictateWith provider control =
     try run >>= \case
         Left (err :: SomeException) ->
             pure (DictationFailed (Text.pack (displayException err)))
         Right result ->
             pure result
   where
-    run = do
-        requireExecutable "ffmpeg"
-        loadOpenAiDictationAuth >>= \case
-            Just loaded ->
-                finish =<<
-                    transcribePcmWithOpenAI
-                        loaded.loadedTokenProvider
-                        (streamMicrophone
-                            openAITranscriptionSampleRate
-                            control.dictationWaitForStop)
-                        control.dictationOnTranscript
-            Nothing ->
-                loadAuth (Just XAIProvider) >>= \case
-                    Left err ->
-                        pure $ DictationFailed $
-                            err
-                                <> " Configure ChatGPT/Codex OAuth or an OpenAI \
-                                   \API key to use OpenAI dictation."
-                    Right loaded ->
-                        finish =<<
-                            transcribePcmWithXAI
-                                loaded.loadedTokenProvider
-                                (streamMicrophone
-                                    16_000
-                                    control.dictationWaitForStop)
-                                control.dictationOnTranscript
+    run =
+        case dictationBackendForProvider provider of
+            Left err ->
+                pure (DictationFailed err)
+            Right backend -> do
+                requireExecutable "ffmpeg"
+                runBackend backend
+    runBackend = \case
+        OpenAIDictation ->
+            loadOpenAiDictationAuth >>= \case
+                Nothing ->
+                    pure $ DictationFailed
+                        "No OpenAI credential found for OpenAI dictation"
+                Just loaded ->
+                    finish =<<
+                        transcribePcmWithOpenAI
+                            loaded.loadedTokenProvider
+                            (streamMicrophone
+                                openAITranscriptionSampleRate
+                                control.dictationWaitForStop)
+                            control.dictationOnTranscript
+        XAIDictation ->
+            loadAuth (Just XAIProvider) >>= \case
+                Left err ->
+                    pure (DictationFailed err)
+                Right loaded ->
+                    finish =<<
+                        transcribePcmWithXAI
+                            loaded.loadedTokenProvider
+                            (streamMicrophone
+                                16_000
+                                control.dictationWaitForStop)
+                            control.dictationOnTranscript
     finish = \case
         Left err ->
             pure (DictationFailed (Text.pack (show err)))

--- a/packages/agent-cli/src/Agent/CLI/Dictation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation.hs
@@ -1,4 +1,4 @@
--- | Terminal microphone recording and xAI streaming transcription.
+-- | Terminal microphone recording and provider transcription.
 module Agent.CLI.Dictation
     ( DictationControl(..)
     , DictationResult(..)
@@ -8,7 +8,15 @@ module Agent.CLI.Dictation
     , transcribeAudio
     ) where
 
-import Agent.CLI.Auth (LoadedAuth(..), loadAuth)
+import Agent.CLI.Auth
+    ( LoadedAuth(..)
+    , loadAuth
+    , loadOpenAiDictationAuth
+    )
+import Agent.OpenAI.Transcription
+    ( openAITranscriptionSampleRate
+    , transcribePcmWithOpenAI
+    )
 import Agent.Provider (Provider(XAIProvider))
 import Agent.XAI.Transcription
     ( transcribeAudioWithXAI
@@ -69,7 +77,7 @@ data DictationResult
     | DictationFailed !Text
     deriving (Eq, Show)
 
--- | Stream the default microphone to xAI until Enter and return the transcript.
+-- | Stream the default microphone until Enter and return the transcript.
 dictate :: IO Text
 dictate = do
     Text.hPutStrLn stderr "● Starting dictation…"
@@ -88,8 +96,8 @@ dictate = do
         DictationTranscript transcript -> pure transcript
         DictationFailed err -> fail (Text.unpack err)
 
--- | Stream microphone audio until the caller signals stop. Partial transcripts
--- are delivered through the control callback so a TUI can stay on-screen.
+-- | Record microphone audio until the caller signals stop. Providers that
+-- stream partial transcripts deliver them through the control callback.
 dictateWith :: DictationControl -> IO DictationResult
 dictateWith control =
     try run >>= \case
@@ -100,19 +108,35 @@ dictateWith control =
   where
     run = do
         requireExecutable "ffmpeg"
-        loadAuth (Just XAIProvider) >>= \case
-            Left err ->
-                pure (DictationFailed err)
-            Right loaded -> do
-                result <-
-                    transcribePcmWithXAI
+        loadOpenAiDictationAuth >>= \case
+            Just loaded ->
+                finish =<<
+                    transcribePcmWithOpenAI
                         loaded.loadedTokenProvider
-                        (streamMicrophone control.dictationWaitForStop)
+                        (streamMicrophone
+                            openAITranscriptionSampleRate
+                            control.dictationWaitForStop)
                         control.dictationOnTranscript
-                pure $ case result of
-                    Left err -> DictationFailed (Text.pack (show err))
-                    Right transcript ->
-                        DictationTranscript (Text.strip transcript)
+            Nothing ->
+                loadAuth (Just XAIProvider) >>= \case
+                    Left err ->
+                        pure $ DictationFailed $
+                            err
+                                <> " Configure ChatGPT/Codex OAuth or an OpenAI \
+                                   \API key to use OpenAI dictation."
+                    Right loaded ->
+                        finish =<<
+                            transcribePcmWithXAI
+                                loaded.loadedTokenProvider
+                                (streamMicrophone
+                                    16_000
+                                    control.dictationWaitForStop)
+                                control.dictationOnTranscript
+    finish = \case
+        Left err ->
+            pure (DictationFailed (Text.pack (show err)))
+        Right transcript ->
+            pure (DictationTranscript (Text.strip transcript))
 
 -- | Transcribe an existing audio file using the configured Grok/xAI
 -- subscription or API-key credential.
@@ -137,8 +161,8 @@ requireExecutable command =
                 command
                     <> " is required for dictation but was not found on PATH"
 
-streamMicrophone :: IO () -> (BS.ByteString -> IO ()) -> IO ()
-streamMicrophone waitForStop sendAudio =
+streamMicrophone :: Int -> IO () -> (BS.ByteString -> IO ()) -> IO ()
+streamMicrophone sampleRate waitForStop sendAudio =
     bracket start stop \(input, output, process) ->
         withAsync waitForStop \stopKey ->
             withAsync (pump output) \audioPump ->
@@ -160,7 +184,7 @@ streamMicrophone waitForStop sendAudio =
                                         <> ")"
   where
     pump output = do
-        bytes <- BS.hGetSome output 3200
+        bytes <- BS.hGetSome output (sampleRate * 2 `div` 10)
         unless (BS.null bytes) do
             sendAudio bytes
             pump output
@@ -173,7 +197,7 @@ streamMicrophone waitForStop sendAudio =
                     , "-f", "avfoundation"
                     , "-i", ":default"
                     , "-ac", "1"
-                    , "-ar", "16000"
+                    , "-ar", show sampleRate
                     , "-c:a", "pcm_s16le"
                     , "-f", "s16le"
                     , "pipe:1"

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -4,8 +4,10 @@
 module Agent.CLI.Input
     ( ReplLine(..)
     , readReplLine
+    , readReplLineForProvider
     , readReplLineWithInitial
     , readReplLineWithCatalog
+    , readReplLineWithCatalogForProvider
     , readReplLineWithSkills
     , readReplLineWithSkillsAndModels
     , readApprovalLine
@@ -35,7 +37,11 @@ import Agent.CLI.Clipboard
     ( nonEmptyClipboardText
     , readClipboardText
     )
-import Agent.CLI.Dictation (dictate, insertDictation)
+import Agent.CLI.Dictation
+    ( dictate
+    , dictateForProvider
+    , insertDictation
+    )
 import Agent.CLI.Command
     ( SkillCommand
     , SlashCatalog(..)
@@ -57,6 +63,7 @@ import Agent.CLI.Interrupt
     , InterruptState
     , noteIdleCtrlC
     )
+import Agent.Provider (Provider)
 import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
     , detectTerminalCapabilities
@@ -128,12 +135,20 @@ import System.Posix.Terminal
 readReplLine :: InterruptState -> Text -> IO ReplLine
 readReplLine interrupt prompt =
     readReplLineConfigured
+        Nothing
+        defaultSlashCatalog False interrupt prompt ""
+
+-- | Read a prompt whose dictation backend follows the active model provider.
+readReplLineForProvider :: Provider -> InterruptState -> Text -> IO ReplLine
+readReplLineForProvider provider interrupt prompt =
+    readReplLineConfigured
+        (Just provider)
         defaultSlashCatalog False interrupt prompt ""
 
 -- | Like 'readReplLine', restoring @initial@ as the in-progress draft.
 readReplLineWithInitial :: InterruptState -> Text -> Text -> IO ReplLine
 readReplLineWithInitial =
-    readReplLineConfigured defaultSlashCatalog True
+    readReplLineConfigured Nothing defaultSlashCatalog True
 
 readReplLineWithCatalog
     :: SlashCatalog
@@ -142,7 +157,17 @@ readReplLineWithCatalog
     -> Text
     -> IO ReplLine
 readReplLineWithCatalog catalog =
-    readReplLineConfigured catalog True
+    readReplLineConfigured Nothing catalog True
+
+readReplLineWithCatalogForProvider
+    :: Provider
+    -> SlashCatalog
+    -> InterruptState
+    -> Text
+    -> Text
+    -> IO ReplLine
+readReplLineWithCatalogForProvider provider catalog =
+    readReplLineConfigured (Just provider) catalog True
 
 readReplLineWithSkills
     :: [SkillCommand]
@@ -152,6 +177,7 @@ readReplLineWithSkills
     -> IO ReplLine
 readReplLineWithSkills skills =
     readReplLineConfigured
+        Nothing
         (slashCatalogWithSkills skills defaultSlashCatalog)
         True
 
@@ -164,19 +190,22 @@ readReplLineWithSkillsAndModels
     -> IO ReplLine
 readReplLineWithSkillsAndModels skills modelIds =
     readReplLineConfigured
+        Nothing
         ((slashCatalogWithSkills skills defaultSlashCatalog)
             { slashCatalogModelIds = modelIds
             })
         True
 
 readReplLineConfigured
-    :: SlashCatalog
+    :: Maybe Provider
+    -> SlashCatalog
     -> Bool
     -> InterruptState
     -> Text
     -> Text
     -> IO ReplLine
-readReplLineConfigured catalog slashEnabled interrupt prompt initial = do
+readReplLineConfigured
+        dictationProvider catalog slashEnabled interrupt prompt initial = do
     isTty <- hIsTerminalDevice stdin
     if isTty
         then do
@@ -185,7 +214,13 @@ readReplLineConfigured catalog slashEnabled interrupt prompt initial = do
             ensureHistoryParent path
             classifyLine <$>
                 readInlineEditor
-                    catalog slashEnabled interrupt path prompt initial
+                    dictationProvider
+                    catalog
+                    slashEnabled
+                    interrupt
+                    path
+                    prompt
+                    initial
         else do
             Text.hPutStr stdout prompt
             hFlush stdout
@@ -201,7 +236,8 @@ readReplLineConfigured catalog slashEnabled interrupt prompt initial = do
 -- | First-party inline editor for the interactive TTY path. It owns the
 -- prompt redraw so slash suggestions can update after every keystroke.
 readInlineEditor
-    :: SlashCatalog
+    :: Maybe Provider
+    -> SlashCatalog
     -> Bool
     -> InterruptState
     -> FilePath
@@ -209,7 +245,13 @@ readInlineEditor
     -> Text
     -> IO ReplLine
 readInlineEditor
-        catalog slashEnabled interrupt historyPath prompt initial = do
+        dictationProvider
+        catalog
+        slashEnabled
+        interrupt
+        historyPath
+        prompt
+        initial = do
     withBracketedPaste $
         withEditorKittyKeyboard $
             withEditorRawStdin $
@@ -255,7 +297,8 @@ readInlineEditor
                 editorLoop history entries next
             DictateIntoEditor -> do
                 finishEditorLine prompt next
-                result <- tryAny dictate
+                result <- tryAny $
+                    maybe dictate dictateForProvider dictationProvider
                 case result of
                     Left err ->
                         Text.putStrLn

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -23,7 +23,7 @@ import Agent.CLI.CancelWatch (withStdinPaused)
 import Agent.CLI.Input
     ( ReplLine(..)
     , readChoiceSelection
-    , readReplLine
+    , readReplLineForProvider
     )
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.Markdown (renderMarkdown)
@@ -48,6 +48,7 @@ import Agent.Tools.PlanMode
     , PlanModeHooks(..)
     , planApprovedContinuation
     )
+import Agent.Provider (Provider)
 import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe (throwIO)
 import Data.Char (toLower)
@@ -65,12 +66,14 @@ import System.IO (Handle, hFlush, hIsTerminalDevice, stderr, stdin)
 
 -- | Build plan-mode prompts. @escPaused@ pauses the Esc cancel watcher so
 -- arrow keys / single-key answers are not stolen mid-turn.
-cliPlanHooks :: InterruptState -> IORef Bool -> IO Bool -> PlanModeHooks
-cliPlanHooks interrupt escPaused resolveColor = PlanModeHooks
+cliPlanHooks :: Provider -> InterruptState -> IORef Bool -> IO Bool -> PlanModeHooks
+cliPlanHooks provider interrupt escPaused resolveColor = PlanModeHooks
     { planConfirmEnter = withStdinPaused escPaused . confirmEnter resolveColor
-    , planDecideExit = withStdinPaused escPaused . decideExit interrupt resolveColor
+    , planDecideExit =
+        withStdinPaused escPaused . decideExit provider interrupt resolveColor
     , planAskQuestion = \q opts ->
-        withStdinPaused escPaused (askQuestion interrupt resolveColor q opts)
+        withStdinPaused escPaused
+            (askQuestion provider interrupt resolveColor q opts)
     }
 
 data PlanEnterChoice = PlanEnter | PlanStayNormal
@@ -133,8 +136,8 @@ enterChoiceFromIndex :: Int -> PlanEnterChoice
 enterChoiceFromIndex 0 = PlanEnter
 enterChoiceFromIndex _ = PlanStayNormal
 
-decideExit :: InterruptState -> IO Bool -> Text -> IO PlanDecision
-decideExit interrupt resolveColor planBody = do
+decideExit :: Provider -> InterruptState -> IO Bool -> Text -> IO PlanDecision
+decideExit provider interrupt resolveColor planBody = do
     color <- resolveColor
     isTty <- hIsTerminalDevice stdin
     putTextLn stderr ""
@@ -146,10 +149,10 @@ decideExit interrupt resolveColor planBody = do
         then pure PlanCancel
         else do
             notifyAttention stderr InputRequested
-            promptDecision interrupt color
+            promptDecision provider interrupt color
 
-promptDecision :: InterruptState -> Bool -> IO PlanDecision
-promptDecision interrupt color = do
+promptDecision :: Provider -> InterruptState -> Bool -> IO PlanDecision
+promptDecision provider interrupt color = do
     result <-
         runOverlay
             (renderPlanExitFrame color)
@@ -163,7 +166,7 @@ promptDecision interrupt color = do
             putTextLn stderr (roleMuted color "plan cancelled")
             pure PlanCancel
         PlanRequestChanges _ -> do
-            notes <- readChangeNotes interrupt color
+            notes <- readChangeNotes provider interrupt color
             pure (PlanRequestChanges notes)
 
 applyPlanExitKey
@@ -205,46 +208,52 @@ renderPlanRow color selected label =
         body = if selected then roleSuccess color label else roleMuted color label
     in cursor <> body
 
-readChangeNotes :: InterruptState -> Bool -> IO Text
-readChangeNotes interrupt color = do
+readChangeNotes :: Provider -> InterruptState -> Bool -> IO Text
+readChangeNotes provider interrupt color = do
     notifyAttention stderr InputRequested
     let chrome =
             rolePrompt color "changes> "
                 <> if color
                     then Text.pack clearFromCursorToLineEndCode
                     else mempty
-    readReplLine interrupt chrome >>= \case
+    readReplLineForProvider provider interrupt chrome >>= \case
         ReplEof -> pure "(no notes)"
         ReplQuitInterrupt -> throwIO UserInterrupt
         ReplPasted text ->
             if Text.null (Text.strip text) then pure "(no notes)" else pure (Text.strip text)
         ReplClipboardPaste text _ ->
             if Text.null (Text.strip text)
-                then readChangeNotes interrupt color
+                then readChangeNotes provider interrupt color
                 else pure (Text.strip text)
         ReplClipboardPasteOrText _ _ text ->
             if Text.null (Text.strip text)
-                then readChangeNotes interrupt color
+                then readChangeNotes provider interrupt color
                 else pure (Text.strip text)
         ReplCycleMode _ ->
             -- Shift+Tab is idle-prompt only; keep asking for notes.
-            readChangeNotes interrupt color
+            readChangeNotes provider interrupt color
         ReplChooseModel _ ->
-            readChangeNotes interrupt color
+            readChangeNotes provider interrupt color
         ReplChooseEffort _ ->
-            readChangeNotes interrupt color
+            readChangeNotes provider interrupt color
         ReplChooseAccount _ ->
-            readChangeNotes interrupt color
+            readChangeNotes provider interrupt color
         ReplRemovePendingImage _ _ ->
-            readChangeNotes interrupt color
+            readChangeNotes provider interrupt color
         ReplMeta _ ->
-            readChangeNotes interrupt color
+            readChangeNotes provider interrupt color
         ReplText text
             | Text.null (Text.strip text) -> pure "(no notes)"
             | otherwise -> pure (Text.strip text)
 
-askQuestion :: InterruptState -> IO Bool -> Text -> [Text] -> IO (Maybe Text)
-askQuestion interrupt resolveColor question options = do
+askQuestion
+    :: Provider
+    -> InterruptState
+    -> IO Bool
+    -> Text
+    -> [Text]
+    -> IO (Maybe Text)
+askQuestion provider interrupt resolveColor question options = do
     color <- resolveColor
     isTty <- hIsTerminalDevice stdin
     putTextLn stderr (roleMuted color question)
@@ -259,7 +268,7 @@ askQuestion interrupt resolveColor question options = do
                                 <> if color
                                     then Text.pack clearFromCursorToLineEndCode
                                     else mempty
-                    readReplLine interrupt chrome >>= \case
+                    readReplLineForProvider provider interrupt chrome >>= \case
                         ReplEof -> pure Nothing
                         ReplQuitInterrupt -> throwIO UserInterrupt
                         ReplPasted text ->
@@ -268,24 +277,32 @@ askQuestion interrupt resolveColor question options = do
                                 else pure (Just (Text.strip text))
                         ReplClipboardPaste text _ ->
                             if Text.null (Text.strip text)
-                                then askQuestion interrupt resolveColor question []
+                                then askQuestion
+                                    provider interrupt resolveColor question []
                                 else pure (Just (Text.strip text))
                         ReplClipboardPasteOrText _ _ text ->
                             if Text.null (Text.strip text)
-                                then askQuestion interrupt resolveColor question []
+                                then askQuestion
+                                    provider interrupt resolveColor question []
                                 else pure (Just (Text.strip text))
                         ReplCycleMode _ ->
-                            askQuestion interrupt resolveColor question []
+                            askQuestion
+                                provider interrupt resolveColor question []
                         ReplChooseModel _ ->
-                            askQuestion interrupt resolveColor question []
+                            askQuestion
+                                provider interrupt resolveColor question []
                         ReplChooseEffort _ ->
-                            askQuestion interrupt resolveColor question []
+                            askQuestion
+                                provider interrupt resolveColor question []
                         ReplChooseAccount _ ->
-                            askQuestion interrupt resolveColor question []
+                            askQuestion
+                                provider interrupt resolveColor question []
                         ReplRemovePendingImage _ _ ->
-                            askQuestion interrupt resolveColor question []
+                            askQuestion
+                                provider interrupt resolveColor question []
                         ReplMeta _ ->
-                            askQuestion interrupt resolveColor question []
+                            askQuestion
+                                provider interrupt resolveColor question []
                         ReplText text
                             | Text.null (Text.strip text) -> pure Nothing
                             | otherwise -> pure (Just (Text.strip text))

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -753,6 +753,7 @@ prepareAgentIterationTracked
                 forM_ fullscreen \runtime ->
                     setFullscreenSessionActions
                         runtime
+                        Nothing
                         (requestCancel toolEnv.toolCancel)
                         (const (pure ()))
                         (const (pure ()))
@@ -822,6 +823,7 @@ resetFullscreenSessionActions :: FullscreenRuntime -> IO ()
 resetFullscreenSessionActions runtime =
     setFullscreenSessionActions
         runtime
+        Nothing
         (pure ())
         (const (pure ()))
         (const (pure ()))

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -344,7 +344,8 @@ runAgentTools
                     , planAskQuestion = \_ _ -> pure Nothing
                     }
             | otherwise =
-                cliPlanHooks interrupt escPaused (resolveColor stderrHandle)
+                cliPlanHooks
+                    provider interrupt escPaused (resolveColor stderrHandle)
         planHooks = fullscreenAwarePlanHooks uiRuntimeRef basePlanHooks
         baseSecretHooks = SecretPromptHooks \request ->
             Right <$> promptSecretLine

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -29,7 +29,7 @@ import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ()
 import Agent.CLI.GatewayBridge ()
-import Agent.CLI.Input ( readReplLineWithCatalog )
+import Agent.CLI.Input ( readReplLineWithCatalogForProvider )
 import Agent.CLI.Interrupt ()
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
@@ -352,7 +352,8 @@ replWithDraft env@SessionEnv
                         <> if stdoutColor
                             then Text.pack clearFromCursorToLineEndCode
                             else mempty
-            result <- readReplLineWithCatalog
+            result <- readReplLineWithCatalogForProvider
+                provider
                 slashCatalog
                 interrupt chromePrompt draft
             when terminal.terminalSemanticPrompts $

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -809,6 +809,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
     forM_ fullscreen \runtime ->
         setFullscreenSessionActions
             runtime
+            (Just provider)
             (requestCancel toolEnv.toolCancel)
             (\text -> do
                 images <- loadImagesFromPastedText text

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -348,13 +348,20 @@ runFullscreen runtime workerAction = do
 
     dictationWorker = forever do
         job <- atomically (readTQueue runtime.runtimeDictationJobs)
-        result <-
-            dictateWith
-                DictationControl
-                    { dictationWaitForStop = job.dictationJobWaitForStop
-                    , dictationOnTranscript =
-                        enqueueAppEvent runtime . AppDictationPartial
-                    }
+        actions <- readIORef runtime.runtimeSessionActions
+        result <- case actions.sessionProvider of
+            Nothing ->
+                pure $ DictationFailed
+                    "Dictation is unavailable while the model is changing"
+            Just provider ->
+                dictateWith
+                    provider
+                    DictationControl
+                        { dictationWaitForStop =
+                            job.dictationJobWaitForStop
+                        , dictationOnTranscript =
+                            enqueueAppEvent runtime . AppDictationPartial
+                        }
         enqueueAppEvent runtime $
             AppDictationFinished $
                 case result of

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -4,6 +4,7 @@ module Agent.CLI.TUI.App.Runtime where
 
 import Agent.CLI.TUI.App.Mailbox (enqueueAppEvent)
 
+import Agent.Provider (Provider)
 import Agent.CLI.Clipboard ( formatImageSize )
 import Agent.CLI.Dictation ( DictationControl(..)
     , DictationResult(..)
@@ -253,7 +254,8 @@ newFullscreenRuntimeWithSyntaxLoader
         colorFgBg <- lookupEnv "COLORFGBG"
         windowTitle <- newIORef Nothing
         sessionActions <- newIORef FullscreenSessionActions
-            { sessionCancel = cancelAction
+            { sessionProvider = Nothing
+            , sessionCancel = cancelAction
             , sessionSteer = const (pure ())
             , sessionBtw = const (pure ())
             , sessionRecap = pure ()
@@ -318,6 +320,7 @@ newFullscreenRuntimeWithSyntaxLoader
 
 setFullscreenSessionActions
     :: FullscreenRuntime
+    -> Maybe Provider
     -> IO ()
     -> (Text -> IO ())
     -> (Text -> IO ())
@@ -329,6 +332,7 @@ setFullscreenSessionActions
     -> IO ()
 setFullscreenSessionActions
     runtime
+    provider
     cancelAction
     steerAction
     btwAction
@@ -338,7 +342,8 @@ setFullscreenSessionActions
     agentSnapshot
     agentSelect =
         writeIORef runtime.runtimeSessionActions FullscreenSessionActions
-            { sessionCancel = cancelAction
+            { sessionProvider = provider
+            , sessionCancel = cancelAction
             , sessionSteer = steerAction
             , sessionBtw = btwAction
             , sessionRecap = recapAction

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -46,6 +46,7 @@ import Agent.CLI.TUI.History
     )
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.Loop (ImageAttachment)
+import Agent.Provider (Provider)
 import Agent.TUI.Model (BlockId, UiEvent, UiState)
 import Agent.Syntax (SyntaxHighlighter)
 import Agent.TUI.Motion (MotionDemand, MotionMode)
@@ -274,7 +275,8 @@ data DictationSession = DictationSession
 -- Replacing the record atomically prevents the retained UI from calling into
 -- resources belonging to a backend that has already shut down.
 data FullscreenSessionActions = FullscreenSessionActions
-    { sessionCancel :: !(IO ())
+    { sessionProvider :: !(Maybe Provider)
+    , sessionCancel :: !(IO ())
     , sessionSteer :: !(Text -> IO ())
     , sessionBtw :: !(Text -> IO ())
     , sessionRecap :: !(IO ())

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -51,7 +51,10 @@ import System.FilePath ((</>))
 import System.IO (hClose, openTempFile)
 import Test.Hspec
 
+fromFilePath :: FilePath -> OsPath
 fromFilePath = unsafeEncodeUtf
+
+toFilePath :: OsPath -> FilePath
 toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
@@ -90,6 +93,109 @@ spec = do
                         Left err -> expectationFailure (Text.unpack err)
                         Right loaded ->
                             loaded.loadedProvider `shouldBe` OpenAIProvider
+
+    describe "loadOpenAiDictationAuth" do
+        it "loads ChatGPT OAuth as subscription-billed OpenAI auth" $
+            withTempHome \_ ->
+                withCleanOpenAiEnv $
+                withEnv
+                    "CODEX_AUTH_JSON"
+                    (Just
+                        "{\"auth_mode\":\"chatgpt\",\
+                        \\"tokens\":{\"access_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.\",\
+                        \\"refresh_token\":\"oauth-refresh\",\
+                        \\"account_id\":\"account-oauth\"}}") do
+                    shouldLoadOpenAiDictationCredential
+                        SubscriptionBilled
+                        "e30.eyJleHAiOjQxMDI0NDQ4MDB9."
+                        "account-oauth"
+
+        it "prefers ChatGPT OAuth over an API key" $
+            withTempHome \_ ->
+                withCleanOpenAiEnv $
+                withEnv "OPENAI_API_KEY" (Just "sk-openai") $
+                withEnv
+                    "CODEX_AUTH_JSON"
+                    (Just
+                        "{\"auth_mode\":\"chatgpt\",\
+                        \\"tokens\":{\"access_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.\",\
+                        \\"refresh_token\":\"oauth-refresh\",\
+                        \\"account_id\":\"account-oauth\"}}") do
+                    shouldLoadOpenAiDictationCredential
+                        SubscriptionBilled
+                        "e30.eyJleHAiOjQxMDI0NDQ4MDB9."
+                        "account-oauth"
+
+        it "loads OPENAI_API_KEY as API-billed OpenAI auth" $
+            withTempHome \_ ->
+                withCleanOpenAiEnv $
+                withEnv "OPENAI_API_KEY" (Just "sk-openai") do
+                    shouldLoadOpenAiDictationToken "sk-openai"
+
+        it "loads Codex's API-key environment variable" $
+            withTempHome \_ ->
+                withCleanOpenAiEnv $
+                withEnv "CODEX_API_KEY" (Just "sk-codex-env") do
+                    shouldLoadOpenAiDictationToken "sk-codex-env"
+
+        it "prefers OPENAI_API_KEY over CODEX_API_KEY" $
+            withTempHome \_ ->
+                withCleanOpenAiEnv $
+                withEnv "CODEX_API_KEY" (Just "sk-codex-env") $
+                withEnv "OPENAI_API_KEY" (Just "sk-openai") do
+                    shouldLoadOpenAiDictationToken "sk-openai"
+
+        it "prefers an explicit API key over a managed API account" $
+            withTempHome \_ ->
+                withCleanOpenAiEnv $
+                withEnv "OPENAI_API_KEY" (Just "sk-openai") do
+                    storeManagedAccount
+                        ApiBilled
+                        OpenAIProvider
+                        "managed-openai"
+                        "managed-account"
+                        "Managed OpenAI"
+                        True
+                        "managed-key"
+                    shouldLoadOpenAiDictationToken "sk-openai"
+
+        it "loads Codex's OPENAI_API_KEY auth JSON field" $
+            withTempHome \_ ->
+                withCleanOpenAiEnv $
+                withEnv
+                    "CODEX_AUTH_JSON"
+                    (Just
+                        "{\"auth_mode\":\"apikey\",\
+                        \\"OPENAI_API_KEY\":\"sk-codex\"}") do
+                    shouldLoadOpenAiDictationToken "sk-codex"
+
+        it "honors CODEX_HOME when reading Codex auth JSON" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    let codexHome = toFilePath home </> "custom-codex"
+                    createDirectory codexHome
+                    LBS.writeFile
+                        (codexHome </> "auth.json")
+                        "{\"OPENAI_API_KEY\":\"sk-codex-home\"}"
+                    withEnv "CODEX_HOME" (Just codexHome) do
+                        shouldLoadOpenAiDictationToken "sk-codex-home"
+
+        it "honors CODEX_HOME for ChatGPT OAuth auth JSON" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    let codexHome = toFilePath home </> "custom-codex"
+                    createDirectory codexHome
+                    LBS.writeFile
+                        (codexHome </> "auth.json")
+                        "{\"auth_mode\":\"chatgpt\",\
+                        \\"tokens\":{\"access_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.\",\
+                        \\"refresh_token\":\"oauth-refresh\",\
+                        \\"account_id\":\"account-home\"}}"
+                    withEnv "CODEX_HOME" (Just codexHome) do
+                        shouldLoadOpenAiDictationCredential
+                            SubscriptionBilled
+                            "e30.eyJleHAiOjQxMDI0NDQ4MDB9."
+                            "account-home"
 
     describe "probeLoadedAuth" do
         it "rejects auth whose accounts are currently cooling down" do
@@ -1334,12 +1440,40 @@ withCleanOpenAiEnv action =
     foldr
         (\name next -> withEnv name Nothing next)
         action
-        [ "CODEX_ACCESS_TOKEN"
+        [ "OPENAI_API_KEY"
+        , "CODEX_API_KEY"
+        , "CODEX_ACCESS_TOKEN"
         , "CODEX_AUTH_JSON"
+        , "CODEX_HOME"
         , "CODEX_ACCOUNT_ID"
         , "CODEX_ID_TOKEN"
         , "OPENAI_OAUTH_CLIENT_ID"
         ]
+
+shouldLoadOpenAiDictationToken :: Text -> Expectation
+shouldLoadOpenAiDictationToken expected =
+    shouldLoadOpenAiDictationCredential ApiBilled expected ""
+
+shouldLoadOpenAiDictationCredential
+    :: BillingMode
+    -> Text
+    -> Text
+    -> Expectation
+shouldLoadOpenAiDictationCredential billing expected expectedAccount =
+    loadOpenAiDictationAuth >>= \case
+        Nothing ->
+            expectationFailure "expected an OpenAI dictation credential"
+        Just loaded -> do
+            loaded.loadedProvider `shouldBe` OpenAIProvider
+            tokenProviderBillingMode loaded.loadedTokenProvider
+                `shouldBe` billing
+            getNextToken loaded.loadedTokenProvider Nothing >>= \case
+                Left err ->
+                    expectationFailure (show err)
+                Right credential -> do
+                    credential.provider `shouldBe` OpenAIProvider
+                    credential.accessToken `shouldBe` expected
+                    credential.accountId `shouldBe` expectedAccount
 
 withCleanGrokEnv :: IO a -> IO a
 withCleanGrokEnv action =

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -15,11 +15,13 @@ import Agent.CLI.TUI.Types
     ( AppEvent(..)
     , AppEventMailbox(..)
     , FullscreenRuntime(..)
+    , FullscreenSessionActions(..)
     , PendingAppEvent(..)
     , SyntaxHighlighterState(..)
     )
 import Agent.TUI.Model
 import Agent.Loop (LoopEvent(..), emptyTurnOutput)
+import Agent.Provider (Provider(XAIProvider))
 import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch (functionToolCall)
 import Agent.TUI.Motion (MotionMode(..))
@@ -157,6 +159,7 @@ spec = describe "fullscreen TUI bridge" do
         runtime.runtimeCancel
         setFullscreenSessionActions
             runtime
+            (Just XAIProvider)
             (modifyIORef' calls (<> ["new cancel"]))
             (const (modifyIORef' calls (<> ["new steer"])))
             (const (modifyIORef' calls (<> ["new btw"])))
@@ -172,6 +175,8 @@ spec = describe "fullscreen TUI bridge" do
         runtime.runtimeRestartEffort "high"
         runtime.runtimeAgentSelect AgentRoot
         decision <- runtime.runtimeCtrlC
+        actions <- readIORef runtime.runtimeSessionActions
+        actions.sessionProvider `shouldBe` Just XAIProvider
         readIORef calls `shouldReturn`
             ["old cancel", "new cancel", "new steer", "new btw", "new recap", "new effort", "new agent"]
         decision `shouldBe` SoftCancel

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -1,6 +1,11 @@
 module Agent.CLI.TUIComposerSpec (spec) where
 
-import Agent.CLI.Dictation (insertDictation)
+import Agent.CLI.Dictation
+    ( DictationBackend(..)
+    , dictationBackendForProvider
+    , insertDictation
+    )
+import Agent.Provider (Provider(..))
 import Agent.CLI.Input
     ( ReplLine(..)
     , displayEditorText
@@ -219,6 +224,18 @@ spec = describe "fullscreen composer" do
             `shouldBe` ("please fix this now", 15)
         insertDictation "hello" 5 ", world"
             `shouldBe` ("hello, world", 12)
+
+    it "routes dictation through the active model provider" do
+        dictationBackendForProvider OpenAIProvider
+            `shouldBe` Right OpenAIDictation
+        dictationBackendForProvider XAIProvider
+            `shouldBe` Right XAIDictation
+        dictationBackendForProvider OpenRouterProvider
+            `shouldBe` Left
+                "Dictation is not supported for openrouter models"
+        dictationBackendForProvider ClaudeCodeProvider
+            `shouldBe` Left
+                "Dictation is not supported for claude-code models"
 
     it "keeps dictation stop keys inside the composer" do
         dictationKeyAction (V.EvKey V.KEnter [])

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -68,6 +68,7 @@ library
                     , Agent.OpenAI.Models.Profile
                     , Agent.OpenAI.Models.Types
                     , Agent.OpenAI.WebSocketClient
+                    , Agent.OpenAI.Transcription
                     , Agent.OpenAI.LoopBackend
                     , Agent.OpenAI.CompactClient
                     , Agent.OpenAI.Compaction
@@ -87,6 +88,7 @@ library
                     , text
                     , bytestring
                     , base64-bytestring
+                    , async
                     , aeson                 >= 2.0
                     , http-client
                     , http-conduit
@@ -137,6 +139,7 @@ test-suite agent-openai-test
                     , Agent.OpenAI.ModelsTypesSpec
                     , Agent.OpenAI.CompactionSpec
                     , Agent.OpenAI.ToolDSLSpec
+                    , Agent.OpenAI.TranscriptionSpec
                     , Agent.OpenAI.UsageSpec
                     , Agent.OpenAI.WebSocketClientSpec
     ghc-options:      -threaded
@@ -162,5 +165,7 @@ test-suite agent-openai-test
                     , unix
                     , case-insensitive
                     , http-types
+                    , network
+                    , safe-exceptions
                     , wai
                     , warp

--- a/packages/agent-openai/package.nix
+++ b/packages/agent-openai/package.nix
@@ -2,9 +2,9 @@
 , agent-responses-types, async, base, base64-bytestring, bytestring
 , case-insensitive, containers, directory, exceptions, filepath
 , HsOpenSSL, hspec, http-client, http-conduit, http-streams
-, http-types, io-streams, lib, network-uri, retry, safe-exceptions
-, scientific, template-haskell, temporary, text, time, unix, vector
-, wai, warp, websockets, wuss
+, http-types, io-streams, lib, network, network-uri, retry
+, safe-exceptions, scientific, template-haskell, temporary, text
+, time, unix, vector, wai, warp, websockets, wuss
 }:
 mkDerivation {
   pname = "agent-openai";
@@ -14,10 +14,10 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson agent-core agent-json agent-responses agent-responses-types
-    base base64-bytestring bytestring containers directory exceptions
-    filepath HsOpenSSL http-client http-conduit http-streams io-streams
-    network-uri retry safe-exceptions scientific template-haskell text
-    time unix vector websockets wuss
+    async base base64-bytestring bytestring containers directory
+    exceptions filepath HsOpenSSL http-client http-conduit http-streams
+    io-streams network-uri retry safe-exceptions scientific
+    template-haskell text time unix vector websockets wuss
   ];
   executableHaskellDepends = [
     agent-core base directory filepath text
@@ -25,8 +25,8 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses agent-responses-types
     async base base64-bytestring bytestring case-insensitive directory
-    filepath hspec http-types retry temporary text time unix vector wai
-    warp websockets
+    filepath hspec http-types network retry safe-exceptions temporary
+    text time unix vector wai warp websockets
   ];
   description = "Haskell client for the OpenAI Responses API";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -1,0 +1,1159 @@
+-- | Microphone transcription through OpenAI and ChatGPT.
+module Agent.OpenAI.Transcription
+    ( ChatGPTDictationEvent(..)
+    , TranscriptEvent(..)
+    , chatGPTTranscriptionBaseUrl
+    , decodeChatGPTDictationEvent
+    , decodeTranscriptEvent
+    , decodeTranscriptionResponse
+    , encodePcm16Wav
+    , openAITranscriptionModel
+    , openAITranscriptionSampleRate
+    , transcribePcmWithOpenAI
+    , transcribePcmWithOpenAIAt
+    ) where
+
+import Agent.Error (ApiError(..))
+import qualified Agent.Json.Decode as Json
+import Agent.Provider
+    ( BillingMode(..)
+    , Credential(..)
+    , Provider(OpenAIProvider)
+    , TokenProvider
+    , getNextToken
+    , runWithTokenProvider
+    , seedTokenProvider
+    , tokenProviderBillingMode
+    )
+import Control.Applicative ((<|>))
+import Control.Concurrent.Async
+    ( cancel
+    , waitCatch
+    , waitEitherCatch
+    , withAsync
+    )
+import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , newEmptyMVar
+    , newMVar
+    , readMVar
+    , takeMVar
+    , tryPutMVar
+    , tryReadMVar
+    )
+import Control.Exception.Safe
+    ( SomeException
+    , displayException
+    , finally
+    , fromException
+    , isSyncException
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (join, unless, void)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text
+import Data.Unique (hashUnique, newUnique)
+import Data.Word (Word32)
+import Network.HTTP.Simple
+    ( getResponseBody
+    , getResponseStatusCode
+    , httpLBS
+    , parseRequest
+    , setRequestBodyLBS
+    , setRequestHeader
+    , setRequestMethod
+    )
+import qualified Network.WebSockets as WS
+import Network.URI
+    ( URI(..)
+    , URIAuth(..)
+    , parseURI
+    )
+import qualified System.Timeout as Timeout
+import Text.Read (readMaybe)
+import qualified Wuss
+
+-- | ChatGPT backend used by the official desktop app's buffered dictation
+-- fallback. Unlike the public OpenAI Realtime endpoint, this route accepts a
+-- ChatGPT OAuth bearer and account id.
+chatGPTTranscriptionBaseUrl :: Text
+chatGPTTranscriptionBaseUrl = "https://chatgpt.com/backend-api"
+
+-- | Codex's transcription model for its Realtime V2 dictation session.
+openAITranscriptionModel :: Text
+openAITranscriptionModel = "gpt-4o-mini-transcribe"
+
+-- | Realtime PCM input is mono, signed 16-bit little-endian audio at 24 kHz.
+openAITranscriptionSampleRate :: Int
+openAITranscriptionSampleRate = 24_000
+
+data TranscriptEvent
+    = SessionUpdated
+    | TranscriptDelta
+        { transcriptText :: !Text
+        }
+    | TranscriptCompleted
+        { transcriptText :: !Text
+        }
+    | TranscriptError
+        { transcriptMessage :: !Text
+        }
+    | TranscriptUnknown
+    deriving (Eq, Show)
+
+transcriptEventDecoder :: Json.Decoder TranscriptEvent
+transcriptEventDecoder = Json.discriminatedObject "type" \case
+    "session.updated" ->
+        pure SessionUpdated
+    "conversation.item.input_audio_transcription.delta" ->
+        Json.object $
+            TranscriptDelta
+                <$> Json.defaultKey "" "delta" Json.text
+    "conversation.item.input_audio_transcription.completed" ->
+        Json.object $
+            TranscriptCompleted
+                <$> Json.defaultKey "" "transcript" Json.text
+    "error" ->
+        Json.object do
+            topLevelMessage <- Json.optionalKey "message" Json.text
+            nestedMessage <-
+                Json.optionalKey
+                    "error"
+                    (Json.object $ Json.optionalKey "message" Json.text)
+            pure $ TranscriptError
+                (fromMaybe
+                    "OpenAI Realtime transcription error"
+                    (topLevelMessage <|> join nestedMessage))
+    _ ->
+        pure TranscriptUnknown
+
+decodeTranscriptEvent :: LBS.ByteString -> Either String TranscriptEvent
+decodeTranscriptEvent body =
+    case Json.decodeEither transcriptEventDecoder (LBS.toStrict body) of
+        Left err -> Left (Text.unpack err.jsonErrorMessage)
+        Right event -> Right event
+
+-- | Events emitted by ChatGPT's subscription-backed dictation stream.
+data ChatGPTDictationEvent
+    = ChatGPTSessionStarted
+    | ChatGPTSessionUpdated !Text
+    | ChatGPTSpeechStarted !Text
+    | ChatGPTSpeechStopped !Text
+    | ChatGPTTranscriptDelta !Text !Text
+    | ChatGPTTranscriptSegment !Text !Text
+    | ChatGPTTranscriptFinal !Text !Text
+    | ChatGPTTranscriptFailed !Text
+    | ChatGPTSessionError !Bool !Text
+    | ChatGPTEventUnknown
+    deriving (Eq, Show)
+
+chatGPTDictationEventDecoder :: Json.Decoder ChatGPTDictationEvent
+chatGPTDictationEventDecoder = Json.discriminatedObject "type" \case
+    "session.started" ->
+        pure ChatGPTSessionStarted
+    "session.updated" ->
+        Json.object $
+            ChatGPTSessionUpdated
+                <$> Json.atKey
+                    "session"
+                    (Json.object $ Json.atKey "status" Json.text)
+    "speech.started" ->
+        Json.object $
+            ChatGPTSpeechStarted
+                <$> Json.atKey "utterance_id" Json.text
+    "speech.stopped" ->
+        Json.object $
+            ChatGPTSpeechStopped
+                <$> Json.atKey "utterance_id" Json.text
+    "transcript.delta" ->
+        Json.object $
+            ChatGPTTranscriptDelta
+                <$> Json.atKey "utterance_id" Json.text
+                <*> Json.atKey "text" Json.text
+    "transcript.segment" ->
+        Json.object $
+            ChatGPTTranscriptSegment
+                <$> Json.atKey "utterance_id" Json.text
+                <*> Json.atKey "text" Json.text
+    "transcript.final" ->
+        Json.object $
+            ChatGPTTranscriptFinal
+                <$> Json.atKey "utterance_id" Json.text
+                <*> Json.atKey "text" Json.text
+    "transcript.failed" ->
+        Json.object $
+            ChatGPTTranscriptFailed
+                <$> Json.atKey
+                    "error"
+                    (Json.object $ Json.atKey "message" Json.text)
+    "session.error" ->
+        Json.object $
+            ChatGPTSessionError
+                <$> Json.defaultKey False "fatal" Json.bool
+                <*> Json.atKey
+                    "error"
+                    (Json.object $ Json.atKey "message" Json.text)
+    _ ->
+        pure ChatGPTEventUnknown
+
+decodeChatGPTDictationEvent
+    :: LBS.ByteString
+    -> Either String ChatGPTDictationEvent
+decodeChatGPTDictationEvent body =
+    case Json.decodeEither
+        chatGPTDictationEventDecoder
+        (LBS.toStrict body) of
+        Left err -> Left (Text.unpack err.jsonErrorMessage)
+        Right event -> Right event
+
+data TranscriptState = TranscriptState
+    { partial :: !Text
+    , completed :: !(Maybe Text)
+    , failure :: !(Maybe Text)
+    }
+
+emptyTranscriptState :: TranscriptState
+emptyTranscriptState = TranscriptState
+    { partial = ""
+    , completed = Nothing
+    , failure = Nothing
+    }
+
+-- | Transcribe live 24 kHz mono signed PCM16 audio. API-billed credentials use
+-- the public OpenAI Realtime endpoint. Subscription credentials use Codex
+-- desktop's ChatGPT dictation stream with its buffered @/transcribe@ fallback.
+transcribePcmWithOpenAI
+    :: TokenProvider
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO (Either ApiError Text)
+transcribePcmWithOpenAI =
+    transcribePcmWithOpenAIAt chatGPTTranscriptionBaseUrl
+
+-- | Variant with an explicit ChatGPT backend base URL. The override is useful
+-- for tests and compatible deployments; API-key Realtime traffic still goes
+-- directly to @api.openai.com@.
+transcribePcmWithOpenAIAt
+    :: Text
+    -> TokenProvider
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO (Either ApiError Text)
+transcribePcmWithOpenAIAt baseUrl provider produceAudio onTranscript =
+    case tokenProviderBillingMode provider of
+        ApiBilled ->
+            transcribeRealtimeWithProvider provider produceAudio onTranscript
+        SubscriptionBilled ->
+            transcribeWithChatGPT
+                baseUrl
+                provider
+                produceAudio
+                onTranscript
+
+transcribeRealtimeWithProvider
+    :: TokenProvider
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO (Either ApiError Text)
+transcribeRealtimeWithProvider provider produceAudio onTranscript =
+    runWithTokenProvider provider \credential ->
+        if credential.provider /= OpenAIProvider
+            then pure $ Left $ CredentialError
+                "OpenAI dictation requires an OpenAI API-key credential"
+            else do
+                result <- tryAny
+                    (transcribe credential produceAudio onTranscript)
+                case result of
+                    Left err
+                        | isSyncException err ->
+                            pure (Left (realtimeTranscriptionException err))
+                        | otherwise ->
+                            throwIO err
+                    Right transcript ->
+                        pure (Right transcript)
+
+realtimeTranscriptionException :: SomeException -> ApiError
+realtimeTranscriptionException err =
+    case fromException err of
+        Just (WS.RequestRejected _ response) ->
+            HttpError
+                (WS.responseCode response)
+                (if WS.responseCode response `elem` [401, 403]
+                    then "OpenAI Realtime transcription authentication was rejected"
+                    else "OpenAI Realtime transcription request was rejected")
+        _ ->
+            ConnectionError
+                ("OpenAI Realtime transcription failed: "
+                    <> Text.pack (displayException err))
+
+transcribeWithChatGPT
+    :: Text
+    -> TokenProvider
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO (Either ApiError Text)
+transcribeWithChatGPT baseUrl provider produceAudio onTranscript =
+    getNextToken provider Nothing >>= \case
+        Left err ->
+            pure (Left err)
+        Right initial
+            | initial.provider /= OpenAIProvider ->
+                pure $ Left $ CredentialError
+                    "ChatGPT dictation requires an OpenAI credential"
+            | otherwise -> do
+                chunks <- newIORef []
+                streamChatGPTDictation
+                    baseUrl
+                    initial
+                    chunks
+                    produceAudio
+                    onTranscript >>= \case
+                        ChatGPTStreamSucceeded transcript ->
+                            pure (Right transcript)
+                        ChatGPTStreamUnavailable _ ->
+                            fallbackToChatGPTBatch
+                                baseUrl
+                                provider
+                                initial
+                                chunks
+                                onTranscript
+                        ChatGPTCaptureFailed message ->
+                            pure $ Left $ ConnectionError
+                                ("OpenAI dictation audio capture failed: "
+                                    <> message)
+
+capturePcmInto
+    :: IORef [BS.ByteString]
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (BS.ByteString -> IO ())
+    -> IO ()
+capturePcmInto chunks produceAudio forward =
+    produceAudio \bytes ->
+        unless (BS.null bytes) do
+            modifyIORef' chunks (bytes :)
+            forward bytes
+
+fallbackToChatGPTBatch
+    :: Text
+    -> TokenProvider
+    -> Credential
+    -> IORef [BS.ByteString]
+    -> (Text -> IO ())
+    -> IO (Either ApiError Text)
+fallbackToChatGPTBatch
+    baseUrl
+    provider
+    initial
+    chunks
+    onTranscript = do
+        pcm <- BS.concat . reverse <$> readIORef chunks
+        case encodePcm16Wav openAITranscriptionSampleRate pcm of
+            Left err ->
+                pure (Left err)
+            Right wav -> do
+                boundary <- transcriptionBoundary
+                let body = multipartWavBody boundary wav
+                seeded <- seedTokenProvider provider initial
+                runWithTokenProvider seeded \credential ->
+                    if credential.provider /= OpenAIProvider
+                        then pure $ Left $ CredentialError
+                            "ChatGPT dictation requires an OpenAI credential"
+                        else
+                            postChatGPTTranscription
+                                baseUrl
+                                credential
+                                boundary
+                                body >>= \case
+                                    Left err ->
+                                        pure (Left err)
+                                    Right transcript -> do
+                                        ignoreSynchronousException
+                                            (onTranscript transcript)
+                                        pure (Right transcript)
+
+data ChatGPTStreamOutcome
+    = ChatGPTStreamSucceeded !Text
+    | ChatGPTStreamUnavailable !Text
+    | ChatGPTCaptureFailed !Text
+    deriving (Eq, Show)
+
+data ChatGPTStreamEndpoint = ChatGPTStreamEndpoint
+    { streamHost :: !String
+    , streamPort :: !Int
+    , streamPath :: !String
+    , streamSecure :: !Bool
+    }
+
+data ChatGPTStreamState = ChatGPTStreamState
+    { utteranceOrder :: ![Text]
+    , finalByUtterance :: !(Map.Map Text Text)
+    }
+
+emptyChatGPTStreamState :: ChatGPTStreamState
+emptyChatGPTStreamState = ChatGPTStreamState
+    { utteranceOrder = []
+    , finalByUtterance = Map.empty
+    }
+
+streamChatGPTDictation
+    :: Text
+    -> Credential
+    -> IORef [BS.ByteString]
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO ChatGPTStreamOutcome
+streamChatGPTDictation
+    baseUrl
+    credential
+    chunks
+    produceAudio
+    onTranscript = do
+        audio <- newChan
+        withAsync
+            (capturePcmInto
+                chunks
+                produceAudio
+                (writeChan audio . Just)
+                `finally` writeChan audio Nothing)
+            \captureWorker -> do
+                withAsync (connectAndStream audio) \streamWorker ->
+                    waitEitherCatch
+                        captureWorker
+                        streamWorker >>= \case
+                            Left captureResult ->
+                                case captureResult of
+                                    Left err
+                                        | isSyncException err -> do
+                                            cancel streamWorker
+                                            pure $ ChatGPTCaptureFailed
+                                                (Text.pack
+                                                    (displayException err))
+                                        | otherwise ->
+                                            throwIO err
+                                    Right () ->
+                                        waitCatch streamWorker
+                                            >>= resolveStreamResult
+                            Right streamResult -> do
+                                outcome <- resolveStreamResult streamResult
+                                waitCatch captureWorker >>= \case
+                                    Left err
+                                        | isSyncException err ->
+                                            pure $ ChatGPTCaptureFailed
+                                                (Text.pack
+                                                    (displayException err))
+                                        | otherwise ->
+                                            throwIO err
+                                    Right () ->
+                                        pure outcome
+  where
+    connectAndStream audio =
+        case chatGPTStreamEndpoint baseUrl of
+            Left message ->
+                pure (ChatGPTStreamUnavailable message)
+            Right endpoint ->
+                tryAny
+                    (runChatGPTWebSocket
+                        endpoint
+                        credential
+                        (chatGPTStreamSession
+                            audio
+                            onTranscript)) >>= \case
+                                Left err
+                                    | isSyncException err ->
+                                        pure $ ChatGPTStreamUnavailable
+                                            (Text.pack
+                                                (displayException err))
+                                    | otherwise ->
+                                        throwIO err
+                                Right result ->
+                                    pure result
+    resolveStreamResult = \case
+        Left err
+            | isSyncException err ->
+                pure $ ChatGPTStreamUnavailable
+                    (Text.pack (displayException err))
+            | otherwise ->
+                throwIO err
+        Right outcome ->
+            pure outcome
+
+chatGPTStreamSession
+    :: Chan (Maybe BS.ByteString)
+    -> (Text -> IO ())
+    -> WS.Connection
+    -> IO ChatGPTStreamOutcome
+chatGPTStreamSession
+    audio
+    onTranscript
+    connection = do
+        WS.sendTextData connection $
+            chatGPTSessionStartMessage openAITranscriptionSampleRate
+        Timeout.timeout
+            (10 * 1_000_000)
+            (awaitChatGPTSessionStarted connection) >>= \case
+                Nothing ->
+                    pure $ ChatGPTStreamUnavailable
+                        "ChatGPT dictation stream timed out during startup"
+                Just (Left message) ->
+                    pure (ChatGPTStreamUnavailable message)
+                Just (Right ()) -> do
+                    state <- newMVar emptyChatGPTStreamState
+                    finished <- newEmptyMVar
+                    withAsync
+                        (receiveChatGPTDictation
+                            connection
+                            state
+                            finished
+                            onTranscript)
+                        \receiver ->
+                            runCapture state finished
+                                `finally` do
+                                    cancel receiver
+                                    ignoreSynchronousException $
+                                        WS.sendClose
+                                            connection
+                                            ("done" :: Text)
+  where
+    runCapture state finished = do
+        sendQueuedChatGPTAudio connection finished audio
+        sendChatGPTMessage
+            finished
+            connection
+            chatGPTSessionCloseMessage
+        Timeout.timeout
+            (8 * 1_000_000)
+            (takeMVar finished) >>= \case
+                Nothing ->
+                    pure $ ChatGPTStreamUnavailable
+                        "ChatGPT dictation stream timed out while closing"
+                Just (Left message) ->
+                    pure (ChatGPTStreamUnavailable message)
+                Just (Right ()) -> do
+                    current <- readMVar state
+                    let transcript =
+                            Text.strip
+                                (renderChatGPTTranscript current)
+                    pure $
+                        if Text.null transcript
+                            then ChatGPTStreamUnavailable
+                                "ChatGPT dictation stream produced no text"
+                            else ChatGPTStreamSucceeded transcript
+
+sendQueuedChatGPTAudio
+    :: WS.Connection
+    -> MVar (Either Text ())
+    -> Chan (Maybe BS.ByteString)
+    -> IO ()
+sendQueuedChatGPTAudio connection finished audio =
+    readChan audio >>= \case
+        Nothing ->
+            pure ()
+        Just bytes -> do
+            tryReadMVar finished >>= \case
+                Just _ ->
+                    pure ()
+                Nothing ->
+                    sendChatGPTMessage
+                        finished
+                        connection
+                        (chatGPTAudioAppendMessage bytes)
+            sendQueuedChatGPTAudio connection finished audio
+
+sendChatGPTMessage
+    :: MVar (Either Text ())
+    -> WS.Connection
+    -> Text
+    -> IO ()
+sendChatGPTMessage finished connection message =
+    tryAny (WS.sendTextData connection message) >>= \case
+        Left err
+            | isSyncException err ->
+                void $ tryPutMVar finished $
+                    Left
+                        ("ChatGPT dictation stream send failed: "
+                            <> Text.pack (displayException err))
+            | otherwise ->
+                throwIO err
+        Right () ->
+            pure ()
+
+awaitChatGPTSessionStarted
+    :: WS.Connection
+    -> IO (Either Text ())
+awaitChatGPTSessionStarted connection = do
+    bytes <- WS.receiveData connection
+    case decodeChatGPTDictationEvent bytes of
+        Left message ->
+            pure $ Left
+                ("ChatGPT dictation stream returned an invalid event: "
+                    <> Text.pack message)
+        Right ChatGPTSessionStarted ->
+            pure (Right ())
+        Right (ChatGPTTranscriptFailed message) ->
+            pure (Left message)
+        Right (ChatGPTSessionError True message) ->
+            pure (Left message)
+        Right _ ->
+            awaitChatGPTSessionStarted connection
+
+receiveChatGPTDictation
+    :: WS.Connection
+    -> MVar ChatGPTStreamState
+    -> MVar (Either Text ())
+    -> (Text -> IO ())
+    -> IO ()
+receiveChatGPTDictation connection state finished onTranscript =
+    tryAny loop >>= \case
+        Left err
+            | isSyncException err ->
+                void $ tryPutMVar finished (receiverFailure err)
+            | otherwise ->
+                throwIO err
+        Right result ->
+            void (tryPutMVar finished result)
+  where
+    loop = do
+        bytes <- WS.receiveData connection
+        case decodeChatGPTDictationEvent bytes of
+            Left message ->
+                pure $ Left
+                    ("ChatGPT dictation stream returned an invalid event: "
+                        <> Text.pack message)
+            Right event ->
+                case event of
+                    ChatGPTSessionUpdated status
+                        | status == "closed" ->
+                            pure (Right ())
+                    ChatGPTTranscriptFailed message ->
+                        pure (Left message)
+                    ChatGPTSessionError True message ->
+                        pure (Left message)
+                    ChatGPTTranscriptFinal _ _ -> do
+                        current <- modifyMVar state \previous ->
+                            let next =
+                                    applyChatGPTDictationEvent
+                                        event
+                                        previous
+                            in pure (next, next)
+                        let transcript = renderChatGPTTranscript current
+                        unless (Text.null transcript) $
+                            ignoreSynchronousException
+                                (onTranscript transcript)
+                        loop
+                    _ -> do
+                        modifyMVar state \previous ->
+                            pure
+                                ( applyChatGPTDictationEvent
+                                    event
+                                    previous
+                                , ()
+                                )
+                        loop
+
+receiverFailure :: SomeException -> Either Text ()
+receiverFailure err =
+    case (fromException err :: Maybe WS.ConnectionException) of
+        Just (WS.CloseRequest 1000 _) ->
+            Right ()
+        _ ->
+            Left
+                ("ChatGPT dictation stream receive failed: "
+                    <> Text.pack (displayException err))
+
+applyChatGPTDictationEvent
+    :: ChatGPTDictationEvent
+    -> ChatGPTStreamState
+    -> ChatGPTStreamState
+applyChatGPTDictationEvent event state =
+    case event of
+        ChatGPTSpeechStarted utteranceId ->
+            ensureChatGPTUtterance utteranceId state
+        ChatGPTSpeechStopped utteranceId ->
+            ensureChatGPTUtterance utteranceId state
+        ChatGPTTranscriptFinal utteranceId text ->
+            let withUtterance =
+                    ensureChatGPTUtterance utteranceId state
+            in withUtterance
+                { finalByUtterance =
+                    Map.insert
+                        utteranceId
+                        text
+                        withUtterance.finalByUtterance
+                }
+        _ ->
+            state
+
+ensureChatGPTUtterance
+    :: Text
+    -> ChatGPTStreamState
+    -> ChatGPTStreamState
+ensureChatGPTUtterance utteranceId state
+    | Map.member utteranceId state.finalByUtterance =
+        state
+    | otherwise =
+        state
+            { utteranceOrder = state.utteranceOrder <> [utteranceId]
+            , finalByUtterance =
+                Map.insert utteranceId "" state.finalByUtterance
+            }
+
+renderChatGPTTranscript :: ChatGPTStreamState -> Text
+renderChatGPTTranscript state =
+    Text.unwords
+        [ transcript
+        | utteranceId <- state.utteranceOrder
+        , Just transcript <- [Map.lookup
+            utteranceId
+            state.finalByUtterance]
+        , not (Text.null (Text.strip transcript))
+        ]
+
+chatGPTSessionStartMessage :: Int -> Text
+chatGPTSessionStartMessage sampleRate =
+    encodeText $ Aeson.object
+        [ "type" .= ("session.start" :: Text)
+        , "config" .= Aeson.object
+            [ "input_audio_format" .= ("pcm16" :: Text)
+            , "sample_rate_hz" .= sampleRate
+            , "num_channels" .= (1 :: Int)
+            , "max_buffer_size_bytes" .= (4 * 1024 * 1024 :: Int)
+            , "max_utterance_duration_ms" .= (30_000 :: Int)
+            , "session_ttl_ms" .= (300_000 :: Int)
+            , "provider_mode" .= ("streaming_sse" :: Text)
+            , "transcript_delivery_mode" .= ("final_only" :: Text)
+            , "vad" .= Aeson.object
+                [ "type" .= ("server_vad" :: Text)
+                , "threshold" .= (0.5 :: Double)
+                , "prefix_padding_ms" .= (300 :: Int)
+                , "silence_duration_ms" .= (500 :: Int)
+                ]
+            ]
+        ]
+
+chatGPTAudioAppendMessage :: BS.ByteString -> Text
+chatGPTAudioAppendMessage bytes =
+    encodeText $ Aeson.object
+        [ "type" .= ("audio.append" :: Text)
+        , "audio" .= Text.decodeUtf8 (Base64.encode bytes)
+        ]
+
+chatGPTSessionCloseMessage :: Text
+chatGPTSessionCloseMessage =
+    encodeText $ Aeson.object
+        [ "type" .= ("session.close" :: Text)
+        ]
+
+runChatGPTWebSocket
+    :: ChatGPTStreamEndpoint
+    -> Credential
+    -> WS.ClientApp a
+    -> IO a
+runChatGPTWebSocket endpoint credential client =
+    if endpoint.streamSecure
+        then
+            Wuss.runSecureClientWith
+                endpoint.streamHost
+                (fromIntegral endpoint.streamPort)
+                endpoint.streamPath
+                WS.defaultConnectionOptions
+                headers
+                client
+        else
+            WS.runClientWith
+                endpoint.streamHost
+                endpoint.streamPort
+                endpoint.streamPath
+                WS.defaultConnectionOptions
+                headers
+                client
+  where
+    headers =
+        [ -- Codex Desktop loads its renderer from @app://-/index.html@.
+          -- ChatGPT validates that renderer origin during the upgrade.
+          ("Origin", "app://-")
+        -- Cloudflare challenges WebSocket upgrades without a browser-shaped
+        -- user agent. Keep our own product token for attribution.
+        , ( "User-Agent"
+          , "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+            \AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 \
+            \Safari/537.36 haskell-agent/0.1"
+          )
+        , ( "Sec-WebSocket-Protocol"
+          , BS.intercalate
+                ", "
+                [ "chatgpt-dictation"
+                , "openai-bearer."
+                    <> Text.encodeUtf8 credential.accessToken
+                , "codex-desktop"
+                ]
+          )
+        ]
+
+chatGPTStreamEndpoint :: Text -> Either Text ChatGPTStreamEndpoint
+chatGPTStreamEndpoint baseUrl = do
+    uri <- maybe
+        (Left "ChatGPT transcription base URL is invalid")
+        Right
+        (parseURI (Text.unpack baseUrl))
+    authority <- maybe
+        (Left "ChatGPT transcription base URL has no authority")
+        Right
+        uri.uriAuthority
+    secure <- case uri.uriScheme of
+        "https:" -> Right True
+        "http:" -> Right False
+        _ -> Left "ChatGPT transcription base URL must use HTTP or HTTPS"
+    port <- case authority.uriPort of
+        "" ->
+            Right (if secure then 443 else 80)
+        ':' : digits ->
+            case readMaybe digits of
+                Just value
+                    | value > 0 && value <= 65_535 ->
+                        Right value
+                _ ->
+                    Left "ChatGPT transcription base URL has an invalid port"
+        _ ->
+            Left "ChatGPT transcription base URL has an invalid port"
+    if null authority.uriRegName
+        then Left "ChatGPT transcription base URL has no host"
+        else
+            Right ChatGPTStreamEndpoint
+                { streamHost = authority.uriRegName
+                , streamPort = port
+                , streamPath =
+                    dropTrailingSlashes uri.uriPath
+                        <> "/dictation/stream"
+                , streamSecure = secure
+                }
+
+dropTrailingSlashes :: String -> String
+dropTrailingSlashes =
+    reverse . dropWhile (== '/') . reverse
+
+ignoreSynchronousException :: IO () -> IO ()
+ignoreSynchronousException action =
+    tryAny action >>= \case
+        Left err
+            | isSyncException err ->
+                pure ()
+            | otherwise ->
+                throwIO err
+        Right () ->
+            pure ()
+
+-- | Wrap mono signed PCM16 little-endian samples in a standard WAV container.
+-- Codex's former open-source TUI used this exact 24 kHz WAV shape for both the
+-- ChatGPT backend and public audio-transcriptions endpoint.
+encodePcm16Wav :: Int -> BS.ByteString -> Either ApiError LBS.ByteString
+encodePcm16Wav sampleRate pcm
+    | sampleRate <= 0 =
+        Left (ConnectionError "OpenAI dictation has an invalid sample rate")
+    | BS.null pcm =
+        Left (ConnectionError "OpenAI dictation captured no audio")
+    | odd dataLength =
+        Left (ConnectionError
+            "OpenAI dictation captured a truncated PCM16 sample")
+    | dataLength > maxWavDataLength =
+        Left (ConnectionError "OpenAI dictation audio is too large for WAV")
+    | otherwise =
+        Right $ Builder.toLazyByteString $ mconcat
+            [ Builder.byteString "RIFF"
+            , Builder.word32LE (fromIntegral (36 + dataLength))
+            , Builder.byteString "WAVE"
+            , Builder.byteString "fmt "
+            , Builder.word32LE 16
+            , Builder.word16LE 1
+            , Builder.word16LE 1
+            , Builder.word32LE (fromIntegral sampleRate)
+            , Builder.word32LE (fromIntegral (sampleRate * bytesPerSample))
+            , Builder.word16LE (fromIntegral bytesPerSample)
+            , Builder.word16LE 16
+            , Builder.byteString "data"
+            , Builder.word32LE (fromIntegral dataLength)
+            , Builder.byteString pcm
+            ]
+  where
+    dataLength = BS.length pcm
+    bytesPerSample = 2
+    maxWavDataLength = fromIntegral (maxBound :: Word32) - 36
+
+postChatGPTTranscription
+    :: Text
+    -> Credential
+    -> BS.ByteString
+    -> LBS.ByteString
+    -> IO (Either ApiError Text)
+postChatGPTTranscription baseUrl credential boundary body = do
+    let contentType = "multipart/form-data; boundary=" <> boundary
+        endpoint =
+            Text.unpack
+                (Text.dropWhileEnd (== '/') baseUrl <> "/transcribe")
+        accountHeader request
+            | Text.null (Text.strip credential.accountId) = request
+            | otherwise =
+                setRequestHeader
+                    "ChatGPT-Account-Id"
+                    [Text.encodeUtf8 credential.accountId]
+                    request
+    tryAny
+        (do
+            request <- parseRequest endpoint
+            httpLBS
+                $ setRequestMethod "POST"
+                $ setRequestBodyLBS body
+                $ setRequestHeader "Content-Type" [contentType]
+                $ setRequestHeader "Accept" ["application/json"]
+                $ setRequestHeader "Originator" ["haskell-agent"]
+                $ setRequestHeader "User-Agent" ["haskell-agent"]
+                $ setRequestHeader
+                    "Authorization"
+                    ["Bearer " <> Text.encodeUtf8 credential.accessToken]
+                $ accountHeader request) >>= \case
+                    Left err
+                        | isSyncException err ->
+                            pure $ Left $ ConnectionError
+                                ("ChatGPT transcription request failed: "
+                                    <> Text.pack (displayException err))
+                        | otherwise ->
+                            throwIO err
+                    Right response -> do
+                        let status = getResponseStatusCode response
+                            responseBody = getResponseBody response
+                        pure $
+                            if status >= 200 && status < 300
+                                then decodeTranscriptionResponse responseBody
+                                else Left $ HttpError status
+                                    (responseBodyPreview responseBody)
+
+transcriptionBoundary :: IO BS.ByteString
+transcriptionBoundary = do
+    unique <- hashUnique <$> newUnique
+    pure $ BS8.pack
+        ("----haskell-agent-transcribe-"
+            <> show (abs (toInteger unique)))
+
+multipartWavBody :: BS.ByteString -> LBS.ByteString -> LBS.ByteString
+multipartWavBody boundary wav =
+    LBS.fromStrict
+        ( "--" <> boundary <> "\r\n"
+        <> "Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n"
+        <> "Content-Type: audio/wav\r\n\r\n"
+        )
+        <> wav
+        <> LBS.fromStrict
+            ("\r\n--" <> boundary <> "--\r\n")
+
+transcriptionResponseDecoder :: Json.Decoder Text
+transcriptionResponseDecoder =
+    Json.object (Json.atKey "text" Json.text)
+
+decodeTranscriptionResponse
+    :: LBS.ByteString
+    -> Either ApiError Text
+decodeTranscriptionResponse body =
+    case Json.decodeEither transcriptionResponseDecoder (LBS.toStrict body) of
+        Left err ->
+            Left $ JsonDecodeError
+                ("Invalid ChatGPT transcription response: "
+                    <> err.jsonErrorMessage)
+                (responseBodyPreview body)
+        Right transcript
+            | Text.null (Text.strip transcript) ->
+                Left $ ConnectionError
+                    "ChatGPT transcription produced no text"
+            | otherwise ->
+                Right (Text.strip transcript)
+
+responseBodyPreview :: LBS.ByteString -> Text
+responseBodyPreview =
+    Text.take 2000
+        . Text.decodeUtf8With Text.lenientDecode
+        . LBS.toStrict
+
+transcribe
+    :: Credential
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO Text
+transcribe credential produceAudio onTranscript =
+    Wuss.runSecureClientWith
+        "api.openai.com"
+        443
+        "/v1/realtime"
+        WS.defaultConnectionOptions
+        [ ("Authorization"
+          , "Bearer " <> Text.encodeUtf8 credential.accessToken)
+        ]
+        \connection -> Json.withDecoderSession \decoderSession -> do
+            WS.sendTextData connection sessionUpdateMessage
+            awaitSessionUpdated decoderSession connection
+            state <- newMVar emptyTranscriptState
+            finished <- newEmptyMVar
+            withAsync
+                (receiveTranscripts
+                    decoderSession
+                    connection
+                    state
+                    finished
+                    onTranscript)
+                \receiver ->
+                    (do
+                        produceAudio \bytes ->
+                            WS.sendTextData connection (audioAppendMessage bytes)
+                        WS.sendTextData connection audioCommitMessage
+                        waitForTranscript state finished)
+                        `finally` do
+                            void (tryAny
+                                (WS.sendClose connection ("done" :: Text)))
+                            cancel receiver
+
+sessionUpdateMessage :: Text
+sessionUpdateMessage =
+    encodeText $ Aeson.object
+        [ "type" .= ("session.update" :: Text)
+        , "session" .= Aeson.object
+            [ "type" .= ("transcription" :: Text)
+            , "audio" .= Aeson.object
+                [ "input" .= Aeson.object
+                    [ "format" .= Aeson.object
+                        [ "type" .= ("audio/pcm" :: Text)
+                        , "rate" .= openAITranscriptionSampleRate
+                        ]
+                    , "transcription" .= Aeson.object
+                        [ "model" .= openAITranscriptionModel
+                        ]
+                    , "turn_detection" .= Aeson.Null
+                    ]
+                ]
+            ]
+        ]
+
+audioAppendMessage :: BS.ByteString -> Text
+audioAppendMessage bytes =
+    encodeText $ Aeson.object
+        [ "type" .= ("input_audio_buffer.append" :: Text)
+        , "audio" .= Text.decodeUtf8 (Base64.encode bytes)
+        ]
+
+audioCommitMessage :: Text
+audioCommitMessage =
+    encodeText $ Aeson.object
+        [ "type" .= ("input_audio_buffer.commit" :: Text)
+        ]
+
+encodeText :: Aeson.Value -> Text
+encodeText = Text.decodeUtf8 . LBS.toStrict . Aeson.encode
+
+awaitSessionUpdated :: Json.DecoderSession -> WS.Connection -> IO ()
+awaitSessionUpdated decoderSession connection = do
+    updated <- Timeout.timeout (10 * 1_000_000) loop
+    case updated of
+        Nothing ->
+            fail "timed out waiting for OpenAI Realtime session.updated"
+        Just () ->
+            pure ()
+  where
+    loop = do
+        bytes <- WS.receiveData connection
+        Json.decodeIO
+            decoderSession
+            transcriptEventDecoder
+            (LBS.toStrict bytes) >>= \case
+            Right SessionUpdated -> pure ()
+            Right TranscriptError{transcriptMessage} ->
+                fail (Text.unpack transcriptMessage)
+            _ -> loop
+
+receiveTranscripts
+    :: Json.DecoderSession
+    -> WS.Connection
+    -> MVar TranscriptState
+    -> MVar (Either SomeException ())
+    -> (Text -> IO ())
+    -> IO ()
+receiveTranscripts decoderSession connection state finished onTranscript =
+    tryAny loop >>= void . tryPutMVar finished
+  where
+    loop = do
+        bytes <- WS.receiveData connection
+        Json.decodeIO
+            decoderSession
+            transcriptEventDecoder
+            (LBS.toStrict bytes) >>= \case
+            Left _ -> loop
+            Right event -> do
+                current <- modifyMVar state \previous ->
+                    let next = applyTranscriptEvent event previous
+                    in pure (next, next)
+                case event of
+                    TranscriptDelta{} ->
+                        notify current
+                    TranscriptCompleted{} ->
+                        notify current
+                    _ ->
+                        pure ()
+                case event of
+                    TranscriptCompleted{} -> pure ()
+                    TranscriptError{} -> pure ()
+                    _ -> loop
+    notify current =
+        void (tryAny (onTranscript (renderTranscript current)))
+
+applyTranscriptEvent :: TranscriptEvent -> TranscriptState -> TranscriptState
+applyTranscriptEvent event state =
+    case event of
+        SessionUpdated ->
+            state
+        TranscriptDelta{transcriptText} ->
+            state { partial = state.partial <> transcriptText }
+        TranscriptCompleted{transcriptText} ->
+            state
+                { completed = Just transcriptText
+                , partial = ""
+                }
+        TranscriptError{transcriptMessage} ->
+            state { failure = Just transcriptMessage }
+        TranscriptUnknown ->
+            state
+
+waitForTranscript
+    :: MVar TranscriptState
+    -> MVar (Either SomeException ())
+    -> IO Text
+waitForTranscript state finished = do
+    completedInTime <- Timeout.timeout (30 * 1_000_000) (takeMVar finished)
+    case completedInTime of
+        Nothing ->
+            fail "timed out waiting for OpenAI Realtime transcription"
+        Just (Left err) ->
+            throwIO err
+        Just (Right ()) -> do
+            current <- readMVar state
+            case current.failure of
+                Just message ->
+                    fail (Text.unpack message)
+                Nothing ->
+                    let transcript = Text.strip (renderTranscript current)
+                    in if Text.null transcript
+                        then fail "OpenAI transcription produced no text"
+                        else pure transcript
+
+renderTranscript :: TranscriptState -> Text
+renderTranscript state =
+    maybe state.partial id state.completed

--- a/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
@@ -1,0 +1,407 @@
+module Agent.OpenAI.TranscriptionSpec (spec) where
+
+import Agent.Error (ApiError(..))
+import Agent.OpenAI.Transcription
+import Agent.Provider
+    ( BillingMode(..)
+    , Credential(..)
+    , FailedCredential(..)
+    , Provider(OpenAIProvider)
+    , tokenProvider
+    )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Exception.Safe (bracket, finally)
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.CaseInsensitive as CI
+import Data.IORef
+    ( atomicModifyIORef'
+    , modifyIORef'
+    , newIORef
+    , readIORef
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import qualified Network.HTTP.Types as HTTP
+import qualified Network.Socket as Socket
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.WebSockets as WS
+import qualified System.Timeout as Timeout
+import Test.Hspec
+
+spec :: Spec
+spec = describe "OpenAI transcription" do
+    it "decodes incremental and completed transcript events" do
+        decodeTranscriptEvent
+            "{\"type\":\"conversation.item.input_audio_transcription.delta\",\"delta\":\"hello \"}"
+            `shouldBe` Right TranscriptDelta
+                { transcriptText = "hello "
+                }
+        decodeTranscriptEvent
+            ("{\"type\":\"conversation.item.input_audio_transcription.completed\","
+                <> "\"transcript\":\"hello world\"}")
+            `shouldBe` Right TranscriptCompleted
+                { transcriptText = "hello world"
+                }
+
+    it "decodes session acknowledgement and nested errors" do
+        decodeTranscriptEvent
+            "{\"type\":\"session.updated\",\"session\":{\"type\":\"transcription\"}}"
+            `shouldBe` Right SessionUpdated
+        decodeTranscriptEvent
+            ("{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\","
+                <> "\"message\":\"bad audio\"}}")
+            `shouldBe` Right TranscriptError
+                { transcriptMessage = "bad audio"
+                }
+        decodeTranscriptEvent
+            "{\"type\":\"error\",\"message\":\"top-level error\"}"
+            `shouldBe` Right TranscriptError
+                { transcriptMessage = "top-level error"
+                }
+
+    it "ignores forward-compatible server events" do
+        decodeTranscriptEvent
+            "{\"type\":\"input_audio_buffer.committed\",\"event_id\":\"evt\"}"
+            `shouldBe` Right TranscriptUnknown
+
+    it "decodes ChatGPT dictation stream events" do
+        decodeChatGPTDictationEvent
+            ("{\"type\":\"session.updated\",\"sequence_no\":4,"
+                <> "\"session\":{\"status\":\"closed\"}}")
+            `shouldBe` Right (ChatGPTSessionUpdated "closed")
+        decodeChatGPTDictationEvent
+            ("{\"type\":\"transcript.final\",\"sequence_no\":3,"
+                <> "\"utterance_id\":\"utterance-1\",\"revision\":1,"
+                <> "\"text\":\"hello world\"}")
+            `shouldBe` Right
+                (ChatGPTTranscriptFinal "utterance-1" "hello world")
+        decodeChatGPTDictationEvent
+            ("{\"type\":\"session.error\",\"sequence_no\":2,\"fatal\":true,"
+                <> "\"error\":{\"code\":\"failed\",\"message\":\"bad audio\","
+                <> "\"retryable\":false}}")
+            `shouldBe` Right (ChatGPTSessionError True "bad audio")
+
+    it "decodes the ChatGPT backend response" do
+        decodeTranscriptionResponse "{\"text\":\"  hello world  \"}"
+            `shouldBe` Right "hello world"
+        decodeTranscriptionResponse "{\"unexpected\":true}"
+            `shouldSatisfy` \case
+                Left JsonDecodeError{} -> True
+                _ -> False
+
+    it "encodes 24 kHz mono PCM16 as WAV" do
+        case encodePcm16Wav 24_000 "\x01\x00\x02\x00" of
+            Left err ->
+                expectationFailure (show err)
+            Right wav -> do
+                LBS.take 4 wav `shouldBe` "RIFF"
+                LBS.take 4 (LBS.drop 8 wav) `shouldBe` "WAVE"
+                LBS.take 4 (LBS.drop 24 wav)
+                    `shouldBe` "\xC0\x5D\x00\x00"
+                LBS.take 4 (LBS.drop 36 wav) `shouldBe` "data"
+                LBS.take 4 (LBS.drop 40 wav)
+                    `shouldBe` "\x04\x00\x00\x00"
+                LBS.drop 44 wav `shouldBe` "\x01\x00\x02\x00"
+
+    it "checks subscription credentials before recording" do
+        captures <- newIORef (0 :: Int)
+        let provider = tokenProvider SubscriptionBilled \_ ->
+                pure (Left (CredentialError "sign in required"))
+        transcribePcmWithOpenAI
+            provider
+            (\_ -> modifyIORef' captures (+ 1))
+            (const (pure ()))
+            `shouldReturn` Left (CredentialError "sign in required")
+        readIORef captures `shouldReturn` 0
+
+    it "streams with Codex Desktop's ChatGPT OAuth protocol" do
+        captures <- newIORef (0 :: Int)
+        callbacks <- newIORef []
+        let credential = openAiCredential "stream-token"
+            provider = tokenProvider SubscriptionBilled \_ ->
+                pure (Right credential)
+            server pending = do
+                let request = WS.pendingRequest pending
+                WS.requestPath request
+                    `shouldBe` "/backend-api/dictation/stream"
+                lookup
+                    (CI.mk "Origin")
+                    (WS.requestHeaders request)
+                    `shouldBe` Just "app://-"
+                lookup
+                    (CI.mk "User-Agent")
+                    (WS.requestHeaders request)
+                    `shouldSatisfy`
+                        maybe False
+                            ("haskell-agent/0.1" `BS.isSuffixOf`)
+                WS.getRequestSubprotocols request
+                    `shouldBe`
+                        [ "chatgpt-dictation"
+                        , "openai-bearer.stream-token"
+                        , "codex-desktop"
+                        ]
+                connection <- WS.acceptRequestWith
+                    pending
+                    WS.defaultAcceptRequest
+                        { WS.acceptSubprotocol =
+                            Just "chatgpt-dictation"
+                        }
+                start <- WS.receiveData connection
+                decodeValue start `shouldBe` Aeson.object
+                    [ "type" .= ("session.start" :: Text)
+                    , "config" .= Aeson.object
+                        [ "input_audio_format" .= ("pcm16" :: Text)
+                        , "sample_rate_hz" .= (24_000 :: Int)
+                        , "num_channels" .= (1 :: Int)
+                        , "max_buffer_size_bytes" .=
+                            (4 * 1024 * 1024 :: Int)
+                        , "max_utterance_duration_ms" .= (30_000 :: Int)
+                        , "session_ttl_ms" .= (300_000 :: Int)
+                        , "provider_mode" .= ("streaming_sse" :: Text)
+                        , "transcript_delivery_mode" .=
+                            ("final_only" :: Text)
+                        , "vad" .= Aeson.object
+                            [ "type" .= ("server_vad" :: Text)
+                            , "threshold" .= (0.5 :: Double)
+                            , "prefix_padding_ms" .= (300 :: Int)
+                            , "silence_duration_ms" .= (500 :: Int)
+                            ]
+                        ]
+                    ]
+                Timeout.timeout
+                    (1 * 1_000_000)
+                    (waitUntil ((> 0) <$> readIORef captures))
+                    `shouldReturn` Just ()
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("session.started" :: Text)
+                    , "sequence_no" .= (1 :: Int)
+                    , "session" .= sessionValue "active"
+                    ]
+                audio <- WS.receiveData connection
+                decodeValue audio `shouldBe` Aeson.object
+                    [ "type" .= ("audio.append" :: Text)
+                    , "audio" .= ("AQACAA==" :: Text)
+                    ]
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("speech.started" :: Text)
+                    , "sequence_no" .= (2 :: Int)
+                    , "utterance_id" .= ("utterance-1" :: Text)
+                    ]
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("transcript.final" :: Text)
+                    , "sequence_no" .= (3 :: Int)
+                    , "utterance_id" .= ("utterance-1" :: Text)
+                    , "revision" .= (1 :: Int)
+                    , "text" .= ("hello from stream" :: Text)
+                    ]
+                close <- WS.receiveData connection
+                decodeValue close `shouldBe` Aeson.object
+                    [ "type" .= ("session.close" :: Text)
+                    ]
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("session.updated" :: Text)
+                    , "sequence_no" .= (4 :: Int)
+                    , "session" .= sessionValue "closed"
+                    ]
+        withWebSocketServer server \port -> do
+            let baseUrl =
+                    "http://127.0.0.1:"
+                        <> Text.pack (show port)
+                        <> "/backend-api"
+                produce send = do
+                    modifyIORef' captures (+ 1)
+                    send "\x01\x00\x02\x00"
+            result <- Timeout.timeout (5 * 1_000_000) $
+                transcribePcmWithOpenAIAt
+                    baseUrl
+                    provider
+                    produce
+                    (\text -> modifyIORef' callbacks (<> [text]))
+            result `shouldBe` Just (Right "hello from stream")
+        readIORef captures `shouldReturn` 1
+        readIORef callbacks `shouldReturn` ["hello from stream"]
+
+    it "falls back to ChatGPT multipart and reuses audio after a 401" do
+        recorded <- newIORef []
+        streamProtocols <- newIORef Nothing
+        attempts <- newIORef (0 :: Int)
+        captures <- newIORef (0 :: Int)
+        callbacks <- newIORef []
+        let stale = openAiCredential "stale-token"
+            fresh = openAiCredential "fresh-token"
+            provider = tokenProvider SubscriptionBilled \case
+                Nothing ->
+                    pure (Right stale)
+                Just failed -> do
+                    failed.credential `shouldBe` stale
+                    pure (Right fresh)
+            app request respond =
+                if Wai.rawPathInfo request
+                    == "/backend-api/dictation/stream"
+                    then do
+                        modifyIORef' streamProtocols $
+                            const $
+                                lookup
+                                    (CI.mk "Sec-WebSocket-Protocol")
+                                    (Wai.requestHeaders request)
+                        respond $ Wai.responseLBS
+                            HTTP.status404
+                            []
+                            ""
+                    else do
+                        body <- Wai.strictRequestBody request
+                        let recordedRequest = RecordedTranscription
+                                { path = Wai.rawPathInfo request
+                                , headers = Wai.requestHeaders request
+                                , body
+                                }
+                        attempt <- atomicModifyIORef' attempts \count ->
+                            (count + 1, count)
+                        modifyIORef' recorded (<> [recordedRequest])
+                        respond $
+                            if attempt == 0
+                                then Wai.responseLBS
+                                    HTTP.status401
+                                    [("Content-Type", "application/json")]
+                                    "{\"error\":\"expired\"}"
+                                else Wai.responseLBS
+                                    HTTP.status200
+                                    [("Content-Type", "application/json")]
+                                    (Aeson.encode (Aeson.object
+                                        [ "text" .=
+                                            ("hello from oauth" :: Text)
+                                        ]))
+        Warp.testWithApplication (pure app) \port -> do
+            let baseUrl =
+                    "http://127.0.0.1:"
+                        <> Text.pack (show port)
+                        <> "/backend-api"
+                produce send = do
+                    modifyIORef' captures (+ 1)
+                    send "\x01\x00\x02\x00"
+            transcribePcmWithOpenAIAt
+                baseUrl
+                provider
+                produce
+                (\text -> modifyIORef' callbacks (<> [text]))
+                `shouldReturn` Right "hello from oauth"
+
+        readIORef captures `shouldReturn` 1
+        readIORef callbacks `shouldReturn` ["hello from oauth"]
+        readIORef streamProtocols
+            `shouldReturn`
+                Just
+                    "chatgpt-dictation, openai-bearer.stale-token, \
+                    \codex-desktop"
+        requests <- readIORef recorded
+        length requests `shouldBe` 2
+        map (.path) requests
+            `shouldBe` ["/backend-api/transcribe", "/backend-api/transcribe"]
+        map (header "Authorization") requests
+            `shouldBe` [Just "Bearer stale-token", Just "Bearer fresh-token"]
+        map (header "ChatGPT-Account-Id") requests
+            `shouldBe` [Just "account-1", Just "account-1"]
+        map (header "Originator") requests
+            `shouldBe` [Just "haskell-agent", Just "haskell-agent"]
+        map (header "Content-Type") requests
+            `shouldSatisfy`
+                all (maybe False
+                    ("multipart/form-data; boundary="
+                        `BS.isPrefixOf`))
+        map (.body) requests `shouldSatisfy` \case
+            [first, second] ->
+                first == second
+                    && all
+                        (`BS.isInfixOf` LBS.toStrict first)
+                        [ "name=\"file\""
+                        , "filename=\"audio.wav\""
+                        , "Content-Type: audio/wav"
+                        , "RIFF"
+                        ]
+            _ -> False
+
+withWebSocketServer
+    :: WS.ServerApp
+    -> (Int -> IO value)
+    -> IO value
+withWebSocketServer server action =
+    bracket
+        (WS.makeListenSocket "127.0.0.1" 0)
+        Socket.close
+        \listenSocket -> do
+            port <- socketAddressPort <$> Socket.getSocketName listenSocket
+            withAsync
+                (do
+                    (socket, _) <- Socket.accept listenSocket
+                    (WS.makePendingConnection
+                        socket
+                        WS.defaultConnectionOptions >>= server)
+                        `finally` Socket.close socket)
+                \serverThread -> do
+                    result <- action port
+                    wait serverThread
+                    pure result
+
+socketAddressPort :: Socket.SockAddr -> Int
+socketAddressPort = \case
+    Socket.SockAddrInet port _ ->
+        fromIntegral port
+    Socket.SockAddrInet6 port _ _ _ ->
+        fromIntegral port
+    address ->
+        error ("unexpected WebSocket test address: " <> show address)
+
+decodeValue :: LBS.ByteString -> Aeson.Value
+decodeValue =
+    either error id . Aeson.eitherDecode
+
+sendEvent :: WS.Connection -> Aeson.Value -> IO ()
+sendEvent connection =
+    WS.sendTextData connection
+        . TextEncoding.decodeUtf8
+        . LBS.toStrict
+        . Aeson.encode
+
+sessionValue :: Text -> Aeson.Value
+sessionValue status =
+    Aeson.object
+        [ "session_id" .= ("session-1" :: Text)
+        , "status" .= status
+        , "config" .= Aeson.object
+            [ "provider_mode" .= ("streaming_sse" :: Text)
+            , "transcript_delivery_mode" .= ("final_only" :: Text)
+            ]
+        ]
+
+waitUntil :: IO Bool -> IO ()
+waitUntil condition =
+    condition >>= \case
+        True ->
+            pure ()
+        False -> do
+            threadDelay 1_000
+            waitUntil condition
+
+data RecordedTranscription = RecordedTranscription
+    { path :: !BS.ByteString
+    , headers :: !HTTP.RequestHeaders
+    , body :: !LBS.ByteString
+    }
+
+openAiCredential :: Text -> Credential
+openAiCredential token = Credential
+    { accessToken = token
+    , accountId = "account-1"
+    , leaseId = Nothing
+    , provider = OpenAIProvider
+    }
+
+header :: BS.ByteString -> RecordedTranscription -> Maybe BS.ByteString
+header name request =
+    lookup (CI.mk name) request.headers

--- a/packages/agent-openai/test/Spec.hs
+++ b/packages/agent-openai/test/Spec.hs
@@ -15,6 +15,7 @@ import qualified Agent.OpenAI.ModelsManagerSpec as ModelsManagerSpec
 import qualified Agent.OpenAI.ModelsTypesSpec as ModelsTypesSpec
 import qualified Agent.OpenAI.CompactionSpec as CompactionSpec
 import qualified Agent.OpenAI.ToolDSLSpec as ToolDSLSpec
+import qualified Agent.OpenAI.TranscriptionSpec as TranscriptionSpec
 import qualified Agent.OpenAI.UsageSpec as UsageSpec
 import qualified Agent.OpenAI.WebSocketClientSpec as WebSocketClientSpec
 
@@ -33,5 +34,6 @@ main = hspec do
     ModelsTypesSpec.spec
     CompactionSpec.spec
     ToolDSLSpec.spec
+    TranscriptionSpec.spec
     UsageSpec.spec
     WebSocketClientSpec.spec


### PR DESCRIPTION
## Summary

- route `Ctrl+R` dictation through the active model provider: OpenAI models use OpenAI, Grok models use xAI
- support ChatGPT/Codex OAuth through the subscription-backed dictation WebSocket used by Codex Desktop
- buffer the same PCM capture concurrently and fall back to ChatGPT's multipart `/transcribe` route if streaming fails
- use the public OpenAI Realtime transcription API for API-key credentials
- discover dictation credentials from Codex OAuth, `OPENAI_API_KEY`, `CODEX_API_KEY`, Codex auth JSON (including `CODEX_HOME`), and managed OpenAI accounts
- fail explicitly for providers without a speech-to-text integration instead of using unrelated credentials

## Implementation

The subscription path mirrors the current Codex Desktop protocol:

- `GET wss://chatgpt.com/backend-api/dictation/stream`
- subprotocols `chatgpt-dictation`, `openai-bearer.<oauth token>`, `codex-desktop`
- `Origin: app://-` and a browser-shaped user agent (required by the Cloudflare WebSocket upgrade)
- exact `session.start`, `audio.append`, and `session.close` messages with server VAD and final-only delivery
- ordered final transcripts across utterances

Provider selection is threaded through the inline REPL, fullscreen composer,
and plan-mode prompts. The fullscreen worker reads the active session provider
when a dictation job starts, so model transitions cannot send audio to the
previous provider.

Audio capture and transport use scoped `withAsync` workers. Capture failure
cancels the stream promptly; stream failure waits for capture to finish and
reuses the buffered PCM as a WAV upload. Authentication rejection on the batch
route goes through the existing token-provider refresh/failover flow without
recording again.

## Validation

- full `agent-cli` GHCi suite: **1255 examples, 0 failures**
- focused provider-routing/plan/TUI bridge GHCi suite: **61 examples, 0 failures**
- exact local WebSocket protocol integration test, including audio queued during handshake
- local streaming-failure + batch-401 integration test, verifying one capture and byte-identical retry bodies
- production ChatGPT OAuth WebSocket probe reached `session.started` (startup/close only; no microphone audio sent)
- live tmux `Ctrl+R` smoke test confirmed capture errors cancel promptly and leave the composer responsive
- `git diff --check`

