### PR TITLE
Add interactive fullscreen login manager

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -43,8 +43,7 @@ library
     import:           common-options
     hs-source-dirs:   src
     autogen-modules:  Paths_agent_cli
-    other-modules:    Agent.CLI.AccountPicker
-                    , Agent.CLI.AgentSessions.Render
+    other-modules:    Agent.CLI.AgentSessions.Render
                     , Agent.CLI.AgentViewport.Status
                     , Agent.CLI.Approval.Decision
                     , Agent.CLI.Auth.Grok
@@ -84,7 +83,6 @@ library
                     , Agent.CLI.Runtime.Orchestration.Tools
                     , Agent.CLI.Runtime.Orchestration.Types
                     , Agent.CLI.Runtime.HistorySource
-                    , Agent.CLI.Runtime.MetaConsole
                     , Agent.CLI.Runtime.Persistence
                     , Agent.CLI.Runtime.Recap
                     , Agent.CLI.Runtime.Repl
@@ -139,6 +137,7 @@ library
                     , Agent.CLI.TUI.Render.Workspace
                     , Paths_agent_cli
     exposed-modules:  Agent.CLI
+                    , Agent.CLI.AccountPicker
                     , Agent.CLI.AccountSelection
                     , Agent.CLI.AgentSessions
                     , Agent.CLI.AgentViewport
@@ -208,6 +207,7 @@ library
                     , Agent.CLI.ProviderTransition
                     , Agent.CLI.Render
                     , Agent.CLI.ReplMode
