### PR TITLE
Add a hardened durable runtime daemon foundation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,6 +15,7 @@ packages:
     packages/agent-store
     packages/claude-agent-sdk-haskell
     packages/agent-claude
+    packages/agent-runtime-daemon
 
 tests: True
 multi-repl: True

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -14,13 +14,18 @@ The first client message must be `hello`, containing a stable client ID, the
 protocol versions it supports, and optionally the sequence number of the last
 event it durably acknowledged. The daemon replies with `welcome` and the
 negotiated version, or `version_rejected` with its supported versions. Protocol
-version 1 is currently supported.
+version 2 is currently supported.
 
 A connection with no resume cursor receives a full snapshot. A reconnecting
 client receives all retained events after its cursor. If the cursor predates
 retention, it receives a fresh snapshot instead. Every event has a strictly
 increasing sequence number. Clients send `ack` after durably applying an event
 and answer `heartbeat` with `pong`.
+
+Snapshots are sent as bounded `snapshot_chunk` messages. Each chunk contains
+an independently base64-encoded slice of the snapshot JSON, plus a zero-based
+chunk index and total chunk count. Clients decode each slice and concatenate
+them in index order before decoding the snapshot JSON.
 
 Commands and command results carry client-generated command IDs. Their JSON
 payload is deliberately opaque to this package so the task supervisor can
@@ -36,6 +41,12 @@ sockets not owned by the effective user are rejected. Accepted connections are
 authenticated with the operating system's Unix peer credentials
 (`getpeereid` via `network` on macOS).
 
+A process-held exclusive lock serializes socket creation and stale-socket
+removal. Shutdown only unlinks the device/inode created by that listener, so a
+replacement path is never removed. Socket reads, writes, command execution,
+and outbound queues have deadlines; per-client event queues are bounded and an
+overflowed client is disconnected.
+
 ## Durability
 
 Task snapshots are atomically replaced and fsynced. Events are appended,
@@ -43,3 +54,8 @@ fsynced, and monotonically numbered. On startup, queued or running tasks become
 `TaskInterrupted`; the daemon never retries them automatically. Event and task
 log retention are bounded, and credential-shaped JSON fields and log lines are
 redacted before persistence.
+
+Journal directories and files must be non-symlinked and owned by the effective
+user. Corrupt snapshots, malformed or non-contiguous event suffixes, and
+oversized recovery files fail startup closed. A persistence error poisons the
+live journal so the process cannot reuse an uncertain sequence number.

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -14,7 +14,7 @@ The first client message must be `hello`, containing a stable client ID, the
 protocol versions it supports, and optionally the sequence number of the last
 event it durably acknowledged. The daemon replies with `welcome` and the
 negotiated version, or `version_rejected` with its supported versions. Protocol
-version 2 is currently supported.
+version 3 is currently supported.
 
 A connection with no resume cursor receives a full snapshot. A reconnecting
 client receives all retained events after its cursor. If the cursor predates
@@ -26,6 +26,11 @@ Snapshots are sent as bounded `snapshot_chunk` messages. Each chunk contains
 an independently base64-encoded slice of the snapshot JSON, plus a zero-based
 chunk index and total chunk count. Clients decode each slice and concatenate
 them in index order before decoding the snapshot JSON.
+
+Events that fit the negotiated frame bound use `event`. Larger events use the
+same scheme in `event_chunk` messages: clients concatenate decoded slices and
+then decode the resulting event envelope. This keeps persisted events
+deliverable without increasing the transport frame bound.
 
 Commands and command results carry client-generated command IDs. Their JSON
 payload is deliberately opaque to this package so the task supervisor can

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -1,0 +1,45 @@
+# Runtime daemon protocol
+
+The runtime daemon is a per-user local service. Its Haskell package is
+`agent-runtime-daemon`; task execution is supplied separately through the
+`Supervisor` seam.
+
+## Transport and negotiation
+
+Messages are UTF-8 JSON prefixed by an unsigned 32-bit big-endian byte length.
+The daemon rejects frames larger than its configured limit (1 MiB by default)
+before allocating the body.
+
+The first client message must be `hello`, containing a stable client ID, the
+protocol versions it supports, and optionally the sequence number of the last
+event it durably acknowledged. The daemon replies with `welcome` and the
+negotiated version, or `version_rejected` with its supported versions. Protocol
+version 1 is currently supported.
+
+A connection with no resume cursor receives a full snapshot. A reconnecting
+client receives all retained events after its cursor. If the cursor predates
+retention, it receives a fresh snapshot instead. Every event has a strictly
+increasing sequence number. Clients send `ack` after durably applying an event
+and answer `heartbeat` with `pong`.
+
+Commands and command results carry client-generated command IDs. Their JSON
+payload is deliberately opaque to this package so the task supervisor can
+evolve independently of the transport.
+
+## Local security
+
+The default endpoint is
+`~/.haskell-agent/runtime/daemon.sock` and can be relocated with
+`HASKELL_AGENT_RUNTIME_DIR`. The runtime directory and socket use modes `0700`
+and `0600`. Existing non-socket paths, symlinked runtime directories, and
+sockets not owned by the effective user are rejected. Accepted connections are
+authenticated with the operating system's Unix peer credentials
+(`getpeereid` via `network` on macOS).
+
+## Durability
+
+Task snapshots are atomically replaced and fsynced. Events are appended,
+fsynced, and monotonically numbered. On startup, queued or running tasks become
+`TaskInterrupted`; the daemon never retries them automatically. Event and task
+log retention are bounded, and credential-shaped JSON fields and log lines are
+redacted before persistence.

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,17 @@
                     ];
                 };
 
+                agentRuntimeDaemonSource = nix-filter.lib {
+                    root = ./packages/agent-runtime-daemon;
+                    include = [
+                        "app"
+                        "src"
+                        "test"
+                        "agent-runtime-daemon.cabal"
+                        "LICENSE"
+                    ];
+                };
+
                 agentResponsesTypesSource = nix-filter.lib {
                     root = ./packages/agent-responses-types;
                     include = [
@@ -320,6 +331,11 @@
                             {
                                 src = agentProcessSource;
                             });
+                        agent-runtime-daemon = localPackage (pkgs.haskell.lib.overrideSrc
+                            (final.callPackage ./packages/agent-runtime-daemon/package.nix { })
+                            {
+                                src = agentRuntimeDaemonSource;
+                            });
                         agent-responses-types = localPackage (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-responses-types/package.nix { }) {
                             src = agentResponsesTypesSource;
                         });
@@ -392,6 +408,8 @@
                 productionHaskellPackages = mkHaskellPackages false;
                 agentCorePackage = productionHaskellPackages.agent-core;
                 agentProcessPackage = productionHaskellPackages.agent-process;
+                agentRuntimeDaemonPackage =
+                    productionHaskellPackages.agent-runtime-daemon;
                 agentCodexDialectPackage = productionHaskellPackages.agent-codex-dialect;
                 agentGrokBuildDialectPackage = productionHaskellPackages.agent-grok-build-dialect;
                 agentSyntaxPackage = productionHaskellPackages.agent-syntax;
@@ -406,6 +424,8 @@
                 agentStorePackage = productionHaskellPackages.agent-store;
                 agentCliPackage = productionHaskellPackages.agent-cli;
                 agentTelegramPackage = productionHaskellPackages.agent-telegram;
+                agentRuntimeDaemonExecutable =
+                    pkgs.haskell.lib.justStaticExecutables agentRuntimeDaemonPackage;
                 agentCliExecutable =
                     (pkgs.haskell.lib.justStaticExecutables agentCliPackage).overrideAttrs
                         (old: {
@@ -592,6 +612,7 @@
                     then "agent-native-bridge" else null} = agentNativeBridgePackage;
                 packages.agent-core = agentCorePackage;
                 packages.agent-process = agentProcessPackage;
+                packages.agent-runtime-daemon = agentRuntimeDaemonExecutable;
                 packages.agent-codex-dialect = agentCodexDialectPackage;
                 packages.agent-grok-build-dialect = agentGrokBuildDialectPackage;
                 packages.agent-syntax = agentSyntaxPackage;
@@ -615,6 +636,10 @@
                     drv = self.packages.${system}.agent-telegram;
                     exePath = "/bin/agent-telegram";
                 };
+                apps.agent-runtime-daemon = flake-utils.lib.mkApp {
+                    drv = self.packages.${system}.agent-runtime-daemon;
+                    exePath = "/bin/agent-runtime-daemon";
+                };
                 apps.agent-openai-login = flake-utils.lib.mkApp {
                     drv = self.packages.${system}.agent-openai-login;
                     exePath = "/bin/agent-openai-login";
@@ -626,6 +651,7 @@
                         packages.agent-telegram
                         packages.agent-core
                         packages.agent-process
+                        packages.agent-runtime-daemon
                         packages.agent-codex-dialect
                         packages.agent-grok-build-dialect
                         packages.agent-syntax
@@ -667,6 +693,8 @@
                     agent-telegram = haskellPackages.agent-telegram;
                     agent-core = haskellPackages.agent-core;
                     agent-process = haskellPackages.agent-process;
+                    agent-runtime-daemon =
+                        haskellPackages.agent-runtime-daemon;
                     agent-codex-dialect = haskellPackages.agent-codex-dialect;
                     agent-grok-build-dialect = haskellPackages.agent-grok-build-dialect;
                     agent-syntax = haskellPackages.agent-syntax;

--- a/packages/agent-runtime-daemon/LICENSE
+++ b/packages/agent-runtime-daemon/LICENSE
@@ -1,0 +1,17 @@
+MIT License
+
+Copyright (c) 2026 digitally induced GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.

--- a/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
+++ b/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
@@ -1,0 +1,86 @@
+cabal-version:      3.0
+name:               agent-runtime-daemon
+version:            0.1.0.0
+synopsis:           Durable local runtime daemon foundation
+description:        Versioned local IPC, event replay, durable task state, and
+                    secure per-user Unix socket primitives for the agent runtime.
+license:            MIT
+license-file:       LICENSE
+author:             digitally induced GmbH
+maintainer:         marc@digitallyinduced.com
+copyright:          (c) 2026 digitally induced GmbH
+category:           System
+build-type:         Simple
+
+common common-options
+    default-language: GHC2021
+    default-extensions: DeriveGeneric
+                      , DerivingStrategies
+                      , DuplicateRecordFields
+                      , GeneralizedNewtypeDeriving
+                      , LambdaCase
+                      , NamedFieldPuns
+                      , NumericUnderscores
+                      , OverloadedStrings
+                      , OverloadedRecordDot
+                      , RecordWildCards
+                      , ScopedTypeVariables
+    ghc-options:      -Wall
+                      -Wcompat
+                      -Werror=incomplete-patterns
+                      -Werror=missing-fields
+
+library
+    import:           common-options
+    hs-source-dirs:   src
+    exposed-modules:  Agent.Runtime.Daemon
+                    , Agent.Runtime.Daemon.Framing
+                    , Agent.Runtime.Daemon.Journal
+                    , Agent.Runtime.Daemon.Protocol
+                    , Agent.Runtime.Daemon.Server
+                    , Agent.Runtime.Daemon.Socket
+                    , Agent.Runtime.Daemon.Supervisor
+                    , Agent.Runtime.Daemon.Task
+    build-depends:    aeson >= 2.0
+                    , async
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , containers
+                    , directory
+                    , filepath
+                    , network
+                    , safe-exceptions
+                    , stm
+                    , text >= 2.0 && < 2.2
+                    , time
+                    , unix
+
+executable agent-runtime-daemon
+    import:           common-options
+    hs-source-dirs:   app
+    main-is:          Main.hs
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N2 -M1G"
+    build-depends:    agent-runtime-daemon
+                    , base >= 4.17 && < 5
+
+test-suite agent-runtime-daemon-test
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Spec.hs
+    ghc-options:      -threaded
+    build-depends:    agent-runtime-daemon
+                    , aeson
+                    , async
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , containers
+                    , directory
+                    , filepath
+                    , hspec >= 2.11 && < 2.12
+                    , network
+                    , safe-exceptions
+                    , temporary
+                    , text
+                    , time
+                    , unix

--- a/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
+++ b/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
@@ -44,10 +44,12 @@ library
     build-depends:    aeson >= 2.0
                     , async
                     , base >= 4.17 && < 5
+                    , base64-bytestring
                     , bytestring
                     , containers
                     , directory
                     , filepath
+                    , filelock
                     , network
                     , safe-exceptions
                     , stm
@@ -80,6 +82,7 @@ test-suite agent-runtime-daemon-test
                     , hspec >= 2.11 && < 2.12
                     , network
                     , safe-exceptions
+                    , stm
                     , temporary
                     , text
                     , time

--- a/packages/agent-runtime-daemon/app/Main.hs
+++ b/packages/agent-runtime-daemon/app/Main.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+import Agent.Runtime.Daemon
+
+main :: IO ()
+main = do
+    config <- defaultDaemonConfig
+    runDaemon config unavailableSupervisor

--- a/packages/agent-runtime-daemon/package.nix
+++ b/packages/agent-runtime-daemon/package.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, aeson, async, base, bytestring, containers
+, directory, filepath, hspec, lib, network, safe-exceptions, stm
+, temporary, text, time, unix
+}:
+mkDerivation {
+  pname = "agent-runtime-daemon";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson async base bytestring containers directory filepath network
+    safe-exceptions stm text time unix
+  ];
+  executableHaskellDepends = [ base ];
+  testHaskellDepends = [
+    aeson async base bytestring containers directory filepath hspec
+    network safe-exceptions temporary text time unix
+  ];
+  description = "Durable local runtime daemon foundation";
+  license = lib.meta.getLicenseFromSpdxId "MIT";
+  mainProgram = "agent-runtime-daemon";
+}

