### PR TITLE
Refactor Responses stream assembly around typed indexes

### DIFF
--- a/packages/agent-responses/src/Agent/Responses/ResponseMerge.hs
+++ b/packages/agent-responses/src/Agent/Responses/ResponseMerge.hs
@@ -1,6 +1,7 @@
 module Agent.Responses.ResponseMerge
     ( mergeCompletedResponseOutput
     , mergeDoneResponse
+    , mergeResponseFragment
     , mergeResponseFragments
     , responseItemIdentities
     , responseItemKind

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -18,14 +18,19 @@ module Agent.Responses.StreamAssembly
 import Agent.Error (ApiError(..))
 import Agent.Responses.ResponseMerge
     ( mergeDoneResponse
-    , mergeResponseFragments
+    , mergeResponseFragment
     , responseItemIdentities
+    , responseItemKind
     )
 import Agent.Responses.Types
 import Control.Applicative ((<|>))
 import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
-import Data.List (find)
+import qualified Data.IntSet as IntSet
+import Data.IntSet (IntSet)
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -51,13 +56,38 @@ data ItemProgress = ItemProgress
     , itemDone  :: !Bool
     }
 
+-- | Provider item ids and tool call ids occupy separate namespaces, as do
+-- identities belonging to different output item kinds.
+data ItemIdentity
+    = ProviderItemId !Text !Text
+    | ToolCallId !Text !Text
+    deriving (Eq, Ord)
+
+-- | Output items retain provider order while supporting the alternate
+-- identities used by streaming events. An identity may occur in more than one
+-- slot in a malformed stream; retaining every slot preserves the historical
+-- rule that the lowest output index for that identity wins.
+data OutputItemStore = OutputItemStore
+    { outputSlots     :: !(IntMap ItemProgress)
+    , outputAliases   :: !(Map ItemIdentity IntSet)
+    , outputPending   :: !IntSet
+    }
+
 data StreamAssemblyState = StreamAssemblyState
