### PR TITLE
Choose subagent models by task complexity

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Dialects.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dialects.hs
@@ -129,7 +129,9 @@ codingToolsForWithTypes
                                 <> instruction
                                 <> " Cite exact artifact line ranges in the report."
                             )
-                            (Just "gpt-5.6-luna")
+                            -- Artifact analysis has no model selector, so inherit
+                            -- rather than silently downgrading the root model.
+                            Nothing
                             Nothing
                             (Just "none")
                 _ -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -51,8 +51,8 @@ subscriptionSubagentModelGuidance provider billing
     | provider == OpenAIProvider
     , billing == SubscriptionBilled =
         Just $ Text.unwords
-            [ "When OpenAI subscription billing is active, choose the subagent"
-            , "model from the delegated goal's complexity, ambiguity, and risk—not"
+            [ "Choose the subagent model from the delegated goal's complexity,"
+            , "ambiguity, and risk—not"
             , "just its apparent size. Consider how much the parent outcome depends"
             , "on the result and how easily errors can be detected. Use"
             , "`gpt-5.6-luna` (fast · low cost) only"

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -43,20 +43,30 @@ import Data.Time.Calendar (Day)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import System.OsPath (OsPath)
 
--- | Nudge subscription-backed OpenAI sessions toward the inexpensive model
--- for bounded delegation without encouraging unnecessary or risky spawning.
+-- | Help subscription-backed OpenAI sessions choose a child model by the
+-- delegated outcome. Keep this as guidance rather than a hard-coded override:
+-- the parent has the goal and context needed to judge ambiguity and risk.
 subscriptionSubagentModelGuidance :: Provider -> BillingMode -> Maybe Text
 subscriptionSubagentModelGuidance provider billing
     | provider == OpenAIProvider
     , billing == SubscriptionBilled =
         Just $ Text.unwords
-            [ "When OpenAI subscription billing is active, prefer"
-            , "`gpt-5.6-luna` for small, bounded tasks such as codebase searches,"
-            , "locating definitions, straightforward reviews, test investigation,"
-            , "and concise summaries. Keep the parent model for complex debugging,"
-            , "architecture, security-sensitive analysis, or work requiring"
-            , "substantial judgment. Do not spawn a subagent when doing the work"
-            , "directly would be faster."
+            [ "When OpenAI subscription billing is active, choose the subagent"
+            , "model from the delegated goal's complexity, ambiguity, and risk—not"
+            , "just its apparent size. Consider how much the parent outcome depends"
+            , "on the result and how easily errors can be detected. Use"
+            , "`gpt-5.6-luna` (fast · low cost) only"
+            , "for mechanical, bounded, easily verified work such as locating"
+            , "definitions or summarizing known material. Use `gpt-5.6-terra`"
+            , "(balanced) for routine implementation, debugging, test investigation,"
+            , "and reviews needing moderate judgment. Use `gpt-5.6-sol` (frontier)"
+            , "for complex or ambiguous debugging, architecture, security- or"
+            , "correctness-sensitive analysis, cross-cutting work, or substantial"
+            , "judgment. Do not use Luna as a blanket default; when uncertain,"
+            , "prefer the stronger tier. Honor an explicitly requested model."
+            , "Omit the override when the parent model already matches the chosen"
+            , "tier. Do not spawn a subagent when doing the work directly would"
+            , "be faster."
             ]
     | otherwise = Nothing
 

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -329,7 +329,7 @@ spec = describe "systemPrompt" do
             "relative paths still resolve against the workspace"
         rootPrompt `shouldSatisfy` Text.isInfixOf "HASKELL_AGENT_TMPDIR"
         childPrompt `shouldSatisfy` Text.isInfixOf "TMPDIR"
-    it "recommends Luna only for subscription-backed OpenAI subagents" do
+    it "gives subscription-backed OpenAI subagents task-based model guidance" do
         let subscriptionGuidance =
                 subscriptionSubagentModelGuidance
                     OpenAIProvider
@@ -337,7 +337,17 @@ spec = describe "systemPrompt" do
         subscriptionGuidance `shouldSatisfy`
             maybe False (Text.isInfixOf "`gpt-5.6-luna`")
         subscriptionGuidance `shouldSatisfy`
-            maybe False (Text.isInfixOf "small, bounded tasks")
+            maybe False (Text.isInfixOf "complexity, ambiguity, and risk")
+        subscriptionGuidance `shouldSatisfy`
+            maybe False (Text.isInfixOf "parent outcome depends on the result")
+        subscriptionGuidance `shouldSatisfy`
+            maybe False (Text.isInfixOf "`gpt-5.6-terra`")
+        subscriptionGuidance `shouldSatisfy`
+            maybe False (Text.isInfixOf "`gpt-5.6-sol`")
+        subscriptionGuidance `shouldSatisfy`
+            maybe False (Text.isInfixOf "Do not use Luna as a blanket default")
+        subscriptionGuidance `shouldSatisfy`
+            maybe False (Text.isInfixOf "Honor an explicitly requested model")
         subscriptionSubagentModelGuidance OpenAIProvider ApiBilled
             `shouldBe` Nothing
         subscriptionSubagentModelGuidance XAIProvider SubscriptionBilled

--- a/packages/agent-core/src/Agent/Tools/OutputArtifact.hs
+++ b/packages/agent-core/src/Agent/Tools/OutputArtifact.hs
@@ -126,7 +126,8 @@ artifactTools env analysis =
     ]
     <> maybe [] (\spawn ->
         [ jsonTool "analyze_tool_output"
-            "Spawn a tracked gpt-5.6-luna child to analyze an oversized tool-output artifact. Use wait_agent for its report."
+            "Spawn a tracked child agent to analyze an oversized tool-output artifact. \
+            \Use wait_agent for its report."
             [ PropertySchema "handle" PropertyString True Nothing
             , PropertySchema "instruction" PropertyString True Nothing
             ]
@@ -441,7 +442,7 @@ renderOutputArtifactNotice source artifact =
                 else "")
         <> ". Full stored output is excluded from model context. "
         <> "Use read_tool_output/search_tool_output, or analyze_tool_output "
-        <> "when available for bounded Luna analysis.]"
+        <> "when available for delegated analysis.]"
 
 -- | Return a bounded head/tail preview.  The bound is in UTF-8 bytes (the
 -- same unit used by the inline and artifact caps). Partial UTF-8 code points

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -113,6 +113,39 @@ spec = describe "Agent.Tools.MultiAgents" do
             }
         closeSubagentRegistry registry
 
+    it "lets host tools inherit instead of forcing a child model" do
+        prepared <- newEmptyTMVarIO
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))
+            (\_ _ -> pure ())
+        let context = (rootContext registry Nothing)
+                { multiPrepareSpawn = Just
+                    (\_ options -> atomically (putTMVar prepared options))
+                }
+            call = ToolCall
+                { callId = "host-tool-inherit"
+                , name = "analyze_tool_output"
+                , arguments = "{}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <- spawnSharedSubagent
+            context
+            call
+            "artifact_analysis"
+            "inspect the artifact"
+            Nothing
+            Nothing
+            (Just "none")
+        result `shouldSatisfy` isRightResult
+        options <- atomically (takeTMVar prepared)
+        options `shouldBe` CollaborationSpawnOptions
+            { collaborationModel = Nothing
+            , collaborationReasoningEffort = Nothing
+            , collaborationForkTurns = Just "none"
+            }
+        closeSubagentRegistry registry
+
     it "spawns canonical paths through depth four and rejects depth five" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))