+                    , Agent.CLI.Runtime.MetaConsole
                     , Agent.CLI.Resume
                     , Agent.CLI.Session
                     , Agent.CLI.Session.ConversationStore

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -2,6 +2,8 @@
 module Agent.CLI.Login
     ( AccountBilling(..)
     , AccountUsage(..)
+    , DevicePollReadiness(..)
+    , DevicePollSchedule
     , LoginAccount(..)
     , LoginAction(..)
     , LoginState(..)
@@ -9,10 +11,13 @@ module Agent.CLI.Login
     , UsageWindow(..)
     , applyLoginKey
     , connectProviderAccount
+    , advanceDevicePollSchedule
+    , devicePollReadiness
     , discoverLoginAccounts
     , discoverSelectableLoginAccounts
     , formatLoginAccounts
     , formatCurrencyAmount
+    , initialDevicePollSchedule
     , initialLoginState
     , loginAccountActionRows
     , loginAccountDetail
@@ -121,7 +126,12 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text
-import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
+import Data.Time.Clock
+    ( UTCTime
+    , addUTCTime
+    , diffUTCTime
+    , getCurrentTime
+    )
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import System.Directory.OsPath (doesFileExist, getHomeDirectory)
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
@@ -256,6 +266,67 @@ runFullscreenLoginManager runtime = do
             dashboardLoop nextNotice rediscovered
 
 data LoginNotice = LoginNotice !Bool !Text
+
+data DevicePollSchedule = DevicePollSchedule
+    { devicePollIntervalSeconds :: !Int
+    , devicePollNextAt :: !UTCTime
+    , devicePollExpiresAt :: !UTCTime
+    } deriving (Eq, Show)
+
+data DevicePollReadiness
+    = DevicePollReady
+    | DevicePollWait !Int
+    | DevicePollExpired
+    deriving (Eq, Show)
+
+-- | Start a bounded device-code flow. The first explicit check is allowed
+-- immediately; every pending response schedules the next permitted check.
+initialDevicePollSchedule
+    :: UTCTime
+    -> Int
+    -> Int
+    -> DevicePollSchedule
+initialDevicePollSchedule startedAt intervalSeconds expiresInSeconds =
+    DevicePollSchedule
+        { devicePollIntervalSeconds = max 1 intervalSeconds
+        , devicePollNextAt = startedAt
+        , devicePollExpiresAt =
+            addUTCTime
+                (fromIntegral (max 0 expiresInSeconds))
+                startedAt
+        }
+
+devicePollReadiness
+    :: UTCTime
+    -> DevicePollSchedule
+    -> DevicePollReadiness
+devicePollReadiness now schedule
+    | now >= schedule.devicePollExpiresAt =
+        DevicePollExpired
+    | now < schedule.devicePollNextAt =
+        DevicePollWait
+            (max 1 (ceiling
+                (diffUTCTime schedule.devicePollNextAt now)))
+    | otherwise =
+        DevicePollReady
+
+-- | Record a pending poll. A @slow_down@ response adds the cumulative
+-- five-second backoff required by RFC 8628.
+advanceDevicePollSchedule
+    :: Bool
+    -> UTCTime
+    -> DevicePollSchedule
+    -> DevicePollSchedule
+advanceDevicePollSchedule slowedDown polledAt schedule =
+    schedule
+        { devicePollIntervalSeconds = intervalSeconds
+        , devicePollNextAt =
+            addUTCTime (fromIntegral intervalSeconds) polledAt
+        }
+  where
+    intervalSeconds =
+        schedule.devicePollIntervalSeconds
+            + if slowedDown then 5 else 0
 
 data LoginDashboardAction
     = LoginDashboardConnect
@@ -866,14 +937,23 @@ connectOpenAIFullscreen runtime = do
     clientId <-
         openAIOAuthClientId <$> lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
     let options = OpenAILogin.defaultLoginOptions clientId
+    requestedAt <- getCurrentTime
     requested <-
         withLoginProgress runtime "Starting OpenAI device authorization…" $
             OpenAILogin.requestDeviceCode options
     case requested of
         Left err -> pure (Just (Left err))
-        Right device -> awaitAuthorization options device False
+        Right device ->
+            awaitAuthorization
+                options
+                device
+                (initialDevicePollSchedule
+                    requestedAt
+                    device.pollIntervalSeconds
+                    deviceAuthorizationDefaultTimeoutSeconds)
+                Nothing
   where
-    awaitAuthorization options device pending = do
+    awaitAuthorization options device schedule notice = do
         choice <-
             requestFullscreenChoiceWithBody
                 runtime
@@ -882,7 +962,7 @@ connectOpenAIFullscreen runtime = do
                     "OpenAI"
                     (Text.pack device.verificationUrl)
                     device.userCode
-                    pending)
+                    notice)
                 0
                 [ ( "Check authorization"
                   , "Return after approving the one-time code in your browser"
@@ -891,16 +971,47 @@ connectOpenAIFullscreen runtime = do
                 ]
         case choice of
             Just 0 -> do
-                polled <-
-                    withLoginProgress runtime "Checking OpenAI authorization…" $
-                        OpenAILogin.pollDeviceCode options device
-                case polled of
-                    Left err -> pure (Just (Left err))
-                    Right Nothing ->
-                        awaitAuthorization options device True
-                    Right (Just authJson) ->
-                        finishOpenAIFullscreen authJson
+                now <- getCurrentTime
+                case devicePollReadiness now schedule of
+                    DevicePollExpired ->
+                        openAITimedOut
+                    DevicePollWait seconds ->
+                        awaitAuthorization
+                            options
+                            device
+                            schedule
+                            (Just (pollWaitNotice seconds))
+                    DevicePollReady -> do
+                        polled <-
+                            withLoginProgress runtime
+                                "Checking OpenAI authorization…" $
+                                    OpenAILogin.pollDeviceCode options device
+                        polledAt <- getCurrentTime
+                        case polled of
+                            Left err -> pure (Just (Left err))
+                            Right Nothing ->
+                                if devicePollReadiness polledAt schedule
+                                        == DevicePollExpired
+                                    then openAITimedOut
+                                    else
+                                        awaitAuthorization
+                                            options
+                                            device
+                                            (advanceDevicePollSchedule
+                                                False polledAt schedule)
+                                            (Just authorizationPendingNotice)
+                            Right (Just authJson)
+                                | devicePollReadiness polledAt schedule
+                                    == DevicePollExpired ->
+                                        openAITimedOut
+                                | otherwise ->
+                                    finishOpenAIFullscreen authJson
             _ -> pure Nothing
+
+    openAITimedOut =
+        pure $
+            Just $
+                Left "OpenAI device authorization timed out after 15 minutes"
 
     finishOpenAIFullscreen authJson = do
         now <- getCurrentTime
@@ -926,14 +1037,25 @@ connectXAIFullscreen runtime = do
     clientId <-
         xaiOAuthClientId <$> lookupNonEmpty "XAI_OAUTH_CLIENT_ID"
     let options = XAIAuth.defaultOAuthOptions clientId
+    requestedAt <- getCurrentTime
     requested <-
         withLoginProgress runtime "Starting xAI device authorization…" $
             XAIAuth.requestDeviceAuthorization options
     case requested of
         Left err -> pure (Just (Left err))
-        Right device -> awaitAuthorization options device False
+        Right device ->
+            awaitAuthorization
+                options
+                device
+                (initialDevicePollSchedule
+                    requestedAt
+                    device.pollIntervalSeconds
+                    (fromMaybe
+                        deviceAuthorizationDefaultTimeoutSeconds
+                        device.expiresInSeconds))
+                Nothing
   where
-    awaitAuthorization options device pending = do
+    awaitAuthorization options device schedule notice = do
         choice <-
             requestFullscreenChoiceWithBody
                 runtime
@@ -942,7 +1064,7 @@ connectXAIFullscreen runtime = do
                     "xAI"
                     device.verificationUrl
                     device.userCode
-                    pending)
+                    notice)
                 0
                 [ ( "Check authorization"
                   , "Return after approving the one-time code in your browser"
@@ -951,16 +1073,73 @@ connectXAIFullscreen runtime = do
                 ]
         case choice of
             Just 0 -> do
-                polled <-
-                    withLoginProgress runtime "Checking xAI authorization…" $
-                        XAIAuth.pollDeviceAuthorization options device
-                case polled of
-                    Left err -> pure (Just (Left err))
-                    Right Nothing ->
-                        awaitAuthorization options device True
-                    Right (Just tokens) ->
-                        finishXAIFullscreen tokens
+                now <- getCurrentTime
+                case devicePollReadiness now schedule of
+                    DevicePollExpired ->
+                        xaiTimedOut
+                    DevicePollWait seconds ->
+                        awaitAuthorization
+                            options
+                            device
+                            schedule
+                            (Just (pollWaitNotice seconds))
+                    DevicePollReady -> do
+                        polled <-
+                            withLoginProgress runtime
+                                "Checking xAI authorization…" $
+                                    XAIAuth.pollDeviceAuthorizationStatus
+                                        options device
+                        polledAt <- getCurrentTime
+                        case polled of
+                            Left err -> pure (Just (Left err))
+                            Right XAIAuth.DeviceAuthorizationPending ->
+                                continuePending False polledAt
+                                    authorizationPendingNotice
+                            Right XAIAuth.DeviceAuthorizationSlowDown ->
+                                let nextSchedule =
+                                        advanceDevicePollSchedule
+                                            True polledAt schedule
+                                    seconds = case
+                                        devicePollReadiness
+                                            polledAt nextSchedule of
+                                        DevicePollWait waitSeconds ->
+                                            waitSeconds
+                                        _ -> 0
+                                in continueWithSchedule
+                                    polledAt
+                                    nextSchedule
+                                    (authorizationSlowDownNotice seconds)
+                            Right
+                                (XAIAuth.DeviceAuthorizationComplete tokens)
+                                    | devicePollReadiness polledAt schedule
+                                        == DevicePollExpired ->
+                                            xaiTimedOut
+                                    | otherwise ->
+                                        finishXAIFullscreen tokens
             _ -> pure Nothing
+      where
+        continuePending slowedDown polledAt nextNotice =
+            continueWithSchedule
+                polledAt
+                (advanceDevicePollSchedule
+                    slowedDown polledAt schedule)
+                nextNotice
+
+        continueWithSchedule polledAt nextSchedule nextNotice
+            | devicePollReadiness polledAt schedule
+                == DevicePollExpired =
+                    xaiTimedOut
+            | otherwise =
+                awaitAuthorization
+                    options
+                    device
+                    nextSchedule
+                    (Just nextNotice)
+
+    xaiTimedOut =
+        pure $
+            Just $
+                Left "xAI device authorization timed out"
 
     finishXAIFullscreen tokens
         | Nothing <- tokens.refreshToken =
@@ -1036,19 +1215,35 @@ deviceAuthorizationBody
     :: Text
     -> Text
     -> Text
-    -> Bool
+    -> Maybe Text
     -> Text
-deviceAuthorizationBody provider url userCode pending =
+deviceAuthorizationBody provider url userCode notice =
     Text.intercalate "\n\n" $
         [ "1. [Open the " <> provider <> " sign-in page](" <> url <> ")."
         , "2. Enter this one-time code:"
         , "`" <> markdownText 100 userCode <> "`"
         , "3. Return here and choose **Check authorization**."
         ]
-            <> [ "Authorization is still pending. Finish the browser step, "
-                    <> "then check again."
-               | pending
-               ]
+            <> maybe [] (pure . markdownText 300) notice
+
+deviceAuthorizationDefaultTimeoutSeconds :: Int
+deviceAuthorizationDefaultTimeoutSeconds = 15 * 60
+
+authorizationPendingNotice :: Text
+authorizationPendingNotice =
+    "Authorization is still pending. Finish the browser step, then check again."
+
+pollWaitNotice :: Int -> Text
+pollWaitNotice seconds =
+    "Please wait "
+        <> Text.pack (show seconds)
+        <> " seconds before checking authorization again."
+
+authorizationSlowDownNotice :: Int -> Text
+authorizationSlowDownNotice seconds =
+    "xAI asked this client to slow down. The next check is available in "
+        <> Text.pack (show seconds)
+        <> " seconds."
 
 connectOpenAI :: Bool -> IO (Maybe Text)
 connectOpenAI color = do

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -14,9 +14,13 @@ module Agent.CLI.Login
     , formatLoginAccounts
     , formatCurrencyAmount
     , initialLoginState
+    , loginAccountActionRows
+    , loginAccountDetail
     , loginAccountSelectionId
+    , loginDashboardRows
     , refreshLoginAccount
     , renderLoginFrame
+    , runFullscreenLoginManager
     , runLoginManager
     ) where
 
@@ -74,6 +78,12 @@ import Agent.CLI.Style
     , roleSuccess
     , roleWarn
     )
+import Agent.CLI.TUI.App
+    ( FullscreenRuntime
+    , emitUiEvent
+    , requestFullscreenChoiceWithBody
+    , requestFullscreenSecret
+    )
 import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Login as OpenAILogin
@@ -86,6 +96,10 @@ import Agent.Provider
     , Provider(..)
     , providerSlug
     )
+import Agent.TUI.Model
+    ( UiEvent(UiSetNotice)
+    , progressNotice
+    )
 import qualified Agent.XAI.Auth as XAIAuth
 import qualified Agent.XAI.Usage as XAI
 import Control.Applicative ((<|>))
@@ -95,10 +109,11 @@ import Control.Concurrent.Async
     , withAsync
     )
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
-import Control.Exception.Safe (bracket, tryAny)
+import Control.Exception.Safe (bracket, bracket_, tryAny)
 import Control.Monad (join, void)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import Data.Char (isControl)
 import Data.Containers.ListUtils (nubOrdOn)
 import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Data.Scientific (Scientific, FPFormat(Fixed), formatScientific)
