### PR TITLE
Show detailed worktree creation progress

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -145,7 +145,8 @@ import Agent.CLI.Tools ()
 import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch ()
-import Agent.CLI.Worktree ( createManagedWorktree )
+import Agent.CLI.Worktree
+    ( createManagedWorktreeWithProgress, worktreeProgressMessage )
 import Agent.Cancel ( requestCancel )
 import Agent.Claude ()
 import Agent.Dialect ()
@@ -700,11 +701,22 @@ prepareAgentIterationTracked
                     Nothing
                         | options.optWorktree -> do
                             readMVar firstFrameReady
-                            case fullscreen of
-                                Just _ -> pure ()
-                                Nothing ->
-                                    putTextLn stderrHandle "Creating worktree…"
-                            createManagedWorktree home source
+                            let reportWorktreeProgress progress = do
+                                    let message =
+                                            worktreeProgressMessage progress
+                                    case fullscreen of
+                                        Nothing ->
+                                            putTextLn stderrHandle message
+                                        Just runtime ->
+                                            emitUiEvent runtime
+                                                (UiSetNotice
+                                                    (Just
+                                                        (progressNotice
+                                                            message)))
+                            createManagedWorktreeWithProgress
+                                reportWorktreeProgress
+                                home
+                                source
                                 >>= either
                                     (\err -> do
                                         mapM_ releaseSessionLock resumeLock

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -121,7 +121,8 @@ import Agent.CLI.Tools ()
 import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch ()
-import Agent.CLI.Worktree ( createManagedWorktree )
+import Agent.CLI.Worktree
+    ( createManagedWorktreeWithProgress, worktreeProgressMessage )
 import Agent.Cancel ()
 import Agent.Claude ()
 import Agent.Dialect ( dialectId, dialectSlug )
@@ -512,8 +513,11 @@ handleSessionAction
                                                         Right message ->
                                                             finishAfk message
     ReplWorktree -> do
-        result <- withReplActivity "Creating worktree…" $
-            createManagedWorktree env.sessionHome cwd
+        result <- withReplActivity \report ->
+            createManagedWorktreeWithProgress
+                (report . worktreeProgressMessage)
+                env.sessionHome
+                cwd
         case result of
             Left err -> do
                 color <- resolveColor stderr
@@ -650,13 +654,15 @@ handleSessionAction
         ShellBash -> "bash"
         ShellBoth -> "ghci + bash"
         ShellNone -> "none"
-    withReplActivity message action = do
+    withReplActivity action =
+        action reportReplActivity `finally` clearReplActivity
+    reportReplActivity message =
         case fullscreen of
             Nothing -> renderEvent render (ActivityUpdated message)
             Just runtime ->
                 emitUiEvent runtime
                     (UiSetNotice (Just (progressNotice message)))
-        action `finally`
-            case fullscreen of
-                Nothing -> clearThinking render
-                Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
+    clearReplActivity =
+        case fullscreen of
+            Nothing -> clearThinking render
+            Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -3,10 +3,13 @@ module Agent.CLI.Worktree
     ( createWorktree
     , createWorktreeWithFetch
     , createManagedWorktree
+    , createManagedWorktreeWithProgress
     , removeWorktree
     , isUnderWorktreeRoot
+    , worktreeProgressMessage
     , worktreePath
     , worktreeRoot
+    , WorktreeProgress(..)
     ) where
 
 import Agent.CLI.Config
@@ -53,6 +56,25 @@ import System.OsPath
     )
 import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
 
+data WorktreeProgress
+    = WorktreeInspectingRepository
+    | WorktreeCheckingRemote !Text
+    | WorktreeFetchingRemote !Text !Text
+    | WorktreeCreating
+    deriving (Eq, Show)
+
+worktreeProgressMessage :: WorktreeProgress -> Text
+worktreeProgressMessage = \case
+    WorktreeInspectingRepository -> "Inspecting Git repository…"
+    WorktreeCheckingRemote remote ->
+        "Checking Git remote " <> remote <> "…"
+    WorktreeFetchingRemote remote remoteHead ->
+        "Fetching latest from " <> remote <> "/" <> branchName remoteHead <> "…"
+    WorktreeCreating -> "Creating worktree…"
+  where
+    branchName ref =
+        maybe ref id (Text.stripPrefix "refs/heads/" ref)
+
 -- | @~/.haskell-agent/worktrees@ given the user's home directory.
 worktreeRoot :: OsPath -> OsPath
 worktreeRoot home =
@@ -80,13 +102,24 @@ createWorktree = createWorktreeWithFetch False
 -- default branch and using that commit as the base.
 createWorktreeWithFetch
     :: Bool -> OsPath -> OsPath -> IO (Either Text OsPath)
-createWorktreeWithFetch fetchLatest source root = runExceptT do
+createWorktreeWithFetch =
+    createWorktreeWithFetchProgress (const (pure ()))
+
+createWorktreeWithFetchProgress
+    :: (WorktreeProgress -> IO ())
+    -> Bool
+    -> OsPath
+    -> OsPath
+    -> IO (Either Text OsPath)
+createWorktreeWithFetchProgress report fetchLatest source root = runExceptT do
+    lift (report WorktreeInspectingRepository)
     repo <- gitToplevel source
     repoName <- gitRepositoryName repo
     base <-
         if fetchLatest