--- a/packages/agent-runtime-daemon/package.nix
+++ b/packages/agent-runtime-daemon/package.nix
@@ -1,6 +1,6 @@
-{ mkDerivation, aeson, async, base, bytestring, containers
-, directory, filepath, hspec, lib, network, safe-exceptions, stm
-, temporary, text, time, unix
+{ mkDerivation, aeson, async, base, base64-bytestring, bytestring
+, containers, directory, filelock, filepath, hspec, lib, network
+, safe-exceptions, stm, temporary, text, time, unix
 }:
 mkDerivation {
   pname = "agent-runtime-daemon";
@@ -9,13 +9,13 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson async base bytestring containers directory filepath network
-    safe-exceptions stm text time unix
+    aeson async base base64-bytestring bytestring containers directory
+    filelock filepath network safe-exceptions stm text time unix
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
     aeson async base bytestring containers directory filepath hspec
-    network safe-exceptions temporary text time unix
+    network safe-exceptions stm temporary text time unix
   ];
   description = "Durable local runtime daemon foundation";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon.hs
@@ -1,0 +1,38 @@
+module Agent.Runtime.Daemon
+    ( DaemonConfig (..)
+    , defaultDaemonConfig
+    , runDaemon
+    , module Agent.Runtime.Daemon.Journal
+    , module Agent.Runtime.Daemon.Protocol
+    , module Agent.Runtime.Daemon.Server
+    , module Agent.Runtime.Daemon.Supervisor
+    , module Agent.Runtime.Daemon.Task
+    ) where
+
+import System.FilePath (takeDirectory, (</>))
+
+import Agent.Runtime.Daemon.Journal
+import Agent.Runtime.Daemon.Protocol
+import Agent.Runtime.Daemon.Server
+import Agent.Runtime.Daemon.Socket
+import Agent.Runtime.Daemon.Supervisor
+import Agent.Runtime.Daemon.Task
+
+data DaemonConfig = DaemonConfig
+    { socket :: SocketConfig
+    , server :: ServerConfig
+    , journal :: JournalConfig
+    }
+    deriving stock (Eq, Show)
+
+defaultDaemonConfig :: IO DaemonConfig
+defaultDaemonConfig = do
+    socket <- defaultSocketConfig
+    let journal = defaultJournalConfig (takeDirectory socket.path </> "journal")
+    pure DaemonConfig {socket, server = defaultServerConfig, journal}
+
+runDaemon :: DaemonConfig -> Supervisor -> IO ()
+runDaemon config supervisor =
+    withUnixListener config.socket $ \listener -> do
+        journal <- openJournal config.journal
+        runServerOnListener listener config.server journal supervisor

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Framing.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Framing.hs
@@ -1,0 +1,76 @@
+module Agent.Runtime.Daemon.Framing
+    ( FrameError (..)
+    , defaultMaximumFrameBytes
+    , sendJSONFrame
+    , receiveJSONFrame
+    ) where
+
+import Control.Exception.Safe (Exception, throwIO)
+import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict', encode)
+import Data.Bits ((.|.), shiftL, shiftR)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Word (Word32, Word8)
+import Network.Socket (Socket)
+import qualified Network.Socket.ByteString as Socket
+
+data FrameError
+    = FrameClosed
+    | FrameTooLarge Int Int
+    | FrameInvalidJSON String
+    deriving stock (Eq, Show)
+
+instance Exception FrameError
+
+defaultMaximumFrameBytes :: Int
+defaultMaximumFrameBytes = 1_048_576
+
+sendJSONFrame :: ToJSON value => Int -> Socket -> value -> IO ()
+sendJSONFrame maximumBytes socket value = do
+    let body = LBS.toStrict (encode value)
+        bodyLength = BS.length body
+    if bodyLength > maximumBytes
+        then throwIO (FrameTooLarge bodyLength maximumBytes)
+        else Socket.sendAll socket (encodeLength bodyLength <> body)
+
+receiveJSONFrame :: FromJSON value => Int -> Socket -> IO value
+receiveJSONFrame maximumBytes socket = do
+    header <- receiveExactly socket 4
+    let bodyLength = decodeLength header
+    if bodyLength > maximumBytes
+        then throwIO (FrameTooLarge bodyLength maximumBytes)
+        else do
+            body <- receiveExactly socket bodyLength
+            either (throwIO . FrameInvalidJSON) pure (eitherDecodeStrict' body)
+
+receiveExactly :: Socket -> Int -> IO BS.ByteString
+receiveExactly socket expected = go [] expected
+  where
+    go chunks remaining
+        | remaining == 0 = pure (BS.concat (reverse chunks))
+        | otherwise = do
+            chunk <- Socket.recv socket remaining
+            if BS.null chunk
+                then throwIO FrameClosed
+                else go (chunk : chunks) (remaining - BS.length chunk)
+
+encodeLength :: Int -> BS.ByteString
+encodeLength lengthValue =
+    let word = fromIntegral lengthValue :: Word32
+     in BS.pack
+            [ byte (word `shiftR` 24)
+            , byte (word `shiftR` 16)
+            , byte (word `shiftR` 8)
+            , byte word
+            ]
+  where
+    byte :: Word32 -> Word8
+    byte = fromIntegral
+
+decodeLength :: BS.ByteString -> Int
+decodeLength bytes =
+    fromIntegral $
+        foldl
+            (\accumulator octet -> (accumulator `shiftL` 8) .|. fromIntegral octet)
+            (0 :: Word32)
+            (BS.unpack bytes)

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -285,7 +285,7 @@ persistTask journal task =
         ensureSnapshotFits journal.config updatedSnapshot
         compacted <- persistOrPoison journal $ do
             appendEventFile journal.config event
-            writeSnapshot journal.config (snapshotAnchor updatedSnapshot updated.retainedEvents)
+            writeSnapshot journal.config updatedSnapshot
             enforceRetention journal.config updated
         publish journal event
         pure (compacted, event)
@@ -405,12 +405,6 @@ validateRecoveryOrigin snapshotExists snapshotSequence events =
                 unless (first.sequenceNumber == expected) $
                     throwIO (JournalEventGap expected first.sequenceNumber)
             | snapshotExists
-            , first.sequenceNumber < snapshotSequence ->
-                throwIO $
-                    JournalCorrupt
-                        "events.jsonl"
-                        "retained event suffix contains a stale prefix before its snapshot anchor"
-            | snapshotExists
             , lastEvent.sequenceNumber < snapshotSequence ->
                 throwIO $
                     JournalCorrupt
@@ -490,12 +484,8 @@ enforceRetention config journalState = do
                                 journalState.retainedEvents
                 byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
                 compacted = journalState {retainedEvents = byteBounded}
+            writeSnapshot config compacted.durableSnapshot
             rewriteEvents config byteBounded
-            -- The first retained event is the durable anchor for this
-            -- suffix.  Persist the rewritten events before advancing the
-            -- snapshot anchor so an interrupted compaction still leaves a
-            -- recoverable (old snapshot, new suffix) pair.
-            writeSnapshot config (snapshotAnchor compacted.durableSnapshot byteBounded)
             pure compacted
         else pure journalState
 
@@ -509,16 +499,6 @@ retainWithinBytes maximumBytes events =
         | otherwise = event : go (used + size) rest
       where
         size = BS.length (encodeLine event)
-
--- | A snapshot is valid alongside a retained suffix when its sequence is the
--- suffix's first event (the anchor), or when the suffix is empty.  The task
--- map is still the latest durable state; recovery skips the anchor event and
--- applies everything after it.
-snapshotAnchor :: JournalSnapshot -> Seq EventEnvelope -> JournalSnapshot
-snapshotAnchor saved events =
-    case Seq.lookup 0 events of
-        Nothing -> saved
-        Just first -> saved {lastSequence = first.sequenceNumber}
 
 readSnapshot :: JournalConfig -> IO (Bool, JournalSnapshot)
 readSnapshot config = do

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -1,0 +1,383 @@
+module Agent.Runtime.Daemon.Journal
+    ( Journal
+    , JournalConfig (..)
+    , JournalSnapshot (..)
+    , Replay (..)
+    , defaultJournalConfig
+    , openJournal
+    , appendEvent
+    , persistTask
+    , snapshot
+    , replayAfter
+    , subscribe
+    , subscribeReplay
+    , redactValue
+    , boundTaskLog
+    ) where
+
+import Control.Concurrent.MVar
+import Control.Concurrent.STM
+import Control.Exception.Safe (IOException, catch, onException)
+import Control.Monad (forM_)
+import Data.Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as LBS
+import Data.Char (toLower)
+import Data.Foldable (toList)
+import Data.List (isInfixOf)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import qualified Data.Sequence as Seq
+import Data.Sequence (Seq)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time (getCurrentTime)
+import GHC.Generics (Generic)
+import System.Directory
+import System.FilePath ((</>))
+import System.IO
+import System.Posix.Files (setFileMode)
+import System.Posix.IO
+    ( OpenMode (ReadOnly)
+    , closeFd
+    , defaultFileFlags
+    , openFd
+    )
+import System.Posix.Unistd (fileSynchronise)
+
+import Agent.Runtime.Daemon.Protocol
+import Agent.Runtime.Daemon.Task
+
+data JournalConfig = JournalConfig
+    { directory :: FilePath
+    , maximumEvents :: Int
+    , maximumJournalBytes :: Int
+    , maximumTaskLogLines :: Int
+    , maximumTaskLogCharacters :: Int
+    }
+    deriving stock (Eq, Show)
+
+defaultJournalConfig :: FilePath -> JournalConfig
+defaultJournalConfig directory =
+    JournalConfig
+        { directory
+        , maximumEvents = 10_000
+        , maximumJournalBytes = 16 * 1_048_576
+        , maximumTaskLogLines = 500
+        , maximumTaskLogCharacters = 256_000
+        }
+
+data JournalSnapshot = JournalSnapshot
+    { lastSequence :: Sequence
+    , tasks :: Map TaskId DurableTask
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON JournalSnapshot
+instance FromJSON JournalSnapshot
+
+data Replay
+    = ReplayEvents [EventEnvelope]
+    | ReplaySnapshot JournalSnapshot
+    deriving stock (Eq, Show)
+
+data JournalState = JournalState
+    { durableSnapshot :: JournalSnapshot
+    , retainedEvents :: Seq EventEnvelope
+    }
+
+data Journal = Journal
+    { config :: JournalConfig
+    , state :: MVar JournalState
+    , eventChannel :: TChan EventEnvelope
+    }
+
+openJournal :: JournalConfig -> IO Journal
+openJournal config = do
+    createDirectoryIfMissing True config.directory
+    setFileMode config.directory 0o700
+    savedSnapshot <- readSnapshot config
+    savedEvents <- readEvents config
+    let recoveredSnapshot = foldl recoverTask savedSnapshot (toList savedEvents)
+        lastEventSequence =
+            maybe 0 (.sequenceNumber) (Seq.lookup (Seq.length savedEvents - 1) savedEvents)
+        nextSequence = max recoveredSnapshot.lastSequence lastEventSequence
+        initialState =
+            JournalState
+                { durableSnapshot = recoveredSnapshot {lastSequence = nextSequence}
+                , retainedEvents = savedEvents
+                }
+    state <- newMVar initialState
+    eventChannel <- newBroadcastTChanIO
+    let journal = Journal {config, state, eventChannel}
+    interruptTasksFromPreviousProcess journal
+    pure journal
+
+recoverTask :: JournalSnapshot -> EventEnvelope -> JournalSnapshot
+recoverTask saved event
+    | event.sequenceNumber <= saved.lastSequence = saved
+    | event.eventType /= "task_changed" = saved
+    | otherwise =
+        case fromJSON event.payload of
+            Error _ -> saved
+            Success task ->
+                saved
+                    { lastSequence = event.sequenceNumber
+                    , tasks = Map.insert task.taskId task saved.tasks
+                    }
+
+synchronisePath :: FilePath -> IO ()
+synchronisePath path =
+    bracketFd (openFd path ReadOnly defaultFileFlags) fileSynchronise
+  where
+    bracketFd acquire use = do
+        descriptor <- acquire
+        _ <- use descriptor `onException` closeFd descriptor
+        closeFd descriptor
+
+appendEvent :: Journal -> Text -> Value -> IO EventEnvelope
+appendEvent journal eventType payload =
+    modifyMVar journal.state $ \journalState -> do
+        let nextSequence = journalState.durableSnapshot.lastSequence + 1
+            event =
+                EventEnvelope
+                    { sequenceNumber = nextSequence
+                    , eventType
+                    , payload = redactValue payload
+                    }
+            updated =
+                journalState
+                    { durableSnapshot =
+                        journalState.durableSnapshot {lastSequence = nextSequence}
+                    , retainedEvents = journalState.retainedEvents Seq.|> event
+                    }
+        appendEventFile journal.config event
+        compacted <- enforceRetention journal.config updated
+        atomically (writeTChan journal.eventChannel event)
+        pure (compacted, event)
+
+persistTask :: Journal -> DurableTask -> IO EventEnvelope
+persistTask journal task =
+    modifyMVar journal.state $ \journalState -> do
+        let boundedTask = boundTaskLog journal.config task
+            nextSequence = journalState.durableSnapshot.lastSequence + 1
+            event =
+                EventEnvelope
+                    { sequenceNumber = nextSequence
+                    , eventType = "task_changed"
+                    , payload = toJSON boundedTask
+                    }
+            updatedSnapshot =
+                JournalSnapshot
+                    { lastSequence = nextSequence
+                    , tasks = Map.insert boundedTask.taskId boundedTask journalState.durableSnapshot.tasks
+                    }
+            updated =
+                JournalState
+                    { durableSnapshot = updatedSnapshot
+                    , retainedEvents = journalState.retainedEvents Seq.|> event
+                    }
+        appendEventFile journal.config event
+        writeSnapshot journal.config updatedSnapshot
+        compacted <- enforceRetention journal.config updated
+        atomically (writeTChan journal.eventChannel event)
+        pure (compacted, event)
+
+snapshot :: Journal -> IO JournalSnapshot
+snapshot journal = durableSnapshot <$> readMVar journal.state
+
+replayAfter :: Journal -> Sequence -> IO Replay
+replayAfter journal cursor =
+    withMVar journal.state (pure . replayFromState cursor)
+
+replayFromState :: Sequence -> JournalState -> Replay
+replayFromState cursor journalState =
+    let events = toList journalState.retainedEvents
+        earliest = maybe (journalState.durableSnapshot.lastSequence + 1) (.sequenceNumber) (safeHead events)
+     in
+        if cursor > journalState.durableSnapshot.lastSequence || cursor + 1 < earliest
+            then ReplaySnapshot journalState.durableSnapshot
+            else ReplayEvents (filter ((> cursor) . (.sequenceNumber)) events)
+
+subscribe :: Journal -> IO (TChan EventEnvelope)
+subscribe journal = atomically (dupTChan journal.eventChannel)
+
+-- | Atomically with respect to appends, capture handshake state, replay, and
+-- a subscription to subsequent events.
+subscribeReplay :: Journal -> Sequence -> IO (JournalSnapshot, Replay, TChan EventEnvelope)
+subscribeReplay journal cursor =
+    withMVar journal.state $ \journalState -> do
+        channel <- atomically (dupTChan journal.eventChannel)
+        pure
+            ( journalState.durableSnapshot
+            , replayFromState cursor journalState
+            , channel
+            )
+
+redactValue :: Value -> Value
+redactValue = \case
+    Object objectValue ->
+        Object $
+            KeyMap.mapWithKey
+                (\key value ->
+                    if isSensitiveKey (Key.toText key)
+                        then String "[REDACTED]"
+                        else redactValue value
+                )
+                objectValue
+    Array values -> Array (fmap redactValue values)
+    other -> other
+
+boundTaskLog :: JournalConfig -> DurableTask -> DurableTask
+boundTaskLog config task =
+    task
+        { logTail =
+            boundCharacters config.maximumTaskLogCharacters
+                . takeLast config.maximumTaskLogLines
+                . fmap redactLogLine
+                $ task.logTail
+        }
+
+interruptTasksFromPreviousProcess :: Journal -> IO ()
+interruptTasksFromPreviousProcess journal = do
+    currentSnapshot <- snapshot journal
+    now <- getCurrentTime
+    forM_ (filter isActive (Map.elems currentSnapshot.tasks)) $ \task -> do
+        _ <- persistTask journal (interruptActive now task)
+        pure ()
+
+enforceRetention :: JournalConfig -> JournalState -> IO JournalState
+enforceRetention config journalState = do
+    journalBytes <- fileSizeOrZero (eventsPath config)
+    let tooMany = Seq.length journalState.retainedEvents > max 0 config.maximumEvents
+        tooLarge = journalBytes > fromIntegral (max 0 config.maximumJournalBytes)
+    if tooMany || tooLarge
+        then do
+            let countBounded =
+                    Seq.drop
+                        (max 0 (Seq.length journalState.retainedEvents - max 0 config.maximumEvents))
+                        journalState.retainedEvents
+                byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
+                compacted = journalState {retainedEvents = byteBounded}
+            rewriteEvents config byteBounded
+            pure compacted
+        else pure journalState
+
+retainWithinBytes :: Int -> Seq EventEnvelope -> Seq EventEnvelope
+retainWithinBytes maximumBytes events =
+    snd $
+        foldr
+            (\event (used, kept) ->
+                let size = BS.length (encodeLine event)
+                 in if used + size <= max 0 maximumBytes
+                        then (used + size, event Seq.<| kept)
+                        else (used, kept)
+            )
+            (0, Seq.empty)
+            events
+
+readSnapshot :: JournalConfig -> IO JournalSnapshot
+readSnapshot config =
+    catch
+        (do
+            bytes <- BS.readFile (snapshotPath config)
+            case eitherDecodeStrict' bytes of
+                Left _ -> pure emptySnapshot
+                Right saved -> pure saved
+        )
+        (\(_ :: IOException) -> pure emptySnapshot)
+  where
+    emptySnapshot = JournalSnapshot {lastSequence = 0, tasks = Map.empty}
+
+readEvents :: JournalConfig -> IO (Seq EventEnvelope)
+readEvents config =
+    catch
+        (do
+            bytes <- BS.readFile (eventsPath config)
+            pure . Seq.fromList $ mapMaybeDecode (BS8.lines bytes)
+        )
+        (\(_ :: IOException) -> pure Seq.empty)
+
+mapMaybeDecode :: FromJSON value => [BS.ByteString] -> [value]
+mapMaybeDecode = foldr step []
+  where
+    step bytes values =
+        case eitherDecodeStrict' bytes of
+            Left _ -> values
+            Right value -> value : values
+
+appendEventFile :: JournalConfig -> EventEnvelope -> IO ()
+appendEventFile config event =
+    withBinaryFile (eventsPath config) AppendMode $ \handle -> do
+        BS.hPut handle (encodeLine event)
+        hFlush handle
+    >> do
+        setFileMode (eventsPath config) 0o600
+        synchronisePath (eventsPath config)
+
+rewriteEvents :: JournalConfig -> Seq EventEnvelope -> IO ()
+rewriteEvents config events =
+    atomicWrite config (eventsPath config) (BS.concat (fmap encodeLine (toList events)))
+
+writeSnapshot :: JournalConfig -> JournalSnapshot -> IO ()
+writeSnapshot config savedSnapshot =
+    atomicWrite config (snapshotPath config) (LBS.toStrict (encode savedSnapshot))
+
+atomicWrite :: JournalConfig -> FilePath -> BS.ByteString -> IO ()
+atomicWrite config destination bytes = do
+    let temporary = destination <> ".tmp"
+        cleanup = removeFile temporary `catch` \(_ :: IOException) -> pure ()
+    (do
+            BS.writeFile temporary bytes
+            setFileMode temporary 0o600
+            synchronisePath temporary
+            renameFile temporary destination
+            synchronisePath config.directory
+        )
+        `onException` cleanup
+    setFileMode config.directory 0o700
+
+fileSizeOrZero :: FilePath -> IO Integer
+fileSizeOrZero path =
+    catch (getFileSize path) (\(_ :: IOException) -> pure 0)
+
+snapshotPath, eventsPath :: JournalConfig -> FilePath
+snapshotPath config = config.directory </> "snapshot.json"
+eventsPath config = config.directory </> "events.jsonl"
+
+encodeLine :: ToJSON value => value -> BS.ByteString
+encodeLine value = LBS.toStrict (encode value) <> "\n"
+
+safeHead :: [value] -> Maybe value
+safeHead = \case
+    value : _ -> Just value
+    [] -> Nothing
+
+takeLast :: Int -> [value] -> [value]
+takeLast count values = drop (max 0 (length values - max 0 count)) values
+
+boundCharacters :: Int -> [Text] -> [Text]
+boundCharacters limit = reverse . go 0 . reverse
+  where
+    go _ [] = []
+    go used (line : rest)
+        | used >= max 0 limit = []
+        | otherwise =
+            let remaining = max 0 limit - used
+                bounded = Text.take remaining line
+             in bounded : go (used + Text.length bounded) rest
+
+redactLogLine :: Text -> Text
+redactLogLine line
+    | any (`Text.isInfixOf` Text.toLower line) sensitiveFragments = "[REDACTED]"
+    | otherwise = line
+  where
+    sensitiveFragments = ["authorization:", "api_key=", "apikey=", "password=", "token=", "secret="]
+
+isSensitiveKey :: Text -> Bool
+isSensitiveKey key =
+    let lowered = fmap toLower (Text.unpack key)
+     in any (`isInfixOf` lowered) ["authorization", "password", "secret", "token", "api_key", "apikey"]

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -155,17 +155,25 @@ openJournal config = do
     savedEvents <- readEvents config
     validateEventSequence savedEvents
     validateRecoveryOrigin snapshotExists savedSnapshot.lastSequence savedEvents
-    recoveredSnapshot <- foldM (recoverTask config) savedSnapshot (toList savedEvents)
+    normalisedEvents <- traverse (normaliseRecoveredEvent config) savedEvents
+    savedTasks <- normaliseRecoveredTasks config savedSnapshot.tasks
+    let normalisedSnapshot = savedSnapshot {tasks = savedTasks}
+    recoveredSnapshot <- foldM (recoverTask config) normalisedSnapshot (toList normalisedEvents)
     recoveredTasks <- enforceTaskCapacity config recoveredSnapshot.tasks
     let boundedSnapshot = recoveredSnapshot {tasks = recoveredTasks}
         lastEventSequence =
-            maybe 0 (.sequenceNumber) (Seq.lookup (Seq.length savedEvents - 1) savedEvents)
+            maybe 0 (.sequenceNumber) (Seq.lookup (Seq.length normalisedEvents - 1) normalisedEvents)
         nextSequence = max boundedSnapshot.lastSequence lastEventSequence
         initialState =
             JournalState
                 { durableSnapshot = boundedSnapshot {lastSequence = nextSequence}
-                , retainedEvents = savedEvents
+                , retainedEvents = normalisedEvents
                 }
+    forM_ normalisedEvents (ensureEventFits config)
+    when (savedTasks /= savedSnapshot.tasks) $
+        writeSnapshot config normalisedSnapshot
+    when (normalisedEvents /= savedEvents) $
+        rewriteEvents config normalisedEvents
     state <- newMVar initialState
     subscribers <- newTVarIO Map.empty
     nextSubscriber <- newTVarIO 0
@@ -193,6 +201,23 @@ recoverTask config saved event
                     { lastSequence = event.sequenceNumber
                     , tasks = boundedTasks
                     }
+
+normaliseRecoveredEvent :: JournalConfig -> EventEnvelope -> IO EventEnvelope
+normaliseRecoveredEvent config event
+    | event.eventType /= "task_changed" =
+        pure event {payload = redactValue event.payload}
+    | otherwise =
+        case fromJSON event.payload of
+            Error message -> throwIO (JournalCorrupt "events.jsonl" message)
+            Success task ->
+                pure event {payload = toJSON (boundTaskLog config task)}
+
+normaliseRecoveredTasks ::
+    JournalConfig ->
+    Map TaskId DurableTask ->
+    IO (Map TaskId DurableTask)
+normaliseRecoveredTasks config recoveredTasks =
+    enforceTaskCapacity config (fmap (boundTaskLog config) recoveredTasks)
 
 synchronisePath :: FilePath -> IO ()
 synchronisePath path =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -21,6 +21,7 @@ import Control.Exception.Safe
     ( Exception
     , IOException
     , catch
+    , finally
     , onException
     , throwIO
     , tryIO
@@ -42,18 +43,20 @@ import Data.Sequence (Seq)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time (getCurrentTime)
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import System.Directory hiding (isSymbolicLink)
 import System.FilePath ((</>))
-import System.IO.Error (isDoesNotExistError)
+import System.IO.Error (isDoesNotExistError, isEOFError)
 import System.Posix.Files
     ( fileOwner
+    , fileSize
     , getFdStatus
     , getSymbolicLinkStatus
     , isDirectory
     , isRegularFile
     , isSymbolicLink
-    , setFileMode
+    , setFdMode
     )
 import System.Posix.User (getEffectiveUserID)
 import System.Posix.IO
@@ -63,7 +66,7 @@ import System.Posix.IO
     , defaultFileFlags
     , openFd
     )
-import System.Posix.IO.ByteString (fdWrite)
+import System.Posix.IO.ByteString (fdRead, fdWrite)
 import System.Posix.Types (Fd)
 import System.Posix.Unistd (fileSynchronise)
 
@@ -107,6 +110,7 @@ data JournalError
     | JournalFileTooLarge FilePath Integer Integer
     | JournalPoisoned String
     | JournalInsecurePath FilePath
+    | JournalSequenceExhausted Sequence
     deriving stock (Eq, Show)
 
 instance Exception JournalError
@@ -147,14 +151,11 @@ openJournal :: JournalConfig -> IO Journal
 openJournal config = do
     createDirectoryIfMissing True config.directory
     verifyPrivateDirectory config.directory
-    setFileMode config.directory 0o700
-    mapM_ verifyPrivateFileIfPresent [snapshotPath config, eventsPath config]
-    snapshotExists <- doesFileExist (snapshotPath config)
-    savedSnapshot <- readSnapshot config
+    (snapshotExists, savedSnapshot) <- readSnapshot config
     savedEvents <- readEvents config
     validateEventSequence savedEvents
-    validateRecoveryOrigin snapshotExists savedEvents
-    recoveredSnapshot <- foldM recoverTask savedSnapshot (toList savedEvents)
+    validateRecoveryOrigin snapshotExists savedSnapshot.lastSequence savedEvents
+    recoveredSnapshot <- foldM (recoverTask config) savedSnapshot (toList savedEvents)
     recoveredTasks <- enforceTaskCapacity config recoveredSnapshot.tasks
     let boundedSnapshot = recoveredSnapshot {tasks = recoveredTasks}
         lastEventSequence =
@@ -176,22 +177,28 @@ openJournal config = do
     interruptTasksFromPreviousProcess journal
     pure journal
 
-recoverTask :: JournalSnapshot -> EventEnvelope -> IO JournalSnapshot
-recoverTask saved event
+recoverTask :: JournalConfig -> JournalSnapshot -> EventEnvelope -> IO JournalSnapshot
+recoverTask config saved event
     | event.sequenceNumber <= saved.lastSequence = pure saved
     | event.eventType /= "task_changed" = pure saved
     | otherwise =
         case fromJSON event.payload of
             Error message -> throwIO (JournalCorrupt "events.jsonl" message)
-            Success task ->
+            Success task -> do
+                let boundedTask = boundTaskLog config task
+                boundedTasks <-
+                    enforceTaskCapacity config $
+                        Map.insert boundedTask.taskId boundedTask saved.tasks
                 pure saved
                     { lastSequence = event.sequenceNumber
-                    , tasks = Map.insert task.taskId task saved.tasks
+                    , tasks = boundedTasks
                     }
 
 synchronisePath :: FilePath -> IO ()
 synchronisePath path =
-    bracketFd (openFd path ReadOnly defaultFileFlags) fileSynchronise
+    bracketFd
+        (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True, directory = True})
+        fileSynchronise
   where
     bracketFd acquire use = do
         descriptor <- acquire
@@ -202,7 +209,8 @@ appendEvent :: Journal -> Text -> Value -> IO EventEnvelope
 appendEvent journal eventType payload =
     modifyMVar journal.state $ \journalState -> do
         ensureHealthy journal
-        let nextSequence = journalState.durableSnapshot.lastSequence + 1
+        nextSequence <- nextSequenceAfter journalState.durableSnapshot.lastSequence
+        let
             event =
                 EventEnvelope
                     { sequenceNumber = nextSequence
@@ -230,8 +238,8 @@ persistTask journal task =
         boundedTasks <-
             enforceTaskCapacity journal.config $
                 Map.insert boundedTask.taskId boundedTask journalState.durableSnapshot.tasks
+        nextSequence <- nextSequenceAfter journalState.durableSnapshot.lastSequence
         let
-            nextSequence = journalState.durableSnapshot.lastSequence + 1
             event =
                 EventEnvelope
                     { sequenceNumber = nextSequence
@@ -272,11 +280,18 @@ replayAfter journal cursor =
 replayFromState :: Sequence -> JournalState -> Replay
 replayFromState cursor journalState =
     let events = toList journalState.retainedEvents
-        earliest = maybe (journalState.durableSnapshot.lastSequence + 1) (.sequenceNumber) (safeHead events)
+        earliest = fmap (.sequenceNumber) (safeHead events)
+        replayGap =
+            case earliest of
+                Nothing -> cursor < journalState.durableSnapshot.lastSequence
+                Just sequenceNumber -> hasGapAfter cursor sequenceNumber
      in
-        if cursor > journalState.durableSnapshot.lastSequence || cursor + 1 < earliest
+        if cursor > journalState.durableSnapshot.lastSequence || replayGap
             then ReplaySnapshot journalState.durableSnapshot
             else ReplayEvents (filter ((> cursor) . (.sequenceNumber)) events)
+  where
+    hasGapAfter (Sequence cursorValue) (Sequence earliestValue) =
+        earliestValue > cursorValue && earliestValue - cursorValue > 1
 
 -- | Atomically with respect to appends, capture handshake state, replay, and
 -- a subscription to subsequent events.
@@ -347,38 +362,49 @@ validateEventSequence events =
             | otherwise -> go first.sequenceNumber rest
   where
     go _ [] = pure ()
-    go previous (event : remaining)
-        | event.sequenceNumber == previous + 1 =
-            go event.sequenceNumber remaining
-        | otherwise =
-            throwIO (JournalEventGap (previous + 1) event.sequenceNumber)
+    go previous (event : remaining) = do
+        expected <- nextSequenceAfter previous
+        if event.sequenceNumber == expected
+            then go event.sequenceNumber remaining
+            else throwIO (JournalEventGap expected event.sequenceNumber)
 
-validateRecoveryOrigin :: Bool -> Seq EventEnvelope -> IO ()
-validateRecoveryOrigin snapshotExists events =
-    case Seq.lookup 0 events of
-        Just first
+validateRecoveryOrigin :: Bool -> Sequence -> Seq EventEnvelope -> IO ()
+validateRecoveryOrigin snapshotExists snapshotSequence events =
+    case (Seq.lookup 0 events, Seq.lookup (Seq.length events - 1) events) of
+        (Just first, Just lastEvent)
             | not snapshotExists && first.sequenceNumber /= 1 ->
                 throwIO (JournalEventGap 1 first.sequenceNumber)
+            | snapshotExists
+            , first.sequenceNumber > snapshotSequence -> do
+                expected <- nextSequenceAfter snapshotSequence
+                unless (first.sequenceNumber == expected) $
+                    throwIO (JournalEventGap expected first.sequenceNumber)
+            | snapshotExists
+            , lastEvent.sequenceNumber < snapshotSequence ->
+                throwIO $
+                    JournalCorrupt
+                        "events.jsonl"
+                        "retained event suffix ends before the snapshot sequence"
         _ -> pure ()
 
-verifyPrivateDirectory :: FilePath -> IO ()
-verifyPrivateDirectory path = do
-    status <- getSymbolicLinkStatus path
-    effectiveUser <- getEffectiveUserID
-    unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
-        throwIO (JournalInsecurePath path)
+nextSequenceAfter :: Sequence -> IO Sequence
+nextSequenceAfter sequenceNumber@(Sequence value)
+    | value == (maxBound :: Word64) = throwIO (JournalSequenceExhausted sequenceNumber)
+    | otherwise = pure (Sequence (value + 1))
 
-verifyPrivateFileIfPresent :: FilePath -> IO ()
-verifyPrivateFileIfPresent path = do
-    tryIO (getSymbolicLinkStatus path) >>= \case
-        Left exception
-            | isDoesNotExistError exception -> pure ()
-            | otherwise -> throwIO exception
-        Right status -> do
-            effectiveUser <- getEffectiveUserID
-            unless (isRegularFile status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
-                throwIO (JournalInsecurePath path)
-            setFileMode path 0o600
+verifyPrivateDirectory :: FilePath -> IO ()
+verifyPrivateDirectory path =
+    tryIO (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True, directory = True}) >>= \case
+        Left (_ :: IOException) -> throwIO (JournalInsecurePath path)
+        Right descriptor ->
+            ( do
+                status <- getFdStatus descriptor
+                effectiveUser <- getEffectiveUserID
+                unless (isDirectory status && fileOwner status == effectiveUser) $
+                    throwIO (JournalInsecurePath path)
+                setFdMode descriptor 0o700
+            )
+                `finally` closeFd descriptor
 
 redactValue :: Value -> Value
 redactValue = \case
@@ -425,11 +451,15 @@ enforceRetention config journalState = do
     if tooMany || tooLarge
         then do
             let countBounded =
-                    Seq.drop
-                        (max 0 (Seq.length journalState.retainedEvents - max 1 config.maximumEvents))
-                        journalState.retainedEvents
+                    if config.maximumEvents <= 0
+                        then Seq.empty
+                        else
+                            Seq.drop
+                                (max 0 (Seq.length journalState.retainedEvents - config.maximumEvents))
+                                journalState.retainedEvents
                 byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
                 compacted = journalState {retainedEvents = byteBounded}
+            writeSnapshot config compacted.durableSnapshot
             rewriteEvents config byteBounded
             pure compacted
         else pure journalState
@@ -445,29 +475,23 @@ retainWithinBytes maximumBytes events =
       where
         size = BS.length (encodeLine event)
 
-readSnapshot :: JournalConfig -> IO JournalSnapshot
+readSnapshot :: JournalConfig -> IO (Bool, JournalSnapshot)
 readSnapshot config = do
-    exists <- doesFileExist (snapshotPath config)
-    if exists
-        then do
-            ensureFileSize (snapshotPath config) (fromIntegral config.maximumSnapshotBytes)
-            bytes <- BS.readFile (snapshotPath config)
+    readPrivateFile (snapshotPath config) (fromIntegral config.maximumSnapshotBytes) >>= \case
+        Just bytes ->
             case eitherDecodeStrict' bytes of
                 Left message -> throwIO (JournalCorrupt (snapshotPath config) message)
-                Right saved -> pure saved
-        else pure emptySnapshot
+                Right saved -> pure (True, saved)
+        Nothing -> pure (False, emptySnapshot)
   where
     emptySnapshot = JournalSnapshot {lastSequence = 0, tasks = Map.empty}
 
 readEvents :: JournalConfig -> IO (Seq EventEnvelope)
 readEvents config = do
-    exists <- doesFileExist (eventsPath config)
-    if exists
-        then do
-            ensureFileSize (eventsPath config) (fromIntegral config.maximumRecoveryJournalBytes)
-            bytes <- BS.readFile (eventsPath config)
+    readPrivateFile (eventsPath config) (fromIntegral config.maximumRecoveryJournalBytes) >>= \case
+        Just bytes ->
             traverse decodeLine (zip [1 :: Int ..] (BS8.lines bytes)) >>= pure . Seq.fromList
-        else pure Seq.empty
+        Nothing -> pure Seq.empty
 
 decodeLine :: FromJSON value => (Int, BS.ByteString) -> IO value
 decodeLine (lineNumber, bytes) =
@@ -475,11 +499,36 @@ decodeLine (lineNumber, bytes) =
         Left message -> throwIO (JournalCorrupt "events.jsonl" ("line " <> show lineNumber <> ": " <> message))
         Right value -> pure value
 
-ensureFileSize :: FilePath -> Integer -> IO ()
-ensureFileSize path maximumBytes = do
-    actual <- getFileSize path
+readPrivateFile :: FilePath -> Integer -> IO (Maybe BS.ByteString)
+readPrivateFile path maximumBytes =
+    tryIO (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True}) >>= \case
+        Left exception
+            | isDoesNotExistError exception -> pure Nothing
+            | otherwise -> throwIO (JournalInsecurePath path)
+        Right descriptor ->
+            Just
+                <$> ( (verifyPrivateDescriptor path descriptor >> setFdMode descriptor 0o600 >> readDescriptorBounded path maximumBytes descriptor)
+                        `finally` closeFd descriptor
+                    )
+
+readDescriptorBounded :: FilePath -> Integer -> Fd -> IO BS.ByteString
+readDescriptorBounded path maximumBytes descriptor = do
+    status <- getFdStatus descriptor
+    let actual = fromIntegral (fileSize status)
     when (maximumBytes < 0 || actual > maximumBytes) $
         throwIO (JournalFileTooLarge path actual maximumBytes)
+    go 0 []
+  where
+    go used chunks = do
+        chunk <- fdRead descriptor 65_536 `catch` \exception ->
+            if isEOFError exception then pure BS.empty else throwIO (exception :: IOException)
+        if BS.null chunk
+            then pure (BS.concat (reverse chunks))
+            else do
+                let total = used + fromIntegral (BS.length chunk)
+                when (maximumBytes < 0 || total > maximumBytes) $
+                    throwIO (JournalFileTooLarge path total maximumBytes)
+                go total (chunk : chunks)
 
 appendEventFile :: JournalConfig -> EventEnvelope -> IO ()
 appendEventFile config event = do
@@ -494,10 +543,10 @@ appendEventFile config event = do
                 , cloexec = True
                 }
     verifyPrivateDescriptor (eventsPath config) descriptor `onException` closeFd descriptor
+    setFdMode descriptor 0o600 `onException` closeFd descriptor
     writeDescriptor descriptor (encodeLine event) `onException` closeFd descriptor
     fileSynchronise descriptor `onException` closeFd descriptor
     closeFd descriptor
-    setFileMode (eventsPath config) 0o600
 
 verifyPrivateDescriptor :: FilePath -> Fd -> IO ()
 verifyPrivateDescriptor path descriptor = do
@@ -538,6 +587,7 @@ atomicWrite config destination bytes = do
                         , nofollow = True
                         , cloexec = True
                         }
+            setFdMode descriptor 0o600 `onException` closeFd descriptor
             writeDescriptor descriptor bytes `onException` closeFd descriptor
             fileSynchronise descriptor `onException` closeFd descriptor
             closeFd descriptor
@@ -545,7 +595,7 @@ atomicWrite config destination bytes = do
             synchronisePath config.directory
         )
         `onException` cleanup