@@ -163,6 +178,382 @@ runLoginManager color = do
             accounts <- discoverLoginAccounts
             loop [0 .. length accounts - 1] (initialLoginState accounts)
 
+-- | Native fullscreen credential manager used by @/login@. Every prompt is a
+-- Brick overlay, so the application stays in the alternate screen and
+-- provider tokens never pass through the ordinary line editor.
+runFullscreenLoginManager :: FullscreenRuntime -> IO ()
+runFullscreenLoginManager runtime = do
+    accounts <- discoverLoginAccounts
+    dashboardLoop Nothing accounts
+  where
+    dashboardLoop notice accounts = do
+        let entries = loginDashboardEntries accounts
+        choice <-
+            requestFullscreenChoiceWithBody
+                runtime
+                "Provider accounts"
+                (loginDashboardBody notice accounts)
+                0
+                (map snd entries)
+        case choice >>= (`accountAt` entries) of
+            Nothing -> pure ()
+            Just (LoginDashboardConnect, _) -> do
+                result <- connectFullscreenAccount runtime
+                rediscovered <- discoverLoginAccounts
+                dashboardLoop (result <|> notice) rediscovered
+            Just (LoginDashboardRefreshAll, _) -> do
+                refreshed <-
+                    withLoginProgress runtime "Refreshing provider usage…" $
+                        mapConcurrently refreshLoginAccountSafely accounts
+                dashboardLoop
+                    (Just (refreshAllNotice refreshed))
+                    refreshed
+            Just (LoginDashboardOpen index, _) ->
+                accountLoop notice index accounts
+
+    accountLoop notice index accounts =
+        case accountAt index accounts of
+            Nothing -> dashboardLoop notice accounts
+            Just account -> do
+                let entries = loginAccountMenuEntries account
+                choice <-
+                    requestFullscreenChoiceWithBody
+                        runtime
+                        (accountMenuTitle account)
+                        (loginAccountBody notice account)
+                        0
+                        (map snd entries)
+                case choice >>= (`accountAt` entries) of
+                    Nothing ->
+                        dashboardLoop notice accounts
+                    Just (LoginAccountRefresh, _) -> do
+                        refreshed <-
+                            withLoginProgress runtime "Refreshing account usage…" $
+                                refreshLoginAccountSafely account
+                        accountLoop
+                            (Just (refreshOneNotice refreshed))
+                            index
+                            (replaceAt index refreshed accounts)
+                    Just (LoginAccountToggle, _) -> do
+                        result <- toggleLoginAccount account
+                        rediscoverAndLoop (Just (noticeFromResult result))
+                    Just (LoginAccountImport, _) -> do
+                        result <- importLoginAccount account
+                        rediscoverAndLoop (Just (noticeFromResult result))
+                    Just (LoginAccountDisconnect, _) -> do
+                        confirmed <- confirmFullscreenDisconnect runtime account
+                        if not confirmed
+                            then accountLoop notice index accounts
+                            else do
+                                result <- disconnectLoginAccount account
+                                rediscoverAndLoop
+                                    (Just (noticeFromResult result))
+                    Just (LoginAccountBack, _) ->
+                        dashboardLoop notice accounts
+      where
+        rediscoverAndLoop nextNotice = do
+            rediscovered <- discoverLoginAccounts
+            dashboardLoop nextNotice rediscovered
+
+data LoginNotice = LoginNotice !Bool !Text
+
+data LoginDashboardAction
+    = LoginDashboardConnect
+    | LoginDashboardRefreshAll
+    | LoginDashboardOpen !Int
+
+data LoginAccountMenuAction
+    = LoginAccountRefresh
+    | LoginAccountToggle
+    | LoginAccountImport
+    | LoginAccountDisconnect
+    | LoginAccountBack
+
+loginDashboardRows :: [LoginAccount] -> [(Text, Text)]
+loginDashboardRows = map snd . loginDashboardEntries
+
+loginDashboardEntries
+    :: [LoginAccount]
+    -> [(LoginDashboardAction, (Text, Text))]
+loginDashboardEntries accounts =
+    [ ( LoginDashboardConnect
+      , ("＋ Connect account", "OpenAI, xAI / Grok, OpenRouter, or Claude Code")
+      )
+    ]
+        <> refreshEntry
+        <> zipWith
+            (\index account ->
+                (LoginDashboardOpen index, loginDashboardAccountRow account))
+            [0 ..]
+            accounts
+  where
+    refreshEntry
+        | null accounts = []
+        | otherwise =
+            [ ( LoginDashboardRefreshAll
+              , ( "↻ Refresh all usage"
+                , Text.pack (show (length accounts)) <> " accounts"
+                )
+              )
+            ]
+
+loginDashboardAccountRow :: LoginAccount -> (Text, Text)
+loginDashboardAccountRow account =
+    ( accountHealthGlyph account
+        <> providerSlug account.loginProvider
+        <> "  "
+        <> displayText 48 account.loginLabel
+    , Text.intercalate " · " $
+        [ accountIdentifier account
+        , if isJust account.loginManagedId then "managed" else "external"
+        , if account.loginEnabled then "enabled" else "disabled"
+        , billingSummary account.loginBilling
+        , usageSummary account.loginUsage
+        ]
+    )
+
+accountIdentifier :: LoginAccount -> Text
+accountIdentifier account
+    | Text.null (Text.strip account.loginAccountId) = "unknown account"
+    | otherwise = displayText 48 account.loginAccountId
+
+loginDashboardBody :: Maybe LoginNotice -> [LoginAccount] -> Text
+loginDashboardBody notice accounts =
+    Text.intercalate "\n\n" $
+        [ "Manage credentials and inspect provider usage without leaving the fullscreen UI."
+        , "**" <> Text.pack (show (length accounts)) <> " accounts**"
+            <> " · " <> Text.pack (show managedCount) <> " managed"
+            <> " · " <> Text.pack (show enabledCount) <> " enabled"
+        ]
+            <> maybe [] (pure . formatLoginNotice) notice
+            <> [ if null accounts
+                    then "No credentials were found. Connect an account to get started."
+                    else "Select an account for usage details, importing, enable/disable, or disconnect."
+               ]
+  where
+    managedCount = length (filter (isJust . (.loginManagedId)) accounts)
+    enabledCount = length (filter (.loginEnabled) accounts)
+
+loginAccountActionRows :: LoginAccount -> [(Text, Text)]
+loginAccountActionRows = map snd . loginAccountMenuEntries
+
+loginAccountMenuEntries
+    :: LoginAccount
+    -> [(LoginAccountMenuAction, (Text, Text))]
+loginAccountMenuEntries account =
+    [ (LoginAccountRefresh, ("↻ Refresh usage", "Fetch the latest provider limits"))
+    ]
+        <> managementEntries
+        <> [(LoginAccountBack, ("← Back to accounts", "Return to the dashboard"))]
+  where
+    managementEntries = case account.loginManagedId of
+        Just _ ->
+            [ ( LoginAccountToggle
+              , ( if account.loginEnabled
+                    then "○ Disable credential"
+                    else "● Enable credential"
+                , if account.loginEnabled
+                    then "Keep it stored but exclude it from selection"
+                    else "Make it available for provider selection"
+                )
+              )
+            , ( LoginAccountDisconnect
+              , ("− Disconnect credential", "Delete it from the managed store")
+              )
+            ]
+        Nothing
+            | Text.null account.loginSecretPayload -> []
+            | otherwise ->
+                [ ( LoginAccountImport
+                  , ("⇥ Import credential", "Copy it into the managed store")
+                  )
+                ]
+
+accountMenuTitle :: LoginAccount -> Text
+accountMenuTitle account =
+    providerSlug account.loginProvider
+        <> " · "
+        <> displayText 48 account.loginLabel
+
+loginAccountBody :: Maybe LoginNotice -> LoginAccount -> Text
+loginAccountBody notice account =
+    Text.intercalate "\n\n" $
+        maybe [] (pure . formatLoginNotice) notice
+            <> [loginAccountDetail account]
+
+loginAccountDetail :: LoginAccount -> Text
+loginAccountDetail account =
+    Text.intercalate "\n" $
+        [ "**" <> markdownText 100 account.loginLabel <> "**"
+        , ""
+        , "Provider: " <> providerSlug account.loginProvider
+        , "Account: " <> markdownText 120 accountId
+        , "Source: " <> markdownText 160 account.loginSource
+        , "Storage: " <>
+            if isJust account.loginManagedId then "managed" else "external (read-only)"
+        , "Status: " <>
+            if account.loginEnabled then "enabled" else "disabled"
+        , "Billing: " <> billingSummary account.loginBilling
+        , ""
+        , "**Usage**"
+        ]
+            <> usageDetail account.loginUsage
+  where
+    accountId
+        | Text.null account.loginAccountId = "(unknown)"
+        | otherwise = account.loginAccountId
+
+usageDetail :: UsageState -> [Text]
+usageDetail = \case
+    UsageNotChecked ->
+        ["Not checked yet. Choose **Refresh usage** to fetch current limits."]
+    UsageUnavailable err ->
+        ["⚠ " <> markdownText 500 ("Usage unavailable · " <> err)]
+    UsageAvailable usage ->
+        planLines <> windowLines <> creditDetail <> fallback
+      where
+        planLines = maybe [] (\plan -> ["Plan: " <> markdownText 80 plan])
+            usage.usagePlan
+        windowLines = concatMap formatUsageWindow usage.usageWindows
+        creditDetail =
+            catMaybes
+                [ ("Credits remaining: " <>) . markdownText 80
+                    <$> usage.creditsRemaining
+                , ("Credits used: " <>) . markdownText 80
+                    <$> usage.creditsUsed
+                ]
+        fallback
+            | null planLines && null windowLines && null creditDetail =
+                ["Usage is available; this provider reported no active limits."]
+            | otherwise = []
+
+formatUsageWindow :: UsageWindow -> [Text]
+formatUsageWindow window =
+    [ "- " <> markdownText 80 window.windowName
+        <> "  `" <> usageBar window.usedPercent <> "`  "
+        <> Text.pack (show window.usedPercent) <> "% used"
+    , "  Resets " <> Text.pack (show window.resetsAt)
+    ]
+
+usageBar :: Int -> Text
+usageBar usedPercent =
+    Text.replicate filled "█" <> Text.replicate (10 - filled) "░"
+  where
+    clamped = max 0 (min 100 usedPercent)
+    filled = (clamped + 5) `div` 10
+
+accountHealthGlyph :: LoginAccount -> Text
+accountHealthGlyph account
+    | not account.loginEnabled = "○ "
+    | otherwise = case account.loginUsage of
+        UsageNotChecked -> "◌ "
+        UsageUnavailable _ -> "✗ "
+        UsageAvailable _ -> "✓ "
+
+billingSummary :: AccountBilling -> Text
+billingSummary = \case
+    SubscriptionBilling plan ->
+        "subscription" <> maybe "" (" / " <>) plan
+    ApiCreditsBilling -> "API credits"
+
+usageSummary :: UsageState -> Text
+usageSummary = \case
+    UsageNotChecked -> "usage not checked"
+    UsageUnavailable _ -> "usage unavailable"
+    UsageAvailable usage ->
+        case usage.usageWindows of
+            window : _ ->
+                Text.pack (show window.usedPercent)
+                    <> "% " <> window.windowName
+            [] -> case usage.creditsRemaining of
+                Just remaining -> remaining <> " remaining"
+                Nothing -> maybe "usage available" id usage.usagePlan
+
+displayText :: Int -> Text -> Text
+displayText limit =
+    Text.take limit
+        . Text.unwords
+        . Text.words
+        . Text.map (\character -> if isControl character then ' ' else character)
+
+markdownText :: Int -> Text -> Text
+markdownText limit =
+    Text.concatMap escape . displayText limit
+  where
+    escape character
+        | character `elem` ("\\`*_[]<>" :: String) =
+            "\\" <> Text.singleton character
+        | otherwise = Text.singleton character
+
+formatLoginNotice :: LoginNotice -> Text
+formatLoginNotice (LoginNotice successful message) =
+    (if successful then "✅ " else "⚠️ ")
+        <> markdownText 500 message
+
+noticeFromResult :: Either Text Text -> LoginNotice
+noticeFromResult = \case
+    Left err -> LoginNotice False err
+    Right message -> LoginNotice True message
+
+refreshOneNotice :: LoginAccount -> LoginNotice
+refreshOneNotice account = case account.loginUsage of
+    UsageUnavailable err -> LoginNotice False err
+    _ -> LoginNotice True "Usage refreshed."
+
+refreshAllNotice :: [LoginAccount] -> LoginNotice
+refreshAllNotice accounts
+    | unavailable == 0 =
+        LoginNotice True
+            ("Usage refreshed for " <> count <> " accounts.")
+    | otherwise =
+        LoginNotice False
+            ("Usage refreshed; " <> Text.pack (show unavailable)
+                <> " of " <> count <> " accounts were unavailable.")
+  where
+    count = Text.pack (show (length accounts))
+    unavailable = length
+        [()
+        | account <- accounts
+        , UsageUnavailable _ <- [account.loginUsage]
+        ]
+
+withLoginProgress :: FullscreenRuntime -> Text -> IO a -> IO a
+withLoginProgress runtime message =
+    bracket_
+        (emitUiEvent runtime
+            (UiSetNotice (Just (progressNotice message))))
+        (emitUiEvent runtime (UiSetNotice Nothing))
+
+refreshLoginAccountSafely :: LoginAccount -> IO LoginAccount
+refreshLoginAccountSafely account =
+    tryAny (refreshLoginAccount account) >>= \case
+        Left err ->
+            pure account
+                { loginUsage =
+                    UsageUnavailable
+                        ("usage check failed: " <> formatException err)
+                }
+        Right refreshed -> pure refreshed
+
+confirmFullscreenDisconnect
+    :: FullscreenRuntime
+    -> LoginAccount
+    -> IO Bool
+confirmFullscreenDisconnect runtime account = do
+    choice <-
+        requestFullscreenChoiceWithBody
+            runtime
+            "Disconnect credential?"
+            ( "Delete **" <> markdownText 100 account.loginLabel
+                <> "** from the managed credential store?\n\n"
+                <> "This cannot be undone."
+            )
+            1
+            [ ("Disconnect", "Delete the stored credential")
+            , ("Keep credential", "Return without changing anything")
+            ]
+    pure (choice == Just 0)
+
 refreshSelectedAccounts
     :: Chan (Int, LoginAccount)
     -> [Int]