-            then fetchLatestUpstream repo
+            then fetchLatestUpstream report repo
             else pure Nothing
+    lift (report WorktreeCreating)
     now <- lift getCurrentTime
     let day = utctDay now
         start = posixMicros now
@@ -97,11 +130,20 @@ createWorktreeWithFetch fetchLatest source root = runExceptT do
 -- Configuration is read for every creation so startup, slash-command, and
 -- subagent worktrees all follow the same current setting.
 createManagedWorktree :: OsPath -> OsPath -> IO (Either Text OsPath)
-createManagedWorktree home source =
+createManagedWorktree =
+    createManagedWorktreeWithProgress (const (pure ()))
+
+createManagedWorktreeWithProgress
+    :: (WorktreeProgress -> IO ())
+    -> OsPath
+    -> OsPath
+    -> IO (Either Text OsPath)
+createManagedWorktreeWithProgress report home source =
     loadHarnessConfig home >>= \case
         Left err -> pure (Left err)
         Right config ->
-            createWorktreeWithFetch
+            createWorktreeWithFetchProgress
+                report
                 config.configWorktree.worktreeFetchLatestUpstream
                 source
                 (worktreeRoot home)
@@ -187,12 +229,17 @@ gitRepositoryName repo = do
 -- branch, or use the local @HEAD@ when the repository has no remotes. The
 -- current branch's configured remote wins, followed by conventional @upstream@
 -- and @origin@ names, then a sole remaining remote.
-fetchLatestUpstream :: OsPath -> ExceptT Text IO (Maybe Text)
-fetchLatestUpstream repo = do
+fetchLatestUpstream
+    :: (WorktreeProgress -> IO ())
+    -> OsPath
+    -> ExceptT Text IO (Maybe Text)
+fetchLatestUpstream report repo = do
     selectUpstreamRemote repo >>= \case
         Nothing -> pure Nothing
         Just remote -> do
+            lift (report (WorktreeCheckingRemote remote))
             remoteHead <- remoteDefaultBranch repo remote
+            lift (report (WorktreeFetchingRemote remote remoteHead))
             localRef <- lift freshFetchRef
             commit <-
                 ExceptT $

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Config
 import Agent.CLI.Worktree
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception.Safe (bracket)
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List (dropWhileEnd, isInfixOf)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -118,7 +119,13 @@ spec = describe "Agent.CLI.Worktree" do
                 latest <- git updater ["rev-parse", "HEAD"]
                 stale `shouldNotBe` latest
 
-                path <- expectRight =<< createManagedWorktree home repo
+                progressRef <- newIORef []
+                path <- expectRight
+                    =<< createManagedWorktreeWithProgress
+                        (\progress ->
+                            modifyIORef' progressRef (<> [progress]))
+                        home
+                        repo
 
                 git path ["rev-parse", "HEAD"] `shouldReturn` latest
                 git repo ["rev-parse", "refs/remotes/origin/master"]
@@ -130,6 +137,19 @@ spec = describe "Agent.CLI.Worktree" do
                 git path ["rev-parse", "--abbrev-ref", "HEAD"]
                     `shouldReturn` toFilePath (takeFileName path)
                 temporaryFetchRefs repo `shouldReturn` ""
+                progress <- readIORef progressRef
+                progress `shouldBe`
+                    [ WorktreeInspectingRepository
+                    , WorktreeCheckingRemote "origin"
+                    , WorktreeFetchingRemote "origin" "refs/heads/master"
+                    , WorktreeCreating
+                    ]
+                map worktreeProgressMessage progress `shouldBe`
+                    [ "Inspecting Git repository…"
+                    , "Checking Git remote origin…"
+                    , "Fetching latest from origin/master…"
+                    , "Creating worktree…"
+                    ]
 
         it "uses local HEAD when latest-upstream fetching is disabled" $
             withTempRemoteRepo \repo updater ->


### PR DESCRIPTION
## Summary
- add typed progress events for managed worktree creation
- show repository inspection, remote discovery, upstream fetch, and local creation phases in both `--worktree` startup and `/worktree`
- preserve existing callers through the no-progress wrapper and test the event order/messages

## Context
Managed worktrees now fetch the selected remote's latest default branch before creation. That requires sequential `git ls-remote` and `git fetch` calls, which accounted for a median 3.67s of remote wait across three diagnostic runs. The new notices make that wait explicit without changing fetch semantics.

## Validation
- loaded `agent-cli:lib:agent-cli` in GHCi (197 modules)
- ran the focused Worktree spec in GHCi: 13 examples, 0 failures
- exercised `withArgs ["--worktree"] run` in a real tmux TTY and observed `Checking Git remote origin…` followed by `Fetching latest from origin/master…`
- verified and removed the smoke-test worktree and branch
- `git diff --check`