-    setFileMode config.directory 0o700
+    verifyPrivateDirectory config.directory
 
 writeDescriptor :: Fd -> BS.ByteString -> IO ()
 writeDescriptor _ bytes | BS.null bytes = pure ()

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -1,5 +1,6 @@
 module Agent.Runtime.Daemon.Journal
     ( Journal
+    , JournalError (..)
     , JournalConfig (..)
     , JournalSnapshot (..)
     , Replay (..)
@@ -9,7 +10,6 @@ module Agent.Runtime.Daemon.Journal
     , persistTask
     , snapshot
     , replayAfter
-    , subscribe
     , subscribeReplay
     , redactValue
     , boundTaskLog
@@ -17,8 +17,15 @@ module Agent.Runtime.Daemon.Journal
 
 import Control.Concurrent.MVar
 import Control.Concurrent.STM
-import Control.Exception.Safe (IOException, catch, onException)
-import Control.Monad (forM_)
+import Control.Exception.Safe
+    ( Exception
+    , IOException
+    , catch
+    , onException
+    , throwIO
+    , tryIO
+    )
+import Control.Monad (foldM, forM_, unless, when)
 import Data.Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -36,16 +43,28 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time (getCurrentTime)
 import GHC.Generics (Generic)
-import System.Directory
+import System.Directory hiding (isSymbolicLink)
 import System.FilePath ((</>))
-import System.IO
-import System.Posix.Files (setFileMode)
+import System.IO.Error (isDoesNotExistError)
+import System.Posix.Files
+    ( fileOwner
+    , getFdStatus
+    , getSymbolicLinkStatus
+    , isDirectory
+    , isRegularFile
+    , isSymbolicLink
+    , setFileMode
+    )
+import System.Posix.User (getEffectiveUserID)
 import System.Posix.IO
-    ( OpenMode (ReadOnly)
+    ( OpenFileFlags (..)
+    , OpenMode (ReadOnly, WriteOnly)
     , closeFd
     , defaultFileFlags
     , openFd
     )
+import System.Posix.IO.ByteString (fdWrite)
+import System.Posix.Types (Fd)
 import System.Posix.Unistd (fileSynchronise)
 
 import Agent.Runtime.Daemon.Protocol
@@ -57,6 +76,11 @@ data JournalConfig = JournalConfig
     , maximumJournalBytes :: Int
     , maximumTaskLogLines :: Int
     , maximumTaskLogCharacters :: Int
+    , maximumTaskDescriptionCharacters :: Int
+    , maximumTasks :: Int
+    , subscriberQueueSize :: Int
+    , maximumSnapshotBytes :: Int
+    , maximumRecoveryJournalBytes :: Int
     }
     deriving stock (Eq, Show)
 
@@ -68,7 +92,24 @@ defaultJournalConfig directory =
         , maximumJournalBytes = 16 * 1_048_576
         , maximumTaskLogLines = 500
         , maximumTaskLogCharacters = 256_000
+        , maximumTaskDescriptionCharacters = 8_192
+        , maximumTasks = 1_000
+        , subscriberQueueSize = 256
+        , maximumSnapshotBytes = 64 * 1_048_576
+        , maximumRecoveryJournalBytes = 64 * 1_048_576
         }
