### PR TITLE
Expose typed learned resource administration

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -151,6 +151,7 @@ library
                     , Agent.CLI.Prompt
                     , Agent.CLI.Recap
                     , Agent.CLI.Request
+                    , Agent.CLI.ResourceAdmin
                     , Agent.CLI.ProviderFallback
                     , Agent.CLI.ProviderAvailability
                     , Agent.CLI.ProviderTransition
@@ -260,6 +261,7 @@ foreign-library haskell-agent-bridge
     other-modules:    Agent.CLI.MacOS.Bridge
                     , Agent.CLI.MacOS.EngineMailbox
                     , Agent.CLI.MacOS.NativeLoopEvent
+                    , Agent.CLI.MacOS.ResourceAdmin
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     includes:         HaskellAgentBridge.h
@@ -360,6 +362,7 @@ test-suite agent-cli-test
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
                     , Agent.CLI.MacOS.BridgeFFISpec
+                    , Agent.CLI.ResourceAdminSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec
@@ -475,6 +478,7 @@ test-suite agent-cli-test
                     , test/cbits/HaskellAgentBridgeImageSmoke.c
                     , cbits/HaskellAgentBridgeRuntime.c
         other-modules: Agent.CLI.MacOS.Bridge
+                     , Agent.CLI.MacOS.ResourceAdmin
 
 benchmark image-preview-latency-bench
     import:           common-options

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -13,6 +13,7 @@ module Agent.CLI.MacOS.Bridge
     , nativeTurnArguments
     ) where
 
