### PR TITLE
Fix Telegram multiline reply delivery

### DIFF
--- a/packages/agent-telegram/src/Agent/Telegram/Client.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Client.hs
@@ -471,7 +471,11 @@ editRichMessageText
     -> Text
     -> IO (Either Text ())
 editRichMessageText client key messageId text =
-    requestUnit client "editMessageText" $ object
+    requestUnit client "editMessageText" richBody >>= \case
+        Left _ -> editMessageText client key messageId text
+        Right () -> pure (Right ())
+  where
+    richBody = object
         [ "chat_id" .= key.chatId
         , "message_id" .= messageId
         , "text" .= markdownToTelegramHtml text

--- a/packages/agent-telegram/src/Agent/Telegram/Markdown.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Markdown.hs
@@ -38,7 +38,7 @@ data ColumnAlignment
     | AlignRight
 
 renderBlocks :: Text -> Text
-renderBlocks = Text.intercalate "<br>" . go . Text.splitOn "\n"
+renderBlocks = Text.intercalate "\n" . go . Text.splitOn "\n"
   where
     go [] = []
     go (header : separator : rest)
@@ -144,8 +144,6 @@ telegramRenderedLength = go 0 . markdownToTelegramHtml
   where
     go count html
         | Text.null html = count
-        | Just rest <- Text.stripPrefix "<br>" html =
-            go (count + 1) rest
         | Just rest <- Text.stripPrefix "<" html =
             case Text.breakOn ">" rest of
                 (_, afterTag)

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -344,9 +344,15 @@ spec = describe "Agent.Telegram" do
             markdownToTelegramHtml
                 "**Bold** and *italic*\n`code` ~~gone~~ [site](https://example.com)"
                 `shouldBe`
-                    "<b>Bold</b> and <i>italic</i><br>\
+                    "<b>Bold</b> and <i>italic</i>\n\
                     \<code>code</code> <s>gone</s> \
                     \<a href=\"https://example.com\">site</a>"
+
+        it "uses Telegram-supported newlines instead of HTML break tags" do
+            let html = markdownToTelegramHtml
+                    "Aktuell frei:\n\n- **Festplatte:** 129 GB frei"
+            html `shouldSatisfy` Text.isInfixOf "\n\n"
+            html `shouldNotSatisfy` Text.isInfixOf "<br>"
 
         it "escapes literal HTML and link attributes" do
             markdownToTelegramHtml
@@ -358,14 +364,14 @@ spec = describe "Agent.Telegram" do
         it "renders fenced code without interpreting its Markdown" do
             markdownToTelegramHtml "before\n```haskell\nx < y && **raw**\n```\nafter"
                 `shouldBe`
-                    "before<br><pre>x &lt; y &amp;&amp; **raw**\n</pre><br>after"
+                    "before\n<pre>x &lt; y &amp;&amp; **raw**\n</pre>\nafter"
 
         it "renders ATX headings with native bold entities" do
             markdownToTelegramHtml
                 "# Summary\n#### Details with *emphasis*\nnot# a heading"
                 `shouldBe`
-                    "<b>Summary</b><br>\
-                    \<b>Details with <i>emphasis</i></b><br>\
+                    "<b>Summary</b>\n\
+                    \<b>Details with <i>emphasis</i></b>\n\
                     \not# a heading"
 
         it "renders Markdown tables as aligned preformatted text" do
@@ -382,7 +388,7 @@ spec = describe "Agent.Telegram" do
 
         it "does not mistake ordinary pipe-separated text for a table" do
             markdownToTelegramHtml "one | two\nstill | text"
-                `shouldBe` "one | two<br>still | text"
+                `shouldBe` "one | two\nstill | text"
 
         it "leaves unmatched delimiters literal" do
             markdownToTelegramHtml "unfinished **bold and `code"


### PR DESCRIPTION
## Summary

- render Telegram Bot API HTML line breaks as literal newlines
- fall back to a plain-text edit when rich finalization fails
- cover multiline Markdown with a production-shaped regression

## Why

Telegram rejects `<br>` in Bot API HTML (`Unsupported start tag "br"`), which caused completed replies to dead-letter during final message editing.

## Testing

- focused `markdownToTelegramHtml` spec: 8 examples, 0 failures
- full `agent-telegram` spec in Nix/GHCi: 72 examples, 0 failures