+
+data JournalError
+    = JournalCorrupt FilePath String
+    | JournalEventGap Sequence Sequence
+    | JournalEventTooLarge Int Int
+    | JournalTaskCapacityExceeded Int
+    | JournalFileTooLarge FilePath Integer Integer
+    | JournalPoisoned String
+    | JournalInsecurePath FilePath
+    deriving stock (Eq, Show)
+
+instance Exception JournalError
 
 data JournalSnapshot = JournalSnapshot
     { lastSequence :: Sequence
@@ -92,39 +133,58 @@ data JournalState = JournalState
 data Journal = Journal
     { config :: JournalConfig
     , state :: MVar JournalState
-    , eventChannel :: TChan EventEnvelope
+    , subscribers :: TVar (Map Int Subscription)
+    , nextSubscriber :: TVar Int
+    , poisoned :: TVar (Maybe String)
+    }
+
+data Subscription = Subscription
+    { events :: TBQueue EventEnvelope
+    , overflowed :: TVar Bool
     }
 
 openJournal :: JournalConfig -> IO Journal
 openJournal config = do
     createDirectoryIfMissing True config.directory
+    verifyPrivateDirectory config.directory
     setFileMode config.directory 0o700
+    mapM_ verifyPrivateFileIfPresent [snapshotPath config, eventsPath config]
+    snapshotExists <- doesFileExist (snapshotPath config)
     savedSnapshot <- readSnapshot config
     savedEvents <- readEvents config
-    let recoveredSnapshot = foldl recoverTask savedSnapshot (toList savedEvents)
+    validateEventSequence savedEvents
+    validateRecoveryOrigin snapshotExists savedEvents
+    recoveredSnapshot <- foldM recoverTask savedSnapshot (toList savedEvents)
+    recoveredTasks <- enforceTaskCapacity config recoveredSnapshot.tasks
+    let boundedSnapshot = recoveredSnapshot {tasks = recoveredTasks}
         lastEventSequence =
             maybe 0 (.sequenceNumber) (Seq.lookup (Seq.length savedEvents - 1) savedEvents)
-        nextSequence = max recoveredSnapshot.lastSequence lastEventSequence
+        nextSequence = max boundedSnapshot.lastSequence lastEventSequence
         initialState =
             JournalState
-                { durableSnapshot = recoveredSnapshot {lastSequence = nextSequence}
+                { durableSnapshot = boundedSnapshot {lastSequence = nextSequence}
                 , retainedEvents = savedEvents
                 }
     state <- newMVar initialState
-    eventChannel <- newBroadcastTChanIO
-    let journal = Journal {config, state, eventChannel}
+    subscribers <- newTVarIO Map.empty
+    nextSubscriber <- newTVarIO 0
+    poisoned <- newTVarIO Nothing
+    let journal = Journal {config, state, subscribers, nextSubscriber, poisoned}
+    _ <- modifyMVar state $ \journalState -> do
+        compacted <- enforceRetention config journalState
+        pure (compacted, ())
     interruptTasksFromPreviousProcess journal
     pure journal
 
-recoverTask :: JournalSnapshot -> EventEnvelope -> JournalSnapshot
+recoverTask :: JournalSnapshot -> EventEnvelope -> IO JournalSnapshot
 recoverTask saved event
-    | event.sequenceNumber <= saved.lastSequence = saved
-    | event.eventType /= "task_changed" = saved
+    | event.sequenceNumber <= saved.lastSequence = pure saved
+    | event.eventType /= "task_changed" = pure saved
     | otherwise =
         case fromJSON event.payload of
-            Error _ -> saved
+            Error message -> throwIO (JournalCorrupt "events.jsonl" message)
             Success task ->
-                saved
+                pure saved
                     { lastSequence = event.sequenceNumber
                     , tasks = Map.insert task.taskId task saved.tasks
                     }
@@ -141,6 +201,7 @@ synchronisePath path =
 appendEvent :: Journal -> Text -> Value -> IO EventEnvelope
 appendEvent journal eventType payload =
     modifyMVar journal.state $ \journalState -> do
+        ensureHealthy journal
         let nextSequence = journalState.durableSnapshot.lastSequence + 1
             event =
                 EventEnvelope
@@ -154,15 +215,22 @@ appendEvent journal eventType payload =
                         journalState.durableSnapshot {lastSequence = nextSequence}
                     , retainedEvents = journalState.retainedEvents Seq.|> event
                     }
-        appendEventFile journal.config event
-        compacted <- enforceRetention journal.config updated
-        atomically (writeTChan journal.eventChannel event)
+        ensureEventFits journal.config event
+        compacted <- persistOrPoison journal $ do
+            appendEventFile journal.config event
+            enforceRetention journal.config updated
+        publish journal event
         pure (compacted, event)
 
 persistTask :: Journal -> DurableTask -> IO EventEnvelope
 persistTask journal task =
     modifyMVar journal.state $ \journalState -> do
+        ensureHealthy journal
         let boundedTask = boundTaskLog journal.config task
+        boundedTasks <-
+            enforceTaskCapacity journal.config $
+                Map.insert boundedTask.taskId boundedTask journalState.durableSnapshot.tasks
+        let
             nextSequence = journalState.durableSnapshot.lastSequence + 1
             event =
                 EventEnvelope
@@ -173,25 +241,33 @@ persistTask journal task =
             updatedSnapshot =
                 JournalSnapshot
                     { lastSequence = nextSequence
-                    , tasks = Map.insert boundedTask.taskId boundedTask journalState.durableSnapshot.tasks
+                    , tasks = boundedTasks
                     }
             updated =
                 JournalState
                     { durableSnapshot = updatedSnapshot
                     , retainedEvents = journalState.retainedEvents Seq.|> event
                     }
-        appendEventFile journal.config event
-        writeSnapshot journal.config updatedSnapshot
-        compacted <- enforceRetention journal.config updated
-        atomically (writeTChan journal.eventChannel event)
+        ensureEventFits journal.config event
+        ensureSnapshotFits journal.config updatedSnapshot
+        compacted <- persistOrPoison journal $ do
+            appendEventFile journal.config event
+            writeSnapshot journal.config updatedSnapshot
+            enforceRetention journal.config updated
+        publish journal event
         pure (compacted, event)
 
 snapshot :: Journal -> IO JournalSnapshot
-snapshot journal = durableSnapshot <$> readMVar journal.state
+snapshot journal =
+    withMVar journal.state $ \journalState -> do
+        ensureHealthy journal
+        pure journalState.durableSnapshot
 
 replayAfter :: Journal -> Sequence -> IO Replay
 replayAfter journal cursor =
-    withMVar journal.state (pure . replayFromState cursor)
+    withMVar journal.state $ \journalState -> do
+        ensureHealthy journal
+        pure (replayFromState cursor journalState)
 
 replayFromState :: Sequence -> JournalState -> Replay
 replayFromState cursor journalState =
@@ -202,20 +278,107 @@ replayFromState cursor journalState =
             then ReplaySnapshot journalState.durableSnapshot
             else ReplayEvents (filter ((> cursor) . (.sequenceNumber)) events)
 
-subscribe :: Journal -> IO (TChan EventEnvelope)
-subscribe journal = atomically (dupTChan journal.eventChannel)
-
 -- | Atomically with respect to appends, capture handshake state, replay, and
 -- a subscription to subsequent events.
-subscribeReplay :: Journal -> Sequence -> IO (JournalSnapshot, Replay, TChan EventEnvelope)
+subscribeReplay ::
+    Journal ->
+    Sequence ->
+    IO (JournalSnapshot, Replay, TBQueue EventEnvelope, TVar Bool, IO ())
 subscribeReplay journal cursor =
     withMVar journal.state $ \journalState -> do
-        channel <- atomically (dupTChan journal.eventChannel)
+        ensureHealthy journal
+        (subscriberId, subscription) <-
+            atomically $ do
+                subscriberId <- readTVar journal.nextSubscriber
+                writeTVar journal.nextSubscriber (subscriberId + 1)
+                events <- newTBQueue (fromIntegral (max 1 journal.config.subscriberQueueSize))
+                overflowed <- newTVar False
+                let subscription = Subscription {events, overflowed}
+                modifyTVar' journal.subscribers (Map.insert subscriberId subscription)
+                pure (subscriberId, subscription)
+        let unsubscribe = atomically (modifyTVar' journal.subscribers (Map.delete subscriberId))
         pure
             ( journalState.durableSnapshot
             , replayFromState cursor journalState
-            , channel
+            , subscription.events
+            , subscription.overflowed
+            , unsubscribe
             )
+
+ensureHealthy :: Journal -> IO ()
+ensureHealthy journal =
+    readTVarIO journal.poisoned >>= \case
+        Nothing -> pure ()
+        Just message -> throwIO (JournalPoisoned message)
+
+persistOrPoison :: Journal -> IO value -> IO value
+persistOrPoison journal action =
+    action `onException`
+        atomically (writeTVar journal.poisoned (Just "persistence operation failed"))
+
+publish :: Journal -> EventEnvelope -> IO ()
+publish journal event =
+    atomically $ do
+        active <- readTVar journal.subscribers
+        forM_ active $ \subscription -> do
+            full <- isFullTBQueue subscription.events
+            if full
+                then writeTVar subscription.overflowed True
+                else writeTBQueue subscription.events event
+
+ensureEventFits :: JournalConfig -> EventEnvelope -> IO ()
+ensureEventFits config event = do
+    let actual = BS.length (encodeLine event)
+        maximumBytes = config.maximumJournalBytes
+    when (maximumBytes <= 0 || actual > maximumBytes) $
+        throwIO (JournalEventTooLarge actual maximumBytes)
+
+enforceTaskCapacity :: JournalConfig -> Map TaskId DurableTask -> IO (Map TaskId DurableTask)
+enforceTaskCapacity config tasks
+    | Map.size tasks <= max 0 config.maximumTasks = pure tasks
+    | otherwise = throwIO (JournalTaskCapacityExceeded config.maximumTasks)
+
+validateEventSequence :: Seq EventEnvelope -> IO ()
+validateEventSequence events =
+    case toList events of
+        [] -> pure ()
+        first : rest
+            | first.sequenceNumber == 0 -> throwIO (JournalEventGap 1 0)
+            | otherwise -> go first.sequenceNumber rest
+  where
+    go _ [] = pure ()
+    go previous (event : remaining)
+        | event.sequenceNumber == previous + 1 =
+            go event.sequenceNumber remaining
+        | otherwise =
+            throwIO (JournalEventGap (previous + 1) event.sequenceNumber)
+
+validateRecoveryOrigin :: Bool -> Seq EventEnvelope -> IO ()
+validateRecoveryOrigin snapshotExists events =
+    case Seq.lookup 0 events of
+        Just first
+            | not snapshotExists && first.sequenceNumber /= 1 ->
+                throwIO (JournalEventGap 1 first.sequenceNumber)
+        _ -> pure ()
+
+verifyPrivateDirectory :: FilePath -> IO ()
+verifyPrivateDirectory path = do
+    status <- getSymbolicLinkStatus path
+    effectiveUser <- getEffectiveUserID
+    unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
+        throwIO (JournalInsecurePath path)
+
+verifyPrivateFileIfPresent :: FilePath -> IO ()
+verifyPrivateFileIfPresent path = do
+    tryIO (getSymbolicLinkStatus path) >>= \case
+        Left exception
+            | isDoesNotExistError exception -> pure ()
+            | otherwise -> throwIO exception
+        Right status -> do
+            effectiveUser <- getEffectiveUserID
+            unless (isRegularFile status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
+                throwIO (JournalInsecurePath path)
+            setFileMode path 0o600
 
 redactValue :: Value -> Value
 redactValue = \case
@@ -234,7 +397,10 @@ redactValue = \case
 boundTaskLog :: JournalConfig -> DurableTask -> DurableTask
 boundTaskLog config task =
     task
-        { logTail =
+        { description =
+            Text.take config.maximumTaskDescriptionCharacters $
+                redactLogLine task.description
+        , logTail =
             boundCharacters config.maximumTaskLogCharacters
                 . takeLast config.maximumTaskLogLines
                 . fmap redactLogLine
@@ -252,13 +418,15 @@ interruptTasksFromPreviousProcess journal = do
 enforceRetention :: JournalConfig -> JournalState -> IO JournalState
 enforceRetention config journalState = do
     journalBytes <- fileSizeOrZero (eventsPath config)
+    forM_ (Seq.lookup (Seq.length journalState.retainedEvents - 1) journalState.retainedEvents) $
+        ensureEventFits config
     let tooMany = Seq.length journalState.retainedEvents > max 0 config.maximumEvents
         tooLarge = journalBytes > fromIntegral (max 0 config.maximumJournalBytes)
     if tooMany || tooLarge
         then do
             let countBounded =
                     Seq.drop
-                        (max 0 (Seq.length journalState.retainedEvents - max 0 config.maximumEvents))
+                        (max 0 (Seq.length journalState.retainedEvents - max 1 config.maximumEvents))
                         journalState.retainedEvents
                 byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
                 compacted = journalState {retainedEvents = byteBounded}
@@ -268,77 +436,135 @@ enforceRetention config journalState = do
 
 retainWithinBytes :: Int -> Seq EventEnvelope -> Seq EventEnvelope
 retainWithinBytes maximumBytes events =
-    snd $
-        foldr
-            (\event (used, kept) ->
-                let size = BS.length (encodeLine event)
-                 in if used + size <= max 0 maximumBytes
-                        then (used + size, event Seq.<| kept)
-                        else (used, kept)
-            )
-            (0, Seq.empty)
-            events
+    Seq.fromList . reverse $ go 0 (reverse (toList events))
+  where
+    go _ [] = []
+    go used (event : rest)
+        | used + size > max 0 maximumBytes = []
+        | otherwise = event : go (used + size) rest
+      where
+        size = BS.length (encodeLine event)
 
 readSnapshot :: JournalConfig -> IO JournalSnapshot
-readSnapshot config =
-    catch
-        (do
+readSnapshot config = do
+    exists <- doesFileExist (snapshotPath config)
+    if exists
+        then do
+            ensureFileSize (snapshotPath config) (fromIntegral config.maximumSnapshotBytes)
             bytes <- BS.readFile (snapshotPath config)
             case eitherDecodeStrict' bytes of
-                Left _ -> pure emptySnapshot
+                Left message -> throwIO (JournalCorrupt (snapshotPath config) message)
                 Right saved -> pure saved
-        )
-        (\(_ :: IOException) -> pure emptySnapshot)
+        else pure emptySnapshot
   where
     emptySnapshot = JournalSnapshot {lastSequence = 0, tasks = Map.empty}
 
 readEvents :: JournalConfig -> IO (Seq EventEnvelope)
-readEvents config =
-    catch
-        (do
+readEvents config = do
+    exists <- doesFileExist (eventsPath config)
+    if exists
+        then do
+            ensureFileSize (eventsPath config) (fromIntegral config.maximumRecoveryJournalBytes)
             bytes <- BS.readFile (eventsPath config)
-            pure . Seq.fromList $ mapMaybeDecode (BS8.lines bytes)
-        )
-        (\(_ :: IOException) -> pure Seq.empty)
+            traverse decodeLine (zip [1 :: Int ..] (BS8.lines bytes)) >>= pure . Seq.fromList
+        else pure Seq.empty
 
-mapMaybeDecode :: FromJSON value => [BS.ByteString] -> [value]
-mapMaybeDecode = foldr step []
-  where
-    step bytes values =
-        case eitherDecodeStrict' bytes of
-            Left _ -> values
-            Right value -> value : values
+decodeLine :: FromJSON value => (Int, BS.ByteString) -> IO value
+decodeLine (lineNumber, bytes) =
+    case eitherDecodeStrict' bytes of
+        Left message -> throwIO (JournalCorrupt "events.jsonl" ("line " <> show lineNumber <> ": " <> message))
+        Right value -> pure value
+
+ensureFileSize :: FilePath -> Integer -> IO ()
+ensureFileSize path maximumBytes = do
+    actual <- getFileSize path
+    when (maximumBytes < 0 || actual > maximumBytes) $
+        throwIO (JournalFileTooLarge path actual maximumBytes)
 
 appendEventFile :: JournalConfig -> EventEnvelope -> IO ()
-appendEventFile config event =
-    withBinaryFile (eventsPath config) AppendMode $ \handle -> do
-        BS.hPut handle (encodeLine event)
-        hFlush handle
-    >> do
-        setFileMode (eventsPath config) 0o600
-        synchronisePath (eventsPath config)
+appendEventFile config event = do
+    descriptor <-
+        openFd
+            (eventsPath config)
+            WriteOnly
+            defaultFileFlags
+                { append = True
+                , creat = Just 0o600
+                , nofollow = True
+                , cloexec = True
+                }
+    verifyPrivateDescriptor (eventsPath config) descriptor `onException` closeFd descriptor
+    writeDescriptor descriptor (encodeLine event) `onException` closeFd descriptor
+    fileSynchronise descriptor `onException` closeFd descriptor
+    closeFd descriptor
+    setFileMode (eventsPath config) 0o600
+
+verifyPrivateDescriptor :: FilePath -> Fd -> IO ()
+verifyPrivateDescriptor path descriptor = do
+    status <- getFdStatus descriptor
+    effectiveUser <- getEffectiveUserID
+    unless (isRegularFile status && fileOwner status == effectiveUser) $
+        throwIO (JournalInsecurePath path)
 
 rewriteEvents :: JournalConfig -> Seq EventEnvelope -> IO ()
 rewriteEvents config events =
     atomicWrite config (eventsPath config) (BS.concat (fmap encodeLine (toList events)))
 
 writeSnapshot :: JournalConfig -> JournalSnapshot -> IO ()
-writeSnapshot config savedSnapshot =
+writeSnapshot config savedSnapshot = do
+    ensureSnapshotFits config savedSnapshot
     atomicWrite config (snapshotPath config) (LBS.toStrict (encode savedSnapshot))
+
+ensureSnapshotFits :: JournalConfig -> JournalSnapshot -> IO ()
+ensureSnapshotFits config savedSnapshot = do
+    let actual = fromIntegral (LBS.length (encode savedSnapshot))
+        maximumBytes = fromIntegral config.maximumSnapshotBytes
+    when (maximumBytes < 0 || actual > maximumBytes) $
+        throwIO (JournalFileTooLarge (snapshotPath config) actual maximumBytes)
 
 atomicWrite :: JournalConfig -> FilePath -> BS.ByteString -> IO ()
 atomicWrite config destination bytes = do
     let temporary = destination <> ".tmp"
         cleanup = removeFile temporary `catch` \(_ :: IOException) -> pure ()
+    verifyTemporaryPath temporary
     (do
-            BS.writeFile temporary bytes
-            setFileMode temporary 0o600
-            synchronisePath temporary
+            descriptor <-
+                openFd
+                    temporary
+                    WriteOnly
+                    defaultFileFlags
+                        { creat = Just 0o600
+                        , exclusive = True
+                        , nofollow = True
+                        , cloexec = True
+                        }
+            writeDescriptor descriptor bytes `onException` closeFd descriptor
+            fileSynchronise descriptor `onException` closeFd descriptor
+            closeFd descriptor
             renameFile temporary destination
             synchronisePath config.directory
         )
         `onException` cleanup
     setFileMode config.directory 0o700
+
+writeDescriptor :: Fd -> BS.ByteString -> IO ()
+writeDescriptor _ bytes | BS.null bytes = pure ()
+writeDescriptor descriptor bytes = do
+    written <- fromIntegral <$> fdWrite descriptor bytes
+    when (written <= 0) (ioError (userError "short journal write"))
+    writeDescriptor descriptor (BS.drop written bytes)
+
+verifyTemporaryPath :: FilePath -> IO ()
+verifyTemporaryPath path = do
+    tryIO (getSymbolicLinkStatus path) >>= \case
+        Left exception
+            | isDoesNotExistError exception -> pure ()
+            | otherwise -> throwIO exception
+        Right status -> do
+            effectiveUser <- getEffectiveUserID
+            unless (isRegularFile status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
+                throwIO (JournalInsecurePath path)
+            removeFile path
 
 fileSizeOrZero :: FilePath -> IO Integer
 fileSizeOrZero path =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -285,7 +285,7 @@ persistTask journal task =
         ensureSnapshotFits journal.config updatedSnapshot
         compacted <- persistOrPoison journal $ do
             appendEventFile journal.config event
-            writeSnapshot journal.config updatedSnapshot
+            writeSnapshot journal.config (snapshotAnchor updatedSnapshot updated.retainedEvents)
             enforceRetention journal.config updated
         publish journal event
         pure (compacted, event)
@@ -405,6 +405,12 @@ validateRecoveryOrigin snapshotExists snapshotSequence events =
                 unless (first.sequenceNumber == expected) $
                     throwIO (JournalEventGap expected first.sequenceNumber)
             | snapshotExists
+            , first.sequenceNumber < snapshotSequence ->
+                throwIO $
+                    JournalCorrupt
+                        "events.jsonl"
+                        "retained event suffix contains a stale prefix before its snapshot anchor"
+            | snapshotExists
             , lastEvent.sequenceNumber < snapshotSequence ->
                 throwIO $
                     JournalCorrupt
@@ -484,8 +490,12 @@ enforceRetention config journalState = do
                                 journalState.retainedEvents
                 byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
                 compacted = journalState {retainedEvents = byteBounded}
-            writeSnapshot config compacted.durableSnapshot
             rewriteEvents config byteBounded
+            -- The first retained event is the durable anchor for this
+            -- suffix.  Persist the rewritten events before advancing the
+            -- snapshot anchor so an interrupted compaction still leaves a
+            -- recoverable (old snapshot, new suffix) pair.
+            writeSnapshot config (snapshotAnchor compacted.durableSnapshot byteBounded)
             pure compacted
         else pure journalState
 
@@ -499,6 +509,16 @@ retainWithinBytes maximumBytes events =
         | otherwise = event : go (used + size) rest
       where
         size = BS.length (encodeLine event)
+
+-- | A snapshot is valid alongside a retained suffix when its sequence is the
+-- suffix's first event (the anchor), or when the suffix is empty.  The task
+-- map is still the latest durable state; recovery skips the anchor event and
+-- applies everything after it.
+snapshotAnchor :: JournalSnapshot -> Seq EventEnvelope -> JournalSnapshot
+snapshotAnchor saved events =
+    case Seq.lookup 0 events of
+        Nothing -> saved
+        Just first -> saved {lastSequence = first.sequenceNumber}
 
 readSnapshot :: JournalConfig -> IO (Bool, JournalSnapshot)
 readSnapshot config = do

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
@@ -1,0 +1,145 @@
+module Agent.Runtime.Daemon.Protocol
+    ( ProtocolVersion (..)
+    , currentProtocolVersion
+    , supportedProtocolVersions
+    , Sequence (..)
+    , ClientId (..)
+    , CommandId (..)
+    , Hello (..)
+    , Welcome (..)
+    , EventEnvelope (..)
+    , ClientMessage (..)
+    , ServerMessage (..)
+    , negotiateVersion
+    ) where
+
+import Data.Aeson
+import Data.Text (Text)
+import Data.Word (Word16, Word64)
+import GHC.Generics (Generic)
+
+newtype ProtocolVersion = ProtocolVersion { unProtocolVersion :: Word16 }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (FromJSON, ToJSON)
+
+currentProtocolVersion :: ProtocolVersion
+currentProtocolVersion = ProtocolVersion 1
+
+supportedProtocolVersions :: [ProtocolVersion]
+supportedProtocolVersions = [currentProtocolVersion]
+
+newtype Sequence = Sequence { unSequence :: Word64 }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (Enum, FromJSON, Num, Real, Integral, ToJSON)
+
+newtype ClientId = ClientId { unClientId :: Text }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (FromJSON, ToJSON)
+
+newtype CommandId = CommandId { unCommandId :: Text }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (FromJSON, ToJSON)
+
+data Hello = Hello
+    { clientId :: ClientId
+    , versions :: [ProtocolVersion]
+    , resumeAfter :: Maybe Sequence
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON Hello
+instance FromJSON Hello
+
+data Welcome = Welcome
+    { version :: ProtocolVersion
+    , currentSequence :: Sequence
+    , heartbeatSeconds :: Int
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON Welcome
+instance FromJSON Welcome
+
+data EventEnvelope = EventEnvelope
+    { sequenceNumber :: Sequence
+    , eventType :: Text
+    , payload :: Value
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON EventEnvelope
+instance FromJSON EventEnvelope
+
+data ClientMessage
+    = ClientHello Hello
+    | ClientAck Sequence
+    | ClientPong Sequence
+    | ClientCommand CommandId Value
+    deriving stock (Eq, Show)
+
+instance ToJSON ClientMessage where
+    toJSON = \case
+        ClientHello hello -> object ["type" .= String "hello", "hello" .= hello]
+        ClientAck sequenceNumber -> object ["type" .= String "ack", "sequence" .= sequenceNumber]
+        ClientPong sequenceNumber -> object ["type" .= String "pong", "sequence" .= sequenceNumber]
+        ClientCommand commandId command ->
+            object ["type" .= String "command", "id" .= commandId, "command" .= command]
+
+instance FromJSON ClientMessage where
+    parseJSON = withObject "ClientMessage" $ \objectValue ->
+        objectValue .: "type" >>= \case
+            ("hello" :: Text) -> ClientHello <$> objectValue .: "hello"
+            "ack" -> ClientAck <$> objectValue .: "sequence"
+            "pong" -> ClientPong <$> objectValue .: "sequence"
+            "command" -> ClientCommand <$> objectValue .: "id" <*> objectValue .: "command"
+            unknown -> fail ("unknown client message type: " <> show unknown)
+
+data ServerMessage
+    = ServerWelcome Welcome
+    | ServerVersionRejected [ProtocolVersion]
+    | ServerSnapshot Sequence Value
+    | ServerEvent EventEnvelope
+    | ServerCommandResult CommandId (Either Text Value)
+    | ServerHeartbeat Sequence
+    deriving stock (Eq, Show)
+
+instance ToJSON ServerMessage where
+    toJSON = \case
+        ServerWelcome welcome -> object ["type" .= String "welcome", "welcome" .= welcome]
+        ServerVersionRejected versions ->
+            object ["type" .= String "version_rejected", "supported" .= versions]
+        ServerSnapshot sequenceNumber snapshot ->
+            object ["type" .= String "snapshot", "sequence" .= sequenceNumber, "snapshot" .= snapshot]
+        ServerEvent event -> object ["type" .= String "event", "event" .= event]
+        ServerCommandResult commandId result ->
+            object
+                [ "type" .= String "command_result"
+                , "id" .= commandId
+                , "ok" .= either (const False) (const True) result
+                , "error" .= either Just (const Nothing) result
+                , "result" .= either (const Nothing) Just result
+                ]
+        ServerHeartbeat sequenceNumber ->
+            object ["type" .= String "heartbeat", "sequence" .= sequenceNumber]
+
+instance FromJSON ServerMessage where
+    parseJSON = withObject "ServerMessage" $ \objectValue ->
+        objectValue .: "type" >>= \case
+            ("welcome" :: Text) -> ServerWelcome <$> objectValue .: "welcome"
+            "version_rejected" -> ServerVersionRejected <$> objectValue .: "supported"
+            "snapshot" -> ServerSnapshot <$> objectValue .: "sequence" <*> objectValue .: "snapshot"
+            "event" -> ServerEvent <$> objectValue .: "event"
+            "command_result" -> do
+                commandId <- objectValue .: "id"
+                succeeded <- objectValue .: "ok"
+                if succeeded
+                    then ServerCommandResult commandId . Right <$> objectValue .: "result"
+                    else ServerCommandResult commandId . Left <$> objectValue .: "error"
+            "heartbeat" -> ServerHeartbeat <$> objectValue .: "sequence"
+            unknown -> fail ("unknown server message type: " <> show unknown)
+
+negotiateVersion :: [ProtocolVersion] -> Maybe ProtocolVersion
+negotiateVersion offered =
+    case filter (`elem` supportedProtocolVersions) offered of
+        [] -> Nothing
+        compatible -> Just (maximum compatible)

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
@@ -23,7 +23,7 @@ newtype ProtocolVersion = ProtocolVersion { unProtocolVersion :: Word16 }
     deriving newtype (FromJSON, ToJSON)
 
 currentProtocolVersion :: ProtocolVersion
-currentProtocolVersion = ProtocolVersion 1
+currentProtocolVersion = ProtocolVersion 2
 
 supportedProtocolVersions :: [ProtocolVersion]
 supportedProtocolVersions = [currentProtocolVersion]
@@ -97,7 +97,7 @@ instance FromJSON ClientMessage where
 data ServerMessage
     = ServerWelcome Welcome
     | ServerVersionRejected [ProtocolVersion]
-    | ServerSnapshot Sequence Value
+    | ServerSnapshotChunk Sequence Int Int Text
     | ServerEvent EventEnvelope
     | ServerCommandResult CommandId (Either Text Value)
     | ServerHeartbeat Sequence
@@ -108,8 +108,14 @@ instance ToJSON ServerMessage where
         ServerWelcome welcome -> object ["type" .= String "welcome", "welcome" .= welcome]
         ServerVersionRejected versions ->
             object ["type" .= String "version_rejected", "supported" .= versions]
-        ServerSnapshot sequenceNumber snapshot ->
-            object ["type" .= String "snapshot", "sequence" .= sequenceNumber, "snapshot" .= snapshot]
+        ServerSnapshotChunk sequenceNumber chunkIndex chunkCount snapshotData ->
+            object
+                [ "type" .= String "snapshot_chunk"
+                , "sequence" .= sequenceNumber
+                , "chunk_index" .= chunkIndex
+                , "chunk_count" .= chunkCount
+                , "snapshot_data" .= snapshotData
+                ]
         ServerEvent event -> object ["type" .= String "event", "event" .= event]
         ServerCommandResult commandId result ->
             object
@@ -127,7 +133,12 @@ instance FromJSON ServerMessage where
         objectValue .: "type" >>= \case
             ("welcome" :: Text) -> ServerWelcome <$> objectValue .: "welcome"
             "version_rejected" -> ServerVersionRejected <$> objectValue .: "supported"
-            "snapshot" -> ServerSnapshot <$> objectValue .: "sequence" <*> objectValue .: "snapshot"
+            "snapshot_chunk" ->
+                ServerSnapshotChunk
+                    <$> objectValue .: "sequence"
+                    <*> objectValue .: "chunk_index"
+                    <*> objectValue .: "chunk_count"
+                    <*> objectValue .: "snapshot_data"
             "event" -> ServerEvent <$> objectValue .: "event"
             "command_result" -> do
                 commandId <- objectValue .: "id"

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
@@ -23,7 +23,7 @@ newtype ProtocolVersion = ProtocolVersion { unProtocolVersion :: Word16 }
     deriving newtype (FromJSON, ToJSON)
 
 currentProtocolVersion :: ProtocolVersion
-currentProtocolVersion = ProtocolVersion 2
+currentProtocolVersion = ProtocolVersion 3
 
 supportedProtocolVersions :: [ProtocolVersion]
 supportedProtocolVersions = [currentProtocolVersion]
@@ -99,6 +99,7 @@ data ServerMessage
     | ServerVersionRejected [ProtocolVersion]
     | ServerSnapshotChunk Sequence Int Int Text
     | ServerEvent EventEnvelope
+    | ServerEventChunk Sequence Int Int Text
     | ServerCommandResult CommandId (Either Text Value)
     | ServerHeartbeat Sequence
     deriving stock (Eq, Show)
@@ -117,6 +118,14 @@ instance ToJSON ServerMessage where
                 , "snapshot_data" .= snapshotData
                 ]
         ServerEvent event -> object ["type" .= String "event", "event" .= event]
+        ServerEventChunk sequenceNumber chunkIndex chunkCount eventData ->
+            object
+                [ "type" .= String "event_chunk"
+                , "sequence" .= sequenceNumber
+                , "chunk_index" .= chunkIndex
+                , "chunk_count" .= chunkCount
+                , "event_data" .= eventData
+                ]
         ServerCommandResult commandId result ->
             object
                 [ "type" .= String "command_result"
@@ -140,6 +149,12 @@ instance FromJSON ServerMessage where
                     <*> objectValue .: "chunk_count"
                     <*> objectValue .: "snapshot_data"
             "event" -> ServerEvent <$> objectValue .: "event"
+            "event_chunk" ->
+                ServerEventChunk
+                    <$> objectValue .: "sequence"
+                    <*> objectValue .: "chunk_index"
+                    <*> objectValue .: "chunk_count"
+                    <*> objectValue .: "event_data"
             "command_result" -> do
                 commandId <- objectValue .: "id"
                 succeeded <- objectValue .: "ok"

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
@@ -7,12 +7,27 @@ module Agent.Runtime.Daemon.Server
     ) where
 
 import Control.Concurrent.Async (concurrently_, mapConcurrently_, race_)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
-import Control.Exception.Safe (bracket, catchAny, finally)
+import Control.Exception.Safe
+    ( Exception
+    , SomeException
+    , bracket
+    , catchAny
+    , finally
+    , isAsyncException
+    , throwIO
+    )
 import Control.Monad (forever)
-import Data.Aeson (toJSON)
+import Data.Aeson (FromJSON, ToJSON, encode)
+import qualified Data.ByteString as BS
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (for_)
+import qualified Data.Text.Encoding as Text
 import Network.Socket (Socket, close)
+import System.Timeout (timeout)
 
 import Agent.Runtime.Daemon.Framing
 import Agent.Runtime.Daemon.Journal
@@ -25,6 +40,8 @@ data ServerConfig = ServerConfig
     , heartbeatSeconds :: Int
     , workerCount :: Int
     , outboundQueueSize :: Int
+    , ioTimeoutSeconds :: Int
+    , supervisorTimeoutSeconds :: Int
     }
     deriving stock (Eq, Show)
 
@@ -35,7 +52,16 @@ defaultServerConfig =
         , heartbeatSeconds = 15
         , workerCount = 8
         , outboundQueueSize = 256
+        , ioTimeoutSeconds = 30
+        , supervisorTimeoutSeconds = 300
         }
+
+data ServerError
+    = ServerTimedOut String
+    | ServerSubscriberOverflow
+    deriving stock (Eq, Show)
+
+instance Exception ServerError
 
 runServer :: SocketConfig -> ServerConfig -> Journal -> Supervisor -> IO ()
 runServer socketConfig serverConfig journal supervisor =
@@ -45,7 +71,10 @@ runServer socketConfig serverConfig journal supervisor =
 runServerOnListener :: Socket -> ServerConfig -> Journal -> Supervisor -> IO ()
 runServerOnListener listener serverConfig journal supervisor = do
     accepted <- newTBQueueIO (fromIntegral (max 1 serverConfig.workerCount))
-    let acceptLoop = forever (acceptOwnedPeer listener >>= atomically . writeTBQueue accepted)
+    let acceptLoop =
+            forever $
+                (acceptOwnedPeer listener >>= atomically . writeTBQueue accepted)
+                    `catchSync` const (threadDelay 100_000)
         worker =
             forever $
                 bracket
@@ -53,7 +82,7 @@ runServerOnListener listener serverConfig journal supervisor = do
                     close
                     ( \peer ->
                         serveConnection serverConfig journal supervisor peer
-                            `catchAny` const (pure ())
+                            `catchSync` const (pure ())
                     )
         closeQueued = atomically (flushTBQueue accepted) >>= mapM_ close
     ( concurrently_ acceptLoop $
@@ -62,14 +91,14 @@ runServerOnListener listener serverConfig journal supervisor = do
 
 serveConnection :: ServerConfig -> Journal -> Supervisor -> Socket -> IO ()
 serveConnection config journal supervisor peer = do
-    receiveJSONFrame config.maximumFrameBytes peer >>= \case
+    receive config peer >>= \case
         ClientHello hello ->
             case negotiateVersion hello.versions of
                 Nothing ->
-                    sendJSONFrame config.maximumFrameBytes peer $
+                    send config peer $
                         ServerVersionRejected supportedProtocolVersions
                 Just version -> serveNegotiated config journal supervisor peer hello version
-        _ -> sendJSONFrame config.maximumFrameBytes peer $
+        _ -> send config peer $
             ServerVersionRejected supportedProtocolVersions
 
 serveNegotiated ::
@@ -82,56 +111,114 @@ serveNegotiated ::
     IO ()
 serveNegotiated config journal supervisor peer hello version = do
     let cursor = maybe 0 id hello.resumeAfter
-    (currentSnapshot, resumableReplay, eventChannel) <- subscribeReplay journal cursor
-    let replay =
-            case hello.resumeAfter of
-                Nothing -> ReplaySnapshot currentSnapshot
-                Just _ -> resumableReplay
-    sendJSONFrame config.maximumFrameBytes peer $
-        ServerWelcome
-            Welcome
-                { version
-                , currentSequence = currentSnapshot.lastSequence
-                , heartbeatSeconds = config.heartbeatSeconds
-                }
-    case replay of
-        ReplaySnapshot saved ->
-            sendJSONFrame config.maximumFrameBytes peer $
-                ServerSnapshot saved.lastSequence (toJSON saved)
-        ReplayEvents events ->
-            for_ events (sendJSONFrame config.maximumFrameBytes peer . ServerEvent)
-    outbound <- newTBQueueIO (fromIntegral (max 1 config.outboundQueueSize))
-    acknowledged <- newTVarIO cursor
-    latestSequence <- newTVarIO currentSnapshot.lastSequence
-    let enqueue message = atomically (writeTBQueue outbound message)
-        receiver =
-            forever $
-                receiveJSONFrame config.maximumFrameBytes peer >>= \case
-                    ClientAck sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
-                    ClientPong sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
-                    ClientCommand commandId command -> do
-                        result <- supervisor.handleCommand commandId command
-                        enqueue (ServerCommandResult commandId result)
-                    ClientHello _ -> pure ()
-        sender = forever $ do
-            delay <- registerDelay (max 1 config.heartbeatSeconds * 1_000_000)
-            message <-
-                atomically $
-                    (readTBQueue outbound)
-                        `orElse` (do
-                            event <- readTChan eventChannel
-                            writeTVar latestSequence event.sequenceNumber
-                            pure (ServerEvent event)
-                        )
-                        `orElse` do
-                            expired <- readTVar delay
-                            check expired
-                            sequenceNumber <- readTVar latestSequence
-                            pure (ServerHeartbeat sequenceNumber)
-            sendJSONFrame config.maximumFrameBytes peer message
-    race_ receiver sender
+    bracket
+        (subscribeReplay journal cursor)
+        (\(_, _, _, _, unsubscribe) -> unsubscribe)
+        $ \(currentSnapshot, resumableReplay, eventQueue, overflowed, _) -> do
+            let replay =
+                    case hello.resumeAfter of
+                        Nothing -> ReplaySnapshot currentSnapshot
+                        Just _ -> resumableReplay
+            send config peer $
+                ServerWelcome
+                    Welcome
+                        { version
+                        , currentSequence = currentSnapshot.lastSequence
+                        , heartbeatSeconds = config.heartbeatSeconds
+                        }
+            case replay of
+                ReplaySnapshot saved ->
+                    sendSnapshot config peer saved
+                ReplayEvents events ->
+                    for_ events (send config peer . ServerEvent)
+            outbound <- newTBQueueIO (fromIntegral (max 1 config.outboundQueueSize))
+            acknowledged <- newTVarIO cursor
+            latestSequence <- newTVarIO currentSnapshot.lastSequence
+            let enqueue message =
+                    within config.ioTimeoutSeconds "outbound queue" $
+                        atomically (writeTBQueue outbound message)
+                receiver =
+                    forever $
+                        receive config peer >>= \case
+                            ClientAck sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
+                            ClientPong sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
+                            ClientCommand commandId command -> do
+                                result <-
+                                    within config.supervisorTimeoutSeconds "supervisor command" $
+                                        supervisor.handleCommand commandId command
+                                enqueue (ServerCommandResult commandId result)
+                            ClientHello _ -> pure ()
+                sender = forever $ do
+                    delay <- registerDelay (max 1 config.heartbeatSeconds * 1_000_000)
+                    next <-
+                        atomically $
+                            (do
+                                didOverflow <- readTVar overflowed
+                                check didOverflow
+                                pure Nothing
+                            )
+                                `orElse` (Just <$> readTBQueue outbound)
+                                `orElse` (do
+                                    event <- readTBQueue eventQueue
+                                    writeTVar latestSequence event.sequenceNumber
+                                    pure (Just (ServerEvent event))
+                                )
+                                `orElse` do
+                                    expired <- readTVar delay
+                                    check expired
+                                    sequenceNumber <- readTVar latestSequence
+                                    pure (Just (ServerHeartbeat sequenceNumber))
+                    case next of
+                        Nothing -> throwIO ServerSubscriberOverflow
+                        Just message -> send config peer message
+            race_ receiver sender
   where
     acknowledge variable latest sequenceNumber =
         atomically $ do
             newest <- readTVar latest
             modifyTVar' variable (max (min sequenceNumber newest))
+
+sendSnapshot :: ServerConfig -> Socket -> JournalSnapshot -> IO ()
+sendSnapshot config peer saved = do
+    let rawChunkBytes = max 1 ((config.maximumFrameBytes - 256) * 3 `div` 4)
+        chunks = chunkBytes rawChunkBytes (LBS.toStrict (encode saved))
+        count = length chunks
+    for_ (zip [0 ..] chunks) $ \(index, bytes) ->
+        send config peer $
+            ServerSnapshotChunk
+                saved.lastSequence
+                index
+                count
+                (Text.decodeUtf8 (Base64.encode bytes))
+
+chunkBytes :: Int -> ByteString -> [ByteString]
+chunkBytes size bytes
+    | BS.null bytes = [BS.empty]
+    | otherwise =
+        let (chunk, rest) = BS.splitAt size bytes
+         in if BS.null rest
+                then [chunk]
+                else chunk : chunkBytes size rest
+
+send :: ToJSON value => ServerConfig -> Socket -> value -> IO ()
+send config peer value =
+    within config.ioTimeoutSeconds "socket write" $
+        sendJSONFrame config.maximumFrameBytes peer value
+
+receive :: FromJSON value => ServerConfig -> Socket -> IO value
+receive config peer =
+    within config.ioTimeoutSeconds "socket read" $
+        receiveJSONFrame config.maximumFrameBytes peer
+
+within :: Int -> String -> IO value -> IO value
+within seconds label action =
+    timeout (max 1 seconds * 1_000_000) action >>= \case
+        Nothing -> throwIO (ServerTimedOut label)
+        Just value -> pure value
+
+catchSync :: IO value -> (SomeException -> IO value) -> IO value
+catchSync action handler =
+    action `catchAny` \exception ->
+        if isAsyncException exception
+            then throwIO exception
+            else handler exception

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
@@ -13,6 +13,7 @@ import Control.Exception.Safe
     ( Exception
     , SomeException
     , bracket
+    , bracketOnError
     , catchAny
     , finally
     , isAsyncException
@@ -73,7 +74,10 @@ runServerOnListener listener serverConfig journal supervisor = do
     accepted <- newTBQueueIO (fromIntegral (max 1 serverConfig.workerCount))
     let acceptLoop =
             forever $
-                (acceptOwnedPeer listener >>= atomically . writeTBQueue accepted)
+                bracketOnError
+                    (acceptOwnedPeer listener)
+                    close
+                    (atomically . writeTBQueue accepted)
                     `catchSync` const (threadDelay 100_000)
         worker =
             forever $
@@ -130,7 +134,7 @@ serveNegotiated config journal supervisor peer hello version = do
                 ReplaySnapshot saved ->
                     sendSnapshot config peer saved
                 ReplayEvents events ->
-                    for_ events (send config peer . ServerEvent)
+                    for_ events (sendEvent config peer)
             outbound <- newTBQueueIO (fromIntegral (max 1 config.outboundQueueSize))
             acknowledged <- newTVarIO cursor
             latestSequence <- newTVarIO currentSnapshot.lastSequence
@@ -170,7 +174,7 @@ serveNegotiated config journal supervisor peer hello version = do
                                     pure (Just (ServerHeartbeat sequenceNumber))
                     case next of
                         Nothing -> throwIO ServerSubscriberOverflow
-                        Just message -> send config peer message
+                        Just message -> sendMessage config peer message
             race_ receiver sender
   where
     acknowledge variable latest sequenceNumber =
@@ -190,6 +194,27 @@ sendSnapshot config peer saved = do
                 index
                 count
                 (Text.decodeUtf8 (Base64.encode bytes))
+
+sendEvent :: ServerConfig -> Socket -> EventEnvelope -> IO ()
+sendEvent config peer event
+    | LBS.length (encode (ServerEvent event)) <= fromIntegral config.maximumFrameBytes =
+        send config peer (ServerEvent event)
+    | otherwise = do
+        let rawChunkBytes = max 1 ((config.maximumFrameBytes - 256) * 3 `div` 4)
+            chunks = chunkBytes rawChunkBytes (LBS.toStrict (encode event))
+            count = length chunks
+        for_ (zip [0 ..] chunks) $ \(index, bytes) ->
+            send config peer $
+                ServerEventChunk
+                    event.sequenceNumber
+                    index
+                    count
+                    (Text.decodeUtf8 (Base64.encode bytes))
+
+sendMessage :: ServerConfig -> Socket -> ServerMessage -> IO ()
+sendMessage config peer = \case
+    ServerEvent event -> sendEvent config peer event
+    message -> send config peer message
 
 chunkBytes :: Int -> ByteString -> [ByteString]
 chunkBytes size bytes

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
@@ -1,0 +1,137 @@
+module Agent.Runtime.Daemon.Server
+    ( ServerConfig (..)
+    , defaultServerConfig
+    , runServer
+    , runServerOnListener
+    , serveConnection
+    ) where
+
+import Control.Concurrent.Async (concurrently_, mapConcurrently_, race_)
+import Control.Concurrent.STM
+import Control.Exception.Safe (bracket, catchAny, finally)
+import Control.Monad (forever)
+import Data.Aeson (toJSON)
+import Data.Foldable (for_)
+import Network.Socket (Socket, close)
+
+import Agent.Runtime.Daemon.Framing
+import Agent.Runtime.Daemon.Journal
+import Agent.Runtime.Daemon.Protocol
+import Agent.Runtime.Daemon.Socket
+import Agent.Runtime.Daemon.Supervisor
+
+data ServerConfig = ServerConfig
+    { maximumFrameBytes :: Int
+    , heartbeatSeconds :: Int
+    , workerCount :: Int
+    , outboundQueueSize :: Int
+    }
+    deriving stock (Eq, Show)
+
+defaultServerConfig :: ServerConfig
+defaultServerConfig =
+    ServerConfig
+        { maximumFrameBytes = defaultMaximumFrameBytes
+        , heartbeatSeconds = 15
+        , workerCount = 8
+        , outboundQueueSize = 256
+        }
+
+runServer :: SocketConfig -> ServerConfig -> Journal -> Supervisor -> IO ()
+runServer socketConfig serverConfig journal supervisor =
+    withUnixListener socketConfig $ \listener ->
+        runServerOnListener listener serverConfig journal supervisor
+
+runServerOnListener :: Socket -> ServerConfig -> Journal -> Supervisor -> IO ()
+runServerOnListener listener serverConfig journal supervisor = do
+    accepted <- newTBQueueIO (fromIntegral (max 1 serverConfig.workerCount))
+    let acceptLoop = forever (acceptOwnedPeer listener >>= atomically . writeTBQueue accepted)
+        worker =
+            forever $
+                bracket
+                    (atomically (readTBQueue accepted))
+                    close
+                    ( \peer ->
+                        serveConnection serverConfig journal supervisor peer
+                            `catchAny` const (pure ())
+                    )
+        closeQueued = atomically (flushTBQueue accepted) >>= mapM_ close
+    ( concurrently_ acceptLoop $
+        mapConcurrently_ (const worker) [1 .. max 1 serverConfig.workerCount]
+      ) `finally` closeQueued
+
+serveConnection :: ServerConfig -> Journal -> Supervisor -> Socket -> IO ()
+serveConnection config journal supervisor peer = do
+    receiveJSONFrame config.maximumFrameBytes peer >>= \case
+        ClientHello hello ->
+            case negotiateVersion hello.versions of
+                Nothing ->
+                    sendJSONFrame config.maximumFrameBytes peer $
+                        ServerVersionRejected supportedProtocolVersions
+                Just version -> serveNegotiated config journal supervisor peer hello version
+        _ -> sendJSONFrame config.maximumFrameBytes peer $
+            ServerVersionRejected supportedProtocolVersions
+
+serveNegotiated ::
+    ServerConfig ->
+    Journal ->
+    Supervisor ->
+    Socket ->
+    Hello ->
+    ProtocolVersion ->
+    IO ()
+serveNegotiated config journal supervisor peer hello version = do
+    let cursor = maybe 0 id hello.resumeAfter
+    (currentSnapshot, resumableReplay, eventChannel) <- subscribeReplay journal cursor
+    let replay =
+            case hello.resumeAfter of
+                Nothing -> ReplaySnapshot currentSnapshot
+                Just _ -> resumableReplay
+    sendJSONFrame config.maximumFrameBytes peer $
+        ServerWelcome
+            Welcome
+                { version
+                , currentSequence = currentSnapshot.lastSequence
+                , heartbeatSeconds = config.heartbeatSeconds
+                }
+    case replay of
+        ReplaySnapshot saved ->
+            sendJSONFrame config.maximumFrameBytes peer $
+                ServerSnapshot saved.lastSequence (toJSON saved)
+        ReplayEvents events ->
+            for_ events (sendJSONFrame config.maximumFrameBytes peer . ServerEvent)
+    outbound <- newTBQueueIO (fromIntegral (max 1 config.outboundQueueSize))
+    acknowledged <- newTVarIO cursor
+    latestSequence <- newTVarIO currentSnapshot.lastSequence
+    let enqueue message = atomically (writeTBQueue outbound message)
+        receiver =
+            forever $
+                receiveJSONFrame config.maximumFrameBytes peer >>= \case
+                    ClientAck sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
+                    ClientPong sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
+                    ClientCommand commandId command -> do
+                        result <- supervisor.handleCommand commandId command
+                        enqueue (ServerCommandResult commandId result)
+                    ClientHello _ -> pure ()
+        sender = forever $ do
+            delay <- registerDelay (max 1 config.heartbeatSeconds * 1_000_000)
+            message <-
+                atomically $
+                    (readTBQueue outbound)
+                        `orElse` (do
+                            event <- readTChan eventChannel
+                            writeTVar latestSequence event.sequenceNumber
+                            pure (ServerEvent event)
+                        )
+                        `orElse` do
+                            expired <- readTVar delay
+                            check expired
+                            sequenceNumber <- readTVar latestSequence
+                            pure (ServerHeartbeat sequenceNumber)
+            sendJSONFrame config.maximumFrameBytes peer message
+    race_ receiver sender
+  where
+    acknowledge variable latest sequenceNumber =
+        atomically $ do
+            newest <- readTVar latest
+            modifyTVar' variable (max (min sequenceNumber newest))

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
@@ -13,7 +13,16 @@ import Network.Socket
 import System.Directory hiding (isSymbolicLink)
 import System.Environment (lookupEnv)
 import System.FilePath ((</>), takeDirectory)
+import qualified System.FileLock as FileLock
 import System.Posix.Files
+import System.Posix.IO
+    ( OpenFileFlags (..)
+    , OpenMode (ReadWrite)
+    , closeFd
+    , defaultFileFlags
+    , openFd
+    )
+import System.Posix.Types (DeviceID, FileID)
 import System.Posix.User (getEffectiveUserID)
 
 data SocketConfig = SocketConfig
@@ -34,8 +43,15 @@ defaultSocketPath = do
     pure $ maybe (home </> ".haskell-agent" </> "runtime") id override </> "daemon.sock"
 
 withUnixListener :: SocketConfig -> (Socket -> IO value) -> IO value
-withUnixListener config =
-    bracket (openListener config) (closeListener config)
+withUnixListener config action = do
+    prepareSocketDirectory config
+    prepareLockFile (lockPath config)
+    result <-
+        FileLock.withTryFileLock (lockPath config) FileLock.Exclusive $ \_ ->
+            bracket (openListener config) (closeListener config) (action . (.listenerSocket))
+    case result of
+        Nothing -> throwString ("runtime daemon already owns: " <> config.path)
+        Just value -> pure value
 
 acceptOwnedPeer :: Socket -> IO Socket
 acceptOwnedPeer listener = do
@@ -50,26 +66,61 @@ verifyPeerOwner peer = do
     unless (peerUser == Just daemonUser) $
         throwString "refusing Unix socket peer owned by another user"
 
-openListener :: SocketConfig -> IO Socket
-openListener config = do
+data Listener = Listener
+    { listenerSocket :: Socket
+    , identity :: FileIdentity
+    }
+
+data FileIdentity = FileIdentity
+    { device :: DeviceID
+    , file :: FileID
+    }
+    deriving stock (Eq)
+
+prepareSocketDirectory :: SocketConfig -> IO ()
+prepareSocketDirectory config = do
     let directory = takeDirectory config.path
     createDirectoryIfMissing True directory
     verifyPrivateDirectory directory
     setFileMode directory 0o700
+
+prepareLockFile :: FilePath -> IO ()
+prepareLockFile path =
+    bracket
+        (openFd path ReadWrite defaultFileFlags {creat = Just 0o600, nofollow = True, cloexec = True})
+        closeFd
+        $ \_ -> do
+            status <- getSymbolicLinkStatus path
+            effectiveUser <- getEffectiveUserID
+            unless (isRegularFile status && fileOwner status == effectiveUser) $
+                throwString ("runtime lock is not a user-owned regular file: " <> path)
+            setFileMode path 0o600
+
+openListener :: SocketConfig -> IO Listener
+openListener config = do
     removeStaleSocket config.path
     listener <- socket AF_UNIX Stream defaultProtocol
     (do
             bind listener (SockAddrUnix config.path)
             setFileMode config.path 0o600
             listen listener config.backlog
-            pure listener
+            status <- getSymbolicLinkStatus config.path
+            pure Listener
+                { listenerSocket = listener
+                , identity = identityOf status
+                }
         )
         `onException` close listener
 
-closeListener :: SocketConfig -> Socket -> IO ()
+closeListener :: SocketConfig -> Listener -> IO ()
 closeListener config listener = do
-    close listener
-    removeFile (path config) `catch` \(_ :: IOException) -> pure ()
+    close listener.listenerSocket
+    current <- tryIO (getSymbolicLinkStatus config.path)
+    case current of
+        Right status
+            | isSocket status && identityOf status == listener.identity ->
+                removeFile config.path `catch` \(_ :: IOException) -> pure ()
+        _ -> pure ()
 
 removeStaleSocket :: FilePath -> IO ()
 removeStaleSocket path = do
@@ -97,3 +148,13 @@ verifyPrivateDirectory directory = do
     effectiveUser <- getEffectiveUserID
     unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
         throwString ("runtime socket directory is not a user-owned directory: " <> directory)
+
+identityOf :: FileStatus -> FileIdentity
+identityOf status =
+    FileIdentity
+        { device = deviceID status
+        , file = fileID status
+        }
+
+lockPath :: SocketConfig -> FilePath
+lockPath config = config.path <> ".lock"

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
@@ -1,0 +1,99 @@
+module Agent.Runtime.Daemon.Socket
+    ( SocketConfig (..)
+    , defaultSocketConfig
+    , defaultSocketPath
+    , withUnixListener
+    , acceptOwnedPeer
+    , verifyPeerOwner
+    ) where
+
+import Control.Exception.Safe (IOException, bracket, catch, onException, throwString, tryIO)
+import Control.Monad (unless, when)
+import Network.Socket
+import System.Directory hiding (isSymbolicLink)
+import System.Environment (lookupEnv)
+import System.FilePath ((</>), takeDirectory)
+import System.Posix.Files
+import System.Posix.User (getEffectiveUserID)
+
+data SocketConfig = SocketConfig
+    { path :: FilePath
+    , backlog :: Int
+    }
+    deriving stock (Eq, Show)
+
+defaultSocketConfig :: IO SocketConfig
+defaultSocketConfig = do
+    path <- defaultSocketPath
+    pure SocketConfig {path, backlog = 16}
+
+defaultSocketPath :: IO FilePath
+defaultSocketPath = do
+    home <- getHomeDirectory
+    override <- lookupEnv "HASKELL_AGENT_RUNTIME_DIR"
+    pure $ maybe (home </> ".haskell-agent" </> "runtime") id override </> "daemon.sock"
+
+withUnixListener :: SocketConfig -> (Socket -> IO value) -> IO value
+withUnixListener config =
+    bracket (openListener config) (closeListener config)
+
+acceptOwnedPeer :: Socket -> IO Socket
+acceptOwnedPeer listener = do
+    (peer, _) <- accept listener
+    verifyPeerOwner peer `onException` close peer
+    pure peer
+
+verifyPeerOwner :: Socket -> IO ()
+verifyPeerOwner peer = do
+    (_, peerUser, _) <- getPeerCredential peer
+    daemonUser <- fromIntegral <$> getEffectiveUserID
+    unless (peerUser == Just daemonUser) $
+        throwString "refusing Unix socket peer owned by another user"
+
+openListener :: SocketConfig -> IO Socket
+openListener config = do
+    let directory = takeDirectory config.path
+    createDirectoryIfMissing True directory
+    verifyPrivateDirectory directory
+    setFileMode directory 0o700
+    removeStaleSocket config.path
+    listener <- socket AF_UNIX Stream defaultProtocol
+    (do
+            bind listener (SockAddrUnix config.path)
+            setFileMode config.path 0o600
+            listen listener config.backlog
+            pure listener
+        )
+        `onException` close listener
+
+closeListener :: SocketConfig -> Socket -> IO ()
+closeListener config listener = do
+    close listener
+    removeFile (path config) `catch` \(_ :: IOException) -> pure ()
+
+removeStaleSocket :: FilePath -> IO ()
+removeStaleSocket path = do
+    exists <- fileExist path
+    when exists $ do
+        status <- getSymbolicLinkStatus path
+        effectiveUser <- getEffectiveUserID
+        if isSocket status && fileOwner status == effectiveUser
+            then do
+                active <- socketAcceptsConnections path
+                if active
+                    then throwString ("runtime daemon is already listening at: " <> path)
+                    else removeFile path
+            else throwString ("refusing to replace non-socket path: " <> path)
+
+socketAcceptsConnections :: FilePath -> IO Bool
+socketAcceptsConnections path =
+    bracket (socket AF_UNIX Stream defaultProtocol) close $ \probe ->
+        either (const False) (const True)
+            <$> tryIO (connect probe (SockAddrUnix path))
+
+verifyPrivateDirectory :: FilePath -> IO ()
+verifyPrivateDirectory directory = do
+    status <- getSymbolicLinkStatus directory
+    effectiveUser <- getEffectiveUserID
+    unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
+        throwString ("runtime socket directory is not a user-owned directory: " <> directory)

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
@@ -7,7 +7,7 @@ module Agent.Runtime.Daemon.Socket
     , verifyPeerOwner
     ) where
 
-import Control.Exception.Safe (IOException, bracket, catch, onException, throwString, tryIO)
+import Control.Exception.Safe (IOException, bracket, catch, finally, onException, throwString, tryIO)
 import Control.Monad (unless, when)
 import Network.Socket
 import System.Directory hiding (isSymbolicLink)
@@ -17,7 +17,7 @@ import qualified System.FileLock as FileLock
 import System.Posix.Files
 import System.Posix.IO
     ( OpenFileFlags (..)
-    , OpenMode (ReadWrite)
+    , OpenMode (ReadOnly, ReadWrite)
     , closeFd
     , defaultFileFlags
     , openFd
@@ -81,20 +81,32 @@ prepareSocketDirectory :: SocketConfig -> IO ()
 prepareSocketDirectory config = do
     let directory = takeDirectory config.path
     createDirectoryIfMissing True directory
-    verifyPrivateDirectory directory
-    setFileMode directory 0o700
+    descriptor <-
+        openFd
+            directory
+            ReadOnly
+            defaultFileFlags {nofollow = True, cloexec = True, directory = True}
+    (do
+            status <- getFdStatus descriptor
+            effectiveUser <- getEffectiveUserID
+            unless (isDirectory status && fileOwner status == effectiveUser) $
+                throwString ("runtime socket directory is not a user-owned directory: " <> directory)
+            setFdMode descriptor 0o700
+        )
+        `finally` closeFd descriptor
 
 prepareLockFile :: FilePath -> IO ()
-prepareLockFile path =
-    bracket
-        (openFd path ReadWrite defaultFileFlags {creat = Just 0o600, nofollow = True, cloexec = True})
-        closeFd
-        $ \_ -> do
-            status <- getSymbolicLinkStatus path
+prepareLockFile path = do
+    descriptor <-
+        openFd path ReadWrite defaultFileFlags {creat = Just 0o600, nofollow = True, cloexec = True}
+    (do
+            status <- getFdStatus descriptor
             effectiveUser <- getEffectiveUserID
             unless (isRegularFile status && fileOwner status == effectiveUser) $
                 throwString ("runtime lock is not a user-owned regular file: " <> path)
-            setFileMode path 0o600
+            setFdMode descriptor 0o600
+        )
+        `finally` closeFd descriptor
 
 openListener :: SocketConfig -> IO Listener
 openListener config = do
@@ -141,13 +153,6 @@ socketAcceptsConnections path =
     bracket (socket AF_UNIX Stream defaultProtocol) close $ \probe ->
         either (const False) (const True)
             <$> tryIO (connect probe (SockAddrUnix path))
-
-verifyPrivateDirectory :: FilePath -> IO ()
-verifyPrivateDirectory directory = do
-    status <- getSymbolicLinkStatus directory
-    effectiveUser <- getEffectiveUserID
-    unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
-        throwString ("runtime socket directory is not a user-owned directory: " <> directory)
 
 identityOf :: FileStatus -> FileIdentity
 identityOf status =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Supervisor.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Supervisor.hs
@@ -1,0 +1,21 @@
+module Agent.Runtime.Daemon.Supervisor
+    ( Supervisor (..)
+    , unavailableSupervisor
+    ) where
+
+import Data.Aeson (Value)
+import Data.Text (Text)
+
+import Agent.Runtime.Daemon.Protocol (CommandId)
+
+-- | Integration seam for the task supervisor. The daemon foundation owns
+-- transport and durability; a supervisor owns task execution and commands.
+newtype Supervisor = Supervisor
+    { handleCommand :: CommandId -> Value -> IO (Either Text Value)
+    }
+
+unavailableSupervisor :: Supervisor
+unavailableSupervisor =
+    Supervisor
+        { handleCommand = \_ _ -> pure (Left "task supervisor is not configured")
+        }

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Task.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Task.hs
@@ -1,0 +1,48 @@
+module Agent.Runtime.Daemon.Task
+    ( TaskId (..)
+    , TaskStatus (..)
+    , DurableTask (..)
+    , isActive
+    , interruptActive
+    ) where
+
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import GHC.Generics (Generic)
+
+newtype TaskId = TaskId { unTaskId :: Text }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+
+data TaskStatus
+    = TaskQueued
+    | TaskRunning
+    | TaskCompleted
+    | TaskFailed
+    | TaskCancelled
+    | TaskInterrupted
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON TaskStatus
+instance FromJSON TaskStatus
+
+data DurableTask = DurableTask
+    { taskId :: TaskId
+    , status :: TaskStatus
+    , description :: Text
+    , updatedAt :: UTCTime
+    , logTail :: [Text]
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON DurableTask
+instance FromJSON DurableTask
+
+isActive :: DurableTask -> Bool
+isActive DurableTask {status} = status == TaskQueued || status == TaskRunning
+
+interruptActive :: UTCTime -> DurableTask -> DurableTask
+interruptActive now task@DurableTask {}
+    | isActive task = task {status = TaskInterrupted, updatedAt = now}
+    | otherwise = task

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -100,6 +100,23 @@ main = hspec $ do
                     ReplaySnapshot saved -> saved.lastSequence == 3
                     ReplayEvents _ -> False)
 
+        it "persists a snapshot anchor before dropping an unanchored prefix" $
+            withSystemTempDirectory "daemon-retention-anchor" $ \directory -> do
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumEvents = 1
+                            , maximumJournalBytes = 1_048_576
+                            }
+                firstProcess <- openJournal config
+                _ <- appendEvent firstProcess "one" Null
+                second <- appendEvent firstProcess "two" Null
+                secondProcess <- openJournal config
+                recovered <- snapshot secondProcess
+                recovered.lastSequence `shouldBe` 2
+                replayAfter secondProcess 1 `shouldReturn` ReplayEvents [second]
+                third <- appendEvent secondProcess "three" Null
+                third.sequenceNumber `shouldBe` 3
+
         it "redacts sensitive fields and bounds retained task logs" $
             withSystemTempDirectory "daemon-redaction" $ \directory -> do
                 now <- getCurrentTime
@@ -290,6 +307,40 @@ main = hspec $ do
                 bounded.description `shouldBe` "[REDACTED]"
                 bounded.logTail `shouldBe` []
 
+        it "applies lowered task limits to snapshots and rejects excess old tasks" $
+            withSystemTempDirectory "daemon-lowered-task-limits" $ \directory -> do
+                now <- getCurrentTime
+                let oldTask taskId =
+                        DurableTask
+                            { taskId
+                            , status = TaskCompleted
+                            , description = "password=private"
+                            , updatedAt = now
+                            , logTail = ["old", "token=private", "new"]
+                            }
+                    oldSnapshot =
+                        JournalSnapshot
+                            { lastSequence = 0
+                            , tasks = Map.singleton (TaskId "old") (oldTask (TaskId "old"))
+                            }
+                    lowered =
+                        (defaultJournalConfig directory)
+                            { maximumTaskDescriptionCharacters = 8
+                            , maximumTaskLogLines = 1
+                            , maximumTaskLogCharacters = 2
+                            }
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode oldSnapshot))
+                first <- openJournal lowered >>= snapshot
+                let bounded = first.tasks Map.! TaskId "old"
+                bounded.description `shouldBe` "[REDACTE"
+                bounded.logTail `shouldBe` ["ne"]
+                second <- openJournal lowered >>= snapshot
+                second `shouldBe` first
+                openJournal (lowered {maximumTasks = 0})
+                    `shouldThrow` \case
+                        JournalTaskCapacityExceeded 0 -> True
+                        _ -> False
+
         it "retains no events when maximumEvents is zero and preserves the sequence" $
             withSystemTempDirectory "daemon-zero-retention" $ \directory -> do
                 let config = (defaultJournalConfig directory) {maximumEvents = 0}
@@ -307,6 +358,23 @@ main = hspec $ do
                 BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode exhausted))
                 journal <- openJournal (defaultJournalConfig directory)
                 appendEvent journal "wrapped" Null
+                    `shouldThrow` \case
+                        JournalSequenceExhausted sequenceNumber ->
+                            sequenceNumber == Sequence maxBound
+                        _ -> False
+
+        it "rejects maxBound-to-zero sequence wrap during recovery" $
+            withSystemTempDirectory "daemon-recovery-sequence-wrap" $ \directory -> do
+                let event sequenceNumber =
+                        EventEnvelope {sequenceNumber, eventType = "test", payload = Null}
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    ( LBS.toStrict (encode (event (Sequence maxBound)))
+                        <> "\n"
+                        <> LBS.toStrict (encode (event 0))
+                        <> "\n"
+                    )
+                openJournal (defaultJournalConfig directory)
                     `shouldThrow` \case
                         JournalSequenceExhausted sequenceNumber ->
                             sequenceNumber == Sequence maxBound

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -1,0 +1,209 @@
+module Main (main) where
+
+import Control.Concurrent.Async (concurrently, withAsync)
+import Control.Exception.Safe (bracket)
+import Data.Aeson (Value (..), object, (.=))
+import Data.Bits ((.&.))
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import Data.Time (getCurrentTime)
+import Network.Socket
+import qualified Network.Socket.ByteString as Socket
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory, withTempDirectory)
+import System.Posix.Files (fileMode, getFileStatus)
+import Test.Hspec
+
+import Agent.Runtime.Daemon.Framing
+import Agent.Runtime.Daemon.Journal
+import Agent.Runtime.Daemon.Protocol
+import Agent.Runtime.Daemon.Server
+import Agent.Runtime.Daemon.Socket
+import Agent.Runtime.Daemon.Supervisor
+import Agent.Runtime.Daemon.Task
+
+main :: IO ()
+main = hspec $ do
+    describe "length-framed JSON IPC" $ do
+        it "round trips a typed message over a Unix stream" $
+            withSocketPair $ \(writer, reader) -> do
+                let expected = ClientAck 42
+                (_, actual) <-
+                    concurrently
+                        (sendJSONFrame defaultMaximumFrameBytes writer expected)
+                        (receiveJSONFrame defaultMaximumFrameBytes reader)
+                actual `shouldBe` expected
+
+        it "rejects an outbound frame above the configured bound" $
+            withSocketPair $ \(writer, _) ->
+                sendJSONFrame 8 writer (String "this frame is too long")
+                    `shouldThrow` \case
+                        FrameTooLarge _ 8 -> True
+                        _ -> False
+
+        it "rejects an advertised inbound length before reading its body" $
+            withSocketPair $ \(writer, reader) -> do
+                Socket.sendAll writer (BS.pack [0, 0, 1, 0])
+                (receiveJSONFrame 32 reader :: IO Value)
+                    `shouldThrow` \case
+                        FrameTooLarge 256 32 -> True
+                        _ -> False
+
+    describe "protocol negotiation" $ do
+        it "chooses the current common version" $ do
+            negotiateVersion [ProtocolVersion 99, currentProtocolVersion]
+                `shouldBe` Just currentProtocolVersion
+            negotiateVersion [ProtocolVersion 99] `shouldBe` Nothing
+
+    describe "durable journal" $ do
+        it "keeps sequence numbers monotonic and replays after a cursor" $
+            withSystemTempDirectory "daemon-journal" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                first <- appendEvent journal "one" Null
+                second <- appendEvent journal "two" Null
+                first.sequenceNumber `shouldBe` 1
+                second.sequenceNumber `shouldBe` 2
+                replayAfter journal 1 `shouldReturn` ReplayEvents [second]
+
+        it "falls back to a snapshot when retention has removed the cursor" $
+            withSystemTempDirectory "daemon-retention" $ \directory -> do
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumEvents = 2
+                            , maximumJournalBytes = 1_048_576
+                            }
+                journal <- openJournal config
+                _ <- appendEvent journal "one" Null
+                second <- appendEvent journal "two" Null
+                third <- appendEvent journal "three" Null
+                replayAfter journal 0 >>= (`shouldSatisfy` \case
+                    ReplaySnapshot saved -> saved.lastSequence == 3
+                    ReplayEvents _ -> False)
+                replayAfter journal 1 `shouldReturn` ReplayEvents [second, third]
+                replayAfter journal 99 >>= (`shouldSatisfy` \case
+                    ReplaySnapshot saved -> saved.lastSequence == 3
+                    ReplayEvents _ -> False)
+
+        it "redacts sensitive fields and bounds retained task logs" $
+            withSystemTempDirectory "daemon-redaction" $ \directory -> do
+                now <- getCurrentTime
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumTaskLogLines = 2
+                            , maximumTaskLogCharacters = 20
+                            }
+                    task =
+                        DurableTask
+                            { taskId = TaskId "task"
+                            , status = TaskRunning
+                            , description = "test"
+                            , updatedAt = now
+                            , logTail = ["old", "authorization: bearer private", "safe"]
+                            }
+                journal <- openJournal config
+                event <- appendEvent journal "credentials" (object ["token" .= ("private" :: Text)])
+                event.payload `shouldBe` object ["token" .= ("[REDACTED]" :: Text)]
+                _ <- persistTask journal task
+                saved <- snapshot journal
+                (.logTail) (saved.tasks Map.! TaskId "task")
+                    `shouldBe` ["[REDACTED]", "safe"]
+
+        it "marks active tasks interrupted on startup without retrying them" $
+            withSystemTempDirectory "daemon-recovery" $ \directory -> do
+                now <- getCurrentTime
+                let config = defaultJournalConfig directory
+                    running =
+                        DurableTask
+                            { taskId = TaskId "active"
+                            , status = TaskRunning
+                            , description = "active before crash"
+                            , updatedAt = now
+                            , logTail = []
+                            }
+                firstProcess <- openJournal config
+                _ <- persistTask firstProcess running
+                secondProcess <- openJournal config
+                recovered <- snapshot secondProcess
+                (.status) (recovered.tasks Map.! TaskId "active")
+                    `shouldBe` TaskInterrupted
+                let recoveredSequence = recovered.lastSequence
+                thirdProcess <- openJournal config
+                unchanged <- snapshot thirdProcess
+                unchanged.lastSequence `shouldBe` recoveredSequence
+                (.status) (unchanged.tasks Map.! TaskId "active")
+                    `shouldBe` TaskInterrupted
+
+    describe "secure Unix socket" $ do
+        it "uses private modes and authenticates the same-user peer" $
+            withTempDirectory "/tmp" "daemon-socket" $ \directory -> do
+                let path = directory </> "private" </> "daemon.sock"
+                    config = SocketConfig {path, backlog = 1}
+                withUnixListener config $ \listener ->
+                    withAsync
+                        (bracket (acceptOwnedPeer listener) close verifyPeerOwner)
+                        $ \_ -> do
+                            client <- socket AF_UNIX Stream defaultProtocol
+                            bracket (pure client) close $ \peer -> do
+                                connect peer (SockAddrUnix path)
+                                verifyPeerOwner peer
+                                socketStatus <- getFileStatus path
+                                directoryStatus <- getFileStatus (directory </> "private")
+                                fileMode socketStatus .&. 0o777 `shouldBe` 0o600
+                                fileMode directoryStatus .&. 0o777 `shouldBe` 0o700
+
+        it "does not unlink an active daemon socket" $
+            withTempDirectory "/tmp" "daemon-active" $ \directory -> do
+                let config =
+                        SocketConfig
+                            { path = directory </> "daemon.sock"
+                            , backlog = 1
+                            }
+                withUnixListener config $ \_ ->
+                    withUnixListener config (const (pure ()))
+                        `shouldThrow` anyException
+
+    describe "server integration" $ do
+        it "handshakes, sends a snapshot, streams events, and uses the supervisor seam" $
+            withSystemTempDirectory "daemon-server" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                let config =
+                        defaultServerConfig
+                            { heartbeatSeconds = 60
+                            , maximumFrameBytes = 4_096
+                            }
+                    supervisor =
+                        Supervisor
+                            { handleCommand = \_ command -> pure (Right command)
+                            }
+                withSocketPair $ \(serverPeer, clientPeer) ->
+                    withAsync (serveConnection config journal supervisor serverPeer) $ \_ -> do
+                        sendJSONFrame config.maximumFrameBytes clientPeer $
+                            ClientHello
+                                Hello
+                                    { clientId = ClientId "test-client"
+                                    , versions = [currentProtocolVersion]
+                                    , resumeAfter = Nothing
+                                    }
+                        welcome <- receiveJSONFrame config.maximumFrameBytes clientPeer
+                        welcome `shouldSatisfy` \case
+                            ServerWelcome accepted -> accepted.version == currentProtocolVersion
+                            _ -> False
+                        initial <- receiveJSONFrame config.maximumFrameBytes clientPeer
+                        initial `shouldSatisfy` \case
+                            ServerSnapshot 0 _ -> True
+                            _ -> False
+                        event <- appendEvent journal "changed" (object ["value" .= (1 :: Int)])
+                        receiveJSONFrame config.maximumFrameBytes clientPeer
+                            `shouldReturn` ServerEvent event
+                        sendJSONFrame config.maximumFrameBytes clientPeer $
+                            ClientCommand (CommandId "command") (String "echo")
+                        receiveJSONFrame config.maximumFrameBytes clientPeer
+                            `shouldReturn` ServerCommandResult (CommandId "command") (Right (String "echo"))
+                        sendJSONFrame config.maximumFrameBytes clientPeer (ClientAck event.sequenceNumber)
+
+withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
+withSocketPair =
+    bracket
+        (socketPair AF_UNIX Stream defaultProtocol)
+        (\(left, right) -> close left >> close right)

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -1,18 +1,32 @@
 module Main (main) where
 
