### PR TITLE
Add Codex workflow slash commands

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -173,6 +173,7 @@ library
                     , Agent.CLI.ImagePreview
                     , Agent.CLI.GatewayBridge
                     , Agent.CLI.GatewayClient
+                    , Agent.CLI.GitDiff
                     , Agent.CLI.Input
                     , Agent.CLI.Input.Types
                     , Agent.CLI.Input.Display
@@ -206,6 +207,7 @@ library
                     , Agent.CLI.Prompt
                     , Agent.CLI.Recap
                     , Agent.CLI.Request
+                    , Agent.CLI.Review
                     , Agent.CLI.ProviderFallback
                     , Agent.CLI.ProviderAvailability
                     , Agent.CLI.ProviderTransition
@@ -231,6 +233,7 @@ library
                     , Agent.CLI.TextLayout
                     , Agent.CLI.Timestamp
                     , Agent.CLI.Transcript
+                    , Agent.CLI.TranscriptExport
                     , Agent.CLI.Tools
                     , Agent.CLI.TUI.App
                     , Agent.CLI.TUI.Bridge
@@ -424,6 +427,7 @@ test-suite agent-cli-test
                     , Agent.CLI.FileUriSpec
                     , Agent.CLI.GatewayBridgeSpec
                     , Agent.CLI.GatewayClientSpec
+                    , Agent.CLI.GitDiffSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec
                     , Agent.CLI.InterruptSpec
@@ -455,6 +459,7 @@ test-suite agent-cli-test
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec
                     , Agent.CLI.ResumeSpec
+                    , Agent.CLI.ReviewSpec
                     , Agent.CLI.SecretSpec
                     , Agent.CLI.StyleSpec
                     , Agent.CLI.TimestampSpec
@@ -462,6 +467,7 @@ test-suite agent-cli-test
                     , Agent.CLI.TextLayoutSpec
                     , Agent.CLI.TranscriptSpec
                     , Agent.CLI.TurnSpec
+                    , Agent.CLI.TranscriptExportSpec
                     , Agent.CLI.SessionSpec
                     , Agent.CLI.SessionHistorySpec
                     , Agent.CLI.SessionStateSpec

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Approval
     , childApprove
     , planApproval
     , resolveApprovalPrompt
+    , setApprovalPolicy
     , toggleAlwaysApprove
     ) where
 
@@ -198,6 +199,18 @@ toggleAlwaysApprove policyRef projectRoot = do
     pure (case next of
         ApproveAll -> "auto-approve on (saved for project)"
         _ -> "auto-approve off (saved for project)")
+
+-- | Set the interactive approval policy and persist the compatible
+-- project-wide auto-approve flag. The on-disk format predates the
+-- read-only policy, so only 'ApproveAll' is persisted as enabled.
+setApprovalPolicy :: IORef ApprovalPolicy -> OsPath -> ApprovalPolicy -> IO Text
+setApprovalPolicy policyRef projectRoot policy = do
+    atomicModifyIORef' policyRef (const (policy, ()))
+    saveProjectAutoApprove projectRoot (policy == ApproveAll)
+    pure $ case policy of
+        ApproveAll -> "full access enabled (saved for project)"
+        PromptMutating -> "ask before changes (saved for project)"
+        DenyMutating -> "read-only enabled for this session"
 
 childApprove :: ApprovalPolicy -> ToolRegistry -> ToolCall -> IO (Either Text Bool)
 childApprove policy tools call = case policy of

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -15,6 +15,7 @@ module Agent.CLI.Command
     , formatSlashHelpWithCatalog
     , formatSlashHelpWithSkills
     , goalInstruction
+    , initInstruction
     , lookupSlashCommand
     , lookupSlashCommandIn
     , loopScheduleInstruction
@@ -48,6 +49,7 @@ import Agent.CLI.Command.Catalog (slashCommands)
 import Agent.CLI.Command.Instructions
     ( deepResearchInstruction
     , goalInstruction
+    , initInstruction
     , loopScheduleInstruction
     , workflowInstruction
     )

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -212,6 +212,31 @@ parseSlash catalog raw line = case Text.words line of
             Nothing -> unknownCommand command
         Just spec -> case spec.slashName of
             "help" -> parseHelpCommand catalog args
+            "init" ->
+                if null args
+                    then ReplInit
+                    else ReplCommandError "usage: /init"
+            "review" ->
+                let instructions =
+                        Text.strip (Text.drop (Text.length command) line)
+                in ReplReview
+                    (if Text.null instructions then Nothing else Just instructions)
+            "diff" ->
+                if null args
+                    then ReplDiff
+                    else ReplCommandError "usage: /diff"
+            "fork" ->
+                let name = Text.strip (Text.drop (Text.length command) line)
+                in ReplFork
+                    (if Text.null name then Nothing else Just name)
+            "export" ->
+                let path = Text.strip (Text.drop (Text.length command) line)
+                in ReplExport
+                    (if Text.null path then Nothing else Just path)
+            "permissions" ->
+                if null args
+                    then ReplPermissions
+                    else ReplCommandError "usage: /permissions"
             "effort" -> parseEffortCommand args
             "fast" ->
                 if null args

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -8,6 +8,12 @@ import Agent.Dialect (DialectId(..))
 slashCommands :: [SlashCommand]
 slashCommands =
     [ cmd "help" [] "/help [NAME]" "List slash commands, or describe one" True
+    , cmd "init" [] "/init" "Create an AGENTS.md contributor guide" False
+    , cmd "review" [] "/review [INSTRUCTIONS]" "Review current changes and find issues" True
+    , cmd "diff" [] "/diff" "Show Git diff, including untracked files" False
+    , cmd "fork" [] "/fork [NAME]" "Fork the current chat into a new session" True
+    , cmd "export" [] "/export [PATH]" "Export the conversation as Markdown" True
+    , cmd "permissions" [] "/permissions" "Choose the tool approval policy" False
     , cmd "model" ["m"] "/model [NAME]" "Open the model picker, or set a model" True
     , cmd "effort" [] "/effort [none|low|medium|high|xhigh|max]" "Show or set reasoning effort" True
     , codexCmd "fast" [] "/fast" "Toggle the Fast service tier" False

--- a/packages/agent-cli/src/Agent/CLI/Command/Instructions.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Instructions.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.Command.Instructions
     ( deepResearchInstruction
     , goalInstruction
+    , initInstruction
     , loopScheduleInstruction
     , workflowInstruction
     ) where
@@ -11,6 +12,58 @@ import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8)
+
+-- | Prompt used by @/init@ to create the repository contributor guide.
+--
+-- Keep this synchronized with Codex's bundled
+-- @prompt_for_init_command.md@ prompt.  It intentionally asks the model to
+-- check for an existing file before writing so an existing guide is never
+-- replaced.
+initInstruction :: Text
+initInstruction =
+    Text.unlines
+        [ "Generate a file named AGENTS.md that serves as a contributor guide for this repository."
+        , "Before writing, check whether AGENTS.md already exists in the current working directory. If it does, do not overwrite or modify it."
+        , "Your goal is to produce a clear, concise, and well-structured document with descriptive headings and actionable explanations for each section."
+        , "Follow the outline below, but adapt as needed — add sections if relevant, and omit those that do not apply to this project."
+        , ""
+        , "Document Requirements"
+        , ""
+        , "- Title the document \"Repository Guidelines\"."
+        , "- Use Markdown headings (#, ##, etc.) for structure."
+        , "- Keep the document concise. 200-400 words is optimal."
+        , "- Keep explanations short, direct, and specific to this repository."
+        , "- Provide examples where helpful (commands, directory paths, naming patterns)."
+        , "- Maintain a professional, instructional tone."
+        , ""
+        , "Recommended Sections"
+        , ""
+        , "Project Structure & Module Organization"
+        , ""
+        , "- Outline the project structure, including where the source code, tests, and assets are located."
+        , ""
+        , "Build, Test, and Development Commands"
+        , ""
+        , "- List key commands for building, testing, and running locally (e.g., npm test, make build)."
+        , "- Briefly explain what each command does."
+        , ""
+        , "Coding Style & Naming Conventions"
+        , ""
+        , "- Specify indentation rules, language-specific style preferences, and naming patterns."
+        , "- Include any formatting or linting tools used."
+        , ""
+        , "Testing Guidelines"
+        , ""
+        , "- Identify testing frameworks and coverage requirements."
+        , "- State test naming conventions and how to run tests."
+        , ""
+        , "Commit & Pull Request Guidelines"
+        , ""
+        , "- Summarize commit message conventions found in the project’s Git history."
+        , "- Outline pull request requirements (descriptions, linked issues, screenshots, etc.)."
+        , ""
+        , "(Optional) Add other sections if relevant, such as Security & Configuration Tips, Architecture Overview, or Agent-Specific Instructions."
+        ]
 
 loopScheduleInstruction :: Text -> Text
 loopScheduleInstruction args =

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -21,6 +21,12 @@ data ReplAction
     | ReplPrompt Text
     | ReplExpandedPrompt !Text !Text
       -- ^ Original user-visible text and the model-visible expansion.
+    | ReplInit
+    | ReplReview (Maybe Text)
+    | ReplDiff
+    | ReplFork (Maybe Text)
+    | ReplExport (Maybe Text)
+    | ReplPermissions
     | ReplShowEffort
     | ReplSetEffort ReasoningEffort
     | ReplToggleFast

