### PR TITLE
Add typed native MCP administration

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -254,6 +254,7 @@ foreign-library haskell-agent-bridge
     options:          standalone
     hs-source-dirs:   ffi
     other-modules:    Agent.CLI.MacOS.Bridge
+                    , Agent.CLI.MacOS.EngineMailbox
                     , Agent.CLI.MacOS.NativeLoopEvent
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
@@ -347,6 +348,8 @@ test-suite agent-cli-test
     main-is:          Spec.hs
     include-dirs:     include
     other-modules:    Agent.CLI.AccountSelectionSpec
+                    , Agent.CLI.MacOS.EngineMailboxSpec
+                    , Agent.CLI.MacOS.EngineMailbox
                     , Agent.CLI.MacOS.NativeLoopEventSpec
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -130,6 +130,7 @@ library
                     , Agent.CLI.LearnedSkills.Store
                     , Agent.CLI.Lsp
                     , Agent.CLI.Markdown
+                    , Agent.CLI.McpAdmin
                     , Agent.CLI.ModelPicker
                     , Agent.CLI.McpManager
                     , Agent.CLI.ModelConfig
@@ -375,6 +376,7 @@ test-suite agent-cli-test
                     , Agent.CLI.LoginSpec
                     , Agent.CLI.LearnedSkillsSpec
                     , Agent.CLI.MarkdownSpec
+                    , Agent.CLI.McpAdminSpec
                     , Agent.CLI.McpManagerSpec
                     , Agent.CLI.ModelPickerSpec
                     , Agent.CLI.ModelConfigSpec

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -8,7 +8,21 @@ import Agent.CLI.NativeRuntime
     , NativeRunHooks(..)
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
+    , restartNativeMcpRuntime
     , runNativeAgent