-import Control.Concurrent.Async (concurrently, withAsync)
-import Control.Exception.Safe (bracket)
-import Data.Aeson (Value (..), object, (.=))
+import Control.Concurrent.Async (cancel, concurrently, waitCatch, withAsync)
+import Control.Concurrent.STM (readTVarIO)
+import Control.Exception.Safe (bracket, isAsyncException)
+import Data.Aeson (Value (..), encode, object, (.=))
 import Data.Bits ((.&.))
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time (getCurrentTime)
 import Network.Socket
 import qualified Network.Socket.ByteString as Socket
+import System.Directory
+    ( createDirectory
+    , doesFileExist
+    , removeFile
+    , renamePath
+    )
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory, withTempDirectory)
-import System.Posix.Files (fileMode, getFileStatus)
+import System.Posix.Files
+    ( createSymbolicLink
+    , fileMode
+    , getFileStatus
+    )
+import System.Timeout (timeout)
 import Test.Hspec
 
 import Agent.Runtime.Daemon.Framing
@@ -108,6 +122,8 @@ main = hspec $ do
                 saved <- snapshot journal
                 (.logTail) (saved.tasks Map.! TaskId "task")
                     `shouldBe` ["[REDACTED]", "safe"]
+                (.description) (saved.tasks Map.! TaskId "task")
+                    `shouldBe` "test"
 
         it "marks active tasks interrupted on startup without retrying them" $
             withSystemTempDirectory "daemon-recovery" $ \directory -> do