--- a/packages/agent-cli/src/Agent/CLI/GitDiff.hs
+++ b/packages/agent-cli/src/Agent/CLI/GitDiff.hs
@@ -1,0 +1,310 @@
+-- | Safe, informational Git inspection used by @/diff@ and @/review@.
+--
+-- Git repositories can configure executable diff, text-conversion, filter,
+-- hook, and fsmonitor helpers.  Slash commands that only inspect a repository
+-- must not execute those helpers as a side effect.
+module Agent.CLI.GitDiff
+    ( GitCommandOutput(..)
+    , GitDiffResult(..)
+    , getGitDiff
+    , gitOutputText
+    , runSafeGit
+    ) where
+
+import Agent.OsPath (unsafeToFilePath)
+import Agent.Process (terminateProcessGroup)
+import Control.Concurrent.Async (concurrently)
+import Control.Exception.Safe (displayException, tryIO)
+import Control.Monad (void)
+import Data.List (intercalate, sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Exit (ExitCode(..))
+import System.IO (Handle, hGetContents)
+import System.OsPath (OsPath)
+import System.Process
+    ( CreateProcess(..)
+    , StdStream(..)
+    , getPid
+    , proc
+    , waitForProcess
+    , withCreateProcess
+    )
+import System.Timeout (timeout)
+
+data GitCommandOutput = GitCommandOutput
+    { gitCommandExitCode :: !ExitCode
+    , gitCommandStdout :: !String
+    , gitCommandStderr :: !String
+    }
+    deriving (Eq, Show)
+
+data GitDiffResult
+    = GitDiffNotRepository
+    | GitDiffOutput !Text
+    deriving (Eq, Show)
+
+-- | Return the working-tree diff, including untracked files.
+--
+-- An empty 'GitDiffOutput' means the directory is a repository with no
+-- working-tree changes.
+getGitDiff :: OsPath -> IO (Either Text GitDiffResult)
+getGitDiff cwd = do
+    inside <- insideGitWorkTree cwd
+    case inside of
+        Left err -> pure (Left err)
+        Right False -> pure (Right GitDiffNotRepository)
+        Right True -> do
+            filterOverrides <- executableFilterOverrides cwd
+            case filterOverrides of
+                Left err -> pure (Left err)
+                Right overrides -> do
+                    (tracked, untracked) <-
+                        concurrently
+                            (runDiff cwd overrides trackedDiffArguments)
+                            (runGitSuccess cwd [] untrackedListArguments)
+                    case (tracked, untracked) of
+                        (Left err, _) -> pure (Left err)
+                        (_, Left err) -> pure (Left err)
+                        (Right trackedText, Right untrackedOutput) -> do
+                            untrackedDiffs <-
+                                traverse
+                                    (runUntrackedDiff cwd overrides)
+                                    (nulSeparatedPaths
+                                        untrackedOutput.gitCommandStdout)
+                            pure do
+                                pieces <- sequence untrackedDiffs
+                                Right
+                                    (GitDiffOutput
+                                        (trackedText <> Text.concat pieces))
+
+insideGitWorkTree :: OsPath -> IO (Either Text Bool)
+insideGitWorkTree cwd =
+    runSafeGit cwd [] ["rev-parse", "--is-inside-work-tree"] >>= \case
+        Left err -> pure (Left err)
+        Right output ->
+            pure $
+                Right
+                    ( output.gitCommandExitCode == ExitSuccess
+                        && Text.strip (gitOutputText output) == "true"
+                    )
+
+executableFilterOverrides
+    :: OsPath
+    -> IO (Either Text [(Text, Text)])
+executableFilterOverrides cwd =
+    runSafeGit
+        cwd
+        []
+        [ "config"
+        , "--null"
+        , "--name-only"
+        , "--get-regexp"
+        , "^filter\\..*\\.(clean|process)$"
+        ] >>= \case
+            Left err -> pure (Left err)
+            Right output
+                | output.gitCommandExitCode == ExitSuccess
+                    || output.gitCommandExitCode == ExitFailure 1 ->
+                        pure $
+                            Right
+                                (concatMap disableDriver
+                                    (configuredFilterDrivers
+                                        output.gitCommandStdout))
+                | otherwise ->
+                    pure (Left (gitFailure "git config" output))
+  where
+    disableDriver driver =
+        [ (driver <> ".clean", "")
+        , (driver <> ".process", "")
+        , (driver <> ".required", "false")
+        ]
+
+configuredFilterDrivers :: String -> [Text]
+configuredFilterDrivers raw =
+    deduplicate . sort $
+        foldMap driverForKey
+            (filter (not . Text.null) (Text.splitOn "\0" (Text.pack raw)))
+  where
+    driverForKey key =
+        case Text.stripSuffix ".clean" key of
+            Just driver -> [driver]
+            Nothing -> maybe [] pure (Text.stripSuffix ".process" key)
+
+    deduplicate [] = []
+    deduplicate (first : rest) =
+        first : deduplicate (dropWhile (== first) rest)
+
+runUntrackedDiff
+    :: OsPath
+    -> [(Text, Text)]
+    -> String
+    -> IO (Either Text Text)
+runUntrackedDiff cwd overrides path =
+    runDiff cwd overrides
+        (commonDiffArguments
+            <> ["--no-index", "--", "/dev/null", path])
+
+runDiff
+    :: OsPath
+    -> [(Text, Text)]
+    -> [String]
+    -> IO (Either Text Text)
+runDiff cwd overrides arguments =
+    runSafeGit cwd overrides arguments >>= \case
+        Left err -> pure (Left err)
+        Right output
+            | output.gitCommandExitCode == ExitSuccess
+                || output.gitCommandExitCode == ExitFailure 1 ->
+                    pure (Right (gitOutputText output))
+            | otherwise ->
+                pure (Left (gitFailure (renderGitCommand arguments) output))
+
+runGitSuccess
+    :: OsPath
+    -> [(Text, Text)]
+    -> [String]
+    -> IO (Either Text GitCommandOutput)
+runGitSuccess cwd overrides arguments =
+    runSafeGit cwd overrides arguments >>= \case
+        Left err -> pure (Left err)
+        Right output
+            | output.gitCommandExitCode == ExitSuccess ->
+                pure (Right output)
+            | otherwise ->
+                pure (Left (gitFailure (renderGitCommand arguments) output))
+
+-- | Run one bounded Git command with repository-configured hooks and
+-- fsmonitor disabled. Additional config values are passed as individual
+-- argv entries, never through a shell.
+runSafeGit
+    :: OsPath
+    -> [(Text, Text)]
+    -> [String]
+    -> IO (Either Text GitCommandOutput)
+runSafeGit cwd overrides arguments = do
+    let allArguments =
+            baseConfigArguments
+                <> foldMap configArgument overrides
+                <> arguments
+        process =
+            (proc "git" allArguments)
+                { cwd = Just (unsafeToFilePath cwd)
+                , close_fds = True
+                , create_group = True
+                , new_session = True
+                , std_in = NoStream
+                , std_out = CreatePipe
+                , std_err = CreatePipe
+                }
+    result <-
+        tryIO $
+            withCreateProcess process \_ stdoutHandle stderrHandle processHandle ->
+                case (stdoutHandle, stderrHandle) of
+                    (Just stdout, Just stderr) -> do
+                        groupId <- getPid processHandle
+                        completed <-
+                            timeout gitCommandTimeoutMicros $
+                                concurrently
+                                    (concurrently
+                                        (readHandleStrict stdout)
+                                        (readHandleStrict stderr))
+                                    (waitForProcess processHandle)
+                        case completed of
+                            Nothing -> do
+                                terminateProcessGroup groupId processHandle
+                                void (timeout processCleanupTimeoutMicros
+                                    (waitForProcess processHandle))
+                                pure Nothing
+                            Just ((stdoutText, stderrText), exitCode) ->
+                                pure $
+                                    Just GitCommandOutput
+                                        { gitCommandExitCode = exitCode
+                                        , gitCommandStdout = stdoutText
+                                        , gitCommandStderr = stderrText
+                                        }
+                    _ -> fail "git did not provide stdout and stderr pipes"
+    pure case result of
+        Left err ->
+            Left
+                (renderGitCommand arguments
+                    <> " failed to start: "
+                    <> Text.pack (displayException err))
+        Right Nothing ->
+            Left
+                (renderGitCommand arguments
+                    <> " timed out after 30 seconds")
+        Right (Just output) -> Right output
+  where
+    configArgument (key, value) =
+        ["-c", Text.unpack key <> "=" <> Text.unpack value]
+
+baseConfigArguments :: [String]
+baseConfigArguments =
+    [ "-c"
+    , "safe.bareRepository=explicit"
+    , "-c"
+    , "core.fsmonitor=false"
+    , "-c"
+    , "core.hooksPath=/dev/null"
+    ]
+
+trackedDiffArguments :: [String]
+trackedDiffArguments = commonDiffArguments
+
+commonDiffArguments :: [String]
+commonDiffArguments =
+    [ "diff"
+    , "--no-textconv"
+    , "--no-ext-diff"
+    , "--submodule=short"
+    , "--ignore-submodules=dirty"
+    , "--color"
+    ]
+
+untrackedListArguments :: [String]
+untrackedListArguments =
+    [ "ls-files"
+    , "--others"
+    , "--exclude-standard"
+    , "-z"
+    ]
+
+nulSeparatedPaths :: String -> [String]
+nulSeparatedPaths =
+    filter (not . null) . splitOnNul
+  where
+    splitOnNul [] = []
+    splitOnNul value =
+        let (path, rest) = break (== '\0') value
+        in path : case rest of
+            [] -> []
+            _ : remaining -> splitOnNul remaining
+
+gitOutputText :: GitCommandOutput -> Text
+gitOutputText = Text.pack . (.gitCommandStdout)
+
+gitFailure :: Text -> GitCommandOutput -> Text
+gitFailure command output =
+    command
+        <> " failed with "
+        <> Text.pack (show output.gitCommandExitCode)
+        <> case Text.strip (Text.pack output.gitCommandStderr) of
+            "" -> ""
+            stderr -> ": " <> stderr
+
+renderGitCommand :: [String] -> Text
+renderGitCommand arguments =
+    Text.pack (intercalate " " ("git" : arguments))
+
+gitCommandTimeoutMicros :: Int
+gitCommandTimeoutMicros = 30 * 1_000_000
+
+processCleanupTimeoutMicros :: Int
+processCleanupTimeoutMicros = 2 * 1_000_000
+
+readHandleStrict :: Handle -> IO String
+readHandleStrict handle = do
+    contents <- hGetContents handle
+    let size = length contents
+    size `seq` pure contents

--- a/packages/agent-cli/src/Agent/CLI/GitDiff.hs
+++ b/packages/agent-cli/src/Agent/CLI/GitDiff.hs
@@ -6,6 +6,7 @@
 module Agent.CLI.GitDiff
     ( GitCommandOutput(..)
     , GitDiffResult(..)
+    , colorizeGitDiff
     , getGitDiff
     , gitOutputText
     , runSafeGit
@@ -13,14 +14,19 @@ module Agent.CLI.GitDiff
 
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Process (terminateProcessGroup)
+import Agent.TUI.TextWidth (displayTerminalText)
+import Agent.CLI.Style (roleError, roleMuted, roleSuccess)
 import Control.Concurrent.Async (concurrently)
 import Control.Exception.Safe (displayException, tryIO)
 import Control.Monad (void)
+import qualified Data.ByteString as ByteString
 import Data.List (intercalate, sort)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.Text.Encoding.Error (lenientDecode)
 import System.Exit (ExitCode(..))
-import System.IO (Handle, hGetContents)
+import System.IO (Handle)
 import System.OsPath (OsPath)
 import System.Process
     ( CreateProcess(..)
@@ -61,7 +67,7 @@ getGitDiff cwd = do
                 Right overrides -> do
                     (tracked, untracked) <-
                         concurrently
-                            (runDiff cwd overrides trackedDiffArguments)
+                            (runTrackedDiff cwd overrides)
                             (runGitSuccess cwd [] untrackedListArguments)
                     case (tracked, untracked) of
                         (Left err, _) -> pure (Left err)
@@ -145,6 +151,27 @@ runUntrackedDiff cwd overrides path =
         (commonDiffArguments
             <> ["--no-index", "--", "/dev/null", path])
 
+runTrackedDiff
+    :: OsPath
+    -> [(Text, Text)]
+    -> IO (Either Text Text)
+runTrackedDiff cwd overrides =
+    runSafeGit cwd [] ["rev-parse", "--verify", "--quiet", "HEAD"] >>= \case
+        Left err -> pure (Left err)
+        Right output
+            | output.gitCommandExitCode == ExitSuccess ->
+                runDiff cwd overrides (commonDiffArguments <> ["HEAD", "--"])
+            | output.gitCommandExitCode == ExitFailure 1 -> do
+                -- In an unborn repository, staged files are compared with the
+                -- empty index while unstaged edits are compared with the index.
+                (staged, unstaged) <-
+                    concurrently
+                        (runDiff cwd overrides cachedDiffArguments)
+                        (runDiff cwd overrides trackedDiffArguments)
+                pure ((<>) <$> staged <*> unstaged)
+            | otherwise ->
+                pure (Left (gitFailure "git rev-parse HEAD" output))
+
 runDiff
     :: OsPath
     -> [(Text, Text)]
@@ -156,7 +183,7 @@ runDiff cwd overrides arguments =
         Right output
             | output.gitCommandExitCode == ExitSuccess
                 || output.gitCommandExitCode == ExitFailure 1 ->
-                    pure (Right (gitOutputText output))
+                    pure (Right (displayTerminalText (gitOutputText output)))
             | otherwise ->
                 pure (Left (gitFailure (renderGitCommand arguments) output))
 
@@ -252,6 +279,10 @@ baseConfigArguments =
 trackedDiffArguments :: [String]
 trackedDiffArguments = commonDiffArguments
 
+cachedDiffArguments :: [String]
+cachedDiffArguments =
+    "diff" : "--cached" : drop 1 commonDiffArguments
+
 commonDiffArguments :: [String]
 commonDiffArguments =
     [ "diff"
@@ -259,7 +290,7 @@ commonDiffArguments =
     , "--no-ext-diff"
     , "--submodule=short"
     , "--ignore-submodules=dirty"
-    , "--color"
+    , "--no-color"
     ]
 
 untrackedListArguments :: [String]
@@ -286,16 +317,35 @@ gitOutputText = Text.pack . (.gitCommandStdout)
 
 gitFailure :: Text -> GitCommandOutput -> Text
 gitFailure command output =
-    command
+    displayTerminalText command
         <> " failed with "
         <> Text.pack (show output.gitCommandExitCode)
         <> case Text.strip (Text.pack output.gitCommandStderr) of
             "" -> ""
-            stderr -> ": " <> stderr
+            stderr -> ": " <> displayTerminalText stderr
 
 renderGitCommand :: [String] -> Text
 renderGitCommand arguments =
-    Text.pack (intercalate " " ("git" : arguments))
+    displayTerminalText (Text.pack (intercalate " " ("git" : arguments)))
+
+-- | Add inert terminal color after Git output has been stripped of all
+-- repository-controlled escape and control characters.
+colorizeGitDiff :: Bool -> Text -> Text
+colorizeGitDiff False = id
+colorizeGitDiff True =
+    Text.intercalate "\n" . map colorLine . Text.splitOn "\n"
+  where
+    colorLine line
+        | "+++ " `Text.isPrefixOf` line
+            || "--- " `Text.isPrefixOf` line =
+                roleMuted True line
+        | "+" `Text.isPrefixOf` line = roleSuccess True line
+        | "-" `Text.isPrefixOf` line = roleError True line
+        | "@@" `Text.isPrefixOf` line
+            || "diff --git " `Text.isPrefixOf` line
+            || "index " `Text.isPrefixOf` line =
+                roleMuted True line
+        | otherwise = line
 
 gitCommandTimeoutMicros :: Int
 gitCommandTimeoutMicros = 30 * 1_000_000
@@ -305,6 +355,7 @@ processCleanupTimeoutMicros = 2 * 1_000_000
 
 readHandleStrict :: Handle -> IO String
 readHandleStrict handle = do
-    contents <- hGetContents handle
-    let size = length contents
-    size `seq` pure contents
+    contents <- ByteString.hGetContents handle
+    pure
+        (Text.unpack
+            (Text.decodeUtf8With lenientDecode contents))

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Input
     , readReplLineWithCatalogForProvider
     , readReplLineWithSkills
     , readReplLineWithSkillsAndModels
+    , readModalText
     , readApprovalLine
     , readChoiceSelection
     , approvalKeyText
@@ -206,14 +207,60 @@ readReplLineConfigured
     -> IO ReplLine
 readReplLineConfigured
         dictationProvider catalog slashEnabled interrupt prompt initial = do
+    readLineConfigured
+        True
+        dictationProvider
+        catalog
+        slashEnabled
+        interrupt
+        prompt
+        initial
+
+-- | Read transient modal text without slash-command completion or modifying
+-- normal REPL history. Escape, Ctrl-C, and EOF cancel on the TTY path.
+readModalText :: InterruptState -> Text -> Text -> IO (Maybe Text)
+readModalText interrupt prompt initial =
+    readLineConfigured
+        False
+        Nothing
+        defaultSlashCatalog
+        False
+        interrupt
+        prompt
+        initial
+        >>= \case
+            ReplText text -> pure (Just text)
+            ReplPasted text -> pure (Just text)
+            ReplEof -> pure Nothing
+            ReplQuitInterrupt -> pure Nothing
+            _ -> pure Nothing
+
+readLineConfigured
+    :: Bool
+    -> Maybe Provider
+    -> SlashCatalog
+    -> Bool
+    -> InterruptState
+    -> Text
+    -> Text
+    -> IO ReplLine
+readLineConfigured
+        historyEnabled
+        dictationProvider
+        catalog
+        slashEnabled
+        interrupt
+        prompt
+        initial = do
     isTty <- hIsTerminalDevice stdin
     if isTty
         then do
             home <- getHomeDirectory
             let path = replHistoryPath home
-            ensureHistoryParent path
+            when historyEnabled (ensureHistoryParent path)
             classifyLine <$>
                 readInlineEditor
+                    historyEnabled
                     dictationProvider
                     catalog
                     slashEnabled
@@ -236,7 +283,8 @@ readReplLineConfigured
 -- | First-party inline editor for the interactive TTY path. It owns the
 -- prompt redraw so slash suggestions can update after every keystroke.
 readInlineEditor
-    :: Maybe Provider
+    :: Bool
+    -> Maybe Provider
     -> SlashCatalog
     -> Bool
     -> InterruptState
@@ -245,6 +293,7 @@ readInlineEditor
     -> Text
     -> IO ReplLine
 readInlineEditor
+        historyEnabled
         dictationProvider
         catalog
         slashEnabled
@@ -259,7 +308,12 @@ readInlineEditor
                     (hHideCursor stdout)
                     (\_ -> hShowCursor stdout >> hFlush stdout)
                     \() -> do
-                        history <- readHistory historyPath `catchIO` \_ -> pure emptyHistory
+                        history <-
+                            if historyEnabled
+                                then
+                                    readHistory historyPath
+                                        `catchIO` \_ -> pure emptyHistory
+                                else pure emptyHistory
                         let entries = map Text.pack (historyLines history)
                             state =
                                 initialEditorState catalog slashEnabled initial
@@ -268,11 +322,22 @@ readInlineEditor
   where
     editorLoop history entries state = do
         key <- readEditorKey
-        let EditorStep
-                { editorStepState = next
-                , editorStepEffect = requested
-                } = reduceEditorKey entries state key
-        case requested of
+        case (historyEnabled, key, currentMenu state) of
+            (False, EditorEscape, Nothing) ->
+                cancelModal state
+            (False, EditorEof, _) ->
+                cancelModal state
+            _ -> applyStep key
+      where
+        cancelModal state = do
+            finishEditorLine prompt state
+            pure ReplQuitInterrupt
+        applyStep key = do
+          let EditorStep
+                  { editorStepState = next
+                  , editorStepEffect = requested
+                  } = reduceEditorKey entries state key
+          case requested of
             RedrawEditor -> do
                 redrawEditor prompt next
                 editorLoop history entries next
@@ -282,15 +347,17 @@ readInlineEditor
                 finishEditorLine prompt next
                 pure line
             CheckEditorInterrupt ->
-                noteIdleCtrlC interrupt >>= \case
-                    ContinuePrompt -> do
-                        finishEditorLine prompt next
-                        Text.putStrLn "^C"
-                        redrawEditor prompt next
-                        editorLoop history entries next
-                    QuitProcess -> do
-                        finishEditorLine prompt next
-                        pure ReplQuitInterrupt
+                if not historyEnabled
+                    then cancelModal next
+                    else noteIdleCtrlC interrupt >>= \case
+                        ContinuePrompt -> do
+                            finishEditorLine prompt next
+                            Text.putStrLn "^C"
+                            redrawEditor prompt next
+                            editorLoop history entries next
+                        QuitProcess -> do
+                            finishEditorLine prompt next
+                            pure ReplQuitInterrupt
             ClearEditorScreen -> do
                 Text.hPutStr stdout "\ESC[2J\ESC[H"
                 redrawEditor prompt next
@@ -329,13 +396,15 @@ readInlineEditor
                 editorLoop history entries next
             IgnoreEditorInput ->
                 editorLoop history entries next
-      where
         finish history' state' = do
             finishEditorLine prompt state'
             let text = state'.editorText
-            unless (Text.all (== ' ') text) $
-                writeHistory historyPath (addHistory (Text.unpack text) history')
-                    `catchIO` \_ -> pure ()
+            when historyEnabled $
+                unless (Text.all (== ' ') text) $
+                    writeHistory
+                        historyPath
+                        (addHistory (Text.unpack text) history')
+                        `catchIO` \_ -> pure ()
             pure $
                 if state'.editorPasted
                     then ReplPasted text

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -13,6 +13,7 @@ module Agent.CLI.Input
     , readModalText
     , readApprovalLine
     , readChoiceSelection
+    , readChoiceSelectionAt
     , approvalKeyText
     , ChoiceKey(..)
     , parseChoiceKey

--- a/packages/agent-cli/src/Agent/CLI/Input/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Approval.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Input.Approval
     ( readApprovalLine
     , readChoiceSelection
+    , readChoiceSelectionAt
     ) where
 
 import Agent.CLI.Input.Picker
@@ -62,7 +63,15 @@ readChoiceSelection
     :: (Bool -> Text -> Text)
     -> [Text]
     -> IO (Maybe Text)
-readChoiceSelection formatLine options = do
+readChoiceSelection = readChoiceSelectionAt 0
+
+-- | Interactive multiple-choice picker with a caller-selected initial row.
+readChoiceSelectionAt
+    :: Int
+    -> (Bool -> Text -> Text)
+    -> [Text]
+    -> IO (Maybe Text)
+readChoiceSelectionAt initial formatLine options = do
     isTty <- hIsTerminalDevice stdin
     case options of
         [] -> pure Nothing
@@ -75,8 +84,10 @@ readChoiceSelection formatLine options = do
                     \() -> do
                         let len = length options
                             menuLines = len + 1
-                        drawMenu formatLine options 0
-                        pickLoop formatLine options len menuLines 0
+                            selected = max 0 (min (len - 1) initial)
+                        drawMenu formatLine options selected
+                        pickLoop
+                            formatLine options len menuLines selected
 
 pickLoop
     :: (Bool -> Text -> Text)

--- a/packages/agent-cli/src/Agent/CLI/Permission.hs
+++ b/packages/agent-cli/src/Agent/CLI/Permission.hs
@@ -7,6 +7,12 @@ module Agent.CLI.Permission
     , promptPermission
     , promptRootAccess
     , renderPermissionFrame
+    , ApprovalPolicyChoice(..)
+    , ApprovalPolicyDecision(..)
+    , ApprovalPolicyState(..)
+    , initialApprovalPolicyState
+    , applyApprovalPolicyKey
+    , renderApprovalPolicyFrame
     ) where
 
 import Agent.CLI.Input (readApprovalLine)
@@ -15,6 +21,7 @@ import Agent.CLI.Notification
     , notifyAttention
     )
 import Agent.CLI.Options (ApprovalAnswer(..), parseApprovalAnswer)
+import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import Agent.CLI.Style (glyphWarn, roleMuted, roleSuccess, roleWarn)
 import Agent.TUI.Presentation (permissionToolCallPromptRelative)
@@ -32,6 +39,89 @@ data PermissionChoice
     | PermissionAllowTool
     | PermissionDeny
     deriving (Eq, Show)
+
+data ApprovalPolicyDecision
+    = ApprovalPolicySelected !ApprovalPolicy
+    | ApprovalPolicyCancelled
+    deriving (Eq, Show)
+
+data ApprovalPolicyChoice
+    = ChoosePromptMutating
+    | ChooseDenyMutating
+    | ChooseApproveAll
+    deriving (Eq, Show)
+
+data ApprovalPolicyState = ApprovalPolicyState
+    { approvalPolicyCurrent :: !ApprovalPolicy
+    , approvalPolicyIndex :: !Int
+    }
+    deriving (Eq, Show)
+
+approvalPolicyChoices :: [ApprovalPolicyChoice]
+approvalPolicyChoices =
+    [ ChoosePromptMutating
+    , ChooseDenyMutating
+    , ChooseApproveAll
+    ]
+
+choicePolicy :: ApprovalPolicyChoice -> ApprovalPolicy
+choicePolicy = \case
+    ChoosePromptMutating -> PromptMutating
+    ChooseDenyMutating -> DenyMutating
+    ChooseApproveAll -> ApproveAll
+
+initialApprovalPolicyState :: ApprovalPolicy -> ApprovalPolicyState
+initialApprovalPolicyState policy =
+    ApprovalPolicyState
+        { approvalPolicyCurrent = policy
+        , approvalPolicyIndex =
+            case policy of
+                PromptMutating -> 0
+                DenyMutating -> 1
+                ApproveAll -> 2
+        }
+
+applyApprovalPolicyKey
+    :: PickerKey
+    -> ApprovalPolicyState
+    -> Either ApprovalPolicyDecision ApprovalPolicyState
+applyApprovalPolicyKey key state = case key of
+    PickerKeyCancel -> Left ApprovalPolicyCancelled
+    PickerKeyConfirm ->
+        Left
+            (ApprovalPolicySelected
+                (choicePolicy (approvalPolicyChoices !! approvalPolicyIndex state)))
+    PickerKeyUp -> Right (move (-1) state)
+    PickerKeyDown -> Right (move 1 state)
+    PickerKeyChar c -> case Text.toLower (Text.singleton c) of
+        "p" -> Left (ApprovalPolicySelected PromptMutating)
+        "r" -> Left (ApprovalPolicySelected DenyMutating)
+        "f" -> Left (ApprovalPolicySelected ApproveAll)
+        _ -> Right state
+    PickerKeyBackspace -> Right state
+  where
+    move delta current =
+        current
+            { approvalPolicyIndex =
+                (approvalPolicyIndex current + delta)
+                    `mod` length approvalPolicyChoices
+            }
+
+renderApprovalPolicyFrame :: Bool -> ApprovalPolicyState -> Text
+renderApprovalPolicyFrame color state =
+    let labels =
+            [ ("Ask before changes", "Prompt before mutating tools")
+            , ("Read-only for this session", "Block all mutating tools")
+            , ("Full access for this project", "Automatically approve tools")
+            ]
+        rows = zipWith
+            (\i (label, detail) ->
+                renderRow color (i == approvalPolicyIndex state)
+                    (label <> " — " <> roleMuted color detail))
+            [0 ..] labels
+    in Text.intercalate "\n"
+        (roleWarn color (glyphWarn <> "Permissions") : rows
+            <> [roleMuted color "↑↓/jk · enter/click · p ask · r read-only · f full access · esc cancel"])
 
 data PermissionState = PermissionState
     { permSummary :: !Text

--- a/packages/agent-cli/src/Agent/CLI/Permission.hs
+++ b/packages/agent-cli/src/Agent/CLI/Permission.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Permission
     , ApprovalPolicyState(..)
     , initialApprovalPolicyState
     , applyApprovalPolicyKey
+    , approvalPolicyOptions
     , renderApprovalPolicyFrame
     ) where
 
@@ -64,6 +65,22 @@ approvalPolicyChoices =
     , ChooseApproveAll
     ]
 
+approvalPolicyOptions :: [(ApprovalPolicy, Text, Text)]
+approvalPolicyOptions =
+    [ ( PromptMutating
+      , "Ask before changes"
+      , "Prompt before mutating tools"
+      )
+    , ( DenyMutating
+      , "Read-only for this session"
+      , "Block all mutating tools"
+      )
+    , ( ApproveAll
+      , "Full access for this project"
+      , "Automatically approve mutating tools"
+      )
+    ]
+
 choicePolicy :: ApprovalPolicyChoice -> ApprovalPolicy
 choicePolicy = \case
     ChoosePromptMutating -> PromptMutating
@@ -90,7 +107,8 @@ applyApprovalPolicyKey key state = case key of
     PickerKeyConfirm ->
         Left
             (ApprovalPolicySelected
-                (choicePolicy (approvalPolicyChoices !! approvalPolicyIndex state)))
+                (choicePolicy
+                    (approvalPolicyChoices !! state.approvalPolicyIndex)))
     PickerKeyUp -> Right (move (-1) state)
     PickerKeyDown -> Right (move 1 state)
     PickerKeyChar c -> case Text.toLower (Text.singleton c) of
@@ -103,20 +121,19 @@ applyApprovalPolicyKey key state = case key of
     move delta current =
         current
             { approvalPolicyIndex =
-                (approvalPolicyIndex current + delta)
+                (current.approvalPolicyIndex + delta)
                     `mod` length approvalPolicyChoices
             }
 
 renderApprovalPolicyFrame :: Bool -> ApprovalPolicyState -> Text
 renderApprovalPolicyFrame color state =
     let labels =
-            [ ("Ask before changes", "Prompt before mutating tools")
-            , ("Read-only for this session", "Block all mutating tools")
-            , ("Full access for this project", "Automatically approve tools")
+            [ (label, detail)
+            | (_, label, detail) <- approvalPolicyOptions
             ]
         rows = zipWith
             (\i (label, detail) ->
-                renderRow color (i == approvalPolicyIndex state)
+                renderRow color (i == state.approvalPolicyIndex)
                     (label <> " — " <> roleMuted color detail))
             [0 ..] labels
     in Text.intercalate "\n"

--- a/packages/agent-cli/src/Agent/CLI/Review.hs
+++ b/packages/agent-cli/src/Agent/CLI/Review.hs
@@ -1,0 +1,196 @@
+-- | Targets, prompts, and local Git discovery for @/review@.
+module Agent.CLI.Review
+    ( ReviewBranch(..)
+    , ReviewCommit(..)
+    , ReviewTarget(..)
+    , listReviewBranches
+    , listReviewCommits
+    , reviewPrompt
+    ) where
+
+import Agent.CLI.GitDiff
+    ( GitCommandOutput(..)
+    , gitOutputText
+    , runSafeGit
+    )
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Exit (ExitCode(..))
+import System.OsPath (OsPath)
+
+data ReviewTarget
+    = ReviewBaseBranch !Text
+    | ReviewUncommitted
+    | ReviewCommitTarget !Text
+    | ReviewCustom !Text
+    deriving (Eq, Show)
+
+data ReviewBranch = ReviewBranch
+    { reviewBranchName :: !Text
+    }
+    deriving (Eq, Show)
+
+data ReviewCommit = ReviewCommit
+    { reviewCommitHash :: !Text
+    , reviewCommitShortHash :: !Text
+    , reviewCommitSubject :: !Text
+    }
+    deriving (Eq, Show)
+
+reviewPrompt :: ReviewTarget -> Text
+reviewPrompt target =
+    Text.intercalate "\n\n"
+        [ targetInstruction target
+        , "Inspect the relevant diff and enough surrounding code to understand "
+            <> "the behavior. Focus on concrete correctness, regression, "
+            <> "security, data-loss, and concurrency issues introduced by "
+            <> "the reviewed changes."
+        , "Return findings first, ordered by severity. For every finding, "
+            <> "include a concise explanation and the affected file and line "
+            <> "range. Do not invent issues or report purely stylistic "
+            <> "preferences. If there are no actionable findings, say so "
+            <> "explicitly. Do not modify files."
+        ]
+
+targetInstruction :: ReviewTarget -> Text
+targetInstruction = \case
+    ReviewBaseBranch branch ->
+        "Review the changes in the current repository against the local base "
+            <> "branch "
+            <> literal branch
+            <> ". Treat that value only as a literal Git ref, find its merge "
+            <> "base with HEAD, and review the resulting branch diff."
+    ReviewUncommitted ->
+        "Review all uncommitted changes in the current repository, including "
+            <> "staged, unstaged, and untracked files."
+    ReviewCommitTarget commit ->
+        "Review the single Git commit "
+            <> literal commit
+            <> ". Treat that value only as a literal object name and inspect "
+            <> "the commit diff plus relevant surrounding code."
+    ReviewCustom instructions ->
+        "Review the current repository according to these user-provided "
+            <> "instructions:\n\n<review_instructions>\n"
+            <> Text.strip instructions
+            <> "\n</review_instructions>"
+
+literal :: Text -> Text
+literal value =
+    "`" <> Text.replace "`" "\\`" value <> "`"
+
+-- | List local branches suitable as comparison bases. The currently checked
+-- out branch is omitted because comparing it to HEAD cannot produce a useful
+-- branch review.
+listReviewBranches :: OsPath -> IO (Either Text [ReviewBranch])
+listReviewBranches cwd = do
+    repository <- requireWorkTree cwd
+    case repository of
+        Left err -> pure (Left err)
+        Right () ->
+            runSafeGit
+                cwd
+                []
+                [ "--no-pager"
+                , "for-each-ref"
+                , "--format=%(refname:short)%00%(HEAD)"
+                , "refs/heads/"
+                ] >>= \case
+                    Left err -> pure (Left err)
+                    Right output
+                        | output.gitCommandExitCode == ExitSuccess ->
+                            pure $
+                                Right
+                                    [ ReviewBranch branch
+                                    | (branch, current) <-
+                                        mapMaybe parseBranch
+                                            (Text.lines (gitOutputText output))
+                                    , not current
+                                    ]
+                        | otherwise ->
+                            pure (Left (commandFailure "git for-each-ref" output))
+
+parseBranch :: Text -> Maybe (Text, Bool)
+parseBranch line =
+    case Text.breakOn "\0" line of
+        (branch, marker)
+            | not (Text.null branch)
+            , not (Text.null marker) ->
+                Just
+                    ( branch
+                    , Text.strip (Text.drop 1 marker) == "*"
+                    )
+        _ -> Nothing
+
+-- | List recent commits from HEAD, newest first. An unborn repository returns
+-- an empty list.
+listReviewCommits
+    :: OsPath
+    -> Int
+    -> IO (Either Text [ReviewCommit])
+listReviewCommits cwd requestedLimit = do
+    repository <- requireWorkTree cwd
+    case repository of
+        Left err -> pure (Left err)
+        Right () ->
+            runSafeGit cwd [] ["rev-parse", "--verify", "HEAD"] >>= \case
+                Left err -> pure (Left err)
+                Right headOutput
+                    | headOutput.gitCommandExitCode /= ExitSuccess ->
+                        pure (Right [])
+                    | otherwise ->
+                        loadCommits cwd (max 1 (min 200 requestedLimit))
+
+loadCommits :: OsPath -> Int -> IO (Either Text [ReviewCommit])
+loadCommits cwd limit =
+    runSafeGit
+        cwd
+        []
+        [ "--no-pager"
+        , "log"
+        , "--max-count=" <> show limit
+        , "--no-decorate"
+        , "--pretty=format:%H%x00%h%x00%s%x1e"
+        ] >>= \case
+            Left err -> pure (Left err)
+            Right output
+                | output.gitCommandExitCode == ExitSuccess ->
+                    pure $
+                        Right
+                            (mapMaybe parseCommit
+                                (Text.splitOn "\x1e" (gitOutputText output)))
+                | otherwise ->
+                    pure (Left (commandFailure "git log" output))
+
+parseCommit :: Text -> Maybe ReviewCommit
+parseCommit raw =
+    case Text.splitOn "\0" (Text.strip raw) of
+        [hash, shortHash, subject]
+            | not (Text.null hash)
+            , not (Text.null shortHash) ->
+                Just ReviewCommit
+                    { reviewCommitHash = hash
+                    , reviewCommitShortHash = shortHash
+                    , reviewCommitSubject = Text.strip subject
+                    }
+        _ -> Nothing
+
+requireWorkTree :: OsPath -> IO (Either Text ())
+requireWorkTree cwd =
+    runSafeGit cwd [] ["rev-parse", "--is-inside-work-tree"] >>= \case
+        Left err -> pure (Left err)
+        Right output
+            | output.gitCommandExitCode == ExitSuccess
+            , Text.strip (gitOutputText output) == "true" ->
+                pure (Right ())
+            | otherwise ->
+                pure (Left "not a Git repository")
+
+commandFailure :: Text -> GitCommandOutput -> Text
+commandFailure command output =
+    command
+        <> " failed with "
+        <> Text.pack (show output.gitCommandExitCode)
+        <> case Text.strip (Text.pack output.gitCommandStderr) of
+            "" -> ""
+            stderr -> ": " <> stderr

--- a/packages/agent-cli/src/Agent/CLI/Review.hs
+++ b/packages/agent-cli/src/Agent/CLI/Review.hs
@@ -13,6 +13,7 @@ import Agent.CLI.GitDiff
     , gitOutputText
     , runSafeGit
     )
+import Agent.TUI.TextWidth (displayTerminalText)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -171,7 +172,8 @@ parseCommit raw =
                 Just ReviewCommit
                     { reviewCommitHash = hash
                     , reviewCommitShortHash = shortHash
-                    , reviewCommitSubject = Text.strip subject
+                    , reviewCommitSubject =
+                        displayTerminalText (Text.strip subject)
                     }
         _ -> Nothing
 
@@ -193,4 +195,4 @@ commandFailure command output =
         <> Text.pack (show output.gitCommandExitCode)
         <> case Text.strip (Text.pack output.gitCommandStderr) of
             "" -> ""
-            stderr -> ": " <> stderr
+            stderr -> ": " <> displayTerminalText stderr

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -97,7 +97,7 @@ import Agent.CLI.Session.History
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
     ( SessionRequest(codexCatalogSession, SessionRequest, catalog, modelInfo,
-                     connectionId, options, provider, dialect, policy, allTools,
+                     connectionId, options, provider, dialect, policyRef, allTools,
                      recordImageGenerationInputs, clearImageGenerationHistory,
                      suspendGhci, grokRuntime, mcpRegistrations, mcpWarnings,
                      mcpInstructions, mcpFleet,
@@ -417,6 +417,7 @@ runAgentSession
                     | otherwise ->
                         resumed >>= \(meta, _) -> meta.metaLastResponseId
         paramsRef <- newIORef params
+        policyRef <- newIORef policy
         automaticCompactionRef <- newIORef Nothing
         automaticCompactionHookRef <-
             newIORef
@@ -441,7 +442,7 @@ runAgentSession
                 { subagentOptions = options
                 , subagentGhciEnabled = ghciEnabledRef
                 , subagentBashEnabled = bashEnabledRef
-                , subagentPolicy = policy
+                , subagentPolicy = policyRef
                 , subagentPlanHooks = planHooks
                 , subagentSkillRoots = toolEnv.toolSkillRoots
                 , subagentAllowedRoots = toolEnv.toolAllowedRoots
@@ -565,7 +566,7 @@ runAgentSession
                                 , options
                                 , provider
                                 , dialect
-                                , policy
+                                , policyRef
                                 , allTools = registryTools
                                 , recordImageGenerationInputs
                                 , clearImageGenerationHistory

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -11,7 +11,7 @@ import Agent.CLI.AgentSessions ()
 import Agent.CLI.AgentViewport
     ( AgentViewportEnv(viewportSelect, viewportEntries,
                        viewportSelected) )
-import Agent.CLI.Approval ( toggleAlwaysApprove )
+import Agent.CLI.Approval ( setApprovalPolicy, toggleAlwaysApprove )
 import Agent.CLI.Artifact ( fencedCodeBlock, lastDiffBlock )
 import Agent.CLI.Auth ()
 import Agent.CLI.Clipboard ( loadImagesFromPastedText )
@@ -34,10 +34,13 @@ import Agent.CLI.Command
                  ReplContext,
                  ReplBtw, ReplMetaConsole, ReplRecap, ReplRetry, ReplResume, ReplSearch, ReplClear, ReplNew,
                  ReplShowSession, ReplShowSessionInfo, ReplAfk, ReplWorktree,
-                 ReplRename, ReplRenameAuto, ReplLogin, ReplUsage, ReplReloadAuth,
+                 ReplRename, ReplRenameAuto, ReplInit, ReplReview, ReplDiff,
+                 ReplFork, ReplExport, ReplPermissions,
+                 ReplLogin, ReplUsage, ReplReloadAuth,
                  ReplHelp),
       ShellMode(ShellNone, ShellGhci, ShellBash, ShellBoth),
       SlashCatalog )
+import Agent.CLI.Command.Instructions ( initInstruction )
 import Agent.CLI.Compaction
     ( CompactOutcome(compactSummary, compactBeforeTokens,
                      compactAfterTokens, compactHistory) )
@@ -50,8 +53,8 @@ import Agent.CLI.Config
 import Agent.CLI.Context ( formatContextReport )
 import Agent.CLI.Transcript
     ( foldTranscriptTurns
-    , renderTranscriptMarkdown
     )
+import qualified Agent.CLI.Transcript as Transcript
 import Agent.CLI.Connectivity ()
 import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
@@ -65,9 +68,16 @@ import Agent.CLI.ExternalProgram
     , withTemporaryTextFile
     )
 import Agent.CLI.GatewayBridge ()
+import Agent.CLI.GitDiff
+    ( GitDiffResult(..)
+    , colorizeGitDiff
+    , getGitDiff
+    )
 import Agent.CLI.Input
     ( formatPasteChip,
       readApprovalLine,
+      readChoiceSelectionAt,
+      readModalText,
       submissionPromptText,
       ReplLine(ReplText, ReplMeta, ReplEof, ReplQuitInterrupt, ReplCycleMode,
                ReplClipboardPaste, ReplClipboardPasteOrText, ReplChooseModel,
@@ -90,6 +100,7 @@ import Agent.CLI.ModelConfig ()
 import Agent.CLI.Models ()
 import Agent.CLI.Options ( ApprovalPolicy(..) )
 import Agent.CLI.PendingInputs ()
+import Agent.CLI.Permission ( approvalPolicyOptions )
 import Agent.CLI.Plan ()
 import Agent.CLI.Progress ()
 import Agent.CLI.Project ()
@@ -117,6 +128,15 @@ import Agent.CLI.Render
       resetRenderPrintedText )
 import Agent.CLI.ReplMode ( replModeLabel )
 import Agent.CLI.Request ()
+import Agent.CLI.Review
+    ( ReviewBranch(reviewBranchName)
+    , ReviewCommit(reviewCommitHash, reviewCommitShortHash,
+                   reviewCommitSubject)
+    , ReviewTarget(..)
+    , listReviewBranches
+    , listReviewCommits
+    , reviewPrompt
+    )
 import Agent.CLI.Runtime.HistorySource ()
 import Agent.CLI.Runtime.MetaConsole
     ( MetaSecretValue(..)
@@ -191,7 +211,16 @@ import Agent.CLI.TUI.Types
     , HistoryCommit(..)
     )
 import Agent.CLI.Terminal
-    ( copyTerminalClipboard, formatTerminalCapabilities, resolveColor )
+    ( copyTerminalClipboard
+    , formatTerminalCapabilities
+    , resolveColor
+    )
+import Agent.CLI.TranscriptExport
+    ( defaultExportFileName
+    , resolveExportPath
+    , saveTranscriptNoClobber
+    )
+import qualified Agent.CLI.TranscriptExport as TranscriptExport
 import Agent.CLI.Tools ()
 import Agent.CLI.Turn ( runOneTurn )
 import Agent.CLI.Usage ()
@@ -208,7 +237,7 @@ import Agent.OpenAI.Compaction ( compactSessionUserText )
 import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient ()
 import Agent.OpenRouter.LoopBackend ()
-import Agent.OsPath ( toText )
+import Agent.OsPath ( toText, unsafeToFilePath )
 import Agent.Provider ( Provider(ClaudeCodeProvider), providerSlug )
 import Agent.Responses.GenericBackend ()
 import Agent.Responses.GenericClient ()
@@ -247,22 +276,22 @@ import Control.Concurrent.MVar ()
 import Control.Concurrent.STM ()
 import Control.Exception ( AsyncException(UserInterrupt) )
 import Control.Exception.Safe
-    ( displayException, finally, throwIO, tryAny )
-import Control.Monad ( foldM, when, forM_ )
+    ( displayException, finally, throwIO, tryAny, tryIO )
+import Control.Monad ( foldM, forM_, unless, when )
 import Data.Foldable ( toList )
 import Data.IORef ( atomicModifyIORef', newIORef, readIORef, writeIORef )
-import Data.List ()
-import Data.Maybe ( isNothing )
+import Data.List ( elemIndex, findIndex )
+import Data.Maybe ( fromMaybe, isNothing )
 import Data.Text ( Text )
 import Data.Time.Clock ( getCurrentTime )
 import System.Console.ANSI ()
 import System.Console.ANSI.Codes ()
-import System.Directory.OsPath ()
 import System.Environment ()
 import System.Exit ()
 import System.IO ( stdout, hFlush, stderr )
-import System.OsPath ()
-import System.Posix.Files ()
+import System.IO.Error ( isDoesNotExistError )
+import System.OsPath ( unsafeEncodeUtf, (</>) )
+import System.Posix.Files ( getSymbolicLinkStatus )
 import qualified Agent.Responses.GenericClient as GenericResponses
     ()
 import qualified Agent.MCP as MCP
@@ -309,9 +338,11 @@ handleReplLine
             , sessionProvider = provider
             , sessionPolicy = policyRef
             , sessionPersist = persist
+            , sessionDatabasePool = databasePool
             , sessionPlanMode = planMode
             , sessionProjectRoot = projectRoot
             , sessionCwd = cwd
+            , sessionHome = home
             , sessionTokenProvider = tokenProvider
             , sessionOpenAiPool = openAiPool
             , sessionSkills = skillsRef
@@ -319,6 +350,7 @@ handleReplLine
             , sessionRefreshSkills = refreshSkills
             , sessionDraft = draftRef
             , sessionPreviewId = previewIdRef
+            , sessionInterrupt = interrupt
             , sessionLastAssistant = lastAssistantRef
             , sessionTerminal = terminal
             , sessionFullscreen = fullscreen
@@ -454,6 +486,115 @@ handleReplLine
                     ReplExpandedPrompt original expanded ->
                         submitExpandedTurn
                             continue color original expanded
+                    ReplInit -> do
+                        let guidePath = cwd </> unsafeEncodeUtf "AGENTS.md"
+                        tryIO
+                            (getSymbolicLinkStatus
+                                (unsafeToFilePath guidePath)) >>= \case
+                            Left err
+                                | isDoesNotExistError err ->
+                                    submitExpandedTurn
+                                        continue
+                                        color
+                                        line
+                                        initInstruction
+                                | otherwise -> do
+                                    let message =
+                                            "could not check AGENTS.md: "
+                                                <> Text.pack
+                                                    (displayException err)
+                                    displayError message $
+                                        Text.hPutStrLn stderr
+                                            (roleError color message)
+                                    continue
+                            Right _ -> do
+                                let message =
+                                        "AGENTS.md already exists; left it unchanged."
+                                displayInfo message $
+                                    Text.putStrLn
+                                        (roleMuted color
+                                            (glyphSession <> message))
+                                continue
+                    ReplReview (Just instructions) ->
+                        submitExpandedTurn
+                            continue
+                            color
+                            line
+                            (reviewPrompt (ReviewCustom instructions))
+                    ReplReview Nothing ->
+                        chooseReviewTarget >>= \case
+                            Left err -> do
+                                displayError err $
+                                    Text.hPutStrLn stderr
+                                        (roleError color err)
+                                continue
+                            Right Nothing -> continue
+                            Right (Just target) ->
+                                submitExpandedTurn
+                                    continue
+                                    color
+                                    line
+                                    (reviewPrompt target)
+                    ReplDiff -> do
+                        result <-
+                            withReplActivity "Loading Git diff…" $
+                                getGitDiff cwd
+                        case result of
+                            Left err -> do
+                                displayError err $
+                                    Text.hPutStrLn stderr
+                                        (roleError color err)
+                                continue
+                            Right GitDiffNotRepository -> do
+                                let message = "not a Git repository"
+                                displayError message $
+                                    Text.hPutStrLn stderr
+                                        (roleError color message)
+                                continue
+                            Right (GitDiffOutput diff)
+                                | Text.null (Text.strip diff) -> do
+                                    let message =
+                                            "No working-tree changes."
+                                    displayInfo message $
+                                        Text.putStrLn
+                                            (roleMuted color
+                                                (glyphSession <> message))
+                                    continue
+                                | otherwise -> do
+                                    displayInfo diff $
+                                        Text.putStrLn
+                                            (colorizeGitDiff color diff)
+                                    continue
+                    ReplExport maybePath -> do
+                        exportTranscript maybePath
+                        continue
+                    ReplPermissions
+                        | provider == ClaudeCodeProvider -> do
+                            let message =
+                                    "Claude Code permissions are fixed for this provider session; restart with --yolo or --no-yolo."
+                            displayInfo message $
+                                Text.hPutStrLn stderr
+                                    (roleMuted color message)
+                            continue
+                        | otherwise -> do
+                            current <- readIORef policyRef
+                            requestChoice
+                                "Permissions"
+                                "Choose how mutating tools are handled."
+                                (approvalPolicyIndex current)
+                                approvalPolicyRows >>= \case
+                                    Nothing -> continue
+                                    Just index -> do
+                                        message <-
+                                            setApprovalPolicy
+                                                policyRef
+                                                projectRoot
+                                                (approvalPolicyAt index)
+                                        displayInfo message $
+                                            Text.hPutStrLn stderr
+                                                (roleMuted color
+                                                    (glyphOk <> message))
+                                        continue
                     ReplInvokeSkill invocationName arguments ->
                         case resolveSkillInvocation
                             skillInvocations invocationName of
@@ -815,7 +956,7 @@ handleReplLine
                                                         else
                                                             legacy
                                                                 (openPager
-                                                                    (renderTranscriptMarkdown
+                                                                    (Transcript.renderTranscriptMarkdown
                                                                         meta
                                                                         blocks))
                                                                 >>= \case
@@ -866,6 +1007,7 @@ handleReplLine
                     action@ReplSearch{} -> handleSessionAction env slashCatalog continue action
                     action@ReplClear -> handleSessionAction env slashCatalog continue action
                     action@ReplNew -> handleSessionAction env slashCatalog continue action
+                    action@ReplFork{} -> handleSessionAction env slashCatalog continue action
                     action@ReplShowSession -> handleSessionAction env slashCatalog continue action
                     action@ReplShowSessionInfo -> handleSessionAction env slashCatalog continue action
                     action@ReplAfk{} -> handleSessionAction env slashCatalog continue action
@@ -1272,6 +1414,243 @@ handleReplLine
                     then ' '
                     else character)
     continue = continueWith ""
+    chooseReviewTarget =
+        requestChoice
+            "Review"
+            "Select what the agent should review."
+            0
+            [ ( "Review against a base branch"
+              , "Compare the current branch with a local base branch"
+              )
+            , ( "Review uncommitted changes"
+              , "Inspect staged, unstaged, and untracked changes"
+              )
+            , ( "Review a commit"
+              , "Inspect one recent commit"
+              )
+            , ( "Custom review instructions"
+              , "Describe the review scope yourself"
+              )
+            ] >>= \case
+                Nothing -> pure (Right Nothing)
+                Just 0 -> do
+                    branches <-
+                        withReplActivity "Loading local branches…" $
+                            listReviewBranches cwd
+                    case branches of
+                        Left err -> pure (Left err)
+                        Right [] ->
+                            pure
+                                (Left
+                                    "no other local branch is available as a review base")
+                        Right available ->
+                            requestChoice
+                                "Review against a base branch"
+                                "Choose the local branch to compare with HEAD."
+                                0
+                                [ (branch.reviewBranchName, "")
+                                | branch <- available
+                                ] >>= \case
+                                    Nothing -> pure (Right Nothing)
+                                    Just index ->
+                                        pure $
+                                            Right $
+                                                ReviewBaseBranch
+                                                    . (.reviewBranchName)
+                                                    <$> indexMaybe index available
+                Just 1 -> pure (Right (Just ReviewUncommitted))
+                Just 2 -> do
+                    commits <-
+                        withReplActivity "Loading recent commits…" $
+                            listReviewCommits cwd 50
+                    case commits of
+                        Left err -> pure (Left err)
+                        Right [] ->
+                            pure
+                                (Left
+                                    "no commits are available to review")
+                        Right available ->
+                            requestChoice
+                                "Review a commit"
+                                "Choose a recent commit."
+                                0
+                                [ ( commit.reviewCommitShortHash
+                                        <> " "
+                                        <> commit.reviewCommitSubject
+                                  , commit.reviewCommitHash
+                                  )
+                                | commit <- available
+                                ] >>= \case
+                                    Nothing -> pure (Right Nothing)
+                                    Just index ->
+                                        pure $
+                                            Right $
+                                                ReviewCommitTarget
+                                                    . (.reviewCommitHash)
+                                                    <$> indexMaybe index available
+                Just _ ->
+                    requestText
+                        "Custom review instructions"
+                        "Describe what the agent should review."
+                        "" >>= \case
+                            Nothing -> pure (Right Nothing)
+                            Just instructions ->
+                                pure
+                                    (Right
+                                        (ReviewCustom
+                                            <$> nonBlank instructions))
+    exportTranscript maybePath =
+        loadActiveTranscript >>= \case
+            Left err ->
+                displayError err $
+                    Text.hPutStrLn stderr (roleError stdoutColor err)
+            Right (sessionId, turns) -> do
+                let markdown = TranscriptExport.renderTranscriptMarkdown turns
+                    defaultPath = defaultExportFileName sessionId
+                case maybePath of
+                    Just path -> saveExport markdown path
+                    Nothing ->
+                        requestChoice
+                            "Export conversation"
+                            "Copy the visible conversation or save it as Markdown."
+                            0
+                            [ ( "Copy Markdown to clipboard"
+                              , "Copy the current visible transcript"
+                              )
+                            , ( "Save Markdown to a file"
+                              , "Create a new file without overwriting"
+                              )
+                            ] >>= \case
+                                Nothing -> pure ()
+                                Just 0 ->
+                                    copyCommand
+                                        "conversation Markdown"
+                                        "conversation is unavailable"
+                                        (Just markdown)
+                                Just _ ->
+                                    requestText
+                                        "Export path"
+                                        "Relative paths use the current working directory. Existing files are never replaced."
+                                        defaultPath >>= mapM_
+                                            (\entered ->
+                                                forM_
+                                                    (nonBlank entered)
+                                                    (saveExport markdown))
+    loadActiveTranscript =
+        case persist of
+            PersistenceDisabled ->
+                pure
+                    (Left
+                        "transcript export requires a persisted session")
+            PersistenceEnabled slotRef ->
+                readIORef slotRef >>= \case
+                    PersistencePending{} ->
+                        pure
+                            (Left
+                                "transcript export requires an active persisted session")
+                    PersistenceActive handle ->
+                        loadSession
+                            databasePool
+                            (sessionsRoot home)
+                            handle.sessionMeta.metaId >>= \case
+                                Left err -> pure (Left err)
+                                Right (_, turns) ->
+                                    pure
+                                        (Right
+                                            ( handle.sessionMeta.metaId
+                                            , turns
+                                            ))
+    saveExport markdown rawPath =
+        resolveExportPath cwd rawPath >>= \case
+            Left err ->
+                displayError err $
+                    Text.hPutStrLn stderr
+                        (roleError stdoutColor err)
+            Right path ->
+                saveTranscriptNoClobber path markdown >>= \case
+                    Left err -> do
+                        let message =
+                                "could not export to "
+                                    <> toText path
+                                    <> ": "
+                                    <> err
+                        displayError message $
+                            Text.hPutStrLn stderr
+                                (roleError stdoutColor message)
+                    Right () -> do
+                        let message =
+                                "exported conversation to " <> toText path
+                        displayInfo message $
+                            Text.hPutStrLn stderr
+                                (roleSuccess stdoutColor
+                                    (glyphOk <> message))
+    requestChoice title body initial rows
+        | null rows = pure Nothing
+        | otherwise =
+            case fullscreen of
+                Just runtime ->
+                    requestFullscreenChoiceWithBody
+                        runtime
+                        title
+                        body
+                        (max 0 (min (length rows - 1) initial))
+                        rows
+                Nothing -> do
+                    color <- resolveColor stderr
+                    Text.hPutStrLn stderr
+                        (roleMuted color
+                            (Text.intercalate
+                                "\n"
+                                (filter
+                                    (not . Text.null)
+                                    [title, body])))
+                    let labels =
+                            [ if Text.null detail
+                                then label
+                                else label <> " — " <> detail
+                            | (label, detail) <- rows
+                            ]
+                    selected <-
+                        readChoiceSelectionAt initial
+                            (\active label ->
+                                if active
+                                    then roleSuccess color label
+                                    else roleMuted color label)
+                            labels
+                    pure (selected >>= (`elemIndex` labels))
+    requestText title body initial =
+        case fullscreen of
+            Just runtime ->
+                requestFullscreenText runtime title body initial
+            Nothing -> do
+                color <- resolveColor stderr
+                unless (Text.null (Text.strip body)) $
+                    Text.hPutStrLn stderr (roleMuted color body)
+                readModalText interrupt (title <> ": ") initial
+    approvalPolicyRows =
+        [ (label, detail)
+        | (_, label, detail) <- approvalPolicyOptions
+        ]
+    approvalPolicyIndex policy =
+        fromMaybe 0 $
+            findIndex
+                (\(candidate, _, _) -> candidate == policy)
+                approvalPolicyOptions
+    approvalPolicyAt index =
+        case indexMaybe index approvalPolicyOptions of
+            Just (policy, _, _) -> policy
+            Nothing -> PromptMutating
+    indexMaybe index values
+        | index < 0 = Nothing
+        | otherwise =
+            case drop index values of
+                value : _ -> Just value
+                [] -> Nothing
+    nonBlank value
+        | Text.null stripped = Nothing
+        | otherwise = Just stripped
+      where
+        stripped = Text.strip value
     legacy action = case fullscreen of
         Nothing -> action
         Just runtime -> withFullscreenSuspended runtime action

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -18,7 +18,7 @@ import Agent.CLI.Command
       currentModel,
       ReplAction(ReplRenameAuto, ReplResume, ReplSearch, ReplClear,
                  ReplNew, ReplShowSession, ReplShowSessionInfo, ReplAfk,
-                 ReplWorktree, ReplRename),
+                 ReplWorktree, ReplRename, ReplFork),
       ShellMode(ShellNone, ShellGhci, ShellBash, ShellBoth),
       SlashCatalog(slashCatalogToolNames) )
 import Agent.CLI.Compaction ()
@@ -69,6 +69,8 @@ import Agent.CLI.Session
     ( TranscriptEffect(TranscriptReset),
       appendTurnKeepTitleIndexed,
       createSession,
+      deleteSession,
+      forkSession,
       loadSession,
       removeSessionTemp,
       resetSessionTitleToAuto,
@@ -85,14 +87,17 @@ import Agent.CLI.Session
       SessionMeta(metaTitle, metaLastResponseId, metaUpdatedAt,
                   metaInputTokens, metaOutputTokens, metaCachedTokens, metaLastRecap,
                   metaLastTurnSummary, metaLastRecapMainTurns, metaTransportModel,
-                  metaId, metaCwd),
+                  metaId, metaCwd, metaTitleUserTurns),
       SessionTransfer(transferTurns, SessionTransfer, transferMeta),
       SessionTurn(turnUsage, SessionTurn, turnAt, turnUserText,
                   turnAssistantText, turnError, turnResponseId, turnEffect,
                   turnItems) )
 import Agent.CLI.Session.Attachments ()
 import Agent.CLI.Session.Choices ()
