### PR TITLE
Add /desktop conversation handoff

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -162,6 +162,7 @@ library
                     , Agent.CLI.Database
                     , Agent.CLI.Database.Store
                     , Agent.CLI.Database.Storage
+                    , Agent.CLI.Desktop
                     , Agent.CLI.Duration
                     , Agent.CLI.Dictation
                     , Agent.CLI.Dialects
@@ -412,6 +413,7 @@ test-suite agent-cli-test
                     , Agent.CLI.CredentialStoreSpec
                     , Agent.CLI.DialectsSpec
                     , Agent.CLI.DatabaseSpec
+                    , Agent.CLI.DesktopSpec
                     , Agent.CLI.ErrorSpec
                     , Agent.CLI.FileUriSpec
                     , Agent.CLI.GatewayBridgeSpec

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -251,6 +251,10 @@ parseSlash catalog raw line = case Text.words line of
                 if null args
                     then ReplShowSessionInfo
                     else ReplCommandError "usage: /session-info"
+            "desktop" ->
+                if null args
+                    then ReplDesktop
+                    else ReplCommandError "usage: /desktop"
             "afk" -> case args of
                 [] -> ReplAfk Nothing
                 [target] -> ReplAfk (Just target)

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -18,6 +18,7 @@ slashCommands =
     , cmd "retry" [] "/retry" "Retry the last failed turn exactly" False
     , cmd "session" [] "/session" "Print the current session id" False
     , cmd "session-info" ["status", "info"] "/session-info" "Show session details (model, tools, and context usage)" False
+    , cmd "desktop" [] "/desktop" "Open this conversation in the Haskell Agent desktop app" False
     , cmd "afk" [] "/afk [HOST:PATH]" "Move this session into tmux, locally or over SSH" True
     , cmd "worktree" [] "/worktree" "Start a fresh session in a new git worktree" False
     , cmd "rename" ["title"] "/rename <TITLE>|--auto" "Rename the current session, or restore automatic titles" True

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -41,6 +41,8 @@ data ReplAction
     -- ^ Retry the last failed turn with its original attachments.
     | ReplShowSession
     | ReplShowSessionInfo
+    | ReplDesktop
+    -- ^ Open the current persisted conversation in the native macOS app.
     | ReplAfk (Maybe Text)
     -- ^ Hand the active session to tmux, optionally on @host:path@.
     | ReplWorktree