@@ -133,6 +149,114 @@ main = hspec $ do
                 unchanged.lastSequence `shouldBe` recoveredSequence
                 (.status) (unchanged.tasks Map.! TaskId "active")
                     `shouldBe` TaskInterrupted
+
+        it "fails closed on corrupt snapshots and event gaps" $
+            withSystemTempDirectory "daemon-corrupt" $ \directory -> do
+                BS.writeFile (directory </> "snapshot.json") "{broken"
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalCorrupt _ _ -> True
+                        _ -> False
+                removeFile (directory </> "snapshot.json")
+                let event sequenceNumber =
+                        EventEnvelope {sequenceNumber, eventType = "test", payload = Null}
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    (LBS.toStrict (encode (event 1)) <> "\n" <> LBS.toStrict (encode (event 3)) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalEventGap 2 3 -> True
+                        _ -> False
+
+        it "enforces contiguous startup retention and rejects an oversized newest event" $
+            withSystemTempDirectory "daemon-startup-retention" $ \directory -> do
+                original <- openJournal ((defaultJournalConfig directory) {maximumEvents = 10})
+                now <- getCurrentTime
+                _ <-
+                    persistTask original $
+                        DurableTask
+                            { taskId = TaskId "snapshot-anchor"
+                            , status = TaskCompleted
+                            , description = "anchor"
+                            , updatedAt = now
+                            , logTail = []
+                            }
+                second <- appendEvent original "two" Null
+                third <- appendEvent original "three" Null
+                reopened <- openJournal ((defaultJournalConfig directory) {maximumEvents = 2})
+                replayAfter reopened 1 `shouldReturn` ReplayEvents [second, third]
+                let tinyConfig =
+                        (defaultJournalConfig (directory </> "oversized"))
+                            { maximumJournalBytes = 4
+                            }
+                bounded <- openJournal tinyConfig
+                appendEvent bounded "large" (String "payload")
+                    `shouldThrow` \case
+                        JournalEventTooLarge _ 4 -> True
+                        _ -> False
+                saved <- snapshot bounded
+                saved.lastSequence `shouldBe` 0
+
+        it "poisons the journal after persistence I/O failure instead of reusing a sequence" $
+            withSystemTempDirectory "daemon-poison" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                _ <- appendEvent journal "first" Null
+                renamePath (directory </> "events.jsonl") (directory </> "events.saved")
+                createDirectory (directory </> "events.jsonl")
+                appendEvent journal "second" Null `shouldThrow` anyException
+                appendEvent journal "third" Null
+                    `shouldThrow` \case
+                        JournalPoisoned _ -> True
+                        _ -> False
+
+        it "redacts descriptions, bounds task count, and bounds subscriber queues" $
+            withSystemTempDirectory "daemon-bounds" $ \directory -> do
+                now <- getCurrentTime
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumTasks = 1
+                            , subscriberQueueSize = 1
+                            }
+                    task name description =
+                        DurableTask
+                            { taskId = TaskId name
+                            , status = TaskCompleted
+                            , description
+                            , updatedAt = now
+                            , logTail = []
+                            }
+                journal <- openJournal config
+                _ <- persistTask journal (task "one" "password=private")
+                saved <- snapshot journal
+                (.description) (saved.tasks Map.! TaskId "one") `shouldBe` "[REDACTED]"
+                persistTask journal (task "two" "safe")
+                    `shouldThrow` \case
+                        JournalTaskCapacityExceeded 1 -> True
+                        _ -> False
+                (_, _, _, overflowed, unsubscribe) <- subscribeReplay journal saved.lastSequence
+                _ <- appendEvent journal "a" Null
+                _ <- appendEvent journal "b" Null
+                readTVarIO overflowed `shouldReturn` True
+                unsubscribe
+
+        it "rejects symlinked journal directories and files" $
+            withSystemTempDirectory "daemon-symlink" $ \directory -> do
+                let target = directory </> "target"
+                    linked = directory </> "linked"
+                createDirectory target
+                createSymbolicLink target linked
+                openJournal (defaultJournalConfig linked)
+                    `shouldThrow` \case
+                        JournalInsecurePath _ -> True
+                        _ -> False
+                let journalDir = directory </> "journal"
+                createDirectory journalDir
+                BS.writeFile (directory </> "outside") "{}"
+                createSymbolicLink (directory </> "outside") (journalDir </> "snapshot.json")
+                openJournal (defaultJournalConfig journalDir)
+                    `shouldThrow` \case
+                        JournalInsecurePath _ -> True
+                        _ -> False
 
     describe "secure Unix socket" $ do
         it "uses private modes and authenticates the same-user peer" $