-import Agent.CLI.Session.History ()
+import Agent.CLI.Session.History
+    ( durableTranscriptCheckpoint
+    , retargetLiveTranscript
+    )
 import Agent.CLI.Session.Interaction ()
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types ()
@@ -164,7 +169,8 @@ import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar ()
 import Control.Concurrent.STM ()
 import Control.Exception ()
-import Control.Exception.Safe ( finally )
+import Control.Exception.Safe
+    ( displayException, finally, mask_, tryAny )
 import Control.Monad ( forM_ )
 import Data.IORef ( readIORef, writeIORef )
 import Data.List ()
@@ -191,7 +197,7 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ( toAscList )
-import qualified Data.Text as Text ( intercalate, null, unlines )
+import qualified Data.Text as Text ( intercalate, pack, unlines )
 import qualified Data.Text.IO as Text ( putStrLn, hPutStrLn )
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Usage as XAIUsage ()
@@ -380,6 +386,69 @@ handleSessionAction
                         (roleMuted color
                             (glyphOk <> message))
                 continue
+    ReplFork requestedTitle -> do
+        color <- resolveColor stderr
+        case persist of
+            PersistenceDisabled -> do
+                let message =
+                        "session forking requires a persisted session"
+                displayError message $
+                    Text.hPutStrLn stderr
+                        (roleError color message)
+                continue
+            PersistenceEnabled slotRef ->
+                readIORef slotRef >>= \case
+                    PersistencePending{} -> do
+                        let message =
+                                "a session must contain at least one turn before it can be forked"
+                        displayError message $
+                            Text.hPutStrLn stderr
+                                (roleError color message)
+                        continue
+                    PersistenceActive source -> do
+                        let root = takeDirectory source.sessionDir
+                        result <-
+                            withReplActivity \report -> do
+                                report "Forking session…"
+                                loadSession
+                                    databasePool
+                                    root
+                                    source.sessionMeta.metaId >>= \case
+                                        Left err ->
+                                            pure (Left err)
+                                        Right (meta, turns) ->
+                                            forkSession
+                                                root
+                                                source { sessionMeta = meta }
+                                                turns
+                                                requestedTitle
+                        case result of
+                            Left err -> do
+                                displayError err $
+                                    Text.hPutStrLn stderr
+                                        (roleError color err)
+                                continue
+                            Right forked -> do
+                                installed <-
+                                    installFork
+                                        slotRef
+                                        source
+                                        forked
+                                case installed of
+                                    Left err -> do
+                                        displayError err $
+                                            Text.hPutStrLn stderr
+                                                (roleError color err)
+                                        continue
+                                    Right () -> do
+                                        let message =
+                                                "forked session: "
+                                                    <> forked.sessionMeta.metaId
+                                        displayInfo message $
+                                            Text.hPutStrLn stderr
+                                                (roleMuted color
+                                                    (glyphOk <> message))
+                                        continue
     ReplShowSession -> do
         color <- resolveColor stdout
         case persist of
