### PR TITLE
Normalize turn attachments

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -37,6 +37,8 @@ import Agent.Loop
     , TurnCompletion(..)
     , TurnInput(..)
     , TurnOutput(..)
+    , turnInputFiles
+    , turnInputImages
     )
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types
@@ -358,23 +360,16 @@ collectTurnInputs inputs = do
             [text]
         AgentMessage message ->
             [renderInterAgentMessage message]
-        UserMultimodal{userText} ->
-            [userText]
-        UserMultimodalFiles{userText} ->
-            [userText]
+        UserMessageWithAttachments text _ ->
+            [text]
         CompletedTool result ->
             pure $
                 "Host tool result for "
                     <> result.callId
                     <> ":\n"
                     <> result.output
-    inputImages = \case
-        UserMultimodal{userImages} -> userImages
-        UserMultimodalFiles{userImages} -> userImages
-        _ -> []
-    inputFiles = \case
-        UserMultimodalFiles{userFiles} -> mapM writeFallbackFile userFiles
-        _ -> pure []
+    inputImages = turnInputImages
+    inputFiles = mapM writeFallbackFile . turnInputFiles
 
     writeFallbackFile :: FileAttachment -> IO (Text, FilePath)
     writeFallbackFile FileAttachment{fileName, fileMime, fileBytes} = do

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -20,8 +20,10 @@ import Agent.Loop
     , ImageAttachment(..)
     , LoopEvent(..)
     , TokenUsage(..)
+    , TurnAttachment(..)
     , TurnInput(..)
     , TurnOutput(..)
+    , userMessageWithAttachments
     )
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types
@@ -446,15 +448,14 @@ spec = do
                         \backend ->
                             submitBackend backend
                                 Nothing
-                                [ UserMultimodal
-                                    { userText = "describe this image"
-                                    , userImages =
-                                        [ ImageAttachment
+                                [ userMessageWithAttachments
+                                    "describe this image"
+                                    [ ImageAttachmentItem
+                                        (ImageAttachment
                                             { imageMime = "image/png"
                                             , imageBytes = "png-bytes"
-                                            }
-                                        ]
-                                    }
+                                            })
+                                    ]
                                 ]
                                 (\_ -> pure ())
                 result `shouldSatisfy` \case
@@ -504,17 +505,15 @@ spec = do
                         \backend ->
                             submitBackend backend
                                 Nothing
-                                [ UserMultimodalFiles
-                                    { userText = "describe this file"
-                                    , userImages = []
-                                    , userFiles =
-                                        [ FileAttachment
+                                [ userMessageWithAttachments
+                                    "describe this file"
+                                    [ FileAttachmentItem
+                                        (FileAttachment
                                             { fileName = Just "attachment.txt"
                                             , fileMime = "text/plain"
                                             , fileBytes = "file-bytes"
-                                            }
-                                        ]
-                                    }
+                                            })
+                                    ]
                                 ]
                                 (\_ -> pure ())
                 result `shouldSatisfy` \case

--- a/packages/agent-cli/src/Agent/CLI/ManagedTurn.hs
+++ b/packages/agent-cli/src/Agent/CLI/ManagedTurn.hs
@@ -16,7 +16,9 @@ module Agent.CLI.ManagedTurn
 import Agent.Loop
     ( FileAttachment(..)
     , ImageAttachment(..)
-    , TurnInput(..)
+    , TurnAttachment(..)
+    , TurnInput(UserMessage)
+    , userMessageWithAttachments
     )
 import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.CLI.Json (decodeLazy, integer)
@@ -176,11 +178,11 @@ managedTurnInputs _ request
         let images = [image | Left image <- loaded]
             files = [file | Right file <- loaded]
         pure