+    )
+import Agent.CLI.McpAdmin
+    ( McpAdminError(..)
+    , McpAdminServer(..)
+    , McpAdminServerInput(..)
+    , McpAdminSnapshot(..)
+    , addMcpAdminServer
+    , editMcpAdminServer
+    , listMcpAdminServers
+    , readMcpAdminServer
+    , removeMcpAdminServer
+    , restartMcpAdminServer
+    , setMcpAdminServerEnabled
     )
 import Agent.Store.Postgres.Session
     ( NativeConversationSearchResult(..)
@@ -288,6 +302,20 @@ type LearnedSkillsListCallback =
     -> CString -> CSize -> CString -> CSize -> CString -> CSize
     -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
 
+type McpServerCallback =
+    Ptr () -> CInt -> Word64
+    -> CString -> CSize -> CInt -> CString -> CSize -> CString -> CSize
+    -> CInt -> CInt -> CSize -> CSize -> CString -> CSize -> IO ()
+
+-- kind 0 is an argument and kind 1 is an environment key. Environment values
+-- never cross the bridge.
+type McpServerFieldCallback =
+    Ptr () -> CString -> CSize -> CInt -> CSize
+    -> CString -> CSize -> IO ()
+
+type McpResultCallback =
+    Ptr () -> CInt -> Word64 -> CString -> CSize -> IO ()
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -317,6 +345,18 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeLearnedSkillsListCallback
         :: FunPtr LearnedSkillsListCallback -> LearnedSkillsListCallback
+
+foreign import ccall "dynamic"
+    invokeMcpServerCallback
+        :: FunPtr McpServerCallback -> McpServerCallback
+
+foreign import ccall "dynamic"
+    invokeMcpServerFieldCallback
+        :: FunPtr McpServerFieldCallback -> McpServerFieldCallback
+
+foreign import ccall "dynamic"
+    invokeMcpResultCallback
+        :: FunPtr McpResultCallback -> McpResultCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -453,6 +493,7 @@ data EngineCommand
     | EngineSearch !Text !Int !(FunPtr SearchCallback) !(Ptr ())
     | EngineSessionMutation
         !SessionMutation !(FunPtr SessionResultCallback) !(Ptr ())
+    | EngineMcpRestart !Word64 !Text !(FunPtr McpResultCallback) !(Ptr ())
     | EngineStop
 
 data SessionMutation
@@ -534,6 +575,338 @@ foreign export ccall ha_account_delete
 
 foreign export ccall ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_servers_list
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback
+    -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_read
+    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
+    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_status
+    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
+    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_add
+    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_edit
+    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_enable
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_mcp_server_restart
+    :: Ptr () -> Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_disable
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_remove
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+ha_mcp_servers_list
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback
+    -> Ptr () -> IO CInt
+ha_mcp_servers_list callback fieldCallback context
+    | callback == nullFunPtr || fieldCallback == nullFunPtr = pure 1
+    | otherwise = do
+        home <- getHomeDirectory
+        _ <- forkIO $
+            mcpAdminTry (listMcpAdminServers home) >>= emitMcpServers
+                callback fieldCallback context
+        pure 0
+
+ha_engine_mcp_server_restart
+    :: Ptr () -> Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_engine_mcp_server_restart pointer expected nameBytes (CSize nameLength)
+        callback context
+    | pointer == nullPtr = pure 1
+    | callback == nullFunPtr = pure 2
+    | nameBytes == nullPtr || nameLength == 0
+        || nameLength > maxMcpTextBytes = pure 2
+    | otherwise = do
+        decodeMcpInput nameBytes nameLength >>= \case
+            Left _ -> pure 2
+            Right name -> do
+                accepted <- tryAny do
+                    let stable =
+                            castPtrToStablePtr pointer :: StablePtr Engine
+                    engine <- deRefStablePtr stable
+                    atomically $ writeTQueue engine.engineCommands
+                        (EngineMcpRestart expected name callback context)
+                pure case accepted of
+                    Left _ -> 3
+                    Right () -> 0
+
+ha_mcp_server_status
+    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
+    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
+ha_mcp_server_status = ha_mcp_server_read
+
+ha_mcp_server_read
+    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
+    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
+ha_mcp_server_read nameBytes (CSize nameLength) callback fieldCallback context
+    | callback == nullFunPtr || fieldCallback == nullFunPtr = pure 1
+    | nameBytes == nullPtr || nameLength == 0
+        || nameLength > maxMcpTextBytes = pure 2
+    | otherwise = do
+        decodeMcpInput nameBytes nameLength >>= \case
+            Left _ -> pure 2
+            Right name -> do
+                home <- getHomeDirectory
+                _ <- forkIO $
+                    mcpAdminTry (readMcpAdminServer home name) >>= emitMcpServer
+                        callback fieldCallback context
+                pure 0
+
+ha_mcp_server_add
+    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_add =
+    mcpServerWrite addMcpAdminServer
+
+ha_mcp_server_edit
+    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_edit =
+    mcpServerWrite editMcpAdminServer
+
+ha_mcp_server_enable
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_enable = mcpServerSetEnabled True
+
+ha_mcp_server_disable
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_disable = mcpServerSetEnabled False
+
+ha_mcp_server_remove
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_remove expected nameBytes (CSize nameLength) callback context
+    | callback == nullFunPtr = pure 1
+    | nameBytes == nullPtr || nameLength == 0
+        || nameLength > maxMcpTextBytes = pure 2
+    | otherwise = do
+        decodeMcpInput nameBytes nameLength >>= \case
+            Left _ -> pure 2
+            Right name -> do
+                home <- getHomeDirectory
+                _ <- forkIO $
+                    mcpAdminTry (removeMcpAdminServer home expected name)
+                        >>= emitMcpResult
+                        callback context
+                pure 0
+
+mcpServerSetEnabled
+    :: Bool -> Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+mcpServerSetEnabled enabled expected nameBytes (CSize nameLength)
+        callback context
+    | callback == nullFunPtr = pure 1
+    | nameBytes == nullPtr || nameLength == 0
+        || nameLength > maxMcpTextBytes = pure 2
+    | otherwise = do
+        decodeMcpInput nameBytes nameLength >>= \case
+            Left _ -> pure 2
+            Right name -> do
+                home <- getHomeDirectory
+                _ <- forkIO $
+                    mcpAdminTry
+                        (setMcpAdminServerEnabled home expected name enabled)
+                        >>= emitMcpResult callback context
+                pure 0
+
+mcpServerWrite
+    :: (OsPath -> Word64 -> Text -> McpAdminServerInput
+        -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer)))
+    -> Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+mcpServerWrite write expected nameBytes (CSize nameLength)
+        commandBytes (CSize commandLength) argsPointer argsCount
+        cwdBytes (CSize cwdLength) envPointer envCount
+        (CInt startupTimeout) (CInt requestTimeout) callback context
+    | callback == nullFunPtr = pure 1
+    | nameBytes == nullPtr || nameLength == 0
+        || nameLength > maxMcpTextBytes
+        || commandBytes == nullPtr || commandLength == 0
+        || commandLength > maxMcpTextBytes
+        || cwdLength > maxMcpTextBytes
+        || argsCount > maxMcpFields || envCount > maxMcpFields = pure 2
+    | argsPointer == nullPtr && argsCount > 0
+        || envPointer == nullPtr && envCount > 0
+        || cwdBytes == nullPtr && cwdLength > 0 = pure 2
+    | otherwise = do
+        decoded <- tryAny do
+            name <- requireMcpInput nameBytes nameLength
+            command <- requireMcpInput commandBytes commandLength
+            cwd <- requireMcpInput cwdBytes cwdLength
+            args <- mapM (peekUtf8Slice argsPointer)
+                [0 .. fromIntegral argsCount - 1]
+            env <- Map.fromList <$> mapM (peekEnvEntry envPointer)
+                [0 .. fromIntegral envCount - 1]
+            pure (name, McpAdminServerInput
+                { mcpAdminInputCommand = command
+                , mcpAdminInputArgs = args
+                , mcpAdminInputCwd = nonEmptyText cwd
+                , mcpAdminInputEnv = env
+                , mcpAdminInputStartupTimeoutSeconds =
+                    fromIntegral startupTimeout
+                , mcpAdminInputRequestTimeoutSeconds =
+                    fromIntegral requestTimeout
+                })
+        case decoded of
+            Left _ -> pure 2
+            Right (name, input) -> do
+                home <- getHomeDirectory
+                _ <- forkIO $
+                    mcpAdminTry (write home expected name input)
+                        >>= emitMcpResult callback context
+                pure 0
+
+peekUtf8Slice :: Ptr () -> Int -> IO Text
+peekUtf8Slice pointer index = do
+    let pointerSize = sizeOf (nullPtr :: Ptr ())
+        sizeSize = sizeOf (undefined :: CSize)
+        base = pointer `plusPtr` (index * (pointerSize + sizeSize))
+    bytes <- peekByteOff base 0
+    CSize length <- peekByteOff base pointerSize
+    if (bytes == (nullPtr :: Ptr Word8) && length > 0)
+            || length > maxMcpTextBytes
+        then ioError (userError "null UTF-8 slice")
+        else requireMcpInput bytes length
+
+decodeMcpInput :: Ptr Word8 -> Word64 -> IO (Either Text Text)
+decodeMcpInput pointer length
+    | pointer == nullPtr || length == 0 = pure (Right "")
+    | otherwise = do
+        bytes <- BS.packCStringLen (castPtr pointer, fromIntegral length)
+        pure (first (Text.pack . show) (TextEncoding.decodeUtf8' bytes))
+
+requireMcpInput :: Ptr Word8 -> Word64 -> IO Text
+requireMcpInput pointer length =
+    decodeMcpInput pointer length >>=
+        either (ioError . userError . Text.unpack) pure
+
+maxMcpTextBytes :: Word64
+maxMcpTextBytes = 1024 * 1024
+
+maxMcpFields :: CSize
+maxMcpFields = 4096
+
+peekEnvEntry :: Ptr () -> Int -> IO (Text, Text)
+peekEnvEntry pointer index = do
+    let sliceSize =
+            sizeOf (nullPtr :: Ptr ()) + sizeOf (undefined :: CSize)
+        base = pointer `plusPtr` (index * sliceSize * 2)
+    key <- peekUtf8Slice base 0
+    value <- peekUtf8Slice (base `plusPtr` sliceSize) 0
+    pure (key, value)
+
+emitMcpServers
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback -> Ptr ()
+    -> Either McpAdminError (McpAdminSnapshot [McpAdminServer]) -> IO ()
+emitMcpServers callback fieldCallback context = \case
+    Left err -> emitMcpServerError callback context err
+    Right snapshot -> do
+        forM_ snapshot.mcpAdminValue \server ->
+            emitMcpServerItem
+                callback fieldCallback context snapshot.mcpAdminRevision server
+        invokeMcpServerCallback callback context 1 snapshot.mcpAdminRevision
+            nullPtr 0 0 nullPtr 0 nullPtr 0 0 0 0 0 nullPtr 0
+
+emitMcpServer
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback -> Ptr ()
+    -> Either McpAdminError (McpAdminSnapshot McpAdminServer) -> IO ()
+emitMcpServer callback fieldCallback context = \case
+    Left err -> emitMcpServerError callback context err
+    Right snapshot ->
+        emitMcpServerItem
+            callback fieldCallback context snapshot.mcpAdminRevision
+            snapshot.mcpAdminValue
+
+emitMcpServerItem
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback -> Ptr ()
+    -> Word64 -> McpAdminServer -> IO ()
+emitMcpServerItem callback fieldCallback context revision server = do
+    withText server.mcpAdminName \name nameLength -> do
+        forM_ (zip [0..] server.mcpAdminArgs) \(index, argument) ->
+            withText argument $
+                invokeMcpServerFieldCallback fieldCallback context
+                    name nameLength 0 index
+        forM_ (zip [0..] server.mcpAdminEnvKeys) \(index, key) ->
+            withText key $
+                invokeMcpServerFieldCallback fieldCallback context
+                    name nameLength 1 index
+        withText server.mcpAdminCommand \command commandLength ->
+            withOptionalText server.mcpAdminCwd \cwd cwdLength ->
+                invokeMcpServerCallback callback context 0 revision
+                    name nameLength
+                    (if server.mcpAdminEnabled then 1 else 0)
+                    command commandLength cwd cwdLength
+                    (fromIntegral server.mcpAdminStartupTimeoutSeconds)
+                    (fromIntegral server.mcpAdminRequestTimeoutSeconds)
+                    (fromIntegral (length server.mcpAdminArgs))
+                    (fromIntegral (length server.mcpAdminEnvKeys))
+                    nullPtr 0
+
+emitMcpServerError
+    :: FunPtr McpServerCallback -> Ptr () -> McpAdminError -> IO ()
+emitMcpServerError callback context err =
+    withText (mcpAdminErrorText err) \errorPtr errorLength ->
+        invokeMcpServerCallback callback context (-1)
+            (mcpAdminErrorRevision err)
+            nullPtr 0 0 nullPtr 0 nullPtr 0 0 0 0 0
+            errorPtr errorLength
+
+emitMcpResult
+    :: FunPtr McpResultCallback -> Ptr ()
+    -> Either McpAdminError (McpAdminSnapshot a) -> IO ()
+emitMcpResult callback context = \case
+    Left err ->
+        withText (mcpAdminErrorText err) $
+            invokeMcpResultCallback callback context (-1)
+                (mcpAdminErrorRevision err)
+    Right snapshot ->
+        invokeMcpResultCallback callback context 0 snapshot.mcpAdminRevision
+            nullPtr 0
+
+mcpAdminErrorRevision :: McpAdminError -> Word64
+mcpAdminErrorRevision = \case
+    McpAdminConflict revision -> revision
+    _ -> 0
+
+mcpAdminErrorText :: McpAdminError -> Text
+mcpAdminErrorText = \case
+    McpAdminConflict _ -> "MCP catalog changed; reload before editing"
+    McpAdminNotFound name -> "MCP server not found: " <> name
+    McpAdminAlreadyExists name -> "MCP server already exists: " <> name
+    McpAdminInvalid err -> err
+
+mcpAdminTry
+    :: IO (Either McpAdminError a)
+    -> IO (Either McpAdminError a)
+mcpAdminTry action =
+    tryAny action >>= \case
+        Left exception ->
+            pure (Left (McpAdminInvalid (Text.pack (show exception))))
+        Right result -> pure result
 
 ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
@@ -1128,6 +1501,23 @@ idleLoop callback context config store root processRuntime commands stagedImages
             runSessionMutation
                 config store root mutation resultCallback resultContext
             continue
+        EngineMcpRestart expected name resultCallback resultContext -> do
+            home <- getHomeDirectory
+            mcpAdminTry (restartMcpAdminServer home expected name) >>= \case
+                Left err -> emitMcpResult resultCallback resultContext
+                    (Left err :: Either McpAdminError (McpAdminSnapshot ()))
+                Right snapshot -> do
+                    restarted <- tryAny (restartNativeMcpRuntime processRuntime)
+                    case restarted of
+                        Left exception ->
+                            withText (Text.pack (show exception)) $
+                                invokeMcpResultCallback resultCallback
+                                    resultContext (-1)
+                                    snapshot.mcpAdminRevision
+                        Right () ->
+                            invokeMcpResultCallback resultCallback resultContext
+                                0 snapshot.mcpAdminRevision nullPtr 0
+            continue
         EngineRequest request
             | request.requestMethod == "turn.start" ->
                 case (parseParams request
@@ -1229,6 +1619,12 @@ activeLoop callback context config store root commands control running =
         Left (EngineSessionMutation mutation resultCallback resultContext) -> do
             runSessionMutation
                 config store root mutation resultCallback resultContext
+            activeLoop
+                callback context config store root commands control running
+        Left (EngineMcpRestart expected _ resultCallback resultContext) -> do
+            withText "cannot restart MCP while a turn is active" $
+                invokeMcpResultCallback resultCallback resultContext (-1)
+                    expected
             activeLoop
                 callback context config store root commands control running
         Left (EngineRequest request) -> do

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1527,11 +1527,8 @@ idleLoop callback context config store root processRuntime commands stagedImages
             restarted <- tryAny do
                 home <- getHomeDirectory
                 mcpAdminTry
-                    (restartMcpAdminServer home expected name) >>= \case
-                        Left err -> pure (Left err)
-                        Right snapshot -> do
-                            restartNativeMcpRuntime processRuntime
-                            pure (Right snapshot)
+                    (restartMcpAdminServer home expected name
+                        (restartNativeMcpRuntime processRuntime))
             case restarted of
                 Left exception ->
                     withText (Text.pack (show exception)) $

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -44,6 +44,14 @@ import Agent.Store.Postgres.Skill
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     )
+import Agent.CLI.MacOS.EngineMailbox
+    ( EngineMailbox
+    , acceptEngineCommand
+    , closeEngineMailbox
+    , drainEngineCommands
+    , newEngineMailboxIO
+    , readEngineCommand
+    )
 import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.Login
     ( AccountBilling(..)
@@ -150,20 +158,16 @@ import Control.Concurrent.MVar
     )
 import Control.Concurrent.STM
     ( TMVar
-    , TQueue
     , TVar
     , atomically
     , modifyTVar'
     , newEmptyTMVarIO
-    , newTQueueIO
     , newTVarIO
     , orElse
-    , readTQueue
     , readTVar
     , readTVarIO
     , takeTMVar
     , tryPutTMVar
-    , writeTQueue
     , writeTVar
     )
 import Control.Applicative ((<|>))
@@ -502,7 +506,7 @@ data SessionMutation
     | SessionArchive !Text !Bool
 
 data Engine = Engine
-    { engineCommands :: !(TQueue EngineCommand)
+    { engineCommands :: !(EngineMailbox EngineCommand)
     , engineDone :: !(MVar ())
     , engineStagedImages :: !(TVar (Map Text [ImageAttachment]))
     }
@@ -643,11 +647,12 @@ ha_engine_mcp_server_restart pointer expected nameBytes (CSize nameLength)
                     let stable =
                             castPtrToStablePtr pointer :: StablePtr Engine
                     engine <- deRefStablePtr stable
-                    atomically $ writeTQueue engine.engineCommands
+                    atomically $ acceptEngineCommand engine.engineCommands
                         (EngineMcpRestart expected name callback context)
                 pure case accepted of
                     Left _ -> 3
-                    Right () -> 0
+                    Right False -> 3
+                    Right True -> 0
 
 ha_mcp_server_status
     :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
@@ -1253,7 +1258,7 @@ ha_engine_create callback context
         created <- tryAny do
             home <- getHomeDirectory
             config <- managedPostgresConfigForHome home
-            commands <- newTQueueIO
+            commands <- newEngineMailboxIO
             done <- newEmptyMVar
             stagedImages <- newTVarIO Map.empty
             _ <- forkFinally
@@ -1292,17 +1297,16 @@ ha_engine_send_json pointer bytes (CSize length)
                 :: Either String BridgeRequest) of
                 Left _ -> do
                     atomically $ writeTVar engine.engineStagedImages Map.empty
-                    pure False
-                Right request -> do
-                    atomically
-                        (writeTQueue
-                            engine.engineCommands
-                            (EngineRequest request))
-                    pure True
+                    pure Nothing
+                Right request -> Just <$> atomically
+                    (acceptEngineCommand
+                        engine.engineCommands
+                        (EngineRequest request))
         pure $ case accepted of
             Left _ -> 3
-            Right False -> 4
-            Right True -> 0
+            Right Nothing -> 4
+            Right (Just False) -> 3
+            Right (Just True) -> 0
 
 ha_engine_search_conversations
     :: Ptr () -> Ptr Word8 -> CSize -> CSize
@@ -1317,19 +1321,21 @@ ha_engine_search_conversations pointer bytes (CSize length) rawLimit callback co
             engine <- deRefStablePtr stable
             payload <- BS.packCStringLen (castPtr bytes, fromIntegral length)
             case TextEncoding.decodeUtf8' payload of
-                Left _ -> pure False
+                Left _ -> pure Nothing
                 Right query
-                    | Text.null (Text.strip query) -> pure False
+                    | Text.null (Text.strip query) -> pure Nothing
                     | otherwise -> do
                         let requested = fromIntegral rawLimit :: Integer
                             limit = fromInteger (max 1 (min 100 requested))
-                        atomically $ writeTQueue engine.engineCommands
-                            (EngineSearch query limit callback context)
-                        pure True
+                        Just <$> atomically
+                            (acceptEngineCommand engine.engineCommands
+                                (EngineSearch
+                                    query limit callback context))
         pure $ case accepted of
             Left _ -> 3
-            Right False -> 2
-            Right True -> 0
+            Right Nothing -> 2
+            Right (Just False) -> 3
+            Right (Just True) -> 0
 
 ha_engine_stage_turn_images
     :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize -> IO CInt
@@ -1438,11 +1444,12 @@ enqueueSessionMutation pointer mutation callback context
         accepted <- tryAny do
             let stable = castPtrToStablePtr pointer :: StablePtr Engine
             engine <- deRefStablePtr stable
-            atomically $ writeTQueue engine.engineCommands
+            atomically $ acceptEngineCommand engine.engineCommands
                 (EngineSessionMutation mutation callback context)
         pure $ case accepted of
             Left _ -> 3
-            Right () -> 0
+            Right False -> 3
+            Right True -> 0
 
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer
@@ -1451,7 +1458,8 @@ ha_engine_destroy pointer
         let stable = castPtrToStablePtr pointer :: StablePtr Engine
         (do
             engine <- deRefStablePtr stable
-            atomically (writeTQueue engine.engineCommands EngineStop)
+            _ <- atomically
+                (closeEngineMailbox engine.engineCommands EngineStop)
             readMVar engine.engineDone)
             `finally` freeStablePtr stable
 
@@ -1460,25 +1468,39 @@ workerLifecycle
     -> Ptr ()
     -> ManagedPostgresConfig
     -> OsPath
-    -> TQueue EngineCommand
+    -> EngineMailbox EngineCommand
     -> TVar (Map Text [ImageAttachment])
     -> IO ()
-workerLifecycle callback context config root commands stagedImages = do
-    store <- newMVar Nothing
-    processRuntime <- newNativeProcessRuntime root
-    let cleanup =
-            closeNativeProcessRuntime processRuntime
-                `finally` closeEngineStore store
-    idleLoop
-        callback
-        context
-        config
-        store
-        root
-        processRuntime
-        commands
-        stagedImages
-        `finally` cleanup
+workerLifecycle callback context config root commands stagedImages =
+    (do
+        store <- newMVar Nothing
+        processRuntime <- newNativeProcessRuntime root
+        let cleanup =
+                closeNativeProcessRuntime processRuntime
+                    `finally` closeEngineStore store
+        idleLoop
+            callback
+            context
+            config
+            store
+            root
+            processRuntime
+            commands
+            stagedImages
+            `finally` cleanup)
+        `finally` cancelPendingMcpRestarts commands
+
+cancelPendingMcpRestarts :: EngineMailbox EngineCommand -> IO ()
+cancelPendingMcpRestarts commands = do
+    pending <- atomically do
+        _ <- closeEngineMailbox commands EngineStop
+        drainEngineCommands commands
+    forM_ pending \case
+        EngineMcpRestart expected _ callback context ->
+            void $ tryAny $
+                withText "engine stopped before MCP restart completed" $
+                    invokeMcpResultCallback callback context (-1) expected
+        _ -> pure ()
 
 idleLoop
     :: FunPtr EventCallback
@@ -1487,11 +1509,11 @@ idleLoop
     -> MVar (Maybe Store)
     -> OsPath
     -> NativeProcessRuntime
-    -> TQueue EngineCommand
+    -> EngineMailbox EngineCommand
     -> TVar (Map Text [ImageAttachment])
     -> IO ()
 idleLoop callback context config store root processRuntime commands stagedImages =
-    atomically (readTQueue commands) >>= \case
+    atomically (readEngineCommand commands) >>= \case
         EngineStop -> pure ()
         EngineSearch query limit searchCallback searchContext -> do
             runConversationSearch
@@ -1502,21 +1524,26 @@ idleLoop callback context config store root processRuntime commands stagedImages
                 config store root mutation resultCallback resultContext
             continue
         EngineMcpRestart expected name resultCallback resultContext -> do
-            home <- getHomeDirectory
-            mcpAdminTry (restartMcpAdminServer home expected name) >>= \case
-                Left err -> emitMcpResult resultCallback resultContext
-                    (Left err :: Either McpAdminError (McpAdminSnapshot ()))
-                Right snapshot -> do
-                    restarted <- tryAny (restartNativeMcpRuntime processRuntime)
-                    case restarted of
-                        Left exception ->
-                            withText (Text.pack (show exception)) $
-                                invokeMcpResultCallback resultCallback
-                                    resultContext (-1)
-                                    snapshot.mcpAdminRevision
-                        Right () ->
-                            invokeMcpResultCallback resultCallback resultContext
-                                0 snapshot.mcpAdminRevision nullPtr 0
+            restarted <- tryAny do
+                home <- getHomeDirectory
+                mcpAdminTry
+                    (restartMcpAdminServer home expected name) >>= \case
+                        Left err -> pure (Left err)
+                        Right snapshot -> do
+                            restartNativeMcpRuntime processRuntime
+                            pure (Right snapshot)
+            case restarted of
+                Left exception ->
+                    withText (Text.pack (show exception)) $
+                        invokeMcpResultCallback resultCallback
+                            resultContext (-1) expected
+                Right (Left err) ->
+                    emitMcpResult resultCallback resultContext
+                        (Left err
+                            :: Either McpAdminError (McpAdminSnapshot ()))
+                Right (Right snapshot) ->
+                    invokeMcpResultCallback resultCallback resultContext
+                        0 snapshot.mcpAdminRevision nullPtr 0
             continue
         EngineRequest request
             | request.requestMethod == "turn.start" ->
@@ -1596,13 +1623,13 @@ activeLoop
     -> ManagedPostgresConfig
     -> MVar (Maybe Store)
     -> OsPath
-    -> TQueue EngineCommand
+    -> EngineMailbox EngineCommand
     -> TurnControl
     -> Async TurnOutcome
     -> IO ActiveExit
 activeLoop callback context config store root commands control running =
     atomically
-        ((Left <$> readTQueue commands)
+        ((Left <$> readEngineCommand commands)
             `orElse` (Right <$> waitCatchSTM running)) >>= \case
         Right outcome -> do
             finishTurnEvent callback context control.turnControlId outcome

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/EngineMailbox.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/EngineMailbox.hs
@@ -1,0 +1,58 @@
+module Agent.CLI.MacOS.EngineMailbox
+    ( EngineMailbox
+    , acceptEngineCommand
+    , closeEngineMailbox
+    , drainEngineCommands
+    , newEngineMailboxIO
+    , readEngineCommand
+    ) where
+
+import Control.Concurrent.STM
+    ( STM
+    , TQueue
+    , TVar
+    , flushTQueue
+    , newTQueueIO
+    , newTVarIO
+    , readTQueue
+    , readTVar
+    , writeTQueue
+    , writeTVar
+    )
+
+-- | A queue with an atomic acceptance boundary. Closing and enqueueing share
+-- one STM linearization point, so a command reported as accepted is always
+-- ordered before the closing command.
+data EngineMailbox command = EngineMailbox
+    { mailboxCommands :: !(TQueue command)
+    , mailboxAccepting :: !(TVar Bool)
+    }
+
+newEngineMailboxIO :: IO (EngineMailbox command)
+newEngineMailboxIO =
+    EngineMailbox <$> newTQueueIO <*> newTVarIO True
+
+acceptEngineCommand :: EngineMailbox command -> command -> STM Bool
+acceptEngineCommand mailbox command = do
+    accepting <- readTVar mailbox.mailboxAccepting
+    if accepting
+        then writeTQueue mailbox.mailboxCommands command >> pure True
+        else pure False
+
+-- | Stop accepting commands and enqueue the closing command. Returns 'True'
+-- only for the transaction that closes the mailbox.
+closeEngineMailbox :: EngineMailbox command -> command -> STM Bool
+closeEngineMailbox mailbox command = do
+    accepting <- readTVar mailbox.mailboxAccepting
+    if accepting
+        then do
+            writeTVar mailbox.mailboxAccepting False
+            writeTQueue mailbox.mailboxCommands command
+            pure True
+        else pure False
+
+readEngineCommand :: EngineMailbox command -> STM command
+readEngineCommand mailbox = readTQueue mailbox.mailboxCommands
+
+drainEngineCommands :: EngineMailbox command -> STM [command]
+drainEngineCommands mailbox = flushTQueue mailbox.mailboxCommands

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -108,10 +108,12 @@ typedef struct ha_mcp_env_entry {
 /*
  * MCP catalog reads expose redacted typed rows. Environment values are never
  * returned: field callbacks use kind 0 for an argument and kind 1 for an
- * environment key. Fields for a row are emitted before that row. status is 0
- * for a row, 1 for list completion, and -1 for failure. revision is an opaque
- * optimistic-concurrency token; a conflict reports the current revision.
- * Callback buffers are valid only until that callback returns.
+ * environment key. Fields for a row are emitted before that row. List uses
+ * status 0 for rows, 1 for terminal completion, and -1 for terminal failure.
+ * Read/status invokes exactly one callback: status 0 for its row or -1 for
+ * failure, with no trailing status 1. revision is an opaque optimistic-
+ * concurrency token; a conflict reports the current revision. Callback
+ * buffers are valid only until that callback returns.
  */
 typedef void (*ha_mcp_server_callback)(
     void *context, int32_t status, uint64_t revision,
@@ -146,7 +148,8 @@ int32_t ha_mcp_servers_list(
 /*
  * Status is a side-effect-free catalog status: enabled means configured for
  * the next turn, disabled means intentionally stopped. It does not start a
- * server or probe its process. The callback contract matches read.
+ * server or probe its process. Like read, it invokes exactly one callback and
+ * does not emit a separate completion callback.
  */
 int32_t ha_mcp_server_status(
     const uint8_t *name, size_t name_length,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -95,6 +95,130 @@ int32_t ha_learned_skills_list(
     ha_learned_skills_list_callback callback, void *context
 );
 
+typedef struct ha_utf8_slice {
+    const uint8_t *bytes;
+    size_t length;
+} ha_utf8_slice;
+
+typedef struct ha_mcp_env_entry {
+    ha_utf8_slice key;
+    ha_utf8_slice value;
+} ha_mcp_env_entry;
+
+/*
+ * MCP catalog reads expose redacted typed rows. Environment values are never
+ * returned: field callbacks use kind 0 for an argument and kind 1 for an
+ * environment key. Fields for a row are emitted before that row. status is 0
+ * for a row, 1 for list completion, and -1 for failure. revision is an opaque
+ * optimistic-concurrency token; a conflict reports the current revision.
+ * Callback buffers are valid only until that callback returns.
+ */
+typedef void (*ha_mcp_server_callback)(
+    void *context, int32_t status, uint64_t revision,
+    const uint8_t *name, size_t name_length,
+    int32_t enabled,
+    const uint8_t *command, size_t command_length,
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t startup_timeout_seconds,
+    int32_t request_timeout_seconds,
+    size_t argument_count,
+    size_t environment_key_count,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_mcp_server_field_callback)(
+    void *context,
+    const uint8_t *name, size_t name_length,
+    int32_t kind, size_t index,
+    const uint8_t *value, size_t value_length
+);
+
+typedef void (*ha_mcp_result_callback)(
+    void *context, int32_t status, uint64_t revision,
+    const uint8_t *error, size_t error_length
+);
+
+int32_t ha_mcp_servers_list(
+    ha_mcp_server_callback callback,
+    ha_mcp_server_field_callback field_callback,
+    void *context
+);
+/*
+ * Status is a side-effect-free catalog status: enabled means configured for
+ * the next turn, disabled means intentionally stopped. It does not start a
+ * server or probe its process. The callback contract matches read.
+ */
+int32_t ha_mcp_server_status(
+    const uint8_t *name, size_t name_length,
+    ha_mcp_server_callback callback,
+    ha_mcp_server_field_callback field_callback,
+    void *context
+);
+int32_t ha_mcp_server_read(
+    const uint8_t *name, size_t name_length,
+    ha_mcp_server_callback callback,
+    ha_mcp_server_field_callback field_callback,
+    void *context
+);
+
+/*
+ * Adds and edits copy all inputs before returning. Environment values are
+ * write-only secrets. edit preserves enabled state; use the explicit
+ * enable/disable operations to change it. expected_revision must come from
+ * the most recent list/read/mutation callback. Text fields are limited to
+ * 1 MiB each and argument/environment arrays to 4096 entries. These calls
+ * return 0 when accepted, 1 for a missing callback, and 2 for invalid or
+ * over-limit input.
+ */
+int32_t ha_mcp_server_add(
+    uint64_t expected_revision,
+    const uint8_t *name, size_t name_length,
+    const uint8_t *command, size_t command_length,
+    const ha_utf8_slice *arguments, size_t argument_count,
+    const uint8_t *cwd, size_t cwd_length,
+    const ha_mcp_env_entry *environment, size_t environment_count,
+    int32_t startup_timeout_seconds,
+    int32_t request_timeout_seconds,
+    ha_mcp_result_callback callback, void *context
+);
+/*
+ * Restart discards the engine's warm MCP fleet after validating name and
+ * revision. It is rejected asynchronously if a turn is active; the next turn
+ * starts servers from the current catalog.
+ */
+int32_t ha_engine_mcp_server_restart(
+    void *engine,
+    uint64_t expected_revision,
+    const uint8_t *name, size_t name_length,
+    ha_mcp_result_callback callback, void *context
+);
+int32_t ha_mcp_server_edit(
+    uint64_t expected_revision,
+    const uint8_t *name, size_t name_length,
+    const uint8_t *command, size_t command_length,
+    const ha_utf8_slice *arguments, size_t argument_count,
+    const uint8_t *cwd, size_t cwd_length,
+    const ha_mcp_env_entry *environment, size_t environment_count,
+    int32_t startup_timeout_seconds,
+    int32_t request_timeout_seconds,
+    ha_mcp_result_callback callback, void *context
+);
+int32_t ha_mcp_server_enable(
+    uint64_t expected_revision,
+    const uint8_t *name, size_t name_length,
+    ha_mcp_result_callback callback, void *context
+);
+int32_t ha_mcp_server_disable(
+    uint64_t expected_revision,
+    const uint8_t *name, size_t name_length,
+    ha_mcp_result_callback callback, void *context
+);
+int32_t ha_mcp_server_remove(
+    uint64_t expected_revision,
+    const uint8_t *name, size_t name_length,
+    ha_mcp_result_callback callback, void *context
+);
+
 /*
  * Account list callbacks use status 0 for an item, 1 for end-of-list, and
  * -1 for an error. Item strings include disabled managed credentials and

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -184,7 +184,11 @@ int32_t ha_mcp_server_add(
 /*
  * Restart discards the engine's warm MCP fleet after validating name and
  * revision. It is rejected asynchronously if a turn is active; the next turn
- * starts servers from the current catalog.
+ * starts servers from the current catalog. A 0 return accepts the callback:
+ * it is delivered exactly once before a concurrent ha_engine_destroy returns,
+ * with success or an error (including shutdown cancellation if the worker
+ * exits early). Once destruction has won the acceptance race, restart returns
+ * 3 synchronously and no callback is delivered.
  */
 int32_t ha_engine_mcp_server_restart(
     void *engine,

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -10,12 +10,15 @@ module Agent.CLI.Config
     , defaultHarnessConfig
     , harnessConfigPath
     , loadHarnessConfig
+    , loadHarnessConfigSnapshot
+    , modifyHarnessConfig
     , saveHarnessConfig
     , useProgressiveMcp
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OsPath (unsafeToFilePath)
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Control.Exception.Safe (displayException, tryIO)
 import Control.Monad (unless, when)
 import Data.Aeson
@@ -28,13 +31,18 @@ import Data.Aeson
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import Data.Bits (xor)
+import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import System.Directory.OsPath (createDirectoryIfMissing, doesFileExist)
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
+import Data.Word (Word64)
+import Text.Read (readMaybe)
 
 harnessConfigSchemaVersion :: Int
 harnessConfigSchemaVersion = 1
@@ -346,59 +354,176 @@ harnessConfigPath home =
 -- empty default. Decode, I/O, and semantic validation failures remain
 -- distinguishable to the CLI through their error text.
 loadHarnessConfig :: OsPath -> IO (Either Text HarnessConfig)
-loadHarnessConfig home = do
+loadHarnessConfig home =
+    fmap (fmap snd) (loadHarnessConfigSnapshot home)
+
+-- | Read one config and its monotonic revision under the same lock used by
+-- every writer. A private content fingerprint advances the revision after an
+-- out-of-band replacement without exposing secret-bearing config bytes.
+loadHarnessConfigSnapshot
+    :: OsPath -> IO (Either Text (Word64, HarnessConfig))
+loadHarnessConfigSnapshot home =
+    withPrivateFileLock (harnessConfigLockPath home) $
+        loadHarnessConfigUnlocked home
+
+loadHarnessConfigUnlocked
+    :: OsPath -> IO (Either Text (Word64, HarnessConfig))
+loadHarnessConfigUnlocked home = do
     let path = harnessConfigPath home
     exists <- doesFileExist path
     if not exists
-        then pure (Right defaultHarnessConfig)
+        then do
+            revision <- syncMissingConfigRevision home
+            pure (Right (revision, defaultHarnessConfig))
         else do
             bytesResult <-
                 tryIO (retryOnFileBusy (LBS.readFile (unsafeToFilePath path)))
-            pure do
-                bytes <- case bytesResult of
-                    Left exception ->
-                        Left
-                            ( "Failed to read "
-                                <> Text.pack (unsafeToFilePath path)
-                                <> ": "
-                                <> Text.pack (displayException exception)
-                            )
-                    Right bytes -> Right bytes
-                config <- case Aeson.eitherDecode' bytes of
-                    Left err ->
-                        Left
-                            ( "Invalid "
-                                <> Text.pack (unsafeToFilePath path)
-                                <> ": "
-                                <> Text.pack err
-                            )
-                    Right parsed -> Right parsed
-                validateHarnessConfig config
+            case bytesResult of
+                Left exception ->
+                    pure . Left $
+                        "Failed to read "
+                            <> Text.pack (unsafeToFilePath path)
+                            <> ": "
+                            <> Text.pack (displayException exception)
+                Right bytes ->
+                    case Aeson.eitherDecode' bytes of
+                        Left err ->
+                            pure . Left $
+                                "Invalid "
+                                    <> Text.pack (unsafeToFilePath path)
+                                    <> ": "
+                                    <> Text.pack err
+                        Right config ->
+                            case validateHarnessConfig config of
+                                Left err -> pure (Left err)
+                                Right valid -> do
+                                    revision <- syncConfigRevision home bytes
+                                    pure (Right (revision, valid))
 
 -- | Persist the machine-wide harness configuration with owner-only
 -- permissions. The replacement is atomic so an interrupted edit cannot leave
 -- a partially-written JSON file for the next agent startup.
 saveHarnessConfig :: OsPath -> HarnessConfig -> IO (Either Text ())
 saveHarnessConfig home config =
+    withPrivateFileLock (harnessConfigLockPath home) $
+        fmap (fmap (const ())) (writeHarnessConfigUnlocked home config)
+
+-- | Atomically read, transform, validate, and replace the config while holding
+-- the process-shared config lock. The returned revision is for the exact bytes
+-- written by this transaction.
+modifyHarnessConfig
+    :: OsPath
+    -> (Word64 -> HarnessConfig -> Either Text (HarnessConfig, a))
+    -> IO (Either Text (Word64, HarnessConfig, a))
+modifyHarnessConfig home change =
+    withPrivateFileLock (harnessConfigLockPath home) do
+        loadHarnessConfigUnlocked home >>= \case
+            Left err -> pure (Left err)
+            Right (revision, config) ->
+                case change revision config of
+                    Left err -> pure (Left err)
+                    Right (updated, value) ->
+                        writeHarnessConfigUnlocked home updated >>= \case
+                            Left err -> pure (Left err)
+                            Right nextRevision ->
+                                pure (Right
+                                    (nextRevision, updated, value))
+
+writeHarnessConfigUnlocked
+    :: OsPath -> HarnessConfig -> IO (Either Text Word64)
+writeHarnessConfigUnlocked home config =
     case validateHarnessConfig config of
         Left err -> pure (Left err)
         Right valid -> do
             let directory =
                     home </> unsafeEncodeUtf ".haskell-agent"
                 path = harnessConfigPath home
+                bytes = Aeson.encode valid
             result <- tryIO do
                 createDirectoryIfMissing True directory
                 setFileMode (unsafeToFilePath directory) 0o700
-                writeLazyFileAtomically path 0o600 (Aeson.encode valid)
-            pure case result of
+                writeLazyFileAtomically path 0o600 bytes
+                advanceConfigRevision home bytes
+            case result of
                 Left exception ->
-                    Left
+                    pure . Left $
                         ( "Failed to write "
                             <> Text.pack (unsafeToFilePath path)
                             <> ": "
                             <> Text.pack (displayException exception)
                         )
-                Right () -> Right ()
+                Right revision -> pure (Right revision)
+
+harnessConfigLockPath :: OsPath -> OsPath
+harnessConfigLockPath home =
+    home
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "config.lock"
+
+configBytesRevision :: LBS.ByteString -> Word64
+configBytesRevision =
+    BS.foldl' step 14695981039346656037 . LBS.toStrict
+  where
+    step hash byte = (hash `xor` fromIntegral byte) * 1099511628211
+
+configRevisionPath :: OsPath -> OsPath
+configRevisionPath home =
+    home
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "config.revision"
+
+syncConfigRevision :: OsPath -> LBS.ByteString -> IO Word64
+syncConfigRevision home bytes = do
+    let fingerprint = configBytesRevision bytes
+    readConfigRevision home >>= \case
+        Just (revision, storedFingerprint)
+            | storedFingerprint == fingerprint -> pure revision
+            | otherwise ->
+                writeConfigRevision home (revision + 1) fingerprint
+        Nothing -> writeConfigRevision home 1 fingerprint
+
+syncMissingConfigRevision :: OsPath -> IO Word64
+syncMissingConfigRevision home = do
+    let fingerprint = configBytesRevision (Aeson.encode defaultHarnessConfig)
+    readConfigRevision home >>= \case
+        Nothing -> pure 0
+        Just (revision, storedFingerprint)
+            | storedFingerprint == fingerprint -> pure revision
+            | otherwise ->
+                writeConfigRevision home (revision + 1) fingerprint
+
+advanceConfigRevision :: OsPath -> LBS.ByteString -> IO Word64
+advanceConfigRevision home bytes = do
+    current <- maybe 0 fst <$> readConfigRevision home
+    writeConfigRevision home (current + 1) (configBytesRevision bytes)
+
+readConfigRevision :: OsPath -> IO (Maybe (Word64, Word64))
+readConfigRevision home = do
+    let path = configRevisionPath home
+    exists <- doesFileExist path
+    if not exists
+        then pure Nothing
+        else do
+            result <- tryIO
+                (retryOnFileBusy (readFile (unsafeToFilePath path)))
+            pure $ either (const Nothing) parseRevision result
+  where
+    parseRevision value =
+        case words value of
+            [rawRevision, rawFingerprint] ->
+                (,) <$> readMaybe rawRevision <*> readMaybe rawFingerprint
+            _ -> Nothing
+
+writeConfigRevision :: OsPath -> Word64 -> Word64 -> IO Word64
+writeConfigRevision home revision fingerprint = do
+    let directory = home </> unsafeEncodeUtf ".haskell-agent"
+        path = configRevisionPath home
+        bytes = LBS.fromStrict . TextEncoding.encodeUtf8 . Text.pack $
+            show revision <> " " <> show fingerprint <> "\n"
+    createDirectoryIfMissing True directory
+    setFileMode (unsafeToFilePath directory) 0o700
+    writeLazyFileAtomically path 0o600 bytes
+    pure revision
 
 validateHarnessConfig :: HarnessConfig -> Either Text HarnessConfig
 validateHarnessConfig config = do

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -37,12 +37,10 @@ import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as TextEncoding
 import System.Directory.OsPath (createDirectoryIfMissing, doesFileExist)
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 import Data.Word (Word64)
-import Text.Read (readMaybe)
 
 harnessConfigSchemaVersion :: Int
 harnessConfigSchemaVersion = 1
@@ -357,9 +355,9 @@ loadHarnessConfig :: OsPath -> IO (Either Text HarnessConfig)
 loadHarnessConfig home =
     fmap (fmap snd) (loadHarnessConfigSnapshot home)
 
--- | Read one config and its monotonic revision under the same lock used by
--- every writer. A private content fingerprint advances the revision after an
--- out-of-band replacement without exposing secret-bearing config bytes.
+-- | Read one config and its content-derived revision under the same lock used
+-- by every writer. The token describes the exact validated bytes and is never
+-- computed from a separately replaceable sidecar.
 loadHarnessConfigSnapshot
     :: OsPath -> IO (Either Text (Word64, HarnessConfig))
 loadHarnessConfigSnapshot home =
@@ -372,9 +370,7 @@ loadHarnessConfigUnlocked home = do
     let path = harnessConfigPath home
     exists <- doesFileExist path
     if not exists
-        then do
-            revision <- syncMissingConfigRevision home
-            pure (Right (revision, defaultHarnessConfig))
+        then pure (Right (0, defaultHarnessConfig))
         else do
             bytesResult <-
                 tryIO (retryOnFileBusy (LBS.readFile (unsafeToFilePath path)))
@@ -396,9 +392,9 @@ loadHarnessConfigUnlocked home = do
                         Right config ->
                             case validateHarnessConfig config of
                                 Left err -> pure (Left err)
-                                Right valid -> do
-                                    revision <- syncConfigRevision home bytes
-                                    pure (Right (revision, valid))
+                                Right valid ->
+                                    pure (Right
+                                        (configBytesRevision bytes, valid))
 
 -- | Persist the machine-wide harness configuration with owner-only
 -- permissions. The replacement is atomic so an interrupted edit cannot leave
@@ -443,7 +439,6 @@ writeHarnessConfigUnlocked home config =
                 createDirectoryIfMissing True directory
                 setFileMode (unsafeToFilePath directory) 0o700
                 writeLazyFileAtomically path 0o600 bytes
-                advanceConfigRevision home bytes
             case result of
                 Left exception ->
                     pure . Left $
@@ -452,7 +447,8 @@ writeHarnessConfigUnlocked home config =
                             <> ": "
                             <> Text.pack (displayException exception)
                         )
-                Right revision -> pure (Right revision)
+                Right () ->
+                    pure (Right (configBytesRevision bytes))
 
 harnessConfigLockPath :: OsPath -> OsPath
 harnessConfigLockPath home =
@@ -466,64 +462,6 @@ configBytesRevision =
   where
     step hash byte = (hash `xor` fromIntegral byte) * 1099511628211
 
-configRevisionPath :: OsPath -> OsPath
-configRevisionPath home =
-    home
-        </> unsafeEncodeUtf ".haskell-agent"
-        </> unsafeEncodeUtf "config.revision"
-
-syncConfigRevision :: OsPath -> LBS.ByteString -> IO Word64
-syncConfigRevision home bytes = do
-    let fingerprint = configBytesRevision bytes
-    readConfigRevision home >>= \case
-        Just (revision, storedFingerprint)
-            | storedFingerprint == fingerprint -> pure revision
-            | otherwise ->
-                writeConfigRevision home (revision + 1) fingerprint
-        Nothing -> writeConfigRevision home 1 fingerprint
-
-syncMissingConfigRevision :: OsPath -> IO Word64
-syncMissingConfigRevision home = do
-    let fingerprint = configBytesRevision (Aeson.encode defaultHarnessConfig)
-    readConfigRevision home >>= \case
-        Nothing -> pure 0
-        Just (revision, storedFingerprint)
-            | storedFingerprint == fingerprint -> pure revision
-            | otherwise ->
-                writeConfigRevision home (revision + 1) fingerprint
-
-advanceConfigRevision :: OsPath -> LBS.ByteString -> IO Word64
-advanceConfigRevision home bytes = do
-    current <- maybe 0 fst <$> readConfigRevision home
-    writeConfigRevision home (current + 1) (configBytesRevision bytes)
-
-readConfigRevision :: OsPath -> IO (Maybe (Word64, Word64))
-readConfigRevision home = do
-    let path = configRevisionPath home
-    exists <- doesFileExist path
-    if not exists
-        then pure Nothing
-        else do
-            result <- tryIO
-                (retryOnFileBusy (readFile (unsafeToFilePath path)))
-            pure $ either (const Nothing) parseRevision result
-  where
-    parseRevision value =
-        case words value of
-            [rawRevision, rawFingerprint] ->
-                (,) <$> readMaybe rawRevision <*> readMaybe rawFingerprint
-            _ -> Nothing
-
-writeConfigRevision :: OsPath -> Word64 -> Word64 -> IO Word64
-writeConfigRevision home revision fingerprint = do
-    let directory = home </> unsafeEncodeUtf ".haskell-agent"
-        path = configRevisionPath home
-        bytes = LBS.fromStrict . TextEncoding.encodeUtf8 . Text.pack $
-            show revision <> " " <> show fingerprint <> "\n"
-    createDirectoryIfMissing True directory
-    setFileMode (unsafeToFilePath directory) 0o700
-    writeLazyFileAtomically path 0o600 bytes
-    pure revision
 
 validateHarnessConfig :: HarnessConfig -> Either Text HarnessConfig
 validateHarnessConfig config = do

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -12,7 +12,7 @@ module Agent.CLI.Config
     , loadHarnessConfig
     , loadHarnessConfigSnapshot
     , modifyHarnessConfig
-    , saveHarnessConfig
+    , withHarnessConfigSnapshot
     , useProgressiveMcp
     ) where
 
@@ -31,7 +31,7 @@ import Data.Aeson
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
-import Data.Bits (xor)
+import Data.Bits ((.|.), rotateL, shiftL, xor)
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
@@ -41,6 +41,7 @@ import System.Directory.OsPath (createDirectoryIfMissing, doesFileExist)
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 import Data.Word (Word64)
+import System.IO (IOMode(ReadMode), withBinaryFile)
 
 harnessConfigSchemaVersion :: Int
 harnessConfigSchemaVersion = 1
@@ -355,54 +356,62 @@ loadHarnessConfig :: OsPath -> IO (Either Text HarnessConfig)
 loadHarnessConfig home =
     fmap (fmap snd) (loadHarnessConfigSnapshot home)
 
--- | Read one config and its content-derived revision under the same lock used
--- by every writer. The token describes the exact validated bytes and is never
--- computed from a separately replaceable sidecar.
+-- | Read one config and its keyed opaque revision under the same lock used by
+-- every writer. The owner-only key prevents the public token from becoming a
+-- dictionary oracle for write-only configuration secrets.
 loadHarnessConfigSnapshot
     :: OsPath -> IO (Either Text (Word64, HarnessConfig))
 loadHarnessConfigSnapshot home =
     withPrivateFileLock (harnessConfigLockPath home) $
         loadHarnessConfigUnlocked home
 
+-- | Run an effect against one locked config snapshot. This is used when an
+-- external side effect must linearize with revision validation.
+withHarnessConfigSnapshot
+    :: OsPath
+    -> (Word64 -> HarnessConfig -> IO a)
+    -> IO (Either Text a)
+withHarnessConfigSnapshot home action =
+    withPrivateFileLock (harnessConfigLockPath home) do
+        loadHarnessConfigUnlocked home >>= \case
+            Left err -> pure (Left err)
+            Right (revision, config) ->
+                Right <$> action revision config
+
 loadHarnessConfigUnlocked
     :: OsPath -> IO (Either Text (Word64, HarnessConfig))
 loadHarnessConfigUnlocked home = do
     let path = harnessConfigPath home
     exists <- doesFileExist path
-    if not exists
-        then pure (Right (0, defaultHarnessConfig))
-        else do
-            bytesResult <-
-                tryIO (retryOnFileBusy (LBS.readFile (unsafeToFilePath path)))
-            case bytesResult of
-                Left exception ->
+    bytesResult <-
+        if exists
+            then tryIO
+                (retryOnFileBusy (LBS.readFile (unsafeToFilePath path)))
+            else pure (Right (Aeson.encode defaultHarnessConfig))
+    case bytesResult of
+        Left exception ->
+            pure . Left $
+                "Failed to read "
+                    <> Text.pack (unsafeToFilePath path)
+                    <> ": "
+                    <> Text.pack (displayException exception)
+        Right bytes ->
+            case Aeson.eitherDecode' bytes of
+                Left err ->
                     pure . Left $
-                        "Failed to read "
+                        "Invalid "
                             <> Text.pack (unsafeToFilePath path)
                             <> ": "
-                            <> Text.pack (displayException exception)
-                Right bytes ->
-                    case Aeson.eitherDecode' bytes of
-                        Left err ->
-                            pure . Left $
-                                "Invalid "
-                                    <> Text.pack (unsafeToFilePath path)
-                                    <> ": "
-                                    <> Text.pack err
-                        Right config ->
-                            case validateHarnessConfig config of
+                            <> Text.pack err
+                Right config ->
+                    case validateHarnessConfig config of
+                        Left err -> pure (Left err)
+                        Right valid ->
+                            loadHarnessRevisionKeyUnlocked home >>= \case
                                 Left err -> pure (Left err)
-                                Right valid ->
+                                Right key ->
                                     pure (Right
-                                        (configBytesRevision bytes, valid))
-
--- | Persist the machine-wide harness configuration with owner-only
--- permissions. The replacement is atomic so an interrupted edit cannot leave
--- a partially-written JSON file for the next agent startup.
-saveHarnessConfig :: OsPath -> HarnessConfig -> IO (Either Text ())
-saveHarnessConfig home config =
-    withPrivateFileLock (harnessConfigLockPath home) $
-        fmap (fmap (const ())) (writeHarnessConfigUnlocked home config)
+                                        (keyedConfigRevision key bytes, valid))
 
 -- | Atomically read, transform, validate, and replace the config while holding
 -- the process-shared config lock. The returned revision is for the exact bytes
@@ -435,20 +444,23 @@ writeHarnessConfigUnlocked home config =
                     home </> unsafeEncodeUtf ".haskell-agent"
                 path = harnessConfigPath home
                 bytes = Aeson.encode valid
-            result <- tryIO do
-                createDirectoryIfMissing True directory
-                setFileMode (unsafeToFilePath directory) 0o700
-                writeLazyFileAtomically path 0o600 bytes
-            case result of
-                Left exception ->
-                    pure . Left $
-                        ( "Failed to write "
-                            <> Text.pack (unsafeToFilePath path)
-                            <> ": "
-                            <> Text.pack (displayException exception)
-                        )
-                Right () ->
-                    pure (Right (configBytesRevision bytes))
+            loadHarnessRevisionKeyUnlocked home >>= \case
+                Left err -> pure (Left err)
+                Right key -> do
+                    result <- tryIO do
+                        createDirectoryIfMissing True directory
+                        setFileMode (unsafeToFilePath directory) 0o700
+                        writeLazyFileAtomically path 0o600 bytes
+                    case result of
+                        Left exception ->
+                            pure . Left $
+                                ( "Failed to write "
+                                    <> Text.pack (unsafeToFilePath path)
+                                    <> ": "
+                                    <> Text.pack (displayException exception)
+                                )
+                        Right () ->
+                            pure (Right (keyedConfigRevision key bytes))
 
 harnessConfigLockPath :: OsPath -> OsPath
 harnessConfigLockPath home =
@@ -456,11 +468,119 @@ harnessConfigLockPath home =
         </> unsafeEncodeUtf ".haskell-agent"
         </> unsafeEncodeUtf "config.lock"
 
-configBytesRevision :: LBS.ByteString -> Word64
-configBytesRevision =
-    BS.foldl' step 14695981039346656037 . LBS.toStrict
+harnessRevisionKeyPath :: OsPath -> OsPath
+harnessRevisionKeyPath home =
+    home
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "config.revision-key"
+
+loadHarnessRevisionKeyUnlocked :: OsPath -> IO (Either Text BS.ByteString)
+loadHarnessRevisionKeyUnlocked home = do
+    let path = harnessRevisionKeyPath home
+        directory = home </> unsafeEncodeUtf ".haskell-agent"
+    exists <- doesFileExist path
+    existing <-
+        if exists
+            then tryIO (BS.readFile (unsafeToFilePath path))
+            else pure (Right BS.empty)
+    case existing of
+        Right key | BS.length key == 16 -> do
+            secured <- tryIO
+                (setFileMode (unsafeToFilePath path) 0o600)
+            case secured of
+                Left exception ->
+                    pure (Left
+                        ("Failed to secure config revision key: "
+                            <> Text.pack (displayException exception)))
+                Right () -> pure (Right key)
+        _ -> do
+            generated <- tryIO $
+                withBinaryFile "/dev/urandom" ReadMode (`BS.hGet` 16)
+            case generated of
+                Left exception ->
+                    pure (Left
+                        ("Failed to generate config revision key: "
+                            <> Text.pack (displayException exception)))
+                Right key | BS.length key == 16 -> do
+                    written <- tryIO do
+                        createDirectoryIfMissing True directory
+                        setFileMode (unsafeToFilePath directory) 0o700
+                        writeLazyFileAtomically path 0o600
+                            (LBS.fromStrict key)
+                    case written of
+                        Left exception ->
+                            pure (Left
+                                ("Failed to store config revision key: "
+                                    <> Text.pack
+                                        (displayException exception)))
+                        Right () -> pure (Right key)
+                Right _ ->
+                    pure (Left "Failed to generate config revision key")
+
+-- SipHash-2-4, used only to derive an opaque revision token from exact config
+-- bytes. The key never crosses the native boundary.
+keyedConfigRevision :: BS.ByteString -> LBS.ByteString -> Word64
+keyedConfigRevision key lazyBytes =
+    finalize (compressBlocks initial bytes)
   where
-    step hash byte = (hash `xor` fromIntegral byte) * 1099511628211
+    bytes = LBS.toStrict lazyBytes
+    k0 = word64LE (BS.take 8 key)
+    k1 = word64LE (BS.drop 8 key)
+    initial =
+        ( 0x736f6d6570736575 `xor` k0
+        , 0x646f72616e646f6d `xor` k1
+        , 0x6c7967656e657261 `xor` k0
+        , 0x7465646279746573 `xor` k1
+        )
+    compressBlocks state remaining
+        | BS.length remaining >= 8 =
+            let message = word64LE (BS.take 8 remaining)
+                (v0, v1, v2, v3) = state
+                mixed = sipRounds 2 (v0, v1, v2, v3 `xor` message)
+                (r0, r1, r2, r3) = mixed
+            in compressBlocks
+                (r0 `xor` message, r1, r2, r3)
+                (BS.drop 8 remaining)
+        | otherwise =
+            let finalBlock =
+                    (fromIntegral (BS.length bytes) `shiftL` 56)
+                        .|. word64LE remaining
+                (v0, v1, v2, v3) = state
+                mixed = sipRounds 2
+                    (v0, v1, v2, v3 `xor` finalBlock)
+                (r0, r1, r2, r3) = mixed
+            in (r0 `xor` finalBlock, r1, r2, r3)
+    finalize (v0, v1, v2, v3) =
+        let (r0, r1, r2, r3) =
+                sipRounds 4 (v0, v1, v2 `xor` 0xff, v3)
+        in r0 `xor` r1 `xor` r2 `xor` r3
+
+word64LE :: BS.ByteString -> Word64
+word64LE =
+    snd . BS.foldl' step (0 :: Int, 0)
+  where
+    step (offset, value) byte =
+        (offset + 8, value .|. (fromIntegral byte `shiftL` offset))
+
+sipRounds
+    :: Int
+    -> (Word64, Word64, Word64, Word64)
+    -> (Word64, Word64, Word64, Word64)
+sipRounds count state
+    | count <= 0 = state
+    | otherwise =
+        let (v0, v1, v2, v3) = state
+            a0 = v0 + v1
+            a1 = rotateL v1 13 `xor` a0
+            a2 = rotateL a0 32
+            a3 = v2 + v3
+            a4 = rotateL v3 16 `xor` a3
+            b0 = a2 + a4
+            b1 = rotateL a4 21 `xor` b0
+            b2 = a3 + a1
+            b3 = rotateL a1 17 `xor` b2
+            b4 = rotateL b2 32
+        in sipRounds (count - 1) (b0, b3, b4, b1)
 
 
 validateHarnessConfig :: HarnessConfig -> Either Text HarnessConfig

--- a/packages/agent-cli/src/Agent/CLI/McpAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpAdmin.hs
@@ -1,0 +1,293 @@
+-- | Typed, revision-checked administration of the machine-wide MCP catalog.
+--
+-- Environment values are accepted on writes but deliberately absent from
+-- 'McpAdminServer': callers can inspect only their key names.
+module Agent.CLI.McpAdmin
+    ( McpAdminError(..)
+    , McpAdminSnapshot(..)
+    , McpAdminServer(..)
+    , McpAdminServerInput(..)
+    , addMcpAdminServer
+    , editMcpAdminServer
+    , listMcpAdminServers
+    , readMcpAdminServer
+    , removeMcpAdminServer
+    , restartMcpAdminServer
+    , setMcpAdminServerEnabled
+    ) where
+
+import Agent.CLI.Config
+    ( HarnessConfig(..)
+    , McpServerConfig(..)
+    , harnessConfigPath
+    , loadHarnessConfig
+    , saveHarnessConfig
+    )
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
+import Control.Monad (when)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import Data.Word (Word64)
+import System.Directory.OsPath (doesFileExist, getModificationTime)
+import System.OsPath
+    ( OsPath
+    , unsafeEncodeUtf
+    , (</>)
+    )
+
+data McpAdminError
+    = McpAdminConflict !Word64
+    | McpAdminNotFound !Text
+    | McpAdminAlreadyExists !Text
+    | McpAdminInvalid !Text
+    deriving (Eq, Show)
+
+data McpAdminSnapshot a = McpAdminSnapshot
+    { mcpAdminRevision :: !Word64
+    , mcpAdminValue :: !a
+    }
+    deriving (Eq, Show)
+
+data McpAdminServer = McpAdminServer
+    { mcpAdminName :: !Text
+    , mcpAdminEnabled :: !Bool
+    , mcpAdminCommand :: !Text
+    , mcpAdminArgs :: ![Text]
+    , mcpAdminCwd :: !(Maybe Text)
+    , mcpAdminEnvKeys :: ![Text]
+    , mcpAdminStartupTimeoutSeconds :: !Int
+    , mcpAdminRequestTimeoutSeconds :: !Int
+    }
+    deriving (Eq, Show)
+
+data McpAdminServerInput = McpAdminServerInput
+    { mcpAdminInputCommand :: !Text
+    , mcpAdminInputArgs :: ![Text]
+    , mcpAdminInputCwd :: !(Maybe Text)
+    , mcpAdminInputEnv :: !(Map Text Text)
+    , mcpAdminInputStartupTimeoutSeconds :: !Int
+    , mcpAdminInputRequestTimeoutSeconds :: !Int
+    }
+    deriving (Eq)
+
+instance Show McpAdminServerInput where
+    show input =
+        "McpAdminServerInput { mcpAdminInputCommand = "
+            <> show input.mcpAdminInputCommand
+            <> ", mcpAdminInputArgs = "
+            <> show input.mcpAdminInputArgs
+            <> ", mcpAdminInputCwd = "
+            <> show input.mcpAdminInputCwd
+            <> ", mcpAdminInputEnv = <redacted:"
+            <> show (Map.size input.mcpAdminInputEnv)
+            <> " entries>, mcpAdminInputStartupTimeoutSeconds = "
+            <> show input.mcpAdminInputStartupTimeoutSeconds
+            <> ", mcpAdminInputRequestTimeoutSeconds = "
+            <> show input.mcpAdminInputRequestTimeoutSeconds
+            <> " }"
+
+listMcpAdminServers
+    :: OsPath -> IO (Either McpAdminError (McpAdminSnapshot [McpAdminServer]))
+listMcpAdminServers home =
+    loadSnapshot home \config ->
+        [ publicServer name server
+        | (name, server) <- Map.toAscList config.configMcpServers
+        ]
+
+readMcpAdminServer
+    :: OsPath
+    -> Text
+    -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer))
+readMcpAdminServer home name = do
+    loaded <- loadSnapshot home (.configMcpServers)
+    pure do
+        snapshot <- loaded
+        server <- maybe
+            (Left (McpAdminNotFound name))
+            Right
+            (Map.lookup name snapshot.mcpAdminValue)
+        pure snapshot
+            { mcpAdminValue = publicServer name server }
+
+addMcpAdminServer
+    :: OsPath
+    -> Word64
+    -> Text
+    -> McpAdminServerInput
+    -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer))
+addMcpAdminServer home expected name input =
+    mutate home expected \config -> do
+        when (Map.member name config.configMcpServers) $
+            Left (McpAdminAlreadyExists name)
+        let server = inputServer True input
+        pure
+            ( config
+                { configMcpServers =
+                    Map.insert name server config.configMcpServers
+                }
+            , publicServer name server
+            )
+
+-- | Validate a restart request against the current catalog. The native engine
+-- performs the process-cache restart after this check succeeds.
+restartMcpAdminServer
+    :: OsPath
+    -> Word64
+    -> Text
+    -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer))
+restartMcpAdminServer home expected name =
+    withPrivateFileLock (adminLockPath home) do
+        readMcpAdminServer home name >>= \case
+            Left err -> pure (Left err)
+            Right snapshot
+                | snapshot.mcpAdminRevision /= expected ->
+                    pure (Left (McpAdminConflict snapshot.mcpAdminRevision))
+                | otherwise -> pure (Right snapshot)
+
+editMcpAdminServer
+    :: OsPath
+    -> Word64
+    -> Text
+    -> McpAdminServerInput
+    -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer))
+editMcpAdminServer home expected name input =
+    mutate home expected \config -> do
+        existing <- maybe
+            (Left (McpAdminNotFound name))
+            Right
+            (Map.lookup name config.configMcpServers)
+        let server = inputServer existing.mcpEnabled input
+        pure
+            ( config
+                { configMcpServers =
+                    Map.insert name server config.configMcpServers
+                }
+            , publicServer name server
+            )
+
+setMcpAdminServerEnabled
+    :: OsPath
+    -> Word64
+    -> Text
+    -> Bool
+    -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer))
+setMcpAdminServerEnabled home expected name enabled =
+    mutate home expected \config -> do
+        existing <- maybe
+            (Left (McpAdminNotFound name))
+            Right
+            (Map.lookup name config.configMcpServers)
+        let server = existing { mcpEnabled = enabled }
+        pure
+            ( config
+                { configMcpServers =
+                    Map.insert name server config.configMcpServers
+                }
+            , publicServer name server
+            )
+
+removeMcpAdminServer
+    :: OsPath
+    -> Word64
+    -> Text
+    -> IO (Either McpAdminError (McpAdminSnapshot ()))
+removeMcpAdminServer home expected name =
+    mutate home expected \config -> do
+        when (not (Map.member name config.configMcpServers)) $
+            Left (McpAdminNotFound name)
+        pure
+            ( config
+                { configMcpServers =
+                    Map.delete name config.configMcpServers
+                }
+            , ()
+            )
+
+loadSnapshot
+    :: OsPath
+    -> (HarnessConfig -> a)
+    -> IO (Either McpAdminError (McpAdminSnapshot a))
+loadSnapshot home project =
+    loadHarnessConfig home >>= \case
+        Left err -> pure (Left (McpAdminInvalid err))
+        Right config -> do
+            revision <- configRevision home
+            pure (Right McpAdminSnapshot
+                { mcpAdminRevision = revision
+                , mcpAdminValue = project config
+                })
+
+mutate
+    :: OsPath
+    -> Word64
+    -> (HarnessConfig -> Either McpAdminError (HarnessConfig, a))
+    -> IO (Either McpAdminError (McpAdminSnapshot a))
+mutate home expected change =
+    withPrivateFileLock (adminLockPath home) do
+        loaded <- loadHarnessConfig home
+        case loaded of
+            Left err -> pure (Left (McpAdminInvalid err))
+            Right config -> do
+                current <- configRevision home
+                if expected /= current
+                    then pure (Left (McpAdminConflict current))
+                    else case change config of
+                        Left err -> pure (Left err)
+                        Right (updated, value) ->
+                            saveHarnessConfig home updated >>= \case
+                                Left err ->
+                                    pure (Left (McpAdminInvalid err))
+                                Right () -> do
+                                    revision <- configRevision home
+                                    pure (Right McpAdminSnapshot
+                                        { mcpAdminRevision = revision
+                                        , mcpAdminValue = value
+                                        })
+
+adminLockPath :: OsPath -> OsPath
+adminLockPath home =
+    home
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "config.admin.lock"
+
+-- Atomic config replacement changes the inode timestamp. The nanosecond token
+-- detects native and existing-CLI edits without deriving any public value from
+-- the (potentially secret-bearing) config bytes.
+configRevision :: OsPath -> IO Word64
+configRevision home = do
+    let path = harnessConfigPath home
+    exists <- doesFileExist path
+    if not exists
+        then pure 0
+        else do
+            modified <- getModificationTime path
+            pure . fromIntegral . max (0 :: Integer) . floor $
+                utcTimeToPOSIXSeconds modified * 1000000000
+
+publicServer :: Text -> McpServerConfig -> McpAdminServer
+publicServer name server = McpAdminServer
+    { mcpAdminName = name
+    , mcpAdminEnabled = server.mcpEnabled
+    , mcpAdminCommand = server.mcpCommand
+    , mcpAdminArgs = server.mcpArgs
+    , mcpAdminCwd = server.mcpCwd
+    , mcpAdminEnvKeys = Map.keys server.mcpEnv
+    , mcpAdminStartupTimeoutSeconds = server.mcpStartupTimeoutSeconds
+    , mcpAdminRequestTimeoutSeconds = server.mcpRequestTimeoutSeconds
+    }
+
+inputServer :: Bool -> McpAdminServerInput -> McpServerConfig
+inputServer enabled input = McpServerConfig
+    { mcpEnabled = enabled
+    , mcpCommand = Text.strip input.mcpAdminInputCommand
+    , mcpArgs = input.mcpAdminInputArgs
+    , mcpCwd = input.mcpAdminInputCwd
+    , mcpEnv = input.mcpAdminInputEnv
+    , mcpStartupTimeoutSeconds =
+        input.mcpAdminInputStartupTimeoutSeconds
+    , mcpRequestTimeoutSeconds =
+        input.mcpAdminInputRequestTimeoutSeconds
+    }