@@ -640,6 +709,69 @@ handleSessionAction
         continue
     _ -> error "handleSessionAction: unsupported action"
   where
+    installFork slotRef source forked = mask_ do
+        prepared <- tryAny do
+            env.sessionSetTempDir forked.sessionTempDir
+            forM_ fullscreen \runtime ->
+                reloadFullscreenHistoryForHandle runtime forked
+            retargetLiveTranscript
+                env.sessionConversation
+                (durableTranscriptCheckpoint
+                    databasePool
+                    (takeDirectory forked.sessionDir)
+                    forked.sessionMeta.metaId)
+        case prepared of
+            Left err -> rollbackBeforeClaim err
+            Right () ->
+                tryAny (env.sessionOnPersisted forked) >>= \case
+                    Left err -> rollbackBeforeClaim err
+                    Right () -> do
+                        -- With the new lock held, all remaining state changes
+                        -- are non-blocking IORef swaps. Keep the live
+                        -- conversation and response parent unchanged.
+                        writeIORef slotRef (PersistenceActive forked)
+                        writeIORef planMode.planSessionDir
+                            (Just forked.sessionDir)
+                        writeIORef storeRoot (Just forked.sessionDir)
+                        writeIORef
+                            env.sessionTitleTurnCount
+                            forked.sessionMeta.metaTitleUserTurns
+                        _ <- tryAny $
+                            setWindowTitle
+                                (cliWindowTitle
+                                    forked.sessionMeta.metaCwd
+                                    (Just forked.sessionMeta.metaTitle))
+                        pure (Right ())
+      where
+        rollbackBeforeClaim err = do
+            _ <- tryAny
+                (env.sessionSetTempDir source.sessionTempDir)
+            _ <- tryAny $
+                forM_ fullscreen \runtime ->
+                    reloadFullscreenHistoryForHandle runtime source
+            _ <- tryAny $
+                retargetLiveTranscript
+                    env.sessionConversation
+                    (durableTranscriptCheckpoint
+                        databasePool
+                        (takeDirectory source.sessionDir)
+                        source.sessionMeta.metaId)
+            cleanup <-
+                deleteSession
+                    databasePool
+                    (takeDirectory forked.sessionDir)
+                    forked.sessionMeta.metaId
+            let base =
+                    "could not activate forked session: "
+                        <> Text.pack (displayException err)
+            pure $
+                Left $
+                    case cleanup of
+                        Right () -> base
+                        Left cleanupErr ->
+                            base
+                                <> "; cleanup also failed: "
+                                <> cleanupErr
     fullscreenEvent event = case fullscreen of
         Nothing -> pure ()
         Just runtime -> emitUiEvent runtime event

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -25,6 +25,7 @@ module Agent.CLI.Session
     , loadSessionActivity
     , cleanupPendingPersistence
     , createSession
