### PR TITLE
Redirect system temp paths to session scratch

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -62,6 +62,7 @@ import Agent.Json.Decode (optionalKey)
 import qualified Agent.Json.Decode as Hermes
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
+import Agent.Tools.IO (sessionTempProcessEnv)
 import Agent.Tools.Types
     ( AppTool
     , ToolExecutionPolicy(..)
@@ -492,11 +493,12 @@ launchSessionTurnInput
         setFileMode readyPath 0o600
         let childEnv =
                 (managedSessionReadyEnv, readyPath)
-                    : filter
-                        (\(name, _) ->
-                            name /= managedSessionReadyEnv
-                                && name `notElem` gatewayOnlyEnv)
-                        parentEnv
+                    : sessionTempProcessEnv handle.sessionTempDir
+                        (filter
+                            (\(name, _) ->
+                                name /= managedSessionReadyEnv
+                                    && name `notElem` gatewayOnlyEnv)
+                            parentEnv)
             logPath = unsafeToFilePath handle.sessionDir FilePath.</> "agent.log"
             approvalArgs = case policy of
                 ApproveAll -> ["--yolo"]

--- a/packages/agent-cli/src/Agent/CLI/Dialects.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dialects.hs
@@ -76,6 +76,7 @@ data CodingTools = CodingTools
     { codingAppTools :: ![AppTool]
     , codingPlanMode :: !PlanModeEnv
     , codingSuspendGhci :: !(IO ())
+    , codingResetSessionTemp :: !(OsPath -> IO ())
     , codingClose :: !(IO ())
     , codingAgentTypes :: !GrokSubagentSpecs
     , codingGrokRuntime :: !(Maybe GrokRuntimeControl)
@@ -137,7 +138,8 @@ codingToolsForWithTypes
                 _ -> Nothing
         secretTools = maybe [] (pure . askSecretTool) secretStore
         imageTools = maybe [] (pure . showImageTool env) imageHooks
-        finish tools includeArtifacts plan suspendGhci close agentTypes grokRuntime =
+        finish tools includeArtifacts plan suspendGhci resetSessionTemp
+                close agentTypes grokRuntime =
             CodingTools
                 { codingAppTools =
                     tools
@@ -148,6 +150,7 @@ codingToolsForWithTypes
                         <> imageTools
                 , codingPlanMode = plan
                 , codingSuspendGhci = suspendGhci
+                , codingResetSessionTemp = resetSessionTemp
                 , codingClose = close `finally` closeSecrets
                 , codingAgentTypes = agentTypes
                 , codingGrokRuntime = grokRuntime
@@ -161,6 +164,7 @@ codingToolsForWithTypes
                     True
                     coding.codexPlanMode
                     coding.codexSuspendGhci
+                    coding.codexResetSessionTemp
                     coding.codexClose
                     typesRef
                     Nothing
@@ -172,6 +176,7 @@ codingToolsForWithTypes
                     True
                     coding.grokPlanMode
                     coding.grokSuspendGhci
+                    coding.grokResetSessionTemp
                     coding.grokClose
                     coding.grokAgentTypes
                     (Just coding.grokRuntimeControl)
@@ -183,6 +188,7 @@ codingToolsForWithTypes
                     False
                     plan
                     (pure ())
+                    (\_tempDir -> pure ())
                     (pure ())
                     typesRef
                     Nothing

--- a/packages/agent-cli/src/Agent/CLI/InputBudget.hs
+++ b/packages/agent-cli/src/Agent/CLI/InputBudget.hs
@@ -15,11 +15,13 @@ import Agent.InterAgentMessage
 import Agent.Loop
     ( FileAttachment(..)
     , ImageAttachment(..)
+    , TurnAttachment(..)
     , TurnInput(..)
     )
 import Agent.ToolDispatch (ToolCallResult(..))
 import qualified Data.ByteString as ByteString
 import Data.Char (ord)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -53,13 +55,10 @@ logicalTurnInputBytes = \case
         logicalTextBytes message.messageAuthor
             `saturatingAdd` logicalTextBytes message.messageRecipient
             `saturatingAdd` logicalTextBytes (interAgentMessagePayload message)
-    UserMultimodal text images ->
+    UserMessageWithAttachments text attachments ->
         logicalTextBytes text
-            `saturatingAdd` foldBytes logicalImageBytes images
-    UserMultimodalFiles text images files ->
-        logicalTextBytes text
-            `saturatingAdd` foldBytes logicalImageBytes images
-            `saturatingAdd` foldBytes logicalFileBytes files
+            `saturatingAdd` foldBytes logicalAttachmentBytes
+                (NonEmpty.toList attachments)
     CompletedTool result ->
         logicalTextBytes result.callId
             `saturatingAdd` logicalTextBytes result.output
@@ -87,6 +86,11 @@ logicalReplLineBytes = \case
 foldBytes :: (a -> Int) -> [a] -> Int
 foldBytes measure =
     foldr (\value total -> measure value `saturatingAdd` total) 0
+
+logicalAttachmentBytes :: TurnAttachment -> Int
+logicalAttachmentBytes = \case
+    ImageAttachmentItem image -> logicalImageBytes image
+    FileAttachmentItem file -> logicalFileBytes file
 
 saturatingAdd :: Int -> Int -> Int
 saturatingAdd left right

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -202,7 +202,8 @@ sessionTempGuidance = \case
             [ "Session temporary directory: " <> toText path
             , "Use this private directory for clones, downloads, extracted files, generated assets, and other scratch work."
             , "Filesystem tools may access both the workspace and this directory; relative paths still resolve against the workspace."
-            , "HASKELL_AGENT_TMPDIR and TMPDIR point to this directory for shell commands."
+            , "Filesystem-tool paths under /tmp or /private/tmp are redirected into this directory."
+            , "HASKELL_AGENT_TMPDIR and TMPDIR point to this directory for shell commands; use $TMPDIR instead of a literal /tmp or /private/tmp path."
             ]
 
 -- | Keep sensitive values outside model-visible text and tool arguments when

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -99,7 +99,8 @@ import Agent.CLI.Session.Runtime.Types
     ( SessionRequest(codexCatalogSession, SessionRequest, catalog, modelInfo,
                      connectionId, options, provider, dialect, policy, allTools,
                      recordImageGenerationInputs, clearImageGenerationHistory,
-                     suspendGhci, grokRuntime, mcpRegistrations, mcpWarnings,
+                     suspendGhci, resetToolSessionTemp, grokRuntime,
+                     mcpRegistrations, mcpWarnings,
                      mcpInstructions, mcpFleet,
                      ghciEnabledRef, bashEnabledRef, toolEnv, planMode, startup,
                      learnAboutUserRequested, databaseScopes, promptRequest,
@@ -570,6 +571,8 @@ runAgentSession
                                 , recordImageGenerationInputs
                                 , clearImageGenerationHistory
                                 , suspendGhci = coding.codingSuspendGhci
+                                , resetToolSessionTemp =
+                                    coding.codingResetSessionTemp
                                 , grokRuntime = coding.codingGrokRuntime
                                 , mcpRegistrations =
                                     mcpFleet.mcpFleetRegistrations

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -63,6 +63,7 @@ import Agent.CLI.Turn
 import Agent.Cancel
 import Agent.Loop
 import Agent.Dialect
+import Agent.GrokBuild.Dialect.Runtime (GrokRuntimeControl(..))
 import Agent.Skills
 import Agent.Subagents
 import Agent.Subagents.TaskPath
@@ -633,6 +634,12 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             refreshShellParams ghciEnabled bashEnabled
             pure ("shell tools: " <> shellModeLabel mode)
         setSessionTempDir tempDir = do
+            -- Persistent tool runtimes capture temp-backed state at startup.
+            -- Reset them before publishing the new root so no process or
+            -- state file remains attached to the previous session.
+            suspendGhci
+            forM_ grokRuntime \runtime ->
+                runtime.grokResetSessionTemp tempDir
             setToolSessionTmp toolEnv (Just tempDir)
             ghciEnabled <- readIORef ghciEnabledRef
             bashEnabled <- readIORef bashEnabledRef

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -63,7 +63,6 @@ import Agent.CLI.Turn
 import Agent.Cancel
 import Agent.Loop
 import Agent.Dialect
-import Agent.GrokBuild.Dialect.Runtime (GrokRuntimeControl(..))
 import Agent.Skills
 import Agent.Subagents
 import Agent.Subagents.TaskPath
@@ -637,9 +636,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             -- Persistent tool runtimes capture temp-backed state at startup.
             -- Reset them before publishing the new root so no process or
             -- state file remains attached to the previous session.
-            suspendGhci
-            forM_ grokRuntime \runtime ->
-                runtime.grokResetSessionTemp tempDir
+            resetToolSessionTemp tempDir
             setToolSessionTmp toolEnv (Just tempDir)
             ghciEnabled <- readIORef ghciEnabledRef
             bashEnabled <- readIORef bashEnabledRef

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -110,6 +110,7 @@ data SessionRequest = SessionRequest
     , recordImageGenerationInputs :: !([ImageAttachment] -> IO ())
     , clearImageGenerationHistory :: !(IO ())
     , suspendGhci :: !(IO ())
+    , resetToolSessionTemp :: !(OsPath -> IO ())
     , grokRuntime :: !(Maybe GrokRuntimeControl)
     , mcpRegistrations :: ![MCP.McpToolRegistration]
     , mcpWarnings :: ![Text]

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -326,6 +326,30 @@ spec = describe "Agent.CLI.AgentSessions" do
                 args `shouldContain` ["--no-ghci", "--bash"]
                 closeSessionProcessManager manager
 
+    it "points managed child processes at their session temp directory" $
+        withTempStoreDir "agent-session-runtime-" \pool root -> do
+            let envPath = toFilePath root FilePath.</> "agent-temp-env"
+            script <- writeFakeAgentBody root $
+                "printf '%s\\n%s\\n%s\\n' "
+                    <> "\"$TMPDIR\" "
+                    <> "\"$HASKELL_AGENT_TMPDIR\" "
+                    <> "\"${HASKELL_AGENT_HOST_TMPDIR-unset}\" > "
+                    <> shellQuote envPath
+                    <> "\nexit 0\n"
+            withExecutableOverride script do
+                handle <- createSession (testCreateAt pool root root)
+                manager <- newSessionProcessManager root
+                launchSessionTurn manager False ApproveAll True False handle "one"
+                    `shouldReturn`
+                        Right ("completed session " <> handle.sessionMeta.metaId)
+                values <- lines <$> readFile envPath
+                values `shouldBe`
+                    [ toFilePath handle.sessionTempDir
+                    , toFilePath handle.sessionTempDir
+                    , "unset"
+                    ]
+                closeSessionProcessManager manager
+
     it "distinguishes managed deny from remote prompt approval" $
         withTempStoreDir "agent-session-runtime-" \pool root -> do
             let argsPath = toFilePath root FilePath.</> "agent-args"

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -64,6 +64,26 @@ spec = do
                                 && message `Text.isInfixOf` notice
                     _ -> False
 
+        it "rejects hardcoded system temp paths before prompting" do
+            let call = functionToolCall
+                    "call-shell"
+                    "shell_command"
+                    "{\"command\":\"render input.svg /tmp/output.png\"}"
+                facts = (approvalFacts call)
+                    { policy = ApproveAll
+                    , allowedForSession = Just True
+                    }
+            planApproval facts
+                `shouldSatisfy` \case
+                    CompleteApproval
+                        (Left message)
+                        [ReportApprovalNotice (ApprovalWarning notice)] ->
+                            "Blocked hardcoded system temp path"
+                                `Text.isInfixOf` message
+                                && "$TMPDIR" `Text.isInfixOf` message
+                                && message `Text.isInfixOf` notice
+                    _ -> False
+
         it "requests facts in security-precedence order" do
             let initial = approvalFacts mutatingCall
                 classified = initial { readOnly = Just False }

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -327,8 +327,12 @@ spec = describe "systemPrompt" do
             "clones, downloads, extracted files, generated assets"
         childPrompt `shouldSatisfy` Text.isInfixOf
             "relative paths still resolve against the workspace"
+        rootPrompt `shouldSatisfy` Text.isInfixOf
+            "paths under /tmp or /private/tmp are redirected"
         rootPrompt `shouldSatisfy` Text.isInfixOf "HASKELL_AGENT_TMPDIR"
         childPrompt `shouldSatisfy` Text.isInfixOf "TMPDIR"
+        childPrompt `shouldSatisfy` Text.isInfixOf
+            "use $TMPDIR instead of a literal /tmp"
     it "gives subscription-backed OpenAI subagents task-based model guidance" do
         let subscriptionGuidance =
                 subscriptionSubagentModelGuidance

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Runtime.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Runtime.hs
@@ -6,6 +6,7 @@ module Agent.Codex.Dialect.Runtime
 import Agent.Codex.Dialect.Shell
     ( closeCodexShellSession
     , newCodexShellSession
+    , resetCodexShellSession
     )
 import Agent.Codex.Dialect.Tools (codexTools)
 import Agent.ResourceScope
@@ -22,11 +23,13 @@ import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks, newPlanModeEnv)
 import Agent.Tools.Types (AppTool, ToolEnv(..))
 import Control.Exception.Safe (onException)
+import System.OsPath (OsPath)
 
 data CodexCodingTools = CodexCodingTools
     { codexAppTools :: ![AppTool]
     , codexPlanMode :: !PlanModeEnv
     , codexSuspendGhci :: !(IO ())
+    , codexResetSessionTemp :: !(OsPath -> IO ())
     , codexClose :: !(IO ())
     }
 
@@ -50,5 +53,8 @@ newCodexCodingTools env hooks multi = do
             { codexAppTools = tools
             , codexPlanMode = plan
             , codexSuspendGhci = suspendGhciSession ghci
+            , codexResetSessionTemp = \_tempDir -> do
+                suspendGhciSession ghci
+                resetCodexShellSession shellSession
             , codexClose = closeResourceScope resources
             }

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Shell.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Shell.hs
@@ -7,6 +7,7 @@ module Agent.Codex.Dialect.Shell
     ( CodexShellSession
     , CodexShellResult(..)
     , newCodexShellSession
+    , resetCodexShellSession
     , closeCodexShellSession
     , startCodexShellCommand
     , continueCodexShellCommand
@@ -88,6 +89,24 @@ closeCodexShellSession session = do
     commands <- modifyMVar session.sessionCommands \case
         Nothing -> pure (Nothing, [])
         Just current -> pure (Nothing, Map.elems current.storeCommands)
+    stopManagedCommands commands
+
+-- | Stop and forget retained commands while keeping the shell session open.
+-- Preserve the id counter so a stale id from the previous conversation can
+-- never alias a newly started command.
+resetCodexShellSession :: CodexShellSession -> IO ()
+resetCodexShellSession session = do
+    commands <- modifyMVar session.sessionCommands \case
+        Nothing -> pure (Nothing, [])
+        Just current ->
+            pure
+                ( Just current { storeCommands = Map.empty }
+                , Map.elems current.storeCommands
+                )
+    stopManagedCommands commands
+
+stopManagedCommands :: [ManagedCommand] -> IO ()
+stopManagedCommands commands =
     mapConcurrently_
         (\task ->
             void $ try @_ @SomeException $

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -36,7 +36,7 @@ import Agent.Codex.Dialect.Shell
     , startCodexShellCommand
     )
 import Agent.Tools.Ghci (GhciSession, runGhciTool)
-import Agent.Tools.Dangerous (forbiddenRmRfReason, commandLooksLikeRmRf)
+import Agent.Tools.Dangerous (blockedShellCommandReason)
 import Agent.Tools.FileSystem.Grep (grepTool)
 import Agent.Tools.FileSystem.ListDir (listDirTool)
 import Agent.Tools.FileSystem.ReadFile (readFileTool)
@@ -169,6 +169,7 @@ shellDescription :: Text
 shellDescription =
     "Runs a shell command and returns its output.\n\
     \- `workdir` is optional; omit it to use the turn cwd. Do not use `cd` unless absolutely necessary.\n\
+    \- Use `$TMPDIR` for temporary files; literal `/tmp` and `/private/tmp` paths are rejected.\n\
     \- For a long-running command, set `yield_time_ms`; if it is still running, use `write_stdin` with the returned session_id to poll or send input."
 
 runShell
@@ -178,8 +179,8 @@ runShell
     -> ShellCommandArgs
     -> IO (Either Text Text)
 runShell env session emitOutput args
-    | commandLooksLikeRmRf args.command =
-        pure (Left (forbiddenRmRfReason args.command))
+    | Just reason <- blockedShellCommandReason args.command =
+        pure (Left reason)
     | args.timeoutMs /= Nothing && args.yieldTimeMs /= Nothing =
         pure (Left "timeout_ms and yield_time_ms are mutually exclusive")
     | otherwise = do

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -25,6 +25,7 @@ import Agent.Tools.Types
     , appToolHandlers
     , defaultToolEnv
     , mkToolRegistry
+    , setToolSessionTmp
     , toolSchedulingPlanFor
     )
 import Control.Exception.Safe (bracket)
@@ -32,7 +33,9 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Calendar (fromGregorian)
 import System.Directory
-    ( doesFileExist
+    ( canonicalizePath
+    , createDirectory
+    , doesFileExist
     , getTemporaryDirectory
     , removeDirectoryRecursive
     )
@@ -98,6 +101,45 @@ spec = describe "Codex dialect" do
                             "{\"command\":\"test -f cwd-marker && printf cwd-defaulted\"}")
                     result.output
                         `shouldSatisfy` Text.isInfixOf "cwd-defaulted"
+
+    it "rejects literal system temp paths in shell commands" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket
+                (newCodexCodingTools env Nothing Nothing)
+                (.codexClose)
+                \coding -> do
+                    result <- dispatchToolCall
+                        testDispatchConfig
+                        (appToolHandlers coding.codexAppTools)
+                        (functionToolCall
+                            "shell-system-tmp"
+                            "shell_command"
+                            "{\"command\":\"touch /tmp/agent-output\"}")
+                    result.output `shouldSatisfy`
+                        Text.isInfixOf "Blocked hardcoded system temp path"
+                    result.output `shouldSatisfy` Text.isInfixOf "$TMPDIR"
+
+    it "maps a /tmp shell workdir to the private session directory" do
+        withTempDir \dir -> do
+            let scratch = dir </> "session-scratch"
+            createDirectory scratch
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            setToolSessionTmp env (Just (unsafeEncodeUtf scratch))
+            canonicalScratch <- canonicalizePath scratch
+            bracket
+                (newCodexCodingTools env Nothing Nothing)
+                (.codexClose)
+                \coding -> do
+                    result <- dispatchToolCall
+                        testDispatchConfig
+                        (appToolHandlers coding.codexAppTools)
+                        (functionToolCall
+                            "shell-system-tmp-workdir"
+                            "shell_command"
+                            "{\"command\":\"pwd\",\"workdir\":\"/tmp\"}")
+                    result.output `shouldSatisfy`
+                        Text.isInfixOf (Text.pack canonicalScratch)
 
     it "formats project instructions as a contextual user fragment" do
         let loaded = LoadedAgentsMd

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -10,6 +10,14 @@ import Agent.Codex.Dialect.Runtime
     ( CodexCodingTools(..)
     , newCodexCodingTools
     )
+import Agent.Codex.Dialect.Shell
+    ( CodexShellResult(..)
+    , closeCodexShellSession
+    , continueCodexShellCommand
+    , newCodexShellSession
+    , resetCodexShellSession
+    , startCodexShellCommand
+    )
 import Agent.Codex.Dialect.Tools (shellCommandIsReadOnly)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
 import Agent.ToolDispatch
@@ -22,12 +30,14 @@ import Agent.ToolDispatch
 import Agent.Tools.Scheduling (schedulingPlansConflict)
 import Agent.Tools.Types
     ( AppTool(..)
+    , ToolEnv(..)
     , appToolHandlers
     , defaultToolEnv
     , mkToolRegistry
     , setToolSessionTmp
     , toolSchedulingPlanFor
     )
+import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (bracket)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -140,6 +150,44 @@ spec = describe "Codex dialect" do
                             "{\"command\":\"pwd\",\"workdir\":\"/tmp\"}")
                     result.output `shouldSatisfy`
                         Text.isInfixOf (Text.pack canonicalScratch)
+
+    it "stops retained shell commands when resetting a session" do
+        withTempDir \dir -> do
+            let scratch = dir </> "session-scratch"
+                output = scratch </> "retained-output"
+            createDirectory scratch
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            setToolSessionTmp env (Just (unsafeEncodeUtf scratch))
+            bracket
+                (newCodexShellSession env)
+                closeCodexShellSession
+                \session -> do
+                    started <- startCodexShellCommand
+                        session
+                        env.toolCwd
+                        "while :; do printf x >> \"$TMPDIR/retained-output\"; sleep 0.02; done"
+                        100
+                        (\_ _ -> pure ())
+                    commandId <- case started of
+                        Right CodexShellRunning
+                                { codexShellSessionId = runningId } ->
+                            pure runningId
+                        _ -> expectationFailure
+                            "expected a retained command"
+                            >> pure 0
+                    waitForFile output `shouldReturn` True
+                    resetCodexShellSession session
+                    before <- Text.readFile output
+                    threadDelay 100000
+                    Text.readFile output `shouldReturn` before
+                    continued <-
+                        continueCodexShellCommand session commandId "" 1
+                    case continued of
+                        Left message ->
+                            message `shouldBe` "Unknown session_id: "
+                                <> Text.pack (show commandId)
+                        Right _ ->
+                            expectationFailure "stale command remained available"
 
     it "formats project instructions as a contextual user fragment" do
         let loaded = LoadedAgentsMd
@@ -327,6 +375,15 @@ withTempDir action = do
         (mkdtemp (tmp </> "agent-codex-dialect-XXXXXX"))
         removeDirectoryRecursive
         action
+
+waitForFile :: FilePath -> IO Bool
+waitForFile path = go (100 :: Int)
+  where
+    go 0 = doesFileExist path
+    go remaining =
+        doesFileExist path >>= \case
+            True -> pure True
+            False -> threadDelay 10000 >> go (remaining - 1)
 
 testDispatchConfig :: ToolDispatchConfig
 testDispatchConfig = ToolDispatchConfig

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -50,10 +50,12 @@ forbiddenRmRfReason command =
 -- quoted data, heredocs, URLs, or nested programs. Instead, require the
 -- environment variable that the runtime points at the session-private temp
 -- directory. This is intentionally best-effort rather than a shell parser; it
--- recognizes an absolute path at a token-like boundary while avoiding ordinary
--- URL path components and names such as @/tmpfile@.
+-- recognizes absolute paths at token-like boundaries, lexically normalizes
+-- dot/parent components, and avoids ordinary URL path components and names
+-- such as @/tmpfile@.
 commandUsesHardcodedSystemTmp :: Text -> Bool
-commandUsesHardcodedSystemTmp = go Nothing
+commandUsesHardcodedSystemTmp command =
+    go Nothing command || normalizedAbsolutePathTargetsTemp command
   where
     go previous remaining
         | Text.null remaining = False
@@ -94,6 +96,37 @@ commandUsesHardcodedSystemTmp = go Nothing
         Text.null suffix
             || Text.head suffix == '/'
             || not (isPathNameChar (Text.head suffix))
+
+    normalizedAbsolutePathTargetsTemp = scan Nothing
+      where
+        scan previous remaining
+            | Text.null remaining = False
+            | pathBoundaryBefore previous
+            , Text.head remaining == '/' =
+                let (candidate, _) =
+                        Text.span isAbsolutePathChar remaining
+                in normalizedPathTargetsTemp candidate
+                    || advance remaining
+            | otherwise = advance remaining
+          where
+            advance text =
+                scan (Just (Text.head text)) (Text.tail text)
+
+        isAbsolutePathChar char =
+            char == '/' || isPathNameChar char
+
+        normalizedPathTargetsTemp path =
+            case reverse (foldl normalizeComponent [] (Text.splitOn "/" path)) of
+                "tmp" : _ -> True
+                "private" : "tmp" : _ -> True
+                _ -> False
+
+        -- The accumulator is reversed, so an absolute parent component pops
+        -- the most recent ordinary component and clamps at the root.
+        normalizeComponent components component
+            | Text.null component || component == "." = components
+            | component == ".." = drop 1 components
+            | otherwise = component : components
 
     -- A preceding URL/path character means this slash is a path component,
     -- rather than the beginning of an absolute temp path.

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -13,7 +13,14 @@ module Agent.Tools.Dangerous
     ) where
 
 import Agent.JsonText (jsonTextField)
-import Data.Char (isAlphaNum, toLower)
+import Data.Char
+    ( chr
+    , digitToInt
+    , isAlphaNum
+    , isHexDigit
+    , isSpace
+    , toLower
+    )
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -55,7 +62,9 @@ forbiddenRmRfReason command =
 -- such as @/tmpfile@.
 commandUsesHardcodedSystemTmp :: Text -> Bool
 commandUsesHardcodedSystemTmp command =
-    go Nothing command || normalizedAbsolutePathTargetsTemp command
+    go Nothing command
+        || normalizedAbsolutePathTargetsTemp command
+        || localFileUrlTargetsTemp command
   where
     go previous remaining
         | Text.null remaining = False
@@ -112,21 +121,57 @@ commandUsesHardcodedSystemTmp command =
             advance text =
                 scan (Just (Text.head text)) (Text.tail text)
 
-        isAbsolutePathChar char =
-            char == '/' || isPathNameChar char
+    localFileUrlTargetsTemp = scan Nothing
+      where
+        scan previous remaining
+            | Text.null remaining = False
+            | pathBoundaryBefore previous
+            , "file:" == Text.toLower (Text.take 5 remaining)
+            , Just path <- fileUrlAbsolutePath (Text.drop 5 remaining) =
+                normalizedPathTargetsTemp
+                    (percentDecodePath
+                        (Text.takeWhile isFileUrlPathChar path))
+                    || advance remaining
+            | otherwise = advance remaining
+          where
+            advance text =
+                scan (Just (Text.head text)) (Text.tail text)
 
-        normalizedPathTargetsTemp path =
-            case reverse (foldl normalizeComponent [] (Text.splitOn "/" path)) of
-                "tmp" : _ -> True
-                "private" : "tmp" : _ -> True
-                _ -> False
+        fileUrlAbsolutePath afterScheme
+            | Just afterAuthority <- Text.stripPrefix "//" afterScheme =
+                let (_, path) = Text.breakOn "/" afterAuthority
+                in if Text.null path then Nothing else Just path
+            | Text.isPrefixOf "/" afterScheme = Just afterScheme
+            | otherwise = Nothing
 
-        -- The accumulator is reversed, so an absolute parent component pops
-        -- the most recent ordinary component and clamps at the root.
-        normalizeComponent components component
-            | Text.null component || component == "." = components
-            | component == ".." = drop 1 components
-            | otherwise = component : components
+        isFileUrlPathChar char =
+            not (isSpace char)
+                && char `notElem` ("'\";|&()?#" :: String)
+
+    isAbsolutePathChar char =
+        char == '/' || isPathNameChar char
+
+    normalizedPathTargetsTemp path =
+        case reverse (foldl normalizeComponent [] (Text.splitOn "/" path)) of
+            "tmp" : _ -> True
+            "private" : "tmp" : _ -> True
+            _ -> False
+
+    -- The accumulator is reversed, so an absolute parent component pops the
+    -- most recent ordinary component and clamps at the root.
+    normalizeComponent components component
+        | Text.null component || component == "." = components
+        | component == ".." = drop 1 components
+        | otherwise = component : components
+
+    percentDecodePath = Text.pack . decode . Text.unpack
+      where
+        decode ('%' : high : low : rest)
+            | isHexDigit high
+            , isHexDigit low =
+                chr (digitToInt high * 16 + digitToInt low) : decode rest
+        decode (char : rest) = char : decode rest
+        decode [] = []
 
     -- A preceding URL/path character means this slash is a path component,
     -- rather than the beginning of an absolute temp path.

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -1,11 +1,15 @@
 -- | Hard-deny patterns for shell tools, even under auto-approve / yolo.
 --
 -- Inspired by Grok Build's "always-approve + deny rules" and Codex's forbidden
--- exec-policy prefixes. First cut blocks recursive force deletes.
+-- exec-policy prefixes. Blocks recursive force deletes and shell references to
+-- the shared host temp namespace.
 module Agent.Tools.Dangerous
     ( shellCommandBlocked
+    , blockedShellCommandReason
     , commandLooksLikeRmRf
+    , commandUsesHardcodedSystemTmp
     , forbiddenRmRfReason
+    , hardcodedSystemTmpReason
     ) where
 
 import Agent.JsonText (jsonTextField)
@@ -18,13 +22,19 @@ import qualified Data.Text as Text
 shellCommandBlocked :: Text -> Text -> Maybe Text
 shellCommandBlocked toolName argumentsJson
     | toolName `elem`
-        ["run_terminal_cmd", "run_terminal_command", "shell_command"] =
+        ["monitor", "run_terminal_cmd", "run_terminal_command", "shell_command"] =
         case jsonTextField "command" argumentsJson of
             Nothing -> Nothing
-            Just command
-                | commandLooksLikeRmRf command ->
-                    Just (forbiddenRmRfReason command)
-                | otherwise -> Nothing
+            Just command -> blockedShellCommandReason command
+    | otherwise = Nothing
+
+-- | Apply every first-party shell hard-deny in stable precedence order.
+blockedShellCommandReason :: Text -> Maybe Text
+blockedShellCommandReason command
+    | commandLooksLikeRmRf command =
+        Just (forbiddenRmRfReason command)
+    | commandUsesHardcodedSystemTmp command =
+        Just (hardcodedSystemTmpReason command)
     | otherwise = Nothing
 
 forbiddenRmRfReason :: Text -> Text
@@ -32,6 +42,72 @@ forbiddenRmRfReason command =
     "Blocked dangerous shell command (rm -rf / recursive force delete). "
         <> "Remove files more narrowly, or ask the user to run the delete outside the agent. "
         <> "Command: "
+        <> Text.take 200 (Text.strip command)
+
+-- | Reject literal references to the host's shared temp namespace.
+--
+-- Shell source cannot be rewritten safely: a textual substitution could alter
+-- quoted data, heredocs, URLs, or nested programs. Instead, require the
+-- environment variable that the runtime points at the session-private temp
+-- directory. This is intentionally best-effort rather than a shell parser; it
+-- recognizes an absolute path at a token-like boundary while avoiding ordinary
+-- URL path components and names such as @/tmpfile@.
+commandUsesHardcodedSystemTmp :: Text -> Bool
+commandUsesHardcodedSystemTmp = go Nothing
+  where
+    go previous remaining
+        | Text.null remaining = False
+        | tempPathStartsHere previous remaining = True
+        | otherwise =
+            let current = Text.head remaining
+            in go (Just current) (Text.tail remaining)
+
+    tempPathStartsHere previous remaining =
+        pathBoundaryBefore previous
+            && case Text.span (== '/') remaining of
+                (slashes, afterSlashes)
+                    | not (Text.null slashes) ->
+                        tempComponentAtStart afterSlashes
+                            || privateTempAtStart afterSlashes
+                _ -> False
+
+    tempComponentAtStart remaining =
+        case Text.stripPrefix "tmp" remaining of
+            Just suffix -> pathBoundaryAfter suffix
+            Nothing -> False
+
+    privateTempAtStart remaining =
+        case Text.stripPrefix "private" remaining of
+            Just afterPrivate ->
+                case Text.span (== '/') afterPrivate of
+                    (slashes, afterSlashes)
+                        | not (Text.null slashes) ->
+                            tempComponentAtStart afterSlashes
+                    _ -> False
+            Nothing -> False
+
+    pathBoundaryBefore = \case
+        Nothing -> True
+        Just char -> not (isPathOrUrlChar char)
+
+    pathBoundaryAfter suffix =
+        Text.null suffix
+            || Text.head suffix == '/'
+            || not (isPathNameChar (Text.head suffix))
+
+    -- A preceding URL/path character means this slash is a path component,
+    -- rather than the beginning of an absolute temp path.
+    isPathOrUrlChar char =
+        isPathNameChar char || char `elem` ("/:" :: String)
+
+    isPathNameChar char =
+        isAlphaNum char || char `elem` ("._-" :: String)
+
+hardcodedSystemTmpReason :: Text -> Text
+hardcodedSystemTmpReason command =
+    "Blocked hardcoded system temp path. Use $TMPDIR (or \
+    \$HASKELL_AGENT_TMPDIR) so scratch files stay in this session's private \
+    \temp directory; do not use literal /tmp or /private/tmp paths. Command: "
         <> Text.take 200 (Text.strip command)
 
 -- | Best-effort detection for recursive force deletes.

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -142,6 +142,8 @@ commandUsesHardcodedSystemTmp command =
                 let (_, path) = Text.breakOn "/" afterAuthority
                 in if Text.null path then Nothing else Just path
             | Text.isPrefixOf "/" afterScheme = Just afterScheme
+            | Text.isPrefixOf "/" (percentDecodePath afterScheme) =
+                Just afterScheme
             | otherwise = Nothing
 
         isFileUrlPathChar char =

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -19,6 +19,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
 import Data.IORef (readIORef)
+import Data.List (stripPrefix)
 import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Directory.OsPath
@@ -33,8 +34,10 @@ import System.Directory.OsPath
     )
 import System.OsPath
     ( OsPath
+    , dropTrailingPathSeparator
     , equalFilePath
     , isAbsolute
+    , joinPath
     , makeRelative
     , splitDirectories
     , takeDirectory
@@ -46,7 +49,9 @@ import System.IO.Error (isDoesNotExistError)
 
 -- | Resolve a model-supplied path against the tool cwd and reject anything
 -- that canonicalizes outside the cwd or an explicitly allowed root, including
--- via symlinks. Relative paths are always cwd-relative.
+-- via symlinks. Relative paths are always cwd-relative. When a private session
+-- temp root is configured, absolute paths under the system @/tmp@ and
+-- @/private/tmp@ aliases are resolved under that private root instead.
 resolveUnderCwd :: ToolEnv -> OsPath -> IO (Either Text OsPath)
 resolveUnderCwd env requested =
     resolveWithRoots env requested []
@@ -104,25 +109,118 @@ resolveWithRootsAttempt env requested extraRoots = do
     sessionTmp <- readIORef env.toolSessionTmp
     canonicalRoots <-
         mapConcurrentlyBounded rootCanonicalizationConcurrency canonicalizePath
-            ( env.toolCwd
-            : configuredRoots <> extraRoots <> maybe [] pure sessionTmp
-            )
-    let (absCwd, allowedRoots) = case canonicalRoots of
+            (env.toolCwd : configuredRoots <> extraRoots)
+    canonicalSessionTmp <- traverse canonicalizePath sessionTmp
+    let (absCwd, configuredAndExtraRoots) = case canonicalRoots of
             root : roots -> (root, roots)
             [] -> error "resolveWithRoots: cwd canonicalization omitted"
+        allowedRoots =
+            configuredAndExtraRoots <> maybe [] pure canonicalSessionTmp
     let combined
             | isAbsolute requested = requested
             | otherwise = absCwd </> requested
-    exists <- doesPathExist combined
-    resolvedResult <- if exists
-        then Right <$> canonicalizePath combined
-        else resolveMissing combined
-    pure $ case resolvedResult of
-        Left err -> Left (ResolverFailure err)
+        roots = absCwd : allowedRoots
+        tempAlias
+            | isAbsolute requested = systemTempRelative combined
+            | otherwise = Nothing
+    case (canonicalSessionTmp, tempAlias) of
+        (Just tempRoot, Just (aliasRoot, relative)) -> do
+            explicitlyAllowed <-
+                systemTempPathIsAllowed roots aliasRoot relative
+            if explicitlyAllowed
+                then resolveOrdinary roots combined
+                else resolvePrivateTemp requested tempRoot relative
+        _ -> resolveOrdinary roots combined
+
+resolveOrdinary :: [OsPath] -> OsPath -> IO (Either ResolveFailure OsPath)
+resolveOrdinary roots path =
+    resolvePath path >>= \case
+        Left err -> pure (Left (ResolverFailure err))
         Right resolved
-            | any (`isInside` resolved) (absCwd : allowedRoots) ->
-                Right resolved
-            | otherwise -> Left (OutsideAllowedRoots resolved)
+            | any (`isInside` resolved) roots -> pure (Right resolved)
+            | otherwise -> pure (Left (OutsideAllowedRoots resolved))
+
+resolvePrivateTemp
+    :: OsPath
+    -> OsPath
+    -> OsPath
+    -> IO (Either ResolveFailure OsPath)
+resolvePrivateTemp requested tempRoot relative =
+    resolvePath (tempRoot </> relative) >>= \case
+        Left err -> pure (Left (ResolverFailure err))
+        Right resolved
+            | tempRoot `isInside` resolved -> pure (Right resolved)
+            | otherwise ->
+                pure (Left (ResolverFailure (tempEscapeMessage requested)))
+
+resolvePath :: OsPath -> IO (Either Text OsPath)
+resolvePath path = do
+    exists <- doesPathExist path
+    if exists
+        then Right <$> canonicalizePath path
+        else resolveMissing path
+
+-- | Treat both common spellings of the conventional POSIX temp namespace as
+-- aliases for the session-private temp root. Match components before resolving
+-- the path so macOS's @/tmp@ symlink and its @/private/tmp@ target behave the
+-- same way, while preserving @..@ and symlink semantics in the remapped path.
+systemTempRelative :: OsPath -> Maybe (OsPath, OsPath)
+systemTempRelative path =
+    firstMatch [systemTmpRoot, privateSystemTmpRoot]
+  where
+    components =
+        normalizePosixRoot $
+            splitDirectories (dropTrailingPathSeparator path)
+    normalizePosixRoot = \case
+        root : rest
+            | let display = toText root
+            , not (Text.null display)
+            , Text.all (== '/') display ->
+                posixRoot : rest
+        other -> other
+    firstMatch [] = Nothing
+    firstMatch (alias : aliases) =
+        case
+            stripPrefix
+                (splitDirectories (dropTrailingPathSeparator alias))
+                components
+        of
+            Just [] -> Just (alias, currentDirectory)
+            Just relative -> Just (alias, joinPath relative)
+            Nothing -> firstMatch aliases
+
+-- | A preconfigured host-temp root is an explicit escape hatch from the
+-- private alias. Canonicalize only the alias root, not its descendants, so
+-- shared-host files and symlinks cannot affect the default remapping decision.
+systemTempPathIsAllowed
+    :: [OsPath]
+    -> OsPath
+    -> OsPath
+    -> IO Bool
+systemTempPathIsAllowed roots aliasRoot relative =
+    tryAny (canonicalizePath aliasRoot) >>= \case
+        Left _ -> pure False
+        Right canonicalAlias ->
+            pure $
+                any
+                    (`isInside` (canonicalAlias </> relative))
+                    roots
+
+systemTmpRoot :: OsPath
+systemTmpRoot = unsafeEncodeUtf "/tmp"
+
+privateSystemTmpRoot :: OsPath
+privateSystemTmpRoot = unsafeEncodeUtf "/private/tmp"
+
+currentDirectory :: OsPath
+currentDirectory = unsafeEncodeUtf "."
+
+posixRoot :: OsPath
+posixRoot = unsafeEncodeUtf "/"
+
+tempEscapeMessage :: OsPath -> Text
+tempEscapeMessage requested =
+    "Path escapes the private session temp directory: " <> toText requested
 
 outsideRootsMessage :: OsPath -> Text
 outsideRootsMessage requested =

--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -22,7 +22,7 @@ import Agent.Tools.Ghci.Classify
     , defaultGhciExtensions
     , typeLooksEffectful
     )
-import Agent.Tools.IO (terminateProcessGroup)
+import Agent.Tools.IO (configuredProcessEnv, terminateProcessGroup)
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
@@ -530,12 +530,14 @@ ghciArgs =
 
 spawnProcess :: ToolEnv -> IO (Either Text GhciProcess)
 spawnProcess env = do
+    processEnv <- configuredProcessEnv env
     let spec = (proc "ghci" ghciArgs)
             { cwd = Just (unsafeToFilePath env.toolCwd)
             , std_in = CreatePipe
             , std_out = CreatePipe
             , std_err = CreatePipe
             , create_group = True
+            , env = processEnv
             }
     spawned <- try @_ @SomeException $ mask \restore -> do
         created@(_, _, _, handle) <- createProcess spec

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -18,6 +18,8 @@ module Agent.Tools.IO
     , runShellCommandStreaming
     , startShellCommand
     , startShellCommandWithInput
+    , configuredProcessEnv
+    , sessionTempProcessEnv
     , writeShellCommandInput
     , interruptShellCommand
     , stopShellCommand
@@ -419,19 +421,27 @@ startShellCommandWithStdin keepStdin env workdir command = do
 configuredProcessEnv :: ToolEnv -> IO (Maybe [(String, String)])
 configuredProcessEnv env = readIORef env.toolSessionTmp >>= \case
     Nothing -> pure Nothing
-    Just temp -> do
-        inherited <- getEnvironment
-        let tempPath = unsafeToFilePath temp
-            withoutTemp =
-                filter
-                    (\(name, _) ->
-                        name /= "TMPDIR" && name /= "HASKELL_AGENT_TMPDIR")
-                    inherited
-        pure $ Just
-            ( ("TMPDIR", tempPath)
-            : ("HASKELL_AGENT_TMPDIR", tempPath)
-            : withoutTemp
-            )
+    Just temp ->
+        Just . sessionTempProcessEnv temp <$> getEnvironment
+
+-- | Point a child process at one session's private scratch directory without
+-- mutating the parent process environment (several sessions may coexist).
+sessionTempProcessEnv :: OsPath -> [(String, String)] -> [(String, String)]
+sessionTempProcessEnv temp inherited =
+    ( ("TMPDIR", tempPath)
+    : ("HASKELL_AGENT_TMPDIR", tempPath)
+    : withoutTemp
+    )
+  where
+    tempPath = unsafeToFilePath temp
+    withoutTemp =
+        filter
+            (\(name, _) ->
+                name /= "TMPDIR"
+                    && name /= "HASKELL_AGENT_TMPDIR"
+                    -- Never propagate an ambient host-temp escape.
+                    && name /= "HASKELL_AGENT_HOST_TMPDIR")
+            inherited
 
 acquireRunningCommand :: ToolEnv -> CreateProcess -> Bool -> IO RunningCommand
 acquireRunningCommand env spec keepStdin = mask \restore -> do

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -115,7 +115,8 @@ data ToolEnv = ToolEnv
     { toolCwd :: !OsPath
     , toolAllowedRoots :: !(IORef [OsPath])
       -- | Additional non-session filesystem roots. The current
-      -- 'toolSessionTmp' is always allowed implicitly.
+      -- 'toolSessionTmp' is always allowed implicitly and receives absolute
+      -- @/tmp@ and @/private/tmp@ filesystem-tool paths by default.
     , toolRootAccessRequest :: !(IORef (Maybe (OsPath -> IO Bool)))
       -- | Optional session-local callback used when a path falls outside
       -- the configured roots. An approved path is added to
@@ -171,8 +172,9 @@ setToolSkillRoots :: ToolEnv -> [OsPath] -> IO ()
 setToolSkillRoots env = writeIORef env.toolSkillRoots
 
 -- | Change the private scratch directory used by subsequent filesystem and
--- shell calls. The resolver treats this value as an allowed root directly, so
--- changing it cannot get out of sync with a separately maintained roots list.
+-- shell calls. The resolver treats this value as an allowed root and the
+-- target of the system-temp aliases directly, so changing it cannot get out of
+-- sync with a separately maintained roots list.
 setToolSessionTmp :: ToolEnv -> Maybe OsPath -> IO ()
 setToolSessionTmp env = writeIORef env.toolSessionTmp
 

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -181,6 +181,18 @@ spec = do
                 ]
                 `shouldBe` replicate 4 True
 
+        it "blocks local file URLs targeting shared temp" do
+            map commandUsesHardcodedSystemTmp
+                [ "curl file:///tmp/other-session"
+                , "curl file:/tmp/other-session"
+                , "curl FILE:///private/tmp/other-session"
+                , "curl file://localhost/tmp/other-session"
+                , "curl file:///usr/../tmp/other-session"
+                , "curl file:///%74mp/other-session"
+                , "curl file:///%2fprivate%2ftmp/other-session"
+                ]
+                `shouldBe` replicate 7 True
+
         it "allows session temp variables and unrelated tmp path components" do
             commandUsesHardcodedSystemTmp "touch \"$TMPDIR/result.png\""
                 `shouldBe` False
@@ -195,6 +207,13 @@ spec = do
                 `shouldBe` False
             commandUsesHardcodedSystemTmp
                 "curl https://example.test/usr/../tmp/file"
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp
+                "curl https://example.test/%74mp/file"
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp "curl file:///tmpfile"
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp "curl file:///var/tmp/file"
                 `shouldBe` False
             commandUsesHardcodedSystemTmp "cat /usr/../tmpfile"
                 `shouldBe` False

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -172,6 +172,15 @@ spec = do
             commandUsesHardcodedSystemTmp "cat /private//tmp/input.txt"
                 `shouldBe` True
 
+        it "normalizes absolute aliases of the shared temp roots" do
+            map commandUsesHardcodedSystemTmp
+                [ "touch /usr/../tmp/output"
+                , "cat /var/../private/tmp/input"
+                , "touch /var/cache/../../tmp/output"
+                , "cat '/usr/local/../../private//tmp/input'"
+                ]
+                `shouldBe` replicate 4 True
+
         it "allows session temp variables and unrelated tmp path components" do
             commandUsesHardcodedSystemTmp "touch \"$TMPDIR/result.png\""
                 `shouldBe` False
@@ -183,6 +192,13 @@ spec = do
             commandUsesHardcodedSystemTmp "cat build/tmp/result.png"
                 `shouldBe` False
             commandUsesHardcodedSystemTmp "curl https://example.test/tmp/file"
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp
+                "curl https://example.test/usr/../tmp/file"
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp "cat /usr/../tmpfile"
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp "cat /usr/../private/tmpfile"
                 `shouldBe` False
 
     describe "shellCommandBlocked" do

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -2,7 +2,9 @@ module Agent.Tools.DangerousSpec (spec) where
 
 import Agent.Tools.Dangerous
     ( commandLooksLikeRmRf
+    , commandUsesHardcodedSystemTmp
     , forbiddenRmRfReason
+    , hardcodedSystemTmpReason
     , shellCommandBlocked
     )
 import qualified Data.Aeson as Aeson
@@ -155,6 +157,34 @@ spec = do
                 \(BenignCommand command) ->
                     commandLooksLikeRmRf command === False
 
+    describe "commandUsesHardcodedSystemTmp" do
+        it "recognizes system temp paths in common shell positions" do
+            commandUsesHardcodedSystemTmp "touch /tmp/result.png"
+                `shouldBe` True
+            commandUsesHardcodedSystemTmp "OUT=/tmp/result.png make"
+                `shouldBe` True
+            commandUsesHardcodedSystemTmp "cat '/private/tmp/input.txt'"
+                `shouldBe` True
+            commandUsesHardcodedSystemTmp "cd /tmp"
+                `shouldBe` True
+            commandUsesHardcodedSystemTmp "touch ///tmp/result.png"
+                `shouldBe` True
+            commandUsesHardcodedSystemTmp "cat /private//tmp/input.txt"
+                `shouldBe` True
+
+        it "allows session temp variables and unrelated tmp path components" do
+            commandUsesHardcodedSystemTmp "touch \"$TMPDIR/result.png\""
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp
+                "touch \"$HASKELL_AGENT_TMPDIR/result.png\""
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp "echo /tmpfile"
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp "cat build/tmp/result.png"
+                `shouldBe` False
+            commandUsesHardcodedSystemTmp "curl https://example.test/tmp/file"
+                `shouldBe` False
+
     describe "shellCommandBlocked" do
         it "blocks shell tools with a clear reason" do
             shouldBlock "run_terminal_cmd" "{\"command\":\"rm -rf /tmp/x\"}"
@@ -167,6 +197,24 @@ spec = do
             msg `shouldSatisfy` Text.isInfixOf "Blocked dangerous shell command"
             msg `shouldSatisfy` Text.isInfixOf "rm -rf /tmp/very-important"
 
+        it "rejects hardcoded system temp paths before approval" do
+            let args = "{\"command\":\"convert in.svg /tmp/out.png\"}"
+            case shellCommandBlocked "shell_command" args of
+                Just msg -> do
+                    msg `shouldSatisfy`
+                        Text.isInfixOf "Blocked hardcoded system temp path"
+                    msg `shouldSatisfy` Text.isInfixOf "$TMPDIR"
+                Nothing -> expectationFailure "expected hardcoded temp block"
+            shellCommandBlocked "monitor"
+                "{\"command\":\"tail -f /private/tmp/events\"}"
+                `shouldSatisfy`
+                    maybe False
+                        (Text.isInfixOf "Blocked hardcoded system temp path")
+
+        it "includes a truncated command snippet in the temp-path reason" do
+            let msg = hardcodedSystemTmpReason "cat /tmp/session.log"
+            msg `shouldSatisfy` Text.isInfixOf "cat /tmp/session.log"
+
         it "parses JSON with whitespace around the command value" do
             shouldBlock "run_terminal_cmd" "{\"command\" : \"rm -rf x\"}"
 
@@ -178,7 +226,8 @@ spec = do
                         [ isBlocked (shellCommandBlocked tool arguments)
                             === True
                         | tool <-
-                            [ "run_terminal_cmd"
+                            [ "monitor"
+                            , "run_terminal_cmd"
                             , "run_terminal_command"
                             , "shell_command"
                             ]

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -190,8 +190,11 @@ spec = do
                 , "curl file:///usr/../tmp/other-session"
                 , "curl file:///%74mp/other-session"
                 , "curl file:///%2fprivate%2ftmp/other-session"
+                , "curl file:%2ftmp/other-session"
+                , "curl file:%2Fprivate%2Ftmp/other-session"
+                , "curl file:%2fusr%2f..%2ftmp/other-session"
                 ]
-                `shouldBe` replicate 7 True
+                `shouldBe` replicate 10 True
 
         it "allows session temp variables and unrelated tmp path components" do
             commandUsesHardcodedSystemTmp "touch \"$TMPDIR/result.png\""

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -24,6 +24,7 @@ import Agent.Tools.Types
     ( ToolEnv(..)
     , defaultToolEnv
     , mkToolRegistry
+    , setToolSessionTmp
     , toolSchedulingPlanFor
     )
 import Control.Concurrent (threadDelay)
@@ -32,7 +33,8 @@ import Control.Exception.Safe (SomeException, bracket, try)
 import Data.Either (isRight)
 import qualified Data.Text as Text
 import System.Directory
-    ( getTemporaryDirectory
+    ( createDirectory
+    , getTemporaryDirectory
     , removeDirectoryRecursive
     )
 import System.FilePath ((</>))
@@ -185,6 +187,20 @@ spec = describe "Agent.Tools.Ghci" do
                 result.ghciOk `shouldBe` True
                 result.ghciOutput `shouldSatisfy`
                     Text.isInfixOf (Text.pack (toFilePath env.toolCwd))
+
+    it "inherits the private session temp environment" do
+        withTempEnv \env -> do
+            let scratch = toFilePath env.toolCwd </> "session-scratch"
+            createDirectory scratch
+            setToolSessionTmp env (Just (fromFilePath scratch))
+            bracket (newGhciSession env) closeGhciSession \ghci -> do
+                result <- evalGhci ghci
+                    "cmd \"sh\" [\"-c\", \"printf '%s|%s|%s' \\\"$TMPDIR\\\" \\\"$HASKELL_AGENT_TMPDIR\\\" \\\"${HASKELL_AGENT_HOST_TMPDIR-unset}\\\"\"]"
+                    10000
+                result.ghciOk `shouldBe` True
+                result.ghciOutput `shouldSatisfy`
+                    Text.isInfixOf
+                        (Text.pack (scratch <> "|" <> scratch <> "|unset"))
 
     it "restores helpers after loading a module clears interactive bindings" do
         withTempEnv \env -> do

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -188,19 +188,33 @@ spec = describe "Agent.Tools.Ghci" do
                 result.ghciOutput `shouldSatisfy`
                     Text.isInfixOf (Text.pack (toFilePath env.toolCwd))
 
-    it "inherits the private session temp environment" do
+    it "refreshes the private temp environment after suspension" do
         withTempEnv \env -> do
-            let scratch = toFilePath env.toolCwd </> "session-scratch"
-            createDirectory scratch
-            setToolSessionTmp env (Just (fromFilePath scratch))
+            let firstScratch = toFilePath env.toolCwd </> "first-session"
+                nextScratch = toFilePath env.toolCwd </> "next-session"
+            createDirectory firstScratch
+            createDirectory nextScratch
+            setToolSessionTmp env (Just (fromFilePath firstScratch))
             bracket (newGhciSession env) closeGhciSession \ghci -> do
-                result <- evalGhci ghci
+                first <- evalGhci ghci
                     "cmd \"sh\" [\"-c\", \"printf '%s|%s|%s' \\\"$TMPDIR\\\" \\\"$HASKELL_AGENT_TMPDIR\\\" \\\"${HASKELL_AGENT_HOST_TMPDIR-unset}\\\"\"]"
                     10000
-                result.ghciOk `shouldBe` True
-                result.ghciOutput `shouldSatisfy`
+                first.ghciOk `shouldBe` True
+                first.ghciOutput `shouldSatisfy`
                     Text.isInfixOf
-                        (Text.pack (scratch <> "|" <> scratch <> "|unset"))
+                        (Text.pack
+                            (firstScratch <> "|" <> firstScratch <> "|unset"))
+
+                setToolSessionTmp env (Just (fromFilePath nextScratch))
+                suspendGhciSession ghci
+                next <- evalGhci ghci
+                    "cmd \"sh\" [\"-c\", \"printf '%s|%s|%s' \\\"$TMPDIR\\\" \\\"$HASKELL_AGENT_TMPDIR\\\" \\\"${HASKELL_AGENT_HOST_TMPDIR-unset}\\\"\"]"
+                    10000
+                next.ghciOk `shouldBe` True
+                next.ghciOutput `shouldSatisfy`
+                    Text.isInfixOf
+                        (Text.pack
+                            (nextScratch <> "|" <> nextScratch <> "|unset"))
 
     it "restores helpers after loading a module clears interactive bindings" do
         withTempEnv \env -> do

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -18,6 +18,7 @@ import Agent.Tools.IO
     , runShellCommand
     , runShellCommandStreaming
     , runningLiveOutput
+    , sessionTempProcessEnv
     , startShellCommand
     , startShellCommandWithInput
     , stopShellCommand
@@ -51,7 +52,7 @@ import System.Directory
     , listDirectory
     , removeDirectoryRecursive
     )
-import System.FilePath ((</>))
+import System.FilePath ((</>), takeFileName)
 import System.IO (IOMode(..), hClose, openFile)
 import System.IO.Error (alreadyInUseErrorType, mkIOError)
 import System.Posix.Temp (mkdtemp)
@@ -225,8 +226,109 @@ spec = describe "Agent.Tools.IO" do
             resolveUnderCwd env (fromFilePath scratchFile)
                 >>= (`shouldSatisfy` isRight)
             resolveUnderCwd env
-                (fromFilePath (dir </> "unrelated" </> "file.txt"))
+                (fromFilePath "/haskell-agent-unrelated-root/file.txt")
                 >>= (`shouldSatisfy` isLeft)
+
+    it "maps system temp paths into the private session temp root" do
+        withTempDir \dir -> do
+            let workspace = dir </> "workspace"
+                scratch = dir </> "scratch"
+                relative = "literal-tmp" </> "artifact.txt"
+            mapM_ createDirectory [workspace, scratch]
+            env <- defaultToolEnv (fromFilePath workspace)
+            setToolSessionTmp env (Just (fromFilePath scratch))
+            requests <- newIORef []
+            setToolRootAccessRequest env $ Just \root -> do
+                modifyIORef' requests (<> [root])
+                pure False
+            canonicalScratch <- canonicalizePath scratch
+            canonicalSystemTmp <- canonicalizePath "/tmp"
+            let expected = Right (fromFilePath (canonicalScratch </> relative))
+            resolveUnderCwd env (fromFilePath "/tmp")
+                `shouldReturn` Right (fromFilePath canonicalScratch)
+            resolveUnderCwd env (fromFilePath "/tmp/")
+                `shouldReturn` Right (fromFilePath canonicalScratch)
+            resolveUnderCwd env (fromFilePath ("/tmp" </> relative))
+                `shouldReturn` expected
+            resolveUnderCwd env (fromFilePath ("//tmp" </> relative))
+                `shouldReturn` expected
+            resolveUnderCwd env (fromFilePath ("///tmp" </> relative))
+                `shouldReturn` expected
+            resolveUnderCwd env (fromFilePath ("////tmp" </> relative))
+                `shouldReturn` expected
+            resolveUnderCwd env
+                (fromFilePath ("/tmp//" <> relative))
+                `shouldReturn` expected
+            resolveUnderCwd env
+                (fromFilePath (canonicalSystemTmp </> relative))
+                `shouldReturn` expected
+            resolveUnderCwd env
+                (fromFilePath ("/private/tmp" </> relative))
+                `shouldReturn` expected
+            readIORef requests `shouldReturn` []
+
+    it "maps an existing host temp file unless its root was explicitly allowed" do
+        withTempDir \dir ->
+            withSystemTempDir \hostTemp -> do
+                let workspace = dir </> "workspace"
+                    scratch = dir </> "scratch"
+                    hostFile = hostTemp </> "existing.txt"
+                    relative = takeFileName hostTemp </> "existing.txt"
+                    requested = "/tmp" </> relative
+                mapM_ createDirectory [workspace, scratch]
+                writeFile hostFile "host"
+                canonicalScratch <- canonicalizePath scratch
+                canonicalHostFile <- canonicalizePath hostFile
+
+                mappedEnv <- defaultToolEnv (fromFilePath workspace)
+                setToolSessionTmp mappedEnv (Just (fromFilePath scratch))
+                resolveUnderCwd mappedEnv (fromFilePath requested)
+                    `shouldReturn` Right
+                        (fromFilePath (canonicalScratch </> relative))
+
+                allowedEnv <- defaultToolEnv (fromFilePath workspace)
+                setToolSessionTmp allowedEnv (Just (fromFilePath scratch))
+                writeIORef allowedEnv.toolAllowedRoots [fromFilePath hostTemp]
+                resolveUnderCwd allowedEnv (fromFilePath requested)
+                    `shouldReturn` Right (fromFilePath canonicalHostFile)
+
+    it "does not let a remapped temp path escape through a session symlink" do
+        withTempDir \dir -> do
+            let workspace = dir </> "workspace"
+                scratch = dir </> "scratch"
+                outside = dir </> "outside"
+                alias = "literal-tmp-link"
+            mapM_ createDirectory [workspace, scratch, outside]
+            createDirectoryLink outside (scratch </> alias)
+            env <- defaultToolEnv (fromFilePath workspace)
+            setToolSessionTmp env (Just (fromFilePath scratch))
+            requests <- newIORef []
+            setToolRootAccessRequest env $ Just \root -> do
+                modifyIORef' requests (<> [root])
+                pure True
+            result <- resolveUnderCwd env
+                (fromFilePath ("/tmp" </> alias </> "missing.txt"))
+            result `shouldSatisfy` isLeft
+            result `shouldSatisfy`
+                either
+                    (Text.isInfixOf
+                        "escapes the private session temp directory")
+                    (const False)
+            traversal <- resolveUnderCwd env
+                (fromFilePath ("/tmp" </> ".." </> "outside.txt"))
+            traversal `shouldSatisfy`
+                either
+                    (Text.isInfixOf
+                        "escapes the private session temp directory")
+                    (const False)
+            doubleSlashTraversal <- resolveUnderCwd env
+                (fromFilePath "//tmp/../outside.txt")
+            doubleSlashTraversal `shouldSatisfy`
+                either
+                    (Text.isInfixOf
+                        "escapes the private session temp directory")
+                    (const False)
+            readIORef requests `shouldReturn` []
 
     it "requests and remembers approval for an escaped filesystem root" do
         withTempDir \dir -> do
@@ -294,10 +396,24 @@ spec = describe "Agent.Tools.IO" do
                 env = base
             setToolSessionTmp env (Just scratchPath)
             result <- runShellCommand env scratchPath
-                "printf '%s\\n%s' \"$TMPDIR\" \"$HASKELL_AGENT_TMPDIR\""
+                "printf '%s\\n%s\\n%s' \"$TMPDIR\" \"$HASKELL_AGENT_TMPDIR\" \"${HASKELL_AGENT_HOST_TMPDIR-unset}\""
                 5000
             result.commandStdout `shouldBe`
-                Text.pack scratch <> "\n" <> Text.pack scratch
+                Text.pack scratch <> "\n" <> Text.pack scratch <> "\nunset"
+
+    it "replaces inherited temp variables without exposing host temp" do
+        let scratch = fromFilePath "/session/private"
+        sessionTempProcessEnv scratch
+            [ ("TMPDIR", "/host/tmp")
+            , ("HASKELL_AGENT_TMPDIR", "/host/tmp")
+            , ("HASKELL_AGENT_HOST_TMPDIR", "/tmp")
+            , ("KEEP", "yes")
+            ]
+            `shouldBe`
+                [ ("TMPDIR", "/session/private")
+                , ("HASKELL_AGENT_TMPDIR", "/session/private")
+                , ("KEEP", "yes")
+                ]
 
     it "switches the effective session temp root without retaining the old one" do
         withTempDir \dir -> do
@@ -307,10 +423,12 @@ spec = describe "Agent.Tools.IO" do
             mapM_ createDirectory [workspace, first, second]
             env <- defaultToolEnv (fromFilePath workspace)
             setToolSessionTmp env (Just (fromFilePath first))
-            resolveUnderCwd env (fromFilePath (first </> "file.txt"))
+            resolveUnderCwd env
+                (fromFilePath (".." </> "first" </> "file.txt"))
                 >>= (`shouldSatisfy` isRight)
             setToolSessionTmp env (Just (fromFilePath second))
-            resolveUnderCwd env (fromFilePath (first </> "file.txt"))
+            resolveUnderCwd env
+                (fromFilePath (".." </> "first" </> "file.txt"))
                 >>= (`shouldSatisfy` isLeft)
             resolveUnderCwd env (fromFilePath (second </> "file.txt"))
                 >>= (`shouldSatisfy` isRight)
@@ -528,3 +646,9 @@ withTempDir action = do
         (mkdtemp (tmp </> "agent-io-XXXXXX"))
         removeDirectoryRecursive
         action
+
+withSystemTempDir :: (FilePath -> IO a) -> IO a
+withSystemTempDir =
+    bracket
+        (mkdtemp "/tmp/agent-io-host-XXXXXX")
+        removeDirectoryRecursive

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Monitor.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Monitor.hs
@@ -6,7 +6,7 @@ module Agent.GrokBuild.Dialect.Monitor
 import qualified Agent.Json.Decode as Json
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
-import Agent.Tools.Dangerous (commandLooksLikeRmRf, forbiddenRmRfReason)
+import Agent.Tools.Dangerous (blockedShellCommandReason)
 import Agent.GrokBuild.Dialect.Common (jsonTool)
 import Agent.GrokBuild.Dialect.Json (optionalBool, optionalIntOrString)
 import Agent.GrokBuild.Dialect.Shell (GrokSession, startMonitor)
@@ -49,14 +49,15 @@ monitorDescription :: Text
 monitorDescription =
     "Start a background monitor that streams events from a long-running script. Each stdout line is an event; exit ends the watch.\n\n\
     \Print only meaningful status changes. Use line-buffered commands in pipes so events are not delayed.\n\n\
+    \Use `$TMPDIR` for temporary files; literal `/tmp` and `/private/tmp` paths are rejected.\n\n\
     \Set persistent=true for session-length watches. Otherwise the monitor stops at timeout_ms (default 10h)."
 
 runMonitor :: GrokSession -> MonitorArgs -> IO (Either Text Text)
 runMonitor session args
     | Text.null (Text.strip args.description) =
         pure (Left "Missing parameter: description")
-    | commandLooksLikeRmRf args.command =
-        pure (Left (forbiddenRmRfReason args.command))
+    | Just reason <- blockedShellCommandReason args.command =
+        pure (Left reason)
     | not args.persistent
     , Just timeout <- args.timeoutMs
     , timeout > maxMonitorTimeoutMs =

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Runtime.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Runtime.hs
@@ -19,6 +19,7 @@ import Agent.GrokBuild.Dialect.Tools
     , grokTools
     , newGrokSession
     )
+import Agent.GrokBuild.Dialect.Shell (resetGrokSessionTemp)
 import Agent.GrokBuild.Dialect.Workflow
     ( WorkflowRuntime
     , newWorkflowRuntime
@@ -39,6 +40,7 @@ import Agent.Tools.Types (AppTool, ToolEnv(..))
 import Control.Exception.Safe (onException)
 import Control.Monad (forM)
 import Data.Maybe (isNothing)
+import System.OsPath (OsPath)
 
 data GrokCodingTools = GrokCodingTools
     { grokAppTools :: ![AppTool]
@@ -56,6 +58,7 @@ data GrokRuntimeControl = GrokRuntimeControl
     { grokGoalRuntime :: !GoalRuntime
     , grokSchedulerRuntime :: !(Maybe SchedulerRuntime)
     , grokWorkflowRuntime :: !(Maybe WorkflowRuntime)
+    , grokResetSessionTemp :: !(OsPath -> IO ())
     }
 
 newGrokCodingTools
@@ -88,6 +91,7 @@ newGrokCodingTools env hooks multi typesRef = do
                 { grokGoalRuntime = goals
                 , grokSchedulerRuntime = scheduler
                 , grokWorkflowRuntime = workflows
+                , grokResetSessionTemp = resetGrokSessionTemp session
                 }
         pure GrokCodingTools
             { grokAppTools =

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Runtime.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Runtime.hs
@@ -46,6 +46,7 @@ data GrokCodingTools = GrokCodingTools
     { grokAppTools :: ![AppTool]
     , grokPlanMode :: !PlanModeEnv
     , grokSuspendGhci :: !(IO ())
+    , grokResetSessionTemp :: !(OsPath -> IO ())
     , grokClose :: !(IO ())
     , grokAgentTypes :: !GrokSubagentSpecs
     , grokRuntimeControl :: !GrokRuntimeControl
@@ -58,7 +59,6 @@ data GrokRuntimeControl = GrokRuntimeControl
     { grokGoalRuntime :: !GoalRuntime
     , grokSchedulerRuntime :: !(Maybe SchedulerRuntime)
     , grokWorkflowRuntime :: !(Maybe WorkflowRuntime)
-    , grokResetSessionTemp :: !(OsPath -> IO ())
     }
 
 newGrokCodingTools
@@ -91,7 +91,6 @@ newGrokCodingTools env hooks multi typesRef = do
                 { grokGoalRuntime = goals
                 , grokSchedulerRuntime = scheduler
                 , grokWorkflowRuntime = workflows
-                , grokResetSessionTemp = resetGrokSessionTemp session
                 }
         pure GrokCodingTools
             { grokAppTools =
@@ -106,6 +105,9 @@ newGrokCodingTools env hooks multi typesRef = do
                     typesRef
             , grokPlanMode = plan
             , grokSuspendGhci = suspendGhciSession ghci
+            , grokResetSessionTemp = \tempDir -> do
+                suspendGhciSession ghci
+                resetGrokSessionTemp session tempDir
             , grokClose = closeResourceScope resources
             , grokAgentTypes = typesRef
             , grokRuntimeControl = runtimeControl

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -106,7 +106,10 @@ newGrokSession env = do
   where
     acquireEnvFile =
         mask \restore -> do
-            tmp <- getCanonicalTemporaryDirectory
+            tmp <-
+                readIORef env.toolSessionTmp >>= \case
+                    Just sessionTmp -> pure (unsafeToFilePath sessionTmp)
+                    Nothing -> getCanonicalTemporaryDirectory
             (envFileRaw, handle) <- restore $
                 openTempFile tmp "agent-grok-env"
             let envFile = unsafeEncodeUtf envFileRaw

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -7,6 +7,7 @@ module Agent.GrokBuild.Dialect.Shell
     ( GrokSession(..)
     , PersistentShell(..)
     , newGrokSession
+    , resetGrokSessionTemp
     , closeGrokSession
     , runForegroundStreaming
     , startBackground
@@ -77,6 +78,7 @@ data BackgroundTaskStore = BackgroundTaskStore
 data GrokSession = GrokSession
     { grokEnv :: !ToolEnv
     , grokShell :: !(MVar PersistentShell)
+    , grokShellEnvResource :: !(IORef ResourceKey)
     , grokTasks :: !(MVar BackgroundTaskStore)
     , grokTodos :: !(IORef (Map Text (Text, Text)))
     , grokResources :: !ResourceScope
@@ -86,11 +88,16 @@ newGrokSession :: ToolEnv -> IO GrokSession
 newGrokSession env = do
     resources <- newResourceScope
     flip onException (closeResourceScope resources) do
-        (_, envFile) <- allocateResource resources acquireEnvFile cleanupEnvFiles
+        tempDir <- currentSessionTempDir env
+        (envResource, envFile) <-
+            allocateResource resources
+                (acquireEnvFile tempDir)
+                cleanupEnvFiles
         shell <- newMVar PersistentShell
             { shellCwd = env.toolCwd
             , shellEnvFile = envFile
             }
+        shellEnvResource <- newIORef envResource
         tasks <- newMVar BackgroundTaskStore
             { backgroundNextId = 0
             , backgroundTasks = Map.empty
@@ -99,30 +106,64 @@ newGrokSession env = do
         pure GrokSession
             { grokEnv = env
             , grokShell = shell
+            , grokShellEnvResource = shellEnvResource
             , grokTasks = tasks
             , grokTodos = todos
             , grokResources = resources
             }
-  where
-    acquireEnvFile =
-        mask \restore -> do
-            tmp <-
-                readIORef env.toolSessionTmp >>= \case
-                    Just sessionTmp -> pure (unsafeToFilePath sessionTmp)
-                    Nothing -> getCanonicalTemporaryDirectory
-            (envFileRaw, handle) <- restore $
-                openTempFile tmp "agent-grok-env"
-            let envFile = unsafeEncodeUtf envFileRaw
-            let rollback = do
-                    void $ tryAny (hClose handle)
-                    removeIfExists envFile
-            flip onException rollback do
-                hClose handle
-                setFileMode envFileRaw
-                    (unionFileModes ownerReadMode ownerWriteMode)
-                Text.writeFile envFileRaw ""
-                pure envFile
-    cleanupEnvFiles envFile = do
+
+-- | Reset the persistent shell state when the host switches conversations.
+-- The previous session directory may already have been removed by the time
+-- this runs, so allocate a fresh state file under the new private temp root
+-- and reset cwd/environment state rather than retaining dead paths.
+resetGrokSessionTemp :: GrokSession -> OsPath -> IO ()
+resetGrokSessionTemp session tempDir =
+    mask \restore -> do
+        (nextResource, nextEnvFile) <- restore $
+            allocateResource session.grokResources
+                (acquireEnvFile tempDir)
+                cleanupEnvFiles
+        previousResource <-
+            (modifyMVar session.grokShell \shell ->
+                do
+                    previous <-
+                        readIORef session.grokShellEnvResource
+                    writeIORef session.grokShellEnvResource nextResource
+                    pure
+                        ( shell
+                            { shellCwd = session.grokEnv.toolCwd
+                            , shellEnvFile = nextEnvFile
+                            }
+                        , previous
+                        ))
+                `onException` releaseResource nextResource
+        releaseResource previousResource
+
+currentSessionTempDir :: ToolEnv -> IO OsPath
+currentSessionTempDir env =
+    readIORef env.toolSessionTmp >>= \case
+        Just sessionTmp -> pure sessionTmp
+        Nothing -> unsafeEncodeUtf <$> getCanonicalTemporaryDirectory
+
+acquireEnvFile :: OsPath -> IO OsPath
+acquireEnvFile tempDir =
+    mask \restore -> do
+        (envFileRaw, handle) <- restore $
+            openTempFile (unsafeToFilePath tempDir) "agent-grok-env"
+        let envFile = unsafeEncodeUtf envFileRaw
+        let rollback = do
+                void $ tryAny (hClose handle)
+                removeIfExists envFile
+        flip onException rollback do
+            hClose handle
+            setFileMode envFileRaw
+                (unionFileModes ownerReadMode ownerWriteMode)
+            Text.writeFile envFileRaw ""
+            pure envFile
+
+cleanupEnvFiles :: OsPath -> IO ()
+cleanupEnvFiles envFile =
+    void $ tryAny do
         removeIfExists envFile
         removeIfExists (envFile <.> unsafeEncodeUtf "cwd")
 

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -39,7 +39,7 @@ import Agent.Tools.IO
     )
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (race)
+import Control.Concurrent.Async (mapConcurrently_, race)
 import Control.Concurrent.MVar
 import Control.Exception.Safe (mask, onException, throwIO, tryAny)
 import Control.Monad (void)
@@ -117,7 +117,8 @@ newGrokSession env = do
 -- this runs, so allocate a fresh state file under the new private temp root
 -- and reset cwd/environment state rather than retaining dead paths.
 resetGrokSessionTemp :: GrokSession -> OsPath -> IO ()
-resetGrokSessionTemp session tempDir =
+resetGrokSessionTemp session tempDir = do
+    resetGrokBackgroundTasks session
     mask \restore -> do
         (nextResource, nextEnvFile) <- restore $
             allocateResource session.grokResources
@@ -171,9 +172,21 @@ cleanupEnvFiles envFile =
 -- Call this when the CLI/session ends, including after exceptions.
 closeGrokSession :: GrokSession -> IO ()
 closeGrokSession session = do
-    modifyMVar_ session.grokTasks \store ->
-        pure store { backgroundTasks = Map.empty }
+    resetGrokBackgroundTasks session
     closeResourceScope session.grokResources
+
+-- | Stop and forget background commands from the previous conversation.
+-- Preserve the id counter so stale task ids cannot alias newly started work.
+resetGrokBackgroundTasks :: GrokSession -> IO ()
+resetGrokBackgroundTasks session = do
+    tasks <- modifyMVar session.grokTasks \store ->
+        pure
+            ( store { backgroundTasks = Map.empty }
+            , Map.elems store.backgroundTasks
+            )
+    mapConcurrently_
+        (\task -> void $ tryAny $ releaseResource task.backgroundResource)
+        tasks
 
 runForegroundStreaming
     :: GrokSession

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
@@ -7,7 +7,7 @@ import Agent.ToolDispatch
     , decodeToolArguments
     , typedStreamingTool
     )
-import Agent.Tools.Dangerous (commandLooksLikeRmRf, forbiddenRmRfReason)
+import Agent.Tools.Dangerous (blockedShellCommandReason)
 import Agent.GrokBuild.Dialect.Common (jsonTool, stripAnsi)
 import Agent.GrokBuild.Dialect.Json
     ( optionalBool
@@ -90,6 +90,7 @@ terminalDescription :: Text
 terminalDescription =
     "Run a bash command and return its output.\n\
     \- Always set a timeout for commands that may hang.\n\
+    \- Use `$TMPDIR` for temporary files; literal `/tmp` and `/private/tmp` paths are rejected.\n\
     \- Prefer dedicated tools (read_file, grep, list_dir, search_replace) over shell equivalents when they exist."
 
 runTerminal
@@ -100,8 +101,8 @@ runTerminal
 runTerminal session emitOutput args
     | Text.null args.description =
         pure (Left "Missing parameter: description")
-    | commandLooksLikeRmRf args.command =
-        pure (Left (forbiddenRmRfReason args.command))
+    | Just reason <- blockedShellCommandReason args.command =
+        pure (Left reason)
     | not args.background && hasUnwaitedBackgroundOp args.command =
         pure $ Left
             "The command contains a background '&'. Set background=true to run it as a background task, or append `wait` if you meant to wait for the children."

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -5,8 +5,10 @@ import Agent.GrokBuild.Dialect.Shell
     , PersistentShell(..)
     , closeGrokSession
     , newGrokSession
+    , readTaskOutput
     , resetGrokSessionTemp
     , runForegroundStreaming
+    , startBackground
     )
 import Agent.GrokBuild.Dialect.ProjectInstructions (formatGrokAgentsMd)
 import Agent.GrokBuild.Dialect.Prompt
@@ -31,6 +33,7 @@ import Agent.Tools.Types
     , setToolSessionTmp
     , toolSchedulingPlanFor
     )
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar (readMVar)
 import Control.Exception.Safe (bracket)
 import Data.Bits ((.&.))
@@ -38,6 +41,7 @@ import Data.IORef (newIORef)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 import Data.Time.Calendar (fromGregorian)
 import System.Directory
     ( createDirectory
@@ -284,6 +288,32 @@ spec = describe "Grok Build dialect" do
                 result.commandExitCode `shouldBe` Just 0
                 result.commandStdout `shouldBe` "reset-ok"
 
+    it "stops background tasks when the session temp directory changes" do
+        withTempDir \dir -> do
+            let firstScratch = dir </> "first-session"
+                nextScratch = dir </> "next-session"
+                output = firstScratch </> "background-output"
+            createDirectory firstScratch
+            createDirectory nextScratch
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            setToolSessionTmp env (Just (unsafeEncodeUtf firstScratch))
+            bracket (newGrokSession env) closeGrokSession \session -> do
+                started <- startBackground session
+                    "while :; do printf x >> \"$TMPDIR/background-output\"; sleep 0.02; done"
+                taskId <- case started of
+                    Right runningId -> pure runningId
+                    Left err -> expectationFailure (Text.unpack err) >> pure ""
+                waitForFile output `shouldReturn` True
+
+                resetGrokSessionTemp session (unsafeEncodeUtf nextScratch)
+                setToolSessionTmp env (Just (unsafeEncodeUtf nextScratch))
+
+                before <- Text.readFile output
+                threadDelay 100000
+                Text.readFile output `shouldReturn` before
+                readTaskOutput session taskId Nothing
+                    `shouldReturn` ("Unknown task_id: " <> taskId)
+
     it "formats and neutralizes project instruction reminders" do
         let loaded = LoadedAgentsMd
                 { loadedGlobal = Nothing
@@ -303,6 +333,15 @@ spec = describe "Grok Build dialect" do
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir = withSystemTempDirectory "agent-grok-build-dialect"
+
+waitForFile :: FilePath -> IO Bool
+waitForFile path = go (100 :: Int)
+  where
+    go 0 = doesFileExist path
+    go remaining =
+        doesFileExist path >>= \case
+            True -> pure True
+            False -> threadDelay 10000 >> go (remaining - 1)
 
 withGrokRegistry
     :: (ToolRegistry -> IO () -> IO a)

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -25,6 +25,7 @@ import Agent.Tools.Types
     , ToolRegistry
     , defaultToolEnv
     , mkToolRegistry
+    , setToolSessionTmp
     , toolSchedulingPlanFor
     )
 import Control.Concurrent.MVar (readMVar)
@@ -35,7 +36,8 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import System.Directory (doesFileExist)
+import System.Directory (createDirectory, doesFileExist)
+import System.FilePath ((</>), takeDirectory)
 import System.IO.Temp (withSystemTempDirectory)
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Files (fileMode, getFileStatus)
@@ -222,6 +224,17 @@ spec = describe "Grok Build dialect" do
                 pure path
         doesFileExist path `shouldReturn` False
         doesFileExist (path <> ".cwd") `shouldReturn` False
+
+    it "stores shell state in the private session temp directory" do
+        withTempDir \dir -> do
+            let scratch = dir </> "session-scratch"
+            createDirectory scratch
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            setToolSessionTmp env (Just (unsafeEncodeUtf scratch))
+            bracket (newGrokSession env) closeGrokSession \session -> do
+                shell <- readMVar session.grokShell
+                takeDirectory (unsafeToFilePath shell.shellEnvFile)
+                    `shouldBe` scratch
 
     it "formats and neutralizes project instruction reminders" do
         let loaded = LoadedAgentsMd

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -5,6 +5,8 @@ import Agent.GrokBuild.Dialect.Shell
     , PersistentShell(..)
     , closeGrokSession
     , newGrokSession
+    , resetGrokSessionTemp
+    , runForegroundStreaming
     )
 import Agent.GrokBuild.Dialect.ProjectInstructions (formatGrokAgentsMd)
 import Agent.GrokBuild.Dialect.Prompt
@@ -20,6 +22,7 @@ import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
 import Agent.OsPath (unsafeToFilePath)
 import Agent.ToolDispatch (ToolCall, functionToolCall)
 import Agent.Tools.Scheduling (schedulingPlansConflict)
+import Agent.Tools.IO (CommandResult(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ToolRegistry
@@ -36,7 +39,11 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import System.Directory (createDirectory, doesFileExist)
+import System.Directory
+    ( createDirectory
+    , doesFileExist
+    , removeDirectoryRecursive
+    )
 import System.FilePath ((</>), takeDirectory)
 import System.IO.Temp (withSystemTempDirectory)
 import System.OsPath (unsafeEncodeUtf)
@@ -235,6 +242,47 @@ spec = describe "Grok Build dialect" do
                 shell <- readMVar session.grokShell
                 takeDirectory (unsafeToFilePath shell.shellEnvFile)
                     `shouldBe` scratch
+
+    it "recreates shell state after the session temp directory changes" do
+        withTempDir \dir -> do
+            let firstScratch = dir </> "first-session"
+                nextScratch = dir </> "next-session"
+            createDirectory firstScratch
+            createDirectory nextScratch
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            setToolSessionTmp env (Just (unsafeEncodeUtf firstScratch))
+            bracket (newGrokSession env) closeGrokSession \session -> do
+                moved <- runForegroundStreaming
+                    session
+                    "cd \"$TMPDIR\""
+                    10000
+                    (\_ _ -> pure ())
+                moved.commandExitCode `shouldBe` Just 0
+                firstShell <- readMVar session.grokShell
+                let firstEnvFile =
+                        unsafeToFilePath firstShell.shellEnvFile
+                unsafeToFilePath firstShell.shellCwd
+                    `shouldBe` firstScratch
+                removeDirectoryRecursive firstScratch
+
+                resetGrokSessionTemp session (unsafeEncodeUtf nextScratch)
+                setToolSessionTmp env (Just (unsafeEncodeUtf nextScratch))
+
+                nextShell <- readMVar session.grokShell
+                let nextEnvFile =
+                        unsafeToFilePath nextShell.shellEnvFile
+                nextEnvFile `shouldNotBe` firstEnvFile
+                takeDirectory nextEnvFile `shouldBe` nextScratch
+                unsafeToFilePath nextShell.shellCwd `shouldBe` dir
+                doesFileExist nextEnvFile `shouldReturn` True
+
+                result <- runForegroundStreaming
+                    session
+                    "printf reset-ok"
+                    10000
+                    (\_ _ -> pure ())
+                result.commandExitCode `shouldBe` Just 0
+                result.commandStdout `shouldBe` "reset-ok"
 
     it "formats and neutralizes project instruction reminders" do
         let loaded = LoadedAgentsMd


### PR DESCRIPTION
## Summary

- transparently redirect structured `/tmp` and `/private/tmp` paths, including shell-tool working directories, into each agent session's private scratch directory
- point shell commands, GHCi, Grok state, and managed child-agent processes at the same scratch directory through `TMPDIR` / `HASKELL_AGENT_TMPDIR`
- reject literal, lexically equivalent, and local `file:` URL references to shared temp in raw shell source with guidance to use `$TMPDIR` (rewriting arbitrary shell text is not safe)
- reset persistent tool runtimes when `/new` changes the private temp root

## Confinement

- preserve `..` and symlink semantics, rejecting structured-path escapes from session scratch without prompting for broader filesystem access
- normalize absolute shell-path candidates so aliases such as `/usr/../tmp` cannot bypass the shared-temp guard
- recognize case-insensitive local `file:` URLs with single/triple slashes, authorities, traversal, and percent-encoded path components while keeping remote HTTP(S) URL paths exempt
- retain an explicitly configured filesystem root as the controlled opt-out
- strip inherited host-temp escape variables rather than exposing shared `/tmp`
- stop and join Codex retained commands and Grok background/monitor tasks before publishing a new temp root
- recreate Grok's private state file and respawn GHCi instead of retaining paths or process environments from the previous session

## Integration

- adapt CLI input-byte accounting to the normalized attachment constructors from the two newly merged base branches; this isolated compatibility commit repairs the current master integration failure

## Validation

- full agent-core suite in GHCi: 465 examples, 0 failures
- full Codex dialect suite in GHCi: 13 examples, 0 failures
- full Grok Build dialect suite in GHCi: 48 examples, 0 failures
- full agent-cli suite in GHCi: 1,361 examples, 0 failures, 1 pending (using `/var/tmp` to keep PostgreSQL Unix-socket paths below the platform limit)
- session-switch regressions delete the old Grok scratch directory, stop looping Codex/Grok writers, reject stale retained ids, and verify GHCi respawns with only the new temp environment
- path regressions cover parent traversal aliases, repeated separators, local file URLs, percent encoding, remote URLs, and `/tmpfile` near-misses
- live tmux smoke with `gpt-5.6-sol`: structured `/tmp` write/read and a `/tmp` workdir resolved under the session temp directory; a literal shell `/tmp` path was rejected; host `/tmp` remained untouched
- `git diff --check` on the final rebased commits