--- a/packages/agent-core/test/Agent/Tools/OutputArtifactSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/OutputArtifactSpec.hs
@@ -89,15 +89,24 @@ spec = describe "Agent.Tools.OutputArtifact" do
         withTempEnv \env -> do
             let names = map (.appToolName)
                 childNames = names (artifactTools env Nothing)
-                rootNames = names
-                    (artifactTools env
-                        (Just (\_ _ _ -> pure (Right "spawned"))))
+                rootTools = artifactTools env
+                    (Just (\_ _ _ -> pure (Right "spawned")))
+                rootNames = names rootTools
             childNames `shouldBe`
                 ["read_tool_output", "search_tool_output"]
             rootNames `shouldBe`
                 [ "read_tool_output"
                 , "search_tool_output"
                 , "analyze_tool_output"
+                ]
+            let analysisDescriptions =
+                    [ tool.appToolDescription
+                    | tool <- rootTools
+                    , tool.appToolName == "analyze_tool_output"
+                    ]
+            analysisDescriptions `shouldBe`
+                [ "Spawn a tracked child agent to analyze an oversized tool-output artifact. \
+                \Use wait_agent for its report."
                 ]
 
 listArtifactHandles :: Text.Text -> IO [Text.Text]

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
@@ -154,7 +154,10 @@ grokChildModelGuidance slugs =
         | lunaSubagentModel `elem` slugs =
             " Use `"
                 <> lunaSubagentModel
-                <> "` for small, bounded tasks; it runs at high reasoning effort."
+                <> "` only for mechanical, bounded, easily verified work; it runs"
+                <> " at high reasoning effort. Do not use Luna as a blanket default."
+                <> " Inherit the parent for ambiguous, high-risk, or"
+                <> " judgment-heavy work."
         | otherwise = ""
 
 taskModelProperty :: Maybe [Text] -> Text

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
@@ -110,6 +110,10 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             Text.isInfixOf "gpt-5.6-luna"
         tool.appToolDescription `shouldSatisfy`
             Text.isInfixOf "ONLY use model slugs"
+        tool.appToolDescription `shouldSatisfy`
+            Text.isInfixOf "Do not use Luna as a blanket default"
+        tool.appToolDescription `shouldSatisfy`
+            Text.isInfixOf "Inherit the parent for ambiguous"
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
                 "{\"prompt\":\"hello\",\"description\":\"luna child\",\"model\":\"luna\"}")


### PR DESCRIPTION
## Summary

- replace the blanket Luna recommendation with task-aware Luna/Terra/Sol guidance based on complexity, ambiguity, risk, and impact on the parent objective
- preserve explicit model choices and parent-model inheritance
- stop forcing artifact-analysis children onto Luna; inherit the root model instead
- align Grok child-model guidance so Luna is reserved for mechanical, easily verified work

## Validation

- `Agent.CLI.PromptSpec`: 15 examples, 0 failures
- `Agent.CLI.DialectsSpec`: 7 examples, 0 failures
- `Agent.Tools.OutputArtifactSpec`: 7 examples, 0 failures
- `Agent.Tools.MultiAgentsSpec`: 20 examples, 0 failures
- `Agent.GrokBuild.TaskSpec`: 14 examples, 0 failures
- `nix develop -c cabal repl agent-cli:lib:agent-cli --offline`: 203 modules loaded
- `git diff --check`