-    { lifecycleResponses :: ![Response]
-    , outputItems        :: !(IntMap ItemProgress)
+    { lifecycleResponse :: !(Maybe Response)
+    , outputItems       :: !OutputItemStore
     }
 
 emptyStreamAssemblyState :: StreamAssemblyState
-emptyStreamAssemblyState = StreamAssemblyState [] IntMap.empty
+emptyStreamAssemblyState =
+    StreamAssemblyState Nothing emptyOutputItemStore
+
+emptyOutputItemStore :: OutputItemStore
+emptyOutputItemStore = OutputItemStore
+    { outputSlots = IntMap.empty
+    , outputAliases = Map.empty
+    , outputPending = IntSet.empty
+    }
 
 applyStreamEvent :: StreamAssemblyState -> ResponseStreamEvent -> StreamAssemblyState
 applyStreamEvent state = \case
@@ -74,13 +104,15 @@ applyStreamEvent state = \case
         updateItem outputIndex True item state
     ResponseFunctionCallArgumentsDeltaEvent
         { delta = Just value, streamItemId, streamOutputIndex } ->
-            updateResolved streamOutputIndex [streamItemId]
+            updateResolved streamOutputIndex
+                [streamItemIdentity "function_call" streamItemId]
                 (mapFunctionCall streamItemId
                     \call -> call { arguments = call.arguments <> value })
                 state
     ResponseFunctionCallArgumentsDoneEvent
         { arguments, functionName, streamItemId, streamOutputIndex } ->
-            updateResolved streamOutputIndex [streamItemId]
+            updateResolved streamOutputIndex
+                [streamItemIdentity "function_call" streamItemId]
                 (mapFunctionCall streamItemId \call -> call
                     { arguments = fromMaybe call.arguments arguments
                     , name = fromMaybe call.name functionName
@@ -89,13 +121,19 @@ applyStreamEvent state = \case
     ResponseCustomToolInputDeltaEvent
         { delta = Just value, streamItemId, streamCallId
         , streamOutputIndex } ->
-            updateResolved streamOutputIndex [streamItemId, streamCallId]
+            updateResolved streamOutputIndex
+                [ streamItemIdentity "custom_tool_call" streamItemId
+                , streamCallIdentity "custom_tool_call" streamCallId
+                ]
                 (mapCustomCall streamItemId streamCallId
                     \call -> call { input = call.input <> value })
                 state
     ResponseCustomToolInputDoneEvent
         { inputText, streamItemId, streamCallId, streamOutputIndex } ->
-            updateResolved streamOutputIndex [streamItemId, streamCallId]
+            updateResolved streamOutputIndex
+                [ streamItemIdentity "custom_tool_call" streamItemId
+                , streamCallIdentity "custom_tool_call" streamCallId
+                ]
                 (mapCustomCall streamItemId streamCallId
                     \call -> call
                         { input = fromMaybe call.input inputText })
@@ -103,7 +141,8 @@ applyStreamEvent state = \case
     ResponseReasoningSummaryTextDoneEvent
         { text = Just value, streamItemId, streamOutputIndex
         , summaryIndex = Just index } ->
-            updateResolved streamOutputIndex [streamItemId]
+            updateResolved streamOutputIndex
+                [streamItemIdentity "reasoning" streamItemId]
                 (mapReasoning streamItemId index
                     \part -> part { text = Just value })
                 state
@@ -111,14 +150,20 @@ applyStreamEvent state = \case
         { otherEventType = EventReasoningSummaryTextDelta
         , eventDelta = Just value, streamItemId, streamOutputIndex
         , summaryIndex = Just index } ->
-            updateResolved streamOutputIndex [streamItemId]
+            updateResolved streamOutputIndex
+                [streamItemIdentity "reasoning" streamItemId]
                 (mapReasoning streamItemId index \part -> part
                     { text = Just (fromMaybe "" part.text <> value) })
                 state
     _ -> state
   where
     lifecycle response =
-        state { lifecycleResponses = state.lifecycleResponses <> [response] }
+        merged `seq` state { lifecycleResponse = Just merged }
+      where
+        merged =
+            maybe response
+                (`mergeResponseFragment` response)
+                state.lifecycleResponse
 
 finishStreamResponse
     :: Maybe Text
@@ -142,7 +187,7 @@ finishStreamResponse modelHint state terminalEvent = do
         _ -> Left $ JsonDecodeError
             "Cannot assemble a non-terminal response event"
             (Text.pack (show terminalEvent))
-    let base = mergeResponseFragments state.lifecycleResponses
+    let base = state.lifecycleResponse
         terminalWithOutput =
             setResponseOutput (assembledTerminalOutput terminal state) terminal
         response = mergeDoneResponse base [] terminalWithOutput
@@ -171,7 +216,7 @@ buildStreamResponseWithModel
 buildStreamResponseWithModel config modelHint = go emptyStreamAssemblyState
   where
     go state [] =
-        case mergeResponseFragments state.lifecycleResponses of
+        case state.lifecycleResponse of
             Just response
                 | response.status `elem`
                     [ResponseFailed, ResponseIncomplete] ->
@@ -246,7 +291,7 @@ failedStreamResponseMessage failure =
 responseFailureFromState :: StreamAssemblyState -> ResponseFailure
 responseFailureFromState state =
     maybe emptyFailure responseFailure
-        (mergeResponseFragments state.lifecycleResponses)
+        state.lifecycleResponse
 
 responseFailure :: Response -> ResponseFailure
 responseFailure response = ResponseFailure
@@ -271,10 +316,6 @@ statusText = \case
     ResponseIncomplete -> "incomplete"
     ResponseStatusUnknown value -> value
 
-assembledOutput :: StreamAssemblyState -> [ResponseItem]
-assembledOutput =
-    map (.itemValue) . IntMap.elems . (.outputItems)
-
 updateItem
     :: Maybe Int
     -> Bool
@@ -283,17 +324,21 @@ updateItem
     -> StreamAssemblyState
 updateItem explicitIndex done item state =
     state
-        { outputItems = IntMap.alter merge index state.outputItems }
+        { outputItems =
+            setOutputSlot index progress state.outputItems
+        }
   where
-    index = fromMaybe (nextOutputIndex state) $
+    index = fromMaybe (nextOutputIndex state.outputItems) $
         explicitIndex
             <|> findItemIndex item state
             <|> if done then findPendingIndex state else Nothing
-    merge Nothing = Just (ItemProgress item done)
-    merge (Just old) = Just
-        (ItemProgress
-            (mergeResponseItem old.itemValue item)
-            (old.itemDone || done))
+    progress =
+        case IntMap.lookup index state.outputItems.outputSlots of
+            Nothing -> ItemProgress item done
+            Just old ->
+                ItemProgress
+                    (mergeResponseItem old.itemValue item)
+                    (old.itemDone || done)
 
 mergeResponseItem :: ResponseItem -> ResponseItem -> ResponseItem
 mergeResponseItem old new =
@@ -314,7 +359,7 @@ mergeResponseItem old new =
 
 updateResolved
     :: Maybe Int
-    -> [Maybe Text]
+    -> [Maybe ItemIdentity]
     -> (ResponseItem -> ResponseItem)
     -> StreamAssemblyState
     -> StreamAssemblyState
@@ -322,45 +367,139 @@ updateResolved explicitIndex identities update state =
     case explicitIndex <|> findIdentityIndex identities state of
         Nothing -> state
         Just index -> state
-            { outputItems = IntMap.adjust
-                (\progress -> progress
-                    { itemValue = update progress.itemValue })
-                index
-                state.outputItems
+            { outputItems =
+                adjustOutputSlot index update state.outputItems
             }
 
 findItemIndex :: ResponseItem -> StreamAssemblyState -> Maybe Int
 findItemIndex item =
-    findIdentityIndex (map (Just . snd) (responseItemIdentities item))
+    findIdentityIndex (map Just (itemAliases item))
 
-findIdentityIndex :: [Maybe Text] -> StreamAssemblyState -> Maybe Int
+findIdentityIndex
+    :: [Maybe ItemIdentity]
+    -> StreamAssemblyState
+    -> Maybe Int
 findIdentityIndex identities state =
     foldr (<|>) Nothing (map findValue values)
   where
-    values = [value | Just value <- identities, not (Text.null value)]
-    findValue value =
-        fst <$> find
-            (elem value . map snd
-                . responseItemIdentities . (.itemValue) . snd)
-            (IntMap.toList state.outputItems)
-
-nextOutputIndex :: StreamAssemblyState -> Int
-nextOutputIndex state =
-    maybe 0 ((+ 1) . fst) (IntMap.lookupMax state.outputItems)
+    values = [identity | Just identity <- identities]
+    findValue identity =
+        Map.lookup identity state.outputItems.outputAliases
+            >>= minimumIndex
 
 findPendingIndex :: StreamAssemblyState -> Maybe Int
 findPendingIndex state =
-    fst <$> find (not . (.itemDone) . snd)
-        (IntMap.toList state.outputItems)
+    minimumIndex state.outputItems.outputPending
+
+minimumIndex :: IntSet -> Maybe Int
+minimumIndex = fmap fst . IntSet.minView
 
 assembledTerminalOutput :: Response -> StreamAssemblyState -> [ResponseItem]
 assembledTerminalOutput terminal state =
     IntMap.elems (IntMap.unionWith
         mergeResponseItem
         finalItems
-        (fmap (.itemValue) state.outputItems))
+        (fmap (.itemValue) state.outputItems.outputSlots))
   where
     finalItems = IntMap.fromList (zip [0..] terminal.output)
+
+adjustOutputSlot
+    :: Int
+    -> (ResponseItem -> ResponseItem)
+    -> OutputItemStore
+    -> OutputItemStore
+adjustOutputSlot index update store =
+    case IntMap.lookup index store.outputSlots of
+        Nothing -> store
+        Just progress ->
+            setOutputSlot
+                index
+                progress { itemValue = update progress.itemValue }
+                store
+
+-- Keep all three projections synchronized in this sole store mutation point.
+setOutputSlot
+    :: Int
+    -> ItemProgress
+    -> OutputItemStore
+    -> OutputItemStore
+setOutputSlot index progress store =
+    OutputItemStore
+        { outputSlots = IntMap.insert index progress store.outputSlots
+        , outputAliases =
+            addItemAliases index progress.itemValue aliasesWithoutOld
+        , outputPending =
+            if progress.itemDone
+                then IntSet.delete index store.outputPending
+                else IntSet.insert index store.outputPending
+        }
+  where
+    aliasesWithoutOld =
+        case IntMap.lookup index store.outputSlots of
+            Nothing -> store.outputAliases
+            Just old -> removeItemAliases index old.itemValue store.outputAliases
+
+addItemAliases
+    :: Int
+    -> ResponseItem
+    -> Map ItemIdentity IntSet
+    -> Map ItemIdentity IntSet
+addItemAliases index item aliases =
+    List.foldl'
+        (\current identity ->
+            Map.insertWith IntSet.union
+                identity
+                (IntSet.singleton index)
+                current)
+        aliases
+        (itemAliases item)
+
+removeItemAliases
+    :: Int
+    -> ResponseItem
+    -> Map ItemIdentity IntSet
+    -> Map ItemIdentity IntSet
+removeItemAliases index item aliases =
+    List.foldl'
+        (\current identity ->
+            Map.update
+                (\indexes ->
+                    let remaining = IntSet.delete index indexes
+                    in if IntSet.null remaining
+                        then Nothing
+                        else Just remaining)
+                identity
+                current)
+        aliases
+        (itemAliases item)
+
+itemAliases :: ResponseItem -> [ItemIdentity]
+itemAliases item =
+    [ identity
+    | (field, value) <- responseItemIdentities item
+    , Just identity <- [itemIdentity (responseItemKind item) field value]
+    ]
+
+itemIdentity
+    :: Text
+    -> Text
+    -> Text
+    -> Maybe ItemIdentity
+itemIdentity kind field value
+    | Text.null value = Nothing
+    | field == "id" = Just (ProviderItemId kind value)
+    | field == "call_id" = Just (ToolCallId kind value)
+    | otherwise = Nothing
+
+streamItemIdentity :: Text -> Maybe Text -> Maybe ItemIdentity
+streamItemIdentity kind = fmap (ProviderItemId kind) . nonEmpty
+
+streamCallIdentity :: Text -> Maybe Text -> Maybe ItemIdentity
+streamCallIdentity kind = fmap (ToolCallId kind) . nonEmpty
+
+nextOutputIndex :: OutputItemStore -> Int
+nextOutputIndex store =
+    maybe 0 ((+ 1) . fst) (IntMap.lookupMax store.outputSlots)
 
 mapFunctionCall
     :: Maybe Text

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -134,6 +134,100 @@ spec = describe "buildStreamResponse" do
         [name | FunctionCallItem FunctionCall { name } <- response.output]
             `shouldBe` ["first", "second"]
 
+    it "keeps item ids and call ids in separate identity namespaces" do
+        response <- expectRight $ buildStreamResponse config $
+            completedItemTrace "resp-identity-fields"
+                [ doneItemAt (Just 0)
+                    (testFunctionCall (Just "item-1") "shared" "first")
+                , doneItemAt Nothing
+                    (testFunctionCall (Just "shared") "call-2" "second")
+                ]
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["first", "second"]
+
+    it "keeps identities from different item kinds separate" do
+        response <- expectRight $ buildStreamResponse config $
+            completedItemTrace "resp-identity-kinds"
+                [ doneItemAt (Just 0)
+                    (testFunctionCall (Just "shared") "call-1" "first")
+                , doneItemAt Nothing (testReasoningItem "shared")
+                ]
+        case response.output of
+            [FunctionCallItem{}, ReasoningItemValue{}] -> pure ()
+            other -> expectationFailure
+                ("expected a function call and reasoning item, got " <> show other)
+
+    it "removes stale aliases when an indexed slot changes identity" do
+        response <- expectRight $ buildStreamResponse config $
+            completedItemTrace "resp-alias-replacement"
+                [ doneItemAt (Just 0)
+                    (testFunctionCall (Just "old-id") "old-call" "old")
+                , doneItemAt (Just 0)
+                    (testFunctionCall (Just "new-id") "new-call" "new")
+                , doneItemAt Nothing
+                    (testFunctionCall
+                        (Just "old-id")
+                        "old-call-again"
+                        "old-again")
+                ]
+        let calls =
+                [ (itemId, name)
+                | FunctionCallItem FunctionCall { itemId, name } <-
+                    response.output
+                ]
+        calls `shouldBe`
+            [ (Just "new-id", "new")
+            , (Just "old-id", "old-again")
+            ]
+
+    it "uses the lowest slot when a typed identity occurs more than once" do
+        response <- expectRight $ buildStreamResponse config $
+            completedItemTrace "resp-duplicate-alias"
+                [ doneItemAt (Just 5)
+                    (testFunctionCall (Just "shared") "call-5" "at-five")
+                , doneItemAt (Just 2)
+                    (testFunctionCall (Just "shared") "call-2" "at-two")
+                , doneItemAt Nothing
+                    (testFunctionCall
+                        (Just "shared")
+                        "call-updated"
+                        "updated-lowest")
+                ]
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["updated-lowest", "at-five"]
+
+    it "uses the lowest pending slot for an unidentified done item" do
+        response <- expectRight $ buildStreamResponse config $
+            completedItemTrace "resp-pending-fallback"
+                [ addedItemAt (Just 5)
+                    (testFunctionCall (Just "item-5") "call-5" "at-five")
+                , addedItemAt (Just 2)
+                    (testFunctionCall (Just "item-2") "call-2" "at-two")
+                , doneItemAt Nothing
+                    (testFunctionCall Nothing "new-call" "done-lowest")
+                ]
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["done-lowest", "at-five"]
+
+    it "allocates an implicit slot immediately after a negative maximum index" do
+        response <- expectRight $ buildStreamResponse config $
+            completedItemTrace "resp-negative-index"
+                [ doneItemAt (Just (-3))
+                    (testFunctionCall (Just "first-id") "first-call" "first")
+                , doneItemAt Nothing
+                    (testFunctionCall
+                        (Just "implicit-id")
+                        "implicit-call"
+                        "implicit")
+                , doneItemAt (Just (-2))
+                    (testFunctionCall
+                        (Just "replacement-id")
+                        "replacement-call"
+                        "replacement")
+                ]
+        [name | FunctionCallItem FunctionCall { name } <- response.output]
+            `shouldBe` ["first", "replacement"]
+
     it "assembles custom-tool input events without output_index" do
         events <- expectRight $ parseSseEvents $ Text.intercalate ""
             [ sseBlock "response.created"
@@ -418,6 +512,43 @@ decodeResponseValue value =
     either error id
         (Codec.decodeResponse (LBS.toStrict (Aeson.encode value)))
 
+completedItemTrace :: Text -> [ResponseStreamEvent] -> [ResponseStreamEvent]
+completedItemTrace responseId itemEvents =
+    ResponseCreatedEvent (responseFragment responseId) Nothing
+        : itemEvents
+        <> [ResponseCompletedEvent (responseFragment responseId) Nothing]
+
+addedItemAt :: Maybe Int -> ResponseItem -> ResponseStreamEvent
+addedItemAt index item =
+    ResponseOutputItemAddedEvent item index Nothing
+
+doneItemAt :: Maybe Int -> ResponseItem -> ResponseStreamEvent
+doneItemAt index item =
+    ResponseOutputItemDoneEvent item index Nothing
+
+testFunctionCall :: Maybe Text -> Text -> Text -> ResponseItem
+testFunctionCall itemId callId name =
+    FunctionCallItem FunctionCall
+        { itemId
+        , callId
+        , name
+        , namespace = Nothing
+        , provider = Nothing
+        , arguments = ""
+        , encryptedFunctionArgs = Nothing
+        , status = Nothing
+        }
+
+testReasoningItem :: Text -> ResponseItem
+testReasoningItem identifier =
+    ReasoningItemValue ReasoningItem
+        { itemId = Just identifier
+        , summary = []
+        , content = Nothing
+        , encryptedContent = Nothing
+        , status = Nothing
+        }
+
 -- This model deliberately stores raw item values rather than reusing the
 -- implementation's progress type. An explicit output index identifies one
 -- item, and later object fields overlay earlier fields.
@@ -613,7 +744,7 @@ applyExpected expected operation =
             operation.operationIndex
                 <|> findModelItemIndex newValue expected
                 <|> if operation.operationDone
-                    then findPendingModelIndex newValue expected
+                    then findPendingModelIndex expected
                     else Nothing
     update Nothing = Just (newValue, operation.operationDone)
     update (Just (oldValue, wasDone)) =
@@ -641,37 +772,34 @@ findModelItemIndex value model =
         | identity <- itemIdentitiesModel value
         ]
 
-findIdentityModel :: Text -> StreamModel -> Maybe Int
+type ModelIdentity = (Text, Text, Text)
+
+findIdentityModel :: ModelIdentity -> StreamModel -> Maybe Int
 findIdentityModel wanted model =
     fst <$> Map.lookupMin
         (Map.filter
-            (matchesIdentityValue wanted . fst)
+            (matchesModelIdentity wanted . fst)
             model)
 
-matchesIdentityValue :: Text -> Aeson.Value -> Bool
-matchesIdentityValue wanted candidate =
-    objectTextFieldModel "id" candidate == Just wanted
-        || objectTextFieldModel "call_id" candidate == Just wanted
+matchesModelIdentity :: ModelIdentity -> Aeson.Value -> Bool
+matchesModelIdentity (wantedKind, wantedField, wantedValue) candidate =
+    objectTextFieldModel "type" candidate == Just wantedKind
+        && objectTextFieldModel wantedField candidate == Just wantedValue
 
-itemIdentitiesModel :: Aeson.Value -> [Text]
+itemIdentitiesModel :: Aeson.Value -> [ModelIdentity]
 itemIdentitiesModel value =
-    [ identity
-    | fieldName <- ["id", "call_id"]
-    , Just identity <- [objectTextFieldModel fieldName value]
-    ]
-
-findPendingModelIndex :: Aeson.Value -> StreamModel -> Maybe Int
-findPendingModelIndex value model =
     case objectTextFieldModel "type" value of
-        Nothing -> Nothing
-        Just wantedType ->
-            fst <$> Map.lookupMin
-                (Map.filter
-                    (\(item, done) ->
-                        not done
-                            && objectTextFieldModel "type" item
-                                == Just wantedType)
-                    model)
+        Nothing -> []
+        Just kind ->
+            [ (kind, fieldName, identity)
+            | fieldName <- ["id", "call_id"]
+            , Just identity <- [objectTextFieldModel fieldName value]
+            , not (Text.null identity)
+            ]
+
+findPendingModelIndex :: StreamModel -> Maybe Int
+findPendingModelIndex model =
+    fst <$> Map.lookupMin (Map.filter (not . snd) model)
 
 firstJustModel :: [Maybe value] -> Maybe value
 firstJustModel = foldr (<|>) Nothing


### PR DESCRIPTION
## Summary

- replace repeated output-item scans with one synchronized store for ordered slots, typed identity aliases, and pending slots
- keep provider item IDs, tool call IDs, and output-item kinds in separate namespaces while removing stale aliases on replacement
- merge lifecycle fragments incrementally while preserving sparse/negative indexes, sticky done state, and lowest-slot fallback behavior
- update the independent stream model and add regressions for collisions, alias replacement, pending fallback, and ordering

## Validation

- `printf ':main\n:quit\n' | nix develop -c cabal repl agent-responses:test:agent-responses-test`
- 74 examples, 0 failures

## Notes

This is a structural simplification; the PR does not make a measured performance claim.