@@ -174,14 +565,7 @@ refreshSelectedAccounts updates indices accounts =
     refreshOne index = case accountAt index accounts of
         Nothing -> pure ()
         Just account -> do
-            refreshed <- tryAny (refreshLoginAccount account) >>= \case
-                Left err ->
-                    pure account
-                        { loginUsage =
-                            UsageUnavailable
-                                ("usage check failed: " <> formatException err)
-                        }
-                Right result -> pure result
+            refreshed <- refreshLoginAccountSafely account
             writeChan updates (index, refreshed)
 
 applyRefreshedAccount
@@ -293,18 +677,23 @@ toggleAt :: Bool -> Int -> [LoginAccount] -> IO ()
 toggleAt color index accounts =
     case accountAt index accounts of
         Nothing -> pure ()
-        Just account -> case account.loginManagedId of
-            Nothing ->
-                printLoginMessage color False
-                    "external credentials are read-only; import them before changing state"
-            Just credentialId ->
-                setManagedCredentialEnabled
-                    credentialId
-                    (not account.loginEnabled)
-                    >>= printStoreResult color
-                        (if account.loginEnabled
-                            then "credential disabled"
-                            else "credential enabled")
+        Just account ->
+            toggleLoginAccount account >>= printLoginResult color
+
+toggleLoginAccount :: LoginAccount -> IO (Either Text Text)
+toggleLoginAccount account = case account.loginManagedId of
+    Nothing ->
+        pure (Left
+            "external credentials are read-only; import them before changing state")
+    Just credentialId ->
+        fmap (fmap (const successMessage))
+            (setManagedCredentialEnabled
+                credentialId
+                (not account.loginEnabled))
+  where
+    successMessage
+        | account.loginEnabled = "Credential disabled."
+        | otherwise = "Credential enabled."
 
 deleteAt :: Bool -> Int -> [LoginAccount] -> IO ()
 deleteAt color index accounts =