@@ -163,6 +287,15 @@ main = hspec $ do
                     withUnixListener config (const (pure ()))
                         `shouldThrow` anyException
 
+        it "only removes the socket inode created by this listener" $
+            withTempDirectory "/tmp" "daemon-identity" $ \directory -> do
+                let path = directory </> "daemon.sock"
+                    config = SocketConfig {path, backlog = 1}
+                withUnixListener config $ \_ -> do
+                    renamePath path (path <> ".replaced")
+                    BS.writeFile path "replacement"
+                doesFileExist path `shouldReturn` True
+
     describe "server integration" $ do
         it "handshakes, sends a snapshot, streams events, and uses the supervisor seam" $
             withSystemTempDirectory "daemon-server" $ \directory -> do
@@ -191,7 +324,7 @@ main = hspec $ do
                             _ -> False
                         initial <- receiveJSONFrame config.maximumFrameBytes clientPeer
                         initial `shouldSatisfy` \case
-                            ServerSnapshot 0 _ -> True
+                            ServerSnapshotChunk 0 0 1 _ -> True
                             _ -> False
                         event <- appendEvent journal "changed" (object ["value" .= (1 :: Int)])
                         receiveJSONFrame config.maximumFrameBytes clientPeer
@@ -201,6 +334,78 @@ main = hspec $ do
                         receiveJSONFrame config.maximumFrameBytes clientPeer
                             `shouldReturn` ServerCommandResult (CommandId "command") (Right (String "echo"))
                         sendJSONFrame config.maximumFrameBytes clientPeer (ClientAck event.sequenceNumber)