--- a/packages/agent-cli/src/Agent/CLI/McpAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpAdmin.hs
@@ -21,6 +21,7 @@ import Agent.CLI.Config
     , McpServerConfig(..)
     , loadHarnessConfigSnapshot
     , modifyHarnessConfig
+    , withHarnessConfigSnapshot
     )
 import Control.Monad (when)
 import Data.Bifunctor (first)
@@ -124,20 +125,32 @@ addMcpAdminServer home expected name input =
             , publicServer name server
             )
 
--- | Validate a restart request against the current catalog. The native engine
--- performs the process-cache restart after this check succeeds.
+-- | Validate a restart request and perform the process-cache restart while
+-- holding the shared config lock. A catalog mutation therefore happens wholly
+-- before or after the restart's revision check and cannot make the accepted
+-- restart stale between validation and its side effect.
 restartMcpAdminServer
     :: OsPath
     -> Word64
     -> Text
+    -> IO ()
     -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer))
-restartMcpAdminServer home expected name =
-    readMcpAdminServer home name >>= \case
-        Left err -> pure (Left err)
-        Right snapshot
-            | snapshot.mcpAdminRevision /= expected ->
-                pure (Left (McpAdminConflict snapshot.mcpAdminRevision))
-            | otherwise -> pure (Right snapshot)
+restartMcpAdminServer home expected name restart =
+    withHarnessConfigSnapshot home
+        (\current config ->
+            if current /= expected
+                then pure (Left (McpAdminConflict current))
+                else case Map.lookup name config.configMcpServers of
+                    Nothing -> pure (Left (McpAdminNotFound name))
+                    Just server -> do
+                        restart
+                        pure (Right McpAdminSnapshot
+                            { mcpAdminRevision = current
+                            , mcpAdminValue = publicServer name server
+                            }))
+        >>= \case
+            Left err -> pure (Left (McpAdminInvalid err))
+            Right result -> pure result
 
 editMcpAdminServer
     :: OsPath