+    , forkSession
     , appendTurn
     , appendTurnIndexed
     , appendTurnWithMetaUpdate
@@ -109,7 +110,13 @@ import Agent.Store.Postgres.Connection (StorePool)
 import qualified Agent.Store.Postgres.Session as Store
 import Agent.Store.Types (StoreError, renderStoreError)
 import Control.Applicative ((<|>))
-import Control.Exception.Safe (displayException, finally, onException, tryIO)
+import Control.Exception.Safe
+    ( displayException
+    , finally
+    , mask
+    , onException
+    , tryIO
+    )
 import Control.Monad (unless, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
@@ -136,15 +143,25 @@ import Data.Word (Word64)
 import qualified Data.Vector as Vector
 import Numeric (showHex)
 import System.Directory.OsPath
-    ( createDirectory
+    ( copyFile
+    , createDirectory
     , createDirectoryIfMissing
     , doesDirectoryExist
     , doesFileExist
+    , listDirectory
     , removePathForcibly
     , removeFile
     )
 import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
-import System.Posix.Files (setFileMode)
+import System.IO.Error (isDoesNotExistError)
+import System.Posix.Files
+    ( FileStatus
+    , getSymbolicLinkStatus
+    , isDirectory
+    , isRegularFile
+    , isSymbolicLink
+    , setFileMode
+    )
 
 sessionSchemaVersion :: Int
 sessionSchemaVersion = 1
@@ -273,6 +290,213 @@ createSession spec = do
     (sessionId, tempDir) <- allocateSessionTemp spec.createRoot
     createReservedSession spec sessionId tempDir
         `onException` removeReservedTemp spec.createRoot sessionId
+
+-- | Clone a persisted session and its durable branch artifacts under a new
+-- id. The returned handle is not locked or installed as the active session;
+-- callers should use the same active-session handoff used by @/new@.
+forkSession
+    :: OsPath
+    -> SessionHandle
+    -> [SessionTurn]
+    -> Maybe Text
+    -> IO (Either Text SessionHandle)
+forkSession root source turns requestedTitle
+    | not (any substantiveTurn turns) =
+        pure (Left "a session must contain at least one turn before it can be forked")
+    | otherwise = mask \restore -> do
+        allocated <- tryIO (restore (allocateSessionTemp root))
+        case allocated of
+            Left err ->
+                pure (Left ("could not reserve fork session: " <> exceptionText err))
+            Right (sessionId, tempDir) ->
+                case sessionDirForId root sessionId of
+                    Left err -> do
+                        cleanupForkFiles root sessionId Nothing
+                        pure (Left err)
+                    Right dir -> do
+                        now <- normalizePostgresTimestamp <$> getCurrentTime
+                        let meta = forkedMetadata now sessionId requestedTitle
+                                source.sessionMeta
+                            storedMeta = toStoredMetadata meta
+                            handle = SessionHandle
+                                { sessionPool = source.sessionPool
+                                , sessionDir = dir
+                                , sessionTempDir = tempDir
+                                , sessionMetaPath =
+                                    dir </> unsafeEncodeUtf "meta.json"
+                                , sessionTranscriptPath =
+                                    dir </> unsafeEncodeUtf "transcript.jsonl"
+                                , sessionMeta = meta
+                                }
+                            cleanupFiles =
+                                cleanupForkFiles root sessionId (Just dir)
+                            cleanupOwned = do
+                                cleanupForkDatabaseIfOwned
+                                    source.sessionPool
+                                    storedMeta
+                                cleanupFiles
+                        prepared <- tryIO $
+                            restore
+                                (prepareForkDirectory source.sessionDir dir)
+                                `onException` cleanupFiles
+                        case prepared of
+                            Left err -> do
+                                cleanupFiles
+                                pure
+                                    (Left
+                                        ("could not copy fork session artifacts: "
+                                            <> exceptionText err))
+                            Right () -> do
+                                stored <-
+                                    restore
+                                        (Store.createSessionFromSnapshot
+                                            source.sessionPool
+                                            storedMeta
+                                            (map toStoredTurn turns))
+                                        `onException` cleanupOwned
+                                case stored of
+                                    Left err -> do
+                                        cleanupOwned
+                                        pure (Left (renderStoreError err))
+                                    Right False -> do
+                                        cleanupFiles
+                                        pure
+                                            (Left
+                                                "could not allocate a unique PostgreSQL session id")
+                                    Right True -> pure (Right handle)
+  where
+    exceptionText = Text.pack . displayException
+
+substantiveTurn :: SessionTurn -> Bool
+substantiveTurn turn =
+    turn.turnEffect /= TranscriptReset
+        && ( not (Text.null (Text.strip turn.turnUserText))
+            || maybe False (not . Text.null . Text.strip)
+                turn.turnAssistantText
+            || maybe False (not . Text.null . Text.strip) turn.turnError
+            || not (null turn.turnItems)
+           )
+
+forkedMetadata
+    :: UTCTime
+    -> Text
+    -> Maybe Text
+    -> SessionMeta
+    -> SessionMeta
+forkedMetadata now sessionId requestedTitle source =
+    source
+        { metaId = sessionId
+        , metaCreatedAt = now
+        , metaUpdatedAt = now
+        , metaTitle = title
+        , metaTitleIsManual =
+            maybe source.metaTitleIsManual (const True) normalizedTitle
+        , metaTitleRefreshIndex =
+            maybe source.metaTitleRefreshIndex
+                (const (max 2 source.metaTitleRefreshIndex))
+                normalizedTitle
+        }
+  where
+    normalizedTitle =
+        requestedTitle
+            >>= \raw ->
+                let normalized = Text.unwords (Text.words raw)
+                in if Text.null normalized then Nothing else Just normalized
+    title = fromMaybe source.metaTitle normalizedTitle
+
+prepareForkDirectory :: OsPath -> OsPath -> IO ()
+prepareForkDirectory sourceDir destinationDir = do
+    createDirectory destinationDir
+    setFileMode (unsafeToFilePath destinationDir) 0o700
+    copyOptionalArtifact
+        ArtifactRegularFile
+        (sourceDir </> unsafeEncodeUtf "plan.md")
+        (destinationDir </> unsafeEncodeUtf "plan.md")
+    copyOptionalArtifact
+        ArtifactDirectory
+        (sourceDir </> unsafeEncodeUtf "agents")
+        (destinationDir </> unsafeEncodeUtf "agents")
+
+data ArtifactKind
+    = ArtifactRegularFile
+    | ArtifactDirectory
+    deriving (Eq)
+
+copyOptionalArtifact :: ArtifactKind -> OsPath -> OsPath -> IO ()
+copyOptionalArtifact expected source destination =
+    symbolicLinkStatusMaybe source >>= \case
+        Nothing -> pure ()
+        Just status
+            | isSymbolicLink status ->
+                fail ("refusing to copy symbolic link: " <> Text.unpack (toText source))
+            | expected == ArtifactRegularFile && isRegularFile status ->
+                copyPrivateFile source destination
+            | expected == ArtifactDirectory && isDirectory status ->
+                copyPrivateDirectory source destination
+            | otherwise ->
+                fail ("unexpected fork artifact type: " <> Text.unpack (toText source))
+
+copyPrivateDirectory :: OsPath -> OsPath -> IO ()
+copyPrivateDirectory source destination = do
+    createDirectory destination
+    setFileMode (unsafeToFilePath destination) 0o700
+    entries <- listDirectory source
+    mapM_
+        (\entry -> do
+            let sourcePath = source </> entry
+                destinationPath = destination </> entry
+            status <- getSymbolicLinkStatus (unsafeToFilePath sourcePath)
+            if isSymbolicLink status
+                then
+                    fail
+                        ("refusing to copy symbolic link: "
+                            <> Text.unpack (toText sourcePath))
+                else if isDirectory status
+                    then copyPrivateDirectory sourcePath destinationPath
+                    else if isRegularFile status
+                        then copyPrivateFile sourcePath destinationPath
+                        else
+                            fail
+                                ("unexpected fork artifact type: "
+                                    <> Text.unpack (toText sourcePath)))
+        entries
+
+copyPrivateFile :: OsPath -> OsPath -> IO ()
+copyPrivateFile source destination = do
+    copyFile source destination
+    setFileMode (unsafeToFilePath destination) 0o600
+
+symbolicLinkStatusMaybe :: OsPath -> IO (Maybe FileStatus)
+symbolicLinkStatusMaybe path =
+    tryIO (getSymbolicLinkStatus (unsafeToFilePath path)) >>= \case
+        Left err
+            | isDoesNotExistError err -> pure Nothing
+            | otherwise -> ioError err
+        Right status -> pure (Just status)
+
+cleanupForkDatabaseIfOwned
+    :: StorePool
+    -> Store.SessionMetadata
+    -> IO ()
+cleanupForkDatabaseIfOwned pool expected = do
+    loaded <- Store.loadSessionMetadata pool expected.sessionMetadataKey
+    case loaded of
+        Right (Just actual)
+            | actual == expected -> do
+                now <- getCurrentTime
+                _ <- Store.deleteSession pool expected.sessionMetadataKey now
+                pure ()
+        _ -> pure ()
+
+cleanupForkFiles :: OsPath -> Text -> Maybe OsPath -> IO ()
+cleanupForkFiles root sessionId dir = do
+    mapM_
+        (\path -> do
+            _ <- tryIO (removePathForcibly path)
+            pure ())
+        dir
+    _ <- removeSessionTemp root sessionId
+    pure ()
 
 createReservedSession
     :: SessionCreate

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -127,19 +127,15 @@ import Control.Monad.Trans.Except
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
-import Data.Bits (xor)
 import Data.Int (Int64)
 import Data.IORef
 import Data.Functor ((<&>))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.IO as Text
 import Data.Time.Clock (UTCTime, getCurrentTime, nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format (defaultTimeLocale, formatTime)
-import Data.Word (Word64)
 import qualified Data.Vector as Vector
 import Numeric (showHex)
 import System.Directory.OsPath
@@ -301,7 +297,7 @@ forkSession
     -> Maybe Text
     -> IO (Either Text SessionHandle)
 forkSession root source turns requestedTitle
-    | not (any substantiveTurn turns) =
+    | not (any substantiveTurn (activeTranscriptTurns turns)) =
         pure (Left "a session must contain at least one turn before it can be forked")
     | otherwise = mask \restore -> do
         allocated <- tryIO (restore (allocateSessionTemp root))
@@ -336,12 +332,10 @@ forkSession root source turns requestedTitle
                                     storedMeta
                                 cleanupFiles
                         prepared <- tryIO $
-                            restore
-                                (prepareForkDirectory source.sessionDir dir)
-                                `onException` cleanupFiles
+                            restore (prepareForkDirectory source.sessionDir dir)
                         case prepared of
                             Left err -> do
-                                cleanupFiles
+                                cleanupForkFiles root sessionId Nothing
                                 pure
                                     (Left
                                         ("could not copy fork session artifacts: "
@@ -377,6 +371,12 @@ substantiveTurn turn =
             || not (null turn.turnItems)
            )
 
+activeTranscriptTurns :: [SessionTurn] -> [SessionTurn]
+activeTranscriptTurns =
+    reverse
+        . takeWhile ((/= TranscriptReset) . (.turnEffect))
+        . reverse
+
 forkedMetadata
     :: UTCTime
     -> Text
@@ -407,15 +407,19 @@ forkedMetadata now sessionId requestedTitle source =
 prepareForkDirectory :: OsPath -> OsPath -> IO ()
 prepareForkDirectory sourceDir destinationDir = do
     createDirectory destinationDir
-    setFileMode (unsafeToFilePath destinationDir) 0o700
-    copyOptionalArtifact
-        ArtifactRegularFile
-        (sourceDir </> unsafeEncodeUtf "plan.md")
-        (destinationDir </> unsafeEncodeUtf "plan.md")
-    copyOptionalArtifact
-        ArtifactDirectory
-        (sourceDir </> unsafeEncodeUtf "agents")
-        (destinationDir </> unsafeEncodeUtf "agents")
+    (do
+        setFileMode (unsafeToFilePath destinationDir) 0o700
+        copyOptionalArtifact
+            ArtifactRegularFile
+            (sourceDir </> unsafeEncodeUtf "plan.md")
+            (destinationDir </> unsafeEncodeUtf "plan.md")
+        copyOptionalArtifact
+            ArtifactDirectory
+            (sourceDir </> unsafeEncodeUtf "agents")
+            (destinationDir </> unsafeEncodeUtf "agents"))
+        `onException` do
+            _ <- tryIO (removePathForcibly destinationDir)
+            pure ()
 
 data ArtifactKind
     = ArtifactRegularFile
@@ -1152,7 +1156,9 @@ allocateSessionTemp root = do
                     root </> unsafeEncodeUtf (Text.unpack sessionId)
                 tempDir =
                     tempRoot </> unsafeEncodeUtf (Text.unpack sessionId)
-            durableExists <- doesDirectoryExist durableDir
+            durableExists <-
+                maybe False (const True)
+                    <$> symbolicLinkStatusMaybe durableDir
             if durableExists
                 then go tempRoot now (attempt + 1)
                 else tryIO (createDirectory tempDir) >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Session/ConversationStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/ConversationStore.hs
@@ -17,6 +17,7 @@ module Agent.CLI.Session.ConversationStore
     , readConversationAttachments
     , readConversationPreviousResponseId
     , replaceConversationTranscript
+    , retargetConversationCheckpoint
     , resetConversationStore
     , withConversationTranscript
     , writeConversationPreviousResponseId
@@ -234,6 +235,30 @@ evictConversationTranscript
                         , False
                         )
             _ -> pure (state, False)
+
+-- | Point an unchanged cold or currently hydrated transcript at an equivalent
+-- durable snapshot under a different identity (for example, after /fork).
+-- A committed resident transcript has no checkpoint yet and is left alone.
+retargetConversationCheckpoint
+    :: ConversationStore
+    -> TranscriptCheckpoint
+    -> IO ()
+retargetConversationCheckpoint
+        (ConversationStore stateVar)
+        checkpoint =
+    modifyMVar_ stateVar \state ->
+        pure state
+            { stateTranscript =
+                case state.stateTranscript of
+                    ColdTranscript _ ->
+                        ColdTranscript checkpoint
+                    ResidentTranscript items
+                            (HydratedResident _ readers) ->
+                        ResidentTranscript
+                            items
+                            (HydratedResident checkpoint readers)
+                    resident@ResidentTranscript{} -> resident
+            }
 
 readConversationPreviousResponseId
     :: ConversationStore

--- a/packages/agent-cli/src/Agent/CLI/Session/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/History.hs
@@ -14,6 +14,7 @@ module Agent.CLI.Session.History
     , readLiveAttachments
     , readLivePreviousResponseId
     , readLiveTranscript
+    , retargetLiveTranscript
     , modifyLiveAttachments
     , resetLiveConversationState
     , resetLiveConversation
@@ -148,6 +149,16 @@ evictLiveTranscript ref generation checkpoint =
     readIORef ref >>= \store ->
         ConversationStore.evictConversationTranscript
             store generation checkpoint
+
+-- | Retarget an unchanged transcript to an equivalent durable session
+-- snapshot without hydrating it.
+retargetLiveTranscript
+    :: IORef LiveConversation
+    -> TranscriptCheckpoint
+    -> IO ()
+retargetLiveTranscript ref checkpoint =
+    readIORef ref >>= \store ->
+        ConversationStore.retargetConversationCheckpoint store checkpoint
 
 -- | Reconstruct the exact root transcript from durable session turns.
 --

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -89,7 +89,6 @@ runSession
 runSession callbacks SessionRequest{..} SessionBackend{..} = do
   initialPrevious <- readLivePreviousResponseId conversationRef
   ioLock <- newMVar ()
-  policyRef <- newIORef policy
   let fullscreen = startup.startupFullscreen
       terminal = startup.startupTerminal
       stdoutHandle = startup.startupStdout

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -105,7 +105,7 @@ data SessionRequest = SessionRequest
     , options :: !CliOptions
     , provider :: !Provider
     , dialect :: !Dialect
-    , policy :: !ApprovalPolicy
+    , policyRef :: !(IORef ApprovalPolicy)
     , allTools :: ![AppTool]
     , recordImageGenerationInputs :: !([ImageAttachment] -> IO ())
     , clearImageGenerationHistory :: !(IO ())

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -863,8 +863,9 @@ runPreparedChild runtime env session toolEnv toolRegistry backend onEvent runChi
             , loopMaxTurns = runtime.subagentOptions.optMaxTurns
             , loopOnEvent = onEvent
             , loopApprove =
-                \call ->
-                    childApprove runtime.subagentPolicy toolRegistry call
+                \call -> do
+                    policy <- readIORef runtime.subagentPolicy
+                    childApprove policy toolRegistry call
             , loopReadSteering = pure []
             , loopCommitSteering = \_ -> pure ()
             , loopCancel = env.subCancel

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
@@ -42,7 +42,7 @@ data SubagentRuntime = SubagentRuntime
     { subagentOptions :: !CliOptions
     , subagentGhciEnabled :: !(IORef Bool)
     , subagentBashEnabled :: !(IORef Bool)
-    , subagentPolicy :: !ApprovalPolicy
+    , subagentPolicy :: !(IORef ApprovalPolicy)
     , subagentPlanHooks :: !PlanModeHooks
     , subagentSkillRoots :: !(IORef [OsPath])
     , subagentAllowedRoots :: !(IORef [OsPath])

--- a/packages/agent-cli/src/Agent/CLI/TranscriptExport.hs
+++ b/packages/agent-cli/src/Agent/CLI/TranscriptExport.hs
@@ -16,7 +16,7 @@ import Agent.CLI.Session
 import Agent.CLI.Session.Types (TranscriptEffect(..))
 import Agent.CLI.TUI.History (HistoryTurn(historyTurnBlocks))
 import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn)
-import Agent.OsPath (toText, unsafeToFilePath)
+import Agent.OsPath (unsafeToFilePath)
 import Agent.TUI.Model
     ( BlockKind(..)
     , UiBlock(..)
@@ -26,11 +26,12 @@ import Control.Exception.Safe
     , displayException
     , tryAny
     )
+import qualified Data.ByteString as ByteString
 import Data.Foldable (toList)
 import Data.List (findIndex)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import qualified Data.Text.Encoding as TextEncoding
 import System.Directory.OsPath
     ( doesDirectoryExist
     , getHomeDirectory
@@ -65,7 +66,8 @@ renderTranscriptMarkdown :: [SessionTurn] -> Text
 renderTranscriptMarkdown turns =
     let blocks =
             concat
-                [ toList (historyTurnBlocks (sessionHistoryTurn index turn))
+                [ toList
+                    ((sessionHistoryTurn index turn).historyTurnBlocks)
                 | (index, turn) <- zip [0 :: Int ..] (visibleSessionTurns turns)
                 ]
         sections = map renderBlock (filter useful blocks)
@@ -135,11 +137,12 @@ saveTranscriptNoClobber target markdown = do
                         _ <- tryAny (removeFile (unsafeEncodeUtf tmp))
                         pure ())
                     \(tmp, handle) -> do
-                        Text.hPutStr handle markdown
+                        ByteString.hPut handle
+                            (TextEncoding.encodeUtf8 markdown)
                         hClose handle
                         createLink tmp (unsafeToFilePath target)
-                        removeFile (unsafeEncodeUtf tmp)
+                        _ <- tryAny (removeFile (unsafeEncodeUtf tmp))
+                        pure ()
             pure $ case result of
                 Left err -> Left (Text.pack (displayException err))
                 Right () -> Right ()
-

--- a/packages/agent-cli/src/Agent/CLI/TranscriptExport.hs
+++ b/packages/agent-cli/src/Agent/CLI/TranscriptExport.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Export the visible session transcript as Markdown.
+module Agent.CLI.TranscriptExport
+    ( defaultExportFileName
+    , renderTranscriptMarkdown
+    , resolveExportPath
+    , saveTranscriptNoClobber
+    , visibleSessionTurns
+    ) where
+
+import Agent.CLI.Session
+    ( SessionTurn(..)
+    )
+import Agent.CLI.Session.Types (TranscriptEffect(..))
+import Agent.CLI.TUI.History (HistoryTurn(historyTurnBlocks))
+import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn)
+import Agent.OsPath (toText, unsafeToFilePath)
+import Agent.TUI.Model
+    ( BlockKind(..)
+    , UiBlock(..)
+    )
+import Control.Exception.Safe
+    ( bracketOnError
+    , displayException
+    , tryAny
+    )
+import Data.Foldable (toList)
+import Data.List (findIndex)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.Directory.OsPath
+    ( doesDirectoryExist
+    , getHomeDirectory
+    , makeAbsolute
+    , removeFile
+    )
+import System.OsPath
+    ( OsPath
+    , isAbsolute
+    , takeDirectory
+    , takeFileName
+    , unsafeEncodeUtf
+    , (</>)
+    )
+import System.IO
+    ( hClose
+    , openBinaryTempFile
+    )
+import System.Posix.Files (createLink)
+
+-- | Keep only the current visible generation. A reset marker itself remains
+-- visible, matching the fullscreen history projection.
+visibleSessionTurns :: [SessionTurn] -> [SessionTurn]
+visibleSessionTurns turns =
+    case findIndex ((== TranscriptReset) . (.turnEffect)) (reverse turns) of
+        Nothing -> turns
+        Just fromEnd -> drop (length turns - fromEnd - 1) turns
+
+-- | Render the visible transcript using the same durable-to-UI projection as
+-- the fullscreen history. Scratchpad reasoning is omitted by that projection.
+renderTranscriptMarkdown :: [SessionTurn] -> Text
+renderTranscriptMarkdown turns =
+    let blocks =
+            concat
+                [ toList (historyTurnBlocks (sessionHistoryTurn index turn))
+                | (index, turn) <- zip [0 :: Int ..] (visibleSessionTurns turns)
+                ]
+        sections = map renderBlock (filter useful blocks)
+    in "# Agent conversation\n\n"
+        <> Text.intercalate "\n\n" sections
+  where
+    useful block =
+        not
+            (Text.null (Text.strip block.blockBody)
+                && Text.null (Text.strip block.blockTitle)
+                && Text.null (Text.strip block.blockDetail))
+
+renderBlock :: UiBlock -> Text
+renderBlock block =
+    let (heading, body) =
+            case block.blockKind of
+                BlockUser -> ("User", block.blockBody)
+                BlockAssistant -> ("Assistant", block.blockBody)
+                BlockThinking -> ("Reasoning", block.blockBody)
+                BlockSystem -> ("System", block.blockBody)
+                BlockRecap -> ("Recap", block.blockBody)
+                BlockError -> ("Error", block.blockBody)
+                _ -> ("Activity", activityBody block)
+    in "## " <> heading <> "\n\n" <> body
+
+activityBody :: UiBlock -> Text
+activityBody block =
+    Text.intercalate
+        "\n\n"
+        (filter (not . Text.null . Text.strip)
+            [block.blockTitle, block.blockBody, block.blockDetail])
+
+defaultExportFileName :: Text -> Text
+defaultExportFileName sessionId =
+    "agent-session-" <> sessionId <> ".md"
+
+-- | Resolve an export argument relative to cwd, expanding @~/@ against HOME.
+resolveExportPath :: OsPath -> Text -> IO (Either Text OsPath)
+resolveExportPath cwd raw =
+    tryAny (do
+        home <- getHomeDirectory
+        let stripped = Text.strip raw
+            path
+                | stripped == "~" = home
+                | Just suffix <- Text.stripPrefix "~/" stripped =
+                    home </> unsafeEncodeUtf (Text.unpack suffix)
+                | otherwise = unsafeEncodeUtf (Text.unpack stripped)
+        makeAbsolute
+            (if isAbsolute path then path else cwd </> path))
+    >>= pure . either (Left . Text.pack . displayException) Right
+
+-- | Save without replacing an existing file. A same-directory temporary file
+-- is hard-linked into place, making target creation atomic and no-clobber.
+saveTranscriptNoClobber :: OsPath -> Text -> IO (Either Text ())
+saveTranscriptNoClobber target markdown = do
+    parentExists <- doesDirectoryExist (takeDirectory target)
+    if not parentExists
+        then pure (Left "export directory does not exist")
+        else do
+            result <- tryAny $
+                bracketOnError
+                    (openBinaryTempFile
+                        (unsafeToFilePath (takeDirectory target))
+                        (unsafeToFilePath (takeFileName target) <> ".tmp"))
+                    (\(tmp, handle) -> do
+                        _ <- tryAny (hClose handle)
+                        _ <- tryAny (removeFile (unsafeEncodeUtf tmp))
+                        pure ())
+                    \(tmp, handle) -> do
+                        Text.hPutStr handle markdown
+                        hClose handle
+                        createLink tmp (unsafeToFilePath target)
+                        removeFile (unsafeEncodeUtf tmp)
+            pure $ case result of
+                Left err -> Left (Text.pack (displayException err))
+                Right () -> Right ()
+

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.CommandSpec (spec) where
 
 import Agent.CLI.Command
+import Agent.CLI.Command.Instructions (initInstruction)
 import Agent.CLI.Afk
 import Agent.Dialect (DialectId(..))
 import Agent.ReasoningEffort (ReasoningEffort(..))
@@ -67,6 +68,32 @@ spec = do
             parseReplLine "/effort XHIGH" `shouldBe` ReplSetEffort EffortXHigh
             parseReplLine "/effort MAX" `shouldBe` ReplSetEffort EffortMax
             parseReplLine "/effort medium" `shouldBe` ReplSetEffort EffortMedium
+
+        it "parses the Codex workflow commands" do
+            parseReplLine "/init" `shouldBe` ReplInit
+            parseReplLine "/init now"
+                `shouldBe` ReplCommandError "usage: /init"
+            parseReplLine "/review" `shouldBe` ReplReview Nothing
+            parseReplLine "/review   inspect auth  "
+                `shouldBe` ReplReview (Just "inspect auth")
+            parseReplLine "/diff" `shouldBe` ReplDiff
+            parseReplLine "/diff now"
+                `shouldBe` ReplCommandError "usage: /diff"
+            parseReplLine "/fork" `shouldBe` ReplFork Nothing
+            parseReplLine "/fork   experiment branch  "
+                `shouldBe` ReplFork (Just "experiment branch")
+            parseReplLine "/export" `shouldBe` ReplExport Nothing
+            parseReplLine "/export  notes/session.md  "
+                `shouldBe` ReplExport (Just "notes/session.md")
+            parseReplLine "/permissions" `shouldBe` ReplPermissions
+            parseReplLine "/permissions now"
+                `shouldBe` ReplCommandError "usage: /permissions"
+
+        it "includes the no-overwrite AGENTS.md init prompt" do
+            initInstruction `shouldSatisfy` Text.isInfixOf
+                "Before writing, check whether AGENTS.md already exists"
+            initInstruction `shouldSatisfy` Text.isInfixOf
+                "Repository Guidelines"
 
         it "toggles always-approve from slash and colon aliases" do
             parseReplLine "/always-approve" `shouldBe` ReplToggleAlwaysApprove
@@ -333,6 +360,12 @@ spec = do
             names
                 `shouldBe`
                     [ "help"
+                    , "init"
+                    , "review"
+                    , "diff"
+                    , "fork"
+                    , "export"
+                    , "permissions"
                     , "model"
                     , "effort"
                     , "fast"

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -1,7 +1,6 @@
 module Agent.CLI.CommandSpec (spec) where
 
 import Agent.CLI.Command
-import Agent.CLI.Command.Instructions (initInstruction)
 import Agent.CLI.Afk
 import Agent.Dialect (DialectId(..))
 import Agent.ReasoningEffort (ReasoningEffort(..))
@@ -496,7 +495,8 @@ spec = do
                     map
                         (("/" <>) . (.slashName))
                         defaultSlashCatalog.slashCatalogCommands
-            displays "/mo" 3 `shouldBe` ["/model", "/codemod"]
+            displays "/mo" 3
+                `shouldBe` ["/model", "/codemod", "/permissions"]
             displays "/ra" 3 `shouldSatisfy` ("/reload-auth" `elem`)
             displays "look at /mo" 11 `shouldBe` []
 

--- a/packages/agent-cli/test/Agent/CLI/ConversationStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConversationStoreSpec.hs
@@ -162,6 +162,25 @@ spec = do
             withConversationTranscript store (`shouldBe` items)
             readIORef newerLoads `shouldReturn` 1
 
+        it "retargets a cold transcript without hydrating the old snapshot" do
+            oldLoads <- newIORef (0 :: Int)
+            newLoads <- newIORef (0 :: Int)
+            let old = TranscriptCheckpoint "source" do
+                    modifyIORef' oldLoads (+ 1)
+                    pure [messageItem "old"]
+                new = TranscriptCheckpoint "fork" do
+                    modifyIORef' newLoads (+ 1)
+                    pure [messageItem "fork"]
+            store <- newColdConversationStore Nothing old []
+
+            retargetConversationCheckpoint store new
+
+            readIORef oldLoads `shouldReturn` 0
+            withConversationTranscript store
+                (`shouldBe` [messageItem "fork"])
+            readIORef oldLoads `shouldReturn` 0
+            readIORef newLoads `shouldReturn` 1
+
         it "keeps response id and attachments independent of hydration" do
             loads <- newIORef (0 :: Int)
             let image = ImageAttachment "image/png" "png"

--- a/packages/agent-cli/test/Agent/CLI/GitDiffSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GitDiffSpec.hs
@@ -33,6 +33,7 @@ spec = describe "Agent.CLI.GitDiff" do
     it "includes tracked changes and NUL-delimited untracked paths" $
         withTempGitRepo \repo -> do
             writeUtf8 (repo </> fromText "README") "changed\n"
+            git repo ["add", "README"]
             writeUtf8 (repo </> fromText "new file.txt") "new\n"
             writeUtf8 (repo </> fromText "line\nbreak.txt") "odd\n"
 
@@ -43,6 +44,16 @@ spec = describe "Agent.CLI.GitDiff" do
             diff `shouldSatisfy` Text.isInfixOf "new file.txt"
             diff `shouldSatisfy` Text.isInfixOf "break.txt"
             diff `shouldSatisfy` Text.isInfixOf "odd"
+
+    it "includes staged files in an unborn repository" $
+        withTempDir "agent-git-diff-unborn-" \repo -> do
+            git repo ["init"]
+            writeUtf8 (repo </> fromText "first") "staged\n"
+            git repo ["add", "first"]
+
+            diff <- expectDiff =<< getGitDiff repo
+            diff `shouldSatisfy` Text.isInfixOf "first"
+            diff `shouldSatisfy` Text.isInfixOf "+staged"
 
     it "does not execute configured clean or textconv helpers" $
         withTempGitRepo \repo -> do
@@ -69,6 +80,18 @@ spec = describe "Agent.CLI.GitDiff" do
             _ <- expectDiff result
             Directory.doesPathExist (unsafeToFilePath marker)
                 `shouldReturn` False
+
+    it "renders repository-controlled terminal escapes inert" $
+        withTempGitRepo \repo -> do
+            writeUtf8
+                (repo </> fromText "README")
+                "hello\n\ESC]52;c;ZXZpbA==\BEL\rhidden\n"
+
+            diff <- expectDiff =<< getGitDiff repo
+            diff `shouldSatisfy` (not . Text.elem '\ESC')
+            diff `shouldSatisfy` (not . Text.elem '\BEL')
+            diff `shouldSatisfy` (not . Text.elem '\r')
+            diff `shouldSatisfy` Text.isInfixOf "␛]52;c;ZXZpbA==␇"
 
 expectDiff :: Either Text GitDiffResult -> IO Text
 expectDiff = \case

--- a/packages/agent-cli/test/Agent/CLI/GitDiffSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GitDiffSpec.hs
@@ -1,0 +1,120 @@
+module Agent.CLI.GitDiffSpec (spec) where
+
+import Agent.CLI.GitDiff
+import Agent.OsPath (fromText, unsafeToFilePath)
+import Control.Exception.Safe (bracket)
+import Control.Monad (unless)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TextIO
+import qualified System.Directory as Directory
+import System.Exit (ExitCode(..))
+import qualified System.FilePath as FilePath
+import System.OsPath (OsPath, (</>))
+import System.Posix.Files (setFileMode)
+import System.Posix.Temp (mkdtemp)
+import System.Process
+    ( CreateProcess(..)
+    , proc
+    , readCreateProcessWithExitCode
+    )
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.GitDiff" do
+    it "reports a directory outside Git without failing" $
+        withTempDir "agent-diff-not-git-" \dir ->
+            getGitDiff dir `shouldReturn` Right GitDiffNotRepository
+
+    it "returns an empty diff for an unchanged repository" $
+        withTempGitRepo \repo ->
+            getGitDiff repo `shouldReturn` Right (GitDiffOutput "")
+
+    it "includes tracked changes and NUL-delimited untracked paths" $
+        withTempGitRepo \repo -> do
+            writeUtf8 (repo </> fromText "README") "changed\n"
+            writeUtf8 (repo </> fromText "new file.txt") "new\n"
+            writeUtf8 (repo </> fromText "line\nbreak.txt") "odd\n"
+
+            result <- getGitDiff repo
+            diff <- expectDiff result
+            diff `shouldSatisfy` Text.isInfixOf "-hello"
+            diff `shouldSatisfy` Text.isInfixOf "changed"
+            diff `shouldSatisfy` Text.isInfixOf "new file.txt"
+            diff `shouldSatisfy` Text.isInfixOf "break.txt"
+            diff `shouldSatisfy` Text.isInfixOf "odd"
+
+    it "does not execute configured clean or textconv helpers" $
+        withTempGitRepo \repo -> do
+            let marker = repo </> fromText "helper-ran"
+                script = repo </> fromText "evil-helper"
+            writeFile (unsafeToFilePath script) $
+                "#!/bin/sh\n"
+                    <> "touch "
+                    <> shellQuote (unsafeToFilePath marker)
+                    <> "\ncat\n"
+            setFileMode (unsafeToFilePath script) 0o700
+            writeUtf8 (repo </> fromText ".gitattributes")
+                "*.bad filter=evil diff=evil\n"
+            writeUtf8 (repo </> fromText "tracked.bad") "old\n"
+            git repo ["add", ".gitattributes", "tracked.bad"]
+            git repo ["commit", "-m", "add filtered file"]
+            git repo ["config", "filter.evil.clean", unsafeToFilePath script]
+            git repo ["config", "filter.evil.process", unsafeToFilePath script]
+            git repo ["config", "filter.evil.required", "true"]
+            git repo ["config", "diff.evil.textconv", unsafeToFilePath script]
+            writeUtf8 (repo </> fromText "tracked.bad") "new\n"
+
+            result <- getGitDiff repo
+            _ <- expectDiff result
+            Directory.doesPathExist (unsafeToFilePath marker)
+                `shouldReturn` False
+
+expectDiff :: Either Text GitDiffResult -> IO Text
+expectDiff = \case
+    Right (GitDiffOutput diff) -> pure diff
+    other -> do
+        expectationFailure ("expected GitDiffOutput, got " <> show other)
+        pure ""
+
+withTempGitRepo :: (OsPath -> IO a) -> IO a
+withTempGitRepo action =
+    withTempDir "agent-git-diff-" \repo -> do
+        git repo ["init"]
+        git repo ["config", "user.email", "test@example.com"]
+        git repo ["config", "user.name", "Test"]
+        git repo ["config", "commit.gpgsign", "false"]
+        writeUtf8 (repo </> fromText "README") "hello\n"
+        git repo ["add", "README"]
+        git repo ["commit", "-m", "initial"]
+        action repo
+
+withTempDir :: String -> (OsPath -> IO a) -> IO a
+withTempDir prefix action = do
+    root <- Directory.getTemporaryDirectory
+    bracket
+        (fromText . Text.pack
+            <$> mkdtemp (root FilePath.</> prefix <> "XXXXXX"))
+        (Directory.removeDirectoryRecursive . unsafeToFilePath)
+        action
+
+git :: OsPath -> [String] -> IO ()
+git cwd arguments = do
+    (exitCode, _stdout, stderr) <-
+        readCreateProcessWithExitCode
+            (proc "git" arguments)
+                { cwd = Just (unsafeToFilePath cwd) }
+            ""
+    unless (exitCode == ExitSuccess) $
+        expectationFailure
+            ("git " <> unwords arguments <> " failed: " <> stderr)
+
+writeUtf8 :: OsPath -> Text -> IO ()
+writeUtf8 path = TextIO.writeFile (unsafeToFilePath path)
+
+shellQuote :: String -> String
+shellQuote value =
+    "'" <> concatMap quote value <> "'"
+  where
+    quote '\'' = "'\\''"
+    quote char = [char]

--- a/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.PermissionSpec (spec) where
 
 import Agent.CLI.Permission
 import Agent.CLI.Picker (PickerKey(..))
+import Agent.CLI.Options (ApprovalPolicy(..))
 import qualified Data.Text as Text
 import Test.Hspec
 
@@ -61,3 +62,26 @@ spec = do
                 Text.isInfixOf "Always approve all tools for this project"
             frame `shouldSatisfy` Text.isInfixOf "Always allow this tool this session"
             frame `shouldSatisfy` Text.isInfixOf "Deny"
+
+    describe "approval policy picker" do
+        it "selects the current policy" do
+            approvalPolicyIndex (initialApprovalPolicyState ApproveAll)
+                `shouldBe` 2
+            approvalPolicyIndex (initialApprovalPolicyState DenyMutating)
+                `shouldBe` 1
+
+        it "maps shortcuts and confirmation" do
+            let state = initialApprovalPolicyState PromptMutating
+            applyApprovalPolicyKey (PickerKeyChar 'f') state
+                `shouldBe` Left (ApprovalPolicySelected ApproveAll)
+            applyApprovalPolicyKey PickerKeyDown state
+                `shouldBe` Right (ApprovalPolicyState PromptMutating 1)
+            applyApprovalPolicyKey PickerKeyConfirm
+                (ApprovalPolicyState PromptMutating 1)
+                `shouldBe` Left (ApprovalPolicySelected DenyMutating)
+
+
+        it "cancels without changing the current policy" do
+            applyApprovalPolicyKey PickerKeyCancel
+                (initialApprovalPolicyState DenyMutating)
+                `shouldBe` Left ApprovalPolicyCancelled

--- a/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
@@ -65,9 +65,9 @@ spec = do
 
     describe "approval policy picker" do
         it "selects the current policy" do
-            approvalPolicyIndex (initialApprovalPolicyState ApproveAll)
+            (initialApprovalPolicyState ApproveAll).approvalPolicyIndex
                 `shouldBe` 2
-            approvalPolicyIndex (initialApprovalPolicyState DenyMutating)
+            (initialApprovalPolicyState DenyMutating).approvalPolicyIndex
                 `shouldBe` 1
 
         it "maps shortcuts and confirmation" do

--- a/packages/agent-cli/test/Agent/CLI/ReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReviewSpec.hs
@@ -1,0 +1,123 @@
+module Agent.CLI.ReviewSpec (spec) where
+
+import Agent.CLI.Review
+import Agent.OsPath (fromText, unsafeToFilePath)
+import Control.Exception.Safe (bracket)
+import Control.Monad (unless)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TextIO
+import qualified System.Directory as Directory
+import System.Exit (ExitCode(..))
+import qualified System.FilePath as FilePath
+import System.OsPath (OsPath, (</>))
+import System.Posix.Temp (mkdtemp)
+import System.Process
+    ( CreateProcess(..)
+    , proc
+    , readCreateProcessWithExitCode
+    )
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.Review" do
+    describe "reviewPrompt" do
+        it "renders an uncommitted review with all worktree categories" do
+            let prompt = reviewPrompt ReviewUncommitted
+            prompt `shouldSatisfy` Text.isInfixOf "staged, unstaged, and untracked"
+            prompt `shouldSatisfy` Text.isInfixOf "file and line range"
+            prompt `shouldSatisfy` Text.isInfixOf "Do not modify files"
+
+        it "treats a base branch as a literal ref" do
+            let prompt = reviewPrompt (ReviewBaseBranch "release`candidate")
+            prompt `shouldSatisfy` Text.isInfixOf "merge base"
+            prompt `shouldSatisfy` Text.isInfixOf "`release\\`candidate`"
+            prompt `shouldSatisfy` Text.isInfixOf "literal Git ref"
+
+        it "renders commit and custom targets" do
+            reviewPrompt (ReviewCommitTarget "abc123")
+                `shouldSatisfy` Text.isInfixOf "single Git commit `abc123`"
+            reviewPrompt (ReviewCustom "Check the parser")
+                `shouldSatisfy`
+                    Text.isInfixOf
+                        "<review_instructions>\nCheck the parser\n</review_instructions>"
+
+    describe "Git discovery" do
+        it "rejects a directory outside Git" $
+            withTempDir "agent-review-not-git-" \dir -> do
+                listReviewBranches dir
+                    `shouldReturn` Left "not a Git repository"
+                listReviewCommits dir 20
+                    `shouldReturn` Left "not a Git repository"
+
+        it "lists non-current local branches" $
+            withTempGitRepo \repo -> do
+                git repo ["branch", "base"]
+                git repo ["branch", "another"]
+                branches <- expectRight =<< listReviewBranches repo
+                map (.reviewBranchName) branches
+                    `shouldMatchList` ["another", "base"]
+
+        it "lists recent commits newest first and respects the limit" $
+            withTempGitRepo \repo -> do
+                writeUtf8 (repo </> fromText "second") "two\n"
+                git repo ["add", "second"]
+                git repo ["commit", "-m", "second subject"]
+                commits <- expectRight =<< listReviewCommits repo 1
+                case commits of
+                    [commit] -> do
+                        commit.reviewCommitSubject `shouldBe` "second subject"
+                        Text.length commit.reviewCommitHash `shouldBe` 40
+                        commit.reviewCommitShortHash
+                            `shouldSatisfy`
+                                (`Text.isPrefixOf` commit.reviewCommitHash)
+                    _ ->
+                        expectationFailure
+                            ("expected one commit, got " <> show commits)
+
+        it "returns no commits for an unborn repository" $
+            withTempDir "agent-review-empty-" \repo -> do
+                git repo ["init"]
+                listReviewCommits repo 20 `shouldReturn` Right []
+
+expectRight :: Either Text a -> IO a
+expectRight = \case
+    Right value -> pure value
+    Left err -> do
+        expectationFailure ("expected Right, got Left " <> Text.unpack err)
+        fail "unreachable"
+
+withTempGitRepo :: (OsPath -> IO a) -> IO a
+withTempGitRepo action =
+    withTempDir "agent-review-git-" \repo -> do
+        git repo ["init", "-b", "main"]
+        git repo ["config", "user.email", "test@example.com"]
+        git repo ["config", "user.name", "Test"]
+        git repo ["config", "commit.gpgsign", "false"]
+        writeUtf8 (repo </> fromText "README") "hello\n"
+        git repo ["add", "README"]
+        git repo ["commit", "-m", "initial subject"]
+        action repo
+
+withTempDir :: String -> (OsPath -> IO a) -> IO a
+withTempDir prefix action = do
+    root <- Directory.getTemporaryDirectory
+    bracket
+        (fromText . Text.pack
+            <$> mkdtemp (root FilePath.</> prefix <> "XXXXXX"))
+        (Directory.removeDirectoryRecursive . unsafeToFilePath)
+        action
+
+git :: OsPath -> [String] -> IO ()
+git cwd arguments = do
+    (exitCode, _stdout, stderr) <-
+        readCreateProcessWithExitCode
+            (proc "git" arguments)
+                { cwd = Just (unsafeToFilePath cwd) }
+            ""
+    unless (exitCode == ExitSuccess) $
+        expectationFailure
+            ("git " <> unwords arguments <> " failed: " <> stderr)
+
+writeUtf8 :: OsPath -> Text -> IO ()
+writeUtf8 path = TextIO.writeFile (unsafeToFilePath path)

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -688,6 +688,135 @@ spec = describe "Agent.CLI.Session" do
                 storedContentPartRoundTrip
 
     describe "PostgreSQL session persistence" do
+        it "forks turns, metadata, and only allowlisted durable artifacts" $
+            withTempStore \store root -> do
+                let pool = trustedPool store
+                source0 <- createSession (testCreate pool root)
+                let sourceTurn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "branch from here"
+                        , turnAssistantText = Just "ready"
+                        , turnError = Nothing
+                        , turnResponseId = Just "response-parent"
+                        , turnItems = []
+                        , turnUsage = Just TokenUsage
+                            { inputTokens = 8
+                            , outputTokens = 3
+                            , cachedTokens = 1
+                            }
+                        , turnEffect = TranscriptAppend
+                        }
+                source <- appendTurnWithMetaUpdate source0 sourceTurn
+                    \meta -> meta
+                        { metaLastRecap = Just "recap"
+                        , metaLastTurnSummary = Just "summary"
+                        }
+                let planPath = source.sessionDir </> unsafeEncodeUtf "plan.md"
+                    agentsDir = source.sessionDir </> unsafeEncodeUtf "agents"
+                    childDir = agentsDir </> unsafeEncodeUtf "child"
+                    childPath = childDir </> unsafeEncodeUtf "meta.json"
+                    ignoredPath = source.sessionDir </> unsafeEncodeUtf "agent.log"
+                createDirectory agentsDir
+                createDirectory childDir
+                LBS.writeFile (toFilePath planPath) "plan"
+                LBS.writeFile (toFilePath childPath) "child"
+                LBS.writeFile (toFilePath ignoredPath) "runtime log"
+
+                forkSession root source [sourceTurn] (Just "Fork title") >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right forked -> do
+                        forked.sessionMeta.metaId
+                            `shouldNotBe` source.sessionMeta.metaId
+                        forked.sessionMeta.metaCreatedAt
+                            `shouldSatisfy` (>= source.sessionMeta.metaCreatedAt)
+                        forked.sessionMeta.metaUpdatedAt
+                            `shouldBe` forked.sessionMeta.metaCreatedAt
+                        forked.sessionMeta.metaTitle `shouldBe` "Fork title"
+                        forked.sessionMeta.metaTitleIsManual `shouldBe` True
+                        forked.sessionMeta.metaLastResponseId
+                            `shouldBe` Just "response-parent"
+                        forked.sessionMeta.metaLastRecap `shouldBe` Just "recap"
+                        forked.sessionMeta.metaLastTurnSummary
+                            `shouldBe` Just "summary"
+                        loadSession pool root forked.sessionMeta.metaId
+                            `shouldReturn`
+                                Right (forked.sessionMeta, [sourceTurn])
+                        doesFileExist
+                            (forked.sessionDir </> unsafeEncodeUtf "plan.md")
+                            `shouldReturn` True
+                        doesFileExist
+                            (forked.sessionDir
+                                </> unsafeEncodeUtf "agents"
+                                </> unsafeEncodeUtf "child"
+                                </> unsafeEncodeUtf "meta.json")
+                            `shouldReturn` True
+                        doesFileExist
+                            (forked.sessionDir </> unsafeEncodeUtf "agent.log")
+                            `shouldReturn` False
+                        let forkOnlyTurn = sourceTurn
+                                { turnUserText = "continue only on fork"
+                                , turnAssistantText = Just "fork response"
+                                , turnResponseId = Just "fork-response"
+                                , turnUsage = Nothing
+                                }
+                        forkedFinal <- appendTurn forked forkOnlyTurn
+                        loadSession pool root source.sessionMeta.metaId
+                            `shouldReturn`
+                                Right (source.sessionMeta, [sourceTurn])
+                        loadSession pool root forkedFinal.sessionMeta.metaId
+                            `shouldReturn`
+                                Right
+                                    ( forkedFinal.sessionMeta
+                                    , [sourceTurn, forkOnlyTurn]
+                                    )
+
+        it "rejects symlinked fork artifacts and cleans reserved state" $
+            withTempStore \store root -> do
+                let pool = trustedPool store
+                source0 <- createSession (testCreate pool root)
+                let sourceTurn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "branch from here"
+                        , turnAssistantText = Just "ready"
+                        , turnError = Nothing
+                        , turnResponseId = Nothing
+                        , turnItems = []
+                        , turnUsage = Nothing
+                        , turnEffect = TranscriptAppend
+                        }
+                source <- appendTurn source0 sourceTurn
+                let outside = source.sessionDir </> unsafeEncodeUtf "outside"
+                    planPath = source.sessionDir </> unsafeEncodeUtf "plan.md"
+                LBS.writeFile (toFilePath outside) "outside"
+                Directory.createFileLink
+                    (toFilePath outside)
+                    (toFilePath planPath)
+                before <- listDirectory root
+                beforeTemps <- listDirectory (sessionTempsRoot root)
+                forkSession root source [sourceTurn] Nothing >>= \case
+                    Left err ->
+                        err `shouldSatisfy`
+                            Text.isInfixOf "refusing to copy symbolic link"
+                    Right forked ->
+                        expectationFailure
+                            ("unexpected fork: " <> show forked.sessionMeta.metaId)
+                after <- listDirectory root
+                after `shouldMatchList` before
+                afterTemps <- listDirectory (sessionTempsRoot root)
+                afterTemps `shouldMatchList` beforeTemps
+
+        it "requires a substantive persisted turn before forking" $
+            withTempStore \store root -> do
+                source <- createSession (testCreate (trustedPool store) root)
+                forkSession root source [] Nothing >>= \case
+                    Left err ->
+                        err
+                            `shouldBe`
+                                "a session must contain at least one turn before it can be forked"
+                    Right forked ->
+                        expectationFailure
+                            ("unexpected fork: " <> show forked.sessionMeta.metaId)
+
         it "round-trips and clears ephemeral session activity" $
             withTempStore \store root -> do
                 let pool = trustedPool store

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -817,6 +817,47 @@ spec = describe "Agent.CLI.Session" do
                         expectationFailure
                             ("unexpected fork: " <> show forked.sessionMeta.metaId)
 
+        it "requires a substantive turn after the latest reset before forking" $
+            withTempStore \store root -> do
+                let pool = trustedPool store
+                source0 <- createSession (testCreate pool root)
+                let sourceTurn = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "old conversation"
+                        , turnAssistantText = Just "old answer"
+                        , turnError = Nothing
+                        , turnResponseId = Just "old-response"
+                        , turnItems = []
+                        , turnUsage = Nothing
+                        , turnEffect = TranscriptAppend
+                        }
+                source <- appendTurn source0 sourceTurn
+                let reset = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "/clear"
+                        , turnAssistantText = Just "Conversation cleared."
+                        , turnError = Nothing
+                        , turnResponseId = Nothing
+                        , turnItems = []
+                        , turnUsage = Nothing
+                        , turnEffect = TranscriptReset
+                        }
+                resetSource <- appendTurnKeepTitle source reset
+
+                forkSession
+                    root resetSource
+                    [ sourceTurn
+                    , reset
+                    ]
+                    Nothing >>= \case
+                        Left err ->
+                            err `shouldBe`
+                                "a session must contain at least one turn before it can be forked"
+                        Right forked ->
+                            expectationFailure
+                                ("unexpected fork: "
+                                    <> show forked.sessionMeta.metaId)
+
         it "round-trips and clears ephemeral session activity" $
             withTempStore \store root -> do
                 let pool = trustedPool store

