### PR TITLE
Add typed native browser control tools

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -93,6 +93,7 @@ library
                     , Agent.CLI.AccountSelection
                     , Agent.CLI.AgentSessions
                     , Agent.CLI.AgentViewport
+                    , Agent.CLI.BrowserTools
                     , Agent.CLI.Approval
                     , Agent.CLI.Artifact
                     , Agent.CLI.Afk
@@ -346,6 +347,7 @@ test-suite agent-cli-test
     main-is:          Spec.hs
     include-dirs:     include
     other-modules:    Agent.CLI.AccountSelectionSpec
+                    , Agent.CLI.MacOS.BrowserBridgeFFISpec
                     , Agent.CLI.MacOS.NativeLoopEventSpec
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
@@ -356,6 +358,7 @@ test-suite agent-cli-test
                     , Agent.CLI.AgentViewportSpec
                     , Agent.CLI.EnvironmentSpec
                     , Agent.CLI.AuthSpec
+                    , Agent.CLI.BrowserToolsSpec
                     , Agent.CLI.BtwSpec
                     , Agent.CLI.CancelWatchSpec
                     , Agent.CLI.ClipboardSpec
@@ -456,7 +459,8 @@ test-suite agent-cli-test
                     , unix
                     , vty >= 6.4 && < 7
     if os(darwin)
-        c-sources:    test/cbits/HaskellAgentBridgeImageSmoke.c
+        c-sources:    test/cbits/HaskellAgentBridgeBrowserSmoke.c
+                    , test/cbits/HaskellAgentBridgeImageSmoke.c
                     , cbits/HaskellAgentBridgeRuntime.c
         other-modules: Agent.CLI.MacOS.Bridge
 

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1,8 +1,21 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
-module Agent.CLI.MacOS.Bridge () where
+module Agent.CLI.MacOS.Bridge
+    ( BrowserCallback
+    , BrowserHost(..)
+    , BrowserRegistration(..)
+    , browserCommandABI
+    , browserOutputCapacity
+    , browserStatusMessage
+    , browserToolsWhenEnabled
+    , invokeBrowserCommand
+    ) where
 
 import qualified Agent.CLI.AgentViewport as Viewport
+import Agent.CLI.BrowserTools
+    ( BrowserCommand(..)
+    , browserTools
+    )
 import Agent.CLI.NativeRuntime
     ( NativeProcessRuntime
     , NativeRunHooks(..)
@@ -118,6 +131,7 @@ import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
     )
+import Agent.Tools.Types (AppTool)
 import Control.Concurrent (forkFinally, forkIO)
 import Control.Concurrent.Async
     ( Async
@@ -129,10 +143,12 @@ import Control.Concurrent.Async
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
+    , modifyMVar_
     , newEmptyMVar
     , newMVar
     , putMVar
     , readMVar
+    , withMVar
     )
 import Control.Concurrent.STM
     ( TMVar
@@ -199,12 +215,16 @@ import Foreign
     , newStablePtr
     , nullFunPtr
     , nullPtr
+    , alloca
+    , peek
+    , poke
     , plusPtr
     , peekByteOff
     , sizeOf
     )
 import Foreign.C.String (CString)
 import Foreign.C.Types (CDouble(..), CInt(..), CLLong(..), CSize(..))
+import Foreign.Marshal.Alloc (allocaBytes)
 import System.Directory
     ( getTemporaryDirectory
     , removeFile
@@ -288,6 +308,15 @@ type LearnedSkillsListCallback =
     -> CString -> CSize -> CString -> CSize -> CString -> CSize
     -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
 
+type BrowserCallback =
+    Ptr () -> CInt
+    -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize
+    -> CDouble -> CDouble
+    -> CInt
+    -> Ptr Word8 -> CSize -> Ptr CSize
+    -> IO CInt
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -317,6 +346,9 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeLearnedSkillsListCallback
         :: FunPtr LearnedSkillsListCallback -> LearnedSkillsListCallback
+
+foreign import ccall "dynamic"
+    invokeBrowserCallback :: FunPtr BrowserCallback -> BrowserCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -464,6 +496,16 @@ data Engine = Engine
     { engineCommands :: !(TQueue EngineCommand)
     , engineDone :: !(MVar ())
     , engineStagedImages :: !(TVar (Map Text [ImageAttachment]))
+    , engineBrowser :: !BrowserHost
+    }
+
+data BrowserRegistration = BrowserRegistration
+    { browserCallback :: !(FunPtr BrowserCallback)
+    , browserContext :: !(Ptr ())
+    }
+
+newtype BrowserHost = BrowserHost
+    { browserRegistration :: MVar (Maybe BrowserRegistration)
     }
 
 data TurnControl = TurnControl
@@ -493,6 +535,9 @@ foreign export ccall ha_engine_send_json
 
 foreign export ccall ha_engine_stage_turn_images
     :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize -> IO CInt
+
+foreign export ccall ha_engine_set_browser_callback
+    :: Ptr () -> FunPtr BrowserCallback -> Ptr () -> IO CInt
 
 foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
@@ -883,6 +928,7 @@ ha_engine_create callback context
             commands <- newTQueueIO
             done <- newEmptyMVar
             stagedImages <- newTVarIO Map.empty
+            browser <- BrowserHost <$> newMVar Nothing
             _ <- forkFinally
                 (workerLifecycle
                     callback
@@ -890,12 +936,14 @@ ha_engine_create callback context
                     config
                     (sessionsRoot home)
                     commands
-                    stagedImages)
+                    stagedImages
+                    browser)
                 (const (putMVar done ()))
             stable <- newStablePtr Engine
                 { engineCommands = commands
                 , engineDone = done
                 , engineStagedImages = stagedImages
+                , engineBrowser = browser
                 }
             pure (castStablePtrToPtr stable)
         case created of
@@ -930,6 +978,26 @@ ha_engine_send_json pointer bytes (CSize length)
             Left _ -> 3
             Right False -> 4
             Right True -> 0
+
+ha_engine_set_browser_callback
+    :: Ptr () -> FunPtr BrowserCallback -> Ptr () -> IO CInt
+ha_engine_set_browser_callback pointer callback context
+    | pointer == nullPtr = pure 1
+    | otherwise = do
+        updated <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            modifyMVar_ engine.engineBrowser.browserRegistration $ \_ ->
+                pure
+                    if callback == nullFunPtr
+                        then Nothing
+                        else Just BrowserRegistration
+                            { browserCallback = callback
+                            , browserContext = context
+                            }
+        pure $ case updated of
+            Left _ -> 2
+            Right () -> 0
 
 ha_engine_search_conversations
     :: Ptr () -> Ptr Word8 -> CSize -> CSize
@@ -1089,8 +1157,9 @@ workerLifecycle
     -> OsPath
     -> TQueue EngineCommand
     -> TVar (Map Text [ImageAttachment])
+    -> BrowserHost
     -> IO ()
-workerLifecycle callback context config root commands stagedImages = do
+workerLifecycle callback context config root commands stagedImages browser = do
     store <- newMVar Nothing
     processRuntime <- newNativeProcessRuntime root
     let cleanup =
@@ -1105,6 +1174,7 @@ workerLifecycle callback context config root commands stagedImages = do
         processRuntime
         commands
         stagedImages
+        browser
         `finally` cleanup
 
 idleLoop
@@ -1116,8 +1186,9 @@ idleLoop
     -> NativeProcessRuntime
     -> TQueue EngineCommand
     -> TVar (Map Text [ImageAttachment])
+    -> BrowserHost
     -> IO ()
-idleLoop callback context config store root processRuntime commands stagedImages =
+idleLoop callback context config store root processRuntime commands stagedImages browser =
     atomically (readTQueue commands) >>= \case
         EngineStop -> pure ()
         EngineSearch query limit searchCallback searchContext -> do
@@ -1144,6 +1215,7 @@ idleLoop callback context config store root processRuntime commands stagedImages
                             writeTVar stagedImages
                                 (Map.delete start.turnStartId staged)
                             pure (Map.findWithDefault [] start.turnStartId staged)
+                        nativeBrowserTools <- browserToolsWhenEnabled browser
                         control <- newTurnControl start.turnStartId
                         sendEvent callback context $
                             successEvent request.requestId $
@@ -1163,6 +1235,7 @@ idleLoop callback context config store root processRuntime commands stagedImages
                                 context
                                 processRuntime
                                 control
+                                nativeBrowserTools
                                 start
                                 images)
                             \running ->
@@ -1199,6 +1272,7 @@ idleLoop callback context config store root processRuntime commands stagedImages
             processRuntime
             commands
             stagedImages
+            browser
 
 activeLoop
     :: FunPtr EventCallback
@@ -1388,15 +1462,111 @@ searchRoleCode = \case
     Just "assistant" -> 2
     _ -> 0
 