--- a/packages/agent-cli/src/Agent/CLI/McpAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpAdmin.hs
@@ -19,24 +19,17 @@ module Agent.CLI.McpAdmin
 import Agent.CLI.Config
     ( HarnessConfig(..)
     , McpServerConfig(..)
-    , harnessConfigPath
-    , loadHarnessConfig
-    , saveHarnessConfig
+    , loadHarnessConfigSnapshot
+    , modifyHarnessConfig
     )
-import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Control.Monad (when)
+import Data.Bifunctor (first)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Word (Word64)
-import System.Directory.OsPath (doesFileExist, getModificationTime)
-import System.OsPath
-    ( OsPath
-    , unsafeEncodeUtf
-    , (</>)
-    )
+import System.OsPath (OsPath)
 
 data McpAdminError
     = McpAdminConflict !Word64
@@ -139,13 +132,12 @@ restartMcpAdminServer
     -> Text
     -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer))
 restartMcpAdminServer home expected name =
-    withPrivateFileLock (adminLockPath home) do
-        readMcpAdminServer home name >>= \case
-            Left err -> pure (Left err)
-            Right snapshot
-                | snapshot.mcpAdminRevision /= expected ->
-                    pure (Left (McpAdminConflict snapshot.mcpAdminRevision))
-                | otherwise -> pure (Right snapshot)
+    readMcpAdminServer home name >>= \case
+        Left err -> pure (Left err)
+        Right snapshot
+            | snapshot.mcpAdminRevision /= expected ->
+                pure (Left (McpAdminConflict snapshot.mcpAdminRevision))
+            | otherwise -> pure (Right snapshot)
 
 editMcpAdminServer
     :: OsPath
