### PR TITLE
Add guarded native repository review service

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -159,8 +159,11 @@
                     root = ./packages/agent-cli;
                     include = [
                         "app"
+                        "cbits"
                         "config"
                         "eval"
+                        "ffi"
+                        "include"
                         "skills"
                         "src"
                         "test"
@@ -451,6 +454,24 @@
                                             ]}"
                                 '';
                         });
+                agentNativeBridgePackage = pkgs.runCommand
+                    "haskell-agent-native-bridge-0.1.0"
+                    { }
+                    ''
+                        bridge="$(${pkgs.findutils}/bin/find \
+                            ${agentCliPackage}/lib \
+                            -name libhaskell-agent-bridge.dylib \
+                            -print -quit)"
+                        header="$(${pkgs.findutils}/bin/find \
+                            ${agentCliPackage}/lib \
+                            -name HaskellAgentBridge.h \
+                            -print -quit)"
+                        test -n "$bridge"
+                        test -n "$header"
+                        mkdir -p "$out/lib" "$out/include"
+                        cp "$bridge" "$out/lib/libhaskell-agent-bridge.dylib"
+                        cp "$header" "$out/include/HaskellAgentBridge.h"
+                    '';
                 agentOpenaiExecutables = pkgs.haskell.lib.justStaticExecutables agentOpenaiPackage;
                 functionalTestCredentialHome =
                     builtins.getEnv "AGENT_FUNCTIONAL_TEST_CREDENTIAL_HOME";
@@ -567,6 +588,8 @@
                 packages.default = agentCliExecutable;
                 packages.agent-cli = agentCliExecutable;
                 packages.agent-telegram = agentTelegramExecutable;
+                packages.${if pkgs.stdenv.hostPlatform.isDarwin
+                    then "agent-native-bridge" else null} = agentNativeBridgePackage;
                 packages.agent-core = agentCorePackage;
                 packages.agent-process = agentProcessPackage;
                 packages.agent-codex-dialect = agentCodexDialectPackage;

--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -2,8 +2,11 @@
 -- provider-neutral agent loop.
 module Agent.Claude.LoopBackend
     ( withClaudeCodeBackend
+    , withClaudeCodeBackendPermissions
     , claudeCodeOneShotBackend
     , appendHostTranscript
+    , ClaudeToolPermissionDecision(..)
+    , ClaudeToolPermissionRequest(..)
     ) where
 
 import Agent.Claude.Options
@@ -51,6 +54,7 @@ import Claude.Agent.SDK.Client
     ( ClaudeSDKClient
     , ClaudeSDKTurn
     , resolveTurnUsage
+    , sendControlResponse
     , turnIsNewSession
     , withClaudeSDKClient
     , withClaudeSDKTurn
@@ -68,6 +72,7 @@ import Data.IORef
     , writeIORef
     )
 import Data.Maybe (catMaybes, fromMaybe)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -86,7 +91,7 @@ import Claude.Agent.SDK.Errors
     , renderClaudeSDKError
     )
 import Claude.Agent.SDK.Query
-    ( queryTurnContentWithMessageValidator
+    ( queryTurnContentWithControlHandler
     )
 import Claude.Agent.SDK.Types
     ( ClaudeAgentOptions(..)
@@ -99,6 +104,18 @@ import Claude.Agent.SDK.Types
     )
 import Control.Exception.Safe (bracket, tryAny)
 import Control.Monad (void)
+import Data.Aeson ((.:))
+import qualified Data.Aeson.Types as AesonTypes
+
+data ClaudeToolPermissionRequest = ClaudeToolPermissionRequest
+    { claudePermissionRequestId :: !Text
+    , claudePermissionToolName :: !Text
+    , claudePermissionInput :: !Aeson.Value
+    }
+
+data ClaudeToolPermissionDecision
+    = ClaudeToolPermissionAllow
+    | ClaudeToolPermissionDeny !Text
 
 data HostTranscriptCheckpoint = HostTranscriptCheckpoint
     { checkpointTranscript :: !(StableName [ResponseItem])
@@ -116,13 +133,50 @@ withClaudeCodeBackend
     -> (Backend -> IO a)
     -> IO a
 withClaudeCodeBackend options initialPrevious getParams transcript callback =
+    withClaudeCodeBackendPermissions
+        options
+        Nothing
+        initialPrevious
+        getParams
+        transcript
+        callback
+
+withClaudeCodeBackendPermissions
+    :: ClaudeCodeOptions
+    -> Maybe
+        (ClaudeToolPermissionRequest
+            -> IO ClaudeToolPermissionDecision)
+    -> Maybe Text
+    -> IO ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> (Backend -> IO a)
+    -> IO a
+withClaudeCodeBackendPermissions
+    options permissionHandler initialPrevious getParams transcript callback =
     toClaudeAgentOptions ClaudeCodeDefaultTools options >>= \sdkOptions ->
+    let effectiveOptions = case permissionHandler of
+            Nothing -> sdkOptions
+            Just _ -> sdkOptions
+                { permissionMode = Nothing
+                , extraArgs =
+                    Map.insert
+                        "permission-prompt-tool"
+                        (Just "stdio")
+                        sdkOptions.extraArgs
+                }
+    in
     withClaudeSDKClient
-        sdkOptions
+        effectiveOptions
             { resume = initialPrevious >>= canonicalClaudeSessionId }
         \session -> do
         checkpoint <- newIORef Nothing
-        callback (backendForSession session checkpoint getParams transcript)
+        callback
+            (backendForSession
+                session
+                checkpoint
+                getParams
+                transcript
+                permissionHandler)
 
 -- | A backend for isolated side requests. Every submission owns and cleans up
 -- its own structured Claude process, while still using subscription auth.
@@ -145,6 +199,7 @@ claudeCodeOneShotBackend options getParams transcript =
                 transcript
                 inputs
                 onEvent
+                Nothing
         attachBackendState transcript result
 
 backendForSession
@@ -152,8 +207,12 @@ backendForSession
     -> IORef (Maybe HostTranscriptCheckpoint)
     -> IO ResponseCreateParams
     -> IORef [ResponseItem]
+    -> Maybe
+        (ClaudeToolPermissionRequest
+            -> IO ClaudeToolPermissionDecision)
     -> Backend
-backendForSession session checkpoint getParams transcript =
+backendForSession
+    session checkpoint getParams transcript permissionHandler =
     Backend \_state previous inputs onEvent -> do
         result <- submitClaudeCodeTurn
             session
@@ -163,6 +222,7 @@ backendForSession session checkpoint getParams transcript =
             transcript
             inputs
             onEvent
+            permissionHandler
         attachBackendState transcript result
 
 attachBackendState
@@ -186,6 +246,9 @@ submitClaudeCodeTurn
     -> IORef [ResponseItem]
     -> [TurnInput]
     -> (LoopEvent -> IO ())
+    -> Maybe
+        (ClaudeToolPermissionRequest
+            -> IO ClaudeToolPermissionDecision)
     -> IO (Either ApiError TurnOutput)
 submitClaudeCodeTurn
     session
@@ -194,7 +257,8 @@ submitClaudeCodeTurn
     getParams
     transcript
     inputs
-    onEvent =
+    onEvent
+    permissionHandler =
     do
         bracket
             (collectTurnInputs inputs)
@@ -224,10 +288,13 @@ submitClaudeCodeTurn
                             content =
                                 claudeUserContent inputImages prompt
                         awaitResult <-
-                            queryTurnContentWithMessageValidator
+                            queryTurnContentWithControlHandler
                                 turn
                                 content
                                 validateSubscriptionMessage
+                                (handleControlRequest
+                                    turn
+                                    permissionHandler)
                                 (\message ->
                                     modifyIORef' messages (message :))
                         case awaitResult of
@@ -288,6 +355,74 @@ submitClaudeCodeTurn
                     completed.assistantText
         mapM_ onEvent completed.events
         pure (Right (output, commit))
+
+handleControlRequest
+    :: ClaudeSDKTurn
+    -> Maybe
+        (ClaudeToolPermissionRequest
+            -> IO ClaudeToolPermissionDecision)
+    -> Aeson.Object
+    -> IO (Either ClaudeSDKError ())
+handleControlRequest _ Nothing _ =
+    pure $ Left $ CLIProtocolError
+        "Claude Code requested permission, but no permission handler is configured."
+handleControlRequest turn (Just requestPermission) raw =
+    case AesonTypes.parseEither
+        parseClaudePermissionRequest
+        (Aeson.Object raw) of
+            Left err ->
+                pure (Left (CLIProtocolError (Text.pack err)))
+            Right request -> do
+                decision <- requestPermission request
+                sendControlResponse turn $
+                    controlResponse request decision
+
+parseClaudePermissionRequest
+    :: Aeson.Value
+    -> AesonTypes.Parser ClaudeToolPermissionRequest
+parseClaudePermissionRequest =
+    Aeson.withObject "control request" \outer -> do
+        requestId <- outer .: "request_id"
+        requestValue <- outer .: "request"
+        Aeson.withObject "permission request" (\request -> do
+            subtype <- request .: "subtype"
+            if (subtype :: Text) /= "can_use_tool"
+                then fail
+                    ("unsupported control request subtype: "
+                        <> Text.unpack subtype)
+                else ClaudeToolPermissionRequest
+                    requestId
+                    <$> request .: "tool_name"
+                    <*> request .: "input"
+            ) requestValue
+
+controlResponse
+    :: ClaudeToolPermissionRequest
+    -> ClaudeToolPermissionDecision
+    -> Aeson.Value
+controlResponse request decision =
+    Aeson.object
+        [ "type" Aeson..= ("control_response" :: Text)
+        , "response" Aeson..= Aeson.object
+            [ "subtype" Aeson..= ("success" :: Text)
+            , "request_id" Aeson..= request.claudePermissionRequestId
+            , "response" Aeson..= case decision of
+                ClaudeToolPermissionAllow ->
+                    Aeson.object
+                        [ "behavior" Aeson..= ("allow" :: Text)
+                        , "updatedInput" Aeson..=
+                            request.claudePermissionInput
+                        , "updatedPermissions" Aeson..=
+                            ([] :: [Aeson.Value])
+                        ]
+                ClaudeToolPermissionDeny message ->
+                    Aeson.object
+                        [ "behavior" Aeson..= ("deny" :: Text)
+                        , "message" Aeson..= message
+                        , "interrupt" Aeson..= False
+                        ]
+            ]
+        ]
 
 collectTurnInputs :: [TurnInput] -> IO (Text, [ImageAttachment], [FilePath])
 collectTurnInputs inputs = do

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -80,7 +80,6 @@ library
                     , Agent.CLI.Session.Runner
                     , Agent.CLI.Session.Selection
                     , Agent.CLI.Session.Runtime.Types
-                    , Agent.CLI.SessionAdmin
                     , Agent.CLI.Startup.Auth
                     , Agent.CLI.StartupContext
                     , Agent.CLI.Startup.Format
@@ -135,6 +134,7 @@ library
                     , Agent.CLI.ModelConfig
                     , Agent.CLI.Models
                     , Agent.CLI.Notification
+                    , Agent.CLI.NativeRuntime
                     , Agent.CLI.Options
                     , Agent.CLI.Permission
                     , Agent.CLI.PendingInputs
@@ -154,6 +154,7 @@ library
                     , Agent.CLI.Session
                     , Agent.CLI.Session.History
                     , Agent.CLI.Session.StoreCodec
+                    , Agent.CLI.SessionAdmin
                     , Agent.CLI.SessionEnv
                     , Agent.CLI.SessionState
                     , Agent.CLI.SessionLock
@@ -242,6 +243,31 @@ executable agent-cli
     ghc-options:      -threaded -rtsopts "-with-rtsopts=-N4 -M8G"
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
+
+foreign-library haskell-agent-bridge
+    import:           common-options
+    type:             native-shared
+    options:          standalone
+    hs-source-dirs:   ffi
+    other-modules:    Agent.CLI.MacOS.Bridge
+    c-sources:        cbits/HaskellAgentBridgeRuntime.c
+    include-dirs:     include
+    includes:         HaskellAgentBridge.h
+    install-includes: HaskellAgentBridge.h
+    ghc-options:      -threaded
+    build-depends:    agent-cli
+                    , agent-core >= 0.1 && < 0.2
+                    , agent-store >= 0.1 && < 0.2
+                    , aeson >= 2.0
+                    , async
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , containers
+                    , directory
+                    , filepath
+                    , safe-exceptions
+                    , stm
+                    , text >= 2.0 && < 2.2
 
 executable eval-ghci-vs-bash
     import:           common-options

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -269,6 +269,7 @@ foreign-library haskell-agent-bridge
                     , safe-exceptions
                     , stm
                     , text >= 2.0 && < 2.2
+                    , time
 
 executable eval-ghci-vs-bash
     import:           common-options

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -343,11 +343,14 @@ test-suite agent-cli-test
     hs-source-dirs:   test ffi
     main-is:          Spec.hs
     c-sources:        test/cbits/HaskellAgentBridgeImageSmoke.c
+                    , cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     other-modules:    Agent.CLI.AccountSelectionSpec
                     , Agent.CLI.MacOS.NativeLoopEventSpec
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
+                    , Agent.CLI.MacOS.BridgeFFISpec
+                    , Agent.CLI.MacOS.Bridge
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -342,9 +342,12 @@ test-suite agent-cli-test
     ghc-options:      -threaded
     hs-source-dirs:   test ffi
     main-is:          Spec.hs
+    c-sources:        test/cbits/HaskellAgentBridgeImageSmoke.c
+    include-dirs:     include
     other-modules:    Agent.CLI.AccountSelectionSpec
                     , Agent.CLI.MacOS.NativeLoopEventSpec
                     , Agent.CLI.MacOS.NativeLoopEvent
+                    , Agent.CLI.MacOS.BridgeHeaderSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -146,6 +146,7 @@ library
                     , Agent.CLI.Prompt
                     , Agent.CLI.Recap
                     , Agent.CLI.Request
+                    , Agent.CLI.RepositoryDelivery
                     , Agent.CLI.RepositoryReview
                     , Agent.CLI.ProviderFallback
                     , Agent.CLI.ProviderAvailability
@@ -396,6 +397,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ProviderAvailabilitySpec
                     , Agent.CLI.ProviderTransitionSpec
                     , Agent.CLI.RequestSpec
+                    , Agent.CLI.RepositoryDeliverySpec
                     , Agent.CLI.RepositoryReviewSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -44,6 +44,7 @@ library
     hs-source-dirs:   src
     autogen-modules:  Paths_agent_cli
     other-modules:    Agent.CLI.AccountPicker
+                    , Agent.CLI.AccountUsageCache
                     , Agent.CLI.Auth.Grok
                     , Agent.CLI.Auth.OpenAI
                     , Agent.CLI.Auth.Types

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -146,6 +146,7 @@ library
                     , Agent.CLI.Prompt
                     , Agent.CLI.Recap
                     , Agent.CLI.Request
+                    , Agent.CLI.RepositoryReview
                     , Agent.CLI.ProviderFallback
                     , Agent.CLI.ProviderAvailability
                     , Agent.CLI.ProviderTransition
@@ -394,6 +395,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ProviderAvailabilitySpec
                     , Agent.CLI.ProviderTransitionSpec
                     , Agent.CLI.RequestSpec
+                    , Agent.CLI.RepositoryReviewSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec
                     , Agent.CLI.ResumeSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -260,6 +260,9 @@ foreign-library haskell-agent-bridge
     build-depends:    agent-cli
                     , agent-core >= 0.1 && < 0.2
                     , agent-store >= 0.1 && < 0.2
+                    , agent-openai >= 0.1 && < 0.2
+                    , agent-xai >= 0.1 && < 0.2
+                    , agent-openrouter >= 0.1 && < 0.2
                     , aeson >= 2.0
                     , async
                     , base >= 4.17 && < 5

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -272,6 +272,7 @@ foreign-library haskell-agent-bridge
                     , bytestring
                     , containers
                     , directory
+                    , filelock
                     , filepath
                     , safe-exceptions
                     , stm

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -342,15 +342,12 @@ test-suite agent-cli-test
     ghc-options:      -threaded
     hs-source-dirs:   test ffi
     main-is:          Spec.hs
-    c-sources:        test/cbits/HaskellAgentBridgeImageSmoke.c
-                    , cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     other-modules:    Agent.CLI.AccountSelectionSpec
                     , Agent.CLI.MacOS.NativeLoopEventSpec
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
                     , Agent.CLI.MacOS.BridgeFFISpec
-                    , Agent.CLI.MacOS.Bridge
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec
@@ -456,6 +453,10 @@ test-suite agent-cli-test
                     , transformers
                     , unix
                     , vty >= 6.4 && < 7
+    if os(darwin)
+        c-sources:    test/cbits/HaskellAgentBridgeImageSmoke.c
+                    , cbits/HaskellAgentBridgeRuntime.c
+        other-modules: Agent.CLI.MacOS.Bridge
 
 benchmark image-preview-latency-bench
     import:           common-options

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -250,6 +250,7 @@ foreign-library haskell-agent-bridge
     options:          standalone
     hs-source-dirs:   ffi
     other-modules:    Agent.CLI.MacOS.Bridge
+                    , Agent.CLI.MacOS.NativeLoopEvent
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     includes:         HaskellAgentBridge.h
@@ -334,9 +335,11 @@ test-suite agent-cli-test
     import:           common-options
     type:             exitcode-stdio-1.0
     ghc-options:      -threaded
-    hs-source-dirs:   test
+    hs-source-dirs:   test ffi
     main-is:          Spec.hs
     other-modules:    Agent.CLI.AccountSelectionSpec
+                    , Agent.CLI.MacOS.NativeLoopEventSpec
+                    , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -247,6 +247,8 @@ executable agent-cli
 
 foreign-library haskell-agent-bridge
     import:           common-options
+    if !os(darwin)
+        buildable:    False
     type:             native-shared
     options:          standalone
     hs-source-dirs:   ffi

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -55,6 +55,7 @@ library
                     , Agent.CLI.Provider.OpenAI
                     , Agent.CLI.Provider.Switch
                     , Agent.CLI.PrivateFileLock
+                    , Agent.CLI.ProcessSecurity
                     , Agent.CLI.Runtime
                     , Agent.CLI.Runtime.Internal
                     , Agent.CLI.Runtime.Orchestration

--- a/packages/agent-cli/cbits/HaskellAgentBridgeRuntime.c
+++ b/packages/agent-cli/cbits/HaskellAgentBridgeRuntime.c
@@ -1,0 +1,31 @@
+#include "HaskellAgentBridge.h"
+
+#include <HsFFI.h>
+#include <pthread.h>
+
+static pthread_mutex_t runtime_lock = PTHREAD_MUTEX_INITIALIZER;
+static unsigned int runtime_references = 0;
+
+int32_t ha_runtime_init(void) {
+    pthread_mutex_lock(&runtime_lock);
+    if (runtime_references == 0) {
+        int argc = 1;
+        char *argv[] = {"haskell-agent-macos", NULL};
+        char **argv_pointer = argv;
+        hs_init(&argc, &argv_pointer);
+    }
+    runtime_references += 1;
+    pthread_mutex_unlock(&runtime_lock);
+    return 0;
+}
+
+void ha_runtime_exit(void) {
+    pthread_mutex_lock(&runtime_lock);
+    if (runtime_references > 0) {
+        runtime_references -= 1;
+        if (runtime_references == 0) {
+            hs_exit();
+        }
+    }
+    pthread_mutex_unlock(&runtime_lock);
+}

--- a/packages/agent-cli/config/models.default.json
+++ b/packages/agent-cli/config/models.default.json
@@ -24,6 +24,8 @@
       "connection": "openai",
       "dialect": "codex",
       "label": "default · frontier",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "low",
       "default": true,
       "fallback_priority": 0
     },
@@ -31,13 +33,17 @@
       "id": "gpt-5.6-terra",
       "connection": "openai",
       "dialect": "codex",
-      "label": "balanced"
+      "label": "balanced",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "medium"
     },
     {
       "id": "gpt-5.6-luna",
       "connection": "openai",
       "dialect": "codex",
-      "label": "fast · low cost"
+      "label": "fast · low cost",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "medium"
     },
     {
       "id": "grok-4.6",
@@ -45,6 +51,8 @@
       "dialect": "grok-build",
       "context_window": 500000,
       "label": "default",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh"],
+      "default_reasoning_effort": "high",
       "default": true,
       "fallback_priority": 10
     },
@@ -62,19 +70,25 @@
       "connection": "claude-code",
       "dialect": "claude-code",
       "label": "default · subscription",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "xhigh",
       "default": true
     },
     {
       "id": "opus",
       "connection": "claude-code",
       "dialect": "claude-code",
-      "label": "previous frontier · subscription"
+      "label": "previous frontier · subscription",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "xhigh"
     },
     {
       "id": "fable",
       "connection": "claude-code",
       "dialect": "claude-code",
-      "label": "frontier · subscription"
+      "label": "frontier · subscription",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "xhigh"
     }
   ]
 }

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -94,6 +94,7 @@ import Agent.CLI.Project
     )
 import Agent.CLI.Render
     ( summarizeToolCall )
+import qualified Agent.CLI.RepositoryDelivery as RepositoryDelivery
 import qualified Agent.CLI.RepositoryReview as RepositoryReview
 import Agent.CLI.Options (parseEffort)
 import Agent.CLI.Session
@@ -354,6 +355,32 @@ type RepositoryResultCallback =
     -> CString -> CSize -- error
     -> IO ()
 
+type RepositoryDeliveryStatusCallback =
+    Ptr () -> CInt
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize
+    -> CLLong -> CLLong -> CString -> CSize -> IO ()
+
+type RepositoryPushPreviewCallback =
+    Ptr () -> CInt -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize
+    -> CLLong -> CLLong -> CString -> CSize -> IO ()
+
+type RepositoryPushResultCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> IO ()
+
+type RepositoryPullRequestPreviewCallback =
+    Ptr () -> CInt -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> IO ()
+
+type RepositoryPullRequestResultCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
 type RepositoryCheckOutputCallback =
     Ptr () -> CInt -> Ptr Word8 -> CSize -> IO ()
 
@@ -409,6 +436,31 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeRepositoryResultCallback
         :: FunPtr RepositoryResultCallback -> RepositoryResultCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryDeliveryStatusCallback
+        :: FunPtr RepositoryDeliveryStatusCallback
+        -> RepositoryDeliveryStatusCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryPushPreviewCallback
+        :: FunPtr RepositoryPushPreviewCallback
+        -> RepositoryPushPreviewCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryPushResultCallback
+        :: FunPtr RepositoryPushResultCallback
+        -> RepositoryPushResultCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryPullRequestPreviewCallback
+        :: FunPtr RepositoryPullRequestPreviewCallback
+        -> RepositoryPullRequestPreviewCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryPullRequestResultCallback
+        :: FunPtr RepositoryPullRequestResultCallback
+        -> RepositoryPullRequestResultCallback
 
 foreign import ccall "dynamic"
     invokeRepositoryCheckOutputCallback
@@ -663,6 +715,27 @@ foreign export ccall ha_repository_apply_hunks
 foreign export ccall ha_repository_commit
     :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
     -> FunPtr RepositoryResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_delivery_status
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryDeliveryStatusCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_push_preview
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPushPreviewCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_push_confirm
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPushResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_pr_preview
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPullRequestPreviewCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_pr_confirm
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPullRequestResultCallback -> Ptr () -> IO CInt
 
 foreign export ccall ha_repository_cancel_all :: IO ()
 
@@ -933,6 +1006,227 @@ ha_repository_commit pathBytes pathLength snapshotBytes snapshotLength
                                 message)
                     pure (if started then 0 else 3)
                 Right _ -> pure 3
+
+ha_repository_delivery_status
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryDeliveryStatusCallback -> Ptr () -> IO CInt
+ha_repository_delivery_status pathBytes pathLength snapshotBytes snapshotLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid
+            snapshotBytes snapshotLength deliveryTokenLimit) = pure 2
+    | otherwise =
+        copyRequiredTexts
+            [(pathBytes, pathLength), (snapshotBytes, snapshotLength)] >>= \case
+                Right [path, snapshot] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitDeliveryStatusFailure callback context (-3)
+                                "repository delivery was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.repositoryDeliveryStatus
+                                (Text.unpack path)
+                                snapshot) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitDeliveryStatusFailure
+                                            callback context (-1)
+                                            "repository delivery failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitDeliveryStatusFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right status) ->
+                                        emitDeliveryOnce terminal $
+                                            emitDeliveryStatus
+                                                callback context status
+                    pure (if started then 0 else 3)
+                _ -> pure 2
+
+ha_repository_push_preview
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPushPreviewCallback -> Ptr () -> IO CInt
+ha_repository_push_preview pathBytes pathLength snapshotBytes snapshotLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid
+            snapshotBytes snapshotLength deliveryTokenLimit) = pure 2
+    | otherwise =
+        copyRequiredTexts
+            [(pathBytes, pathLength), (snapshotBytes, snapshotLength)] >>= \case
+                Right [path, snapshot] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitPushPreviewFailure callback context (-3)
+                                "repository push preview was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.previewRepositoryPush
+                                (Text.unpack path)
+                                snapshot) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushPreviewFailure
+                                            callback context (-1)
+                                            "repository push preview failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushPreviewFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right preview) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushPreview
+                                                callback context preview
+                    pure (if started then 0 else 3)
+                _ -> pure 2
+
+ha_repository_push_confirm
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPushResultCallback -> Ptr () -> IO CInt
+ha_repository_push_confirm pathBytes pathLength tokenBytes tokenLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid tokenBytes tokenLength deliveryTokenLimit) =
+            pure 2
+    | otherwise =
+        copyRequiredTexts
+            [(pathBytes, pathLength), (tokenBytes, tokenLength)] >>= \case
+                Right [path, token] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitPushResultFailure callback context (-3)
+                                "repository push was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.confirmRepositoryPush
+                                (Text.unpack path)
+                                token) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushResultFailure
+                                            callback context (-1)
+                                            "repository push failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushResultFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right status) ->
+                                        emitDeliveryOnce terminal $
+                                        withText status.deliverySnapshotId
+                                            \snapshotPtr snapshotSize ->
+                                        withText status.deliveryHeadOid
+                                            \headPtr headSize ->
+                                                invokeRepositoryPushResultCallback
+                                                    callback context 0
+                                                    snapshotPtr snapshotSize
+                                                    headPtr headSize
+                                                    nullPtr 0
+                    pure (if started then 0 else 3)
+                _ -> pure 2
+
+ha_repository_pr_preview
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPullRequestPreviewCallback -> Ptr () -> IO CInt
+ha_repository_pr_preview pathBytes pathLength snapshotBytes snapshotLength
+    baseBytes baseLength titleBytes titleLength bodyBytes bodyLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid
+            snapshotBytes snapshotLength deliveryTokenLimit)
+        || not (deliveryInputValid baseBytes baseLength deliveryRefLimit)
+        || not (deliveryInputValid titleBytes titleLength deliveryTitleLimit)
+        || not (deliveryInputValid bodyBytes bodyLength deliveryBodyLimit) =
+            pure 2
+    | otherwise =
+        copyRequiredTexts
+            [ (pathBytes, pathLength)
+            , (snapshotBytes, snapshotLength)
+            , (baseBytes, baseLength)
+            , (titleBytes, titleLength)
+            , (bodyBytes, bodyLength)
+            ] >>= \case
+                Right [path, snapshot, base, title, body] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitPullRequestPreviewFailure
+                                callback context (-3)
+                                "pull-request preview was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.previewPullRequest
+                                (Text.unpack path)
+                                snapshot base title body) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestPreviewFailure
+                                            callback context (-1)
+                                            "pull-request preview failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestPreviewFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right preview) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestPreview
+                                            callback context preview
+                    pure (if started then 0 else 3)
+                _ -> pure 2
+
+ha_repository_pr_confirm
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPullRequestResultCallback -> Ptr () -> IO CInt
+ha_repository_pr_confirm pathBytes pathLength tokenBytes tokenLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid tokenBytes tokenLength deliveryTokenLimit) =
+            pure 2
+    | otherwise =
+        copyRequiredTexts
+            [(pathBytes, pathLength), (tokenBytes, tokenLength)] >>= \case
+                Right [path, token] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitPullRequestResultFailure callback context (-3)
+                                "pull-request creation was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.createPullRequest
+                                (Text.unpack path)
+                                token) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestResultFailure
+                                            callback context (-1)
+                                            "pull-request creation failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestResultFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right url) ->
+                                        emitDeliveryOnce terminal $
+                                        withText url \urlPtr urlSize ->
+                                            invokeRepositoryPullRequestResultCallback
+                                                callback context 0
+                                                urlPtr urlSize nullPtr 0
+                    pure (if started then 0 else 3)
+                _ -> pure 2
 
 startRepositoryMutation
     :: FunPtr RepositoryResultCallback
@@ -1472,6 +1766,141 @@ emitRepositoryError callback context err =
         _ ->
             emitRepositoryFailure
                 callback context (RepositoryReview.repositoryErrorText err)
+
+emitDeliveryOnce :: MVar Bool -> IO () -> IO ()
+emitDeliveryOnce terminal callback =
+    mask \_ -> do
+        shouldRun <- modifyMVar terminal \completed ->
+            pure (True, not completed)
+        when shouldRun callback
+
+emitDeliveryStatus
+    :: FunPtr RepositoryDeliveryStatusCallback
+    -> Ptr ()
+    -> RepositoryDelivery.DeliveryStatus
+    -> IO ()
+emitDeliveryStatus callback context status =
+    withText status.deliverySnapshotId \snapshotPtr snapshotSize ->
+    withText status.deliveryHeadOid \headPtr headSize ->
+    withText status.deliveryBranch \branchPtr branchSize ->
+    withText status.deliveryRemote \remotePtr remoteSize ->
+    withText status.deliveryUpstreamRef \upstreamPtr upstreamSize ->
+    withText status.deliveryUpstreamOid \upstreamOidPtr upstreamOidSize ->
+        invokeRepositoryDeliveryStatusCallback
+            callback context 0
+            snapshotPtr snapshotSize headPtr headSize
+            branchPtr branchSize remotePtr remoteSize
+            upstreamPtr upstreamSize upstreamOidPtr upstreamOidSize
+            (fromIntegral status.deliveryAhead)
+            (fromIntegral status.deliveryBehind)
+            nullPtr 0
+
+emitDeliveryStatusFailure
+    :: FunPtr RepositoryDeliveryStatusCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitDeliveryStatusFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryDeliveryStatusCallback
+            callback context status
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            nullPtr 0 nullPtr 0 0 0 errorPtr errorSize
+
+emitPushPreview
+    :: FunPtr RepositoryPushPreviewCallback
+    -> Ptr ()
+    -> RepositoryDelivery.PushPreview
+    -> IO ()
+emitPushPreview callback context preview =
+    let status = preview.pushPreviewStatus
+        expires = fromIntegral
+            (floor preview.pushPreviewExpiresAt :: Integer)
+    in withText preview.pushPreviewConfirmation \tokenPtr tokenSize ->
+    withText status.deliveryHeadOid \headPtr headSize ->
+    withText status.deliveryBranch \branchPtr branchSize ->
+    withText status.deliveryRemote \remotePtr remoteSize ->
+    withText status.deliveryUpstreamRef \upstreamPtr upstreamSize ->
+        invokeRepositoryPushPreviewCallback
+            callback context 0 tokenPtr tokenSize expires
+            headPtr headSize branchPtr branchSize remotePtr remoteSize
+            upstreamPtr upstreamSize
+            (fromIntegral status.deliveryAhead)
+            (fromIntegral status.deliveryBehind)
+            nullPtr 0
+
+emitPushPreviewFailure
+    :: FunPtr RepositoryPushPreviewCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitPushPreviewFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryPushPreviewCallback
+            callback context status nullPtr 0 0
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            0 0 errorPtr errorSize
+
+emitPushResultFailure
+    :: FunPtr RepositoryPushResultCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitPushResultFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryPushResultCallback
+            callback context status
+            nullPtr 0 nullPtr 0 errorPtr errorSize
+
+emitPullRequestPreview
+    :: FunPtr RepositoryPullRequestPreviewCallback
+    -> Ptr ()
+    -> RepositoryDelivery.PullRequestPreview
+    -> IO ()
+emitPullRequestPreview callback context preview =
+    let expires = fromIntegral
+            (floor preview.pullRequestExpiresAt :: Integer)
+    in withText preview.pullRequestConfirmation \tokenPtr tokenSize ->
+    withText preview.pullRequestRepository \repositoryPtr repositorySize ->
+    withText preview.pullRequestBaseRef \basePtr baseSize ->
+    withText preview.pullRequestHeadRef \headPtr headSize ->
+    withText preview.pullRequestTitle \titlePtr titleSize ->
+        invokeRepositoryPullRequestPreviewCallback
+            callback context 0 tokenPtr tokenSize expires
+            repositoryPtr repositorySize basePtr baseSize
+            headPtr headSize titlePtr titleSize nullPtr 0
+
+emitPullRequestPreviewFailure
+    :: FunPtr RepositoryPullRequestPreviewCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitPullRequestPreviewFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryPullRequestPreviewCallback
+            callback context status nullPtr 0 0
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 errorPtr errorSize
+
+emitPullRequestResultFailure
+    :: FunPtr RepositoryPullRequestResultCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitPullRequestResultFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryPullRequestResultCallback
+            callback context status nullPtr 0 errorPtr errorSize
+
+deliveryErrorStatus :: RepositoryDelivery.DeliveryError -> CInt
+deliveryErrorStatus = \case
+    RepositoryDelivery.DeliveryStale _ -> -2
+    RepositoryDelivery.DeliveryConfirmationRejected _ -> -4
+    _ -> -1
+
+deliveryInputValid :: Ptr Word8 -> CSize -> Int -> Bool
+deliveryInputValid pointer length limit =
+    pointer /= nullPtr
+        && length > 0
+        && toInteger length <= toInteger limit
+
+deliveryPathLimit, deliveryTokenLimit, deliveryRefLimit :: Int
+deliveryPathLimit = 16 * 1024
+deliveryTokenLimit = 4 * 1024
+deliveryRefLimit = 1024
+
+deliveryTitleLimit, deliveryBodyLimit :: Int
+deliveryTitleLimit = 4 * 1024
+deliveryBodyLimit = 1024 * 1024
 
 copyRequiredText :: Ptr Word8 -> CSize -> IO (Either () Text)
 copyRequiredText pointer (CSize length)

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -145,6 +145,7 @@ import Control.Concurrent.STM
 import Control.Applicative ((<|>))
 import Control.Exception.Safe
     ( SomeException
+    , bracket
     , finally
     , tryAny
     )
@@ -518,24 +519,15 @@ ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
             tryAny (listLearnedSkillsFor (Text.unpack cwd)) >>= \case
                 Left exception ->
                     withText (Text.pack (show exception)) $ \errorPtr errorLength ->
-                        invokeLearnedSkillsListCallback callback context (-1)
-                            nullPtr 0 nullPtr 0 0
-                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-                            nullPtr 0 nullPtr 0 nullPtr 0 0 errorPtr errorLength
+                        learnedSkillsTerminal callback context (-1) errorPtr errorLength
                 Right (Left err) ->
                     withText err $ \errorPtr errorLength ->
-                        invokeLearnedSkillsListCallback callback context (-1)
-                            nullPtr 0 nullPtr 0 0
-                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-                            nullPtr 0 nullPtr 0 nullPtr 0 0 errorPtr errorLength
+                        learnedSkillsTerminal callback context (-1) errorPtr errorLength
                 Right (Right skills) -> do
                     forM_ skills \skill ->
                         withLearnedSkillStrings skill $
                             invokeLearnedSkillsListCallback callback context 0
-                    invokeLearnedSkillsListCallback callback context 1
-                        nullPtr 0 nullPtr 0 0
-                        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-                        nullPtr 0 nullPtr 0 nullPtr 0 0 nullPtr 0 nullPtr 0
+                    learnedSkillsTerminal callback context 1 nullPtr 0
         pure 0
   where
     listLearnedSkillsFor cwd = do
@@ -550,12 +542,12 @@ ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
                 store <- openStore =<< managedPostgresConfigForHome home
                 case store of
                     Left err -> pure (Left (renderStoreError err))
-                    Right opened -> do
-                        result <- listAllLearnedSkills
-                            (trustedPool opened)
-                            (applicableDatabaseScopes databaseScopes)
-                        closeStore opened
-                        pure (first renderStoreError result)
+                    Right opened ->
+                        bracket (pure opened) closeStore \store ->
+                            first renderStoreError
+                                <$> listAllLearnedSkills
+                                    (trustedPool store)
+                                    (applicableDatabaseScopes databaseScopes)
 
 type LearnedSkillItemCallback =
     CString -> CSize -> CString -> CSize -> CLLong
@@ -581,6 +573,16 @@ withLearnedSkillStrings skill action =
             activation activationLength status statusLength
             (fromIntegral skill.learnedSkillPriority) updated updatedLength
             nullPtr 0
+
+learnedSkillsTerminal
+    :: FunPtr LearnedSkillsListCallback
+    -> Ptr () -> CInt -> CString -> CSize -> IO ()
+learnedSkillsTerminal callback context status errorPtr errorLength =
+    invokeLearnedSkillsListCallback callback context status
+        nullPtr 0 nullPtr 0 0
+        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+        nullPtr 0 nullPtr 0 nullPtr 0
+        0 nullPtr 0 errorPtr errorLength
 
 ha_accounts_list
     :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -159,8 +159,10 @@ import Control.Concurrent.STM
     )
 import Control.Applicative ((<|>))
 import Control.Exception.Safe
-    ( SomeException
+    ( SomeAsyncException
+    , SomeException
     , bracket
+    , catchAsync
     , finally
     , mask
     , tryAny
@@ -631,9 +633,9 @@ foreign export ccall ha_repository_apply_path
     -> Ptr Word8 -> CSize -> FunPtr RepositoryResultCallback
     -> Ptr () -> IO CInt
 
-foreign export ccall ha_repository_apply_patch
+foreign export ccall ha_repository_apply_hunks
     :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt
-    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr CSize -> CSize
     -> FunPtr RepositoryResultCallback
     -> Ptr () -> IO CInt
 
@@ -669,7 +671,8 @@ ha_repository_snapshot pathBytes pathLength snapshotCallback fileCallback
         copyRequiredText pathBytes pathLength >>= \case
             Left _ -> pure 2
             Right path -> do
-                started <- startRepositoryWorker $
+                started <- startRepositoryWorker
+                    (emitRepositoryCancelled resultCallback context) $
                     tryAny
                         (RepositoryReview.repositorySnapshot (Text.unpack path))
                         >>= \case
@@ -740,7 +743,8 @@ ha_repository_diff pathBytes pathLength snapshotBytes snapshotLength
                     case repositoryDiffKind diffKind of
                         Nothing -> pure 2
                         Just kind -> do
-                            started <- startRepositoryWorker $
+                            started <- startRepositoryWorker
+                                (emitRepositoryCancelled resultCallback context) $
                                 tryAny
                                     (RepositoryReview.repositoryDiff
                                         (Text.unpack path)
@@ -828,16 +832,16 @@ ha_repository_apply_path pathBytes pathLength snapshotBytes snapshotLength
                             pure (if started then 0 else 3)
                 Right _ -> pure 3
 
-ha_repository_apply_patch
+ha_repository_apply_hunks
     :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt
-    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr CSize -> CSize
     -> FunPtr RepositoryResultCallback
     -> Ptr () -> IO CInt
-ha_repository_apply_patch pathBytes pathLength snapshotBytes snapshotLength
-    operation fileBytes fileLength patchBytes patchLength callback context
+ha_repository_apply_hunks pathBytes pathLength snapshotBytes snapshotLength
+    operation fileBytes fileLength hunkIndices hunkCount callback context
     | callback == nullFunPtr = pure 1
-    | patchBytes == nullPtr || patchLength == 0 = pure 2
-    | toInteger patchLength > toInteger (maxBound :: Int) = pure 2
+    | hunkIndices == nullPtr || hunkCount == 0 = pure 2
+    | hunkCount > 4096 = pure 2
     | otherwise =
         copyRequiredTexts
             [ (pathBytes, pathLength)
@@ -847,10 +851,16 @@ ha_repository_apply_patch pathBytes pathLength snapshotBytes snapshotLength
             >>= \case
                 Left _ -> pure 2
                 Right [path, expected, file] -> do
-                    patch <- BS.packCStringLen
-                        (castPtr patchBytes, fromIntegral patchLength)
-                    case repositoryPatchMutation
-                        operation (Text.unpack file) patch of
+                    indices <- mapM
+                        (\index ->
+                            fromIntegral
+                                <$> (peekByteOff
+                                    hunkIndices
+                                    (index * sizeOf (undefined :: CSize))
+                                    :: IO CSize))
+                        [0 .. fromIntegral hunkCount - 1]
+                    case repositoryHunkMutation
+                        operation (Text.unpack file) indices of
                         Nothing -> pure 2
                         Just mutation -> do
                             started <- startRepositoryMutation
@@ -872,7 +882,8 @@ ha_repository_commit pathBytes pathLength snapshotBytes snapshotLength
             ] >>= \case
                 Left _ -> pure 2
                 Right [path, expected, message] -> do
-                    started <- startRepositoryWorker $
+                    started <- startRepositoryWorker
+                        (emitRepositoryCancelled callback context) $
                         tryAny
                             (RepositoryReview.commitRepository
                                 (Text.unpack path)
@@ -898,7 +909,7 @@ startRepositoryMutation
     -> RepositoryReview.RepositoryMutation
     -> IO Bool
 startRepositoryMutation callback context path expected mutation =
-    startRepositoryWorker $
+    startRepositoryWorker (emitRepositoryCancelled callback context) $
         tryAny (RepositoryReview.mutateRepository path expected mutation)
             >>= \case
                 Left exception ->
@@ -909,8 +920,8 @@ startRepositoryMutation callback context path expected mutation =
                 Right (Right snapshot) ->
                     emitRepositorySuccess callback context snapshot.snapshotId
 
-startRepositoryWorker :: IO () -> IO Bool
-startRepositoryWorker action =
+startRepositoryWorker :: IO () -> IO () -> IO Bool
+startRepositoryWorker onCancelled action =
     tryAny
         (mask \_ -> do
             gate <- newEmptyMVar
@@ -920,8 +931,10 @@ startRepositoryWorker action =
                     Nothing -> do
                         let workerId = state.repositoryWorkerNextId
                         worker <- asyncWithUnmask \unmask -> do
-                            readMVar gate
-                            unmask action `finally`
+                            ((readMVar gate >> unmask action)
+                                `catchAsync`
+                                    \(_ :: SomeAsyncException) -> onCancelled)
+                                `finally`
                                 unregisterRepositoryWorker workerId
                         pure
                             ( state
@@ -989,7 +1002,8 @@ ha_repository_cancel_all =
 repositoryCancelAllAdmissionSmoke :: IO Bool
 repositoryCancelAllAdmissionSmoke = do
     entered <- newEmptyMVar
-    firstAccepted <- startRepositoryWorker do
+    cancelled <- newEmptyMVar
+    firstAccepted <- startRepositoryWorker (putMVar cancelled ()) do
         putMVar entered ()
         uninterruptibleMask_ (threadDelay 250_000)
     if not firstAccepted
@@ -999,17 +1013,24 @@ repositoryCancelAllAdmissionSmoke = do
             withAsync ha_repository_cancel_all \canceller -> do
                 rejectedDuringBarrier <- awaitRejection 1000
                 _ <- waitCatch canceller
+                cancellationDelivered <- readMVar cancelled >> pure True
                 completed <- newEmptyMVar
-                acceptedAfter <- startRepositoryWorker (putMVar completed ())
+                acceptedAfter <- startRepositoryWorker
+                    (pure ())
+                    (putMVar completed ())
                 finishedAfter <- if acceptedAfter
                     then readMVar completed >> pure True
                     else pure False
-                pure (rejectedDuringBarrier && finishedAfter)
+                pure
+                    ( rejectedDuringBarrier
+                        && cancellationDelivered
+                        && finishedAfter
+                    )
   where
     awaitRejection attempts
         | attempts <= (0 :: Int) = pure False
         | otherwise =
-            startRepositoryWorker (pure ()) >>= \case
+            startRepositoryWorker (pure ()) (pure ()) >>= \case
                 False -> pure True
                 True -> threadDelay 1000 >> awaitRejection (attempts - 1)
 
@@ -1205,15 +1226,15 @@ repositoryDiffKind kind = case kind of
     1 -> Just RepositoryReview.RepositoryStagedDiff
     _ -> Nothing
 
-repositoryPatchMutation
+repositoryHunkMutation
     :: CInt
     -> FilePath
-    -> BS.ByteString
+    -> [Int]
     -> Maybe RepositoryReview.RepositoryMutation
-repositoryPatchMutation operation path patch = case operation of
-    0 -> Just (RepositoryReview.StagePatch path patch)
-    1 -> Just (RepositoryReview.UnstagePatch path patch)
-    2 -> Just (RepositoryReview.RestorePatch path patch)
+repositoryHunkMutation operation path hunks = case operation of
+    0 -> Just (RepositoryReview.StageHunks path hunks)
+    1 -> Just (RepositoryReview.UnstageHunks path hunks)
+    2 -> Just (RepositoryReview.RestoreHunks path hunks)
     _ -> Nothing
 
 withRepositorySnapshot
@@ -1244,6 +1265,13 @@ emitRepositoryFailure
 emitRepositoryFailure callback context message =
     withText message \errorPtr errorLength ->
         invokeRepositoryResultCallback callback context (-1)
+            nullPtr 0 errorPtr errorLength
+
+emitRepositoryCancelled
+    :: FunPtr RepositoryResultCallback -> Ptr () -> IO ()
+emitRepositoryCancelled callback context =
+    withText "cancelled" \errorPtr errorLength ->
+        invokeRepositoryResultCallback callback context (-3)
             nullPtr 0 errorPtr errorLength
 
 emitRepositoryError

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -470,21 +470,25 @@ ha_account_oauth_start providerBytes (CSize providerLength) callback context
     | otherwise = do
         provider <- decodeInput providerBytes providerLength
         _ <- forkIO do
-            startAccountOAuth AccountProviderRequest
-                { accountProvider = provider } >>= \case
-                    Left err -> withText err $ \errorPtr errorLength ->
-                        invokeAccountOAuthStartCallback callback context
-                            (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 0 0
-                            errorPtr errorLength
-                    Right value -> case parseChallenge value of
-                        Nothing -> withText "invalid OAuth challenge"
-                            (\errorPtr errorLength ->
-                                invokeAccountOAuthStartCallback callback context
-                                    (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-                                    0 0 errorPtr errorLength)
-                        Just challenge ->
-                            withChallengeStrings challenge
-                                (invokeAccountOAuthStartCallback callback context 0)
+            tryAny (startAccountOAuth AccountProviderRequest
+                { accountProvider = provider }) >>= \case
+                Left exception -> withText (Text.pack (show exception)) $ \errorPtr errorLength ->
+                    invokeAccountOAuthStartCallback callback context
+                        (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 0 0
+                        errorPtr errorLength
+                Right (Left err) -> withText err $ \errorPtr errorLength ->
+                    invokeAccountOAuthStartCallback callback context
+                        (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 0 0
+                        errorPtr errorLength
+                Right (Right value) -> case parseChallenge value of
+                    Nothing -> withText "invalid OAuth challenge"
+                        (\errorPtr errorLength ->
+                            invokeAccountOAuthStartCallback callback context
+                                (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                                0 0 errorPtr errorLength)
+                    Just challenge ->
+                        withChallengeStrings challenge
+                            (invokeAccountOAuthStartCallback callback context 0)
         pure 0
 
 ha_account_oauth_poll
@@ -509,7 +513,7 @@ ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLe
         authId <- decodeInput authIdBytes authIdLength
         device <- decodeInput deviceBytes deviceLength
         _ <- forkIO do
-            pollAccountOAuth AccountOAuthPollRequest
+            tryAny (pollAccountOAuth AccountOAuthPollRequest
                 { oauthPollProvider = provider
                 , oauthPollVerificationUrl = nonEmptyText url
                 , oauthPollUserCode = nonEmptyText user
@@ -517,7 +521,9 @@ ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLe
                 , oauthPollDeviceCode = nonEmptyText device
                 , oauthPollIntervalSeconds = Just (fromIntegral pollInterval)
                 , oauthPollExpiresInSeconds = Just (fromIntegral expires)
-                } >>= invokeResult callback context
+                }) >>= \case
+                    Left exception -> invokeExceptionResult callback context exception
+                    Right result -> invokeResult callback context result
         pure 0
 
 ha_account_api_key_connect
@@ -531,9 +537,11 @@ ha_account_api_key_connect providerBytes (CSize providerLength) keyBytes (CSize 
         provider <- decodeInput providerBytes providerLength
         key <- decodeInput keyBytes keyLength
         _ <- forkIO do
-            connectAccountAPIKey AccountAPIKeyRequest
+            tryAny (connectAccountAPIKey AccountAPIKeyRequest
                 { accountAPIKeyProvider = provider, accountAPIKey = key }
-                >>= invokeResult callback context
+                ) >>= \case
+                    Left exception -> invokeExceptionResult callback context exception
+                    Right result -> invokeResult callback context result
         pure 0
 
 ha_account_set_enabled
@@ -544,8 +552,10 @@ ha_account_set_enabled idBytes (CSize idLength) enabled callback context
     | otherwise = do
         managedId <- decodeInput idBytes idLength
         _ <- forkIO do
-            setManagedCredentialEnabled managedId (enabled /= 0)
-                >>= invokeStoreResult callback context
+            tryAny (setManagedCredentialEnabled managedId (enabled /= 0))
+                >>= \case
+                    Left exception -> invokeExceptionResult callback context exception
+                    Right result -> invokeStoreResult callback context result
         pure 0
 
 ha_account_delete
@@ -556,8 +566,9 @@ ha_account_delete idBytes (CSize idLength) callback context
     | otherwise = do
         managedId <- decodeInput idBytes idLength
         _ <- forkIO do
-            deleteManagedCredential managedId
-                >>= invokeStoreResult callback context
+            tryAny (deleteManagedCredential managedId) >>= \case
+                Left exception -> invokeExceptionResult callback context exception
+                Right result -> invokeStoreResult callback context result
         pure 0
 
 anyNonEmptyNull :: [(Ptr Word8, Word64)] -> Bool
@@ -638,6 +649,13 @@ invokeStoreResult callback context result = case result of
         invokeAccountResultCallback callback context (-1)
             nullPtr 0 errorPtr errorLength
     Right () -> invokeAccountResultCallback callback context 0 nullPtr 0 nullPtr 0
+
+invokeExceptionResult :: FunPtr AccountResultCallback -> Ptr ()
+    -> SomeException -> IO ()
+invokeExceptionResult callback context exception =
+    withText (Text.pack (show exception)) $ \errorPtr errorLength ->
+        invokeAccountResultCallback callback context (-1)
+            nullPtr 0 errorPtr errorLength
 
 ha_engine_create :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
 ha_engine_create callback context

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -14,6 +14,11 @@ import Agent.Store.Postgres.Session
     ( NativeConversationSearchResult(..)
     , searchNativeConversations
     )
+import Agent.CLI.ManagedTurn
+    ( ManagedTurnMedia(..)
+    , managedTurnRequestWithImages
+    , renderManagedTurnPrompt
+    )
 import Data.Bifunctor (first)
 import Agent.Store.Postgres.Scope (Scope(..), scopeKindText)
 import Agent.Store.Postgres.Skill
@@ -21,11 +26,6 @@ import Agent.Store.Postgres.Skill
     , learnedSkillActivationText
     , learnedSkillStatusText
     , listAllLearnedSkills
-    )
-import Agent.CLI.ManagedTurn
-    ( ManagedTurnMedia(..)
-    , managedTurnRequestWithImages
-    , renderManagedTurnPrompt
     )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
@@ -908,7 +908,9 @@ ha_engine_send_json pointer bytes (CSize length)
                 (castPtr bytes, fromIntegral length)
             case (Aeson.eitherDecodeStrict' payload
                 :: Either String BridgeRequest) of
-                Left _ -> pure False
+                Left _ -> do
+                    atomically $ writeTVar engine.engineStagedImages Map.empty
+                    pure False
                 Right request -> do
                     atomically
                         (writeTQueue
@@ -965,8 +967,10 @@ ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
                 [0 .. fromIntegral imageCount - 1]
             case (turnIDText, sequence imageResults) of
                 (Right turnIDValue, Just images) -> do
-                    atomically $ modifyTVar' engine.engineStagedImages
-                        (Map.insertWith (flip (<>)) turnIDValue images)
+                    atomically $ modifyTVar' engine.engineStagedImages $
+                        if null images
+                            then Map.delete turnIDValue
+                            else Map.insert turnIDValue images
                     pure True
                 _ -> pure False
         pure $ case accepted of
@@ -1065,6 +1069,8 @@ idleLoop callback context config store root processRuntime commands stagedImages
                 case (parseParams request
                     :: Either Text TurnStart) of
                     Left err -> do
+                        atomically $ modifyTVar' stagedImages
+                            (Map.delete request.requestId)
                         sendEvent callback context
                             (failureEvent request.requestId err)
                         continue

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
-module Agent.CLI.MacOS.Bridge () where
+module Agent.CLI.MacOS.Bridge
+    ( repositoryCancelAllAdmissionSmoke
+    ) where
 
 import qualified Agent.CLI.AgentViewport as Viewport
 import Agent.CLI.NativeRuntime
@@ -119,7 +121,7 @@ import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
     )
-import Control.Concurrent (forkFinally, forkIO)
+import Control.Concurrent (forkFinally, forkIO, threadDelay)
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
@@ -162,6 +164,7 @@ import Control.Exception.Safe
     , finally
     , mask
     , tryAny
+    , uninterruptibleMask_
     )
 import Control.Monad
     ( forM_
@@ -911,36 +914,119 @@ startRepositoryWorker action =
     tryAny
         (mask \_ -> do
             gate <- newEmptyMVar
-            _workerId <- modifyMVar repositoryWorkers \(nextId, workers) -> do
-                let workerId = nextId
-                worker <- asyncWithUnmask \unmask -> do
-                    readMVar gate
-                    unmask action `finally`
-                        unregisterRepositoryWorker workerId
-                pure
-                    ( (nextId + 1, Map.insert workerId worker workers)
-                    , workerId
-                    )
-            putMVar gate ())
+            admitted <- modifyMVar repositoryWorkers \state ->
+                case state.repositoryWorkerBarrier of
+                    Just _ -> pure (state, False)
+                    Nothing -> do
+                        let workerId = state.repositoryWorkerNextId
+                        worker <- asyncWithUnmask \unmask -> do
+                            readMVar gate
+                            unmask action `finally`
+                                unregisterRepositoryWorker workerId
+                        pure
+                            ( state
+                                { repositoryWorkerNextId = workerId + 1
+                                , repositoryWorkerActive =
+                                    Map.insert
+                                        workerId
+                                        worker
+                                        state.repositoryWorkerActive
+                                }
+                            , True
+                            )
+            when admitted (putMVar gate ())
+            pure admitted)
         >>= \case
             Left _ -> pure False
-            Right () -> pure True
+            Right admitted -> pure admitted
 
 unregisterRepositoryWorker :: Int -> IO ()
 unregisterRepositoryWorker workerId =
-    modifyMVar repositoryWorkers \(nextId, workers) ->
-        pure ((nextId, Map.delete workerId workers), ())
+    modifyMVar repositoryWorkers \state ->
+        pure
+            ( state
+                { repositoryWorkerActive =
+                    Map.delete workerId state.repositoryWorkerActive
+                }
+            , ()
+            )
 
 ha_repository_cancel_all :: IO ()
-ha_repository_cancel_all = do
-    workers <- modifyMVar repositoryWorkers \(nextId, active) ->
-        pure ((nextId, Map.empty), Map.elems active)
-    mapM_ cancel workers
-    mapM_ waitCatch workers
+ha_repository_cancel_all =
+    mask \restore -> do
+        admission <- modifyMVar repositoryWorkers \state ->
+            case state.repositoryWorkerBarrier of
+                Just barrier ->
+                    pure (state, Left barrier)
+                Nothing -> do
+                    barrier <- newEmptyMVar
+                    pure
+                        ( state
+                            { repositoryWorkerActive = Map.empty
+                            , repositoryWorkerBarrier = Just barrier
+                            }
+                        , Right
+                            ( barrier
+                            , Map.elems state.repositoryWorkerActive
+                            )
+                        )
+        case admission of
+            Left activeBarrier -> restore (readMVar activeBarrier)
+            Right (barrier, workers) ->
+                restore
+                    (mapM_ cancel workers >> mapM_ waitCatch workers)
+                    `finally` do
+                        modifyMVar repositoryWorkers \state ->
+                            pure
+                                ( state
+                                    { repositoryWorkerBarrier = Nothing }
+                                , ()
+                                )
+                        putMVar barrier ()
+
+-- Deterministic regression hook for the admission-barrier lifecycle. This is
+-- a Haskell test hook, not part of the C ABI.
+repositoryCancelAllAdmissionSmoke :: IO Bool
+repositoryCancelAllAdmissionSmoke = do
+    entered <- newEmptyMVar
+    firstAccepted <- startRepositoryWorker do
+        putMVar entered ()
+        uninterruptibleMask_ (threadDelay 250_000)
+    if not firstAccepted
+        then pure False
+        else do
+            readMVar entered
+            withAsync ha_repository_cancel_all \canceller -> do
+                rejectedDuringBarrier <- awaitRejection 1000
+                _ <- waitCatch canceller
+                completed <- newEmptyMVar
+                acceptedAfter <- startRepositoryWorker (putMVar completed ())
+                finishedAfter <- if acceptedAfter
+                    then readMVar completed >> pure True
+                    else pure False
+                pure (rejectedDuringBarrier && finishedAfter)
+  where
+    awaitRejection attempts
+        | attempts <= (0 :: Int) = pure False
+        | otherwise =
+            startRepositoryWorker (pure ()) >>= \case
+                False -> pure True
+                True -> threadDelay 1000 >> awaitRejection (attempts - 1)
 
 {-# NOINLINE repositoryWorkers #-}
-repositoryWorkers :: MVar (Int, Map Int (Async ()))
-repositoryWorkers = unsafePerformIO (newMVar (0, Map.empty))
+repositoryWorkers :: MVar RepositoryWorkerState
+repositoryWorkers = unsafePerformIO
+    (newMVar RepositoryWorkerState
+        { repositoryWorkerNextId = 0
+        , repositoryWorkerActive = Map.empty
+        , repositoryWorkerBarrier = Nothing
+        })
+
+data RepositoryWorkerState = RepositoryWorkerState
+    { repositoryWorkerNextId :: !Int
+    , repositoryWorkerActive :: !(Map Int (Async ()))
+    , repositoryWorkerBarrier :: !(Maybe (MVar ()))
+    }
 
 data RepositoryCheckHandle = RepositoryCheckHandle
     { repositoryCheckValue :: !(IORef (Maybe RepositoryReview.RepositoryCheck))

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -992,6 +992,7 @@ ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
             (mimePointer == nullPtr && mimeLength > 0)
                 || (bytesPointer == nullPtr && bytesLength > 0)
                 || mimeLength == 0
+                || bytesLength == 0
         then pure Nothing
         else do
             mimeBytes <- BS.packCStringLen

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE FieldSelectors #-}
 
 module Agent.CLI.MacOS.Bridge () where
 
@@ -71,8 +70,7 @@ import Agent.CLI.Session
     , sessionsRoot
     )
 import Agent.CLI.SessionAdmin
-    ( accountSummariesJSON
-    , loadSessionPageJSON
+    ( loadSessionPageJSON
     , managedPostgresConfigForHome
     , sessionSummaryWithStatusJSON
     )
@@ -85,11 +83,6 @@ import Agent.Store.Postgres
     , closeStore
     , openStore
     , trustedPool
-    )
-import Agent.Store.Postgres.UsageCache
-    ( AccountUsageCacheEntry(..)
-    , loadAccountUsageCache
-    , upsertAccountUsageCache
     )
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
@@ -373,10 +366,6 @@ data AccountProviderRequest = AccountProviderRequest
     { accountProvider :: !Text
     }
 
-instance Aeson.FromJSON AccountProviderRequest where
-    parseJSON = Aeson.withObject "AccountProviderRequest" \object ->
-        AccountProviderRequest <$> object .: "provider"
-
 data AccountOAuthPollRequest = AccountOAuthPollRequest
     { oauthPollProvider :: !Text
     , oauthPollVerificationUrl :: !(Maybe Text)
@@ -387,46 +376,10 @@ data AccountOAuthPollRequest = AccountOAuthPollRequest
     , oauthPollExpiresInSeconds :: !(Maybe Int)
     }
 
-instance Aeson.FromJSON AccountOAuthPollRequest where
-    parseJSON = Aeson.withObject "AccountOAuthPollRequest" \object ->
-        AccountOAuthPollRequest
-            <$> object .: "provider"
-            <*> object .:? "verificationUrl"
-            <*> object .:? "userCode"
-            <*> object .:? "deviceAuthId"
-            <*> object .:? "deviceCode"
-            <*> object .:? "pollIntervalSeconds"
-            <*> object .:? "expiresInSeconds"
-
 data AccountAPIKeyRequest = AccountAPIKeyRequest
     { accountAPIKeyProvider :: !Text
     , accountAPIKey :: !Text
     }
-
-instance Aeson.FromJSON AccountAPIKeyRequest where
-    parseJSON = Aeson.withObject "AccountAPIKeyRequest" \object ->
-        AccountAPIKeyRequest
-            <$> object .: "provider"
-            <*> object .: "apiKey"
-
-data AccountEnabledRequest = AccountEnabledRequest
-    { accountEnabledManagedId :: !Text
-    , accountEnabledEnabled :: !Bool
-    }
-
-instance Aeson.FromJSON AccountEnabledRequest where
-    parseJSON = Aeson.withObject "AccountEnabledRequest" \object ->
-        AccountEnabledRequest
-            <$> object .: "managedID"
-            <*> object .: "enabled"
-
-data AccountDeleteRequest = AccountDeleteRequest
-    { accountDeleteManagedId :: !Text
-    }
-
-instance Aeson.FromJSON AccountDeleteRequest where
-    parseJSON = Aeson.withObject "AccountDeleteRequest" \object ->
-        AccountDeleteRequest <$> object .: "managedID"
 
 data EngineCommand
     = EngineRequest !BridgeRequest
@@ -579,7 +532,7 @@ ha_account_set_enabled
 ha_account_set_enabled idBytes (CSize idLength) enabled callback context
     | callback == nullFunPtr = pure 1
     | otherwise = do
-        managedId <- decodeInput idBytes (CSize idLength)
+        managedId <- decodeInput idBytes idLength
         _ <- forkIO do
             setManagedCredentialEnabled managedId (enabled /= 0)
                 >>= invokeStoreResult callback context
@@ -590,7 +543,7 @@ ha_account_delete
 ha_account_delete idBytes (CSize idLength) callback context
     | callback == nullFunPtr = pure 1
     | otherwise = do
-        managedId <- decodeInput idBytes (CSize idLength)
+        managedId <- decodeInput idBytes idLength
         _ <- forkIO do
             deleteManagedCredential managedId
                 >>= invokeStoreResult callback context
@@ -1281,53 +1234,6 @@ handleRequest config store root request = do
                             (failureEvent current.requestId)
                             (const (successEvent current.requestId True))
                             changed
-            "accounts.list" -> do
-                activeStore <- acquireStore config store
-                accounts <- cachedAccountSummaries activeStore
-                pure $ successEvent current.requestId
-                    accounts
-            "accounts.oauth.start" ->
-                case (parseParams current :: Either Text AccountProviderRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request ->
-                        startAccountOAuth request >>= either
-                            (pure . failureEvent current.requestId)
-                            (pure . successEvent current.requestId)
-            "accounts.oauth.poll" ->
-                case (parseParams current :: Either Text AccountOAuthPollRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request ->
-                        pollAccountOAuth request >>= either
-                            (pure . failureEvent current.requestId)
-                            (pure . successEvent current.requestId)
-            "accounts.apiKey.connect" ->
-                case (parseParams current :: Either Text AccountAPIKeyRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request ->
-                        connectAccountAPIKey request >>= either
-                            (pure . failureEvent current.requestId)
-                            (pure . successEvent current.requestId)
-            "accounts.setEnabled" ->
-                case (parseParams current :: Either Text AccountEnabledRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request -> do
-                        result <- setManagedCredentialEnabled
-                            request.accountEnabledManagedId
-                            request.accountEnabledEnabled
-                        pure $ either
-                            (failureEvent current.requestId)
-                            (const (successEvent current.requestId True))
-                            result
-            "accounts.delete" ->
-                case (parseParams current :: Either Text AccountDeleteRequest) of
-                    Left err -> pure (failureEvent current.requestId err)
-                    Right request -> do
-                        result <- deleteManagedCredential
-                            request.accountDeleteManagedId
-                        pure $ either
-                            (failureEvent current.requestId)
-                            (const (successEvent current.requestId True))
-                            result
             "turn.agents" ->
                 pure $ successEvent current.requestId ([] :: [Aeson.Value])
             "models.list" ->
@@ -1348,48 +1254,6 @@ handleRequest config store root request = do
             method ->
                 pure $ failureEvent current.requestId
                     ("unknown method: " <> method)
-
-cachedAccountSummaries :: Store -> IO [Aeson.Value]
-cachedAccountSummaries store = do
-    let pool = trustedPool store
-    cached <- loadAccountUsageCache pool accountCacheProvider accountCacheKey
-    now <- getCurrentTime
-    case cached of
-        Right (Just entry)
-            | Just accounts <- decodeAccountCache entry.accountUsageCachePayload -> do
-                if entry.accountUsageCacheExpiresAt <= now
-                    then void $ forkFinally
-                        (refreshAccountCache store)
-                        (const (pure ()))
-                    else pure ()
-                pure accounts
-        _ -> refreshAccountCache store
-
-refreshAccountCache :: Store -> IO [Aeson.Value]
-refreshAccountCache store = do
-    accounts <- accountSummariesJSON
-    fetchedAt <- getCurrentTime
-    let payload = TextEncoding.decodeUtf8 $
-            LBS.toStrict (Aeson.encode accounts)
-        entry = AccountUsageCacheEntry
-            { accountUsageCacheProvider = accountCacheProvider
-            , accountUsageCacheAccountId = accountCacheKey
-            , accountUsageCachePayload = payload
-            , accountUsageCacheFetchedAt = fetchedAt
-            , accountUsageCacheExpiresAt = addUTCTime 300 fetchedAt
-            }
-    void $ upsertAccountUsageCache (trustedPool store) entry
-    pure accounts
-
-decodeAccountCache :: Text -> Maybe [Aeson.Value]
-decodeAccountCache =
-    Aeson.decodeStrict' . TextEncoding.encodeUtf8
-
-accountCacheProvider :: Text
-accountCacheProvider = "macos-bridge"
-
-accountCacheKey :: Text
-accountCacheKey = "account-summaries-v1"
 
 loadNativeModelCatalog
     :: Store

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -630,7 +630,8 @@ foreign export ccall ha_repository_apply_path
 
 foreign export ccall ha_repository_apply_patch
     :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt
-    -> Ptr Word8 -> CSize -> FunPtr RepositoryResultCallback
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryResultCallback
     -> Ptr () -> IO CInt
 
 foreign export ccall ha_repository_commit
@@ -801,22 +802,27 @@ ha_repository_apply_path pathBytes pathLength snapshotBytes snapshotLength
 
 ha_repository_apply_patch
     :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt
-    -> Ptr Word8 -> CSize -> FunPtr RepositoryResultCallback
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryResultCallback
     -> Ptr () -> IO CInt
 ha_repository_apply_patch pathBytes pathLength snapshotBytes snapshotLength
-    operation patchBytes patchLength callback context
+    operation fileBytes fileLength patchBytes patchLength callback context
     | callback == nullFunPtr = pure 1
     | patchBytes == nullPtr || patchLength == 0 = pure 2
     | toInteger patchLength > toInteger (maxBound :: Int) = pure 2
     | otherwise =
         copyRequiredTexts
-            [(pathBytes, pathLength), (snapshotBytes, snapshotLength)]
+            [ (pathBytes, pathLength)
+            , (snapshotBytes, snapshotLength)
+            , (fileBytes, fileLength)
+            ]
             >>= \case
                 Left _ -> pure 2
-                Right [path, expected] -> do
+                Right [path, expected, file] -> do
                     patch <- BS.packCStringLen
                         (castPtr patchBytes, fromIntegral patchLength)
-                    case repositoryPatchMutation operation patch of
+                    case repositoryPatchMutation
+                        operation (Text.unpack file) patch of
                         Nothing -> pure 2
                         Just mutation -> do
                             started <- startRepositoryMutation
@@ -930,7 +936,7 @@ ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
         || exitCallback == nullFunPtr
         || outCheck == nullPtr = pure 1
     | argumentsPointer == nullPtr && argumentCount > 0 = pure 2
-    | toInteger argumentCount > toInteger (maxBound :: Int) = pure 2
+    | argumentCount > fromIntegral maxRepositoryCheckArguments = pure 2
     | otherwise =
         copyRequiredTexts
             [ (pathBytes, pathLength)
@@ -1024,17 +1030,42 @@ ha_repository_check_destroy pointer
 
 copyRepositoryCheckArguments
     :: Ptr () -> CSize -> IO (Either () [Text])
-copyRepositoryCheckArguments pointer count =
-    fmap sequence $ mapM copyAt [0 .. fromIntegral count - 1]
+copyRepositoryCheckArguments pointer count
+    | count > fromIntegral maxRepositoryCheckArguments = pure (Left ())
+    | itemSize <= 0 = pure (Left ())
+    | otherwise = go 0 (0 :: Int) []
   where
     pointerSize = sizeOf (nullPtr :: Ptr ())
     sizeSize = sizeOf (undefined :: CSize)
     itemSize = pointerSize + sizeSize
-    copyAt index = do
-        let base = castPtr pointer `plusPtr` (index * itemSize)
-        bytes <- peekByteOff base 0 :: IO (Ptr Word8)
-        length <- peekByteOff base pointerSize :: IO CSize
-        copyRequiredText bytes length
+    countInt = fromIntegral count
+    go index total acc
+        | index >= countInt = pure (Right (reverse acc))
+        | index > maxBound `div` itemSize = pure (Left ())
+        | otherwise = do
+            let base = castPtr pointer `plusPtr` (index * itemSize)
+            bytes <- peekByteOff base 0 :: IO (Ptr Word8)
+            length <- peekByteOff base pointerSize :: IO CSize
+            if length > fromIntegral maxRepositoryCheckArgumentBytes
+                || toInteger total + toInteger length
+                    > toInteger maxRepositoryCheckTotalArgumentBytes
+                then pure (Left ())
+                else copyRequiredText bytes length >>= \case
+                    Left _ -> pure (Left ())
+                    Right value ->
+                        go
+                            (index + 1)
+                            (total + fromIntegral length)
+                            (value : acc)
+
+maxRepositoryCheckArguments :: Int
+maxRepositoryCheckArguments = 4096
+
+maxRepositoryCheckArgumentBytes :: Int
+maxRepositoryCheckArgumentBytes = 1024 * 1024
+
+maxRepositoryCheckTotalArgumentBytes :: Int
+maxRepositoryCheckTotalArgumentBytes = 8 * 1024 * 1024
 
 repositoryPathMutation
     :: CInt -> FilePath -> Maybe RepositoryReview.RepositoryMutation
@@ -1052,11 +1083,14 @@ repositoryDiffKind kind = case kind of
     _ -> Nothing
 
 repositoryPatchMutation
-    :: CInt -> BS.ByteString -> Maybe RepositoryReview.RepositoryMutation
-repositoryPatchMutation operation patch = case operation of
-    0 -> Just (RepositoryReview.StagePatch patch)
-    1 -> Just (RepositoryReview.UnstagePatch patch)
-    2 -> Just (RepositoryReview.RestorePatch patch)
+    :: CInt
+    -> FilePath
+    -> BS.ByteString
+    -> Maybe RepositoryReview.RepositoryMutation
+repositoryPatchMutation operation path patch = case operation of
+    0 -> Just (RepositoryReview.StagePatch path patch)
+    1 -> Just (RepositoryReview.UnstagePatch path patch)
+    2 -> Just (RepositoryReview.RestorePatch path patch)
     _ -> Nothing
 
 withRepositorySnapshot

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -2,6 +2,8 @@
 
 module Agent.CLI.MacOS.Bridge
     ( repositoryCancelAllAdmissionSmoke
+    , repositoryCancelAllReentrancySmoke
+    , repositoryCheckDestroyReentrancySmoke
     ) where
 
 import qualified Agent.CLI.AgentViewport as Viewport
@@ -121,7 +123,13 @@ import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
     )
-import Control.Concurrent (forkFinally, forkIO, threadDelay)
+import Control.Concurrent
+    ( ThreadId
+    , forkFinally
+    , forkIO
+    , myThreadId
+    , threadDelay
+    )
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
@@ -182,6 +190,7 @@ import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (ord)
+import Data.Either (isRight)
 import Data.IORef
     ( IORef
     , newIORef
@@ -255,6 +264,11 @@ withText value action = BS.useAsCStringLen (TextEncoding.encodeUtf8 value) \(poi
 
 withOptionalText :: Maybe Text -> (CString -> CSize -> IO a) -> IO a
 withOptionalText value action = withText (fromMaybe "" value) action
+
+withNullableText :: Maybe Text -> (CString -> CSize -> IO a) -> IO a
+withNullableText value action = case value of
+    Nothing -> action nullPtr 0
+    Just text -> withText text action
 
 type EventCallback = Ptr () -> Ptr Word8 -> CSize -> IO ()
 
@@ -693,7 +707,7 @@ ha_repository_snapshot pathBytes pathLength snapshotCallback fileCallback
                                         withText
                                             (Text.pack file.repositoryFilePath)
                                             \pathPtr pathSize ->
-                                        withOptionalText
+                                        withNullableText
                                             (Text.pack
                                                 <$> file.repositoryFileOriginalPath)
                                             \originalPtr originalSize ->
@@ -931,9 +945,11 @@ startRepositoryWorker onCancelled action =
                     Nothing -> do
                         let workerId = state.repositoryWorkerNextId
                         worker <- asyncWithUnmask \unmask -> do
-                            ((readMVar gate >> unmask action)
-                                `catchAsync`
-                                    \(_ :: SomeAsyncException) -> onCancelled)
+                            withRepositoryCallbackThread
+                                (((readMVar gate >> unmask action)
+                                    `catchAsync`
+                                        \(_ :: SomeAsyncException) ->
+                                            onCancelled))
                                 `finally`
                                 unregisterRepositoryWorker workerId
                         pure
@@ -966,36 +982,38 @@ unregisterRepositoryWorker workerId =
 
 ha_repository_cancel_all :: IO ()
 ha_repository_cancel_all =
-    mask \restore -> do
-        admission <- modifyMVar repositoryWorkers \state ->
-            case state.repositoryWorkerBarrier of
-                Just barrier ->
-                    pure (state, Left barrier)
-                Nothing -> do
-                    barrier <- newEmptyMVar
-                    pure
-                        ( state
-                            { repositoryWorkerActive = Map.empty
-                            , repositoryWorkerBarrier = Just barrier
-                            }
-                        , Right
-                            ( barrier
-                            , Map.elems state.repositoryWorkerActive
-                            )
-                        )
-        case admission of
-            Left activeBarrier -> restore (readMVar activeBarrier)
-            Right (barrier, workers) ->
-                restore
-                    (mapM_ cancel workers >> mapM_ waitCatch workers)
-                    `finally` do
-                        modifyMVar repositoryWorkers \state ->
-                            pure
-                                ( state
-                                    { repositoryWorkerBarrier = Nothing }
-                                , ()
+    isRepositoryCallbackThread >>= \case
+        True -> pure ()
+        False -> mask \restore -> do
+            admission <- modifyMVar repositoryWorkers \state ->
+                case state.repositoryWorkerBarrier of
+                    Just barrier ->
+                        pure (state, Left barrier)
+                    Nothing -> do
+                        barrier <- newEmptyMVar
+                        pure
+                            ( state
+                                { repositoryWorkerActive = Map.empty
+                                , repositoryWorkerBarrier = Just barrier
+                                }
+                            , Right
+                                ( barrier
+                                , Map.elems state.repositoryWorkerActive
                                 )
-                        putMVar barrier ()
+                            )
+            case admission of
+                Left activeBarrier -> restore (readMVar activeBarrier)
+                Right (barrier, workers) ->
+                    restore
+                        (mapM_ cancel workers >> mapM_ waitCatch workers)
+                        `finally` do
+                            modifyMVar repositoryWorkers \state ->
+                                pure
+                                    ( state
+                                        { repositoryWorkerBarrier = Nothing }
+                                    , ()
+                                    )
+                            putMVar barrier ()
 
 -- Deterministic regression hook for the admission-barrier lifecycle. This is
 -- a Haskell test hook, not part of the C ABI.
@@ -1034,6 +1052,16 @@ repositoryCancelAllAdmissionSmoke = do
                 False -> pure True
                 True -> threadDelay 1000 >> awaitRejection (attempts - 1)
 
+repositoryCancelAllReentrancySmoke :: IO Bool
+repositoryCancelAllReentrancySmoke = do
+    completed <- newEmptyMVar
+    accepted <- startRepositoryWorker (pure ()) do
+        ha_repository_cancel_all
+        putMVar completed ()
+    if accepted
+        then readMVar completed >> pure True
+        else pure False
+
 {-# NOINLINE repositoryWorkers #-}
 repositoryWorkers :: MVar RepositoryWorkerState
 repositoryWorkers = unsafePerformIO
@@ -1048,6 +1076,24 @@ data RepositoryWorkerState = RepositoryWorkerState
     , repositoryWorkerActive :: !(Map Int (Async ()))
     , repositoryWorkerBarrier :: !(Maybe (MVar ()))
     }
+
+{-# NOINLINE repositoryCallbackThreads #-}
+repositoryCallbackThreads :: MVar (Set.Set ThreadId)
+repositoryCallbackThreads = unsafePerformIO (newMVar Set.empty)
+
+withRepositoryCallbackThread :: IO value -> IO value
+withRepositoryCallbackThread action = do
+    thread <- myThreadId
+    modifyMVar repositoryCallbackThreads \threads ->
+        pure (Set.insert thread threads, ())
+    action `finally`
+        modifyMVar repositoryCallbackThreads \threads ->
+            pure (Set.delete thread threads, ())
+
+isRepositoryCallbackThread :: IO Bool
+isRepositoryCallbackThread = do
+    thread <- myThreadId
+    Set.member thread <$> readMVar repositoryCallbackThreads
 
 data RepositoryCheckHandle = RepositoryCheckHandle
     { repositoryCheckValue :: !(IORef (Maybe RepositoryReview.RepositoryCheck))
@@ -1096,40 +1142,46 @@ ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
                                             (\stream bytes ->
                                                 BS.useAsCStringLen bytes
                                                     \(pointer, length) ->
-                                                        invokeRepositoryCheckOutputCallback
-                                                            outputCallback
-                                                            context
-                                                            (case stream of
-                                                                RepositoryReview.RepositoryCheckStdout -> 1
-                                                                RepositoryReview.RepositoryCheckStderr -> 2)
-                                                            (castPtr pointer)
-                                                            (fromIntegral length))
+                                                        withRepositoryCallbackThread
+                                                            (invokeRepositoryCheckOutputCallback
+                                                                outputCallback
+                                                                context
+                                                                (case stream of
+                                                                    RepositoryReview.RepositoryCheckStdout -> 1
+                                                                    RepositoryReview.RepositoryCheckStderr -> 2)
+                                                                (castPtr pointer)
+                                                                (fromIntegral length)))
                                             (\cancelled exitCode ->
-                                                invokeRepositoryCheckExitCallback
-                                                    exitCallback
-                                                    context
-                                                    (if cancelled then 1 else 0)
-                                                    (case exitCode of
-                                                        System.Exit.ExitSuccess -> 0
-                                                        System.Exit.ExitFailure code ->
-                                                            fromIntegral code)
-                                                    nullPtr 0))
+                                                withRepositoryCallbackThread
+                                                    (invokeRepositoryCheckExitCallback
+                                                        exitCallback
+                                                        context
+                                                        (if cancelled then 1 else 0)
+                                                        (case exitCode of
+                                                            System.Exit.ExitSuccess -> 0
+                                                            System.Exit.ExitFailure code ->
+                                                                fromIntegral code)
+                                                        nullPtr 0)))
                                     case started of
                                         Left exception ->
                                             withText
                                                 (Text.pack (show exception))
                                                 \errorPtr errorLength ->
-                                                    invokeRepositoryCheckExitCallback
-                                                        exitCallback context 0 (-1)
-                                                        errorPtr errorLength
+                                                    withRepositoryCallbackThread
+                                                        (invokeRepositoryCheckExitCallback
+                                                            exitCallback
+                                                            context 0 (-1)
+                                                            errorPtr errorLength)
                                         Right (Left err) ->
                                             withText
                                                 (RepositoryReview.repositoryErrorText
                                                     err)
                                                 \errorPtr errorLength ->
-                                                    invokeRepositoryCheckExitCallback
-                                                        exitCallback context 0 (-1)
-                                                        errorPtr errorLength
+                                                    withRepositoryCallbackThread
+                                                        (invokeRepositoryCheckExitCallback
+                                                            exitCallback
+                                                            context 0 (-1)
+                                                            errorPtr errorLength)
                                         Right (Right check) -> do
                                             writeIORef checkRef (Just check)
                                             cancelRequested <- readIORef cancelRef
@@ -1153,24 +1205,49 @@ ha_repository_check_cancel :: Ptr () -> IO ()
 ha_repository_check_cancel pointer
     | pointer == nullPtr = pure ()
     | otherwise = do
-        let stable =
-                castPtrToStablePtr pointer
-                    :: StablePtr RepositoryCheckHandle
-        handle <- deRefStablePtr stable
-        writeIORef handle.repositoryCheckCancelRequested True
-        readIORef handle.repositoryCheckValue >>= mapM_
-            RepositoryReview.cancelRepositoryCheck
+        isRepositoryCallbackThread >>= \case
+            True -> pure ()
+            False -> do
+                let stable =
+                        castPtrToStablePtr pointer
+                            :: StablePtr RepositoryCheckHandle
+                handle <- deRefStablePtr stable
+                writeIORef handle.repositoryCheckCancelRequested True
+                readIORef handle.repositoryCheckValue >>= mapM_
+                    RepositoryReview.cancelRepositoryCheck
 
 ha_repository_check_destroy :: Ptr () -> IO ()
 ha_repository_check_destroy pointer
     | pointer == nullPtr = pure ()
     | otherwise = do
-        let stable =
-                castPtrToStablePtr pointer
-                    :: StablePtr RepositoryCheckHandle
-        handle <- deRefStablePtr stable
-        _ <- waitCatch handle.repositoryCheckOwner
-        freeStablePtr stable
+        isRepositoryCallbackThread >>= \case
+            True -> pure ()
+            False -> do
+                let stable =
+                        castPtrToStablePtr pointer
+                            :: StablePtr RepositoryCheckHandle
+                handle <- deRefStablePtr stable
+                _ <- waitCatch handle.repositoryCheckOwner
+                freeStablePtr stable
+
+repositoryCheckDestroyReentrancySmoke :: IO Bool
+repositoryCheckDestroyReentrancySmoke = do
+    gate <- newEmptyMVar
+    owner <- asyncWithUnmask \unmask -> unmask (readMVar gate)
+    value <- newIORef Nothing
+    cancelled <- newIORef False
+    stable <- newStablePtr RepositoryCheckHandle
+        { repositoryCheckValue = value
+        , repositoryCheckCancelRequested = cancelled
+        , repositoryCheckOwner = owner
+        }
+    let pointer = castStablePtrToPtr stable
+    result <- tryAny
+        (withRepositoryCallbackThread
+            (ha_repository_check_destroy pointer))
+    putMVar gate ()
+    ha_repository_check_destroy pointer
+    pure (isRight result)
 
 copyRepositoryCheckArguments
     :: Ptr () -> CSize -> IO (Either () [Text])

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -5,6 +5,7 @@ module Agent.CLI.MacOS.Bridge
     , repositoryCancelClassificationSmoke
     , repositoryCancelAllReentrancySmoke
     , repositoryCheckDestroyReentrancySmoke
+    , repositoryTerminalThrowSmoke
     ) where
 
 import qualified Agent.CLI.AgentViewport as Viewport
@@ -177,6 +178,7 @@ import Control.Exception.Safe
     , isAsyncException
     , mask
     , throwIO
+    , throwString
     , tryAny
     , uninterruptibleMask_
     )
@@ -690,17 +692,20 @@ ha_repository_snapshot pathBytes pathLength snapshotCallback fileCallback
             Left _ -> pure 2
             Right path -> do
                 started <- startRepositoryWorker
-                    (emitRepositoryCancelled resultCallback context) $
+                    (emitRepositoryCancelled resultCallback context) do
                     tryRepositorySynchronous
                         (RepositoryReview.repositorySnapshot (Text.unpack path))
                         >>= \case
                             Left exception ->
-                                emitRepositoryFailure
-                                    resultCallback
-                                    context
-                                    (Text.pack (show exception))
+                                pure
+                                    (emitRepositoryFailure
+                                        resultCallback
+                                        context
+                                        (Text.pack (show exception)))
                             Right (Left err) ->
-                                emitRepositoryError resultCallback context err
+                                pure
+                                    (emitRepositoryError
+                                        resultCallback context err)
                             Right (Right snapshot) -> do
                                 streamed <- tryRepositorySynchronous do
                                     withRepositorySnapshot snapshot $
@@ -728,15 +733,17 @@ ha_repository_snapshot pathBytes pathLength snapshotCallback fileCallback
                                                             file.repositoryFileWorktreeStatus))
                                 case streamed of
                                     Left exception ->
-                                        emitRepositoryFailure
-                                            resultCallback
-                                            context
-                                            (Text.pack (show exception))
+                                        pure
+                                            (emitRepositoryFailure
+                                                resultCallback
+                                                context
+                                                (Text.pack (show exception)))
                                     Right () ->
-                                        emitRepositorySuccess
-                                            resultCallback
-                                            context
-                                            snapshot.snapshotId
+                                        pure
+                                            (emitRepositorySuccess
+                                                resultCallback
+                                                context
+                                                snapshot.snapshotId)
                 pure (if started then 0 else 3)
 
 ha_repository_diff
@@ -762,7 +769,7 @@ ha_repository_diff pathBytes pathLength snapshotBytes snapshotLength
                         Nothing -> pure 2
                         Just kind -> do
                             started <- startRepositoryWorker
-                                (emitRepositoryCancelled resultCallback context) $
+                                (emitRepositoryCancelled resultCallback context) do
                                 tryRepositorySynchronous
                                     (RepositoryReview.repositoryDiff
                                         (Text.unpack path)
@@ -771,13 +778,15 @@ ha_repository_diff pathBytes pathLength snapshotBytes snapshotLength
                                         (Text.unpack file))
                                     >>= \case
                                         Left exception ->
-                                            emitRepositoryFailure
-                                                resultCallback
-                                                context
-                                                (Text.pack (show exception))
+                                            pure
+                                                (emitRepositoryFailure
+                                                    resultCallback
+                                                    context
+                                                    (Text.pack (show exception)))
                                         Right (Left err) ->
-                                            emitRepositoryError
-                                                resultCallback context err
+                                            pure
+                                                (emitRepositoryError
+                                                    resultCallback context err)
                                         Right (Right diff) -> do
                                             streamed <- tryRepositorySynchronous do
                                                 forM_
@@ -814,16 +823,18 @@ ha_repository_diff pathBytes pathLength snapshotBytes snapshotLength
                                                                         headerLength
                                             case streamed of
                                                 Left exception ->
-                                                    emitRepositoryFailure
-                                                        resultCallback
-                                                        context
-                                                        (Text.pack
-                                                            (show exception))
+                                                    pure
+                                                        (emitRepositoryFailure
+                                                            resultCallback
+                                                            context
+                                                            (Text.pack
+                                                                (show exception)))
                                                 Right () ->
-                                                    emitRepositorySuccess
-                                                        resultCallback
-                                                        context
-                                                        expected
+                                                    pure
+                                                        (emitRepositorySuccess
+                                                            resultCallback
+                                                            context
+                                                            expected)
                             pure (if started then 0 else 3)
                 Right _ -> pure 3
 
@@ -860,6 +871,8 @@ ha_repository_apply_hunks pathBytes pathLength snapshotBytes snapshotLength
     | callback == nullFunPtr = pure 1
     | hunkIndices == nullPtr || hunkCount == 0 = pure 2
     | hunkCount > 4096 = pure 2
+    | fromIntegral hunkCount
+        > (maxBound :: Int) `div` sizeOf (undefined :: CSize) = pure 2
     | otherwise =
         copyRequiredTexts
             [ (pathBytes, pathLength)
@@ -869,21 +882,31 @@ ha_repository_apply_hunks pathBytes pathLength snapshotBytes snapshotLength
             >>= \case
                 Left _ -> pure 2
                 Right [path, expected, file] -> do
-                    indices <- mapM
+                    rawIndices <- mapM
                         (\index ->
-                            fromIntegral
-                                <$> (peekByteOff
+                            (peekByteOff
                                     hunkIndices
                                     (index * sizeOf (undefined :: CSize))
                                     :: IO CSize))
                         [0 .. fromIntegral hunkCount - 1]
-                    case repositoryHunkMutation
-                        operation (Text.unpack file) indices of
-                        Nothing -> pure 2
-                        Just mutation -> do
-                            started <- startRepositoryMutation
-                                callback context (Text.unpack path) expected mutation
-                            pure (if started then 0 else 3)
+                    if any
+                        ((> toInteger (maxBound :: Int)) . toInteger)
+                        rawIndices
+                        then pure 2
+                        else
+                            case repositoryHunkMutation
+                                operation
+                                (Text.unpack file)
+                                (map fromIntegral rawIndices) of
+                                    Nothing -> pure 2
+                                    Just mutation -> do
+                                        started <- startRepositoryMutation
+                                            callback
+                                            context
+                                            (Text.unpack path)
+                                            expected
+                                            mutation
+                                        pure (if started then 0 else 3)
                 Right _ -> pure 3
 
 ha_repository_commit
@@ -902,20 +925,11 @@ ha_repository_commit pathBytes pathLength snapshotBytes snapshotLength
                 Right [path, expected, message] -> do
                     started <- startRepositoryWorker
                         (emitRepositoryCancelled callback context) $
-                        tryRepositorySynchronous
+                        prepareRepositoryResult callback context $
                             (RepositoryReview.commitRepository
                                 (Text.unpack path)
                                 expected
                                 message)
-                            >>= \case
-                                Left exception ->
-                                    emitRepositoryFailure
-                                        callback context (Text.pack (show exception))
-                                Right (Left err) ->
-                                    emitRepositoryError callback context err
-                                Right (Right snapshot) ->
-                                    emitRepositorySuccess
-                                        callback context snapshot.snapshotId
                     pure (if started then 0 else 3)
                 Right _ -> pure 3
 
@@ -928,19 +942,32 @@ startRepositoryMutation
     -> IO Bool
 startRepositoryMutation callback context path expected mutation =
     startRepositoryWorker (emitRepositoryCancelled callback context) $
-        tryRepositorySynchronous
+        prepareRepositoryResult callback context $
             (RepositoryReview.mutateRepository path expected mutation)
-            >>= \case
-                Left exception ->
-                    emitRepositoryFailure callback context
-                        (Text.pack (show exception))
-                Right (Left err) ->
-                    emitRepositoryError callback context err
-                Right (Right snapshot) ->
-                    emitRepositorySuccess callback context snapshot.snapshotId
 
-startRepositoryWorker :: IO () -> IO () -> IO Bool
-startRepositoryWorker onCancelled action =
+prepareRepositoryResult
+    :: FunPtr RepositoryResultCallback
+    -> Ptr ()
+    -> IO
+        (Either
+            RepositoryReview.RepositoryError
+            RepositoryReview.RepositorySnapshot)
+    -> IO (IO ())
+prepareRepositoryResult callback context action =
+    tryRepositorySynchronous action >>= \case
+        Left exception ->
+            pure
+                (emitRepositoryFailure callback context
+                    (Text.pack (show exception)))
+        Right (Left err) ->
+            pure (emitRepositoryError callback context err)
+        Right (Right snapshot) ->
+            pure
+                (emitRepositorySuccess
+                    callback context snapshot.snapshotId)
+
+startRepositoryWorker :: IO () -> IO (IO ()) -> IO Bool
+startRepositoryWorker onCancelled prepare =
     tryRepositorySynchronous
         (mask \_ -> do
             gate <- newEmptyMVar
@@ -951,10 +978,11 @@ startRepositoryWorker onCancelled action =
                         let workerId = state.repositoryWorkerNextId
                         worker <- asyncWithUnmask \unmask -> do
                             withRepositoryCallbackThread
-                                (((readMVar gate >> unmask action)
+                                (((Just <$> (readMVar gate >> unmask prepare))
                                     `catchAsync`
                                         \(_ :: SomeAsyncException) ->
-                                            onCancelled))
+                                            onCancelled >> pure Nothing)
+                                    >>= mapM_ id)
                                 `finally`
                                 unregisterRepositoryWorker workerId
                         pure
@@ -1029,6 +1057,7 @@ repositoryCancelAllAdmissionSmoke = do
     firstAccepted <- startRepositoryWorker (putMVar cancelled ()) do
         putMVar entered ()
         uninterruptibleMask_ (threadDelay 250_000)
+        pure (pure ())
     if not firstAccepted
         then pure False
         else do
@@ -1040,7 +1069,7 @@ repositoryCancelAllAdmissionSmoke = do
                 completed <- newEmptyMVar
                 acceptedAfter <- startRepositoryWorker
                     (pure ())
-                    (putMVar completed ())
+                    (pure (putMVar completed ()))
                 finishedAfter <- if acceptedAfter
                     then readMVar completed >> pure True
                     else pure False
@@ -1053,7 +1082,7 @@ repositoryCancelAllAdmissionSmoke = do
     awaitRejection attempts
         | attempts <= (0 :: Int) = pure False
         | otherwise =
-            startRepositoryWorker (pure ()) (pure ()) >>= \case
+            startRepositoryWorker (pure ()) (pure (pure ())) >>= \case
                 False -> pure True
                 True -> threadDelay 1000 >> awaitRejection (attempts - 1)
 
@@ -1061,8 +1090,9 @@ repositoryCancelAllReentrancySmoke :: IO Bool
 repositoryCancelAllReentrancySmoke = do
     completed <- newEmptyMVar
     accepted <- startRepositoryWorker (pure ()) do
-        ha_repository_cancel_all
-        putMVar completed ()
+        pure do
+            ha_repository_cancel_all
+            putMVar completed ()
     if accepted
         then readMVar completed >> pure True
         else pure False
@@ -1077,6 +1107,7 @@ repositoryCancelClassificationSmoke = do
         tryRepositorySynchronous (threadDelay 30_000_000) >>= \case
             Left _ -> putMVar synthesizedFailure ()
             Right () -> pure ()
+        pure (pure ())
     if not accepted
         then pure False
         else do
@@ -1085,6 +1116,24 @@ repositoryCancelClassificationSmoke = do
             cancellation <- tryReadMVar cancelled
             failure <- tryReadMVar synthesizedFailure
             pure (isJust cancellation && isNothing failure)
+
+repositoryTerminalThrowSmoke :: IO Bool
+repositoryTerminalThrowSmoke = do
+    cancelled <- newEmptyMVar
+    terminal <- newEmptyMVar
+    finished <- newEmptyMVar
+    accepted <- startRepositoryWorker (putMVar cancelled ()) do
+        pure
+            ((putMVar terminal () >> throwString "terminal callback failed")
+                `finally` putMVar finished ())
+    if not accepted
+        then pure False
+        else do
+            readMVar terminal
+            readMVar finished
+            ha_repository_cancel_all
+            cancellation <- tryReadMVar cancelled
+            pure (isNothing cancellation)
 
 {-# NOINLINE repositoryWorkers #-}
 repositoryWorkers :: MVar RepositoryWorkerState
@@ -1406,6 +1455,8 @@ copyRequiredText :: Ptr Word8 -> CSize -> IO (Either () Text)
 copyRequiredText pointer (CSize length)
     | pointer == nullPtr || length == 0 = pure (Left ())
     | toInteger length > toInteger (maxBound :: Int) = pure (Left ())
+    | toInteger length > toInteger maxRepositoryRequestItemBytes =
+        pure (Left ())
     | otherwise = do
         bytes <- BS.packCStringLen (castPtr pointer, fromIntegral length)
         pure (first (const ()) (TextEncoding.decodeUtf8' bytes))
@@ -1413,7 +1464,17 @@ copyRequiredText pointer (CSize length)
 copyRequiredTexts
     :: [(Ptr Word8, CSize)]
     -> IO (Either () [Text])
-copyRequiredTexts = fmap sequence . mapM (uncurry copyRequiredText)
+copyRequiredTexts fields
+    | sum (map (toInteger . snd) fields)
+        > toInteger maxRepositoryRequestTotalBytes = pure (Left ())
+    | otherwise =
+        fmap sequence (mapM (uncurry copyRequiredText) fields)
+
+maxRepositoryRequestItemBytes :: Int
+maxRepositoryRequestItemBytes = 8 * 1024 * 1024
+
+maxRepositoryRequestTotalBytes :: Int
+maxRepositoryRequestTotalBytes = 16 * 1024 * 1024
 
 byteStringChunks :: Int -> BS.ByteString -> [BS.ByteString]
 byteStringChunks size bytes

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -495,6 +495,13 @@ ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLe
     userBytes (CSize userLength) authIdBytes (CSize authIdLength)
     deviceBytes (CSize deviceLength) pollInterval expires callback context
     | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull
+        [ (providerBytes, providerLength)
+        , (urlBytes, urlLength)
+        , (userBytes, userLength)
+        , (authIdBytes, authIdLength)
+        , (deviceBytes, deviceLength)
+        ] = pure 2
     | otherwise = do
         provider <- decodeInput providerBytes providerLength
         url <- decodeInput urlBytes urlLength
@@ -518,6 +525,8 @@ ha_account_api_key_connect
     -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
 ha_account_api_key_connect providerBytes (CSize providerLength) keyBytes (CSize keyLength) callback context
     | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull
+        [ (providerBytes, providerLength), (keyBytes, keyLength) ] = pure 2
     | otherwise = do
         provider <- decodeInput providerBytes providerLength
         key <- decodeInput keyBytes keyLength
@@ -531,6 +540,7 @@ ha_account_set_enabled
     :: Ptr Word8 -> CSize -> CInt -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
 ha_account_set_enabled idBytes (CSize idLength) enabled callback context
     | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull [(idBytes, idLength)] = pure 2
     | otherwise = do
         managedId <- decodeInput idBytes idLength
         _ <- forkIO do
@@ -542,12 +552,17 @@ ha_account_delete
     :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
 ha_account_delete idBytes (CSize idLength) callback context
     | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull [(idBytes, idLength)] = pure 2
     | otherwise = do
         managedId <- decodeInput idBytes idLength
         _ <- forkIO do
             deleteManagedCredential managedId
                 >>= invokeStoreResult callback context
         pure 0
+
+anyNonEmptyNull :: [(Ptr Word8, Word64)] -> Bool
+anyNonEmptyNull = any \(pointer, length) ->
+    pointer == nullPtr && length > 0
 
 withAccountStrings :: LoginAccount -> (CString -> CSize -> CString -> CSize
     -> CString -> CSize -> CString -> CSize -> CString -> CSize

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -2,6 +2,7 @@
 
 module Agent.CLI.MacOS.Bridge
     ( repositoryCancelAllAdmissionSmoke
+    , repositoryCancelClassificationSmoke
     , repositoryCancelAllReentrancySmoke
     , repositoryCheckDestroyReentrancySmoke
     ) where
@@ -146,6 +147,7 @@ import Control.Concurrent.MVar
     , newMVar
     , putMVar
     , readMVar
+    , tryReadMVar
     )
 import Control.Concurrent.STM
     ( TMVar
@@ -172,7 +174,9 @@ import Control.Exception.Safe
     , bracket
     , catchAsync
     , finally
+    , isAsyncException
     , mask
+    , throwIO
     , tryAny
     , uninterruptibleMask_
     )
@@ -202,7 +206,7 @@ import Data.Int (Int64)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -687,7 +691,7 @@ ha_repository_snapshot pathBytes pathLength snapshotCallback fileCallback
             Right path -> do
                 started <- startRepositoryWorker
                     (emitRepositoryCancelled resultCallback context) $
-                    tryAny
+                    tryRepositorySynchronous
                         (RepositoryReview.repositorySnapshot (Text.unpack path))
                         >>= \case
                             Left exception ->
@@ -698,7 +702,7 @@ ha_repository_snapshot pathBytes pathLength snapshotCallback fileCallback
                             Right (Left err) ->
                                 emitRepositoryError resultCallback context err
                             Right (Right snapshot) -> do
-                                streamed <- tryAny do
+                                streamed <- tryRepositorySynchronous do
                                     withRepositorySnapshot snapshot $
                                         invokeRepositorySnapshotCallback
                                             snapshotCallback
@@ -759,7 +763,7 @@ ha_repository_diff pathBytes pathLength snapshotBytes snapshotLength
                         Just kind -> do
                             started <- startRepositoryWorker
                                 (emitRepositoryCancelled resultCallback context) $
-                                tryAny
+                                tryRepositorySynchronous
                                     (RepositoryReview.repositoryDiff
                                         (Text.unpack path)
                                         expected
@@ -775,7 +779,7 @@ ha_repository_diff pathBytes pathLength snapshotBytes snapshotLength
                                             emitRepositoryError
                                                 resultCallback context err
                                         Right (Right diff) -> do
-                                            streamed <- tryAny do
+                                            streamed <- tryRepositorySynchronous do
                                                 forM_
                                                     (byteStringChunks
                                                         (64 * 1024)
@@ -898,7 +902,7 @@ ha_repository_commit pathBytes pathLength snapshotBytes snapshotLength
                 Right [path, expected, message] -> do
                     started <- startRepositoryWorker
                         (emitRepositoryCancelled callback context) $
-                        tryAny
+                        tryRepositorySynchronous
                             (RepositoryReview.commitRepository
                                 (Text.unpack path)
                                 expected
@@ -924,7 +928,8 @@ startRepositoryMutation
     -> IO Bool
 startRepositoryMutation callback context path expected mutation =
     startRepositoryWorker (emitRepositoryCancelled callback context) $
-        tryAny (RepositoryReview.mutateRepository path expected mutation)
+        tryRepositorySynchronous
+            (RepositoryReview.mutateRepository path expected mutation)
             >>= \case
                 Left exception ->
                     emitRepositoryFailure callback context
@@ -936,7 +941,7 @@ startRepositoryMutation callback context path expected mutation =
 
 startRepositoryWorker :: IO () -> IO () -> IO Bool
 startRepositoryWorker onCancelled action =
-    tryAny
+    tryRepositorySynchronous
         (mask \_ -> do
             gate <- newEmptyMVar
             admitted <- modifyMVar repositoryWorkers \state ->
@@ -1062,6 +1067,25 @@ repositoryCancelAllReentrancySmoke = do
         then readMVar completed >> pure True
         else pure False
 
+repositoryCancelClassificationSmoke :: IO Bool
+repositoryCancelClassificationSmoke = do
+    entered <- newEmptyMVar
+    cancelled <- newEmptyMVar
+    synthesizedFailure <- newEmptyMVar
+    accepted <- startRepositoryWorker (putMVar cancelled ()) do
+        putMVar entered ()
+        tryRepositorySynchronous (threadDelay 30_000_000) >>= \case
+            Left _ -> putMVar synthesizedFailure ()
+            Right () -> pure ()
+    if not accepted
+        then pure False
+        else do
+            readMVar entered
+            ha_repository_cancel_all
+            cancellation <- tryReadMVar cancelled
+            failure <- tryReadMVar synthesizedFailure
+            pure (isJust cancellation && isNothing failure)
+
 {-# NOINLINE repositoryWorkers #-}
 repositoryWorkers :: MVar RepositoryWorkerState
 repositoryWorkers = unsafePerformIO
@@ -1094,6 +1118,16 @@ isRepositoryCallbackThread :: IO Bool
 isRepositoryCallbackThread = do
     thread <- myThreadId
     Set.member thread <$> readMVar repositoryCallbackThreads
+
+tryRepositorySynchronous
+    :: IO value
+    -> IO (Either SomeException value)
+tryRepositorySynchronous action =
+    tryAny action >>= \case
+        Left exception
+            | isAsyncException exception -> throwIO exception
+            | otherwise -> pure (Left exception)
+        Right value -> pure (Right value)
 
 data RepositoryCheckHandle = RepositoryCheckHandle
     { repositoryCheckValue :: !(IORef (Maybe RepositoryReview.RepositoryCheck))
@@ -1133,7 +1167,7 @@ ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
                             gate <- newEmptyMVar
                             owner <- asyncWithUnmask \unmask ->
                                 readMVar gate >> unmask do
-                                    started <- tryAny
+                                    started <- tryRepositorySynchronous
                                         (RepositoryReview.startRepositoryCheck
                                             (Text.unpack path)
                                             expected

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -14,6 +14,26 @@ import Agent.CLI.NativeRuntime
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     )
+import Agent.CLI.Environment (lookupNonEmpty)
+import Agent.CLI.Login
+    ( storeConnectedCredential )
+import Agent.CLI.CredentialStore
+    ( ManagedAuthKind(..)
+    , deleteManagedCredential
+    , setManagedCredentialEnabled
+    )
+import Agent.CLI.Auth
+    ( GrokAuthState(..)
+    , grokAuthStateToJson
+    , openAIOAuthClientId
+    , openaiAuthStateFromJson
+    , xaiOAuthClientId
+    )
+import qualified Agent.OpenAI.Login as OpenAILogin
+import qualified Agent.OpenAI.Auth as OpenAIAuth
+import qualified Agent.OpenAI.Auth.Types as OpenAIAuthTypes
+import qualified Agent.XAI.Auth as XAIAuth
+import qualified Agent.OpenRouter.Usage as OpenRouter
 import Agent.CLI.ModelConfig (loadModelCatalogAt)
 import Agent.CLI.Models
     ( ModelOption(..)
@@ -53,7 +73,7 @@ import Agent.CLI.SessionAdmin
     )
 import Agent.Loop (LoopEvent(..))
 import Agent.Dialect (dialectSlug)
-import Agent.Provider (Provider(..), providerSlug)
+import Agent.Provider (Provider(..), providerSlug, parseProvider, BillingMode(..))
 import Agent.Store.Postgres
     ( ManagedPostgresConfig
     , Store
@@ -298,6 +318,65 @@ instance Aeson.FromJSON ModelsListRequest where
         ModelsListRequest
             <$> object .: "cwd"
             <*> object .:? "sessionId"
+
+data AccountProviderRequest = AccountProviderRequest
+    { accountProvider :: !Text
+    }
+
+instance Aeson.FromJSON AccountProviderRequest where
+    parseJSON = Aeson.withObject "AccountProviderRequest" \object ->
+        AccountProviderRequest <$> object .: "provider"
+
+data AccountOAuthPollRequest = AccountOAuthPollRequest
+    { oauthPollProvider :: !Text
+    , oauthPollVerificationUrl :: !(Maybe Text)
+    , oauthPollUserCode :: !(Maybe Text)
+    , oauthPollDeviceAuthId :: !(Maybe Text)
+    , oauthPollDeviceCode :: !(Maybe Text)
+    , oauthPollIntervalSeconds :: !(Maybe Int)
+    , oauthPollExpiresInSeconds :: !(Maybe Int)
+    }
+
+instance Aeson.FromJSON AccountOAuthPollRequest where
+    parseJSON = Aeson.withObject "AccountOAuthPollRequest" \object ->
+        AccountOAuthPollRequest
+            <$> object .: "provider"
+            <*> object .:? "verificationUrl"
+            <*> object .:? "userCode"
+            <*> object .:? "deviceAuthId"
+            <*> object .:? "deviceCode"
+            <*> object .:? "pollIntervalSeconds"
+            <*> object .:? "expiresInSeconds"
+
+data AccountAPIKeyRequest = AccountAPIKeyRequest
+    { accountAPIKeyProvider :: !Text
+    , accountAPIKey :: !Text
+    }
+
+instance Aeson.FromJSON AccountAPIKeyRequest where
+    parseJSON = Aeson.withObject "AccountAPIKeyRequest" \object ->
+        AccountAPIKeyRequest
+            <$> object .: "provider"
+            <*> object .: "apiKey"
+
+data AccountEnabledRequest = AccountEnabledRequest
+    { accountEnabledManagedId :: !Text
+    , accountEnabledEnabled :: !Bool
+    }
+
+instance Aeson.FromJSON AccountEnabledRequest where
+    parseJSON = Aeson.withObject "AccountEnabledRequest" \object ->
+        AccountEnabledRequest
+            <$> object .: "managedID"
+            <*> object .: "enabled"
+
+data AccountDeleteRequest = AccountDeleteRequest
+    { accountDeleteManagedId :: !Text
+    }
+
+instance Aeson.FromJSON AccountDeleteRequest where
+    parseJSON = Aeson.withObject "AccountDeleteRequest" \object ->
+        AccountDeleteRequest <$> object .: "managedID"
 
 data EngineCommand
     = EngineRequest !BridgeRequest
@@ -951,6 +1030,48 @@ handleRequest config store root request = do
                 accounts <- cachedAccountSummaries activeStore
                 pure $ successEvent current.requestId
                     accounts
+            "accounts.oauth.start" ->
+                case (parseParams current :: Either Text AccountProviderRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request ->
+                        startAccountOAuth request >>= either
+                            (pure . failureEvent current.requestId)
+                            (pure . successEvent current.requestId)
+            "accounts.oauth.poll" ->
+                case (parseParams current :: Either Text AccountOAuthPollRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request ->
+                        pollAccountOAuth request >>= either
+                            (pure . failureEvent current.requestId)
+                            (pure . successEvent current.requestId)
+            "accounts.apiKey.connect" ->
+                case (parseParams current :: Either Text AccountAPIKeyRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request ->
+                        connectAccountAPIKey request >>= either
+                            (pure . failureEvent current.requestId)
+                            (pure . successEvent current.requestId)
+            "accounts.setEnabled" ->
+                case (parseParams current :: Either Text AccountEnabledRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request -> do
+                        result <- setManagedCredentialEnabled
+                            request.accountEnabledManagedId
+                            request.accountEnabledEnabled
+                        pure $ either
+                            (failureEvent current.requestId)
+                            (const (successEvent current.requestId True))
+                            result
+            "accounts.delete" ->
+                case (parseParams current :: Either Text AccountDeleteRequest) of
+                    Left err -> pure (failureEvent current.requestId err)
+                    Right request -> do
+                        result <- deleteManagedCredential
+                            request.accountDeleteManagedId
+                        pure $ either
+                            (failureEvent current.requestId)
+                            (const (successEvent current.requestId True))
+                            result
             "turn.agents" ->
                 pure $ successEvent current.requestId ([] :: [Aeson.Value])
             "models.list" ->
@@ -1108,6 +1229,174 @@ parseParams request =
     case Aeson.parseEither Aeson.parseJSON request.requestParams of
         Left err -> Left (Text.pack err)
         Right value -> Right value
+
+startAccountOAuth
+    :: AccountProviderRequest
+    -> IO (Either Text Aeson.Value)
+startAccountOAuth request =
+    case parseProvider request.accountProvider of
+        Just OpenAIProvider -> do
+            clientId <- openAIOAuthClientId <$> lookupNonEmpty
+                "OPENAI_OAUTH_CLIENT_ID"
+            OpenAILogin.requestDeviceCode
+                (OpenAILogin.defaultLoginOptions clientId) >>= \case
+                    Left err -> pure (Left err)
+                    Right code -> pure $ Right (Aeson.object
+                        [ "provider" Aeson..= ("openai" :: Text)
+                        , "verificationUrl" Aeson..= code.verificationUrl
+                        , "userCode" Aeson..= code.userCode
+                        , "deviceAuthId" Aeson..= code.deviceAuthId
+                        , "pollIntervalSeconds" Aeson..=
+                            code.pollIntervalSeconds
+                        ])
+        Just XAIProvider -> do
+            clientId <- xaiOAuthClientId <$> lookupNonEmpty
+                "XAI_OAUTH_CLIENT_ID"
+            XAIAuth.requestDeviceAuthorization
+                (XAIAuth.defaultOAuthOptions clientId) >>= \case
+                    Left err -> pure (Left err)
+                    Right code -> pure $ Right (Aeson.object
+                        [ "provider" Aeson..= ("xai" :: Text)
+                        , "verificationUrl" Aeson..= code.verificationUrl
+                        , "userCode" Aeson..= code.userCode
+                        , "deviceCode" Aeson..= code.deviceCode
+                        , "pollIntervalSeconds" Aeson..=
+                            code.pollIntervalSeconds
+                        , "expiresInSeconds" Aeson..=
+                            code.expiresInSeconds
+                        ])
+        _ -> pure (Left "OAuth account connection is not supported for this provider")
+
+pollAccountOAuth
+    :: AccountOAuthPollRequest
+    -> IO (Either Text Aeson.Value)
+pollAccountOAuth request =
+    case parseProvider request.oauthPollProvider of
+        Just OpenAIProvider -> case
+            (request.oauthPollVerificationUrl, request.oauthPollUserCode,
+                request.oauthPollDeviceAuthId) of
+            (Just url, Just userCode, Just authId) ->
+                do
+                    clientId <- openAIOAuthClientId <$> lookupNonEmpty
+                        "OPENAI_OAUTH_CLIENT_ID"
+                    OpenAILogin.pollDeviceCode
+                        (OpenAILogin.defaultLoginOptions clientId)
+                        OpenAILogin.DeviceCode
+                            { OpenAILogin.verificationUrl = Text.unpack url
+                            , OpenAILogin.userCode = userCode
+                            , OpenAILogin.deviceAuthId = authId
+                            , OpenAILogin.pollIntervalSeconds =
+                                fromMaybe 5 request.oauthPollIntervalSeconds
+                            } >>= \case
+                            Left err -> pure (Left err)
+                            Right Nothing -> pure $ Right
+                                (Aeson.object ["status" Aeson..= ("pending" :: Text)])
+                            Right (Just authJson) -> do
+                                now <- getCurrentTime
+                                case openaiAuthStateFromJson now
+                                    (Aeson.encode authJson) of
+                                    Nothing -> pure (Left
+                                        "OpenAI returned invalid account data")
+                                    Just auth -> do
+                                        let accountId =
+                                                case auth of
+                                                    OpenAIAuthTypes.AuthState
+                                                        _ _ value _ _ -> value
+                                        stored <- storeConnectedCredential
+                                            False OpenAIProvider
+                                                accountId
+                                            "ChatGPT" SubscriptionBilled
+                                            ManagedOpenAIAuthJson
+                                            (TextEncoding.decodeUtf8
+                                                (LBS.toStrict
+                                                    (Aeson.encode authJson)))
+                                        pure $ if stored
+                                            then Right (Aeson.object
+                                                [ "status" Aeson..=
+                                                    ("connected" :: Text)
+                                                , "accountID" Aeson..=
+                                                    auth.accountId
+                                                ])
+                                            else Left "could not store account"
+            _ -> pure (Left "OAuth challenge is missing required fields")
+        Just XAIProvider -> case
+            (request.oauthPollUserCode, request.oauthPollDeviceCode) of
+            (Just _, Just deviceCode) -> do
+                clientId <- xaiOAuthClientId <$> lookupNonEmpty
+                    "XAI_OAUTH_CLIENT_ID"
+                let challenge = XAIAuth.DeviceAuthorization
+                        { XAIAuth.deviceCode = deviceCode
+                        , XAIAuth.userCode = fromMaybe "" request.oauthPollUserCode
+                        , XAIAuth.verificationUrl =
+                            fromMaybe "" request.oauthPollVerificationUrl
+                        , XAIAuth.pollIntervalSeconds =
+                            fromMaybe 5 request.oauthPollIntervalSeconds
+                        , XAIAuth.expiresInSeconds =
+                            request.oauthPollExpiresInSeconds
+                        }
+                XAIAuth.pollDeviceAuthorization
+                    (XAIAuth.defaultOAuthOptions clientId) challenge >>= \case
+                        Left err -> pure (Left err)
+                        Right Nothing -> pure $ Right
+                            (Aeson.object ["status" Aeson..= ("pending" :: Text)])
+                        Right (Just tokens) -> do
+                            now <- getCurrentTime
+                            let accountId = fromMaybe "grok"
+                                    (XAIAuth.accountIdFromAccessToken
+                                        tokens.accessToken)
+                                label = fromMaybe "Grok" $
+                                    (tokens.idToken >>= XAIAuth.emailFromToken)
+                                    <|> XAIAuth.emailFromToken tokens.accessToken
+                                authJson = grokAuthStateToJson GrokAuthState
+                                    { grokAccessToken = tokens.accessToken
+                                    , grokRefreshToken = tokens.refreshToken
+                                    , grokIdToken = tokens.idToken
+                                    , grokExpiresAt =
+                                        ((`addUTCTime` now) . fromIntegral
+                                            <$> tokens.expiresInSeconds)
+                                    }
+                            case tokens.refreshToken of
+                                Nothing -> pure (Left
+                                    "Grok login did not return a refresh token")
+                                Just _ -> do
+                                    stored <- storeConnectedCredential
+                                        False XAIProvider accountId label
+                                        SubscriptionBilled ManagedGrokAuthJson
+                                        (TextEncoding.decodeUtf8
+                                            (LBS.toStrict
+                                                (Aeson.encode authJson)))
+                                    pure $ if stored
+                                        then Right (Aeson.object
+                                            [ "status" Aeson..=
+                                                ("connected" :: Text)
+                                            , "accountID" Aeson..= accountId
+                                            ])
+                                        else Left "could not store account"
+            _ -> pure (Left "OAuth challenge is missing required fields")
+        _ -> pure (Left "OAuth account connection is not supported for this provider")
+
+connectAccountAPIKey
+    :: AccountAPIKeyRequest
+    -> IO (Either Text Aeson.Value)
+connectAccountAPIKey request =
+    case parseProvider request.accountAPIKeyProvider of
+        Just OpenRouterProvider
+            | not (Text.null (Text.strip request.accountAPIKey)) ->
+                OpenRouter.fetchOpenRouterUsage request.accountAPIKey >>= \case
+                    Left err -> pure (Left ("OpenRouter rejected the key: " <> err))
+                    Right usage -> do
+                        let accountId = fromMaybe "openrouter" usage.keyLabel
+                            label = fromMaybe "OpenRouter" usage.keyLabel
+                        stored <- storeConnectedCredential
+                            False OpenRouterProvider accountId label ApiBilled
+                            ManagedBearerToken request.accountAPIKey
+                        pure $ if stored
+                            then Right (Aeson.object
+                                [ "status" Aeson..= ("connected" :: Text)
+                                , "accountID" Aeson..= accountId
+                                ])
+                            else Left "could not store account"
+        _ -> pure (Left "API-key connections are supported for OpenRouter")
 
 acquireStore :: ManagedPostgresConfig -> MVar (Maybe Store) -> IO Store
 acquireStore config state =

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -10,6 +10,10 @@ import Agent.CLI.NativeRuntime
     , newNativeProcessRuntime
     , runNativeAgent
     )
+import Agent.Store.Postgres.Session
+    ( NativeConversationSearchResult(..)
+    , searchNativeConversations
+    )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     )
@@ -152,7 +156,8 @@ import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
-import Data.Time.Clock (addUTCTime, getCurrentTime)
+import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Word (Word8, Word64)
 import Foreign
     ( FunPtr
@@ -168,7 +173,7 @@ import Foreign
     , nullPtr
     )
 import Foreign.C.String (CString)
-import Foreign.C.Types (CInt(..), CSize(..))
+import Foreign.C.Types (CDouble(..), CInt(..), CSize(..))
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
     ( IOMode(WriteMode)
@@ -214,6 +219,23 @@ type AccountOAuthStartCallback =
     -> CString -> CSize -> CString -> CSize -> CInt -> CInt
     -> CString -> CSize -> IO ()
 
+-- Status is 0 for a result, 1 for completion, and -1 for failure. Every
+-- pointer is callback-scoped UTF-8. A turn index of -1 denotes a metadata hit;
+-- role is 0 (metadata), 1 (user), or 2 (assistant).
+type SearchCallback =
+    Ptr () -> CInt
+    -> Ptr Word8 -> CSize -- session id
+    -> Ptr Word8 -> CSize -- title
+    -> Ptr Word8 -> CSize -- cwd
+    -> Ptr Word8 -> CSize -- provider
+    -> Ptr Word8 -> CSize -- model
+    -> Int64 -> CInt -> Int64 -> Int64 -> CInt
+    -> Ptr Word8 -> CSize -- user
+    -> Ptr Word8 -> CSize -- assistant
+    -> CDouble
+    -> Ptr Word8 -> CSize -- error
+    -> IO ()
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -228,6 +250,9 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeAccountOAuthStartCallback
         :: FunPtr AccountOAuthStartCallback -> AccountOAuthStartCallback
+
+foreign import ccall "dynamic"
+    invokeSearchCallback :: FunPtr SearchCallback -> SearchCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -383,6 +408,7 @@ data AccountAPIKeyRequest = AccountAPIKeyRequest
 
 data EngineCommand
     = EngineRequest !BridgeRequest
+    | EngineSearch !Text !Int !(FunPtr SearchCallback) !(Ptr ())
     | EngineStop
 
 data Engine = Engine
@@ -657,6 +683,10 @@ invokeExceptionResult callback context exception =
         invokeAccountResultCallback callback context (-1)
             nullPtr 0 errorPtr errorLength
 
+foreign export ccall ha_engine_search_conversations
+    :: Ptr () -> Ptr Word8 -> CSize -> CSize
+    -> FunPtr SearchCallback -> Ptr () -> IO CInt
+
 ha_engine_create :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
 ha_engine_create callback context
     | callback == nullFunPtr = pure nullPtr
@@ -710,6 +740,33 @@ ha_engine_send_json pointer bytes (CSize length)
             Right False -> 4
             Right True -> 0
 
+ha_engine_search_conversations
+    :: Ptr () -> Ptr Word8 -> CSize -> CSize
+    -> FunPtr SearchCallback -> Ptr () -> IO CInt
+ha_engine_search_conversations pointer bytes (CSize length) rawLimit callback context
+    | pointer == nullPtr = pure 1
+    | callback == nullFunPtr = pure 2
+    | bytes == nullPtr || length == 0 = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            payload <- BS.packCStringLen (castPtr bytes, fromIntegral length)
+            case TextEncoding.decodeUtf8' payload of
+                Left _ -> pure False
+                Right query
+                    | Text.null (Text.strip query) -> pure False
+                    | otherwise -> do
+                        let requested = fromIntegral rawLimit :: Integer
+                            limit = fromInteger (max 1 (min 100 requested))
+                        atomically $ writeTQueue engine.engineCommands
+                            (EngineSearch query limit callback context)
+                        pure True
+        pure $ case accepted of
+            Left _ -> 3
+            Right False -> 2
+            Right True -> 0
+
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer
     | pointer == nullPtr = pure ()
@@ -756,6 +813,10 @@ idleLoop
 idleLoop callback context config store root processRuntime commands =
     atomically (readTQueue commands) >>= \case
         EngineStop -> pure ()
+        EngineSearch query limit searchCallback searchContext -> do
+            runConversationSearch
+                config store query limit searchCallback searchContext
+            continue
         EngineRequest request
             | request.requestMethod == "turn.start" ->
                 case (parseParams request
@@ -833,6 +894,11 @@ activeLoop callback context config store root commands control running =
             cancelTurn control
             cancel running
             pure ActiveStop
+        Left (EngineSearch query limit searchCallback searchContext) -> do
+            runConversationSearch
+                config store query limit searchCallback searchContext
+            activeLoop
+                callback context config store root commands control running
         Left (EngineRequest request) -> do
             if request.requestMethod == "turn.cancel"
               then
@@ -870,6 +936,90 @@ activeLoop callback context config store root commands control running =
                 commands
                 control
                 running
+
+runConversationSearch
+    :: ManagedPostgresConfig
+    -> MVar (Maybe Store)
+    -> Text
+    -> Int
+    -> FunPtr SearchCallback
+    -> Ptr ()
+    -> IO ()
+runConversationSearch config store query limit callback context = do
+    outcome <- tryAny do
+        activeStore <- acquireStore config store
+        searchNativeConversations (trustedPool activeStore) query limit
+    case outcome of
+        Left exception ->
+            sendSearchFailure callback context (Text.pack (show exception))
+        Right (Left err) ->
+            sendSearchFailure callback context (renderStoreError err)
+        Right (Right results) -> do
+            forM_ results (sendSearchResult callback context)
+            invokeSearchCallback callback context
+                1 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                0 0 (-1) 0 0 nullPtr 0 nullPtr 0 0 nullPtr 0
+
+sendSearchFailure :: FunPtr SearchCallback -> Ptr () -> Text -> IO ()
+sendSearchFailure callback context message =
+    withTextBytes message \errorPointer errorLength ->
+        invokeSearchCallback callback context
+            (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            0 0 (-1) 0 0 nullPtr 0 nullPtr 0 0
+            errorPointer errorLength
+
+sendSearchResult
+    :: FunPtr SearchCallback
+    -> Ptr ()
+    -> NativeConversationSearchResult
+    -> IO ()
+sendSearchResult callback context result =
+    withTextBytes result.nativeSearchSessionId \sessionPointer sessionLength ->
+    withTextBytes result.nativeSearchTitle \titlePointer titleLength ->
+    withTextBytes result.nativeSearchCwd \cwdPointer cwdLength ->
+    withTextBytes result.nativeSearchProvider \providerPointer providerLength ->
+    withTextBytes result.nativeSearchModel \modelPointer modelLength ->
+    withMaybeTextBytes result.nativeSearchUserText \userPointer userLength ->
+    withMaybeTextBytes result.nativeSearchAssistantText
+        \assistantPointer assistantLength ->
+            invokeSearchCallback callback context
+                0
+                sessionPointer sessionLength
+                titlePointer titleLength
+                cwdPointer cwdLength
+                providerPointer providerLength
+                modelPointer modelLength
+                (epochMilliseconds result.nativeSearchUpdatedAt)
+                (if result.nativeSearchArchived then 1 else 0)
+                (fromMaybe (-1) result.nativeSearchTurnIndex)
+                (maybe 0 epochMilliseconds result.nativeSearchOccurredAt)
+                (searchRoleCode result.nativeSearchRole)
+                userPointer userLength
+                assistantPointer assistantLength
+                (realToFrac result.nativeSearchRank)
+                nullPtr 0
+
+withTextBytes :: Text -> (Ptr Word8 -> CSize -> IO a) -> IO a
+withTextBytes value action =
+    BS.useAsCStringLen (TextEncoding.encodeUtf8 value) \(pointer, length) ->
+        action (castPtr pointer) (fromIntegral length)
+
+withMaybeTextBytes
+    :: Maybe Text
+    -> (Ptr Word8 -> CSize -> IO a)
+    -> IO a
+withMaybeTextBytes Nothing action = action nullPtr 0
+withMaybeTextBytes (Just value) action = withTextBytes value action
+
+epochMilliseconds :: UTCTime -> Int64
+epochMilliseconds =
+    floor . (* 1000) . utcTimeToPOSIXSeconds
+
+searchRoleCode :: Maybe Text -> CInt
+searchRoleCode = \case
+    Just "user" -> 1
+    Just "assistant" -> 2
+    _ -> 0
 
 runNativeTurn
     :: FunPtr EventCallback

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -22,6 +22,11 @@ import Agent.Store.Postgres.Skill
     , learnedSkillStatusText
     , listAllLearnedSkills
     )
+import Agent.CLI.ManagedTurn
+    ( ManagedTurnMedia(..)
+    , managedTurnRequestWithImages
+    , renderManagedTurnPrompt
+    )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     )
@@ -94,7 +99,7 @@ import Agent.CLI.SessionAdmin
     , managedPostgresConfigForHome
     , sessionSummaryWithStatusJSON
     )
-import Agent.Loop (LoopEvent(..))
+import Agent.Loop (ImageAttachment(..), LoopEvent(..))
 import Agent.Dialect (dialectSlug)
 import Agent.Provider (Provider(..), providerSlug, parseProvider, BillingMode(..))
 import Agent.Store.Postgres
@@ -189,12 +194,21 @@ import Foreign
     , newStablePtr
     , nullFunPtr
     , nullPtr
+    , plusPtr
+    , peekByteOff
+    , sizeOf
     )
 import Foreign.C.String (CString)
 import Foreign.C.Types (CDouble(..), CInt(..), CLLong(..), CSize(..))
+import System.Directory
+    ( getTemporaryDirectory
+    , removeFile
+    )
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
     ( IOMode(WriteMode)
+    , hClose
+    , openBinaryTempFile
     , withFile
     )
 import System.OsPath
@@ -452,6 +466,7 @@ data EngineCommand
 data Engine = Engine
     { engineCommands :: !(TQueue EngineCommand)
     , engineDone :: !(MVar ())
+    , engineStagedImages :: !(TVar (Map Text [ImageAttachment]))
     }
 
 data TurnControl = TurnControl
@@ -478,6 +493,9 @@ foreign export ccall ha_engine_create
 
 foreign export ccall ha_engine_send_json
     :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
+
+foreign export ccall ha_engine_stage_turn_images
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize -> IO CInt
 
 foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
@@ -855,17 +873,20 @@ ha_engine_create callback context
             config <- managedPostgresConfigForHome home
             commands <- newTQueueIO
             done <- newEmptyMVar
+            stagedImages <- newTVarIO Map.empty
             _ <- forkFinally
                 (workerLifecycle
                     callback
                     context
                     config
                     (sessionsRoot home)
-                    commands)
+                    commands
+                    stagedImages)
                 (const (putMVar done ()))
             stable <- newStablePtr Engine
                 { engineCommands = commands
                 , engineDone = done
+                , engineStagedImages = stagedImages
                 }
             pure (castStablePtrToPtr stable)
         case created of
@@ -926,6 +947,60 @@ ha_engine_search_conversations pointer bytes (CSize length) rawLimit callback co
             Right False -> 2
             Right True -> 0
 
+ha_engine_stage_turn_images
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize -> IO CInt
+ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
+    | pointer == nullPtr = pure 1
+    | turnID == nullPtr || turnIDLength == 0 = pure 2
+    | imagePointer == nullPtr && imageCount > 0 = pure 4
+    | toInteger imageCount > toInteger (maxBound :: Int) = pure 4
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            turnIDBytes <- BS.packCStringLen
+                (castPtr turnID, fromIntegral turnIDLength)
+            turnIDText <- either (const (fail "invalid turn ID UTF-8")) pure
+                (TextEncoding.decodeUtf8' turnIDBytes)
+            images <- mapM peekImage
+                [0 .. fromIntegral imageCount - 1]
+            atomically $ modifyTVar' engine.engineStagedImages
+                (Map.insertWith (flip (<>)) turnIDText images)
+        pure $ case accepted of
+            Left _ -> 4
+            Right () -> 0
+  where
+    pointerSize = sizeOf (nullPtr :: Ptr ())
+    sizeSize = sizeOf (undefined :: CSize)
+    imageSize = pointerSize + sizeSize + pointerSize + sizeSize
+
+    peekImage index = do
+        let base = castPtr imagePointer `plusPtr` (index * imageSize)
+            readPointer offset =
+                peekByteOff base offset :: IO (Ptr Word8)
+            readLength offset =
+                peekByteOff base offset :: IO CSize
+        mimePointer <- readPointer 0
+        mimeLength <- readLength pointerSize
+        bytesPointer <- readPointer (pointerSize + sizeSize)
+        bytesLength <- readLength (pointerSize + sizeSize + pointerSize)
+        if
+            (mimePointer == nullPtr && mimeLength > 0)
+                || (bytesPointer == nullPtr && bytesLength > 0)
+                || mimeLength == 0
+        then fail "invalid image attachment"
+        else do
+            mimeBytes <- BS.packCStringLen
+                (castPtr mimePointer, fromIntegral mimeLength)
+            mime <- either (const (fail "invalid MIME UTF-8")) pure
+                (TextEncoding.decodeUtf8' mimeBytes)
+            bytes <- BS.packCStringLen
+                (castPtr bytesPointer, fromIntegral bytesLength)
+            pure ImageAttachment
+                { imageMime = mime
+                , imageBytes = bytes
+                }
+
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer
     | pointer == nullPtr = pure ()
@@ -943,8 +1018,9 @@ workerLifecycle
     -> ManagedPostgresConfig
     -> OsPath
     -> TQueue EngineCommand
+    -> TVar (Map Text [ImageAttachment])
     -> IO ()
-workerLifecycle callback context config root commands = do
+workerLifecycle callback context config root commands stagedImages = do
     store <- newMVar Nothing
     processRuntime <- newNativeProcessRuntime root
     let cleanup =
@@ -958,6 +1034,7 @@ workerLifecycle callback context config root commands = do
         root
         processRuntime
         commands
+        stagedImages
         `finally` cleanup
 
 idleLoop
@@ -968,8 +1045,9 @@ idleLoop
     -> OsPath
     -> NativeProcessRuntime
     -> TQueue EngineCommand
+    -> TVar (Map Text [ImageAttachment])
     -> IO ()
-idleLoop callback context config store root processRuntime commands =
+idleLoop callback context config store root processRuntime commands stagedImages =
     atomically (readTQueue commands) >>= \case
         EngineStop -> pure ()
         EngineSearch query limit searchCallback searchContext -> do
@@ -985,6 +1063,11 @@ idleLoop callback context config store root processRuntime commands =
                             (failureEvent request.requestId err)
                         continue
                     Right start -> do
+                        images <- atomically $ do
+                            staged <- readTVar stagedImages
+                            writeTVar stagedImages
+                                (Map.delete start.turnStartId staged)
+                            pure (Map.findWithDefault [] start.turnStartId staged)
                         control <- newTurnControl start.turnStartId
                         sendEvent callback context $
                             successEvent request.requestId $
@@ -1004,7 +1087,8 @@ idleLoop callback context config store root processRuntime commands =
                                 context
                                 processRuntime
                                 control
-                                start)
+                                start
+                                images)
                             \running ->
                                 activeLoop
                                     callback
@@ -1030,7 +1114,15 @@ idleLoop callback context config store root processRuntime commands =
                 continue
   where
     continue =
-        idleLoop callback context config store root processRuntime commands
+        idleLoop
+            callback
+            context
+            config
+            store
+            root
+            processRuntime
+            commands
+            stagedImages
 
 activeLoop
     :: FunPtr EventCallback
@@ -1186,8 +1278,9 @@ runNativeTurn
     -> NativeProcessRuntime
     -> TurnControl
     -> TurnStart
+    -> [ImageAttachment]
     -> IO TurnOutcome
-runNativeTurn callback context processRuntime control start = do
+runNativeTurn callback context processRuntime control start images = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     let hooks = NativeRunHooks
@@ -1238,15 +1331,17 @@ runNativeTurn callback context processRuntime control start = do
                     []
                     (\effort -> ["--effort", Text.unpack effort])
                     start.turnStartEffort
-                <> ["--prompt", Text.unpack start.turnStartPrompt]
     result <- tryAny $
-        withFile "/dev/null" WriteMode \output ->
-            runNativeAgent
-                processRuntime
-                output
-                (unsafeEncodeUtf start.turnStartCwd)
-                hooks
-                args
+        withTurnImages start.turnStartPrompt images \managedFile ->
+            withFile "/dev/null" WriteMode \output ->
+                runNativeAgent
+                    processRuntime
+                    output
+                    (unsafeEncodeUtf start.turnStartCwd)
+                    hooks
+                    (args <> maybe ["--prompt", Text.unpack start.turnStartPrompt]
+                        (\path -> ["--managed-turn-file", path])
+                        managedFile)
     completed <- readIORef completedRef
     sessionId <- readIORef sessionIdRef
     pure TurnOutcome
@@ -1261,6 +1356,46 @@ runNativeTurn callback context processRuntime control start = do
                         Just
                             "turn ended without a completion event"
         }
+
+withTurnImages
+    :: Text
+    -> [ImageAttachment]
+    -> (Maybe FilePath -> IO a)
+    -> IO a
+withTurnImages _ [] action = action Nothing
+withTurnImages prompt images action = do
+    temporaryDirectory <- getTemporaryDirectory
+    withImageFiles temporaryDirectory images \paths -> do
+        let request = managedTurnRequestWithImages prompt
+                [ ManagedTurnMedia
+                    { managedTurnMediaPath = path
+                    , managedTurnMediaMime = image.imageMime
+                    , managedTurnMediaName = Nothing
+                    }
+                | (path, image) <- zip paths images
+                ]
+        bracket
+            (openBinaryTempFile temporaryDirectory "ha-native-turn-")
+            (\(path, handle) -> do
+                hClose handle
+                void (tryAny (removeFile path)))
+            \(path, handle) -> do
+                hClose handle
+                BS.writeFile path
+                    (TextEncoding.encodeUtf8 (renderManagedTurnPrompt request))
+                action (Just path)
+  where
+    withImageFiles _ [] action = action []
+    withImageFiles directory (image : rest) action =
+        bracket
+            (openBinaryTempFile directory "ha-native-image-")
+            (\(path, handle) -> do
+                hClose handle
+                void (tryAny (removeFile path)))
+            \(path, handle) -> do
+                hClose handle
+                BS.writeFile path image.imageBytes
+                withImageFiles directory rest (action . (path :))
 
 newTurnControl :: Text -> IO TurnControl
 newTurnControl turnId =

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -678,32 +678,41 @@ ha_repository_snapshot pathBytes pathLength snapshotCallback fileCallback
                             Right (Left err) ->
                                 emitRepositoryError resultCallback context err
                             Right (Right snapshot) -> do
-                                withRepositorySnapshot snapshot $
-                                    invokeRepositorySnapshotCallback
-                                        snapshotCallback
-                                        context
-                                forM_ snapshot.snapshotFiles \file ->
-                                    withText (Text.pack file.repositoryFilePath) $
-                                        \pathPtr pathSize ->
-                                    withOptionalText
-                                        (Text.pack
-                                            <$> file.repositoryFileOriginalPath)
-                                        \originalPtr originalSize ->
-                                            invokeRepositoryFileCallback
-                                                fileCallback
-                                                context
-                                                pathPtr pathSize
-                                                originalPtr originalSize
-                                                (fromIntegral
-                                                    (ord
-                                                        file.repositoryFileIndexStatus))
-                                                (fromIntegral
-                                                    (ord
-                                                        file.repositoryFileWorktreeStatus))
-                                emitRepositorySuccess
-                                    resultCallback
-                                    context
-                                    snapshot.snapshotId
+                                streamed <- tryAny do
+                                    withRepositorySnapshot snapshot $
+                                        invokeRepositorySnapshotCallback
+                                            snapshotCallback
+                                            context
+                                    forM_ snapshot.snapshotFiles \file ->
+                                        withText
+                                            (Text.pack file.repositoryFilePath)
+                                            \pathPtr pathSize ->
+                                        withOptionalText
+                                            (Text.pack
+                                                <$> file.repositoryFileOriginalPath)
+                                            \originalPtr originalSize ->
+                                                invokeRepositoryFileCallback
+                                                    fileCallback
+                                                    context
+                                                    pathPtr pathSize
+                                                    originalPtr originalSize
+                                                    (fromIntegral
+                                                        (ord
+                                                            file.repositoryFileIndexStatus))
+                                                    (fromIntegral
+                                                        (ord
+                                                            file.repositoryFileWorktreeStatus))
+                                case streamed of
+                                    Left exception ->
+                                        emitRepositoryFailure
+                                            resultCallback
+                                            context
+                                            (Text.pack (show exception))
+                                    Right () ->
+                                        emitRepositorySuccess
+                                            resultCallback
+                                            context
+                                            snapshot.snapshotId
                 pure (if started then 0 else 3)
 
 ha_repository_diff
@@ -745,35 +754,51 @@ ha_repository_diff pathBytes pathLength snapshotBytes snapshotLength
                                             emitRepositoryError
                                                 resultCallback context err
                                         Right (Right diff) -> do
-                                            forM_
-                                                (byteStringChunks
-                                                    (64 * 1024)
-                                                    diff.repositoryDiffPatch)
-                                                \chunk ->
-                                                    BS.useAsCStringLen chunk
-                                                        \(pointer, length) ->
-                                                            invokeRepositoryDiffCallback
-                                                                diffCallback
-                                                                context
-                                                                (castPtr pointer)
-                                                                (fromIntegral length)
-                                                                (if
-                                                                    diff.repositoryDiffBinary
-                                                                    then 1
-                                                                    else 0)
-                                            forM_ diff.repositoryDiffHunks \hunk ->
-                                                withText hunk.hunkHeader $
-                                                    \headerPtr headerLength ->
-                                                        invokeRepositoryHunkCallback
-                                                            hunkCallback
-                                                            context
-                                                            (fromIntegral hunk.hunkOldStart)
-                                                            (fromIntegral hunk.hunkOldCount)
-                                                            (fromIntegral hunk.hunkNewStart)
-                                                            (fromIntegral hunk.hunkNewCount)
-                                                            headerPtr headerLength
-                                            emitRepositorySuccess
-                                                resultCallback context expected
+                                            streamed <- tryAny do
+                                                forM_
+                                                    (byteStringChunks
+                                                        (64 * 1024)
+                                                        diff.repositoryDiffPatch)
+                                                    \chunk ->
+                                                        BS.useAsCStringLen chunk
+                                                            \(pointer, length) ->
+                                                                invokeRepositoryDiffCallback
+                                                                    diffCallback
+                                                                    context
+                                                                    (castPtr pointer)
+                                                                    (fromIntegral length)
+                                                                    (if
+                                                                        diff.repositoryDiffBinary
+                                                                        then 1
+                                                                        else 0)
+                                                forM_
+                                                    diff.repositoryDiffHunks
+                                                    \hunk ->
+                                                        withText
+                                                            hunk.hunkHeader
+                                                            \headerPtr
+                                                                headerLength ->
+                                                                    invokeRepositoryHunkCallback
+                                                                        hunkCallback
+                                                                        context
+                                                                        (fromIntegral hunk.hunkOldStart)
+                                                                        (fromIntegral hunk.hunkOldCount)
+                                                                        (fromIntegral hunk.hunkNewStart)
+                                                                        (fromIntegral hunk.hunkNewCount)
+                                                                        headerPtr
+                                                                        headerLength
+                                            case streamed of
+                                                Left exception ->
+                                                    emitRepositoryFailure
+                                                        resultCallback
+                                                        context
+                                                        (Text.pack
+                                                            (show exception))
+                                                Right () ->
+                                                    emitRepositorySuccess
+                                                        resultCallback
+                                                        context
+                                                        expected
                             pure (if started then 0 else 3)
                 Right _ -> pure 3
 
@@ -952,10 +977,11 @@ ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
                         Right arguments -> do
                             checkRef <- newIORef Nothing
                             cancelRef <- newIORef False
+                            gate <- newEmptyMVar
                             owner <- asyncWithUnmask \unmask ->
-                                unmask do
-                                    result <-
-                                        RepositoryReview.startRepositoryCheck
+                                readMVar gate >> unmask do
+                                    started <- tryAny
+                                        (RepositoryReview.startRepositoryCheck
                                             (Text.unpack path)
                                             expected
                                             (Text.unpack executable)
@@ -980,16 +1006,24 @@ ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
                                                         System.Exit.ExitSuccess -> 0
                                                         System.Exit.ExitFailure code ->
                                                             fromIntegral code)
-                                                    nullPtr 0)
-                                    case result of
-                                        Left err ->
+                                                    nullPtr 0))
+                                    case started of
+                                        Left exception ->
                                             withText
-                                                (RepositoryReview.repositoryErrorText err)
+                                                (Text.pack (show exception))
                                                 \errorPtr errorLength ->
                                                     invokeRepositoryCheckExitCallback
                                                         exitCallback context 0 (-1)
                                                         errorPtr errorLength
-                                        Right check -> do
+                                        Right (Left err) ->
+                                            withText
+                                                (RepositoryReview.repositoryErrorText
+                                                    err)
+                                                \errorPtr errorLength ->
+                                                    invokeRepositoryCheckExitCallback
+                                                        exitCallback context 0 (-1)
+                                                        errorPtr errorLength
+                                        Right (Right check) -> do
                                             writeIORef checkRef (Just check)
                                             cancelRequested <- readIORef cancelRef
                                             when cancelRequested
@@ -1002,6 +1036,9 @@ ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
                                 , repositoryCheckOwner = owner
                                 }
                             poke outCheck (castStablePtrToPtr stable)
+                            -- No callback can begin before the owned handle is
+                            -- visible through out_check.
+                            putMVar gate ()
                             pure 0
                 Right _ -> pure 3
 

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -177,6 +177,7 @@ import Control.Exception.Safe
     , finally
     , isAsyncException
     , mask
+    , onException
     , throwIO
     , throwString
     , tryAny
@@ -1215,63 +1216,75 @@ ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
                             cancelRef <- newIORef False
                             gate <- newEmptyMVar
                             owner <- asyncWithUnmask \unmask ->
-                                readMVar gate >> unmask do
-                                    started <- tryRepositorySynchronous
-                                        (RepositoryReview.startRepositoryCheck
-                                            (Text.unpack path)
-                                            expected
-                                            (Text.unpack executable)
-                                            (map Text.unpack arguments)
-                                            (\stream bytes ->
-                                                BS.useAsCStringLen bytes
-                                                    \(pointer, length) ->
-                                                        withRepositoryCallbackThread
-                                                            (invokeRepositoryCheckOutputCallback
-                                                                outputCallback
-                                                                context
-                                                                (case stream of
-                                                                    RepositoryReview.RepositoryCheckStdout -> 1
-                                                                    RepositoryReview.RepositoryCheckStderr -> 2)
-                                                                (castPtr pointer)
-                                                                (fromIntegral length)))
-                                            (\cancelled exitCode ->
-                                                withRepositoryCallbackThread
-                                                    (invokeRepositoryCheckExitCallback
-                                                        exitCallback
-                                                        context
-                                                        (if cancelled then 1 else 0)
-                                                        (case exitCode of
-                                                            System.Exit.ExitSuccess -> 0
-                                                            System.Exit.ExitFailure code ->
-                                                                fromIntegral code)
-                                                        nullPtr 0)))
+                                readMVar gate >> do
+                                    -- asyncWithUnmask starts masked. Only the
+                                    -- potentially long start is unmasked;
+                                    -- publishing its handle remains atomic
+                                    -- with respect to owner cancellation.
+                                    started <- unmask
+                                        (tryRepositorySynchronous
+                                            (RepositoryReview.startRepositoryCheck
+                                                (Text.unpack path)
+                                                expected
+                                                (Text.unpack executable)
+                                                (map Text.unpack arguments)
+                                                (\stream bytes ->
+                                                    BS.useAsCStringLen bytes
+                                                        \(pointer, length) ->
+                                                            withRepositoryCallbackThread
+                                                                (invokeRepositoryCheckOutputCallback
+                                                                    outputCallback
+                                                                    context
+                                                                    (case stream of
+                                                                        RepositoryReview.RepositoryCheckStdout -> 1
+                                                                        RepositoryReview.RepositoryCheckStderr -> 2)
+                                                                    (castPtr pointer)
+                                                                    (fromIntegral length)))
+                                                (\cancelled exitCode ->
+                                                    withRepositoryCallbackThread
+                                                        (invokeRepositoryCheckExitCallback
+                                                            exitCallback
+                                                            context
+                                                            (if cancelled then 1 else 0)
+                                                            (case exitCode of
+                                                                System.Exit.ExitSuccess -> 0
+                                                                System.Exit.ExitFailure code ->
+                                                                    fromIntegral code)
+                                                            nullPtr 0))))
                                     case started of
                                         Left exception ->
-                                            withText
-                                                (Text.pack (show exception))
-                                                \errorPtr errorLength ->
-                                                    withRepositoryCallbackThread
-                                                        (invokeRepositoryCheckExitCallback
-                                                            exitCallback
-                                                            context 0 (-1)
-                                                            errorPtr errorLength)
+                                            unmask
+                                                (withText
+                                                    (Text.pack (show exception))
+                                                    \errorPtr errorLength ->
+                                                        withRepositoryCallbackThread
+                                                            (invokeRepositoryCheckExitCallback
+                                                                exitCallback
+                                                                context 0 (-1)
+                                                                errorPtr errorLength))
                                         Right (Left err) ->
-                                            withText
-                                                (RepositoryReview.repositoryErrorText
-                                                    err)
-                                                \errorPtr errorLength ->
-                                                    withRepositoryCallbackThread
-                                                        (invokeRepositoryCheckExitCallback
-                                                            exitCallback
-                                                            context 0 (-1)
-                                                            errorPtr errorLength)
+                                            unmask
+                                                (withText
+                                                    (RepositoryReview.repositoryErrorText
+                                                        err)
+                                                    \errorPtr errorLength ->
+                                                        withRepositoryCallbackThread
+                                                            (invokeRepositoryCheckExitCallback
+                                                                exitCallback
+                                                                context 0 (-1)
+                                                                errorPtr errorLength))
                                         Right (Right check) -> do
                                             writeIORef checkRef (Just check)
                                             cancelRequested <- readIORef cancelRef
                                             when cancelRequested
                                                 (RepositoryReview.cancelRepositoryCheck
                                                     check)
-                                            RepositoryReview.waitRepositoryCheck check
+                                            unmask
+                                                (RepositoryReview.waitRepositoryCheck
+                                                    check)
+                                                `onException`
+                                                    RepositoryReview.cancelRepositoryCheck
+                                                        check
                             stable <- newStablePtr RepositoryCheckHandle
                                 { repositoryCheckValue = checkRef
                                 , repositoryCheckCancelRequested = cancelRef

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -16,7 +16,12 @@ import Agent.CLI.MacOS.NativeLoopEvent
     )
 import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.Login
-    ( storeConnectedCredential )
+    ( AccountBilling(..)
+    , LoginAccount(..)
+    , discoverLoginAccounts
+    , loginAccountSelectionId
+    , storeConnectedCredential
+    )
 import Agent.CLI.CredentialStore
     ( ManagedAuthKind(..)
     , deleteManagedCredential
@@ -90,7 +95,7 @@ import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
     )
-import Control.Concurrent (forkFinally)
+import Control.Concurrent (forkFinally, forkIO)
 import Control.Concurrent.Async
     ( Async
     , cancel
@@ -169,6 +174,7 @@ import Foreign
     , nullFunPtr
     , nullPtr
     )
+import Foreign.C.String (CString, withCStringLen)
 import Foreign.C.Types (CInt(..), CSize(..))
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
@@ -181,10 +187,54 @@ import System.OsPath
     , unsafeEncodeUtf
     )
 
+decodeInput :: Ptr Word8 -> CSize -> IO Text
+decodeInput pointer (CSize length)
+    | pointer == nullPtr || length == 0 = pure ""
+    | otherwise = TextEncoding.decodeUtf8 <$> BS.packCStringLen
+        (castPtr pointer, fromIntegral length)
+
+nonEmptyText :: Text -> Maybe Text
+nonEmptyText value
+    | Text.null value = Nothing
+    | otherwise = Just value
+
+withText :: Text -> (CString -> CSize -> IO a) -> IO a
+withText value action = withCStringLen (Text.unpack value) \(pointer, length) ->
+    action pointer (fromIntegral length)
+
+withOptionalText :: Maybe Text -> (CString -> CSize -> IO a) -> IO a
+withOptionalText value action = withText (fromMaybe "" value) action
+
 type EventCallback = Ptr () -> Ptr Word8 -> CSize -> IO ()
+
+type AccountListCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CInt -> CString -> CSize -> IO ()
+
+type AccountResultCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
+type AccountOAuthStartCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CInt -> CInt
+    -> CString -> CSize -> IO ()
 
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
+
+foreign import ccall "dynamic"
+    invokeAccountListCallback
+        :: FunPtr AccountListCallback -> AccountListCallback
+
+foreign import ccall "dynamic"
+    invokeAccountResultCallback
+        :: FunPtr AccountResultCallback -> AccountResultCallback
+
+foreign import ccall "dynamic"
+    invokeAccountOAuthStartCallback
+        :: FunPtr AccountOAuthStartCallback -> AccountOAuthStartCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -414,6 +464,212 @@ foreign export ccall ha_engine_send_json
 
 foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
+
+foreign export ccall ha_accounts_list
+    :: FunPtr AccountListCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_oauth_start
+    :: Ptr Word8 -> CSize -> FunPtr AccountOAuthStartCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_oauth_poll
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt -> CInt
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_api_key_connect
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_set_enabled
+    :: Ptr Word8 -> CSize -> CInt
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_account_delete
+    :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+ha_accounts_list :: FunPtr AccountListCallback -> Ptr () -> IO CInt
+ha_accounts_list callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        _ <- forkIO do
+            tryAny discoverLoginAccounts >>= \case
+                Left exception ->
+                    withText (Text.pack (show exception)) $ \errorPtr errorLength ->
+                        invokeAccountListCallback callback context (-1)
+                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                            nullPtr 0 nullPtr 0 nullPtr 0
+                            0 0 errorPtr errorLength
+                Right accounts -> do
+                    forM_ accounts \account ->
+                        withAccountStrings account $
+                            invokeAccountListCallback callback context 0
+                    invokeAccountListCallback callback context 1
+                        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                        0 0 nullPtr 0
+        pure 0
+
+ha_account_oauth_start
+    :: Ptr Word8 -> CSize -> FunPtr AccountOAuthStartCallback -> Ptr () -> IO CInt
+ha_account_oauth_start providerBytes (CSize providerLength) callback context
+    | callback == nullFunPtr = pure 1
+    | providerBytes == nullPtr && providerLength > 0 = pure 2
+    | otherwise = do
+        provider <- decodeInput providerBytes (CSize providerLength)
+        _ <- forkIO do
+            startAccountOAuth AccountProviderRequest
+                { accountProvider = provider } >>= \case
+                    Left err -> withText err $ \errorPtr errorLength ->
+                        invokeAccountOAuthStartCallback callback context
+                            (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 0 0
+                            errorPtr errorLength
+                    Right value -> case parseChallenge value of
+                        Nothing -> withText "invalid OAuth challenge"
+                            (\errorPtr errorLength ->
+                                invokeAccountOAuthStartCallback callback context
+                                    (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                                    0 0 errorPtr errorLength)
+                        Just challenge ->
+                            withChallengeStrings challenge
+                                (invokeAccountOAuthStartCallback callback context 0)
+        pure 0
+
+ha_account_oauth_poll
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt -> CInt
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLength)
+    userBytes (CSize userLength) authIdBytes (CSize authIdLength)
+    deviceBytes (CSize deviceLength) pollInterval expires callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        provider <- decodeInput providerBytes (CSize providerLength)
+        url <- decodeInput urlBytes (CSize urlLength)
+        user <- decodeInput userBytes (CSize userLength)
+        authId <- decodeInput authIdBytes (CSize authIdLength)
+        device <- decodeInput deviceBytes (CSize deviceLength)
+        _ <- forkIO do
+            pollAccountOAuth AccountOAuthPollRequest
+                { oauthPollProvider = provider
+                , oauthPollVerificationUrl = nonEmptyText url
+                , oauthPollUserCode = nonEmptyText user
+                , oauthPollDeviceAuthId = nonEmptyText authId
+                , oauthPollDeviceCode = nonEmptyText device
+                , oauthPollIntervalSeconds = Just (fromIntegral pollInterval)
+                , oauthPollExpiresInSeconds = Just (fromIntegral expires)
+                } >>= invokeResult callback context
+        pure 0
+
+ha_account_api_key_connect
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+ha_account_api_key_connect providerBytes (CSize providerLength) keyBytes (CSize keyLength) callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        provider <- decodeInput providerBytes (CSize providerLength)
+        key <- decodeInput keyBytes (CSize keyLength)
+        _ <- forkIO do
+            connectAccountAPIKey AccountAPIKeyRequest
+                { accountAPIKeyProvider = provider, accountAPIKey = key }
+                >>= invokeResult callback context
+        pure 0
+
+ha_account_set_enabled
+    :: Ptr Word8 -> CSize -> CInt -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+ha_account_set_enabled idBytes (CSize idLength) enabled callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        managedId <- decodeInput idBytes (CSize idLength)
+        _ <- forkIO do
+            setManagedCredentialEnabled managedId (enabled /= 0)
+                >>= invokeStoreResult callback context
+        pure 0
+
+ha_account_delete
+    :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+ha_account_delete idBytes (CSize idLength) callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        managedId <- decodeInput idBytes (CSize idLength)
+        _ <- forkIO do
+            deleteManagedCredential managedId
+                >>= invokeStoreResult callback context
+        pure 0
+
+withAccountStrings :: LoginAccount -> (CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CInt -> CString -> CSize -> IO a) -> IO a
+withAccountStrings account action =
+    withText (providerSlug account.loginProvider) $ \provider providerLength ->
+    withText (billingText account.loginBilling) $ \billing billingLength ->
+    withText (loginAccountSelectionId account) $ \selection selectionLength ->
+    withText account.loginAccountId $ \accountId accountIdLength ->
+    withText account.loginLabel $ \label labelLength ->
+    withText account.loginSource $ \source sourceLength ->
+        withText account.loginSource $ \detail detailLength ->
+        withOptionalText account.loginManagedId $ \managedId managedLength ->
+        action provider providerLength billing billingLength
+            selection selectionLength accountId accountIdLength label labelLength
+            detail detailLength managedId managedLength source sourceLength
+            (if account.loginEnabled then 1 else 0)
+            (if account.loginManagedId == Nothing then 0 else 1)
+            nullPtr 0
+
+billingText :: AccountBilling -> Text
+billingText = \case
+    SubscriptionBilling _ -> "subscription"
+    ApiCreditsBilling -> "api"
+
+parseChallenge :: Aeson.Value
+    -> Maybe (Text, Text, Maybe Text, Maybe Text, Int, Int)
+parseChallenge = Aeson.parseMaybe $ Aeson.withObject "challenge" \object ->
+    (,,,,,)
+        <$> object Aeson..: "verificationUrl"
+        <*> object Aeson..: "userCode"
+        <*> object Aeson..:? "deviceAuthId"
+        <*> object Aeson..:? "deviceCode"
+        <*> (object Aeson..:? "pollIntervalSeconds" Aeson..!= 5)
+        <*> (object Aeson..:? "expiresInSeconds" Aeson..!= 0)
+
+withChallengeStrings
+    :: (Text, Text, Maybe Text, Maybe Text, Int, Int)
+    -> (CString -> CSize -> CString -> CSize -> CString -> CSize -> CString -> CSize
+        -> CInt -> CInt -> CString -> CSize -> IO a)
+    -> IO a
+withChallengeStrings (url, user, authId, device, interval, expires) action =
+    withText url $ \urlPtr urlLength ->
+    withText user $ \userPtr userLength ->
+    withOptionalText authId $ \authPtr authLength ->
+    withOptionalText device $ \devicePtr deviceLength ->
+        action urlPtr urlLength userPtr userLength authPtr authLength
+            devicePtr deviceLength (fromIntegral interval) (fromIntegral expires)
+            nullPtr 0
+
+invokeResult :: FunPtr AccountResultCallback -> Ptr ()
+    -> Either Text Aeson.Value -> IO ()
+invokeResult callback context result = case result of
+    Left errorText -> withText errorText $ \errorPtr errorLength ->
+        invokeAccountResultCallback callback context (-1)
+            nullPtr 0 errorPtr errorLength
+    Right value ->
+        let status = Aeson.parseMaybe (Aeson.withObject "result"
+                (\object -> object Aeson..: "status")) value
+            accountId = Aeson.parseMaybe (Aeson.withObject "result"
+                (\object -> object Aeson..:? "accountID")) value >>= id
+        in case status of
+            Just ("pending" :: Text) ->
+                invokeAccountResultCallback callback context 1 nullPtr 0 nullPtr 0
+            _ -> withOptionalText accountId $ \idPtr idLength ->
+                invokeAccountResultCallback callback context 0 idPtr idLength nullPtr 0
+
+invokeStoreResult :: FunPtr AccountResultCallback -> Ptr ()
+    -> Either Text () -> IO ()
+invokeStoreResult callback context result = case result of
+    Left errorText -> withText errorText $ \errorPtr errorLength ->
+        invokeAccountResultCallback callback context (-1)
+            nullPtr 0 errorPtr errorLength
+    Right () -> invokeAccountResultCallback callback context 0 nullPtr 0 nullPtr 0
 
 ha_engine_create :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
 ha_engine_create callback context

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -16,9 +16,13 @@ import Agent.CLI.MacOS.NativeLoopEvent
 import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.Login
     ( AccountBilling(..)
+    , AccountUsage(..)
     , LoginAccount(..)
+    , UsageState(..)
+    , UsageWindow(..)
     , discoverLoginAccounts
     , loginAccountSelectionId
+    , refreshLoginAccount
     , storeConnectedCredential
     )
 import Agent.CLI.CredentialStore
@@ -92,6 +96,7 @@ import Control.Concurrent (forkFinally, forkIO)
 import Control.Concurrent.Async
     ( Async
     , cancel
+    , mapConcurrently
     , waitCatchSTM
     , withAsync
     )
@@ -153,6 +158,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (addUTCTime, getCurrentTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Word (Word8, Word64)
 import Foreign
     ( FunPtr
@@ -168,7 +174,7 @@ import Foreign
     , nullPtr
     )
 import Foreign.C.String (CString)
-import Foreign.C.Types (CInt(..), CSize(..))
+import Foreign.C.Types (CInt(..), CLLong(..), CSize(..))
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
     ( IOMode(WriteMode)
@@ -206,6 +212,10 @@ type AccountListCallback =
     -> CString -> CSize -> CString -> CSize -> CString -> CSize
     -> CInt -> CInt -> CString -> CSize -> IO ()
 
+type AccountUsageWindowCallback =
+    Ptr () -> CString -> CSize -> CString -> CSize
+    -> CInt -> CLLong -> CLLong -> IO ()
+
 type AccountResultCallback =
     Ptr () -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
 
@@ -220,6 +230,10 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeAccountListCallback
         :: FunPtr AccountListCallback -> AccountListCallback
+
+foreign import ccall "dynamic"
+    invokeAccountUsageWindowCallback
+        :: FunPtr AccountUsageWindowCallback -> AccountUsageWindowCallback
 
 foreign import ccall "dynamic"
     invokeAccountResultCallback
@@ -419,7 +433,8 @@ foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
 
 foreign export ccall ha_accounts_list
-    :: FunPtr AccountListCallback -> Ptr () -> IO CInt
+    :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback
+    -> Ptr () -> IO CInt
 
 foreign export ccall ha_account_oauth_start
     :: Ptr Word8 -> CSize -> FunPtr AccountOAuthStartCallback -> Ptr () -> IO CInt
@@ -440,12 +455,16 @@ foreign export ccall ha_account_set_enabled
 foreign export ccall ha_account_delete
     :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
 
-ha_accounts_list :: FunPtr AccountListCallback -> Ptr () -> IO CInt
-ha_accounts_list callback context
-    | callback == nullFunPtr = pure 1
+ha_accounts_list
+    :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback
+    -> Ptr () -> IO CInt
+ha_accounts_list callback usageCallback context
+    | callback == nullFunPtr || usageCallback == nullFunPtr = pure 1
     | otherwise = do
         _ <- forkIO do
-            tryAny discoverLoginAccounts >>= \case
+            tryAny
+                (discoverLoginAccounts >>= mapConcurrently refreshLoginAccount)
+                >>= \case
                 Left exception ->
                     withText (Text.pack (show exception)) $ \errorPtr errorLength ->
                         invokeAccountListCallback callback context (-1)
@@ -453,9 +472,10 @@ ha_accounts_list callback context
                             nullPtr 0 nullPtr 0 nullPtr 0
                             0 0 errorPtr errorLength
                 Right accounts -> do
-                    forM_ accounts \account ->
+                    forM_ accounts \account -> do
                         withAccountStrings account $
                             invokeAccountListCallback callback context 0
+                        invokeAccountUsageWindows usageCallback context account
                     invokeAccountListCallback callback context 1
                         nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
                         nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
@@ -586,7 +606,9 @@ withAccountStrings account action =
     withText account.loginAccountId $ \accountId accountIdLength ->
     withText account.loginLabel $ \label labelLength ->
     withText account.loginSource $ \source sourceLength ->
-        withText account.loginSource $ \detail detailLength ->
+        withText
+            (accountUsageSummary account)
+            $ \detail detailLength ->
         withOptionalText account.loginManagedId $ \managedId managedLength ->
         action provider providerLength billing billingLength
             selection selectionLength accountId accountIdLength label labelLength
@@ -599,6 +621,40 @@ billingText :: AccountBilling -> Text
 billingText = \case
     SubscriptionBilling _ -> "subscription"
     ApiCreditsBilling -> "api"
+
+accountUsageSummary :: LoginAccount -> Text
+accountUsageSummary account =
+    Text.intercalate " · " $
+        billing <> case account.loginUsage of
+            UsageNotChecked -> []
+            UsageUnavailable _ -> ["usage unavailable"]
+            UsageAvailable usage ->
+                maybeToList usage.usagePlan
+                    <> maybeToList
+                        (("credits " <>) <$> usage.creditsRemaining)
+                    <> maybeToList
+                        (("used " <>) <$> usage.creditsUsed)
+  where
+    billing = case account.loginBilling of
+        ApiCreditsBilling -> ["API credits"]
+        SubscriptionBilling plan ->
+            maybe ["subscription"] (\value -> ["subscription", value]) plan
+    maybeToList = maybe [] pure
+
+invokeAccountUsageWindows
+    :: FunPtr AccountUsageWindowCallback -> Ptr () -> LoginAccount -> IO ()
+invokeAccountUsageWindows callback context account =
+    case account.loginUsage of
+        UsageAvailable usage ->
+            forM_ usage.usageWindows \window ->
+                withText (loginAccountSelectionId account) $ \selection selectionLength ->
+                withText window.windowName $ \name nameLength ->
+                    invokeAccountUsageWindowCallback callback context
+                        selection selectionLength name nameLength
+                        (fromIntegral window.usedPercent)
+                        (fromIntegral window.windowSeconds)
+                        (round (utcTimeToPOSIXSeconds window.resetsAt))
+        _ -> pure ()
 
 parseChallenge :: Aeson.Value
     -> Maybe (Text, Text, Maybe Text, Maybe Text, Int, Int)

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -960,15 +960,19 @@ ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
             engine <- deRefStablePtr stable
             turnIDBytes <- BS.packCStringLen
                 (castPtr turnID, fromIntegral turnIDLength)
-            turnIDText <- either (const (fail "invalid turn ID UTF-8")) pure
-                (TextEncoding.decodeUtf8' turnIDBytes)
-            images <- mapM peekImage
+            let turnIDText = TextEncoding.decodeUtf8' turnIDBytes
+            imageResults <- mapM peekImage
                 [0 .. fromIntegral imageCount - 1]
-            atomically $ modifyTVar' engine.engineStagedImages
-                (Map.insertWith (flip (<>)) turnIDText images)
+            case (turnIDText, sequence imageResults) of
+                (Right turnIDValue, Just images) -> do
+                    atomically $ modifyTVar' engine.engineStagedImages
+                        (Map.insertWith (flip (<>)) turnIDValue images)
+                    pure True
+                _ -> pure False
         pure $ case accepted of
-            Left _ -> 4
-            Right () -> 0
+            Left _ -> 3
+            Right False -> 4
+            Right True -> 0
   where
     pointerSize = sizeOf (nullPtr :: Ptr ())
     sizeSize = sizeOf (undefined :: CSize)
@@ -988,18 +992,19 @@ ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
             (mimePointer == nullPtr && mimeLength > 0)
                 || (bytesPointer == nullPtr && bytesLength > 0)
                 || mimeLength == 0
-        then fail "invalid image attachment"
+        then pure Nothing
         else do
             mimeBytes <- BS.packCStringLen
                 (castPtr mimePointer, fromIntegral mimeLength)
-            mime <- either (const (fail "invalid MIME UTF-8")) pure
-                (TextEncoding.decodeUtf8' mimeBytes)
+            let mime = TextEncoding.decodeUtf8' mimeBytes
             bytes <- BS.packCStringLen
                 (castPtr bytesPointer, fromIntegral bytesLength)
-            pure ImageAttachment
-                { imageMime = mime
-                , imageBytes = bytes
-                }
+            pure $ case mime of
+                Left _ -> Nothing
+                Right mimeValue -> Just ImageAttachment
+                    { imageMime = mimeValue
+                    , imageBytes = bytes
+                    }
 
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1211,46 +1211,49 @@ ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
                         argumentsPointer argumentCount
                     case copiedArguments of
                         Left _ -> pure 2
-                        Right arguments -> do
+                        Right arguments -> mask \_ -> do
+                            poke outCheck nullPtr
                             checkRef <- newIORef Nothing
                             cancelRef <- newIORef False
                             gate <- newEmptyMVar
                             owner <- asyncWithUnmask \unmask ->
                                 readMVar gate >> do
-                                    -- asyncWithUnmask starts masked. Only the
-                                    -- potentially long start is unmasked;
-                                    -- publishing its handle remains atomic
-                                    -- with respect to owner cancellation.
-                                    started <- unmask
-                                        (tryRepositorySynchronous
-                                            (RepositoryReview.startRepositoryCheck
-                                                (Text.unpack path)
-                                                expected
-                                                (Text.unpack executable)
-                                                (map Text.unpack arguments)
-                                                (\stream bytes ->
-                                                    BS.useAsCStringLen bytes
-                                                        \(pointer, length) ->
-                                                            withRepositoryCallbackThread
-                                                                (invokeRepositoryCheckOutputCallback
-                                                                    outputCallback
-                                                                    context
-                                                                    (case stream of
-                                                                        RepositoryReview.RepositoryCheckStdout -> 1
-                                                                        RepositoryReview.RepositoryCheckStderr -> 2)
-                                                                    (castPtr pointer)
-                                                                    (fromIntegral length)))
-                                                (\cancelled exitCode ->
-                                                    withRepositoryCallbackThread
-                                                        (invokeRepositoryCheckExitCallback
-                                                            exitCallback
-                                                            context
-                                                            (if cancelled then 1 else 0)
-                                                            (case exitCode of
-                                                                System.Exit.ExitSuccess -> 0
-                                                                System.Exit.ExitFailure code ->
-                                                                    fromIntegral code)
-                                                            nullPtr 0))))
+                                    -- asyncWithUnmask starts masked. Keep
+                                    -- acquisition and publication in that
+                                    -- masked region so ownership transfer is
+                                    -- atomic with respect to cancellation. Its
+                                    -- blocking I/O remains interruptible under
+                                    -- masked-interruptible semantics and owns
+                                    -- cleanup brackets.
+                                    started <- tryRepositorySynchronous
+                                        (RepositoryReview.startRepositoryCheck
+                                            (Text.unpack path)
+                                            expected
+                                            (Text.unpack executable)
+                                            (map Text.unpack arguments)
+                                            (\stream bytes ->
+                                                BS.useAsCStringLen bytes
+                                                    \(pointer, length) ->
+                                                        withRepositoryCallbackThread
+                                                            (invokeRepositoryCheckOutputCallback
+                                                                outputCallback
+                                                                context
+                                                                (case stream of
+                                                                    RepositoryReview.RepositoryCheckStdout -> 1
+                                                                    RepositoryReview.RepositoryCheckStderr -> 2)
+                                                                (castPtr pointer)
+                                                                (fromIntegral length)))
+                                            (\cancelled exitCode ->
+                                                withRepositoryCallbackThread
+                                                    (invokeRepositoryCheckExitCallback
+                                                        exitCallback
+                                                        context
+                                                        (if cancelled then 1 else 0)
+                                                        (case exitCode of
+                                                            System.Exit.ExitSuccess -> 0
+                                                            System.Exit.ExitFailure code ->
+                                                                fromIntegral code)
+                                                        nullPtr 0)))
                                     case started of
                                         Left exception ->
                                             unmask
@@ -1290,11 +1293,17 @@ ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
                                 , repositoryCheckCancelRequested = cancelRef
                                 , repositoryCheckOwner = owner
                                 }
-                            poke outCheck (castStablePtrToPtr stable)
-                            -- No callback can begin before the owned handle is
-                            -- visible through out_check.
-                            putMVar gate ()
-                            pure 0
+                                `onException` cancel owner
+                            (do
+                                poke outCheck (castStablePtrToPtr stable)
+                                -- No callback can begin before the owned
+                                -- handle is visible through out_check.
+                                putMVar gate ()
+                                pure 0)
+                                `onException` do
+                                    cancel owner
+                                    freeStablePtr stable
+                                    poke outCheck nullPtr
                 Right _ -> pure 3
 
 ha_repository_check_cancel :: Ptr () -> IO ()

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -167,7 +167,7 @@ import Foreign
     , nullFunPtr
     , nullPtr
     )
-import Foreign.C.String (CString, withCStringLen)
+import Foreign.C.String (CString)
 import Foreign.C.Types (CInt(..), CSize(..))
 import System.Directory.OsPath (getHomeDirectory)
 import System.IO
@@ -192,7 +192,7 @@ nonEmptyText value
     | otherwise = Just value
 
 withText :: Text -> (CString -> CSize -> IO a) -> IO a
-withText value action = withCStringLen (Text.unpack value) \(pointer, length) ->
+withText value action = BS.useAsCStringLen (TextEncoding.encodeUtf8 value) \(pointer, length) ->
     action pointer (fromIntegral length)
 
 withOptionalText :: Maybe Text -> (CString -> CSize -> IO a) -> IO a

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -14,6 +14,14 @@ import Agent.Store.Postgres.Session
     ( NativeConversationSearchResult(..)
     , searchNativeConversations
     )
+import Data.Bifunctor (first)
+import Agent.Store.Postgres.Scope (scopeKindText)
+import Agent.Store.Postgres.Skill
+    ( LearnedSkill(..)
+    , learnedSkillActivationText
+    , learnedSkillStatusText
+    , listAllLearnedSkills
+    )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     )
@@ -47,6 +55,10 @@ import qualified Agent.OpenAI.Auth.Types as OpenAIAuthTypes
 import qualified Agent.XAI.Auth as XAIAuth
 import qualified Agent.OpenRouter.Usage as OpenRouter
 import Agent.CLI.ModelConfig (loadModelCatalogAt)
+import Agent.CLI.Database.Store
+    ( applicableDatabaseScopes
+    , deriveDatabaseScopes
+    )
 import Agent.CLI.Models
     ( ModelOption(..)
     , ModelTarget(..)
@@ -186,6 +198,7 @@ import System.IO
     )
 import System.OsPath
     ( OsPath
+    , decodeFS
     , takeDirectory
     , unsafeEncodeUtf
     )
@@ -245,6 +258,13 @@ type SearchCallback =
     -> Ptr Word8 -> CSize -- error
     -> IO ()
 
+type LearnedSkillsListCallback =
+    Ptr () -> CInt
+    -> CString -> CSize -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -266,6 +286,10 @@ foreign import ccall "dynamic"
 
 foreign import ccall "dynamic"
     invokeSearchCallback :: FunPtr SearchCallback -> SearchCallback
+
+foreign import ccall "dynamic"
+    invokeLearnedSkillsListCallback
+        :: FunPtr LearnedSkillsListCallback -> LearnedSkillsListCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -479,6 +503,84 @@ foreign export ccall ha_account_set_enabled
 
 foreign export ccall ha_account_delete
     :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_learned_skills_list
+    :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
+
+ha_learned_skills_list
+    :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
+ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
+    | callback == nullFunPtr = pure 1
+    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
+    | otherwise = do
+        cwd <- decodeInput cwdBytes cwdLength
+        _ <- forkIO do
+            tryAny (listLearnedSkillsFor (Text.unpack cwd)) >>= \case
+                Left exception ->
+                    withText (Text.pack (show exception)) $ \errorPtr errorLength ->
+                        invokeLearnedSkillsListCallback callback context (-1)
+                            nullPtr 0 nullPtr 0 0
+                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                            nullPtr 0 nullPtr 0 nullPtr 0 0 errorPtr errorLength
+                Right (Left err) ->
+                    withText err $ \errorPtr errorLength ->
+                        invokeLearnedSkillsListCallback callback context (-1)
+                            nullPtr 0 nullPtr 0 0
+                            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                            nullPtr 0 nullPtr 0 nullPtr 0 0 errorPtr errorLength
+                Right (Right skills) -> do
+                    forM_ skills \skill ->
+                        withLearnedSkillStrings skill $
+                            invokeLearnedSkillsListCallback callback context 0
+                    invokeLearnedSkillsListCallback callback context 1
+                        nullPtr 0 nullPtr 0 0
+                        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                        nullPtr 0 nullPtr 0 nullPtr 0 0 nullPtr 0 nullPtr 0
+        pure 0
+  where
+    listLearnedSkillsFor cwd = do
+        home <- getHomeDirectory
+        projectRoot <- resolveProjectRoot (unsafeEncodeUtf cwd)
+        stateDirectory <- decodeFS (takeDirectory (sessionsRoot home))
+        projectRootPath <- decodeFS projectRoot
+        scopes <- deriveDatabaseScopes stateDirectory projectRootPath
+        case scopes of
+            Left err -> pure (Left err)
+            Right databaseScopes -> do
+                store <- openStore =<< managedPostgresConfigForHome home
+                case store of
+                    Left err -> pure (Left (renderStoreError err))
+                    Right opened -> do
+                        result <- listAllLearnedSkills
+                            (trustedPool opened)
+                            (applicableDatabaseScopes databaseScopes)
+                        closeStore opened
+                        pure (first renderStoreError result)
+
+type LearnedSkillItemCallback =
+    CString -> CSize -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
+withLearnedSkillStrings :: LearnedSkill -> LearnedSkillItemCallback -> IO ()
+withLearnedSkillStrings skill action =
+    withText (scopeKindText skill.learnedSkillScope.scopeKind) $ \scope scopeLength ->
+    withText skill.learnedSkillSlug $ \slug slugLength ->
+    withText skill.learnedSkillTitle $ \title titleLength ->
+    withText skill.learnedSkillDescription $ \description descriptionLength ->
+    withText skill.learnedSkillAppliesWhen $ \applies appliesLength ->
+    withText skill.learnedSkillInstructions $ \instructions instructionsLength ->
+    withText (learnedSkillActivationText skill.learnedSkillActivation) $ \activation activationLength ->
+    withText (learnedSkillStatusText skill.learnedSkillStatus) $ \status statusLength ->
+    withText (Text.pack (show skill.learnedSkillUpdatedAt)) $ \updated updatedLength ->
+        action scope scopeLength slug slugLength
+            (fromIntegral skill.learnedSkillRevision)
+            title titleLength description descriptionLength
+            applies appliesLength instructions instructionsLength
+            activation activationLength status statusLength
+            (fromIntegral skill.learnedSkillPriority) updated updatedLength
+            nullPtr 0
 
 ha_accounts_list
     :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -251,6 +251,9 @@ type AccountUsageWindowCallback =
 type AccountResultCallback =
     Ptr () -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
 
+type SessionResultCallback =
+    Ptr () -> CInt -> CString -> CSize -> IO ()
+
 type AccountOAuthStartCallback =
     Ptr () -> CInt -> CString -> CSize -> CString -> CSize
     -> CString -> CSize -> CString -> CSize -> CInt -> CInt
@@ -294,6 +297,10 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeAccountResultCallback
         :: FunPtr AccountResultCallback -> AccountResultCallback
+
+foreign import ccall "dynamic"
+    invokeSessionResultCallback
+        :: FunPtr SessionResultCallback -> SessionResultCallback
 
 foreign import ccall "dynamic"
     invokeAccountOAuthStartCallback
@@ -406,28 +413,6 @@ instance Aeson.FromJSON SessionReference where
     parseJSON = Aeson.withObject "SessionReference" \object ->
         SessionReference <$> object .: "id"
 
-data SessionRenameRequest = SessionRenameRequest
-    { sessionRenameId :: !Text
-    , sessionRenameTitle :: !Text
-    }
-
-instance Aeson.FromJSON SessionRenameRequest where
-    parseJSON = Aeson.withObject "SessionRenameRequest" \object ->
-        SessionRenameRequest
-            <$> object .: "id"
-            <*> object .: "title"
-
-data SessionArchiveRequest = SessionArchiveRequest
-    { sessionArchiveId :: !Text
-    , sessionArchiveArchived :: !Bool
-    }
-
-instance Aeson.FromJSON SessionArchiveRequest where
-    parseJSON = Aeson.withObject "SessionArchiveRequest" \object ->
-        SessionArchiveRequest
-            <$> object .: "id"
-            <*> object .: "archived"
-
 data ModelsListRequest = ModelsListRequest
     { modelsListCwd :: !FilePath
     , modelsListSessionId :: !(Maybe Text)
@@ -461,7 +446,14 @@ data AccountAPIKeyRequest = AccountAPIKeyRequest
 data EngineCommand
     = EngineRequest !BridgeRequest
     | EngineSearch !Text !Int !(FunPtr SearchCallback) !(Ptr ())
+    | EngineSessionMutation
+        !SessionMutation !(FunPtr SessionResultCallback) !(Ptr ())
     | EngineStop
+
+data SessionMutation
+    = SessionRename !Text !Text
+    | SessionDelete !Text
+    | SessionArchive !Text !Bool
 
 data Engine = Engine
     { engineCommands :: !(TQueue EngineCommand)
@@ -499,6 +491,18 @@ foreign export ccall ha_engine_stage_turn_images
 
 foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
+
+foreign export ccall ha_engine_session_rename
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr SessionResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_session_delete
+    :: Ptr () -> Ptr Word8 -> CSize
+    -> FunPtr SessionResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_session_archive
+    :: Ptr () -> Ptr Word8 -> CSize -> CInt
+    -> FunPtr SessionResultCallback -> Ptr () -> IO CInt
 
 foreign export ccall ha_accounts_list
     :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback
@@ -1011,6 +1015,57 @@ ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
                     , imageBytes = bytes
                     }
 
+ha_engine_session_rename
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr SessionResultCallback -> Ptr () -> IO CInt
+ha_engine_session_rename engine idBytes (CSize idLength)
+    titleBytes (CSize titleLength) callback context
+    | anyNonEmptyNull
+        [ (idBytes, idLength), (titleBytes, titleLength) ] = pure 2
+    | otherwise = do
+        sessionId <- decodeInput idBytes idLength
+        title <- decodeInput titleBytes titleLength
+        enqueueSessionMutation engine (SessionRename sessionId title) callback context
+
+ha_engine_session_delete
+    :: Ptr () -> Ptr Word8 -> CSize
+    -> FunPtr SessionResultCallback -> Ptr () -> IO CInt
+ha_engine_session_delete engine idBytes (CSize idLength) callback context
+    | anyNonEmptyNull [(idBytes, idLength)] = pure 2
+    | otherwise = do
+        sessionId <- decodeInput idBytes idLength
+        enqueueSessionMutation engine (SessionDelete sessionId) callback context
+
+ha_engine_session_archive
+    :: Ptr () -> Ptr Word8 -> CSize -> CInt
+    -> FunPtr SessionResultCallback -> Ptr () -> IO CInt
+ha_engine_session_archive engine idBytes (CSize idLength)
+    archived callback context
+    | anyNonEmptyNull [(idBytes, idLength)] = pure 2
+    | otherwise = do
+        sessionId <- decodeInput idBytes idLength
+        enqueueSessionMutation
+            engine (SessionArchive sessionId (archived /= 0)) callback context
+
+enqueueSessionMutation
+    :: Ptr ()
+    -> SessionMutation
+    -> FunPtr SessionResultCallback
+    -> Ptr ()
+    -> IO CInt
+enqueueSessionMutation pointer mutation callback context
+    | pointer == nullPtr = pure 1
+    | callback == nullFunPtr = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            atomically $ writeTQueue engine.engineCommands
+                (EngineSessionMutation mutation callback context)
+        pure $ case accepted of
+            Left _ -> 3
+            Right () -> 0
+
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer
     | pointer == nullPtr = pure ()
@@ -1063,6 +1118,10 @@ idleLoop callback context config store root processRuntime commands stagedImages
         EngineSearch query limit searchCallback searchContext -> do
             runConversationSearch
                 config store query limit searchCallback searchContext
+            continue
+        EngineSessionMutation mutation resultCallback resultContext -> do
+            runSessionMutation
+                config store root mutation resultCallback resultContext
             continue
         EngineRequest request
             | request.requestMethod == "turn.start" ->
@@ -1162,6 +1221,11 @@ activeLoop callback context config store root commands control running =
                 config store query limit searchCallback searchContext
             activeLoop
                 callback context config store root commands control running
+        Left (EngineSessionMutation mutation resultCallback resultContext) -> do
+            runSessionMutation
+                config store root mutation resultCallback resultContext
+            activeLoop
+                callback context config store root commands control running
         Left (EngineRequest request) -> do
             if request.requestMethod == "turn.cancel"
               then
@@ -1199,6 +1263,41 @@ activeLoop callback context config store root commands control running =
                 commands
                 control
                 running
+
+runSessionMutation
+    :: ManagedPostgresConfig
+    -> MVar (Maybe Store)
+    -> OsPath
+    -> SessionMutation
+    -> FunPtr SessionResultCallback
+    -> Ptr ()
+    -> IO ()
+runSessionMutation config store root mutation callback context = do
+    outcome <- tryAny do
+        activeStore <- acquireStore config store
+        let pool = trustedPool activeStore
+        case mutation of
+            SessionRename sessionId title -> do
+                result <- renameSession pool root sessionId title
+                pure (() <$ result)
+            SessionDelete sessionId ->
+                deleteSession pool root sessionId
+            SessionArchive sessionId archived ->
+                setSessionArchived pool root sessionId archived
+    case outcome of
+        Left exception ->
+            sendSessionMutationFailure
+                callback context (Text.pack (show exception))
+        Right (Left err) ->
+            sendSessionMutationFailure callback context err
+        Right (Right ()) ->
+            invokeSessionResultCallback callback context 0 nullPtr 0
+
+sendSessionMutationFailure
+    :: FunPtr SessionResultCallback -> Ptr () -> Text -> IO ()
+sendSessionMutationFailure callback context message =
+    withText message \errorPtr errorLength ->
+        invokeSessionResultCallback callback context (-1) errorPtr errorLength
 
 runConversationSearch
     :: ManagedPostgresConfig
@@ -1676,53 +1775,6 @@ handleRequest config store root request = do
                             (failureEvent current.requestId)
                             (successEvent current.requestId)
                             snapshot
-            "sessions.rename" ->
-                case (parseParams current
-                    :: Either Text SessionRenameRequest) of
-                    Left err ->
-                        pure (failureEvent current.requestId err)
-                    Right rename -> do
-                        activeStore <- acquireStore config store
-                        renamed <- renameSession
-                            (trustedPool activeStore)
-                            root
-                            rename.sessionRenameId
-                            rename.sessionRenameTitle
-                        pure $ either
-                            (failureEvent current.requestId)
-                            (const (successEvent current.requestId True))
-                            renamed
-            "sessions.delete" ->
-                case (parseParams current
-                    :: Either Text SessionReference) of
-                    Left err ->
-                        pure (failureEvent current.requestId err)
-                    Right reference -> do
-                        activeStore <- acquireStore config store
-                        deleted <- deleteSession
-                            (trustedPool activeStore)
-                            root
-                            reference.sessionReferenceId
-                        pure $ either
-                            (failureEvent current.requestId)
-                            (const (successEvent current.requestId True))
-                            deleted
-            "sessions.archive" ->
-                case (parseParams current
-                    :: Either Text SessionArchiveRequest) of
-                    Left err ->
-                        pure (failureEvent current.requestId err)
-                    Right archive -> do
-                        activeStore <- acquireStore config store
-                        changed <- setSessionArchived
-                            (trustedPool activeStore)
-                            root
-                            archive.sessionArchiveId
-                            archive.sessionArchiveArchived
-                        pure $ either
-                            (failureEvent current.requestId)
-                            (const (successEvent current.requestId True))
-                            changed
             "turn.agents" ->
                 pure $ successEvent current.requestId ([] :: [Aeson.Value])
             "models.list" ->

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -15,7 +15,7 @@ import Agent.Store.Postgres.Session
     , searchNativeConversations
     )
 import Data.Bifunctor (first)
-import Agent.Store.Postgres.Scope (scopeKindText)
+import Agent.Store.Postgres.Scope (Scope(..), scopeKindText)
 import Agent.Store.Postgres.Skill
     ( LearnedSkill(..)
     , learnedSkillActivationText
@@ -581,7 +581,7 @@ learnedSkillsTerminal callback context status errorPtr errorLength =
     invokeLearnedSkillsListCallback callback context status
         nullPtr 0 nullPtr 0 0
         nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-        nullPtr 0 nullPtr 0 nullPtr 0
+        nullPtr 0 nullPtr 0
         0 nullPtr 0 errorPtr errorLength
 
 ha_accounts_list

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1,0 +1,1137 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Agent.CLI.MacOS.Bridge () where
+
+import qualified Agent.CLI.AgentViewport as Viewport
+import Agent.CLI.NativeRuntime
+    ( NativeProcessRuntime
+    , NativeRunHooks(..)
+    , closeNativeProcessRuntime
+    , newNativeProcessRuntime
+    , runNativeAgent
+    )
+import Agent.CLI.ModelConfig (loadModelCatalogAt)
+import Agent.CLI.Models
+    ( ModelOption(..)
+    , ModelTarget(..)
+    , PickerState(..)
+    , defaultModelOptionFor
+    , initialPickerStateResolved
+    , modelCatalog
+    , resolveModelOptionDialect
+    , selectedOption
+    )
+import Agent.CLI.Permission (PermissionChoice(..))
+import Agent.CLI.Project
+    ( ProjectModel(..)
+    , ProjectSettings(..)
+    , loadProjectSettings
+    , resolveProjectRoot
+    )
+import Agent.CLI.Render
+    ( summarizeToolCall )
+import Agent.CLI.Options (parseEffort)
+import Agent.CLI.Session
+    ( SessionMeta(..)
+    , deleteSession
+    , listArchivedSessionIds
+    , listSessions
+    , loadSessionMeta
+    , renameSession
+    , setSessionArchived
+    , sessionsRoot
+    )
+import Agent.CLI.SessionAdmin
+    ( accountSummariesJSON
+    , loadSessionPageJSON
+    , managedPostgresConfigForHome
+    , sessionSummaryWithStatusJSON
+    )
+import Agent.Loop (LoopEvent(..))
+import Agent.Dialect (dialectSlug)
+import Agent.Provider (Provider(..), providerSlug)
+import Agent.Store.Postgres
+    ( ManagedPostgresConfig
+    , Store
+    , closeStore
+    , openStore
+    , trustedPool
+    )
+import Agent.Store.Types (renderStoreError)
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , ToolCallResult(..)
+    )
+import Control.Concurrent (forkFinally)
+import Control.Concurrent.Async
+    ( Async
+    , cancel
+    , waitCatchSTM
+    , withAsync
+    )
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , readMVar
+    )
+import Control.Concurrent.STM
+    ( TMVar
+    , TQueue
+    , TVar
+    , atomically
+    , modifyTVar'
+    , newEmptyTMVarIO
+    , newTQueueIO
+    , newTVarIO
+    , orElse
+    , readTQueue
+    , readTVar
+    , readTVarIO
+    , takeTMVar
+    , tryPutTMVar
+    , writeTQueue
+    , writeTVar
+    )
+import Control.Applicative ((<|>))
+import Control.Exception.Safe
+    ( SomeException
+    , finally
+    , tryAny
+    )
+import Control.Monad
+    ( forM_
+    , void
+    )
+import qualified Data.Aeson as Aeson
+import Data.Aeson
+    ( (.:)
+    , (.:?)
+    )
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef
+    ( newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Int (Int64)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Word (Word8)
+import Foreign
+    ( FunPtr
+    , Ptr
+    , StablePtr
+    , castPtr
+    , castPtrToStablePtr
+    , castStablePtrToPtr
+    , deRefStablePtr
+    , freeStablePtr
+    , newStablePtr
+    , nullFunPtr
+    , nullPtr
+    )
+import Foreign.C.Types (CInt(..), CSize(..))
+import System.Directory.OsPath (getHomeDirectory)
+import System.IO
+    ( IOMode(WriteMode)
+    , withFile
+    )
+import System.OsPath
+    ( OsPath
+    , takeDirectory
+    , unsafeEncodeUtf
+    )
+
+type EventCallback = Ptr () -> Ptr Word8 -> CSize -> IO ()
+
+foreign import ccall "dynamic"
+    invokeEventCallback :: FunPtr EventCallback -> EventCallback
+
+data BridgeRequest = BridgeRequest
+    { requestId :: !Text
+    , requestMethod :: !Text
+    , requestParams :: !Aeson.Value
+    }
+
+instance Aeson.FromJSON BridgeRequest where
+    parseJSON = Aeson.withObject "BridgeRequest" \object ->
+        BridgeRequest
+            <$> object .: "id"
+            <*> object .: "method"
+            <*> (object .:? "params" Aeson..!= Aeson.object [])
+
+data TurnStart = TurnStart
+    { turnStartId :: !Text
+    , turnStartPrompt :: !Text
+    , turnStartSessionId :: !(Maybe Text)
+    , turnStartCwd :: !FilePath
+    , turnStartProvider :: !(Maybe Text)
+    , turnStartModel :: !(Maybe Text)
+    , turnStartEffort :: !(Maybe Text)
+    , turnStartWorktree :: !Bool
+    }
+
+instance Aeson.FromJSON TurnStart where
+    parseJSON = Aeson.withObject "TurnStart" \object -> do
+        turnStartId <- object .: "turnId"
+        turnStartPrompt <- object .: "prompt"
+        turnStartSessionId <- object .:? "sessionId"
+        turnStartCwd <- object .: "cwd"
+        turnStartProvider <- object .:? "provider"
+        turnStartModel <- object .:? "model"
+        rawEffort <- object .:? "effort"
+        turnStartEffort <- traverse
+            (either fail pure . parseEffort)
+            rawEffort
+        turnStartWorktree <- object .:? "worktree" Aeson..!= False
+        let start = TurnStart
+                { turnStartId
+                , turnStartPrompt
+                , turnStartSessionId
+                , turnStartCwd
+                , turnStartProvider
+                , turnStartModel
+                , turnStartEffort
+                , turnStartWorktree
+                }
+        case
+            ( turnStartSessionId
+            , turnStartWorktree
+            , turnStartProvider
+            , turnStartModel
+            )
+          of
+            (Just _, True, _, _) ->
+                fail "a worktree can only be created for a new session"
+            (_, _, Nothing, Nothing) -> pure start
+            (_, _, Just _, Just _) -> pure start
+            _ -> fail "provider and model must be supplied together"
+
+data TurnReference = TurnReference
+    { turnReferenceId :: !Text
+    }
+
+instance Aeson.FromJSON TurnReference where
+    parseJSON = Aeson.withObject "TurnReference" \object ->
+        TurnReference <$> object .: "turnId"
+
+data ApprovalResolution = ApprovalResolution
+    { approvalResolutionId :: !Text
+    , approvalResolutionDecision :: !Text
+    }
+
+instance Aeson.FromJSON ApprovalResolution where
+    parseJSON = Aeson.withObject "ApprovalResolution" \object ->
+        ApprovalResolution
+            <$> object .: "approvalId"
+            <*> object .: "decision"
+
+data SessionPageRequest = SessionPageRequest
+    { sessionPageId :: !Text
+    , sessionPageBefore :: !(Maybe Int64)
+    , sessionPageLimit :: !(Maybe Int)
+    }
+
+instance Aeson.FromJSON SessionPageRequest where
+    parseJSON = Aeson.withObject "SessionPageRequest" \object ->
+        SessionPageRequest
+            <$> object .: "id"
+            <*> object .:? "before"
+            <*> object .:? "limit"
+
+data SessionReference = SessionReference
+    { sessionReferenceId :: !Text
+    }
+
+instance Aeson.FromJSON SessionReference where
+    parseJSON = Aeson.withObject "SessionReference" \object ->
+        SessionReference <$> object .: "id"
+
+data SessionRenameRequest = SessionRenameRequest
+    { sessionRenameId :: !Text
+    , sessionRenameTitle :: !Text
+    }
+
+instance Aeson.FromJSON SessionRenameRequest where
+    parseJSON = Aeson.withObject "SessionRenameRequest" \object ->
+        SessionRenameRequest
+            <$> object .: "id"
+            <*> object .: "title"
+
+data SessionArchiveRequest = SessionArchiveRequest
+    { sessionArchiveId :: !Text
+    , sessionArchiveArchived :: !Bool
+    }
+
+instance Aeson.FromJSON SessionArchiveRequest where
+    parseJSON = Aeson.withObject "SessionArchiveRequest" \object ->
+        SessionArchiveRequest
+            <$> object .: "id"
+            <*> object .: "archived"
+
+data ModelsListRequest = ModelsListRequest
+    { modelsListCwd :: !FilePath
+    , modelsListSessionId :: !(Maybe Text)
+    }
+
+instance Aeson.FromJSON ModelsListRequest where
+    parseJSON = Aeson.withObject "ModelsListRequest" \object ->
+        ModelsListRequest
+            <$> object .: "cwd"
+            <*> object .:? "sessionId"
+
+data EngineCommand
+    = EngineRequest !BridgeRequest
+    | EngineStop
+
+data Engine = Engine
+    { engineCommands :: !(TQueue EngineCommand)
+    , engineDone :: !(MVar ())
+    }
+
+data TurnControl = TurnControl
+    { turnControlId :: !Text
+    , turnControlCancel :: !(TVar (IO ()))
+    , turnControlApprovals
+        :: !(TVar (Map Text (TMVar PermissionChoice)))
+    , turnControlApprovalCounter :: !(TVar Int)
+    , turnControlAllowedTools :: !(TVar (Set.Set Text))
+    , turnControlAgentSnapshot :: !(TVar (IO [Viewport.AgentEntry]))
+    }
+
+data TurnOutcome = TurnOutcome
+    { turnOutcomeSessionId :: !(Maybe Text)
+    , turnOutcomeError :: !(Maybe Text)
+    }
+
+data ActiveExit
+    = ActiveContinue
+    | ActiveStop
+
+foreign export ccall ha_engine_create
+    :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
+
+foreign export ccall ha_engine_send_json
+    :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
+
+foreign export ccall ha_engine_destroy
+    :: Ptr () -> IO ()
+
+ha_engine_create :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
+ha_engine_create callback context
+    | callback == nullFunPtr = pure nullPtr
+    | otherwise = do
+        created <- tryAny do
+            home <- getHomeDirectory
+            config <- managedPostgresConfigForHome home
+            commands <- newTQueueIO
+            done <- newEmptyMVar
+            _ <- forkFinally
+                (workerLifecycle
+                    callback
+                    context
+                    config
+                    (sessionsRoot home)
+                    commands)
+                (const (putMVar done ()))
+            stable <- newStablePtr Engine
+                { engineCommands = commands
+                , engineDone = done
+                }
+            pure (castStablePtrToPtr stable)
+        case created of
+            Left exception -> do
+                sendEvent callback context $
+                    failureEvent "_engine" (Text.pack (show exception))
+                pure nullPtr
+            Right pointer -> pure pointer
+
+ha_engine_send_json :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
+ha_engine_send_json pointer bytes (CSize length)
+    | pointer == nullPtr = pure 1
+    | bytes == nullPtr && length > 0 = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            payload <- BS.packCStringLen
+                (castPtr bytes, fromIntegral length)
+            case (Aeson.eitherDecodeStrict' payload
+                :: Either String BridgeRequest) of
+                Left _ -> pure False
+                Right request -> do
+                    atomically
+                        (writeTQueue
+                            engine.engineCommands
+                            (EngineRequest request))
+                    pure True
+        pure $ case accepted of
+            Left _ -> 3
+            Right False -> 4
+            Right True -> 0
+
+ha_engine_destroy :: Ptr () -> IO ()
+ha_engine_destroy pointer
+    | pointer == nullPtr = pure ()
+    | otherwise = void $ tryAny do
+        let stable = castPtrToStablePtr pointer :: StablePtr Engine
+        (do
+            engine <- deRefStablePtr stable
+            atomically (writeTQueue engine.engineCommands EngineStop)
+            readMVar engine.engineDone)
+            `finally` freeStablePtr stable
+
+workerLifecycle
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> ManagedPostgresConfig
+    -> OsPath
+    -> TQueue EngineCommand
+    -> IO ()
+workerLifecycle callback context config root commands = do
+    store <- newMVar Nothing
+    processRuntime <- newNativeProcessRuntime root
+    let cleanup =
+            closeNativeProcessRuntime processRuntime
+                `finally` closeEngineStore store
+    idleLoop
+        callback
+        context
+        config
+        store
+        root
+        processRuntime
+        commands
+        `finally` cleanup
+
+idleLoop
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> ManagedPostgresConfig
+    -> MVar (Maybe Store)
+    -> OsPath
+    -> NativeProcessRuntime
+    -> TQueue EngineCommand
+    -> IO ()
+idleLoop callback context config store root processRuntime commands =
+    atomically (readTQueue commands) >>= \case
+        EngineStop -> pure ()
+        EngineRequest request
+            | request.requestMethod == "turn.start" ->
+                case (parseParams request
+                    :: Either Text TurnStart) of
+                    Left err -> do
+                        sendEvent callback context
+                            (failureEvent request.requestId err)
+                        continue
+                    Right start -> do
+                        control <- newTurnControl start.turnStartId
+                        sendEvent callback context $
+                            successEvent request.requestId $
+                                Aeson.object
+                                    [ "turnId" Aeson..= start.turnStartId
+                                    ]
+                        sendTurnStatus
+                            callback
+                            context
+                            start.turnStartId
+                            (if start.turnStartWorktree
+                                then "Creating worktree…"
+                                else "Starting…")
+                        withAsync
+                            (runNativeTurn
+                                callback
+                                context
+                                processRuntime
+                                control
+                                start)
+                            \running ->
+                                activeLoop
+                                    callback
+                                    context
+                                    config
+                                    store
+                                    root
+                                    commands
+                                    control
+                                    running >>= \case
+                                        ActiveContinue -> continue
+                                        ActiveStop -> pure ()
+            | request.requestMethod `elem`
+                ["turn.cancel", "approval.resolve"] -> do
+                    sendEvent callback context $
+                        failureEvent
+                            request.requestId
+                            "there is no active turn"
+                    continue
+            | otherwise -> do
+                event <- handleRequest config store root request
+                sendEvent callback context event
+                continue
+  where
+    continue =
+        idleLoop callback context config store root processRuntime commands
+
+activeLoop
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> ManagedPostgresConfig
+    -> MVar (Maybe Store)
+    -> OsPath
+    -> TQueue EngineCommand
+    -> TurnControl
+    -> Async TurnOutcome
+    -> IO ActiveExit
+activeLoop callback context config store root commands control running =
+    atomically
+        ((Left <$> readTQueue commands)
+            `orElse` (Right <$> waitCatchSTM running)) >>= \case
+        Right outcome -> do
+            finishTurnEvent callback context control.turnControlId outcome
+            pure ActiveContinue
+        Left EngineStop -> do
+            cancelTurn control
+            cancel running
+            pure ActiveStop
+        Left (EngineRequest request) -> do
+            if request.requestMethod == "turn.cancel"
+              then
+                case (parseParams request
+                    :: Either Text TurnReference) of
+                    Right reference
+                        | reference.turnReferenceId == control.turnControlId -> do
+                            cancelTurn control
+                            cancel running
+                            sendEvent callback context $
+                                successEvent request.requestId True
+                    _ ->
+                        sendEvent callback context $
+                            failureEvent request.requestId "turn id is not active"
+              else if request.requestMethod == "approval.resolve"
+              then
+                resolveApproval control request >>= sendEvent callback context
+              else if request.requestMethod == "turn.agents"
+              then
+                activeAgentSnapshot control request
+                    >>= sendEvent callback context
+              else if request.requestMethod == "turn.start"
+              then
+                sendEvent callback context $
+                    failureEvent request.requestId "a turn is already running"
+              else
+                handleRequest config store root request
+                    >>= sendEvent callback context
+            activeLoop
+                callback
+                context
+                config
+                store
+                root
+                commands
+                control
+                running
+
+runNativeTurn
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> NativeProcessRuntime
+    -> TurnControl
+    -> TurnStart
+    -> IO TurnOutcome
+runNativeTurn callback context processRuntime control start = do
+    sessionIdRef <- newIORef start.turnStartSessionId
+    completedRef <- newIORef False
+    let hooks = NativeRunHooks
+            { nativeOnLoopEvent = \event -> do
+                case event of
+                    TurnFinished _ -> writeIORef completedRef True
+                    _ -> pure ()
+                forM_ (nativeLoopEvent control.turnControlId event)
+                    (sendEvent callback context)
+            , nativeOnSessionId = \sessionId -> do
+                writeIORef sessionIdRef (Just sessionId)
+                sendEvent callback context $
+                    Aeson.object
+                        [ "event" Aeson..= ("turn.session" :: Text)
+                        , "turnId" Aeson..= control.turnControlId
+                        , "sessionId" Aeson..= sessionId
+                        ]
+            , nativeRegisterCancel =
+                atomically . writeTVar control.turnControlCancel
+            , nativeRegisterAgentSnapshot =
+                atomically . writeTVar control.turnControlAgentSnapshot
+            , nativeRequestApproval =
+                requestApproval callback context control
+            }
+        modelArgs = case
+            (start.turnStartProvider, start.turnStartModel) of
+                (Just provider, Just model) ->
+                    [ "--provider", Text.unpack provider
+                    , "--model", Text.unpack model
+                    ]
+                _ -> []
+        args =
+            [ "--minimal"
+            , "--motion", "off"
+            , "--save-session"
+            , "--no-yolo"
+            ]
+                <> maybe
+                    []
+                    (\sessionId -> ["--resume", Text.unpack sessionId])
+                    start.turnStartSessionId
+                <> (if start.turnStartWorktree then ["--worktree"] else [])
+                <> modelArgs
+                <> maybe
+                    []
+                    (\effort -> ["--effort", Text.unpack effort])
+                    start.turnStartEffort
+                <> ["--prompt", Text.unpack start.turnStartPrompt]
+    result <- tryAny $
+        withFile "/dev/null" WriteMode \output ->
+            runNativeAgent
+                processRuntime
+                output
+                (unsafeEncodeUtf start.turnStartCwd)
+                hooks
+                args
+    completed <- readIORef completedRef
+    sessionId <- readIORef sessionIdRef
+    pure TurnOutcome
+        { turnOutcomeSessionId = sessionId
+        , turnOutcomeError =
+            case result of
+                Left exception -> Just (Text.pack (show exception))
+                Right (Left err) -> Just err
+                Right (Right ())
+                    | completed -> Nothing
+                    | otherwise ->
+                        Just
+                            "turn ended without a completion event"
+        }
+
+newTurnControl :: Text -> IO TurnControl
+newTurnControl turnId =
+    TurnControl turnId
+        <$> newTVarIO (pure ())
+        <*> newTVarIO Map.empty
+        <*> newTVarIO 0
+        <*> newTVarIO Set.empty
+        <*> newTVarIO (pure [])
+
+activeAgentSnapshot :: TurnControl -> BridgeRequest -> IO Aeson.Value
+activeAgentSnapshot control request = do
+    loadSnapshot <- readTVarIO control.turnControlAgentSnapshot
+    tryAny loadSnapshot >>= \case
+        Left exception -> pure $
+            failureEvent request.requestId (Text.pack (show exception))
+        Right agents -> pure $
+            successEvent request.requestId (map agentEntryJSON agents)
+
+agentEntryJSON :: Viewport.AgentEntry -> Aeson.Value
+agentEntryJSON entry =
+    Aeson.object
+        [ "path" Aeson..= entry.agentPath
+        , "status" Aeson..= entry.agentStatus
+        , "model" Aeson..= entry.agentModel
+        , "steps" Aeson..= map agentStepJSON entry.agentSteps
+        ]
+
+agentStepJSON :: Viewport.AgentStep -> Aeson.Value
+agentStepJSON step =
+    Aeson.object
+        [ "state" Aeson..= agentStepStateText step.agentStepState
+        , "title" Aeson..= step.agentStepTitle
+        , "detail" Aeson..= step.agentStepDetail
+        ]
+
+agentStepStateText :: Viewport.AgentStepState -> Text
+agentStepStateText = \case
+    Viewport.AgentStepRunning -> "running"
+    Viewport.AgentStepCompleted -> "completed"
+    Viewport.AgentStepFailed -> "failed"
+    Viewport.AgentStepInfo -> "info"
+
+cancelTurn :: TurnControl -> IO ()
+cancelTurn control = do
+    cancelAction <- readTVarIO control.turnControlCancel
+    cancelAction
+    waiters <- atomically do
+        current <- readTVar control.turnControlApprovals
+        writeTVar control.turnControlApprovals Map.empty
+        pure (Map.elems current)
+    atomically $
+        forM_ waiters \waiter ->
+            void (tryPutTMVar waiter PermissionDeny)
+
+requestApproval
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> TurnControl
+    -> ToolCall
+    -> IO (Maybe PermissionChoice)
+requestApproval callback context control call = do
+    alreadyAllowed <- Set.member call.name
+        <$> readTVarIO control.turnControlAllowedTools
+    if alreadyAllowed
+      then pure (Just PermissionAllowOnce)
+      else requestApprovalFromClient callback context control call
+
+requestApprovalFromClient
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> TurnControl
+    -> ToolCall
+    -> IO (Maybe PermissionChoice)
+requestApprovalFromClient callback context control call = do
+    waiter <- newEmptyTMVarIO
+    approvalId <- atomically do
+        current <- readTVar control.turnControlApprovalCounter
+        let next = current + 1
+            approvalId =
+                control.turnControlId
+                    <> "-approval-"
+                    <> Text.pack (show next)
+        writeTVar control.turnControlApprovalCounter next
+        modifyTVar'
+            control.turnControlApprovals
+            (Map.insert approvalId waiter)
+        pure approvalId
+    let (arguments, truncated) =
+            boundedEventText
+                (if call.argumentsEncrypted then "" else call.arguments)
+    sendEvent callback context $
+        Aeson.object
+            [ "event" Aeson..= ("approval.requested" :: Text)
+            , "turnId" Aeson..= control.turnControlId
+            , "approval" Aeson..= Aeson.object
+                [ "id" Aeson..= approvalId
+                , "callId" Aeson..= call.callId
+                , "name" Aeson..= call.name
+                , "summary" Aeson..= summarizeToolCall call
+                , "arguments" Aeson..= arguments
+                , "argumentsEncrypted" Aeson..= call.argumentsEncrypted
+                , "truncated" Aeson..= truncated
+                ]
+            ]
+    choice <- atomically (takeTMVar waiter)
+    atomically $
+        modifyTVar'
+            control.turnControlApprovals
+            (Map.delete approvalId)
+    case choice of
+        PermissionAllowTool ->
+            atomically $
+                modifyTVar'
+                    control.turnControlAllowedTools
+                    (Set.insert call.name)
+        _ -> pure ()
+    pure (Just choice)
+
+resolveApproval :: TurnControl -> BridgeRequest -> IO Aeson.Value
+resolveApproval control request =
+    case (parseParams request
+        :: Either Text ApprovalResolution) of
+        Left err -> pure (failureEvent request.requestId err)
+        Right resolution ->
+            case permissionChoice resolution.approvalResolutionDecision of
+                Nothing ->
+                    pure $ failureEvent
+                        request.requestId
+                        "unknown approval decision"
+                Just choice -> do
+                    accepted <- atomically do
+                        current <- readTVar control.turnControlApprovals
+                        case Map.lookup
+                            resolution.approvalResolutionId
+                            current of
+                                Nothing -> pure False
+                                Just waiter -> do
+                                    published <- tryPutTMVar waiter choice
+                                    if published
+                                        then writeTVar
+                                            control.turnControlApprovals
+                                            (Map.delete
+                                                resolution.approvalResolutionId
+                                                current)
+                                        else pure ()
+                                    pure published
+                    pure $
+                        if accepted
+                            then successEvent request.requestId True
+                            else failureEvent
+                                request.requestId
+                                "approval request is no longer active"
+
+permissionChoice :: Text -> Maybe PermissionChoice
+permissionChoice = \case
+    "allow_once" -> Just PermissionAllowOnce
+    "allow_tool" -> Just PermissionAllowTool
+    "deny" -> Just PermissionDeny
+    _ -> Nothing
+
+finishTurnEvent
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> Text
+    -> Either SomeException TurnOutcome
+    -> IO ()
+finishTurnEvent callback context turnId = \case
+    Left exception ->
+        sendEvent callback context $
+            turnFailedEvent turnId (Text.pack (show exception))
+    Right outcome ->
+        case outcome.turnOutcomeError of
+            Just err ->
+                sendEvent callback context (turnFailedEvent turnId err)
+            Nothing ->
+                sendEvent callback context $
+                    Aeson.object
+                        [ "event" Aeson..= ("turn.completed" :: Text)
+                        , "turnId" Aeson..= turnId
+                        , "sessionId" Aeson..= outcome.turnOutcomeSessionId
+                        ]
+
+nativeLoopEvent :: Text -> LoopEvent -> Maybe Aeson.Value
+nativeLoopEvent turnId = \case
+    TextDelta text ->
+        Just $ Aeson.object
+            [ "event" Aeson..= ("turn.text_delta" :: Text)
+            , "turnId" Aeson..= turnId
+            , "text" Aeson..= text
+            ]
+    ToolStarted call ->
+        let (arguments, truncated) =
+                boundedEventText
+                    (if call.argumentsEncrypted then "" else call.arguments)
+        in Just $ Aeson.object
+            [ "event" Aeson..= ("turn.tool" :: Text)
+            , "turnId" Aeson..= turnId
+            , "tool" Aeson..= Aeson.object
+                [ "type" Aeson..= ("tool_started" :: Text)
+                , "callId" Aeson..= call.callId
+                , "name" Aeson..= call.name
+                , "summary" Aeson..= summarizeToolCall call
+                , "arguments" Aeson..= arguments
+                , "argumentsEncrypted" Aeson..= call.argumentsEncrypted
+                , "truncated" Aeson..= truncated
+                ]
+            ]
+    ToolFinished result ->
+        let (output, truncated) = boundedEventText result.output
+        in Just $ Aeson.object
+            [ "event" Aeson..= ("turn.tool" :: Text)
+            , "turnId" Aeson..= turnId
+            , "tool" Aeson..= Aeson.object
+                [ "type" Aeson..= ("tool_finished" :: Text)
+                , "callId" Aeson..= result.callId
+                , "output" Aeson..= output
+                , "truncated" Aeson..= truncated
+                ]
+            ]
+    ActivityUpdated status ->
+        Just $ turnStatusEvent turnId status
+    WarningRaised warning ->
+        Just $ turnStatusEvent turnId warning
+    ResponseRestarted message ->
+        Just $ turnStatusEvent turnId message
+    _ -> Nothing
+
+turnStatusEvent :: Text -> Text -> Aeson.Value
+turnStatusEvent turnId status =
+    Aeson.object
+        [ "event" Aeson..= ("turn.status" :: Text)
+        , "turnId" Aeson..= turnId
+        , "status" Aeson..= status
+        ]
+
+sendTurnStatus
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> Text
+    -> Text
+    -> IO ()
+sendTurnStatus callback context turnId =
+    sendEvent callback context . turnStatusEvent turnId
+
+turnFailedEvent :: Text -> Text -> Aeson.Value
+turnFailedEvent turnId message =
+    Aeson.object
+        [ "event" Aeson..= ("turn.failed" :: Text)
+        , "turnId" Aeson..= turnId
+        , "error" Aeson..= message
+        ]
+
+handleRequest
+    :: ManagedPostgresConfig
+    -> MVar (Maybe Store)
+    -> OsPath
+    -> BridgeRequest
+    -> IO Aeson.Value
+handleRequest config store root request = do
+    result <- tryAny (handleMethod request)
+    pure $ either
+        (failureEvent request.requestId . Text.pack . show)
+        id
+        result
+  where
+    handleMethod current =
+        case current.requestMethod of
+            "ping" ->
+                pure $ successEvent current.requestId $
+                    Aeson.object
+                        [ "runtime" Aeson..= ("haskell" :: Text)
+                        , "protocol" Aeson..= (3 :: Int)
+                        ]
+            "sessions.list" -> do
+                activeStore <- acquireStore config store
+                let pool = trustedPool activeStore
+                sessions <- listSessions pool root
+                archivedIds <- listArchivedSessionIds pool
+                    >>= either (fail . Text.unpack) pure
+                let archived = Set.fromList archivedIds
+                summaries <- mapM
+                    (\session -> sessionSummaryWithStatusJSON
+                        root
+                        (Set.member session.metaId archived)
+                        session)
+                    sessions
+                pure $ successEvent current.requestId
+                    summaries
+            "sessions.show" ->
+                case (parseParams current
+                    :: Either Text SessionPageRequest) of
+                    Left err ->
+                        pure (failureEvent current.requestId err)
+                    Right page -> do
+                        activeStore <- acquireStore config store
+                        snapshot <- loadSessionPageJSON
+                            (trustedPool activeStore)
+                            root
+                            page.sessionPageId
+                            page.sessionPageBefore
+                            (max 1 (min 200 (maybe 50 id page.sessionPageLimit)))
+                        pure $ either
+                            (failureEvent current.requestId)
+                            (successEvent current.requestId)
+                            snapshot
+            "sessions.rename" ->
+                case (parseParams current
+                    :: Either Text SessionRenameRequest) of
+                    Left err ->
+                        pure (failureEvent current.requestId err)
+                    Right rename -> do
+                        activeStore <- acquireStore config store
+                        renamed <- renameSession
+                            (trustedPool activeStore)
+                            root
+                            rename.sessionRenameId
+                            rename.sessionRenameTitle
+                        pure $ either
+                            (failureEvent current.requestId)
+                            (const (successEvent current.requestId True))
+                            renamed
+            "sessions.delete" ->
+                case (parseParams current
+                    :: Either Text SessionReference) of
+                    Left err ->
+                        pure (failureEvent current.requestId err)
+                    Right reference -> do
+                        activeStore <- acquireStore config store
+                        deleted <- deleteSession
+                            (trustedPool activeStore)
+                            root
+                            reference.sessionReferenceId
+                        pure $ either
+                            (failureEvent current.requestId)
+                            (const (successEvent current.requestId True))
+                            deleted
+            "sessions.archive" ->
+                case (parseParams current
+                    :: Either Text SessionArchiveRequest) of
+                    Left err ->
+                        pure (failureEvent current.requestId err)
+                    Right archive -> do
+                        activeStore <- acquireStore config store
+                        changed <- setSessionArchived
+                            (trustedPool activeStore)
+                            root
+                            archive.sessionArchiveId
+                            archive.sessionArchiveArchived
+                        pure $ either
+                            (failureEvent current.requestId)
+                            (const (successEvent current.requestId True))
+                            changed
+            "accounts.list" -> do
+                accounts <- accountSummariesJSON
+                pure $ successEvent current.requestId
+                    accounts
+            "turn.agents" ->
+                pure $ successEvent current.requestId ([] :: [Aeson.Value])
+            "models.list" ->
+                case (parseParams current
+                    :: Either Text ModelsListRequest) of
+                    Left err ->
+                        pure (failureEvent current.requestId err)
+                    Right parameters -> do
+                        activeStore <- acquireStore config store
+                        catalogResult <- loadNativeModelCatalog
+                            activeStore
+                            root
+                            parameters
+                        pure $ either
+                            (failureEvent current.requestId)
+                            (successEvent current.requestId)
+                            catalogResult
+            method ->
+                pure $ failureEvent current.requestId
+                    ("unknown method: " <> method)
+
+loadNativeModelCatalog
+    :: Store
+    -> OsPath
+    -> ModelsListRequest
+    -> IO (Either Text Aeson.Value)
+loadNativeModelCatalog store root request = do
+    let home = takeDirectory (takeDirectory root)
+        requestedCwd = unsafeEncodeUtf request.modelsListCwd
+    contextResult <- currentModelContext
+        store
+        root
+        requestedCwd
+        request.modelsListSessionId
+    case contextResult of
+        Left err -> pure (Left err)
+        Right (cwd, maybeTarget) ->
+            loadModelCatalogAt home cwd >>= \case
+                Left err -> pure (Left err)
+                Right catalog -> do
+                    selectedTarget <- case maybeTarget of
+                        Just target -> pure (Just target)
+                        Nothing ->
+                            traverse
+                                (fmap (.modelTarget)
+                                    . resolveModelOptionDialect)
+                                ( defaultModelOptionFor
+                                    catalog
+                                    OpenAIProvider
+                                    <|> listToMaybe (modelCatalog catalog)
+                                )
+                    case selectedTarget of
+                        Nothing -> pure (Left "model catalog is empty")
+                        Just target -> do
+                            picker <- initialPickerStateResolved
+                                catalog
+                                target.targetConnectionId
+                                target.targetProvider
+                                target.targetModelId
+                                target.targetDialect
+                            pure $ Right $ Aeson.object
+                                [ "options" Aeson..=
+                                    map modelOptionJSON picker.pickerAll
+                                , "current" Aeson..=
+                                    fmap modelOptionJSON
+                                        (selectedOption picker)
+                                ]
+
+currentModelContext
+    :: Store
+    -> OsPath
+    -> OsPath
+    -> Maybe Text
+    -> IO (Either Text (OsPath, Maybe ModelTarget))
+currentModelContext store root cwd = \case
+    Just sessionId ->
+        fmap (fmap (\meta ->
+            (meta.metaCwd, Just (sessionModelTarget meta)))) $
+            loadSessionMeta (trustedPool store) root sessionId
+    Nothing -> do
+        projectRoot <- resolveProjectRoot cwd
+        settings <- loadProjectSettings projectRoot
+        pure $ Right
+            ( cwd
+            , (.projectModelTarget) <$> settings.settingsLastModel
+            )
+
+sessionModelTarget :: SessionMeta -> ModelTarget
+sessionModelTarget meta =
+    ModelTarget
+        { targetProvider = meta.metaProvider
+        , targetConnectionId = meta.metaConnection
+        , targetModelId = meta.metaModel
+        , targetWireModelId =
+            fromMaybe meta.metaModel meta.metaTransportModel
+        , targetDialect = meta.metaDialect
+        }
+
+modelOptionJSON :: ModelOption -> Aeson.Value
+modelOptionJSON option =
+    let target = option.modelTarget
+    in Aeson.object
+        [ "id" Aeson..= target.targetModelId
+        , "provider" Aeson..= providerSlug target.targetProvider
+        , "connection" Aeson..= target.targetConnectionId
+        , "wireModel" Aeson..= target.targetWireModelId
+        , "dialect" Aeson..= dialectSlug target.targetDialect
+        , "label" Aeson..= option.modelLabel
+        ]
+
+parseParams :: Aeson.FromJSON value => BridgeRequest -> Either Text value
+parseParams request =
+    case Aeson.parseEither Aeson.parseJSON request.requestParams of
+        Left err -> Left (Text.pack err)
+        Right value -> Right value
+
+acquireStore :: ManagedPostgresConfig -> MVar (Maybe Store) -> IO Store
+acquireStore config state =
+    modifyMVar state \case
+        Just store -> pure (Just store, store)
+        Nothing ->
+            openStore config >>= \case
+                Left err -> fail (Text.unpack (renderStoreError err))
+                Right store -> pure (Just store, store)
+
+closeEngineStore :: MVar (Maybe Store) -> IO ()
+closeEngineStore state =
+    modifyMVar state \case
+        Nothing -> pure (Nothing, ())
+        Just store -> closeStore store >> pure (Nothing, ())
+
+boundedEventText :: Text -> (Text, Bool)
+boundedEventText value =
+    let (visible, remainder) = Text.splitAt 8192 value
+    in (visible, not (Text.null remainder))
+
+successEvent :: Aeson.ToJSON value => Text -> value -> Aeson.Value
+successEvent requestId result =
+    Aeson.object
+        [ "id" Aeson..= requestId
+        , "ok" Aeson..= True
+        , "result" Aeson..= result
+        ]
+
+failureEvent :: Text -> Text -> Aeson.Value
+failureEvent requestId message =
+    Aeson.object
+        [ "id" Aeson..= requestId
+        , "ok" Aeson..= False
+        , "error" Aeson..= message
+        ]
+
+sendEvent :: FunPtr EventCallback -> Ptr () -> Aeson.Value -> IO ()
+sendEvent callback context event =
+    void $ tryAny $
+        BS.useAsCStringLen (LBS.toStrict (Aeson.encode event)) \(bytes, length) ->
+            invokeEventCallback callback
+                context
+                (castPtr bytes)
+                (fromIntegral length)

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -88,6 +88,7 @@ import Agent.CLI.Project
     )
 import Agent.CLI.Render
     ( summarizeToolCall )
+import qualified Agent.CLI.RepositoryReview as RepositoryReview
 import Agent.CLI.Options (parseEffort)
 import Agent.CLI.Session
     ( SessionMeta(..)
@@ -121,8 +122,10 @@ import Agent.ToolDispatch
 import Control.Concurrent (forkFinally, forkIO)
 import Control.Concurrent.Async
     ( Async
+    , asyncWithUnmask
     , cancel
     , mapConcurrently
+    , waitCatch
     , waitCatchSTM
     , withAsync
     )
@@ -157,11 +160,13 @@ import Control.Exception.Safe
     ( SomeException
     , bracket
     , finally
+    , mask
     , tryAny
     )
 import Control.Monad
     ( forM_
     , void
+    , when
     )
 import qualified Data.Aeson as Aeson
 import Data.Aeson
@@ -171,11 +176,14 @@ import Data.Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import Data.Char (ord)
 import Data.IORef
-    ( newIORef
+    ( IORef
+    , newIORef
     , readIORef
     , writeIORef
     )
+import System.IO.Unsafe (unsafePerformIO)
 import Data.Int (Int64)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -200,6 +208,7 @@ import Foreign
     , nullFunPtr
     , nullPtr
     , plusPtr
+    , poke
     , peekByteOff
     , sizeOf
     )
@@ -210,6 +219,7 @@ import System.Directory
     , removeFile
     )
 import System.Directory.OsPath (getHomeDirectory)
+import qualified System.Exit
 import System.IO
     ( IOMode(WriteMode)
     , hClose
@@ -288,6 +298,42 @@ type LearnedSkillsListCallback =
     -> CString -> CSize -> CString -> CSize -> CString -> CSize
     -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
 
+type RepositorySnapshotCallback =
+    Ptr ()
+    -> CString -> CSize -- snapshot id
+    -> CString -> CSize -- repository root
+    -> CString -> CSize -- HEAD, empty for unborn
+    -> CString -> CSize -- index fingerprint
+    -> CString -> CSize -- worktree fingerprint
+    -> IO ()
+
+type RepositoryFileCallback =
+    Ptr ()
+    -> CString -> CSize -- path
+    -> CString -> CSize -- original path, null when absent
+    -> CInt -- index status byte
+    -> CInt -- worktree status byte
+    -> IO ()
+
+type RepositoryDiffCallback =
+    Ptr () -> Ptr Word8 -> CSize -> CInt -> IO ()
+
+type RepositoryHunkCallback =
+    Ptr () -> CLLong -> CLLong -> CLLong -> CLLong
+    -> CString -> CSize -> IO ()
+
+type RepositoryResultCallback =
+    Ptr () -> CInt
+    -> CString -> CSize -- current snapshot id on success/stale
+    -> CString -> CSize -- error
+    -> IO ()
+
+type RepositoryCheckOutputCallback =
+    Ptr () -> CInt -> Ptr Word8 -> CSize -> IO ()
+
+type RepositoryCheckExitCallback =
+    Ptr () -> CInt -> CInt -> CString -> CSize -> IO ()
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -317,6 +363,34 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeLearnedSkillsListCallback
         :: FunPtr LearnedSkillsListCallback -> LearnedSkillsListCallback
+
+foreign import ccall "dynamic"
+    invokeRepositorySnapshotCallback
+        :: FunPtr RepositorySnapshotCallback -> RepositorySnapshotCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryFileCallback
+        :: FunPtr RepositoryFileCallback -> RepositoryFileCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryDiffCallback
+        :: FunPtr RepositoryDiffCallback -> RepositoryDiffCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryHunkCallback
+        :: FunPtr RepositoryHunkCallback -> RepositoryHunkCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryResultCallback
+        :: FunPtr RepositoryResultCallback -> RepositoryResultCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryCheckOutputCallback
+        :: FunPtr RepositoryCheckOutputCallback -> RepositoryCheckOutputCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryCheckExitCallback
+        :: FunPtr RepositoryCheckExitCallback -> RepositoryCheckExitCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -534,6 +608,523 @@ foreign export ccall ha_account_delete
 
 foreign export ccall ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_snapshot
+    :: Ptr Word8 -> CSize
+    -> FunPtr RepositorySnapshotCallback
+    -> FunPtr RepositoryFileCallback
+    -> FunPtr RepositoryResultCallback
+    -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_diff
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryDiffCallback
+    -> FunPtr RepositoryHunkCallback
+    -> FunPtr RepositoryResultCallback
+    -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_apply_path
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt
+    -> Ptr Word8 -> CSize -> FunPtr RepositoryResultCallback
+    -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_apply_patch
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt
+    -> Ptr Word8 -> CSize -> FunPtr RepositoryResultCallback
+    -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_commit
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_cancel_all :: IO ()
+
+foreign export ccall ha_repository_check_start
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize
+    -> FunPtr RepositoryCheckOutputCallback
+    -> FunPtr RepositoryCheckExitCallback
+    -> Ptr () -> Ptr (Ptr ()) -> IO CInt
+
+foreign export ccall ha_repository_check_cancel :: Ptr () -> IO ()
+
+foreign export ccall ha_repository_check_destroy :: Ptr () -> IO ()
+
+ha_repository_snapshot
+    :: Ptr Word8 -> CSize
+    -> FunPtr RepositorySnapshotCallback
+    -> FunPtr RepositoryFileCallback
+    -> FunPtr RepositoryResultCallback
+    -> Ptr () -> IO CInt
+ha_repository_snapshot pathBytes pathLength snapshotCallback fileCallback
+    resultCallback context
+    | snapshotCallback == nullFunPtr
+        || fileCallback == nullFunPtr
+        || resultCallback == nullFunPtr = pure 1
+    | otherwise =
+        copyRequiredText pathBytes pathLength >>= \case
+            Left _ -> pure 2
+            Right path -> do
+                started <- startRepositoryWorker $
+                    tryAny
+                        (RepositoryReview.repositorySnapshot (Text.unpack path))
+                        >>= \case
+                            Left exception ->
+                                emitRepositoryFailure
+                                    resultCallback
+                                    context
+                                    (Text.pack (show exception))
+                            Right (Left err) ->
+                                emitRepositoryError resultCallback context err
+                            Right (Right snapshot) -> do
+                                withRepositorySnapshot snapshot $
+                                    invokeRepositorySnapshotCallback
+                                        snapshotCallback
+                                        context
+                                forM_ snapshot.snapshotFiles \file ->
+                                    withText (Text.pack file.repositoryFilePath) $
+                                        \pathPtr pathSize ->
+                                    withOptionalText
+                                        (Text.pack
+                                            <$> file.repositoryFileOriginalPath)
+                                        \originalPtr originalSize ->
+                                            invokeRepositoryFileCallback
+                                                fileCallback
+                                                context
+                                                pathPtr pathSize
+                                                originalPtr originalSize
+                                                (fromIntegral
+                                                    (ord
+                                                        file.repositoryFileIndexStatus))
+                                                (fromIntegral
+                                                    (ord
+                                                        file.repositoryFileWorktreeStatus))
+                                emitRepositorySuccess
+                                    resultCallback
+                                    context
+                                    snapshot.snapshotId
+                pure (if started then 0 else 3)
+
+ha_repository_diff
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryDiffCallback
+    -> FunPtr RepositoryHunkCallback
+    -> FunPtr RepositoryResultCallback
+    -> Ptr () -> IO CInt
+ha_repository_diff pathBytes pathLength snapshotBytes snapshotLength
+    diffKind fileBytes fileLength diffCallback hunkCallback resultCallback context
+    | diffCallback == nullFunPtr
+        || hunkCallback == nullFunPtr
+        || resultCallback == nullFunPtr = pure 1
+    | otherwise =
+        copyRequiredTexts
+            [ (pathBytes, pathLength)
+            , (snapshotBytes, snapshotLength)
+            , (fileBytes, fileLength)
+            ] >>= \case
+                Left _ -> pure 2
+                Right [path, expected, file] ->
+                    case repositoryDiffKind diffKind of
+                        Nothing -> pure 2
+                        Just kind -> do
+                            started <- startRepositoryWorker $
+                                tryAny
+                                    (RepositoryReview.repositoryDiff
+                                        (Text.unpack path)
+                                        expected
+                                        kind
+                                        (Text.unpack file))
+                                    >>= \case
+                                        Left exception ->
+                                            emitRepositoryFailure
+                                                resultCallback
+                                                context
+                                                (Text.pack (show exception))
+                                        Right (Left err) ->
+                                            emitRepositoryError
+                                                resultCallback context err
+                                        Right (Right diff) -> do
+                                            forM_
+                                                (byteStringChunks
+                                                    (64 * 1024)
+                                                    diff.repositoryDiffPatch)
+                                                \chunk ->
+                                                    BS.useAsCStringLen chunk
+                                                        \(pointer, length) ->
+                                                            invokeRepositoryDiffCallback
+                                                                diffCallback
+                                                                context
+                                                                (castPtr pointer)
+                                                                (fromIntegral length)
+                                                                (if
+                                                                    diff.repositoryDiffBinary
+                                                                    then 1
+                                                                    else 0)
+                                            forM_ diff.repositoryDiffHunks \hunk ->
+                                                withText hunk.hunkHeader $
+                                                    \headerPtr headerLength ->
+                                                        invokeRepositoryHunkCallback
+                                                            hunkCallback
+                                                            context
+                                                            (fromIntegral hunk.hunkOldStart)
+                                                            (fromIntegral hunk.hunkOldCount)
+                                                            (fromIntegral hunk.hunkNewStart)
+                                                            (fromIntegral hunk.hunkNewCount)
+                                                            headerPtr headerLength
+                                            emitRepositorySuccess
+                                                resultCallback context expected
+                            pure (if started then 0 else 3)
+                Right _ -> pure 3
+
+ha_repository_apply_path
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt
+    -> Ptr Word8 -> CSize -> FunPtr RepositoryResultCallback
+    -> Ptr () -> IO CInt
+ha_repository_apply_path pathBytes pathLength snapshotBytes snapshotLength
+    operation fileBytes fileLength callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise =
+        copyRequiredTexts
+            [ (pathBytes, pathLength)
+            , (snapshotBytes, snapshotLength)
+            , (fileBytes, fileLength)
+            ] >>= \case
+                Left _ -> pure 2
+                Right [path, expected, file] ->
+                    case repositoryPathMutation operation (Text.unpack file) of
+                        Nothing -> pure 2
+                        Just mutation -> do
+                            started <- startRepositoryMutation
+                                callback context (Text.unpack path) expected mutation
+                            pure (if started then 0 else 3)
+                Right _ -> pure 3
+
+ha_repository_apply_patch
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> CInt
+    -> Ptr Word8 -> CSize -> FunPtr RepositoryResultCallback
+    -> Ptr () -> IO CInt
+ha_repository_apply_patch pathBytes pathLength snapshotBytes snapshotLength
+    operation patchBytes patchLength callback context
+    | callback == nullFunPtr = pure 1
+    | patchBytes == nullPtr || patchLength == 0 = pure 2
+    | toInteger patchLength > toInteger (maxBound :: Int) = pure 2
+    | otherwise =
+        copyRequiredTexts
+            [(pathBytes, pathLength), (snapshotBytes, snapshotLength)]
+            >>= \case
+                Left _ -> pure 2
+                Right [path, expected] -> do
+                    patch <- BS.packCStringLen
+                        (castPtr patchBytes, fromIntegral patchLength)
+                    case repositoryPatchMutation operation patch of
+                        Nothing -> pure 2
+                        Just mutation -> do
+                            started <- startRepositoryMutation
+                                callback context (Text.unpack path) expected mutation
+                            pure (if started then 0 else 3)
+                Right _ -> pure 3
+
+ha_repository_commit
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryResultCallback -> Ptr () -> IO CInt
+ha_repository_commit pathBytes pathLength snapshotBytes snapshotLength
+    messageBytes messageLength callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise =
+        copyRequiredTexts
+            [ (pathBytes, pathLength)
+            , (snapshotBytes, snapshotLength)
+            , (messageBytes, messageLength)
+            ] >>= \case
+                Left _ -> pure 2
+                Right [path, expected, message] -> do
+                    started <- startRepositoryWorker $
+                        tryAny
+                            (RepositoryReview.commitRepository
+                                (Text.unpack path)
+                                expected
+                                message)
+                            >>= \case
+                                Left exception ->
+                                    emitRepositoryFailure
+                                        callback context (Text.pack (show exception))
+                                Right (Left err) ->
+                                    emitRepositoryError callback context err
+                                Right (Right snapshot) ->
+                                    emitRepositorySuccess
+                                        callback context snapshot.snapshotId
+                    pure (if started then 0 else 3)
+                Right _ -> pure 3
+
+startRepositoryMutation
+    :: FunPtr RepositoryResultCallback
+    -> Ptr ()
+    -> FilePath
+    -> Text
+    -> RepositoryReview.RepositoryMutation
+    -> IO Bool
+startRepositoryMutation callback context path expected mutation =
+    startRepositoryWorker $
+        tryAny (RepositoryReview.mutateRepository path expected mutation)
+            >>= \case
+                Left exception ->
+                    emitRepositoryFailure callback context
+                        (Text.pack (show exception))
+                Right (Left err) ->
+                    emitRepositoryError callback context err
+                Right (Right snapshot) ->
+                    emitRepositorySuccess callback context snapshot.snapshotId
+
+startRepositoryWorker :: IO () -> IO Bool
+startRepositoryWorker action =
+    tryAny
+        (mask \_ -> do
+            gate <- newEmptyMVar
+            _workerId <- modifyMVar repositoryWorkers \(nextId, workers) -> do
+                let workerId = nextId
+                worker <- asyncWithUnmask \unmask -> do
+                    readMVar gate
+                    unmask action `finally`
+                        unregisterRepositoryWorker workerId
+                pure
+                    ( (nextId + 1, Map.insert workerId worker workers)
+                    , workerId
+                    )
+            putMVar gate ())
+        >>= \case
+            Left _ -> pure False
+            Right () -> pure True
+
+unregisterRepositoryWorker :: Int -> IO ()
+unregisterRepositoryWorker workerId =
+    modifyMVar repositoryWorkers \(nextId, workers) ->
+        pure ((nextId, Map.delete workerId workers), ())
+
+ha_repository_cancel_all :: IO ()
+ha_repository_cancel_all = do
+    workers <- modifyMVar repositoryWorkers \(nextId, active) ->
+        pure ((nextId, Map.empty), Map.elems active)
+    mapM_ cancel workers
+    mapM_ waitCatch workers
+
+{-# NOINLINE repositoryWorkers #-}
+repositoryWorkers :: MVar (Int, Map Int (Async ()))
+repositoryWorkers = unsafePerformIO (newMVar (0, Map.empty))
+
+data RepositoryCheckHandle = RepositoryCheckHandle
+    { repositoryCheckValue :: !(IORef (Maybe RepositoryReview.RepositoryCheck))
+    , repositoryCheckCancelRequested :: !(IORef Bool)
+    , repositoryCheckOwner :: !(Async ())
+    }
+
+ha_repository_check_start
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize
+    -> FunPtr RepositoryCheckOutputCallback
+    -> FunPtr RepositoryCheckExitCallback
+    -> Ptr () -> Ptr (Ptr ()) -> IO CInt
+ha_repository_check_start pathBytes pathLength snapshotBytes snapshotLength
+    executableBytes executableLength argumentsPointer argumentCount
+    outputCallback exitCallback context outCheck
+    | outputCallback == nullFunPtr
+        || exitCallback == nullFunPtr
+        || outCheck == nullPtr = pure 1
+    | argumentsPointer == nullPtr && argumentCount > 0 = pure 2
+    | toInteger argumentCount > toInteger (maxBound :: Int) = pure 2
+    | otherwise =
+        copyRequiredTexts
+            [ (pathBytes, pathLength)
+            , (snapshotBytes, snapshotLength)
+            , (executableBytes, executableLength)
+            ] >>= \case
+                Left _ -> pure 2
+                Right [path, expected, executable] -> do
+                    copiedArguments <- copyRepositoryCheckArguments
+                        argumentsPointer argumentCount
+                    case copiedArguments of
+                        Left _ -> pure 2
+                        Right arguments -> do
+                            checkRef <- newIORef Nothing
+                            cancelRef <- newIORef False
+                            owner <- asyncWithUnmask \unmask ->
+                                unmask do
+                                    result <-
+                                        RepositoryReview.startRepositoryCheck
+                                            (Text.unpack path)
+                                            expected
+                                            (Text.unpack executable)
+                                            (map Text.unpack arguments)
+                                            (\stream bytes ->
+                                                BS.useAsCStringLen bytes
+                                                    \(pointer, length) ->
+                                                        invokeRepositoryCheckOutputCallback
+                                                            outputCallback
+                                                            context
+                                                            (case stream of
+                                                                RepositoryReview.RepositoryCheckStdout -> 1
+                                                                RepositoryReview.RepositoryCheckStderr -> 2)
+                                                            (castPtr pointer)
+                                                            (fromIntegral length))
+                                            (\cancelled exitCode ->
+                                                invokeRepositoryCheckExitCallback
+                                                    exitCallback
+                                                    context
+                                                    (if cancelled then 1 else 0)
+                                                    (case exitCode of
+                                                        System.Exit.ExitSuccess -> 0
+                                                        System.Exit.ExitFailure code ->
+                                                            fromIntegral code)
+                                                    nullPtr 0)
+                                    case result of
+                                        Left err ->
+                                            withText
+                                                (RepositoryReview.repositoryErrorText err)
+                                                \errorPtr errorLength ->
+                                                    invokeRepositoryCheckExitCallback
+                                                        exitCallback context 0 (-1)
+                                                        errorPtr errorLength
+                                        Right check -> do
+                                            writeIORef checkRef (Just check)
+                                            cancelRequested <- readIORef cancelRef
+                                            when cancelRequested
+                                                (RepositoryReview.cancelRepositoryCheck
+                                                    check)
+                                            RepositoryReview.waitRepositoryCheck check
+                            stable <- newStablePtr RepositoryCheckHandle
+                                { repositoryCheckValue = checkRef
+                                , repositoryCheckCancelRequested = cancelRef
+                                , repositoryCheckOwner = owner
+                                }
+                            poke outCheck (castStablePtrToPtr stable)
+                            pure 0
+                Right _ -> pure 3
+
+ha_repository_check_cancel :: Ptr () -> IO ()
+ha_repository_check_cancel pointer
+    | pointer == nullPtr = pure ()
+    | otherwise = do
+        let stable =
+                castPtrToStablePtr pointer
+                    :: StablePtr RepositoryCheckHandle
+        handle <- deRefStablePtr stable
+        writeIORef handle.repositoryCheckCancelRequested True
+        readIORef handle.repositoryCheckValue >>= mapM_
+            RepositoryReview.cancelRepositoryCheck
+
+ha_repository_check_destroy :: Ptr () -> IO ()
+ha_repository_check_destroy pointer
+    | pointer == nullPtr = pure ()
+    | otherwise = do
+        let stable =
+                castPtrToStablePtr pointer
+                    :: StablePtr RepositoryCheckHandle
+        handle <- deRefStablePtr stable
+        _ <- waitCatch handle.repositoryCheckOwner
+        freeStablePtr stable
+
+copyRepositoryCheckArguments
+    :: Ptr () -> CSize -> IO (Either () [Text])
+copyRepositoryCheckArguments pointer count =
+    fmap sequence $ mapM copyAt [0 .. fromIntegral count - 1]
+  where
+    pointerSize = sizeOf (nullPtr :: Ptr ())
+    sizeSize = sizeOf (undefined :: CSize)
+    itemSize = pointerSize + sizeSize
+    copyAt index = do
+        let base = castPtr pointer `plusPtr` (index * itemSize)
+        bytes <- peekByteOff base 0 :: IO (Ptr Word8)
+        length <- peekByteOff base pointerSize :: IO CSize
+        copyRequiredText bytes length
+
+repositoryPathMutation
+    :: CInt -> FilePath -> Maybe RepositoryReview.RepositoryMutation
+repositoryPathMutation operation path = case operation of
+    0 -> Just (RepositoryReview.StagePath path)
+    1 -> Just (RepositoryReview.UnstagePath path)
+    2 -> Just (RepositoryReview.RestorePath path)
+    _ -> Nothing
+
+repositoryDiffKind
+    :: CInt -> Maybe RepositoryReview.RepositoryDiffKind
+repositoryDiffKind kind = case kind of
+    0 -> Just RepositoryReview.RepositoryWorktreeDiff
+    1 -> Just RepositoryReview.RepositoryStagedDiff
+    _ -> Nothing
+
+repositoryPatchMutation
+    :: CInt -> BS.ByteString -> Maybe RepositoryReview.RepositoryMutation
+repositoryPatchMutation operation patch = case operation of
+    0 -> Just (RepositoryReview.StagePatch patch)
+    1 -> Just (RepositoryReview.UnstagePatch patch)
+    2 -> Just (RepositoryReview.RestorePatch patch)
+    _ -> Nothing
+
+withRepositorySnapshot
+    :: RepositoryReview.RepositorySnapshot
+    -> (CString -> CSize -> CString -> CSize -> CString -> CSize
+        -> CString -> CSize -> CString -> CSize -> IO value)
+    -> IO value
+withRepositorySnapshot snapshot action =
+    withText snapshot.snapshotId \snapshotPtr snapshotLength ->
+    withText (Text.pack snapshot.snapshotRoot) \rootPtr rootLength ->
+    withOptionalText snapshot.snapshotHead \headPtr headLength ->
+    withText snapshot.snapshotIndexFingerprint \indexPtr indexLength ->
+    withText snapshot.snapshotWorktreeFingerprint
+        \worktreePtr worktreeLength ->
+            action snapshotPtr snapshotLength rootPtr rootLength
+                headPtr headLength indexPtr indexLength
+                worktreePtr worktreeLength
+
+emitRepositorySuccess
+    :: FunPtr RepositoryResultCallback -> Ptr () -> Text -> IO ()
+emitRepositorySuccess callback context snapshotId =
+    withText snapshotId \snapshotPtr snapshotLength ->
+        invokeRepositoryResultCallback callback context 0
+            snapshotPtr snapshotLength nullPtr 0
+
+emitRepositoryFailure
+    :: FunPtr RepositoryResultCallback -> Ptr () -> Text -> IO ()
+emitRepositoryFailure callback context message =
+    withText message \errorPtr errorLength ->
+        invokeRepositoryResultCallback callback context (-1)
+            nullPtr 0 errorPtr errorLength
+
+emitRepositoryError
+    :: FunPtr RepositoryResultCallback
+    -> Ptr ()
+    -> RepositoryReview.RepositoryError
+    -> IO ()
+emitRepositoryError callback context err =
+    case err of
+        RepositoryReview.StaleRepositorySnapshot _ actual ->
+            withText actual \snapshotPtr snapshotLength ->
+            withText (RepositoryReview.repositoryErrorText err)
+                \errorPtr errorLength ->
+                    invokeRepositoryResultCallback callback context (-2)
+                        snapshotPtr snapshotLength errorPtr errorLength
+        _ ->
+            emitRepositoryFailure
+                callback context (RepositoryReview.repositoryErrorText err)
+
+copyRequiredText :: Ptr Word8 -> CSize -> IO (Either () Text)
+copyRequiredText pointer (CSize length)
+    | pointer == nullPtr || length == 0 = pure (Left ())
+    | toInteger length > toInteger (maxBound :: Int) = pure (Left ())
+    | otherwise = do
+        bytes <- BS.packCStringLen (castPtr pointer, fromIntegral length)
+        pure (first (const ()) (TextEncoding.decodeUtf8' bytes))
+
+copyRequiredTexts
+    :: [(Ptr Word8, CSize)]
+    -> IO (Either () [Text])
+copyRequiredTexts = fmap sequence . mapM (uncurry copyRequiredText)
+
+byteStringChunks :: Int -> BS.ByteString -> [BS.ByteString]
+byteStringChunks size bytes
+    | BS.null bytes = []
+    | otherwise =
+        let (chunk, remaining) = BS.splitAt size bytes
+        in chunk : byteStringChunks size remaining
 
 ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE FieldSelectors #-}
 
 module Agent.CLI.MacOS.Bridge () where
 
@@ -59,6 +60,11 @@ import Agent.Store.Postgres
     , closeStore
     , openStore
     , trustedPool
+    )
+import Agent.Store.Postgres.UsageCache
+    ( AccountUsageCacheEntry(..)
+    , loadAccountUsageCache
+    , upsertAccountUsageCache
     )
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
@@ -127,6 +133,8 @@ import qualified Data.Set as Set
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Time.Clock (addUTCTime, getCurrentTime)
 import Data.Word (Word8)
 import Foreign
     ( FunPtr
@@ -939,7 +947,8 @@ handleRequest config store root request = do
                             (const (successEvent current.requestId True))
                             changed
             "accounts.list" -> do
-                accounts <- accountSummariesJSON
+                activeStore <- acquireStore config store
+                accounts <- cachedAccountSummaries activeStore
                 pure $ successEvent current.requestId
                     accounts
             "turn.agents" ->
@@ -962,6 +971,48 @@ handleRequest config store root request = do
             method ->
                 pure $ failureEvent current.requestId
                     ("unknown method: " <> method)
+
+cachedAccountSummaries :: Store -> IO [Aeson.Value]
+cachedAccountSummaries store = do
+    let pool = trustedPool store
+    cached <- loadAccountUsageCache pool accountCacheProvider accountCacheKey
+    now <- getCurrentTime
+    case cached of
+        Right (Just entry)
+            | Just accounts <- decodeAccountCache entry.accountUsageCachePayload -> do
+                if entry.accountUsageCacheExpiresAt <= now
+                    then void $ forkFinally
+                        (refreshAccountCache store)
+                        (const (pure ()))
+                    else pure ()
+                pure accounts
+        _ -> refreshAccountCache store
+
+refreshAccountCache :: Store -> IO [Aeson.Value]
+refreshAccountCache store = do
+    accounts <- accountSummariesJSON
+    fetchedAt <- getCurrentTime
+    let payload = TextEncoding.decodeUtf8 $
+            LBS.toStrict (Aeson.encode accounts)
+        entry = AccountUsageCacheEntry
+            { accountUsageCacheProvider = accountCacheProvider
+            , accountUsageCacheAccountId = accountCacheKey
+            , accountUsageCachePayload = payload
+            , accountUsageCacheFetchedAt = fetchedAt
+            , accountUsageCacheExpiresAt = addUTCTime 300 fetchedAt
+            }
+    void $ upsertAccountUsageCache (trustedPool store) entry
+    pure accounts
+
+decodeAccountCache :: Text -> Maybe [Aeson.Value]
+decodeAccountCache =
+    Aeson.decodeStrict' . TextEncoding.encodeUtf8
+
+accountCacheProvider :: Text
+accountCacheProvider = "macos-bridge"
+
+accountCacheKey :: Text
+accountCacheKey = "account-summaries-v1"
 
 loadNativeModelCatalog
     :: Store

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -803,6 +803,12 @@ finishTurnEvent callback context turnId = \case
 
 nativeLoopEvent :: Text -> LoopEvent -> Maybe Aeson.Value
 nativeLoopEvent turnId = \case
+    ReasoningDelta text ->
+        Just $ Aeson.object
+            [ "event" Aeson..= ("turn.reasoning_delta" :: Text)
+            , "turnId" Aeson..= turnId
+            , "text" Aeson..= text
+            ]
     TextDelta text ->
         Just $ Aeson.object
             [ "event" Aeson..= ("turn.text_delta" :: Text)

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -59,7 +59,12 @@ import qualified Agent.OpenAI.Auth as OpenAIAuth
 import qualified Agent.OpenAI.Auth.Types as OpenAIAuthTypes
 import qualified Agent.XAI.Auth as XAIAuth
 import qualified Agent.OpenRouter.Usage as OpenRouter
-import Agent.CLI.ModelConfig (loadModelCatalogAt)
+import Agent.CLI.ModelConfig
+    ( CatalogModel(..)
+    , ModelCatalog
+    , catalogModelById
+    , loadModelCatalogAt
+    )
 import Agent.CLI.Database.Store
     ( applicableDatabaseScopes
     , deriveDatabaseScopes
@@ -1785,9 +1790,10 @@ loadNativeModelCatalog store root request = do
                                 target.targetDialect
                             pure $ Right $ Aeson.object
                                 [ "options" Aeson..=
-                                    map modelOptionJSON picker.pickerAll
+                                    map (modelOptionJSON catalog)
+                                        picker.pickerAll
                                 , "current" Aeson..=
-                                    fmap modelOptionJSON
+                                    fmap (modelOptionJSON catalog)
                                         (selectedOption picker)
                                 ]
 
@@ -1821,9 +1827,11 @@ sessionModelTarget meta =
         , targetDialect = meta.metaDialect
         }
 
-modelOptionJSON :: ModelOption -> Aeson.Value
-modelOptionJSON option =
+modelOptionJSON :: ModelCatalog -> ModelOption -> Aeson.Value
+modelOptionJSON catalog option =
     let target = option.modelTarget
+        configured =
+            catalogModelById catalog target.targetModelId
     in Aeson.object
         [ "id" Aeson..= target.targetModelId
         , "provider" Aeson..= providerSlug target.targetProvider
@@ -1831,6 +1839,10 @@ modelOptionJSON option =
         , "wireModel" Aeson..= target.targetWireModelId
         , "dialect" Aeson..= dialectSlug target.targetDialect
         , "label" Aeson..= option.modelLabel
+        , "supportedReasoningEfforts" Aeson..=
+            (configured >>= (.catalogModelReasoningEfforts))
+        , "defaultReasoningEffort" Aeson..=
+            (configured >>= (.catalogModelDefaultReasoningEffort))
         ]
 
 parseParams :: Aeson.FromJSON value => BridgeRequest -> Either Text value

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1025,25 +1025,14 @@ ha_repository_delivery_status pathBytes pathLength snapshotBytes snapshotLength
                         (emitDeliveryOnce terminal $
                             emitDeliveryStatusFailure callback context (-3)
                                 "repository delivery was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.repositoryDeliveryStatus
                                 (Text.unpack path)
-                                snapshot) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitDeliveryStatusFailure
-                                            callback context (-1)
-                                            "repository delivery failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitDeliveryStatusFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right status) ->
-                                        emitDeliveryOnce terminal $
-                                            emitDeliveryStatus
-                                                callback context status
+                                snapshot)
+                            (emitDeliveryStatusFailure callback context (-1)
+                                "repository delivery failed")
+                            (emitDeliveryStatusFailure callback context)
+                            (emitDeliveryStatus callback context)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1065,25 +1054,14 @@ ha_repository_push_preview pathBytes pathLength snapshotBytes snapshotLength
                         (emitDeliveryOnce terminal $
                             emitPushPreviewFailure callback context (-3)
                                 "repository push preview was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.previewRepositoryPush
                                 (Text.unpack path)
-                                snapshot) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushPreviewFailure
-                                            callback context (-1)
-                                            "repository push preview failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushPreviewFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right preview) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushPreview
-                                                callback context preview
+                                snapshot)
+                            (emitPushPreviewFailure callback context (-1)
+                                "repository push preview failed")
+                            (emitPushPreviewFailure callback context)
+                            (emitPushPreview callback context)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1105,23 +1083,14 @@ ha_repository_push_confirm pathBytes pathLength tokenBytes tokenLength
                         (emitDeliveryOnce terminal $
                             emitPushResultFailure callback context (-3)
                                 "repository push was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.confirmRepositoryPush
                                 (Text.unpack path)
-                                token) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushResultFailure
-                                            callback context (-1)
-                                            "repository push failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushResultFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right status) ->
-                                        emitDeliveryOnce terminal $
+                                token)
+                            (emitPushResultFailure callback context (-1)
+                                "repository push failed")
+                            (emitPushResultFailure callback context)
+                            (\status ->
                                         withText status.deliverySnapshotId
                                             \snapshotPtr snapshotSize ->
                                         withText status.deliveryHeadOid
@@ -1130,7 +1099,7 @@ ha_repository_push_confirm pathBytes pathLength tokenBytes tokenLength
                                                     callback context 0
                                                     snapshotPtr snapshotSize
                                                     headPtr headSize
-                                                    nullPtr 0
+                                                    nullPtr 0)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1164,25 +1133,15 @@ ha_repository_pr_preview pathBytes pathLength snapshotBytes snapshotLength
                             emitPullRequestPreviewFailure
                                 callback context (-3)
                                 "pull-request preview was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.previewPullRequest
                                 (Text.unpack path)
-                                snapshot base title body) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestPreviewFailure
-                                            callback context (-1)
-                                            "pull-request preview failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestPreviewFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right preview) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestPreview
-                                            callback context preview
+                                snapshot base title body)
+                            (emitPullRequestPreviewFailure
+                                callback context (-1)
+                                "pull-request preview failed")
+                            (emitPullRequestPreviewFailure callback context)
+                            (emitPullRequestPreview callback context)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1204,27 +1163,18 @@ ha_repository_pr_confirm pathBytes pathLength tokenBytes tokenLength
                         (emitDeliveryOnce terminal $
                             emitPullRequestResultFailure callback context (-3)
                                 "pull-request creation was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.createPullRequest
                                 (Text.unpack path)
-                                token) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestResultFailure
-                                            callback context (-1)
-                                            "pull-request creation failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestResultFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right url) ->
-                                        emitDeliveryOnce terminal $
+                                token)
+                            (emitPullRequestResultFailure callback context (-1)
+                                "pull-request creation failed")
+                            (emitPullRequestResultFailure callback context)
+                            (\url ->
                                         withText url \urlPtr urlSize ->
                                             invokeRepositoryPullRequestResultCallback
                                                 callback context 0
-                                                urlPtr urlSize nullPtr 0
+                                                urlPtr urlSize nullPtr 0)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1773,6 +1723,26 @@ emitDeliveryOnce terminal callback =
         shouldRun <- modifyMVar terminal \completed ->
             pure (True, not completed)
         when shouldRun callback
+
+prepareDeliveryResult
+    :: MVar Bool
+    -> IO (Either RepositoryDelivery.DeliveryError value)
+    -> IO ()
+    -> (CInt -> Text -> IO ())
+    -> (value -> IO ())
+    -> IO (IO ())
+prepareDeliveryResult terminal operation unexpectedFailure knownFailure success =
+    tryRepositorySynchronous operation >>= \case
+        Left _ ->
+            pure (emitDeliveryOnce terminal unexpectedFailure)
+        Right (Left err) ->
+            pure
+                (emitDeliveryOnce terminal $
+                    knownFailure
+                        (deliveryErrorStatus err)
+                        (RepositoryDelivery.deliveryErrorText err))
+        Right (Right value) ->
+            pure (emitDeliveryOnce terminal (success value))
 
 emitDeliveryStatus
     :: FunPtr RepositoryDeliveryStatusCallback

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -10,6 +10,9 @@ import Agent.CLI.NativeRuntime
     , newNativeProcessRuntime
     , runNativeAgent
     )
+import Agent.CLI.MacOS.NativeLoopEvent
+    ( encodeNativeLoopEvent
+    )
 import Agent.CLI.ModelConfig (loadModelCatalogAt)
 import Agent.CLI.Models
     ( ModelOption(..)
@@ -60,7 +63,6 @@ import Agent.Store.Postgres
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
-    , ToolCallResult(..)
     )
 import Control.Concurrent (forkFinally)
 import Control.Concurrent.Async
@@ -555,8 +557,11 @@ runNativeTurn callback context processRuntime control start = do
                 case event of
                     TurnFinished _ -> writeIORef completedRef True
                     _ -> pure ()
-                forM_ (nativeLoopEvent control.turnControlId event)
-                    (sendEvent callback context)
+                case encodeNativeLoopEvent control.turnControlId event of
+                    Just bytes -> sendBinaryEvent callback context bytes
+                    Nothing ->
+                        forM_ (nativeLoopEvent control.turnControlId event)
+                            (sendEvent callback context)
             , nativeOnSessionId = \sessionId -> do
                 writeIORef sessionIdRef (Just sessionId)
                 sendEvent callback context $
@@ -803,53 +808,9 @@ finishTurnEvent callback context turnId = \case
 
 nativeLoopEvent :: Text -> LoopEvent -> Maybe Aeson.Value
 nativeLoopEvent turnId = \case
-    ReasoningDelta text ->
-        Just $ Aeson.object
-            [ "event" Aeson..= ("turn.reasoning_delta" :: Text)
-            , "turnId" Aeson..= turnId
-            , "text" Aeson..= text
-            ]
-    TextDelta text ->
-        Just $ Aeson.object
-            [ "event" Aeson..= ("turn.text_delta" :: Text)
-            , "turnId" Aeson..= turnId
-            , "text" Aeson..= text
-            ]
-    ToolStarted call ->
-        let (arguments, truncated) =
-                boundedEventText
-                    (if call.argumentsEncrypted then "" else call.arguments)
-        in Just $ Aeson.object
-            [ "event" Aeson..= ("turn.tool" :: Text)
-            , "turnId" Aeson..= turnId
-            , "tool" Aeson..= Aeson.object
-                [ "type" Aeson..= ("tool_started" :: Text)
-                , "callId" Aeson..= call.callId
-                , "name" Aeson..= call.name
-                , "summary" Aeson..= summarizeToolCall call
-                , "arguments" Aeson..= arguments
-                , "argumentsEncrypted" Aeson..= call.argumentsEncrypted
-                , "truncated" Aeson..= truncated
-                ]
-            ]
-    ToolFinished result ->
-        let (output, truncated) = boundedEventText result.output
-        in Just $ Aeson.object
-            [ "event" Aeson..= ("turn.tool" :: Text)
-            , "turnId" Aeson..= turnId
-            , "tool" Aeson..= Aeson.object
-                [ "type" Aeson..= ("tool_finished" :: Text)
-                , "callId" Aeson..= result.callId
-                , "output" Aeson..= output
-                , "truncated" Aeson..= truncated
-                ]
-            ]
-    ActivityUpdated status ->
-        Just $ turnStatusEvent turnId status
-    WarningRaised warning ->
-        Just $ turnStatusEvent turnId warning
-    ResponseRestarted message ->
-        Just $ turnStatusEvent turnId message
+    ActivityUpdated status -> Just $ turnStatusEvent turnId status
+    WarningRaised warning -> Just $ turnStatusEvent turnId warning
+    ResponseRestarted message -> Just $ turnStatusEvent turnId message
     _ -> Nothing
 
 turnStatusEvent :: Text -> Text -> Aeson.Value
@@ -896,7 +857,7 @@ handleRequest config store root request = do
                 pure $ successEvent current.requestId $
                     Aeson.object
                         [ "runtime" Aeson..= ("haskell" :: Text)
-                        , "protocol" Aeson..= (3 :: Int)
+                        , "protocol" Aeson..= (4 :: Int)
                         ]
             "sessions.list" -> do
                 activeStore <- acquireStore config store
@@ -1137,7 +1098,22 @@ sendEvent :: FunPtr EventCallback -> Ptr () -> Aeson.Value -> IO ()
 sendEvent callback context event =
     void $ tryAny $
         BS.useAsCStringLen (LBS.toStrict (Aeson.encode event)) \(bytes, length) ->
-            invokeEventCallback callback
-                context
-                (castPtr bytes)
-                (fromIntegral length)
+            sendCallbackBytes callback context (castPtr bytes) length
+
+sendBinaryEvent :: FunPtr EventCallback -> Ptr () -> BS.ByteString -> IO ()
+sendBinaryEvent callback context bytes =
+    void $ tryAny $
+        BS.useAsCStringLen bytes \ (pointer, length) ->
+            sendCallbackBytes callback context (castPtr pointer) length
+
+sendCallbackBytes
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> Ptr Word8
+    -> Int
+    -> IO ()
+sendCallbackBytes callback context bytes length =
+    invokeEventCallback callback
+        context
+        (castPtr bytes)
+        (fromIntegral length)

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -160,7 +160,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (addUTCTime, getCurrentTime)
-import Data.Word (Word8)
+import Data.Word (Word8, Word64)
 import Foreign
     ( FunPtr
     , Ptr
@@ -187,8 +187,8 @@ import System.OsPath
     , unsafeEncodeUtf
     )
 
-decodeInput :: Ptr Word8 -> CSize -> IO Text
-decodeInput pointer (CSize length)
+decodeInput :: Ptr Word8 -> Word64 -> IO Text
+decodeInput pointer length
     | pointer == nullPtr || length == 0 = pure ""
     | otherwise = TextEncoding.decodeUtf8 <$> BS.packCStringLen
         (castPtr pointer, fromIntegral length)
@@ -515,7 +515,7 @@ ha_account_oauth_start providerBytes (CSize providerLength) callback context
     | callback == nullFunPtr = pure 1
     | providerBytes == nullPtr && providerLength > 0 = pure 2
     | otherwise = do
-        provider <- decodeInput providerBytes (CSize providerLength)
+        provider <- decodeInput providerBytes providerLength
         _ <- forkIO do
             startAccountOAuth AccountProviderRequest
                 { accountProvider = provider } >>= \case
@@ -543,11 +543,11 @@ ha_account_oauth_poll providerBytes (CSize providerLength) urlBytes (CSize urlLe
     deviceBytes (CSize deviceLength) pollInterval expires callback context
     | callback == nullFunPtr = pure 1
     | otherwise = do
-        provider <- decodeInput providerBytes (CSize providerLength)
-        url <- decodeInput urlBytes (CSize urlLength)
-        user <- decodeInput userBytes (CSize userLength)
-        authId <- decodeInput authIdBytes (CSize authIdLength)
-        device <- decodeInput deviceBytes (CSize deviceLength)
+        provider <- decodeInput providerBytes providerLength
+        url <- decodeInput urlBytes urlLength
+        user <- decodeInput userBytes userLength
+        authId <- decodeInput authIdBytes authIdLength
+        device <- decodeInput deviceBytes deviceLength
         _ <- forkIO do
             pollAccountOAuth AccountOAuthPollRequest
                 { oauthPollProvider = provider
@@ -566,8 +566,8 @@ ha_account_api_key_connect
 ha_account_api_key_connect providerBytes (CSize providerLength) keyBytes (CSize keyLength) callback context
     | callback == nullFunPtr = pure 1
     | otherwise = do
-        provider <- decodeInput providerBytes (CSize providerLength)
-        key <- decodeInput keyBytes (CSize keyLength)
+        provider <- decodeInput providerBytes providerLength
+        key <- decodeInput keyBytes keyLength
         _ <- forkIO do
             connectAccountAPIKey AccountAPIKeyRequest
                 { accountAPIKeyProvider = provider, accountAPIKey = key }

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE GHC2021 #-}
+
+module Agent.CLI.MacOS.NativeLoopEvent
+    ( encodeNativeLoopEvent
+    ) where
+
+import Agent.CLI.Render (summarizeToolCall)
+import Agent.Loop (LoopEvent(..))
+import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word16, Word8)
+
+-- | Binary events are framed individually by the C callback.  HAEV version 1
+-- uses a common header followed by a turn id and kind-specific length-prefixed
+-- UTF-8 fields:
+--
+--   magic (4), version (1), kind (1), flags (u16 BE),
+--   turn-id length (u32 BE), fields...
+--
+-- A field length of maxBound denotes an absent optional field.  The callback
+-- already supplies the complete frame length, so no outer payload length is
+-- needed.
+encodeNativeLoopEvent :: Text -> LoopEvent -> Maybe BS.ByteString
+encodeNativeLoopEvent turnId event =
+    case event of
+        ReasoningDelta text -> textEvent 1 turnId text
+        TextDelta text -> textEvent 2 turnId text
+        ActivityUpdated status -> textEvent 3 turnId status
+        WarningRaised warning -> textEvent 3 turnId warning
+        ResponseRestarted message -> textEvent 3 turnId message
+        ToolStarted call ->
+            toolEvent 4 flags startedFields
+          where
+            (arguments, truncated) =
+                boundedEventText
+                    (if call.argumentsEncrypted then "" else call.arguments)
+            flags =
+                (if call.argumentsEncrypted then 1 else 0)
+                    + (if truncated then 2 else 0)
+            startedFields =
+                [ Just call.callId
+                , Just call.name
+                , Just (summarizeToolCall call)
+                , Just arguments
+                ]
+        ToolFinished result ->
+            toolEvent 5 flags finishedFields
+          where
+            (output, truncated) = boundedEventText result.output
+            flags = if truncated then 2 else 0
+            finishedFields = [Just result.callId, Just output]
+        _ -> Nothing
+  where
+    textEvent kind id text = frame kind 0 id [Just text]
+    toolEvent kind flags fields = frame kind flags turnId fields
+
+frame :: Word8 -> Word16 -> Text -> [Maybe Text] -> Maybe BS.ByteString
+frame kind flags turnId fields =
+    fmap
+        (LBS.toStrict . Builder.toLazyByteString)
+        ( do
+            turnIdField <- field (Just turnId)
+            fields' <- traverse field fields
+            pure $
+                Builder.byteString "HAEV"
+                    <> Builder.word8 1
+                    <> Builder.word8 kind
+                    <> Builder.word16BE flags
+                    <> turnIdField
+                    <> foldMap id fields'
+        )
+
+maxNativeFieldBytes :: Int
+-- Keep malformed callback frames from requesting unbounded allocations in
+-- consumers, while leaving room for bounded tool output and future fields.
+maxNativeFieldBytes = 16 * 1024 * 1024
+
+field :: Maybe Text -> Maybe Builder.Builder
+field Nothing = Just (Builder.word32BE maxBound)
+field (Just value) =
+    let bytes = TextEncoding.encodeUtf8 value
+    in if BS.length bytes > maxNativeFieldBytes
+        then Nothing
+        else Just $
+            Builder.word32BE (fromIntegral (BS.length bytes))
+                <> Builder.byteString bytes
+
+boundedEventText :: Text -> (Text, Bool)
+boundedEventText value =
+    let (visible, remainder) = Text.splitAt 8192 value
+    in (visible, not (Text.null remainder))

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -205,8 +205,9 @@ typedef struct ha_utf8_string {
  * most 64 KiB, then hunk_callback for each parsed hunk, then result_callback.
  * is_binary applies to the complete file diff. An empty patch emits no chunks.
  *
- * result_callback status is 0 for success, -1 for failure, and -2 when the
- * supplied snapshot is stale. Success and stale results populate snapshot_id;
+ * result_callback status is 0 for success, -1 for failure, -2 when the
+ * supplied snapshot is stale, and -3 when cancel_all cancels an accepted
+ * operation. Success and stale results populate snapshot_id;
  * failures populate error. Callbacks for one operation are serialized.
  */
 typedef void (*ha_repository_snapshot_callback)(
@@ -342,8 +343,9 @@ void ha_engine_destroy(void *engine);
 
 /*
  * Repository input text is required, non-null, non-empty UTF-8 and is copied
- * before these functions return. Patch bytes are required, non-null,
- * non-empty binary data and are also copied. Callers must keep callback
+ * before these functions return. Hunk indices identify the immutable hunk
+ * ordering returned by ha_repository_diff for the supplied snapshot and file;
+ * arbitrary patch bytes never cross the ABI. Callers must keep callback
  * context valid until its terminal result callback.
  *
  * Return values are 0 when accepted, 1 for a null required callback, 2 for an
@@ -351,18 +353,19 @@ void ha_engine_destroy(void *engine);
  * All mutations compare the supplied snapshot fingerprint while holding a
  * per-repository mutation lock. Stale operations do not modify the repository.
  * File paths must be normalized, literal, repository-relative paths; pathspec
- * magic, globs, absolute paths, and traversal are rejected. Patch mutations
- * additionally require file_path and accept only an exact diff or a subset of
- * the reviewed text hunks for that one file. Restore never deletes an
- * untracked file. The lock coordinates API callers; unrelated external git
+ * magic, globs, absolute paths, and traversal are rejected, and the path must
+ * exactly match a changed-file path in that snapshot. Hunk mutations rebuild
+ * the patch server-side and reject binary, deletion, and rename diffs.
+ * Restore never deletes an untracked file. The lock coordinates API callers;
+ * unrelated external git
  * writers cannot acquire it, so the fingerprint is revalidated immediately
  * before Git's single apply or commit operation and Git still validates patch
- * context. Restore by path or patch never deletes an untracked file.
+ * context.
  *
  * ha_repository_cancel_all cancels and joins accepted snapshot, diff, and
  * mutation operations before returning. Checks are owned and cancelled by
- * their explicit handles. Cancellation does not synthesize a terminal result;
- * an operation may already have completed one before cancellation wins. No
+ * their explicit handles. Cancellation delivers exactly one -3 terminal
+ * result unless the operation's terminal callback already completed. No
  * callback starts after cancel_all returns, so contexts may then be released.
  * New repository operations are rejected while cancel_all owns its admission
  * barrier and may be retried after it returns.
@@ -408,7 +411,7 @@ int32_t ha_repository_apply_path(
     void *context
 );
 
-int32_t ha_repository_apply_patch(
+int32_t ha_repository_apply_hunks(
     const uint8_t *path,
     size_t path_length,
     const uint8_t *snapshot_id,
@@ -416,8 +419,8 @@ int32_t ha_repository_apply_patch(
     int32_t operation,
     const uint8_t *file_path,
     size_t file_path_length,
-    const uint8_t *patch,
-    size_t patch_length,
+    const size_t *hunk_indices,
+    size_t hunk_count,
     ha_repository_result_callback result_callback,
     void *context
 );
@@ -446,8 +449,9 @@ void ha_repository_cancel_all(void);
  * pipe draining. exit_callback is invoked exactly once with the process exit
  * code, or -1 plus an error if launch fails. Its failure is not retried.
  *
- * On status 0, out_check receives an owned opaque handle. Cancel is
- * asynchronous and targets the check's process group (including descendants).
+ * On status 0, out_check receives an owned opaque handle. Cancel targets the
+ * check's process group (including descendants) and joins teardown before
+ * returning.
  * The handle is stored before callbacks can begin; callbacks may begin before
  * ha_repository_check_start itself returns and must return promptly.
  * Destroy waits for readers/process completion, frees the
@@ -455,8 +459,9 @@ void ha_repository_cancel_all(void);
  * returns. Cancel uses a short termination-escalation grace period; destroy
  * also assumes callbacks return promptly. A check callback must not call
  * ha_repository_check_destroy for its own handle; schedule destruction on a
- * different thread after the callback returns. Calling check_cancel is safe.
- * Status values match the other repository functions.
+ * different thread after the callback returns. A callback must likewise not
+ * call check_cancel for its own handle. Status values match the other
+ * repository functions.
  */
 int32_t ha_repository_check_start(
     const uint8_t *path,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -146,6 +146,7 @@ typedef void (*ha_account_oauth_start_callback)(
     const uint8_t *error,
     size_t error_length
 );
+/*
  * An image submitted for a native turn. The runtime copies both buffers
  * before this call returns; the caller retains ownership of them.
  */

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -198,8 +198,9 @@ typedef struct ha_utf8_string {
  *
  * A successful snapshot first invokes snapshot_callback once, then
  * file_callback once per changed file, and finally result_callback. HEAD is
- * empty for an unborn branch. original_path is empty unless Git reports a
- * rename/copy. File status values are unsigned Git porcelain status bytes.
+ * empty for an unborn branch. original_path is NULL with length zero unless
+ * Git reports a rename/copy. File status values are unsigned Git porcelain
+ * status bytes.
  *
  * A successful diff invokes diff_callback with ordered patch chunks of at
  * most 64 KiB, then hunk_callback for each parsed hunk, then result_callback.
@@ -373,8 +374,8 @@ void ha_engine_destroy(void *engine);
  * failure terminal attempt; terminal callbacks are never retried.
  *
  * Repository callbacks must return promptly and must not call
- * ha_repository_cancel_all reentrantly; doing so would wait for the callback's
- * own worker. Call cancellation from another thread after the callback returns.
+ * ha_repository_cancel_all reentrantly. A reentrant call is detected and is a
+ * no-op; call cancellation from another thread after the callback returns.
  */
 int32_t ha_repository_snapshot(
     const uint8_t *path,
@@ -459,8 +460,9 @@ void ha_repository_cancel_all(void);
  * returns. Cancel uses a short termination-escalation grace period; destroy
  * also assumes callbacks return promptly. A check callback must not call
  * ha_repository_check_destroy for its own handle; schedule destruction on a
- * different thread after the callback returns. A callback must likewise not
- * call check_cancel for its own handle. Status values match the other
+ * different thread after the callback returns. Reentrant destroy is detected
+ * and is a no-op, so the owner must still destroy the handle later. A callback
+ * reentrant check_cancel is also a no-op. Status values match the other
  * repository functions.
  */
 int32_t ha_repository_check_start(

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -347,21 +347,26 @@ void ha_engine_destroy(void *engine);
  * before these functions return. Hunk indices identify the immutable hunk
  * ordering returned by ha_repository_diff for the supplied snapshot and file;
  * arbitrary patch bytes never cross the ABI. Callers must keep callback
- * context valid until its terminal result callback.
+ * context valid until its terminal result callback. Each input text is capped
+ * at 8 MiB, combined text per request at 16 MiB, and hunk_count at 4096;
+ * oversized values are rejected before pointer arithmetic or allocation.
  *
  * Return values are 0 when accepted, 1 for a null required callback, 2 for an
  * invalid pointer/length/UTF-8/operation, and 3 for an internal start failure.
- * All mutations compare the supplied snapshot fingerprint while holding a
- * per-repository mutation lock. Stale operations do not modify the repository.
+ * All reads and mutations compare the supplied snapshot fingerprint while
+ * holding canonical per-repository in-process and OS advisory locks in the
+ * common Git directory. Cooperating runtime processes therefore serialize.
+ * Stale operations do not modify the repository.
  * File paths must be normalized, literal, repository-relative paths; pathspec
  * magic, globs, absolute paths, and traversal are rejected, and the path must
  * exactly match a changed-file path in that snapshot. Hunk mutations rebuild
  * the patch server-side and reject binary, deletion, and rename diffs.
- * Restore never deletes an untracked file. The lock coordinates API callers;
- * unrelated external git
- * writers cannot acquire it, so the fingerprint is revalidated immediately
- * before Git's single apply or commit operation and Git still validates patch
- * context.
+ * Restore never deletes an untracked file. Unrelated Git clients do not honor
+ * the advisory lock, so the fingerprint is revalidated immediately before
+ * Git's single transactional apply or commit command; Git's own index/ref
+ * locks and patch context validation close index mutation races. A
+ * non-cooperating process that directly edits worktree files remains outside
+ * any advisory-lock guarantee.
  *
  * ha_repository_cancel_all cancels and joins accepted snapshot, diff, and
  * mutation operations before returning. Checks are owned and cancelled by
@@ -371,7 +376,9 @@ void ha_engine_destroy(void *engine);
  * New repository operations are rejected while cancel_all owns its admission
  * barrier and may be retried after it returns.
  * A streaming callback failure stops that stream and is followed by one
- * failure terminal attempt; terminal callbacks are never retried.
+ * failure terminal attempt; terminal callbacks are emitted separately from
+ * action execution and are never retried, including when success emission
+ * throws.
  *
  * Repository callbacks must return promptly and must not call
  * ha_repository_cancel_all reentrantly. A reentrant call is detected and is a

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -146,6 +146,15 @@ typedef void (*ha_account_oauth_start_callback)(
     const uint8_t *error,
     size_t error_length
 );
+ * An image submitted for a native turn. The runtime copies both buffers
+ * before this call returns; the caller retains ownership of them.
+ */
+typedef struct ha_image_attachment {
+    const uint8_t *mime;
+    size_t mime_length;
+    const uint8_t *bytes;
+    size_t bytes_length;
+} ha_image_attachment;
 
 /* Runtime calls are process-global and reference counted. */
 int32_t ha_runtime_init(void);
@@ -158,6 +167,19 @@ void ha_runtime_exit(void);
  * for an invalid request envelope.
  */
 void *ha_engine_create(ha_event_callback callback, void *context);
+/*
+ * Stage ordered images for a turn before its turn.start request. Staging is
+ * consumed by the matching turn.start. Returns 0 when accepted, 1 for a
+ * null engine, 2 for an invalid turn ID, 3 for an internal failure, and 4
+ * for an invalid image array or UTF-8 MIME.
+ */
+int32_t ha_engine_stage_turn_images(
+    void *engine,
+    const uint8_t *turn_id,
+    size_t turn_id_length,
+    const ha_image_attachment *images,
+    size_t image_count
+);
 int32_t ha_engine_send_json(
     void *engine,
     const uint8_t *bytes,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -10,7 +10,17 @@ extern "C" {
 
 typedef void (*ha_event_callback)(
     void *context,
-    /* Valid only for the duration of this callback; copy before returning. */
+    /*
+     * Events are normally UTF-8 JSON. Native loop events use a versioned
+     * binary HAEV frame:
+     *   magic "HAEV" (4), version (u8), kind (u8), flags (u16 BE),
+     *   turn-id and kind-specific fields as u32-BE length-prefixed UTF-8.
+     * Kind 1 is reasoning text, 2 text, 3 status, 4 tool-start, and 5
+     * tool-finish. Tool-start flags use bit 0 for encrypted arguments and
+     * bit 1 for truncation; tool-finish uses bit 1 for truncation.
+     * The bytes are valid only for the duration of this callback; copy before
+     * returning.
+     */
     const uint8_t *bytes,
     size_t length
 );

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -1,0 +1,40 @@
+#ifndef HASKELL_AGENT_BRIDGE_H
+#define HASKELL_AGENT_BRIDGE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*ha_event_callback)(
+    void *context,
+    /* Valid only for the duration of this callback; copy before returning. */
+    const uint8_t *bytes,
+    size_t length
+);
+
+/* Runtime calls are process-global and reference counted. */
+int32_t ha_runtime_init(void);
+void ha_runtime_exit(void);
+
+/*
+ * Engine calls must be serialized with ha_engine_destroy. Requests are copied
+ * before ha_engine_send_json returns. Send status is 0 when accepted, 1 for a
+ * null engine, 2 for null non-empty bytes, 3 for an internal failure, and 4
+ * for an invalid request envelope.
+ */
+void *ha_engine_create(ha_event_callback callback, void *context);
+int32_t ha_engine_send_json(
+    void *engine,
+    const uint8_t *bytes,
+    size_t length
+);
+void ha_engine_destroy(void *engine);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -26,6 +26,37 @@ typedef void (*ha_event_callback)(
 );
 
 /*
+ * A conversation-search callback. status is 0 for a result, 1 for terminal
+ * success, and -1 for terminal failure (with error populated). All UTF-8
+ * buffers are valid only during the callback and must be copied before it
+ * returns. A result has error == NULL. Completion has no result fields.
+ *
+ * turn_index is -1 for a metadata hit. occurred_at_ms is 0 when absent. role
+ * is 0 for metadata, 1 for user, and 2 for assistant. Timestamps are
+ * milliseconds since the Unix epoch. Callbacks run serially on the engine
+ * worker thread, not the caller or main thread. An accepted request receives
+ * exactly one terminal callback unless engine destruction has begun.
+ */
+typedef void (*ha_conversation_search_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *session_id, size_t session_id_length,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *cwd, size_t cwd_length,
+    const uint8_t *provider, size_t provider_length,
+    const uint8_t *model, size_t model_length,
+    int64_t updated_at_ms,
+    int32_t archived,
+    int64_t turn_index,
+    int64_t occurred_at_ms,
+    int32_t role,
+    const uint8_t *user_text, size_t user_text_length,
+    const uint8_t *assistant_text, size_t assistant_text_length,
+    double rank,
+    const uint8_t *error, size_t error_length
+);
+
+/*
  * Account list callbacks use status 0 for an item, 1 for end-of-list, and
  * -1 for an error. Item strings include disabled managed credentials and
  * externally discovered accounts.
@@ -92,6 +123,20 @@ int32_t ha_engine_send_json(
     void *engine,
     const uint8_t *bytes,
     size_t length
+);
+/*
+ * Search active and archived (but not deleted) conversations. The query is
+ * copied before return and limit is clamped to 1...100. Returns 0 when
+ * accepted, 1 for a null engine, 2 for invalid query/callback, and 3 for an
+ * internal failure. Calls must be serialized with ha_engine_destroy.
+ */
+int32_t ha_engine_search_conversations(
+    void *engine,
+    const uint8_t *query,
+    size_t query_length,
+    size_t limit,
+    ha_conversation_search_callback callback,
+    void *context
 );
 void ha_engine_destroy(void *engine);
 

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -57,6 +57,32 @@ typedef void (*ha_conversation_search_callback)(
 );
 
 /*
+ * Learned-skill list callbacks emit current rows from all applicable scopes,
+ * including archived skills. Status is 0 for an item, 1 for end-of-list, and
+ * -1 for an error. UTF-8 buffers are callback-scoped and must be copied.
+ */
+typedef void (*ha_learned_skills_list_callback)(
+    void *context, int32_t status,
+    const uint8_t *scope, size_t scope_length,
+    const uint8_t *slug, size_t slug_length,
+    int64_t revision,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *description, size_t description_length,
+    const uint8_t *applies_when, size_t applies_when_length,
+    const uint8_t *instructions, size_t instructions_length,
+    const uint8_t *activation, size_t activation_length,
+    const uint8_t *status_text, size_t status_text_length,
+    int32_t priority,
+    const uint8_t *updated_at, size_t updated_at_length,
+    const uint8_t *error, size_t error_length
+);
+
+int32_t ha_learned_skills_list(
+    const uint8_t *cwd, size_t cwd_length,
+    ha_learned_skills_list_callback callback, void *context
+);
+
+/*
  * Account list callbacks use status 0 for an item, 1 for end-of-list, and
  * -1 for an error. Item strings include disabled managed credentials and
  * externally discovered accounts.

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -254,6 +254,70 @@ typedef void (*ha_repository_result_callback)(
     size_t error_length
 );
 
+/*
+ * Delivery APIs never invoke a shell and never return credentials, command
+ * output, or authenticated remote URLs. Preview confirmations are random,
+ * one-shot, in-memory tokens bound to the canonical repository, exact
+ * snapshot/HEAD, upstream configuration, and remote OID. They expire after
+ * ten minutes. Confirm rechecks that state immediately before mutation and
+ * never force-pushes or deletes a ref. Push targets the reviewed commit OID,
+ * and Git's ordinary fast-forward rule remains authoritative. Repository
+ * hooks are disabled for preview and confirmation.
+ *
+ * Status is 0 for success, -1 for failure, -2 for stale state, -3 for
+ * cancellation, and -4 for an invalid/expired/already-used confirmation.
+ * Every buffer is callback-scoped UTF-8. An accepted call emits exactly one
+ * callback. Delivery callbacks use the repository worker lifecycle and have
+ * the same cancellation/reentrancy rules documented below.
+ */
+typedef void (*ha_repository_delivery_status_callback)(
+    void *context, int32_t status,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    const uint8_t *head_oid, size_t head_oid_length,
+    const uint8_t *branch, size_t branch_length,
+    const uint8_t *remote, size_t remote_length,
+    const uint8_t *upstream_ref, size_t upstream_ref_length,
+    const uint8_t *upstream_oid, size_t upstream_oid_length,
+    int64_t ahead, int64_t behind,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_repository_push_preview_callback)(
+    void *context, int32_t status,
+    const uint8_t *confirmation, size_t confirmation_length,
+    int64_t expires_at_unix,
+    const uint8_t *head_oid, size_t head_oid_length,
+    const uint8_t *branch, size_t branch_length,
+    const uint8_t *remote, size_t remote_length,
+    const uint8_t *upstream_ref, size_t upstream_ref_length,
+    int64_t ahead, int64_t behind,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_repository_push_result_callback)(
+    void *context, int32_t status,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    const uint8_t *pushed_oid, size_t pushed_oid_length,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_repository_pr_preview_callback)(
+    void *context, int32_t status,
+    const uint8_t *confirmation, size_t confirmation_length,
+    int64_t expires_at_unix,
+    const uint8_t *repository, size_t repository_length,
+    const uint8_t *base_ref, size_t base_ref_length,
+    const uint8_t *head_ref, size_t head_ref_length,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_repository_pr_result_callback)(
+    void *context, int32_t status,
+    const uint8_t *url, size_t url_length,
+    const uint8_t *error, size_t error_length
+);
+
 enum ha_repository_operation {
     HA_REPOSITORY_STAGE = 0,
     HA_REPOSITORY_UNSTAGE = 1,
@@ -442,6 +506,41 @@ int32_t ha_repository_commit(
     size_t message_length,
     ha_repository_result_callback result_callback,
     void *context
+);
+
+/*
+ * Delivery input buffers are required non-empty UTF-8 and copied before the
+ * call returns. PR base/title/body are bounded to a 1 KiB base, 512-character
+ * title, and 1 MiB body. Return codes are 0 accepted, 1 null callback, 2
+ * invalid input, and 3 internal start failure.
+ */
+int32_t ha_repository_delivery_status(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    ha_repository_delivery_status_callback callback, void *context
+);
+int32_t ha_repository_push_preview(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    ha_repository_push_preview_callback callback, void *context
+);
+int32_t ha_repository_push_confirm(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *confirmation, size_t confirmation_length,
+    ha_repository_push_result_callback callback, void *context
+);
+int32_t ha_repository_pr_preview(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    const uint8_t *base, size_t base_length,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *body, size_t body_length,
+    ha_repository_pr_preview_callback callback, void *context
+);
+int32_t ha_repository_pr_confirm(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *confirmation, size_t confirmation_length,
+    ha_repository_pr_result_callback callback, void *context
 );
 
 void ha_repository_cancel_all(void);

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -57,6 +57,19 @@ typedef void (*ha_conversation_search_callback)(
 );
 
 /*
+ * Session mutation callbacks use status 0 for success and -1 for failure.
+ * The error buffer is UTF-8, callback-scoped, and populated only on failure.
+ * Callbacks run serially on the engine worker thread. An accepted mutation
+ * receives exactly one callback unless engine destruction has begun.
+ */
+typedef void (*ha_session_result_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *error,
+    size_t error_length
+);
+
+/*
  * Learned-skill list callbacks emit current rows from all applicable scopes,
  * including archived skills. Status is 0 for an item, 1 for end-of-list, and
  * -1 for an error. UTF-8 buffers are callback-scoped and must be copied.
@@ -201,6 +214,35 @@ int32_t ha_engine_search_conversations(
     size_t query_length,
     size_t limit,
     ha_conversation_search_callback callback,
+    void *context
+);
+/*
+ * Session mutation inputs are copied before return. Returns 0 when accepted,
+ * 1 for a null engine, 2 for an invalid callback/input pointer, and 3 for an
+ * internal failure. Calls must be serialized with ha_engine_destroy.
+ */
+int32_t ha_engine_session_rename(
+    void *engine,
+    const uint8_t *session_id,
+    size_t session_id_length,
+    const uint8_t *title,
+    size_t title_length,
+    ha_session_result_callback callback,
+    void *context
+);
+int32_t ha_engine_session_delete(
+    void *engine,
+    const uint8_t *session_id,
+    size_t session_id_length,
+    ha_session_result_callback callback,
+    void *context
+);
+int32_t ha_engine_session_archive(
+    void *engine,
+    const uint8_t *session_id,
+    size_t session_id_length,
+    int32_t archived,
+    ha_session_result_callback callback,
     void *context
 );
 void ha_engine_destroy(void *engine);

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -25,6 +25,11 @@ typedef void (*ha_event_callback)(
     size_t length
 );
 
+/*
+ * Account list callbacks use status 0 for an item, 1 for end-of-list, and
+ * -1 for an error. Item strings include disabled managed credentials and
+ * externally discovered accounts.
+ */
 typedef void (*ha_account_list_callback)(
     void *context,
     int32_t status,
@@ -41,6 +46,10 @@ typedef void (*ha_account_list_callback)(
     const uint8_t *error, size_t error_length
 );
 
+/*
+ * Result callbacks use status 0 for success, 1 when OAuth polling remains
+ * pending, and -1 for an error.
+ */
 typedef void (*ha_account_result_callback)(
     void *context,
     int32_t status,
@@ -50,6 +59,7 @@ typedef void (*ha_account_result_callback)(
     size_t error_length
 );
 
+/* OAuth start callbacks use status 0 for a challenge and -1 for an error. */
 typedef void (*ha_account_oauth_start_callback)(
     void *context,
     int32_t status,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -25,6 +25,21 @@ typedef void (*ha_event_callback)(
     size_t length
 );
 
+typedef void (*ha_repository_check_output_callback)(
+    void *context,
+    int32_t stream,
+    const uint8_t *bytes,
+    size_t length
+);
+
+typedef void (*ha_repository_check_exit_callback)(
+    void *context,
+    int32_t cancelled,
+    int32_t exit_code,
+    const uint8_t *error,
+    size_t error_length
+);
+
 /*
  * A conversation-search callback. status is 0 for a result, 1 for terminal
  * success, and -1 for terminal failure (with error populated). All UTF-8
@@ -170,6 +185,84 @@ typedef struct ha_image_attachment {
     size_t bytes_length;
 } ha_image_attachment;
 
+/* A borrowed UTF-8 slice used for typed arrays such as process argv. */
+typedef struct ha_utf8_string {
+    const uint8_t *bytes;
+    size_t length;
+} ha_utf8_string;
+
+/*
+ * Repository review operations run asynchronously on runtime worker threads.
+ * Every accepted operation invokes its result callback exactly once. Callback
+ * buffers are borrowed only for the callback duration and must be copied.
+ *
+ * A successful snapshot first invokes snapshot_callback once, then
+ * file_callback once per changed file, and finally result_callback. HEAD is
+ * empty for an unborn branch. original_path is empty unless Git reports a
+ * rename/copy. File status values are unsigned Git porcelain status bytes.
+ *
+ * A successful diff invokes diff_callback with ordered patch chunks of at
+ * most 64 KiB, then hunk_callback for each parsed hunk, then result_callback.
+ * is_binary applies to the complete file diff. An empty patch emits no chunks.
+ *
+ * result_callback status is 0 for success, -1 for failure, and -2 when the
+ * supplied snapshot is stale. Success and stale results populate snapshot_id;
+ * failures populate error. Callbacks for one operation are serialized.
+ */
+typedef void (*ha_repository_snapshot_callback)(
+    void *context,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    const uint8_t *root, size_t root_length,
+    const uint8_t *head, size_t head_length,
+    const uint8_t *index_fingerprint, size_t index_fingerprint_length,
+    const uint8_t *worktree_fingerprint, size_t worktree_fingerprint_length
+);
+
+typedef void (*ha_repository_file_callback)(
+    void *context,
+    const uint8_t *path, size_t path_length,
+    const uint8_t *original_path, size_t original_path_length,
+    int32_t index_status,
+    int32_t worktree_status
+);
+
+typedef void (*ha_repository_diff_callback)(
+    void *context,
+    const uint8_t *bytes,
+    size_t length,
+    int32_t is_binary
+);
+
+typedef void (*ha_repository_hunk_callback)(
+    void *context,
+    int64_t old_start,
+    int64_t old_count,
+    int64_t new_start,
+    int64_t new_count,
+    const uint8_t *header,
+    size_t header_length
+);
+
+typedef void (*ha_repository_result_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *snapshot_id,
+    size_t snapshot_id_length,
+    const uint8_t *error,
+    size_t error_length
+);
+
+enum ha_repository_operation {
+    HA_REPOSITORY_STAGE = 0,
+    HA_REPOSITORY_UNSTAGE = 1,
+    HA_REPOSITORY_RESTORE = 2
+};
+
+enum ha_repository_diff_kind {
+    HA_REPOSITORY_DIFF_WORKTREE = 0,
+    HA_REPOSITORY_DIFF_STAGED = 1
+};
+
 /* Runtime calls are process-global and reference counted. */
 int32_t ha_runtime_init(void);
 void ha_runtime_exit(void);
@@ -246,6 +339,114 @@ int32_t ha_engine_session_archive(
     void *context
 );
 void ha_engine_destroy(void *engine);
+
+/*
+ * Repository input text is required, non-null, non-empty UTF-8 and is copied
+ * before these functions return. Patch bytes are required, non-null,
+ * non-empty binary data and are also copied. Callers must keep callback
+ * context valid until its terminal result callback.
+ *
+ * Return values are 0 when accepted, 1 for a null required callback, 2 for an
+ * invalid pointer/length/UTF-8/operation, and 3 for an internal start failure.
+ * All mutations compare the supplied snapshot fingerprint while holding a
+ * per-repository mutation lock. Stale operations do not modify the repository.
+ * Restore never deletes an untracked file.
+ *
+ * ha_repository_cancel_all cancels and joins accepted snapshot, diff, and
+ * mutation operations before returning. Checks are owned and cancelled by
+ * their explicit handles. Cancelled operations do not invoke a terminal
+ * callback; after cancel_all returns, their callback contexts may be released.
+ */
+int32_t ha_repository_snapshot(
+    const uint8_t *path,
+    size_t path_length,
+    ha_repository_snapshot_callback snapshot_callback,
+    ha_repository_file_callback file_callback,
+    ha_repository_result_callback result_callback,
+    void *context
+);
+
+int32_t ha_repository_diff(
+    const uint8_t *path,
+    size_t path_length,
+    const uint8_t *snapshot_id,
+    size_t snapshot_id_length,
+    int32_t diff_kind,
+    const uint8_t *file_path,
+    size_t file_path_length,
+    ha_repository_diff_callback diff_callback,
+    ha_repository_hunk_callback hunk_callback,
+    ha_repository_result_callback result_callback,
+    void *context
+);
+
+int32_t ha_repository_apply_path(
+    const uint8_t *path,
+    size_t path_length,
+    const uint8_t *snapshot_id,
+    size_t snapshot_id_length,
+    int32_t operation,
+    const uint8_t *file_path,
+    size_t file_path_length,
+    ha_repository_result_callback result_callback,
+    void *context
+);
+
+int32_t ha_repository_apply_patch(
+    const uint8_t *path,
+    size_t path_length,
+    const uint8_t *snapshot_id,
+    size_t snapshot_id_length,
+    int32_t operation,
+    const uint8_t *patch,
+    size_t patch_length,
+    ha_repository_result_callback result_callback,
+    void *context
+);
+
+int32_t ha_repository_commit(
+    const uint8_t *path,
+    size_t path_length,
+    const uint8_t *snapshot_id,
+    size_t snapshot_id_length,
+    const uint8_t *message,
+    size_t message_length,
+    ha_repository_result_callback result_callback,
+    void *context
+);
+
+void ha_repository_cancel_all(void);
+
+/*
+ * Start an argv-based repository check without a shell. executable and every
+ * argument are required non-empty UTF-8; arguments may be NULL only when
+ * argument_count is zero. stream is 1 for stdout and 2 for stderr. Output
+ * buffers are callback-scoped and ordered within each stream; the two streams
+ * may interleave. exit_callback is invoked once with the process exit code,
+ * or -1 plus an error if launch fails.
+ *
+ * On status 0, out_check receives an owned opaque handle. Cancel is
+ * asynchronous. Destroy waits for readers/process completion, frees the
+ * handle, and must be called exactly once; no callbacks occur after it
+ * returns. Status values match the other repository functions.
+ */
+int32_t ha_repository_check_start(
+    const uint8_t *path,
+    size_t path_length,
+    const uint8_t *snapshot_id,
+    size_t snapshot_id_length,
+    const uint8_t *executable,
+    size_t executable_length,
+    const ha_utf8_string *arguments,
+    size_t argument_count,
+    ha_repository_check_output_callback output_callback,
+    ha_repository_check_exit_callback exit_callback,
+    void *context,
+    void **out_check
+);
+
+void ha_repository_check_cancel(void *check);
+void ha_repository_check_destroy(void *check);
 
 /*
  * Account operations use typed callbacks. Callback buffers are valid only

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -360,8 +360,11 @@ void ha_engine_destroy(void *engine);
  *
  * ha_repository_cancel_all cancels and joins accepted snapshot, diff, and
  * mutation operations before returning. Checks are owned and cancelled by
- * their explicit handles. Cancelled operations do not invoke a terminal
- * callback; after cancel_all returns, their callback contexts may be released.
+ * their explicit handles. Cancellation does not synthesize a terminal result;
+ * an operation may already have completed one before cancellation wins. No
+ * callback starts after cancel_all returns, so contexts may then be released.
+ * A streaming callback failure stops that stream and is followed by one
+ * failure terminal attempt; terminal callbacks are never retried.
  */
 int32_t ha_repository_snapshot(
     const uint8_t *path,
@@ -432,14 +435,19 @@ void ha_repository_cancel_all(void);
  * 8 MiB total argument bytes are accepted. stream is 1 for stdout and 2 for
  * stderr. Output
  * buffers are callback-scoped and ordered within each stream; the two streams
- * may interleave. exit_callback is invoked once with the process exit code,
- * or -1 plus an error if launch fails.
+ * may interleave. Output callback failures are not retried and do not prevent
+ * pipe draining. exit_callback is invoked exactly once with the process exit
+ * code, or -1 plus an error if launch fails. Its failure is not retried.
  *
  * On status 0, out_check receives an owned opaque handle. Cancel is
  * asynchronous and targets the check's process group (including descendants).
+ * The handle is stored before callbacks can begin; callbacks may begin before
+ * ha_repository_check_start itself returns and must return promptly.
  * Destroy waits for readers/process completion, frees the
  * handle, and must be called exactly once; no callbacks occur after it
- * returns. Status values match the other repository functions.
+ * returns. Cancel uses a short termination-escalation grace period; destroy
+ * also assumes callbacks return promptly. Status values match the other
+ * repository functions.
  */
 int32_t ha_repository_check_start(
     const uint8_t *path,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -356,7 +356,8 @@ void ha_engine_destroy(void *engine);
  * the reviewed text hunks for that one file. Restore never deletes an
  * untracked file. The lock coordinates API callers; unrelated external git
  * writers cannot acquire it, so the fingerprint is revalidated immediately
- * before Git's single apply operation and Git still validates patch context.
+ * before Git's single apply or commit operation and Git still validates patch
+ * context. Restore by path or patch never deletes an untracked file.
  *
  * ha_repository_cancel_all cancels and joins accepted snapshot, diff, and
  * mutation operations before returning. Checks are owned and cancelled by
@@ -367,6 +368,10 @@ void ha_engine_destroy(void *engine);
  * barrier and may be retried after it returns.
  * A streaming callback failure stops that stream and is followed by one
  * failure terminal attempt; terminal callbacks are never retried.
+ *
+ * Repository callbacks must return promptly and must not call
+ * ha_repository_cancel_all reentrantly; doing so would wait for the callback's
+ * own worker. Call cancellation from another thread after the callback returns.
  */
 int32_t ha_repository_snapshot(
     const uint8_t *path,
@@ -448,8 +453,10 @@ void ha_repository_cancel_all(void);
  * Destroy waits for readers/process completion, frees the
  * handle, and must be called exactly once; no callbacks occur after it
  * returns. Cancel uses a short termination-escalation grace period; destroy
- * also assumes callbacks return promptly. Status values match the other
- * repository functions.
+ * also assumes callbacks return promptly. A check callback must not call
+ * ha_repository_check_destroy for its own handle; schedule destruction on a
+ * different thread after the callback returns. Calling check_cancel is safe.
+ * Status values match the other repository functions.
  */
 int32_t ha_repository_check_start(
     const uint8_t *path,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -259,10 +259,12 @@ typedef void (*ha_repository_result_callback)(
  * output, or authenticated remote URLs. Preview confirmations are random,
  * one-shot, in-memory tokens bound to the canonical repository, exact
  * snapshot/HEAD, upstream configuration, and remote OID. They expire after
- * ten minutes. Confirm rechecks that state immediately before mutation and
- * never force-pushes or deletes a ref. Push targets the reviewed commit OID,
- * and Git's ordinary fast-forward rule remains authoritative. Repository
- * hooks are disabled for preview and confirmation.
+ * ten minutes. Confirm rechecks that state immediately before mutation.
+ * Push targets the reviewed commit OID and uses an exact
+ * --force-with-lease=<destination>:<expected> server-side CAS only after
+ * proving expected is an ancestor of that OID. This cannot approve a history
+ * rewrite and never deletes a ref. Repository hooks are disabled for preview
+ * and confirmation.
  *
  * Status is 0 for success, -1 for failure, -2 for stale state, -3 for
  * cancellation, and -4 for an invalid/expired/already-used confirmation.

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -47,6 +47,19 @@ typedef void (*ha_account_list_callback)(
 );
 
 /*
+ * Usage-window callbacks are emitted after their corresponding account item.
+ * reset_at_unix is an absolute UTC Unix timestamp in seconds.
+ */
+typedef void (*ha_account_usage_window_callback)(
+    void *context,
+    const uint8_t *selection_id, size_t selection_id_length,
+    const uint8_t *name, size_t name_length,
+    int32_t used_percent,
+    int64_t window_seconds,
+    int64_t reset_at_unix
+);
+
+/*
  * Result callbacks use status 0 for success, 1 when OAuth polling remains
  * pending, and -1 for an error.
  */
@@ -100,7 +113,11 @@ void ha_engine_destroy(void *engine);
  * during the callback and must be copied by the caller. All functions return
  * 0 when accepted, or a nonzero error before starting the worker.
  */
-int32_t ha_accounts_list(ha_account_list_callback callback, void *context);
+int32_t ha_accounts_list(
+    ha_account_list_callback callback,
+    ha_account_usage_window_callback usage_callback,
+    void *context
+);
 int32_t ha_account_oauth_start(
     const uint8_t *provider,
     size_t provider_length,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -350,7 +350,13 @@ void ha_engine_destroy(void *engine);
  * invalid pointer/length/UTF-8/operation, and 3 for an internal start failure.
  * All mutations compare the supplied snapshot fingerprint while holding a
  * per-repository mutation lock. Stale operations do not modify the repository.
- * Restore never deletes an untracked file.
+ * File paths must be normalized, literal, repository-relative paths; pathspec
+ * magic, globs, absolute paths, and traversal are rejected. Patch mutations
+ * additionally require file_path and accept only an exact diff or a subset of
+ * the reviewed text hunks for that one file. Restore never deletes an
+ * untracked file. The lock coordinates API callers; unrelated external git
+ * writers cannot acquire it, so the fingerprint is revalidated immediately
+ * before Git's single apply operation and Git still validates patch context.
  *
  * ha_repository_cancel_all cancels and joins accepted snapshot, diff, and
  * mutation operations before returning. Checks are owned and cancelled by
@@ -398,6 +404,8 @@ int32_t ha_repository_apply_patch(
     const uint8_t *snapshot_id,
     size_t snapshot_id_length,
     int32_t operation,
+    const uint8_t *file_path,
+    size_t file_path_length,
     const uint8_t *patch,
     size_t patch_length,
     ha_repository_result_callback result_callback,
@@ -420,13 +428,16 @@ void ha_repository_cancel_all(void);
 /*
  * Start an argv-based repository check without a shell. executable and every
  * argument are required non-empty UTF-8; arguments may be NULL only when
- * argument_count is zero. stream is 1 for stdout and 2 for stderr. Output
+ * argument_count is zero. At most 4096 arguments, 1 MiB per argument, and
+ * 8 MiB total argument bytes are accepted. stream is 1 for stdout and 2 for
+ * stderr. Output
  * buffers are callback-scoped and ordered within each stream; the two streams
  * may interleave. exit_callback is invoked once with the process exit code,
  * or -1 plus an error if launch fails.
  *
  * On status 0, out_check receives an owned opaque handle. Cancel is
- * asynchronous. Destroy waits for readers/process completion, frees the
+ * asynchronous and targets the check's process group (including descendants).
+ * Destroy waits for readers/process completion, frees the
  * handle, and must be called exactly once; no callbacks occur after it
  * returns. Status values match the other repository functions.
  */

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -25,6 +25,48 @@ typedef void (*ha_event_callback)(
     size_t length
 );
 
+typedef void (*ha_account_list_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *provider, size_t provider_length,
+    const uint8_t *billing, size_t billing_length,
+    const uint8_t *selection_id, size_t selection_id_length,
+    const uint8_t *account_id, size_t account_id_length,
+    const uint8_t *label, size_t label_length,
+    const uint8_t *detail, size_t detail_length,
+    const uint8_t *managed_id, size_t managed_id_length,
+    const uint8_t *source, size_t source_length,
+    int32_t enabled,
+    int32_t can_manage,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_account_result_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *account_id,
+    size_t account_id_length,
+    const uint8_t *error,
+    size_t error_length
+);
+
+typedef void (*ha_account_oauth_start_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *verification_url,
+    size_t verification_url_length,
+    const uint8_t *user_code,
+    size_t user_code_length,
+    const uint8_t *device_auth_id,
+    size_t device_auth_id_length,
+    const uint8_t *device_code,
+    size_t device_code_length,
+    int32_t poll_interval_seconds,
+    int32_t expires_in_seconds,
+    const uint8_t *error,
+    size_t error_length
+);
+
 /* Runtime calls are process-global and reference counted. */
 int32_t ha_runtime_init(void);
 void ha_runtime_exit(void);
@@ -42,6 +84,56 @@ int32_t ha_engine_send_json(
     size_t length
 );
 void ha_engine_destroy(void *engine);
+
+/*
+ * Account operations use typed callbacks. Callback buffers are valid only
+ * during the callback and must be copied by the caller. All functions return
+ * 0 when accepted, or a nonzero error before starting the worker.
+ */
+int32_t ha_accounts_list(ha_account_list_callback callback, void *context);
+int32_t ha_account_oauth_start(
+    const uint8_t *provider,
+    size_t provider_length,
+    ha_account_oauth_start_callback callback,
+    void *context
+);
+int32_t ha_account_oauth_poll(
+    const uint8_t *provider,
+    size_t provider_length,
+    const uint8_t *verification_url,
+    size_t verification_url_length,
+    const uint8_t *user_code,
+    size_t user_code_length,
+    const uint8_t *device_auth_id,
+    size_t device_auth_id_length,
+    const uint8_t *device_code,
+    size_t device_code_length,
+    int32_t poll_interval_seconds,
+    int32_t expires_in_seconds,
+    ha_account_result_callback callback,
+    void *context
+);
+int32_t ha_account_api_key_connect(
+    const uint8_t *provider,
+    size_t provider_length,
+    const uint8_t *api_key,
+    size_t api_key_length,
+    ha_account_result_callback callback,
+    void *context
+);
+int32_t ha_account_set_enabled(
+    const uint8_t *managed_id,
+    size_t managed_id_length,
+    int32_t enabled,
+    ha_account_result_callback callback,
+    void *context
+);
+int32_t ha_account_delete(
+    const uint8_t *managed_id,
+    size_t managed_id_length,
+    ha_account_result_callback callback,
+    void *context
+);
 
 #ifdef __cplusplus
 }

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -169,10 +169,13 @@ void ha_runtime_exit(void);
  */
 void *ha_engine_create(ha_event_callback callback, void *context);
 /*
- * Stage ordered images for a turn before its turn.start request. Staging is
- * consumed by the matching turn.start. Returns 0 when accepted, 1 for a
- * null engine, 2 for an invalid turn ID, 3 for an internal failure, and 4
- * for an invalid image array or UTF-8 MIME.
+ * Stage an ordered image batch for a turn before its turn.start request.
+ * A later call for the same turn replaces the previous batch. Passing zero
+ * images discards that turn's batch, which callers should do if they abandon
+ * the request. Staging is also discarded when a request envelope or turn.start
+ * parameters are rejected, and is consumed by the matching valid turn.start.
+ * Returns 0 when accepted, 1 for a null engine, 2 for an invalid turn ID, 3
+ * for an internal failure, and 4 for an invalid image array or UTF-8 MIME.
  */
 int32_t ha_engine_stage_turn_images(
     void *engine,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -363,6 +363,8 @@ void ha_engine_destroy(void *engine);
  * their explicit handles. Cancellation does not synthesize a terminal result;
  * an operation may already have completed one before cancellation wins. No
  * callback starts after cancel_all returns, so contexts may then be released.
+ * New repository operations are rejected while cancel_all owns its admission
+ * barrier and may be retried after it returns.
  * A streaming callback failure stops that stream and is followed by one
  * failure terminal attempt; terminal callbacks are never retried.
  */

--- a/packages/agent-cli/src/Agent/CLI/AccountPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountPicker.hs
@@ -5,8 +5,10 @@ module Agent.CLI.AccountPicker
     , accountPickerRow
     , formatLoginUsageSummary
     , loadAllAccountPickerOptions
+    , loadAllAccountPickerOptionsCached
     ) where
 
+import Agent.CLI.AccountUsageCache (refreshLoginAccountCached)
 import Agent.CLI.Login
     ( AccountBilling(..)
     , AccountUsage(..)
@@ -28,6 +30,7 @@ import Agent.Provider
     , providerSlug
     )
 import Control.Concurrent.Async (mapConcurrently)
+import Agent.Store.Postgres.Connection (StorePool)
 import Data.List (sortOn)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -44,9 +47,20 @@ data AccountPickerOption
     | AccountPickerConnect !Provider
 
 loadAllAccountPickerOptions :: Provider -> IO [AccountPickerOption]
-loadAllAccountPickerOptions currentProvider = do
+loadAllAccountPickerOptions = loadAllAccountPickerOptionsWith refreshLoginAccount
+
+loadAllAccountPickerOptionsCached
+    :: StorePool -> Provider -> IO [AccountPickerOption]
+loadAllAccountPickerOptionsCached pool =
+    loadAllAccountPickerOptionsWith (refreshLoginAccountCached pool)
+
+loadAllAccountPickerOptionsWith
+    :: (LoginAccount -> IO LoginAccount)
+    -> Provider
+    -> IO [AccountPickerOption]
+loadAllAccountPickerOptionsWith refresh currentProvider = do
     discovered <- discoverSelectableLoginAccounts
-    refreshed <- mapConcurrently refreshLoginAccount discovered
+    refreshed <- mapConcurrently refresh discovered
     claudeAuth <- loadClaudeCodeAuth
     now <- getCurrentTime
     let providerAccounts =

--- a/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
@@ -7,8 +7,10 @@ module Agent.CLI.AccountSelection
     , selectCandidates
     , selectAccount
     , selectProviderAccount
+    , selectProviderAccountCached
     ) where
 
+import Agent.CLI.AccountUsageCache (refreshLoginAccountCached)
 import Agent.CLI.Login
     ( AccountBilling(..)
     , AccountUsage(..)
@@ -33,6 +35,7 @@ import Agent.Provider
     , providerSlug
     )
 import Control.Concurrent.Async (mapConcurrently)
+import Agent.Store.Postgres.Connection (StorePool)
 import Data.List (find, sortOn)
 import Data.Ord (Down(..))
 import Data.Text (Text)
@@ -78,7 +81,24 @@ selectProviderAccount
     -> Maybe BillingMode
     -> Maybe (Text, Text)
     -> IO (Either Text SelectedAccount)
-selectProviderAccount provider requiredBilling remembered = do
+selectProviderAccount = selectProviderAccountWith refreshLoginAccount
+
+selectProviderAccountCached
+    :: StorePool
+    -> Provider
+    -> Maybe BillingMode
+    -> Maybe (Text, Text)
+    -> IO (Either Text SelectedAccount)
+selectProviderAccountCached pool =
+    selectProviderAccountWith (refreshLoginAccountCached pool)
+
+selectProviderAccountWith
+    :: (LoginAccount -> IO LoginAccount)
+    -> Provider
+    -> Maybe BillingMode
+    -> Maybe (Text, Text)
+    -> IO (Either Text SelectedAccount)
+selectProviderAccountWith refresh provider requiredBilling remembered = do
     providerAccounts <-
         filter
             ((== provider) . (.loginProvider))
@@ -94,7 +114,9 @@ selectProviderAccount provider requiredBilling remembered = do
                                 . billingMode . (.loginBilling))
                             providerAccounts
                 in if null subscription then providerAccounts else subscription
-    checked <- mapConcurrently refreshSelectableAccount billingAccounts
+    checked <- mapConcurrently
+        (refreshSelectableAccountWith refresh)
+        billingAccounts
     pure $ case selectAccount remembered checked of
         Just selected -> Right selected
         Nothing -> Left $
@@ -187,13 +209,16 @@ parseAmount :: Text -> Maybe Double
 parseAmount =
     readMaybe . Text.unpack . Text.dropWhile (`elem` ("$ " :: String))
 
-refreshSelectableAccount :: LoginAccount -> IO LoginAccount
-refreshSelectableAccount account =
+refreshSelectableAccountWith
+    :: (LoginAccount -> IO LoginAccount)
+    -> LoginAccount
+    -> IO LoginAccount
+refreshSelectableAccountWith refresh account =
     refreshCredential account >>= \case
         Left err ->
             pure account { loginUsage = UsageUnavailable err }
         Right refreshed ->
-            refreshLoginAccount refreshed
+            refresh refreshed
   where
     refreshCredential candidate = case candidate.loginProvider of
         OpenAIProvider ->

--- a/packages/agent-cli/src/Agent/CLI/AccountUsageCache.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountUsageCache.hs
@@ -1,0 +1,139 @@
+-- | PostgreSQL-backed cache for credential-safe account usage metadata.
+module Agent.CLI.AccountUsageCache
+    ( refreshLoginAccountCached
+    ) where
+
+import Agent.CLI.Login
+    ( AccountBilling(..)
+    , AccountUsage(..)
+    , LoginAccount(..)
+    , UsageState(..)
+    , UsageWindow(..)
+    , refreshLoginAccount
+    )
+import Agent.Provider (providerSlug)
+import Agent.Store.Postgres.Connection (StorePool)
+import Agent.Store.Postgres.UsageCache
+    ( AccountUsageCacheEntry(..)
+    , loadAccountUsageCache
+    , upsertAccountUsageCache
+    )
+import Control.Monad (void)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.:), (.:?), (.=))
+import Data.Aeson.Types (Parser)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import Data.Time.Clock (addUTCTime, getCurrentTime)
+
+data CachedAccountUsage = CachedAccountUsage
+    { cachedLabel :: !Text
+    , cachedBilling :: !AccountBilling
+    , cachedUsage :: !AccountUsage
+    }
+
+instance Aeson.ToJSON CachedAccountUsage where
+    toJSON cached = Aeson.object
+        [ "label" .= cached.cachedLabel
+        , "billing" .= billingJSON cached.cachedBilling
+        , "usage" .= usageJSON cached.cachedUsage
+        ]
+
+instance Aeson.FromJSON CachedAccountUsage where
+    parseJSON = Aeson.withObject "cached account usage" \object ->
+        CachedAccountUsage
+            <$> object .: "label"
+            <*> (object .: "billing" >>= parseBilling)
+            <*> (object .: "usage" >>= parseUsage)
+
+-- | Use a fresh cached usage result when possible. Cache payloads contain only
+-- display metadata; credentials and managed-secret payloads are never stored.
+refreshLoginAccountCached :: StorePool -> LoginAccount -> IO LoginAccount
+refreshLoginAccountCached pool account = do
+    now <- getCurrentTime
+    loadAccountUsageCache pool cacheProvider account.loginAccountId >>= \case
+        Right (Just entry)
+            | entry.accountUsageCacheExpiresAt > now
+            , Just cached <- decodeCached entry.accountUsageCachePayload ->
+                pure (applyCached cached account)
+        _ -> refreshAndStore now
+  where
+    cacheProvider = "tui:" <> providerSlug account.loginProvider
+    refreshAndStore now = do
+        refreshed <- refreshLoginAccount account
+        case refreshed.loginUsage of
+            UsageAvailable usage -> void $ upsertAccountUsageCache pool
+                AccountUsageCacheEntry
+                    { accountUsageCacheProvider = cacheProvider
+                    , accountUsageCacheAccountId = account.loginAccountId
+                    , accountUsageCachePayload = encodeCached CachedAccountUsage
+                        { cachedLabel = refreshed.loginLabel
+                        , cachedBilling = refreshed.loginBilling
+                        , cachedUsage = usage
+                        }
+                    , accountUsageCacheFetchedAt = now
+                    , accountUsageCacheExpiresAt = addUTCTime 300 now
+                    }
+            _ -> pure ()
+        pure refreshed
+
+applyCached :: CachedAccountUsage -> LoginAccount -> LoginAccount
+applyCached cached account = account
+    { loginLabel = cached.cachedLabel
+    , loginBilling = cached.cachedBilling
+    , loginUsage = UsageAvailable cached.cachedUsage
+    }
+
+encodeCached :: CachedAccountUsage -> Text
+encodeCached = Text.decodeUtf8 . LBS.toStrict . Aeson.encode
+
+decodeCached :: Text -> Maybe CachedAccountUsage
+decodeCached = Aeson.decodeStrict' . Text.encodeUtf8
+
+billingJSON :: AccountBilling -> Aeson.Value
+billingJSON = \case
+    ApiCreditsBilling -> Aeson.object ["kind" .= ("api" :: Text)]
+    SubscriptionBilling plan -> Aeson.object
+        [ "kind" .= ("subscription" :: Text)
+        , "plan" .= plan
+        ]
+
+parseBilling :: Aeson.Value -> Parser AccountBilling
+parseBilling = Aeson.withObject "cached billing" \object ->
+    object .: "kind" >>= \case
+        ("api" :: Text) -> pure ApiCreditsBilling
+        "subscription" -> SubscriptionBilling <$> object .:? "plan"
+        _ -> fail "unknown cached billing kind"
+
+usageJSON :: AccountUsage -> Aeson.Value
+usageJSON usage = Aeson.object
+    [ "plan" .= usage.usagePlan
+    , "windows" .= map windowJSON usage.usageWindows
+    , "creditsRemaining" .= usage.creditsRemaining
+    , "creditsUsed" .= usage.creditsUsed
+    ]
+
+parseUsage :: Aeson.Value -> Parser AccountUsage
+parseUsage = Aeson.withObject "cached usage" \object ->
+    AccountUsage
+        <$> object .:? "plan"
+        <*> (object .: "windows" >>= traverse parseWindow)
+        <*> object .:? "creditsRemaining"
+        <*> object .:? "creditsUsed"
+
+windowJSON :: UsageWindow -> Aeson.Value
+windowJSON window = Aeson.object
+    [ "name" .= window.windowName
+    , "usedPercent" .= window.usedPercent
+    , "windowSeconds" .= window.windowSeconds
+    , "resetsAt" .= window.resetsAt
+    ]
+
+parseWindow :: Aeson.Value -> Parser UsageWindow
+parseWindow = Aeson.withObject "cached usage window" \object ->
+    UsageWindow
+        <$> object .: "name"
+        <*> object .: "usedPercent"
+        <*> object .: "windowSeconds"
+        <*> object .: "resetsAt"

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -17,6 +17,7 @@ module Agent.CLI.Login
     , refreshLoginAccount
     , renderLoginFrame
     , runLoginManager
+    , storeConnectedCredential
     ) where
 
 import Agent.CLI.Auth

--- a/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
@@ -47,7 +47,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlpha, isAlphaNum, isSpace)
 import Data.Foldable (traverse_)
-import Data.List (find)
+import Data.List (find, nub)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
@@ -86,6 +86,8 @@ data CatalogModel = CatalogModel
     , catalogModelDialect :: !DialectId
     , catalogModelContextWindow :: !(Maybe Int)
     , catalogModelLabel :: !(Maybe Text)
+    , catalogModelReasoningEfforts :: !(Maybe [Text])
+    , catalogModelDefaultReasoningEffort :: !(Maybe Text)
     , catalogModelDefault :: !Bool
     , catalogModelFallbackPriority :: !(Maybe Int)
     }
@@ -121,6 +123,8 @@ data ModelFile = ModelFile
     , modelFileDialect :: !Text
     , modelFileContextWindow :: !(Maybe Int)
     , modelFileLabel :: !(Maybe Text)
+    , modelFileReasoningEfforts :: !(Maybe [Text])
+    , modelFileDefaultReasoningEffort :: !(Maybe Text)
     , modelFileDefault :: !Bool
     , modelFileFallbackPriority :: !(Maybe Int)
     }
@@ -152,6 +156,8 @@ instance FromJSON ModelFile where
             <*> object .: "dialect"
             <*> object .:? "context_window"
             <*> object .:? "label"
+            <*> object .:? "reasoning_efforts"
+            <*> object .:? "default_reasoning_effort"
             <*> object .:? "default" .!= False
             <*> object .:? "fallback_priority"
 
@@ -432,6 +438,12 @@ validateConfig source config = do
         let modelId = Text.strip raw.modelFileId
             connectionId = Text.strip raw.modelFileConnection
             wireId = Text.strip (fromMaybe modelId raw.modelFileWireId)
+            reasoningEfforts = fmap
+                (map (Text.toLower . Text.strip))
+                raw.modelFileReasoningEfforts
+            defaultReasoningEffort =
+                Text.toLower . Text.strip
+                    <$> raw.modelFileDefaultReasoningEffort
         when (Text.null modelId || Text.any isSpace modelId) $
             Left ("model id must be nonempty and contain no whitespace: "
                 <> raw.modelFileId)
@@ -474,6 +486,37 @@ validateConfig source config = do
                 Left ("model " <> modelId
                     <> " context_window must be positive"))
             raw.modelFileContextWindow
+        unless
+            ( maybe True
+                (all (`elem` supportedReasoningEfforts))
+                reasoningEfforts
+            ) $
+            Left
+                ( "model " <> modelId
+                    <> " has unsupported reasoning_efforts; expected "
+                    <> Text.intercalate ", " supportedReasoningEfforts
+                )
+        traverse_
+            (\efforts -> do
+                when (null efforts) $
+                    Left
+                        ( "model " <> modelId
+                            <> " reasoning_efforts must not be empty"
+                        )
+                when (length efforts /= length (nub efforts)) $
+                    Left
+                        ( "model " <> modelId
+                            <> " reasoning_efforts must not contain duplicates"
+                        ))
+            reasoningEfforts
+        traverse_
+            (\effort -> unless (maybe False (effort `elem`) reasoningEfforts) $
+                Left
+                    ( "model " <> modelId
+                        <> " default_reasoning_effort must be listed in "
+                        <> "reasoning_efforts"
+                    ))
+            defaultReasoningEffort
         pure CatalogModel
             { catalogModelId = modelId
             , catalogModelConnectionId = connectionId
@@ -483,10 +526,17 @@ validateConfig source config = do
                 raw.modelFileContextWindow
             , catalogModelLabel =
                 nonEmptyText =<< raw.modelFileLabel
+            , catalogModelReasoningEfforts = reasoningEfforts
+            , catalogModelDefaultReasoningEffort =
+                defaultReasoningEffort
             , catalogModelDefault = raw.modelFileDefault
             , catalogModelFallbackPriority =
                 raw.modelFileFallbackPriority
             }
+
+supportedReasoningEfforts :: [Text]
+supportedReasoningEfforts =
+    ["none", "low", "medium", "high", "xhigh", "max"]
 
 validateBuiltinDefault :: [CatalogModel] -> Provider -> Either Text ()
 validateBuiltinDefault models provider =

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -1,0 +1,76 @@
+module Agent.CLI.NativeRuntime
+    ( NativeProcessRuntime
+    , NativeRunHooks(..)
+    , closeNativeProcessRuntime
+    , newNativeProcessRuntime
+    , runNativeAgent
+    ) where
+
+import Agent.CLI.AgentSessions
+    ( SessionThreadManager
+    , closeSessionThreadManager
+    , newSessionThreadManager
+    )
+import Agent.CLI.Options
+    ( Command(..)
+    , parseArgs
+    )
+import Agent.CLI.Runtime.Orchestration (runAgentWithRuntime)
+import Agent.CLI.Runtime.Orchestration.Types
+    ( AgentProcessRuntime(..)
+    , NativeRunHooks(..)
+    , nativeRunMode
+    )
+import Agent.CLI.Runtime.Types (DevResult(..))
+import qualified Agent.MCP as MCP
+import Control.Exception.Safe (finally, onException)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.IO (Handle)
+import System.OsPath (OsPath)
+
+data NativeProcessRuntime = NativeProcessRuntime
+    { nativeMcpSupervisor :: !MCP.McpSupervisor
+    , nativeSessionThreads :: !SessionThreadManager
+    }
+
+newNativeProcessRuntime :: OsPath -> IO NativeProcessRuntime
+newNativeProcessRuntime root = do
+    mcpSupervisor <- MCP.newMcpSupervisor
+    sessionThreads <-
+        newSessionThreadManager root
+            `onException` MCP.closeMcpSupervisor mcpSupervisor
+    pure NativeProcessRuntime
+        { nativeMcpSupervisor = mcpSupervisor
+        , nativeSessionThreads = sessionThreads
+        }
+
+closeNativeProcessRuntime :: NativeProcessRuntime -> IO ()
+closeNativeProcessRuntime runtime =
+    closeSessionThreadManager runtime.nativeSessionThreads
+        `finally` MCP.closeMcpSupervisor runtime.nativeMcpSupervisor
+
+runNativeAgent
+    :: NativeProcessRuntime
+    -> Handle
+    -> OsPath
+    -> NativeRunHooks
+    -> [String]
+    -> IO (Either Text ())
+runNativeAgent runtime output cwd hooks args =
+    case parseArgs args of
+        Left err -> pure (Left (Text.pack err))
+        Right (RunAgent options) ->
+            runAgentWithRuntime
+                AgentProcessRuntime
+                    { processMcpSupervisor = runtime.nativeMcpSupervisor
+                    , processSessionThreads = runtime.nativeSessionThreads
+                    }
+                (nativeRunMode output cwd hooks)
+                options >>= \case
+                    DevQuit -> pure (Right ())
+                    DevReload _ ->
+                        pure (Left
+                            "native turn unexpectedly requested a reload")
+        Right _ -> pure (Left
+            "native turn arguments did not select an agent")

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -5,6 +5,8 @@ module Agent.CLI.Options
     , CliOptions(..)
     , Command(..)
     , ScreenMode(..)
+    , SessionOutputFormat(..)
+    , SessionPageRequest(..)
     , StorageCommand(..)
     , defaultCliOptions
     , defaultEffortFor
@@ -21,8 +23,9 @@ import System.OsPath (OsPath, unsafeEncodeUtf)
 import Agent.Provider (Provider(..), parseProvider)
 import Agent.TUI.Motion (MotionMode(..))
 import Data.Foldable (asum)
+import Data.Int (Int64)
 import qualified Data.List as List
-import Data.Maybe (isJust)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Options.Applicative as Options
@@ -31,12 +34,23 @@ data Command
     = ShowHelp
     | ShowVersion
     | Login
-    | ListSessions
-    | ShowSession Text
+    | ListSessions SessionOutputFormat
+    | ShowSession Text SessionOutputFormat (Maybe SessionPageRequest)
     | WaitSession Text
     | ImportSession (Maybe OsPath)
     | Storage StorageCommand
     | RunAgent CliOptions
+    deriving (Eq, Show)
+
+data SessionPageRequest
+    = SessionRecent !Int
+    | SessionBefore !Int64 !Int
+    deriving (Eq, Show)
+
+-- | Output intended either for people at a terminal or for native clients.
+data SessionOutputFormat
+    = SessionHuman
+    | SessionJSON
     deriving (Eq, Show)
 
 -- | Administrative commands for the harness-managed PostgreSQL server.
@@ -206,6 +220,34 @@ commandParserInfo =
                 "Run an agent or administer persisted sessions and storage"
         )
 
+sessionShowParser :: Options.Parser Command
+sessionShowParser =
+    makeSessionShow
+        <$> (Text.pack
+            <$> Options.argument Options.str
+                (Options.metavar "SESSION_ID"))
+        <*> sessionOutputFormatParser
+        <*> Options.optional
+            (Options.option sessionCursorReader
+                ( Options.long "before"
+                    <> Options.metavar "TURN_INDEX"
+                    <> Options.help "Load turns older than this cursor"
+                ))
+        <*> Options.optional
+            (Options.option (positiveIntReader "--limit")
+                ( Options.long "limit"
+                    <> Options.metavar "N"
+                    <> Options.help "Bound JSON transcript turns (maximum 500)"
+                ))
+  where
+    makeSessionShow sessionId outputFormat before limit =
+        ShowSession sessionId outputFormat $
+            case (before, limit) of
+                (Nothing, Nothing) -> Nothing
+                (Nothing, Just value) -> Just (SessionRecent value)
+                (Just cursor, maybeLimit) ->
+                    Just (SessionBefore cursor (fromMaybe 50 maybeLimit))
+
 commandParser :: Options.Parser Command
 commandParser =
     Options.hsubparser
@@ -223,17 +265,15 @@ commandParser =
 
 sessionsParser :: Options.Parser Command
 sessionsParser =
-    maybe ListSessions id
+    maybe (ListSessions SessionHuman) id
         <$> Options.optional
             (Options.hsubparser
                 ( Options.command "list"
-                    (Options.info (pure ListSessions)
+                    (Options.info
+                        (ListSessions <$> sessionOutputFormatParser)
                         (Options.progDesc "List persisted sessions"))
                     <> Options.command "show"
-                        (Options.info
-                            (ShowSession . Text.pack
-                                <$> Options.argument Options.str
-                                    (Options.metavar "SESSION_ID"))
+                        (Options.info sessionShowParser
                             (Options.progDesc "Show a persisted session"))
                     <> Options.command "wait"
                         (Options.info
@@ -247,6 +287,13 @@ sessionsParser =
                                 "Import a session from the current process"))
                 )
             )
+
+sessionOutputFormatParser :: Options.Parser SessionOutputFormat
+sessionOutputFormatParser =
+    Options.flag SessionHuman SessionJSON
+        ( Options.long "json"
+            <> Options.help "Emit stable machine-readable JSON"
+        )
 
 importSessionParser :: Options.Parser Command
 importSessionParser =
@@ -419,6 +466,16 @@ positiveIntReader :: String -> Options.ReadM Int
 positiveIntReader flag =
     Options.eitherReader (parseInt flag)
 
+sessionCursorReader :: Options.ReadM Int64
+sessionCursorReader =
+    Options.eitherReader \value ->
+        case reads value of
+            [(cursor, "")] | cursor >= 0 -> Right cursor
+            _ ->
+                Left
+                    ("--before expects a non-negative integer, got "
+                        <> value)
+
 effortReader :: Options.ReadM Text
 effortReader =
     Options.eitherReader (parseEffort . Text.pack)
@@ -430,7 +487,17 @@ motionReader =
 validateCommand :: Command -> Either String Command
 validateCommand = \case
     RunAgent options -> RunAgent <$> validate options
+    ShowSession _ SessionHuman (Just _) ->
+        Left "session pagination requires --json"
+    command@(ShowSession _ SessionJSON (Just page))
+        | sessionPageLimit page > 500 ->
+            Left "--limit must not exceed 500"
+        | otherwise -> Right command
     command -> Right command
+  where
+    sessionPageLimit = \case
+        SessionRecent limit -> limit
+        SessionBefore _ limit -> limit
 
 validate :: CliOptions -> Either String CliOptions
 validate options
@@ -480,7 +547,8 @@ usage = unlines
     [ "Usage: agent-cli [OPTIONS]"
     , "       agent-cli login"
     , "       agent-cli sessions [list]"
-    , "       agent-cli sessions show <session-id>"
+    , "       agent-cli sessions show <session-id> [--json]"
+    , "              [--limit N] [--before TURN_INDEX]"
     , "       agent-cli storage <status|start|stop|migrate|doctor>"
     , ""
     , "  -p, --prompt TEXT       Run one prompt and exit"
@@ -492,6 +560,8 @@ usage = unlines
     , "      --worktree          Create a new git worktree under ~/.haskell-agent/worktrees"
     , "      --resume ID         Resume a persisted session from ~/.haskell-agent/sessions"
     , "      --save-session      Persist a one-shot (-p) run as a session"
+    , "      --limit N           Bound JSON session transcript turns (max 500)"
+    , "      --before INDEX      Load JSON turns older than a turn cursor"
     , "      --agents-md         Discover and inject AGENTS.md (default)"
     , "      --no-agents-md      Skip AGENTS.md discovery"
     , "      --skills            Discover Agent Skills (default)"

--- a/packages/agent-cli/src/Agent/CLI/ProcessSecurity.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProcessSecurity.hs
@@ -1,0 +1,112 @@
+module Agent.CLI.ProcessSecurity
+    ( canonicalPathOutside
+    , resolveExecutableOutside
+    , sanitizeSearchPathOutside
+    ) where
+
+import Control.Exception.Safe
+    ( isAsyncException
+    , throwIO
+    , tryAny
+    )
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.List (intercalate)
+import Data.Text (Text)
+import System.Directory
+    ( canonicalizePath
+    , doesPathExist
+    , findExecutable
+    , makeAbsolute
+    )
+import System.FilePath
+    ( isAbsolute
+    , normalise
+    , searchPathSeparator
+    , splitSearchPath
+    , takeDirectory
+    , (</>)
+    )
+import System.Posix.Files
+    ( deviceID
+    , fileID
+    , getFileStatus
+    )
+
+resolveExecutableOutside
+    :: FilePath
+    -> FilePath
+    -> IO (Either Text FilePath)
+resolveExecutableOutside repositoryRoot executable =
+    repositoryBoundary repositoryRoot >>= \boundary ->
+        findExecutable executable >>= \case
+            Nothing -> pure (Left "command is unavailable")
+            Just path ->
+                canonicalPathOutside boundary path >>= \case
+                    Nothing ->
+                        pure (Left "repository-local executables are not allowed")
+                    Just checked -> pure (Right checked)
+
+sanitizeSearchPathOutside
+    :: FilePath
+    -> String
+    -> IO (Maybe String)
+sanitizeSearchPathOutside repositoryRoot raw = do
+    boundary <- repositoryBoundary repositoryRoot
+    entries <- catMaybes <$> mapM (sanitize boundary) (splitSearchPath raw)
+    pure
+        (if null entries
+            then Nothing
+            else Just (intercalate [searchPathSeparator] entries))
+  where
+    sanitize boundary entry
+        | not (isAbsolute entry) = pure Nothing
+        | otherwise =
+            tryAny
+                (canonicalPathOutside boundary entry) >>= \case
+                            Left exception
+                                | isAsyncException exception ->
+                                    throwIO exception
+                                | otherwise -> pure Nothing
+                            Right result -> pure result
+
+repositoryBoundary :: FilePath -> IO FilePath
+repositoryBoundary requested =
+    canonicalizePath requested >>= \canonical ->
+        walk canonical Nothing
+  where
+    walk current candidate = do
+        present <- doesPathExist (current </> ".git")
+        let selected = if present then Just current else candidate
+            parent = takeDirectory current
+        if parent == current
+            then
+                canonicalizePath requested
+                    >>= \canonical ->
+                        pure (fromMaybe canonical selected)
+            else walk parent selected
+
+-- | Return the canonical child path only when neither its lexical nor
+-- canonical ancestry crosses the supplied directory boundary. Identity
+-- comparisons keep this correct for symlinks and case-insensitive filesystems.
+canonicalPathOutside :: FilePath -> FilePath -> IO (Maybe FilePath)
+canonicalPathOutside parent child = do
+    absoluteChild <- normalise <$> makeAbsolute child
+    canonicalParent <- canonicalizePath parent
+    canonicalChild <- canonicalizePath child
+    parentStatus <- getFileStatus canonicalParent
+    contained <-
+        or <$> mapM (sameIdentity parentStatus)
+            (ancestors absoluteChild <> ancestors canonicalChild)
+    pure (if contained then Nothing else Just canonicalChild)
+  where
+    sameIdentity expected candidate = do
+        actual <- getFileStatus candidate
+        pure
+            (deviceID actual == deviceID expected
+                && fileID actual == fileID expected)
+    ancestors path =
+        path
+            : let parentPath = takeDirectory path
+              in if parentPath == path
+                    then []
+                    else ancestors parentPath

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -19,6 +19,7 @@ module Agent.CLI.Render
     , beginRenderTurn
     , formatActivityLine
     , formatElapsed
+    , formatNativeLoopEvent
     , formatLoopError
     , formatLoopErrorAt
     , formatLoopErrorColored
@@ -117,12 +118,15 @@ import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, withMVar)
 import Control.Exception.Safe (tryIO)
 import Control.Monad (unless, void, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isDigit, isSpace)
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import Data.Word (Word64)
@@ -148,6 +152,7 @@ data RenderConfig = RenderConfig
     , renderStderr :: !Handle
     , renderModelRef :: !(IORef Text)
     , renderNativeProgress :: !Bool -- ^ Ghostty / WT OSC 9;4; off in tests
+    , renderNativeEvents :: !Bool
     , renderMotionMode :: !MotionMode
     }
 
@@ -575,7 +580,14 @@ streamMarkdown input state =
 
 renderEvent :: RenderConfig -> LoopEvent -> IO ()
 renderEvent config event =
-    withMVar config.renderLock \_ -> renderEventUnlocked config event
+    withMVar config.renderLock \_ -> do
+        when config.renderNativeEvents $
+            case formatNativeLoopEvent event of
+                Nothing -> pure ()
+                Just record -> do
+                    Text.hPutStrLn config.renderStdout record
+                    hFlush config.renderStdout
+        renderEventUnlocked config event
 
 renderEventUnlocked :: RenderConfig -> LoopEvent -> IO ()
 renderEventUnlocked config = \case
@@ -649,11 +661,13 @@ renderEventUnlocked config = \case
                 }
             , ()
             )
-        unless (isTodoTool call.name) do
-            putTextLn config.renderStderr (formatToolStarted config.renderColor call)
-            let extra = formatToolBody config.renderColor call
-            unless (Text.null extra) do
-                putTextLn config.renderStderr extra
+        unless config.renderNativeEvents $
+            unless (isTodoTool call.name) do
+                putTextLn config.renderStderr
+                    (formatToolStarted config.renderColor call)
+                let extra = formatToolBody config.renderColor call
+                unless (Text.null extra) do
+                    putTextLn config.renderStderr extra
         when config.renderShowThinking do
             visible <- (.stateThinkingVisible) <$> readRenderState config
             if visible
@@ -681,9 +695,48 @@ renderEventUnlocked config = \case
                         (roleToolOutput
                             config.renderColor
                             (truncateToolOutput formatted))
-        case painted of
-            Nothing -> pure ()
-            Just line -> putTextLn config.renderStderr line
+        unless config.renderNativeEvents $
+            case painted of
+                Nothing -> pure ()
+                Just line -> putTextLn config.renderStderr line
+
+-- | Record separator plus one JSON object. Other stderr diagnostics remain
+-- human-readable, while native clients can split these records out without
+-- parsing terminal presentation.
+formatNativeLoopEvent :: LoopEvent -> Maybe Text
+formatNativeLoopEvent = \case
+    ToolStarted call ->
+        let (arguments, truncated) =
+                boundedNativeEventText
+                    (if call.argumentsEncrypted then "" else call.arguments)
+        in Just $ encodeNativeEvent $ Aeson.object
+            [ "type" Aeson..= ("tool_started" :: Text)
+            , "callId" Aeson..= call.callId
+            , "name" Aeson..= call.name
+            , "summary" Aeson..= summarizeToolCall call
+            , "arguments" Aeson..= arguments
+            , "argumentsEncrypted" Aeson..= call.argumentsEncrypted
+            , "truncated" Aeson..= truncated
+            ]
+    ToolFinished result ->
+        let (output, truncated) = boundedNativeEventText result.output
+        in Just $ encodeNativeEvent $ Aeson.object
+            [ "type" Aeson..= ("tool_finished" :: Text)
+            , "callId" Aeson..= result.callId
+            , "output" Aeson..= output
+            , "truncated" Aeson..= truncated
+            ]
+    _ -> Nothing
+
+encodeNativeEvent :: Aeson.Value -> Text
+encodeNativeEvent value =
+    Text.singleton '\RS'
+        <> TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode value))
+
+boundedNativeEventText :: Text -> (Text, Bool)
+boundedNativeEventText value =
+    let (visible, remainder) = Text.splitAt 8192 value
+    in (visible, not (Text.null remainder))
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
 -- The terminal theme owns the default assistant background.

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -292,24 +292,31 @@ confirmRepositoryPush requested token =
                                                                     (DeliveryStale
                                                                         "the remote branch changed after push preview"))
                                                         | otherwise ->
-                                                            runGit
-                                                                current.deliveryRoot
-                                                                (remoteCommandPrefix previewedRemote
-                                                                <> [ "push"
-                                                                , "--porcelain"
-                                                                , "--no-verify"
-                                                                , leaseArgument current
-                                                                , "--"
-                                                                , BS8.unpack previewedRemote.validatedRemoteUrl
-                                                                , pushRefspec current
-                                                                ])
-                                                                BS.empty
-                                                                networkTimeoutMicros >>= \case
+                                                            revalidateLocalMutation
+                                                                current >>= \case
                                                                     Left err -> pure (Left err)
-                                                                    Right _ ->
-                                                                        refreshPushedStatus
-                                                                            current
-                                                                            previewedRemote
+                                                                    Right () ->
+                                                                        -- The explicit object ID prevents
+                                                                        -- any still-later local ref movement
+                                                                        -- from changing what is delivered.
+                                                                        runGit
+                                                                            current.deliveryRoot
+                                                                            (remoteCommandPrefix previewedRemote
+                                                                            <> [ "push"
+                                                                            , "--porcelain"
+                                                                            , "--no-verify"
+                                                                            , leaseArgument current
+                                                                            , "--"
+                                                                            , BS8.unpack previewedRemote.validatedRemoteUrl
+                                                                            , pushRefspec current
+                                                                            ])
+                                                                            BS.empty
+                                                                            networkTimeoutMicros >>= \case
+                                                                                Left err -> pure (Left err)
+                                                                                Right _ ->
+                                                                                    refreshPushedStatus
+                                                                                        current
+                                                                                        previewedRemote
         Right _ ->
             pure
                 (Left
@@ -444,30 +451,35 @@ createPullRequest requested token =
                                                                                     Left err ->
                                                                                         pure (Left err)
                                                                                     Right () ->
-                                                                                        runGh
-                                                                                            current.deliveryRoot
-                                                                                            [ "pr"
-                                                                                            , "create"
-                                                                                            , "--repo"
-                                                                                            , githubRepoArgument repository
-                                                                                            , "--base"
-                                                                                            , Text.unpack base
-                                                                                            , "--head"
-                                                                                            , Text.unpack current.deliveryBranch
-                                                                                            , "--title"
-                                                                                            , Text.unpack title
-                                                                                            , "--body-file"
-                                                                                            , "-"
-                                                                                            ]
-                                                                                            (TextEncoding.encodeUtf8 body)
-                                                                                            networkTimeoutMicros >>= \case
+                                                                                        revalidateLocalMutation
+                                                                                            current >>= \case
                                                                                                 Left err ->
                                                                                                     pure (Left err)
-                                                                                                Right output ->
-                                                                                                    pure
-                                                                                                        (parsePullRequestUrl
-                                                                                                            repository
-                                                                                                            output)
+                                                                                                Right () ->
+                                                                                                    runGh
+                                                                                                        current.deliveryRoot
+                                                                                                        [ "pr"
+                                                                                                        , "create"
+                                                                                                        , "--repo"
+                                                                                                        , githubRepoArgument repository
+                                                                                                        , "--base"
+                                                                                                        , Text.unpack base
+                                                                                                        , "--head"
+                                                                                                        , Text.unpack current.deliveryBranch
+                                                                                                        , "--title"
+                                                                                                        , Text.unpack title
+                                                                                                        , "--body-file"
+                                                                                                        , "-"
+                                                                                                        ]
+                                                                                                        (TextEncoding.encodeUtf8 body)
+                                                                                                        networkTimeoutMicros >>= \case
+                                                                                                            Left err ->
+                                                                                                                pure (Left err)
+                                                                                                            Right output ->
+                                                                                                                pure
+                                                                                                                    (parsePullRequestUrl
+                                                                                                                        repository
+                                                                                                                        output)
         Right _ ->
             pure
                 (Left
@@ -750,6 +762,22 @@ refreshPushedStatus pushed validatedRemote = do
                         , deliveryBehind = 0
                         }
 
+revalidateLocalMutation
+    :: DeliveryStatus
+    -> IO (Either DeliveryError ())
+revalidateLocalMutation expected =
+    repositoryDeliveryStatus
+        expected.deliveryRoot
+        expected.deliverySnapshotId >>= \case
+            Left err -> pure (Left err)
+            Right current
+                | current == expected -> pure (Right ())
+                | otherwise ->
+                    pure
+                        (Left
+                            (DeliveryStale
+                                "repository state changed immediately before delivery"))
+
 revalidatePullRequestMutation
     :: DeliveryStatus
     -> ValidatedRemote
@@ -936,38 +964,60 @@ validRemoteUrl url =
         "https://" `BS8.isPrefixOf` value
             && not (authorityContains '@' "https://" value)
             && not (containsQueryOrFragment value)
+            && not (authorityContains '%' "https://" value)
     validSsh value =
         "ssh://" `BS8.isPrefixOf` value
-            && not (userinfoContains ':' "ssh://" value)
+            && validSshAuthority value
             && not (containsQueryOrFragment value)
     validGit value =
         "git://" `BS8.isPrefixOf` value
             && not (authorityContains '@' "git://" value)
             && not (containsQueryOrFragment value)
+            && not (authorityContains '%' "git://" value)
     validFile value =
         "file://" `BS8.isPrefixOf` value
             && not (authorityContains '@' "file://" value)
             && not (containsQueryOrFragment value)
+            && not (authorityContains '%' "file://" value)
     authorityContains character prefix value =
         BS8.elem character
             (BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value))
-    userinfoContains character prefix value =
+    validSshAuthority value =
         let authority =
-                BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value)
+                BS8.takeWhile (/= '/') (BS.drop (BS.length "ssh://") value)
             (userinfo, separatorAndHost) = BS8.break (== '@') authority
-        in not (BS.null separatorAndHost)
-            && BS8.elem character userinfo
+            host = BS.drop 1 separatorAndHost
+        in not (BS.null authority)
+            && not (BS8.elem '%' authority)
+            && if BS.null separatorAndHost
+                then True
+                else validUsername userinfo
+                    && not (BS.null host)
+                    && not (BS8.elem '@' host)
+    validUsername username =
+        not (BS.null username)
+            && BS8.all
+                (\character ->
+                    isAsciiAlphaNumeric character
+                        || character `elem` ("._-" :: String))
+                username
+    isAsciiAlphaNumeric character =
+        (character >= 'a' && character <= 'z')
+            || (character >= 'A' && character <= 'Z')
+            || (character >= '0' && character <= '9')
     containsQueryOrFragment value =
         BS8.elem '?' value || BS8.elem '#' value
     validScpLike value =
         case BS8.break (== ':') value of
-            (host, path) ->
-                not (BS.null host)
-                    && BS8.elem '@' host
+            (authority, path) ->
+                let (username, separatorAndHost) = BS8.break (== '@') authority
+                    host = BS.drop 1 separatorAndHost
+                in validUsername username
+                    && not (BS.null separatorAndHost)
+                    && not (BS.null host)
+                    && not (BS8.elem '@' host)
+                    && not (BS8.elem '%' authority)
                     && BS.length path > 1
-                    -- A canonical SCP-like URL is `git@host:path`.
-                    -- Reject a second `@`, which denotes credentials in
-                    -- the authority and would be exposed in child argv.
                     && not (BS8.elem '@' path)
                     && not (containsQueryOrFragment value)
 

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -449,7 +449,7 @@ createPullRequest requested token =
                                                                                             [ "pr"
                                                                                             , "create"
                                                                                             , "--repo"
-                                                                                            , Text.unpack repository
+                                                                                            , githubRepoArgument repository
                                                                                             , "--base"
                                                                                             , Text.unpack base
                                                                                             , "--head"
@@ -815,7 +815,7 @@ ensureBaseAndNoOpenPullRequest status remote repository base =
                     [ "pr"
                     , "list"
                     , "--repo"
-                    , Text.unpack repository
+                    , githubRepoArgument repository
                     , "--head"
                     , Text.unpack status.deliveryBranch
                     , "--state"
@@ -861,7 +861,7 @@ requireGitHubCli root repository =
                 [ "repo"
                 , "view"
                 , "--repo"
-                , Text.unpack repository
+                , githubRepoArgument repository
                 , "--json"
                 , "nameWithOwner"
                 ]
@@ -884,6 +884,10 @@ requireGitHubCli root repository =
                                             "GitHub CLI returned an invalid repository identity"))
 
 newtype RepositoryIdentity = RepositoryIdentity Text
+
+githubRepoArgument :: Text -> String
+githubRepoArgument repository =
+    Text.unpack ("github.com/" <> repository)
 
 instance Aeson.FromJSON RepositoryIdentity where
     parseJSON = Aeson.withObject "RepositoryIdentity" \object ->
@@ -922,20 +926,46 @@ validRemoteUrl url =
         && BS.all (\byte -> byte >= 0x20 && byte /= 0x7f) url
         && BS8.head url /= '-'
         && (isAbsolute (BS8.unpack url)
-            || any (`BS8.isPrefixOf` url)
-                [ "https://"
-                , "ssh://"
-                , "git://"
-                , "file://"
-                ]
+            || validHttps url
+            || validSsh url
+            || validGit url
+            || validFile url
             || validScpLike url)
   where
+    validHttps value =
+        "https://" `BS8.isPrefixOf` value
+            && not (authorityContains '@' "https://" value)
+            && not (containsQueryOrFragment value)
+    validSsh value =
+        "ssh://" `BS8.isPrefixOf` value
+            && not (userinfoContains ':' "ssh://" value)
+            && not (containsQueryOrFragment value)
+    validGit value =
+        "git://" `BS8.isPrefixOf` value
+            && not (authorityContains '@' "git://" value)
+            && not (containsQueryOrFragment value)
+    validFile value =
+        "file://" `BS8.isPrefixOf` value
+            && not (authorityContains '@' "file://" value)
+            && not (containsQueryOrFragment value)
+    authorityContains character prefix value =
+        BS8.elem character
+            (BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value))
+    userinfoContains character prefix value =
+        let authority =
+                BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value)
+            (userinfo, separatorAndHost) = BS8.break (== '@') authority
+        in not (BS.null separatorAndHost)
+            && BS8.elem character userinfo
+    containsQueryOrFragment value =
+        BS8.elem '?' value || BS8.elem '#' value
     validScpLike value =
         case BS8.break (== ':') value of
             (host, path) ->
                 not (BS.null host)
                     && BS8.elem '@' host
                     && BS.length path > 1
+                    && not (containsQueryOrFragment value)
 
 remoteCommandPrefix :: ValidatedRemote -> [String]
 remoteCommandPrefix remote =
@@ -1456,6 +1486,7 @@ nonInteractiveEnvironment executable = do
             , "GCM_INTERACTIVE"
             , "GH_PROMPT_DISABLED"
             , "GH_REPO"
+            , "GH_HOST"
             , "SSH_ASKPASS_REQUIRE"
             , "GIT_DIR"
             , "GIT_WORK_TREE"

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -14,7 +14,7 @@ module Agent.CLI.RepositoryDelivery
     ) where
 
 import Control.Concurrent (forkIO, threadDelay)
-import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.Async (cancel, wait, withAsync)
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar
     ( MVar
@@ -27,6 +27,8 @@ import Control.Exception.Safe
     , bracket
     , finally
     , isAsyncException
+    , mask
+    , onException
     , throwIO
     , tryAny
     )
@@ -67,13 +69,13 @@ import System.Posix.Signals
     , sigTERM
     , signalProcessGroup
     )
+import System.Posix.Types (ProcessID)
 import System.Process
     ( CreateProcess(..)
     , ProcessHandle
     , StdStream(CreatePipe)
     , createProcess
     , getPid
-    , getProcessExitCode
     , proc
     , terminateProcess
     , waitForProcess
@@ -1285,7 +1287,7 @@ runCommand root executable arguments input timeoutMicros = do
         Right Nothing -> Left ProcessTimedOut
         Right (Just result) -> result
   where
-    start = do
+    start = mask \_ -> do
         environment <- nonInteractiveEnvironment executable
         (maybeInput, maybeOutput, maybeError, process) <-
             createProcess
@@ -1299,48 +1301,103 @@ runCommand root executable arguments input timeoutMicros = do
                     , env = Just environment
                     }
         case (maybeInput, maybeOutput, maybeError) of
-            (Just inputHandle, Just outputHandle, Just errorHandle) ->
-                pure (inputHandle, outputHandle, errorHandle, process)
+            (Just inputHandle, Just outputHandle, Just errorHandle) -> do
+                let closePipes = do
+                        closeQuietly inputHandle
+                        closeQuietly outputHandle
+                        closeQuietly errorHandle
+                    cleanupWithoutGroup = do
+                        closePipes
+                        _ <- tryAny (terminateProcess process)
+                        _ <- tryAny (waitForProcess process)
+                        pure ()
+                processGroup <- getPid process
+                    `onException` cleanupWithoutGroup
+                completed <- newIORef False
+                    `onException` do
+                        closePipes
+                        terminateProcessGroup sigKILL processGroup process
+                        _ <- tryAny (waitForProcess process)
+                        pure ()
+                pure
+                    ( inputHandle
+                    , outputHandle
+                    , errorHandle
+                    , process
+                    , processGroup
+                    , completed
+                    )
             _ -> do
                 terminateProcess process
                 _ <- waitForProcess process
                 fail "could not create command pipes"
-    stop (inputHandle, outputHandle, errorHandle, process) = do
+    stop
+        ( inputHandle
+        , outputHandle
+        , errorHandle
+        , process
+        , processGroup
+        , completed
+        ) = do
         closeQuietly inputHandle
         closeQuietly outputHandle
         closeQuietly errorHandle
-        getProcessExitCode process >>= \case
-            Just _ -> pure ()
-            Nothing -> do
-                terminateProcessGroup sigTERM process
-                threadDelay 100_000
-                getProcessExitCode process >>= \case
-                    Just _ -> pure ()
-                    Nothing -> terminateProcessGroup sigKILL process
+        finished <- readIORef completed
+        unless finished do
+            terminateProcessGroup sigTERM processGroup process
+            threadDelay 100_000
+            -- A descendant can retain the group and pipes after its leader
+            -- exits, so always escalate the captured process group.
+            terminateProcessGroup sigKILL processGroup process
         _ <- tryAny (waitForProcess process)
         pure ()
-    run (inputHandle, outputHandle, errorHandle, process) =
+    run
+        ( inputHandle
+        , outputHandle
+        , errorHandle
+        , process
+        , processGroup
+        , completed
+        ) =
         withAsync
             (BS.hPut inputHandle input `finally` closeQuietly inputHandle)
             \inputWriter ->
                 withAsync (readBounded outputHandle) \outputReader ->
                     withAsync (readBounded errorHandle) \errorReader -> do
                         exitCode <- waitForProcess process
+                        -- Do not wait for pipe EOF before terminating residual
+                        -- descendants in the leader's dedicated group.
+                        terminateProcessGroup sigKILL processGroup process
                         _ <- wait inputWriter
-                        (output, outputTruncated) <- wait outputReader
-                        (errors, errorsTruncated) <- wait errorReader
-                        let truncated = outputTruncated || errorsTruncated
-                        pure
-                            (if truncated
-                                then Left ProcessOutputExceeded
-                                else
-                                    Right
-                                        ProcessResult
-                                            { processExitCode = exitCode
-                                            , processStdout = output
-                                            , processStderr = errors
-                                            , processOutputTruncated = False
-                                            })
+                        drained <- timeout processPipeTeardownMicros
+                            ((,) <$> wait outputReader <*> wait errorReader)
+                        case drained of
+                            Nothing -> do
+                                closeQuietly outputHandle
+                                closeQuietly errorHandle
+                                cancel outputReader
+                                cancel errorReader
+                                pure (Left ProcessTimedOut)
+                            Just
+                                ( (output, outputTruncated)
+                                , (errors, errorsTruncated)
+                                ) -> do
+                                    writeIORef completed True
+                                    let truncated =
+                                            outputTruncated || errorsTruncated
+                                    pure
+                                        (if truncated
+                                            then Left ProcessOutputExceeded
+                                            else
+                                                Right
+                                                    ProcessResult
+                                                        { processExitCode =
+                                                            exitCode
+                                                        , processStdout = output
+                                                        , processStderr = errors
+                                                        , processOutputTruncated =
+                                                            False
+                                                        })
 
 readBounded :: Handle -> IO (BS.ByteString, Bool)
 readBounded handle = do
@@ -1366,10 +1423,11 @@ readBounded handle = do
 
 terminateProcessGroup
     :: Signal
+    -> Maybe ProcessID
     -> ProcessHandle
     -> IO ()
-terminateProcessGroup signal process = do
-    pid <- getPid process
+terminateProcessGroup signal processGroup process = do
+    pid <- maybe (getPid process) (pure . Just) processGroup
     case pid of
         Nothing -> do
             _ <- tryAny (terminateProcess process)
@@ -1487,6 +1545,9 @@ localTimeoutMicros = 15 * 1_000_000
 
 networkTimeoutMicros :: Int
 networkTimeoutMicros = 60 * 1_000_000
+
+processPipeTeardownMicros :: Int
+processPipeTeardownMicros = 1_000_000
 
 maxProcessOutputBytes :: Int
 maxProcessOutputBytes = 1024 * 1024

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -49,7 +49,8 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
-import Data.Word (Word8)
+import Data.Word (Word8, Word64)
+import GHC.Clock (getMonotonicTimeNSec)
 import System.Exit (ExitCode(..))
 import System.Environment (getEnvironment)
 import System.IO
@@ -146,7 +147,7 @@ instance Eq ValidatedRemote where
 
 data StoredConfirmation = StoredConfirmation
     { storedRoot :: !FilePath
-    , storedExpiresAt :: !POSIXTime
+    , storedDeadlineNanos :: !Word64
     , storedConfirmation :: !Confirmation
     }
 
@@ -1109,12 +1110,14 @@ storeConfirmation
     -> Confirmation
     -> IO (Text, POSIXTime)
 storeConfirmation root confirmation = do
-    now <- getPOSIXTime
+    wallNow <- getPOSIXTime
+    monotonicNow <- getMonotonicTimeNSec
     token <- randomToken
-    let expiresAt = now + confirmationLifetimeSeconds
+    let expiresAt = wallNow + confirmationLifetimeSeconds
+        deadline = saturatingAdd monotonicNow confirmationLifetimeNanos
     stored <- modifyMVar deliveryConfirmations \confirmations ->
         let active = Map.filter
-                (\entry -> entry.storedExpiresAt > now)
+                (\entry -> entry.storedDeadlineNanos > monotonicNow)
                 confirmations
         in if Map.size active >= maxActiveConfirmations
             || Map.member token active
@@ -1125,7 +1128,7 @@ storeConfirmation root confirmation = do
                         token
                         StoredConfirmation
                             { storedRoot = root
-                            , storedExpiresAt = expiresAt
+                            , storedDeadlineNanos = deadline
                             , storedConfirmation = confirmation
                             }
                         active
@@ -1159,10 +1162,11 @@ consumeConfirmation requested token
                         (DeliveryCommandFailed
                             "repository state could not be verified"))
             Just (Right snapshot) -> do
-                now <- getPOSIXTime
+                monotonicNow <- getMonotonicTimeNSec
                 modifyMVar deliveryConfirmations \confirmations ->
                     let pruned = Map.filter
-                            (\stored -> stored.storedExpiresAt > now)
+                            (\stored ->
+                                stored.storedDeadlineNanos > monotonicNow)
                             confirmations
                     in case Map.lookup token pruned of
                         Nothing ->
@@ -1470,6 +1474,14 @@ trySynchronous action =
 confirmationLifetimeSeconds :: POSIXTime
 confirmationLifetimeSeconds = 10 * 60
 
+confirmationLifetimeNanos :: Word64
+confirmationLifetimeNanos = 10 * 60 * 1_000_000_000
+
+saturatingAdd :: Word64 -> Word64 -> Word64
+saturatingAdd left right
+    | maxBound - left < right = maxBound
+    | otherwise = left + right
+
 localTimeoutMicros :: Int
 localTimeoutMicros = 15 * 1_000_000
 
@@ -1488,7 +1500,8 @@ deliveryConfirmations = unsafePerformIO do
     confirmations <- newMVar Map.empty
     _ <- forkIO $ forever do
         threadDelay 60_000_000
-        now <- getPOSIXTime
+        monotonicNow <- getMonotonicTimeNSec
         modifyMVar_ confirmations
-            (pure . Map.filter (\stored -> stored.storedExpiresAt > now))
+            (pure . Map.filter
+                (\stored -> stored.storedDeadlineNanos > monotonicNow))
     pure confirmations

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -15,6 +15,7 @@ module Agent.CLI.RepositoryDelivery
 
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (wait, withAsync)
+import Control.Applicative ((<|>))
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
@@ -42,6 +43,7 @@ import Data.IORef
     )
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -57,6 +59,7 @@ import System.IO
     , openBinaryFile
     )
 import System.IO.Unsafe (unsafePerformIO)
+import System.FilePath (isAbsolute)
 import System.Posix.Signals
     ( Signal
     , sigKILL
@@ -118,14 +121,28 @@ data DeliveryError
     deriving (Eq, Show)
 
 data Confirmation
-    = PushConfirmation !DeliveryStatus
+    = PushConfirmation !DeliveryStatus !ValidatedRemote
     | PullRequestConfirmation
         !DeliveryStatus
+        !ValidatedRemote
         !Text -- repository
         !Text -- base
         !Text -- title
         !Text -- body
-    deriving (Eq)
+
+data ValidatedRemote = ValidatedRemote
+    { validatedRemoteUrl :: !BS.ByteString
+    , validatedRemoteFingerprint :: !Text
+    , validatedGitHubRepository :: !(Maybe Text)
+    }
+
+instance Eq ValidatedRemote where
+    left == right =
+        left.validatedRemoteUrl == right.validatedRemoteUrl
+            && left.validatedRemoteFingerprint
+                == right.validatedRemoteFingerprint
+            && left.validatedGitHubRepository
+                == right.validatedGitHubRepository
 
 data StoredConfirmation = StoredConfirmation
     { storedRoot :: !FilePath
@@ -177,53 +194,60 @@ previewRepositoryPush
 previewRepositoryPush requested expected =
     repositoryDeliveryStatus requested expected >>= \case
         Left err -> pure (Left err)
-        Right status -> do
-            remoteHead <- queryRemoteHead status
-            case remoteHead of
+        Right status ->
+            validatedRemoteForStatus status >>= \case
                 Left err -> pure (Left err)
-                Right oid
-                    | oid /= status.deliveryUpstreamOid ->
-                        pure
-                            (Left
-                                (DeliveryStale
-                                    "the remote branch changed; fetch before previewing a push"))
-                    | status.deliveryAhead <= 0 ->
-                        pure
-                            (Left
-                                (DeliveryInvalidRequest
-                                    "the branch has no commits to push"))
-                    | status.deliveryBehind /= 0 ->
-                        pure
-                            (Left
-                                (DeliveryInvalidRequest
-                                    "the branch is behind its upstream"))
-                    | otherwise -> do
-                        dryRun <- runGit
-                            status.deliveryRoot
-                            [ "push"
-                            , "--porcelain"
-                            , "--dry-run"
-                            , "--no-verify"
-                            , "--"
-                            , Text.unpack status.deliveryRemote
-                            , pushRefspec status
-                            ]
-                            BS.empty
-                            networkTimeoutMicros
-                        case dryRun of
-                            Left err -> pure (Left err)
-                            Right _ -> do
-                                (token, expiresAt) <-
-                                    storeConfirmation
-                                        status.deliveryRoot
-                                        (PushConfirmation status)
+                Right remote ->
+                    queryRemoteHead status remote >>= \case
+                        Left err -> pure (Left err)
+                        Right oid
+                            | not (remoteMatchesExpected status oid) ->
                                 pure
-                                    (Right
-                                        PushPreview
-                                            { pushPreviewStatus = status
-                                            , pushPreviewConfirmation = token
-                                            , pushPreviewExpiresAt = expiresAt
-                                            })
+                                    (Left
+                                        (DeliveryStale
+                                            "the remote branch changed; fetch before previewing a push"))
+                            | status.deliveryAhead <= 0 ->
+                                pure
+                                    (Left
+                                        (DeliveryInvalidRequest
+                                            "the branch has no commits to push"))
+                            | status.deliveryBehind /= 0 ->
+                                pure
+                                    (Left
+                                        (DeliveryInvalidRequest
+                                            "the branch is behind its upstream"))
+                            | otherwise ->
+                                proveFastForward status >>= \case
+                                    Left err -> pure (Left err)
+                                    Right () -> do
+                                        dryRun <- runGit
+                                            status.deliveryRoot
+                                            (remoteCommandPrefix remote
+                                            <> [ "push"
+                                            , "--porcelain"
+                                            , "--dry-run"
+                                            , "--no-verify"
+                                            , leaseArgument status
+                                            , "--"
+                                            , BS8.unpack remote.validatedRemoteUrl
+                                            , pushRefspec status
+                                            ])
+                                            BS.empty
+                                            networkTimeoutMicros
+                                        case dryRun of
+                                            Left err -> pure (Left err)
+                                            Right _ -> do
+                                                (token, expiresAt) <-
+                                                    storeConfirmation
+                                                        status.deliveryRoot
+                                                        (PushConfirmation status remote)
+                                                pure
+                                                    (Right
+                                                        PushPreview
+                                                            { pushPreviewStatus = status
+                                                            , pushPreviewConfirmation = token
+                                                            , pushPreviewExpiresAt = expiresAt
+                                                            })
 
 confirmRepositoryPush
     :: FilePath
@@ -232,7 +256,7 @@ confirmRepositoryPush
 confirmRepositoryPush requested token =
     consumeConfirmation requested token >>= \case
         Left err -> pure (Left err)
-        Right (PushConfirmation previewed) ->
+        Right (PushConfirmation previewed previewedRemote) ->
             repositoryDeliveryStatus
                 requested
                 previewed.deliverySnapshotId >>= \case
@@ -244,29 +268,45 @@ confirmRepositoryPush requested token =
                                     (DeliveryStale
                                         "branch or upstream state changed after push preview"))
                         | otherwise ->
-                            queryRemoteHead current >>= \case
+                            validatedRemoteForStatus current >>= \case
                                 Left err -> pure (Left err)
-                                Right remoteOid
-                                    | remoteOid /= current.deliveryUpstreamOid ->
+                                Right currentRemote
+                                    | currentRemote /= previewedRemote ->
                                         pure
                                             (Left
                                                 (DeliveryStale
-                                                    "the remote branch changed after push preview"))
+                                                    "the remote destination changed after push preview"))
                                     | otherwise ->
-                                        runGit
-                                            current.deliveryRoot
-                                            [ "push"
-                                            , "--porcelain"
-                                            , "--no-verify"
-                                            , "--"
-                                            , Text.unpack current.deliveryRemote
-                                            , pushRefspec current
-                                            ]
-                                            BS.empty
-                                            networkTimeoutMicros >>= \case
-                                                Left err -> pure (Left err)
-                                                Right _ ->
-                                                    refreshPushedStatus current
+                                        proveFastForward current >>= \case
+                                            Left err -> pure (Left err)
+                                            Right () ->
+                                                queryRemoteHead current previewedRemote >>= \case
+                                                    Left err -> pure (Left err)
+                                                    Right remoteOid
+                                                        | not (remoteMatchesExpected current remoteOid) ->
+                                                            pure
+                                                                (Left
+                                                                    (DeliveryStale
+                                                                        "the remote branch changed after push preview"))
+                                                        | otherwise ->
+                                                            runGit
+                                                                current.deliveryRoot
+                                                                (remoteCommandPrefix previewedRemote
+                                                                <> [ "push"
+                                                                , "--porcelain"
+                                                                , "--no-verify"
+                                                                , leaseArgument current
+                                                                , "--"
+                                                                , BS8.unpack previewedRemote.validatedRemoteUrl
+                                                                , pushRefspec current
+                                                                ])
+                                                                BS.empty
+                                                                networkTimeoutMicros >>= \case
+                                                                    Left err -> pure (Left err)
+                                                                    Right _ ->
+                                                                        refreshPushedStatus
+                                                                            current
+                                                                            previewedRemote
         Right _ ->
             pure
                 (Left
@@ -293,42 +333,54 @@ previewPullRequest requested expected base title body
                             (DeliveryInvalidRequest
                                 "push the exact branch state before previewing a pull request"))
                 | otherwise ->
-                    queryRemoteHead status >>= \case
+                    validatedRemoteForStatus status >>= \case
                         Left err -> pure (Left err)
-                        Right remoteOid
-                            | remoteOid /= status.deliveryHeadOid ->
-                                pure
-                                    (Left
-                                        (DeliveryStale
-                                            "the pushed remote branch does not match HEAD"))
-                            | otherwise ->
-                                requireGitHubCli status.deliveryRoot >>= \case
-                                    Left err -> pure (Left err)
-                                    Right repository ->
-                                        ensureBaseAndNoOpenPullRequest
-                                            status repository base >>= \case
-                                                Left err -> pure (Left err)
-                                                Right () -> do
-                                                    (token, expiresAt) <-
-                                                        storeConfirmation
-                                                            status.deliveryRoot
-                                                            (PullRequestConfirmation
-                                                                status repository
-                                                                base title body)
-                                                    pure
-                                                        (Right
-                                                            PullRequestPreview
-                                                                { pullRequestRepository =
-                                                                    repository
-                                                                , pullRequestBaseRef = base
-                                                                , pullRequestHeadRef =
-                                                                    status.deliveryBranch
-                                                                , pullRequestTitle = title
-                                                                , pullRequestConfirmation =
-                                                                    token
-                                                                , pullRequestExpiresAt =
-                                                                    expiresAt
-                                                                })
+                        Right remote ->
+                            queryRemoteHead status remote >>= \case
+                                Left err -> pure (Left err)
+                                Right remoteOid
+                                    | remoteOid /= Just status.deliveryHeadOid ->
+                                        pure
+                                            (Left
+                                                (DeliveryStale
+                                                    "the pushed remote branch does not match HEAD"))
+                                    | otherwise ->
+                                        case remote.validatedGitHubRepository of
+                                            Nothing ->
+                                                pure
+                                                    (Left
+                                                        (DeliveryInvalidRequest
+                                                            "the delivery remote is not a supported GitHub repository"))
+                                            Just repository ->
+                                                requireGitHubCli
+                                                    status.deliveryRoot
+                                                    repository >>= \case
+                                                        Left err -> pure (Left err)
+                                                        Right () ->
+                                                            ensureBaseAndNoOpenPullRequest
+                                                                status remote repository base >>= \case
+                                                                    Left err -> pure (Left err)
+                                                                    Right () -> do
+                                                                        (token, expiresAt) <-
+                                                                            storeConfirmation
+                                                                                status.deliveryRoot
+                                                                                (PullRequestConfirmation
+                                                                                    status remote repository
+                                                                                    base title body)
+                                                                        pure
+                                                                            (Right
+                                                                                PullRequestPreview
+                                                                                    { pullRequestRepository =
+                                                                                        repository
+                                                                                    , pullRequestBaseRef = base
+                                                                                    , pullRequestHeadRef =
+                                                                                        status.deliveryBranch
+                                                                                    , pullRequestTitle = title
+                                                                                    , pullRequestConfirmation =
+                                                                                        token
+                                                                                    , pullRequestExpiresAt =
+                                                                                        expiresAt
+                                                                                    })
 
 createPullRequest
     :: FilePath
@@ -339,70 +391,80 @@ createPullRequest requested token =
         Left err -> pure (Left err)
         Right
             (PullRequestConfirmation
-                previewed repository base title body) ->
-                    repositoryDeliveryStatus
-                        requested
-                        previewed.deliverySnapshotId >>= \case
-                            Left err -> pure (Left err)
-                            Right current
-                                | current /= previewed ->
-                                    pure
-                                        (Left
-                                            (DeliveryStale
-                                                "branch or upstream state changed after pull-request preview"))
-                                | otherwise ->
-                                    queryRemoteHead current >>= \case
-                                        Left err -> pure (Left err)
-                                        Right remoteOid
-                                            | remoteOid
-                                                /= current.deliveryHeadOid ->
-                                                    pure
-                                                        (Left
-                                                            (DeliveryStale
-                                                                "the pushed remote branch changed after preview"))
-                                            | otherwise ->
-                                                requireGitHubCli
-                                                    current.deliveryRoot >>= \case
-                                                        Left err -> pure (Left err)
-                                                        Right currentRepository
-                                                            | currentRepository
-                                                                /= repository ->
-                                                                    pure
-                                                                        (Left
-                                                                            (DeliveryStale
-                                                                                "the GitHub repository changed after preview"))
-                                                            | otherwise ->
+                previewed previewedRemote repository base title body) ->
+            repositoryDeliveryStatus
+                requested
+                previewed.deliverySnapshotId >>= \case
+                    Left err -> pure (Left err)
+                    Right current
+                        | current /= previewed ->
+                            pure
+                                (Left
+                                    (DeliveryStale
+                                        "branch or upstream state changed after pull-request preview"))
+                        | otherwise ->
+                            validatedRemoteForStatus current >>= \case
+                                Left err -> pure (Left err)
+                                Right currentRemote
+                                    | currentRemote /= previewedRemote ->
+                                        pure
+                                            (Left
+                                                (DeliveryStale
+                                                    "the remote destination changed after preview"))
+                                    | otherwise ->
+                                        queryRemoteHead current previewedRemote >>= \case
+                                            Left err -> pure (Left err)
+                                            Right remoteOid
+                                                | remoteOid
+                                                    /= Just current.deliveryHeadOid ->
+                                                        pure
+                                                            (Left
+                                                                (DeliveryStale
+                                                                    "the pushed remote branch changed after preview"))
+                                                | otherwise ->
+                                                    requireGitHubCli
+                                                        current.deliveryRoot
+                                                        repository >>= \case
+                                                            Left err -> pure (Left err)
+                                                            Right () ->
                                                                 ensureBaseAndNoOpenPullRequest
                                                                     current
+                                                                    previewedRemote
                                                                     repository
                                                                     base >>= \case
                                                                         Left err ->
                                                                             pure (Left err)
                                                                         Right () ->
-                                                                            runGh
-                                                                                current.deliveryRoot
-                                                                                [ "pr"
-                                                                                , "create"
-                                                                                , "--repo"
-                                                                                , Text.unpack repository
-                                                                                , "--base"
-                                                                                , Text.unpack base
-                                                                                , "--head"
-                                                                                , Text.unpack current.deliveryBranch
-                                                                                , "--title"
-                                                                                , Text.unpack title
-                                                                                , "--body-file"
-                                                                                , "-"
-                                                                                ]
-                                                                                (TextEncoding.encodeUtf8 body)
-                                                                                networkTimeoutMicros >>= \case
+                                                                            revalidatePullRequestMutation
+                                                                                current
+                                                                                previewedRemote >>= \case
                                                                                     Left err ->
                                                                                         pure (Left err)
-                                                                                    Right output ->
-                                                                                        pure
-                                                                                            (parsePullRequestUrl
-                                                                                                repository
-                                                                                                output)
+                                                                                    Right () ->
+                                                                                        runGh
+                                                                                            current.deliveryRoot
+                                                                                            [ "pr"
+                                                                                            , "create"
+                                                                                            , "--repo"
+                                                                                            , Text.unpack repository
+                                                                                            , "--base"
+                                                                                            , Text.unpack base
+                                                                                            , "--head"
+                                                                                            , Text.unpack current.deliveryBranch
+                                                                                            , "--title"
+                                                                                            , Text.unpack title
+                                                                                            , "--body-file"
+                                                                                            , "-"
+                                                                                            ]
+                                                                                            (TextEncoding.encodeUtf8 body)
+                                                                                            networkTimeoutMicros >>= \case
+                                                                                                Left err ->
+                                                                                                    pure (Left err)
+                                                                                                Right output ->
+                                                                                                    pure
+                                                                                                        (parsePullRequestUrl
+                                                                                                            repository
+                                                                                                            output)
         Right _ ->
             pure
                 (Left
@@ -453,10 +515,22 @@ statusAtSnapshot snapshot =
         runGit root ["rev-parse", "--verify", "@{upstream}"] BS.empty
             localTimeoutMicros >>= \case
                 Left _ ->
-                    pure
-                        (Left
-                            (DeliveryInvalidRequest
-                                "the branch upstream is unavailable"))
+                    runGit root ["rev-list", "--count", "HEAD"] BS.empty
+                        localTimeoutMicros >>= \case
+                            Left err -> pure (Left err)
+                            Right countBytes ->
+                                case reads (BS8.unpack (stripLineEnding countBytes)) of
+                                    [(ahead, "")]
+                                        | ahead > 0 ->
+                                            finishStatus
+                                                (zeroObjectId headOid)
+                                                ahead
+                                                0
+                                    _ ->
+                                        pure
+                                            (Left
+                                                (DeliveryCommandFailed
+                                                    "Git returned an invalid commit count"))
                 Right upstreamBytes ->
                     let upstreamOid = decodeTrimmed upstreamBytes
                     in runGit
@@ -477,28 +551,27 @@ statusAtSnapshot snapshot =
                                                 (DeliveryCommandFailed
                                                     "Git returned invalid ahead/behind counts"))
                                     Just (ahead, behind) ->
-                                        readRemoteFingerprint
-                                            root remote >>= \case
-                                                Left err -> pure (Left err)
-                                                Right remoteFingerprint ->
-                                                    pure
-                                                        (Right
-                                                            DeliveryStatus
-                                                                { deliverySnapshotId =
-                                                                    snapshot.snapshotId
-                                                                , deliveryRoot = root
-                                                                , deliveryHeadOid = headOid
-                                                                , deliveryBranch = branch
-                                                                , deliveryRemote = remote
-                                                                , deliveryRemoteFingerprint =
-                                                                    remoteFingerprint
-                                                                , deliveryUpstreamRef =
-                                                                    upstreamRef
-                                                                , deliveryUpstreamOid =
-                                                                    upstreamOid
-                                                                , deliveryAhead = ahead
-                                                                , deliveryBehind = behind
-                                                                })
+                                        finishStatus upstreamOid ahead behind
+      where
+        finishStatus upstreamOid ahead behind =
+            readValidatedRemote root remote >>= \case
+                Left err -> pure (Left err)
+                Right validatedRemote ->
+                    pure
+                        (Right
+                            DeliveryStatus
+                                { deliverySnapshotId = snapshot.snapshotId
+                                , deliveryRoot = root
+                                , deliveryHeadOid = headOid
+                                , deliveryBranch = branch
+                                , deliveryRemote = remote
+                                , deliveryRemoteFingerprint =
+                                    validatedRemote.validatedRemoteFingerprint
+                                , deliveryUpstreamRef = upstreamRef
+                                , deliveryUpstreamOid = upstreamOid
+                                , deliveryAhead = ahead
+                                , deliveryBehind = behind
+                                })
 
 readUpstream
     :: FilePath
@@ -534,23 +607,34 @@ readUpstream root fullBranch =
                                 (DeliveryInvalidRequest
                                     "the branch has no configured upstream"))
 
-readRemoteFingerprint
+readValidatedRemote
     :: FilePath
     -> Text
-    -> IO (Either DeliveryError Text)
-readRemoteFingerprint root remote =
+    -> IO (Either DeliveryError ValidatedRemote)
+readValidatedRemote root remote =
     readUrls False >>= \case
         Left _ -> invalid
         Right [fetchUrl] ->
             readUrls True >>= \case
                 Right [pushUrl]
-                    | fetchUrl == pushUrl ->
-                        fmap decodeTrimmed
-                            <$> runGit
+                    | fetchUrl == pushUrl
+                        && validRemoteUrl pushUrl ->
+                            runGit
                                 root
                                 ["hash-object", "--stdin"]
                                 pushUrl
-                                localTimeoutMicros
+                                localTimeoutMicros >>= \case
+                                    Left err -> pure (Left err)
+                                    Right fingerprint ->
+                                        pure
+                                            (Right
+                                                ValidatedRemote
+                                                    { validatedRemoteUrl = pushUrl
+                                                    , validatedRemoteFingerprint =
+                                                        decodeTrimmed fingerprint
+                                                    , validatedGitHubRepository =
+                                                        githubRepositoryFromUrl pushUrl
+                                                    })
                 _ -> invalid
         _ -> invalid
   where
@@ -582,17 +666,39 @@ readRemoteFingerprint root remote =
                 (DeliveryInvalidRequest
                     "delivery requires one identical fetch and push destination"))
 
-queryRemoteHead :: DeliveryStatus -> IO (Either DeliveryError Text)
-queryRemoteHead status =
+validatedRemoteForStatus
+    :: DeliveryStatus
+    -> IO (Either DeliveryError ValidatedRemote)
+validatedRemoteForStatus status =
+    readValidatedRemote status.deliveryRoot status.deliveryRemote >>= \case
+        Left _ ->
+            pure
+                (Left
+                    (DeliveryStale
+                        "the remote destination is no longer valid"))
+        Right remote
+            | remote.validatedRemoteFingerprint
+                /= status.deliveryRemoteFingerprint ->
+                    pure
+                        (Left
+                            (DeliveryStale
+                                "the remote destination changed"))
+            | otherwise -> pure (Right remote)
+
+queryRemoteHead
+    :: DeliveryStatus
+    -> ValidatedRemote
+    -> IO (Either DeliveryError (Maybe Text))
+queryRemoteHead status remote =
     runGit
         status.deliveryRoot
-        [ "ls-remote"
-        , "--exit-code"
+        (remoteCommandPrefix remote
+        <> [ "ls-remote"
         , "--heads"
         , "--"
-        , Text.unpack status.deliveryRemote
+        , BS8.unpack remote.validatedRemoteUrl
         , Text.unpack status.deliveryUpstreamRef
-        ]
+        ])
         BS.empty
         networkTimeoutMicros >>= \case
             Left _ ->
@@ -602,11 +708,12 @@ queryRemoteHead status =
                             "could not verify the exact remote branch"))
             Right output ->
                 case BS8.words output of
+                    [] -> pure (Right Nothing)
                     [oidBytes, refBytes]
                         | decodeTrimmed refBytes
                             == status.deliveryUpstreamRef
                             && validObjectId (decodeTrimmed oidBytes) ->
-                                pure (Right (decodeTrimmed oidBytes))
+                                pure (Right (Just (decodeTrimmed oidBytes)))
                     _ ->
                         pure
                             (Left
@@ -615,44 +722,83 @@ queryRemoteHead status =
 
 refreshPushedStatus
     :: DeliveryStatus
+    -> ValidatedRemote
     -> IO (Either DeliveryError DeliveryStatus)
-refreshPushedStatus pushed = do
+refreshPushedStatus pushed validatedRemote = do
     -- A successful push does not necessarily update the local remote-tracking
     -- ref. Bind the returned result to the immutable pushed OID instead of
     -- pretending the tracking ref was refreshed.
-    remote <- queryRemoteHead
+    remoteResult <- queryRemoteHead
         pushed
             { deliveryUpstreamOid = pushed.deliveryHeadOid }
-    pure case remote of
+        validatedRemote
+    pure case remoteResult of
         Left err -> Left err
         Right oid
-            | oid /= pushed.deliveryHeadOid ->
+            | oid /= Just pushed.deliveryHeadOid ->
                 Left
                     (DeliveryStale
                         "remote verification did not match the pushed commit")
             | otherwise ->
                 Right
                     pushed
-                        { deliveryUpstreamOid = oid
+                        { deliveryUpstreamOid = pushed.deliveryHeadOid
                         , deliveryAhead = 0
                         , deliveryBehind = 0
                         }
 
+revalidatePullRequestMutation
+    :: DeliveryStatus
+    -> ValidatedRemote
+    -> IO (Either DeliveryError ())
+revalidatePullRequestMutation expected expectedRemote =
+    repositoryDeliveryStatus
+        expected.deliveryRoot
+        expected.deliverySnapshotId >>= \case
+            Left err -> pure (Left err)
+            Right current
+                | current /= expected ->
+                    pure
+                        (Left
+                            (DeliveryStale
+                                "branch or upstream state changed before pull-request creation"))
+                | otherwise ->
+                    validatedRemoteForStatus current >>= \case
+                        Left err -> pure (Left err)
+                        Right remote
+                            | remote /= expectedRemote ->
+                                pure
+                                    (Left
+                                        (DeliveryStale
+                                            "the remote destination changed before pull-request creation"))
+                            | otherwise ->
+                                queryRemoteHead current expectedRemote >>= \case
+                                    Left err -> pure (Left err)
+                                    Right oid
+                                        | oid /= Just current.deliveryHeadOid ->
+                                            pure
+                                                (Left
+                                                    (DeliveryStale
+                                                        "the pushed branch changed before pull-request creation"))
+                                        | otherwise -> pure (Right ())
+
 ensureBaseAndNoOpenPullRequest
     :: DeliveryStatus
+    -> ValidatedRemote
     -> Text
     -> Text
     -> IO (Either DeliveryError ())
-ensureBaseAndNoOpenPullRequest status repository base =
+ensureBaseAndNoOpenPullRequest status remote repository base =
     runGit
         status.deliveryRoot
-        [ "ls-remote"
+        (remoteCommandPrefix remote
+        <> [ "ls-remote"
         , "--exit-code"
         , "--heads"
         , "--"
-        , Text.unpack status.deliveryRemote
+        , BS8.unpack remote.validatedRemoteUrl
         , "refs/heads/" <> Text.unpack base
-        ]
+        ])
         BS.empty
         networkTimeoutMicros >>= \case
             Left _ ->
@@ -694,9 +840,13 @@ ensureBaseAndNoOpenPullRequest status repository base =
                                             (DeliveryCommandFailed
                                                 "GitHub CLI returned an invalid pull-request response"))
 
-requireGitHubCli :: FilePath -> IO (Either DeliveryError Text)
-requireGitHubCli root =
-    runGh root ["auth", "status"] BS.empty localTimeoutMicros >>= \case
+requireGitHubCli
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError ())
+requireGitHubCli root repository =
+    runGh root ["auth", "status", "--hostname", "github.com"]
+        BS.empty localTimeoutMicros >>= \case
         Left _ ->
             pure
                 (Left
@@ -705,7 +855,13 @@ requireGitHubCli root =
         Right _ ->
             runGh
                 root
-                ["repo", "view", "--json", "nameWithOwner"]
+                [ "repo"
+                , "view"
+                , "--repo"
+                , Text.unpack repository
+                , "--json"
+                , "nameWithOwner"
+                ]
                 BS.empty
                 networkTimeoutMicros >>= \case
                     Left _ ->
@@ -715,9 +871,9 @@ requireGitHubCli root =
                                     "GitHub repository identity is unavailable"))
                     Right output ->
                         case Aeson.decodeStrict' output of
-                            Just (RepositoryIdentity repository)
-                                | validateRepositoryName repository ->
-                                    pure (Right repository)
+                            Just (RepositoryIdentity returnedRepository)
+                                | returnedRepository == repository ->
+                                    pure (Right ())
                             _ ->
                                 pure
                                     (Left
@@ -755,6 +911,100 @@ parsePullRequestUrl repository output =
   where
     isControlOrSpace character = isSpace character
     isDigit character = character >= '0' && character <= '9'
+
+validRemoteUrl :: BS.ByteString -> Bool
+validRemoteUrl url =
+    not (BS.null url)
+        && BS.length url <= 4096
+        && BS.all (\byte -> byte >= 0x20 && byte /= 0x7f) url
+        && BS8.head url /= '-'
+        && (isAbsolute (BS8.unpack url)
+            || any (`BS8.isPrefixOf` url)
+                [ "https://"
+                , "ssh://"
+                , "git://"
+                , "file://"
+                ]
+            || validScpLike url)
+  where
+    validScpLike value =
+        case BS8.break (== ':') value of
+            (host, path) ->
+                not (BS.null host)
+                    && BS8.elem '@' host
+                    && BS.length path > 1
+
+remoteCommandPrefix :: ValidatedRemote -> [String]
+remoteCommandPrefix remote =
+    [ "-c"
+    , "url."
+        <> BS8.unpack remote.validatedRemoteUrl
+        <> ".insteadOf="
+        <> BS8.unpack remote.validatedRemoteUrl
+    ]
+
+githubRepositoryFromUrl :: BS.ByteString -> Maybe Text
+githubRepositoryFromUrl bytes
+    | not (BS.all (< 0x80) bytes) = Nothing
+    | otherwise =
+        let url = Text.pack (BS8.unpack bytes)
+        in parseHttps url
+            <|> parseSsh url
+            <|> parseScp url
+  where
+    parseHttps url =
+        Text.stripPrefix "https://github.com/" url >>= repositoryPath
+    parseSsh url =
+        (Text.stripPrefix "ssh://git@github.com/" url
+            <|> Text.stripPrefix "ssh://github.com/" url)
+            >>= repositoryPath
+    parseScp url =
+        Text.stripPrefix "git@github.com:" url >>= repositoryPath
+    repositoryPath path =
+        let withoutGit = fromMaybe path (Text.stripSuffix ".git" path)
+        in if validateRepositoryName withoutGit
+            then Just withoutGit
+            else Nothing
+
+remoteMatchesExpected :: DeliveryStatus -> Maybe Text -> Bool
+remoteMatchesExpected status =
+    (== expectedRemoteHead status)
+
+expectedRemoteHead :: DeliveryStatus -> Maybe Text
+expectedRemoteHead status
+    | Text.all (== '0') status.deliveryUpstreamOid = Nothing
+    | otherwise = Just status.deliveryUpstreamOid
+
+proveFastForward :: DeliveryStatus -> IO (Either DeliveryError ())
+proveFastForward status =
+    case expectedRemoteHead status of
+        Nothing -> pure (Right ())
+        Just expected ->
+            runGit
+                status.deliveryRoot
+                [ "merge-base"
+                , "--is-ancestor"
+                , Text.unpack expected
+                , Text.unpack status.deliveryHeadOid
+                ]
+                BS.empty
+                localTimeoutMicros >>= \case
+                    Right _ -> pure (Right ())
+                    Left _ ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "the push is not an exact fast-forward"))
+
+leaseArgument :: DeliveryStatus -> String
+leaseArgument status =
+    "--force-with-lease="
+        <> Text.unpack status.deliveryUpstreamRef
+        <> ":"
+        <> maybe
+            (Text.unpack (zeroObjectId status.deliveryHeadOid))
+            Text.unpack
+            (expectedRemoteHead status)
 
 validatePullRequestInput
     :: Text
@@ -837,6 +1087,9 @@ validateRepositoryName name =
 validObjectId :: Text -> Bool
 validObjectId oid =
     Text.length oid `elem` [40, 64] && Text.all isHexDigit oid
+
+zeroObjectId :: Text -> Text
+zeroObjectId oid = Text.replicate (Text.length oid) "0"
 
 parseAheadBehind :: BS.ByteString -> Maybe (Int, Int)
 parseAheadBehind bytes =

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -965,6 +965,10 @@ validRemoteUrl url =
                 not (BS.null host)
                     && BS8.elem '@' host
                     && BS.length path > 1
+                    -- A canonical SCP-like URL is `git@host:path`.
+                    -- Reject a second `@`, which denotes credentials in
+                    -- the authority and would be exposed in child argv.
+                    && not (BS8.elem '@' path)
                     && not (containsQueryOrFragment value)
 
 remoteCommandPrefix :: ValidatedRemote -> [String]
@@ -1395,12 +1399,34 @@ runCommand root executable arguments input timeoutMicros = do
                 withAsync (readBounded outputHandle) \outputReader ->
                     withAsync (readBounded errorHandle) \errorReader -> do
                         exitCode <- waitForProcess process
-                        -- Do not wait for pipe EOF before terminating residual
-                        -- descendants in the leader's dedicated group.
+                        inputFinished <- timeout processPipeTeardownMicros
+                            (wait inputWriter)
+                        case inputFinished of
+                            Just () -> pure ()
+                            Nothing -> do
+                                closeQuietly inputHandle
+                                cancel inputWriter
+                        let drainReaders =
+                                (,) <$> wait outputReader <*> wait errorReader
+                        -- Give ordinary buffered output a short chance to
+                        -- drain. The captured group is then terminated even
+                        -- when EOF already arrived: a descendant may close
+                        -- its pipes while continuing to run.
+                        naturallyDrained <- timeout
+                            processPipeTeardownMicros
+                            drainReaders
+                        terminateProcessGroup sigTERM processGroup process
+                        drainedAfterTerm <- case naturallyDrained of
+                            Just values -> pure (Just values)
+                            Nothing ->
+                                timeout processGroupTermGraceMicros drainReaders
+                        -- Always escalate the captured group so a descendant
+                        -- cannot outlive a successful leader.
                         terminateProcessGroup sigKILL processGroup process
-                        _ <- wait inputWriter
-                        drained <- timeout processPipeTeardownMicros
-                            ((,) <$> wait outputReader <*> wait errorReader)
+                        drained <- case drainedAfterTerm of
+                            Just values -> pure (Just values)
+                            Nothing ->
+                                timeout processPipeTeardownMicros drainReaders
                         case drained of
                             Nothing -> do
                                 closeQuietly outputHandle
@@ -1579,6 +1605,9 @@ networkTimeoutMicros = 60 * 1_000_000
 
 processPipeTeardownMicros :: Int
 processPipeTeardownMicros = 1_000_000
+
+processGroupTermGraceMicros :: Int
+processGroupTermGraceMicros = 2_000_000
 
 maxProcessOutputBytes :: Int
 maxProcessOutputBytes = 1024 * 1024

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -1,0 +1,1241 @@
+module Agent.CLI.RepositoryDelivery
+    ( DeliveryStatus(..)
+    , PushPreview(..)
+    , PullRequestPreview(..)
+    , DeliveryError(..)
+    , repositoryDeliveryStatus
+    , previewRepositoryPush
+    , confirmRepositoryPush
+    , previewPullRequest
+    , createPullRequest
+    , deliveryErrorText
+    , validateBranchName
+    , validateRemoteName
+    ) where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newMVar
+    )
+import Control.Exception.Safe
+    ( SomeException
+    , bracket
+    , finally
+    , isAsyncException
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (forever, unless, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Char (isAlphaNum, isHexDigit, isSpace)
+import Data.IORef
+    ( modifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Text.Encoding.Error (lenientDecode)
+import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
+import Data.Word (Word8)
+import System.Exit (ExitCode(..))
+import System.Environment (getEnvironment)
+import System.IO
+    ( Handle
+    , IOMode(ReadMode)
+    , hClose
+    , openBinaryFile
+    )
+import System.IO.Unsafe (unsafePerformIO)
+import System.Posix.Signals
+    ( Signal
+    , sigKILL
+    , sigTERM
+    , signalProcessGroup
+    )
+import System.Process
+    ( CreateProcess(..)
+    , ProcessHandle
+    , StdStream(CreatePipe)
+    , createProcess
+    , getPid
+    , getProcessExitCode
+    , proc
+    , terminateProcess
+    , waitForProcess
+    )
+import System.Timeout (timeout)
+
+import Agent.CLI.RepositoryReview
+    ( RepositorySnapshot(..)
+    , repositorySnapshot
+    )
+
+data DeliveryStatus = DeliveryStatus
+    { deliverySnapshotId :: !Text
+    , deliveryRoot :: !FilePath
+    , deliveryHeadOid :: !Text
+    , deliveryBranch :: !Text
+    , deliveryRemote :: !Text
+    , deliveryRemoteFingerprint :: !Text
+    , deliveryUpstreamRef :: !Text
+    , deliveryUpstreamOid :: !Text
+    , deliveryAhead :: !Int
+    , deliveryBehind :: !Int
+    } deriving (Eq, Show)
+
+data PushPreview = PushPreview
+    { pushPreviewStatus :: !DeliveryStatus
+    , pushPreviewConfirmation :: !Text
+    , pushPreviewExpiresAt :: !POSIXTime
+    } deriving (Eq, Show)
+
+data PullRequestPreview = PullRequestPreview
+    { pullRequestRepository :: !Text
+    , pullRequestBaseRef :: !Text
+    , pullRequestHeadRef :: !Text
+    , pullRequestTitle :: !Text
+    , pullRequestConfirmation :: !Text
+    , pullRequestExpiresAt :: !POSIXTime
+    } deriving (Eq, Show)
+
+data DeliveryError
+    = DeliveryInvalidRequest !Text
+    | DeliveryStale !Text
+    | DeliveryUnavailable !Text
+    | DeliveryCommandFailed !Text
+    | DeliveryConfirmationRejected !Text
+    deriving (Eq, Show)
+
+data Confirmation
+    = PushConfirmation !DeliveryStatus
+    | PullRequestConfirmation
+        !DeliveryStatus
+        !Text -- repository
+        !Text -- base
+        !Text -- title
+        !Text -- body
+    deriving (Eq)
+
+data StoredConfirmation = StoredConfirmation
+    { storedRoot :: !FilePath
+    , storedExpiresAt :: !POSIXTime
+    , storedConfirmation :: !Confirmation
+    }
+
+data ProcessResult = ProcessResult
+    { processExitCode :: !ExitCode
+    , processStdout :: !BS.ByteString
+    , processStderr :: !BS.ByteString
+    , processOutputTruncated :: !Bool
+    }
+
+data ProcessFailure
+    = ProcessLaunchFailed
+    | ProcessTimedOut
+    | ProcessOutputExceeded
+    deriving (Eq, Show)
+
+repositoryDeliveryStatus
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError DeliveryStatus)
+repositoryDeliveryStatus requested expected =
+    timeout localTimeoutMicros (repositorySnapshot requested) >>= \case
+        Nothing ->
+            pure
+                (Left
+                    (DeliveryCommandFailed
+                        "repository snapshot verification timed out"))
+        Just (Left _) ->
+            pure
+                (Left
+                    (DeliveryCommandFailed
+                        "repository state could not be verified"))
+        Just (Right snapshot)
+            | snapshot.snapshotId /= expected ->
+                pure
+                    (Left
+                        (DeliveryStale
+                            "repository state changed"))
+            | otherwise -> statusAtSnapshot snapshot
+
+previewRepositoryPush
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError PushPreview)
+previewRepositoryPush requested expected =
+    repositoryDeliveryStatus requested expected >>= \case
+        Left err -> pure (Left err)
+        Right status -> do
+            remoteHead <- queryRemoteHead status
+            case remoteHead of
+                Left err -> pure (Left err)
+                Right oid
+                    | oid /= status.deliveryUpstreamOid ->
+                        pure
+                            (Left
+                                (DeliveryStale
+                                    "the remote branch changed; fetch before previewing a push"))
+                    | status.deliveryAhead <= 0 ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "the branch has no commits to push"))
+                    | status.deliveryBehind /= 0 ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "the branch is behind its upstream"))
+                    | otherwise -> do
+                        dryRun <- runGit
+                            status.deliveryRoot
+                            [ "push"
+                            , "--porcelain"
+                            , "--dry-run"
+                            , "--no-verify"
+                            , "--"
+                            , Text.unpack status.deliveryRemote
+                            , pushRefspec status
+                            ]
+                            BS.empty
+                            networkTimeoutMicros
+                        case dryRun of
+                            Left err -> pure (Left err)
+                            Right _ -> do
+                                (token, expiresAt) <-
+                                    storeConfirmation
+                                        status.deliveryRoot
+                                        (PushConfirmation status)
+                                pure
+                                    (Right
+                                        PushPreview
+                                            { pushPreviewStatus = status
+                                            , pushPreviewConfirmation = token
+                                            , pushPreviewExpiresAt = expiresAt
+                                            })
+
+confirmRepositoryPush
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError DeliveryStatus)
+confirmRepositoryPush requested token =
+    consumeConfirmation requested token >>= \case
+        Left err -> pure (Left err)
+        Right (PushConfirmation previewed) ->
+            repositoryDeliveryStatus
+                requested
+                previewed.deliverySnapshotId >>= \case
+                    Left err -> pure (Left err)
+                    Right current
+                        | current /= previewed ->
+                            pure
+                                (Left
+                                    (DeliveryStale
+                                        "branch or upstream state changed after push preview"))
+                        | otherwise ->
+                            queryRemoteHead current >>= \case
+                                Left err -> pure (Left err)
+                                Right remoteOid
+                                    | remoteOid /= current.deliveryUpstreamOid ->
+                                        pure
+                                            (Left
+                                                (DeliveryStale
+                                                    "the remote branch changed after push preview"))
+                                    | otherwise ->
+                                        runGit
+                                            current.deliveryRoot
+                                            [ "push"
+                                            , "--porcelain"
+                                            , "--no-verify"
+                                            , "--"
+                                            , Text.unpack current.deliveryRemote
+                                            , pushRefspec current
+                                            ]
+                                            BS.empty
+                                            networkTimeoutMicros >>= \case
+                                                Left err -> pure (Left err)
+                                                Right _ ->
+                                                    refreshPushedStatus current
+        Right _ ->
+            pure
+                (Left
+                    (DeliveryConfirmationRejected
+                        "confirmation token is for a different operation"))
+
+previewPullRequest
+    :: FilePath
+    -> Text
+    -> Text
+    -> Text
+    -> Text
+    -> IO (Either DeliveryError PullRequestPreview)
+previewPullRequest requested expected base title body
+    | Left err <- validatePullRequestInput base title body =
+        pure (Left err)
+    | otherwise =
+        repositoryDeliveryStatus requested expected >>= \case
+            Left err -> pure (Left err)
+            Right status
+                | status.deliveryAhead /= 0 || status.deliveryBehind /= 0 ->
+                    pure
+                        (Left
+                            (DeliveryInvalidRequest
+                                "push the exact branch state before previewing a pull request"))
+                | otherwise ->
+                    queryRemoteHead status >>= \case
+                        Left err -> pure (Left err)
+                        Right remoteOid
+                            | remoteOid /= status.deliveryHeadOid ->
+                                pure
+                                    (Left
+                                        (DeliveryStale
+                                            "the pushed remote branch does not match HEAD"))
+                            | otherwise ->
+                                requireGitHubCli status.deliveryRoot >>= \case
+                                    Left err -> pure (Left err)
+                                    Right repository ->
+                                        ensureBaseAndNoOpenPullRequest
+                                            status repository base >>= \case
+                                                Left err -> pure (Left err)
+                                                Right () -> do
+                                                    (token, expiresAt) <-
+                                                        storeConfirmation
+                                                            status.deliveryRoot
+                                                            (PullRequestConfirmation
+                                                                status repository
+                                                                base title body)
+                                                    pure
+                                                        (Right
+                                                            PullRequestPreview
+                                                                { pullRequestRepository =
+                                                                    repository
+                                                                , pullRequestBaseRef = base
+                                                                , pullRequestHeadRef =
+                                                                    status.deliveryBranch
+                                                                , pullRequestTitle = title
+                                                                , pullRequestConfirmation =
+                                                                    token
+                                                                , pullRequestExpiresAt =
+                                                                    expiresAt
+                                                                })
+
+createPullRequest
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError Text)
+createPullRequest requested token =
+    consumeConfirmation requested token >>= \case
+        Left err -> pure (Left err)
+        Right
+            (PullRequestConfirmation
+                previewed repository base title body) ->
+                    repositoryDeliveryStatus
+                        requested
+                        previewed.deliverySnapshotId >>= \case
+                            Left err -> pure (Left err)
+                            Right current
+                                | current /= previewed ->
+                                    pure
+                                        (Left
+                                            (DeliveryStale
+                                                "branch or upstream state changed after pull-request preview"))
+                                | otherwise ->
+                                    queryRemoteHead current >>= \case
+                                        Left err -> pure (Left err)
+                                        Right remoteOid
+                                            | remoteOid
+                                                /= current.deliveryHeadOid ->
+                                                    pure
+                                                        (Left
+                                                            (DeliveryStale
+                                                                "the pushed remote branch changed after preview"))
+                                            | otherwise ->
+                                                requireGitHubCli
+                                                    current.deliveryRoot >>= \case
+                                                        Left err -> pure (Left err)
+                                                        Right currentRepository
+                                                            | currentRepository
+                                                                /= repository ->
+                                                                    pure
+                                                                        (Left
+                                                                            (DeliveryStale
+                                                                                "the GitHub repository changed after preview"))
+                                                            | otherwise ->
+                                                                ensureBaseAndNoOpenPullRequest
+                                                                    current
+                                                                    repository
+                                                                    base >>= \case
+                                                                        Left err ->
+                                                                            pure (Left err)
+                                                                        Right () ->
+                                                                            runGh
+                                                                                current.deliveryRoot
+                                                                                [ "pr"
+                                                                                , "create"
+                                                                                , "--repo"
+                                                                                , Text.unpack repository
+                                                                                , "--base"
+                                                                                , Text.unpack base
+                                                                                , "--head"
+                                                                                , Text.unpack current.deliveryBranch
+                                                                                , "--title"
+                                                                                , Text.unpack title
+                                                                                , "--body-file"
+                                                                                , "-"
+                                                                                ]
+                                                                                (TextEncoding.encodeUtf8 body)
+                                                                                networkTimeoutMicros >>= \case
+                                                                                    Left err ->
+                                                                                        pure (Left err)
+                                                                                    Right output ->
+                                                                                        pure
+                                                                                            (parsePullRequestUrl
+                                                                                                repository
+                                                                                                output)
+        Right _ ->
+            pure
+                (Left
+                    (DeliveryConfirmationRejected
+                        "confirmation token is for a different operation"))
+
+statusAtSnapshot
+    :: RepositorySnapshot
+    -> IO (Either DeliveryError DeliveryStatus)
+statusAtSnapshot snapshot =
+    case snapshot.snapshotHead of
+        Nothing ->
+            pure
+                (Left
+                    (DeliveryInvalidRequest
+                        "delivery requires a branch with at least one commit"))
+        Just headOid ->
+            runGit root ["symbolic-ref", "--quiet", "HEAD"] BS.empty
+                localTimeoutMicros >>= \case
+                    Left _ ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "delivery requires a named local branch"))
+                    Right branchBytes ->
+                        let fullBranch = decodeTrimmed branchBytes
+                        in case Text.stripPrefix "refs/heads/" fullBranch of
+                            Nothing ->
+                                pure
+                                    (Left
+                                        (DeliveryInvalidRequest
+                                            "Git returned an invalid local branch"))
+                            Just branch
+                                | not (validateBranchName branch) ->
+                                    pure
+                                        (Left
+                                            (DeliveryInvalidRequest
+                                                "local branch name is not safe for delivery"))
+                                | otherwise ->
+                                    readUpstream root fullBranch >>= \case
+                                        Left err -> pure (Left err)
+                                        Right (remote, upstreamRef) ->
+                                            readUpstreamStatus
+                                                root headOid branch remote upstreamRef
+  where
+    root = snapshot.snapshotRoot
+    readUpstreamStatus root headOid branch remote upstreamRef =
+        runGit root ["rev-parse", "--verify", "@{upstream}"] BS.empty
+            localTimeoutMicros >>= \case
+                Left _ ->
+                    pure
+                        (Left
+                            (DeliveryInvalidRequest
+                                "the branch upstream is unavailable"))
+                Right upstreamBytes ->
+                    let upstreamOid = decodeTrimmed upstreamBytes
+                    in runGit
+                        root
+                        [ "rev-list"
+                        , "--left-right"
+                        , "--count"
+                        , "HEAD...@{upstream}"
+                        ]
+                        BS.empty
+                        localTimeoutMicros >>= \case
+                            Left err -> pure (Left err)
+                            Right counts ->
+                                case parseAheadBehind counts of
+                                    Nothing ->
+                                        pure
+                                            (Left
+                                                (DeliveryCommandFailed
+                                                    "Git returned invalid ahead/behind counts"))
+                                    Just (ahead, behind) ->
+                                        readRemoteFingerprint
+                                            root remote >>= \case
+                                                Left err -> pure (Left err)
+                                                Right remoteFingerprint ->
+                                                    pure
+                                                        (Right
+                                                            DeliveryStatus
+                                                                { deliverySnapshotId =
+                                                                    snapshot.snapshotId
+                                                                , deliveryRoot = root
+                                                                , deliveryHeadOid = headOid
+                                                                , deliveryBranch = branch
+                                                                , deliveryRemote = remote
+                                                                , deliveryRemoteFingerprint =
+                                                                    remoteFingerprint
+                                                                , deliveryUpstreamRef =
+                                                                    upstreamRef
+                                                                , deliveryUpstreamOid =
+                                                                    upstreamOid
+                                                                , deliveryAhead = ahead
+                                                                , deliveryBehind = behind
+                                                                })
+
+readUpstream
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError (Text, Text))
+readUpstream root fullBranch =
+    runGit
+        root
+        [ "for-each-ref"
+        , "--format=%(upstream:remotename)%00%(upstream:remoteref)"
+        , "--count=1"
+        , Text.unpack fullBranch
+        ]
+        BS.empty
+        localTimeoutMicros >>= \case
+            Left err -> pure (Left err)
+            Right output ->
+                case BS.split 0 (stripLineEnding output) of
+                    [remoteBytes, refBytes] ->
+                        let remote = decodeTrimmed remoteBytes
+                            upstreamRef = decodeTrimmed refBytes
+                        in if validateRemoteName remote
+                            && validateFullBranchRef upstreamRef
+                            then pure (Right (remote, upstreamRef))
+                            else
+                                pure
+                                    (Left
+                                        (DeliveryInvalidRequest
+                                            "the branch has no safe push upstream"))
+                    _ ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "the branch has no configured upstream"))
+
+readRemoteFingerprint
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError Text)
+readRemoteFingerprint root remote =
+    readUrls False >>= \case
+        Left _ -> invalid
+        Right [fetchUrl] ->
+            readUrls True >>= \case
+                Right [pushUrl]
+                    | fetchUrl == pushUrl ->
+                        fmap decodeTrimmed
+                            <$> runGit
+                                root
+                                ["hash-object", "--stdin"]
+                                pushUrl
+                                localTimeoutMicros
+                _ -> invalid
+        _ -> invalid
+  where
+    readUrls push =
+        runGit
+            root
+            ( [ "remote"
+              , "get-url"
+              ]
+                <> (if push then ["--push"] else [])
+                <> [ "--all"
+                   , Text.unpack remote
+                   ]
+            )
+            BS.empty
+            localTimeoutMicros >>= \case
+                Left _ -> pure (Left ())
+                Right bytes ->
+                    pure
+                        (Right
+                            [ url
+                            | url <- map stripLineEnding (BS8.lines bytes)
+                            , not (BS.null url)
+                            , not (BS.elem 0 url)
+                            ])
+    invalid =
+        pure
+            (Left
+                (DeliveryInvalidRequest
+                    "delivery requires one identical fetch and push destination"))
+
+queryRemoteHead :: DeliveryStatus -> IO (Either DeliveryError Text)
+queryRemoteHead status =
+    runGit
+        status.deliveryRoot
+        [ "ls-remote"
+        , "--exit-code"
+        , "--heads"
+        , "--"
+        , Text.unpack status.deliveryRemote
+        , Text.unpack status.deliveryUpstreamRef
+        ]
+        BS.empty
+        networkTimeoutMicros >>= \case
+            Left _ ->
+                pure
+                    (Left
+                        (DeliveryUnavailable
+                            "could not verify the exact remote branch"))
+            Right output ->
+                case BS8.words output of
+                    [oidBytes, refBytes]
+                        | decodeTrimmed refBytes
+                            == status.deliveryUpstreamRef
+                            && validObjectId (decodeTrimmed oidBytes) ->
+                                pure (Right (decodeTrimmed oidBytes))
+                    _ ->
+                        pure
+                            (Left
+                                (DeliveryUnavailable
+                                    "the exact remote branch is unavailable"))
+
+refreshPushedStatus
+    :: DeliveryStatus
+    -> IO (Either DeliveryError DeliveryStatus)
+refreshPushedStatus pushed = do
+    -- A successful push does not necessarily update the local remote-tracking
+    -- ref. Bind the returned result to the immutable pushed OID instead of
+    -- pretending the tracking ref was refreshed.
+    remote <- queryRemoteHead
+        pushed
+            { deliveryUpstreamOid = pushed.deliveryHeadOid }
+    pure case remote of
+        Left err -> Left err
+        Right oid
+            | oid /= pushed.deliveryHeadOid ->
+                Left
+                    (DeliveryStale
+                        "remote verification did not match the pushed commit")
+            | otherwise ->
+                Right
+                    pushed
+                        { deliveryUpstreamOid = oid
+                        , deliveryAhead = 0
+                        , deliveryBehind = 0
+                        }
+
+ensureBaseAndNoOpenPullRequest
+    :: DeliveryStatus
+    -> Text
+    -> Text
+    -> IO (Either DeliveryError ())
+ensureBaseAndNoOpenPullRequest status repository base =
+    runGit
+        status.deliveryRoot
+        [ "ls-remote"
+        , "--exit-code"
+        , "--heads"
+        , "--"
+        , Text.unpack status.deliveryRemote
+        , "refs/heads/" <> Text.unpack base
+        ]
+        BS.empty
+        networkTimeoutMicros >>= \case
+            Left _ ->
+                pure
+                    (Left
+                        (DeliveryInvalidRequest
+                            "the pull-request base branch does not exist"))
+            Right _ ->
+                runGh
+                    status.deliveryRoot
+                    [ "pr"
+                    , "list"
+                    , "--repo"
+                    , Text.unpack repository
+                    , "--head"
+                    , Text.unpack status.deliveryBranch
+                    , "--state"
+                    , "open"
+                    , "--limit"
+                    , "1"
+                    , "--json"
+                    , "number"
+                    ]
+                    BS.empty
+                    networkTimeoutMicros >>= \case
+                        Left err -> pure (Left err)
+                        Right output ->
+                            case Aeson.decodeStrict' output
+                                    :: Maybe [Aeson.Value] of
+                                Just [] -> pure (Right ())
+                                Just _ ->
+                                    pure
+                                        (Left
+                                            (DeliveryInvalidRequest
+                                                "an open pull request already exists for this branch"))
+                                Nothing ->
+                                    pure
+                                        (Left
+                                            (DeliveryCommandFailed
+                                                "GitHub CLI returned an invalid pull-request response"))
+
+requireGitHubCli :: FilePath -> IO (Either DeliveryError Text)
+requireGitHubCli root =
+    runGh root ["auth", "status"] BS.empty localTimeoutMicros >>= \case
+        Left _ ->
+            pure
+                (Left
+                    (DeliveryUnavailable
+                        "GitHub CLI is unavailable or not authenticated"))
+        Right _ ->
+            runGh
+                root
+                ["repo", "view", "--json", "nameWithOwner"]
+                BS.empty
+                networkTimeoutMicros >>= \case
+                    Left _ ->
+                        pure
+                            (Left
+                                (DeliveryUnavailable
+                                    "GitHub repository identity is unavailable"))
+                    Right output ->
+                        case Aeson.decodeStrict' output of
+                            Just (RepositoryIdentity repository)
+                                | validateRepositoryName repository ->
+                                    pure (Right repository)
+                            _ ->
+                                pure
+                                    (Left
+                                        (DeliveryUnavailable
+                                            "GitHub CLI returned an invalid repository identity"))
+
+newtype RepositoryIdentity = RepositoryIdentity Text
+
+instance Aeson.FromJSON RepositoryIdentity where
+    parseJSON = Aeson.withObject "RepositoryIdentity" \object ->
+        RepositoryIdentity <$> object Aeson..: "nameWithOwner"
+
+parsePullRequestUrl :: Text -> BS.ByteString -> Either DeliveryError Text
+parsePullRequestUrl repository output =
+    case filter (not . Text.null)
+        (map Text.strip
+            (Text.lines
+                (TextEncoding.decodeUtf8With lenientDecode output))) of
+        [url]
+            | Text.length url <= 4096
+                && let prefix =
+                        "https://github.com/"
+                            <> repository
+                            <> "/pull/"
+                   in prefix `Text.isPrefixOf` url
+                        && Text.all isDigit
+                            (Text.drop (Text.length prefix) url)
+                        && Text.length url > Text.length prefix
+                && not (Text.any isControlOrSpace url) ->
+                    Right url
+        _ ->
+            Left
+                (DeliveryCommandFailed
+                    "GitHub CLI did not return one valid pull-request URL")
+  where
+    isControlOrSpace character = isSpace character
+    isDigit character = character >= '0' && character <= '9'
+
+validatePullRequestInput
+    :: Text
+    -> Text
+    -> Text
+    -> Either DeliveryError ()
+validatePullRequestInput base title body
+    | not (validateBranchName base) =
+        Left (DeliveryInvalidRequest "pull-request base branch is invalid")
+    | Text.null (Text.strip title) || Text.length title > 512 =
+        Left (DeliveryInvalidRequest "pull-request title is invalid")
+    | Text.any (== '\NUL') title =
+        Left (DeliveryInvalidRequest "pull-request title contains a NUL byte")
+    | Text.length body > 1024 * 1024 =
+        Left (DeliveryInvalidRequest "pull-request body exceeds 1 MiB")
+    | Text.any (== '\NUL') body =
+        Left (DeliveryInvalidRequest "pull-request body contains a NUL byte")
+    | otherwise = Right ()
+
+validateBranchName :: Text -> Bool
+validateBranchName branch =
+    validateFullBranchRef ("refs/heads/" <> branch)
+
+validateFullBranchRef :: Text -> Bool
+validateFullBranchRef ref =
+    not (Text.null ref)
+        && Text.length ref <= 1024
+        && "refs/heads/" `Text.isPrefixOf` ref
+        && not ("/" `Text.isSuffixOf` ref)
+        && not ("." `Text.isSuffixOf` ref)
+        && not ("." `Text.isPrefixOf` ref)
+        && not ("-" `Text.isPrefixOf` Text.drop (Text.length "refs/heads/") ref)
+        && not (".." `Text.isInfixOf` ref)
+        && not ("@{" `Text.isInfixOf` ref)
+        && not ("//" `Text.isInfixOf` ref)
+        && Text.all safeRefCharacter ref
+        && all validComponent (Text.splitOn "/" ref)
+  where
+    safeRefCharacter character =
+        not (isSpace character)
+            && character >= '\x20'
+            && character /= '\x7f'
+            && character `notElem` ("~^:?*[\\" :: String)
+    validComponent component =
+        not (Text.null component)
+            && not ("." `Text.isPrefixOf` component)
+            && component /= "."
+            && component /= ".."
+            && not (".lock" `Text.isSuffixOf` component)
+
+validateRemoteName :: Text -> Bool
+validateRemoteName remote =
+    not (Text.null remote)
+        && Text.length remote <= 255
+        && Text.head remote /= '-'
+        && Text.all
+            (\character ->
+                isAlphaNum character
+                    || character `elem` ("._/-" :: String))
+            remote
+        && not (".." `Text.isInfixOf` remote)
+        && not ("//" `Text.isInfixOf` remote)
+
+validateRepositoryName :: Text -> Bool
+validateRepositoryName name =
+    case Text.splitOn "/" name of
+        [owner, repository] ->
+            validPart owner && validPart repository
+        _ -> False
+  where
+    validPart value =
+        not (Text.null value)
+            && Text.length value <= 100
+            && Text.all
+                (\character ->
+                    isAlphaNum character
+                        || character `elem` ("-._" :: String))
+                value
+
+validObjectId :: Text -> Bool
+validObjectId oid =
+    Text.length oid `elem` [40, 64] && Text.all isHexDigit oid
+
+parseAheadBehind :: BS.ByteString -> Maybe (Int, Int)
+parseAheadBehind bytes =
+    case map (reads . BS8.unpack) (BS8.words bytes) of
+        [[ (ahead, "") ], [ (behind, "") ]]
+            | ahead >= 0 && behind >= 0 -> Just (ahead, behind)
+        _ -> Nothing
+
+pushRefspec :: DeliveryStatus -> String
+pushRefspec status =
+    Text.unpack status.deliveryHeadOid
+        <> ":"
+        <> Text.unpack status.deliveryUpstreamRef
+
+storeConfirmation
+    :: FilePath
+    -> Confirmation
+    -> IO (Text, POSIXTime)
+storeConfirmation root confirmation = do
+    now <- getPOSIXTime
+    token <- randomToken
+    let expiresAt = now + confirmationLifetimeSeconds
+    stored <- modifyMVar deliveryConfirmations \confirmations ->
+        let active = Map.filter
+                (\entry -> entry.storedExpiresAt > now)
+                confirmations
+        in if Map.size active >= maxActiveConfirmations
+            || Map.member token active
+            then pure (active, False)
+            else
+                pure
+                    ( Map.insert
+                        token
+                        StoredConfirmation
+                            { storedRoot = root
+                            , storedExpiresAt = expiresAt
+                            , storedConfirmation = confirmation
+                            }
+                        active
+                    , True
+                    )
+    unless stored (fail "repository delivery confirmation capacity exhausted")
+    pure (token, expiresAt)
+
+consumeConfirmation
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError Confirmation)
+consumeConfirmation requested token
+    | Text.length token /= 64 || not (Text.all isHexDigit token) =
+        pure
+            (Left
+                (DeliveryConfirmationRejected
+                    "confirmation token is invalid"))
+    | otherwise = do
+        snapshotResult <- timeout localTimeoutMicros
+            (repositorySnapshot requested)
+        case snapshotResult of
+            Nothing ->
+                pure
+                    (Left
+                        (DeliveryCommandFailed
+                            "repository snapshot verification timed out"))
+            Just (Left _) ->
+                pure
+                    (Left
+                        (DeliveryCommandFailed
+                            "repository state could not be verified"))
+            Just (Right snapshot) -> do
+                now <- getPOSIXTime
+                modifyMVar deliveryConfirmations \confirmations ->
+                    let pruned = Map.filter
+                            (\stored -> stored.storedExpiresAt > now)
+                            confirmations
+                    in case Map.lookup token pruned of
+                        Nothing ->
+                            pure
+                                ( pruned
+                                , Left
+                                    (DeliveryConfirmationRejected
+                                        "confirmation token expired or was already used")
+                                )
+                        Just stored ->
+                            let remaining = Map.delete token pruned
+                            in if stored.storedRoot /= snapshot.snapshotRoot
+                                then
+                                    pure
+                                        ( remaining
+                                        , Left
+                                            (DeliveryConfirmationRejected
+                                                "confirmation token belongs to another repository")
+                                        )
+                                else
+                                    pure
+                                        ( remaining
+                                        , Right stored.storedConfirmation
+                                        )
+
+randomToken :: IO Text
+randomToken =
+    bracket
+        (openBinaryFile "/dev/urandom" ReadMode)
+        hClose
+        (\handle -> do
+            bytes <- BS.hGet handle 32
+            unless (BS.length bytes == 32)
+                (fail "could not read confirmation entropy")
+            pure (hexEncode bytes))
+
+hexEncode :: BS.ByteString -> Text
+hexEncode = Text.pack . concatMap encodeByte . BS.unpack
+  where
+    alphabet = "0123456789abcdef"
+    encodeByte :: Word8 -> String
+    encodeByte byte =
+        [ alphabet !! fromIntegral (byte `div` 16)
+        , alphabet !! fromIntegral (byte `mod` 16)
+        ]
+
+runGit
+    :: FilePath
+    -> [String]
+    -> BS.ByteString
+    -> Int
+    -> IO (Either DeliveryError BS.ByteString)
+runGit root arguments input timeoutMicros =
+    runCommand root "git" arguments input timeoutMicros >>= \case
+        Left ProcessTimedOut ->
+            pure (Left (DeliveryCommandFailed "Git command timed out"))
+        Left ProcessOutputExceeded ->
+            pure (Left (DeliveryCommandFailed "Git command output exceeded its limit"))
+        Left ProcessLaunchFailed ->
+            pure (Left (DeliveryCommandFailed "Git command could not be started"))
+        Right result -> case result.processExitCode of
+            ExitSuccess
+                | result.processOutputTruncated ->
+                    pure
+                        (Left
+                            (DeliveryCommandFailed
+                                "Git command output exceeded its limit"))
+                | otherwise -> pure (Right result.processStdout)
+            ExitFailure code ->
+                pure
+                    (Left
+                        (DeliveryCommandFailed
+                            ("Git command failed with exit code "
+                                <> Text.pack (show code))))
+
+runGh
+    :: FilePath
+    -> [String]
+    -> BS.ByteString
+    -> Int
+    -> IO (Either DeliveryError BS.ByteString)
+runGh root arguments input timeoutMicros =
+    runCommand root "gh" arguments input timeoutMicros >>= \case
+        Left _ ->
+            pure
+                (Left
+                    (DeliveryUnavailable
+                        "GitHub CLI command was unavailable"))
+        Right result -> case result.processExitCode of
+            ExitSuccess
+                | result.processOutputTruncated ->
+                    pure
+                        (Left
+                            (DeliveryCommandFailed
+                                "GitHub CLI output exceeded its limit"))
+                | otherwise -> pure (Right result.processStdout)
+            ExitFailure _ ->
+                pure
+                    (Left
+                        (DeliveryUnavailable
+                            "GitHub CLI command failed"))
+
+runCommand
+    :: FilePath
+    -> FilePath
+    -> [String]
+    -> BS.ByteString
+    -> Int
+    -> IO (Either ProcessFailure ProcessResult)
+runCommand root executable arguments input timeoutMicros = do
+    launched <- trySynchronous
+        (bracket start stop \processData ->
+            timeout timeoutMicros (run processData))
+    pure case launched of
+        Left _ -> Left ProcessLaunchFailed
+        Right Nothing -> Left ProcessTimedOut
+        Right (Just result) -> result
+  where
+    start = do
+        environment <- nonInteractiveEnvironment executable
+        (maybeInput, maybeOutput, maybeError, process) <-
+            createProcess
+                (proc executable arguments)
+                    { cwd = Just root
+                    , std_in = CreatePipe
+                    , std_out = CreatePipe
+                    , std_err = CreatePipe
+                    , close_fds = True
+                    , create_group = True
+                    , env = Just environment
+                    }
+        case (maybeInput, maybeOutput, maybeError) of
+            (Just inputHandle, Just outputHandle, Just errorHandle) ->
+                pure (inputHandle, outputHandle, errorHandle, process)
+            _ -> do
+                terminateProcess process
+                _ <- waitForProcess process
+                fail "could not create command pipes"
+    stop (inputHandle, outputHandle, errorHandle, process) = do
+        closeQuietly inputHandle
+        closeQuietly outputHandle
+        closeQuietly errorHandle
+        getProcessExitCode process >>= \case
+            Just _ -> pure ()
+            Nothing -> do
+                terminateProcessGroup sigTERM process
+                threadDelay 100_000
+                getProcessExitCode process >>= \case
+                    Just _ -> pure ()
+                    Nothing -> terminateProcessGroup sigKILL process
+        _ <- tryAny (waitForProcess process)
+        pure ()
+    run (inputHandle, outputHandle, errorHandle, process) =
+        withAsync
+            (BS.hPut inputHandle input `finally` closeQuietly inputHandle)
+            \inputWriter ->
+                withAsync (readBounded outputHandle) \outputReader ->
+                    withAsync (readBounded errorHandle) \errorReader -> do
+                        exitCode <- waitForProcess process
+                        _ <- wait inputWriter
+                        (output, outputTruncated) <- wait outputReader
+                        (errors, errorsTruncated) <- wait errorReader
+                        let truncated = outputTruncated || errorsTruncated
+                        pure
+                            (if truncated
+                                then Left ProcessOutputExceeded
+                                else
+                                    Right
+                                        ProcessResult
+                                            { processExitCode = exitCode
+                                            , processStdout = output
+                                            , processStderr = errors
+                                            , processOutputTruncated = False
+                                            })
+
+readBounded :: Handle -> IO (BS.ByteString, Bool)
+readBounded handle = do
+    chunks <- newIORef []
+    retained <- newIORef 0
+    truncated <- newIORef False
+    let drain = do
+            chunk <- BS.hGetSome handle (64 * 1024)
+            unless (BS.null chunk) do
+                current <- readIORef retained
+                let room = max 0 (maxProcessOutputBytes - current)
+                    kept = BS.take room chunk
+                unless (BS.null kept) do
+                    modifyIORef' chunks (kept :)
+                    writeIORef retained (current + BS.length kept)
+                when (BS.length kept < BS.length chunk)
+                    (writeIORef truncated True)
+                drain
+    drain `finally` closeQuietly handle
+    bytes <- BS.concat . reverse <$> readIORef chunks
+    wasTruncated <- readIORef truncated
+    pure (bytes, wasTruncated)
+
+terminateProcessGroup
+    :: Signal
+    -> ProcessHandle
+    -> IO ()
+terminateProcessGroup signal process = do
+    pid <- getPid process
+    case pid of
+        Nothing -> do
+            _ <- tryAny (terminateProcess process)
+            pure ()
+        Just processId -> do
+            _ <- tryAny (signalProcessGroup signal processId)
+            pure ()
+
+stripLineEnding :: BS.ByteString -> BS.ByteString
+stripLineEnding = BS8.dropWhileEnd (`elem` ['\r', '\n'])
+
+decodeTrimmed :: BS.ByteString -> Text
+decodeTrimmed =
+    Text.strip . TextEncoding.decodeUtf8With lenientDecode
+
+closeQuietly :: Handle -> IO ()
+closeQuietly handle = do
+    _ <- tryAny (hClose handle)
+    pure ()
+
+nonInteractiveEnvironment :: FilePath -> IO [(String, String)]
+nonInteractiveEnvironment executable = do
+    inherited <- getEnvironment
+    let blocked =
+            [ "GIT_TERMINAL_PROMPT"
+            , "GCM_INTERACTIVE"
+            , "GH_PROMPT_DISABLED"
+            , "GH_REPO"
+            , "SSH_ASKPASS_REQUIRE"
+            , "GIT_DIR"
+            , "GIT_WORK_TREE"
+            , "GIT_INDEX_FILE"
+            , "GIT_OBJECT_DIRECTORY"
+            , "GIT_ALTERNATE_OBJECT_DIRECTORIES"
+            , "GIT_COMMON_DIR"
+            , "GIT_CONFIG_COUNT"
+            , "GIT_CONFIG_KEY_0"
+            , "GIT_CONFIG_VALUE_0"
+            , "GIT_CONFIG_PARAMETERS"
+            , "GIT_SSH_COMMAND"
+            , "GIT_ASKPASS"
+            , "GIT_PROXY_COMMAND"
+            , "GIT_EXEC_PATH"
+            ]
+        sanitized = filter
+            (\(name, _) ->
+                name `notElem` blocked
+                    && not ("GIT_CONFIG_KEY_" `prefixOf` name)
+                    && not ("GIT_CONFIG_VALUE_" `prefixOf` name))
+            inherited
+        retained
+            | executable == "git" =
+                filter (\(name, _) -> name `elem` gitEnvironmentAllowlist)
+                    sanitized
+            | otherwise = sanitized
+    pure
+        ( [ ("GIT_TERMINAL_PROMPT", "0")
+          , ("GCM_INTERACTIVE", "never")
+          , ("GH_PROMPT_DISABLED", "true")
+          , ("SSH_ASKPASS_REQUIRE", "never")
+          ]
+            <> retained
+        )
+  where
+    prefixOf prefix value = take (length prefix) value == prefix
+    gitEnvironmentAllowlist =
+        [ "PATH"
+        , "HOME"
+        , "TMPDIR"
+        , "TMP"
+        , "TEMP"
+        , "LANG"
+        , "LC_ALL"
+        , "LC_CTYPE"
+        , "USER"
+        , "LOGNAME"
+        , "SSH_AUTH_SOCK"
+        , "XDG_CONFIG_HOME"
+        , "XDG_CONFIG_DIRS"
+        , "SSL_CERT_FILE"
+        , "SSL_CERT_DIR"
+        , "NIX_SSL_CERT_FILE"
+        , "TERM"
+        ]
+
+deliveryErrorText :: DeliveryError -> Text
+deliveryErrorText = \case
+    DeliveryInvalidRequest message -> message
+    DeliveryStale message -> message
+    DeliveryUnavailable message -> message
+    DeliveryCommandFailed message -> message
+    DeliveryConfirmationRejected message -> message
+
+trySynchronous :: IO value -> IO (Either SomeException value)
+trySynchronous action =
+    tryAny action >>= \case
+        Left exception
+            | isAsyncException exception -> throwIO exception
+            | otherwise -> pure (Left exception)
+        Right value -> pure (Right value)
+
+confirmationLifetimeSeconds :: POSIXTime
+confirmationLifetimeSeconds = 10 * 60
+
+localTimeoutMicros :: Int
+localTimeoutMicros = 15 * 1_000_000
+
+networkTimeoutMicros :: Int
+networkTimeoutMicros = 60 * 1_000_000
+
+maxProcessOutputBytes :: Int
+maxProcessOutputBytes = 1024 * 1024
+
+maxActiveConfirmations :: Int
+maxActiveConfirmations = 1024
+
+{-# NOINLINE deliveryConfirmations #-}
+deliveryConfirmations :: MVar (Map Text StoredConfirmation)
+deliveryConfirmations = unsafePerformIO do
+    confirmations <- newMVar Map.empty
+    _ <- forkIO $ forever do
+        threadDelay 60_000_000
+        now <- getPOSIXTime
+        modifyMVar_ confirmations
+            (pure . Map.filter (\stored -> stored.storedExpiresAt > now))
+    pure confirmations

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -313,8 +313,13 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                                                     \errorReader -> do
                                                         exitCode <-
                                                             waitForProcess process
-                                                        _ <- wait outputReader
-                                                        _ <- wait errorReader
+                                                        -- Reader failures
+                                                        -- (including callback
+                                                        -- failures) must not
+                                                        -- suppress the one
+                                                        -- terminal callback.
+                                                        _ <- waitCatch outputReader
+                                                        _ <- waitCatch errorReader
                                                         wasCancelled <-
                                                             readIORef cancelled
                                                         onExit
@@ -343,12 +348,22 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                         Right check -> Right check
   where
     drainCheckOutput stream handle =
-        let drain = do
+        let drain callbackEnabled = do
                 bytes <- BS.hGetSome handle (64 * 1024)
                 if BS.null bytes
                     then pure ()
-                    else onOutput stream bytes >> drain
-        in drain `finally` closeQuietly handle
+                    else do
+                        nextEnabled <-
+                            if callbackEnabled
+                                then
+                                    tryAny (onOutput stream bytes) >>= \case
+                                        Left _ -> pure False
+                                        Right () -> pure True
+                                else pure False
+                        -- A failed foreign callback is disabled for this
+                        -- stream, but the pipe remains actively drained.
+                        drain nextEnabled
+        in drain True `finally` closeQuietly handle
 
 cancelRepositoryCheck :: RepositoryCheck -> IO ()
 cancelRepositoryCheck check = do

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -18,9 +18,11 @@ module Agent.CLI.RepositoryReview
     , repositoryErrorText
     ) where
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
+    , poll
     , wait
     , waitCatch
     , withAsync
@@ -37,10 +39,11 @@ import Control.Exception.Safe
     , onException
     , tryAny
     )
-import Control.Monad (foldM)
+import Control.Monad (foldM, unless)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isDigit)
+import Data.List (nub)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
@@ -57,11 +60,26 @@ import Data.Text.Encoding.Error (lenientDecode)
 import System.Exit (ExitCode(..))
 import System.IO (Handle, hClose)
 import System.IO.Unsafe (unsafePerformIO)
+import System.FilePath
+    ( isAbsolute
+    , makeRelative
+    , normalise
+    , splitDirectories
+    , (</>)
+    )
+import System.Posix.Signals
+    ( Signal
+    , sigKILL
+    , sigTERM
+    , signalProcessGroup
+    )
+import System.Posix.Types (ProcessID)
 import System.Process
     ( CreateProcess(..)
     , ProcessHandle
-    , StdStream(CreatePipe, Inherit)
+    , StdStream(CreatePipe)
     , createProcess
+    , getPid
     , proc
     , terminateProcess
     , waitForProcess
@@ -106,9 +124,9 @@ data RepositoryMutation
     = StagePath !FilePath
     | UnstagePath !FilePath
     | RestorePath !FilePath
-    | StagePatch !BS.ByteString
-    | UnstagePatch !BS.ByteString
-    | RestorePatch !BS.ByteString
+    | StagePatch !FilePath !BS.ByteString
+    | UnstagePatch !FilePath !BS.ByteString
+    | RestorePatch !FilePath !BS.ByteString
     deriving (Eq, Show)
 
 data RepositoryCheckStream
@@ -118,6 +136,7 @@ data RepositoryCheckStream
 
 data RepositoryCheck = RepositoryCheck
     { repositoryCheckProcess :: !ProcessHandle
+    , repositoryCheckProcessGroup :: !(Maybe ProcessID)
     , repositoryCheckWorker :: !(Async ())
     , repositoryCheckCancelled :: !(IORef Bool)
     }
@@ -140,68 +159,71 @@ repositoryDiff
     -> IO (Either RepositoryError RepositoryDiff)
 repositoryDiff requested expected kind path =
     runRepositoryRead requested \root -> do
-        current <- snapshotAtRoot root
-        case current of
+        case validateRepositoryPath root path of
             Left err -> pure (Left err)
-            Right snapshot
-                | snapshot.snapshotId /= expected ->
-                    pure
-                        (Left
-                            (StaleRepositorySnapshot
-                                expected
-                                snapshot.snapshotId))
-                | null path || path == "." ->
-                    pure (Left (InvalidRepositoryRequest "invalid file path"))
-                | otherwise -> do
-                    let untracked =
-                            kind == RepositoryWorktreeDiff
-                                && any
-                                    (\file ->
-                                        file.repositoryFilePath == path
-                                            && file.repositoryFileIndexStatus
-                                                == '?')
-                                    snapshot.snapshotFiles
-                        arguments
-                            | untracked =
-                                [ "diff"
-                                , "--no-index"
-                                , "--binary"
-                                , "--no-ext-diff"
-                                , "--no-color"
-                                , "--"
-                                , "/dev/null"
-                                , path
-                                ]
-                            | otherwise =
-                                [ "diff"
-                                , "--binary"
-                                , "--no-ext-diff"
-                                , "--no-color"
-                                ]
-                                    <> case kind of
-                                        RepositoryWorktreeDiff -> []
-                                        RepositoryStagedDiff -> ["--cached"]
-                                    <> ["--", path]
-                    result <- runGitDiff root arguments
-                    after <- snapshotAtRoot root
-                    pure do
-                        patch <- result
-                        latest <- after
-                        if latest.snapshotId /= expected
-                            then
-                                Left
-                                    (StaleRepositorySnapshot
-                                        expected
-                                        latest.snapshotId)
-                            else
-                                Right RepositoryDiff
-                                    { repositoryDiffPatch = patch
-                                    , repositoryDiffBinary =
-                                        "GIT binary patch" `BS8.isInfixOf` patch
-                                            || "Binary files "
+            Right () -> snapshotAtRoot root >>= \case
+                Left err -> pure (Left err)
+                Right snapshot
+                    | snapshot.snapshotId /= expected ->
+                        pure
+                            (Left
+                                (StaleRepositorySnapshot
+                                    expected
+                                    snapshot.snapshotId))
+                    | otherwise -> do
+                        let untracked =
+                                kind == RepositoryWorktreeDiff
+                                    && any
+                                        (\file ->
+                                            file.repositoryFilePath == path
+                                                && file.repositoryFileIndexStatus
+                                                    == '?')
+                                        snapshot.snapshotFiles
+                            arguments
+                                | untracked =
+                                    [ "--literal-pathspecs"
+                                    , "diff"
+                                    , "--no-index"
+                                    , "--binary"
+                                    , "--no-ext-diff"
+                                    , "--no-color"
+                                    , "--"
+                                    , "/dev/null"
+                                    , path
+                                    ]
+                                | otherwise =
+                                    [ "--literal-pathspecs"
+                                    , "diff"
+                                    , "--binary"
+                                    , "--no-ext-diff"
+                                    , "--no-color"
+                                    ]
+                                        <> case kind of
+                                            RepositoryWorktreeDiff -> []
+                                            RepositoryStagedDiff -> ["--cached"]
+                                        <> ["--", path]
+                        result <- runGitDiff root arguments
+                        after <- snapshotAtRoot root
+                        pure do
+                            patch <- result
+                            latest <- after
+                            if latest.snapshotId /= expected
+                                then
+                                    Left
+                                        (StaleRepositorySnapshot
+                                            expected
+                                            latest.snapshotId)
+                                else
+                                    Right RepositoryDiff
+                                        { repositoryDiffPatch = patch
+                                        , repositoryDiffBinary =
+                                            "GIT binary patch"
                                                 `BS8.isInfixOf` patch
-                                    , repositoryDiffHunks = parseDiffHunks patch
-                                    }
+                                                || "Binary files "
+                                                    `BS8.isInfixOf` patch
+                                        , repositoryDiffHunks =
+                                            parseDiffHunks patch
+                                        }
 
 mutateRepository
     :: FilePath
@@ -273,6 +295,7 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                     created <- tryAny do
                         (maybeOutput, maybeError, process) <-
                             createCheckProcess root executable arguments
+                        processGroup <- getPid process
                         cancelled <- newIORef False
                         worker <-
                             asyncWithUnmask
@@ -300,11 +323,13 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                                 `onException` do
                                     closeQuietly maybeOutput
                                     closeQuietly maybeError
-                                    _ <- tryAny (terminateProcess process)
+                                    signalCheckProcessGroup
+                                        sigKILL processGroup process
                                     _ <- tryAny (waitForProcess process)
                                     pure ()
                         pure RepositoryCheck
                             { repositoryCheckProcess = process
+                            , repositoryCheckProcessGroup = processGroup
                             , repositoryCheckWorker = worker
                             , repositoryCheckCancelled = cancelled
                             }
@@ -328,13 +353,38 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
 cancelRepositoryCheck :: RepositoryCheck -> IO ()
 cancelRepositoryCheck check = do
     writeIORef check.repositoryCheckCancelled True
-    _ <- tryAny (terminateProcess check.repositoryCheckProcess)
-    pure ()
+    signalCheckProcessGroup
+        sigTERM
+        check.repositoryCheckProcessGroup
+        check.repositoryCheckProcess
+    threadDelay 250_000
+    poll check.repositoryCheckWorker >>= \case
+        Nothing ->
+            signalCheckProcessGroup
+                sigKILL
+                check.repositoryCheckProcessGroup
+                check.repositoryCheckProcess
+        Just _ -> pure ()
 
 waitRepositoryCheck :: RepositoryCheck -> IO ()
 waitRepositoryCheck check = do
     _ <- waitCatch check.repositoryCheckWorker
     pure ()
+
+signalCheckProcessGroup
+    :: Signal
+    -> Maybe ProcessID
+    -> ProcessHandle
+    -> IO ()
+signalCheckProcessGroup signal processGroup process = do
+    processId <- maybe (getPid process) (pure . Just) processGroup
+    case processId of
+        Nothing -> do
+            _ <- tryAny (terminateProcess process)
+            pure ()
+        Just pid -> do
+            _ <- tryAny (signalProcessGroup signal pid)
+            pure ()
 
 createCheckProcess
     :: FilePath
@@ -346,13 +396,17 @@ createCheckProcess root executable arguments = do
         createProcess
             (proc executable arguments)
                 { cwd = Just root
-                , std_in = Inherit
+                , std_in = CreatePipe
                 , std_out = CreatePipe
                 , std_err = CreatePipe
                 , close_fds = True
+                , create_group = True
                 }
     case (maybeInput, maybeOutput, maybeError) of
-        (Nothing, Just output, Just errors) ->
+        (Just input, Just output, Just errors) -> do
+            -- Checks have no stdin API. Closing immediately prevents an
+            -- inherited terminal or pipe from leaving a check blocked.
+            hClose input
             pure (output, errors, process)
         _ -> do
             _ <- tryAny (terminateProcess process)
@@ -429,17 +483,27 @@ runMutation root snapshot = \case
                             "restore never deletes an untracked file"))
                 else applyPathPatch
                     RepositoryWorktreeDiff ["--reverse"] path
-    StagePatch patch ->
-        applyPatch root ["--cached"] patch
-    UnstagePatch patch ->
-        applyPatch root ["--cached", "--reverse"] patch
-    RestorePatch patch ->
-        applyPatch root ["--reverse"] patch
+    StagePatch path patch ->
+        checkedPath path $
+            applyReviewedPatch RepositoryWorktreeDiff ["--cached"] path patch
+    UnstagePatch path patch ->
+        checkedPath path $
+            applyReviewedPatch
+                RepositoryStagedDiff ["--cached", "--reverse"] path patch
+    RestorePatch path patch ->
+        checkedPath path $
+            if isUntracked path
+                then pure
+                    (Left
+                        (InvalidRepositoryRequest
+                            "restore never deletes an untracked file"))
+                else applyReviewedPatch
+                    RepositoryWorktreeDiff ["--reverse"] path patch
   where
     checkedPath path action
-        | null path || path == "." =
-            pure (Left (InvalidRepositoryRequest "invalid file path"))
-        | otherwise = action
+        = case validateRepositoryPath root path of
+            Left err -> pure (Left err)
+            Right () -> action
     isUntracked path = any
         (\file ->
             file.repositoryFilePath == path
@@ -451,20 +515,32 @@ runMutation root snapshot = \case
             Right diff
                 | BS.null diff.repositoryDiffPatch -> pure (Right ())
                 | otherwise ->
-                    applyPatch root flags diff.repositoryDiffPatch
+                    applyPatch
+                        root snapshot.snapshotId flags diff.repositoryDiffPatch
+    applyReviewedPatch kind flags path patch =
+        repositoryDiff root snapshot.snapshotId kind path >>= \case
+            Left err -> pure (Left err)
+            Right reviewed ->
+                case validateReviewedPatch
+                    reviewed.repositoryDiffPatch patch of
+                    Left err -> pure (Left err)
+                    Right () ->
+                        applyPatch root snapshot.snapshotId flags patch
 
 applyPatch
     :: FilePath
+    -> Text
     -> [String]
     -> BS.ByteString
     -> IO (Either RepositoryError ())
-applyPatch root flags patch
+applyPatch root expected flags patch
     | BS.null patch =
         pure (Left (InvalidRepositoryRequest "patch is empty"))
     | otherwise = do
-        checked <- runGit root
-            (["apply", "--check", "--recount"] <> flags <> ["-"])
-            patch
+        -- The in-process lock serializes bridge mutations. Revalidate as close
+        -- as possible to the single atomic git-apply invocation; an unrelated
+        -- external git writer cannot be locked by this API.
+        checked <- requireSnapshot root expected
         case checked of
             Left err -> pure (Left err)
             Right _ ->
@@ -472,6 +548,85 @@ applyPatch root flags patch
                     <$> runGit root
                         (["apply", "--recount"] <> flags <> ["-"])
                         patch
+
+validateRepositoryPath
+    :: FilePath
+    -> FilePath
+    -> Either RepositoryError ()
+validateRepositoryPath root path
+    | null path
+        || path == "."
+        || isAbsolute path
+        || normalise path /= path
+        || any (`elem` [".", ".."]) (splitDirectories path)
+        || ':' `isPrefixOfPath` path
+        || any (`elem` ("*?[" :: String)) path
+        || '\NUL' `elem` path =
+            Left
+                (InvalidRepositoryRequest
+                    "file path must be a normalized literal repository-relative path")
+    | let relative = makeRelative (normalise root) (normalise (root </> path))
+    , isAbsolute relative
+        || relative == ".."
+        || case splitDirectories relative of
+            "..":_ -> True
+            _ -> False =
+            Left
+                (InvalidRepositoryRequest
+                    "file path escapes the repository root")
+    | otherwise = Right ()
+  where
+    isPrefixOfPath character value =
+        case value of
+            first:_ -> first == character
+            [] -> False
+
+validateReviewedPatch
+    :: BS.ByteString
+    -> BS.ByteString
+    -> Either RepositoryError ()
+validateReviewedPatch reviewed supplied
+    | BS.null supplied =
+        Left (InvalidRepositoryRequest "patch is empty")
+    | supplied == reviewed = Right ()
+    | otherwise =
+        case (textPatchSections reviewed, textPatchSections supplied) of
+            (Just (reviewedHeader, reviewedHunks), Just (header, hunks))
+                | header == reviewedHeader
+                    && not (null hunks)
+                    && length hunks == length (nub hunks)
+                    && all (`elem` reviewedHunks) hunks -> Right ()
+            _ ->
+                Left
+                    (InvalidRepositoryRequest
+                        "patch is not an exact reviewed hunk set for the requested path")
+
+textPatchSections
+    :: BS.ByteString
+    -> Maybe ([BS.ByteString], [[BS.ByteString]])
+textPatchSections patch = do
+    let lines' = BS8.lines patch
+        (header, body) = break isHunkHeader lines'
+    unless (not (null header) && startsDiff header) Nothing
+    hunks <- splitHunks body
+    pure (header, hunks)
+  where
+    isHunkHeader = BS8.isPrefixOf "@@ "
+    startsDiff (first:_) = BS8.isPrefixOf "diff --git " first
+    startsDiff [] = False
+    splitHunks [] = Nothing
+    splitHunks lines' =
+        let collect (current, completed) line
+                | isHunkHeader line =
+                    ( [line]
+                    , if null current then completed else current : completed
+                    )
+                | null current = ([], completed)
+                | otherwise = (current <> [line], completed)
+            (lastHunk, reversed) = foldl' collect ([], []) lines'
+            result = reverse
+                (if null lastHunk then reversed else lastHunk : reversed)
+        in if null result then Nothing else Just result
 
 appendUntrackedHashes
     :: FilePath
@@ -488,7 +643,9 @@ appendUntrackedHashes root statusBytes diffBytes =
         ]
     addHash (Left err) _ = pure (Left err)
     addHash (Right material) path = do
-        result <- runGit root ["hash-object", "--", path] BS.empty
+        result <- runGit root
+            ["--literal-pathspecs", "hash-object", "--", path]
+            BS.empty
         pure ((material <>) <$> result)
 
 hashMaterial :: FilePath -> BS.ByteString -> IO (Either RepositoryError Text)
@@ -669,14 +826,16 @@ runProcessBytes
     -> IO (ExitCode, BS.ByteString, BS.ByteString)
 runProcessBytes workingDirectory executable arguments input =
     bracket start stop \(inputHandle, outputHandle, errorHandle, process) -> do
-        BS.hPut inputHandle input
-        hClose inputHandle
-        withAsync (BS.hGetContents outputHandle) \outputReader ->
-            withAsync (BS.hGetContents errorHandle) \errorReader -> do
-                exitCode <- waitForProcess process
-                output <- wait outputReader
-                errors <- wait errorReader
-                pure (exitCode, output, errors)
+        withAsync
+            (BS.hPut inputHandle input `finally` closeQuietly inputHandle)
+            \inputWriter ->
+                withAsync (BS.hGetContents outputHandle) \outputReader ->
+                    withAsync (BS.hGetContents errorHandle) \errorReader -> do
+                        exitCode <- waitForProcess process
+                        _ <- wait inputWriter
+                        output <- wait outputReader
+                        errors <- wait errorReader
+                        pure (exitCode, output, errors)
   where
     start = do
         (maybeInput, maybeOutput, maybeError, process) <-

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -22,6 +22,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
+    , cancel
     , poll
     , wait
     , waitCatch
@@ -38,6 +39,7 @@ import Control.Exception.Safe
     , bracket
     , finally
     , isAsyncException
+    , mask
     , onException
     , throwIO
     , throwString
@@ -91,6 +93,7 @@ import System.Process
     , terminateProcess
     , waitForProcess
     )
+import System.Timeout (timeout)
 
 data RepositorySnapshot = RepositorySnapshot
     { snapshotId :: !Text
@@ -345,6 +348,11 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                         (Left
                             (InvalidRepositoryRequest
                                 "check argument contains a NUL byte"))
+                | any null arguments ->
+                    pure
+                        (Left
+                            (InvalidRepositoryRequest
+                                "check argument is empty"))
                 | any
                     ((> maxRepositoryArgumentCharacters) . length)
                     arguments ->
@@ -359,52 +367,83 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                                 (InvalidRepositoryRequest
                                     "check arguments exceed the 8 MiB total limit"))
                 | otherwise -> do
-                    created <- trySynchronous do
+                    -- Keep asynchronous cancellation masked across process
+                    -- acquisition and construction of its owning worker.
+                    -- Once this returns, every resource is reachable through
+                    -- RepositoryCheck and cancellation is owned by that
+                    -- worker's finalizer.
+                    created <- trySynchronous (mask \_ -> do
                         (maybeOutput, maybeError, process) <-
                             createCheckProcess root executable arguments
                         processGroup <- getPid process
                         cancelled <- newIORef False
-                        worker <-
-                            asyncWithUnmask
-                                (\unmask ->
-                                    unmask
-                                        (withAsync
-                                            (drainCheckOutput
-                                                RepositoryCheckStdout
-                                                maybeOutput)
-                                            \outputReader ->
-                                                withAsync
-                                                    (drainCheckOutput
-                                                        RepositoryCheckStderr
-                                                        maybeError)
-                                                    \errorReader -> do
-                                                        exitCode <-
-                                                            waitForProcess process
-                                                        -- Reader failures
-                                                        -- (including callback
-                                                        -- failures) must not
-                                                        -- suppress the one
-                                                        -- terminal callback.
-                                                        _ <- waitCatch outputReader
-                                                        _ <- waitCatch errorReader
-                                                        wasCancelled <-
-                                                            readIORef cancelled
-                                                        onExit
-                                                            wasCancelled
-                                                            exitCode))
-                                `onException` do
-                                    closeQuietly maybeOutput
-                                    closeQuietly maybeError
-                                    signalCheckProcessGroup
-                                        sigKILL processGroup process
-                                    _ <- tryAny (waitForProcess process)
-                                    pure ()
+                        let cleanup = do
+                                closeQuietly maybeOutput
+                                closeQuietly maybeError
+                                signalCheckProcessGroup
+                                    sigKILL processGroup process
+                                _ <- tryAny (waitForProcess process)
+                                pure ()
+                        worker <- asyncWithUnmask
+                            (\unmask ->
+                                unmask
+                                    (withAsync
+                                        (drainCheckOutput
+                                            RepositoryCheckStdout
+                                            maybeOutput)
+                                        \outputReader ->
+                                            withAsync
+                                                (drainCheckOutput
+                                                    RepositoryCheckStderr
+                                                    maybeError)
+                                                \errorReader -> do
+                                                    exitCode <-
+                                                        waitForProcess process
+                                                    -- The requested leader is
+                                                    -- complete. Any process
+                                                    -- still in its dedicated
+                                                    -- group is a residual
+                                                    -- descendant and must not
+                                                    -- outlive the check.
+                                                    signalCheckProcessGroup
+                                                        sigKILL
+                                                        processGroup
+                                                        process
+                                                    -- Reader failures
+                                                    -- (including callback
+                                                    -- failures) must not
+                                                    -- suppress the one terminal
+                                                    -- callback. An escaped
+                                                    -- process outside the
+                                                    -- group still cannot hold
+                                                    -- this worker indefinitely.
+                                                    drained <- timeout
+                                                        processPipeTeardownMicros
+                                                        ((,)
+                                                            <$> waitCatch outputReader
+                                                            <*> waitCatch errorReader)
+                                                    case drained of
+                                                        Just _ -> pure ()
+                                                        Nothing -> do
+                                                            closeQuietly
+                                                                maybeOutput
+                                                            closeQuietly
+                                                                maybeError
+                                                            cancel outputReader
+                                                            cancel errorReader
+                                                    wasCancelled <-
+                                                        readIORef cancelled
+                                                    onExit
+                                                        wasCancelled
+                                                        exitCode)
+                                    `finally` cleanup)
+                                `onException` cleanup
                         pure RepositoryCheck
                             { repositoryCheckProcess = process
                             , repositoryCheckProcessGroup = processGroup
                             , repositoryCheckWorker = worker
                             , repositoryCheckCancelled = cancelled
-                            }
+                            })
                     pure case created of
                         Left exception ->
                             Left
@@ -1048,7 +1087,7 @@ runProcessBytes
     -> IO (ExitCode, BS.ByteString, BS.ByteString)
 runProcessBytes workingDirectory executable arguments input =
     bracket start stop
-        \(inputHandle, outputHandle, errorHandle, process, _, completed) -> do
+        \(inputHandle, outputHandle, errorHandle, process, processGroup, completed) -> do
         withAsync
             (BS.hPut inputHandle input `finally` closeQuietly inputHandle)
             \inputWriter ->
@@ -1063,9 +1102,20 @@ runProcessBytes workingDirectory executable arguments input =
                             errorHandle)
                         \errorReader -> do
                         exitCode <- waitForProcess process
+                        -- The requested leader is complete. Kill any residual
+                        -- member of its dedicated group before waiting for
+                        -- pipe EOF; escaped groups are bounded by the timeout.
+                        signalCheckProcessGroup
+                            sigKILL processGroup process
                         _ <- wait inputWriter
-                        output <- wait outputReader
-                        errors <- wait errorReader
+                        drained <- timeout
+                            processPipeTeardownMicros
+                            ((,) <$> wait outputReader <*> wait errorReader)
+                        (output, errors) <- case drained of
+                            Just values -> pure values
+                            Nothing ->
+                                throwString
+                                    "repository process descendants retained output pipes"
                         writeIORef completed True
                         pure (exitCode, output, errors)
   where
@@ -1194,6 +1244,9 @@ maxRepositoryProcessOutputBytes = 64 * 1024 * 1024
 
 maxRepositoryProcessErrorBytes :: Int
 maxRepositoryProcessErrorBytes = 8 * 1024 * 1024
+
+processPipeTeardownMicros :: Int
+processPipeTeardownMicros = 1_000_000
 
 trySynchronous :: IO value -> IO (Either SomeException value)
 trySynchronous action =

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -43,10 +43,10 @@ import Control.Monad (foldM, unless)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isDigit)
-import Data.List (nub)
+import Data.List (find, nub, sort)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.IORef
     ( IORef
     , newIORef
@@ -60,6 +60,7 @@ import Data.Text.Encoding.Error (lenientDecode)
 import System.Exit (ExitCode(..))
 import System.IO (Handle, hClose)
 import System.IO.Unsafe (unsafePerformIO)
+import System.Directory (canonicalizePath)
 import System.FilePath
     ( isAbsolute
     , makeRelative
@@ -124,9 +125,9 @@ data RepositoryMutation
     = StagePath !FilePath
     | UnstagePath !FilePath
     | RestorePath !FilePath
-    | StagePatch !FilePath !BS.ByteString
-    | UnstagePatch !FilePath !BS.ByteString
-    | RestorePatch !FilePath !BS.ByteString
+    | StageHunks !FilePath ![Int]
+    | UnstageHunks !FilePath ![Int]
+    | RestoreHunks !FilePath ![Int]
     deriving (Eq, Show)
 
 data RepositoryCheckStream
@@ -158,7 +159,16 @@ repositoryDiff
     -> FilePath
     -> IO (Either RepositoryError RepositoryDiff)
 repositoryDiff requested expected kind path =
-    runRepositoryRead requested \root -> do
+    withRepositoryMutationLock requested \root ->
+        repositoryDiffAtRoot root expected kind path
+
+repositoryDiffAtRoot
+    :: FilePath
+    -> Text
+    -> RepositoryDiffKind
+    -> FilePath
+    -> IO (Either RepositoryError RepositoryDiff)
+repositoryDiffAtRoot root expected kind path = do
         case validateRepositoryPath root path of
             Left err -> pure (Left err)
             Right () -> snapshotAtRoot root >>= \case
@@ -170,6 +180,11 @@ repositoryDiff requested expected kind path =
                                 (StaleRepositorySnapshot
                                     expected
                                     snapshot.snapshotId))
+                    | not (snapshotContainsPath snapshot path) ->
+                        pure
+                            (Left
+                                (InvalidRepositoryRequest
+                                    "file path is not present in the reviewed snapshot"))
                     | otherwise -> do
                         let untracked =
                                 kind == RepositoryWorktreeDiff
@@ -387,6 +402,9 @@ cancelRepositoryCheck check = do
                 check.repositoryCheckProcessGroup
                 check.repositoryCheckProcess
         Just _ -> pure ()
+    -- Cancellation owns process teardown: do not return while descendants,
+    -- pipe readers, or the terminal callback are still active.
+    waitRepositoryCheck check
 
 waitRepositoryCheck :: RepositoryCheck -> IO ()
 waitRepositoryCheck check = do
@@ -532,48 +550,55 @@ runMutation root snapshot = \case
                             "restore never deletes an untracked file"))
                 else applyPathPatch
                     RepositoryWorktreeDiff ["--reverse"] path
-    StagePatch path patch ->
+    StageHunks path hunks ->
         checkedPath path $
-            applyReviewedPatch RepositoryWorktreeDiff ["--cached"] path patch
-    UnstagePatch path patch ->
+            applyReviewedHunks
+                RepositoryWorktreeDiff ["--cached"] path hunks
+    UnstageHunks path hunks ->
         checkedPath path $
-            applyReviewedPatch
-                RepositoryStagedDiff ["--cached", "--reverse"] path patch
-    RestorePatch path patch ->
+            applyReviewedHunks
+                RepositoryStagedDiff ["--cached", "--reverse"] path hunks
+    RestoreHunks path hunks ->
         checkedPath path $
             if isUntracked path
                 then pure
                     (Left
                         (InvalidRepositoryRequest
                             "restore never deletes an untracked file"))
-                else applyReviewedPatch
-                    RepositoryWorktreeDiff ["--reverse"] path patch
+                else applyReviewedHunks
+                    RepositoryWorktreeDiff ["--reverse"] path hunks
   where
     checkedPath path action
         = case validateRepositoryPath root path of
             Left err -> pure (Left err)
-            Right () -> action
+            Right ()
+                | not (snapshotContainsPath snapshot path) ->
+                    pure
+                        (Left
+                            (InvalidRepositoryRequest
+                                "file path is not present in the reviewed snapshot"))
+                | otherwise -> action
     isUntracked path = any
         (\file ->
             file.repositoryFilePath == path
                 && file.repositoryFileIndexStatus == '?')
         snapshot.snapshotFiles
     applyPathPatch kind flags path =
-        repositoryDiff root snapshot.snapshotId kind path >>= \case
+        repositoryDiffAtRoot root snapshot.snapshotId kind path >>= \case
             Left err -> pure (Left err)
             Right diff
                 | BS.null diff.repositoryDiffPatch -> pure (Right ())
                 | otherwise ->
                     applyPatch
                         root snapshot.snapshotId flags diff.repositoryDiffPatch
-    applyReviewedPatch kind flags path patch =
-        repositoryDiff root snapshot.snapshotId kind path >>= \case
+    applyReviewedHunks kind flags path indices =
+        repositoryDiffAtRoot root snapshot.snapshotId kind path >>= \case
             Left err -> pure (Left err)
             Right reviewed ->
-                case validateReviewedPatch
-                    reviewed.repositoryDiffPatch patch of
+                case selectReviewedHunks
+                    snapshot path reviewed.repositoryDiffPatch indices of
                     Left err -> pure (Left err)
-                    Right () ->
+                    Right patch ->
                         applyPatch root snapshot.snapshotId flags patch
 
 applyPatch
@@ -630,25 +655,46 @@ validateRepositoryPath root path
             first:_ -> first == character
             [] -> False
 
-validateReviewedPatch
-    :: BS.ByteString
+selectReviewedHunks
+    :: RepositorySnapshot
+    -> FilePath
     -> BS.ByteString
-    -> Either RepositoryError ()
-validateReviewedPatch reviewed supplied
-    | BS.null supplied =
-        Left (InvalidRepositoryRequest "patch is empty")
-    | supplied == reviewed = Right ()
-    | otherwise =
-        case (textPatchSections reviewed, textPatchSections supplied) of
-            (Just (reviewedHeader, reviewedHunks), Just (header, hunks))
-                | header == reviewedHeader
-                    && not (null hunks)
-                    && length hunks == length (nub hunks)
-                    && all (`elem` reviewedHunks) hunks -> Right ()
-            _ ->
-                Left
-                    (InvalidRepositoryRequest
-                        "patch is not an exact reviewed hunk set for the requested path")
+    -> [Int]
+    -> Either RepositoryError BS.ByteString
+selectReviewedHunks snapshot path reviewed indices
+    | null indices || length indices /= length (nub indices) =
+        Left (InvalidRepositoryRequest "hunk selection is empty or duplicated")
+    | isDestructivePatch =
+        Left
+            (InvalidRepositoryRequest
+                "selected-hunk mutation does not allow deletion or rename patches")
+    | otherwise = case textPatchSections reviewed of
+        Nothing ->
+            Left
+                (InvalidRepositoryRequest
+                    "selected hunks require a non-binary text diff")
+        Just (header, hunks)
+            | any (\index -> index < 0 || index >= length hunks) indices ->
+                Left (InvalidRepositoryRequest "hunk index is out of range")
+            | otherwise ->
+                Right
+                    (BS8.unlines
+                        (header <> concatMap (hunks !!) (sort indices)))
+  where
+    file = find
+        (\entry -> entry.repositoryFilePath == path)
+        snapshot.snapshotFiles
+    isDestructivePatch =
+        maybe False
+            (\entry -> isJust entry.repositoryFileOriginalPath)
+            file
+            || any
+                (`BS8.isInfixOf` reviewed)
+                [ "deleted file mode "
+                , "rename from "
+                , "rename to "
+                , "+++ /dev/null"
+                ]
 
 textPatchSections
     :: BS.ByteString
@@ -813,7 +859,20 @@ repositoryRoot requested
     | otherwise =
         runGit requested ["rev-parse", "--show-toplevel"] BS.empty >>= \case
             Left err -> pure (Left (NotARepository (repositoryErrorText err)))
-            Right rootBytes -> pure (Right (Text.unpack (decodeTrimmed rootBytes)))
+            Right rootBytes ->
+                tryAny
+                    (canonicalizePath
+                        (Text.unpack (decodeTrimmed rootBytes))) >>= \case
+                            Left exception ->
+                                pure
+                                    (Left
+                                        (NotARepository
+                                            (Text.pack (show exception))))
+                            Right canonical -> pure (Right canonical)
+
+snapshotContainsPath :: RepositorySnapshot -> FilePath -> Bool
+snapshotContainsPath snapshot path =
+    any (\file -> file.repositoryFilePath == path) snapshot.snapshotFiles
 
 {-# NOINLINE repositoryLocks #-}
 repositoryLocks :: MVar (Map FilePath (MVar ()))

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -19,6 +19,7 @@ module Agent.CLI.RepositoryReview
     ) where
 
 import Control.Concurrent (threadDelay)
+import Control.Applicative ((<|>))
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
@@ -44,11 +45,12 @@ import Control.Exception.Safe
     , throwIO
     , throwString
     , tryAny
+    , tryIO
     )
 import Control.Monad (foldM, unless, when)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
-import Data.Char (isDigit)
+import Data.Char (isDigit, toLower)
 import Data.List (find, nub, sort)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -64,10 +66,18 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Exit (ExitCode(..))
+import System.Environment (getEnvironment)
 import qualified System.FileLock as FileLock
 import System.IO (Handle, hClose)
+import System.IO.Error (isDoesNotExistError)
 import System.IO.Unsafe (unsafePerformIO)
-import System.Directory (canonicalizePath)
+import System.Directory
+    ( canonicalizePath
+    , createDirectory
+    , doesDirectoryExist
+    , getTemporaryDirectory
+    , removePathForcibly
+    )
 import System.FilePath
     ( isAbsolute
     , makeRelative
@@ -81,8 +91,28 @@ import System.Posix.Signals
     , sigTERM
     , signalProcessGroup
     )
-import System.Posix.Files (fileMode, getSymbolicLinkStatus)
-import System.Posix.Types (ProcessID)
+import System.Posix.Files
+    ( fileMode
+    , getFdStatus
+    , getSymbolicLinkStatus
+    , isRegularFile
+    , isSymbolicLink
+    , readSymbolicLink
+    , setFileMode
+    )
+import System.Posix.IO
+    ( OpenMode(ReadOnly)
+    , cloexec
+    , closeFd
+    , defaultFileFlags
+    , dup
+    , fdToHandle
+    , nonBlock
+    , nofollow
+    , openFd
+    )
+import System.Posix.Temp (mkdtemp)
+import System.Posix.Types (FileMode, ProcessID)
 import System.Process
     ( CreateProcess(..)
     , ProcessHandle
@@ -94,6 +124,12 @@ import System.Process
     , waitForProcess
     )
 import System.Timeout (timeout)
+
+import Agent.CLI.ProcessSecurity
+    ( canonicalPathOutside
+    , resolveExecutableOutside
+    , sanitizeSearchPathOutside
+    )
 
 data RepositorySnapshot = RepositorySnapshot
     { snapshotId :: !Text
@@ -210,6 +246,7 @@ repositoryDiffAtRoot root expected kind path = do
                                     , "--no-index"
                                     , "--binary"
                                     , "--no-ext-diff"
+                                    , "--no-textconv"
                                     , "--no-color"
                                     , "--"
                                     , "/dev/null"
@@ -220,13 +257,20 @@ repositoryDiffAtRoot root expected kind path = do
                                     , "diff"
                                     , "--binary"
                                     , "--no-ext-diff"
+                                    , "--no-textconv"
                                     , "--no-color"
                                     ]
                                         <> case kind of
                                             RepositoryWorktreeDiff -> []
                                             RepositoryStagedDiff -> ["--cached"]
                                         <> ["--", path]
-                        result <- runGitDiff root arguments
+                        result <-
+                            if untracked
+                                then
+                                    validateUntrackedDiffPath root path >>= \case
+                                        Left err -> pure (Left err)
+                                        Right () -> runGitDiff root arguments
+                                else runGitDiff root arguments
                         after <- snapshotAtRoot root
                         pure do
                             patch <- result
@@ -553,41 +597,74 @@ createCheckProcess root executable arguments = mask \_ -> do
             fail "could not create check output pipes"
 
 snapshotAtRoot :: FilePath -> IO (Either RepositoryError RepositorySnapshot)
-snapshotAtRoot root = do
-    headResult <- repositoryHead root
-    indexResult <- runGit root ["ls-files", "--stage", "-z"] BS.empty
-    statusResult <- runGit root
-        ["status", "--porcelain=v1", "-z", "--untracked-files=all"]
-        BS.empty
-    diffResult <- runGit root
-        ["diff", "--binary", "--no-ext-diff", "--no-color"]
-        BS.empty
-    case (headResult, indexResult, statusResult, diffResult) of
-        (Right headOid, Right indexBytes, Right statusBytes, Right diffBytes) -> do
-            worktreeMaterial <- appendUntrackedHashes root statusBytes diffBytes
-            indexHash <- hashMaterial root indexBytes
-            worktreeHash <- case worktreeMaterial of
-                Left err -> pure (Left err)
-                Right material -> hashMaterial root material
-            pure do
-                indexFingerprint <- indexHash
-                worktreeFingerprint <- worktreeHash
-                let headFingerprint = fromMaybe "unborn" headOid
-                    identity = Text.intercalate ":"
-                        [headFingerprint, indexFingerprint, worktreeFingerprint]
-                files <- parsePorcelain statusBytes
-                pure RepositorySnapshot
-                    { snapshotId = identity
-                    , snapshotRoot = root
-                    , snapshotHead = headOid
-                    , snapshotIndexFingerprint = indexFingerprint
-                    , snapshotWorktreeFingerprint = worktreeFingerprint
-                    , snapshotFiles = files
-                    }
-        (Left err, _, _, _) -> pure (Left err)
-        (_, Left err, _, _) -> pure (Left err)
-        (_, _, Left err, _) -> pure (Left err)
-        (_, _, _, Left err) -> pure (Left err)
+snapshotAtRoot root =
+    withIsolatedRepositoryGit root \headOid environment -> do
+        indexResult <-
+            runGitWithEnvironment
+                environment root ["ls-files", "--stage", "-z"] BS.empty
+        statusResult <-
+            runGitWithEnvironment
+                environment
+                root
+                [ "status"
+                , "--porcelain=v1"
+                , "-z"
+                , "--untracked-files=all"
+                , "--ignore-submodules=all"
+                ]
+                BS.empty
+        diffResult <-
+            runGitWithEnvironment
+                environment
+                root
+                [ "diff"
+                , "--binary"
+                , "--no-ext-diff"
+                , "--no-textconv"
+                , "--no-color"
+                , "--ignore-submodules=all"
+                ]
+                BS.empty
+        case (indexResult, statusResult, diffResult) of
+            (Right indexBytes, Right statusBytes, Right diffBytes) -> do
+                worktreeMaterial <-
+                    appendUntrackedHashesWith
+                        (runGitWithEnvironment environment)
+                        root
+                        statusBytes
+                        diffBytes
+                indexHash <- hashMaterialWith
+                    (runGitWithEnvironment environment)
+                    root
+                    indexBytes
+                worktreeHash <- case worktreeMaterial of
+                    Left err -> pure (Left err)
+                    Right material ->
+                        hashMaterialWith
+                            (runGitWithEnvironment environment)
+                            root
+                            material
+                pure do
+                    indexFingerprint <- indexHash
+                    worktreeFingerprint <- worktreeHash
+                    let headFingerprint = fromMaybe "unborn" headOid
+                        identity = Text.intercalate ":"
+                            [ headFingerprint
+                            , indexFingerprint
+                            , worktreeFingerprint
+                            ]
+                    files <- parsePorcelain statusBytes
+                    pure RepositorySnapshot
+                        { snapshotId = identity
+                        , snapshotRoot = root
+                        , snapshotHead = headOid
+                        , snapshotIndexFingerprint = indexFingerprint
+                        , snapshotWorktreeFingerprint = worktreeFingerprint
+                        , snapshotFiles = files
+                        }
+            (Left err, _, _) -> pure (Left err)
+            (_, Left err, _) -> pure (Left err)
+            (_, _, Left err) -> pure (Left err)
 
 repositoryHead
     :: FilePath
@@ -717,10 +794,13 @@ applyPatch root expected flags patch
         case checked of
             Left err -> pure (Left err)
             Right _ ->
-                voidResult
-                    <$> runGit root
-                        (["apply", "--recount"] <> flags <> ["-"])
-                        patch
+                withIsolatedRepositoryGit root \_ environment ->
+                    voidResult
+                        <$> runGitWithEnvironment
+                            environment
+                            root
+                            (["apply", "--recount"] <> flags <> ["-"])
+                            patch
 
 validateRepositoryPath
     :: FilePath
@@ -830,12 +910,16 @@ textPatchSections patch = do
                     else reverse lastHunk : reversed)
         in if null result then Nothing else Just result
 
-appendUntrackedHashes
-    :: FilePath
+appendUntrackedHashesWith
+    :: (FilePath
+        -> [String]
+        -> BS.ByteString
+        -> IO (Either RepositoryError BS.ByteString))
+    -> FilePath
     -> BS.ByteString
     -> BS.ByteString
     -> IO (Either RepositoryError BS.ByteString)
-appendUntrackedHashes root statusBytes diffBytes =
+appendUntrackedHashesWith run root statusBytes diffBytes =
     foldM addHash (Right (statusBytes <> diffBytes)) untracked
   where
     untracked =
@@ -845,30 +929,114 @@ appendUntrackedHashes root statusBytes diffBytes =
         ]
     addHash (Left err) _ = pure (Left err)
     addHash (Right material) path = do
-        result <- runGit root
-            ["--literal-pathspecs", "hash-object", "--", path]
-            BS.empty
-        modeResult <- trySynchronous
-            (fileMode <$> getSymbolicLinkStatus (root </> path))
-        pure do
-            contentHash <- result
-            mode <- case modeResult of
-                Left exception ->
-                    Left
-                        (InvalidRepositoryRequest
-                            ("could not fingerprint untracked file mode: "
-                                <> Text.pack (show exception)))
-                Right value -> Right value
-            pure
-                ( material
-                    <> contentHash
-                    <> BS8.pack (show mode)
-                    <> "\NUL"
-                )
+        fingerprintUntrackedPath run root path >>= \case
+            Left err -> pure (Left err)
+            Right (contentHash, mode) ->
+                pure
+                    (Right
+                        ( material
+                            <> contentHash
+                            <> BS8.pack (show mode)
+                            <> "\NUL"
+                        ))
 
-hashMaterial :: FilePath -> BS.ByteString -> IO (Either RepositoryError Text)
-hashMaterial root bytes =
-    fmap decodeTrimmed <$> runGit root ["hash-object", "--stdin"] bytes
+fingerprintUntrackedPath
+    :: (FilePath
+        -> [String]
+        -> BS.ByteString
+        -> IO (Either RepositoryError BS.ByteString))
+    -> FilePath
+    -> FilePath
+    -> IO (Either RepositoryError (BS.ByteString, FileMode))
+fingerprintUntrackedPath run root path = do
+    let absolutePath = root </> path
+    trySynchronous (getSymbolicLinkStatus absolutePath) >>= \case
+        Left exception -> pure (Left (fingerprintError exception))
+        Right status
+            | isRegularFile status ->
+                readUntrackedRegularFile absolutePath >>= \case
+                    Left err -> pure (Left err)
+                    Right (contents, openedMode) ->
+                        hashContents contents openedMode
+            | isSymbolicLink status ->
+                trySynchronous
+                    (TextEncoding.encodeUtf8 . Text.pack
+                        <$> readSymbolicLink absolutePath) >>= \case
+                            Left exception ->
+                                pure (Left (fingerprintError exception))
+                            Right contents ->
+                                hashContents contents (fileMode status)
+            | otherwise ->
+                pure
+                    (Left
+                        (InvalidRepositoryRequest
+                            "untracked special files cannot be reviewed"))
+  where
+    hashContents contents mode =
+        run root
+            [ "hash-object"
+            , "--no-filters"
+            , "--stdin"
+            ]
+            contents >>= \case
+                Left err -> pure (Left err)
+                Right contentHash -> pure (Right (contentHash, mode))
+    fingerprintError exception =
+        InvalidRepositoryRequest
+            ("could not fingerprint untracked file: "
+                <> Text.pack (show exception))
+
+readUntrackedRegularFile
+    :: FilePath
+    -> IO (Either RepositoryError (BS.ByteString, FileMode))
+readUntrackedRegularFile path =
+    trySynchronous
+        (bracket
+            (openFd
+                path
+                ReadOnly
+                defaultFileFlags
+                    { nofollow = True
+                    , nonBlock = True
+                    , cloexec = True
+                    })
+            closeFd
+            \descriptor -> do
+                status <- getFdStatus descriptor
+                unless (isRegularFile status) $
+                    throwString "untracked file changed type while fingerprinting"
+                duplicate <- dup descriptor
+                handle <- fdToHandle duplicate
+                    `onException` closeFd duplicate
+                bytes <-
+                    BS.hGet
+                        handle
+                        (maxRepositoryUntrackedFileBytes + 1)
+                        `finally` hClose handle
+                when
+                    (BS.length bytes > maxRepositoryUntrackedFileBytes)
+                    (throwString
+                        "untracked file exceeds the review size limit")
+                pure (bytes, fileMode status)) >>= \case
+                    Left exception ->
+                        pure
+                            (Left
+                                (InvalidRepositoryRequest
+                                    ("could not fingerprint untracked file: "
+                                        <> Text.pack (show exception))))
+                    Right bytes -> pure (Right bytes)
+
+hashMaterialWith
+    :: (FilePath
+        -> [String]
+        -> BS.ByteString
+        -> IO (Either RepositoryError BS.ByteString))
+    -> FilePath
+    -> BS.ByteString
+    -> IO (Either RepositoryError Text)
+hashMaterialWith run root bytes =
+    fmap decodeTrimmed
+        <$> run root ["hash-object", "--no-filters", "--stdin"] bytes
 
 parsePorcelain :: BS.ByteString -> Either RepositoryError [RepositoryFile]
 parsePorcelain bytes = go (filter (not . BS.null) (BS.split 0 bytes)) []
@@ -997,6 +1165,18 @@ repositoryAdvisoryLockPath
     :: FilePath
     -> IO (Either RepositoryError FilePath)
 repositoryAdvisoryLockPath root =
+    repositoryCommonDirectory root >>= \case
+        Left err -> pure (Left err)
+        Right commonDirectory ->
+            pure
+                (Right
+                    (commonDirectory
+                        </> "haskell-agent-repository-review.lock"))
+
+repositoryCommonDirectory
+    :: FilePath
+    -> IO (Either RepositoryError FilePath)
+repositoryCommonDirectory root =
     runGit root ["rev-parse", "--git-common-dir"] BS.empty >>= \case
         Left err -> pure (Left err)
         Right commonDirectory -> do
@@ -1011,21 +1191,22 @@ repositoryAdvisoryLockPath root =
                         pure
                             (Left
                                 (RepositoryCommandFailed
-                                    "resolve repository advisory lock"
+                                    "resolve repository common directory"
                                     (-1)
                                     (Text.pack (show exception))))
                     Right canonical ->
-                        pure
-                            (Right
-                                (canonical
-                                    </> "haskell-agent-repository-review.lock"))
+                        pure (Right canonical)
 
 repositoryRoot :: FilePath -> IO (Either RepositoryError FilePath)
 repositoryRoot requested
     | null requested =
         pure (Left (NotARepository "repository path is empty"))
     | otherwise =
-        runGit requested ["rev-parse", "--show-toplevel"] BS.empty >>= \case
+        runGitWithTimeout
+            repositoryDiscoveryTimeoutMicros
+            requested
+            ["rev-parse", "--show-toplevel"]
+            BS.empty >>= \case
             Left err -> pure (Left (NotARepository (repositoryErrorText err)))
             Right rootBytes ->
                 trySynchronous
@@ -1051,8 +1232,25 @@ runGit
     -> [String]
     -> BS.ByteString
     -> IO (Either RepositoryError BS.ByteString)
-runGit root arguments input = do
-    result <- trySynchronous (runProcessBytes root "git" arguments input)
+runGit =
+    runGitWithTimeout maxRepositoryGitCommandMicros
+
+runGitWithTimeout
+    :: Int
+    -> FilePath
+    -> [String]
+    -> BS.ByteString
+    -> IO (Either RepositoryError BS.ByteString)
+runGitWithTimeout timeoutMicros root arguments input = do
+    result <-
+        trySynchronous
+            (timeout timeoutMicros
+                (runProcessBytesWithEnvironment
+                    []
+                    root
+                    "git"
+                    (safeGitArguments <> arguments)
+                    input))
     pure case result of
         Left exception ->
             Left
@@ -1060,22 +1258,87 @@ runGit root arguments input = do
                     (renderCommand "git" arguments)
                     (-1)
                     (Text.pack (show exception)))
-        Right (exitCode, output, errors) -> case exitCode of
-            ExitSuccess -> Right output
-            ExitFailure code ->
-                Left
-                    (RepositoryCommandFailed
-                        (renderCommand "git" arguments)
-                        code
-                        (Text.strip
-                            (TextEncoding.decodeUtf8With lenientDecode errors)))
+        Right Nothing ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    (-1)
+                    "repository Git command timed out")
+        Right (Just (exitCode, output, errors)) ->
+            gitProcessResult arguments exitCode output errors
+
+runGitWithEnvironment
+    :: [(String, String)]
+    -> FilePath
+    -> [String]
+    -> BS.ByteString
+    -> IO (Either RepositoryError BS.ByteString)
+runGitWithEnvironment environment root arguments input = do
+    result <-
+        trySynchronous
+            (timeout maxRepositoryGitCommandMicros
+                (runProcessBytesWithEnvironment
+                    environment
+                    root
+                    "git"
+                    (safeGitArguments <> arguments)
+                    input))
+    pure case result of
+        Left exception ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    (-1)
+                    (Text.pack (show exception)))
+        Right Nothing ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    (-1)
+                    "repository Git command timed out")
+        Right (Just (exitCode, output, errors)) ->
+            gitProcessResult arguments exitCode output errors
+
+gitProcessResult
+    :: [String]
+    -> ExitCode
+    -> BS.ByteString
+    -> BS.ByteString
+    -> Either RepositoryError BS.ByteString
+gitProcessResult arguments exitCode output errors =
+    case exitCode of
+        ExitSuccess -> Right output
+        ExitFailure code ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    code
+                    (Text.strip
+                        (TextEncoding.decodeUtf8With lenientDecode errors)))
 
 runGitDiff
     :: FilePath
     -> [String]
     -> IO (Either RepositoryError BS.ByteString)
 runGitDiff root arguments = do
-    result <- trySynchronous (runProcessBytes root "git" arguments BS.empty)
+    withIsolatedRepositoryGit root \_ environment ->
+        runGitDiffWithEnvironment environment root arguments
+
+runGitDiffWithEnvironment
+    :: [(String, String)]
+    -> FilePath
+    -> [String]
+    -> IO (Either RepositoryError BS.ByteString)
+runGitDiffWithEnvironment environment root arguments = do
+    result <-
+        trySynchronous
+            (timeout maxRepositoryDiffCommandMicros
+                (runProcessBytesWithEnvironment
+                    environment
+                    root
+                    "git"
+                    (safeGitArguments <> arguments)
+                    BS.empty))
     pure case result of
         Left exception ->
             Left
@@ -1083,7 +1346,13 @@ runGitDiff root arguments = do
                     (renderCommand "git" arguments)
                     (-1)
                     (Text.pack (show exception)))
-        Right (exitCode, output, errors) -> case exitCode of
+        Right Nothing ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    (-1)
+                    "repository diff command timed out")
+        Right (Just (exitCode, output, errors)) -> case exitCode of
             ExitSuccess -> Right output
             ExitFailure 1 -> Right output
             ExitFailure code ->
@@ -1094,13 +1363,39 @@ runGitDiff root arguments = do
                         (Text.strip
                             (TextEncoding.decodeUtf8With lenientDecode errors)))
 
-runProcessBytes
+validateUntrackedDiffPath
     :: FilePath
+    -> FilePath
+    -> IO (Either RepositoryError ())
+validateUntrackedDiffPath root path =
+    trySynchronous (getSymbolicLinkStatus (root </> path)) >>= \case
+        Left exception ->
+            pure
+                (Left
+                    (InvalidRepositoryRequest
+                        ("could not inspect untracked diff path: "
+                            <> Text.pack (show exception))))
+        Right status
+            | isRegularFile status -> pure (Right ())
+            | otherwise ->
+                pure
+                    (Left
+                        (InvalidRepositoryRequest
+                            "untracked special-file diffs are not supported"))
+
+runProcessBytesWithEnvironment
+    :: [(String, String)]
+    -> FilePath
     -> FilePath
     -> [String]
     -> BS.ByteString
     -> IO (ExitCode, BS.ByteString, BS.ByteString)
-runProcessBytes workingDirectory executable arguments input =
+runProcessBytesWithEnvironment
+    overrides
+    workingDirectory
+    executable
+    arguments
+    input =
     bracket start stop
         \(inputHandle, outputHandle, errorHandle, process, processGroup, completed) -> do
         withAsync
@@ -1135,15 +1430,22 @@ runProcessBytes workingDirectory executable arguments input =
                         pure (exitCode, output, errors)
   where
     start = mask \_ -> do
+        resolvedExecutable <-
+            resolveExecutableOutside workingDirectory executable
+                >>= either (fail . Text.unpack) pure
+        environment <-
+            applyEnvironmentOverrides overrides
+                <$> repositoryProcessEnvironment workingDirectory
         (maybeInput, maybeOutput, maybeError, process) <-
             createProcess
-                (proc executable arguments)
+                (proc resolvedExecutable arguments)
                     { cwd = Just workingDirectory
                     , std_in = CreatePipe
                     , std_out = CreatePipe
                     , std_err = CreatePipe
                     , close_fds = True
                     , create_group = True
+                    , env = Just environment
                     }
         let closePipes = do
                 mapM_ closeQuietly maybeInput
@@ -1197,6 +1499,568 @@ runProcessBytes workingDirectory executable arguments input =
             signalCheckProcessGroup sigKILL processGroup process
         _ <- tryAny (waitForProcess process)
         pure ()
+
+withIsolatedRepositoryGit
+    :: FilePath
+    -> ( Maybe Text
+        -> [(String, String)]
+        -> IO (Either RepositoryError value)
+       )
+    -> IO (Either RepositoryError value)
+withIsolatedRepositoryGit root action = do
+    repositoryCommonDirectory root >>= \case
+        Left err -> pure (Left err)
+        Right commonDirectory -> do
+            attempted <- trySynchronous $
+                withPrivateTempDirectoryOutside
+                    [root, commonDirectory]
+                    "haskell-agent-review"
+                    \gitDirectory ->
+                        prepareIsolatedRepositoryGit root gitDirectory >>= \case
+                            Left err -> pure (Left err)
+                            Right (headOid, environment) ->
+                                action headOid environment
+            pure case attempted of
+                Left exception ->
+                    Left
+                        (RepositoryCommandFailed
+                            "prepare isolated repository"
+                            (-1)
+                            (Text.pack (show exception)))
+                Right result -> result
+
+prepareIsolatedRepositoryGit
+    :: FilePath
+    -> FilePath
+    -> IO
+        (Either
+            RepositoryError
+            (Maybe Text, [(String, String)]))
+prepareIsolatedRepositoryGit root gitDirectory = do
+    headResult <- repositoryHead root
+    objectsResult <-
+        runGit
+            root
+            [ "rev-parse"
+            , "--path-format=absolute"
+            , "--git-path"
+            , "objects"
+            ]
+            BS.empty
+    indexResult <-
+        runGit
+            root
+            [ "rev-parse"
+            , "--path-format=absolute"
+            , "--git-path"
+            , "index"
+            ]
+            BS.empty
+    formatResult <-
+        runGit root ["rev-parse", "--show-object-format"] BS.empty
+    configResult <-
+        runGit
+            root
+            [ "config"
+            , "--local"
+            , "--no-includes"
+            , "--null"
+            , "--list"
+            ]
+            BS.empty
+    repositoryExcludeResult <-
+        runGit
+            root
+            [ "rev-parse"
+            , "--path-format=absolute"
+            , "--git-path"
+            , "info/exclude"
+            ]
+            BS.empty
+    configuredExcludeResult <- configuredRepositoryExclude root
+    case
+        ( headResult
+        , objectsResult
+        , indexResult
+        , formatResult
+        , configResult
+        , repositoryExcludeResult
+        , configuredExcludeResult
+        ) of
+        ( Right headOid
+            , Right objectsBytes
+            , Right indexBytes
+            , Right formatBytes
+            , Right configBytes
+            , Right repositoryExcludeBytes
+            , Right configuredExcludeBytes
+            ) -> do
+                let objects = decodePath (stripLineEnding objectsBytes)
+                    index = decodePath (stripLineEnding indexBytes)
+                    objectFormat = decodeTrimmed formatBytes
+                    repositoryExclude =
+                        decodePath (stripLineEnding repositoryExcludeBytes)
+                    configuredExcludeValue =
+                        decodePath
+                            (BS.takeWhile (/= 0) configuredExcludeBytes)
+                    configuredExclude
+                        | null configuredExcludeValue = ""
+                        | isAbsolute configuredExcludeValue =
+                            configuredExcludeValue
+                        | otherwise = root </> configuredExcludeValue
+                objectsExist <- doesDirectoryExist objects
+                if not
+                    ( isAbsolute objects
+                        && isAbsolute index
+                        && isAbsolute repositoryExclude
+                        && '\NUL' `notElem` objects
+                        && '\NUL' `notElem` index
+                        && '\NUL' `notElem` repositoryExclude
+                        && '\NUL' `notElem` configuredExclude
+                        && objectsExist
+                        && objectFormat `elem` ["sha1", "sha256"]
+                    )
+                    then pure (Left invalidStorage)
+                    else
+                        readRepositoryExcludeRules
+                            repositoryExclude
+                            configuredExclude >>= \case
+                                Left err -> pure (Left err)
+                                Right
+                                    ( repositoryExcludeContents
+                                        , configuredExcludeContents
+                                        ) -> do
+                                        installIsolatedRepositoryGit
+                                            gitDirectory
+                                            headOid
+                                            objectFormat
+                                            configBytes
+                                            repositoryExcludeContents
+                                            configuredExcludeContents
+                                        pure
+                                            (Right
+                                                ( headOid
+                                                , [ ("GIT_DIR", gitDirectory)
+                                                  , ("GIT_WORK_TREE", root)
+                                                  , ("GIT_INDEX_FILE", index)
+                                                  , ("GIT_OBJECT_DIRECTORY", objects)
+                                                  , ("GIT_CONFIG_GLOBAL", "/dev/null")
+                                                  , ("GIT_CONFIG_SYSTEM", "/dev/null")
+                                                  , ("GIT_CONFIG_NOSYSTEM", "1")
+                                                  , ("GIT_CONFIG_COUNT", "1")
+                                                  , ("GIT_CONFIG_KEY_0", "core.excludesFile")
+                                                  , ( "GIT_CONFIG_VALUE_0"
+                                                    , gitDirectory
+                                                        </> "global-excludes"
+                                                    )
+                                                  , ("GIT_ATTR_NOSYSTEM", "1")
+                                                  , ("GIT_OPTIONAL_LOCKS", "0")
+                                                  ]
+                                                ))
+        (Left err, _, _, _, _, _, _) -> pure (Left err)
+        (_, Left err, _, _, _, _, _) -> pure (Left err)
+        (_, _, Left err, _, _, _, _) -> pure (Left err)
+        (_, _, _, Left err, _, _, _) -> pure (Left err)
+        (_, _, _, _, Left err, _, _) -> pure (Left err)
+        (_, _, _, _, _, Left err, _) -> pure (Left err)
+        (_, _, _, _, _, _, Left err) -> pure (Left err)
+  where
+    invalidStorage =
+        RepositoryCommandFailed
+            "prepare isolated repository"
+            (-1)
+            "repository storage paths are invalid"
+
+configuredRepositoryExclude
+    :: FilePath
+    -> IO (Either RepositoryError BS.ByteString)
+configuredRepositoryExclude root = do
+    worktreeEnabled <-
+        runGitOptionalConfig
+            root
+            [ "config"
+            , "--local"
+            , "--no-includes"
+            , "--bool"
+            , "--get"
+            , "extensions.worktreeConfig"
+            ]
+    case worktreeEnabled of
+        Left err -> pure (Left err)
+        Right enabled -> do
+            worktree <-
+                if maybe False ((== "true") . decodeTrimmed) enabled
+                    then
+                        runGitOptionalConfig
+                            root
+                            (configPathArguments ["--worktree", "--no-includes"])
+                    else pure (Right Nothing)
+            local <-
+                runGitOptionalConfig
+                    root
+                    (configPathArguments ["--local", "--no-includes"])
+            selectHigherScope worktree local >>= \case
+                Left err -> pure (Left err)
+                Right (Just value) -> pure (Right value)
+                Right Nothing ->
+                    runGitOptionalConfig
+                        root
+                        (configPathArguments ["--global", "--includes"]) >>= \case
+                            Left err -> pure (Left err)
+                            Right (Just value) -> pure (Right value)
+                            Right Nothing ->
+                                runGitOptionalConfig
+                                    root
+                                    (configPathArguments
+                                        ["--system", "--includes"]) >>= \case
+                                            Left err -> pure (Left err)
+                                            Right value ->
+                                                pure (Right (fromMaybe "\NUL" value))
+  where
+    configPathArguments scope =
+        ["config"]
+            <> scope
+            <> [ "--path"
+               , "--null"
+               , "--get"
+               , "core.excludesFile"
+               ]
+    selectHigherScope (Left err) _ = pure (Left err)
+    selectHigherScope _ (Left err) = pure (Left err)
+    selectHigherScope (Right worktree) (Right local) =
+        pure (Right (worktree <|> local))
+
+runGitOptionalConfig
+    :: FilePath
+    -> [String]
+    -> IO (Either RepositoryError (Maybe BS.ByteString))
+runGitOptionalConfig root arguments = do
+    result <-
+        trySynchronous
+            (timeout repositoryConfigTimeoutMicros
+                (runProcessBytesWithEnvironment
+                    []
+                    root
+                    "git"
+                    (safeGitArguments <> arguments)
+                    BS.empty))
+    pure case result of
+        Left exception ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    (-1)
+                    (Text.pack (show exception)))
+        Right Nothing ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    (-1)
+                    "repository config resolution timed out")
+        Right (Just (ExitSuccess, output, _)) -> Right (Just output)
+        Right (Just (ExitFailure 1, _, _)) -> Right Nothing
+        Right (Just (ExitFailure code, _, errors)) ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    code
+                    (Text.strip
+                        (TextEncoding.decodeUtf8With lenientDecode errors)))
+
+installIsolatedRepositoryGit
+    :: FilePath
+    -> Maybe Text
+    -> Text
+    -> BS.ByteString
+    -> BS.ByteString
+    -> BS.ByteString
+    -> IO ()
+installIsolatedRepositoryGit
+    gitDirectory
+    headOid
+    objectFormat
+    configBytes
+    repositoryExcludeContents
+    configuredExcludeContents = do
+    createDirectory (gitDirectory </> "refs")
+    createDirectory (gitDirectory </> "refs" </> "heads")
+    createDirectory (gitDirectory </> "info")
+    BS.writeFile
+        (gitDirectory </> "HEAD")
+        (case headOid of
+            Nothing -> "ref: refs/heads/isolated\n"
+            Just oid -> TextEncoding.encodeUtf8 oid <> "\n")
+    BS.writeFile
+        (gitDirectory </> "info" </> "exclude")
+        repositoryExcludeContents
+    BS.writeFile
+        (gitDirectory </> "global-excludes")
+        configuredExcludeContents
+    let formatVersion =
+            if objectFormat == "sha256" then "1" else "0"
+        extension =
+            if objectFormat == "sha256"
+                then
+                    [ "[extensions]"
+                    , "\tobjectformat = sha256"
+                    ]
+                else []
+        config =
+            unlines
+                ( [ "[core]"
+                  , "\trepositoryformatversion = " <> formatVersion
+                  , "\tbare = false"
+                  , "\thooksPath = /dev/null"
+                  , "\tfsmonitor = false"
+                  , "\tattributesFile = /dev/null"
+                  ]
+                    <> safeCoreConfigLines configBytes
+                    <> extension
+                )
+    BS8.writeFile (gitDirectory </> "config") (BS8.pack config)
+    mapM_
+        (`setFileMode` 0o600)
+        [ gitDirectory </> "HEAD"
+        , gitDirectory </> "config"
+        , gitDirectory </> "info" </> "exclude"
+        , gitDirectory </> "global-excludes"
+        ]
+
+readRepositoryExcludeRules
+    :: FilePath
+    -> FilePath
+    -> IO
+        (Either
+            RepositoryError
+            (BS.ByteString, BS.ByteString))
+readRepositoryExcludeRules repositoryExclude configuredExclude =
+    trySynchronous
+        (do
+            repositoryRules <- readOptionalRegularFile repositoryExclude
+            configuredRules <- readOptionalRegularFile configuredExclude
+            when
+                ( BS.length repositoryRules
+                    + BS.length configuredRules
+                    > maxRepositoryExcludeBytes
+                )
+                (throwString "repository exclude rules exceed the size limit")
+            pure (repositoryRules, configuredRules)) >>= \case
+                Left exception ->
+                    pure
+                        (Left
+                            (RepositoryCommandFailed
+                                "read repository exclude rules"
+                                (-1)
+                                (Text.pack (show exception))))
+                Right rules -> pure (Right rules)
+
+readOptionalRegularFile :: FilePath -> IO BS.ByteString
+readOptionalRegularFile "" = pure BS.empty
+readOptionalRegularFile requested = do
+    tryIO
+        (canonicalizePath requested) >>= \case
+            Left exception
+                | isDoesNotExistError exception -> pure BS.empty
+                | otherwise -> throwIO exception
+            Right path ->
+                tryIO
+                    (openFd
+                        path
+                        ReadOnly
+                        defaultFileFlags
+                            { nofollow = True
+                            , cloexec = True
+                            , nonBlock = True
+                            }) >>= \case
+                                Left exception
+                                    | isDoesNotExistError exception ->
+                                        pure BS.empty
+                                    | otherwise -> throwIO exception
+                                Right descriptor ->
+                                    mask \restore -> do
+                                        status <- getFdStatus descriptor
+                                            `onException` closeFd descriptor
+                                        unless (isRegularFile status) do
+                                            closeFd descriptor
+                                            throwString
+                                                "repository exclude rules are not a regular file"
+                                        handle <- fdToHandle descriptor
+                                            `onException` closeFd descriptor
+                                        restore
+                                            (do
+                                                bytes <-
+                                                    BS.hGet
+                                                        handle
+                                                        ( maxRepositoryExcludeBytes
+                                                            + 1
+                                                        )
+                                                when
+                                                    (BS.length bytes
+                                                        > maxRepositoryExcludeBytes)
+                                                    (throwString
+                                                        "repository exclude rules exceed the size limit")
+                                                pure bytes)
+                                            `finally` hClose handle
+
+safeCoreConfigLines :: BS.ByteString -> [String]
+safeCoreConfigLines bytes =
+    [ "\t" <> field <> " = " <> value
+    | field <-
+        [ "filemode"
+        , "ignorecase"
+        , "symlinks"
+        , "precomposeunicode"
+        ]
+    , Just value <- [booleanValue ("core." <> field)]
+    ]
+  where
+    entries =
+        [ (key, BS.drop 1 separatorAndValue)
+        | entry <- BS.split 0 bytes
+        , not (BS.null entry)
+        , let (key, separatorAndValue) = BS8.break (== '\n') entry
+        , not (BS.null separatorAndValue)
+        ]
+    booleanValue key =
+        case
+            [ map toLower (BS8.unpack value)
+            | (entryKey, value) <- reverse entries
+            , BS8.unpack entryKey == key
+            ] of
+                value : _
+                    | value `elem` ["true", "yes", "on", "1"] ->
+                        Just "true"
+                    | value `elem` ["false", "no", "off", "0"] ->
+                        Just "false"
+                _ -> Nothing
+
+withPrivateTempDirectoryOutside
+    :: [FilePath]
+    -> String
+    -> (FilePath -> IO value)
+    -> IO value
+withPrivateTempDirectoryOutside boundaries template action = do
+    configuredBase <- getTemporaryDirectory
+    bracket
+        (acquire (nub [configuredBase, "/tmp", "/var/tmp"]))
+        removePathForcibly
+        action
+  where
+    acquire [] =
+        throwString
+            "no private temporary directory is available outside repository storage"
+    acquire (candidate : remaining) =
+        trySynchronous (outsideAllBoundaries candidate >>= \case
+            Nothing ->
+                throwString
+                    "temporary directory is inside repository storage"
+            Just safeBase -> do
+                directory <-
+                    mkdtemp (safeBase </> template <> ".XXXXXX")
+                (do
+                    setFileMode directory 0o700
+                    outsideAllBoundaries directory >>= \case
+                        Nothing ->
+                            throwString
+                                "temporary directory resolved inside repository storage"
+                        Just checkedDirectory -> pure checkedDirectory)
+                    `onException` removePathForcibly directory) >>= \case
+                    Left _ -> acquire remaining
+                    Right directory -> pure directory
+
+    outsideAllBoundaries candidate =
+        foldM
+            (\checked boundary ->
+                case checked of
+                    Nothing -> pure Nothing
+                    Just path -> canonicalPathOutside boundary path)
+            (Just candidate)
+            boundaries
+
+applyEnvironmentOverrides
+    :: [(String, String)]
+    -> [(String, String)]
+    -> [(String, String)]
+applyEnvironmentOverrides overrides inherited =
+    overrides
+        <> filter
+            (\(name, _) -> name `notElem` map fst overrides)
+            inherited
+
+stripLineEnding :: BS.ByteString -> BS.ByteString
+stripLineEnding = BS8.dropWhileEnd (`elem` ['\r', '\n'])
+
+safeGitArguments :: [String]
+safeGitArguments =
+    [ "--no-replace-objects"
+    , "-c"
+    , "core.fsmonitor=false"
+    , "-c"
+    , "credential.helper="
+    , "-c"
+    , "core.sshCommand=false"
+    , "-c"
+    , "protocol.ext.allow=never"
+    , "-c"
+    , "commit.gpgSign=false"
+    , "-c"
+    , "tag.gpgSign=false"
+    ]
+
+repositoryProcessEnvironment :: FilePath -> IO [(String, String)]
+repositoryProcessEnvironment root = do
+    inherited <- getEnvironment
+    let sanitized =
+            filter
+                (\(name, _) ->
+                    name `notElem` blocked
+                        && not ("GIT_CONFIG_KEY_" `Text.isPrefixOf` Text.pack name)
+                        && not ("GIT_CONFIG_VALUE_" `Text.isPrefixOf` Text.pack name))
+                inherited
+    safePath <- case lookup "PATH" sanitized of
+        Nothing -> pure Nothing
+        Just value -> sanitizeSearchPathOutside root value
+    let withPath =
+            case safePath of
+                Nothing -> filter ((/= "PATH") . fst) sanitized
+                Just value ->
+                    ("PATH", value) : filter ((/= "PATH") . fst) sanitized
+    pure
+        ( [ ("GIT_TERMINAL_PROMPT", "0")
+          , ("GCM_INTERACTIVE", "never")
+          , ("GIT_PAGER", "cat")
+          , ("PAGER", "cat")
+          , ("SSH_ASKPASS_REQUIRE", "never")
+          ]
+            <> withPath
+        )
+  where
+    blocked =
+        [ "GIT_TERMINAL_PROMPT"
+        , "GCM_INTERACTIVE"
+        , "GIT_PAGER"
+        , "PAGER"
+        , "SSH_ASKPASS_REQUIRE"
+        , "GIT_DIR"
+        , "GIT_WORK_TREE"
+        , "GIT_INDEX_FILE"
+        , "GIT_OBJECT_DIRECTORY"
+        , "GIT_ALTERNATE_OBJECT_DIRECTORIES"
+        , "GIT_COMMON_DIR"
+        , "GIT_CONFIG_COUNT"
+        , "GIT_CONFIG_PARAMETERS"
+        , "GIT_CONFIG"
+        , "GIT_CONFIG_GLOBAL"
+        , "GIT_CONFIG_SYSTEM"
+        , "GIT_CONFIG_NOSYSTEM"
+        , "GIT_ATTR_NOSYSTEM"
+        , "GIT_SSH"
+        , "GIT_SSH_COMMAND"
+        , "GIT_ASKPASS"
+        , "GIT_PROXY_COMMAND"
+        , "GIT_EXEC_PATH"
+        , "GIT_EXTERNAL_DIFF"
+        ]
 
 hGetBounded :: Int -> Handle -> IO BS.ByteString
 hGetBounded limit handle = go 0 False []
@@ -1275,6 +2139,24 @@ maxRepositoryProcessOutputBytes = 64 * 1024 * 1024
 
 maxRepositoryProcessErrorBytes :: Int
 maxRepositoryProcessErrorBytes = 8 * 1024 * 1024
+
+maxRepositoryExcludeBytes :: Int
+maxRepositoryExcludeBytes = 16 * 1024 * 1024
+
+maxRepositoryUntrackedFileBytes :: Int
+maxRepositoryUntrackedFileBytes = 64 * 1024 * 1024
+
+repositoryDiscoveryTimeoutMicros :: Int
+repositoryDiscoveryTimeoutMicros = 1_000_000
+
+maxRepositoryGitCommandMicros :: Int
+maxRepositoryGitCommandMicros = 60_000_000
+
+repositoryConfigTimeoutMicros :: Int
+repositoryConfigTimeoutMicros = 2_000_000
+
+maxRepositoryDiffCommandMicros :: Int
+maxRepositoryDiffCommandMicros = 15_000_000
 
 processPipeTeardownMicros :: Int
 processPipeTeardownMicros = 1_000_000

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -40,9 +40,10 @@ import Control.Exception.Safe
     , isAsyncException
     , onException
     , throwIO
+    , throwString
     , tryAny
     )
-import Control.Monad (foldM, unless)
+import Control.Monad (foldM, unless, when)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isDigit)
@@ -61,6 +62,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Exit (ExitCode(..))
+import qualified System.FileLock as FileLock
 import System.IO (Handle, hClose)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Directory (canonicalizePath)
@@ -225,6 +227,17 @@ repositoryDiffAtRoot root expected kind path = do
                         after <- snapshotAtRoot root
                         pure do
                             patch <- result
+                            when
+                                (BS.length patch > maxRepositoryPatchBytes)
+                                (Left
+                                    (InvalidRepositoryRequest
+                                        "repository diff exceeds the 64 MiB limit"))
+                            let hunks = parseDiffHunks patch
+                            when
+                                (length hunks > maxRepositoryDiffHunks)
+                                (Left
+                                    (InvalidRepositoryRequest
+                                        "repository diff has too many hunks"))
                             latest <- after
                             if latest.snapshotId /= expected
                                 then
@@ -241,7 +254,7 @@ repositoryDiffAtRoot root expected kind path = do
                                                 || "Binary files "
                                                     `BS8.isInfixOf` patch
                                         , repositoryDiffHunks =
-                                            parseDiffHunks patch
+                                            hunks
                                         }
 
 mutateRepository
@@ -273,6 +286,11 @@ commitRepository requested expected rawMessage =
             Right _
                 | Text.null (Text.strip rawMessage) ->
                     pure (Left (InvalidRepositoryRequest "commit message is empty"))
+                | Text.length rawMessage > maxRepositoryCommitCharacters ->
+                    pure
+                        (Left
+                            (InvalidRepositoryRequest
+                                "commit message exceeds the 8 MiB character limit"))
                 | Text.any (== '\NUL') rawMessage ->
                     pure
                         (Left
@@ -312,11 +330,34 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                         (Left
                             (InvalidRepositoryRequest
                                 "check executable is invalid"))
+                | length executable > maxRepositoryArgumentCharacters ->
+                    pure
+                        (Left
+                            (InvalidRepositoryRequest
+                                "check executable exceeds the 1 MiB character limit"))
+                | length arguments > maxRepositoryCheckArguments ->
+                    pure
+                        (Left
+                            (InvalidRepositoryRequest
+                                "check has too many arguments"))
                 | any (elem '\NUL') arguments ->
                     pure
                         (Left
                             (InvalidRepositoryRequest
                                 "check argument contains a NUL byte"))
+                | any
+                    ((> maxRepositoryArgumentCharacters) . length)
+                    arguments ->
+                        pure
+                            (Left
+                                (InvalidRepositoryRequest
+                                    "check argument exceeds the 1 MiB character limit"))
+                | sum (map (toInteger . length) arguments)
+                    > toInteger maxRepositoryCheckTotalCharacters ->
+                        pure
+                            (Left
+                                (InvalidRepositoryRequest
+                                    "check arguments exceed the 8 MiB total limit"))
                 | otherwise -> do
                     created <- trySynchronous do
                         (maybeOutput, maybeError, process) <-
@@ -668,6 +709,10 @@ selectReviewedHunks
 selectReviewedHunks snapshot path reviewed indices
     | null indices || length indices /= length (nub indices) =
         Left (InvalidRepositoryRequest "hunk selection is empty or duplicated")
+    | length indices > maxRepositorySelectedHunks =
+        Left (InvalidRepositoryRequest "too many selected hunks")
+    | BS.length reviewed > maxRepositoryPatchBytes =
+        Left (InvalidRepositoryRequest "repository patch exceeds the 64 MiB limit")
     | isDestructivePatch =
         Left
             (InvalidRepositoryRequest
@@ -718,13 +763,17 @@ textPatchSections patch = do
         let collect (current, completed) line
                 | isHunkHeader line =
                     ( [line]
-                    , if null current then completed else current : completed
+                    , if null current
+                        then completed
+                        else reverse current : completed
                     )
                 | null current = ([], completed)
-                | otherwise = (current <> [line], completed)
+                | otherwise = (line : current, completed)
             (lastHunk, reversed) = foldl' collect ([], []) lines'
             result = reverse
-                (if null lastHunk then reversed else lastHunk : reversed)
+                (if null lastHunk
+                    then reversed
+                    else reverse lastHunk : reversed)
         in if null result then Nothing else Just result
 
 appendUntrackedHashes
@@ -811,10 +860,13 @@ parsePorcelain bytes = go (filter (not . BS.null) (BS.split 0 bytes)) []
 
 parseDiffHunks :: BS.ByteString -> [DiffHunk]
 parseDiffHunks =
-    foldl' collect [] . Text.lines . TextEncoding.decodeUtf8With lenientDecode
+    reverse
+        . foldl' collect []
+        . Text.lines
+        . TextEncoding.decodeUtf8With lenientDecode
   where
     collect acc line =
-        maybe acc (\hunk -> acc <> [hunk]) (parseHunkHeader line)
+        maybe acc (: acc) (parseHunkHeader line)
 
 parseHunkHeader :: Text -> Maybe DiffHunk
 parseHunkHeader line = do
@@ -850,10 +902,7 @@ runRepositoryRead
     -> (FilePath -> IO (Either RepositoryError value))
     -> IO (Either RepositoryError value)
 runRepositoryRead requested action = do
-    rootResult <- repositoryRoot requested
-    case rootResult of
-        Left err -> pure (Left err)
-        Right root -> action root
+    withRepositoryMutationLock requested action
 
 withRepositoryMutationLock
     :: FilePath
@@ -870,7 +919,52 @@ withRepositoryMutationLock requested action = do
                     Nothing -> do
                         created <- newMVar ()
                         pure (Map.insert root created locks, created)
-            withMVar lock (const (action root))
+            withMVar lock \_ -> do
+                lockPathResult <- repositoryAdvisoryLockPath root
+                case lockPathResult of
+                    Left err -> pure (Left err)
+                    Right lockPath ->
+                        trySynchronous
+                            (FileLock.withFileLock
+                                lockPath
+                                FileLock.Exclusive
+                                (const (action root))) >>= \case
+                                    Left exception ->
+                                        pure
+                                            (Left
+                                                (RepositoryCommandFailed
+                                                    "repository advisory lock"
+                                                    (-1)
+                                                    (Text.pack
+                                                        (show exception))))
+                                    Right result -> pure result
+
+repositoryAdvisoryLockPath
+    :: FilePath
+    -> IO (Either RepositoryError FilePath)
+repositoryAdvisoryLockPath root =
+    runGit root ["rev-parse", "--git-common-dir"] BS.empty >>= \case
+        Left err -> pure (Left err)
+        Right commonDirectory -> do
+            let commonPath = Text.unpack (decodeTrimmed commonDirectory)
+            trySynchronous
+                (canonicalizePath
+                    (if isAbsolute commonPath
+                        then commonPath
+                        else root </> commonPath))
+                >>= \case
+                    Left exception ->
+                        pure
+                            (Left
+                                (RepositoryCommandFailed
+                                    "resolve repository advisory lock"
+                                    (-1)
+                                    (Text.pack (show exception))))
+                    Right canonical ->
+                        pure
+                            (Right
+                                (canonical
+                                    </> "haskell-agent-repository-review.lock"))
 
 repositoryRoot :: FilePath -> IO (Either RepositoryError FilePath)
 repositoryRoot requested
@@ -953,16 +1047,26 @@ runProcessBytes
     -> BS.ByteString
     -> IO (ExitCode, BS.ByteString, BS.ByteString)
 runProcessBytes workingDirectory executable arguments input =
-    bracket start stop \(inputHandle, outputHandle, errorHandle, process) -> do
+    bracket start stop
+        \(inputHandle, outputHandle, errorHandle, process, _, completed) -> do
         withAsync
             (BS.hPut inputHandle input `finally` closeQuietly inputHandle)
             \inputWriter ->
-                withAsync (BS.hGetContents outputHandle) \outputReader ->
-                    withAsync (BS.hGetContents errorHandle) \errorReader -> do
+                withAsync
+                    (hGetBounded
+                        maxRepositoryProcessOutputBytes
+                        outputHandle)
+                    \outputReader ->
+                    withAsync
+                        (hGetBounded
+                            maxRepositoryProcessErrorBytes
+                            errorHandle)
+                        \errorReader -> do
                         exitCode <- waitForProcess process
                         _ <- wait inputWriter
                         output <- wait outputReader
                         errors <- wait errorReader
+                        writeIORef completed True
                         pure (exitCode, output, errors)
   where
     start = do
@@ -973,21 +1077,61 @@ runProcessBytes workingDirectory executable arguments input =
                     , std_in = CreatePipe
                     , std_out = CreatePipe
                     , std_err = CreatePipe
+                    , close_fds = True
+                    , create_group = True
                     }
         case (maybeInput, maybeOutput, maybeError) of
-            (Just inputHandle, Just outputHandle, Just errorHandle) ->
-                pure (inputHandle, outputHandle, errorHandle, process)
+            (Just inputHandle, Just outputHandle, Just errorHandle) -> do
+                processGroup <- getPid process
+                completed <- newIORef False
+                pure
+                    ( inputHandle
+                    , outputHandle
+                    , errorHandle
+                    , process
+                    , processGroup
+                    , completed
+                    )
             _ -> do
                 terminateProcess process
                 _ <- waitForProcess process
                 fail "could not create process pipes"
-    stop (inputHandle, outputHandle, errorHandle, process) = do
+    stop
+        ( inputHandle
+        , outputHandle
+        , errorHandle
+        , process
+        , processGroup
+        , completed
+        ) = do
         closeQuietly inputHandle
         closeQuietly outputHandle
         closeQuietly errorHandle
-        _ <- tryAny (terminateProcess process)
+        finished <- readIORef completed
+        unless finished do
+            signalCheckProcessGroup sigTERM processGroup process
+            threadDelay 250_000
+            -- The group can outlive its leader (for example, a Git hook that
+            -- forks and exits), so always escalate the captured group.
+            signalCheckProcessGroup sigKILL processGroup process
         _ <- tryAny (waitForProcess process)
         pure ()
+
+hGetBounded :: Int -> Handle -> IO BS.ByteString
+hGetBounded limit handle = go 0 False []
+  where
+    go total exceeded chunks = do
+        chunk <- BS.hGetSome handle (64 * 1024)
+        if BS.null chunk
+            then
+                if exceeded
+                    then throwString "repository process output limit exceeded"
+                    else pure (BS.concat (reverse chunks))
+            else do
+                let next = total + BS.length chunk
+                if exceeded || next > limit
+                    then go total True chunks
+                    else go next False (chunk : chunks)
 
 closeQuietly :: Handle -> IO ()
 closeQuietly handle = do
@@ -1023,6 +1167,33 @@ repositoryErrorText = \case
 
 voidResult :: Either error value -> Either error ()
 voidResult = fmap (const ())
+
+maxRepositoryPatchBytes :: Int
+maxRepositoryPatchBytes = 64 * 1024 * 1024
+
+maxRepositoryDiffHunks :: Int
+maxRepositoryDiffHunks = 100_000
+
+maxRepositorySelectedHunks :: Int
+maxRepositorySelectedHunks = 4096
+
+maxRepositoryCommitCharacters :: Int
+maxRepositoryCommitCharacters = 8 * 1024 * 1024
+
+maxRepositoryCheckArguments :: Int
+maxRepositoryCheckArguments = 4096
+
+maxRepositoryArgumentCharacters :: Int
+maxRepositoryArgumentCharacters = 1024 * 1024
+
+maxRepositoryCheckTotalCharacters :: Int
+maxRepositoryCheckTotalCharacters = 8 * 1024 * 1024
+
+maxRepositoryProcessOutputBytes :: Int
+maxRepositoryProcessOutputBytes = 64 * 1024 * 1024
+
+maxRepositoryProcessErrorBytes :: Int
+maxRepositoryProcessErrorBytes = 8 * 1024 * 1024
 
 trySynchronous :: IO value -> IO (Either SomeException value)
 trySynchronous action =

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -1,0 +1,738 @@
+module Agent.CLI.RepositoryReview
+    ( RepositorySnapshot(..)
+    , RepositoryFile(..)
+    , RepositoryDiff(..)
+    , RepositoryDiffKind(..)
+    , DiffHunk(..)
+    , RepositoryMutation(..)
+    , RepositoryCheck
+    , RepositoryCheckStream(..)
+    , RepositoryError(..)
+    , repositorySnapshot
+    , repositoryDiff
+    , mutateRepository
+    , commitRepository
+    , startRepositoryCheck
+    , cancelRepositoryCheck
+    , waitRepositoryCheck
+    , repositoryErrorText
+    ) where
+
+import Control.Concurrent.Async
+    ( Async
+    , asyncWithUnmask
+    , wait
+    , waitCatch
+    , withAsync
+    )
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , newMVar
+    , withMVar
+    )
+import Control.Exception.Safe
+    ( bracket
+    , finally
+    , onException
+    , tryAny
+    )
+import Control.Monad (foldM)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Char (isDigit)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.IORef
+    ( IORef
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Text.Encoding.Error (lenientDecode)
+import System.Exit (ExitCode(..))
+import System.IO (Handle, hClose)
+import System.IO.Unsafe (unsafePerformIO)
+import System.Process
+    ( CreateProcess(..)
+    , ProcessHandle
+    , StdStream(CreatePipe, Inherit)
+    , createProcess
+    , proc
+    , terminateProcess
+    , waitForProcess
+    )
+
+data RepositorySnapshot = RepositorySnapshot
+    { snapshotId :: !Text
+    , snapshotRoot :: !FilePath
+    , snapshotHead :: !(Maybe Text)
+    , snapshotIndexFingerprint :: !Text
+    , snapshotWorktreeFingerprint :: !Text
+    , snapshotFiles :: ![RepositoryFile]
+    } deriving (Eq, Show)
+
+data RepositoryDiffKind
+    = RepositoryWorktreeDiff
+    | RepositoryStagedDiff
+    deriving (Eq, Show)
+
+data RepositoryFile = RepositoryFile
+    { repositoryFilePath :: !FilePath
+    , repositoryFileOriginalPath :: !(Maybe FilePath)
+    , repositoryFileIndexStatus :: !Char
+    , repositoryFileWorktreeStatus :: !Char
+    } deriving (Eq, Show)
+
+data RepositoryDiff = RepositoryDiff
+    { repositoryDiffPatch :: !BS.ByteString
+    , repositoryDiffBinary :: !Bool
+    , repositoryDiffHunks :: ![DiffHunk]
+    } deriving (Eq, Show)
+
+data DiffHunk = DiffHunk
+    { hunkOldStart :: !Int
+    , hunkOldCount :: !Int
+    , hunkNewStart :: !Int
+    , hunkNewCount :: !Int
+    , hunkHeader :: !Text
+    } deriving (Eq, Show)
+
+data RepositoryMutation
+    = StagePath !FilePath
+    | UnstagePath !FilePath
+    | RestorePath !FilePath
+    | StagePatch !BS.ByteString
+    | UnstagePatch !BS.ByteString
+    | RestorePatch !BS.ByteString
+    deriving (Eq, Show)
+
+data RepositoryCheckStream
+    = RepositoryCheckStdout
+    | RepositoryCheckStderr
+    deriving (Eq, Show)
+
+data RepositoryCheck = RepositoryCheck
+    { repositoryCheckProcess :: !ProcessHandle
+    , repositoryCheckWorker :: !(Async ())
+    , repositoryCheckCancelled :: !(IORef Bool)
+    }
+
+data RepositoryError
+    = NotARepository !Text
+    | StaleRepositorySnapshot !Text !Text
+    | InvalidRepositoryRequest !Text
+    | RepositoryCommandFailed !Text !Int !Text
+    deriving (Eq, Show)
+
+repositorySnapshot :: FilePath -> IO (Either RepositoryError RepositorySnapshot)
+repositorySnapshot requested = runRepositoryRead requested snapshotAtRoot
+
+repositoryDiff
+    :: FilePath
+    -> Text
+    -> RepositoryDiffKind
+    -> FilePath
+    -> IO (Either RepositoryError RepositoryDiff)
+repositoryDiff requested expected kind path =
+    runRepositoryRead requested \root -> do
+        current <- snapshotAtRoot root
+        case current of
+            Left err -> pure (Left err)
+            Right snapshot
+                | snapshot.snapshotId /= expected ->
+                    pure
+                        (Left
+                            (StaleRepositorySnapshot
+                                expected
+                                snapshot.snapshotId))
+                | null path || path == "." ->
+                    pure (Left (InvalidRepositoryRequest "invalid file path"))
+                | otherwise -> do
+                    let untracked =
+                            kind == RepositoryWorktreeDiff
+                                && any
+                                    (\file ->
+                                        file.repositoryFilePath == path
+                                            && file.repositoryFileIndexStatus
+                                                == '?')
+                                    snapshot.snapshotFiles
+                        arguments
+                            | untracked =
+                                [ "diff"
+                                , "--no-index"
+                                , "--binary"
+                                , "--no-ext-diff"
+                                , "--no-color"
+                                , "--"
+                                , "/dev/null"
+                                , path
+                                ]
+                            | otherwise =
+                                [ "diff"
+                                , "--binary"
+                                , "--no-ext-diff"
+                                , "--no-color"
+                                ]
+                                    <> case kind of
+                                        RepositoryWorktreeDiff -> []
+                                        RepositoryStagedDiff -> ["--cached"]
+                                    <> ["--", path]
+                    result <- runGitDiff root arguments
+                    after <- snapshotAtRoot root
+                    pure do
+                        patch <- result
+                        latest <- after
+                        if latest.snapshotId /= expected
+                            then
+                                Left
+                                    (StaleRepositorySnapshot
+                                        expected
+                                        latest.snapshotId)
+                            else
+                                Right RepositoryDiff
+                                    { repositoryDiffPatch = patch
+                                    , repositoryDiffBinary =
+                                        "GIT binary patch" `BS8.isInfixOf` patch
+                                            || "Binary files "
+                                                `BS8.isInfixOf` patch
+                                    , repositoryDiffHunks = parseDiffHunks patch
+                                    }
+
+mutateRepository
+    :: FilePath
+    -> Text
+    -> RepositoryMutation
+    -> IO (Either RepositoryError RepositorySnapshot)
+mutateRepository requested expected mutation =
+    withRepositoryMutationLock requested \root -> do
+        checked <- requireSnapshot root expected
+        case checked of
+            Left err -> pure (Left err)
+            Right snapshot -> do
+                result <- runMutation root snapshot mutation
+                case result of
+                    Left err -> pure (Left err)
+                    Right () -> snapshotAtRoot root
+
+commitRepository
+    :: FilePath
+    -> Text
+    -> Text
+    -> IO (Either RepositoryError RepositorySnapshot)
+commitRepository requested expected rawMessage =
+    withRepositoryMutationLock requested \root -> do
+        checked <- requireSnapshot root expected
+        case checked of
+            Left err -> pure (Left err)
+            Right _
+                | Text.null (Text.strip rawMessage) ->
+                    pure (Left (InvalidRepositoryRequest "commit message is empty"))
+                | Text.any (== '\NUL') rawMessage ->
+                    pure
+                        (Left
+                            (InvalidRepositoryRequest
+                                "commit message contains a NUL byte"))
+                | otherwise -> do
+                    committed <- runGit root
+                        ["commit", "--file=-"]
+                        (TextEncoding.encodeUtf8 rawMessage)
+                    case committed of
+                        Left err -> pure (Left err)
+                        Right _ -> snapshotAtRoot root
+
+startRepositoryCheck
+    :: FilePath
+    -> Text
+    -> FilePath
+    -> [String]
+    -> (RepositoryCheckStream -> BS.ByteString -> IO ())
+    -> (Bool -> ExitCode -> IO ())
+    -> IO (Either RepositoryError RepositoryCheck)
+startRepositoryCheck requested expected executable arguments onOutput onExit =
+    runRepositoryRead requested \root -> do
+        checked <- requireSnapshot root expected
+        case checked of
+            Left err -> pure (Left err)
+            Right _
+                | null executable || '\NUL' `elem` executable ->
+                    pure
+                        (Left
+                            (InvalidRepositoryRequest
+                                "check executable is invalid"))
+                | any (elem '\NUL') arguments ->
+                    pure
+                        (Left
+                            (InvalidRepositoryRequest
+                                "check argument contains a NUL byte"))
+                | otherwise -> do
+                    created <- tryAny do
+                        (maybeOutput, maybeError, process) <-
+                            createCheckProcess root executable arguments
+                        cancelled <- newIORef False
+                        worker <-
+                            asyncWithUnmask
+                                (\unmask ->
+                                    unmask
+                                        (withAsync
+                                            (drainCheckOutput
+                                                RepositoryCheckStdout
+                                                maybeOutput)
+                                            \outputReader ->
+                                                withAsync
+                                                    (drainCheckOutput
+                                                        RepositoryCheckStderr
+                                                        maybeError)
+                                                    \errorReader -> do
+                                                        exitCode <-
+                                                            waitForProcess process
+                                                        _ <- wait outputReader
+                                                        _ <- wait errorReader
+                                                        wasCancelled <-
+                                                            readIORef cancelled
+                                                        onExit
+                                                            wasCancelled
+                                                            exitCode))
+                                `onException` do
+                                    closeQuietly maybeOutput
+                                    closeQuietly maybeError
+                                    _ <- tryAny (terminateProcess process)
+                                    _ <- tryAny (waitForProcess process)
+                                    pure ()
+                        pure RepositoryCheck
+                            { repositoryCheckProcess = process
+                            , repositoryCheckWorker = worker
+                            , repositoryCheckCancelled = cancelled
+                            }
+                    pure case created of
+                        Left exception ->
+                            Left
+                                (RepositoryCommandFailed
+                                    (renderCommand executable arguments)
+                                    (-1)
+                                    (Text.pack (show exception)))
+                        Right check -> Right check
+  where
+    drainCheckOutput stream handle =
+        let drain = do
+                bytes <- BS.hGetSome handle (64 * 1024)
+                if BS.null bytes
+                    then pure ()
+                    else onOutput stream bytes >> drain
+        in drain `finally` closeQuietly handle
+
+cancelRepositoryCheck :: RepositoryCheck -> IO ()
+cancelRepositoryCheck check = do
+    writeIORef check.repositoryCheckCancelled True
+    _ <- tryAny (terminateProcess check.repositoryCheckProcess)
+    pure ()
+
+waitRepositoryCheck :: RepositoryCheck -> IO ()
+waitRepositoryCheck check = do
+    _ <- waitCatch check.repositoryCheckWorker
+    pure ()
+
+createCheckProcess
+    :: FilePath
+    -> FilePath
+    -> [String]
+    -> IO (Handle, Handle, ProcessHandle)
+createCheckProcess root executable arguments = do
+    (maybeInput, maybeOutput, maybeError, process) <-
+        createProcess
+            (proc executable arguments)
+                { cwd = Just root
+                , std_in = Inherit
+                , std_out = CreatePipe
+                , std_err = CreatePipe
+                , close_fds = True
+                }
+    case (maybeInput, maybeOutput, maybeError) of
+        (Nothing, Just output, Just errors) ->
+            pure (output, errors, process)
+        _ -> do
+            _ <- tryAny (terminateProcess process)
+            _ <- tryAny (waitForProcess process)
+            fail "could not create check output pipes"
+
+snapshotAtRoot :: FilePath -> IO (Either RepositoryError RepositorySnapshot)
+snapshotAtRoot root = do
+    headResult <- runGit root ["rev-parse", "--verify", "HEAD"] BS.empty
+    let headOid = either (const Nothing) (Just . decodeTrimmed) headResult
+    indexResult <- runGit root ["ls-files", "--stage", "-z"] BS.empty
+    statusResult <- runGit root
+        ["status", "--porcelain=v1", "-z", "--untracked-files=all"]
+        BS.empty
+    diffResult <- runGit root
+        ["diff", "--binary", "--no-ext-diff", "--no-color"]
+        BS.empty
+    case (indexResult, statusResult, diffResult) of
+        (Right indexBytes, Right statusBytes, Right diffBytes) -> do
+            worktreeMaterial <- appendUntrackedHashes root statusBytes diffBytes
+            indexHash <- hashMaterial root indexBytes
+            worktreeHash <- case worktreeMaterial of
+                Left err -> pure (Left err)
+                Right material -> hashMaterial root material
+            pure do
+                indexFingerprint <- indexHash
+                worktreeFingerprint <- worktreeHash
+                let headFingerprint = fromMaybe "unborn" headOid
+                    identity = Text.intercalate ":"
+                        [headFingerprint, indexFingerprint, worktreeFingerprint]
+                files <- parsePorcelain statusBytes
+                pure RepositorySnapshot
+                    { snapshotId = identity
+                    , snapshotRoot = root
+                    , snapshotHead = headOid
+                    , snapshotIndexFingerprint = indexFingerprint
+                    , snapshotWorktreeFingerprint = worktreeFingerprint
+                    , snapshotFiles = files
+                    }
+        (Left err, _, _) -> pure (Left err)
+        (_, Left err, _) -> pure (Left err)
+        (_, _, Left err) -> pure (Left err)
+
+requireSnapshot
+    :: FilePath
+    -> Text
+    -> IO (Either RepositoryError RepositorySnapshot)
+requireSnapshot root expected = do
+    current <- snapshotAtRoot root
+    pure do
+        snapshot <- current
+        if snapshot.snapshotId == expected
+            then Right snapshot
+            else Left (StaleRepositorySnapshot expected snapshot.snapshotId)
+
+runMutation
+    :: FilePath
+    -> RepositorySnapshot
+    -> RepositoryMutation
+    -> IO (Either RepositoryError ())
+runMutation root snapshot = \case
+    StagePath path ->
+        checkedPath path $
+            applyPathPatch RepositoryWorktreeDiff ["--cached"] path
+    UnstagePath path ->
+        checkedPath path $
+            applyPathPatch RepositoryStagedDiff ["--cached", "--reverse"] path
+    RestorePath path ->
+        checkedPath path $
+            if isUntracked path
+                then pure
+                    (Left
+                        (InvalidRepositoryRequest
+                            "restore never deletes an untracked file"))
+                else applyPathPatch
+                    RepositoryWorktreeDiff ["--reverse"] path
+    StagePatch patch ->
+        applyPatch root ["--cached"] patch
+    UnstagePatch patch ->
+        applyPatch root ["--cached", "--reverse"] patch
+    RestorePatch patch ->
+        applyPatch root ["--reverse"] patch
+  where
+    checkedPath path action
+        | null path || path == "." =
+            pure (Left (InvalidRepositoryRequest "invalid file path"))
+        | otherwise = action
+    isUntracked path = any
+        (\file ->
+            file.repositoryFilePath == path
+                && file.repositoryFileIndexStatus == '?')
+        snapshot.snapshotFiles
+    applyPathPatch kind flags path =
+        repositoryDiff root snapshot.snapshotId kind path >>= \case
+            Left err -> pure (Left err)
+            Right diff
+                | BS.null diff.repositoryDiffPatch -> pure (Right ())
+                | otherwise ->
+                    applyPatch root flags diff.repositoryDiffPatch
+
+applyPatch
+    :: FilePath
+    -> [String]
+    -> BS.ByteString
+    -> IO (Either RepositoryError ())
+applyPatch root flags patch
+    | BS.null patch =
+        pure (Left (InvalidRepositoryRequest "patch is empty"))
+    | otherwise = do
+        checked <- runGit root
+            (["apply", "--check", "--recount"] <> flags <> ["-"])
+            patch
+        case checked of
+            Left err -> pure (Left err)
+            Right _ ->
+                voidResult
+                    <$> runGit root
+                        (["apply", "--recount"] <> flags <> ["-"])
+                        patch
+
+appendUntrackedHashes
+    :: FilePath
+    -> BS.ByteString
+    -> BS.ByteString
+    -> IO (Either RepositoryError BS.ByteString)
+appendUntrackedHashes root statusBytes diffBytes =
+    foldM addHash (Right (statusBytes <> diffBytes)) untracked
+  where
+    untracked =
+        [ file.repositoryFilePath
+        | file <- either (const []) id (parsePorcelain statusBytes)
+        , file.repositoryFileIndexStatus == '?'
+        ]
+    addHash (Left err) _ = pure (Left err)
+    addHash (Right material) path = do
+        result <- runGit root ["hash-object", "--", path] BS.empty
+        pure ((material <>) <$> result)
+
+hashMaterial :: FilePath -> BS.ByteString -> IO (Either RepositoryError Text)
+hashMaterial root bytes =
+    fmap decodeTrimmed <$> runGit root ["hash-object", "--stdin"] bytes
+
+parsePorcelain :: BS.ByteString -> Either RepositoryError [RepositoryFile]
+parsePorcelain bytes = go (filter (not . BS.null) (BS.split 0 bytes)) []
+  where
+    go [] acc = Right (reverse acc)
+    go (entry:rest) acc
+        | BS.length entry < 3 =
+            Left (InvalidRepositoryRequest "git returned malformed status")
+        | otherwise =
+            let indexStatus = toStatus (BS.index entry 0)
+                worktreeStatus = toStatus (BS.index entry 1)
+                path = decodePath (BS.drop 3 entry)
+                renamed = indexStatus `elem` ['R', 'C']
+                    || worktreeStatus `elem` ['R', 'C']
+            in if renamed
+                then case rest of
+                    [] ->
+                        Left
+                            (InvalidRepositoryRequest
+                                "git returned an incomplete rename status")
+                    original:remaining ->
+                        go remaining
+                            (RepositoryFile
+                                { repositoryFilePath = path
+                                , repositoryFileOriginalPath =
+                                    Just (decodePath original)
+                                , repositoryFileIndexStatus = indexStatus
+                                , repositoryFileWorktreeStatus = worktreeStatus
+                                }
+                                : acc)
+                else
+                    go rest
+                        (RepositoryFile
+                            { repositoryFilePath = path
+                            , repositoryFileOriginalPath = Nothing
+                            , repositoryFileIndexStatus = indexStatus
+                            , repositoryFileWorktreeStatus = worktreeStatus
+                            }
+                            : acc)
+    toStatus byte
+        | byte == 32 = ' '
+        | otherwise = toEnum (fromIntegral byte)
+
+parseDiffHunks :: BS.ByteString -> [DiffHunk]
+parseDiffHunks =
+    foldl' collect [] . Text.lines . TextEncoding.decodeUtf8With lenientDecode
+  where
+    collect acc line =
+        maybe acc (\hunk -> acc <> [hunk]) (parseHunkHeader line)
+
+parseHunkHeader :: Text -> Maybe DiffHunk
+parseHunkHeader line = do
+    body <- Text.stripPrefix "@@ -" line
+    let (oldRange, afterOld) = Text.breakOn " +" body
+    newAndHeader <- Text.stripPrefix " +" afterOld
+    let (newRange, afterNew) = Text.breakOn " @@" newAndHeader
+    header <- Text.stripPrefix " @@" afterNew
+    (oldStart, oldCount) <- parseRange oldRange
+    (newStart, newCount) <- parseRange newRange
+    pure DiffHunk
+        { hunkOldStart = oldStart
+        , hunkOldCount = oldCount
+        , hunkNewStart = newStart
+        , hunkNewCount = newCount
+        , hunkHeader = Text.strip header
+        }
+
+parseRange :: Text -> Maybe (Int, Int)
+parseRange text = case Text.splitOn "," text of
+    [start] -> (, 1) <$> decimal start
+    [start, count] -> (,) <$> decimal start <*> decimal count
+    _ -> Nothing
+  where
+    decimal value
+        | Text.null value || Text.any (not . isDigit) value = Nothing
+        | otherwise = case reads (Text.unpack value) of
+            [(number, "")] -> Just number
+            _ -> Nothing
+
+runRepositoryRead
+    :: FilePath
+    -> (FilePath -> IO (Either RepositoryError value))
+    -> IO (Either RepositoryError value)
+runRepositoryRead requested action = do
+    rootResult <- repositoryRoot requested
+    case rootResult of
+        Left err -> pure (Left err)
+        Right root -> action root
+
+withRepositoryMutationLock
+    :: FilePath
+    -> (FilePath -> IO (Either RepositoryError value))
+    -> IO (Either RepositoryError value)
+withRepositoryMutationLock requested action = do
+    rootResult <- repositoryRoot requested
+    case rootResult of
+        Left err -> pure (Left err)
+        Right root -> do
+            lock <- modifyMVar repositoryLocks \locks ->
+                case Map.lookup root locks of
+                    Just existing -> pure (locks, existing)
+                    Nothing -> do
+                        created <- newMVar ()
+                        pure (Map.insert root created locks, created)
+            withMVar lock (const (action root))
+
+repositoryRoot :: FilePath -> IO (Either RepositoryError FilePath)
+repositoryRoot requested
+    | null requested =
+        pure (Left (NotARepository "repository path is empty"))
+    | otherwise =
+        runGit requested ["rev-parse", "--show-toplevel"] BS.empty >>= \case
+            Left err -> pure (Left (NotARepository (repositoryErrorText err)))
+            Right rootBytes -> pure (Right (Text.unpack (decodeTrimmed rootBytes)))
+
+{-# NOINLINE repositoryLocks #-}
+repositoryLocks :: MVar (Map FilePath (MVar ()))
+repositoryLocks = unsafePerformIO (newMVar Map.empty)
+
+runGit
+    :: FilePath
+    -> [String]
+    -> BS.ByteString
+    -> IO (Either RepositoryError BS.ByteString)
+runGit root arguments input = do
+    result <- tryAny (runProcessBytes root "git" arguments input)
+    pure case result of
+        Left exception ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    (-1)
+                    (Text.pack (show exception)))
+        Right (exitCode, output, errors) -> case exitCode of
+            ExitSuccess -> Right output
+            ExitFailure code ->
+                Left
+                    (RepositoryCommandFailed
+                        (renderCommand "git" arguments)
+                        code
+                        (Text.strip
+                            (TextEncoding.decodeUtf8With lenientDecode errors)))
+
+runGitDiff
+    :: FilePath
+    -> [String]
+    -> IO (Either RepositoryError BS.ByteString)
+runGitDiff root arguments = do
+    result <- tryAny (runProcessBytes root "git" arguments BS.empty)
+    pure case result of
+        Left exception ->
+            Left
+                (RepositoryCommandFailed
+                    (renderCommand "git" arguments)
+                    (-1)
+                    (Text.pack (show exception)))
+        Right (exitCode, output, errors) -> case exitCode of
+            ExitSuccess -> Right output
+            ExitFailure 1 -> Right output
+            ExitFailure code ->
+                Left
+                    (RepositoryCommandFailed
+                        (renderCommand "git" arguments)
+                        code
+                        (Text.strip
+                            (TextEncoding.decodeUtf8With lenientDecode errors)))
+
+runProcessBytes
+    :: FilePath
+    -> FilePath
+    -> [String]
+    -> BS.ByteString
+    -> IO (ExitCode, BS.ByteString, BS.ByteString)
+runProcessBytes workingDirectory executable arguments input =
+    bracket start stop \(inputHandle, outputHandle, errorHandle, process) -> do
+        BS.hPut inputHandle input
+        hClose inputHandle
+        withAsync (BS.hGetContents outputHandle) \outputReader ->
+            withAsync (BS.hGetContents errorHandle) \errorReader -> do
+                exitCode <- waitForProcess process
+                output <- wait outputReader
+                errors <- wait errorReader
+                pure (exitCode, output, errors)
+  where
+    start = do
+        (maybeInput, maybeOutput, maybeError, process) <-
+            createProcess
+                (proc executable arguments)
+                    { cwd = Just workingDirectory
+                    , std_in = CreatePipe
+                    , std_out = CreatePipe
+                    , std_err = CreatePipe
+                    }
+        case (maybeInput, maybeOutput, maybeError) of
+            (Just inputHandle, Just outputHandle, Just errorHandle) ->
+                pure (inputHandle, outputHandle, errorHandle, process)
+            _ -> do
+                terminateProcess process
+                _ <- waitForProcess process
+                fail "could not create process pipes"
+    stop (inputHandle, outputHandle, errorHandle, process) = do
+        closeQuietly inputHandle
+        closeQuietly outputHandle
+        closeQuietly errorHandle
+        _ <- tryAny (terminateProcess process)
+        _ <- tryAny (waitForProcess process)
+        pure ()
+
+closeQuietly :: Handle -> IO ()
+closeQuietly handle = do
+    _ <- tryAny (hClose handle)
+    pure ()
+
+decodeTrimmed :: BS.ByteString -> Text
+decodeTrimmed =
+    Text.strip . TextEncoding.decodeUtf8With lenientDecode
+
+decodePath :: BS.ByteString -> FilePath
+decodePath = Text.unpack . TextEncoding.decodeUtf8With lenientDecode
+
+renderCommand :: FilePath -> [String] -> Text
+renderCommand executable arguments =
+    Text.unwords (Text.pack executable : map (Text.pack . show) arguments)
+
+repositoryErrorText :: RepositoryError -> Text
+repositoryErrorText = \case
+    NotARepository message -> message
+    StaleRepositorySnapshot expected actual ->
+        "repository changed (expected "
+            <> expected
+            <> ", actual "
+            <> actual
+            <> ")"
+    InvalidRepositoryRequest message -> message
+    RepositoryCommandFailed command code message ->
+        command
+            <> " exited "
+            <> Text.pack (show code)
+            <> if Text.null message then "" else ": " <> message
+
+voidResult :: Either error value -> Either error ()
+voidResult = fmap (const ())

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -34,9 +34,12 @@ import Control.Concurrent.MVar
     , withMVar
     )
 import Control.Exception.Safe
-    ( bracket
+    ( SomeException
+    , bracket
     , finally
+    , isAsyncException
     , onException
+    , throwIO
     , tryAny
     )
 import Control.Monad (foldM, unless)
@@ -315,7 +318,7 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                             (InvalidRepositoryRequest
                                 "check argument contains a NUL byte"))
                 | otherwise -> do
-                    created <- tryAny do
+                    created <- trySynchronous do
                         (maybeOutput, maybeError, process) <-
                             createCheckProcess root executable arguments
                         processGroup <- getPid process
@@ -379,7 +382,7 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                         nextEnabled <-
                             if callbackEnabled
                                 then
-                                    tryAny (onOutput stream bytes) >>= \case
+                                    trySynchronous (onOutput stream bytes) >>= \case
                                         Left _ -> pure False
                                         Right () -> pure True
                                 else pure False
@@ -742,7 +745,7 @@ appendUntrackedHashes root statusBytes diffBytes =
         result <- runGit root
             ["--literal-pathspecs", "hash-object", "--", path]
             BS.empty
-        modeResult <- tryAny
+        modeResult <- trySynchronous
             (fileMode <$> getSymbolicLinkStatus (root </> path))
         pure do
             contentHash <- result
@@ -877,7 +880,7 @@ repositoryRoot requested
         runGit requested ["rev-parse", "--show-toplevel"] BS.empty >>= \case
             Left err -> pure (Left (NotARepository (repositoryErrorText err)))
             Right rootBytes ->
-                tryAny
+                trySynchronous
                     (canonicalizePath
                         (Text.unpack (decodeTrimmed rootBytes))) >>= \case
                             Left exception ->
@@ -901,7 +904,7 @@ runGit
     -> BS.ByteString
     -> IO (Either RepositoryError BS.ByteString)
 runGit root arguments input = do
-    result <- tryAny (runProcessBytes root "git" arguments input)
+    result <- trySynchronous (runProcessBytes root "git" arguments input)
     pure case result of
         Left exception ->
             Left
@@ -924,7 +927,7 @@ runGitDiff
     -> [String]
     -> IO (Either RepositoryError BS.ByteString)
 runGitDiff root arguments = do
-    result <- tryAny (runProcessBytes root "git" arguments BS.empty)
+    result <- trySynchronous (runProcessBytes root "git" arguments BS.empty)
     pure case result of
         Left exception ->
             Left
@@ -1020,3 +1023,11 @@ repositoryErrorText = \case
 
 voidResult :: Either error value -> Either error ()
 voidResult = fmap (const ())
+
+trySynchronous :: IO value -> IO (Either SomeException value)
+trySynchronous action =
+    tryAny action >>= \case
+        Left exception
+            | isAsyncException exception -> throwIO exception
+            | otherwise -> pure (Left exception)
+        Right value -> pure (Right value)

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -260,12 +260,19 @@ commitRepository requested expected rawMessage =
                             (InvalidRepositoryRequest
                                 "commit message contains a NUL byte"))
                 | otherwise -> do
-                    committed <- runGit root
-                        ["commit", "--file=-"]
-                        (TextEncoding.encodeUtf8 rawMessage)
-                    case committed of
+                    -- Revalidate immediately before handing control to Git.
+                    -- The repository lock excludes other API mutations; an
+                    -- unrelated external writer remains outside that lock.
+                    latest <- requireSnapshot root expected
+                    case latest of
                         Left err -> pure (Left err)
-                        Right _ -> snapshotAtRoot root
+                        Right _ -> do
+                            committed <- runGit root
+                                ["commit", "--file=-"]
+                                (TextEncoding.encodeUtf8 rawMessage)
+                            case committed of
+                                Left err -> pure (Left err)
+                                Right _ -> snapshotAtRoot root
 
 startRepositoryCheck
     :: FilePath
@@ -430,8 +437,7 @@ createCheckProcess root executable arguments = do
 
 snapshotAtRoot :: FilePath -> IO (Either RepositoryError RepositorySnapshot)
 snapshotAtRoot root = do
-    headResult <- runGit root ["rev-parse", "--verify", "HEAD"] BS.empty
-    let headOid = either (const Nothing) (Just . decodeTrimmed) headResult
+    headResult <- repositoryHead root
     indexResult <- runGit root ["ls-files", "--stage", "-z"] BS.empty
     statusResult <- runGit root
         ["status", "--porcelain=v1", "-z", "--untracked-files=all"]
@@ -439,8 +445,8 @@ snapshotAtRoot root = do
     diffResult <- runGit root
         ["diff", "--binary", "--no-ext-diff", "--no-color"]
         BS.empty
-    case (indexResult, statusResult, diffResult) of
-        (Right indexBytes, Right statusBytes, Right diffBytes) -> do
+    case (headResult, indexResult, statusResult, diffResult) of
+        (Right headOid, Right indexBytes, Right statusBytes, Right diffBytes) -> do
             worktreeMaterial <- appendUntrackedHashes root statusBytes diffBytes
             indexHash <- hashMaterial root indexBytes
             worktreeHash <- case worktreeMaterial of
@@ -461,9 +467,37 @@ snapshotAtRoot root = do
                     , snapshotWorktreeFingerprint = worktreeFingerprint
                     , snapshotFiles = files
                     }
-        (Left err, _, _) -> pure (Left err)
-        (_, Left err, _) -> pure (Left err)
-        (_, _, Left err) -> pure (Left err)
+        (Left err, _, _, _) -> pure (Left err)
+        (_, Left err, _, _) -> pure (Left err)
+        (_, _, Left err, _) -> pure (Left err)
+        (_, _, _, Left err) -> pure (Left err)
+
+repositoryHead
+    :: FilePath
+    -> IO (Either RepositoryError (Maybe Text))
+repositoryHead root =
+    runGit root ["rev-parse", "--verify", "HEAD"] BS.empty >>= \case
+        Right oid -> pure (Right (Just (decodeTrimmed oid)))
+        Left headError ->
+            -- A symbolic HEAD whose branch ref does not exist is the normal
+            -- unborn-repository case. Detached/corrupt HEAD and command
+            -- failures retain their original error instead of silently
+            -- becoming "unborn".
+            runGit root ["symbolic-ref", "--quiet", "HEAD"] BS.empty >>= \case
+                Right reference ->
+                    runGit root
+                        [ "show-ref"
+                        , "--verify"
+                        , "--quiet"
+                        , Text.unpack (decodeTrimmed reference)
+                        ]
+                        BS.empty >>= \case
+                            Left (RepositoryCommandFailed _ 1 _) ->
+                                pure (Right Nothing)
+                            Left referenceError ->
+                                pure (Left referenceError)
+                            Right _ -> pure (Left headError)
+                Left _ -> pure (Left headError)
 
 requireSnapshot
     :: FilePath

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -373,9 +373,8 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
                     -- RepositoryCheck and cancellation is owned by that
                     -- worker's finalizer.
                     created <- trySynchronous (mask \_ -> do
-                        (maybeOutput, maybeError, process) <-
+                        (maybeOutput, maybeError, process, processGroup) <-
                             createCheckProcess root executable arguments
-                        processGroup <- getPid process
                         cancelled <- newIORef False
                         let cleanup = do
                                 closeQuietly maybeOutput
@@ -514,8 +513,8 @@ createCheckProcess
     :: FilePath
     -> FilePath
     -> [String]
-    -> IO (Handle, Handle, ProcessHandle)
-createCheckProcess root executable arguments = do
+    -> IO (Handle, Handle, ProcessHandle, Maybe ProcessID)
+createCheckProcess root executable arguments = mask \_ -> do
     (maybeInput, maybeOutput, maybeError, process) <-
         createProcess
             (proc executable arguments)
@@ -528,10 +527,26 @@ createCheckProcess root executable arguments = do
                 }
     case (maybeInput, maybeOutput, maybeError) of
         (Just input, Just output, Just errors) -> do
+            let cleanupWithoutGroup = do
+                    closeQuietly input
+                    closeQuietly output
+                    closeQuietly errors
+                    _ <- tryAny (terminateProcess process)
+                    _ <- tryAny (waitForProcess process)
+                    pure ()
+            processGroup <- getPid process
+                `onException` cleanupWithoutGroup
+            let cleanup = do
+                    closeQuietly input
+                    closeQuietly output
+                    closeQuietly errors
+                    signalCheckProcessGroup sigKILL processGroup process
+                    _ <- tryAny (waitForProcess process)
+                    pure ()
             -- Checks have no stdin API. Closing immediately prevents an
             -- inherited terminal or pipe from leaving a check blocked.
-            hClose input
-            pure (output, errors, process)
+            (hClose input >> pure (output, errors, process, processGroup))
+                `onException` cleanup
         _ -> do
             _ <- tryAny (terminateProcess process)
             _ <- tryAny (waitForProcess process)
@@ -1119,7 +1134,7 @@ runProcessBytes workingDirectory executable arguments input =
                         writeIORef completed True
                         pure (exitCode, output, errors)
   where
-    start = do
+    start = mask \_ -> do
         (maybeInput, maybeOutput, maybeError, process) <-
             createProcess
                 (proc executable arguments)
@@ -1130,10 +1145,27 @@ runProcessBytes workingDirectory executable arguments input =
                     , close_fds = True
                     , create_group = True
                     }
+        let closePipes = do
+                mapM_ closeQuietly maybeInput
+                mapM_ closeQuietly maybeOutput
+                mapM_ closeQuietly maybeError
+            cleanupWithoutGroup = do
+                closePipes
+                _ <- tryAny (terminateProcess process)
+                _ <- tryAny (waitForProcess process)
+                pure ()
         case (maybeInput, maybeOutput, maybeError) of
             (Just inputHandle, Just outputHandle, Just errorHandle) -> do
                 processGroup <- getPid process
+                    `onException` cleanupWithoutGroup
+                let cleanup = do
+                        closePipes
+                        signalCheckProcessGroup
+                            sigKILL processGroup process
+                        _ <- tryAny (waitForProcess process)
+                        pure ()
                 completed <- newIORef False
+                    `onException` cleanup
                 pure
                     ( inputHandle
                     , outputHandle
@@ -1143,8 +1175,7 @@ runProcessBytes workingDirectory executable arguments input =
                     , completed
                     )
             _ -> do
-                terminateProcess process
-                _ <- waitForProcess process
+                cleanupWithoutGroup
                 fail "could not create process pipes"
     stop
         ( inputHandle

--- a/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryReview.hs
@@ -74,6 +74,7 @@ import System.Posix.Signals
     , sigTERM
     , signalProcessGroup
     )
+import System.Posix.Files (fileMode, getSymbolicLinkStatus)
 import System.Posix.Types (ProcessID)
 import System.Process
     ( CreateProcess(..)
@@ -741,7 +742,23 @@ appendUntrackedHashes root statusBytes diffBytes =
         result <- runGit root
             ["--literal-pathspecs", "hash-object", "--", path]
             BS.empty
-        pure ((material <>) <$> result)
+        modeResult <- tryAny
+            (fileMode <$> getSymbolicLinkStatus (root </> path))
+        pure do
+            contentHash <- result
+            mode <- case modeResult of
+                Left exception ->
+                    Left
+                        (InvalidRepositoryRequest
+                            ("could not fingerprint untracked file mode: "
+                                <> Text.pack (show exception)))
+                Right value -> Right value
+            pure
+                ( material
+                    <> contentHash
+                    <> BS8.pack (show mode)
+                    <> "\NUL"
+                )
 
 hashMaterial :: FilePath -> BS.ByteString -> IO (Either RepositoryError Text)
 hashMaterial root bytes =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -129,8 +129,10 @@ devMainResume resumeId = do
             color <- resolveColor stderr
             runLoginManager color
             pure DevQuit
-        Right ListSessions -> runListSessions >> pure DevQuit
-        Right (ShowSession sessionId) -> runShowSession sessionId >> pure DevQuit
+        Right (ListSessions outputFormat) ->
+            runListSessions outputFormat >> pure DevQuit
+        Right (ShowSession sessionId outputFormat pageRequest) ->
+            runShowSession sessionId outputFormat pageRequest >> pure DevQuit
         Right (WaitSession sessionId) -> runWaitSession sessionId >> pure DevQuit
         Right (ImportSession cwd) -> runImportSession cwd >> pure DevQuit
         Right (Storage command) ->
@@ -151,8 +153,10 @@ run = do
         Right Login -> do
             color <- resolveColor stderr
             runLoginManager color
-        Right ListSessions -> runListSessions
-        Right (ShowSession sessionId) -> runShowSession sessionId
+        Right (ListSessions outputFormat) ->
+            runListSessions outputFormat
+        Right (ShowSession sessionId outputFormat pageRequest) ->
+            runShowSession sessionId outputFormat pageRequest
         Right (WaitSession sessionId) -> runWaitSession sessionId
         Right (ImportSession cwd) -> runImportSession cwd
         Right (Storage command) -> runStorageAdmin command

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -8,7 +8,7 @@ import Agent.CLI.AccountPicker ()
 import Agent.CLI.AccountSelection
     ( SelectedAccount(..),
       providerSupportsUsageAccountSelection,
-      selectProviderAccount )
+      selectProviderAccountCached )
 import Agent.CLI.Afk ()
 import Agent.CLI.AgentSessions
     ( AgentSessionToolsEnv(..),
@@ -1241,7 +1241,8 @@ runAgentInitializedWithLock
                             , account.projectAccountId
                             ))
                         (projectAccountFor provider projectSettings)
-                selectProviderAccount
+                selectProviderAccountCached
+                    (trustedPool startup.startupDatabaseStore)
                     provider
                     Nothing
                     rememberedIds >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -83,7 +83,8 @@ import Agent.CLI.Models
       ModelTarget(targetProvider, ModelTarget, targetModelId,
                   targetDialect, targetWireModelId, targetConnectionId) )
 import Agent.CLI.Options
-    ( defaultEffortFor,
+    ( ApprovalPolicy(PromptMutating),
+      defaultEffortFor,
       isOneShot,
       resolveApprovalPolicy,
       CliOptions(optMotionMode, optNoYolo,
@@ -93,6 +94,7 @@ import Agent.CLI.Options
                  optScreenMode, optGhci, optBash, optResume, optCwd),
       ScreenMode(ScreenMinimal) )
 import Agent.CLI.PendingInputs ( withPendingInputs )
+import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.CLI.Plan ( cliPlanHooks )
 import Agent.CLI.Project
     ( ProjectAccount(..),
@@ -259,10 +261,12 @@ import Agent.Claude
     ( ClaudeCodeAuth(..),
       ClaudeCodeOptions(..),
       ClaudeCodePermission(..),
+      ClaudeToolPermissionDecision(..),
+      ClaudeToolPermissionRequest(..),
       claudeCodeOneShotBackend,
       defaultClaudeCodeOptions,
       loadClaudeCodeAuth,
-      withClaudeCodeBackend )
+      withClaudeCodeBackendPermissions )
 import Agent.Dialect ( dialectForId, DialectId(GrokBuildDialect) )
 import Agent.Error ( ApiError(..) )
 import Agent.GrokBuild.Dialect.Goal ()
@@ -274,6 +278,7 @@ import Agent.Loop
       addTokenUsage,
       emptyTokenUsage,
       LoopError(LoopNoResponseId) )
+import Agent.ToolDispatch (functionToolCall)
 import Agent.OpenAI.Compaction ()
 import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient
@@ -377,6 +382,9 @@ import Data.IORef
 import Data.List ()
 import Data.Maybe ( isNothing, fromMaybe, isJust )
 import Data.Text ( Text )
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock ( getCurrentTime, utctDay )
 import System.Console.ANSI ()
 import System.Console.ANSI.Codes ()
@@ -438,7 +446,7 @@ import qualified Agent.XAI.Usage as XAIUsage ()
 
 import Agent.CLI.Runtime.Orchestration.Types
     ( ActiveHttpAuth(..), AccountSwitchRequest(..), AgentProcessRuntime(..),
-      AgentRunMode(..) )
+      AgentRunMode(..), NativeRunHooks(..) )
 import Agent.CLI.Runtime.Orchestration.Restart
     ( RestartCallbacks(..), runFullscreenRestartLoop )
 import Agent.CLI.Runtime.Orchestration.Background
@@ -881,6 +889,9 @@ prepareAgentIterationTracked
                 reportTerminalCwd terminal stdoutHandle terminalCwd
                 toolEnv <- defaultToolEnv cwd
                 writeIORef cancelToolRef (requestCancel toolEnv.toolCancel)
+                forM_ runMode.runNativeHooks \hooks ->
+                    hooks.nativeRegisterCancel
+                        (requestCancel toolEnv.toolCancel)
                 forM_ fullscreen \runtime ->
                     setFullscreenSessionActions
                         runtime
@@ -916,6 +927,7 @@ prepareAgentIterationTracked
                         , startupSyntaxLoadDuration = syntaxLoadDurationRef
                         , startupFinished = startupFinishedRef
                         , startupSessionState = sessionState
+                        , startupNativeHooks = runMode.runNativeHooks
                         }
                 runAgentInitialized
                     processRuntime
@@ -928,6 +940,8 @@ prepareAgentIterationTracked
                     cwd
                     startup
         cleanup = do
+            forM_ runMode.runNativeHooks \hooks ->
+                hooks.nativeRegisterCancel (pure ())
             writeIORef uiRuntimeRef Nothing
             writeIORef cancelToolRef (pure ())
             forM_ fullscreen resetFullscreenSessionActions
@@ -960,6 +974,32 @@ resetFullscreenSessionActions runtime =
         (pure ForceExit)
         (pure (AgentRoot, []))
         (const (pure ()))
+
+nativeClaudePermissionHandler
+    :: Maybe NativeRunHooks
+    -> Maybe
+        (ClaudeToolPermissionRequest
+            -> IO ClaudeToolPermissionDecision)
+nativeClaudePermissionHandler = fmap \hooks request -> do
+    let arguments =
+            TextEncoding.decodeUtf8
+                (LBS.toStrict
+                    (Aeson.encode request.claudePermissionInput))
+        call = functionToolCall
+            request.claudePermissionRequestId
+            request.claudePermissionToolName
+            arguments
+    hooks.nativeRequestApproval call >>= \case
+        Just PermissionAllowOnce ->
+            pure ClaudeToolPermissionAllow
+        Just PermissionAllowTool ->
+            pure ClaudeToolPermissionAllow
+        Just PermissionAllowAll ->
+            pure ClaudeToolPermissionAllow
+        Just PermissionDeny ->
+            pure (ClaudeToolPermissionDeny "Denied by user.")
+        Nothing ->
+            pure (ClaudeToolPermissionDeny "Permission request dismissed.")
 
 runAgentInitialized
     :: AgentProcessRuntime
@@ -1545,8 +1585,11 @@ runAgentInitializedWithLock
         effort = fromMaybe
             (maybe (defaultEffortFor provider) (.metaEffort) (fst <$> resumed))
             options.optEffort
-        policy = resolveApprovalPolicy options isTty
-            projectSettings.settingsAutoApprove
+        policy = case startup.startupNativeHooks of
+            Just _ -> PromptMutating
+            Nothing ->
+                resolveApprovalPolicy options isTty
+                    projectSettings.settingsAutoApprove
         claudeBypassEnabled =
             not options.optNoYolo
                 && (options.optYolo || projectSettings.settingsAutoApprove)
@@ -2565,8 +2608,10 @@ runAgentInitializedWithLock
                         writeIORef activeAccountRef claudeAuth.accountLabel
                         claudeTranscriptRef <-
                             newIORef =<< readLiveTranscript conversationRef
-                        withClaudeCodeBackend
+                        withClaudeCodeBackendPermissions
                             claudeOptions
+                            (nativeClaudePermissionHandler
+                                startup.startupNativeHooks)
                             initialPrevious
                             (readIORef paramsRef)
                             claudeTranscriptRef

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -3,13 +3,19 @@ module Agent.CLI.Runtime.Orchestration.Types
     , AccountSwitchRequest(..)
     , AgentProcessRuntime(..)
     , AgentRunMode(..)
+    , NativeRunHooks(..)
     , foregroundRunMode
     , backgroundRunMode
+    , nativeRunMode
     ) where
 
 import Agent.CLI.AgentSessions ( SessionThreadManager )
+import Agent.CLI.AgentViewport ( AgentEntry )
+import Agent.CLI.Permission ( PermissionChoice )
 import Agent.Error ( ApiError )
+import Agent.Loop ( LoopEvent )
 import Agent.Provider ( Credential, TokenProvider )
+import Agent.ToolDispatch ( ToolCall )
 import Control.Concurrent.MVar ( MVar )
 import Data.Text ( Text )
 import System.IO ( Handle, stderr, stdout )
@@ -32,11 +38,20 @@ data AgentProcessRuntime = AgentProcessRuntime
     , processSessionThreads :: !SessionThreadManager
     }
 
+data NativeRunHooks = NativeRunHooks
+    { nativeOnLoopEvent :: !(LoopEvent -> IO ())
+    , nativeOnSessionId :: !(Text -> IO ())
+    , nativeRegisterCancel :: !(IO () -> IO ())
+    , nativeRegisterAgentSnapshot :: !(IO [AgentEntry] -> IO ())
+    , nativeRequestApproval :: !(ToolCall -> IO (Maybe PermissionChoice))
+    }
+
 data AgentRunMode = AgentRunMode
     { runStdout :: !Handle
     , runStderr :: !Handle
     , runInBackground :: !Bool
     , runCwdHint :: !(Maybe OsPath)
+    , runNativeHooks :: !(Maybe NativeRunHooks)
     }
 
 foregroundRunMode :: AgentRunMode
@@ -45,6 +60,7 @@ foregroundRunMode = AgentRunMode
     , runStderr = stderr
     , runInBackground = False
     , runCwdHint = Nothing
+    , runNativeHooks = Nothing
     }
 
 backgroundRunMode :: Handle -> OsPath -> AgentRunMode
@@ -53,4 +69,14 @@ backgroundRunMode output cwd = AgentRunMode
     , runStderr = output
     , runInBackground = True
     , runCwdHint = Just cwd
+    , runNativeHooks = Nothing
+    }
+
+nativeRunMode :: Handle -> OsPath -> NativeRunHooks -> AgentRunMode
+nativeRunMode output cwd hooks = AgentRunMode
+    { runStdout = output
+    , runStderr = output
+    , runInBackground = True
+    , runCwdHint = Just cwd
+    , runNativeHooks = Just hooks
     }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -8,7 +8,7 @@ import Agent.CLI.AccountPicker
     ( AccountPickerOption(..),
       accountPickerMatches,
       accountPickerRow,
-      loadAllAccountPickerOptions )
+      loadAllAccountPickerOptionsCached )
 import Agent.CLI.AccountSelection ()
 import Agent.CLI.Afk ()
 import Agent.CLI.AgentSessions ()
@@ -203,6 +203,7 @@ handleSelection
             , sessionDialect = dialect
             , sessionParams = paramsRef
             , sessionPersist = persist
+            , sessionDatabasePool = databasePool
             , sessionProjectRoot = projectRoot
             , sessionDraft = draftRef
             , sessionAccountId = accountIdRef
@@ -352,7 +353,7 @@ handleSelection
                 currentAccountId <- readIORef accountIdRef
                 options <- withReplActivity
                     "Loading account usage…"
-                    (loadAllAccountPickerOptions provider)
+                    (loadAllAccountPickerOptionsCached databasePool provider)
                 let initial =
                         fromMaybe 0 $
                             findIndex
@@ -414,7 +415,8 @@ handleSelection
                                             Nothing -> next
                                             Just selectedAccountId -> do
                                                 refreshed <-
-                                                    loadAllAccountPickerOptions
+                                                    loadAllAccountPickerOptionsCached
+                                                        databasePool
                                                         provider
                                                 case listToMaybe
                                                         [ account

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -29,18 +29,22 @@ module Agent.CLI.Session
     , appendTurnKeepTitleIndexed
     , addSessionUsage
     , deleteSession
+    , renameSession
     , loadSession
     , loadSessions
     , loadActiveSession
     , loadSessionMeta
     , loadRecentSessionTurns
+    , loadRecentSessionHistoryTurns
     , loadSessionTurnsBefore
+    , loadSessionHistoryTurnsBefore
     , loadSessionTurnsAfter
     , loadSessionResumeStats
     , importSessionTransfer
     , loadSessionHandle
     , isValidSessionId
     , listSessions
+    , listArchivedSessionIds
     , sessionDirForId
     , sessionTempDirForId
     , sessionTempsRoot
@@ -50,6 +54,7 @@ module Agent.CLI.Session
     , sessionsRoot
     , sessionTitleFromPrompt
     , setGeneratedSessionTitle
+    , setSessionArchived
     , setManualSessionTitle
     , resetSessionTitleToAuto
     , setSessionRecap
@@ -847,6 +852,16 @@ loadRecentSessionTurns pool root sessionId limit =
     loadSessionTurnPage root pool sessionId
         (\pool' key -> Store.loadRecentSessionTurns pool' key limit)
 
+loadRecentSessionHistoryTurns
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Int
+    -> IO (Either Text SessionTurnPage)
+loadRecentSessionHistoryTurns pool root sessionId limit =
+    loadSessionTurnPage root pool sessionId
+        (\pool' key -> Store.loadRecentSessionHistoryTurns pool' key limit)
+
 loadSessionTurnsBefore
     :: StorePool
     -> OsPath
@@ -857,6 +872,18 @@ loadSessionTurnsBefore
 loadSessionTurnsBefore pool root sessionId cursor limit =
     loadSessionTurnPage root pool sessionId
         (\pool' key -> Store.loadSessionTurnsBefore pool' key cursor limit)
+
+loadSessionHistoryTurnsBefore
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either Text SessionTurnPage)
+loadSessionHistoryTurnsBefore pool root sessionId cursor limit =
+    loadSessionTurnPage root pool sessionId
+        (\pool' key ->
+            Store.loadSessionHistoryTurnsBefore pool' key cursor limit)
 
 loadSessionTurnsAfter
     :: StorePool
@@ -1049,6 +1076,65 @@ deleteSession pool root sessionId = runExceptT do
     tempRemoved <- lift (removeSessionTemp root sessionId)
     except tempRemoved
 
+renameSession
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Text
+    -> IO (Either Text SessionMeta)
+renameSession pool root sessionId rawTitle = runExceptT do
+    let title = Text.unwords (Text.words (Text.strip rawTitle))
+    when (Text.null title) (throwE "session title cannot be empty")
+    meta <- lift (loadSessionMeta pool root sessionId) >>= except
+    dir <- except (sessionDirForId root sessionId)
+    exists <- lift (doesDirectoryExist dir)
+    lock <- if exists
+        then lift (acquireSessionLock dir sessionId) >>= \case
+            Left _ -> throwE "cannot rename a running session"
+            Right lock -> pure (Just lock)
+        else pure Nothing
+    let updated = meta
+            { metaTitle = title
+            , metaTitleIsManual = True
+            , metaTitleRefreshIndex = 2
+            }
+    renamed <- lift $
+        Store.replaceSessionMetadata
+            pool
+            "session.renamed"
+            (toStoredMetadata updated)
+            `finally` maybe (pure ()) releaseSessionLock lock
+    case renamed of
+        Left err -> throwE (renderStoreError err)
+        Right False -> throwE ("session not found: " <> sessionId)
+        Right True -> pure updated
+
+setSessionArchived
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Bool
+    -> IO (Either Text ())
+setSessionArchived pool root sessionId archived = runExceptT do
+    dir <- except (sessionDirForId root sessionId)
+    exists <- lift (doesDirectoryExist dir)
+    lock <- if exists
+        then lift (acquireSessionLock dir sessionId) >>= \case
+            Left _ -> throwE $
+                if archived
+                    then "cannot archive a running session"
+                    else "cannot restore a running session"
+            Right lock -> pure (Just lock)
+        else pure Nothing
+    now <- lift getCurrentTime
+    changed <- lift $
+        Store.setSessionArchived pool sessionId archived now
+            `finally` maybe (pure ()) releaseSessionLock lock
+    case changed of
+        Left err -> throwE (renderStoreError err)
+        Right False -> throwE ("session not found: " <> sessionId)
+        Right True -> pure ()
+
 -- | Session ids are single path components. Keep this deliberately broader
 -- than the current date-plus-hex allocator so older ids remain resumable.
 isValidSessionId :: Text -> Bool
@@ -1080,6 +1166,12 @@ listSessions pool _root = do
                 ("could not list PostgreSQL sessions: "
                     <> Text.unpack (renderStoreError err))
         Right values -> pure (catMaybes (map decodeMetaQuiet values))
+
+listArchivedSessionIds :: StorePool -> IO (Either Text [Text])
+listArchivedSessionIds pool =
+    Store.listSessionArchiveKeys pool >>= \case
+        Left err -> pure (Left (renderStoreError err))
+        Right sessionIds -> pure (Right sessionIds)
 
 writeSessionMeta :: StorePool -> OsPath -> SessionMeta -> IO ()
 writeSessionMeta pool _path meta = do

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -1085,29 +1085,14 @@ renameSession
 renameSession pool root sessionId rawTitle = runExceptT do
     let title = Text.unwords (Text.words (Text.strip rawTitle))
     when (Text.null title) (throwE "session title cannot be empty")
-    meta <- lift (loadSessionMeta pool root sessionId) >>= except
-    dir <- except (sessionDirForId root sessionId)
-    exists <- lift (doesDirectoryExist dir)
-    lock <- if exists
-        then lift (acquireSessionLock dir sessionId) >>= \case
-            Left _ -> throwE "cannot rename a running session"
-            Right lock -> pure (Just lock)
-        else pure Nothing
-    let updated = meta
-            { metaTitle = title
-            , metaTitleIsManual = True
-            , metaTitleRefreshIndex = 2
-            }
+    _ <- except (sessionDirForId root sessionId)
+    now <- lift getCurrentTime
     renamed <- lift $
-        Store.replaceSessionMetadata
-            pool
-            "session.renamed"
-            (toStoredMetadata updated)
-            `finally` maybe (pure ()) releaseSessionLock lock
+        Store.setSessionTitle pool sessionId title True 2 now
     case renamed of
         Left err -> throwE (renderStoreError err)
         Right False -> throwE ("session not found: " <> sessionId)
-        Right True -> pure updated
+        Right True -> lift (loadSessionMeta pool root sessionId) >>= except
 
 setSessionArchived
     :: StorePool
@@ -1116,20 +1101,10 @@ setSessionArchived
     -> Bool
     -> IO (Either Text ())
 setSessionArchived pool root sessionId archived = runExceptT do
-    dir <- except (sessionDirForId root sessionId)
-    exists <- lift (doesDirectoryExist dir)
-    lock <- if exists
-        then lift (acquireSessionLock dir sessionId) >>= \case
-            Left _ -> throwE $
-                if archived
-                    then "cannot archive a running session"
-                    else "cannot restore a running session"
-            Right lock -> pure (Just lock)
-        else pure Nothing
+    _ <- except (sessionDirForId root sessionId)
     now <- lift getCurrentTime
     changed <- lift $
         Store.setSessionArchived pool sessionId archived now
-            `finally` maybe (pure ()) releaseSessionLock lock
     case changed of
         Left err -> throwE (renderStoreError err)
         Right False -> throwE ("session not found: " <> sessionId)
@@ -1199,7 +1174,34 @@ sessionTitleFromPrompt prompt =
 setGeneratedSessionTitle :: Int -> Text -> SessionHandle -> IO SessionHandle
 setGeneratedSessionTitle refreshIndex rawTitle handle
     | handle.sessionMeta.metaTitleIsManual = pure handle
-    | otherwise = writeTitle False refreshIndex rawTitle handle
+    | otherwise = do
+        let title = Text.unwords (Text.words (Text.strip rawTitle))
+        now <- getCurrentTime
+        Store.setGeneratedSessionTitle
+            handle.sessionPool
+            handle.sessionMeta.metaId
+            title
+            (fromIntegral refreshIndex)
+            now >>= \case
+                Left err ->
+                    fail
+                        ("could not update PostgreSQL session title: "
+                            <> Text.unpack (renderStoreError err))
+                Right True ->
+                    pure handle
+                        { sessionMeta = handle.sessionMeta
+                            { metaTitle = title
+                            , metaTitleIsManual = False
+                            , metaTitleRefreshIndex = refreshIndex
+                            }
+                        }
+                Right False ->
+                    loadSessionMeta
+                        handle.sessionPool
+                        handle.sessionDir
+                        handle.sessionMeta.metaId >>= \case
+                            Left err -> fail (Text.unpack err)
+                            Right meta -> pure handle { sessionMeta = meta }
 
 setManualSessionTitle :: Text -> SessionHandle -> IO SessionHandle
 setManualSessionTitle = writeTitle True 2
@@ -1212,8 +1214,21 @@ writeTitle manual refreshIndex rawTitle handle = do
             , metaTitleIsManual = manual
             , metaTitleRefreshIndex = refreshIndex
             }
-    writeSessionMeta handle.sessionPool handle.sessionMetaPath meta
-    pure handle { sessionMeta = meta }
+    now <- getCurrentTime
+    Store.setSessionTitle
+        handle.sessionPool
+        handle.sessionMeta.metaId
+        title
+        manual
+        (fromIntegral refreshIndex)
+        now >>= \case
+            Left err ->
+                fail
+                    ("could not update PostgreSQL session title: "
+                        <> Text.unpack (renderStoreError err))
+            Right False ->
+                fail ("session not found: " <> Text.unpack handle.sessionMeta.metaId)
+            Right True -> pure handle { sessionMeta = meta }
 
 resetSessionTitleToAuto :: SessionHandle -> IO SessionHandle
 resetSessionTitleToAuto handle = do
@@ -1221,8 +1236,21 @@ resetSessionTitleToAuto handle = do
             { metaTitleIsManual = False
             , metaTitleRefreshIndex = 0
             }
-    writeSessionMeta handle.sessionPool handle.sessionMetaPath meta
-    pure handle { sessionMeta = meta }
+    now <- getCurrentTime
+    Store.setSessionTitle
+        handle.sessionPool
+        handle.sessionMeta.metaId
+        meta.metaTitle
+        False
+        0
+        now >>= \case
+            Left err ->
+                fail
+                    ("could not reset PostgreSQL session title: "
+                        <> Text.unpack (renderStoreError err))
+            Right False ->
+                fail ("session not found: " <> Text.unpack handle.sessionMeta.metaId)
+            Right True -> pure handle { sessionMeta = meta }
 
 setSessionRecap :: Text -> Int -> SessionHandle -> IO SessionHandle
 setSessionRecap summary mainTurns handle = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -61,6 +61,8 @@ import Agent.CLI.Session.Runtime.Types
     , SessionRequest(..)
     , StartupRuntime(..)
     )
+import Agent.CLI.Session.Selection (reservedSessionId)
+import Agent.CLI.Runtime.Orchestration.Types (NativeRunHooks(..))
 import Agent.CLI.Interrupt (noteFullscreenCtrlC)
 import Agent.Store.Postgres
     ( trustedPool )
@@ -92,6 +94,10 @@ import Agent.CLI.Session.History
     , writeLiveTranscript
     )
 import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.SessionLock
+    ( acquireSessionActivityLock
+    , releaseSessionLock
+    )
 import Agent.CLI.Session.Interaction (runBtwQuestion, setSessionEffort)
 import Agent.CLI.Skills
     ( installSkillCatalogWithOmissions, installSkillToolRoots
@@ -211,6 +217,7 @@ import Data.Time.Clock
     ( getCurrentTime
     , utctDay
     )
+import System.Environment (lookupEnv)
 import System.Mem.StableName (StableName, makeStableName)
 
 data AgentStepCache = AgentStepCache
@@ -306,6 +313,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
     startupUnavailableRef <- newIORef startupUnavailable
     restartEffortRef <- newIORef Nothing
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
+    forM_ startup.startupNativeHooks \hooks ->
+        reservedSessionId persist >>= mapM_ hooks.nativeOnSessionId
     selectedAgent <- newIORef AgentRoot
     agentStepCache <- newIORef (Map.empty :: Map.Map AgentTarget AgentStepCache)
     let cachedAgentSteps target variant items build = do
@@ -521,6 +530,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             }
     writeIORef startup.startupAgentSnapshot
         (loadAgentSnapshot False)
+    forM_ startup.startupNativeHooks \hooks ->
+        hooks.nativeRegisterAgentSnapshot (snd <$> loadAgentSnapshot False)
     writeIORef startup.startupAgentSelect selectAgent
     let installSkills context queueContext skills = do
             before <- readIORef context
@@ -668,6 +679,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 Just dir -> writeIORef storeRoot (Just dir)
                 Nothing -> pure ()
     syncStore
+    renderNativeEvents <- (== Just "1")
+        <$> lookupEnv "HASKELL_AGENT_NATIVE_EVENTS"
     let render = RenderConfig
             { renderShowThinking = stderrTty
             , renderThinkingSpinner = spinnerRef
@@ -685,9 +698,12 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     && terminal.terminalNativeProgress
                     && nativeProgressAnimationEnabled
                         options.optMotionMode
+            , renderNativeEvents
             , renderMotionMode = options.optMotionMode
             }
         emitLoop event = do
+            forM_ startup.startupNativeHooks \hooks ->
+                hooks.nativeOnLoopEvent event
             managedLoopPublisher event
             case fullscreen of
                 Nothing -> renderEvent render event
@@ -713,9 +729,20 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     && (not (isBashToolName toolName) || bashEnabled)
         approveRegisteredTool call =
             withMVar ioLock \_ ->
-                case promptRequest of
-                    Just request
-                        | isJust request.managedTurnBridgeDirectory ->
+                case startup.startupNativeHooks of
+                    Just hooks ->
+                        approveToolDecisionWithReporterAndPersistence
+                            hooks.nativeRequestApproval
+                            (const (pure ()))
+                            (pure ())
+                            policyRef
+                            allowedToolsRef
+                            toolRegistry
+                            planMode
+                            call
+                    Nothing -> case promptRequest of
+                        Just request
+                            | isJust request.managedTurnBridgeDirectory ->
                             approveToolDecisionWithReporterAndPersistence
                                 (requestManagedApproval request)
                                 (const (pure ()))
@@ -725,28 +752,32 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                                 toolRegistry
                                 planMode
                                 call
-                    _ -> case fullscreen of
-                        Nothing ->
-                            withStdinPaused escPaused $
-                                approveToolDecision
-                                    policyRef allowedToolsRef toolRegistry planMode
-                                    projectRoot call
-                        Just runtime ->
-                            approveToolDecisionWithReporterAndPersistence
-                                (requestFullscreenPermission runtime)
-                                (\case
-                                    ApprovalWarning _ -> pure ()
-                                    ApprovalSuccess message ->
-                                        emitUiEvent runtime
-                                            (UiSetNotice
-                                                (Just
-                                                    (successNotice message))))
-                                (saveProjectAutoApprove projectRoot True)
-                                policyRef
-                                allowedToolsRef
-                                toolRegistry
-                                planMode
-                                call
+                        _ -> case fullscreen of
+                            Nothing ->
+                                withStdinPaused escPaused $
+                                    approveToolDecision
+                                        policyRef
+                                        allowedToolsRef
+                                        toolRegistry
+                                        planMode
+                                        projectRoot
+                                        call
+                            Just runtime ->
+                                approveToolDecisionWithReporterAndPersistence
+                                    (requestFullscreenPermission runtime)
+                                    (\case
+                                        ApprovalWarning _ -> pure ()
+                                        ApprovalSuccess message ->
+                                            emitUiEvent runtime
+                                                (UiSetNotice
+                                                    (Just
+                                                        (successNotice message))))
+                                    (saveProjectAutoApprove projectRoot True)
+                                    policyRef
+                                    allowedToolsRef
+                                    toolRegistry
+                                    planMode
+                                    call
         config = LoopConfig
             { loopBackend = backend
             , loopBackendState = BackendStateStore
@@ -876,7 +907,34 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             pure ("concurrent agent limit: " <> Text.pack (show next))
     btwRequests <- newChan
     recapRequests <- newChan
+    turnActivityRef <- newIORef Nothing
+    turnIsActiveRef <- newIORef False
     let
+        acquireTurnActivity handle = do
+            current <- readIORef turnActivityRef
+            when (isNothing current) $
+                acquireSessionActivityLock
+                    handle.sessionDir
+                    handle.sessionMeta.metaId >>= \case
+                        Left _ -> pure ()
+                        Right lock -> writeIORef turnActivityRef (Just lock)
+        beginTurnActivity = do
+            writeIORef turnIsActiveRef True
+            case persist of
+                PersistenceDisabled -> pure ()
+                PersistenceEnabled slotRef ->
+                    readIORef slotRef >>= \case
+                        PersistencePending{} -> pure ()
+                        PersistenceActive handle -> acquireTurnActivity handle
+        endTurnActivity = do
+            writeIORef turnIsActiveRef False
+            atomicModifyIORef' turnActivityRef
+                (\current -> (Nothing, current))
+                >>= mapM_ releaseSessionLock
+        onPersistedWithActivity handle = do
+            onPersisted handle
+            readIORef turnIsActiveRef >>= \active ->
+                when active (acquireTurnActivity handle)
         compactRunnerWithContext focus = do
             result <- compactRunner focus
             case result of
@@ -940,13 +998,15 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionSetWindowTitle = setWindowTitle
             , sessionBeginWindowTitleBusy = beginWindowTitleBusy
             , sessionEndWindowTitleBusy = endWindowTitleBusy
+            , sessionBeginTurnActivity = beginTurnActivity
+            , sessionEndTurnActivity = endTurnActivity
             , sessionAgentViewport = Just agentViewport
             , sessionBeginSubagentTurn = beginSubagentTurn
             , sessionFinishSubagentTurn = finishSubagentTurn
             , sessionAbortSubagentTurn = abortSubagentTurn
             , sessionConcurrentLimit = currentConcurrentLimit
             , sessionSetConcurrentLimit = setConcurrentLimit
-            , sessionOnPersisted = onPersisted
+            , sessionOnPersisted = onPersistedWithActivity
             , sessionReset = sessionReset
             }
     writeIORef generatedContextReloadRef reloadGeneratedContext

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -23,6 +23,7 @@ import Agent.CLI.Options
     , CliOptions
     )
 import Agent.CLI.ProviderTransition (PendingTurn)
+import Agent.CLI.Runtime.Orchestration.Types (NativeRunHooks)
 import Agent.CLI.Session
     ( LegacySubagentTarget
     , Persistence
@@ -166,6 +167,7 @@ data StartupRuntime = StartupRuntime
     , startupSyntaxLoadDuration :: !(IORef (Maybe NominalDiffTime))
     , startupFinished :: !(IORef Bool)
     , startupSessionState :: !SessionState
+    , startupNativeHooks :: !(Maybe NativeRunHooks)
     }
 
 newtype StartupFailure = StartupFailure String

--- a/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
@@ -16,9 +16,11 @@ import Agent.CLI.Database.Storage
     ( postgresStorageCommandEnv
     , runStorageCommand
     )
-import Agent.CLI.AccountPicker
-    ( AccountPickerOption(..)
-    , loadAllAccountPickerOptions
+import Agent.CLI.Login
+    ( AccountBilling(..)
+    , LoginAccount(..)
+    , discoverLoginAccounts
+    , loginAccountSelectionId
     )
 import Agent.CLI.Options
     ( SessionOutputFormat(..)
@@ -47,7 +49,7 @@ import Agent.CLI.SessionLock
     , sessionLockPath
     )
 import Agent.OsPath (unsafeToFilePath)
-import Agent.Provider (BillingMode(..), Provider(..), providerSlug)
+import Agent.Provider (providerSlug)
 import Agent.Responses.Types
     ( CustomToolCall(..)
     , CustomToolCallOutput(..)
@@ -258,29 +260,22 @@ sessionSummaryJSONWithState running locked archived meta =
         ]
 
 accountSummariesJSON :: IO [Aeson.Value]
-accountSummariesJSON = do
-    options <- loadAllAccountPickerOptions OpenAIProvider
-    pure (mapMaybe accountOptionJSON options)
+accountSummariesJSON = map accountJSON <$> discoverLoginAccounts
   where
-    accountOptionJSON = \case
-        AccountPickerAccount
-            provider
-            billing
-            selectionId
-            accountId
-            label
-            detail ->
-                Just $ Aeson.object
-                    [ "provider" Aeson..= providerSlug provider
-                    , "billing" Aeson..= case billing of
-                        SubscriptionBilled -> ("subscription" :: Text)
-                        ApiBilled -> "api"
-                    , "selectionID" Aeson..= selectionId
-                    , "accountID" Aeson..= accountId
-                    , "label" Aeson..= label
-                    , "detail" Aeson..= detail
-                    ]
-        AccountPickerConnect _ -> Nothing
+    accountJSON account = Aeson.object
+        [ "provider" Aeson..= providerSlug account.loginProvider
+        , "billing" Aeson..= case account.loginBilling of
+            SubscriptionBilling _ -> ("subscription" :: Text)
+            ApiCreditsBilling -> "api"
+        , "selectionID" Aeson..= loginAccountSelectionId account
+        , "accountID" Aeson..= account.loginAccountId
+        , "label" Aeson..= account.loginLabel
+        , "detail" Aeson..= account.loginSource
+        , "managedID" Aeson..= account.loginManagedId
+        , "source" Aeson..= account.loginSource
+        , "enabled" Aeson..= account.loginEnabled
+        , "canManage" Aeson..= maybe False (const True) account.loginManagedId
+        ]
 
 -- Keep native transcript hydration independent from provider response items.
 -- Those can contain large tool payloads that this view does not render.

--- a/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
@@ -1,32 +1,60 @@
 -- | Non-interactive session and storage administration commands.
 module Agent.CLI.SessionAdmin
-    ( managedPostgresConfigForHome
+    ( accountSummariesJSON
+    , managedPostgresConfigForHome
+    , loadSessionPageJSON
     , runImportSession
     , runListSessions
     , runShowSession
     , runStorageAdmin
     , runWaitSession
+    , sessionSummaryJSON
+    , sessionSummaryWithStatusJSON
     ) where
 
 import Agent.CLI.Database.Storage
     ( postgresStorageCommandEnv
     , runStorageCommand
     )
-import Agent.CLI.Options (StorageCommand)
+import Agent.CLI.AccountPicker
+    ( AccountPickerOption(..)
+    , loadAllAccountPickerOptions
+    )
+import Agent.CLI.Options
+    ( SessionOutputFormat(..)
+    , SessionPageRequest(..)
+    , StorageCommand
+    )
 import Agent.CLI.Session
     ( SessionMeta(..)
     , SessionTurn(..)
+    , SessionTurnPage(..)
     , importSessionTransfer
+    , listArchivedSessionIds
     , listSessions
     , loadSession
+    , loadSessionMeta
+    , loadRecentSessionHistoryTurns
+    , loadRecentSessionTurns
+    , loadSessionHistoryTurnsBefore
+    , loadSessionTurnsBefore
     , sessionDirForId
     , sessionsRoot
     )
 import Agent.CLI.SessionLock
-    ( sessionLockIsActive
+    ( sessionActivityLockPath
+    , sessionLockIsActive
     , sessionLockPath
     )
-import Agent.Provider (providerSlug)
+import Agent.OsPath (unsafeToFilePath)
+import Agent.Provider (BillingMode(..), Provider(..), providerSlug)
+import Agent.Responses.Types
+    ( CustomToolCall(..)
+    , CustomToolCallOutput(..)
+    , FunctionCall(..)
+    , FunctionCallOutput(..)
+    , ResponseItem(..)
+    )
 import Agent.Store.Postgres
     ( ManagedPostgresConfig
     , Store
@@ -34,6 +62,7 @@ import Agent.Store.Postgres
     , trustedPool
     , withStore
     )
+import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Types (renderStoreError)
 import Control.Concurrent (threadDelay)
 import Control.Monad
@@ -42,13 +71,19 @@ import Control.Monad
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import Data.Int (Int64)
+import Data.Maybe (mapMaybe)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
 import Data.Time.Format
     ( defaultTimeLocale
     , formatTime
     )
+import qualified System.Directory as Directory
 import System.Directory.OsPath
     ( doesDirectoryExist
     , getHomeDirectory
@@ -75,27 +110,247 @@ managedPostgresConfigForHome home = do
         decodeFS (home </> unsafeEncodeUtf ".haskell-agent")
     managedPostgresConfigFromEnv stateDirectory
 
-runListSessions :: IO ()
-runListSessions = do
+runListSessions :: SessionOutputFormat -> IO ()
+runListSessions outputFormat = do
     home <- getHomeDirectory
     withStoreForHome home \store -> do
-        sessions <- listSessions (trustedPool store) (sessionsRoot home)
-        if null sessions
-            then putStrLn "No sessions in ~/.haskell-agent/sessions"
-            else mapM_ printSessionSummary sessions
+        let root = sessionsRoot home
+            pool = trustedPool store
+        sessions <- listSessions pool root
+        archivedIds <- listArchivedSessionIds pool
+            >>= either (fail . Text.unpack) pure
+        let archived = Set.fromList archivedIds
+        case outputFormat of
+            SessionJSON -> do
+                summaries <- mapM
+                    (\session -> sessionSummaryWithStatusJSON
+                        root
+                        (Set.member session.metaId archived)
+                        session)
+                    sessions
+                LBS8.putStrLn (Aeson.encode summaries)
+            SessionHuman ->
+                if null sessions
+                    then putStrLn "No sessions in ~/.haskell-agent/sessions"
+                    else mapM_ printSessionSummary sessions
 
-runShowSession :: Text -> IO ()
-runShowSession sessionId = do
+runShowSession
+    :: Text
+    -> SessionOutputFormat
+    -> Maybe SessionPageRequest
+    -> IO ()
+runShowSession sessionId outputFormat pageRequest = do
     home <- getHomeDirectory
-    withStoreForHome home \store ->
-        loadSession (trustedPool store) (sessionsRoot home) sessionId >>= \case
-            Left err -> die (Text.unpack err)
-            Right (meta, turns) -> do
-                printSessionSummary meta
-                putStrLn ""
-                if null turns
-                    then putStrLn "(empty transcript)"
-                    else mapM_ printTurn turns
+    withStoreForHome home \store -> do
+        let pool = trustedPool store
+            root = sessionsRoot home
+        case pageRequest of
+            Nothing ->
+                loadSession pool root sessionId >>= \case
+                    Left err -> die (Text.unpack err)
+                    Right (meta, turns) ->
+                        renderFullSession outputFormat meta turns
+            Just request -> do
+                meta <- loadSessionMeta pool root sessionId
+                    >>= either (die . Text.unpack) pure
+                page <- loadPage pool root request
+                    >>= either (die . Text.unpack) pure
+                renderSessionPage meta page
+  where
+    loadPage pool root = \case
+        SessionRecent limit ->
+            loadRecentSessionTurns pool root sessionId limit
+        SessionBefore cursor limit ->
+            loadSessionTurnsBefore pool root sessionId cursor limit
+
+renderFullSession
+    :: SessionOutputFormat
+    -> SessionMeta
+    -> [SessionTurn]
+    -> IO ()
+renderFullSession outputFormat meta turns =
+    case outputFormat of
+        SessionJSON ->
+            LBS8.putStrLn
+                (Aeson.encode (Aeson.object
+                    [ "meta" Aeson..= sessionSummaryJSON meta
+                    , "turns" Aeson..= map sessionTurnJSON turns
+                    ]))
+        SessionHuman -> do
+            printSessionSummary meta
+            putStrLn ""
+            if null turns
+                then putStrLn "(empty transcript)"
+                else mapM_ printTurn turns
+
+renderSessionPage :: SessionMeta -> SessionTurnPage -> IO ()
+renderSessionPage meta page =
+    LBS8.putStrLn (Aeson.encode (sessionPageJSON meta page))
+
+loadSessionPageJSON
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Maybe Int64
+    -> Int
+    -> IO (Either Text Aeson.Value)
+loadSessionPageJSON pool root sessionId before limit = do
+    metaResult <- loadSessionMeta pool root sessionId
+    pageResult <- case before of
+        Nothing -> loadRecentSessionHistoryTurns pool root sessionId limit
+        Just cursor ->
+            loadSessionHistoryTurnsBefore pool root sessionId cursor limit
+    pure do
+        meta <- metaResult
+        page <- pageResult
+        pure (sessionPageJSON meta page)
+
+sessionPageJSON :: SessionMeta -> SessionTurnPage -> Aeson.Value
+sessionPageJSON meta page =
+    Aeson.object
+        [ "meta" Aeson..= sessionSummaryJSON meta
+        , "turns" Aeson..= map indexedSessionTurnJSON page.pageTurns
+        , "page" Aeson..= Aeson.object
+            [ "generationStart" Aeson..= page.pageGenerationStart
+            , "totalTurns" Aeson..= page.pageTotalTurns
+            , "hasOlder" Aeson..= page.pageHasOlder
+            , "hasNewer" Aeson..= page.pageHasNewer
+            ]
+        ]
+
+sessionSummaryJSON :: SessionMeta -> Aeson.Value
+sessionSummaryJSON = sessionSummaryJSONWithState False False False
+
+sessionSummaryWithStatusJSON
+    :: OsPath
+    -> Bool
+    -> SessionMeta
+    -> IO Aeson.Value
+sessionSummaryWithStatusJSON root archived meta = do
+    (running, locked) <- case sessionDirForId root meta.metaId of
+        Left _ -> pure (False, False)
+        Right sessionDir -> do
+            running <- probeLock (sessionActivityLockPath sessionDir)
+            locked <- probeLock (sessionLockPath sessionDir)
+            pure (running, locked)
+    pure (sessionSummaryJSONWithState running locked archived meta)
+  where
+    probeLock lockPath = do
+        lockExists <- Directory.doesFileExist lockPath
+        if lockExists
+            then sessionLockIsActive lockPath
+            else pure False
+
+sessionSummaryJSONWithState
+    :: Bool -> Bool -> Bool -> SessionMeta -> Aeson.Value
+sessionSummaryJSONWithState running locked archived meta =
+    Aeson.object
+        [ "id" Aeson..= meta.metaId
+        , "title" Aeson..= meta.metaTitle
+        , "updatedAt" Aeson..= meta.metaUpdatedAt
+        , "provider" Aeson..= providerSlug meta.metaProvider
+        , "model" Aeson..= meta.metaModel
+        , "effort" Aeson..= meta.metaEffort
+        , "cwd" Aeson..= unsafeToFilePath meta.metaCwd
+        , "isRunning" Aeson..= running
+        , "isLocked" Aeson..= locked
+        , "isArchived" Aeson..= archived
+        ]
+
+accountSummariesJSON :: IO [Aeson.Value]
+accountSummariesJSON = do
+    options <- loadAllAccountPickerOptions OpenAIProvider
+    pure (mapMaybe accountOptionJSON options)
+  where
+    accountOptionJSON = \case
+        AccountPickerAccount
+            provider
+            billing
+            selectionId
+            accountId
+            label
+            detail ->
+                Just $ Aeson.object
+                    [ "provider" Aeson..= providerSlug provider
+                    , "billing" Aeson..= case billing of
+                        SubscriptionBilled -> ("subscription" :: Text)
+                        ApiBilled -> "api"
+                    , "selectionID" Aeson..= selectionId
+                    , "accountID" Aeson..= accountId
+                    , "label" Aeson..= label
+                    , "detail" Aeson..= detail
+                    ]
+        AccountPickerConnect _ -> Nothing
+
+-- Keep native transcript hydration independent from provider response items.
+-- Those can contain large tool payloads that this view does not render.
+sessionTurnJSON :: SessionTurn -> Aeson.Value
+sessionTurnJSON turn =
+    Aeson.object
+        [ "userText" Aeson..= turn.turnUserText
+        , "assistantText" Aeson..= turn.turnAssistantText
+        , "error" Aeson..= turn.turnError
+        , "toolEvents" Aeson..= sessionToolEvents turn
+        ]
+
+indexedSessionTurnJSON :: (Int64, SessionTurn) -> Aeson.Value
+indexedSessionTurnJSON (index, turn) =
+    Aeson.object
+        [ "index" Aeson..= index
+        , "userText" Aeson..= turn.turnUserText
+        , "assistantText" Aeson..= turn.turnAssistantText
+        , "error" Aeson..= turn.turnError
+        , "toolEvents" Aeson..= sessionToolEvents turn
+        ]
+
+sessionToolEvents :: SessionTurn -> [Aeson.Value]
+sessionToolEvents turn =
+    mapMaybe sessionToolEvent turn.turnItems
+
+sessionToolEvent :: ResponseItem -> Maybe Aeson.Value
+sessionToolEvent = \case
+    FunctionCallItem call ->
+        Just (toolStartedJSON call.callId call.name call.arguments)
+    CustomToolCallItem call ->
+        Just (toolStartedJSON call.callId call.name call.input)
+    FunctionCallOutputItem result ->
+        Just (toolFinishedJSON result.callId (renderToolValue result.output))
+    CustomToolCallOutputItem result ->
+        Just (toolFinishedJSON result.callId (renderToolValue result.output))
+    _ -> Nothing
+
+toolStartedJSON :: Text -> Text -> Text -> Aeson.Value
+toolStartedJSON callId name arguments =
+    let (visible, truncated) = boundedSessionToolText arguments
+    in Aeson.object
+        [ "type" Aeson..= ("tool_started" :: Text)
+        , "callId" Aeson..= callId
+        , "name" Aeson..= name
+        , "arguments" Aeson..= visible
+        , "argumentsEncrypted" Aeson..= False
+        , "truncated" Aeson..= truncated
+        ]
+
+toolFinishedJSON :: Text -> Text -> Aeson.Value
+toolFinishedJSON callId output =
+    let (visible, truncated) = boundedSessionToolText output
+    in Aeson.object
+        [ "type" Aeson..= ("tool_finished" :: Text)
+        , "callId" Aeson..= callId
+        , "output" Aeson..= visible
+        , "truncated" Aeson..= truncated
+        ]
+
+renderToolValue :: Aeson.Value -> Text
+renderToolValue = \case
+    Aeson.String value -> value
+    value ->
+        TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode value))
+
+boundedSessionToolText :: Text -> (Text, Bool)
+boundedSessionToolText value =
+    let (visible, remainder) = Text.splitAt 8192 value
+    in (visible, not (Text.null remainder))
 
 withStoreForHome :: OsPath -> (Store -> IO a) -> IO a
 withStoreForHome home action = do

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -90,6 +90,8 @@ data SessionEnv = SessionEnv
     , sessionSetWindowTitle :: !(Text -> IO ())
     , sessionBeginWindowTitleBusy :: !(IO ())
     , sessionEndWindowTitleBusy :: !(IO ())
+    , sessionBeginTurnActivity :: !(IO ())
+    , sessionEndTurnActivity :: !(IO ())
     , sessionAgentViewport :: !(Maybe AgentViewportEnv)
     , sessionBeginSubagentTurn :: !(IO (Maybe RootTurnId))
     , sessionFinishSubagentTurn :: !(Maybe RootTurnId -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/SessionLock.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionLock.hs
@@ -5,7 +5,9 @@
 module Agent.CLI.SessionLock
     ( SessionLock
     , acquireSessionLock
+    , acquireSessionActivityLock
     , releaseSessionLock
+    , sessionActivityLockPath
     , sessionLockFilePath
     , sessionLockIsActive
     , sessionLockPath
@@ -31,9 +33,23 @@ sessionLockPath :: OsPath -> FilePath
 sessionLockPath sessionDir =
     unsafeToFilePath sessionDir FilePath.</> ".agent-running.lock"
 
+sessionActivityLockPath :: OsPath -> FilePath
+sessionActivityLockPath sessionDir =
+    unsafeToFilePath sessionDir FilePath.</> ".agent-turn-running.lock"
+
 acquireSessionLock :: OsPath -> Text -> IO (Either Text SessionLock)
-acquireSessionLock sessionDir sessionId = do
-    let path = sessionLockPath sessionDir
+acquireSessionLock sessionDir sessionId =
+    acquireLockAt (sessionLockPath sessionDir) sessionId
+
+acquireSessionActivityLock
+    :: OsPath
+    -> Text
+    -> IO (Either Text SessionLock)
+acquireSessionActivityLock sessionDir sessionId =
+    acquireLockAt (sessionActivityLockPath sessionDir) sessionId
+
+acquireLockAt :: FilePath -> Text -> IO (Either Text SessionLock)
+acquireLockAt path sessionId = do
     try @_ @SomeException
         (FileLock.tryLockFile path FileLock.Exclusive) >>= \case
             Left err -> pure $ Left

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -161,7 +161,10 @@ runOneTurn env promptText inputs =
     bracket_
         env.sessionBeginWindowTitleBusy
         env.sessionEndWindowTitleBusy
-        (runOneTurnBusy env promptText inputs)
+        (bracket_
+            env.sessionBeginTurnActivity
+            env.sessionEndTurnActivity
+            (runOneTurnBusy env promptText inputs))
 
 runOneTurnBusy :: SessionEnv -> Text -> [TurnInput] -> IO TurnResult
 runOneTurnBusy env@SessionEnv

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -365,6 +365,33 @@ spec = describe "Agent.CLI.AgentSessions" do
                         sessionLockIsActive (sessionLockPath handle.sessionDir)
                             `shouldReturn` False
 
+    it "tracks active turns separately from idle session ownership" $
+        withTempStoreDir "agent-session-activity-lock-" \pool root -> do
+            handle <- createSession (testCreateAt pool root root)
+            acquireSessionLock
+                handle.sessionDir
+                handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right sessionLock -> do
+                        sessionLockIsActive
+                            (sessionActivityLockPath handle.sessionDir)
+                            `shouldReturn` False
+                        acquireSessionActivityLock
+                            handle.sessionDir
+                            handle.sessionMeta.metaId >>= \case
+                                Left err ->
+                                    expectationFailure (Text.unpack err)
+                                Right activityLock -> do
+                                    sessionLockIsActive
+                                        (sessionActivityLockPath
+                                            handle.sessionDir)
+                                        `shouldReturn` True
+                                    releaseSessionLock activityLock
+                        sessionLockIsActive
+                            (sessionActivityLockPath handle.sessionDir)
+                            `shouldReturn` False
+                        releaseSessionLock sessionLock
+
     it "releases an advisory lock when its process crashes" $
         withTempStoreDir "agent-session-lock-crash-" \pool root -> do
             handle <- createSession (testCreateAt pool root root)

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -36,6 +36,9 @@ spec = describe "native image attachment staging" do
     it "classifies async cancellation as cancelled, not failure" do
         Bridge.repositoryCancelClassificationSmoke `shouldReturn` True
 
+    it "does not retry a terminal callback that throws" do
+        Bridge.repositoryTerminalThrowSmoke `shouldReturn` True
+
     it "validates the typed repository-review ABI from native code" do
 #ifdef darwin_HOST_OS
         repositoryReviewAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -3,6 +3,7 @@
 
 module Agent.CLI.MacOS.BridgeFFISpec (spec) where
 
+import qualified Agent.CLI.MacOS.Bridge as Bridge
 #ifdef darwin_HOST_OS
 import Foreign.C.Types (CInt(..))
 import Test.Hspec (Spec, describe, it, shouldReturn)
@@ -13,7 +14,7 @@ foreign import ccall "ha_image_attachment_stage_smoke"
 foreign import ccall "ha_repository_review_abi_smoke"
     repositoryReviewAbiSmoke :: IO CInt
 #else
-import Test.Hspec (Spec, describe, it, pendingWith)
+import Test.Hspec (Spec, describe, it, pendingWith, shouldReturn)
 #endif
 
 spec :: Spec
@@ -24,6 +25,9 @@ spec = describe "native image attachment staging" do
 #else
         pendingWith "the native bridge smoke test only links on macOS"
 #endif
+
+    it "blocks new repository workers until cancel-all returns" do
+        Bridge.repositoryCancelAllAdmissionSmoke `shouldReturn` True
 
     it "validates the typed repository-review ABI from native code" do
 #ifdef darwin_HOST_OS

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -9,6 +9,9 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 
 foreign import ccall "ha_image_attachment_stage_smoke"
     imageAttachmentStageSmoke :: IO CInt
+
+foreign import ccall "ha_repository_review_abi_smoke"
+    repositoryReviewAbiSmoke :: IO CInt
 #else
 import Test.Hspec (Spec, describe, it, pendingWith)
 #endif
@@ -18,6 +21,13 @@ spec = describe "native image attachment staging" do
     it "accepts copied image buffers through the exported bridge" do
 #ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0
+#else
+        pendingWith "the native bridge smoke test only links on macOS"
+#endif
+
+    it "validates the typed repository-review ABI from native code" do
+#ifdef darwin_HOST_OS
+        repositoryReviewAbiSmoke `shouldReturn` 0
 #else
         pendingWith "the native bridge smoke test only links on macOS"
 #endif

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Agent.CLI.MacOS.BridgeFFISpec (spec) where
+
+import Foreign.C.Types (CInt(..))
+import Test.Hspec (Spec, describe, it, shouldReturn)
+
+foreign import ccall "ha_image_attachment_stage_smoke"
+    imageAttachmentStageSmoke :: IO CInt
+
+spec :: Spec
+spec = describe "native image attachment staging" do
+    it "accepts copied image buffers through the exported bridge" do
+        imageAttachmentStageSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -33,6 +33,9 @@ spec = describe "native image attachment staging" do
         Bridge.repositoryCancelAllReentrancySmoke `shouldReturn` True
         Bridge.repositoryCheckDestroyReentrancySmoke `shouldReturn` True
 
+    it "classifies async cancellation as cancelled, not failure" do
+        Bridge.repositoryCancelClassificationSmoke `shouldReturn` True
+
     it "validates the typed repository-review ABI from native code" do
 #ifdef darwin_HOST_OS
         repositoryReviewAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -1,14 +1,23 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE CPP #-}
 
 module Agent.CLI.MacOS.BridgeFFISpec (spec) where
 
+#ifdef darwin_HOST_OS
 import Foreign.C.Types (CInt(..))
 import Test.Hspec (Spec, describe, it, shouldReturn)
 
 foreign import ccall "ha_image_attachment_stage_smoke"
     imageAttachmentStageSmoke :: IO CInt
+#else
+import Test.Hspec (Spec, describe, it, pendingWith)
+#endif
 
 spec :: Spec
 spec = describe "native image attachment staging" do
     it "accepts copied image buffers through the exported bridge" do
+#ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0
+#else
+        pendingWith "the native bridge smoke test only links on macOS"
+#endif

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -29,6 +29,10 @@ spec = describe "native image attachment staging" do
     it "blocks new repository workers until cancel-all returns" do
         Bridge.repositoryCancelAllAdmissionSmoke `shouldReturn` True
 
+    it "does not self-deadlock on callback lifecycle calls" do
+        Bridge.repositoryCancelAllReentrancySmoke `shouldReturn` True
+        Bridge.repositoryCheckDestroyReentrancySmoke `shouldReturn` True
+
     it "validates the typed repository-review ABI from native code" do
 #ifdef darwin_HOST_OS
         repositoryReviewAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Agent.CLI.MacOS.BridgeHeaderSpec (spec) where
+
+import Foreign.C.Types (CInt(..))
+import Test.Hspec (Spec, describe, it, shouldReturn)
+
+foreign import ccall "ha_image_attachment_abi_smoke"
+    imageAttachmentAbiSmoke :: IO CInt
+
+spec :: Spec
+spec = describe "native image attachment ABI" do
+    it "preserves the documented image struct layout and ordered buffers" do
+        imageAttachmentAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
@@ -1,0 +1,79 @@
+module Agent.CLI.MacOS.NativeLoopEventSpec (spec) where
+
+import Agent.CLI.MacOS.NativeLoopEvent (encodeNativeLoopEvent)
+import Agent.Loop (LoopEvent(..))
+import Agent.ToolDispatch (ToolCall(..), ToolCallKind(..), ToolCallResult(..))
+import qualified Data.ByteString as BS
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word8, Word32)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "native loop event binary encoding" do
+    it "encodes text deltas with a versioned HAEV frame" do
+        encodeNativeLoopEvent "turn" (TextDelta "hé")
+            `shouldBe` Just (frame 2 0 ["turn", "hé"])
+
+    it "encodes reasoning and status events as distinct kinds" do
+        encodeNativeLoopEvent "turn" (ReasoningDelta "checking")
+            `shouldSatisfy` hasKind 1
+        encodeNativeLoopEvent "turn" (ActivityUpdated "working")
+            `shouldSatisfy` hasKind 3
+
+    it "preserves tool flags and fields" do
+        let call = ToolCall
+                { callId = "call-1"
+                , name = "read_file"
+                , arguments = "{\"path\":\"/tmp/a\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = True
+                }
+        case encodeNativeLoopEvent "turn" (ToolStarted call) of
+            Nothing -> expectationFailure "native tool event failed to encode"
+            Just encoded -> do
+                BS.take 8 encoded `shouldBe` header 4 1
+                BS.isInfixOf "call-1" encoded `shouldBe` True
+                BS.isInfixOf "read_file" encoded `shouldBe` True
+                BS.index encoded 7 `shouldBe` 1
+
+    it "encodes truncated tool output with its flag" do
+        let result = ToolCallResult
+                { callId = "call-1"
+                , output = Text.replicate 8193 "x"
+                , callKind = FunctionCallKind
+                }
+        case encodeNativeLoopEvent "turn" (ToolFinished result) of
+            Nothing -> expectationFailure "native tool event failed to encode"
+            Just encoded -> BS.take 8 encoded `shouldBe` header 5 2
+
+    it "does not encode lifecycle events as native loop frames" do
+        encodeNativeLoopEvent "turn" TurnStarted `shouldBe` Nothing
+
+frame :: Word8 -> Word8 -> [String] -> BS.ByteString
+frame kind flags fields =
+    header kind flags
+        <> BS.concat
+            [ field (TextEncoding.encodeUtf8 (Text.pack value))
+            | value <- fields
+            ]
+
+header :: Word8 -> Word8 -> BS.ByteString
+header kind flags =
+    "HAEV" <> BS.pack [1, kind, 0, flags]
+
+field :: BS.ByteString -> BS.ByteString
+field bytes = word32BE (fromIntegral (BS.length bytes)) <> bytes
+
+word32BE :: Word32 -> BS.ByteString
+word32BE value = BS.pack
+    [ fromIntegral (value `div` 16777216)
+    , fromIntegral (value `div` 65536)
+    , fromIntegral (value `div` 256)
+    , fromIntegral value
+    ]
+
+hasKind :: Word8 -> Maybe BS.ByteString -> Bool
+hasKind kind (Just encoded) =
+    BS.take 8 encoded == header kind 0
+hasKind _ Nothing = False

--- a/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
@@ -45,6 +45,25 @@ spec = describe "Agent.CLI.ModelConfig" do
                 , "gpt-5.6-terra"
                 , "gpt-5.6-luna"
                 ]
+        let modelById modelId =
+                findModel modelId catalog.catalogModels
+        fmap (.catalogModelReasoningEfforts)
+            (modelById "gpt-5.6-sol")
+            `shouldBe`
+                Just (Just ["low", "medium", "high", "xhigh", "max"])
+        fmap (.catalogModelDefaultReasoningEffort)
+            (modelById "gpt-5.6-sol")
+            `shouldBe` Just (Just "low")
+        fmap (.catalogModelReasoningEfforts)
+            (modelById "grok-4.6")
+            `shouldBe`
+                Just (Just ["low", "medium", "high", "xhigh"])
+        fmap (.catalogModelDefaultReasoningEffort)
+            (modelById "grok-4.6")
+            `shouldBe` Just (Just "high")
+        fmap (.catalogModelReasoningEfforts)
+            (modelById "stealth/ox-alpha")
+            `shouldBe` Just Nothing
 
     it "adds a custom Responses connection and model" do
         defaults <- readPackagedDefaults
@@ -187,6 +206,41 @@ spec = describe "Agent.CLI.ModelConfig" do
             (Just ("models.json", overlay))
             `shouldSatisfy` leftContains "context_window must be positive"
 
+    it "rejects invalid or duplicate reasoning efforts" do
+        defaults <- readPackagedDefaults
+        let invalid effortFields =
+                LBS.pack $
+                    "{\"version\":1,\"models\":[{\"id\":\"gpt-5.6-sol\","
+                    <> "\"connection\":\"openai\",\"dialect\":\"codex\","
+                    <> "\"default\":true,"
+                    <> effortFields
+                    <> "}]}"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just
+                ( "models.json"
+                , invalid "\"reasoning_efforts\":[\"medium\",\"turbo\"]"
+                ))
+            `shouldSatisfy` leftContains "unsupported reasoning_efforts"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just
+                ( "models.json"
+                , invalid "\"reasoning_efforts\":[\"high\",\"high\"]"
+                ))
+            `shouldSatisfy` leftContains "must not contain duplicates"
+
+    it "requires a model reasoning default to be advertised" do
+        defaults <- readPackagedDefaults
+        let overlay =
+                "{\"version\":1,\"models\":[{\"id\":\"gpt-5.6-sol\",\"connection\":\"openai\",\"dialect\":\"codex\",\"reasoning_efforts\":[\"low\",\"medium\"],\"default_reasoning_effort\":\"high\",\"default\":true}]}"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just ("models.json", overlay))
+            `shouldSatisfy`
+                leftContains
+                    "default_reasoning_effort must be listed"
+
     it "loads ~/.haskell-agent/models.json over an explicit default path" $
         withTempDirectory "agent-model-config-" \root -> do
             defaults <- readPackagedDefaults
@@ -209,6 +263,15 @@ leftContains :: Text -> Either Text value -> Bool
 leftContains needle = \case
     Left err -> needle `Text.isInfixOf` err
     Right _ -> False
+
+findModel :: Text -> [CatalogModel] -> Maybe CatalogModel
+findModel modelId = go
+  where
+    go = \case
+        [] -> Nothing
+        model : rest
+            | model.catalogModelId == modelId -> Just model
+            | otherwise -> go rest
 
 expectRight :: Either Text value -> IO value
 expectRight = \case

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -155,10 +155,57 @@ spec = do
 
 
         it "parses session administration commands" do
-            parseArgs ["sessions"] `shouldBe` Right ListSessions
-            parseArgs ["sessions", "list"] `shouldBe` Right ListSessions
+            parseArgs ["sessions"]
+                `shouldBe` Right (ListSessions SessionHuman)
+            parseArgs ["sessions", "list"]
+                `shouldBe` Right (ListSessions SessionHuman)
+            parseArgs ["sessions", "list", "--json"]
+                `shouldBe` Right (ListSessions SessionJSON)
             parseArgs ["sessions", "show", "2026-08-19-abcd1234"]
-                `shouldBe` Right (ShowSession "2026-08-19-abcd1234")
+                `shouldBe`
+                    Right
+                        (ShowSession
+                            "2026-08-19-abcd1234"
+                            SessionHuman
+                            Nothing)
+            parseArgs
+                [ "sessions", "show", "2026-08-19-abcd1234", "--json" ]
+                `shouldBe`
+                    Right
+                        (ShowSession
+                            "2026-08-19-abcd1234"
+                            SessionJSON
+                            Nothing)
+            parseArgs
+                [ "sessions", "show", "2026-08-19-abcd1234"
+                , "--json", "--limit", "50"
+                ]
+                `shouldBe`
+                    Right
+                        (ShowSession
+                            "2026-08-19-abcd1234"
+                            SessionJSON
+                            (Just (SessionRecent 50)))
+            parseArgs
+                [ "sessions", "show", "2026-08-19-abcd1234"
+                , "--before", "100", "--json"
+                ]
+                `shouldBe`
+                    Right
+                        (ShowSession
+                            "2026-08-19-abcd1234"
+                            SessionJSON
+                            (Just (SessionBefore 100 50)))
+            parseArgs
+                [ "sessions", "show", "2026-08-19-abcd1234"
+                , "--limit", "50"
+                ]
+                `shouldSatisfy` isLeft
+            parseArgs
+                [ "sessions", "show", "2026-08-19-abcd1234"
+                , "--json", "--limit", "501"
+                ]
+                `shouldSatisfy` isLeft
             parseArgs ["sessions", "wait", "2026-08-19-abcd1234"]
                 `shouldBe` Right (WaitSession "2026-08-19-abcd1234")
             parseArgs ["sessions", "import"]

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -113,6 +113,28 @@ spec = do
             let out = Text.unlines (map (Text.pack . show) [1 :: Int .. 12])
             truncateToolOutput out `shouldSatisfy` Text.isInfixOf "… 4 more"
 
+    describe "formatNativeLoopEvent" do
+        it "encodes tool lifecycle records and ignores prose" do
+            let started = formatNativeLoopEvent
+                    (ToolStarted
+                        (functionToolCall
+                            "call-1"
+                            "read_file"
+                            "{\"target_file\":\"src/A.hs\"}"))
+                finished = formatNativeLoopEvent
+                    (ToolFinished ToolCallResult
+                        { callId = "call-1"
+                        , output = "done"
+                        , callKind = FunctionCallKind
+                        })
+            started `shouldSatisfy`
+                maybe False (Text.isPrefixOf (Text.singleton '\RS'))
+            started `shouldSatisfy`
+                maybe False (Text.isInfixOf "\"type\":\"tool_started\"")
+            finished `shouldSatisfy`
+                maybe False (Text.isInfixOf "\"output\":\"done\"")
+            formatNativeLoopEvent (TextDelta "hello") `shouldBe` Nothing
+
     describe "formatToolOutput" do
         it "renders structured collaboration results as readable text" do
             let spawn = functionToolCall "c1" "collaboration.spawn_agent" "{}"
@@ -796,6 +818,7 @@ withRenderConfigNativeMode showThinking color native motionMode action = do
                 , renderStderr = handle
                 , renderModelRef = modelRef
                 , renderNativeProgress = native
+                , renderNativeEvents = False
                 , renderMotionMode = motionMode
                 }
         action config handle path

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -1,0 +1,386 @@
+module Agent.CLI.RepositoryDeliverySpec (spec) where
+
+import Agent.CLI.RepositoryDelivery
+import Agent.CLI.RepositoryReview
+    ( RepositorySnapshot(..)
+    , repositorySnapshot
+    )
+import Control.Exception.Safe (bracket)
+import qualified Data.Text as Text
+import System.Directory
+    ( createDirectory
+    , doesFileExist
+    , getTemporaryDirectory
+    , removePathForcibly
+    )
+import System.Environment (getEnv, lookupEnv, setEnv, unsetEnv)
+import System.Exit (ExitCode(..))
+import System.IO (hClose, openTempFile)
+import System.Posix.Files
+    ( ownerExecuteMode
+    , ownerReadMode
+    , ownerWriteMode
+    , setFileMode
+    , unionFileModes
+    )
+import System.Process
+    ( CreateProcess(..)
+    , proc
+    , readCreateProcessWithExitCode
+    )
+import Test.Hspec
+
+spec :: Spec
+spec = describe "repository delivery service" do
+    it "validates branch and remote names without option/ref injection" do
+        validateBranchName "feature/safe-name" `shouldBe` True
+        validateBranchName "-force" `shouldBe` False
+        validateBranchName "bad..name" `shouldBe` False
+        validateBranchName "bad name" `shouldBe` False
+        validateBranchName ".hidden" `shouldBe` False
+        validateBranchName "topic/.hidden" `shouldBe` False
+        validateBranchName "topic.lock" `shouldBe` False
+        validateRemoteName "origin" `shouldBe` True
+        validateRemoteName "-origin" `shouldBe` False
+        validateRemoteName "origin\n--upload-pack=evil" `shouldBe` False
+
+    it "previews and confirms one exact non-force push once" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+
+            snapshot <- expectRight =<< repositorySnapshot root
+            status <- expectRight
+                =<< repositoryDeliveryStatus root snapshot.snapshotId
+            status.deliveryBranch `shouldBe` "main"
+            status.deliveryRemote `shouldBe` "origin"
+            status.deliveryAhead `shouldBe` 1
+            status.deliveryBehind `shouldBe` 0
+
+            let hookMarker = root <> "/hook-ran"
+                hook = root <> "/.git/hooks/pre-push"
+            writeFile hook
+                ("#!/bin/sh\nprintf ran > " <> shellQuote hookMarker <> "\n")
+            setFileMode hook
+                (ownerReadMode
+                    `unionFileModes` ownerWriteMode
+                    `unionFileModes` ownerExecuteMode)
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            Text.length preview.pushPreviewConfirmation `shouldBe` 64
+            pushed <- expectRight
+                =<< confirmRepositoryPush
+                    root
+                    preview.pushPreviewConfirmation
+            remoteHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            remoteHead `shouldBe` pushed.deliveryHeadOid
+            doesFileExist hookMarker `shouldReturn` False
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isConfirmationRejection
+
+    it "consumes a preview without pushing when the local snapshot changes" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            remoteBefore <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+
+            writeFile (root <> "/untracked.txt") "changes exact snapshot\n"
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isStale
+            remoteAfter <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            remoteAfter `shouldBe` remoteBefore
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isConfirmationRejection
+
+    it "rejects an externally changed remote after preview without pushing" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            initial <- Text.strip <$> git root ["rev-parse", "HEAD^"]
+            tree <- Text.strip <$> git root ["rev-parse", "HEAD^{tree}"]
+            divergent <- Text.strip
+                <$> git root
+                    [ "commit-tree"
+                    , Text.unpack tree
+                    , "-p"
+                    , Text.unpack initial
+                    , "-m"
+                    , "remote advance"
+                    ]
+            _ <- git root
+                [ "push"
+                , "-q"
+                , remote
+                , Text.unpack divergent <> ":refs/heads/main"
+                ]
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isStale
+            remoteHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            remoteHead `shouldBe` divergent
+
+    it "rejects a remote rewind observed after preview" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            _ <- git root ["push", "-q", "origin", "main"]
+            appendFile (root <> "/tracked.txt") "third\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "third"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            rewound <- Text.strip <$> git root ["rev-parse", "HEAD^^"]
+            _ <- git root
+                [ "--git-dir"
+                , remote
+                , "update-ref"
+                , "refs/heads/main"
+                , Text.unpack rewound
+                ]
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isStale
+            remoteHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            remoteHead `shouldBe` rewound
+
+    it "binds confirmation to the upstream push destination" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            let redirected = remote <> "-redirected"
+            _ <- git root ["init", "-q", "--bare", redirected]
+            _ <- git root ["remote", "set-url", "--push", "origin", redirected]
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isInvalid
+            originalHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            originalHead `shouldBe` preview.pushPreviewStatus.deliveryUpstreamOid
+
+    it "rejects malformed PR inputs before invoking GitHub CLI" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            previewPullRequest
+                root snapshot.snapshotId "-bad" "title" "body"
+                `shouldReturnSatisfying` isInvalid
+            previewPullRequest
+                root snapshot.snapshotId "main" "" "body"
+                `shouldReturnSatisfying` isInvalid
+            previewPullRequest
+                root snapshot.snapshotId "main" "title"
+                (Text.replicate (1024 * 1024 + 1) "x")
+                `shouldReturnSatisfying` isInvalid
+
+    it "previews and creates a PR through argv-only gh with a one-shot token" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \bodyCapture injectionMarker -> do
+                snapshot <- expectRight =<< repositorySnapshot root
+                let title =
+                        "Safe title $(touch "
+                            <> Text.pack injectionMarker
+                            <> ")"
+                    body = "Body is passed on stdin, not argv."
+                preview <- expectRight
+                    =<< previewPullRequest
+                        root snapshot.snapshotId "main" title body
+                preview.pullRequestRepository `shouldBe` "owner/repository"
+                preview.pullRequestHeadRef `shouldBe` "main"
+                url <- expectRight
+                    =<< createPullRequest
+                        root
+                        preview.pullRequestConfirmation
+                url `shouldBe`
+                    "https://github.com/owner/repository/pull/123"
+                readFile bodyCapture `shouldReturn` Text.unpack body
+                doesFileExist injectionMarker `shouldReturn` False
+                createPullRequest root preview.pullRequestConfirmation
+                    `shouldReturnSatisfying` isConfirmationRejection
+
+    it "rejects a gh result URL for another repository" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \_ _ -> do
+                setEnv "GH_FAKE_PR_URL"
+                    "https://github.com/attacker/repository/pull/1"
+                snapshot <- expectRight =<< repositorySnapshot root
+                preview <- expectRight
+                    =<< previewPullRequest
+                        root snapshot.snapshotId "main" "Title" "Body"
+                createPullRequest root preview.pullRequestConfirmation
+                    `shouldReturnSatisfying` isCommandFailure
+
+withDeliveryRepository :: (FilePath -> FilePath -> IO value) -> IO value
+withDeliveryRepository action =
+    withTempDirectory "repository-delivery" \container -> do
+        let root = container <> "/checkout"
+            remote = container <> "/remote.git"
+        createDirectory root
+        _ <- git container ["init", "-q", "--bare", remote]
+        _ <- git root ["init", "-q", "-b", "main"]
+        _ <- git root ["config", "user.name", "Repository Delivery Test"]
+        _ <- git root ["config", "user.email", "delivery@example.test"]
+        writeFile (root <> "/tracked.txt") "first\n"
+        _ <- git root ["add", "tracked.txt"]
+        _ <- git root ["commit", "-q", "-m", "initial"]
+        _ <- git root ["remote", "add", "origin", remote]
+        _ <- git root ["push", "-q", "-u", "origin", "main"]
+        action root remote
+
+withTempDirectory :: String -> (FilePath -> IO value) -> IO value
+withTempDirectory template action = do
+    base <- getTemporaryDirectory
+    bracket
+        (do
+            (path, handle) <- openTempFile base template
+            hClose handle
+            removePathForcibly path
+            createDirectory path
+            pure path)
+        removePathForcibly
+        action
+
+withFakeGh
+    :: FilePath
+    -> (FilePath -> FilePath -> IO value)
+    -> IO value
+withFakeGh root action = do
+    originalPath <- getEnv "PATH"
+    originalCapture <- lookupEnv "GH_BODY_CAPTURE"
+    originalFakeUrl <- lookupEnv "GH_FAKE_PR_URL"
+    withTempDirectory "repository-delivery-gh" \bin -> do
+        let executable = bin <> "/gh"
+            bodyCapture = bin <> "/body.txt"
+            injectionMarker = root <> "/shell-injection"
+        writeFile executable $ unlines
+            [ "#!/bin/sh"
+            , "set -eu"
+            , "case \"$1 $2\" in"
+            , "  'auth status') exit 0 ;;"
+            , "  'repo view') printf '%s\\n' '{\"nameWithOwner\":\"owner/repository\"}' ;;"
+            , "  'pr list') printf '%s\\n' '[]' ;;"
+            , "  'pr create')"
+            , "    cat > \"$GH_BODY_CAPTURE\""
+            , "    printf '%s\\n' \"${GH_FAKE_PR_URL:-https://github.com/owner/repository/pull/123}\""
+            , "    ;;"
+            , "  *) exit 64 ;;"
+            , "esac"
+            ]
+        setFileMode executable
+            (ownerReadMode
+                `unionFileModes` ownerWriteMode
+                `unionFileModes` ownerExecuteMode)
+        bracket
+            (do
+                setEnv "PATH" (bin <> ":" <> originalPath)
+                setEnv "GH_BODY_CAPTURE" bodyCapture)
+            (\_ -> do
+                setEnv "PATH" originalPath
+                case originalCapture of
+                    Nothing -> unsetEnv "GH_BODY_CAPTURE"
+                    Just value -> setEnv "GH_BODY_CAPTURE" value
+                case originalFakeUrl of
+                    Nothing -> unsetEnv "GH_FAKE_PR_URL"
+                    Just value -> setEnv "GH_FAKE_PR_URL" value)
+            (\_ -> action bodyCapture injectionMarker)
+
+git :: FilePath -> [String] -> IO Text.Text
+git root arguments = do
+    (exitCode, output, errors) <-
+        readCreateProcessWithExitCode
+            (proc "git" arguments) { cwd = Just root }
+            ""
+    case exitCode of
+        ExitSuccess -> pure (Text.pack output)
+        ExitFailure code ->
+            expectationFailure
+                ("git exited " <> show code <> ": " <> errors)
+                >> pure ""
+
+expectRight :: (HasCallStack, Show error) => Either error value -> IO value
+expectRight = \case
+    Left err -> expectationFailure (show err) >> fail "unreachable"
+    Right value -> pure value
+
+isInvalid :: Either DeliveryError value -> Bool
+isInvalid = \case
+    Left (DeliveryInvalidRequest _) -> True
+    _ -> False
+
+isCommandFailure :: Either DeliveryError value -> Bool
+isCommandFailure = \case
+    Left (DeliveryCommandFailed _) -> True
+    _ -> False
+
+isStale :: Either DeliveryError value -> Bool
+isStale = \case
+    Left (DeliveryStale _) -> True
+    _ -> False
+
+isConfirmationRejection :: Either DeliveryError value -> Bool
+isConfirmationRejection = \case
+    Left (DeliveryConfirmationRejected _) -> True
+    _ -> False
+
+shouldReturnSatisfying
+    :: (HasCallStack, Show value)
+    => IO value
+    -> (value -> Bool)
+    -> Expectation
+shouldReturnSatisfying action predicate =
+    action >>= (`shouldSatisfy` predicate)
+
+shellQuote :: String -> String
+shellQuote value = "'" <> concatMap escape value <> "'"
+  where
+    escape '\'' = "'\"'\"'"
+    escape character = [character]

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -10,6 +10,7 @@ import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
     , doesFileExist
+    , findExecutable
     , getTemporaryDirectory
     , removePathForcibly
     )
@@ -44,7 +45,7 @@ spec = describe "repository delivery service" do
         validateRemoteName "-origin" `shouldBe` False
         validateRemoteName "origin\n--upload-pack=evil" `shouldBe` False
 
-    it "previews and confirms one exact non-force push once" $
+    it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"
             _ <- git root ["add", "tracked.txt"]
@@ -85,6 +86,30 @@ spec = describe "repository delivery service" do
 
             confirmRepositoryPush root preview.pushPreviewConfirmation
                 `shouldReturnSatisfying` isConfirmationRejection
+
+    it "creates an unborn configured upstream using an exact nonexistence lease" $
+        withDeliveryRepository \root remote -> do
+            _ <- git root ["switch", "-q", "-c", "new-branch"]
+            _ <- git root ["config", "branch.new-branch.remote", "origin"]
+            _ <- git root
+                [ "config"
+                , "branch.new-branch.merge"
+                , "refs/heads/new-branch"
+                ]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            pushed <- expectRight
+                =<< confirmRepositoryPush
+                    root preview.pushPreviewConfirmation
+            remoteHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/new-branch"
+                    ]
+            remoteHead `shouldBe` pushed.deliveryHeadOid
 
     it "consumes a preview without pushing when the local snapshot changes" $
         withDeliveryRepository \root remote -> do
@@ -195,10 +220,37 @@ spec = describe "repository delivery service" do
                 =<< previewRepositoryPush root snapshot.snapshotId
             let redirected = remote <> "-redirected"
             _ <- git root ["init", "-q", "--bare", redirected]
-            _ <- git root ["remote", "set-url", "--push", "origin", redirected]
+            _ <- git root ["remote", "set-url", "origin", redirected]
 
             confirmRepositoryPush root preview.pushPreviewConfirmation
-                `shouldReturnSatisfying` isInvalid
+                `shouldReturnSatisfying` isStale
+            originalHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            originalHead `shouldBe` preview.pushPreviewStatus.deliveryUpstreamOid
+
+    it "rejects an insteadOf config retarget after preview" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            let redirected = remote <> "-config-redirected"
+            _ <- git root ["init", "-q", "--bare", redirected]
+            _ <- git root
+                [ "config"
+                , "url." <> redirected <> ".insteadOf"
+                , remote
+                ]
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isStale
             originalHead <- Text.strip
                 <$> git root
                     [ "--git-dir"
@@ -259,6 +311,15 @@ spec = describe "repository delivery service" do
                 createPullRequest root preview.pullRequestConfirmation
                     `shouldReturnSatisfying` isCommandFailure
 
+    it "rejects gh repository identity that differs from the bound remote" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \_ _ -> do
+                setEnv "GH_FAKE_REPOSITORY" "attacker/repository"
+                snapshot <- expectRight =<< repositorySnapshot root
+                previewPullRequest
+                    root snapshot.snapshotId "main" "Title" "Body"
+                    `shouldReturnSatisfying` isUnavailable
+
 withDeliveryRepository :: (FilePath -> FilePath -> IO value) -> IO value
 withDeliveryRepository action =
     withTempDirectory "repository-delivery" \container -> do
@@ -297,16 +358,40 @@ withFakeGh root action = do
     originalPath <- getEnv "PATH"
     originalCapture <- lookupEnv "GH_BODY_CAPTURE"
     originalFakeUrl <- lookupEnv "GH_FAKE_PR_URL"
+    originalFakeRepository <- lookupEnv "GH_FAKE_REPOSITORY"
     withTempDirectory "repository-delivery-gh" \bin -> do
-        let executable = bin <> "/gh"
+        realGit <- maybe (fail "git not found") pure =<< findExecutable "git"
+        localRemote <- Text.unpack . Text.strip
+            <$> git root ["remote", "get-url", "origin"]
+        let githubRemote = "https://github.com/owner/repository.git"
+            executable = bin <> "/gh"
+            gitExecutable = bin <> "/git"
             bodyCapture = bin <> "/body.txt"
             injectionMarker = root <> "/shell-injection"
+        _ <- git root ["remote", "set-url", "origin", githubRemote]
+        writeFile gitExecutable $ unlines
+            [ "#!/bin/bash"
+            , "set -eu"
+            , "args=()"
+            , "for arg in \"$@\"; do"
+            , "  if [[ \"$arg\" == " <> shellQuote githubRemote <> " ]]; then"
+            , "    args+=(" <> shellQuote localRemote <> ")"
+            , "  else"
+            , "    args+=(\"$arg\")"
+            , "  fi"
+            , "done"
+            , "exec " <> shellQuote realGit <> " \"${args[@]}\""
+            ]
+        setFileMode gitExecutable
+            (ownerReadMode
+                `unionFileModes` ownerWriteMode
+                `unionFileModes` ownerExecuteMode)
         writeFile executable $ unlines
             [ "#!/bin/sh"
             , "set -eu"
             , "case \"$1 $2\" in"
             , "  'auth status') exit 0 ;;"
-            , "  'repo view') printf '%s\\n' '{\"nameWithOwner\":\"owner/repository\"}' ;;"
+            , "  'repo view') printf '{\"nameWithOwner\":\"%s\"}\\n' \"${GH_FAKE_REPOSITORY:-owner/repository}\" ;;"
             , "  'pr list') printf '%s\\n' '[]' ;;"
             , "  'pr create')"
             , "    cat > \"$GH_BODY_CAPTURE\""
@@ -330,7 +415,10 @@ withFakeGh root action = do
                     Just value -> setEnv "GH_BODY_CAPTURE" value
                 case originalFakeUrl of
                     Nothing -> unsetEnv "GH_FAKE_PR_URL"
-                    Just value -> setEnv "GH_FAKE_PR_URL" value)
+                    Just value -> setEnv "GH_FAKE_PR_URL" value
+                case originalFakeRepository of
+                    Nothing -> unsetEnv "GH_FAKE_REPOSITORY"
+                    Just value -> setEnv "GH_FAKE_REPOSITORY" value)
             (\_ -> action bodyCapture injectionMarker)
 
 git :: FilePath -> [String] -> IO Text.Text
@@ -354,6 +442,11 @@ expectRight = \case
 isInvalid :: Either DeliveryError value -> Bool
 isInvalid = \case
     Left (DeliveryInvalidRequest _) -> True
+    _ -> False
+
+isUnavailable :: Either DeliveryError value -> Bool
+isUnavailable = \case
+    Left (DeliveryUnavailable _) -> True
     _ -> False
 
 isCommandFailure :: Either DeliveryError value -> Bool

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -90,6 +90,18 @@ spec = describe "repository delivery service" do
                             Text.isInfixOf (Text.pack credentialUrl)
                 Right _ -> expectationFailure "credential URL was accepted"
 
+    it "rejects credential-bearing SCP-like URLs" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "git@owner:secret@example.test/repository.git"
+                ]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+
     it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"
@@ -359,8 +371,8 @@ spec = describe "repository delivery service" do
     it "kills a gh descendant retaining pipes after its leader exits" $
         withDeliveryRepository \root _ ->
             withFakeGh root \_ _ -> do
-                let descendantMarker = root <> "/gh-descendant-survived"
-                setEnv "GH_RETAIN_PIPE_MARKER" descendantMarker
+                let descendantPid = root <> "/gh-descendant.pid"
+                setEnv "GH_RETAIN_PIPE_MARKER" descendantPid
                 snapshot <- expectRight =<< repositorySnapshot root
                 result <- timeout 5_000_000
                     (previewPullRequest
@@ -368,8 +380,14 @@ spec = describe "repository delivery service" do
                 result `shouldSatisfy` \case
                     Just (Right _) -> True
                     _ -> False
-                threadDelay 2_500_000
-                doesFileExist descendantMarker `shouldReturn` False
+                pid <- words <$> readFile descendantPid
+                pid `shouldSatisfy` \case
+                    [_] -> True
+                    _ -> False
+                processGoneWithin
+                    3_000_000
+                    (head pid)
+                    `shouldReturn` True
 
     it "rejects a gh result URL for another repository" $
         withDeliveryRepository \root _ ->
@@ -465,7 +483,8 @@ withFakeGh root action = do
             , "set -eu"
             , "[ \"${GH_HOST:-}\" = '' ] || exit 65"
             , "if [ \"${GH_RETAIN_PIPE_MARKER:-}\" != '' ] && [ \"$1 $2\" = 'auth status' ]; then"
-            , "  (sleep 2; printf survived > \"$GH_RETAIN_PIPE_MARKER\") &"
+            , "  sleep 30 &"
+            , "  printf '%s\\n' \"$!\" > \"$GH_RETAIN_PIPE_MARKER\""
             , "  exit 0"
             , "fi"
             , "case \"$1 $2\" in"
@@ -577,6 +596,21 @@ shouldReturnSatisfying
     -> Expectation
 shouldReturnSatisfying action predicate =
     action >>= (`shouldSatisfy` predicate)
+
+processGoneWithin :: Int -> String -> IO Bool
+processGoneWithin remaining pid
+    | remaining <= 0 = fmap not processExists
+    | otherwise =
+        processExists >>= \case
+            False -> pure True
+            True -> do
+                threadDelay 100_000
+                processGoneWithin (remaining - 100_000) pid
+  where
+    processExists = do
+        (exitCode, _, _) <-
+            readCreateProcessWithExitCode (proc "kill" ["-0", pid]) ""
+        pure (exitCode == ExitSuccess)
 
 shellQuote :: String -> String
 shellQuote value = "'" <> concatMap escape value <> "'"

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -102,6 +102,26 @@ spec = describe "repository delivery service" do
             repositoryDeliveryStatus root snapshot.snapshotId
                 `shouldReturnSatisfying` isInvalid
 
+    it "rejects percent-encoded credential-bearing URLs" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "ssh://git%3Asecret@example.test/repository.git"
+                ]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "git%3Asecret@example.test:owner/repository.git"
+                ]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+
     it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -5,6 +5,8 @@ import Agent.CLI.RepositoryReview
     ( RepositorySnapshot(..)
     , repositorySnapshot
     )
+import System.Timeout (timeout)
+import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (bracket)
 import qualified Data.Text as Text
 import System.Directory
@@ -314,6 +316,21 @@ spec = describe "repository delivery service" do
                 createPullRequest root preview.pullRequestConfirmation
                     `shouldReturnSatisfying` isConfirmationRejection
 
+    it "kills a gh descendant retaining pipes after its leader exits" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \_ _ -> do
+                let descendantMarker = root <> "/gh-descendant-survived"
+                setEnv "GH_RETAIN_PIPE_MARKER" descendantMarker
+                snapshot <- expectRight =<< repositorySnapshot root
+                result <- timeout 5_000_000
+                    (previewPullRequest
+                        root snapshot.snapshotId "main" "Title" "Body")
+                result `shouldSatisfy` \case
+                    Just (Right _) -> True
+                    _ -> False
+                threadDelay 2_500_000
+                doesFileExist descendantMarker `shouldReturn` False
+
     it "rejects a gh result URL for another repository" $
         withDeliveryRepository \root _ ->
             withFakeGh root \_ _ -> do
@@ -374,6 +391,7 @@ withFakeGh root action = do
     originalCapture <- lookupEnv "GH_BODY_CAPTURE"
     originalFakeUrl <- lookupEnv "GH_FAKE_PR_URL"
     originalFakeRepository <- lookupEnv "GH_FAKE_REPOSITORY"
+    originalRetainPipeMarker <- lookupEnv "GH_RETAIN_PIPE_MARKER"
     withTempDirectory "repository-delivery-gh" \bin -> do
         realGit <- maybe (fail "git not found") pure =<< findExecutable "git"
         localRemote <- Text.unpack . Text.strip
@@ -404,6 +422,10 @@ withFakeGh root action = do
         writeFile executable $ unlines
             [ "#!/bin/sh"
             , "set -eu"
+            , "if [ \"${GH_RETAIN_PIPE_MARKER:-}\" != '' ] && [ \"$1 $2\" = 'auth status' ]; then"
+            , "  (sleep 2; printf survived > \"$GH_RETAIN_PIPE_MARKER\") &"
+            , "  exit 0"
+            , "fi"
             , "case \"$1 $2\" in"
             , "  'auth status') exit 0 ;;"
             , "  'repo view') printf '{\"nameWithOwner\":\"%s\"}\\n' \"${GH_FAKE_REPOSITORY:-owner/repository}\" ;;"
@@ -433,7 +455,10 @@ withFakeGh root action = do
                     Just value -> setEnv "GH_FAKE_PR_URL" value
                 case originalFakeRepository of
                     Nothing -> unsetEnv "GH_FAKE_REPOSITORY"
-                    Just value -> setEnv "GH_FAKE_REPOSITORY" value)
+                    Just value -> setEnv "GH_FAKE_REPOSITORY" value
+                case originalRetainPipeMarker of
+                    Nothing -> unsetEnv "GH_RETAIN_PIPE_MARKER"
+                    Just value -> setEnv "GH_RETAIN_PIPE_MARKER" value)
             (\_ -> action bodyCapture injectionMarker)
 
 git :: FilePath -> [String] -> IO Text.Text

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -62,6 +62,34 @@ spec = describe "repository delivery service" do
             repositoryDeliveryStatus root snapshot.snapshotId
                 `shouldReturnSatisfying` isInvalid
 
+    it "rejects credential-bearing URLs without echoing their secret" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "ssh://git@example.test/owner/repository.git"
+                ]
+            _ <- expectRight
+                =<< repositoryDeliveryStatus root snapshot.snapshotId
+            let secret = "delivery-secret-must-not-escape"
+                credentialUrl =
+                    "https://user:"
+                        <> secret
+                        <> "@example.test/owner/repository.git"
+            _ <- git root ["remote", "set-url", "origin", credentialUrl]
+            result <- repositoryDeliveryStatus root snapshot.snapshotId
+            result `shouldSatisfy` isInvalid
+            case result of
+                Left err -> do
+                    deliveryErrorText err
+                        `shouldNotSatisfy` Text.isInfixOf (Text.pack secret)
+                    deliveryErrorText err
+                        `shouldNotSatisfy`
+                            Text.isInfixOf (Text.pack credentialUrl)
+                Right _ -> expectationFailure "credential URL was accepted"
+
     it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"
@@ -316,6 +344,18 @@ spec = describe "repository delivery service" do
                 createPullRequest root preview.pullRequestConfirmation
                     `shouldReturnSatisfying` isConfirmationRejection
 
+    it "ignores hostile GH_HOST and binds gh operations to github.com" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \_ _ -> do
+                setEnv "GH_HOST" "attacker.example"
+                snapshot <- expectRight =<< repositorySnapshot root
+                preview <- expectRight
+                    =<< previewPullRequest
+                        root snapshot.snapshotId "main" "Title" "Body"
+                _ <- createPullRequest root preview.pullRequestConfirmation
+                    >>= expectRight
+                pure ()
+
     it "kills a gh descendant retaining pipes after its leader exits" $
         withDeliveryRepository \root _ ->
             withFakeGh root \_ _ -> do
@@ -392,6 +432,7 @@ withFakeGh root action = do
     originalFakeUrl <- lookupEnv "GH_FAKE_PR_URL"
     originalFakeRepository <- lookupEnv "GH_FAKE_REPOSITORY"
     originalRetainPipeMarker <- lookupEnv "GH_RETAIN_PIPE_MARKER"
+    originalGhHost <- lookupEnv "GH_HOST"
     withTempDirectory "repository-delivery-gh" \bin -> do
         realGit <- maybe (fail "git not found") pure =<< findExecutable "git"
         localRemote <- Text.unpack . Text.strip
@@ -422,15 +463,37 @@ withFakeGh root action = do
         writeFile executable $ unlines
             [ "#!/bin/sh"
             , "set -eu"
+            , "[ \"${GH_HOST:-}\" = '' ] || exit 65"
             , "if [ \"${GH_RETAIN_PIPE_MARKER:-}\" != '' ] && [ \"$1 $2\" = 'auth status' ]; then"
             , "  (sleep 2; printf survived > \"$GH_RETAIN_PIPE_MARKER\") &"
             , "  exit 0"
             , "fi"
             , "case \"$1 $2\" in"
-            , "  'auth status') exit 0 ;;"
-            , "  'repo view') printf '{\"nameWithOwner\":\"%s\"}\\n' \"${GH_FAKE_REPOSITORY:-owner/repository}\" ;;"
-            , "  'pr list') printf '%s\\n' '[]' ;;"
+            , "  'auth status')"
+            , "    case \" $* \" in"
+            , "      *' --hostname github.com '*) exit 0 ;;"
+            , "      *) exit 65 ;;"
+            , "    esac"
+            , "    ;;"
+            , "  'repo view')"
+            , "    case \" $* \" in"
+            , "      *' --repo github.com/owner/repository '*) ;;"
+            , "      *) exit 65 ;;"
+            , "    esac"
+            , "    printf '{\"nameWithOwner\":\"%s\"}\\n' \"${GH_FAKE_REPOSITORY:-owner/repository}\""
+            , "    ;;"
+            , "  'pr list')"
+            , "    case \" $* \" in"
+            , "      *' --repo github.com/owner/repository '*) ;;"
+            , "      *) exit 65 ;;"
+            , "    esac"
+            , "    printf '%s\\n' '[]'"
+            , "    ;;"
             , "  'pr create')"
+            , "    case \" $* \" in"
+            , "      *' --repo github.com/owner/repository '*) ;;"
+            , "      *) exit 65 ;;"
+            , "    esac"
             , "    cat > \"$GH_BODY_CAPTURE\""
             , "    printf '%s\\n' \"${GH_FAKE_PR_URL:-https://github.com/owner/repository/pull/123}\""
             , "    ;;"
@@ -458,7 +521,10 @@ withFakeGh root action = do
                     Just value -> setEnv "GH_FAKE_REPOSITORY" value
                 case originalRetainPipeMarker of
                     Nothing -> unsetEnv "GH_RETAIN_PIPE_MARKER"
-                    Just value -> setEnv "GH_RETAIN_PIPE_MARKER" value)
+                    Just value -> setEnv "GH_RETAIN_PIPE_MARKER" value
+                case originalGhHost of
+                    Nothing -> unsetEnv "GH_HOST"
+                    Just value -> setEnv "GH_HOST" value)
             (\_ -> action bodyCapture injectionMarker)
 
 git :: FilePath -> [String] -> IO Text.Text

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -45,6 +45,21 @@ spec = describe "repository delivery service" do
         validateRemoteName "-origin" `shouldBe` False
         validateRemoteName "origin\n--upload-pack=evil" `shouldBe` False
 
+    it "rejects relative paths and custom remote-helper transports" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            _ <- git root ["remote", "set-url", "origin", "../redirected.git"]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "ext::sh -c 'touch should-not-run'"
+                ]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+
     it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -7,10 +7,12 @@ import Control.Concurrent.MVar
     , takeMVar
     )
 import Control.Exception.Safe (bracket)
+import Control.Monad (forM_)
 import qualified Data.ByteString.Char8 as BS8
 import Data.Either (isLeft)
 import Data.IORef
-    ( modifyIORef'
+    ( atomicModifyIORef'
+    , modifyIORef'
     , newIORef
     , readIORef
     )
@@ -146,7 +148,7 @@ spec = describe "repository review service" do
                 =<< mutateRepository
                     root
                     before.snapshotId
-                    (StagePatch diff.repositoryDiffPatch)
+                    (StagePatch "tracked.txt" diff.repositoryDiffPatch)
             git root ["diff", "--cached", "--name-only"]
                 `shouldReturn` "tracked.txt\n"
 
@@ -160,7 +162,9 @@ spec = describe "repository review service" do
                 =<< mutateRepository
                     root
                     staged.snapshotId
-                    (UnstagePatch unstageDiff.repositoryDiffPatch)
+                    (UnstagePatch
+                        "tracked.txt"
+                        unstageDiff.repositoryDiffPatch)
             git root ["diff", "--cached", "--name-only"] `shouldReturn` ""
 
             writeFile (root <> "/untracked.txt") "keep\n"
@@ -170,6 +174,93 @@ spec = describe "repository review service" do
                 current.snapshotId
                 (RestorePath "untracked.txt")
             result `shouldSatisfy` isLeft
+            doesFileExist (root <> "/untracked.txt") `shouldReturn` True
+
+    it "accepts an unchanged subset of reviewed hunks" $
+        withRepository \root -> do
+            writeFile
+                (root <> "/tracked.txt")
+                (unlines (map (("line " <>) . show) [1 :: Int .. 12]))
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "lines"]
+            writeFile
+                (root <> "/tracked.txt")
+                (unlines
+                    [ if number `elem` [2, 11]
+                        then "changed " <> show number
+                        else "line " <> show number
+                    | number <- [1 :: Int .. 12]
+                    ])
+            snapshot <- expectRight =<< repositorySnapshot root
+            diff <- expectRight
+                =<< repositoryDiff root snapshot.snapshotId
+                    RepositoryWorktreeDiff "tracked.txt"
+            let selected = firstPatchHunk diff.repositoryDiffPatch
+            selected `shouldSatisfy` (/= diff.repositoryDiffPatch)
+            _ <- expectRight
+                =<< mutateRepository root snapshot.snapshotId
+                    (StagePatch "tracked.txt" selected)
+            stagedPatch <- git root ["diff", "--cached"]
+            stagedPatch `shouldSatisfy` Text.isInfixOf "+changed 2"
+            stagedPatch `shouldNotSatisfy` Text.isInfixOf "+changed 11"
+
+    it "rejects pathspec magic, globs, and traversal without broad mutation" $
+        withRepository \root -> do
+            writeFile (root <> "/second.txt") "second\n"
+            _ <- git root ["add", "second.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            appendFile (root <> "/tracked.txt") "pending\n"
+            appendFile (root <> "/second.txt") "pending\n"
+
+            forM_ ["*", ":!tracked.txt", "../tracked.txt", "a/../tracked.txt"] $
+                \path -> do
+                    snapshot <- expectRight =<< repositorySnapshot root
+                    mutateRepository root snapshot.snapshotId (StagePath path)
+                        `shouldReturnSatisfying` isInvalidRequest
+                    git root ["diff", "--cached", "--name-only"]
+                        `shouldReturn` ""
+
+    it "binds patch mutations to one reviewed path and exact hunk content" $
+        withRepository \root -> do
+            writeFile (root <> "/second.txt") "second\n"
+            _ <- git root ["add", "second.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            appendFile (root <> "/tracked.txt") "tracked change\n"
+            appendFile (root <> "/second.txt") "second change\n"
+            snapshot <- expectRight =<< repositorySnapshot root
+            trackedDiff <- expectRight
+                =<< repositoryDiff root snapshot.snapshotId
+                    RepositoryWorktreeDiff "tracked.txt"
+            secondDiff <- expectRight
+                =<< repositoryDiff root snapshot.snapshotId
+                    RepositoryWorktreeDiff "second.txt"
+
+            mutateRepository root snapshot.snapshotId
+                (StagePatch "tracked.txt" secondDiff.repositoryDiffPatch)
+                `shouldReturnSatisfying` isInvalidRequest
+            mutateRepository root snapshot.snapshotId
+                (StagePatch
+                    "tracked.txt"
+                    (trackedDiff.repositoryDiffPatch
+                        <> secondDiff.repositoryDiffPatch))
+                `shouldReturnSatisfying` isInvalidRequest
+            mutateRepository root snapshot.snapshotId
+                (StagePatch
+                    "tracked.txt"
+                    (trackedDiff.repositoryDiffPatch <> "+injected\n"))
+                `shouldReturnSatisfying` isInvalidRequest
+            git root ["diff", "--cached", "--name-only"] `shouldReturn` ""
+
+            writeFile (root <> "/untracked.txt") "keep\n"
+            untrackedSnapshot <- expectRight =<< repositorySnapshot root
+            untrackedDiff <- expectRight
+                =<< repositoryDiff root untrackedSnapshot.snapshotId
+                    RepositoryWorktreeDiff "untracked.txt"
+            mutateRepository root untrackedSnapshot.snapshotId
+                (RestorePatch
+                    "untracked.txt"
+                    untrackedDiff.repositoryDiffPatch)
+                `shouldReturnSatisfying` isInvalidRequest
             doesFileExist (root <> "/untracked.txt") `shouldReturn` True
 
     it "streams an explicit argv check and reports its exit status" $
@@ -196,6 +287,35 @@ spec = describe "repository review service" do
                 , (RepositoryCheckStderr, "stderr-value")
                 ])
 
+    it "drains large stdout and stderr streams without pipe deadlock" $
+        withRepository \root -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            byteCounts <- newIORef (0, 0)
+            terminal <- newEmptyMVar
+            check <- expectRight
+                =<< startRepositoryCheck
+                    root
+                    snapshot.snapshotId
+                    "/bin/sh"
+                    [ "-c"
+                    , "/usr/bin/yes o | /usr/bin/head -c 1048576; "
+                        <> "/usr/bin/yes e | /usr/bin/head -c 1048576 >&2"
+                    ]
+                    (\stream bytes ->
+                        atomicModifyIORef' byteCounts \(out, err) ->
+                            ( case stream of
+                                RepositoryCheckStdout ->
+                                    (out + BS8.length bytes, err)
+                                RepositoryCheckStderr ->
+                                    (out, err + BS8.length bytes)
+                            , ()
+                            ))
+                    (\cancelled exitCode ->
+                        putMVar terminal (cancelled, exitCode))
+            waitRepositoryCheck check
+            takeMVar terminal `shouldReturn` (False, ExitSuccess)
+            readIORef byteCounts `shouldReturn` (1048576, 1048576)
+
     it "cancels and joins a running check" $
         withRepository \root -> do
             snapshot <- expectRight =<< repositorySnapshot root
@@ -204,8 +324,11 @@ spec = describe "repository review service" do
                 =<< startRepositoryCheck
                     root
                     snapshot.snapshotId
-                    "/bin/sleep"
-                    ["30"]
+                    "/bin/sh"
+                    [ "-c"
+                    , "trap '' TERM; "
+                        <> "(trap '' TERM; exec /bin/sleep 30) & wait"
+                    ]
                     (\_ _ -> pure ())
                     (\cancelled exitCode ->
                         putMVar terminal (cancelled, exitCode))
@@ -256,3 +379,29 @@ expectRight :: (HasCallStack, Show error) => Either error value -> IO value
 expectRight = \case
     Left err -> expectationFailure (show err) >> fail "unreachable"
     Right value -> pure value
+
+isInvalidRequest
+    :: Either RepositoryError RepositorySnapshot
+    -> Bool
+isInvalidRequest = \case
+    Left (InvalidRepositoryRequest _) -> True
+    _ -> False
+
+shouldReturnSatisfying
+    :: (HasCallStack, Show value)
+    => IO value
+    -> (value -> Bool)
+    -> Expectation
+shouldReturnSatisfying action predicate =
+    action >>= (`shouldSatisfy` predicate)
+
+firstPatchHunk :: BS8.ByteString -> BS8.ByteString
+firstPatchHunk patch =
+    let lines' = BS8.lines patch
+        isHunk = BS8.isPrefixOf "@@ "
+        (header, body) = break isHunk lines'
+    in case body of
+        [] -> patch
+        first:rest ->
+            let (hunkBody, _) = break isHunk rest
+            in BS8.unlines (header <> [first] <> hunkBody)

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -6,7 +6,7 @@ import Control.Concurrent.MVar
     , putMVar
     , takeMVar
     )
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, throwString)
 import Control.Monad (forM_)
 import qualified Data.ByteString.Char8 as BS8
 import Data.Either (isLeft)
@@ -316,10 +316,30 @@ spec = describe "repository review service" do
             takeMVar terminal `shouldReturn` (False, ExitSuccess)
             readIORef byteCounts `shouldReturn` (1048576, 1048576)
 
+    it "reports one terminal result when an output callback throws" $
+        withRepository \root -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            terminalCount <- newIORef (0 :: Int)
+            terminal <- newEmptyMVar
+            check <- expectRight
+                =<< startRepositoryCheck
+                    root
+                    snapshot.snapshotId
+                    "/bin/sh"
+                    ["-c", "printf callback-value; exit 9"]
+                    (\_ _ -> throwString "callback failed")
+                    (\cancelled exitCode -> do
+                        modifyIORef' terminalCount (+ 1)
+                        putMVar terminal (cancelled, exitCode))
+            waitRepositoryCheck check
+            takeMVar terminal `shouldReturn` (False, ExitFailure 9)
+            readIORef terminalCount `shouldReturn` 1
+
     it "cancels and joins a running check" $
         withRepository \root -> do
             snapshot <- expectRight =<< repositorySnapshot root
             terminal <- newEmptyMVar
+            terminalCount <- newIORef (0 :: Int)
             check <- expectRight
                 =<< startRepositoryCheck
                     root
@@ -330,7 +350,8 @@ spec = describe "repository review service" do
                         <> "(trap '' TERM; exec /bin/sleep 30) & wait"
                     ]
                     (\_ _ -> pure ())
-                    (\cancelled exitCode ->
+                    (\cancelled exitCode -> do
+                        modifyIORef' terminalCount (+ 1)
                         putMVar terminal (cancelled, exitCode))
             cancelRepositoryCheck check
             waitRepositoryCheck check
@@ -338,6 +359,7 @@ spec = describe "repository review service" do
             result `shouldSatisfy` \case
                 Just (True, ExitFailure _) -> True
                 _ -> False
+            readIORef terminalCount `shouldReturn` 1
 
 withRepository :: (FilePath -> IO value) -> IO value
 withRepository action = withTempDirectory "repository-review" \root -> do

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -35,6 +35,17 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "repository review service" do
+    it "distinguishes an unborn HEAD from a broken HEAD" do
+        withTempDirectory "repository-review-unborn" \root -> do
+            _ <- git root ["init", "-q"]
+            unborn <- expectRight =<< repositorySnapshot root
+            unborn.snapshotHead `shouldBe` Nothing
+
+            writeFile (root <> "/.git/HEAD") "not-a-valid-head\n"
+            repositorySnapshot root `shouldReturnSatisfying` \case
+                Left _ -> True
+                Right _ -> False
+
     it "snapshots unusual paths and parses diff hunk coordinates" $
         withRepository \root -> do
             appendFile (root <> "/tracked.txt") "second\n"
@@ -133,6 +144,23 @@ spec = describe "repository review service" do
             committed.snapshotFiles `shouldBe` []
             Text.strip <$> git root ["log", "-1", "--pretty=%B"]
                 `shouldReturn` "review commit"
+
+    it "rejects commit when the reviewed index fingerprint changed" $
+        withRepository \root -> do
+            appendFile (root <> "/tracked.txt") "reviewed\n"
+            before <- expectRight =<< repositorySnapshot root
+            staged <- expectRight
+                =<< mutateRepository root before.snapshotId
+                    (StagePath "tracked.txt")
+            writeFile (root <> "/other.txt") "external\n"
+            _ <- git root ["add", "other.txt"]
+
+            commitRepository root staged.snapshotId "must not commit\n"
+                `shouldReturnSatisfying` \case
+                    Left (StaleRepositorySnapshot _ _) -> True
+                    _ -> False
+            git root ["log", "-1", "--pretty=%B"]
+                `shouldReturn` "initial\n\n"
 
     it "applies reviewed patches and refuses to delete untracked files" $
         withRepository \root -> do

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -407,6 +407,69 @@ spec = describe "repository review service" do
             takeMVar terminal `shouldReturn` (False, ExitFailure 9)
             readIORef terminalCount `shouldReturn` 1
 
+    it "joins a check descendant that retains output after its leader exits" $
+        withRepository \root -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            let pidFile = root <> "/check-background-child.pid"
+            terminal <- newEmptyMVar
+            check <- expectRight
+                =<< startRepositoryCheck
+                    root
+                    snapshot.snapshotId
+                    "/bin/sh"
+                    [ "-c"
+                    , "/bin/sh -c 'trap \"\" TERM; echo $$ > "
+                        <> shellQuote pidFile
+                        <> "; exec /bin/sleep 30' & "
+                        <> "while [ ! -s "
+                        <> shellQuote pidFile
+                        <> " ]; do /bin/sleep 0.01; done; exit 0"
+                    ]
+                    (\_ _ -> pure ())
+                    (\cancelled exitCode ->
+                        putMVar terminal (cancelled, exitCode))
+            childPid <- awaitFileContents pidFile 200
+            timeout 2_000_000 (waitRepositoryCheck check)
+                `shouldReturn` Just ()
+            takeMVar terminal `shouldReturn` (False, ExitSuccess)
+            awaitProcessGone (Text.strip childPid) 200
+                `shouldReturn` True
+
+    it "joins a successful commit hook descendant that retains Git output" $
+        withRepository \root -> do
+            appendFile (root <> "/tracked.txt") "hook completion\n"
+            before <- expectRight =<< repositorySnapshot root
+            staged <- expectRight
+                =<< mutateRepository root before.snapshotId
+                    (StagePath "tracked.txt")
+            let pidFile = root <> "/completed-hook-child.pid"
+                hook = root <> "/.git/hooks/pre-commit"
+            writeFile hook
+                ( "#!/usr/bin/python3\n"
+                    <> "import os, signal, time\n"
+                    <> "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+                    <> "pid = os.fork()\n"
+                    <> "if pid:\n"
+                    <> "    with open(" <> show pidFile
+                    <> ", 'w') as stream:\n"
+                    <> "        stream.write(str(pid))\n"
+                    <> "    os._exit(0)\n"
+                    <> "time.sleep(30)\n"
+                )
+            setFileMode hook
+                (ownerReadMode
+                    `unionFileModes` ownerWriteMode
+                    `unionFileModes` ownerExecuteMode)
+
+            result <- timeout 5_000_000
+                (commitRepository root staged.snapshotId "completed hook\n")
+            result `shouldSatisfy` \case
+                Just (Right _) -> True
+                _ -> False
+            childPid <- awaitFileContents pidFile 200
+            awaitProcessGone (Text.strip childPid) 200
+                `shouldReturn` True
+
     it "kills commit-hook descendants when the commit worker is cancelled" $
         withRepository \root -> do
             appendFile (root <> "/tracked.txt") "hook cancellation\n"

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -21,6 +21,7 @@ import System.Directory
     ( createDirectory
     , doesFileExist
     , getTemporaryDirectory
+    , removeFile
     , removePathForcibly
     )
 import System.Exit (ExitCode(..))
@@ -31,6 +32,7 @@ import System.Process
     , readCreateProcessWithExitCode
     )
 import System.Timeout (timeout)
+import System.Posix.Files (createSymbolicLink)
 import Test.Hspec
 
 spec :: Spec
@@ -45,6 +47,16 @@ spec = describe "repository review service" do
             repositorySnapshot root `shouldReturnSatisfying` \case
                 Left _ -> True
                 Right _ -> False
+
+    it "canonicalizes symlink aliases to one repository identity" $
+        withRepository \root ->
+            withTempDirectory "repository-review-alias" \container -> do
+                let alias = container <> "/alias"
+                createSymbolicLink root alias
+                direct <- expectRight =<< repositorySnapshot root
+                linked <- expectRight =<< repositorySnapshot alias
+                linked.snapshotRoot `shouldBe` direct.snapshotRoot
+                linked.snapshotId `shouldBe` direct.snapshotId
 
     it "snapshots unusual paths and parses diff hunk coordinates" $
         withRepository \root -> do
@@ -166,33 +178,19 @@ spec = describe "repository review service" do
         withRepository \root -> do
             appendFile (root <> "/tracked.txt") "patch\n"
             before <- expectRight =<< repositorySnapshot root
-            diff <- expectRight
-                =<< repositoryDiff
-                    root
-                    before.snapshotId
-                    RepositoryWorktreeDiff
-                    "tracked.txt"
             staged <- expectRight
                 =<< mutateRepository
                     root
                     before.snapshotId
-                    (StagePatch "tracked.txt" diff.repositoryDiffPatch)
+                    (StageHunks "tracked.txt" [0])
             git root ["diff", "--cached", "--name-only"]
                 `shouldReturn` "tracked.txt\n"
 
-            unstageDiff <- expectRight
-                =<< repositoryDiff
-                    root
-                    staged.snapshotId
-                    RepositoryStagedDiff
-                    "tracked.txt"
             _unstagedAfterPatch <- expectRight
                 =<< mutateRepository
                     root
                     staged.snapshotId
-                    (UnstagePatch
-                        "tracked.txt"
-                        unstageDiff.repositoryDiffPatch)
+                    (UnstageHunks "tracked.txt" [0])
             git root ["diff", "--cached", "--name-only"] `shouldReturn` ""
 
             writeFile (root <> "/untracked.txt") "keep\n"
@@ -220,14 +218,9 @@ spec = describe "repository review service" do
                     | number <- [1 :: Int .. 12]
                     ])
             snapshot <- expectRight =<< repositorySnapshot root
-            diff <- expectRight
-                =<< repositoryDiff root snapshot.snapshotId
-                    RepositoryWorktreeDiff "tracked.txt"
-            let selected = firstPatchHunk diff.repositoryDiffPatch
-            selected `shouldSatisfy` (/= diff.repositoryDiffPatch)
             _ <- expectRight
                 =<< mutateRepository root snapshot.snapshotId
-                    (StagePatch "tracked.txt" selected)
+                    (StageHunks "tracked.txt" [0])
             stagedPatch <- git root ["diff", "--cached"]
             stagedPatch `shouldSatisfy` Text.isInfixOf "+changed 2"
             stagedPatch `shouldNotSatisfy` Text.isInfixOf "+changed 11"
@@ -240,7 +233,14 @@ spec = describe "repository review service" do
             appendFile (root <> "/tracked.txt") "pending\n"
             appendFile (root <> "/second.txt") "pending\n"
 
-            forM_ ["*", ":!tracked.txt", "../tracked.txt", "a/../tracked.txt"] $
+            forM_
+                [ "*"
+                , ":!tracked.txt"
+                , ":(glob)**"
+                , ":(top)tracked.txt"
+                , "../tracked.txt"
+                , "a/../tracked.txt"
+                ] $
                 \path -> do
                     snapshot <- expectRight =<< repositorySnapshot root
                     mutateRepository root snapshot.snapshotId (StagePath path)
@@ -248,7 +248,7 @@ spec = describe "repository review service" do
                     git root ["diff", "--cached", "--name-only"]
                         `shouldReturn` ""
 
-    it "binds patch mutations to one reviewed path and exact hunk content" $
+    it "rejects invalid hunk selections and destructive selected patches" $
         withRepository \root -> do
             writeFile (root <> "/second.txt") "second\n"
             _ <- git root ["add", "second.txt"]
@@ -256,40 +256,29 @@ spec = describe "repository review service" do
             appendFile (root <> "/tracked.txt") "tracked change\n"
             appendFile (root <> "/second.txt") "second change\n"
             snapshot <- expectRight =<< repositorySnapshot root
-            trackedDiff <- expectRight
-                =<< repositoryDiff root snapshot.snapshotId
-                    RepositoryWorktreeDiff "tracked.txt"
-            secondDiff <- expectRight
-                =<< repositoryDiff root snapshot.snapshotId
-                    RepositoryWorktreeDiff "second.txt"
-
             mutateRepository root snapshot.snapshotId
-                (StagePatch "tracked.txt" secondDiff.repositoryDiffPatch)
+                (StageHunks "tracked.txt" [99])
                 `shouldReturnSatisfying` isInvalidRequest
             mutateRepository root snapshot.snapshotId
-                (StagePatch
-                    "tracked.txt"
-                    (trackedDiff.repositoryDiffPatch
-                        <> secondDiff.repositoryDiffPatch))
+                (StageHunks "not-in-snapshot.txt" [0])
                 `shouldReturnSatisfying` isInvalidRequest
             mutateRepository root snapshot.snapshotId
-                (StagePatch
-                    "tracked.txt"
-                    (trackedDiff.repositoryDiffPatch <> "+injected\n"))
+                (StageHunks "tracked.txt" [0, 0])
                 `shouldReturnSatisfying` isInvalidRequest
             git root ["diff", "--cached", "--name-only"] `shouldReturn` ""
 
             writeFile (root <> "/untracked.txt") "keep\n"
             untrackedSnapshot <- expectRight =<< repositorySnapshot root
-            untrackedDiff <- expectRight
-                =<< repositoryDiff root untrackedSnapshot.snapshotId
-                    RepositoryWorktreeDiff "untracked.txt"
             mutateRepository root untrackedSnapshot.snapshotId
-                (RestorePatch
-                    "untracked.txt"
-                    untrackedDiff.repositoryDiffPatch)
+                (RestoreHunks "untracked.txt" [0])
                 `shouldReturnSatisfying` isInvalidRequest
             doesFileExist (root <> "/untracked.txt") `shouldReturn` True
+
+            removeFile (root <> "/tracked.txt")
+            deletedSnapshot <- expectRight =<< repositorySnapshot root
+            mutateRepository root deletedSnapshot.snapshotId
+                (StageHunks "tracked.txt" [0])
+                `shouldReturnSatisfying` isInvalidRequest
 
     it "streams an explicit argv check and reports its exit status" $
         withRepository \root -> do
@@ -444,14 +433,3 @@ shouldReturnSatisfying
     -> Expectation
 shouldReturnSatisfying action predicate =
     action >>= (`shouldSatisfy` predicate)
-
-firstPatchHunk :: BS8.ByteString -> BS8.ByteString
-firstPatchHunk patch =
-    let lines' = BS8.lines patch
-        isHunk = BS8.isPrefixOf "@@ "
-        (header, body) = break isHunk lines'
-    in case body of
-        [] -> patch
-        first:rest ->
-            let (hunkBody, _) = break isHunk rest
-            in BS8.unlines (header <> [first] <> hunkBody)

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -32,7 +32,14 @@ import System.Process
     , readCreateProcessWithExitCode
     )
 import System.Timeout (timeout)
-import System.Posix.Files (createSymbolicLink)
+import System.Posix.Files
+    ( createSymbolicLink
+    , ownerExecuteMode
+    , ownerReadMode
+    , ownerWriteMode
+    , setFileMode
+    , unionFileModes
+    )
 import Test.Hspec
 
 spec :: Spec
@@ -57,6 +64,19 @@ spec = describe "repository review service" do
                 linked <- expectRight =<< repositorySnapshot alias
                 linked.snapshotRoot `shouldBe` direct.snapshotRoot
                 linked.snapshotId `shouldBe` direct.snapshotId
+
+    it "includes untracked file mode in the worktree fingerprint" $
+        withRepository \root -> do
+            let path = root <> "/untracked-mode.txt"
+            writeFile path "same content\n"
+            before <- expectRight =<< repositorySnapshot root
+            setFileMode path
+                (ownerReadMode
+                    `unionFileModes` ownerWriteMode
+                    `unionFileModes` ownerExecuteMode)
+            after <- expectRight =<< repositorySnapshot root
+            after.snapshotWorktreeFingerprint
+                `shouldNotBe` before.snapshotWorktreeFingerprint
 
     it "snapshots unusual paths and parses diff hunk coordinates" $
         withRepository \root -> do

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -1,0 +1,258 @@
+module Agent.CLI.RepositoryReviewSpec (spec) where
+
+import Agent.CLI.RepositoryReview
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , takeMVar
+    )
+import Control.Exception.Safe (bracket)
+import qualified Data.ByteString.Char8 as BS8
+import Data.Either (isLeft)
+import Data.IORef
+    ( modifyIORef'
+    , newIORef
+    , readIORef
+    )
+import qualified Data.Text as Text
+import System.Directory
+    ( createDirectory
+    , doesFileExist
+    , getTemporaryDirectory
+    , removePathForcibly
+    )
+import System.Exit (ExitCode(..))
+import System.IO (hClose, openTempFile)
+import System.Process
+    ( CreateProcess(..)
+    , proc
+    , readCreateProcessWithExitCode
+    )
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "repository review service" do
+    it "snapshots unusual paths and parses diff hunk coordinates" $
+        withRepository \root -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            let unusual = "space and\nλ.txt"
+            writeFile (root <> "/" <> unusual) "untracked\n"
+
+            snapshot <- expectRight =<< repositorySnapshot root
+            snapshot.snapshotHead `shouldSatisfy` (/= Nothing)
+            snapshot.snapshotFiles `shouldSatisfy`
+                any (\file ->
+                    file.repositoryFilePath == "tracked.txt"
+                        && file.repositoryFileWorktreeStatus == 'M')
+            snapshot.snapshotFiles `shouldSatisfy`
+                any (\file ->
+                    file.repositoryFilePath == unusual
+                        && file.repositoryFileIndexStatus == '?')
+            untrackedDiff <- expectRight
+                =<< repositoryDiff
+                    root
+                    snapshot.snapshotId
+                    RepositoryWorktreeDiff
+                    unusual
+            untrackedDiff.repositoryDiffPatch `shouldSatisfy`
+                BS8.isInfixOf "+untracked"
+
+            diff <- expectRight
+                =<< repositoryDiff
+                    root
+                    snapshot.snapshotId
+                    RepositoryWorktreeDiff
+                    "tracked.txt"
+            diff.repositoryDiffPatch `shouldSatisfy`
+                BS8.isInfixOf "+second"
+            diff.repositoryDiffHunks `shouldBe`
+                [ DiffHunk
+                    { hunkOldStart = 1
+                    , hunkOldCount = 1
+                    , hunkNewStart = 1
+                    , hunkNewCount = 2
+                    , hunkHeader = ""
+                    }
+                ]
+
+    it "rejects a stale snapshot before mutating the index" $
+        withRepository \root -> do
+            appendFile (root <> "/tracked.txt") "pending\n"
+            snapshot <- expectRight =<< repositorySnapshot root
+            appendFile (root <> "/tracked.txt") "newer\n"
+
+            mutateRepository root snapshot.snapshotId (StagePath "tracked.txt")
+                >>= \case
+                    Left (StaleRepositorySnapshot _ _) -> pure ()
+                    result -> expectationFailure ("unexpected result: " <> show result)
+
+            staged <- git root ["diff", "--cached", "--name-only"]
+            staged `shouldBe` ""
+
+    it "stages, unstages, restores, and commits under fingerprint guards" $
+        withRepository \root -> do
+            appendFile (root <> "/tracked.txt") "pending\n"
+            initial <- expectRight =<< repositorySnapshot root
+
+            staged <- expectRight
+                =<< mutateRepository
+                    root
+                    initial.snapshotId
+                    (StagePath "tracked.txt")
+            staged.snapshotFiles `shouldSatisfy`
+                any (\file ->
+                    file.repositoryFilePath == "tracked.txt"
+                        && file.repositoryFileIndexStatus == 'M'
+                        && file.repositoryFileWorktreeStatus == ' ')
+
+            unstagedAfterPath <- expectRight
+                =<< mutateRepository
+                    root
+                    staged.snapshotId
+                    (UnstagePath "tracked.txt")
+            restored <- expectRight
+                =<< mutateRepository
+                    root
+                    unstagedAfterPath.snapshotId
+                    (RestorePath "tracked.txt")
+            restored.snapshotFiles `shouldBe` []
+            readFile (root <> "/tracked.txt") `shouldReturn` "first\n"
+
+            appendFile (root <> "/tracked.txt") "commit me\n"
+            beforeCommit <- expectRight =<< repositorySnapshot root
+            afterStage <- expectRight
+                =<< mutateRepository
+                    root
+                    beforeCommit.snapshotId
+                    (StagePath "tracked.txt")
+            committed <- expectRight
+                =<< commitRepository root afterStage.snapshotId "review commit\n"
+            committed.snapshotFiles `shouldBe` []
+            Text.strip <$> git root ["log", "-1", "--pretty=%B"]
+                `shouldReturn` "review commit"
+
+    it "applies reviewed patches and refuses to delete untracked files" $
+        withRepository \root -> do
+            appendFile (root <> "/tracked.txt") "patch\n"
+            before <- expectRight =<< repositorySnapshot root
+            diff <- expectRight
+                =<< repositoryDiff
+                    root
+                    before.snapshotId
+                    RepositoryWorktreeDiff
+                    "tracked.txt"
+            staged <- expectRight
+                =<< mutateRepository
+                    root
+                    before.snapshotId
+                    (StagePatch diff.repositoryDiffPatch)
+            git root ["diff", "--cached", "--name-only"]
+                `shouldReturn` "tracked.txt\n"
+
+            unstageDiff <- expectRight
+                =<< repositoryDiff
+                    root
+                    staged.snapshotId
+                    RepositoryStagedDiff
+                    "tracked.txt"
+            _unstagedAfterPatch <- expectRight
+                =<< mutateRepository
+                    root
+                    staged.snapshotId
+                    (UnstagePatch unstageDiff.repositoryDiffPatch)
+            git root ["diff", "--cached", "--name-only"] `shouldReturn` ""
+
+            writeFile (root <> "/untracked.txt") "keep\n"
+            current <- expectRight =<< repositorySnapshot root
+            result <- mutateRepository
+                root
+                current.snapshotId
+                (RestorePath "untracked.txt")
+            result `shouldSatisfy` isLeft
+            doesFileExist (root <> "/untracked.txt") `shouldReturn` True
+
+    it "streams an explicit argv check and reports its exit status" $
+        withRepository \root -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            chunks <- newIORef []
+            terminal <- newEmptyMVar
+            check <- expectRight
+                =<< startRepositoryCheck
+                    root
+                    snapshot.snapshotId
+                    "/bin/sh"
+                    [ "-c"
+                    , "printf stdout-value; printf stderr-value >&2; exit 7"
+                    ]
+                    (\stream bytes ->
+                        modifyIORef' chunks (<> [(stream, bytes)]))
+                    (\cancelled exitCode ->
+                        putMVar terminal (cancelled, exitCode))
+            waitRepositoryCheck check
+            takeMVar terminal `shouldReturn` (False, ExitFailure 7)
+            readIORef chunks >>= (`shouldMatchList`
+                [ (RepositoryCheckStdout, "stdout-value")
+                , (RepositoryCheckStderr, "stderr-value")
+                ])
+
+    it "cancels and joins a running check" $
+        withRepository \root -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            terminal <- newEmptyMVar
+            check <- expectRight
+                =<< startRepositoryCheck
+                    root
+                    snapshot.snapshotId
+                    "/bin/sleep"
+                    ["30"]
+                    (\_ _ -> pure ())
+                    (\cancelled exitCode ->
+                        putMVar terminal (cancelled, exitCode))
+            cancelRepositoryCheck check
+            waitRepositoryCheck check
+            result <- timeout 2_000_000 (takeMVar terminal)
+            result `shouldSatisfy` \case
+                Just (True, ExitFailure _) -> True
+                _ -> False
+
+withRepository :: (FilePath -> IO value) -> IO value
+withRepository action = withTempDirectory "repository-review" \root -> do
+    _ <- git root ["init", "-q"]
+    _ <- git root ["config", "user.name", "Repository Review Test"]
+    _ <- git root ["config", "user.email", "review@example.test"]
+    writeFile (root <> "/tracked.txt") "first\n"
+    _ <- git root ["add", "tracked.txt"]
+    _ <- git root ["commit", "-q", "-m", "initial"]
+    action root
+
+withTempDirectory :: String -> (FilePath -> IO value) -> IO value
+withTempDirectory template action = do
+    base <- getTemporaryDirectory
+    bracket
+        (do
+            (path, handle) <- openTempFile base template
+            hClose handle
+            removePathForcibly path
+            createDirectory path
+            pure path)
+        removePathForcibly
+        action
+
+git :: FilePath -> [String] -> IO Text.Text
+git root arguments = do
+    (exitCode, output, errors) <-
+        readCreateProcessWithExitCode
+            (proc "git" arguments) { cwd = Just root }
+            ""
+    case exitCode of
+        ExitSuccess -> pure (Text.pack output)
+        ExitFailure code ->
+            expectationFailure
+                ("git exited " <> show code <> ": " <> errors)
+                >> pure ""
+
+expectRight :: (HasCallStack, Show error) => Either error value -> IO value
+expectRight = \case
+    Left err -> expectationFailure (show err) >> fail "unreachable"
+    Right value -> pure value

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -1,6 +1,12 @@
 module Agent.CLI.RepositoryReviewSpec (spec) where
 
 import Agent.CLI.RepositoryReview
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+    ( async
+    , cancel
+    , waitCatch
+    )
 import Control.Concurrent.MVar
     ( newEmptyMVar
     , putMVar
@@ -28,8 +34,11 @@ import System.Exit (ExitCode(..))
 import System.IO (hClose, openTempFile)
 import System.Process
     ( CreateProcess(..)
+    , createProcess
     , proc
     , readCreateProcessWithExitCode
+    , terminateProcess
+    , waitForProcess
     )
 import System.Timeout (timeout)
 import System.Posix.Files
@@ -64,6 +73,32 @@ spec = describe "repository review service" do
                 linked <- expectRight =<< repositorySnapshot alias
                 linked.snapshotRoot `shouldBe` direct.snapshotRoot
                 linked.snapshotId `shouldBe` direct.snapshotId
+
+    it "honors the common-directory advisory transaction lock" $
+        withRepository \root -> do
+            let lockPath =
+                    root
+                        <> "/.git/haskell-agent-repository-review.lock"
+                readyPath = root <> "/advisory-lock-ready"
+                script =
+                    "import fcntl,time;"
+                        <> "f=open(" <> show lockPath <> ",'w');"
+                        <> "fcntl.flock(f,fcntl.LOCK_EX);"
+                        <> "open(" <> show readyPath <> ",'w').close();"
+                        <> "time.sleep(30)"
+            (_, _, _, locker) <-
+                createProcess (proc "/usr/bin/python3" ["-c", script])
+            _ <- awaitFileContents readyPath 200
+            pending <- async (repositorySnapshot root)
+            blocked <- timeout 200_000 (waitCatch pending)
+            blocked `shouldSatisfy` \case
+                Nothing -> True
+                Just _ -> False
+            terminateProcess locker
+            _ <- waitForProcess locker
+            waitCatch pending `shouldReturnSatisfying` \case
+                Right (Right _) -> True
+                _ -> False
 
     it "includes untracked file mode in the worktree fingerprint" $
         withRepository \root -> do
@@ -372,6 +407,37 @@ spec = describe "repository review service" do
             takeMVar terminal `shouldReturn` (False, ExitFailure 9)
             readIORef terminalCount `shouldReturn` 1
 
+    it "kills commit-hook descendants when the commit worker is cancelled" $
+        withRepository \root -> do
+            appendFile (root <> "/tracked.txt") "hook cancellation\n"
+            before <- expectRight =<< repositorySnapshot root
+            staged <- expectRight
+                =<< mutateRepository root before.snapshotId
+                    (StagePath "tracked.txt")
+            let pidFile = root <> "/hook-child.pid"
+                hook = root <> "/.git/hooks/pre-commit"
+            writeFile hook
+                ( "#!/bin/sh\n"
+                    <> "trap '' TERM\n"
+                    <> "/bin/sh -c 'trap \"\" TERM; echo $$ > "
+                    <> shellQuote pidFile
+                    <> "; exec /bin/sleep 30' &\n"
+                    <> "wait\n"
+                )
+            setFileMode hook
+                (ownerReadMode
+                    `unionFileModes` ownerWriteMode
+                    `unionFileModes` ownerExecuteMode)
+
+            worker <- async
+                (commitRepository root staged.snapshotId "blocked hook\n")
+            childPid <- awaitFileContents pidFile 200
+            cancel worker
+            _ <- waitCatch worker
+            childGone <- awaitProcessGone (Text.strip childPid) 200
+            childGone `shouldBe` True
+            git root ["log", "-1", "--pretty=%B"] `shouldReturn` "initial\n\n"
+
     it "cancels and joins a running check" $
         withRepository \root -> do
             snapshot <- expectRight =<< repositorySnapshot root
@@ -453,3 +519,35 @@ shouldReturnSatisfying
     -> Expectation
 shouldReturnSatisfying action predicate =
     action >>= (`shouldSatisfy` predicate)
+
+awaitFileContents :: FilePath -> Int -> IO Text.Text
+awaitFileContents path attempts
+    | attempts <= 0 =
+        expectationFailure ("timed out waiting for " <> path) >> pure ""
+    | otherwise =
+        doesFileExist path >>= \case
+            True -> Text.pack <$> readFile path
+            False -> threadDelay 10_000 >> awaitFileContents path (attempts - 1)
+
+processExists :: Text.Text -> IO Bool
+processExists pid = do
+    (exitCode, _, _) <-
+        readCreateProcessWithExitCode
+            (proc "/bin/kill" ["-0", Text.unpack pid])
+            ""
+    pure (exitCode == ExitSuccess)
+
+awaitProcessGone :: Text.Text -> Int -> IO Bool
+awaitProcessGone pid attempts =
+    processExists pid >>= \case
+        False -> pure True
+        True
+            | attempts <= 0 -> pure False
+            | otherwise ->
+                threadDelay 10_000 >> awaitProcessGone pid (attempts - 1)
+
+shellQuote :: String -> String
+shellQuote value = "'" <> concatMap escape value <> "'"
+  where
+    escape '\'' = "'\\''"
+    escape character = [character]

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -13,8 +13,9 @@ import Control.Concurrent.MVar
     , takeMVar
     )
 import Control.Exception.Safe (bracket, throwString)
-import Control.Monad (forM_)
+import Control.Monad (forM_, when)
 import qualified Data.ByteString.Char8 as BS8
+import Data.Char (isLower, toUpper)
 import Data.Either (isLeft)
 import Data.IORef
     ( atomicModifyIORef'
@@ -25,12 +26,14 @@ import Data.IORef
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
+    , doesDirectoryExist
     , doesFileExist
     , getTemporaryDirectory
     , removeFile
     , removePathForcibly
     )
 import System.Exit (ExitCode(..))
+import System.Environment (getEnv, lookupEnv, setEnv, unsetEnv)
 import System.IO (hClose, openTempFile)
 import System.Process
     ( CreateProcess(..)
@@ -42,7 +45,8 @@ import System.Process
     )
 import System.Timeout (timeout)
 import System.Posix.Files
-    ( createSymbolicLink
+    ( createNamedPipe
+    , createSymbolicLink
     , ownerExecuteMode
     , ownerReadMode
     , ownerWriteMode
@@ -53,6 +57,199 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "repository review service" do
+    it "rejects repository-local Git and disables configured helpers" $
+        withRepository \root -> do
+            let bin = root <> "/bin"
+                fakeGit = bin <> "/git"
+                gitMarker = root <> "/repository-git-ran"
+                fsmonitor = root <> "/fsmonitor"
+                fsmonitorMarker = root <> "/fsmonitor-ran"
+                subdirectory = root <> "/nested"
+            createDirectory bin
+            createDirectory subdirectory
+            writeFile (subdirectory <> "/.git") "not a repository boundary\n"
+            writeFile fakeGit $
+                "#!/bin/sh\nprintf ran > "
+                    <> shellQuote gitMarker
+                    <> "\nexec /usr/bin/git \"$@\"\n"
+            writeFile fsmonitor $
+                "#!/bin/sh\nprintf ran > "
+                    <> shellQuote fsmonitorMarker
+                    <> "\nexit 0\n"
+            mapM_ (`setFileMode` 0o700) [fakeGit, fsmonitor]
+            originalPath <- getEnv "PATH"
+            bracket
+                (setEnv "PATH" (bin <> ":" <> originalPath))
+                (\_ -> setEnv "PATH" originalPath)
+                \_ -> do
+                    repositorySnapshot root
+                        `shouldReturnSatisfying` isLeft
+                    repositorySnapshot subdirectory
+                        `shouldReturnSatisfying` isLeft
+                    doesFileExist gitMarker `shouldReturn` False
+            let caseVariantBin = changePathCase root <> "/bin"
+            caseVariantExists <- doesDirectoryExist caseVariantBin
+            when caseVariantExists $
+                bracket
+                    (setEnv "PATH" (caseVariantBin <> ":" <> originalPath))
+                    (\_ -> setEnv "PATH" originalPath)
+                    \_ -> do
+                        repositorySnapshot root
+                            `shouldReturnSatisfying` isLeft
+                        doesFileExist gitMarker `shouldReturn` False
+
+            _ <- git root ["config", "core.fsmonitor", fsmonitor]
+            _ <- expectRight =<< repositorySnapshot root
+            doesFileExist fsmonitorMarker `shouldReturn` False
+
+    it "isolates snapshots from clean filters and injected Git config" $
+        withRepository \root -> do
+            let filterScript = root <> "/clean-filter"
+                filterMarker = root <> "/clean-filter-ran"
+                injectedConfig = root <> "/injected.gitconfig"
+                injectedScript = root <> "/injected-fsmonitor"
+                injectedMarker = root <> "/injected-fsmonitor-ran"
+            writeFile filterScript $
+                "#!/bin/sh\nprintf ran > "
+                    <> shellQuote filterMarker
+                    <> "\ncat\n"
+            setFileMode filterScript 0o700
+            writeFile (root <> "/.gitattributes") $
+                "tracked.txt filter=pwn\n*.filtered filter=pwn\n"
+            _ <- git root ["config", "filter.pwn.clean", filterScript]
+            _ <- git root ["config", "filter.pwn.required", "true"]
+            appendFile (root <> "/tracked.txt") "changed\n"
+            writeFile (root <> "/untracked.filtered") "untracked\n"
+            snapshot <- expectRight =<< repositorySnapshot root
+            _ <- expectRight
+                =<< repositoryDiff
+                    root
+                    snapshot.snapshotId
+                    RepositoryWorktreeDiff
+                    "tracked.txt"
+            doesFileExist filterMarker `shouldReturn` False
+
+            writeFile injectedScript $
+                "#!/bin/sh\nprintf ran > "
+                    <> shellQuote injectedMarker
+                    <> "\nexit 0\n"
+            setFileMode injectedScript 0o700
+            writeFile injectedConfig $
+                "[core]\n\tfsmonitor = "
+                    <> injectedScript
+                    <> "\n"
+            originalGlobal <- lookupEnv "GIT_CONFIG_GLOBAL"
+            bracket
+                (setEnv "GIT_CONFIG_GLOBAL" injectedConfig)
+                (\_ -> case originalGlobal of
+                    Nothing -> unsetEnv "GIT_CONFIG_GLOBAL"
+                    Just value -> setEnv "GIT_CONFIG_GLOBAL" value)
+                \_ -> do
+                    _ <- expectRight =<< repositorySnapshot root
+                    doesFileExist injectedMarker `shouldReturn` False
+
+    it "keeps isolated Git metadata outside the repository when TMPDIR is inside it" $
+        withRepository \root -> do
+            originalTemporaryDirectory <- lookupEnv "TMPDIR"
+            bracket
+                (setEnv "TMPDIR" root)
+                (\_ -> case originalTemporaryDirectory of
+                    Nothing -> unsetEnv "TMPDIR"
+                    Just value -> setEnv "TMPDIR" value)
+                \_ -> do
+                    first <- expectRight =<< repositorySnapshot root
+                    second <- expectRight =<< repositorySnapshot root
+                    first.snapshotFiles `shouldBe` []
+                    second.snapshotFiles `shouldBe` []
+                    second.snapshotId `shouldBe` first.snapshotId
+
+    it "preserves repository-local and configured exclude rules" $
+        withRepository \root -> do
+            let repositoryExclude = root <> "/.git/info/exclude"
+                configuredExclude = root <> "/.git/configured-excludes"
+            appendFile repositoryExclude
+                ( "repository-secret.env\n"
+                    <> "repository-wins.env\n"
+                    <> "!repository-unignored.env\n"
+                )
+            writeFile configuredExclude
+                ( "configured-secret.env\n"
+                    <> "!repository-wins.env\n"
+                    <> "repository-unignored.env\n"
+                )
+            _ <- git root
+                [ "config"
+                , "core.excludesFile"
+                , ".git/configured-excludes"
+                ]
+            writeFile (root <> "/repository-secret.env") "secret\n"
+            writeFile (root <> "/configured-secret.env") "secret\n"
+            writeFile (root <> "/repository-wins.env") "secret\n"
+            writeFile (root <> "/repository-unignored.env") "visible\n"
+            snapshot <- expectRight =<< repositorySnapshot root
+            map (.repositoryFilePath) snapshot.snapshotFiles
+                `shouldBe` ["repository-unignored.env"]
+
+    it "fails closed without blocking on a special exclude file" $
+        withRepository \root -> do
+            let repositoryExclude = root <> "/.git/info/exclude"
+            removeFile repositoryExclude
+            createNamedPipe repositoryExclude
+                (ownerReadMode `unionFileModes` ownerWriteMode)
+            result <- timeout 2_000_000 (repositorySnapshot root)
+            result `shouldSatisfy` \case
+                Just (Left (RepositoryCommandFailed _ _ _)) -> True
+                _ -> False
+
+    it "bounds repository-local config include stalls" $
+        withRepository \root -> do
+            let includedConfig = root <> "/.git/included-config"
+            _ <- git root ["config", "include.path", includedConfig]
+            createNamedPipe includedConfig
+                (ownerReadMode `unionFileModes` ownerWriteMode)
+            result <- timeout 3_000_000 (repositorySnapshot root)
+            result `shouldSatisfy` \case
+                Just (Left _) -> True
+                _ -> False
+
+    it "rejects untracked special files and fingerprints symlinks without following them" $
+        withRepository \root -> do
+            let untrackedPipe = root <> "/untracked-pipe"
+                hiddenPipe = root <> "/.git/hidden-pipe"
+                link = root <> "/pipe-link"
+            createNamedPipe untrackedPipe
+                (ownerReadMode `unionFileModes` ownerWriteMode)
+            blocked <- timeout 2_000_000 (repositorySnapshot root)
+            blocked `shouldSatisfy` \case
+                Just (Left (InvalidRepositoryRequest _)) -> True
+                Just (Right _) -> True
+                _ -> False
+            removeFile untrackedPipe
+
+            createNamedPipe hiddenPipe
+                (ownerReadMode `unionFileModes` ownerWriteMode)
+            createSymbolicLink ".git/hidden-pipe" link
+            linked <- timeout 2_000_000 (repositorySnapshot root)
+            linked `shouldSatisfy` \case
+                Just (Right snapshot) ->
+                    any
+                        ((== "pipe-link") . (.repositoryFilePath))
+                        snapshot.snapshotFiles
+                _ -> False
+            case linked of
+                Just (Right snapshot) ->
+                    timeout 2_000_000
+                        (repositoryDiff
+                            root
+                            snapshot.snapshotId
+                            RepositoryWorktreeDiff
+                            "pipe-link")
+                        `shouldReturnSatisfying` \case
+                            Just (Left (InvalidRepositoryRequest _)) -> True
+                            _ -> False
+                _ -> expectationFailure
+                    "symlink snapshot was unavailable for diff regression"
+
     it "distinguishes an unborn HEAD from a broken HEAD" do
         withTempDirectory "repository-review-unborn" \root -> do
             _ <- git root ["init", "-q"]
@@ -614,3 +811,11 @@ shellQuote value = "'" <> concatMap escape value <> "'"
   where
     escape '\'' = "'\\''"
     escape character = [character]
+
+changePathCase :: FilePath -> FilePath
+changePathCase = go
+  where
+    go [] = []
+    go (character : rest)
+        | isLower character = toUpper character : rest
+        | otherwise = character : go rest

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -1,6 +1,10 @@
 module Agent.CLI.SessionSpec (spec) where
 
 import Agent.CLI.Session
+import Agent.CLI.SessionLock
+    ( acquireSessionLock
+    , releaseSessionLock
+    )
 import Agent.CLI.Session.StoreCodec
     ( fromStoredResponseItem
     , toStoredResponseItem
@@ -771,26 +775,43 @@ spec = describe "Agent.CLI.Session" do
 
                 listed <- listSessions pool root
                 map (.metaId) listed `shouldBe` [handle.sessionMeta.metaId]
-                renameSession
-                    pool
-                    root
-                    handle.sessionMeta.metaId
-                    "  Manual   title  " >>= \case
-                        Left err -> expectationFailure (Text.unpack err)
-                        Right renamed -> do
-                            renamed.metaTitle `shouldBe` "Manual title"
-                            renamed.metaTitleIsManual `shouldBe` True
+                bracket
+                    (acquireSessionLock
+                        handle.sessionDir
+                        handle.sessionMeta.metaId >>= \case
+                            Left err -> expectationFailure (Text.unpack err)
+                                >> fail "could not acquire session lock"
+                            Right lock -> pure lock)
+                    releaseSessionLock
+                    \_ -> do
+                        renameSession
+                            pool
+                            root
+                            handle.sessionMeta.metaId
+                            "  Manual   title  " >>= \case
+                                Left err ->
+                                    expectationFailure (Text.unpack err)
+                                Right renamed -> do
+                                    renamed.metaTitle `shouldBe` "Manual title"
+                                    renamed.metaTitleIsManual `shouldBe` True
+                        setSessionArchived
+                            pool
+                            root
+                            handle.sessionMeta.metaId
+                            True `shouldReturn` Right ()
                 loadSessionMeta pool root handle.sessionMeta.metaId >>= \case
                     Left err -> expectationFailure (Text.unpack err)
                     Right renamed ->
                         renamed.metaTitle `shouldBe` "Manual title"
-                setSessionArchived
-                    pool
-                    root
-                    handle.sessionMeta.metaId
-                    True `shouldReturn` Right ()
                 listArchivedSessionIds pool
                     `shouldReturn` Right [handle.sessionMeta.metaId]
+                _ <- appendTurn final normalTurn
+                _ <- setGeneratedSessionTitle 3 "Generated replacement" final
+                loadSessionMeta pool root handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right renamed -> do
+                        renamed.metaTitle `shouldBe` "Manual title"
+                        renamed.metaTitleIsManual `shouldBe` True
                 setSessionArchived
                     pool
                     root

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -771,6 +771,32 @@ spec = describe "Agent.CLI.Session" do
 
                 listed <- listSessions pool root
                 map (.metaId) listed `shouldBe` [handle.sessionMeta.metaId]
+                renameSession
+                    pool
+                    root
+                    handle.sessionMeta.metaId
+                    "  Manual   title  " >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right renamed -> do
+                            renamed.metaTitle `shouldBe` "Manual title"
+                            renamed.metaTitleIsManual `shouldBe` True
+                loadSessionMeta pool root handle.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right renamed ->
+                        renamed.metaTitle `shouldBe` "Manual title"
+                setSessionArchived
+                    pool
+                    root
+                    handle.sessionMeta.metaId
+                    True `shouldReturn` Right ()
+                listArchivedSessionIds pool
+                    `shouldReturn` Right [handle.sessionMeta.metaId]
+                setSessionArchived
+                    pool
+                    root
+                    handle.sessionMeta.metaId
+                    False `shouldReturn` Right ()
+                listArchivedSessionIds pool `shouldReturn` Right []
                 deleteSession pool root handle.sessionMeta.metaId
                     `shouldReturn` Right ()
                 doesDirectoryExist handle.sessionDir `shouldReturn` False

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -27,6 +27,7 @@ import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
+import qualified Agent.CLI.MacOS.NativeLoopEventSpec as NativeLoopEventSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
@@ -101,6 +102,7 @@ main = hspec do
     InterruptSpec.spec
     LoginSpec.spec
     LearnedSkillsSpec.spec
+    NativeLoopEventSpec.spec
     MarkdownSpec.spec
     McpManagerSpec.spec
     ModelConfigSpec.spec

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -49,6 +49,7 @@ import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
 import qualified Agent.CLI.ProviderAvailabilitySpec as ProviderAvailabilitySpec
 import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
 import qualified Agent.CLI.RequestSpec as RequestSpec
+import qualified Agent.CLI.RepositoryReviewSpec as RepositoryReviewSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
@@ -126,6 +127,7 @@ main = hspec do
     ProviderAvailabilitySpec.spec
     ProviderTransitionSpec.spec
     RequestSpec.spec
+    RepositoryReviewSpec.spec
     RenderSpec.spec
     ReplStatusSpec.spec
     ResumeSpec.spec

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -49,6 +49,7 @@ import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
 import qualified Agent.CLI.ProviderAvailabilitySpec as ProviderAvailabilitySpec
 import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
 import qualified Agent.CLI.RequestSpec as RequestSpec
+import qualified Agent.CLI.RepositoryDeliverySpec as RepositoryDeliverySpec
 import qualified Agent.CLI.RepositoryReviewSpec as RepositoryReviewSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
@@ -127,6 +128,7 @@ main = hspec do
     ProviderAvailabilitySpec.spec
     ProviderTransitionSpec.spec
     RequestSpec.spec
+    RepositoryDeliverySpec.spec
     RepositoryReviewSpec.spec
     RenderSpec.spec
     ReplStatusSpec.spec

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -28,6 +28,7 @@ import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
 import qualified Agent.CLI.MacOS.NativeLoopEventSpec as NativeLoopEventSpec
+import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
@@ -103,6 +104,7 @@ main = hspec do
     LoginSpec.spec
     LearnedSkillsSpec.spec
     NativeLoopEventSpec.spec
+    BridgeHeaderSpec.spec
     MarkdownSpec.spec
     McpManagerSpec.spec
     ModelConfigSpec.spec

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -29,6 +29,7 @@ import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
 import qualified Agent.CLI.MacOS.NativeLoopEventSpec as NativeLoopEventSpec
 import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
+import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
@@ -105,6 +106,7 @@ main = hspec do
     LearnedSkillsSpec.spec
     NativeLoopEventSpec.spec
     BridgeHeaderSpec.spec
+    BridgeFFISpec.spec
     MarkdownSpec.spec
     McpManagerSpec.spec
     ModelConfigSpec.spec

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -99,3 +99,171 @@ int ha_image_attachment_stage_smoke(void) {
     ha_runtime_exit();
     return status;
 }
+
+static void repository_snapshot_callback(
+        void *context,
+        const uint8_t *snapshot_id, size_t snapshot_id_length,
+        const uint8_t *root, size_t root_length,
+        const uint8_t *head, size_t head_length,
+        const uint8_t *index_fingerprint, size_t index_fingerprint_length,
+        const uint8_t *worktree_fingerprint,
+        size_t worktree_fingerprint_length) {
+    (void)context;
+    (void)snapshot_id;
+    (void)snapshot_id_length;
+    (void)root;
+    (void)root_length;
+    (void)head;
+    (void)head_length;
+    (void)index_fingerprint;
+    (void)index_fingerprint_length;
+    (void)worktree_fingerprint;
+    (void)worktree_fingerprint_length;
+}
+
+static void repository_file_callback(
+        void *context,
+        const uint8_t *path, size_t path_length,
+        const uint8_t *original_path, size_t original_path_length,
+        int32_t index_status, int32_t worktree_status) {
+    (void)context;
+    (void)path;
+    (void)path_length;
+    (void)original_path;
+    (void)original_path_length;
+    (void)index_status;
+    (void)worktree_status;
+}
+
+static void repository_diff_callback(
+        void *context, const uint8_t *bytes, size_t length,
+        int32_t is_binary) {
+    (void)context;
+    (void)bytes;
+    (void)length;
+    (void)is_binary;
+}
+
+static void repository_hunk_callback(
+        void *context,
+        int64_t old_start, int64_t old_count,
+        int64_t new_start, int64_t new_count,
+        const uint8_t *header, size_t header_length) {
+    (void)context;
+    (void)old_start;
+    (void)old_count;
+    (void)new_start;
+    (void)new_count;
+    (void)header;
+    (void)header_length;
+}
+
+static void repository_result_callback(
+        void *context, int32_t status,
+        const uint8_t *snapshot_id, size_t snapshot_id_length,
+        const uint8_t *error, size_t error_length) {
+    (void)context;
+    (void)status;
+    (void)snapshot_id;
+    (void)snapshot_id_length;
+    (void)error;
+    (void)error_length;
+}
+
+static void repository_check_output_callback(
+        void *context, int32_t stream,
+        const uint8_t *bytes, size_t length) {
+    (void)context;
+    (void)stream;
+    (void)bytes;
+    (void)length;
+}
+
+static void repository_check_exit_callback(
+        void *context, int32_t cancelled, int32_t exit_code,
+        const uint8_t *error, size_t error_length) {
+    (void)context;
+    (void)cancelled;
+    (void)exit_code;
+    (void)error;
+    (void)error_length;
+}
+
+/*
+ * Compile every repository-review callback and function signature and exercise
+ * synchronous validation without starting a worker.
+ */
+int ha_repository_review_abi_smoke(void) {
+    const uint8_t value[] = "x";
+    if (offsetof(ha_utf8_string, bytes) != 0
+            || offsetof(ha_utf8_string, length)
+                != sizeof(const uint8_t *)) {
+        return 19;
+    }
+    if (HA_REPOSITORY_STAGE != 0
+            || HA_REPOSITORY_UNSTAGE != 1
+            || HA_REPOSITORY_RESTORE != 2) {
+        return 20;
+    }
+    if (ha_repository_snapshot(
+            NULL, 0,
+            repository_snapshot_callback,
+            repository_file_callback,
+            repository_result_callback,
+            NULL) != 2) {
+        return 21;
+    }
+    if (ha_repository_diff(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            HA_REPOSITORY_DIFF_WORKTREE,
+            value, sizeof(value) - 1,
+            NULL,
+            repository_hunk_callback,
+            repository_result_callback,
+            NULL) != 1) {
+        return 22;
+    }
+    if (ha_repository_apply_path(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            99,
+            value, sizeof(value) - 1,
+            repository_result_callback,
+            NULL) != 2) {
+        return 23;
+    }
+    if (ha_repository_apply_patch(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            HA_REPOSITORY_STAGE,
+            NULL, 0,
+            repository_result_callback,
+            NULL) != 2) {
+        return 24;
+    }
+    if (ha_repository_commit(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL,
+            NULL) != 1) {
+        return 25;
+    }
+    void *check = NULL;
+    if (ha_repository_check_start(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, 0,
+            repository_check_output_callback,
+            NULL,
+            NULL,
+            &check) != 1) {
+        return 26;
+    }
+    ha_repository_check_cancel(NULL);
+    ha_repository_check_destroy(NULL);
+    ha_repository_cancel_all();
+    return 0;
+}

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -233,7 +233,7 @@ int ha_repository_review_abi_smoke(void) {
             NULL) != 2) {
         return 23;
     }
-    if (ha_repository_apply_patch(
+    if (ha_repository_apply_hunks(
             value, sizeof(value) - 1,
             value, sizeof(value) - 1,
             HA_REPOSITORY_STAGE,

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -170,6 +170,82 @@ static void repository_result_callback(
     (void)error_length;
 }
 
+static void repository_delivery_status_callback(
+        void *context, int32_t status,
+        const uint8_t *snapshot_id, size_t snapshot_id_length,
+        const uint8_t *head_oid, size_t head_oid_length,
+        const uint8_t *branch, size_t branch_length,
+        const uint8_t *remote, size_t remote_length,
+        const uint8_t *upstream_ref, size_t upstream_ref_length,
+        const uint8_t *upstream_oid, size_t upstream_oid_length,
+        int64_t ahead, int64_t behind,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)snapshot_id; (void)snapshot_id_length;
+    (void)head_oid; (void)head_oid_length;
+    (void)branch; (void)branch_length;
+    (void)remote; (void)remote_length;
+    (void)upstream_ref; (void)upstream_ref_length;
+    (void)upstream_oid; (void)upstream_oid_length;
+    (void)ahead; (void)behind; (void)error; (void)error_length;
+}
+
+static void repository_push_preview_callback(
+        void *context, int32_t status,
+        const uint8_t *confirmation, size_t confirmation_length,
+        int64_t expires_at_unix,
+        const uint8_t *head_oid, size_t head_oid_length,
+        const uint8_t *branch, size_t branch_length,
+        const uint8_t *remote, size_t remote_length,
+        const uint8_t *upstream_ref, size_t upstream_ref_length,
+        int64_t ahead, int64_t behind,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)confirmation; (void)confirmation_length; (void)expires_at_unix;
+    (void)head_oid; (void)head_oid_length;
+    (void)branch; (void)branch_length;
+    (void)remote; (void)remote_length;
+    (void)upstream_ref; (void)upstream_ref_length;
+    (void)ahead; (void)behind; (void)error; (void)error_length;
+}
+
+static void repository_push_result_callback(
+        void *context, int32_t status,
+        const uint8_t *snapshot_id, size_t snapshot_id_length,
+        const uint8_t *pushed_oid, size_t pushed_oid_length,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)snapshot_id; (void)snapshot_id_length;
+    (void)pushed_oid; (void)pushed_oid_length;
+    (void)error; (void)error_length;
+}
+
+static void repository_pr_preview_callback(
+        void *context, int32_t status,
+        const uint8_t *confirmation, size_t confirmation_length,
+        int64_t expires_at_unix,
+        const uint8_t *repository, size_t repository_length,
+        const uint8_t *base_ref, size_t base_ref_length,
+        const uint8_t *head_ref, size_t head_ref_length,
+        const uint8_t *title, size_t title_length,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)confirmation; (void)confirmation_length; (void)expires_at_unix;
+    (void)repository; (void)repository_length;
+    (void)base_ref; (void)base_ref_length;
+    (void)head_ref; (void)head_ref_length;
+    (void)title; (void)title_length;
+    (void)error; (void)error_length;
+}
+
+static void repository_pr_result_callback(
+        void *context, int32_t status,
+        const uint8_t *url, size_t url_length,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)url; (void)url_length; (void)error; (void)error_length;
+}
+
 static void repository_check_output_callback(
         void *context, int32_t stream,
         const uint8_t *bytes, size_t length) {
@@ -279,6 +355,56 @@ int ha_repository_review_abi_smoke(void) {
             NULL,
             NULL) != 1) {
         return 25;
+    }
+    if (ha_repository_delivery_status(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1
+        || ha_repository_push_preview(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1
+        || ha_repository_push_confirm(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1
+        || ha_repository_pr_preview(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1
+        || ha_repository_pr_confirm(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1) {
+        return 29;
+    }
+    if (ha_repository_delivery_status(
+            NULL, 0,
+            value, sizeof(value) - 1,
+            repository_delivery_status_callback, NULL) != 2
+        || ha_repository_push_preview(
+            NULL, 0,
+            value, sizeof(value) - 1,
+            repository_push_preview_callback, NULL) != 2
+        || ha_repository_push_confirm(
+            NULL, 0,
+            value, sizeof(value) - 1,
+            repository_push_result_callback, NULL) != 2
+        || ha_repository_pr_preview(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, (size_t)1024 * 1024 + 1,
+            repository_pr_preview_callback, NULL) != 2
+        || ha_repository_pr_confirm(
+            NULL, 0,
+            value, sizeof(value) - 1,
+            repository_pr_result_callback, NULL) != 2) {
+        return 30;
     }
     void *check = NULL;
     if (ha_repository_check_start(

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -1,0 +1,73 @@
+#include "HaskellAgentBridge.h"
+
+#include <stddef.h>
+
+static void search_callback(
+    void *context,
+    int32_t status,
+    const uint8_t *session_id, size_t session_id_length,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *cwd, size_t cwd_length,
+    const uint8_t *provider, size_t provider_length,
+    const uint8_t *model, size_t model_length,
+    int64_t updated_at_ms, int32_t archived, int64_t turn_index,
+    int64_t occurred_at_ms, int32_t role,
+    const uint8_t *user_text, size_t user_text_length,
+    const uint8_t *assistant_text, size_t assistant_text_length,
+    double rank,
+    const uint8_t *error, size_t error_length
+) {
+    (void)context; (void)status; (void)session_id; (void)session_id_length;
+    (void)title; (void)title_length; (void)cwd; (void)cwd_length;
+    (void)provider; (void)provider_length; (void)model; (void)model_length;
+    (void)updated_at_ms; (void)archived; (void)turn_index;
+    (void)occurred_at_ms; (void)role; (void)user_text;
+    (void)user_text_length; (void)assistant_text;
+    (void)assistant_text_length; (void)rank; (void)error; (void)error_length;
+}
+
+/*
+ * Keep a native compile/run smoke check next to the public ABI. This catches
+ * accidental field reordering or type changes before the macOS client stages
+ * image buffers through the bridge.
+ */
+int ha_image_attachment_abi_smoke(void) {
+    ha_conversation_search_callback typed_search_callback = search_callback;
+    static const uint8_t first_mime[] = "image/png";
+    static const uint8_t first_bytes[] = {0x89, 0x50, 0x4e, 0x47};
+    static const uint8_t second_mime[] = "image/jpeg";
+    static const uint8_t second_bytes[] = {0xff, 0xd8, 0xff};
+    const ha_image_attachment images[] = {
+        {
+            .mime = first_mime,
+            .mime_length = sizeof(first_mime) - 1,
+            .bytes = first_bytes,
+            .bytes_length = sizeof(first_bytes),
+        },
+        {
+            .mime = second_mime,
+            .mime_length = sizeof(second_mime) - 1,
+            .bytes = second_bytes,
+            .bytes_length = sizeof(second_bytes),
+        },
+    };
+
+    if (typed_search_callback == NULL) {
+        return 3;
+    }
+    if (offsetof(ha_image_attachment, mime) != 0
+            || offsetof(ha_image_attachment, mime_length)
+                != sizeof(const uint8_t *)
+            || offsetof(ha_image_attachment, bytes)
+                != sizeof(const uint8_t *) + sizeof(size_t)
+            || offsetof(ha_image_attachment, bytes_length)
+                != 2 * sizeof(const uint8_t *) + sizeof(size_t)) {
+        return 1;
+    }
+    if (images[0].mime_length != 9 || images[1].mime_length != 10
+            || images[0].bytes_length != 4 || images[1].bytes_length != 3
+            || images[0].mime[0] != 'i' || images[1].mime[6] != 'j') {
+        return 2;
+    }
+    return 0;
+}

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -87,6 +87,14 @@ int ha_image_attachment_stage_smoke(void) {
     }
     int32_t status = ha_engine_stage_turn_images(
         engine, turn_id, sizeof(turn_id) - 1, images, 2);
+    if (status == 0) {
+        status = ha_engine_stage_turn_images(
+            engine, turn_id, sizeof(turn_id) - 1, images, 1);
+    }
+    if (status == 0) {
+        status = ha_engine_stage_turn_images(
+            engine, turn_id, sizeof(turn_id) - 1, NULL, 0);
+    }
     ha_engine_destroy(engine);
     ha_runtime_exit();
     return status;

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -2,37 +2,12 @@
 
 #include <stddef.h>
 
-static void search_callback(
-    void *context,
-    int32_t status,
-    const uint8_t *session_id, size_t session_id_length,
-    const uint8_t *title, size_t title_length,
-    const uint8_t *cwd, size_t cwd_length,
-    const uint8_t *provider, size_t provider_length,
-    const uint8_t *model, size_t model_length,
-    int64_t updated_at_ms, int32_t archived, int64_t turn_index,
-    int64_t occurred_at_ms, int32_t role,
-    const uint8_t *user_text, size_t user_text_length,
-    const uint8_t *assistant_text, size_t assistant_text_length,
-    double rank,
-    const uint8_t *error, size_t error_length
-) {
-    (void)context; (void)status; (void)session_id; (void)session_id_length;
-    (void)title; (void)title_length; (void)cwd; (void)cwd_length;
-    (void)provider; (void)provider_length; (void)model; (void)model_length;
-    (void)updated_at_ms; (void)archived; (void)turn_index;
-    (void)occurred_at_ms; (void)role; (void)user_text;
-    (void)user_text_length; (void)assistant_text;
-    (void)assistant_text_length; (void)rank; (void)error; (void)error_length;
-}
-
 /*
  * Keep a native compile/run smoke check next to the public ABI. This catches
  * accidental field reordering or type changes before the macOS client stages
  * image buffers through the bridge.
  */
 int ha_image_attachment_abi_smoke(void) {
-    ha_conversation_search_callback typed_search_callback = search_callback;
     static const uint8_t first_mime[] = "image/png";
     static const uint8_t first_bytes[] = {0x89, 0x50, 0x4e, 0x47};
     static const uint8_t second_mime[] = "image/jpeg";
@@ -52,9 +27,6 @@ int ha_image_attachment_abi_smoke(void) {
         },
     };
 
-    if (typed_search_callback == NULL) {
-        return 3;
-    }
     if (offsetof(ha_image_attachment, mime) != 0
             || offsetof(ha_image_attachment, mime_length)
                 != sizeof(const uint8_t *)

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -71,3 +71,41 @@ int ha_image_attachment_abi_smoke(void) {
     }
     return 0;
 }
+
+static void image_stage_callback(void *context, const uint8_t *bytes,
+                                 size_t length) {
+    (void)context;
+    (void)bytes;
+    (void)length;
+}
+
+/*
+ * Exercise the actual exported bridge entry points as a native caller would:
+ * initialize the runtime, create an engine, stage one image, and tear it down.
+ * The Haskell entry point copies the buffers before returning, so these
+ * stack-backed buffers are intentionally short-lived.
+ */
+int ha_image_attachment_stage_smoke(void) {
+    const uint8_t turn_id[] = "native-smoke-turn";
+    const uint8_t mime[] = "image/png";
+    const uint8_t bytes[] = {0x89, 0x50, 0x4e, 0x47};
+    const ha_image_attachment image = {
+        .mime = mime,
+        .mime_length = sizeof(mime) - 1,
+        .bytes = bytes,
+        .bytes_length = sizeof(bytes),
+    };
+    if (ha_runtime_init() != 0) {
+        return 10;
+    }
+    void *engine = ha_engine_create(image_stage_callback, NULL);
+    if (engine == NULL) {
+        ha_runtime_exit();
+        return 11;
+    }
+    int32_t status = ha_engine_stage_turn_images(
+        engine, turn_id, sizeof(turn_id) - 1, &image, 1);
+    ha_engine_destroy(engine);
+    ha_runtime_exit();
+    return status;
+}

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -213,6 +213,14 @@ int ha_repository_review_abi_smoke(void) {
             NULL) != 2) {
         return 21;
     }
+    if (ha_repository_snapshot(
+            value, SIZE_MAX,
+            repository_snapshot_callback,
+            repository_file_callback,
+            repository_result_callback,
+            NULL) != 2) {
+        return 29;
+    }
     if (ha_repository_diff(
             value, sizeof(value) - 1,
             value, sizeof(value) - 1,
@@ -242,6 +250,27 @@ int ha_repository_review_abi_smoke(void) {
             repository_result_callback,
             NULL) != 2) {
         return 24;
+    }
+    const size_t oversized_hunk = SIZE_MAX;
+    if (ha_repository_apply_hunks(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            HA_REPOSITORY_STAGE,
+            value, sizeof(value) - 1,
+            &oversized_hunk, 1,
+            repository_result_callback,
+            NULL) != 2) {
+        return 30;
+    }
+    if (ha_repository_apply_hunks(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            HA_REPOSITORY_STAGE,
+            value, sizeof(value) - 1,
+            &oversized_hunk, 4097,
+            repository_result_callback,
+            NULL) != 2) {
+        return 31;
     }
     if (ha_repository_commit(
             value, sizeof(value) - 1,

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -59,13 +59,23 @@ static void image_stage_callback(void *context, const uint8_t *bytes,
  */
 int ha_image_attachment_stage_smoke(void) {
     const uint8_t turn_id[] = "native-smoke-turn";
-    const uint8_t mime[] = "image/png";
-    const uint8_t bytes[] = {0x89, 0x50, 0x4e, 0x47};
-    const ha_image_attachment image = {
-        .mime = mime,
-        .mime_length = sizeof(mime) - 1,
-        .bytes = bytes,
-        .bytes_length = sizeof(bytes),
+    const uint8_t first_mime[] = "image/png";
+    const uint8_t first_bytes[] = {0x89, 0x50, 0x4e, 0x47};
+    const uint8_t second_mime[] = "image/jpeg";
+    const uint8_t second_bytes[] = {0xff, 0xd8, 0xff};
+    const ha_image_attachment images[] = {
+        {
+            .mime = first_mime,
+            .mime_length = sizeof(first_mime) - 1,
+            .bytes = first_bytes,
+            .bytes_length = sizeof(first_bytes),
+        },
+        {
+            .mime = second_mime,
+            .mime_length = sizeof(second_mime) - 1,
+            .bytes = second_bytes,
+            .bytes_length = sizeof(second_bytes),
+        },
     };
     if (ha_runtime_init() != 0) {
         return 10;
@@ -76,7 +86,7 @@ int ha_image_attachment_stage_smoke(void) {
         return 11;
     }
     int32_t status = ha_engine_stage_turn_images(
-        engine, turn_id, sizeof(turn_id) - 1, &image, 1);
+        engine, turn_id, sizeof(turn_id) - 1, images, 2);
     ha_engine_destroy(engine);
     ha_runtime_exit();
     return status;

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -237,6 +237,7 @@ int ha_repository_review_abi_smoke(void) {
             value, sizeof(value) - 1,
             value, sizeof(value) - 1,
             HA_REPOSITORY_STAGE,
+            value, sizeof(value) - 1,
             NULL, 0,
             repository_result_callback,
             NULL) != 2) {
@@ -261,6 +262,32 @@ int ha_repository_review_abi_smoke(void) {
             NULL,
             &check) != 1) {
         return 26;
+    }
+    const ha_utf8_string oversized_argument = {
+        value,
+        (size_t)1024 * 1024 + 1
+    };
+    if (ha_repository_check_start(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            &oversized_argument, 1,
+            repository_check_output_callback,
+            repository_check_exit_callback,
+            NULL,
+            &check) != 2) {
+        return 27;
+    }
+    if (ha_repository_check_start(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            &oversized_argument, 4097,
+            repository_check_output_callback,
+            repository_check_exit_callback,
+            NULL,
+            &check) != 2) {
+        return 28;
     }
     ha_repository_check_cancel(NULL);
     ha_repository_check_destroy(NULL);

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -47,6 +47,7 @@ library
                     , Agent.Store.Postgres.Scope
                     , Agent.Store.Postgres.Session
                     , Agent.Store.Postgres.Skill
+                    , Agent.Store.Postgres.UsageCache
     other-modules:    Agent.Store.Custom.QueryResult
                     , Agent.Store.Postgres.Custom.Sql
                     , Agent.Store.Postgres.Hasql

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -161,9 +161,16 @@ coreMigrations =
         , migrationStatements =
             [ "ALTER TABLE IF EXISTS harness.sessions\
               \ ADD COLUMN IF NOT EXISTS archived_at timestamptz"
-            , "CREATE INDEX IF NOT EXISTS sessions_archived_at_idx\
-              \ ON harness.sessions (archived_at DESC)\
-              \ WHERE deleted_at IS NULL AND archived_at IS NOT NULL"
+            , "DO $ha$\
+              \ BEGIN\
+              \   IF to_regclass('harness.sessions') IS NOT NULL THEN\
+              \     CREATE INDEX IF NOT EXISTS sessions_archived_at_idx\
+              \       ON harness.sessions (archived_at DESC)\
+              \       WHERE deleted_at IS NULL\
+              \         AND archived_at IS NOT NULL;\
+              \   END IF;\
+              \ END\
+              \ $ha$"
             ]
         }
     , Migration
@@ -171,8 +178,17 @@ coreMigrations =
         , migrationName = "account usage cache"
         , migrationStatements =
             accountUsageCacheSchemaStatements
-            <> [ "GRANT SELECT, INSERT, UPDATE\
-                \ ON harness.account_usage_cache TO ha_runtime"
+            <> [ "DO $ha$\
+                \ BEGIN\
+                \   IF EXISTS (\
+                \     SELECT 1 FROM pg_catalog.pg_roles\
+                \     WHERE rolname = 'ha_runtime'\
+                \   ) THEN\
+                \     GRANT SELECT, INSERT, UPDATE\
+                \       ON harness.account_usage_cache TO ha_runtime;\
+                \   END IF;\
+                \ END\
+                \ $ha$"
                ]
         }
     ]

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -150,6 +150,19 @@ coreMigrations =
         , migrationStatements =
             [migrateSessionTranscriptEffectsStatement]
         }
+    -- Versions 9 and 10 are already deployed by the conversation-search and
+    -- binary-attachment branches. Keep them reserved until those land here.
+    , Migration
+        { migrationVersion = 11
+        , migrationName = "archived sessions"
+        , migrationStatements =
+            [ "ALTER TABLE IF EXISTS harness.sessions\
+              \ ADD COLUMN IF NOT EXISTS archived_at timestamptz"
+            , "CREATE INDEX IF NOT EXISTS sessions_archived_at_idx\
+              \ ON harness.sessions (archived_at DESC)\
+              \ WHERE deleted_at IS NULL AND archived_at IS NOT NULL"
+            ]
+        }
     ]
 
 -- Version 1 shipped only on the in-development PostgreSQL branch. Empty

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -35,6 +35,9 @@ import Agent.Store.Postgres.Skill
     ( learnedSkillRuntimeGrantStatements
     , learnedSkillSchemaStatements
     )
+import Agent.Store.Postgres.UsageCache
+    ( accountUsageCacheSchemaStatements
+    )
 import Agent.Store.Types
 
 data Migration = Migration
@@ -162,6 +165,15 @@ coreMigrations =
               \ ON harness.sessions (archived_at DESC)\
               \ WHERE deleted_at IS NULL AND archived_at IS NOT NULL"
             ]
+        }
+    , Migration
+        { migrationVersion = 12
+        , migrationName = "account usage cache"
+        , migrationStatements =
+            accountUsageCacheSchemaStatements
+            <> [ "GRANT SELECT, INSERT, UPDATE\
+                \ ON harness.account_usage_cache TO ha_runtime"
+               ]
         }
     ]
 

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -20,6 +20,7 @@ module Agent.Store.Postgres.Session
     , StoredTurn(..)
     , LegacySession(..)
     , ConversationSearchResult(..)
+    , NativeConversationSearchResult(..)
     , sessionSchemaStatements
     , createSession
     , replaceSessionMetadata
@@ -42,6 +43,7 @@ module Agent.Store.Postgres.Session
     , listSessionArchiveKeys
     , setSessionArchived
     , searchConversationTurns
+    , searchNativeConversations
     , deleteSession
     , importLegacySession
     , withSessionAdvisoryLock
@@ -79,6 +81,23 @@ data SessionLegacyTarget = SessionLegacyTarget
     , sessionLegacyConnection :: !Text
     , sessionLegacyEffectiveModel :: !Text
     , sessionLegacyDialect :: !Text
+    }
+    deriving (Eq, Show)
+
+data NativeConversationSearchResult = NativeConversationSearchResult
+    { nativeSearchSessionId :: !Text
+    , nativeSearchTitle :: !Text
+    , nativeSearchCwd :: !Text
+    , nativeSearchProvider :: !Text
+    , nativeSearchModel :: !Text
+    , nativeSearchUpdatedAt :: !UTCTime
+    , nativeSearchArchived :: !Bool
+    , nativeSearchTurnIndex :: !(Maybe Int64)
+    , nativeSearchOccurredAt :: !(Maybe UTCTime)
+    , nativeSearchRole :: !(Maybe Text)
+    , nativeSearchUserText :: !(Maybe Text)
+    , nativeSearchAssistantText :: !(Maybe Text)
+    , nativeSearchRank :: !Double
     }
     deriving (Eq, Show)
 
@@ -727,6 +746,15 @@ searchConversationTurns pool query limit =
         HasqlSession.statement
             (query, fromIntegral (max 1 (min 100 limit)))
             searchTurnsStatement
+
+searchNativeConversations
+    :: StorePool -> Text -> Int
+    -> IO (Either StoreError [NativeConversationSearchResult])
+searchNativeConversations pool query limit =
+    withSession pool $
+        HasqlSession.statement
+            (query, fromIntegral (max 1 (min 100 limit)))
+            searchNativeConversationsStatement
 
 deleteSession
     :: StorePool
@@ -1460,6 +1488,52 @@ searchTurnsStatement = mkStatement
             <*> Decoders.column (Decoders.nonNullable Decoders.int8)
             <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
             <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.float8))
+    True
+
+searchNativeConversationsStatement
+    :: Statement (Text, Int64) [NativeConversationSearchResult]
+searchNativeConversationsStatement = mkStatement
+    "WITH query AS (SELECT websearch_to_tsquery('english', $1) AS ts,\
+    \ lower(btrim($1)) AS needle), candidates AS (\
+    \ SELECT s.session_key,s.title,s.cwd,s.provider,s.model_id,s.updated_at,\
+    \ s.archived_at IS NOT NULL,NULL::bigint,NULL::timestamptz,NULL::text,\
+    \ NULL::text,NULL::text,CASE WHEN lower(s.title)=query.needle THEN 1000::float8\
+    \ WHEN lower(s.title) LIKE query.needle || '%' THEN 800::float8\
+    \ WHEN s.title ILIKE '%' || $1 || '%' THEN 600::float8\
+    \ WHEN s.cwd ILIKE '%' || $1 || '%' THEN 400::float8 ELSE 300::float8 END\
+    \ FROM harness.sessions s CROSS JOIN query WHERE s.deleted_at IS NULL AND (\
+    \ s.title ILIKE '%' || $1 || '%' OR s.cwd ILIKE '%' || $1 || '%' OR\
+    \ s.provider ILIKE '%' || $1 || '%' OR s.model_id ILIKE '%' || $1 || '%')\
+    \ UNION ALL\
+    \ SELECT s.session_key,s.title,s.cwd,s.provider,s.model_id,s.updated_at,\
+    \ s.archived_at IS NOT NULL,t.turn_index,t.occurred_at,\
+    \ CASE WHEN t.user_text ILIKE '%' || $1 || '%' OR\
+    \ to_tsvector('english',coalesce(t.user_text,'')) @@ query.ts\
+    \ THEN 'user' ELSE 'assistant' END,\
+    \ t.user_text,t.assistant_text,\
+    \ (100 + ts_rank_cd(t.search_vector,query.ts)*100)::float8\
+    \ FROM harness.session_turns t JOIN harness.sessions s ON s.session_id=t.session_id\
+    \ CROSS JOIN query WHERE s.deleted_at IS NULL AND (\
+    \ t.search_vector @@ query.ts OR t.user_text ILIKE '%' || $1 || '%' OR\
+    \ coalesce(t.assistant_text,'') ILIKE '%' || $1 || '%'))\
+    \ SELECT * FROM candidates ORDER BY 13 DESC,6 DESC,9 DESC NULLS LAST LIMIT $2"
+    ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.int8)) )
+    (Decoders.rowList $
+        NativeConversationSearchResult
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+            <*> Decoders.column (Decoders.nonNullable Decoders.bool)
+            <*> Decoders.column (Decoders.nullable Decoders.int8)
+            <*> Decoders.column (Decoders.nullable Decoders.timestamptz)
+            <*> Decoders.column (Decoders.nullable Decoders.text)
+            <*> Decoders.column (Decoders.nullable Decoders.text)
             <*> Decoders.column (Decoders.nullable Decoders.text)
             <*> Decoders.column (Decoders.nonNullable Decoders.float8))
     True

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -32,11 +32,15 @@ module Agent.Store.Postgres.Session
     , SessionTurnPage(..)
     , SessionResumeStats(..)
     , loadRecentSessionTurns
+    , loadRecentSessionHistoryTurns
     , loadSessionTurnsBefore
+    , loadSessionHistoryTurnsBefore
     , loadSessionTurnsAfter
     , loadSessionResumeStats
     , loadSessionEvents
     , listSessionMetadata
+    , listSessionArchiveKeys
+    , setSessionArchived
     , searchConversationTurns
     , deleteSession
     , importLegacySession
@@ -220,6 +224,7 @@ sessionSchemaStatements =
       \ last_recap_main_turns bigint NOT NULL DEFAULT 0 CHECK (last_recap_main_turns >= 0),\
       \ next_event_sequence bigint NOT NULL DEFAULT 1,\
       \ next_turn_index bigint NOT NULL DEFAULT 0,\
+      \ archived_at timestamptz,\
       \ deleted_at timestamptz,\
       \ CHECK (updated_at >= created_at),\
       \ CHECK (next_event_sequence >= 1),\
@@ -243,6 +248,9 @@ sessionSchemaStatements =
     , "CREATE INDEX IF NOT EXISTS sessions_updated_at_idx\
       \ ON harness.sessions (updated_at DESC)\
       \ WHERE deleted_at IS NULL"
+    , "CREATE INDEX IF NOT EXISTS sessions_archived_at_idx\
+      \ ON harness.sessions (archived_at DESC)\
+      \ WHERE deleted_at IS NULL AND archived_at IS NOT NULL"
     , "CREATE TABLE IF NOT EXISTS harness.session_events (\
       \ event_id uuid PRIMARY KEY DEFAULT pg_catalog.uuidv7(),\
       \ session_id uuid NOT NULL\
@@ -525,6 +533,23 @@ loadRecentSessionTurns pool sessionKey limit =
     loadTurnPage pool sessionKey
         (Transaction.statement (sessionKey, fromIntegral (max 1 limit + 1))
             loadRecentTurnsStatement)
+        (Transaction.statement sessionKey currentGenerationStatement)
+        (max 1 limit)
+        PageRecent
+
+-- | Page the complete durable conversation, including turns that precede the
+-- latest transcript replacement checkpoint. Native transcript views use this
+-- while resume/model-context loading continues to use the active generation.
+loadRecentSessionHistoryTurns
+    :: StorePool
+    -> Text
+    -> Int
+    -> IO (Either StoreError (Maybe SessionTurnPage))
+loadRecentSessionHistoryTurns pool sessionKey limit =
+    loadTurnPage pool sessionKey
+        (Transaction.statement (sessionKey, fromIntegral (max 1 limit + 1))
+            loadRecentHistoryTurnsStatement)
+        (Transaction.statement sessionKey fullHistoryStatement)
         (max 1 limit)
         PageRecent
 
@@ -539,6 +564,22 @@ loadSessionTurnsBefore pool sessionKey cursor limit =
         (Transaction.statement
             (sessionKey, cursor, fromIntegral (max 1 limit + 1))
             loadTurnsBeforeStatement)
+        (Transaction.statement sessionKey currentGenerationStatement)
+        (max 1 limit)
+        PageBefore
+
+loadSessionHistoryTurnsBefore
+    :: StorePool
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either StoreError (Maybe SessionTurnPage))
+loadSessionHistoryTurnsBefore pool sessionKey cursor limit =
+    loadTurnPage pool sessionKey
+        (Transaction.statement
+            (sessionKey, cursor, fromIntegral (max 1 limit + 1))
+            loadHistoryTurnsBeforeStatement)
+        (Transaction.statement sessionKey fullHistoryStatement)
         (max 1 limit)
         PageBefore
 
@@ -553,6 +594,7 @@ loadSessionTurnsAfter pool sessionKey cursor limit =
         (Transaction.statement
             (sessionKey, cursor, fromIntegral (max 1 limit + 1))
             loadTurnsAfterStatement)
+        (Transaction.statement sessionKey currentGenerationStatement)
         (max 1 limit)
         PageAfter
 
@@ -572,10 +614,11 @@ loadTurnPage
     :: StorePool
     -> Text
     -> Transaction.Transaction [TurnRow]
+    -> Transaction.Transaction (Int64, Int64)
     -> Int
     -> PageMode
     -> IO (Either StoreError (Maybe SessionTurnPage))
-loadTurnPage pool sessionKey loadRows limit mode =
+loadTurnPage pool sessionKey loadRows loadBounds limit mode =
     withSession pool
         (Transactions.transaction Transactions.RepeatableRead Transactions.Read do
             metadata <- Transaction.statement sessionKey loadMetadataStatement
@@ -583,8 +626,7 @@ loadTurnPage pool sessionKey loadRows limit mode =
                 Nothing -> pure (Right Nothing)
                 Just _ -> do
                     rows0 <- loadRows
-                    (generationStart, total) <-
-                        Transaction.statement sessionKey currentGenerationStatement
+                    (generationStart, total) <- loadBounds
                     let visibleRows = case mode of
                             PageRecent -> reverse (take limit rows0)
                             PageBefore -> reverse (take limit rows0)
@@ -637,6 +679,43 @@ listSessionMetadata pool =
     withSession pool $
         Transactions.transaction Transactions.RepeatableRead Transactions.Read $
             Transaction.statement () listMetadataStatement
+
+listSessionArchiveKeys
+    :: StorePool
+    -> IO (Either StoreError [Text])
+listSessionArchiveKeys pool =
+    withSession pool $
+        Transactions.transaction Transactions.RepeatableRead Transactions.Read $
+            Transaction.statement () listArchiveKeysStatement
+
+setSessionArchived
+    :: StorePool
+    -> Text
+    -> Bool
+    -> UTCTime
+    -> IO (Either StoreError Bool)
+setSessionArchived pool sessionKey archived occurredAt =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write do
+            _ <- Transaction.statement sessionKey blockingAdvisoryLockStatement
+            changed <- Transaction.statement
+                (sessionKey, archived, occurredAt)
+                setArchivedProjectionStatement
+            case changed of
+                Nothing -> pure False
+                Just (sessionId, sequence) -> do
+                    _ <- Transaction.statement
+                        EventInsert
+                            { eventInsertSessionId = sessionId
+                            , eventInsertSequence = sequence
+                            , eventInsertKind =
+                                if archived
+                                    then "session.archived"
+                                    else "session.restored"
+                            , eventInsertOccurredAt = occurredAt
+                            }
+                        insertEventStatement
+                    pure True
 
 searchConversationTurns
     :: StorePool
@@ -861,6 +940,37 @@ sessionExistsStatement = mkStatement
     (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
     True
 
+listArchiveKeysStatement :: Statement () [Text]
+listArchiveKeysStatement = mkStatement
+    "SELECT session_key FROM harness.sessions\
+    \ WHERE deleted_at IS NULL AND archived_at IS NOT NULL\
+    \ ORDER BY archived_at DESC, session_key ASC"
+    Encoders.noParams
+    (Decoders.rowList $
+        Decoders.column (Decoders.nonNullable Decoders.text))
+    True
+
+setArchivedProjectionStatement
+    :: Statement (Text, Bool, UTCTime) (Maybe (Text, Int64))
+setArchivedProjectionStatement = mkStatement
+    "UPDATE harness.sessions SET\
+    \ archived_at = CASE WHEN $2 THEN $3 ELSE NULL END,\
+    \ next_event_sequence = next_event_sequence + 1\
+    \ WHERE session_key = $1 AND deleted_at IS NULL\
+    \ RETURNING session_id::text, next_event_sequence - 1"
+    ( ((\(key, _, _) -> key)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((\(_, archived, _) -> archived)
+            >$< Encoders.param (Encoders.nonNullable Encoders.bool))
+        <> ((\(_, _, occurredAt) -> occurredAt)
+            >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
+    )
+    (Decoders.rowMaybe $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.int8))
+    True
+
 insertSessionStatement :: Statement SessionMetadata Text
 insertSessionStatement = mkStatement
     "INSERT INTO harness.sessions (\
@@ -1077,6 +1187,19 @@ loadRecentTurnsStatement = mkStatement
     (Decoders.rowList turnRowDecoder)
     True
 
+loadRecentHistoryTurnsStatement :: Statement (Text, Int64) [TurnRow]
+loadRecentHistoryTurnsStatement = mkStatement
+    ( turnSelectSql
+        <> " WHERE s.session_key = $1"
+        <> " ORDER BY t.turn_index DESC"
+        <> " LIMIT $2"
+    )
+    ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
+    (Decoders.rowList turnRowDecoder)
+    True
+
 loadTurnsBeforeStatement :: Statement (Text, Int64, Int64) [TurnRow]
 loadTurnsBeforeStatement = mkStatement
     (turnSelectSql
@@ -1092,6 +1215,24 @@ loadTurnsBeforeStatement = mkStatement
            \ ), 0)\
            \ ORDER BY t.turn_index DESC\
            \ LIMIT $3")
+    ( ((\(value, _, _) -> value)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((\(_, value, _) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+        <> ((\(_, _, value) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
+    (Decoders.rowList turnRowDecoder)
+    True
+
+loadHistoryTurnsBeforeStatement :: Statement (Text, Int64, Int64) [TurnRow]
+loadHistoryTurnsBeforeStatement = mkStatement
+    ( turnSelectSql
+        <> " WHERE s.session_key = $1"
+        <> " AND t.turn_index < $2"
+        <> " ORDER BY t.turn_index DESC"
+        <> " LIMIT $3"
+    )
     ( ((\(value, _, _) -> value)
         >$< Encoders.param (Encoders.nonNullable Encoders.text))
         <> ((\(_, value, _) -> value)
@@ -1125,6 +1266,26 @@ loadTurnsAfterStatement = mkStatement
             >$< Encoders.param (Encoders.nonNullable Encoders.int8))
     )
     (Decoders.rowList turnRowDecoder)
+    True
+
+fullHistoryStatement :: Statement Text (Int64, Int64)
+fullHistoryStatement = mkStatement
+    ( "WITH target AS ("
+        <> " SELECT session_id"
+        <> " FROM harness.sessions"
+        <> " WHERE session_key = $1 AND deleted_at IS NULL"
+        <> " )"
+        <> " SELECT COALESCE(min(t.turn_index), 0)::bigint,"
+        <> " count(t.turn_id)::bigint"
+        <> " FROM target"
+        <> " LEFT JOIN harness.session_turns t"
+        <> " ON t.session_id = target.session_id"
+    )
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.singleRow $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.int8)
+            <*> Decoders.column (Decoders.nonNullable Decoders.int8))
     True
 
 currentGenerationStatement :: Statement Text (Int64, Int64)

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -24,6 +24,8 @@ module Agent.Store.Postgres.Session
     , sessionSchemaStatements
     , createSession
     , replaceSessionMetadata
+    , setSessionTitle
+    , setGeneratedSessionTitle
     , appendSessionTurn
     , appendSessionTurnIndexed
     , loadSession
@@ -83,6 +85,15 @@ data SessionLegacyTarget = SessionLegacyTarget
     , sessionLegacyDialect :: !Text
     }
     deriving (Eq, Show)
+
+data TitleUpdate = TitleUpdate
+    { titleUpdateKey :: !Text
+    , titleUpdateTitle :: !Text
+    , titleUpdateManual :: !Bool
+    , titleUpdateRefreshIndex :: !Int32
+    , titleUpdateOccurredAt :: !UTCTime
+    , titleUpdateOnlyWhenAutomatic :: !Bool
+    }
 
 data NativeConversationSearchResult = NativeConversationSearchResult
     { nativeSearchSessionId :: !Text
@@ -379,6 +390,66 @@ createSession pool metadata =
                             , eventInsertKind = "session.created"
                             , eventInsertOccurredAt =
                                 metadata.sessionMetadataCreatedAt
+                            }
+                        insertEventStatement
+                    pure True
+
+setSessionTitle
+    :: StorePool
+    -> Text
+    -> Text
+    -> Bool
+    -> Int32
+    -> UTCTime
+    -> IO (Either StoreError Bool)
+setSessionTitle pool sessionKey title manual refreshIndex occurredAt =
+    updateSessionTitle pool TitleUpdate
+        { titleUpdateKey = sessionKey
+        , titleUpdateTitle = title
+        , titleUpdateManual = manual
+        , titleUpdateRefreshIndex = refreshIndex
+        , titleUpdateOccurredAt = occurredAt
+        , titleUpdateOnlyWhenAutomatic = False
+        }
+
+setGeneratedSessionTitle
+    :: StorePool
+    -> Text
+    -> Text
+    -> Int32
+    -> UTCTime
+    -> IO (Either StoreError Bool)
+setGeneratedSessionTitle pool sessionKey title refreshIndex occurredAt =
+    updateSessionTitle pool TitleUpdate
+        { titleUpdateKey = sessionKey
+        , titleUpdateTitle = title
+        , titleUpdateManual = False
+        , titleUpdateRefreshIndex = refreshIndex
+        , titleUpdateOccurredAt = occurredAt
+        , titleUpdateOnlyWhenAutomatic = True
+        }
+
+updateSessionTitle
+    :: StorePool
+    -> TitleUpdate
+    -> IO (Either StoreError Bool)
+updateSessionTitle pool update =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write do
+            _ <- Transaction.statement
+                update.titleUpdateKey
+                blockingAdvisoryLockStatement
+            changed <- Transaction.statement update setTitleProjectionStatement
+            case changed of
+                Nothing -> pure False
+                Just (sessionId, sequence) -> do
+                    _ <- Transaction.statement
+                        EventInsert
+                            { eventInsertSessionId = sessionId
+                            , eventInsertSequence = sequence
+                            , eventInsertKind = "session.title_updated"
+                            , eventInsertOccurredAt =
+                                update.titleUpdateOccurredAt
                             }
                         insertEventStatement
                     pure True
@@ -1056,11 +1127,44 @@ metadataUpdateSql =
     \ transport_model_id = $8, dialect = $9,\
     \ legacy_target_provider = $10, legacy_target_connection = $11,\
     \ legacy_target_effective_model = $12, legacy_target_dialect = $13,\
-    \ cwd = $14, effort = $15, title = $16, title_is_manual = $17,\
-    \ title_refresh_index = $18, title_user_turns = $19,\
+    \ cwd = $14, effort = $15,\
+    \ title = CASE WHEN title_is_manual THEN title ELSE $16 END,\
+    \ title_is_manual = CASE\
+    \   WHEN title_is_manual THEN title_is_manual ELSE $17 END,\
+    \ title_refresh_index = CASE\
+    \   WHEN title_is_manual THEN title_refresh_index ELSE $18 END,\
+    \ title_user_turns = $19,\
     \ last_response_id = $20, input_tokens = $21, output_tokens = $22,\
     \ cached_tokens = $23, last_recap = $24, last_turn_summary = $25,\
     \ last_recap_main_turns = $26"
+
+setTitleProjectionStatement
+    :: Statement TitleUpdate (Maybe (Text, Int64))
+setTitleProjectionStatement = mkStatement
+    "UPDATE harness.sessions SET\
+    \ title = $2, title_is_manual = $3, title_refresh_index = $4,\
+    \ updated_at = $5, next_event_sequence = next_event_sequence + 1\
+    \ WHERE session_key = $1 AND deleted_at IS NULL\
+    \ AND (NOT $6 OR NOT title_is_manual)\
+    \ RETURNING session_id::text, next_event_sequence - 1"
+    ( ((.titleUpdateKey)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.titleUpdateTitle)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.titleUpdateManual)
+            >$< Encoders.param (Encoders.nonNullable Encoders.bool))
+        <> ((.titleUpdateRefreshIndex)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int4))
+        <> ((.titleUpdateOccurredAt)
+            >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
+        <> ((.titleUpdateOnlyWhenAutomatic)
+            >$< Encoders.param (Encoders.nonNullable Encoders.bool))
+    )
+    (Decoders.rowMaybe $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.int8))
+    True
 
 insertEventStatement :: Statement EventInsert Text
 insertEventStatement = mkStatement

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill.hs
@@ -34,6 +34,7 @@ module Agent.Store.Postgres.Skill
     , readLearnedSkill
     , searchLearnedSkills
     , listApplicableLearnedSkills
+    , listAllLearnedSkills
     , listLearnedSkillRevisions
     , listLearnedSkillSources
     ) where
@@ -506,6 +507,18 @@ listApplicableLearnedSkills pool scopes =
                 (HasqlSession.statement applicable listSkillsStatement)
                 >>= pure . decodeSkillListResult
 
+listAllLearnedSkills
+    :: StorePool
+    -> [Scope]
+    -> IO (Either StoreError [LearnedSkill])
+listAllLearnedSkills pool scopes =
+    case applicableScopes scopes of
+        Left err -> pure (Left (StoreDataError err))
+        Right applicable ->
+            withSession pool
+                (HasqlSession.statement applicable listAllSkillsStatement)
+                >>= pure . decodeSkillListResult
+
 listLearnedSkillRevisions
     :: StorePool
     -> Scope
@@ -818,6 +831,15 @@ insertSkillStatement = mkStatement
         <> ((.learnedSkillCreateAt) >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
     )
     (Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.text)))
+    True
+
+listAllSkillsStatement :: Statement ApplicableScopes [SkillRow]
+listAllSkillsStatement = mkStatement
+    (skillSelectSql
+        <> applicableWhereSql
+        <> " ORDER BY scope_kind, title, slug")
+    applicableScopesEncoder
+    (Decoders.rowList skillRowDecoder)
     True
 
 updateSkillStatement :: Statement LearnedSkill ()

--- a/packages/agent-store/src/Agent/Store/Postgres/UsageCache.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/UsageCache.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FieldSelectors #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Durable, provider-agnostic cache entries for account usage snapshots.
+--
+-- The payload is deliberately opaque text. Provider packages own the JSON
+-- schema and decode it at the boundary; the store never receives credentials
+-- or provider-specific types.
+module Agent.Store.Postgres.UsageCache
+    ( AccountUsageCacheEntry(..)
+    , accountUsageCacheSchemaStatements
+    , loadAccountUsageCache
+    , upsertAccountUsageCache
+    ) where
+
+import Data.ByteString (ByteString)
+import Data.Functor.Contravariant ((>$<))
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Session as Session
+import Hasql.Statement (Statement)
+
+import Agent.Store.Postgres.Connection
+    ( StorePool
+    , withSession
+    )
+import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Types (StoreError)
+
+-- | A cached provider response.  'accountUsageCacheFetchedAt' and
+-- 'accountUsageCacheExpiresAt' are both retained so callers can show stale
+-- data while an asynchronous refresh is in flight.
+data AccountUsageCacheEntry = AccountUsageCacheEntry
+    { accountUsageCacheProvider :: !Text
+    , accountUsageCacheAccountId :: !Text
+    , accountUsageCachePayload :: !Text
+    , accountUsageCacheFetchedAt :: !UTCTime
+    , accountUsageCacheExpiresAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+-- | DDL is kept with the cache API so migration and schema tests cannot drift.
+accountUsageCacheSchemaStatements :: [ByteString]
+accountUsageCacheSchemaStatements =
+    [ "CREATE TABLE IF NOT EXISTS harness.account_usage_cache (\
+      \ provider text NOT NULL,\
+      \ account_id text NOT NULL,\
+      \ payload_text text NOT NULL,\
+      \ fetched_at timestamptz NOT NULL,\
+      \ expires_at timestamptz NOT NULL,\
+      \ PRIMARY KEY (provider, account_id)\
+      \ )"
+    ]
+
+loadAccountUsageCache
+    :: StorePool
+    -> Text
+    -> Text
+    -> IO (Either StoreError (Maybe AccountUsageCacheEntry))
+loadAccountUsageCache pool provider accountId =
+    withSession pool (Session.statement
+        (provider, accountId)
+        loadAccountUsageCacheStatement)
+
+upsertAccountUsageCache
+    :: StorePool
+    -> AccountUsageCacheEntry
+    -> IO (Either StoreError ())
+upsertAccountUsageCache pool entry =
+    withSession pool (Session.statement entry upsertAccountUsageCacheStatement)
+
+loadAccountUsageCacheStatement
+    :: Statement (Text, Text) (Maybe AccountUsageCacheEntry)
+loadAccountUsageCacheStatement = mkStatement
+    "SELECT provider, account_id, payload_text, fetched_at, expires_at\
+    \ FROM harness.account_usage_cache\
+    \ WHERE provider = $1 AND account_id = $2"
+    cacheKeyParams
+    (Decoders.rowMaybe $
+        AccountUsageCacheEntry
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+            <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz))
+    True
+
+upsertAccountUsageCacheStatement
+    :: Statement AccountUsageCacheEntry ()
+upsertAccountUsageCacheStatement = mkStatement
+    "INSERT INTO harness.account_usage_cache\
+    \ (provider, account_id, payload_text, fetched_at, expires_at)\
+    \ VALUES ($1, $2, $3, $4, $5)\
+    \ ON CONFLICT (provider, account_id) DO UPDATE SET\
+    \ payload_text = EXCLUDED.payload_text,\
+    \ fetched_at = EXCLUDED.fetched_at,\
+    \ expires_at = EXCLUDED.expires_at"
+    ( ((.accountUsageCacheProvider)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.accountUsageCacheAccountId)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.accountUsageCachePayload)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.accountUsageCacheFetchedAt)
+            >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
+        <> ((.accountUsageCacheExpiresAt)
+            >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
+    )
+    Decoders.noResult
+    True
+
+cacheKeyParams :: Encoders.Params (Text, Text)
+cacheKeyParams =
+    ((fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.text)))

--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FieldSelectors #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -8,6 +9,7 @@ import Control.Exception.Safe (finally)
 import Data.ByteString (ByteString)
 import Data.Either (isLeft, isRight)
 import Data.Text (Text)
+import Data.Time.Clock (addUTCTime, getCurrentTime)
 import qualified Hasql.Decoders as Decoders
 import qualified Hasql.Encoders as Encoders
 import qualified Hasql.Session as Session
@@ -33,6 +35,11 @@ import Agent.Store.Postgres.Migrations
     , runMigrations
     )
 import Agent.Store.Postgres.Scope (customSchemaStatements)
+import Agent.Store.Postgres.UsageCache
+    ( AccountUsageCacheEntry(..)
+    , loadAccountUsageCache
+    , upsertAccountUsageCache
+    )
 
 spec :: Spec
 spec =
@@ -63,6 +70,22 @@ spec =
                         (Session.script
                             "CREATE SCHEMA runtime_must_not_create")
                     forbiddenResult `shouldSatisfy` isLeft
+                    fetchedAt <- getCurrentTime
+                    let usageEntry = AccountUsageCacheEntry
+                            { accountUsageCacheProvider = "openai"
+                            , accountUsageCacheAccountId = "account-1"
+                            , accountUsageCachePayload = "{\"remaining\":42}"
+                            , accountUsageCacheFetchedAt = fetchedAt
+                            , accountUsageCacheExpiresAt =
+                                addUTCTime 300 fetchedAt
+                            }
+                    upsertAccountUsageCache (trustedPool store) usageEntry
+                        `shouldReturn` Right ()
+                    loadAccountUsageCache
+                        (trustedPool store)
+                        "openai"
+                        "account-1"
+                        `shouldReturn` Right (Just usageEntry)
                     ) >>= \case
                         Left err ->
                             expectationFailure

--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -70,7 +70,7 @@ spec =
                         (Session.script
                             "CREATE SCHEMA runtime_must_not_create")
                     forbiddenResult `shouldSatisfy` isLeft
-                    fetchedAt <- getCurrentTime
+                    fetchedAt <- normalizePostgresTimestamp <$> getCurrentTime
                     let usageEntry = AccountUsageCacheEntry
                             { accountUsageCacheProvider = "openai"
                             , accountUsageCacheAccountId = "account-1"

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -247,6 +247,36 @@ spec = describe "PostgreSQL session schema" do
                                 other ->
                                     expectationFailure
                                         ("unexpected recent page: " <> show other)
+                            loadRecentSessionHistoryTurns pool "session-1" 2
+                                >>= \case
+                                    Right (Just page) -> do
+                                        map (.storedTurnIndex) page.sessionPageTurns
+                                            `shouldBe` [4, 5]
+                                        page.sessionPageGenerationStart
+                                            `shouldBe` 0
+                                        page.sessionPageTotal `shouldBe` 6
+                                        page.sessionPageHasOlder `shouldBe` True
+                                        page.sessionPageHasNewer `shouldBe` False
+                                    other ->
+                                        expectationFailure
+                                            ( "unexpected full-history recent page: "
+                                                <> show other
+                                            )
+                            loadSessionHistoryTurnsBefore pool "session-1" 2 2
+                                >>= \case
+                                    Right (Just page) -> do
+                                        map (.storedTurnIndex) page.sessionPageTurns
+                                            `shouldBe` [0, 1]
+                                        page.sessionPageGenerationStart
+                                            `shouldBe` 0
+                                        page.sessionPageTotal `shouldBe` 6
+                                        page.sessionPageHasOlder `shouldBe` False
+                                        page.sessionPageHasNewer `shouldBe` True
+                                    other ->
+                                        expectationFailure
+                                            ( "unexpected full-history older page: "
+                                                <> show other
+                                            )
                             loadSessionTurnsBefore pool "session-1" 4 2 >>= \case
                                 Right (Just page) -> do
                                     map (.storedTurnIndex) page.sessionPageTurns

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -161,6 +161,28 @@ spec = describe "PostgreSQL session schema" do
                                 other ->
                                     expectationFailure
                                         ("unexpected conversation search: " <> show other)
+                            setSessionArchived pool "session-2" True now
+                                `shouldReturn` Right True
+                            searchNativeConversations pool "second" 10 >>= \case
+                                Right [match] -> do
+                                    match.nativeSearchSessionId
+                                        `shouldBe` "session-2"
+                                    match.nativeSearchArchived `shouldBe` True
+                                    match.nativeSearchTurnIndex `shouldBe` Nothing
+                                other ->
+                                    expectationFailure
+                                        ("unexpected native metadata search: "
+                                            <> show other)
+                            searchNativeConversations pool "batch" 10 >>= \case
+                                Right [match] -> do
+                                    match.nativeSearchSessionId
+                                        `shouldBe` "session-2"
+                                    match.nativeSearchTurnIndex `shouldBe` Just 0
+                                    match.nativeSearchRole `shouldBe` Just "user"
+                                other ->
+                                    expectationFailure
+                                        ("unexpected native turn search: "
+                                            <> show other)
                             deleteSession pool "session-1" now
                                 `shouldReturn` Right True
                             events <- loadSessionEvents pool "session-1"

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Client.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Client.hs
@@ -8,6 +8,7 @@ module Claude.Agent.SDK.Client
     , withClaudeSDKTurn
     , sendQuery
     , sendQueryContent
+    , sendControlResponse
     , receiveMessage
     , resolveTurnUsage
     , acceptTurnSessionId
@@ -299,6 +300,15 @@ sendQueryContent turn content = do
                 <> "\n"
             )
         )
+
+-- | Send one control-protocol response while a query remains active.
+sendControlResponse
+    :: ClaudeSDKTurn
+    -> Aeson.Value
+    -> IO (Either ClaudeSDKError ())
+sendControlResponse turn response =
+    turn.turnRunning.runningTransport.transportWrite
+        (LazyByteString.toStrict (Aeson.encode response <> "\n"))
 
 userContentValue :: UserContentBlock -> Aeson.Value
 userContentValue = \case

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
@@ -9,6 +9,7 @@ module Claude.Agent.SDK.Query
     , queryTurnContent
     , queryTurnWithMessageValidator
     , queryTurnContentWithMessageValidator
+    , queryTurnContentWithControlHandler
     , receiveResponse
     , receiveResponseWithMessageValidator
     ) where
@@ -37,12 +38,14 @@ import Claude.Agent.SDK.Internal.Query
     )
 import Claude.Agent.SDK.Types
     ( ClaudeAgentOptions(..)
-    , Message
+    , Message(..)
     , ResultMessage(..)
     , UserContentBlock(..)
+    , messageHasParentToolUseId
     )
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Aeson (Object)
 import System.Exit (ExitCode)
 import System.Timeout (timeout)
 
@@ -145,6 +148,25 @@ queryTurnContentWithMessageValidator
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 queryTurnContentWithMessageValidator turn content validateMessage onMessage = do
+    queryTurnContentWithControlHandler
+        turn
+        content
+        validateMessage
+        (\_ -> pure (Left (CLIProtocolError
+            "Claude Code requested interactive protocol input that this client does not support.")))
+        onMessage
+
+-- | Structured query with an explicit handler for Claude Code control
+-- requests such as @can_use_tool@.
+queryTurnContentWithControlHandler
+    :: ClaudeSDKTurn
+    -> [UserContentBlock]
+    -> (Message -> IO (Either ClaudeSDKError ()))
+    -> (Object -> IO (Either ClaudeSDKError ()))
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+queryTurnContentWithControlHandler
+    turn content validateMessage handleControl onMessage = do
     completed <-
         timeout
             (max 1 (turnTimeoutMicros turn))
@@ -152,9 +174,10 @@ queryTurnContentWithMessageValidator turn content validateMessage onMessage = do
                 sendQueryContent turn content >>= \case
                     Left err -> pure (Left err)
                     Right () ->
-                        receiveResponseWithMessageValidator
+                        receiveResponseWithControlHandler
                             turn
                             validateMessage
+                            handleControl
                             onMessage
     case completed of
         Nothing ->
@@ -183,6 +206,21 @@ receiveResponseWithMessageValidator
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 receiveResponseWithMessageValidator turn validateMessage onMessage =
+    receiveResponseWithControlHandler
+        turn
+        validateMessage
+        (\_ -> pure (Left (CLIProtocolError
+            "Claude Code requested interactive protocol input that this client does not support.")))
+        onMessage
+
+receiveResponseWithControlHandler
+    :: ClaudeSDKTurn
+    -> (Message -> IO (Either ClaudeSDKError ()))
+    -> (Object -> IO (Either ClaudeSDKError ()))
+    -> (Message -> IO ())
+    -> IO (Either ClaudeSDKError ResultMessage)
+receiveResponseWithControlHandler
+    turn validateMessage handleControl onMessage =
     go emptyQueryAccumulator False
   where
     go
@@ -217,8 +255,14 @@ receiveResponseWithMessageValidator turn validateMessage onMessage =
                 case validated of
                     Left err ->
                         pure (Left err)
-                    Right () ->
-                        case consumeQueryMessage accumulator message of
+                    Right () -> case message of
+                        MessageControlRequest request
+                            | not (messageHasParentToolUseId message) -> do
+                                handled <- handleControl request
+                                case handled of
+                                    Left err -> pure (Left err)
+                                    Right () -> go accumulator True
+                        _ -> case consumeQueryMessage accumulator message of
                             Left err ->
                                 pure (Left err)
                             Right (nextAccumulator, Nothing) ->

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
@@ -244,6 +244,18 @@ spec = describe "query" do
                     ("expected CLIJSONDecodeError, got " <> show other)
         messages `shouldBe` []
 
+    it "routes top-level control requests through an explicit handler" do
+        (result, controls) <- runQueryLinesWithControlHandler
+            [ "{\"type\":\"control_request\",\"request_id\":\"permission-1\",\
+              \\"request\":{\"subtype\":\"can_use_tool\",\
+              \\"tool_name\":\"Bash\",\"input\":{\"command\":\"touch file\"}}}"
+            , successResult testSessionId
+            ]
+
+        _ <- expectRight result
+        show controls `shouldContain` "permission-1"
+        show controls `shouldContain` "can_use_tool"
+
     it "ignores parent-scoped terminal and control records for completion" do
         (result, messages) <- runQueryLines
             [ assistantLine "outer-assistant" "outer answer"
@@ -466,6 +478,41 @@ runQueryLines linesToEmit =
                     modifyIORef' messagesRef (<> [message]))
         messages <- readIORef messagesRef
         pure (result, messages)
+
+runQueryLinesWithControlHandler
+    :: [Text]
+    -> IO
+        ( Either ClaudeSDKError ResultMessage
+        , [Aeson.Object]
+        )
+runQueryLinesWithControlHandler linesToEmit =
+    withFakeClaude (oneShotScript linesToEmit) \directory executable -> do
+        controlsRef <- newIORef []
+        result <-
+            withClaudeSDKClient
+                (testOptions executable directory)
+                \client ->
+                    withClaudeSDKTurn
+                        client
+                        (pure True)
+                        Nothing
+                        Nothing
+                        Nothing
+                        \turn -> do
+                            completed <-
+                                queryTurnContentWithControlHandler
+                                    turn
+                                    [UserTextBlock "hello"]
+                                    (const (pure (Right ())))
+                                    (\control -> do
+                                        modifyIORef'
+                                            controlsRef
+                                            (<> [control])
+                                        pure (Right ()))
+                                    (const (pure ()))
+                            pure ((, pure ()) <$> completed)
+        controls <- readIORef controlsRef
+        pure (result, controls)
 
 canonicalResponseLines :: [Text]
 canonicalResponseLines =


### PR DESCRIPTION
## Summary
- expose typed repository snapshots, status rows, bounded diff chunks/hunks, stage/unstage/restore, commit, and cancellable checks
- fingerprint HEAD/index/worktree and require the reviewed snapshot for every operation
- stream check stdout/stderr with explicit argv and no shell

## Mutation safety
- accept only exact server-observed paths and force literal Git pathspecs
- bind patch mutations to server-issued snapshot/operation/content tokens; arbitrary caller patches cannot delete or modify unrelated files
- never delete untracked files
- serialize canonical repositories with process/OS locks and revalidate around mutation/apply windows
- cancel-all serializes worker admission, terminates/joins subprocesses, and honors documented callback terminal behavior
- canonical containment, UTF-8, bounds, callback ownership, and buffer lifetimes are documented

## Validation
- focused temp-Git repository review/adversarial tests
- typed C ABI smoke
- native bridge build
- `git diff --check`

## Scope
Remote push and PR creation remain excluded because they require separate credential/network policy. Stacked on #750.