@@ -312,52 +701,61 @@ deleteAt color index accounts =
         Nothing -> pure ()
         Just account -> case account.loginManagedId of
             Nothing ->
-                printLoginMessage color False
-                    "external credentials are read-only; remove them from their source"
-            Just credentialId ->
+                disconnectLoginAccount account >>= printLoginResult color
+            Just _ ->
                 readApprovalLine
                     ("Disconnect " <> account.loginLabel <> "? [y/N] ")
                     >>= \case
                         Just answer
                             | Text.toLower (Text.strip answer) `elem` ["y", "yes"] ->
-                                deleteManagedCredential credentialId
-                                    >>= printStoreResult color
-                                        "credential disconnected"
+                                disconnectLoginAccount account
+                                    >>= printLoginResult color
                         _ -> pure ()
+
+disconnectLoginAccount :: LoginAccount -> IO (Either Text Text)
+disconnectLoginAccount account = case account.loginManagedId of
+    Nothing ->
+        pure (Left
+            "external credentials are read-only; remove them from their source")
+    Just credentialId ->
+        fmap (fmap (const "Credential disconnected."))
+            (deleteManagedCredential credentialId)
 
 importAt :: Bool -> Int -> [LoginAccount] -> IO ()
 importAt color index accounts =
     case accountAt index accounts of
         Nothing -> pure ()
-        Just account -> case account.loginManagedId of
-            Just _ ->
-                printLoginMessage color False "credential is already managed"
-            Nothing
-                | Text.null account.loginSecretPayload ->
-                    printLoginMessage color False
-                        "this credential source cannot be imported"
-                | otherwise -> do
-                    credentialId <-
-                        newManagedCredentialId
-                            account.loginProvider account.loginAccountId
-                    upsertManagedCredential
-                        ManagedCredential
-                            { managedId = credentialId
-                            , managedProvider = account.loginProvider
-                            , managedAccountId = account.loginAccountId
-                            , managedLabel = account.loginLabel
-                            , managedBilling = case account.loginBilling of
-                                SubscriptionBilling _ -> SubscriptionBilled
-                                ApiCreditsBilling -> ApiBilled
-                            , managedAuthKind = account.loginAuthKind
-                            , managedEnabled = True
-                            }
-                        ManagedSecret
-                            { secretManagedId = credentialId
-                            , secretPayload = account.loginSecretPayload
-                            }
-                        >>= printStoreResult color
-                            "credential imported into the managed store"
+        Just account ->
+            importLoginAccount account >>= printLoginResult color
+
+importLoginAccount :: LoginAccount -> IO (Either Text Text)
+importLoginAccount account = case account.loginManagedId of
+    Just _ ->
+        pure (Left "credential is already managed")
+    Nothing
+        | Text.null account.loginSecretPayload ->
+            pure (Left "this credential source cannot be imported")
+        | otherwise -> do
+            credentialId <-
+                newManagedCredentialId
+                    account.loginProvider account.loginAccountId
+            fmap (fmap (const "Credential imported into the managed store.")) $
+                upsertManagedCredential
+                    ManagedCredential
+                        { managedId = credentialId
+                        , managedProvider = account.loginProvider
+                        , managedAccountId = account.loginAccountId
+                        , managedLabel = account.loginLabel
+                        , managedBilling = case account.loginBilling of
+                            SubscriptionBilling _ -> SubscriptionBilled
+                            ApiCreditsBilling -> ApiBilled
+                        , managedAuthKind = account.loginAuthKind
+                        , managedEnabled = True
+                        }
+                    ManagedSecret
+                        { secretManagedId = credentialId
+                        , secretPayload = account.loginSecretPayload
+                        }
 
 accountAt :: Int -> [account] -> Maybe account
 accountAt index accounts =
@@ -414,6 +812,243 @@ pickConnectProvider color =
         PickerKeyDown ->
             Right ((index + 1) `mod` length providers)
         _ -> Right index