+browserToolsWhenEnabled :: BrowserHost -> IO [AppTool]
+browserToolsWhenEnabled host =
+    withMVar host.browserRegistration \case
+        Nothing -> pure []
+        Just _ -> pure (browserTools (invokeBrowserCommand host))
+
+invokeBrowserCommand
+    :: BrowserHost
+    -> BrowserCommand
+    -> IO (Either Text Text)
+invokeBrowserCommand host command =
+    tryAny (withMVar host.browserRegistration invoke) >>= \case
+        Left exception -> pure (Left (Text.pack (show exception)))
+        Right result -> pure result
+  where
+    invoke Nothing =
+        pure (Left "The browser view is not active.")
+    invoke (Just registration) = do
+        let
+            ( commandCode
+                , argument1
+                , argument2
+                , scrollDeltaX
+                , scrollDeltaY
+                , flags
+                ) =
+                browserCommandABI command
+        withText argument1 \argument1Ptr argument1Length ->
+            withText argument2 \argument2Ptr argument2Length ->
+                allocaBytes browserOutputCapacity \output ->
+                    alloca \outputLength -> do
+                        poke outputLength 0
+                        status <- invokeBrowserCallback
+                            registration.browserCallback
+                            registration.browserContext
+                            commandCode
+                            (castPtr argument1Ptr)
+                            argument1Length
+                            (castPtr argument2Ptr)
+                            argument2Length
+                            scrollDeltaX
+                            scrollDeltaY
+                            flags
+                            output
+                            (fromIntegral browserOutputCapacity)
+                            outputLength
+                        CSize length <- peek outputLength
+                        if length > fromIntegral browserOutputCapacity
+                            then pure (Left
+                                "The browser returned more than the 256 KiB output limit.")
+                            else do
+                                bytes <- BS.packCStringLen
+                                    (castPtr output, fromIntegral length)
+                                pure $ case TextEncoding.decodeUtf8' bytes of
+                                    Left _ ->
+                                        Left "The browser returned invalid UTF-8."
+                                    Right text
+                                        | status == 0 -> Right text
+                                        | Text.null text ->
+                                            Left (browserStatusMessage status)
+                                        | otherwise -> Left text
+
+browserCommandABI
+    :: BrowserCommand
+    -> (CInt, Text, Text, CDouble, CDouble, CInt)
+browserCommandABI = \case
+    BrowserNavigate url -> (1, url, "", 0, 0, 0)
+    BrowserSnapshot -> (2, "", "", 0, 0, 0)
+    BrowserClick selector -> (3, selector, "", 0, 0, 0)
+    BrowserType selector text submit ->
+        (4, selector, text, 0, 0, if submit then 1 else 0)
+    BrowserBack -> (5, "", "", 0, 0, 0)
+    BrowserForward -> (6, "", "", 0, 0, 0)
+    BrowserReload -> (7, "", "", 0, 0, 0)
+    BrowserKey key -> (8, key, "", 0, 0, 0)
+    BrowserScroll deltaX deltaY ->
+        (9, "", "", realToFrac deltaX, realToFrac deltaY, 0)
+
+browserOutputCapacity :: Int
+browserOutputCapacity = 256 * 1024
+
+browserStatusMessage :: CInt -> Text
+browserStatusMessage = \case
+    1 -> "The browser host rejected an invalid argument."
+    2 -> "The native browser bridge is unavailable."
+    3 -> "The browser command timed out."
+    4 -> "The browser host denied website or extension access."
+    5 -> "The browser host does not support this operation."
+    6 -> "The native browser bridge failed internally."
+    7 -> "The browser host returned a result that was too large."
+    status ->
+        "The browser command failed (status "
+            <> Text.pack (show status)
+            <> ")."
+
 runNativeTurn
     :: FunPtr EventCallback
     -> Ptr ()
     -> NativeProcessRuntime
     -> TurnControl
+    -> [AppTool]
     -> TurnStart
     -> [ImageAttachment]
     -> IO TurnOutcome
-runNativeTurn callback context processRuntime control start images = do
+runNativeTurn callback context processRuntime control nativeBrowserTools start images = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     let hooks = NativeRunHooks
@@ -1423,6 +1593,7 @@ runNativeTurn callback context processRuntime control start images = do
                 atomically . writeTVar control.turnControlAgentSnapshot
             , nativeRequestApproval =
                 requestApproval callback context control
+            , nativeTools = nativeBrowserTools
             }
         modelArgs = case
             (start.turnStartProvider, start.turnStartModel) of

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -24,6 +24,95 @@ typedef void (*ha_event_callback)(
     const uint8_t *bytes,
     size_t length
 );