@@ -211,10 +203,9 @@ loadSnapshot
     -> (HarnessConfig -> a)
     -> IO (Either McpAdminError (McpAdminSnapshot a))
 loadSnapshot home project =
-    loadHarnessConfig home >>= \case
+    loadHarnessConfigSnapshot home >>= \case
         Left err -> pure (Left (McpAdminInvalid err))
-        Right config -> do
-            revision <- configRevision home
+        Right (revision, config) ->
             pure (Right McpAdminSnapshot
                 { mcpAdminRevision = revision
                 , mcpAdminValue = project config
@@ -226,46 +217,36 @@ mutate
     -> (HarnessConfig -> Either McpAdminError (HarnessConfig, a))
     -> IO (Either McpAdminError (McpAdminSnapshot a))
 mutate home expected change =
-    withPrivateFileLock (adminLockPath home) do
-        loaded <- loadHarnessConfig home
-        case loaded of
-            Left err -> pure (Left (McpAdminInvalid err))
-            Right config -> do
-                current <- configRevision home
-                if expected /= current
-                    then pure (Left (McpAdminConflict current))
-                    else case change config of
-                        Left err -> pure (Left err)
-                        Right (updated, value) ->
-                            saveHarnessConfig home updated >>= \case
-                                Left err ->
-                                    pure (Left (McpAdminInvalid err))
-                                Right () -> do
-                                    revision <- configRevision home
-                                    pure (Right McpAdminSnapshot
-                                        { mcpAdminRevision = revision
-                                        , mcpAdminValue = value
-                                        })
-
-adminLockPath :: OsPath -> OsPath
-adminLockPath home =
-    home
-        </> unsafeEncodeUtf ".haskell-agent"
-        </> unsafeEncodeUtf "config.admin.lock"
-
--- Atomic config replacement changes the inode timestamp. The nanosecond token
--- detects native and existing-CLI edits without deriving any public value from
--- the (potentially secret-bearing) config bytes.
-configRevision :: OsPath -> IO Word64
-configRevision home = do
-    let path = harnessConfigPath home
-    exists <- doesFileExist path
-    if not exists
-        then pure 0
-        else do
-            modified <- getModificationTime path
-            pure . fromIntegral . max (0 :: Integer) . floor $
-                utcTimeToPOSIXSeconds modified * 1000000000
+    modifyHarnessConfig home
+        (\current config ->
+            if expected /= current
+                then Left ("conflict:" <> Text.pack (show current))
+                else first renderMutationError (change config))
+        >>= \case
+                Left err -> pure (Left (parseMutationError err))
+                Right (revision, _, value) ->
+                    pure (Right McpAdminSnapshot
+                        { mcpAdminRevision = revision
+                        , mcpAdminValue = value
+                        })
+  where
+    renderMutationError = \case
+        McpAdminNotFound name -> "not-found:" <> name
+        McpAdminAlreadyExists name -> "exists:" <> name
+        McpAdminInvalid err -> "invalid:" <> err
+        McpAdminConflict revision ->
+            "conflict:" <> Text.pack (show revision)
+    parseMutationError err
+        | Just raw <- Text.stripPrefix "conflict:" err
+        , [(revision, "")] <- reads (Text.unpack raw) =
+            McpAdminConflict revision
+        | Just name <- Text.stripPrefix "not-found:" err =
+            McpAdminNotFound name
+        | Just name <- Text.stripPrefix "exists:" err =
+            McpAdminAlreadyExists name
+        | Just invalid <- Text.stripPrefix "invalid:" err =
+            McpAdminInvalid invalid
+        | otherwise = McpAdminInvalid err
 
 publicServer :: Text -> McpServerConfig -> McpAdminServer
 publicServer name server = McpAdminServer

--- a/packages/agent-cli/src/Agent/CLI/McpManager.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager.hs
@@ -15,8 +15,8 @@ module Agent.CLI.McpManager
 import Agent.CLI.Config
     ( HarnessConfig(..)
     , McpServerConfig(..)
-    , loadHarnessConfig
-    , saveHarnessConfig
+    , loadHarnessConfigSnapshot
+    , modifyHarnessConfig
     )
 import Agent.CLI.Input (readApprovalLine)
 import Agent.CLI.Picker
@@ -204,11 +204,11 @@ runMcpManager
     -> [Text]
     -> IO Bool
 runMcpManager color home registrations warnings = do
-    loadHarnessConfig home >>= \case
+    loadHarnessConfigSnapshot home >>= \case
         Left err -> do
             Text.hPutStrLn stderr (roleError color err)
             pure False
-        Right config -> do
+        Right (revision, config) -> do
             tty <- hIsTerminalDevice stdin
             if not tty
                 then do
@@ -218,9 +218,9 @@ runMcpManager color home registrations warnings = do
                                 config registrations warnings Set.empty Nothing)
                     hFlush stderr
                     pure False
-                else loop config Set.empty False Nothing
+                else loop revision config Set.empty False Nothing
   where
-    loop config pending changed notice = do
+    loop revision config pending changed notice = do
         let state =
                 initialMcpManagerState
                     config registrations warnings pending notice
@@ -232,9 +232,10 @@ runMcpManager color home registrations warnings = do
                 Just McpManagerAdd ->
                     promptNewServer config >>= \case
                         Left err ->
-                            loop config pending changed (Just (False, err))
+                            loop revision config pending changed
+                                (Just (False, err))
                         Right Nothing ->
-                            loop config pending changed Nothing
+                            loop revision config pending changed Nothing
                         Right (Just (label, server)) ->
                             persist
                                 (config
@@ -247,7 +248,7 @@ runMcpManager color home registrations warnings = do
                 Just (McpManagerToggle label) ->
                     case Map.lookup label config.configMcpServers of
                         Nothing ->
-                            loop config pending changed
+                            loop revision config pending changed
                                 (Just (False, "MCP server no longer exists"))
                         Just server ->
                             let enabled = not server.mcpEnabled
@@ -268,7 +269,7 @@ runMcpManager color home registrations warnings = do
                         confirm
                             ("Remove MCP server " <> quote label <> "? [y/N] ")
                     if not confirmed
-                        then loop config pending changed Nothing
+                        then loop revision config pending changed Nothing
                         else
                             persist
                                 (config
@@ -279,11 +280,17 @@ runMcpManager color home registrations warnings = do
                                 ("Removed " <> label)
       where
         persist updated pending' message =
-            saveHarnessConfig home updated >>= \case
+            modifyHarnessConfig home
+                (\current _ ->
+                    if current /= revision
+                        then Left
+                            "MCP configuration changed; reopen /mcp and retry"
+                        else Right (updated, ())) >>= \case
                 Left err ->
-                    loop config pending changed (Just (False, err))
-                Right () ->
-                    loop updated pending' True (Just (True, message))
+                    loop revision config pending changed (Just (False, err))
+                Right (nextRevision, _, ()) ->
+                    loop nextRevision updated pending' True
+                        (Just (True, message))
 
 promptNewServer
     :: HarnessConfig

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -3,6 +3,7 @@ module Agent.CLI.NativeRuntime
     , NativeRunHooks(..)
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
+    , restartNativeMcpRuntime
     , runNativeAgent
     ) where
 
@@ -49,6 +50,10 @@ closeNativeProcessRuntime :: NativeProcessRuntime -> IO ()
 closeNativeProcessRuntime runtime =
     closeSessionThreadManager runtime.nativeSessionThreads
         `finally` MCP.closeMcpSupervisor runtime.nativeMcpSupervisor
+
+restartNativeMcpRuntime :: NativeProcessRuntime -> IO ()
+restartNativeMcpRuntime runtime =
+    MCP.restartMcpSupervisor runtime.nativeMcpSupervisor
 
 runNativeAgent
     :: NativeProcessRuntime

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -199,7 +199,7 @@ spec = describe "Agent.CLI.Config" do
                 Right config ->
                     config.configMaxConcurrentAgents `shouldBe` Just 32
 
-    it "returns a monotonic revision for the exact locked snapshot" $
+    it "returns a stable content revision for the exact locked snapshot" $
         withTempDir "agent-config-" \home -> do
             Right (initialRevision, initial) <-
                 loadHarnessConfigSnapshot home
@@ -207,12 +207,31 @@ spec = describe "Agent.CLI.Config" do
             Right (firstRevision, firstConfig) <-
                 loadHarnessConfigSnapshot home
             saveHarnessConfig home firstConfig `shouldReturn` Right ()
-            Right (secondRevision, secondConfig) <-
+            Right (sameRevision, sameConfig) <-
+                loadHarnessConfigSnapshot home
+            saveHarnessConfig home
+                (firstConfig { configMaxConcurrentAgents = Just 7 })
+                `shouldReturn` Right ()
+            Right (changedRevision, changedConfig) <-
                 loadHarnessConfigSnapshot home
             initialRevision `shouldBe` 0
-            firstRevision `shouldSatisfy` (> initialRevision)
-            secondRevision `shouldSatisfy` (> firstRevision)
-            secondConfig `shouldBe` firstConfig
+            firstRevision `shouldNotBe` initialRevision
+            sameRevision `shouldBe` firstRevision
+            sameConfig `shouldBe` firstConfig
+            changedRevision `shouldNotBe` firstRevision
+            changedConfig.configMaxConcurrentAgents `shouldBe` Just 7
+
+    it "derives a new token after an out-of-band config replacement" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home "{\"maxConcurrentAgents\":2}"
+            Right (firstRevision, firstConfig) <-
+                loadHarnessConfigSnapshot home
+            writeConfig home "{\"maxConcurrentAgents\":3}"
+            Right (secondRevision, secondConfig) <-
+                loadHarnessConfigSnapshot home
+            firstConfig.configMaxConcurrentAgents `shouldBe` Just 2
+            secondConfig.configMaxConcurrentAgents `shouldBe` Just 3
+            secondRevision `shouldNotBe` firstRevision
 
 writeConfig :: OsPath -> LBS.ByteString -> IO ()
 writeConfig home bytes = do

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -1,9 +1,11 @@
 module Agent.CLI.ConfigSpec (spec) where
 
 import Agent.CLI.Config
+import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
+import Data.Either (isRight)
 import qualified Data.Text as Text
 import System.Directory.OsPath
     ( createDirectoryIfMissing
@@ -176,6 +178,41 @@ spec = describe "Agent.CLI.Config" do
             saveHarnessConfig home broken
                 `shouldReturn`
                     Left "MCP server 'broken' has an empty command"
+
+    it "serializes concurrent read-modify-write transactions without loss" $
+        withTempDir "agent-config-" \home -> do
+            let increment _ config =
+                    Right
+                        ( config
+                            { configMaxConcurrentAgents =
+                                Just (maybe 1 (+ 1)
+                                    config.configMaxConcurrentAgents)
+                            }
+                        , ()
+                        )
+            results <- mapConcurrently
+                (const (modifyHarnessConfig home increment))
+                [1 .. 32 :: Int]
+            results `shouldSatisfy` all isRight
+            loadHarnessConfig home >>= \case
+                Left err -> expectationFailure (show err)
+                Right config ->
+                    config.configMaxConcurrentAgents `shouldBe` Just 32
+
+    it "returns a monotonic revision for the exact locked snapshot" $
+        withTempDir "agent-config-" \home -> do
+            Right (initialRevision, initial) <-
+                loadHarnessConfigSnapshot home
+            saveHarnessConfig home initial `shouldReturn` Right ()
+            Right (firstRevision, firstConfig) <-
+                loadHarnessConfigSnapshot home
+            saveHarnessConfig home firstConfig `shouldReturn` Right ()
+            Right (secondRevision, secondConfig) <-
+                loadHarnessConfigSnapshot home
+            initialRevision `shouldBe` 0
+            firstRevision `shouldSatisfy` (> initialRevision)
+            secondRevision `shouldSatisfy` (> firstRevision)
+            secondConfig `shouldBe` firstConfig
 
 writeConfig :: OsPath -> LBS.ByteString -> IO ()
 writeConfig home bytes = do

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -18,6 +18,7 @@ import System.OsPath
     , decodeUtf
     , takeDirectory
     , unsafeEncodeUtf
+    , (</>)
     )
 import System.Posix.Temp (mkdtemp)
 import System.Posix.Files
@@ -156,7 +157,7 @@ spec = describe "Agent.CLI.Config" do
                     { configMcpServers = Map.singleton "seo-mcp" server
                     , configMaxConcurrentAgents = Just 48
                     }
-            saveHarnessConfig home config `shouldReturn` Right ()
+            replaceConfig home config `shouldReturn` Right ()
             loadHarnessConfig home `shouldReturn` Right config
             status <- getFileStatus (filePath (harnessConfigPath home))
             fileMode status `shouldBe` 0o100600
@@ -175,7 +176,7 @@ spec = describe "Agent.CLI.Config" do
                             , mcpRequestTimeoutSeconds = 60
                             }
                     }