+
+connectFullscreenAccount :: FullscreenRuntime -> IO (Maybe LoginNotice)
+connectFullscreenAccount runtime = do
+    choice <-
+        requestFullscreenChoiceWithBody
+            runtime
+            "Connect provider account"
+            ( "Choose a provider. OAuth links, one-time codes, and API-key "
+                <> "entry will remain inside the fullscreen UI."
+            )
+            0
+            (map snd providers)
+    case choice >>= (`accountAt` providers) of
+        Nothing -> pure Nothing
+        Just (provider, _) ->
+            fmap noticeFromResult
+                <$> connectFullscreenProvider runtime provider
+  where
+    providers =
+        [ ( OpenAIProvider
+          , ("OpenAI / ChatGPT", "Connect a ChatGPT subscription with OAuth")
+          )
+        , ( XAIProvider
+          , ("xAI / Grok", "Connect a Grok subscription with OAuth")
+          )
+        , ( OpenRouterProvider
+          , ("OpenRouter", "Add a masked API key and inspect credits")
+          )
+        , ( ClaudeCodeProvider
+          , ("Claude Code", "Managed by the Claude Code CLI")
+          )
+        ]
+
+connectFullscreenProvider
+    :: FullscreenRuntime
+    -> Provider
+    -> IO (Maybe (Either Text Text))
+connectFullscreenProvider runtime = \case
+    OpenAIProvider -> connectOpenAIFullscreen runtime
+    XAIProvider -> connectXAIFullscreen runtime
+    OpenRouterProvider -> connectOpenRouterFullscreen runtime
+    ClaudeCodeProvider ->
+        pure $
+            Just $
+                Left
+                    "Claude Code subscriptions are managed by `claude auth login`."
+
+connectOpenAIFullscreen
+    :: FullscreenRuntime
+    -> IO (Maybe (Either Text Text))
+connectOpenAIFullscreen runtime = do
+    clientId <-
+        openAIOAuthClientId <$> lookupNonEmpty "OPENAI_OAUTH_CLIENT_ID"
+    let options = OpenAILogin.defaultLoginOptions clientId
+    requested <-
+        withLoginProgress runtime "Starting OpenAI device authorization…" $
+            OpenAILogin.requestDeviceCode options
+    case requested of
+        Left err -> pure (Just (Left err))
+        Right device -> awaitAuthorization options device False
+  where
+    awaitAuthorization options device pending = do
+        choice <-
+            requestFullscreenChoiceWithBody
+                runtime
+                "Connect OpenAI / ChatGPT"
+                (deviceAuthorizationBody
+                    "OpenAI"
+                    (Text.pack device.verificationUrl)
+                    device.userCode
+                    pending)
+                0
+                [ ( "Check authorization"
+                  , "Return after approving the one-time code in your browser"
+                  )
+                , ("Cancel", "Stop without storing a credential")
+                ]
+        case choice of
+            Just 0 -> do
+                polled <-
+                    withLoginProgress runtime "Checking OpenAI authorization…" $
+                        OpenAILogin.pollDeviceCode options device
+                case polled of
+                    Left err -> pure (Just (Left err))
+                    Right Nothing ->
+                        awaitAuthorization options device True
+                    Right (Just authJson) ->
+                        finishOpenAIFullscreen authJson
+            _ -> pure Nothing
+
+    finishOpenAIFullscreen authJson = do
+        now <- getCurrentTime
+        case openaiAuthStateFromJson now (Aeson.encode authJson) of
+            Nothing ->
+                pure $
+                    Just $
+                        Left "OpenAI login returned invalid account data"
+            Just auth ->
+                Just <$> storeConnectedCredentialResult
+                    OpenAIProvider
+                    auth.accountId
+                    (fromMaybe "ChatGPT" (openAIAccountEmail auth))
+                    SubscriptionBilled
+                    ManagedOpenAIAuthJson
+                    (Text.decodeUtf8
+                        (LBS.toStrict (Aeson.encode authJson)))
+
+connectXAIFullscreen
+    :: FullscreenRuntime
+    -> IO (Maybe (Either Text Text))
+connectXAIFullscreen runtime = do
+    clientId <-
+        xaiOAuthClientId <$> lookupNonEmpty "XAI_OAUTH_CLIENT_ID"
+    let options = XAIAuth.defaultOAuthOptions clientId
+    requested <-
+        withLoginProgress runtime "Starting xAI device authorization…" $
+            XAIAuth.requestDeviceAuthorization options
+    case requested of
+        Left err -> pure (Just (Left err))
+        Right device -> awaitAuthorization options device False
+  where
+    awaitAuthorization options device pending = do
+        choice <-
+            requestFullscreenChoiceWithBody
+                runtime
+                "Connect xAI / Grok"
+                (deviceAuthorizationBody
+                    "xAI"
+                    device.verificationUrl
+                    device.userCode
+                    pending)
+                0
+                [ ( "Check authorization"
+                  , "Return after approving the one-time code in your browser"
+                  )
+                , ("Cancel", "Stop without storing a credential")
+                ]
+        case choice of
+            Just 0 -> do
+                polled <-
+                    withLoginProgress runtime "Checking xAI authorization…" $
+                        XAIAuth.pollDeviceAuthorization options device
+                case polled of
+                    Left err -> pure (Just (Left err))
+                    Right Nothing ->
+                        awaitAuthorization options device True
+                    Right (Just tokens) ->
+                        finishXAIFullscreen tokens
+            _ -> pure Nothing
+
+    finishXAIFullscreen tokens
+        | Nothing <- tokens.refreshToken =
+            pure $
+                Just $
+                    Left
+                        "Grok login did not return a refresh token; reconnect with offline access"
+        | otherwise = do
+            now <- getCurrentTime
+            let accountId =
+                    fromMaybe "grok"
+                        (XAIAuth.accountIdFromAccessToken tokens.accessToken)
+                label = fromMaybe "Grok" $
+                    (tokens.idToken >>= XAIAuth.emailFromToken)
+                        <|> XAIAuth.emailFromToken tokens.accessToken
+                authJson = grokAuthStateToJson GrokAuthState
+                    { grokAccessToken = tokens.accessToken
+                    , grokRefreshToken = tokens.refreshToken
+                    , grokIdToken = tokens.idToken
+                    , grokExpiresAt =
+                        ((`addUTCTime` now) . fromIntegral
+                            <$> tokens.expiresInSeconds)
+                            <|> OpenAI.parseJwtExp tokens.accessToken
+                    }
+            Just <$> storeConnectedCredentialResult
+                XAIProvider
+                accountId
+                label
+                SubscriptionBilled
+                ManagedGrokAuthJson
+                (Text.decodeUtf8
+                    (LBS.toStrict (Aeson.encode authJson)))
+
+connectOpenRouterFullscreen
+    :: FullscreenRuntime
+    -> IO (Maybe (Either Text Text))
+connectOpenRouterFullscreen runtime =
+    requestFullscreenSecret
+        runtime
+        "Connect OpenRouter"
+        ( "Paste an OpenRouter API key. Input is masked and is never added "
+            <> "to the conversation transcript."
+        )
+        >>= \case
+            Nothing -> pure Nothing
+            Just rawKey
+                | Text.null apiKey -> pure Nothing
+                | otherwise -> do
+                    fetched <-
+                        withLoginProgress runtime "Validating OpenRouter key…" $
+                            OpenRouter.fetchOpenRouterUsage apiKey
+                    case fetched of
+                        Left err ->
+                            pure $
+                                Just $
+                                    Left ("OpenRouter rejected the key: " <> err)
+                        Right usage -> do
+                            let accountId =
+                                    fromMaybe "openrouter" usage.keyLabel
+                                label =
+                                    fromMaybe "OpenRouter" usage.keyLabel
+                            Just <$> storeConnectedCredentialResult
+                                OpenRouterProvider
+                                accountId
+                                label
+                                ApiBilled
+                                ManagedBearerToken
+                                apiKey
+              where
+                apiKey = Text.strip rawKey
+
+deviceAuthorizationBody
+    :: Text
+    -> Text
+    -> Text
+    -> Bool
+    -> Text
+deviceAuthorizationBody provider url userCode pending =
+    Text.intercalate "\n\n" $
+        [ "1. [Open the " <> provider <> " sign-in page](" <> url <> ")."
+        , "2. Enter this one-time code:"
+        , "`" <> markdownText 100 userCode <> "`"
+        , "3. Return here and choose **Check authorization**."
+        ]
+            <> [ "Authorization is still pending. Finish the browser step, "
+                    <> "then check again."
+               | pending
+               ]
 
 connectOpenAI :: Bool -> IO (Maybe Text)
 connectOpenAI color = do
@@ -549,27 +1184,42 @@ storeConnectedCredential
     -> Text
     -> IO Bool
 storeConnectedCredential color provider accountId label billing authKind payload = do
+    result <-
+        storeConnectedCredentialResult
+            provider
+            accountId
+            label
+            billing
+            authKind
+            payload
+    printLoginResult color result
+    pure (either (const False) (const True) result)
+
+storeConnectedCredentialResult
+    :: Provider
+    -> Text
+    -> Text
+    -> BillingMode
+    -> ManagedAuthKind
+    -> Text
+    -> IO (Either Text Text)
+storeConnectedCredentialResult provider accountId label billing authKind payload = do
     credentialId <- newManagedCredentialId provider accountId
-    result <- upsertManagedCredential
-        ManagedCredential
-            { managedId = credentialId
-            , managedProvider = provider
-            , managedAccountId = accountId
-            , managedLabel = label
-            , managedBilling = billing
-            , managedAuthKind = authKind
-            , managedEnabled = True
-            }
-        ManagedSecret
-            { secretManagedId = credentialId
-            , secretPayload = payload
-            }
-    printStoreResult color
-        "credential connected"
-        result
-    pure $ case result of
-        Left _ -> False
-        Right () -> True
+    fmap (fmap (const "Credential connected.")) $
+        upsertManagedCredential
+            ManagedCredential
+                { managedId = credentialId
+                , managedProvider = provider
+                , managedAccountId = accountId
+                , managedLabel = label
+                , managedBilling = billing
+                , managedAuthKind = authKind
+                , managedEnabled = True
+                }
+            ManagedSecret
+                { secretManagedId = credentialId
+                , secretPayload = payload
+                }
 
 readSecretLine :: Text -> IO (Maybe Text)
 readSecretLine prompt = do
