### PR TITLE
Model valid LSP request shapes

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Lsp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Lsp.hs
@@ -42,8 +42,10 @@ import Agent.Json.Decode
 import Agent.Json.Decode qualified as Hermes
 import Agent.GrokBuild.Dialect.Lsp
     ( LspOperation(..)
+    , LspPosition(..)
+    , LspPositionOperation(..)
     , LspRequest(..)
-    , lspOperationName
+    , lspPositionOperation
     , lspTool
     )
 import Agent.OsPath (unsafeToFilePath)
@@ -449,175 +451,185 @@ initializeClient client = do
                                                         ("settings notification failed: "
                                                             <> err))
                                             Right () -> pure (Right ())
+
 runLsp :: LspRuntime -> LspRequest -> IO (Either Text Text)
-runLsp runtime request =
-    case request.lspOperation of
-        WorkspaceSymbol -> runWorkspaceSymbol runtime request
-        operation -> do
-            prepared <- prepareFileRequest runtime request
-            case prepared of
-                Left err -> pure (Left err)
-                Right (client, path, uri) ->
-                    dispatchFileOperation client path uri request operation
-runWorkspaceSymbol
+runLsp runtime = \case
+    LspWorkspaceSymbols query ->
+        runWorkspaceSymbols runtime query
+    LspDocumentSymbols filePath ->
+        runFileOperation runtime filePath runDocumentSymbols
+    LspAtPosition operation filePath position ->
+        runFileOperation runtime filePath \client uri ->
+            runPositionOperation client uri operation position
+
+runWorkspaceSymbols
     :: LspRuntime
-    -> LspRequest
+    -> Text
     -> IO (Either Text Text)