-            saveHarnessConfig home broken
+            replaceConfig home broken
                 `shouldReturn`
                     Left "MCP server 'broken' has an empty command"
 
@@ -199,23 +200,22 @@ spec = describe "Agent.CLI.Config" do
                 Right config ->
                     config.configMaxConcurrentAgents `shouldBe` Just 32
 
-    it "returns a stable content revision for the exact locked snapshot" $
+    it "returns a stable keyed revision for the exact locked snapshot" $
         withTempDir "agent-config-" \home -> do
             Right (initialRevision, initial) <-
                 loadHarnessConfigSnapshot home
-            saveHarnessConfig home initial `shouldReturn` Right ()
+            replaceConfig home initial `shouldReturn` Right ()
             Right (firstRevision, firstConfig) <-
                 loadHarnessConfigSnapshot home
-            saveHarnessConfig home firstConfig `shouldReturn` Right ()
+            replaceConfig home firstConfig `shouldReturn` Right ()
             Right (sameRevision, sameConfig) <-
                 loadHarnessConfigSnapshot home
-            saveHarnessConfig home
+            replaceConfig home
                 (firstConfig { configMaxConcurrentAgents = Just 7 })
                 `shouldReturn` Right ()
             Right (changedRevision, changedConfig) <-
                 loadHarnessConfigSnapshot home