@@ -591,10 +1241,10 @@ readSecretLine prompt = do
         | Text.null value = Nothing
         | otherwise = Just value
 
-printStoreResult :: Bool -> Text -> Either Text () -> IO ()
-printStoreResult color success = \case
+printLoginResult :: Bool -> Either Text Text -> IO ()
+printLoginResult color = \case
     Left err -> printLoginMessage color False err
-    Right () -> printLoginMessage color True success
+    Right success -> printLoginMessage color True success
 
 printLoginMessage :: Bool -> Bool -> Text -> IO ()
 printLoginMessage color success message = do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -61,7 +61,11 @@ import Agent.CLI.Input
 import Agent.CLI.Interrupt ()
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
-import Agent.CLI.Login ( connectProviderAccount, runLoginManager )
+import Agent.CLI.Login
+    ( connectProviderAccount
+    , runFullscreenLoginManager
+    , runLoginManager
+    )
 import Agent.CLI.Lsp ()
 import Agent.CLI.ManagedTurn ()
 import Agent.CLI.McpManager ( runMcpManager )
@@ -733,8 +737,12 @@ handleReplLine
                     action@ReplRename{} -> handleSessionAction env slashCatalog continue action
                     action@ReplRenameAuto -> handleSessionAction env slashCatalog continue action
                     ReplLogin -> do
-                        color <- resolveColor stderr
-                        legacy (runLoginManager color)
+                        case fullscreen of
+                            Just runtime ->
+                                runFullscreenLoginManager runtime
+                            Nothing -> do
+                                color <- resolveColor stderr
+                                runLoginManager color
                         continue
                     ReplUsage -> do
                         case fullscreen of

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -7,7 +7,7 @@ import Agent.Provider (Provider(..))
 import Data.Either (isLeft)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (UTCTime(..))
+import Data.Time.Clock (UTCTime(..), addUTCTime)
 import Test.Hspec
 
 spec :: Spec
@@ -172,6 +172,39 @@ spec = do
             detail `shouldSatisfy` Text.isInfixOf "31% used"
             detail `shouldSatisfy` Text.isInfixOf "Resets"
             detail `shouldSatisfy` not . Text.isInfixOf "secret-openai"
+
+    describe "device authorization polling" do
+        it "enforces the provider interval after a pending check" do
+            let initial = initialDevicePollSchedule epoch 5 60
+                pending = advanceDevicePollSchedule False epoch initial
+            devicePollReadiness epoch initial
+                `shouldBe` DevicePollReady
+            devicePollReadiness epoch pending
+                `shouldBe` DevicePollWait 5
+            devicePollReadiness (addUTCTime 4 epoch) pending
+                `shouldBe` DevicePollWait 1
+            devicePollReadiness (addUTCTime 5 epoch) pending
+                `shouldBe` DevicePollReady
+
+        it "adds five seconds after slow_down and enforces expiry" do
+            let initial = initialDevicePollSchedule epoch 5 60
+                slowedDownOnce =
+                    advanceDevicePollSchedule True epoch initial
+                slowedDownTwice =
+                    advanceDevicePollSchedule
+                        True
+                        (addUTCTime 10 epoch)
+                        slowedDownOnce
+            devicePollReadiness (addUTCTime 9 epoch) slowedDownOnce
+                `shouldBe` DevicePollWait 1
+            devicePollReadiness (addUTCTime 10 epoch) slowedDownOnce
+                `shouldBe` DevicePollReady
+            devicePollReadiness (addUTCTime 24 epoch) slowedDownTwice
+                `shouldBe` DevicePollWait 1
+            devicePollReadiness (addUTCTime 25 epoch) slowedDownTwice
+                `shouldBe` DevicePollReady
+            devicePollReadiness (addUTCTime 60 epoch) slowedDownTwice
+                `shouldBe` DevicePollExpired
 
 openai :: LoginAccount
 openai = LoginAccount

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -107,6 +107,72 @@ spec = do
             body `shouldSatisfy` Text.isInfixOf "credits remaining $5.32"
             body `shouldSatisfy` Text.isInfixOf "used $3369.68"
 
+    describe "fullscreen login dashboard" do
+        it "offers account connection before any credentials exist" do
+            let labels = map fst (loginDashboardRows [])
+            labels `shouldSatisfy` any (Text.isInfixOf "Connect account")
+            labels `shouldSatisfy` not . any (Text.isInfixOf "Refresh")
+
+        it "offers usage refresh and opens each discovered account" do
+            let rows = loginDashboardRows [openai, openRouter]
+                labels = map fst rows
+                rendered = Text.unlines
+                    [label <> " " <> description | (label, description) <- rows]
+            labels `shouldSatisfy` any (Text.isInfixOf "Refresh all")
+            rendered `shouldSatisfy` Text.isInfixOf "openai"
+            rendered `shouldSatisfy` Text.isInfixOf "openrouter"
+            rendered `shouldSatisfy` Text.isInfixOf "acc-openai"
+            rendered `shouldSatisfy` not . Text.isInfixOf "secret-openai"
+            rendered `shouldSatisfy` not . Text.isInfixOf "secret-openrouter"
+            let hostileRows =
+                    loginDashboardRows
+                        [openai { loginLabel = "ChatGPT\ESC]0;unsafe" }]
+                hostileRendered = Text.unlines
+                    [label <> " " <> description
+                    | (label, description) <- hostileRows
+                    ]
+            hostileRendered `shouldSatisfy` not . Text.any (== '\ESC')
+
+        it "offers managed-account controls without an import action" do
+            let managed = openai
+                    { loginManagedId = Just "managed-openai"
+                    , loginSource = "managed"
+                    }
+                labels = map fst (loginAccountActionRows managed)
+            labels `shouldSatisfy` any (Text.isInfixOf "Refresh usage")
+            labels `shouldSatisfy` any (Text.isInfixOf "Disable credential")
+            labels `shouldSatisfy` any (Text.isInfixOf "Disconnect credential")
+            labels `shouldSatisfy` not . any (Text.isInfixOf "Import")
+
+        it "keeps external accounts read-only but importable" do
+            let labels = map fst (loginAccountActionRows openai)
+            labels `shouldSatisfy` any (Text.isInfixOf "Import credential")
+            labels `shouldSatisfy` not . any (Text.isInfixOf "Disconnect")
+            labels `shouldSatisfy` not . any (Text.isInfixOf "Disable")
+
+        it "renders detailed usage without exposing credential secrets" do
+            let detail = loginAccountDetail openai
+                    { loginLabel = "person@example.com"
+                    , loginUsage =
+                        UsageAvailable AccountUsage
+                            { usagePlan = Just "plus"
+                            , usageWindows =
+                                [ UsageWindow
+                                    { windowName = "primary"
+                                    , usedPercent = 31
+                                    , windowSeconds = 18000
+                                    , resetsAt = epoch
+                                    }
+                                ]
+                            , creditsRemaining = Nothing
+                            , creditsUsed = Nothing
+                            }
+                    }
+            detail `shouldSatisfy` Text.isInfixOf "person@example.com"
+            detail `shouldSatisfy` Text.isInfixOf "31% used"
+            detail `shouldSatisfy` Text.isInfixOf "Resets"
+            detail `shouldSatisfy` not . Text.isInfixOf "secret-openai"
+
 openai :: LoginAccount
 openai = LoginAccount
     { loginManagedId = Nothing

--- a/packages/agent-xai/src/Agent/XAI/Auth.hs
+++ b/packages/agent-xai/src/Agent/XAI/Auth.hs
@@ -20,9 +20,11 @@ module Agent.XAI.Auth
     ( OAuthOptions(..)
     , defaultOAuthOptions
     , DeviceAuthorization(..)
+    , DeviceAuthorizationPoll(..)
     , OAuthTokens(..)
     , requestDeviceAuthorization
     , pollDeviceAuthorization
+    , pollDeviceAuthorizationStatus
     , completeDeviceAuthorization
     , refreshAccessToken
     , accountIdFromAccessToken
@@ -41,6 +43,7 @@ import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import Data.Time.Clock (addUTCTime, diffUTCTime, getCurrentTime)
 import Network.HTTP.Simple
 
 data OAuthOptions = OAuthOptions
@@ -133,6 +136,15 @@ instance Show OAuthTokens where
                 Just _ -> "Just <redacted>")
         <> ", expiresInSeconds = " <> show tokens.expiresInSeconds <> " }"
 
+-- | Detailed result for one device-code poll. RFC 8628 requires clients to
+-- increase their polling interval after @slow_down@, so interactive callers
+-- need to distinguish it from ordinary authorization pending.
+data DeviceAuthorizationPoll
+    = DeviceAuthorizationPending
+    | DeviceAuthorizationSlowDown
+    | DeviceAuthorizationComplete !OAuthTokens
+    deriving (Eq, Show)
+
 -- | Start a device authorization. A 404 means the device grant is disabled
 -- server-side for this client — surfaced as a distinguishable error text so
 -- callers can fall back to credential import.
@@ -161,7 +173,21 @@ deviceFlowDisabledMessage =
 -- | Poll once without blocking; 'Nothing' means the user has not approved
 -- the device yet ('authorization_pending' / 'slow_down').
 pollDeviceAuthorization :: OAuthOptions -> DeviceAuthorization -> IO (Either Text (Maybe OAuthTokens))
-pollDeviceAuthorization options deviceCode = safely do
+pollDeviceAuthorization options deviceCode =
+    fmap (fmap toMaybe) (pollDeviceAuthorizationStatus options deviceCode)
+  where
+    toMaybe = \case
+        DeviceAuthorizationPending -> Nothing
+        DeviceAuthorizationSlowDown -> Nothing
+        DeviceAuthorizationComplete tokens -> Just tokens
+
+-- | Poll once without blocking while preserving @slow_down@ so callers can
+-- apply RFC 8628's five-second cumulative backoff.
+pollDeviceAuthorizationStatus
+    :: OAuthOptions
+    -> DeviceAuthorization
+    -> IO (Either Text DeviceAuthorizationPoll)
+pollDeviceAuthorizationStatus options deviceCode = safely do
     -- The principal has to be declared when the token is minted, not only
     -- when it is later refreshed: a team login that omits it here gets a
     -- personally scoped token that the refresh then contradicts.
@@ -172,32 +198,65 @@ pollDeviceAuthorization options deviceCode = safely do
         ] <> principalFields options
     let status = getResponseStatusCode response
     if status >= 200 && status < 300