--- a/packages/agent-cli/src/Agent/CLI/Desktop.hs
+++ b/packages/agent-cli/src/Agent/CLI/Desktop.hs
@@ -1,0 +1,67 @@
+-- | Open persisted conversations in the native macOS desktop application.
+module Agent.CLI.Desktop
+    ( desktopBundleIdentifier
+    , desktopConversationUrl
+    , desktopOpenArguments
+    , openDesktopConversation
+    ) where
+
+import Control.Exception.Safe
+    ( displayException
+    , tryAny
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Network.URI (escapeURIString, isUnreserved)
+import System.Exit (ExitCode(..))
+import qualified System.Info as SystemInfo
+import System.Process (readProcessWithExitCode)
+
+desktopBundleIdentifier :: String
+desktopBundleIdentifier = "dev.haskell-agent.macos"
+
+-- | Deep-link contract consumed by the private native macOS application.
+desktopConversationUrl :: Text -> Text
+desktopConversationUrl sessionId =
+    "haskell-agent://session/"
+        <> Text.pack
+            (escapeURIString isUnreserved (Text.unpack sessionId))
+
+desktopOpenArguments :: Text -> [String]
+desktopOpenArguments sessionId =
+    [ "-b"
+    , desktopBundleIdentifier
+    , Text.unpack (desktopConversationUrl sessionId)
+    ]
+
+openDesktopConversation :: Text -> IO (Either Text ())
+openDesktopConversation sessionId
+    | SystemInfo.os /= "darwin" =
+        pure (Left "/desktop is only available on macOS")
+    | otherwise = do
+        attempted <-
+            tryAny
+                (readProcessWithExitCode
+                    "/usr/bin/open"
+                    (desktopOpenArguments sessionId)
+                    "")
+        pure case attempted of
+            Left exception ->
+                Left
+                    (desktopOpenFailure
+                        (Text.pack (displayException exception)))
+            Right (ExitSuccess, _, _) -> Right ()
+            Right (ExitFailure _, _, errorOutput) ->
+                Left
+                    (desktopOpenFailure (Text.pack errorOutput))
+
+desktopOpenFailure :: Text -> Text
+desktopOpenFailure rawDetail =
+    "could not open this conversation in Haskell Agent; \
+    \make sure the desktop app is installed and up to date"
+        <> case normalizedDetail of
+            "" -> ""
+            detail -> " (" <> detail <> ")"
+  where
+    normalizedDetail =
+        Text.take 300 (Text.unwords (Text.words rawDetail))

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -614,6 +614,7 @@ usage = unlines
     , "<project>/.haskell-agent/settings.json. Permission prompts offer Allow once"
     , "or Always this tool this session; /always-approve still enables project yolo."
     , "/resume [ID] resumes a persisted session (TTY: two-pane picker)."
+    , "/desktop opens the current persisted conversation in the macOS app."
     , "/paste [TEXT] attaches a clipboard image to the next"
     , "message and draws an in-terminal preview (Kitty/Ghostty/WezTerm/iTerm2);"
     , "/paste --send [TEXT] sends immediately. Cmd+V of a Finder image path also"

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -26,6 +26,7 @@ import Agent.CLI.Command
                  ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
                  ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopyLast,
                  ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
+                 ReplDesktop,
                  ReplShowTerminal, ReplShowEffort, ReplSetEffort, ReplShowModel,
                  ReplSetModel, ReplToggleFast, ReplEnableCodeMode,
                  ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
@@ -47,6 +48,7 @@ import Agent.CLI.Config
 import Agent.CLI.Connectivity ()
 import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
+import Agent.CLI.Desktop ( openDesktopConversation )
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ()
 import Agent.CLI.GatewayBridge ()
@@ -593,6 +595,32 @@ handleReplLine
                             "session id"
                             "this session has no persisted id yet"
                             sessionId
+                        continue
+                    ReplDesktop -> do
+                        currentSessionId persist >>= \case
+                            Nothing -> do
+                                let err =
+                                        "/desktop requires a persisted \
+                                        \conversation"
+                                color <- resolveColor stderr
+                                displayError err $
+                                    Text.hPutStrLn stderr (roleError color err)
+                            Just sessionId ->
+                                openDesktopConversation sessionId >>= \case
+                                    Left err -> do
+                                        color <- resolveColor stderr
+                                        displayError err $
+                                            Text.hPutStrLn stderr
+                                                (roleError color err)
+                                    Right () -> do
+                                        let message =
+                                                "opened conversation in \
+                                                \Haskell Agent"
+                                        color <- resolveColor stderr
+                                        displayInfo message $
+                                            Text.hPutStrLn stderr
+                                                (roleSuccess color
+                                                    (glyphOk <> message))
                         continue
                     ReplShowTerminal -> do
                         let message = formatTerminalCapabilities terminal

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -109,6 +109,12 @@ spec = do
             parseReplLine "/status now"
                 `shouldBe` ReplCommandError "usage: /session-info"
 
+        it "opens the current conversation in the desktop app" do
+            parseReplLine "/desktop" `shouldBe` ReplDesktop
+            parseReplLine "  /Desktop  " `shouldBe` ReplDesktop
+            parseReplLine "/desktop now"
+                `shouldBe` ReplCommandError "usage: /desktop"
+
         it "hands the session to local or remote tmux" do
             parseReplLine "/afk" `shouldBe` ReplAfk Nothing
             parseReplLine "/afk office-builder:~/haskell-agent"
@@ -317,6 +323,7 @@ spec = do
                     , "retry"
                     , "session"
                     , "session-info"
+                    , "desktop"
                     , "afk"
                     , "worktree"
                     , "rename"
@@ -662,10 +669,10 @@ spec = do
                 `shouldBe` ReplCommandError "usage: /skills [reload]"
 
         it "adds skills to completion, the live menu, and help" do
-            slashCompletionCandidatesWithSkills skills "" "/de"
+            slashCompletionCandidatesWithSkills skills "" "/depl"
                 `shouldBe` ["/deploy"]
             fmap (map (.slashSuggestionDisplay) . (.slashMenuSuggestions))
-                (slashMenuForWithSkills skills "/dep" 4)
+                (slashMenuForWithSkills skills "/depl" 5)
                 `shouldBe` Just ["/deploy"]
             let help = formatSlashHelpWithSkills False skills (Just "deploy")
             Text.unpack help `shouldSatisfy` ("Deploy the service" `isInfixOf`)

--- a/packages/agent-cli/test/Agent/CLI/DesktopSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DesktopSpec.hs
@@ -1,0 +1,20 @@
+module Agent.CLI.DesktopSpec (spec) where
+
+import Agent.CLI.Desktop
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "desktop conversation deep links" do
+        it "targets the installed native app by bundle identifier" do
+            desktopOpenArguments "2026-08-30-1234abcd"
+                `shouldBe`
+                    [ "-b"
+                    , "dev.haskell-agent.macos"
+                    , "haskell-agent://session/2026-08-30-1234abcd"
+                    ]
+
+        it "percent-encodes reserved and non-ASCII session-id bytes" do
+            desktopConversationUrl "legacy café #%?"
+                `shouldBe`
+                    "haskell-agent://session/legacy%20caf%C3%A9%20%23%25%3F"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -20,6 +20,7 @@ import qualified Agent.CLI.ConnectivitySpec as ConnectivitySpec
 import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
 import qualified Agent.CLI.DialectsSpec as DialectsSpec
 import qualified Agent.CLI.DatabaseSpec as DatabaseSpec
+import qualified Agent.CLI.DesktopSpec as DesktopSpec
 import qualified Agent.CLI.EnvironmentSpec as EnvironmentSpec
 import qualified Agent.CLI.ErrorSpec as ErrorSpec
 import qualified Agent.CLI.FileUriSpec as FileUriSpec
@@ -99,6 +100,7 @@ main = hspec do
     CredentialStoreSpec.spec
     DialectsSpec.spec
     DatabaseSpec.spec
+    DesktopSpec.spec
     EnvironmentSpec.spec
     ErrorSpec.spec
     FileUriSpec.spec


### PR DESCRIPTION
## Summary

- add `/desktop` to the slash-command catalog, parser, help, and REPL dispatch
- open the current persisted conversation in the installed macOS app through a percent-encoded `haskell-agent://session/...` deep link
- report clear errors on non-macOS hosts, missing/outdated desktop installations, and conversations without a persisted session ID
- add command parsing and desktop launch-contract coverage

A companion change in the private native macOS repository registers and handles the deep link.

## Validation

- `nix develop -c cabal repl agent-cli:lib:agent-cli --offline` (all 200 modules loaded; `/desktop` parser and URL/launch assertions passed)
- live tmux smoke: `/desktop` reported success and opened the expected persisted conversation in the native app
- Nix flake CI: passed (1,287 examples)
- `git diff --check`