--- a/packages/agent-cli/test/Agent/CLI/TranscriptExportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TranscriptExportSpec.hs
@@ -10,25 +10,29 @@ import Agent.CLI.TranscriptExport
     , saveTranscriptNoClobber
     , visibleSessionTurns
     )
+import Agent.OsPath (unsafeToFilePath)
+import Control.Exception.Safe (bracket)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.IO as TextIO
 import Data.Time.Clock (UTCTime(..))
 import Data.Time.Calendar (fromGregorian)
 import System.Directory
-    ( createDirectoryIfMissing
-    , doesFileExist
+    ( doesFileExist
     , getTemporaryDirectory
     , removePathForcibly
     )
+import qualified System.Directory.OsPath as Directory
+import qualified System.FilePath as FilePath
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
-import Agent.OsPath (unsafeToFilePath)
+import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
 spec :: Spec
 spec = do
     describe "visibleSessionTurns" do
         it "starts at the most recent reset marker" do
-            map turnUserText
+            map (.turnUserText)
                 (visibleSessionTurns
                     [turn "old" TranscriptAppend, turn "clear" TranscriptReset, turn "new" TranscriptAppend])
                 `shouldBe` ["clear", "new"]
@@ -40,24 +44,26 @@ spec = do
                     , turnWithAnswer "clear" (Just "Conversation cleared.") TranscriptReset
                     , turnWithAnswer "new" (Just "fresh") TranscriptAppend
                     ]