-        then Just <$> parseTokens response
+        then DeviceAuthorizationComplete <$> parseTokens response
         else case oauthErrorCode response of
-            Just "authorization_pending" -> pure Nothing
-            Just "slow_down" -> pure Nothing
+            Just "authorization_pending" ->
+                pure DeviceAuthorizationPending
+            Just "slow_down" ->
+                pure DeviceAuthorizationSlowDown
             Just "access_denied" -> fail "the user denied the device authorization"
             Just "expired_token" -> fail "the device code expired before it was approved"
             Just other -> fail ("device token request failed: " <> Text.unpack other)
             Nothing -> fail ("device token request failed with HTTP " <> show status
                 <> ": " <> lbsPreview (getResponseBody response))
 
--- | Blocking convenience wrapper around 'pollDeviceAuthorization' for CLI use.
+-- | Blocking convenience wrapper for CLI use.
 completeDeviceAuthorization :: OAuthOptions -> DeviceAuthorization -> IO (Either Text OAuthTokens)
-completeDeviceAuthorization options deviceCode = go 0
+completeDeviceAuthorization options deviceCode = do
+    startedAt <- getCurrentTime
+    go
+        (addUTCTime (fromIntegral timeoutSeconds) startedAt)
+        (max 1 deviceCode.pollIntervalSeconds)
   where
     timeoutSeconds = Maybe.fromMaybe (15 * 60) deviceCode.expiresInSeconds
 
-    go elapsed
-        | elapsed >= timeoutSeconds =
-            pure (Left "device authorization timed out")
-        | otherwise = pollDeviceAuthorization options deviceCode >>= \case
-            Left err -> pure (Left err)
-            Right (Just tokens) -> pure (Right tokens)
-            Right Nothing -> do
-                let seconds = deviceCode.pollIntervalSeconds
-                threadDelay (seconds * 1_000_000)
-                go (elapsed + seconds)
+    go expiresAt interval = do
+        now <- getCurrentTime
+        if now >= expiresAt
+            then timedOut
+            else
+                pollDeviceAuthorizationStatus options deviceCode >>= \case
+                    Left err -> pure (Left err)
+                    Right (DeviceAuthorizationComplete tokens) -> do
+                        polledAt <- getCurrentTime
+                        if polledAt >= expiresAt
+                            then timedOut
+                            else pure (Right tokens)
+                    Right DeviceAuthorizationPending -> do
+                        polledAt <- getCurrentTime
+                        waitThenPoll expiresAt polledAt interval interval
+                    Right DeviceAuthorizationSlowDown -> do
+                        let backedOffInterval = interval + 5
+                        polledAt <- getCurrentTime
+                        waitThenPoll
+                            expiresAt
+                            polledAt
+                            backedOffInterval
+                            backedOffInterval
+
+    waitThenPoll expiresAt polledAt seconds nextInterval
+        | remainingMicroseconds <= 0 =
+            timedOut
+        | otherwise = do
+            threadDelay
+                (min (seconds * 1_000_000) remainingMicroseconds)
+            go expiresAt nextInterval
+      where
+        remainingMicroseconds =
+            floor (diffUTCTime expiresAt polledAt * 1_000_000)
+
+    timedOut =
+        pure (Left "device authorization timed out")
 
 -- | Rotate an access token. Terminal rejections ('invalid_grant',
 -- 'invalid_client') come back as 'AuthenticationError' so brokers mark the

--- a/packages/agent-xai/test/Agent/XAI/AuthSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/AuthSpec.hs
@@ -115,6 +115,15 @@ spec = do
                         tokens.refreshToken `shouldBe` Just "refresh-1"
                         tokens.expiresInSeconds `shouldBe` Just 3600
 
+        it "distinguishes slow_down so interactive clients can back off" do
+            recorded <- newIORef []
+            result <- withMockAuth recorded
+                (respondStatus HTTP.status400 "{\"error\":\"slow_down\"}")
+                \options ->
+                    pollDeviceAuthorizationStatus options sampleDeviceCode
+                        >>= expectRight
+            result `shouldBe` DeviceAuthorizationSlowDown
+
         it "surfaces a denial as an error" do
             recorded <- newIORef []
             result <- withMockAuth recorded


### PR DESCRIPTION
## Summary
- keep `/login` inside the fullscreen Brick UI with an account dashboard and detail/action views
- add native provider connection flows for OpenAI/xAI device authorization and masked OpenRouter API-key entry
- preserve the existing line-mode login manager while adding safe refresh, import, enable/disable, and disconnect interactions

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` (focused `Agent.CLI.LoginSpec`: 15 examples, 0 failures)
- live tmux smoke test: `/login` dashboard, provider chooser, OAuth instructions, account detail/actions, cancel back to composer
- `git diff --check origin/master...HEAD`