-            [ UserMultimodalFiles
-                { userText = request.managedTurnText
-                , userImages = images
-                , userFiles = files
-                }
+            [ userMessageWithAttachments
+                request.managedTurnText
+                ( map ImageAttachmentItem images
+                    <> map FileAttachmentItem files
+                )
             ]
   where
     loadMedia = \case

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
@@ -27,8 +27,10 @@ import Agent.CLI.TUI.App
 import Agent.CLI.Terminal ( resolveColor )
 import Agent.CLI.Turn ( runOneTurn )
 import Agent.Loop
-    ( TurnInput(UserMultimodal, userImages, userText),
-      ImageAttachment(imageBytes, imageMime) )
+    ( ImageAttachment(imageBytes, imageMime)
+    , TurnAttachment(ImageAttachmentItem)
+    , userMessageWithAttachments
+    )
 import Agent.TUI.Model
     ( UiEvent(UiUserSubmitted, UiSetNotice, UiErrorMessage, UiSystemMessage) )
 import Control.Monad ( forM_, when )
@@ -180,10 +182,9 @@ handleAttachmentAction
                         fullscreenEvent
                             (UiUserSubmitted promptText)
                         let turnInputs =
-                                [ UserMultimodal
-                                    { userText = promptText
-                                    , userImages = images
-                                    }
+                                [ userMessageWithAttachments
+                                    promptText
+                                    (map ImageAttachmentItem images)
                                 ]
                         result <- runOneTurn env promptText turnInputs
                         finishTurn False result

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -202,8 +202,11 @@ import Agent.Claude ()
 import Agent.Dialect ()
 import Agent.Error ()
 import Agent.Loop
-    ( TurnInput(UserMessage, UserMultimodal, userText, userImages),
-      LoopEvent(ActivityUpdated) )
+    ( LoopEvent(ActivityUpdated)
+    , TurnAttachment(ImageAttachmentItem)
+    , TurnInput(UserMessage)
+    , userMessageWithAttachments
+    )
 import Agent.OpenAI.Compaction ( compactSessionUserText )
 import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient ()
@@ -433,14 +436,12 @@ handleReplLine
                                     commitFullscreenImagePreviews runtime pendingImages
                                 resetRenderPrintedText render
                                 let turnInputs =
-                                        if null pendingImages
-                                            then [UserMessage text]
-                                            else
-                                                [ UserMultimodal
-                                                    { userText = text
-                                                    , userImages = pendingImages
-                                                    }
-                                                ]
+                                        [ userMessageWithAttachments
+                                            text
+                                            (map
+                                                ImageAttachmentItem
+                                                pendingImages)
+                                        ]
                                 preparePromptSkillInputs env text turnInputs >>= \case
                                     Left err -> do
                                         displayError err $
@@ -475,12 +476,11 @@ handleReplLine
                                                 <> " skill."
                                             else arguments
                                     userInput =
-                                        if null pendingImages
-                                            then UserMessage userText
-                                            else UserMultimodal
-                                                { userText = userText
-                                                , userImages = pendingImages
-                                                }
+                                        userMessageWithAttachments
+                                            userText
+                                            (map
+                                                ImageAttachmentItem
+                                                pendingImages)
                                     skillInputs =
                                         [ UserMessage
                                             (formatSkillActivation
@@ -921,14 +921,10 @@ handleReplLine
         forM_ fullscreen \runtime ->
             commitFullscreenImagePreviews runtime pendingImages
         let turnInputs =
-                if null pendingImages
-                    then [UserMessage expanded]
-                    else
-                        [ UserMultimodal
-                            { userText = expanded
-                            , userImages = pendingImages
-                            }
-                        ]
+                [ userMessageWithAttachments
+                    expanded
+                    (map ImageAttachmentItem pendingImages)
+                ]
         preparePromptSkillInputs env original turnInputs >>= \case
             Left err -> do
                 displayError err $

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -815,10 +815,9 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 images <- loadImagesFromPastedText text
                 let input = case images of
                         Just attached@(_:_) ->
-                            UserMultimodal
-                                { userText = "Image attached."
-                                , userImages = attached
-                                }
+                            userMessageWithAttachments
+                                "Image attached."
+                                (map ImageAttachmentItem attached)
                         _ -> UserMessage text
                 callbacks.runnerPreparePromptSkillInputs
                     env text [input] >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Timestamp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Timestamp.hs
@@ -15,7 +15,7 @@ module Agent.CLI.Timestamp
     , timeContextGuidance
     ) where
 
-import Agent.Loop (TurnInput(..))
+import Agent.Loop (TurnInput, mapTurnInputUserText)
 import Data.Char (isAsciiUpper, isDigit)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -66,28 +66,16 @@ stampUserTextAt tz now text =
             then stripped
             else stripped <> " " <> stamp
 
--- | Stamp every human 'UserMessage' / 'UserMultimodal' payload. Tool results
--- and other turn inputs are left unchanged.
+-- | Stamp every human user payload. Tool results and other turn inputs are
+-- left unchanged.
 stampTurnInputs :: [TurnInput] -> IO [TurnInput]
 stampTurnInputs inputs = do
     now <- getCurrentTime
     tz <- getCurrentTimeZone
-    pure (map (stampOne tz now) inputs)
-  where
-    stampOne tz now = \case
-        UserMessage text -> UserMessage (stampUserTextAt tz now text)
-        UserMultimodal{userText, userImages} ->
-            UserMultimodal
-                { userText = stampUserTextAt tz now userText
-                , userImages
-                }
-        UserMultimodalFiles{userText, userImages, userFiles} ->
-            UserMultimodalFiles
-                { userText = stampUserTextAt tz now userText
-                , userImages
-                , userFiles
-                }
-        other -> other
+    pure
+        (map
+            (mapTurnInputUserText (stampUserTextAt tz now))
+            inputs)
 
 hasTrailingTimestamp :: Text -> Bool
 hasTrailingTimestamp text =

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -115,12 +115,12 @@ import Agent.Loop
     , LoopError(..)
     , LoopProgress(..)
     , LoopResult(..)
-    , ImageAttachment
     , TurnCompletion(..)
     , TurnInput(..)
     , TurnOutput(..)
     , addTokenUsage
     , runLoopInputsDetailed
+    , turnInputImages
     )
 import Agent.Provider (Provider(..))
 import Agent.Responses.Types (ResponseItem)
@@ -173,12 +173,6 @@ runOneTurn = runOneTurnWithContext True
 -- be generated again.
 retryCheckpointedTurn :: SessionEnv -> IO TurnResult
 retryCheckpointedTurn env = runOneTurnWithContext False env "" []
-
-turnInputImages :: TurnInput -> [ImageAttachment]
-turnInputImages = \case
-    UserMultimodal{userImages} -> userImages
-    UserMultimodalFiles{userImages} -> userImages
-    _ -> []
 
 runOneTurnWithContext
     :: Bool
@@ -668,10 +662,11 @@ grokFrameLastUserInput = reverse . go . reverse
     go [] = []
     go (UserMessage text : rest) =
         UserMessage (grokUserQuery text) : rest
-    go (input@UserMultimodal{userText} : rest) =
-        input { userText = grokUserQuery userText } : rest
-    go (input@UserMultimodalFiles{userText} : rest) =
-        input { userText = grokUserQuery userText } : rest
+    go (UserMessageWithAttachments text attachments : rest) =
+        UserMessageWithAttachments
+            (grokUserQuery text)
+            attachments
+            : rest
     go (input : rest) = input : go rest
 
 grokUserQuery :: Text -> Text

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1208,10 +1208,9 @@ spec = do
                         , imageBytes = ByteString.replicate (1024 * 1024) 1
                         }
                 inputs =
-                    [ UserMultimodal
-                        { userText = "what does this screenshot show?"
-                        , userImages = [image]
-                        }
+                    [ userMessageWithAttachments
+                        "what does this screenshot show?"
+                        [ImageAttachmentItem image]
                     ]
                 items = turnInputsToItems inputs
                 naiveTokens =

--- a/packages/agent-cli/test/Agent/CLI/ManagedTurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ManagedTurnSpec.hs
@@ -12,7 +12,8 @@ import Agent.CLI.ManagedTurn
 import Agent.Loop
     ( FileAttachment(..)
     , ImageAttachment(..)
-    , TurnInput(..)
+    , TurnAttachment(..)
+    , userMessageWithAttachments
     )
 import Agent.OsPath (fromText)
 import qualified Data.ByteString.Char8 as ByteString.Char8
@@ -104,31 +105,31 @@ spec = describe "Agent.CLI.ManagedTurn" do
                         }
             managedTurnInputs (fromText (Text.pack dir)) request
                 `shouldReturn`
-                    [ UserMultimodalFiles
-                        { userText = "summarize"
-                        , userImages =
-                            [ ImageAttachment
+                    [ userMessageWithAttachments
+                        "summarize"
+                        [ ImageAttachmentItem
+                            (ImageAttachment
                                 { imageMime = "image/test"
                                 , imageBytes = "image-one"
-                                }
-                            , ImageAttachment
+                                })
+                        , ImageAttachmentItem
+                            (ImageAttachment
                                 { imageMime = "image/test"
                                 , imageBytes = "image-two"
-                                }
-                            ]
-                        , userFiles =
-                            [ FileAttachment
+                                })
+                        , FileAttachmentItem
+                            (FileAttachment
                                 { fileName = Just "one.txt"
                                 , fileMime = "text/plain"
                                 , fileBytes = "file-one"
-                                }
-                            , FileAttachment
+                                })
+                        , FileAttachmentItem
+                            (FileAttachment
                                 { fileName = Just "two.txt"
                                 , fileMime = "text/plain"
                                 , fileBytes = "file-two"
-                                }
-                            ]
-                        }
+                                })
+                        ]
                     ]
 
 withManagedTempDir :: (FilePath -> IO a) -> IO a

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -15,10 +15,12 @@ import Agent.Loop
     , LoopExecution(..)
     , LoopProgress(..)
     , TokenUsage(..)