-            output `shouldContain` "# Agent conversation"
-            output `shouldContain` "## User"
-            output `shouldContain` "fresh"
-            output `shouldNotContain` "stale"
+            output `shouldSatisfy` Text.isInfixOf "# Agent conversation"
+            output `shouldSatisfy` Text.isInfixOf "## User"
+            output `shouldSatisfy` Text.isInfixOf "fresh"
+            output `shouldSatisfy` (not . Text.isInfixOf "stale")
 
     describe "path and save helpers" do
-        it "expands tilde and refuses to overwrite" do
-            tmp <- getTemporaryDirectory
-            let root = unsafeEncodeUtf (tmp <> "/agent-export-spec")
+        it "expands tilde, writes UTF-8, and refuses to overwrite" $
+          withTempDir "agent-export-spec-" \root -> do
+            home <- Directory.getHomeDirectory
+            let
                 target = root `appendPath` "conversation.md"
-            createDirectoryIfMissing True (unsafeToFilePath root)
             resolved <- resolveExportPath root "~/conversation.md"
-            resolved `shouldSatisfy` either (const False) (const True)
-            saveTranscriptNoClobber target "first" `shouldReturn` Right ()
+            resolved `shouldBe`
+                Right (home `appendPath` "conversation.md")
+            saveTranscriptNoClobber target "first 🌍" `shouldReturn` Right ()
             saveTranscriptNoClobber target "second"