+
+        it "times out idle clients and preserves async cancellation" $
+            withSystemTempDirectory "daemon-timeout" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                let config = defaultServerConfig {ioTimeoutSeconds = 1}
+                withSocketPair $ \(serverPeer, _) -> do
+                    withAsync (serveConnection config journal unavailableSupervisor serverPeer) $ \server -> do
+                        result <- timeout 2_500_000 (waitCatch server)
+                        result `shouldSatisfy` \case
+                            Just (Left exception) -> not (isAsyncException exception)
+                            _ -> False
+                withTempDirectory "/tmp" "daemon-cancel" $ \socketDirectory -> do
+                    let socketConfig =
+                            SocketConfig
+                                { path = socketDirectory </> "daemon.sock"
+                                , backlog = 1
+                                }
+                    withUnixListener socketConfig $ \listener ->
+                        withAsync (runServerOnListener listener config journal unavailableSupervisor) $ \server -> do
+                            client <- socket AF_UNIX Stream defaultProtocol
+                            bracket (pure client) close $ \peer -> do
+                                connect peer (SockAddrUnix socketConfig.path)
+                                cancel server
+                                outcome <- timeout 2_000_000 (waitCatch server)
+                                outcome `shouldSatisfy` \case
+                                    Just (Left exception) -> isAsyncException exception
+                                    _ -> False
+
+        it "chunks large snapshots below the configured frame bound" $
+            withSystemTempDirectory "daemon-snapshot-chunks" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                now <- getCurrentTime
+                _ <-
+                    persistTask journal $
+                        DurableTask
+                            { taskId = TaskId "large"
+                            , status = TaskCompleted
+                            , description = "large snapshot"
+                            , updatedAt = now
+                            , logTail = [Text.replicate 2_000 "x"]
+                            }
+                let config =
+                        defaultServerConfig
+                            { maximumFrameBytes = 512
+                            , heartbeatSeconds = 60
+                            }
+                withSocketPair $ \(serverPeer, clientPeer) ->
+                    withAsync (serveConnection config journal unavailableSupervisor serverPeer) $ \_ -> do
+                        sendJSONFrame config.maximumFrameBytes clientPeer $
+                            ClientHello
+                                Hello
+                                    { clientId = ClientId "snapshot-client"
+                                    , versions = [currentProtocolVersion]
+                                    , resumeAfter = Nothing
+                                    }
+                        _ <- receiveJSONFrame config.maximumFrameBytes clientPeer :: IO ServerMessage
+                        first <- receiveJSONFrame config.maximumFrameBytes clientPeer
+                        chunkCount <-
+                            case first of
+                                ServerSnapshotChunk 1 0 count _ -> do
+                                    count `shouldSatisfy` (> 1)
+                                    pure count
+                                _ -> expectationFailure ("unexpected snapshot message: " <> show first) >> pure 0
+                        sequenceNumbers <-
+                            traverse
+                                ( \_ ->
+                                    receiveJSONFrame config.maximumFrameBytes clientPeer >>= \case
+                                        ServerSnapshotChunk 1 index count _ | count == chunkCount -> pure index
+                                        other -> expectationFailure ("unexpected snapshot chunk: " <> show other) >> pure (-1)
+                                )
+                                [1 .. chunkCount - 1]
+                        sequenceNumbers `shouldBe` [1 .. chunkCount - 1]
 
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -152,6 +152,19 @@ main = hspec $ do
                 replayAfter reopened 3 `shouldReturn` ReplayEvents [boundary, next]
                 replayAfter reopened 4 `shouldReturn` ReplayEvents [next]
 
+        it "fails closed on duplicate retained sequence numbers" $
+            withSystemTempDirectory "daemon-duplicate-boundary" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    duplicate = EventEnvelope {sequenceNumber = 4, eventType = "duplicate", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    (LBS.toStrict (encode duplicate) <> "\n" <> LBS.toStrict (encode duplicate) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalEventGap 5 4 -> True
+                        _ -> False
+
         it "redacts sensitive fields and bounds retained task logs" $
             withSystemTempDirectory "daemon-redaction" $ \directory -> do
                 now <- getCurrentTime

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -117,6 +117,26 @@ main = hspec $ do
                 third <- appendEvent secondProcess "three" Null
                 third.sequenceNumber `shouldBe` 3
 
+        it "reopens a compacted replay suffix without requiring sequence one" $
+            withSystemTempDirectory "daemon-reopen-compaction" $ \directory -> do
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumEvents = 2
+                            , maximumJournalBytes = 1_048_576
+                            }
+                firstProcess <- openJournal config
+                _ <- appendEvent firstProcess "one" Null
+                second <- appendEvent firstProcess "two" Null
+                third <- appendEvent firstProcess "three" Null
+                secondProcess <- openJournal config
+                replayAfter secondProcess 1 `shouldReturn` ReplayEvents [second, third]
+                snapshot secondProcess >>= \saved ->
+                    saved.lastSequence `shouldBe` 3
+                thirdProcess <- openJournal config
+                replayAfter thirdProcess 1 `shouldReturn` ReplayEvents [second, third]
+                fourth <- appendEvent thirdProcess "four" Null
+                fourth.sequenceNumber `shouldBe` 4
+
         it "redacts sensitive fields and bounds retained task logs" $
             withSystemTempDirectory "daemon-redaction" $ \directory -> do
                 now <- getCurrentTime

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -129,6 +129,8 @@ main = hspec $ do
                 second <- appendEvent firstProcess "two" Null
                 third <- appendEvent firstProcess "three" Null
                 secondProcess <- openJournal config
+                BS.readFile (directory </> "events.jsonl")
+                    `shouldReturn` (LBS.toStrict (encode second) <> "\n" <> LBS.toStrict (encode third) <> "\n")
                 replayAfter secondProcess 1 `shouldReturn` ReplayEvents [second, third]
                 snapshot secondProcess >>= \saved ->
                     saved.lastSequence `shouldBe` 3
@@ -136,6 +138,19 @@ main = hspec $ do
                 replayAfter thirdProcess 1 `shouldReturn` ReplayEvents [second, third]
                 fourth <- appendEvent thirdProcess "four" Null
                 fourth.sequenceNumber `shouldBe` 4
+
+        it "accepts the snapshot boundary event in a retained replay suffix" $
+            withSystemTempDirectory "daemon-snapshot-boundary" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    boundary = EventEnvelope {sequenceNumber = 4, eventType = "boundary", payload = Null}
+                    next = EventEnvelope {sequenceNumber = 5, eventType = "next", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    (LBS.toStrict (encode boundary) <> "\n" <> LBS.toStrict (encode next) <> "\n")
+                reopened <- openJournal (defaultJournalConfig directory)
+                replayAfter reopened 3 `shouldReturn` ReplayEvents [boundary, next]
+                replayAfter reopened 4 `shouldReturn` ReplayEvents [next]
 
         it "redacts sensitive fields and bounds retained task logs" $
             withSystemTempDirectory "daemon-redaction" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -208,6 +208,40 @@ main = hspec $ do
                         JournalCorrupt _ _ -> True
                         _ -> False
 
+        it "rejects a stale prefix before an otherwise current snapshot anchor" $
+            withSystemTempDirectory "daemon-stale-prefix" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    stale = EventEnvelope {sequenceNumber = 3, eventType = "test", payload = Null}
+                    anchor = EventEnvelope {sequenceNumber = 4, eventType = "test", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    (LBS.toStrict (encode stale) <> "\n" <> LBS.toStrict (encode anchor) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalCorrupt _ _ -> True
+                        _ -> False
+
+        it "can reopen repeatedly after startup compaction" $
+            withSystemTempDirectory "daemon-reopen-compaction" $ \directory -> do
+                let originalConfig = (defaultJournalConfig directory) {maximumEvents = 10}
+                    compactedConfig = originalConfig {maximumEvents = 2}
+                original <- openJournal originalConfig
+                _ <- appendEvent original "one" Null
+                _ <- appendEvent original "two" Null
+                _ <- appendEvent original "three" Null
+                first <- openJournal compactedConfig
+                firstSnapshot <- snapshot first
+                firstSnapshot.lastSequence `shouldBe` 3
+                second <- openJournal compactedConfig
+                secondSnapshot <- snapshot second
+                secondSnapshot `shouldBe` firstSnapshot
+                fourth <- appendEvent second "four" Null
+                fourth.sequenceNumber `shouldBe` 4
+                third <- openJournal compactedConfig
+                thirdSnapshot <- snapshot third
+                thirdSnapshot.lastSequence `shouldBe` 4
+
         it "enforces contiguous startup retention and rejects an oversized newest event" $
             withSystemTempDirectory "daemon-startup-retention" $ \directory -> do
                 original <- openJournal ((defaultJournalConfig directory) {maximumEvents = 10})

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -208,40 +208,6 @@ main = hspec $ do
                         JournalCorrupt _ _ -> True
                         _ -> False
 
-        it "rejects a stale prefix before an otherwise current snapshot anchor" $
-            withSystemTempDirectory "daemon-stale-prefix" $ \directory -> do
-                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
-                    stale = EventEnvelope {sequenceNumber = 3, eventType = "test", payload = Null}
-                    anchor = EventEnvelope {sequenceNumber = 4, eventType = "test", payload = Null}
-                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
-                BS.writeFile
-                    (directory </> "events.jsonl")
-                    (LBS.toStrict (encode stale) <> "\n" <> LBS.toStrict (encode anchor) <> "\n")
-                openJournal (defaultJournalConfig directory)
-                    `shouldThrow` \case
-                        JournalCorrupt _ _ -> True
-                        _ -> False
-
-        it "can reopen repeatedly after startup compaction" $
-            withSystemTempDirectory "daemon-reopen-compaction" $ \directory -> do
-                let originalConfig = (defaultJournalConfig directory) {maximumEvents = 10}
-                    compactedConfig = originalConfig {maximumEvents = 2}
-                original <- openJournal originalConfig
-                _ <- appendEvent original "one" Null
-                _ <- appendEvent original "two" Null
-                _ <- appendEvent original "three" Null
-                first <- openJournal compactedConfig
-                firstSnapshot <- snapshot first
-                firstSnapshot.lastSequence `shouldBe` 3
-                second <- openJournal compactedConfig
-                secondSnapshot <- snapshot second
-                secondSnapshot `shouldBe` firstSnapshot
-                fourth <- appendEvent second "four" Null
-                fourth.sequenceNumber `shouldBe` 4
-                third <- openJournal compactedConfig
-                thirdSnapshot <- snapshot third
-                thirdSnapshot.lastSequence `shouldBe` 4
-
         it "enforces contiguous startup retention and rejects an oversized newest event" $
             withSystemTempDirectory "daemon-startup-retention" $ \directory -> do
                 original <- openJournal ((defaultJournalConfig directory) {maximumEvents = 10})

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -1,9 +1,10 @@
 module Main (main) where
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (cancel, concurrently, waitCatch, withAsync)
 import Control.Concurrent.STM (readTVarIO)
 import Control.Exception.Safe (bracket, isAsyncException)
-import Data.Aeson (Value (..), encode, object, (.=))
+import Data.Aeson (Value (..), encode, object, toJSON, (.=))
 import Data.Bits ((.&.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -168,6 +169,28 @@ main = hspec $ do
                         JournalEventGap 2 3 -> True
                         _ -> False
 
+        it "rejects a retained suffix that starts after a snapshot gap" $
+            withSystemTempDirectory "daemon-snapshot-gap" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    event = EventEnvelope {sequenceNumber = 6, eventType = "test", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile (directory </> "events.jsonl") (LBS.toStrict (encode event) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalEventGap 5 6 -> True
+                        _ -> False
+
+        it "rejects a nonempty retained suffix that ends before its snapshot" $
+            withSystemTempDirectory "daemon-stale-suffix" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    event = EventEnvelope {sequenceNumber = 3, eventType = "test", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile (directory </> "events.jsonl") (LBS.toStrict (encode event) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalCorrupt _ _ -> True
+                        _ -> False
+
         it "enforces contiguous startup retention and rejects an oversized newest event" $
             withSystemTempDirectory "daemon-startup-retention" $ \directory -> do
                 original <- openJournal ((defaultJournalConfig directory) {maximumEvents = 10})
@@ -238,6 +261,56 @@ main = hspec $ do
                 _ <- appendEvent journal "b" Null
                 readTVarIO overflowed `shouldReturn` True
                 unsubscribe
+
+        it "applies task bounds while recovering task_changed events" $
+            withSystemTempDirectory "daemon-recovered-task-bounds" $ \directory -> do
+                now <- getCurrentTime
+                let task =
+                        DurableTask
+                            { taskId = TaskId "recovered"
+                            , status = TaskCompleted
+                            , description = "password=private"
+                            , updatedAt = now
+                            , logTail = ["token=private"]
+                            }
+                    event =
+                        EventEnvelope
+                            { sequenceNumber = 1
+                            , eventType = "task_changed"
+                            , payload = toJSON task
+                            }
+                    config =
+                        (defaultJournalConfig directory)
+                            { maximumTaskDescriptionCharacters = 64
+                            , maximumTaskLogLines = 0
+                            }
+                BS.writeFile (directory </> "events.jsonl") (LBS.toStrict (encode event) <> "\n")
+                recovered <- openJournal config >>= snapshot
+                let bounded = recovered.tasks Map.! TaskId "recovered"
+                bounded.description `shouldBe` "[REDACTED]"
+                bounded.logTail `shouldBe` []
+
+        it "retains no events when maximumEvents is zero and preserves the sequence" $
+            withSystemTempDirectory "daemon-zero-retention" $ \directory -> do
+                let config = (defaultJournalConfig directory) {maximumEvents = 0}
+                journal <- openJournal config
+                _ <- appendEvent journal "discarded" Null
+                BS.readFile (directory </> "events.jsonl") `shouldReturn` BS.empty
+                reopened <- openJournal config
+                recovered <- snapshot reopened
+                recovered.lastSequence `shouldBe` 1
+                replayAfter reopened 0 `shouldReturn` ReplaySnapshot recovered
+
+        it "refuses to wrap an exhausted sequence number" $
+            withSystemTempDirectory "daemon-sequence-overflow" $ \directory -> do
+                let exhausted = JournalSnapshot {lastSequence = Sequence maxBound, tasks = Map.empty}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode exhausted))
+                journal <- openJournal (defaultJournalConfig directory)
+                appendEvent journal "wrapped" Null
+                    `shouldThrow` \case
+                        JournalSequenceExhausted sequenceNumber ->
+                            sequenceNumber == Sequence maxBound
+                        _ -> False
 
         it "rejects symlinked journal directories and files" $
             withSystemTempDirectory "daemon-symlink" $ \directory -> do
@@ -362,6 +435,36 @@ main = hspec $ do
                                     Just (Left exception) -> isAsyncException exception
                                     _ -> False
 
+        it "closes an accepted peer when cancellation interrupts full-queue admission" $
+            withSystemTempDirectory "daemon-admission-cancel" $ \directory ->
+                withTempDirectory "/tmp" "daemon-admission" $ \socketDirectory -> do
+                    journal <- openJournal (defaultJournalConfig directory)
+                    let socketConfig =
+                            SocketConfig
+                                { path = socketDirectory </> "daemon.sock"
+                                , backlog = 8
+                                }
+                        config =
+                            defaultServerConfig
+                                { workerCount = 1
+                                , ioTimeoutSeconds = 30
+                                }
+                    withUnixListener socketConfig $ \listener ->
+                        withAsync (runServerOnListener listener config journal unavailableSupervisor) $ \server ->
+                            bracket
+                                (traverse (const (socket AF_UNIX Stream defaultProtocol)) [1 :: Int .. 3])
+                                (mapM_ close)
+                                $ \clients -> do
+                                    mapM_ (`connect` SockAddrUnix socketConfig.path) clients
+                                    threadDelay 200_000
+                                    cancel server
+                                    _ <- waitCatch server
+                                    results <-
+                                        traverse
+                                            (\client -> timeout 1_000_000 (Socket.recv client 1))
+                                            clients
+                                    results `shouldBe` replicate 3 (Just BS.empty)
+
         it "chunks large snapshots below the configured frame bound" $
             withSystemTempDirectory "daemon-snapshot-chunks" $ \directory -> do
                 journal <- openJournal (defaultJournalConfig directory)
@@ -406,6 +509,46 @@ main = hspec $ do
                                 )
                                 [1 .. chunkCount - 1]
                         sequenceNumbers `shouldBe` [1 .. chunkCount - 1]
+
+        it "chunks events that exceed the transport frame bound" $
+            withSystemTempDirectory "daemon-event-chunks" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                event <- appendEvent journal "large" (String (Text.replicate 2_000 "x"))
+                let config =
+                        defaultServerConfig
+                            { maximumFrameBytes = 512
+                            , heartbeatSeconds = 60
+                            }
+                withSocketPair $ \(serverPeer, clientPeer) ->
+                    withAsync (serveConnection config journal unavailableSupervisor serverPeer) $ \_ -> do
+                        sendJSONFrame config.maximumFrameBytes clientPeer $
+                            ClientHello
+                                Hello
+                                    { clientId = ClientId "event-client"
+                                    , versions = [currentProtocolVersion]
+                                    , resumeAfter = Just 0
+                                    }
+                        _ <- receiveJSONFrame config.maximumFrameBytes clientPeer :: IO ServerMessage
+                        first <- receiveJSONFrame config.maximumFrameBytes clientPeer
+                        chunkCount <- case first of
+                            ServerEventChunk sequenceNumber 0 count _ ->
+                                if sequenceNumber == event.sequenceNumber && count > 1
+                                    then pure count
+                                    else expectationFailure ("unexpected event chunk: " <> show first) >> pure 0
+                            _ -> expectationFailure ("unexpected event message: " <> show first) >> pure 0
+                        indices <-
+                            traverse
+                                ( \_ ->
+                                    receiveJSONFrame config.maximumFrameBytes clientPeer >>= \case
+                                        ServerEventChunk sequenceNumber index count _
+                                            | sequenceNumber == event.sequenceNumber
+                                            , count == chunkCount ->
+                                                pure index
+                                        other ->
+                                            expectationFailure ("unexpected event chunk: " <> show other) >> pure (-1)
+                                )
+                                [1 .. chunkCount - 1]
+                        indices `shouldBe` [1 .. chunkCount - 1]
 
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =


### PR DESCRIPTION
## Summary
- add a per-user Unix-socket daemon with bounded, versioned framed IPC
- persist task snapshots/events with fsync, replay cursors, acknowledgements, heartbeats, and interrupted-on-restart recovery
- provide a structured supervisor seam for the native task scheduler

## Security and durability
- same-user peer credentials, exclusive socket ownership lock, no-follow files, owner/mode/inode checks
- read/write/command deadlines and bounded outbound/subscriber queues
- fail closed on corrupt/gapped/oversized/wrong-owner journal state
- contiguous retention, sequence poisoning after uncertain writes, bounded/redacted descriptions, task/snapshot caps
- protocol v3 chunks oversized snapshots and events below the negotiated frame limit
- async cancellation is preserved; accept/client failures remain isolated

## Validation
- 19+ focused framing, replay, corruption, retention, socket-race, slow-client, and restart tests
- daemon executable and Nix package builds
- `git diff --check`

## Dependency and scope
Stacked on #752. This PR establishes the audited daemon boundary; `Main` deliberately reports supervisor-unavailable until the next adapter PR wires real task submission. It does not make a survival-across-quit product claim by itself.