-            initialRevision `shouldBe` 0
-            firstRevision `shouldNotBe` initialRevision
+            initialRevision `shouldBe` firstRevision
             sameRevision `shouldBe` firstRevision
             sameConfig `shouldBe` firstConfig
             changedRevision `shouldNotBe` firstRevision
@@ -232,6 +232,26 @@ spec = describe "Agent.CLI.Config" do
             firstConfig.configMaxConcurrentAgents `shouldBe` Just 2
             secondConfig.configMaxConcurrentAgents `shouldBe` Just 3
             secondRevision `shouldNotBe` firstRevision
+
+    it "invalidates old tokens when the owner-only key is missing or corrupt" $
+        withTempDir "agent-config-" \home -> do
+            Right (firstRevision, _) <- loadHarnessConfigSnapshot home
+            let key = home
+                    </> unsafeEncodeUtf ".haskell-agent"
+                    </> unsafeEncodeUtf "config.revision-key"
+            Directory.removeFile (filePath key)
+            Right (secondRevision, _) <- loadHarnessConfigSnapshot home
+            secondRevision `shouldNotBe` firstRevision
+            LBS.writeFile (filePath key) "corrupt"
+            Right (thirdRevision, _) <- loadHarnessConfigSnapshot home
+            thirdRevision `shouldNotBe` secondRevision
+            status <- getFileStatus (filePath key)
+            fileMode status `shouldBe` 0o100600
+
+replaceConfig :: OsPath -> HarnessConfig -> IO (Either Text.Text ())
+replaceConfig home replacement =
+    fmap (fmap (const ())) $
+        modifyHarnessConfig home \_ _ -> Right (replacement, ())
 
 writeConfig :: OsPath -> LBS.ByteString -> IO ()
 writeConfig home bytes = do

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -9,13 +9,14 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 
 foreign import ccall "ha_image_attachment_stage_smoke"
     imageAttachmentStageSmoke :: IO CInt
+
 #else
 import Test.Hspec (Spec, describe, it, pendingWith)
 #endif
 
 spec :: Spec
-spec = describe "native image attachment staging" do
-    it "accepts copied image buffers through the exported bridge" do
+spec = describe "native engine lifecycle smoke" do
+    it "stages copied images and completes restart before destroy returns" do
 #ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0
 #else

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -8,7 +8,12 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 foreign import ccall "ha_image_attachment_abi_smoke"
     imageAttachmentAbiSmoke :: IO CInt
 
+foreign import ccall "ha_mcp_admin_abi_smoke"
+    mcpAdminAbiSmoke :: IO CInt
+
 spec :: Spec
 spec = describe "native image attachment ABI" do
     it "preserves the documented image struct layout and ordered buffers" do
         imageAttachmentAbiSmoke `shouldReturn` 0
+    it "preserves the typed MCP argument and environment layouts" do
+        mcpAdminAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/EngineMailboxSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/EngineMailboxSpec.hs
@@ -1,0 +1,38 @@
+module Agent.CLI.MacOS.EngineMailboxSpec (spec) where
+
+import Agent.CLI.MacOS.EngineMailbox
+    ( EngineMailbox
+    , acceptEngineCommand
+    , closeEngineMailbox
+    , newEngineMailboxIO
+    , readEngineCommand
+    )
+import Control.Concurrent.Async (concurrently)
+import Control.Concurrent.STM (atomically)
+import Control.Monad (replicateM_)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec :: Spec
+spec = describe "native engine mailbox" do
+    it "orders every accepted callback command before concurrent shutdown" $
+        replicateM_ 1000 do
+            mailbox <- newEngineMailboxIO :: IO (EngineMailbox String)
+            (accepted, closed) <- concurrently
+                (atomically (acceptEngineCommand mailbox "restart"))
+                (atomically (closeEngineMailbox mailbox "stop"))
+            closed `shouldBe` True
+            first <- atomically (readEngineCommand mailbox)
+            if accepted
+                then do
+                    second <- atomically (readEngineCommand mailbox)
+                    [first, second] `shouldBe` ["restart", "stop"]
+                else first `shouldBe` "stop"
+
+    it "rejects callback commands after shutdown wins" do
+        mailbox <- newEngineMailboxIO :: IO (EngineMailbox String)
+        closed <- atomically (closeEngineMailbox mailbox "stop")
+        accepted <- atomically (acceptEngineCommand mailbox "restart")
+        command <- atomically (readEngineCommand mailbox)
+        closed `shouldBe` True
+        accepted `shouldBe` False
+        command `shouldBe` "stop"

--- a/packages/agent-cli/test/Agent/CLI/McpAdminSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpAdminSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.McpAdminSpec (spec) where
 
 import Agent.CLI.Config (HarnessConfig(..), loadHarnessConfig)
 import Agent.CLI.McpAdmin
+import Control.Concurrent.Async (concurrently)
 import Control.Exception.Safe (bracket)
 import qualified Data.Map.Strict as Map
 import System.Directory.OsPath (getTemporaryDirectory)
@@ -69,6 +70,19 @@ spec = describe "Agent.CLI.McpAdmin" do
                     , mcpAdminValue = []
                     }
 
+    it "allows exactly one writer for a shared snapshot revision" $
+        withTempDir \home -> do
+            Right initial <- listMcpAdminServers home
+            (left, right) <- concurrently
+                (addMcpAdminServer home initial.mcpAdminRevision "left" input)
+                (addMcpAdminServer home initial.mcpAdminRevision "right" input)
+            length (filter isSuccess [left, right]) `shouldBe` 1
+            length (filter isConflict [left, right]) `shouldBe` 1
+            Right final <- listMcpAdminServers home
+            length final.mcpAdminValue `shouldBe` 1
+            final.mcpAdminRevision `shouldSatisfy`
+                (> initial.mcpAdminRevision)
+
 input :: McpAdminServerInput
 input = McpAdminServerInput
     { mcpAdminInputCommand = "mcp-docs"
@@ -89,3 +103,11 @@ withTempDir action = do
 
 filePath :: OsPath -> FilePath
 filePath value = either (error . show) id (decodeUtf value)
+
+isSuccess :: Either McpAdminError a -> Bool
+isSuccess = either (const False) (const True)
+
+isConflict :: Either McpAdminError a -> Bool
+isConflict = \case
+    Left (McpAdminConflict _) -> True
+    _ -> False

--- a/packages/agent-cli/test/Agent/CLI/McpAdminSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpAdminSpec.hs
@@ -2,7 +2,13 @@ module Agent.CLI.McpAdminSpec (spec) where
 
 import Agent.CLI.Config (HarnessConfig(..), loadHarnessConfig)
 import Agent.CLI.McpAdmin
-import Control.Concurrent.Async (concurrently)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (concurrently, poll, wait, withAsync)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , takeMVar
+    )
 import Control.Exception.Safe (bracket)
 import qualified Data.Map.Strict as Map
 import System.Directory.OsPath (getTemporaryDirectory)
@@ -61,6 +67,7 @@ spec = describe "Agent.CLI.McpAdmin" do
             Right disabled <- setMcpAdminServerEnabled home
                 edited.mcpAdminRevision "docs" False
             restartMcpAdminServer home disabled.mcpAdminRevision "docs"
+                (pure ())
                 `shouldReturn` Right disabled
             Right removed <- removeMcpAdminServer home
                 disabled.mcpAdminRevision "docs"
@@ -82,6 +89,49 @@ spec = describe "Agent.CLI.McpAdmin" do
             length final.mcpAdminValue `shouldBe` 1
             final.mcpAdminRevision `shouldSatisfy`
                 (> initial.mcpAdminRevision)