+    , TurnAttachment(..)
     , TurnCompletion(..)
     , TurnInput(..)
     , TurnOutput(..)
     , emptyTurnOutput
+    , userMessageWithAttachments
     )
 import Agent.Responses.LoopBackend (toolResultToItem, turnInputsToItems)
 import Agent.Responses.Types
@@ -105,7 +107,10 @@ spec = do
                     { preparedBeforeItems = history
                     , preparedConsumedStartup = Nothing
                     , preparedTurnInputs =
-                        [UserMultimodal "inspect this" [image]]
+                        [ userMessageWithAttachments
+                            "inspect this"
+                            [ImageAttachmentItem image]
+                        ]
                     }
                 final = applyConversationPatch
                     (finishConversation
@@ -117,7 +122,10 @@ spec = do
                 `shouldBe`
                     history
                         <> turnInputsToItems
-                            [UserMultimodal "inspect this" [image]]
+                            [ userMessageWithAttachments
+                                "inspect this"
+                                [ImageAttachmentItem image]
+                            ]
 
         it "restores startup without changing conversation state for retry" do
             let final = applyConversationPatch
@@ -410,11 +418,14 @@ spec = do
         it "wraps multimodal user text without changing images" do
             let image = ImageAttachment "image/png" "png"
             grokFrameLastUserInput
-                [UserMultimodal "describe this" [image]]
+                [ userMessageWithAttachments
+                    "describe this"
+                    [ImageAttachmentItem image]
+                ]
                 `shouldBe`
-                    [ UserMultimodal
+                    [ userMessageWithAttachments
                         "<user_query>\ndescribe this\n</user_query>"
-                        [image]
+                        [ImageAttachmentItem image]
                     ]
 
         it "renders first-turn environment and optional git status" do

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -32,6 +32,7 @@ import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
+import qualified Agent.CLI.ManagedTurnSpec as ManagedTurnSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.MetaConsoleSpec as MetaConsoleSpec
@@ -115,6 +116,7 @@ main = hspec do
     InterruptSpec.spec
     LoginSpec.spec
     LearnedSkillsSpec.spec
+    ManagedTurnSpec.spec
     MarkdownSpec.spec
     McpManagerSpec.spec
     MetaConsoleSpec.spec

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -15,6 +15,7 @@ module Agent.Loop
     , LoopProgress(..)
     , LoopResult(..)
     , TokenUsage(..)
+    , TurnAttachment(..)
     , TurnCompletion(..)
     , TurnInput(..)
     , TurnOutput(..)
@@ -28,11 +29,15 @@ module Agent.Loop
     , generationTokensPerSecond
     , liveTokenRateMinMillis
     , liveTokensPerSecond
+    , mapTurnInputUserText
     , runLoop
-    , tokensPerSecond
-    , tokenUsageDecoder
     , runLoopInputs
     , runLoopInputsDetailed
+    , tokensPerSecond
+    , tokenUsageDecoder
+    , turnInputFiles
+    , turnInputImages
+    , userMessageWithAttachments
     ) where
 
 import Agent.Loop.Internal

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -49,6 +49,8 @@ import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntSet as IntSet
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -84,20 +86,54 @@ instance Show FileAttachment where
             <> ", fileByteLength = " <> show (ByteString.length file.fileBytes)
             <> " }"
 
+-- | A provider-neutral user attachment, retained in source order.
+data TurnAttachment
+    = ImageAttachmentItem !ImageAttachment
+    | FileAttachmentItem !FileAttachment
+    deriving (Eq, Show)
+
+-- | One input supplied to the provider-neutral agent loop.
 data TurnInput
     = UserMessage Text
     | AgentMessage InterAgentMessage
-    | UserMultimodal
-        { userText :: !Text
-        , userImages :: ![ImageAttachment]
-        }
-    | UserMultimodalFiles
-        { userText :: !Text
-        , userImages :: ![ImageAttachment]
-        , userFiles :: ![FileAttachment]
-        }
+    | UserMessageWithAttachments !Text !(NonEmpty TurnAttachment)
     | CompletedTool ToolCallResult
     deriving (Eq, Show)
+
+-- | Build a user message, using the text-only representation when the
+-- attachment list is empty.
+userMessageWithAttachments :: Text -> [TurnAttachment] -> TurnInput
+userMessageWithAttachments text =
+    maybe (UserMessage text) (UserMessageWithAttachments text)
+        . NonEmpty.nonEmpty
+
+-- | Images attached to a user input, in source order.
+turnInputImages :: TurnInput -> [ImageAttachment]
+turnInputImages = \case
+    UserMessageWithAttachments _ attachments ->
+        [ image
+        | ImageAttachmentItem image <- NonEmpty.toList attachments
+        ]
+    _ -> []
+
+-- | Files attached to a user input, in source order.
+turnInputFiles :: TurnInput -> [FileAttachment]
+turnInputFiles = \case
+    UserMessageWithAttachments _ attachments ->
+        [ file
+        | FileAttachmentItem file <- NonEmpty.toList attachments
+        ]
+    _ -> []
+
+-- | Transform user-authored text without changing attachments or other input
+-- variants.
+mapTurnInputUserText :: (Text -> Text) -> TurnInput -> TurnInput
+mapTurnInputUserText transform = \case
+    UserMessage text ->
+        UserMessage (transform text)
+    UserMessageWithAttachments text attachments ->
+        UserMessageWithAttachments (transform text) attachments
+    other -> other
 
 -- | Provider-reported token counts for one model response. @inputTokens@
 -- typically includes any cached prefix; @cachedTokens@ is that subset when

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -60,6 +60,10 @@ spec = describe "runLoop" do
         rendered `shouldContain` "<redacted>"
         rendered `shouldNotContain` "secret-file-bytes"
 
+    it "normalizes an empty attachment list to a text-only message" do
+        userMessageWithAttachments "hello" []
+            `shouldBe` UserMessage "hello"
+
     it "combines TokenUsage component-wise" do
         TokenUsage 10 4 6 <> TokenUsage 3 2 1
             `shouldBe` TokenUsage 13 6 7
@@ -113,10 +117,9 @@ spec = describe "runLoop" do
             ]
         let image = ImageAttachment "image/png" "abc"
             inputs =