-                `shouldSatisfy` isLeft
+                >>= (`shouldSatisfy` isLeft)
             doesFileExist (unsafeToFilePath target) `shouldReturn` True
-            removePathForcibly (unsafeToFilePath root)
+            TextIO.readFile (unsafeToFilePath target)
+                `shouldReturn` "first 🌍"
 
         it "uses a stable default filename" do
             defaultExportFileName "2026-01-01-abcd"
@@ -70,6 +76,14 @@ isLeft _ = False
 appendPath :: OsPath -> Text -> OsPath
 appendPath path name = path </> unsafeEncodeUtf (Text.unpack name)
 
+withTempDir :: String -> (OsPath -> IO a) -> IO a
+withTempDir prefix action = do
+    root <- getTemporaryDirectory
+    bracket
+        (unsafeEncodeUtf <$> mkdtemp (root FilePath.</> prefix <> "XXXXXX"))
+        (removePathForcibly . unsafeToFilePath)
+        action
+
 turn :: Text -> TranscriptEffect -> SessionTurn
 turn text effect = turnWithAnswer text Nothing effect
 
@@ -77,7 +91,7 @@ turnWithAnswer :: Text -> Maybe Text -> TranscriptEffect -> SessionTurn
 turnWithAnswer user assistant effect = SessionTurn
     { turnAt = UTCTime (fromGregorian 2026 1 1) 0
     , turnUserText = user
-    , turnAssistantText = Just assistant
+    , turnAssistantText = assistant
     , turnError = Nothing
     , turnResponseId = Nothing
     , turnEffect = effect

--- a/packages/agent-cli/test/Agent/CLI/TranscriptExportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TranscriptExportSpec.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Agent.CLI.TranscriptExportSpec (spec) where
+
+import Agent.CLI.Session (SessionTurn(..), TranscriptEffect(..))
+import Agent.CLI.TranscriptExport
+    ( defaultExportFileName
+    , renderTranscriptMarkdown
+    , resolveExportPath
+    , saveTranscriptNoClobber
+    , visibleSessionTurns
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (UTCTime(..))
+import Data.Time.Calendar (fromGregorian)
+import System.Directory
+    ( createDirectoryIfMissing
+    , doesFileExist
+    , getTemporaryDirectory
+    , removePathForcibly
+    )
+import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+import Agent.OsPath (unsafeToFilePath)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "visibleSessionTurns" do
+        it "starts at the most recent reset marker" do
+            map turnUserText
+                (visibleSessionTurns
+                    [turn "old" TranscriptAppend, turn "clear" TranscriptReset, turn "new" TranscriptAppend])
+                `shouldBe` ["clear", "new"]
+
+    describe "renderTranscriptMarkdown" do
+        it "renders role headings and excludes superseded turns" do
+            let output = renderTranscriptMarkdown
+                    [ turnWithAnswer "old" (Just "stale") TranscriptAppend
+                    , turnWithAnswer "clear" (Just "Conversation cleared.") TranscriptReset
+                    , turnWithAnswer "new" (Just "fresh") TranscriptAppend
+                    ]
+            output `shouldContain` "# Agent conversation"
+            output `shouldContain` "## User"
+            output `shouldContain` "fresh"
+            output `shouldNotContain` "stale"
+
+    describe "path and save helpers" do
+        it "expands tilde and refuses to overwrite" do
+            tmp <- getTemporaryDirectory
+            let root = unsafeEncodeUtf (tmp <> "/agent-export-spec")
+                target = root `appendPath` "conversation.md"
+            createDirectoryIfMissing True (unsafeToFilePath root)
+            resolved <- resolveExportPath root "~/conversation.md"
+            resolved `shouldSatisfy` either (const False) (const True)
+            saveTranscriptNoClobber target "first" `shouldReturn` Right ()
+            saveTranscriptNoClobber target "second"
+                `shouldSatisfy` isLeft
+            doesFileExist (unsafeToFilePath target) `shouldReturn` True
+            removePathForcibly (unsafeToFilePath root)
+
+        it "uses a stable default filename" do
+            defaultExportFileName "2026-01-01-abcd"
+                `shouldBe` "agent-session-2026-01-01-abcd.md"
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False
+
+appendPath :: OsPath -> Text -> OsPath
+appendPath path name = path </> unsafeEncodeUtf (Text.unpack name)
+
+turn :: Text -> TranscriptEffect -> SessionTurn
+turn text effect = turnWithAnswer text Nothing effect
+
+turnWithAnswer :: Text -> Maybe Text -> TranscriptEffect -> SessionTurn
+turnWithAnswer user assistant effect = SessionTurn
+    { turnAt = UTCTime (fromGregorian 2026 1 1) 0
+    , turnUserText = user
+    , turnAssistantText = Just assistant
+    , turnError = Nothing
+    , turnResponseId = Nothing
+    , turnEffect = effect
+    , turnItems = []
+    , turnUsage = Nothing
+    }

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -28,6 +28,7 @@ import qualified Agent.CLI.ExternalProgramSpec as ExternalProgramSpec
 import qualified Agent.CLI.FileUriSpec as FileUriSpec
 import qualified Agent.CLI.GatewayBridgeSpec as GatewayBridgeSpec
 import qualified Agent.CLI.GatewayClientSpec as GatewayClientSpec
+import qualified Agent.CLI.GitDiffSpec as GitDiffSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
@@ -58,6 +59,7 @@ import qualified Agent.CLI.RequestSpec as RequestSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
 import qualified Agent.CLI.ResumeSpec as ResumeSpec
+import qualified Agent.CLI.ReviewSpec as ReviewSpec
 import qualified Agent.CLI.SecretSpec as SecretSpec
 import qualified Agent.CLI.SessionSpec as SessionSpec
 import qualified Agent.CLI.SessionHistorySpec as SessionHistorySpec
@@ -68,6 +70,7 @@ import qualified Agent.CLI.SubagentStoreSpec as SubagentStoreSpec
 import qualified Agent.CLI.StyleSpec as StyleSpec
 import qualified Agent.CLI.TimestampSpec as TimestampSpec
 import qualified Agent.CLI.TranscriptSpec as TranscriptSpec
+import qualified Agent.CLI.TranscriptExportSpec as TranscriptExportSpec
 import qualified Agent.CLI.TurnSpec as TurnSpec
 import qualified Agent.CLI.TerminalSpec as TerminalSpec
 import qualified Agent.CLI.TextLayoutSpec as TextLayoutSpec
@@ -112,6 +115,7 @@ main = hspec do
     FileUriSpec.spec
     GatewayBridgeSpec.spec
     GatewayClientSpec.spec
+    GitDiffSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec
     InterruptSpec.spec
@@ -142,11 +146,13 @@ main = hspec do
     RenderSpec.spec
     ReplStatusSpec.spec
     ResumeSpec.spec
+    ReviewSpec.spec
     SecretSpec.spec
     StyleSpec.spec
     SessionHistorySpec.spec
     TimestampSpec.spec
     TranscriptSpec.spec
+    TranscriptExportSpec.spec
     TurnSpec.spec
     TerminalSpec.spec
     TextLayoutSpec.spec

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -14,6 +14,7 @@ module Agent.Store.Postgres.Session
     , sessionSchemaStatements
     , sessionSearchIndexStatements
     , createSession
+    , createSessionFromSnapshot
     , replaceSessionMetadata
     , appendSessionTurn
     , appendSessionTurnIndexed

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
@@ -6,6 +6,7 @@
 -- | PostgreSQL write operations for harness sessions.
 module Agent.Store.Postgres.Session.Write
     ( createSession
+    , createSessionFromSnapshot
     , replaceSessionMetadata
     , appendSessionTurn
     , appendSessionTurnIndexed
@@ -60,6 +61,32 @@ createSession pool metadata =
                                 metadata.sessionMetadataCreatedAt
                             }
                         insertEventStatement
+                    pure True
+
+-- | Atomically create a session from an already-materialized transcript.
+--
+-- This is the neutral counterpart to 'importLegacySession': it records the
+-- ordinary session/turn events and final metadata projection, but no legacy
+-- import provenance. A conflicting session key leaves the existing session
+-- untouched and returns 'False'.
+createSessionFromSnapshot
+    :: StorePool
+    -> SessionMetadata
+    -> [SessionTurn]
+    -> IO (Either StoreError Bool)
+createSessionFromSnapshot pool metadata turns =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write do
+            let sessionKey = metadata.sessionMetadataKey
+            _ <- Transaction.statement sessionKey blockingAdvisoryLockStatement
+            exists <- Transaction.statement sessionKey sessionExistsStatement
+            if exists
+                then pure False
+                else do
+                    _ <- insertSessionSnapshot
+                        "session.snapshot_created"
+                        metadata
+                        turns
                     pure True
 
 replaceSessionMetadata
@@ -171,39 +198,53 @@ importLegacySession pool legacy =
             if exists
                 then pure False
                 else do
-                    sessionId <- Transaction.statement metadata insertSessionStatement
-                    _ <- Transaction.statement
-                        EventInsert
-                            { eventInsertSessionId = sessionId
-                            , eventInsertSequence = 0
-                            , eventInsertKind = "session.created"
-                            , eventInsertOccurredAt =
-                                metadata.sessionMetadataCreatedAt
-                            }
-                        insertEventStatement
-                    forM_ legacy.legacyTurns \turn -> do
-                        appended <- appendTurnTransaction turn metadata
-                        unless appended Transaction.condemn
-                    changed <- Transaction.statement metadata replaceProjectionStatement
-                    case changed of
-                        Nothing -> Transaction.condemn
-                        Just (internalId, sequence) -> do
-                            _ <- Transaction.statement
-                                EventInsert
-                                    { eventInsertSessionId = internalId
-                                    , eventInsertSequence = sequence
-                                    , eventInsertKind = "legacy.import_completed"
-                                    , eventInsertOccurredAt =
-                                        metadata.sessionMetadataUpdatedAt
-                                    }
-                                insertEventStatement
-                            pure ()
+                    sessionId <- insertSessionSnapshot
+                        "legacy.import_completed"
+                        metadata
+                        legacy.legacyTurns
                     Transaction.statement
                         ( legacy.legacySourcePath
                         , legacy.legacyContentHash
                         , sessionId
                         )
                         recordLegacyImportStatement
+
+-- | Insert a complete session while the caller owns its advisory lock and
+-- transaction. The final projection replacement preserves metadata that
+-- cannot be derived solely from replaying transcript turns.
+insertSessionSnapshot
+    :: Text
+    -> SessionMetadata
+    -> [SessionTurn]
+    -> Transaction.Transaction Text
+insertSessionSnapshot completionKind metadata turns = do
+    sessionId <- Transaction.statement metadata insertSessionStatement
+    _ <- Transaction.statement
+        EventInsert
+            { eventInsertSessionId = sessionId
+            , eventInsertSequence = 0
+            , eventInsertKind = "session.created"
+            , eventInsertOccurredAt =
+                metadata.sessionMetadataCreatedAt
+            }
+        insertEventStatement
+    forM_ turns \turn -> do
+        appended <- appendTurnTransaction turn metadata
+        unless appended Transaction.condemn
+    changed <- Transaction.statement metadata replaceProjectionStatement
+    case changed of
+        Nothing -> Transaction.condemn >> pure sessionId
+        Just (internalId, sequence) -> do
+            _ <- Transaction.statement
+                EventInsert
+                    { eventInsertSessionId = internalId
+                    , eventInsertSequence = sequence
+                    , eventInsertKind = completionKind
+                    , eventInsertOccurredAt =
+                        metadata.sessionMetadataUpdatedAt
+                    }
+                insertEventStatement
+            pure sessionId
 
 withSessionAdvisoryLock
     :: StorePool

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -168,6 +168,49 @@ spec = describe "PostgreSQL session schema" do
                                                       ]
                                                     ))
                                             ]
+                            let snapshotMetadata = metadata
+                                    { sessionMetadataKey = "session-snapshot"
+                                    , sessionMetadataTitle = "forked session"
+                                    , sessionMetadataTitleIsManual = True
+                                    , sessionMetadataLastResponseId =
+                                        Just "response-parent"
+                                    }
+                                snapshotTurns =
+                                    [ turn
+                                        { sessionTurnUserText = "snapshot one"
+                                        }
+                                    , turn
+                                        { sessionTurnUserText = "snapshot two"
+                                        , sessionTurnResponseId =
+                                            Just "response-parent"
+                                        }
+                                    ]
+                            createSessionFromSnapshot
+                                pool snapshotMetadata snapshotTurns
+                                `shouldReturn` Right True
+                            createSessionFromSnapshot
+                                pool snapshotMetadata snapshotTurns
+                                `shouldReturn` Right False
+                            loadSession pool "session-snapshot" >>= \case
+                                Right (Just stored) -> do
+                                    stored.storedMetadata
+                                        `shouldBe` snapshotMetadata
+                                    map (.storedTurn)
+                                        (toList stored.storedTurns)
+                                        `shouldBe` snapshotTurns
+                                other ->
+                                    expectationFailure
+                                        ("unexpected snapshot session: " <> show other)
+                            snapshotEvents <-
+                                loadSessionEvents pool "session-snapshot"
+                            fmap (map (.storedEventKind)) snapshotEvents
+                                `shouldBe`
+                                    Right
+                                        [ "session.created"
+                                        , "turn.appended"
+                                        , "turn.appended"
+                                        , "session.snapshot_created"
+                                        ]
                             let metadata3 = metadata
                                     { sessionMetadataKey = "session-batched"
                                     , sessionMetadataTitle = "batched"


### PR DESCRIPTION
## Summary

- add Codex-style `/init`, `/diff`, `/review`, `/permissions`, `/export`, and `/fork` commands
- add safe Git diff/review discovery, runtime approval-policy selection, and no-clobber Markdown transcript export
- add transactional session forking that snapshots persisted turns and durable artifacts, then safely hands the live runtime to the fork

## Safety

- Git subprocesses disable external diff, text conversion, and repository-configured filters; rendered output neutralizes terminal control sequences
- transcript export writes UTF-8 atomically and never replaces an existing target
- session forks reject symlinked artifacts and commit the relational snapshot before changing live checkpoint/lock state
- `/init` does not replace an existing `AGENTS.md`

## Validation

- GHCi library typecheck: 255 modules loaded
- combined CLI/store test typecheck: 94 modules loaded
- focused slash-command suite: 110 examples, 0 failures
- session-fork suite: 4 examples, 0 failures
- PostgreSQL session snapshot test: 1 example, 0 failures
- live tmux TTY smoke: `/init`, `/permissions`, `/review`, `/diff`, `/export`, `/fork`, and minimal-editor Escape cancellation
- regenerated `packages/agent-cli/package.nix` matches the checked-in file