+
+    it "linearizes revision validation with the supervisor restart" $
+        withTempDir \home -> do
+            Right initial <- listMcpAdminServers home
+            Right added <- addMcpAdminServer home initial.mcpAdminRevision
+                "docs" input
+            entered <- newEmptyMVar
+            release <- newEmptyMVar
+            let restart = putMVar entered () >> takeMVar release
+            withAsync
+                (restartMcpAdminServer home added.mcpAdminRevision
+                    "docs" restart)
+                \restarting -> do
+                    takeMVar entered
+                    withAsync
+                        (setMcpAdminServerEnabled home
+                            added.mcpAdminRevision "docs" False)
+                        \writing -> do
+                            threadDelay 20000
+                            poll writing >>= \case
+                                Nothing -> pure ()
+                                Just _ ->
+                                    expectationFailure
+                                        "writer bypassed restart lock"
+                            putMVar release ()
+                            wait restarting `shouldReturn` Right added
+                            wait writing >>= \case
+                                Left err -> expectationFailure (show err)
+                                Right disabled ->
+                                    disabled.mcpAdminValue.mcpAdminEnabled
+                                        `shouldBe` False
+
+    it "does not run the supervisor restart for a stale revision" $
+        withTempDir \home -> do
+            Right initial <- listMcpAdminServers home
+            Right added <- addMcpAdminServer home initial.mcpAdminRevision
+                "docs" input
+            Right disabled <- setMcpAdminServerEnabled home
+                added.mcpAdminRevision "docs" False
+            result <- restartMcpAdminServer home added.mcpAdminRevision
+                "docs" (expectationFailure "stale restart action ran")
+            result `shouldBe`
+                Left (McpAdminConflict disabled.mcpAdminRevision)
 
 input :: McpAdminServerInput
 input = McpAdminServerInput

--- a/packages/agent-cli/test/Agent/CLI/McpAdminSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpAdminSpec.hs
@@ -1,0 +1,91 @@
+module Agent.CLI.McpAdminSpec (spec) where
+
+import Agent.CLI.Config (HarnessConfig(..), loadHarnessConfig)
+import Agent.CLI.McpAdmin
+import Control.Exception.Safe (bracket)
+import qualified Data.Map.Strict as Map
+import System.Directory.OsPath (getTemporaryDirectory)
+import qualified System.Directory as Directory
+import qualified System.FilePath as FilePath
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.McpAdmin" do
+    it "redacts environment values and preserves their sorted keys" $
+        withTempDir \home -> do
+            Right initial <- listMcpAdminServers home
+            Right added <- addMcpAdminServer home initial.mcpAdminRevision
+                "docs" input
+                    { mcpAdminInputEnv =
+                        Map.fromList [("TOKEN", "top-secret"), ("A", "hidden")]
+                    }
+            added.mcpAdminValue.mcpAdminEnvKeys `shouldBe` ["A", "TOKEN"]
+            show added.mcpAdminValue `shouldNotContain` "top-secret"
+            Right listed <- listMcpAdminServers home
+            listed.mcpAdminValue `shouldBe` [added.mcpAdminValue]
+
+    it "rejects stale revisions without overwriting a concurrent edit" $
+        withTempDir \home -> do
+            Right initial <- listMcpAdminServers home
+            Right added <- addMcpAdminServer home initial.mcpAdminRevision
+                "docs" input
+            stale <- setMcpAdminServerEnabled home initial.mcpAdminRevision
+                "docs" False
+            stale `shouldBe`
+                Left (McpAdminConflict added.mcpAdminRevision)
+            Right current <- readMcpAdminServer home "docs"
+            current.mcpAdminValue.mcpAdminEnabled `shouldBe` True
+
+    it "validates writes through the shared harness config validator" $
+        withTempDir \home -> do
+            Right initial <- listMcpAdminServers home
+            result <- addMcpAdminServer home initial.mcpAdminRevision
+                "broken" input { mcpAdminInputStartupTimeoutSeconds = 0 }
+            result `shouldBe`
+                Left (McpAdminInvalid
+                    "MCP server 'broken' startupTimeoutSeconds must be positive")
+            Right config <- loadHarnessConfig home
+            config.configMcpServers `shouldBe` Map.empty
+
+    it "supports edit, disable, and remove with successive revisions" $
+        withTempDir \home -> do
+            Right initial <- listMcpAdminServers home
+            Right added <- addMcpAdminServer home initial.mcpAdminRevision
+                "docs" input
+            Right edited <- editMcpAdminServer home added.mcpAdminRevision
+                "docs" input { mcpAdminInputCommand = "other" }
+            edited.mcpAdminValue.mcpAdminEnabled `shouldBe` True
+            Right disabled <- setMcpAdminServerEnabled home
+                edited.mcpAdminRevision "docs" False
+            restartMcpAdminServer home disabled.mcpAdminRevision "docs"
+                `shouldReturn` Right disabled
+            Right removed <- removeMcpAdminServer home
+                disabled.mcpAdminRevision "docs"
+            listMcpAdminServers home `shouldReturn`
+                Right McpAdminSnapshot
+                    { mcpAdminRevision = removed.mcpAdminRevision
+                    , mcpAdminValue = []
+                    }
+
+input :: McpAdminServerInput
+input = McpAdminServerInput
+    { mcpAdminInputCommand = "mcp-docs"
+    , mcpAdminInputArgs = ["--stdio"]
+    , mcpAdminInputCwd = Just "/tmp"
+    , mcpAdminInputEnv = Map.empty
+    , mcpAdminInputStartupTimeoutSeconds = 30
+    , mcpAdminInputRequestTimeoutSeconds = 60
+    }
+
+withTempDir :: (OsPath -> IO a) -> IO a
+withTempDir action = do
+    tmp <- getTemporaryDirectory
+    bracket
+        (mkdtemp (filePath tmp FilePath.</> "mcp-admin-"))
+        Directory.removeDirectoryRecursive
+        (action . unsafeEncodeUtf)
+
+filePath :: OsPath -> FilePath
+filePath value = either (error . show) id (decodeUtf value)

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -28,6 +28,7 @@ import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
 import qualified Agent.CLI.MacOS.NativeLoopEventSpec as NativeLoopEventSpec
+import qualified Agent.CLI.MacOS.EngineMailboxSpec as EngineMailboxSpec
 import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
 import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
@@ -105,6 +106,7 @@ main = hspec do
     InterruptSpec.spec
     LoginSpec.spec
     LearnedSkillsSpec.spec
+    EngineMailboxSpec.spec
     NativeLoopEventSpec.spec
     BridgeHeaderSpec.spec
     BridgeFFISpec.spec

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -32,6 +32,7 @@ import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
 import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
+import qualified Agent.CLI.McpAdminSpec as McpAdminSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
 import qualified Agent.CLI.ModelPickerSpec as ModelPickerSpec
 import qualified Agent.CLI.ModelsSpec as ModelsSpec
@@ -108,6 +109,7 @@ main = hspec do
     BridgeHeaderSpec.spec
     BridgeFFISpec.spec
     MarkdownSpec.spec
+    McpAdminSpec.spec
     McpManagerSpec.spec
     ModelConfigSpec.spec
     ModelPickerSpec.spec

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -44,6 +44,31 @@ int ha_image_attachment_abi_smoke(void) {
     return 0;
 }
 
+int ha_mcp_admin_abi_smoke(void) {
+    static const uint8_t arg[] = "--stdio";
+    static const uint8_t key[] = "TOKEN";
+    static const uint8_t secret[] = "not-returned";
+    const ha_utf8_slice arguments[] = {
+        {.bytes = arg, .length = sizeof(arg) - 1},
+    };
+    const ha_mcp_env_entry environment[] = {
+        {
+            .key = {.bytes = key, .length = sizeof(key) - 1},
+            .value = {.bytes = secret, .length = sizeof(secret) - 1},
+        },
+    };
+    if (offsetof(ha_utf8_slice, bytes) != 0
+            || offsetof(ha_utf8_slice, length) != sizeof(const uint8_t *)
+            || sizeof(ha_mcp_env_entry) != 2 * sizeof(ha_utf8_slice)) {
+        return 1;
+    }
+    if (arguments[0].length != 7 || environment[0].key.length != 5
+            || environment[0].value.length != 12) {
+        return 2;
+    }
+    return 0;
+}
+
 static void image_stage_callback(void *context, const uint8_t *bytes,
                                  size_t length) {
     (void)context;

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -1,6 +1,17 @@
 #include "HaskellAgentBridge.h"
 
 #include <stddef.h>
+#include <stdatomic.h>
+
+static void restart_result_callback(void *context, int32_t status,
+                                    uint64_t revision, const uint8_t *error,
+                                    size_t error_length) {
+    (void)status;
+    (void)revision;
+    (void)error;
+    (void)error_length;
+    atomic_fetch_add((_Atomic int *)context, 1);
+}
 
 /*
  * Keep a native compile/run smoke check next to the public ABI. This catches
@@ -120,7 +131,18 @@ int ha_image_attachment_stage_smoke(void) {
         status = ha_engine_stage_turn_images(
             engine, turn_id, sizeof(turn_id) - 1, NULL, 0);
     }
+    _Atomic int callbacks = 0;
+    if (status == 0) {
+        const uint8_t missing_name[] =
+            "__ha_restart_destroy_smoke_missing__";
+        status = ha_engine_mcp_server_restart(
+            engine, 0, missing_name, sizeof(missing_name) - 1,
+            restart_result_callback, &callbacks);
+    }
     ha_engine_destroy(engine);
+    if (status == 0 && atomic_load(&callbacks) != 1) {
+        status = 13;
+    }
     ha_runtime_exit();
     return status;
 }

--- a/packages/agent-core/src/Agent/MCP.hs
+++ b/packages/agent-core/src/Agent/MCP.hs
@@ -18,6 +18,7 @@ module Agent.MCP
     , acquireMcpFleetProgressive
     , releaseMcpFleetLease
     , closeMcpSupervisor
+    , restartMcpSupervisor
     , startMcpFleet
     , startMcpFleetWithProgress
     , startMcpFleetProgressive
@@ -654,6 +655,48 @@ closeMcpSupervisor supervisor = do
             (\entry ->
                 void (tryPutTMVar entry.supervisorPendingResult
                     (Left "MCP supervisor closed")))
+            pending
+    forConcurrentlyBounded_ 8
+        (\entry -> do
+            worker <- atomically
+                (readTMVar entry.supervisorPendingWorker)
+            cancel worker
+            void (waitCatch worker))
+        pending
+    forConcurrentlyBounded_ 4 closeMcpFleet fleets
+
+-- | Discard every cached fleet while keeping the supervisor reusable. Callers
+-- must ensure no active lease is in use; the native engine does so by
+-- serializing this operation in its idle loop.
+restartMcpSupervisor :: McpSupervisor -> IO ()
+restartMcpSupervisor supervisor = do
+    (fleets, pending) <-
+        modifyMVar supervisor.supervisorState \state ->
+            if state.supervisorClosed
+                then ioError (userError "MCP supervisor closed")
+                else if
+                    any ((> 0) . (.supervisorEntryLeases))
+                        state.supervisorEntries
+                        || any ((> 0) . (.supervisorPendingLeases))
+                            state.supervisorPending
+                then ioError (userError
+                    "cannot restart MCP supervisor while a lease is active")
+                else
+                    pure
+                        ( state
+                            { supervisorEntries = []
+                            , supervisorPending = []
+                            }
+                        , ( map (.supervisorEntryFleet)
+                                state.supervisorEntries
+                          , state.supervisorPending
+                          )
+                        )
+    atomically $
+        mapM_
+            (\entry ->
+                void (tryPutTMVar entry.supervisorPendingResult
+                    (Left "MCP supervisor restarted")))
             pending
     forConcurrentlyBounded_ 8
         (\entry -> do

--- a/packages/agent-core/test/Agent/MCPSpec.hs
+++ b/packages/agent-core/test/Agent/MCPSpec.hs
@@ -338,6 +338,23 @@ spec = describe "Agent.MCP" do
                     releaseMcpFleetLease second
                     countStarts counter `shouldReturn` 2
 
+        it "restarts idle fleets but refuses an active lease" $
+            withCountingFakeServer \script counter -> do
+                supervisor <- newMcpSupervisor
+                bracket (pure supervisor) closeMcpSupervisor \_ -> do
+                    let config =
+                            (baseConfig "restartable" script)
+                                { mcpServerArgs = [counter]
+                                }
+                    first <- acquireMcpFleet supervisor [config]
+                    restartMcpSupervisor supervisor
+                        `shouldThrow` anyIOException
+                    releaseMcpFleetLease first
+                    restartMcpSupervisor supervisor
+                    second <- acquireMcpFleet supervisor [config]
+                    releaseMcpFleetLease second
+                    countStarts counter `shouldReturn` 2
+
         it "does not reuse an inherited-cwd fleet after the cwd changes" $
             withCountingFakeServer \script counter ->
                 withDistinctWorkingDirectories \firstDir secondDir -> do


### PR DESCRIPTION
## Summary
- expose typed list/status/read/add/edit/enable/disable/restart/remove MCP APIs
- redact environment values on every read and accept replacements only as write-only inputs
- add exact optimistic revisions and shared config transactions across native admin and interactive manager writers
- restart idle MCP fleets while refusing active leases

## Concurrency and lifecycle
- all config readers/writers share one owner-only lock and CAS transform API; blind full-config saves are removed
- public revision tokens use a private 128-bit key and exact config bytes, avoiding a secret-value dictionary oracle
- revision validation and supervisor restart are linearized under the same lock
- accepted callback-bearing restart commands complete exactly once during engine shutdown
- callback thread, status, nullability, and borrowed buffer lifetimes are documented

## Validation
- native bridge `-fno-code` load
- focused Config/ModelConfig and MCP admin tests, including concurrent CAS/no-lost-update cases
- C ABI smoke with `-Wall -Wextra -Werror`
- `git diff --check`

## Dependency
Stacked on #750 for the partial-schema migration baseline. Learned Skills/Memory administration is a separate store-backed PR rather than being mixed into MCP config handling.