-                [ UserMultimodal
-                    { userText = "see this"
-                    , userImages = [image]
-                    }
+                [ userMessageWithAttachments
+                    "see this"
+                    [ImageAttachmentItem image]
                 ]
         config <- testConfig backend
         result <- runLoopInputs config Nothing inputs
@@ -137,11 +140,11 @@ spec = describe "runLoop" do
         let image = ImageAttachment "image/png" "abc"
             file = FileAttachment (Just "notes.txt") "text/plain" "file-bytes"
             inputs =
-                [ UserMultimodalFiles
-                    { userText = "see this"
-                    , userImages = [image]
-                    , userFiles = [file]
-                    }
+                [ userMessageWithAttachments
+                    "see this"
+                    [ ImageAttachmentItem image
+                    , FileAttachmentItem file
+                    ]
                 ]
         config <- testConfig backend
         result <- runLoopInputs config Nothing inputs

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -118,7 +118,10 @@ spec = do
         it "encodes multimodal turns as input_text plus input_image data URLs" do
             let image = ImageAttachment "image/png" "png-bytes"
             case turnInputsToItems
-                    [UserMultimodal "see this" [image]] of
+                    [ userMessageWithAttachments
+                        "see this"
+                        [ImageAttachmentItem image]
+                    ] of
                 [MessageItem message] -> do
                     message.role `shouldBe` RoleUser
                     case message.content of
@@ -145,7 +148,12 @@ spec = do
             let image = ImageAttachment "image/png" "png-bytes"
                 file = FileAttachment (Just "notes.txt") "text/plain" "file-bytes"
             case turnInputsToItems
-                    [UserMultimodalFiles "see this" [image] [file]] of
+                    [ userMessageWithAttachments
+                        "see this"
+                        [ ImageAttachmentItem image
+                        , FileAttachmentItem file
+                        ]
+                    ] of
                 [MessageItem message] -> do
                     message.role `shouldBe` RoleUser
                     case message.content of

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -36,6 +36,7 @@ import Agent.Loop
     , ImageAttachment(..)
     , LoopEvent(..)
     , TokenUsage(..)
+    , TurnAttachment(..)
     , TurnCompletion(..)
     , TurnInput(..)
     , TurnOutput(..)
@@ -64,6 +65,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
 import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import Data.IORef (atomicModifyIORef', newIORef)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, mapMaybe, maybeToList)
@@ -282,9 +284,8 @@ turnInputToItem :: TurnInput -> ResponseItem
 turnInputToItem = \case
     UserMessage text -> userMessageItem text
     AgentMessage message -> agentMessageItem message
-    UserMultimodal{userText, userImages} -> multimodalUserItem userText userImages
-    UserMultimodalFiles{userText, userImages, userFiles} ->
-        multimodalFilesItem userText userImages userFiles
+    UserMessageWithAttachments text attachments ->
+        userMessageWithAttachmentsItem text attachments
     CompletedTool result -> toolResultToItem result
 
 userMessageItem :: Text -> ResponseItem
@@ -298,13 +299,15 @@ userMessageItem text = MessageItem ResponseMessage
 
     }
 
-multimodalFilesItem :: Text -> [ImageAttachment] -> [FileAttachment] -> ResponseItem
-multimodalFilesItem text images files = MessageItem ResponseMessage
+userMessageWithAttachmentsItem
+    :: Text
+    -> NonEmpty.NonEmpty TurnAttachment
+    -> ResponseItem
+userMessageWithAttachmentsItem text attachments = MessageItem ResponseMessage
     { messageId = Nothing
     , content = MessageContentParts
         ( InputTextPart text Nothing
-        : map imageAttachmentPart images
-        <> map fileAttachmentPart files
+        : map attachmentPart (NonEmpty.toList attachments)
         )
     , role = RoleUser
     , status = Nothing
@@ -333,20 +336,10 @@ agentMessageContent message = case message.messageContent of
             Nothing
         , EncryptedContentPart encrypted
         ]
-
-multimodalUserItem :: Text -> [ImageAttachment] -> ResponseItem
-multimodalUserItem text images = MessageItem ResponseMessage
-    { messageId = Nothing
-    , content = MessageContentParts
-        ( InputTextPart text Nothing
-        : map imageAttachmentPart images
-        )
-    , role = RoleUser
-    , status = Nothing
-    , phase = Nothing
-    , passthrough = Nothing
-
-    }
+attachmentPart :: TurnAttachment -> ResponseContentPart
+attachmentPart = \case
+    ImageAttachmentItem image -> imageAttachmentPart image
+    FileAttachmentItem file -> fileAttachmentPart file
 
 imageAttachmentPart :: ImageAttachment -> ResponseContentPart
 imageAttachmentPart ImageAttachment{imageMime, imageBytes} =

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -6,7 +6,9 @@ import Agent.Loop
     , FileAttachment(..)
     , ImageAttachment(..)
     , LoopEvent(..)
+    , TurnAttachment(..)
     , TurnInput(..)
+    , userMessageWithAttachments
     )
 import Agent.Provider
     ( Credential(..)
@@ -114,13 +116,18 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
         let image = ImageAttachment "image/png" "png-bytes"
             file = FileAttachment (Just "notes.txt") "text/plain" "file-bytes"
         case turnInputsToItems
-                [UserMultimodalFiles "see this" [image] [file]] of
+                [ userMessageWithAttachments
+                    "see this"
+                    [ ImageAttachmentItem image
+                    , FileAttachmentItem file
+                    ]
+                ] of
             [MessageItem message] -> do
                 message.role `shouldBe` RoleUser
                 case message.content of
-                    MessageContentParts parts ->
-                        parts `shouldSatisfy` \ps ->
-                            any isInputFile ps && any isInputImage ps
+                    MessageContentParts
+                        [InputTextPart{}, InputImagePart{}, InputFilePart{}] ->
+                            pure ()
                     _ -> expectationFailure "expected multimodal message parts"
             other -> expectationFailure ("unexpected items: " <> show other)
 
@@ -771,16 +778,6 @@ credential label = Credential
     , leaseId = Nothing
     , provider = OpenRouterProvider
     }
-
-isInputFile :: ResponseContentPart -> Bool
-isInputFile = \case
-    InputFilePart{} -> True
-    _ -> False
-
-isInputImage :: ResponseContentPart -> Bool
-isInputImage = \case
-    InputImagePart{} -> True
-    _ -> False
 
 isUserMessage :: ResponseItem -> Bool
 isUserMessage = \case


### PR DESCRIPTION
## Summary

- replace the parallel `UserMultimodal` input variants with one ordered `NonEmpty TurnAttachment` representation
- centralize empty-list normalization, attachment projections, and user-text transformations in `Agent.Loop`
- migrate CLI, Responses, OpenAI, and Claude integrations while preserving text/image/file behavior and ordering
- register `Agent.CLI.ManagedTurnSpec` in the CLI test runner and strengthen attachment-order regression coverage

## Validation

- multi-library GHCi load: 384 modules loaded
- `agent-core`: 433 examples, 0 failures
- `agent-responses`: 75 examples, 0 failures
- `agent-claude`: 41 examples, 0 failures
- focused `agent-openai` conversion tests: 6 examples, 0 failures
- focused CLI tests (`finishConversation`, Grok framing, compaction image handling, and `ManagedTurn`): 19 examples, 0 failures
- `git diff --check`
- independent review found no actionable issues

The full CLI GHCi suite progressed through the affected areas without an Hspec failure, then the GHCi process segfaulted later in the unrelated generated fullscreen-rendering property section. The focused affected CLI groups all pass in fresh GHCi sessions.