+import Agent.CLI.MacOS.ResourceAdmin ()
 import qualified Agent.CLI.AgentViewport as Viewport
 import Agent.CLI.BrowserTools
     ( BrowserCommand(..)
@@ -54,7 +55,7 @@ import Agent.Store.Postgres.Skill
     ( LearnedSkill(..)
     , learnedSkillActivationText
     , learnedSkillStatusText
-    , listAllLearnedSkills
+    , listAllLearnedSkillsLimited
     )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
@@ -1071,9 +1072,11 @@ ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
                     Right opened ->
                         bracket (pure opened) closeStore \store ->
                             first renderStoreError
-                                <$> listAllLearnedSkills
+                                <$> listAllLearnedSkillsLimited
                                     (trustedPool store)
                                     (applicableDatabaseScopes databaseScopes)
+                                    Nothing
+                                    1000
 
 type LearnedSkillItemCallback =
     CString -> CSize -> CString -> CSize -> CLLong

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/ResourceAdmin.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/ResourceAdmin.hs
@@ -1,0 +1,708 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE NoFieldSelectors #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module Agent.CLI.MacOS.ResourceAdmin () where
+
+import Agent.CLI.Database.Store
+    ( DatabaseScopes
+    , deriveDatabaseScopes
+    )
+import Agent.CLI.Project (resolveProjectRoot)
+import Agent.CLI.ResourceAdmin
+    ( ResourceAdminError(..)
+    , ResourceScope(..)
+    , ResourceSkill(..)
+    , ResourceSkillDraft(..)
+    , ResourceSkillRevision(..)
+    , archiveResourceSkill
+    , createResourceSkill
+    , historyResourceSkill
+    , listResourceSkills
+    , readResourceSkill
+    , restoreResourceSkill
+    , rollbackResourceSkill
+    , updateResourceSkill
+    , validateResourceSlug
+    , validateResourceSummary
+    , validateResourceSkillDraft
+    )
+import Agent.CLI.Session (sessionsRoot)
+import Agent.CLI.SessionAdmin (managedPostgresConfigForHome)
+import Agent.Store.Postgres
+    ( Store
+    , closeStore
+    , openStore
+    )
+import Agent.Store.Postgres.Skill
+    ( LearnedSkillActivation(..) )
+import Control.Exception.Safe (bracket, tryAny)
+import Control.Monad (forM_)
+import qualified Data.ByteString as BS
+import Data.Int (Int64)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Time.Clock (UTCTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import Data.Word (Word8, Word64)
+import Foreign
+    ( FunPtr
+    , Ptr
+    , castPtr
+    , nullFunPtr
+    , nullPtr
+    )
+import Foreign.C.String (CString)
+import Foreign.C.Types (CInt(..), CLLong(..), CSize(..))
+import System.Directory.OsPath (getHomeDirectory)
+import System.OsPath
+    ( decodeFS
+    , takeDirectory
+    , unsafeEncodeUtf
+    )
+import Control.Concurrent (forkIO)
+
+-- status: 0 item/success, 1 list completion, -1 generic error, -2 not found,
+-- -3 revision conflict, -4 already exists, -5 revision not found.
+type ResourceSkillCallback =
+    Ptr () -> CInt -> CInt
+    -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CInt -> CInt -> CInt
+    -> CLLong -> CLLong -> CString -> CSize -> IO ()
+
+type ResourceRevisionCallback =
+    Ptr () -> CInt -> CLLong
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CInt -> CInt -> CInt
+    -> CString -> CSize -> CLLong -> CString -> CSize -> IO ()
+
+type ResourceResultCallback =
+    Ptr () -> CInt -> CLLong -> CString -> CSize -> IO ()
+
+foreign import ccall "dynamic"
+    invokeResourceSkillCallback
+        :: FunPtr ResourceSkillCallback -> ResourceSkillCallback
+
+foreign import ccall "dynamic"
+    invokeResourceRevisionCallback
+        :: FunPtr ResourceRevisionCallback -> ResourceRevisionCallback
+
+foreign import ccall "dynamic"
+    invokeResourceResultCallback
+        :: FunPtr ResourceResultCallback -> ResourceResultCallback
+
+foreign export ccall ha_learned_skill_list
+    :: Ptr Word8 -> CSize -> CInt -> CSize
+    -> FunPtr ResourceSkillCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_learned_skill_read
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64
+    -> FunPtr ResourceSkillCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_learned_skill_create
+    :: Ptr Word8 -> CSize -> CInt
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> CInt -> CInt -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_learned_skill_update
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> CInt -> CInt -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_learned_skill_archive
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64
+    -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_learned_skill_restore
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64
+    -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_learned_skill_rollback
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64 -> Word64
+    -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_learned_skill_history
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> CSize
+    -> FunPtr ResourceRevisionCallback -> Ptr () -> IO CInt
+
+ha_learned_skill_list
+    :: Ptr Word8 -> CSize -> CInt -> CSize
+    -> FunPtr ResourceSkillCallback -> Ptr () -> IO CInt
+ha_learned_skill_list cwdPointer cwdLength rawScope rawLimit
+        callback context
+    | callback == nullFunPtr = pure 1
+    | rawLimit < 1 || rawLimit > 1000 = pure 2
+    | otherwise =
+        case parseOptionalScope rawScope of
+            Nothing -> pure 2
+            Just selected ->
+                decodeRequired "cwd" maxPathBytes cwdPointer cwdLength >>= \case
+                    Left _ -> pure 2
+                    Right cwd -> do
+                        runResourceAsync
+                            (withResourceStore cwd \store scopes ->
+                                listResourceSkills store scopes selected
+                                    (fromIntegral rawLimit))
+                            (emitSkillList callback context)
+                        pure 0
+
+ha_learned_skill_read
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64
+    -> FunPtr ResourceSkillCallback -> Ptr () -> IO CInt
+ha_learned_skill_read cwdPointer cwdLength rawScope
+        slugPointer slugLength rawRevision callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise =
+        case parseScope rawScope of
+            Nothing -> pure 2
+            Just scope ->
+                decodeCommon cwdPointer cwdLength slugPointer slugLength
+                    >>= \case
+                        Left _ -> pure 2
+                        Right (cwd, slug) ->
+                            case ( validateResourceSlug slug
+                                 , word64Revision rawRevision
+                                 ) of
+                                (Left _, _) -> pure 2
+                                (_, Left _) -> pure 2
+                                (Right _, Right revision) -> do
+                                    runResourceAsync
+                                        (withResourceStore cwd \store scopes ->
+                                            readResourceSkill store scopes scope
+                                                slug revision)
+                                        (emitSkillOne callback context)
+                                    pure 0
+
+ha_learned_skill_create
+    :: Ptr Word8 -> CSize -> CInt
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> CInt -> CInt -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+ha_learned_skill_create cwdPointer cwdLength rawScope
+        slugPointer slugLength titlePointer titleLength
+        descriptionPointer descriptionLength
+        appliesPointer appliesLength
+        instructionsPointer instructionsLength
+        rawActivation (CInt priority)
+        summaryPointer summaryLength callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise =
+        case (parseScope rawScope, parseActivation rawActivation) of
+            (Just scope, Just activation) ->
+                decodeDraft
+                    cwdPointer cwdLength slugPointer slugLength
+                    titlePointer titleLength descriptionPointer descriptionLength
+                    appliesPointer appliesLength
+                    instructionsPointer instructionsLength
+                    summaryPointer summaryLength
+                    >>= \case
+                        Left _ -> pure 2
+                        Right (cwd, slug, title, description, applies,
+                                instructions, summary) -> do
+                            let draft = ResourceSkillDraft
+                                    { resourceDraftTitle = title
+                                    , resourceDraftDescription = description
+                                    , resourceDraftAppliesWhen = applies
+                                    , resourceDraftInstructions = instructions
+                                    , resourceDraftActivation = activation
+                                    , resourceDraftPriority = priority
+                                    }
+                            case validatePayload slug draft summary of
+                                Left _ -> pure 2
+                                Right () -> do
+                                    runResourceAsync
+                                        (withResourceStore cwd \store scopes ->
+                                            createResourceSkill store scopes
+                                                scope slug draft summary)
+                                        (emitMutation callback context)
+                                    pure 0
+            _ -> pure 2
+
+ha_learned_skill_update
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> CInt -> CInt -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+ha_learned_skill_update cwdPointer cwdLength rawScope
+        slugPointer slugLength rawExpected
+        titlePointer titleLength
+        descriptionPointer descriptionLength
+        appliesPointer appliesLength
+        instructionsPointer instructionsLength
+        rawActivation (CInt priority)
+        summaryPointer summaryLength callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise =
+        case
+            ( parseScope rawScope
+            , parseActivation rawActivation
+            , positiveWord64Revision rawExpected
+            )
+          of
+            (Just scope, Just activation, Right expected) ->
+                decodeDraft
+                    cwdPointer cwdLength slugPointer slugLength
+                    titlePointer titleLength descriptionPointer descriptionLength
+                    appliesPointer appliesLength
+                    instructionsPointer instructionsLength
+                    summaryPointer summaryLength
+                    >>= \case
+                        Left _ -> pure 2
+                        Right (cwd, slug, title, description, applies,
+                                instructions, summary) -> do
+                            let draft = ResourceSkillDraft
+                                    { resourceDraftTitle = title
+                                    , resourceDraftDescription = description
+                                    , resourceDraftAppliesWhen = applies
+                                    , resourceDraftInstructions = instructions
+                                    , resourceDraftActivation = activation
+                                    , resourceDraftPriority = priority
+                                    }
+                            case validatePayload slug draft summary of
+                                Left _ -> pure 2
+                                Right () -> do
+                                    runResourceAsync
+                                        (withResourceStore cwd \store scopes ->
+                                            updateResourceSkill store scopes
+                                                scope slug expected draft summary)
+                                        (emitMutation callback context)
+                                    pure 0
+            _ -> pure 2
+
+ha_learned_skill_archive
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64
+    -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+ha_learned_skill_archive =
+    statusMutation archiveResourceSkill
+
+ha_learned_skill_restore
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64
+    -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+ha_learned_skill_restore =
+    statusMutation restoreResourceSkill
+
+ha_learned_skill_rollback
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64 -> Word64
+    -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+ha_learned_skill_rollback cwdPointer cwdLength rawScope
+        slugPointer slugLength rawExpected rawTarget
+        summaryPointer summaryLength callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise =
+        case
+            ( parseScope rawScope
+            , positiveWord64Revision rawExpected
+            , positiveWord64Revision rawTarget
+            )
+          of
+            (Just scope, Right expected, Right target) ->
+                decodeMutation
+                    cwdPointer cwdLength slugPointer slugLength
+                    summaryPointer summaryLength
+                    >>= \case
+                        Left _ -> pure 2
+                        Right (cwd, slug, summary)
+                            | target >= expected -> pure 2
+                            | otherwise ->
+                                case validateMutationPayload slug summary of
+                                    Left _ -> pure 2
+                                    Right () -> do
+                                        runResourceAsync
+                                            (withResourceStore cwd \store scopes ->
+                                                rollbackResourceSkill store
+                                                    scopes scope slug expected
+                                                    target summary)
+                                            (emitMutation callback context)
+                                        pure 0
+            _ -> pure 2
+
+ha_learned_skill_history
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> CSize
+    -> FunPtr ResourceRevisionCallback -> Ptr () -> IO CInt
+ha_learned_skill_history cwdPointer cwdLength rawScope
+        slugPointer slugLength rawLimit callback context
+    | callback == nullFunPtr = pure 1
+    | rawLimit < 1 || rawLimit > 1000 = pure 2
+    | otherwise =
+        case parseScope rawScope of
+            Nothing -> pure 2
+            Just scope ->
+                decodeCommon cwdPointer cwdLength slugPointer slugLength
+                    >>= \case
+                        Left _ -> pure 2
+                        Right (cwd, slug) ->
+                            case validateResourceSlug slug of
+                                Left _ -> pure 2
+                                Right _ -> do
+                                    runResourceAsync
+                                        (withResourceStore cwd \store scopes ->
+                                            historyResourceSkill store scopes
+                                                scope slug
+                                                (fromIntegral rawLimit))
+                                        (emitRevisionList callback context)
+                                    pure 0
+
+statusMutation
+    :: (Store -> DatabaseScopes -> ResourceScope -> Text -> Int64 -> Text
+        -> IO (Either ResourceAdminError ResourceSkill))
+    -> Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize -> Word64
+    -> Ptr Word8 -> CSize
+    -> FunPtr ResourceResultCallback -> Ptr () -> IO CInt
+statusMutation mutation cwdPointer cwdLength rawScope
+        slugPointer slugLength rawExpected
+        summaryPointer summaryLength callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise =
+        case (parseScope rawScope, positiveWord64Revision rawExpected) of
+            (Just scope, Right expected) ->
+                decodeMutation
+                    cwdPointer cwdLength slugPointer slugLength
+                    summaryPointer summaryLength
+                    >>= \case
+                        Left _ -> pure 2
+                        Right (cwd, slug, summary) ->
+                            case validateMutationPayload slug summary of
+                                Left _ -> pure 2
+                                Right () -> do
+                                    runResourceAsync
+                                        (withResourceStore cwd \store scopes ->
+                                            mutation store scopes scope slug
+                                                expected summary)
+                                        (emitMutation callback context)
+                                    pure 0
+            _ -> pure 2
+
+-- Store setup errors and unexpected exceptions intentionally collapse to a
+-- fixed error. PostgreSQL connection details and process environments must not
+-- cross the public bridge.
+withResourceStore
+    :: Text
+    -> (Store -> DatabaseScopes
+        -> IO (Either ResourceAdminError value))
+    -> IO (Either ResourceAdminError value)
+withResourceStore cwd action = do
+    home <- getHomeDirectory
+    projectRoot <- resolveProjectRoot (unsafeEncodeUtf (Text.unpack cwd))
+    stateDirectory <- decodeFS (takeDirectory (sessionsRoot home))
+    projectRootPath <- decodeFS projectRoot
+    deriveDatabaseScopes stateDirectory projectRootPath >>= \case
+        Left _ -> pure (Left ResourceAdminUnavailable)
+        Right scopes -> do
+            config <- managedPostgresConfigForHome home
+            openStore config >>= \case
+                Left _ -> pure (Left ResourceAdminUnavailable)
+                Right opened ->
+                    bracket (pure opened) closeStore (`action` scopes)
+
+runResourceAsync
+    :: IO (Either ResourceAdminError value)
+    -> (Either ResourceAdminError value -> IO ())
+    -> IO ()
+runResourceAsync action emit = do
+    _ <- forkIO $
+        tryAny action >>= \case
+            Left _ -> emit (Left ResourceAdminUnavailable)
+            Right result -> emit result
+    pure ()
+
+emitSkillList
+    :: FunPtr ResourceSkillCallback
+    -> Ptr ()
+    -> Either ResourceAdminError [ResourceSkill]
+    -> IO ()
+emitSkillList callback context = \case
+    Left err -> emitSkillError callback context err
+    Right skills -> do
+        forM_ skills (emitSkillItem callback context)
+        invokeResourceSkillCallback callback context 1 0
+            nullPtr 0 0
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            0 0 0 0 0 nullPtr 0
+
+emitSkillOne
+    :: FunPtr ResourceSkillCallback
+    -> Ptr ()
+    -> Either ResourceAdminError ResourceSkill
+    -> IO ()
+emitSkillOne callback context =
+    either (emitSkillError callback context)
+        (emitSkillItem callback context)
+
+emitSkillItem
+    :: FunPtr ResourceSkillCallback -> Ptr () -> ResourceSkill -> IO ()
+emitSkillItem callback context skill =
+    withText skill.resourceSkillSlug \slug slugLength ->
+    withText skill.resourceSkillTitle \title titleLength ->
+    withText skill.resourceSkillDescription \description descriptionLength ->
+    withText skill.resourceSkillAppliesWhen \applies appliesLength ->
+    withText skill.resourceSkillInstructions \instructions instructionsLength ->
+        invokeResourceSkillCallback callback context 0
+            (scopeCode skill.resourceSkillScope)
+            slug slugLength
+            (fromIntegral skill.resourceSkillRevision)
+            title titleLength description descriptionLength
+            applies appliesLength instructions instructionsLength
+            (activationCode skill.resourceSkillActivation)
+            (fromIntegral skill.resourceSkillPriority)
+            (if skill.resourceSkillArchived then 1 else 0)
+            (timestampMillis skill.resourceSkillCreatedAt)
+            (timestampMillis skill.resourceSkillUpdatedAt)
+            nullPtr 0
+
+emitSkillError
+    :: FunPtr ResourceSkillCallback
+    -> Ptr ()
+    -> ResourceAdminError
+    -> IO ()
+emitSkillError callback context err =
+    withText (errorMessage err) \pointer length ->
+        invokeResourceSkillCallback callback context (errorStatus err) 0
+            nullPtr 0 (conflictRevision err)
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            0 0 0 0 0 pointer length
+
+emitRevisionList
+    :: FunPtr ResourceRevisionCallback
+    -> Ptr ()
+    -> Either ResourceAdminError [ResourceSkillRevision]
+    -> IO ()
+emitRevisionList callback context = \case
+    Left err -> emitRevisionError callback context err
+    Right revisions -> do
+        forM_ revisions (emitRevisionItem callback context)
+        invokeResourceRevisionCallback callback context 1 0
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            0 0 0 nullPtr 0 0 nullPtr 0
+
+emitRevisionItem
+    :: FunPtr ResourceRevisionCallback
+    -> Ptr ()
+    -> ResourceSkillRevision
+    -> IO ()
+emitRevisionItem callback context revision =
+    withText revision.resourceRevisionTitle \title titleLength ->
+    withText revision.resourceRevisionDescription \description descriptionLength ->
+    withText revision.resourceRevisionAppliesWhen \applies appliesLength ->
+    withText revision.resourceRevisionInstructions \instructions instructionsLength ->
+    withText revision.resourceRevisionSummary \summary summaryLength ->
+        invokeResourceRevisionCallback callback context 0
+            (fromIntegral revision.resourceRevisionNumber)
+            title titleLength description descriptionLength
+            applies appliesLength instructions instructionsLength
+            (activationCode revision.resourceRevisionActivation)
+            (fromIntegral revision.resourceRevisionPriority)
+            (if revision.resourceRevisionArchived then 1 else 0)
+            summary summaryLength
+            (timestampMillis revision.resourceRevisionCreatedAt)
+            nullPtr 0
+
+emitRevisionError
+    :: FunPtr ResourceRevisionCallback
+    -> Ptr ()
+    -> ResourceAdminError
+    -> IO ()
+emitRevisionError callback context err =
+    withText (errorMessage err) \pointer length ->
+        invokeResourceRevisionCallback callback context (errorStatus err)
+            (conflictRevision err)
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            0 0 0 nullPtr 0 0 pointer length
+
+emitMutation
+    :: FunPtr ResourceResultCallback
+    -> Ptr ()
+    -> Either ResourceAdminError ResourceSkill
+    -> IO ()
+emitMutation callback context = \case
+    Right skill ->
+        invokeResourceResultCallback callback context 0
+            (fromIntegral skill.resourceSkillRevision) nullPtr 0
+    Left err -> withText (errorMessage err) \pointer length ->
+        invokeResourceResultCallback callback context (errorStatus err)
+            (conflictRevision err) pointer length
+
+decodeDraft
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize
+    -> IO (Either Text (Text, Text, Text, Text, Text, Text, Text))
+decodeDraft cwdPointer cwdLength slugPointer slugLength
+        titlePointer titleLength descriptionPointer descriptionLength
+        appliesPointer appliesLength instructionsPointer instructionsLength
+        summaryPointer summaryLength =
+    sequence7
+        <$> decodeRequired "cwd" maxPathBytes cwdPointer cwdLength
+        <*> decodeRequired "slug" 320 slugPointer slugLength
+        <*> decodeRequired "title" 800 titlePointer titleLength
+        <*> decodeRequired "description" 4000
+            descriptionPointer descriptionLength
+        <*> decodeOptional "applies_when" 8000 appliesPointer appliesLength
+        <*> decodeRequired "instructions" 120000
+            instructionsPointer instructionsLength
+        <*> decodeRequired "change_summary" 4000 summaryPointer summaryLength
+
+decodeMutation
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> IO (Either Text (Text, Text, Text))
+decodeMutation cwdPointer cwdLength slugPointer slugLength
+        summaryPointer summaryLength =
+    sequence3
+        <$> decodeRequired "cwd" maxPathBytes cwdPointer cwdLength
+        <*> decodeRequired "slug" 320 slugPointer slugLength
+        <*> decodeRequired "change_summary" 4000 summaryPointer summaryLength
+
+decodeCommon
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> IO (Either Text (Text, Text))
+decodeCommon cwdPointer cwdLength slugPointer slugLength =
+    sequence2
+        <$> decodeRequired "cwd" maxPathBytes cwdPointer cwdLength
+        <*> decodeRequired "slug" 320 slugPointer slugLength
+
+decodeRequired
+    :: Text -> CSize -> Ptr Word8 -> CSize -> IO (Either Text Text)
+decodeRequired label maximum pointer length
+    | pointer == nullPtr || length == 0 =
+        pure (Left (label <> " must not be empty"))
+    | otherwise = decodeOptional label maximum pointer length
+
+decodeOptional
+    :: Text -> CSize -> Ptr Word8 -> CSize -> IO (Either Text Text)
+decodeOptional label maximum pointer length
+    | length > maximum || toInteger length > toInteger (maxBound :: Int) =
+        pure (Left (label <> " is too large"))
+    | pointer == nullPtr && length > 0 =
+        pure (Left (label <> " pointer is null"))
+    | length == 0 = pure (Right "")
+    | otherwise = do
+        bytes <- BS.packCStringLen (castPtr pointer, fromIntegral length)
+        pure $ case TextEncoding.decodeUtf8' bytes of
+            Left _ -> Left (label <> " is not valid UTF-8")
+            Right value
+                | Text.any (== '\NUL') value ->
+                    Left (label <> " contains NUL")
+                | otherwise -> Right value
+
+parseScope :: CInt -> Maybe ResourceScope
+parseScope = \case
+    0 -> Just ResourceUserScope
+    1 -> Just ResourceRepositoryScope
+    2 -> Just ResourceCheckoutScope
+    _ -> Nothing
+
+parseOptionalScope :: CInt -> Maybe (Maybe ResourceScope)
+parseOptionalScope (-1) = Just Nothing
+parseOptionalScope value = Just <$> parseScope value
+
+parseActivation :: CInt -> Maybe LearnedSkillActivation
+parseActivation = \case
+    0 -> Just SkillAlways
+    1 -> Just SkillRelevant
+    2 -> Just SkillManual
+    _ -> Nothing
+
+scopeCode :: ResourceScope -> CInt
+scopeCode = \case
+    ResourceUserScope -> 0
+    ResourceRepositoryScope -> 1
+    ResourceCheckoutScope -> 2
+
+activationCode :: LearnedSkillActivation -> CInt
+activationCode = \case
+    SkillAlways -> 0
+    SkillRelevant -> 1
+    SkillManual -> 2
+
+word64Revision :: Word64 -> Either Text (Maybe Int64)
+word64Revision 0 = Right Nothing
+word64Revision value = Just <$> positiveWord64Revision value
+
+positiveWord64Revision :: Word64 -> Either Text Int64
+positiveWord64Revision value
+    | value == 0 || value > fromIntegral (maxBound :: Int64) =
+        Left "revision is out of range"
+    | otherwise = Right (fromIntegral value)
+
+timestampMillis :: UTCTime -> CLLong
+timestampMillis =
+    fromIntegral . (floor :: Rational -> Int64) . (* 1000)
+        . toRational . utcTimeToPOSIXSeconds
+
+errorStatus :: ResourceAdminError -> CInt
+errorStatus = \case
+    ResourceAdminNotFound -> -2
+    ResourceAdminConflict _ -> -3
+    ResourceAdminAlreadyExists -> -4
+    ResourceAdminRevisionNotFound -> -5
+    _ -> -1
+
+conflictRevision :: ResourceAdminError -> CLLong
+conflictRevision = \case
+    ResourceAdminConflict revision -> fromIntegral revision
+    _ -> 0
+
+errorMessage :: ResourceAdminError -> Text
+errorMessage = \case
+    ResourceAdminInvalid message -> message
+    ResourceAdminNotFound -> "resource not found"
+    ResourceAdminAlreadyExists -> "resource already exists"
+    ResourceAdminConflict _ -> "resource revision conflict"
+    ResourceAdminRevisionNotFound -> "resource revision not found"
+    ResourceAdminUnavailable -> "resource store unavailable"
+
+withText :: Text -> (CString -> CSize -> IO value) -> IO value
+withText value action =
+    BS.useAsCStringLen (TextEncoding.encodeUtf8 value) \(pointer, length) ->
+        action pointer (fromIntegral length)
+
+maxPathBytes :: CSize
+maxPathBytes = 1024 * 1024
+
+validatePayload
+    :: Text
+    -> ResourceSkillDraft
+    -> Text
+    -> Either ResourceAdminError ()
+validatePayload slug draft summary = do
+    _ <- validateResourceSlug slug
+    _ <- validateResourceSkillDraft draft
+    _ <- validateResourceSummary summary
+    pure ()
+
+validateMutationPayload
+    :: Text -> Text -> Either ResourceAdminError ()
+validateMutationPayload slug summary = do
+    _ <- validateResourceSlug slug
+    _ <- validateResourceSummary summary
+    pure ()
+
+sequence2
+    :: Either error a -> Either error b -> Either error (a, b)
+sequence2 left right = (,) <$> left <*> right
+
+sequence3
+    :: Either error a -> Either error b -> Either error c
+    -> Either error (a, b, c)
+sequence3 one two three = (,,) <$> one <*> two <*> three
+
+sequence7
+    :: Either error a -> Either error b -> Either error c
+    -> Either error d -> Either error e -> Either error f
+    -> Either error g -> Either error (a, b, c, d, e, f, g)
+sequence7 one two three four five six seven =
+    (,,,,,,) <$> one <*> two <*> three <*> four <*> five <*> six <*> seven

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -171,8 +171,10 @@ typedef void (*ha_session_result_callback)(
 
 /*
  * Learned-skill list callbacks emit current rows from all applicable scopes,
- * including archived skills. Status is 0 for an item, 1 for end-of-list, and
- * -1 for an error. UTF-8 buffers are callback-scoped and must be copied.
+ * including archived skills, capped at 1000 rows for compatibility. Status is
+ * 0 for an item, 1 for end-of-list, and -1 for an error. UTF-8 buffers are
+ * callback-scoped and must be copied. New clients should use the typed,
+ * scope-filterable ha_learned_skill_list API below.
  */
 typedef void (*ha_learned_skills_list_callback)(
     void *context, int32_t status,
@@ -324,6 +326,182 @@ int32_t ha_mcp_server_remove(
     uint64_t expected_revision,
     const uint8_t *name, size_t name_length,
     ha_mcp_result_callback callback, void *context
+);
+
+/*
+ * Typed Skills / Memory administration.
+ *
+ * A learned skill is the durable, versioned memory resource used by future
+ * agent sessions. Scope values are 0 user, 1 repository, and 2 checkout.
+ * List also accepts -1 for all applicable scopes. Activation values are
+ * 0 always, 1 relevant, and 2 manual. "archived" is 0 or 1.
+ *
+ * Every input buffer is copied before the call returns. UTF-8 must be valid
+ * and contain no NUL. All input text pointers must be non-NULL with positive
+ * length except applies_when, which may be NULL only when its length is zero.
+ * context may be NULL. Callback text pointers may be NULL whenever their
+ * associated length is zero and must not be dereferenced in that case;
+ * fields omitted on errors/completion use NULL with zero length.
+ * Fields enforce the store's character limits: slug 80, title 200,
+ * description 1000, applies_when 2000, instructions 30000, and
+ * change_summary 1000. Lists are explicitly limited to 1...1000 items.
+ * expected_revision is exact, positive optimistic concurrency; it is never
+ * interpreted as "latest". Read revision 0 selects the current revision.
+ *
+ * Functions return 0 when accepted, 1 for a missing callback, and 2 for an
+ * invalid pointer, enum, UTF-8 buffer, bound, count, or revision. Accepted
+ * calls invoke callbacks on a dedicated Haskell worker thread, never the
+ * caller or main thread. Calls for different requests may overlap. Item and
+ * error buffers are valid only until that callback returns and must be copied.
+ * The callback function and context must remain valid through the terminal
+ * callback. Accepted operations deliver their documented terminal callback
+ * unless the process exits; there is no cancellation handle.
+ *
+ * Item/list status is 0 for an item, 1 for successful list completion, -1
+ * for invalid/store failure, -2 not found, -3 revision conflict, -4 already
+ * exists, and -5 revision not found. A conflict places the current revision
+ * in the revision field. A read has one item or one error callback; list and
+ * history have zero or more items followed by exactly one terminal callback.
+ *
+ * Mutation callbacks use status 0 for success and the same negative failures.
+ * Their revision is the new revision on success or current revision on
+ * conflict. The ABI never accepts credentials or caller-provided provenance
+ * and never returns source evidence/session identifiers. Skill content itself
+ * is not secret storage and callers must not place credentials in it.
+ *
+ * cwd selects the same canonical user/repository/checkout identities as the
+ * CLI. Slugs are lower-case ASCII words separated by single hyphens. Update
+ * is a full content replacement and preserves active/archive state; use the
+ * explicit archive and restore operations for state changes.
+ */
+#define HA_LEARNED_SKILL_SCOPE_ALL        INT32_C(-1)
+#define HA_LEARNED_SKILL_SCOPE_USER       INT32_C(0)
+#define HA_LEARNED_SKILL_SCOPE_REPOSITORY INT32_C(1)
+#define HA_LEARNED_SKILL_SCOPE_CHECKOUT   INT32_C(2)
+
+#define HA_LEARNED_SKILL_ACTIVATION_ALWAYS   INT32_C(0)
+#define HA_LEARNED_SKILL_ACTIVATION_RELEVANT INT32_C(1)
+#define HA_LEARNED_SKILL_ACTIVATION_MANUAL   INT32_C(2)
+
+#define HA_RESOURCE_STATUS_ITEM               INT32_C(0)
+#define HA_RESOURCE_STATUS_COMPLETE           INT32_C(1)
+#define HA_RESOURCE_STATUS_ERROR              INT32_C(-1)
+#define HA_RESOURCE_STATUS_NOT_FOUND          INT32_C(-2)
+#define HA_RESOURCE_STATUS_REVISION_CONFLICT  INT32_C(-3)
+#define HA_RESOURCE_STATUS_ALREADY_EXISTS     INT32_C(-4)
+#define HA_RESOURCE_STATUS_REVISION_NOT_FOUND INT32_C(-5)
+
+typedef void (*ha_learned_skill_callback)(
+    void *context,
+    int32_t status,
+    int32_t scope,
+    const uint8_t *slug, size_t slug_length,
+    int64_t revision,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *description, size_t description_length,
+    const uint8_t *applies_when, size_t applies_when_length,
+    const uint8_t *instructions, size_t instructions_length,
+    int32_t activation,
+    int32_t priority,
+    int32_t archived,
+    int64_t created_at_ms,
+    int64_t updated_at_ms,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_learned_skill_revision_callback)(
+    void *context,
+    int32_t status,
+    int64_t revision,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *description, size_t description_length,
+    const uint8_t *applies_when, size_t applies_when_length,
+    const uint8_t *instructions, size_t instructions_length,
+    int32_t activation,
+    int32_t priority,
+    int32_t archived,
+    const uint8_t *change_summary, size_t change_summary_length,
+    int64_t created_at_ms,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_resource_result_callback)(
+    void *context,
+    int32_t status,
+    int64_t revision,
+    const uint8_t *error, size_t error_length
+);
+
+int32_t ha_learned_skill_list(
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t scope, size_t limit,
+    ha_learned_skill_callback callback, void *context
+);
+int32_t ha_learned_skill_read(
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t scope,
+    const uint8_t *slug, size_t slug_length,
+    uint64_t revision,
+    ha_learned_skill_callback callback, void *context
+);
+int32_t ha_learned_skill_create(
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t scope,
+    const uint8_t *slug, size_t slug_length,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *description, size_t description_length,
+    const uint8_t *applies_when, size_t applies_when_length,
+    const uint8_t *instructions, size_t instructions_length,
+    int32_t activation,
+    int32_t priority,
+    const uint8_t *change_summary, size_t change_summary_length,
+    ha_resource_result_callback callback, void *context
+);
+int32_t ha_learned_skill_update(
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t scope,
+    const uint8_t *slug, size_t slug_length,
+    uint64_t expected_revision,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *description, size_t description_length,
+    const uint8_t *applies_when, size_t applies_when_length,
+    const uint8_t *instructions, size_t instructions_length,
+    int32_t activation,
+    int32_t priority,
+    const uint8_t *change_summary, size_t change_summary_length,
+    ha_resource_result_callback callback, void *context
+);
+int32_t ha_learned_skill_archive(
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t scope,
+    const uint8_t *slug, size_t slug_length,
+    uint64_t expected_revision,
+    const uint8_t *change_summary, size_t change_summary_length,
+    ha_resource_result_callback callback, void *context
+);
+int32_t ha_learned_skill_restore(
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t scope,
+    const uint8_t *slug, size_t slug_length,
+    uint64_t expected_revision,
+    const uint8_t *change_summary, size_t change_summary_length,
+    ha_resource_result_callback callback, void *context
+);
+int32_t ha_learned_skill_rollback(
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t scope,
+    const uint8_t *slug, size_t slug_length,
+    uint64_t expected_revision,
+    uint64_t target_revision,
+    const uint8_t *change_summary, size_t change_summary_length,
+    ha_resource_result_callback callback, void *context
+);
+int32_t ha_learned_skill_history(
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t scope,
+    const uint8_t *slug, size_t slug_length,
+    size_t limit,
+    ha_learned_skill_revision_callback callback, void *context
 );
 
 /*

--- a/packages/agent-cli/src/Agent/CLI/ResourceAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/ResourceAdmin.hs
@@ -1,0 +1,564 @@
+{-# LANGUAGE NoFieldSelectors #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
+-- | Typed administration of the learned-skill store used as agent memory.
+--
+-- This module deliberately does not expose source evidence. Native
+-- administration records a fixed, non-secret audit source instead.
+module Agent.CLI.ResourceAdmin
+    ( ResourceScope(..)
+    , ResourceSkillDraft(..)
+    , ResourceSkill(..)
+    , ResourceSkillRevision(..)
+    , ResourceAdminError(..)
+    , validateResourceSlug
+    , validateResourceSummary
+    , validateResourceSkillDraft
+    , listResourceSkills
+    , readResourceSkill
+    , createResourceSkill
+    , updateResourceSkill
+    , archiveResourceSkill
+    , restoreResourceSkill
+    , rollbackResourceSkill
+    , historyResourceSkill
+    ) where
+
+import Agent.CLI.Database.Store
+    ( DatabaseScopes
+    , applicableDatabaseScopes
+    , scopeForDatabase
+    )
+import Agent.CLI.Database (DatabaseScope(..))
+import Agent.Store.Postgres (Store, trustedPool)
+import Agent.Store.Postgres.Scope
+    ( Scope(..)
+    , ScopeKind(..)
+    )
+import Agent.Store.Postgres.Skill
+    ( LearnedSkill(..)
+    , LearnedSkillActivation(..)
+    , LearnedSkillCreate(..)
+    , LearnedSkillMutationResult(..)
+    , LearnedSkillPatch(..)
+    , LearnedSkillRevision(..)
+    , LearnedSkillRollback(..)
+    , LearnedSkillSourceInput(..)
+    , LearnedSkillStatus(..)
+    , LearnedSkillUpdate(..)
+    , createLearnedSkill
+    , listAllLearnedSkillsLimited
+    , listLearnedSkillRevisionsLimited
+    , readLearnedSkill
+    , readLearnedSkillRevision
+    , rollbackLearnedSkill
+    , updateLearnedSkill
+    )
+import Agent.Store.Types (StoreError(..))
+import Data.Char (isAsciiLower, isDigit)
+import Data.Int (Int32, Int64)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (UTCTime, getCurrentTime)
+
+data ResourceScope
+    = ResourceUserScope
+    | ResourceRepositoryScope
+    | ResourceCheckoutScope
+    deriving (Eq, Ord, Show)
+
+data ResourceSkillDraft = ResourceSkillDraft
+    { resourceDraftTitle :: !Text
+    , resourceDraftDescription :: !Text
+    , resourceDraftAppliesWhen :: !Text
+    , resourceDraftInstructions :: !Text
+    , resourceDraftActivation :: !LearnedSkillActivation
+    , resourceDraftPriority :: !Int32
+    }
+    deriving (Eq, Show)
+
+data ResourceSkill = ResourceSkill
+    { resourceSkillScope :: !ResourceScope
+    , resourceSkillSlug :: !Text
+    , resourceSkillRevision :: !Int64
+    , resourceSkillTitle :: !Text
+    , resourceSkillDescription :: !Text
+    , resourceSkillAppliesWhen :: !Text
+    , resourceSkillInstructions :: !Text
+    , resourceSkillActivation :: !LearnedSkillActivation
+    , resourceSkillPriority :: !Int32
+    , resourceSkillArchived :: !Bool
+    , resourceSkillCreatedAt :: !UTCTime
+    , resourceSkillUpdatedAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+data ResourceSkillRevision = ResourceSkillRevision
+    { resourceRevisionNumber :: !Int64
+    , resourceRevisionTitle :: !Text
+    , resourceRevisionDescription :: !Text
+    , resourceRevisionAppliesWhen :: !Text
+    , resourceRevisionInstructions :: !Text
+    , resourceRevisionActivation :: !LearnedSkillActivation
+    , resourceRevisionPriority :: !Int32
+    , resourceRevisionArchived :: !Bool
+    , resourceRevisionSummary :: !Text
+    , resourceRevisionCreatedAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+data ResourceAdminError
+    = ResourceAdminInvalid !Text
+    | ResourceAdminNotFound
+    | ResourceAdminAlreadyExists
+    | ResourceAdminConflict !Int64
+    | ResourceAdminRevisionNotFound
+    | ResourceAdminUnavailable
+    deriving (Eq, Show)
+
+validateResourceSlug :: Text -> Either ResourceAdminError Text
+validateResourceSlug slug
+    | Text.null slug =
+        invalid "slug must not be empty"
+    | Text.length slug > 80 =
+        invalid "slug must contain at most 80 characters"
+    | any invalidSegment (Text.splitOn "-" slug) =
+        invalid "slug must use lower-case ASCII words separated by single hyphens"
+    | otherwise = Right slug
+  where
+    invalidSegment segment =
+        Text.null segment
+            || Text.any (\char -> not (isAsciiLower char || isDigit char)) segment
+
+validateResourceSummary :: Text -> Either ResourceAdminError Text
+validateResourceSummary summary =
+    validateRequired "change summary" 1000 summary
+
+validateResourceSkillDraft
+    :: ResourceSkillDraft
+    -> Either ResourceAdminError ResourceSkillDraft
+validateResourceSkillDraft draft = do
+    title <- validateRequired "title" 200 draft.resourceDraftTitle
+    description <-
+        validateRequired "description" 1000 draft.resourceDraftDescription
+    appliesWhen <-
+        validateOptional "applies_when" 2000 draft.resourceDraftAppliesWhen
+    instructions <-
+        validateRequired "instructions" 30000 draft.resourceDraftInstructions
+    if draft.resourceDraftPriority < -100
+        || draft.resourceDraftPriority > 100
+    then invalid "priority must be between -100 and 100"
+    else Right draft
+        { resourceDraftTitle = title
+        , resourceDraftDescription = description
+        , resourceDraftAppliesWhen = appliesWhen
+        , resourceDraftInstructions = instructions
+        }
+
+listResourceSkills
+    :: Store
+    -> DatabaseScopes
+    -> Maybe ResourceScope
+    -> Int
+    -> IO (Either ResourceAdminError [ResourceSkill])
+listResourceSkills store scopes selected limit
+    | limit < 1 || limit > 1000 =
+        pure (invalid "list limit must be between 1 and 1000")
+    | otherwise =
+        fmap
+            ( fmap
+                ( map skillFromStored
+                    . take limit
+                    . maybe id
+                        (\scope -> filter
+                            ((== scope) . resourceScopeFromStored
+                                . (.scopeKind) . (.learnedSkillScope)))
+                        selected
+                )
+                . mapStoreError
+            ) $
+            listAllLearnedSkillsLimited
+                (trustedPool store)
+                (applicableDatabaseScopes scopes)
+                (resourceScopeKind <$> selected)
+                limit
+
+readResourceSkill
+    :: Store
+    -> DatabaseScopes
+    -> ResourceScope
+    -> Text
+    -> Maybe Int64
+    -> IO (Either ResourceAdminError ResourceSkill)
+readResourceSkill store scopes selected slug requestedRevision =
+    case validateKey slug requestedRevision of
+        Left err -> pure (Left err)
+        Right () -> do
+            let scope = selectScope scopes selected
+                pool = trustedPool store
+            mapStoreError <$> readLearnedSkill pool scope slug >>= \case
+                Left err -> pure (Left err)
+                Right Nothing -> pure (Left ResourceAdminNotFound)
+                Right (Just current) ->
+                    case requestedRevision of
+                        Nothing -> pure (Right (skillFromStored current))
+                        Just revision ->
+                            mapStoreError
+                                <$> readLearnedSkillRevision
+                                    pool scope slug revision
+                                >>= pure . (>>= \case
+                                    Nothing ->
+                                        Left ResourceAdminRevisionNotFound
+                                    Just stored ->
+                                        Right
+                                            (historicalSkill current stored))
+
+createResourceSkill
+    :: Store
+    -> DatabaseScopes
+    -> ResourceScope
+    -> Text
+    -> ResourceSkillDraft
+    -> Text
+    -> IO (Either ResourceAdminError ResourceSkill)
+createResourceSkill store scopes selected slug rawDraft rawSummary =
+    case (,,)
+        <$> validateResourceSlug slug
+        <*> validateResourceSkillDraft rawDraft
+        <*> validateResourceSummary rawSummary of
+        Left err -> pure (Left err)
+        Right (_, draft, summary) -> do
+            now <- getCurrentTime
+            finishMutation =<< mapStoreError
+                <$> createLearnedSkill
+                    (trustedPool store)
+                    LearnedSkillCreate
+                        { learnedSkillCreateScope = selectScope scopes selected
+                        , learnedSkillCreateSlug = slug
+                        , learnedSkillCreateTitle = draft.resourceDraftTitle
+                        , learnedSkillCreateDescription =
+                            draft.resourceDraftDescription
+                        , learnedSkillCreateAppliesWhen =
+                            draft.resourceDraftAppliesWhen
+                        , learnedSkillCreateInstructions =
+                            draft.resourceDraftInstructions
+                        , learnedSkillCreateActivation =
+                            draft.resourceDraftActivation
+                        , learnedSkillCreatePriority =
+                            draft.resourceDraftPriority
+                        , learnedSkillCreateStatus = SkillActive
+                        , learnedSkillCreateSummary = summary
+                        , learnedSkillCreateSource = nativeAdminSource
+                        , learnedSkillCreateAt = now
+                        }
+
+updateResourceSkill
+    :: Store
+    -> DatabaseScopes
+    -> ResourceScope
+    -> Text
+    -> Int64
+    -> ResourceSkillDraft
+    -> Text
+    -> IO (Either ResourceAdminError ResourceSkill)
+updateResourceSkill store scopes selected slug expected rawDraft rawSummary =
+    case (,,)
+        <$> validateMutationKey slug expected
+        <*> validateResourceSkillDraft rawDraft
+        <*> validateResourceSummary rawSummary of
+        Left err -> pure (Left err)
+        Right (_, draft, summary) ->
+            updateWithPatch store scopes selected slug expected summary
+                LearnedSkillPatch
+                    { learnedSkillPatchTitle =
+                        Just draft.resourceDraftTitle
+                    , learnedSkillPatchDescription =
+                        Just draft.resourceDraftDescription
+                    , learnedSkillPatchAppliesWhen =
+                        Just draft.resourceDraftAppliesWhen
+                    , learnedSkillPatchInstructions =
+                        Just draft.resourceDraftInstructions
+                    , learnedSkillPatchActivation =
+                        Just draft.resourceDraftActivation
+                    , learnedSkillPatchPriority =
+                        Just draft.resourceDraftPriority
+                    , learnedSkillPatchStatus = Nothing
+                    }
+
+archiveResourceSkill
+    :: Store -> DatabaseScopes -> ResourceScope -> Text -> Int64 -> Text
+    -> IO (Either ResourceAdminError ResourceSkill)
+archiveResourceSkill =
+    setResourceSkillArchived SkillArchived
+
+restoreResourceSkill
+    :: Store -> DatabaseScopes -> ResourceScope -> Text -> Int64 -> Text
+    -> IO (Either ResourceAdminError ResourceSkill)
+restoreResourceSkill =
+    setResourceSkillArchived SkillActive
+
+rollbackResourceSkill
+    :: Store
+    -> DatabaseScopes
+    -> ResourceScope
+    -> Text
+    -> Int64
+    -> Int64
+    -> Text
+    -> IO (Either ResourceAdminError ResourceSkill)
+rollbackResourceSkill store scopes selected slug expected target rawSummary =
+    case (,,)
+        <$> validateMutationKey slug expected
+        <*> validatePositiveRevision "target revision" target
+        <*> validateResourceSummary rawSummary of
+        Left err -> pure (Left err)
+        Right (_, _, summary) -> do
+            now <- getCurrentTime
+            finishMutation =<< mapStoreError
+                <$> rollbackLearnedSkill
+                    (trustedPool store)
+                    LearnedSkillRollback
+                        { learnedSkillRollbackScope =
+                            selectScope scopes selected
+                        , learnedSkillRollbackSlug = slug
+                        , learnedSkillRollbackExpectedRevision = expected
+                        , learnedSkillRollbackTargetRevision = target
+                        , learnedSkillRollbackSummary = summary
+                        , learnedSkillRollbackSource = nativeAdminSource
+                        , learnedSkillRollbackAt = now
+                        }
+
+historyResourceSkill
+    :: Store
+    -> DatabaseScopes
+    -> ResourceScope
+    -> Text
+    -> Int
+    -> IO (Either ResourceAdminError [ResourceSkillRevision])
+historyResourceSkill store scopes selected slug limit
+    | limit < 1 || limit > 1000 =
+        pure (invalid "history limit must be between 1 and 1000")
+    | otherwise = case validateResourceSlug slug of
+        Left err -> pure (Left err)
+        Right _ -> do
+            result <- mapStoreError <$> listLearnedSkillRevisionsLimited
+                (trustedPool store)
+                (selectScope scopes selected)
+                slug
+                limit
+            pure case result of
+                Right [] -> Left ResourceAdminNotFound
+                Right revisions ->
+                    Right (map revisionFromStored revisions)
+                Left err -> Left err
+
+setResourceSkillArchived
+    :: LearnedSkillStatus
+    -> Store -> DatabaseScopes -> ResourceScope -> Text -> Int64 -> Text
+    -> IO (Either ResourceAdminError ResourceSkill)
+setResourceSkillArchived status store scopes selected slug expected rawSummary =
+    case (,)
+        <$> validateMutationKey slug expected
+        <*> validateResourceSummary rawSummary of
+        Left err -> pure (Left err)
+        Right (_, summary) ->
+            updateWithPatch store scopes selected slug expected summary
+                emptyPatch
+                    { learnedSkillPatchStatus = Just status
+                    }
+
+updateWithPatch
+    :: Store
+    -> DatabaseScopes
+    -> ResourceScope
+    -> Text
+    -> Int64
+    -> Text
+    -> LearnedSkillPatch
+    -> IO (Either ResourceAdminError ResourceSkill)
+updateWithPatch store scopes selected slug expected summary patch = do
+    now <- getCurrentTime
+    finishMutation =<< mapStoreError
+        <$> updateLearnedSkill
+            (trustedPool store)
+            LearnedSkillUpdate
+                { learnedSkillUpdateScope = selectScope scopes selected
+                , learnedSkillUpdateSlug = slug
+                , learnedSkillUpdateExpectedRevision = expected
+                , learnedSkillUpdatePatch = patch
+                , learnedSkillUpdateSummary = summary
+                , learnedSkillUpdateSource = nativeAdminSource
+                , learnedSkillUpdateAt = now
+                }
+
+finishMutation
+    :: Either ResourceAdminError LearnedSkillMutationResult
+    -> IO (Either ResourceAdminError ResourceSkill)
+finishMutation = pure . (>>= \case
+    LearnedSkillMutationApplied skill -> Right (skillFromStored skill)
+    LearnedSkillMutationAlreadyExists -> Left ResourceAdminAlreadyExists
+    LearnedSkillMutationNotFound -> Left ResourceAdminNotFound
+    LearnedSkillMutationConflict revision ->
+        Left (ResourceAdminConflict revision)
+    LearnedSkillMutationRevisionNotFound ->
+        Left ResourceAdminRevisionNotFound)
+
+validateKey :: Text -> Maybe Int64 -> Either ResourceAdminError ()
+validateKey slug revision = do
+    _ <- validateResourceSlug slug
+    traverse_ (validatePositiveRevision "revision") revision
+
+validateMutationKey :: Text -> Int64 -> Either ResourceAdminError ()
+validateMutationKey slug revision =
+    validateKey slug (Just revision)
+
+validatePositiveRevision
+    :: Text -> Int64 -> Either ResourceAdminError Int64
+validatePositiveRevision label revision
+    | revision < 1 = invalid (label <> " must be positive")
+    | otherwise = Right revision
+
+validateRequired
+    :: Text -> Int -> Text -> Either ResourceAdminError Text
+validateRequired label maximum value
+    | Text.any (== '\NUL') value =
+        invalid (label <> " must not contain NUL")
+    | Text.null (Text.strip value) =
+        invalid (label <> " must not be empty")
+    | Text.length value > maximum =
+        invalid
+            (label <> " must contain at most "
+                <> Text.pack (show maximum) <> " characters")
+    | otherwise = Right value
+
+validateOptional
+    :: Text -> Int -> Text -> Either ResourceAdminError Text
+validateOptional label maximum value
+    | Text.any (== '\NUL') value =
+        invalid (label <> " must not contain NUL")
+    | Text.length value > maximum =
+        invalid
+            (label <> " must contain at most "
+                <> Text.pack (show maximum) <> " characters")
+    | otherwise = Right value
+
+invalid :: Text -> Either ResourceAdminError value
+invalid = Left . ResourceAdminInvalid
+
+mapStoreError :: Either StoreError value -> Either ResourceAdminError value
+mapStoreError = either (Left . mapOne) Right
+  where
+    mapOne = \case
+        StoreDataError message
+            | "does not change any stored field" `Text.isInfixOf` message ->
+                ResourceAdminInvalid "mutation does not change the resource"
+        _ -> ResourceAdminUnavailable
+
+historicalSkill
+    :: LearnedSkill
+    -> LearnedSkillRevision
+    -> ResourceSkill
+historicalSkill current revision =
+    ResourceSkill
+        { resourceSkillScope =
+            resourceScopeFromStored current.learnedSkillScope.scopeKind
+        , resourceSkillSlug = current.learnedSkillSlug
+        , resourceSkillRevision = revision.learnedSkillRevisionNumber
+        , resourceSkillTitle = revision.learnedSkillRevisionTitle
+        , resourceSkillDescription =
+            revision.learnedSkillRevisionDescription
+        , resourceSkillAppliesWhen =
+            revision.learnedSkillRevisionAppliesWhen
+        , resourceSkillInstructions =
+            revision.learnedSkillRevisionInstructions
+        , resourceSkillActivation =
+            revision.learnedSkillRevisionActivation
+        , resourceSkillPriority = revision.learnedSkillRevisionPriority
+        , resourceSkillArchived =
+            revision.learnedSkillRevisionStatus == SkillArchived
+        , resourceSkillCreatedAt = current.learnedSkillCreatedAt
+        , resourceSkillUpdatedAt = revision.learnedSkillRevisionCreatedAt
+        }
+
+skillFromStored :: LearnedSkill -> ResourceSkill
+skillFromStored skill = ResourceSkill
+    { resourceSkillScope =
+        resourceScopeFromStored skill.learnedSkillScope.scopeKind
+    , resourceSkillSlug = skill.learnedSkillSlug
+    , resourceSkillRevision = skill.learnedSkillRevision
+    , resourceSkillTitle = skill.learnedSkillTitle
+    , resourceSkillDescription = skill.learnedSkillDescription
+    , resourceSkillAppliesWhen = skill.learnedSkillAppliesWhen
+    , resourceSkillInstructions = skill.learnedSkillInstructions
+    , resourceSkillActivation = skill.learnedSkillActivation
+    , resourceSkillPriority = skill.learnedSkillPriority
+    , resourceSkillArchived = skill.learnedSkillStatus == SkillArchived
+    , resourceSkillCreatedAt = skill.learnedSkillCreatedAt
+    , resourceSkillUpdatedAt = skill.learnedSkillUpdatedAt
+    }
+
+revisionFromStored :: LearnedSkillRevision -> ResourceSkillRevision
+revisionFromStored revision = ResourceSkillRevision
+    { resourceRevisionNumber = revision.learnedSkillRevisionNumber
+    , resourceRevisionTitle = revision.learnedSkillRevisionTitle
+    , resourceRevisionDescription =
+        revision.learnedSkillRevisionDescription
+    , resourceRevisionAppliesWhen =
+        revision.learnedSkillRevisionAppliesWhen
+    , resourceRevisionInstructions =
+        revision.learnedSkillRevisionInstructions
+    , resourceRevisionActivation =
+        revision.learnedSkillRevisionActivation
+    , resourceRevisionPriority = revision.learnedSkillRevisionPriority
+    , resourceRevisionArchived =
+        revision.learnedSkillRevisionStatus == SkillArchived
+    , resourceRevisionSummary = revision.learnedSkillRevisionSummary
+    , resourceRevisionCreatedAt = revision.learnedSkillRevisionCreatedAt
+    }
+
+selectScope :: DatabaseScopes -> ResourceScope -> Scope
+selectScope scopes = \case
+    ResourceUserScope -> scopeForDatabase scopes DatabaseUserScope
+    ResourceRepositoryScope ->
+        scopeForDatabase scopes DatabaseRepositoryScope
+    ResourceCheckoutScope ->
+        scopeForDatabase scopes DatabaseCheckoutScope
+
+resourceScopeFromStored :: ScopeKind -> ResourceScope
+resourceScopeFromStored = \case
+    UserScope -> ResourceUserScope
+    RepositoryScope -> ResourceRepositoryScope
+    CheckoutScope -> ResourceCheckoutScope
+
+resourceScopeKind :: ResourceScope -> ScopeKind
+resourceScopeKind = \case
+    ResourceUserScope -> UserScope
+    ResourceRepositoryScope -> RepositoryScope
+    ResourceCheckoutScope -> CheckoutScope
+
+nativeAdminSource :: LearnedSkillSourceInput
+nativeAdminSource = LearnedSkillSourceInput
+    { learnedSkillSourceInputSessionKey = Nothing
+    , learnedSkillSourceInputTurnIndex = Nothing
+    , learnedSkillSourceInputResponseItemId = Nothing
+    , learnedSkillSourceInputEvidence =
+        "Changed through typed native memory administration."
+    }
+
+emptyPatch :: LearnedSkillPatch
+emptyPatch = LearnedSkillPatch
+    { learnedSkillPatchTitle = Nothing
+    , learnedSkillPatchDescription = Nothing
+    , learnedSkillPatchAppliesWhen = Nothing
+    , learnedSkillPatchInstructions = Nothing
+    , learnedSkillPatchActivation = Nothing
+    , learnedSkillPatchPriority = Nothing
+    , learnedSkillPatchStatus = Nothing
+    }
+
+traverse_
+    :: Applicative f
+    => (a -> f b)
+    -> Maybe a
+    -> f ()
+traverse_ action = maybe (pure ()) ((() <$) . action)

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -10,6 +10,9 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 foreign import ccall "ha_image_attachment_stage_smoke"
     imageAttachmentStageSmoke :: IO CInt
 
+foreign import ccall "ha_learned_skill_admin_validation_smoke"
+    learnedSkillAdminValidationSmoke :: IO CInt
+
 #else
 import Test.Hspec (Spec, describe, it, pendingWith)
 #endif
@@ -19,6 +22,12 @@ spec = describe "native engine lifecycle smoke" do
     it "stages copied images and completes restart before destroy returns" do
 #ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0
+#else
+        pendingWith "the native bridge smoke test only links on macOS"
+#endif
+    it "rejects invalid learned resource inputs through exported symbols" do
+#ifdef darwin_HOST_OS
+        learnedSkillAdminValidationSmoke `shouldReturn` 0
 #else
         pendingWith "the native bridge smoke test only links on macOS"
 #endif

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -14,6 +14,9 @@ foreign import ccall "ha_gateway_abi_smoke"
 foreign import ccall "ha_mcp_admin_abi_smoke"
     mcpAdminAbiSmoke :: IO CInt
 
+foreign import ccall "ha_learned_skill_admin_abi_smoke"
+    learnedSkillAdminAbiSmoke :: IO CInt
+
 spec :: Spec
 spec = describe "native image attachment ABI" do
     it "preserves the documented image struct layout and ordered buffers" do
@@ -23,3 +26,5 @@ spec = describe "native image attachment ABI" do
 
     it "preserves the typed MCP argument and environment layouts" do
         mcpAdminAbiSmoke `shouldReturn` 0
+    it "compiles typed learned resource callbacks and stable enum values" do
+        learnedSkillAdminAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/ResourceAdminSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResourceAdminSpec.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Agent.CLI.ResourceAdminSpec (spec) where
+
+import Agent.CLI.ResourceAdmin
+import Agent.Store.Postgres.Skill (LearnedSkillActivation(..))
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "typed learned-resource administration validation" do
+    it "accepts the three documented scopes and canonical slugs" do
+        validateResourceSlug "remember-user-preference" `shouldBe`
+            Right "remember-user-preference"
+
+    it "rejects malformed slugs without exposing input values" do
+        validateResourceSlug "Bad/secret" `shouldBe`
+            Left (ResourceAdminInvalid
+                "slug must use lower-case ASCII words separated by single hyphens")
+
+    it "enforces required content and bounded fields" do
+        validateResourceSkillDraft validDraft `shouldBe` Right validDraft
+        validateResourceSkillDraft
+            validDraft { resourceDraftInstructions = "" }
+            `shouldBe` Left (ResourceAdminInvalid
+                "instructions must not be empty")
+
+    it "rejects out-of-range priorities" do
+        validateResourceSkillDraft
+            validDraft { resourceDraftPriority = 101 }
+            `shouldBe` Left (ResourceAdminInvalid
+                "priority must be between -100 and 100")
+
+    it "enforces exact store character bounds" do
+        validateResourceSkillDraft
+            validDraft { resourceDraftTitle = Text.replicate 201 "ü" }
+            `shouldBe` Left (ResourceAdminInvalid
+                "title must contain at most 200 characters")
+        validateResourceSummary (Text.replicate 1001 "x")
+            `shouldBe` Left (ResourceAdminInvalid
+                "change summary must contain at most 1000 characters")
+
+    it "rejects NUL and noncanonical slug forms" do
+        validateResourceSkillDraft
+            validDraft { resourceDraftDescription = "safe\NULsecret" }
+            `shouldBe` Left (ResourceAdminInvalid
+                "description must not contain NUL")
+        map validateResourceSlug ["double--dash", "-leading", "trailing-"]
+            `shouldSatisfy` all isLeft
+
+validDraft :: ResourceSkillDraft
+validDraft = ResourceSkillDraft
+    { resourceDraftTitle = "Remember"
+    , resourceDraftDescription = "A preference"
+    , resourceDraftAppliesWhen = ""
+    , resourceDraftInstructions = "Use the preference."
+    , resourceDraftActivation = SkillRelevant
+    , resourceDraftPriority = 0
+    }
+
+isLeft :: Either error value -> Bool
+isLeft = either (const True) (const False)

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -57,6 +57,7 @@ import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
 import qualified Agent.CLI.ProviderAvailabilitySpec as ProviderAvailabilitySpec
 import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
 import qualified Agent.CLI.RequestSpec as RequestSpec
+import qualified Agent.CLI.ResourceAdminSpec as ResourceAdminSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
@@ -142,6 +143,7 @@ main = hspec do
     ProviderAvailabilitySpec.spec
     ProviderTransitionSpec.spec
     RequestSpec.spec
+    ResourceAdminSpec.spec
     RenderSpec.spec
     ReplStatusSpec.spec
     ResumeSpec.spec

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -136,6 +136,129 @@ int ha_mcp_admin_abi_smoke(void) {
     return 0;
 }
 
+static void learned_skill_callback(
+        void *context, int32_t status, int32_t scope,
+        const uint8_t *slug, size_t slug_length, int64_t revision,
+        const uint8_t *title, size_t title_length,
+        const uint8_t *description, size_t description_length,
+        const uint8_t *applies_when, size_t applies_when_length,
+        const uint8_t *instructions, size_t instructions_length,
+        int32_t activation, int32_t priority, int32_t archived,
+        int64_t created_at_ms, int64_t updated_at_ms,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status; (void)scope; (void)slug; (void)slug_length;
+    (void)revision; (void)title; (void)title_length; (void)description;
+    (void)description_length; (void)applies_when; (void)applies_when_length;
+    (void)instructions; (void)instructions_length; (void)activation;
+    (void)priority; (void)archived; (void)created_at_ms; (void)updated_at_ms;
+    (void)error; (void)error_length;
+}
+
+static void learned_skill_revision_callback(
+        void *context, int32_t status, int64_t revision,
+        const uint8_t *title, size_t title_length,
+        const uint8_t *description, size_t description_length,
+        const uint8_t *applies_when, size_t applies_when_length,
+        const uint8_t *instructions, size_t instructions_length,
+        int32_t activation, int32_t priority, int32_t archived,
+        const uint8_t *change_summary, size_t change_summary_length,
+        int64_t created_at_ms,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status; (void)revision; (void)title;
+    (void)title_length; (void)description; (void)description_length;
+    (void)applies_when; (void)applies_when_length; (void)instructions;
+    (void)instructions_length; (void)activation; (void)priority;
+    (void)archived; (void)change_summary; (void)change_summary_length;
+    (void)created_at_ms; (void)error; (void)error_length;
+}
+
+static void learned_skill_result_callback(
+        void *context, int32_t status, int64_t revision,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status; (void)revision; (void)error;
+    (void)error_length;
+}
+
+/* Compile every typed entry point and verify public enum/status values. */
+int ha_learned_skill_admin_abi_smoke(void) {
+    ha_learned_skill_callback item = learned_skill_callback;
+    ha_learned_skill_revision_callback revision =
+        learned_skill_revision_callback;
+    ha_resource_result_callback result = learned_skill_result_callback;
+    int32_t (*list_fn)(const uint8_t *, size_t, int32_t, size_t,
+        ha_learned_skill_callback, void *) = ha_learned_skill_list;
+    int32_t (*read_fn)(const uint8_t *, size_t, int32_t,
+        const uint8_t *, size_t, uint64_t, ha_learned_skill_callback,
+        void *) = ha_learned_skill_read;
+    (void)item; (void)revision; (void)result; (void)list_fn; (void)read_fn;
+    if (HA_LEARNED_SKILL_SCOPE_ALL != -1
+            || HA_LEARNED_SKILL_SCOPE_USER != 0
+            || HA_LEARNED_SKILL_SCOPE_REPOSITORY != 1
+            || HA_LEARNED_SKILL_SCOPE_CHECKOUT != 2
+            || HA_LEARNED_SKILL_ACTIVATION_MANUAL != 2
+            || HA_RESOURCE_STATUS_REVISION_CONFLICT != -3) {
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * Exercise synchronous validation through the actual exported symbols. None
+ * of these rejected calls starts PostgreSQL or schedules a callback.
+ */
+int ha_learned_skill_admin_validation_smoke(void) {
+    const uint8_t cwd[] = ".";
+    const uint8_t slug[] = "safe-slug";
+    const uint8_t text[] = "value";
+    const uint8_t invalid_utf8[] = {0xff};
+
+    if (ha_learned_skill_list(cwd, 1, HA_LEARNED_SKILL_SCOPE_ALL, 0,
+            learned_skill_callback, NULL) != 2) {
+        return 1;
+    }
+    if (ha_learned_skill_read(cwd, 1, 9, slug, sizeof(slug) - 1, 0,
+            learned_skill_callback, NULL) != 2) {
+        return 2;
+    }
+    if (ha_learned_skill_create(cwd, 1, HA_LEARNED_SKILL_SCOPE_USER,
+            slug, sizeof(slug) - 1, text, sizeof(text) - 1,
+            text, sizeof(text) - 1, NULL, 0, text, sizeof(text) - 1,
+            9, 0, text, sizeof(text) - 1,
+            learned_skill_result_callback, NULL) != 2) {
+        return 3;
+    }
+    if (ha_learned_skill_update(cwd, 1, HA_LEARNED_SKILL_SCOPE_USER,
+            slug, sizeof(slug) - 1, 0, text, sizeof(text) - 1,
+            text, sizeof(text) - 1, NULL, 0, text, sizeof(text) - 1,
+            HA_LEARNED_SKILL_ACTIVATION_RELEVANT, 0,
+            text, sizeof(text) - 1,
+            learned_skill_result_callback, NULL) != 2) {
+        return 4;
+    }
+    if (ha_learned_skill_archive(cwd, 1, HA_LEARNED_SKILL_SCOPE_USER,
+            invalid_utf8, sizeof(invalid_utf8), 1,
+            text, sizeof(text) - 1,
+            learned_skill_result_callback, NULL) != 2) {
+        return 5;
+    }
+    if (ha_learned_skill_restore(cwd, 1, HA_LEARNED_SKILL_SCOPE_USER,
+            NULL, 0, 1, text, sizeof(text) - 1,
+            learned_skill_result_callback, NULL) != 2) {
+        return 6;
+    }
+    if (ha_learned_skill_rollback(cwd, 1, HA_LEARNED_SKILL_SCOPE_USER,
+            slug, sizeof(slug) - 1, 2, 0, text, sizeof(text) - 1,
+            learned_skill_result_callback, NULL) != 2) {
+        return 7;
+    }
+    if (ha_learned_skill_history(cwd, 1, HA_LEARNED_SKILL_SCOPE_USER,
+            slug, sizeof(slug) - 1, 1001,
+            learned_skill_revision_callback, NULL) != 2) {
+        return 8;
+    }
+    return 0;
+}
+
 static void image_stage_callback(void *context, const uint8_t *bytes,
                                  size_t length) {
     (void)context;

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill.hs
@@ -32,10 +32,13 @@ module Agent.Store.Postgres.Skill
     , archiveLearnedSkill
     , rollbackLearnedSkill
     , readLearnedSkill
+    , readLearnedSkillRevision
     , searchLearnedSkills
     , listApplicableLearnedSkills
     , listAllLearnedSkills
+    , listAllLearnedSkillsLimited
     , listLearnedSkillRevisions
+    , listLearnedSkillRevisionsLimited
     , listLearnedSkillSources
     ) where
 
@@ -474,6 +477,19 @@ readLearnedSkill pool scope slug =
         (HasqlSession.statement (scope, slug) readSkillStatement)
         >>= pure . decodeMaybeSkillResult
 
+readLearnedSkillRevision
+    :: StorePool
+    -> Scope
+    -> Text
+    -> Int64
+    -> IO (Either StoreError (Maybe LearnedSkillRevision))
+readLearnedSkillRevision pool scope slug revision =
+    withSession pool
+        (HasqlSession.statement
+            (scope, slug, revision)
+            readRevisionStatement)
+        >>= pure . decodeMaybeRevisionResult
+
 searchLearnedSkills
     :: StorePool
     -> [Scope]
@@ -519,6 +535,31 @@ listAllLearnedSkills pool scopes =
                 (HasqlSession.statement applicable listAllSkillsStatement)
                 >>= pure . decodeSkillListResult
 
+-- | List a bounded administration page, optionally restricted to one of the
+-- three applicable scope kinds. Unlike the model-context list this includes
+-- archived rows.
+listAllLearnedSkillsLimited
+    :: StorePool
+    -> [Scope]
+    -> Maybe ScopeKind
+    -> Int
+    -> IO (Either StoreError [LearnedSkill])
+listAllLearnedSkillsLimited pool scopes selectedKind limit =
+    case applicableScopes scopes of
+        Left err -> pure (Left (StoreDataError err))
+        Right applicable ->
+            withSession pool
+                (HasqlSession.statement
+                    SkillListParams
+                        { skillListScopes = applicable
+                        , skillListKind =
+                            scopeKindText <$> selectedKind
+                        , skillListLimit =
+                            fromIntegral (max 1 (min 1000 limit))
+                        }
+                    listAllSkillsLimitedStatement)
+                >>= pure . decodeSkillListResult
+
 listLearnedSkillRevisions
     :: StorePool
     -> Scope
@@ -527,6 +568,19 @@ listLearnedSkillRevisions
 listLearnedSkillRevisions pool scope slug =
     withSession pool
         (HasqlSession.statement (scope, slug) listRevisionsStatement)
+        >>= pure . decodeRevisionListResult
+
+listLearnedSkillRevisionsLimited
+    :: StorePool
+    -> Scope
+    -> Text
+    -> Int
+    -> IO (Either StoreError [LearnedSkillRevision])
+listLearnedSkillRevisionsLimited pool scope slug limit =
+    withSession pool
+        (HasqlSession.statement
+            (scope, slug, fromIntegral (max 1 (min 1000 limit)))
+            listRevisionsLimitedStatement)
         >>= pure . decodeRevisionListResult
 
 listLearnedSkillSources
@@ -772,6 +826,15 @@ decodeRevisionListResult = \case
     Right rows ->
         either (Left . StoreDataError) Right (traverse decodeRevisionRow rows)
 
+decodeMaybeRevisionResult
+    :: Either StoreError (Maybe RevisionRow)
+    -> Either StoreError (Maybe LearnedSkillRevision)
+decodeMaybeRevisionResult = \case
+    Left err -> Left err
+    Right Nothing -> Right Nothing
+    Right (Just row) ->
+        either (Left . StoreDataError) (Right . Just) (decodeRevisionRow row)
+
 decodeSearchResult
     :: Either StoreError [(SkillRow, Double)]
     -> Either StoreError [LearnedSkillSearchResult]
@@ -808,6 +871,12 @@ data SkillSearchParams = SkillSearchParams
     , skillSearchLimit :: !Int64
     }
 
+data SkillListParams = SkillListParams
+    { skillListScopes :: !ApplicableScopes
+    , skillListKind :: !(Maybe Text)
+    , skillListLimit :: !Int64
+    }
+
 insertSkillStatement :: Statement LearnedSkillCreate (Maybe Text)
 insertSkillStatement = mkStatement
     "INSERT INTO harness.skills\
@@ -831,6 +900,78 @@ insertSkillStatement = mkStatement
         <> ((.learnedSkillCreateAt) >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
     )
     (Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.text)))
+    True
+
+readRevisionStatement
+    :: Statement (Scope, Text, Int64) (Maybe RevisionRow)
+readRevisionStatement = mkStatement
+    ("SELECT r.skill_revision_id::text, r.revision_number, r.title,\
+    \ r.description, r.applies_when, r.instructions_text,\
+    \ r.activation_mode, r.priority, r.status, r.change_summary, r.created_at\
+    \ FROM harness.skill_revisions r\
+    \ JOIN harness.skills s ON s.skill_id = r.skill_id\
+    \ WHERE s.scope_kind = $1 AND s.scope_id = $2::uuid AND s.slug = $3\
+    \   AND r.revision_number = $4")
+    ( (scopeKindText . (.scopeKind) . first4
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (scopeIdText . (.scopeId) . first4
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (second4
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (third4
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
+    (Decoders.rowMaybe revisionRowDecoder)
+    True
+  where
+    first4 (scope, _, _) = scope
+    second4 (_, slug, _) = slug
+    third4 (_, _, revision) = revision
+
+listRevisionsLimitedStatement
+    :: Statement (Scope, Text, Int64) [RevisionRow]
+listRevisionsLimitedStatement = mkStatement
+    ("SELECT r.skill_revision_id::text, r.revision_number, r.title,\
+    \ r.description, r.applies_when, r.instructions_text,\
+    \ r.activation_mode, r.priority, r.status, r.change_summary, r.created_at\
+    \ FROM harness.skill_revisions r\
+    \ JOIN harness.skills s ON s.skill_id = r.skill_id\
+    \ WHERE s.scope_kind = $1 AND s.scope_id = $2::uuid AND s.slug = $3\
+    \ ORDER BY r.revision_number DESC LIMIT $4")
+    ( (scopeKindText . (.scopeKind) . first3
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (scopeIdText . (.scopeId) . first3
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (second3
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (third3
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
+    (Decoders.rowList revisionRowDecoder)
+    True
+  where
+    first3 (scope, _, _) = scope
+    second3 (_, slug, _) = slug
+    third3 (_, _, limit) = limit
+
+listAllSkillsLimitedStatement :: Statement SkillListParams [SkillRow]
+listAllSkillsLimitedStatement = mkStatement
+    (skillSelectSql
+        <> applicableWhereSql
+        <> " AND ($4::text IS NULL OR scope_kind = $4)\
+           \ ORDER BY scope_kind, title, slug LIMIT $5")
+    ( ((.applicableUserScopeId) . (.skillListScopes)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.applicableRepositoryScopeId) . (.skillListScopes)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.applicableCheckoutScopeId) . (.skillListScopes)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((.skillListKind)
+            >$< Encoders.param (Encoders.nullable Encoders.text))
+        <> ((.skillListLimit)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
+    (Decoders.rowList skillRowDecoder)
     True
 
 listAllSkillsStatement :: Statement ApplicableScopes [SkillRow]

--- a/packages/agent-store/test/Agent/Store/Postgres/SkillSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SkillSpec.hs
@@ -151,6 +151,14 @@ exerciseStore pool = do
 
     readLearnedSkill pool repositoryScope "postgres-session-storage"
         `shouldReturn` Right (Just createdSkill)
+    fmap (fmap (map (.learnedSkillSlug))) (
+        listAllLearnedSkillsLimited
+            pool scopes (Just RepositoryScope) 1)
+        `shouldReturn` Right ["postgres-session-storage"]
+    fmap (fmap (map (.learnedSkillSlug))) (
+        listAllLearnedSkillsLimited
+            pool scopes (Just UserScope) 1)
+        `shouldReturn` Right []
     searchLearnedSkills pool scopes "tool outputs text" 10 >>= \case
         Right [match] -> do
             match.learnedSkillSearchSkill.learnedSkillSlug
@@ -205,6 +213,14 @@ exerciseStore pool = do
                 map (.learnedSkillRevisionNumber) revisions `shouldBe` [2, 1]
             other ->
                 expectationFailure ("unexpected skill revisions: " <> show other)
+    fmap (fmap (map (.learnedSkillRevisionNumber))) (
+        listLearnedSkillRevisionsLimited
+            pool repositoryScope "postgres-session-storage" 1)
+        `shouldReturn` Right [2]
+    fmap (fmap (fmap (.learnedSkillRevisionNumber))) (
+        readLearnedSkillRevision
+            pool repositoryScope "postgres-session-storage" 1)
+        `shouldReturn` Right (Just 1)
     listLearnedSkillSources
         pool repositoryScope "postgres-session-storage" 2 >>= \case
             Right [storedSource] -> do


### PR DESCRIPTION
## Summary
- expose typed list/read/create/update/archive/restore/rollback/history APIs for learned Skills/Memory
- support user, repository, and checkout scopes using the existing PostgreSQL learned-skill store
- preserve revision history and enforce optimistic revision conflicts

## Safety and ABI
- validate scope identifiers, lower-case slugs, field lengths, priorities, UTF-8, list counts, and integer conversions
- bound list/history results and callback payloads
- keep source evidence/private audit data out of native responses and errors
- document callback thread, borrowed pointer/array lifetimes, nullability, status codes, and terminal behavior
- archive/restore/rollback create new durable revisions; stale expected revisions fail without overwriting

## Validation
- focused resource validation/revision tests
- C ABI header/smoke coverage
- `git diff --check`

## Dependency
Stacked on #750. This is separate from MCP config administration #764 because it uses the learned-resource PostgreSQL store and different scope/revision semantics.