+enum {
+    HA_BROWSER_NAVIGATE = 1,
+    HA_BROWSER_SNAPSHOT = 2,
+    HA_BROWSER_CLICK = 3,
+    HA_BROWSER_TYPE = 4,
+    HA_BROWSER_BACK = 5,
+    HA_BROWSER_FORWARD = 6,
+    HA_BROWSER_RELOAD = 7,
+    HA_BROWSER_KEY = 8,
+    HA_BROWSER_SCROLL = 9
+};
+
+enum {
+    HA_BROWSER_TYPE_SUBMIT = 1
+};
+
+enum {
+    HA_BROWSER_STATUS_SUCCESS = 0,
+    HA_BROWSER_STATUS_INVALID_ARGUMENT = 1,
+    HA_BROWSER_STATUS_UNAVAILABLE = 2,
+    HA_BROWSER_STATUS_TIMEOUT = 3,
+    HA_BROWSER_STATUS_PERMISSION_DENIED = 4,
+    HA_BROWSER_STATUS_UNSUPPORTED = 5,
+    HA_BROWSER_STATUS_FAILED = 6,
+    HA_BROWSER_STATUS_OUTPUT_TOO_LARGE = 7
+};
+
+enum {
+    HA_BROWSER_OUTPUT_CAPACITY = 262144
+};
+
+/*
+ * Host-browser callback used by browser tools in native agent turns.
+ *
+ * Commands use these typed fields:
+ *   NAVIGATE: argument1 is an absolute URL.
+ *   SNAPSHOT: no arguments.
+ *   CLICK: argument1 is a CSS selector.
+ *   TYPE: argument1 is a CSS selector, argument2 is text, and flags bit
+ *         HA_BROWSER_TYPE_SUBMIT requests form submission.
+ *   KEY: argument1 is a DOM KeyboardEvent.key value.
+ *   SCROLL: scroll_delta_x and scroll_delta_y are finite CSS-pixel deltas.
+ *   BACK, FORWARD, RELOAD: no arguments.
+ *
+ * Unused text fields have length zero. Unused scroll fields and flags are
+ * zero. Unknown commands or nonzero unused fields must be rejected with
+ * HA_BROWSER_STATUS_INVALID_ARGUMENT.
+ *
+ * Input buffers are nonnull, callback-scoped UTF-8 and may have zero length.
+ * output is a nonnull, callback-scoped writable buffer. Set *output_length to
+ * the UTF-8 bytes written, never above output_capacity. Return 0 for success
+ * or a HA_BROWSER_STATUS_* value for failure; on failure, write a useful UTF-8
+ * error to output when possible. The runtime supplies
+ * HA_BROWSER_OUTPUT_CAPACITY bytes. The callback runs synchronously on an
+ * agent tool worker, never the setter's caller or AppKit main thread. It must
+ * not call engine functions.
+ *
+ * The runtime does not retain input/output buffers. The host owns callback
+ * and context. ha_engine_set_browser_callback may wait for an in-flight
+ * callback; after it returns, a replaced callback/context will not be used
+ * again. The currently installed callback/context must remain valid until
+ * replaced, disabled, or ha_engine_destroy returns.
+ */
+typedef int32_t (*ha_browser_callback)(
+    void *context,
+    int32_t command,
+    const uint8_t *argument1, size_t argument1_length,
+    const uint8_t *argument2, size_t argument2_length,
+    double scroll_delta_x,
+    double scroll_delta_y,
+    int32_t flags,
+    uint8_t *output, size_t output_capacity, size_t *output_length
+);
+
+/*
+ * Installs browser support for future turns. A turn exposes browser tools only
+ * when its turn.start processing observes a nonnull callback. Passing NULL
+ * disables browser support; context is ignored in that case. Tools retained
+ * by an already-started turn fail as inactive after disabling.
+ *
+ * Returns 0 on success, 1 for a null engine, or 2 for an internal failure.
+ * Calls must be serialized with ha_engine_destroy. This function may block
+ * until a running browser callback returns.
+ */
+int32_t ha_engine_set_browser_callback(
+    void *engine,
+    ha_browser_callback callback,
+    void *context
+);
 
 /*
  * A conversation-search callback. status is 0 for a result, 1 for terminal

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -52,6 +52,11 @@ enum {
 };
 
 enum {
+    HA_BROWSER_URL_MAX_BYTES = 8192,
+    HA_BROWSER_SELECTOR_MAX_BYTES = 4096,
+    HA_BROWSER_TEXT_MAX_BYTES = 65536,
+    HA_BROWSER_KEY_MAX_BYTES = 128,
+    HA_BROWSER_SCROLL_MAX_ABS_DELTA = 10000,
     HA_BROWSER_OUTPUT_CAPACITY = 262144
 };
 
@@ -59,13 +64,19 @@ enum {
  * Host-browser callback used by browser tools in native agent turns.
  *
  * Commands use these typed fields:
- *   NAVIGATE: argument1 is an absolute URL.
+ *   NAVIGATE: argument1 is an absolute HTTP(S) URL without userinfo, at most
+ *             HA_BROWSER_URL_MAX_BYTES UTF-8 bytes.
  *   SNAPSHOT: no arguments.
- *   CLICK: argument1 is a CSS selector.
- *   TYPE: argument1 is a CSS selector, argument2 is text, and flags bit
+ *   CLICK: argument1 is a CSS selector, at most
+ *          HA_BROWSER_SELECTOR_MAX_BYTES UTF-8 bytes.
+ *   TYPE: argument1 is a selector with the same limit as CLICK; argument2 is
+ *         at most HA_BROWSER_TEXT_MAX_BYTES UTF-8 bytes; flags bit
  *         HA_BROWSER_TYPE_SUBMIT requests form submission.
- *   KEY: argument1 is a DOM KeyboardEvent.key value.
- *   SCROLL: scroll_delta_x and scroll_delta_y are finite CSS-pixel deltas.
+ *   KEY: argument1 is a nonempty DOM KeyboardEvent.key value, at most
+ *        HA_BROWSER_KEY_MAX_BYTES UTF-8 bytes.
+ *   SCROLL: scroll_delta_x and scroll_delta_y are finite CSS-pixel deltas,
+ *           each with absolute value at most
+ *           HA_BROWSER_SCROLL_MAX_ABS_DELTA; at least one must be nonzero.
  *   BACK, FORWARD, RELOAD: no arguments.
  *
  * Unused text fields have length zero. Unused scroll fields and flags are

--- a/packages/agent-cli/src/Agent/CLI/BrowserTools.hs
+++ b/packages/agent-cli/src/Agent/CLI/BrowserTools.hs
@@ -35,7 +35,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Network.URI
     ( URI(uriAuthority, uriScheme)
-    , URIAuth(uriRegName)
+    , URIAuth(uriRegName, uriUserInfo)
     , parseURI
     )
 
@@ -227,7 +227,10 @@ validateHttpUrl value = do
                     `elem` ["http:", "https:"]
                 , Just authority <- uriAuthority uri
                 , not (null (uriRegName authority)) ->
-                    pure url
+                    if null (uriUserInfo authority)
+                        then pure url
+                        else failParser
+                            "url must not contain embedded credentials"
             _ -> invalid
   where
     invalid = failParser "url must be an absolute HTTP or HTTPS URL"

--- a/packages/agent-cli/src/Agent/CLI/BrowserTools.hs
+++ b/packages/agent-cli/src/Agent/CLI/BrowserTools.hs
@@ -30,9 +30,11 @@ import Data.Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (Object, Parser)
+import qualified Data.ByteString as BS
 import Data.Scientific (toRealFloat)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Network.URI
     ( URI(uriAuthority, uriScheme)
     , URIAuth(uriRegName, uriUserInfo)
@@ -182,16 +184,16 @@ newtype ClickArgs = ClickArgs Text
 instance FromJSON ClickArgs where
     parseJSON = objectArgs \input -> do
         selector <- reqText input "selector"
-        ClickArgs <$> validateNonBlank "selector" maxSelectorLength selector
+        ClickArgs <$> validateNonBlank "selector" maxSelectorBytes selector
 
 data TypeArgs = TypeArgs !Text !Text !Bool
 
 instance FromJSON TypeArgs where
     parseJSON = objectArgs \input -> do
         selector <- reqText input "selector"
-            >>= validateNonBlank "selector" maxSelectorLength
+            >>= validateNonBlank "selector" maxSelectorBytes
         text <- reqText input "text"
-            >>= validateLength "text" maxTextLength
+            >>= validateByteLength "text" maxTextBytes
         submit <- maybe False id <$> optBool input "submit"
         pure (TypeArgs selector text submit)
 
@@ -200,7 +202,7 @@ newtype KeyArgs = KeyArgs Text
 instance FromJSON KeyArgs where
     parseJSON = objectArgs \input -> do
         key <- reqText input "key"
-        KeyArgs <$> validateNonBlank "key" maxKeyLength key
+        KeyArgs <$> validateNonBlank "key" maxKeyBytes key
 
 data ScrollArgs = ScrollArgs !Double !Double
 
@@ -210,7 +212,7 @@ instance FromJSON ScrollArgs where
         deltaY <- requiredFiniteNumber input "delta_y"
         if abs deltaX > maxScrollDelta || abs deltaY > maxScrollDelta
             then failParser
-                "delta_x and delta_y must be between -100000 and 100000"
+                "delta_x and delta_y must be between -10000 and 10000"
             else if deltaX == 0 && deltaY == 0
                 then failParser
                     "at least one of delta_x and delta_y must be nonzero"
@@ -218,7 +220,7 @@ instance FromJSON ScrollArgs where
 
 validateHttpUrl :: Text -> Parser Text
 validateHttpUrl value = do
-    url <- validateNonBlank "url" maxUrlLength value
+    url <- validateNonBlank "url" maxUrlBytes value
     if Text.strip url /= url
         then invalid
         else case parseURI (Text.unpack url) of
@@ -239,14 +241,14 @@ validateNonBlank :: Text -> Int -> Text -> Parser Text
 validateNonBlank name limit value
     | Text.null (Text.strip value) =
         failParser (name <> " must not be empty")
-    | otherwise = validateLength name limit value
+    | otherwise = validateByteLength name limit value
 
-validateLength :: Text -> Int -> Text -> Parser Text
-validateLength name limit value
-    | Text.length value > limit =
+validateByteLength :: Text -> Int -> Text -> Parser Text
+validateByteLength name limit value
+    | BS.length (TextEncoding.encodeUtf8 value) > limit =
         failParser
             (name <> " must not exceed " <> Text.pack (show limit)
-                <> " characters")
+                <> " UTF-8 bytes")
     | otherwise = pure value
 
 requiredFiniteNumber :: Object -> Text -> Parser Double
@@ -263,11 +265,11 @@ requiredFiniteNumber input name =
 failParser :: Text -> Parser a
 failParser = fail . Text.unpack
 
-maxUrlLength, maxSelectorLength, maxTextLength, maxKeyLength :: Int
-maxUrlLength = 8192
-maxSelectorLength = 4096
-maxTextLength = 256 * 1024
-maxKeyLength = 128
+maxUrlBytes, maxSelectorBytes, maxTextBytes, maxKeyBytes :: Int
+maxUrlBytes = 8192
+maxSelectorBytes = 4096
+maxTextBytes = 64 * 1024
+maxKeyBytes = 128
 
 maxScrollDelta :: Double
-maxScrollDelta = 100000
+maxScrollDelta = 10000

--- a/packages/agent-cli/src/Agent/CLI/BrowserTools.hs
+++ b/packages/agent-cli/src/Agent/CLI/BrowserTools.hs
@@ -30,12 +30,12 @@ import Data.Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (Object, Parser)
-import Data.Maybe (isJust)
 import Data.Scientific (toRealFloat)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Network.URI
     ( URI(uriAuthority, uriScheme)
+    , URIAuth(uriRegName)
     , parseURI
     )
 
@@ -223,8 +223,10 @@ validateHttpUrl value = do
         then invalid
         else case parseURI (Text.unpack url) of
             Just uri
-                | uriScheme uri `elem` ["http:", "https:"]
-                , isJust (uriAuthority uri) ->
+                | Text.toCaseFold (Text.pack (uriScheme uri))
+                    `elem` ["http:", "https:"]
+                , Just authority <- uriAuthority uri
+                , not (null (uriRegName authority)) ->
                     pure url
             _ -> invalid
   where

--- a/packages/agent-cli/src/Agent/CLI/BrowserTools.hs
+++ b/packages/agent-cli/src/Agent/CLI/BrowserTools.hs
@@ -1,0 +1,268 @@
+module Agent.CLI.BrowserTools
+    ( BrowserCommand(..)
+    , BrowserCommandHandler
+    , browserTools
+    ) where
+
+import Agent.ToolArgs
+    ( objectArgs
+    , optBool
+    , reqText
+    )
+import Agent.ToolDSL
+    ( PropertySchema(..)
+    , PropertyType(..)
+    )
+import Agent.ToolDispatch
+    ( noArgsTool
+    , typedTool
+    )
+import Agent.Tools.Types
+    ( AppTool
+    , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
+    , jsonAppToolWithExecution
+    )
+import Data.Aeson
+    ( FromJSON(..)
+    , Value(..)
+    )
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.Types (Object, Parser)
+import Data.Maybe (isJust)
+import Data.Scientific (toRealFloat)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Network.URI
+    ( URI(uriAuthority, uriScheme)
+    , parseURI
+    )
+
+data BrowserCommand
+    = BrowserNavigate !Text
+    | BrowserSnapshot
+    | BrowserClick !Text
+    | BrowserType !Text !Text !Bool
+    | BrowserKey !Text
+    | BrowserScroll !Double !Double
+    | BrowserBack
+    | BrowserForward
+    | BrowserReload
+    deriving (Eq, Show)
+
+type BrowserCommandHandler =
+    BrowserCommand -> IO (Either Text Text)
+
+browserTools :: BrowserCommandHandler -> [AppTool]
+browserTools handler =
+    [ navigateTool
+    , snapshotTool
+    , clickTool
+    , typeTool
+    , keyTool
+    , scrollTool
+    , noArgumentTool
+        "browser_back"
+        "Navigate the active browser view back one page."
+        AlwaysReadOnly
+        BrowserBack
+    , noArgumentTool
+        "browser_forward"
+        "Navigate the active browser view forward one page."
+        AlwaysReadOnly
+        BrowserForward
+    , noArgumentTool
+        "browser_reload"
+        "Reload the current page in the active browser view."
+        AlwaysReadOnly
+        BrowserReload
+    ]
+  where
+    navigateTool = jsonAppToolWithExecution
+        "browser_navigate"
+        "Navigate the active browser view to an absolute HTTP or HTTPS URL."
+        [ PropertySchema "url" PropertyString True $ Just
+            "Absolute HTTP or HTTPS URL to open."
+        ]
+        AlwaysReadOnly
+        TurnSequential
+        (typedTool "browser_navigate" runNavigate)
+
+    snapshotTool = noArgumentTool
+        "browser_snapshot"
+        "Read the active page's URL, title, visible text, and interactive controls. Controls include CSS selectors accepted by browser_click and browser_type."
+        AlwaysReadOnly
+        BrowserSnapshot
+
+    clickTool = jsonAppToolWithExecution
+        "browser_click"
+        "Click an element in the active browser view using a CSS selector from browser_snapshot."
+        [ PropertySchema "selector" PropertyString True $ Just
+            "CSS selector identifying the element to click."
+        ]
+        AlwaysPrompt
+        TurnSequential
+        (typedTool "browser_click" runClick)
+
+    typeTool = jsonAppToolWithExecution
+        "browser_type"
+        "Replace the contents of a text control in the active browser view, optionally submitting its form."
+        [ PropertySchema "selector" PropertyString True $ Just
+            "CSS selector identifying an input, textarea, or content-editable element."
+        , PropertySchema "text" PropertyString True $ Just
+            "Text to enter."
+        , PropertySchema "submit" PropertyBoolean False $ Just
+            "Whether to submit the form after typing. Defaults to false."
+        ]
+        AlwaysPrompt
+        TurnSequential
+        (typedTool "browser_type" runType)
+
+    keyTool = jsonAppToolWithExecution
+        "browser_key"
+        "Send a keyboard key to the focused element in the active browser view."
+        [ PropertySchema "key" PropertyString True $ Just
+            "DOM KeyboardEvent.key value such as Enter, Escape, Tab, ArrowDown, or a single character."
+        ]
+        AlwaysPrompt
+        TurnSequential
+        (typedTool "browser_key" runKey)
+
+    scrollTool = jsonAppToolWithExecution
+        "browser_scroll"
+        "Scroll the active browser view by bounded horizontal and vertical CSS-pixel deltas."
+        [ PropertySchema "delta_x" PropertyNumber True $ Just
+            "Horizontal delta in CSS pixels; negative scrolls left."
+        , PropertySchema "delta_y" PropertyNumber True $ Just
+            "Vertical delta in CSS pixels; negative scrolls up."
+        ]
+        AlwaysReadOnly
+        TurnSequential
+        (typedTool "browser_scroll" runScroll)
+
+    runNavigate :: NavigateArgs -> IO (Either Text Text)
+    runNavigate (NavigateArgs url) =
+        handler (BrowserNavigate url)
+
+    runClick :: ClickArgs -> IO (Either Text Text)
+    runClick (ClickArgs selector) =
+        handler (BrowserClick selector)
+
+    runType :: TypeArgs -> IO (Either Text Text)
+    runType (TypeArgs selector text submit) =
+        handler (BrowserType selector text submit)
+
+    runKey :: KeyArgs -> IO (Either Text Text)
+    runKey (KeyArgs key) =
+        handler (BrowserKey key)
+
+    runScroll :: ScrollArgs -> IO (Either Text Text)
+    runScroll (ScrollArgs deltaX deltaY) =
+        handler (BrowserScroll deltaX deltaY)
+
+    noArgumentTool name description approval command =
+        jsonAppToolWithExecution
+            name
+            description
+            []
+            approval
+            TurnSequential
+            (noArgsTool name (handler command))
+
+newtype NavigateArgs = NavigateArgs Text
+
+instance FromJSON NavigateArgs where
+    parseJSON = objectArgs \input -> do
+        url <- reqText input "url"
+        NavigateArgs <$> validateHttpUrl url
+
+newtype ClickArgs = ClickArgs Text
+
+instance FromJSON ClickArgs where
+    parseJSON = objectArgs \input -> do
+        selector <- reqText input "selector"
+        ClickArgs <$> validateNonBlank "selector" maxSelectorLength selector
+
+data TypeArgs = TypeArgs !Text !Text !Bool
+
+instance FromJSON TypeArgs where
+    parseJSON = objectArgs \input -> do
+        selector <- reqText input "selector"
+            >>= validateNonBlank "selector" maxSelectorLength
+        text <- reqText input "text"
+            >>= validateLength "text" maxTextLength
+        submit <- maybe False id <$> optBool input "submit"
+        pure (TypeArgs selector text submit)
+
+newtype KeyArgs = KeyArgs Text
+
+instance FromJSON KeyArgs where
+    parseJSON = objectArgs \input -> do
+        key <- reqText input "key"
+        KeyArgs <$> validateNonBlank "key" maxKeyLength key
+
+data ScrollArgs = ScrollArgs !Double !Double
+
+instance FromJSON ScrollArgs where
+    parseJSON = objectArgs \input -> do
+        deltaX <- requiredFiniteNumber input "delta_x"
+        deltaY <- requiredFiniteNumber input "delta_y"
+        if abs deltaX > maxScrollDelta || abs deltaY > maxScrollDelta
+            then failParser
+                "delta_x and delta_y must be between -100000 and 100000"
+            else if deltaX == 0 && deltaY == 0
+                then failParser
+                    "at least one of delta_x and delta_y must be nonzero"
+                else pure (ScrollArgs deltaX deltaY)
+
+validateHttpUrl :: Text -> Parser Text
+validateHttpUrl value = do
+    url <- validateNonBlank "url" maxUrlLength value
+    if Text.strip url /= url
+        then invalid
+        else case parseURI (Text.unpack url) of
+            Just uri
+                | uriScheme uri `elem` ["http:", "https:"]
+                , isJust (uriAuthority uri) ->
+                    pure url
+            _ -> invalid
+  where
+    invalid = failParser "url must be an absolute HTTP or HTTPS URL"
+
+validateNonBlank :: Text -> Int -> Text -> Parser Text
+validateNonBlank name limit value
+    | Text.null (Text.strip value) =
+        failParser (name <> " must not be empty")
+    | otherwise = validateLength name limit value
+
+validateLength :: Text -> Int -> Text -> Parser Text
+validateLength name limit value
+    | Text.length value > limit =
+        failParser
+            (name <> " must not exceed " <> Text.pack (show limit)
+                <> " characters")
+    | otherwise = pure value
+
+requiredFiniteNumber :: Object -> Text -> Parser Double
+requiredFiniteNumber input name =
+    case KeyMap.lookup (Key.fromText name) input of
+        Just (Number scientific) ->
+            let value = toRealFloat scientific
+            in if isNaN value || isInfinite value
+                then failParser (name <> " must be a finite number")
+                else pure value
+        Just _ -> failParser ("Expected number for key: " <> name)
+        Nothing -> failParser ("Missing parameter: " <> name)
+
+failParser :: Text -> Parser a
+failParser = fail . Text.unpack
+
+maxUrlLength, maxSelectorLength, maxTextLength, maxKeyLength :: Int
+maxUrlLength = 8192
+maxSelectorLength = 4096
+maxTextLength = 256 * 1024
+maxKeyLength = 128
+
+maxScrollDelta :: Double
+maxScrollDelta = 100000

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -1928,6 +1928,8 @@ runAgentInitializedWithLock
         databaseAppTools = databaseTools databaseToolsEnv
         learnedSkillAppTools =
             learnedSkillTools skillInvocationsRef learnedSkillToolsEnv
+        nativeAppTools =
+            maybe [] (.nativeTools) startup.startupNativeHooks
         allTools =
             coding.codingAppTools
                 ++ extraTools
@@ -1936,6 +1938,7 @@ runAgentInitializedWithLock
                 ++ gatewayTools
                 ++ databaseAppTools
                 ++ learnedSkillAppTools
+                ++ nativeAppTools
         tools =
             filterGhciTools options.optGhci
                 (filterBashTools options.optBash coding.codingAppTools)
@@ -1945,6 +1948,7 @@ runAgentInitializedWithLock
                 ++ gatewayTools
                 ++ databaseAppTools
                 ++ learnedSkillAppTools
+                ++ nativeAppTools
         planMode = coding.codingPlanMode
         -- Keep planSessionDir and subagent store root in sync.
         noteSessionDir dir = do
@@ -1980,6 +1984,7 @@ runAgentInitializedWithLock
                         ++ gatewayTools
                         ++ databaseAppTools
                         ++ learnedSkillAppTools
+                        ++ nativeAppTools
                     )
                     mcpFleet.mcpFleetRegistrations
             of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -16,6 +16,7 @@ import Agent.Error ( ApiError )
 import Agent.Loop ( LoopEvent )
 import Agent.Provider ( Credential, TokenProvider )
 import Agent.ToolDispatch ( ToolCall )
+import Agent.Tools.Types ( AppTool )
 import Control.Concurrent.MVar ( MVar )
 import Data.Text ( Text )
 import System.IO ( Handle, stderr, stdout )
@@ -44,6 +45,7 @@ data NativeRunHooks = NativeRunHooks
     , nativeRegisterCancel :: !(IO () -> IO ())
     , nativeRegisterAgentSnapshot :: !(IO [AgentEntry] -> IO ())
     , nativeRequestApproval :: !(ToolCall -> IO (Maybe PermissionChoice))
+    , nativeTools :: ![AppTool]
     }
 
 data AgentRunMode = AgentRunMode

--- a/packages/agent-cli/test/Agent/CLI/BrowserToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BrowserToolsSpec.hs
@@ -162,6 +162,56 @@ spec = describe "native browser tools" do
                         "url must not contain embedded credentials"
         readIORef invoked `shouldReturn` False
 
+    it "enforces the app-group UTF-8 byte limits exactly" do
+        invocationCount <- newIORef (0 :: Int)
+        let handler _ = do
+                current <- readIORef invocationCount
+                writeIORef invocationCount (current + 1)
+                pure (Right "ok")
+            run name arguments = dispatchToolCall defaultLoopDispatch
+                (appToolHandlers (browserTools handler))
+                (functionToolCall "browser-call" name arguments)
+            shouldSucceed name arguments = do
+                result <- run name arguments
+                result.output `shouldBe` "ok"
+            shouldFailWith name arguments message = do
+                result <- run name arguments
+                result.output `shouldSatisfy` Text.isInfixOf message
+            urlPrefix = "https://example.com/"
+            exactUrl =
+                urlPrefix <> Text.replicate (8192 - Text.length urlPrefix) "a"
+            exactSelector = Text.replicate 4096 "a"
+            exactText = Text.replicate 32768 "λ"
+            exactKey = Text.replicate 64 "λ"
+        shouldSucceed "browser_navigate"
+            ("{\"url\":\"" <> exactUrl <> "\"}")
+        shouldSucceed "browser_click"
+            ("{\"selector\":\"" <> exactSelector <> "\"}")
+        shouldSucceed "browser_type"
+            ("{\"selector\":\"#q\",\"text\":\"" <> exactText <> "\"}")
+        shouldSucceed "browser_key"
+            ("{\"key\":\"" <> exactKey <> "\"}")
+        shouldSucceed "browser_scroll"
+            "{\"delta_x\":10000,\"delta_y\":-10000}"
+        readIORef invocationCount `shouldReturn` 5
+
+        shouldFailWith "browser_navigate"
+            ("{\"url\":\"" <> exactUrl <> "a\"}")
+            "url must not exceed 8192 UTF-8 bytes"
+        shouldFailWith "browser_click"
+            ("{\"selector\":\"" <> exactSelector <> "a\"}")
+            "selector must not exceed 4096 UTF-8 bytes"
+        shouldFailWith "browser_type"
+            ("{\"selector\":\"#q\",\"text\":\"" <> exactText <> "a\"}")
+            "text must not exceed 65536 UTF-8 bytes"
+        shouldFailWith "browser_key"
+            ("{\"key\":\"" <> exactKey <> "a\"}")
+            "key must not exceed 128 UTF-8 bytes"
+        shouldFailWith "browser_scroll"
+            "{\"delta_x\":10000.01,\"delta_y\":0}"
+            "delta_x and delta_y must be between -10000 and 10000"
+        readIORef invocationCount `shouldReturn` 5
+
     it "rejects empty selectors, empty keys, and invalid scroll deltas" do
         let run name arguments = dispatchToolCall defaultLoopDispatch
                 (appToolHandlers (browserTools successHandler))
@@ -177,8 +227,8 @@ spec = describe "native browser tools" do
             "{\"delta_x\":0,\"delta_y\":0}"
             "must be nonzero"
         shouldFailWith "browser_scroll"
-            "{\"delta_x\":100001,\"delta_y\":1}"
-            "between -100000 and 100000"
+            "{\"delta_x\":10001,\"delta_y\":1}"
+            "between -10000 and 10000"
         shouldFailWith "browser_scroll"
             "{\"delta_x\":\"down\",\"delta_y\":1}"
             "Expected number for key: delta_x"

--- a/packages/agent-cli/test/Agent/CLI/BrowserToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BrowserToolsSpec.hs
@@ -1,0 +1,170 @@
+module Agent.CLI.BrowserToolsSpec (spec) where
+
+import Agent.CLI.BrowserTools
+    ( BrowserCommand(..)
+    , browserTools
+    )
+import Agent.Loop (defaultLoopDispatch)
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
+import Agent.Tools.Types
+    ( AppTool(..)
+    , ApprovalRule(..)
+    , appToolHandlers
+    )
+import Control.Monad (forM_)
+import Data.IORef
+    ( newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "native browser tools" do
+    it "registers the complete stable tool surface" do
+        let names = map (.appToolName) (browserTools successHandler)
+        names `shouldBe`
+            [ "browser_navigate"
+            , "browser_snapshot"
+            , "browser_click"
+            , "browser_type"
+            , "browser_key"
+            , "browser_scroll"
+            , "browser_back"
+            , "browser_forward"
+            , "browser_reload"
+            ]
+
+    it "maps typed arguments and submit flags to host commands" do
+        observed <- newIORef Nothing
+        let handler command = do
+                writeIORef observed (Just command)
+                pure (Right "host result")
+            run name arguments = do
+                result <- dispatchToolCall defaultLoopDispatch
+                    (appToolHandlers (browserTools handler))
+                    (functionToolCall "browser-call" name arguments)
+                result.output `shouldBe` "host result"
+                readIORef observed
+        run "browser_navigate" "{\"url\":\"https://example.com\"}"
+            `shouldReturn` Just (BrowserNavigate "https://example.com")
+        run "browser_click" "{\"selector\":\"#continue\"}"
+            `shouldReturn` Just (BrowserClick "#continue")
+        run "browser_type"
+            "{\"selector\":\"input[name=q]\",\"text\":\"haskell\",\"submit\":true}"
+            `shouldReturn`
+                Just (BrowserType "input[name=q]" "haskell" True)
+        run "browser_type"
+            "{\"selector\":\"textarea\",\"text\":\"draft\"}"
+            `shouldReturn` Just (BrowserType "textarea" "draft" False)
+        run "browser_key" "{\"key\":\"Enter\"}"
+            `shouldReturn` Just (BrowserKey "Enter")
+        run "browser_scroll" "{\"delta_x\":12.5,\"delta_y\":-800}"
+            `shouldReturn` Just (BrowserScroll 12.5 (-800))
+
+    it "routes no-argument commands and preserves host failures" do
+        let handler = \case
+                BrowserSnapshot -> pure (Left "browser unavailable")
+                command -> pure (Right (showText command))
+            run name = dispatchToolCall defaultLoopDispatch
+                (appToolHandlers (browserTools handler))
+                (functionToolCall "browser-call" name "{}")
+        result <- run "browser_snapshot"
+        result.output `shouldBe` "Error: browser unavailable"
+        back <- run "browser_back"
+        back.output `shouldBe` "BrowserBack"
+
+    it "prompts only for page interactions that can submit data" do
+        let approvals =
+                [ (tool.appToolName, tool.appToolApproval)
+                | tool <- browserTools successHandler
+                ]
+        lookup "browser_snapshot" approvals `shouldSatisfyApproval`
+            isAlwaysReadOnly
+        lookup "browser_navigate" approvals `shouldSatisfyApproval`
+            isAlwaysReadOnly
+        lookup "browser_click" approvals `shouldSatisfyApproval`
+            isAlwaysPrompt
+        lookup "browser_type" approvals `shouldSatisfyApproval`
+            isAlwaysPrompt
+        lookup "browser_key" approvals `shouldSatisfyApproval`
+            isAlwaysPrompt
+        lookup "browser_scroll" approvals `shouldSatisfyApproval`
+            isAlwaysReadOnly
+        lookup "browser_back" approvals `shouldSatisfyApproval`
+            isAlwaysReadOnly
+        lookup "browser_forward" approvals `shouldSatisfyApproval`
+            isAlwaysReadOnly
+        lookup "browser_reload" approvals `shouldSatisfyApproval`
+            isAlwaysReadOnly
+
+    it "rejects invalid URLs before invoking the host" do
+        invoked <- newIORef False
+        let handler _ = do
+                writeIORef invoked True
+                pure (Right "unexpected")
+            run url = dispatchToolCall defaultLoopDispatch
+                (appToolHandlers (browserTools handler))
+                (functionToolCall "browser-call" "browser_navigate"
+                    ("{\"url\":\"" <> url <> "\"}"))
+        forM_
+            [ "file:///tmp/private"
+            , "javascript:alert(1)"
+            , "https:relative"
+            , " https://example.com"
+            ]
+            \url -> do
+                result <- run url
+                result.output `shouldSatisfy`
+                    Text.isInfixOf "absolute HTTP or HTTPS URL"
+        readIORef invoked `shouldReturn` False
+
+    it "rejects empty selectors, empty keys, and invalid scroll deltas" do
+        let run name arguments = dispatchToolCall defaultLoopDispatch
+                (appToolHandlers (browserTools successHandler))
+                (functionToolCall "browser-call" name arguments)
+            shouldFailWith name arguments message = do
+                result <- run name arguments
+                result.output `shouldSatisfy` Text.isInfixOf message
+        shouldFailWith "browser_click" "{\"selector\":\"  \"}"
+            "selector must not be empty"
+        shouldFailWith "browser_key" "{\"key\":\"\"}"
+            "key must not be empty"
+        shouldFailWith "browser_scroll"
+            "{\"delta_x\":0,\"delta_y\":0}"
+            "must be nonzero"
+        shouldFailWith "browser_scroll"
+            "{\"delta_x\":100001,\"delta_y\":1}"
+            "between -100000 and 100000"
+        shouldFailWith "browser_scroll"
+            "{\"delta_x\":\"down\",\"delta_y\":1}"
+            "Expected number for key: delta_x"
+
+successHandler :: BrowserCommand -> IO (Either Text Text)
+successHandler _ = pure (Right "ok")
+
+showText :: Show a => a -> Text
+showText = Text.pack . show
+
+shouldSatisfyApproval
+    :: Maybe ApprovalRule
+    -> (ApprovalRule -> Bool)
+    -> Expectation
+shouldSatisfyApproval (Just approval) predicate =
+    predicate approval `shouldBe` True
+shouldSatisfyApproval Nothing _ =
+    expectationFailure "missing browser tool approval rule"
+
+isAlwaysReadOnly :: ApprovalRule -> Bool
+isAlwaysReadOnly AlwaysReadOnly = True
+isAlwaysReadOnly _ = False
+
+isAlwaysPrompt :: ApprovalRule -> Bool
+isAlwaysPrompt AlwaysPrompt = True
+isAlwaysPrompt _ = False

--- a/packages/agent-cli/test/Agent/CLI/BrowserToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BrowserToolsSpec.hs
@@ -141,6 +141,27 @@ spec = describe "native browser tools" do
         readIORef observed `shouldReturn`
             Just (BrowserNavigate "HTTPS://example.com/path")
 
+    it "rejects URL userinfo before invoking the host" do
+        invoked <- newIORef False
+        let handler _ = do
+                writeIORef invoked True
+                pure (Right "unexpected")
+            run url = dispatchToolCall defaultLoopDispatch
+                (appToolHandlers (browserTools handler))
+                (functionToolCall "browser-call" "browser_navigate"
+                    ("{\"url\":\"" <> url <> "\"}"))
+        forM_
+            [ "https://user@example.com/private"
+            , "https://user:password@example.com/private"
+            , "https://%75ser@example.com/private"
+            ]
+            \url -> do
+                result <- run url
+                result.output `shouldSatisfy`
+                    Text.isInfixOf
+                        "url must not contain embedded credentials"
+        readIORef invoked `shouldReturn` False
+
     it "rejects empty selectors, empty keys, and invalid scroll deltas" do
         let run name arguments = dispatchToolCall defaultLoopDispatch
                 (appToolHandlers (browserTools successHandler))

--- a/packages/agent-cli/test/Agent/CLI/BrowserToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BrowserToolsSpec.hs
@@ -117,6 +117,9 @@ spec = describe "native browser tools" do
             [ "file:///tmp/private"
             , "javascript:alert(1)"
             , "https:relative"
+            , "http://"
+            , "http:///missing-host"
+            , "https://#missing-host"
             , " https://example.com"
             ]
             \url -> do
@@ -124,6 +127,19 @@ spec = describe "native browser tools" do
                 result.output `shouldSatisfy`
                     Text.isInfixOf "absolute HTTP or HTTPS URL"
         readIORef invoked `shouldReturn` False
+
+    it "accepts case-insensitive HTTP schemes with a nonempty host" do
+        observed <- newIORef Nothing
+        let handler command = do
+                writeIORef observed (Just command)
+                pure (Right "ok")
+        result <- dispatchToolCall defaultLoopDispatch
+            (appToolHandlers (browserTools handler))
+            (functionToolCall "browser-call" "browser_navigate"
+                "{\"url\":\"HTTPS://example.com/path\"}")
+        result.output `shouldBe` "ok"
+        readIORef observed `shouldReturn`
+            Just (BrowserNavigate "HTTPS://example.com/path")
 
     it "rejects empty selectors, empty keys, and invalid scroll deltas" do
         let run name arguments = dispatchToolCall defaultLoopDispatch
@@ -145,6 +161,9 @@ spec = describe "native browser tools" do
         shouldFailWith "browser_scroll"
             "{\"delta_x\":\"down\",\"delta_y\":1}"
             "Expected number for key: delta_x"
+        shouldFailWith "browser_scroll"
+            "{\"delta_x\":1e999,\"delta_y\":1}"
+            "delta_x must be a finite number"
 
 successHandler :: BrowserCommand -> IO (Either Text Text)
 successHandler _ = pure (Right "ok")

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BrowserBridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BrowserBridgeFFISpec.hs
@@ -1,0 +1,271 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE CPP #-}
+
+module Agent.CLI.MacOS.BrowserBridgeFFISpec (spec) where
+
+#ifdef darwin_HOST_OS
+import Agent.CLI.BrowserTools (BrowserCommand(..))
+import Agent.CLI.MacOS.Bridge
+    ( BrowserCallback
+    , BrowserHost(..)
+    , BrowserRegistration(..)
+    , browserCommandABI
+    , browserOutputCapacity
+    , browserStatusMessage
+    , browserToolsWhenEnabled
+    , invokeBrowserCommand
+    )
+import Agent.Loop (defaultLoopDispatch)
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
+import Agent.Tools.Types
+    ( AppTool(..)
+    , appToolHandlers
+    )
+import Control.Concurrent.MVar
+    ( modifyMVar_
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , takeMVar
+    )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+    ( poll
+    , wait
+    , withAsync
+    )
+import Control.Exception.Safe (bracket)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.IORef
+    ( IORef
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TextEncoding
+import Foreign
+    ( FunPtr
+    , Ptr
+    , castPtr
+    , copyBytes
+    , freeHaskellFunPtr
+    , nullPtr
+    , poke
+    )
+import Foreign.C.Types
+    ( CDouble(..)
+    , CInt(..)
+    , CSize(..)
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldReturn
+    , shouldSatisfy
+    )
+
+foreign import ccall "ha_browser_callback_abi_smoke"
+    browserCallbackAbiSmoke :: IO CInt
+
+foreign import ccall "wrapper"
+    wrapBrowserCallback :: BrowserCallback -> IO (FunPtr BrowserCallback)
+
+spec :: Spec
+spec = describe "native browser callback ABI" do
+    it "matches the C ABI and installs/disables a host callback" do
+        browserCallbackAbiSmoke `shouldReturn` 0
+
+    it "maps every typed command to stable ABI fields" do
+        browserCommandABI (BrowserNavigate "https://example.com")
+            `shouldBe` (1, "https://example.com", "", 0, 0, 0)
+        browserCommandABI BrowserSnapshot
+            `shouldBe` (2, "", "", 0, 0, 0)
+        browserCommandABI (BrowserClick "#continue")
+            `shouldBe` (3, "#continue", "", 0, 0, 0)
+        browserCommandABI (BrowserType "#query" "λ" True)
+            `shouldBe` (4, "#query", "λ", 0, 0, 1)
+        browserCommandABI BrowserBack
+            `shouldBe` (5, "", "", 0, 0, 0)
+        browserCommandABI BrowserForward
+            `shouldBe` (6, "", "", 0, 0, 0)
+        browserCommandABI BrowserReload
+            `shouldBe` (7, "", "", 0, 0, 0)
+        browserCommandABI (BrowserKey "Enter")
+            `shouldBe` (8, "Enter", "", 0, 0, 0)
+        browserCommandABI (BrowserScroll 12.5 (-800))
+            `shouldBe` (9, "", "", 12.5, -800, 0)
+        browserOutputCapacity `shouldBe` 262144
+
+    it "passes UTF-8 text and scroll fields to the registered callback" do
+        observed <- newIORef Nothing
+        withBrowserHost (recordingCallback observed) \host -> do
+            invokeBrowserCommand host
+                (BrowserType "#query" "Haskell λ" True)
+                `shouldReturn` Right "native ✓"
+            readIORef observed `shouldReturn`
+                Just (4, "#query", "Haskell λ", 0, 0, 1)
+            invokeBrowserCommand host (BrowserScroll 12.5 (-800))
+                `shouldReturn` Right "native ✓"
+            readIORef observed `shouldReturn`
+                Just (9, "", "", 12.5, -800, 0)
+
+    it "exposes tools only while a callback is registered" do
+        registration <- newMVar Nothing
+        let host = BrowserHost registration
+        disabledTools <- browserToolsWhenEnabled host
+        map (.appToolName) disabledTools `shouldBe` []
+        withCallback (successCallback "ok") \callback -> do
+            modifyMVar_ registration \_ ->
+                pure (Just (BrowserRegistration callback nullContext))
+            tools <- browserToolsWhenEnabled host
+            map (.appToolName) tools `shouldBe`
+                [ "browser_navigate"
+                , "browser_snapshot"
+                , "browser_click"
+                , "browser_type"
+                , "browser_key"
+                , "browser_scroll"
+                , "browser_back"
+                , "browser_forward"
+                , "browser_reload"
+                ]
+            modifyMVar_ registration (const (pure Nothing))
+            retained <- dispatchToolCall defaultLoopDispatch
+                (appToolHandlers tools)
+                (functionToolCall
+                    "browser-call"
+                    "browser_snapshot"
+                    "{}")
+            retained.output `shouldBe`
+                "Error: The browser view is not active."
+
+    it "rejects oversized and invalid UTF-8 callback output" do
+        withBrowserHost oversizedCallback \host ->
+            invokeBrowserCommand host BrowserSnapshot `shouldReturn`
+                Left "The browser returned more than the 256 KiB output limit."
+        withBrowserHost invalidUtf8Callback \host ->
+            invokeBrowserCommand host BrowserSnapshot `shouldReturn`
+                Left "The browser returned invalid UTF-8."
+
+    it "renders stable fallback errors for host statuses" do
+        browserStatusMessage 1 `shouldBe`
+            "The browser host rejected an invalid argument."
+        browserStatusMessage 2 `shouldBe`
+            "The native browser bridge is unavailable."
+        browserStatusMessage 3 `shouldBe`
+            "The browser command timed out."
+        browserStatusMessage 4 `shouldBe`
+            "The browser host denied website or extension access."
+        browserStatusMessage 5 `shouldBe`
+            "The browser host does not support this operation."
+        browserStatusMessage 6 `shouldBe`
+            "The native browser bridge failed internally."
+        browserStatusMessage 7 `shouldBe`
+            "The browser host returned a result that was too large."
+        browserStatusMessage 99 `shouldSatisfy`
+            (== "The browser command failed (status 99).")
+
+    it "waits for an in-flight callback before disabling its context" do
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        let blockingCallback _ _ _ _ _ _ _ _ _
+                output outputCapacity outputLength = do
+                putMVar entered ()
+                takeMVar release
+                writeResult "done" output outputCapacity outputLength
+        withCallback blockingCallback \callback -> do
+            registration <- newMVar
+                (Just (BrowserRegistration callback nullContext))
+            let host = BrowserHost registration
+            withAsync (invokeBrowserCommand host BrowserSnapshot) \running -> do
+                takeMVar entered
+                withAsync
+                    (modifyMVar_ registration (const (pure Nothing)))
+                    \disabling -> do
+                        threadDelay 20000
+                        poll disabling >>= \case
+                            Nothing -> pure ()
+                            Just _ -> expectationFailure
+                                "disabling returned before the callback completed"
+                        putMVar release ()
+                        wait running `shouldReturn` Right "done"
+                        wait disabling
+            invokeBrowserCommand host BrowserSnapshot `shouldReturn`
+                Left "The browser view is not active."
+
+type ObservedCall = (CInt, Text, Text, CDouble, CDouble, CInt)
+
+recordingCallback
+    :: IORef (Maybe ObservedCall)
+    -> BrowserCallback
+recordingCallback observed _ command argument1 argument1Length
+        argument2 argument2Length deltaX deltaY flags
+        output outputCapacity outputLength = do
+    first <- decodeBytes argument1 argument1Length
+    second <- decodeBytes argument2 argument2Length
+    writeIORef observed (Just
+        (command, first, second, deltaX, deltaY, flags))
+    writeResult ("native " <> BS.pack [0xe2, 0x9c, 0x93])
+        output outputCapacity outputLength
+
+successCallback :: ByteString -> BrowserCallback
+successCallback result _ _ _ _ _ _ _ _ _ output capacity length =
+    writeResult result output capacity length
+
+oversizedCallback :: BrowserCallback
+oversizedCallback _ _ _ _ _ _ _ _ _ _ _ outputLength = do
+    poke outputLength (fromIntegral browserOutputCapacity + 1)
+    pure 0
+
+invalidUtf8Callback :: BrowserCallback
+invalidUtf8Callback _ _ _ _ _ _ _ _ _
+        output outputCapacity outputLength =
+    writeResult (BS.pack [0xff]) output outputCapacity outputLength
+
+writeResult :: ByteString -> Ptr a -> CSize -> Ptr CSize -> IO CInt
+writeResult result output (CSize capacity) outputLength
+    | BS.length result > fromIntegral capacity = pure 7
+    | otherwise = do
+        BS.useAsCStringLen result \(source, length) ->
+            copyBytes output (castPtr source) length
+        poke outputLength (fromIntegral (BS.length result))
+        pure 0
+
+decodeBytes :: Ptr a -> CSize -> IO Text
+decodeBytes pointer (CSize length) = do
+    bytes <- BS.packCStringLen
+        (castPtr pointer, fromIntegral length)
+    case TextEncoding.decodeUtf8' bytes of
+        Left _ -> expectationFailure "callback input was not UTF-8" >> pure ""
+        Right value -> pure value
+
+withBrowserHost :: BrowserCallback -> (BrowserHost -> IO a) -> IO a
+withBrowserHost callback action =
+    withCallback callback \funPtr -> do
+        registration <- newMVar
+            (Just (BrowserRegistration funPtr nullContext))
+        action (BrowserHost registration)
+
+withCallback :: BrowserCallback -> (FunPtr BrowserCallback -> IO a) -> IO a
+withCallback callback =
+    bracket (wrapBrowserCallback callback) freeHaskellFunPtr
+
+nullContext :: Ptr ()
+nullContext = nullPtr
+#else
+import Test.Hspec (Spec, describe, it, pendingWith)
+
+spec :: Spec
+spec = describe "native browser callback ABI" do
+    it "links only on macOS" do
+        pendingWith "the native browser bridge smoke test only links on macOS"
+#endif

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BrowserBridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BrowserBridgeFFISpec.hs
@@ -112,11 +112,11 @@ spec = describe "native browser callback ABI" do
                 (BrowserType "#query" "Haskell λ" True)
                 `shouldReturn` Right "native ✓"
             readIORef observed `shouldReturn`
-                Just (4, "#query", "Haskell λ", 0, 0, 1)
+                Just (4, "#query", 6, "Haskell λ", 10, 0, 0, 1)
             invokeBrowserCommand host (BrowserScroll 12.5 (-800))
                 `shouldReturn` Right "native ✓"
             readIORef observed `shouldReturn`
-                Just (9, "", "", 12.5, -800, 0)
+                Just (9, "", 0, "", 0, 12.5, -800, 0)
 
     it "exposes tools only while a callback is registered" do
         registration <- newMVar Nothing
@@ -202,7 +202,8 @@ spec = describe "native browser callback ABI" do
             invokeBrowserCommand host BrowserSnapshot `shouldReturn`
                 Left "The browser view is not active."
 
-type ObservedCall = (CInt, Text, Text, CDouble, CDouble, CInt)
+type ObservedCall =
+    (CInt, Text, CSize, Text, CSize, CDouble, CDouble, CInt)
 
 recordingCallback
     :: IORef (Maybe ObservedCall)
@@ -213,7 +214,15 @@ recordingCallback observed _ command argument1 argument1Length
     first <- decodeBytes argument1 argument1Length
     second <- decodeBytes argument2 argument2Length
     writeIORef observed (Just
-        (command, first, second, deltaX, deltaY, flags))
+        ( command
+        , first
+        , argument1Length
+        , second
+        , argument2Length
+        , deltaX
+        , deltaY
+        , flags
+        ))
     writeResult ("native " <> BS.pack [0xe2, 0x9c, 0x93])
         output outputCapacity outputLength
 

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Agent.CLI.ApprovalSpec as ApprovalSpec
 import qualified Agent.CLI.ArtifactSpec as ArtifactSpec
 import qualified Agent.CLI.AuthSpec as AuthSpec
 import qualified Agent.CLI.BtwSpec as BtwSpec
+import qualified Agent.CLI.BrowserToolsSpec as BrowserToolsSpec
 import qualified Agent.CLI.CancelWatchSpec as CancelWatchSpec
 import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
@@ -30,6 +31,7 @@ import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
 import qualified Agent.CLI.MacOS.NativeLoopEventSpec as NativeLoopEventSpec
 import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
 import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
+import qualified Agent.CLI.MacOS.BrowserBridgeFFISpec as BrowserBridgeFFISpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.ModelConfigSpec as ModelConfigSpec
@@ -86,6 +88,7 @@ main = hspec do
     ArtifactSpec.spec
     AuthSpec.spec
     BtwSpec.spec
+    BrowserToolsSpec.spec
     CancelWatchSpec.spec
     ClipboardSpec.spec
     CommandSpec.spec
@@ -107,6 +110,7 @@ main = hspec do
     NativeLoopEventSpec.spec
     BridgeHeaderSpec.spec
     BridgeFFISpec.spec
+    BrowserBridgeFFISpec.spec
     MarkdownSpec.spec
     McpManagerSpec.spec
     ModelConfigSpec.spec

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeBrowserSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeBrowserSmoke.c
@@ -89,6 +89,11 @@ int ha_browser_callback_abi_smoke(void) {
             || HA_BROWSER_STATUS_UNSUPPORTED != 5
             || HA_BROWSER_STATUS_FAILED != 6
             || HA_BROWSER_STATUS_OUTPUT_TOO_LARGE != 7
+            || HA_BROWSER_URL_MAX_BYTES != 8192
+            || HA_BROWSER_SELECTOR_MAX_BYTES != 4096
+            || HA_BROWSER_TEXT_MAX_BYTES != 65536
+            || HA_BROWSER_KEY_MAX_BYTES != 128
+            || HA_BROWSER_SCROLL_MAX_ABS_DELTA != 10000
             || HA_BROWSER_OUTPUT_CAPACITY != 262144) {
         return 1;
     }

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeBrowserSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeBrowserSmoke.c
@@ -1,0 +1,142 @@
+#include "HaskellAgentBridge.h"
+
+#include <string.h>
+
+static void event_callback(
+    void *context,
+    const uint8_t *bytes,
+    size_t length
+) {
+    (void)context;
+    (void)bytes;
+    (void)length;
+}
+
+static int32_t browser_callback(
+    void *context,
+    int32_t command,
+    const uint8_t *argument1,
+    size_t argument1_length,
+    const uint8_t *argument2,
+    size_t argument2_length,
+    double scroll_delta_x,
+    double scroll_delta_y,
+    int32_t flags,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_length
+) {
+    const char *result = "native browser \xE2\x9C\x93";
+    size_t result_length = strlen(result);
+    (void)context;
+    if (output == NULL || output_length == NULL
+            || output_capacity < result_length) {
+        return HA_BROWSER_STATUS_INVALID_ARGUMENT;
+    }
+    switch (command) {
+        case HA_BROWSER_TYPE:
+            if (argument1_length != 6
+                    || memcmp(argument1, "#query", 6) != 0
+                    || argument2_length != 7
+                    || memcmp(argument2, "haskell", 7) != 0
+                    || scroll_delta_x != 0 || scroll_delta_y != 0
+                    || flags != HA_BROWSER_TYPE_SUBMIT) {
+                return HA_BROWSER_STATUS_INVALID_ARGUMENT;
+            }
+            break;
+        case HA_BROWSER_KEY:
+            if (argument1_length != 5
+                    || memcmp(argument1, "Enter", 5) != 0
+                    || argument2_length != 0
+                    || scroll_delta_x != 0 || scroll_delta_y != 0
+                    || flags != 0) {
+                return HA_BROWSER_STATUS_INVALID_ARGUMENT;
+            }
+            break;
+        case HA_BROWSER_SCROLL:
+            if (argument1_length != 0 || argument2_length != 0
+                    || scroll_delta_x != 12.5 || scroll_delta_y != -800
+                    || flags != 0) {
+                return HA_BROWSER_STATUS_INVALID_ARGUMENT;
+            }
+            break;
+        default:
+            return HA_BROWSER_STATUS_INVALID_ARGUMENT;
+    }
+    memcpy(output, result, result_length);
+    *output_length = result_length;
+    return HA_BROWSER_STATUS_SUCCESS;
+}
+
+/*
+ * Compile and exercise the exported setter exactly as a native UI host does.
+ * Stack-backed callback context is safe because disabling synchronizes with
+ * any callback before returning.
+ */
+int ha_browser_callback_abi_smoke(void) {
+    uint8_t output[64];
+    size_t output_length = 0;
+    if (HA_BROWSER_NAVIGATE != 1 || HA_BROWSER_SNAPSHOT != 2
+            || HA_BROWSER_CLICK != 3 || HA_BROWSER_TYPE != 4
+            || HA_BROWSER_BACK != 5 || HA_BROWSER_FORWARD != 6
+            || HA_BROWSER_RELOAD != 7 || HA_BROWSER_KEY != 8
+            || HA_BROWSER_SCROLL != 9 || HA_BROWSER_TYPE_SUBMIT != 1
+            || HA_BROWSER_STATUS_SUCCESS != 0
+            || HA_BROWSER_STATUS_INVALID_ARGUMENT != 1
+            || HA_BROWSER_STATUS_UNAVAILABLE != 2
+            || HA_BROWSER_STATUS_TIMEOUT != 3
+            || HA_BROWSER_STATUS_PERMISSION_DENIED != 4
+            || HA_BROWSER_STATUS_UNSUPPORTED != 5
+            || HA_BROWSER_STATUS_FAILED != 6
+            || HA_BROWSER_STATUS_OUTPUT_TOO_LARGE != 7
+            || HA_BROWSER_OUTPUT_CAPACITY != 262144) {
+        return 1;
+    }
+    if (browser_callback(
+            NULL, HA_BROWSER_TYPE,
+            (const uint8_t *)"#query", 6,
+            (const uint8_t *)"haskell", 7,
+            0, 0,
+            HA_BROWSER_TYPE_SUBMIT,
+            output, sizeof(output), &output_length) != 0
+            || output_length != 18
+            || memcmp(output, "native browser \xE2\x9C\x93", 18) != 0) {
+        return 2;
+    }
+    output_length = 0;
+    if (browser_callback(
+            NULL, HA_BROWSER_KEY,
+            (const uint8_t *)"Enter", 5,
+            (const uint8_t *)"", 0,
+            0, 0, 0,
+            output, sizeof(output), &output_length) != 0
+            || output_length != 18) {
+        return 3;
+    }
+    output_length = 0;
+    if (browser_callback(
+            NULL, HA_BROWSER_SCROLL,
+            (const uint8_t *)"", 0,
+            (const uint8_t *)"", 0,
+            12.5, -800, 0,
+            output, sizeof(output), &output_length) != 0
+            || output_length != 18) {
+        return 4;
+    }
+    if (ha_runtime_init() != 0) {
+        return 5;
+    }
+    void *engine = ha_engine_create(event_callback, NULL);
+    if (engine == NULL) {
+        ha_runtime_exit();
+        return 6;
+    }
+    int32_t status =
+        ha_engine_set_browser_callback(engine, browser_callback, NULL);
+    if (status == 0) {
+        status = ha_engine_set_browser_callback(engine, NULL, NULL);
+    }
+    ha_engine_destroy(engine);
+    ha_runtime_exit();
+    return status;
+}


### PR DESCRIPTION
## Summary

- add a typed native browser callback ABI with stable commands, statuses, UTF-8 bounds, and documented ownership/threading rules
- expose navigate, snapshot, click, type, key, scroll, history, and reload tools only while a native browser host is registered
- reject credential-bearing URLs, invalid selectors/keys/scroll values, oversized input/output, and calls made after browser deactivation
- synchronize callback replacement with in-flight calls so native hosts can safely tear down their context

## Validation

- native browser tool tests: 9 examples, 0 failures
- native browser callback ABI tests: 7 examples, 0 failures
- C ABI smoke coverage for registration, all typed commands, UTF-8/scroll fields, status mapping, output bounds, activation gating, and in-flight teardown