-runWorkspaceSymbol runtime request =
-    case Text.strip <$> request.lspQuery of
-        Nothing -> pure (Left "workspaceSymbol requires query")
-        Just query | Text.null query ->
-            pure (Left "workspaceSymbol requires a non-empty query")
-        Just query -> do
-            results <-
-                forM
-                    (Map.toAscList runtime.runtimeClients)
-                    \(name, client) -> do
-                        result <-
-                            requestClient client requestTimeoutMilliseconds
-                                "workspace/symbol"
-                                (Aeson.object ["query" .= query])
-                        pure (name, result)
-            let successes =
-                    [ (name, value)
-                    | (name, Right value) <- results
+runWorkspaceSymbols runtime rawQuery
+    | Text.null query =
+        pure (Left "workspaceSymbol requires a non-empty query")
+    | otherwise = do
+        results <-
+            forM
+                (Map.toAscList runtime.runtimeClients)
+                \(name, client) -> do
+                    result <-
+                        requestClient client requestTimeoutMilliseconds
+                            "workspace/symbol"
+                            (Aeson.object ["query" .= query])
+                    pure (name, result)
+        let successes =
+                [ (name, value)
+                | (name, Right value) <- results
+                ]
+        if null successes
+            then
+                pure . Left $
+                    "workspaceSymbol failed for every configured server: "
+                        <> Text.intercalate "; "
+                            [ name <> ": " <> err
+                            | (name, Left err) <- results
+                            ]
+            else
+                pure . Right . Text.intercalate "\n\n" $
+                    [ "## " <> name <> "\n"
+                        <> formatLspResult WorkspaceSymbol value
+                    | (name, value) <- successes
                     ]
-            if null successes
-                then
-                    pure . Left $
-                        "workspaceSymbol failed for every configured server: "
-                            <> Text.intercalate "; "
-                                [ name <> ": " <> err
-                                | (name, Left err) <- results
-                                ]
-                else
-                    pure . Right . Text.intercalate "\n\n" $
-                        [ "## " <> name <> "\n"
-                            <> formatLspResult WorkspaceSymbol value
-                        | (name, value) <- successes
-                        ]
+  where
+    query = Text.strip rawQuery
+
+runFileOperation
+    :: LspRuntime
+    -> Text
+    -> (LspClient -> Text -> IO (Either Text Text))
+    -> IO (Either Text Text)
+runFileOperation runtime rawPath operation =
+    prepareFileRequest runtime rawPath >>= \case
+        Left err -> pure (Left err)
+        Right (client, path, uri) ->
+            withMVar client.clientOperationLock \() ->
+                synchronizeDocument client path uri >>= \case
+                    Left err -> pure (Left err)
+                    Right () -> operation client uri
+
 prepareFileRequest
     :: LspRuntime
-    -> LspRequest
-    -> IO (Either Text (LspClient, FilePath, Text))
-prepareFileRequest runtime request =
-    case request.lspFilePath of
-        Nothing ->
-            pure
-                (Left
-                    ( lspOperationName request.lspOperation
-                        <> " requires file_path"
-                    ))
-        Just rawPath -> do
-            let path = Text.unpack rawPath
-            if not (FilePath.isAbsolute path)
-                then pure (Left "lsp file_path must be absolute")
-                else do
-                    canonicalResult <-
-                        tryAny $
-                            (,)
-                                <$> canonicalizePath runtime.runtimeWorkspace
-                                <*> canonicalizePath path
-                    case canonicalResult of
-                        Left exception ->
-                            pure . Left $
-                                "lsp could not resolve file_path: "
-                                    <> exceptionText exception
-                        Right (workspace, canonical)
-                            | not
-                                (pathWithin
-                                    workspace
-                                    canonical) ->
-                                pure
-                                    (Left
-                                        "lsp file_path must be inside the \
-                                        \active workspace")
-                            | otherwise ->
-                                case clientForPath
-                                    runtime.runtimeClients canonical
-                                of
-                                    Nothing ->
-                                        pure . Left $
-                                            "No initialized LSP server is \
-                                            \configured for "
-                                                <> Text.pack
-                                                    (FilePath.takeExtension
-                                                        canonical)
-                                    Just client
-                                        | not
-                                            (pathWithin
-                                                client.clientWorkspace
-                                                canonical) ->
-                                            pure . Left $
-                                                "lsp file_path is outside the \
-                                                \configured server workspace for "
-                                                    <> client.clientName
-                                    Just client ->
-                                        pure
-                                            (Right
-                                                ( client
-                                                , canonical
-                                                , fileUri canonical
-                                                ))
-dispatchFileOperation
-    :: LspClient
-    -> FilePath
     -> Text
-    -> LspRequest
-    -> LspOperation
+    -> IO (Either Text (LspClient, FilePath, Text))
+prepareFileRequest runtime rawPath = do
+    let path = Text.unpack rawPath
+    if not (FilePath.isAbsolute path)
+        then pure (Left "lsp file_path must be absolute")
+        else do
+            canonicalResult <-
+                tryAny $
+                    (,)
+                        <$> canonicalizePath runtime.runtimeWorkspace
+                        <*> canonicalizePath path
+            case canonicalResult of
+                Left exception ->
+                    pure . Left $
+                        "lsp could not resolve file_path: "
+                            <> exceptionText exception
+                Right (workspace, canonical)
+                    | not
+                        (pathWithin
+                            workspace
+                            canonical) ->
+                        pure
+                            (Left
+                                "lsp file_path must be inside the \
+                                \active workspace")
+                    | otherwise ->
+                        case clientForPath
+                            runtime.runtimeClients canonical
+                        of
+                            Nothing ->
+                                pure . Left $
+                                    "No initialized LSP server is \
+                                    \configured for "
+                                        <> Text.pack
+                                            (FilePath.takeExtension canonical)
+                            Just client
+                                | not
+                                    (pathWithin
+                                        client.clientWorkspace
+                                        canonical) ->
+                                    pure . Left $
+                                        "lsp file_path is outside the \
+                                        \configured server workspace for "
+                                            <> client.clientName
+                            Just client ->
+                                pure
+                                    (Right
+                                        ( client
+                                        , canonical
+                                        , fileUri canonical
+                                        ))
+
+runDocumentSymbols
+    :: LspClient
+    -> Text
     -> IO (Either Text Text)
-dispatchFileOperation client path uri request operation =
-    withMVar client.clientOperationLock \() ->
-        synchronizeDocument client path uri >>= \case
-            Left err -> pure (Left err)
-            Right () ->
-                case operation of
-                    DocumentSymbol ->
-                        run "textDocument/documentSymbol"
-                            (Aeson.object
-                                [ "textDocument" .=
-                                    Aeson.object ["uri" .= uri]
-                                ])
-                    GoToDefinition ->
-                        position "textDocument/definition"
-                    FindReferences ->
-                        positionWith
-                            "textDocument/references"
-                            ["context" .=
-                                Aeson.object
-                                    ["includeDeclaration" .= True]]
-                    Hover -> position "textDocument/hover"
-                    GoToImplementation ->
-                        position "textDocument/implementation"
-                    WorkspaceSymbol ->
-                        pure (Left "internal LSP dispatch error")
+runDocumentSymbols client uri =
+    runClientOperation
+        client
+        DocumentSymbol
+        "textDocument/documentSymbol"
+        (Aeson.object
+            [ "textDocument" .=
+                Aeson.object ["uri" .= uri]
+            ])
+
+runPositionOperation
+    :: LspClient
+    -> Text
+    -> LspPositionOperation
+    -> LspPosition
+    -> IO (Either Text Text)
+runPositionOperation client uri positionOperation position =
+    runClientOperation client operation method $
+        Aeson.object
+            ( [ "textDocument" .=
+                    Aeson.object ["uri" .= uri]
+              , "position" .= Aeson.object
+                    [ "line" .= position.positionLine
+                    , "character" .= position.positionCharacter
+                    ]
+              ]
+                <> extras
+            )
   where
-    position method = positionWith method []
-    positionWith method extras =
-        case (request.lspLine, request.lspCharacter) of
-            (Just line, Just character)
-                | line >= 0 && character >= 0 ->
-                    run method
-                        (Aeson.object
-                            ( [ "textDocument" .=
-                                    Aeson.object ["uri" .= uri]
-                              , "position" .= Aeson.object
-                                    [ "line" .= line
-                                    , "character" .= character
-                                    ]
-                              ]
-                                <> extras
-                            ))
-            _ ->
-                pure . Left $
-                    lspOperationName operation
-                        <> " requires non-negative line and character"
-    run method params =
-        requestClient client requestTimeoutMilliseconds method params
-            >>= \case
-                Left err -> pure (Left err)
-                Right value ->
-                    pure (Right (formatLspResult operation value))
+    operation = lspPositionOperation positionOperation
+    (method, extras) = case positionOperation of
+        LspGoToDefinition ->
+            ("textDocument/definition", [])
+        LspFindReferences ->
+            ( "textDocument/references"
+            , [ "context" .=
+                    Aeson.object ["includeDeclaration" .= True]
+              ]
+            )
+        LspHover ->
+            ("textDocument/hover", [])
+        LspGoToImplementation ->
+            ("textDocument/implementation", [])
+
+runClientOperation
+    :: LspClient
+    -> LspOperation
+    -> Text
+    -> Aeson.Value
+    -> IO (Either Text Text)
+runClientOperation client operation method params =
+    requestClient client requestTimeoutMilliseconds method params
+        >>= \case
+            Left err -> pure (Left err)
+            Right value ->
+                pure (Right (formatLspResult operation value))
+
 synchronizeDocument
     :: LspClient
     -> FilePath

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Lsp.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Lsp.hs
@@ -1,8 +1,11 @@
 -- | Grok Build's model-facing @lsp@ contract.
 module Agent.GrokBuild.Dialect.Lsp
     ( LspOperation(..)
+    , LspPosition(..)
+    , LspPositionOperation(..)
     , LspRequest(..)
     , lspOperationName
+    , lspPositionOperation
     , lspTool
     ) where
 
@@ -14,6 +17,7 @@ import Agent.ToolDispatch (typedTool)
 import Agent.Tools.Types (AppTool, ToolExecutionPolicy(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Numeric.Natural (Natural)
 
 data LspOperation
     = GoToDefinition
@@ -23,6 +27,27 @@ data LspOperation
     | DocumentSymbol
     | WorkspaceSymbol
     deriving (Eq, Show)
+
+-- | An LSP operation that requires a source position.
+data LspPositionOperation
+    = LspGoToDefinition
+    | LspFindReferences
+    | LspHover
+    | LspGoToImplementation
+    deriving (Eq, Show)
+
+data LspPosition = LspPosition
+    { positionLine :: !Natural
+    , positionCharacter :: !Natural
+    }
+    deriving (Eq, Show)
+
+lspPositionOperation :: LspPositionOperation -> LspOperation
+lspPositionOperation = \case
+    LspGoToDefinition -> GoToDefinition
+    LspFindReferences -> FindReferences
+    LspHover -> Hover
+    LspGoToImplementation -> GoToImplementation
 
 lspOperationName :: LspOperation -> Text
 lspOperationName = \case
@@ -48,23 +73,59 @@ lspOperationDecoder = Json.withText \value ->
                         <> Text.unpack value
                     )
 
-data LspRequest = LspRequest
-    { lspOperation :: !LspOperation
-    , lspFilePath :: !(Maybe Text)
-    , lspLine :: !(Maybe Int)
-    , lspCharacter :: !(Maybe Int)
-    , lspQuery :: !(Maybe Text)
-    }
+-- | A structurally valid request decoded from the flat model-facing schema.
+data LspRequest
+    = LspAtPosition !LspPositionOperation !Text !LspPosition
+    | LspDocumentSymbols !Text
+    | LspWorkspaceSymbols !Text
     deriving (Eq, Show)
 
 lspRequestDecoder :: Json.Decoder LspRequest
-lspRequestDecoder = Json.object $
-        LspRequest
-            <$> Json.atKey "operation" lspOperationDecoder
-            <*> optionalTextValue "file_path"
-            <*> optionalInt "line"
-            <*> optionalInt "character"
-            <*> optionalTextValue "query"
+lspRequestDecoder = Json.object do
+    operation <- Json.atKey "operation" lspOperationDecoder
+    case operation of
+        GoToDefinition ->
+            positionRequest LspGoToDefinition operation
+        FindReferences ->
+            positionRequest LspFindReferences operation
+        Hover ->
+            positionRequest LspHover operation
+        GoToImplementation ->
+            positionRequest LspGoToImplementation operation
+        DocumentSymbol ->
+            LspDocumentSymbols <$> requiredFilePath operation
+        WorkspaceSymbol ->
+            workspaceSymbolsRequest
+  where
+    positionRequest positionOperation operation =
+        LspAtPosition positionOperation
+            <$> requiredFilePath operation
+            <*> (LspPosition
+                <$> coordinate operation "line"
+                <*> coordinate operation "character")
+    coordinate operation key =
+        optionalInt key >>= \case
+            Just value | value >= 0 ->
+                pure (fromIntegral value)
+            _ ->
+                fail . Text.unpack $
+                    lspOperationName operation
+                        <> " requires non-negative line and character"
+    requiredFilePath operation =
+        optionalTextValue "file_path" >>= \case
+            Just filePath -> pure filePath
+            Nothing ->
+                fail . Text.unpack $
+                    lspOperationName operation <> " requires file_path"
+    workspaceSymbolsRequest =
+        optionalTextValue "query" >>= \case
+            Nothing ->
+                fail "workspaceSymbol requires query"
+            Just rawQuery
+                | Text.null (Text.strip rawQuery) ->
+                    fail "workspaceSymbol requires a non-empty query"
+                | otherwise ->
+                    pure (LspWorkspaceSymbols (Text.strip rawQuery))
 
 lspTool
     :: (LspRequest -> IO (Either Text Text))

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/WebLspSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/WebLspSpec.hs
@@ -1,14 +1,28 @@
 module Agent.GrokBuild.WebLspSpec (spec) where
 
-import Agent.GrokBuild.Dialect.Lsp (lspTool)
+import Agent.GrokBuild.Dialect.Lsp
+    ( LspPosition(..)
+    , LspPositionOperation(..)
+    , LspRequest(..)
+    , lspTool
+    )
 import Agent.GrokBuild.Dialect.WebFetch (webFetchTool)
+import Agent.Loop (defaultLoopDispatch)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
     , jsonToolParameters
     )
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -49,7 +63,78 @@ spec = describe "Grok Build web_fetch/lsp contracts" do
             [] -> expectationFailure "missing lsp operation parameter"
         expectReadOnly tool.appToolApproval
 
+    describe "lsp request decoding" do
+        it "normalizes every valid operation into its required fields" do
+            let position operation expected =
+                    dispatchLspRequest
+                        ( "{\"operation\":\"" <> operation
+                            <> "\",\"file_path\":\"/tmp/Test.hs\","
+                            <> "\"line\":2,\"character\":3}"
+                        )
+                        `shouldReturn`
+                            Right
+                                (LspAtPosition
+                                    expected
+                                    "/tmp/Test.hs"
+                                    (LspPosition 2 3))
+            position "goToDefinition" LspGoToDefinition
+            position "findReferences" LspFindReferences
+            position "hover" LspHover
+            position "goToImplementation" LspGoToImplementation
+            dispatchLspRequest
+                "{\"operation\":\"documentSymbol\",\
+                \\"file_path\":\"/tmp/Test.hs\"}"
+                `shouldReturn`
+                    Right (LspDocumentSymbols "/tmp/Test.hs")
+            dispatchLspRequest
+                "{\"operation\":\"workspaceSymbol\",\"query\":\"  Result  \"}"
+                `shouldReturn`
+                    Right (LspWorkspaceSymbols "Result")
+
+        it "rejects operation-specific missing or invalid fields" do
+            expectRejected
+                "{\"operation\":\"documentSymbol\"}"
+                "documentSymbol requires file_path"
+            expectRejected
+                "{\"operation\":\"hover\",\"line\":0,\"character\":0}"
+                "hover requires file_path"
+            expectRejected
+                "{\"operation\":\"hover\",\"file_path\":\"/tmp/Test.hs\"}"
+                "hover requires non-negative line and character"
+            expectRejected
+                "{\"operation\":\"goToDefinition\",\
+                \\"file_path\":\"/tmp/Test.hs\",\"line\":0,\"character\":-1}"
+                "goToDefinition requires non-negative line and character"
+            expectRejected
+                "{\"operation\":\"workspaceSymbol\"}"
+                "workspaceSymbol requires query"
+            expectRejected
+                "{\"operation\":\"workspaceSymbol\",\"query\":\"  \"}"
+                "workspaceSymbol requires a non-empty query"
+
 expectReadOnly :: ApprovalRule -> Expectation
 expectReadOnly = \case
     AlwaysReadOnly -> pure ()
     _ -> expectationFailure "expected read-only tool approval"
+
+dispatchLspRequest :: Text -> IO (Either Text LspRequest)
+dispatchLspRequest arguments = do
+    decoded <- newIORef Nothing
+    let tool = lspTool \request -> do
+            writeIORef decoded (Just request)
+            pure (Right "ok")
+    result <-
+        dispatchToolCall defaultLoopDispatch [tool.appToolHandler] $
+            functionToolCall "lsp-call" "lsp" arguments
+    readIORef decoded >>= \case
+        Just request -> pure (Right request)
+        Nothing -> pure (Left result.output)
+
+expectRejected :: Text -> Text -> Expectation
+expectRejected arguments expected =
+    dispatchLspRequest arguments >>= \case
+        Left err ->
+            err `shouldSatisfy` Text.isInfixOf expected
+        Right request ->
+            expectationFailure
+                ("unexpected decoded request: " <> show request)


### PR DESCRIPTION
## Summary

- replace the optional-field `LspRequest` record with operation-specific constructors
- represent position operations separately and use `Natural` coordinates so invalid combinations cannot be constructed
- simplify CLI routing while preserving the flat model-facing schema and filesystem/runtime validation
- add decoder regression coverage for every operation and invalid required-field combinations

## Testing

- `nix develop -c cabal repl agent-grok-build-dialect:test:agent-grok-build-dialect-test` (`:main`): 45 examples, 0 failures
- `TMPDIR=/tmp nix develop -c cabal repl agent-cli:test:agent-cli-test` (`:main --match "web_fetch and LSP runtime support"`): 10 examples, 0 failures
