### PR TITLE
Add safe repository push and PR delivery APIs

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -146,6 +146,7 @@ library
                     , Agent.CLI.Prompt
                     , Agent.CLI.Recap
                     , Agent.CLI.Request
+                    , Agent.CLI.RepositoryDelivery
                     , Agent.CLI.RepositoryReview
                     , Agent.CLI.ProviderFallback
                     , Agent.CLI.ProviderAvailability
@@ -396,6 +397,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ProviderAvailabilitySpec
                     , Agent.CLI.ProviderTransitionSpec
                     , Agent.CLI.RequestSpec
+                    , Agent.CLI.RepositoryDeliverySpec
                     , Agent.CLI.RepositoryReviewSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -94,6 +94,7 @@ import Agent.CLI.Project
     )
 import Agent.CLI.Render
     ( summarizeToolCall )
+import qualified Agent.CLI.RepositoryDelivery as RepositoryDelivery
 import qualified Agent.CLI.RepositoryReview as RepositoryReview
 import Agent.CLI.Options (parseEffort)
 import Agent.CLI.Session
@@ -354,6 +355,32 @@ type RepositoryResultCallback =
     -> CString -> CSize -- error
     -> IO ()
 
+type RepositoryDeliveryStatusCallback =
+    Ptr () -> CInt
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize
+    -> CLLong -> CLLong -> CString -> CSize -> IO ()
+
+type RepositoryPushPreviewCallback =
+    Ptr () -> CInt -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize
+    -> CLLong -> CLLong -> CString -> CSize -> IO ()
+
+type RepositoryPushResultCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> IO ()
+
+type RepositoryPullRequestPreviewCallback =
+    Ptr () -> CInt -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> IO ()
+
+type RepositoryPullRequestResultCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
 type RepositoryCheckOutputCallback =
     Ptr () -> CInt -> Ptr Word8 -> CSize -> IO ()
 
@@ -409,6 +436,31 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeRepositoryResultCallback
         :: FunPtr RepositoryResultCallback -> RepositoryResultCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryDeliveryStatusCallback
+        :: FunPtr RepositoryDeliveryStatusCallback
+        -> RepositoryDeliveryStatusCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryPushPreviewCallback
+        :: FunPtr RepositoryPushPreviewCallback
+        -> RepositoryPushPreviewCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryPushResultCallback
+        :: FunPtr RepositoryPushResultCallback
+        -> RepositoryPushResultCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryPullRequestPreviewCallback
+        :: FunPtr RepositoryPullRequestPreviewCallback
+        -> RepositoryPullRequestPreviewCallback
+
+foreign import ccall "dynamic"
+    invokeRepositoryPullRequestResultCallback
+        :: FunPtr RepositoryPullRequestResultCallback
+        -> RepositoryPullRequestResultCallback
 
 foreign import ccall "dynamic"
     invokeRepositoryCheckOutputCallback
@@ -663,6 +715,27 @@ foreign export ccall ha_repository_apply_hunks
 foreign export ccall ha_repository_commit
     :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
     -> FunPtr RepositoryResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_delivery_status
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryDeliveryStatusCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_push_preview
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPushPreviewCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_push_confirm
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPushResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_pr_preview
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPullRequestPreviewCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_repository_pr_confirm
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPullRequestResultCallback -> Ptr () -> IO CInt
 
 foreign export ccall ha_repository_cancel_all :: IO ()
 
@@ -933,6 +1006,227 @@ ha_repository_commit pathBytes pathLength snapshotBytes snapshotLength
                                 message)
                     pure (if started then 0 else 3)
                 Right _ -> pure 3
+
+ha_repository_delivery_status
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryDeliveryStatusCallback -> Ptr () -> IO CInt
+ha_repository_delivery_status pathBytes pathLength snapshotBytes snapshotLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid
+            snapshotBytes snapshotLength deliveryTokenLimit) = pure 2
+    | otherwise =
+        copyRequiredTexts
+            [(pathBytes, pathLength), (snapshotBytes, snapshotLength)] >>= \case
+                Right [path, snapshot] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitDeliveryStatusFailure callback context (-3)
+                                "repository delivery was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.repositoryDeliveryStatus
+                                (Text.unpack path)
+                                snapshot) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitDeliveryStatusFailure
+                                            callback context (-1)
+                                            "repository delivery failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitDeliveryStatusFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right status) ->
+                                        emitDeliveryOnce terminal $
+                                            emitDeliveryStatus
+                                                callback context status
+                    pure (if started then 0 else 3)
+                _ -> pure 2
+
+ha_repository_push_preview
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPushPreviewCallback -> Ptr () -> IO CInt
+ha_repository_push_preview pathBytes pathLength snapshotBytes snapshotLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid
+            snapshotBytes snapshotLength deliveryTokenLimit) = pure 2
+    | otherwise =
+        copyRequiredTexts
+            [(pathBytes, pathLength), (snapshotBytes, snapshotLength)] >>= \case
+                Right [path, snapshot] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitPushPreviewFailure callback context (-3)
+                                "repository push preview was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.previewRepositoryPush
+                                (Text.unpack path)
+                                snapshot) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushPreviewFailure
+                                            callback context (-1)
+                                            "repository push preview failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushPreviewFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right preview) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushPreview
+                                                callback context preview
+                    pure (if started then 0 else 3)
+                _ -> pure 2
+
+ha_repository_push_confirm
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPushResultCallback -> Ptr () -> IO CInt
+ha_repository_push_confirm pathBytes pathLength tokenBytes tokenLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid tokenBytes tokenLength deliveryTokenLimit) =
+            pure 2
+    | otherwise =
+        copyRequiredTexts
+            [(pathBytes, pathLength), (tokenBytes, tokenLength)] >>= \case
+                Right [path, token] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitPushResultFailure callback context (-3)
+                                "repository push was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.confirmRepositoryPush
+                                (Text.unpack path)
+                                token) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushResultFailure
+                                            callback context (-1)
+                                            "repository push failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPushResultFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right status) ->
+                                        emitDeliveryOnce terminal $
+                                        withText status.deliverySnapshotId
+                                            \snapshotPtr snapshotSize ->
+                                        withText status.deliveryHeadOid
+                                            \headPtr headSize ->
+                                                invokeRepositoryPushResultCallback
+                                                    callback context 0
+                                                    snapshotPtr snapshotSize
+                                                    headPtr headSize
+                                                    nullPtr 0
+                    pure (if started then 0 else 3)
+                _ -> pure 2
+
+ha_repository_pr_preview
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPullRequestPreviewCallback -> Ptr () -> IO CInt
+ha_repository_pr_preview pathBytes pathLength snapshotBytes snapshotLength
+    baseBytes baseLength titleBytes titleLength bodyBytes bodyLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid
+            snapshotBytes snapshotLength deliveryTokenLimit)
+        || not (deliveryInputValid baseBytes baseLength deliveryRefLimit)
+        || not (deliveryInputValid titleBytes titleLength deliveryTitleLimit)
+        || not (deliveryInputValid bodyBytes bodyLength deliveryBodyLimit) =
+            pure 2
+    | otherwise =
+        copyRequiredTexts
+            [ (pathBytes, pathLength)
+            , (snapshotBytes, snapshotLength)
+            , (baseBytes, baseLength)
+            , (titleBytes, titleLength)
+            , (bodyBytes, bodyLength)
+            ] >>= \case
+                Right [path, snapshot, base, title, body] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitPullRequestPreviewFailure
+                                callback context (-3)
+                                "pull-request preview was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.previewPullRequest
+                                (Text.unpack path)
+                                snapshot base title body) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestPreviewFailure
+                                            callback context (-1)
+                                            "pull-request preview failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestPreviewFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right preview) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestPreview
+                                            callback context preview
+                    pure (if started then 0 else 3)
+                _ -> pure 2
+
+ha_repository_pr_confirm
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr RepositoryPullRequestResultCallback -> Ptr () -> IO CInt
+ha_repository_pr_confirm pathBytes pathLength tokenBytes tokenLength
+    callback context
+    | callback == nullFunPtr = pure 1
+    | not (deliveryInputValid pathBytes pathLength deliveryPathLimit)
+        || not (deliveryInputValid tokenBytes tokenLength deliveryTokenLimit) =
+            pure 2
+    | otherwise =
+        copyRequiredTexts
+            [(pathBytes, pathLength), (tokenBytes, tokenLength)] >>= \case
+                Right [path, token] -> do
+                    terminal <- newMVar False
+                    started <- startRepositoryWorker
+                        (emitDeliveryOnce terminal $
+                            emitPullRequestResultFailure callback context (-3)
+                                "pull-request creation was cancelled") $
+                        tryRepositorySynchronous
+                            (RepositoryDelivery.createPullRequest
+                                (Text.unpack path)
+                                token) >>= \case
+                                    Left _ ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestResultFailure
+                                            callback context (-1)
+                                            "pull-request creation failed"
+                                    Right (Left err) ->
+                                        emitDeliveryOnce terminal $
+                                            emitPullRequestResultFailure
+                                            callback context
+                                            (deliveryErrorStatus err)
+                                            (RepositoryDelivery.deliveryErrorText err)
+                                    Right (Right url) ->
+                                        emitDeliveryOnce terminal $
+                                        withText url \urlPtr urlSize ->
+                                            invokeRepositoryPullRequestResultCallback
+                                                callback context 0
+                                                urlPtr urlSize nullPtr 0
+                    pure (if started then 0 else 3)
+                _ -> pure 2
 
 startRepositoryMutation
     :: FunPtr RepositoryResultCallback
@@ -1472,6 +1766,141 @@ emitRepositoryError callback context err =
         _ ->
             emitRepositoryFailure
                 callback context (RepositoryReview.repositoryErrorText err)
+
+emitDeliveryOnce :: MVar Bool -> IO () -> IO ()
+emitDeliveryOnce terminal callback =
+    mask \_ -> do
+        shouldRun <- modifyMVar terminal \completed ->
+            pure (True, not completed)
+        when shouldRun callback
+
+emitDeliveryStatus
+    :: FunPtr RepositoryDeliveryStatusCallback
+    -> Ptr ()
+    -> RepositoryDelivery.DeliveryStatus
+    -> IO ()
+emitDeliveryStatus callback context status =
+    withText status.deliverySnapshotId \snapshotPtr snapshotSize ->
+    withText status.deliveryHeadOid \headPtr headSize ->
+    withText status.deliveryBranch \branchPtr branchSize ->
+    withText status.deliveryRemote \remotePtr remoteSize ->
+    withText status.deliveryUpstreamRef \upstreamPtr upstreamSize ->
+    withText status.deliveryUpstreamOid \upstreamOidPtr upstreamOidSize ->
+        invokeRepositoryDeliveryStatusCallback
+            callback context 0
+            snapshotPtr snapshotSize headPtr headSize
+            branchPtr branchSize remotePtr remoteSize
+            upstreamPtr upstreamSize upstreamOidPtr upstreamOidSize
+            (fromIntegral status.deliveryAhead)
+            (fromIntegral status.deliveryBehind)
+            nullPtr 0
+
+emitDeliveryStatusFailure
+    :: FunPtr RepositoryDeliveryStatusCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitDeliveryStatusFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryDeliveryStatusCallback
+            callback context status
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            nullPtr 0 nullPtr 0 0 0 errorPtr errorSize
+
+emitPushPreview
+    :: FunPtr RepositoryPushPreviewCallback
+    -> Ptr ()
+    -> RepositoryDelivery.PushPreview
+    -> IO ()
+emitPushPreview callback context preview =
+    let status = preview.pushPreviewStatus
+        expires = fromIntegral
+            (floor preview.pushPreviewExpiresAt :: Integer)
+    in withText preview.pushPreviewConfirmation \tokenPtr tokenSize ->
+    withText status.deliveryHeadOid \headPtr headSize ->
+    withText status.deliveryBranch \branchPtr branchSize ->
+    withText status.deliveryRemote \remotePtr remoteSize ->
+    withText status.deliveryUpstreamRef \upstreamPtr upstreamSize ->
+        invokeRepositoryPushPreviewCallback
+            callback context 0 tokenPtr tokenSize expires
+            headPtr headSize branchPtr branchSize remotePtr remoteSize
+            upstreamPtr upstreamSize
+            (fromIntegral status.deliveryAhead)
+            (fromIntegral status.deliveryBehind)
+            nullPtr 0
+
+emitPushPreviewFailure
+    :: FunPtr RepositoryPushPreviewCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitPushPreviewFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryPushPreviewCallback
+            callback context status nullPtr 0 0
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            0 0 errorPtr errorSize
+
+emitPushResultFailure
+    :: FunPtr RepositoryPushResultCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitPushResultFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryPushResultCallback
+            callback context status
+            nullPtr 0 nullPtr 0 errorPtr errorSize
+
+emitPullRequestPreview
+    :: FunPtr RepositoryPullRequestPreviewCallback
+    -> Ptr ()
+    -> RepositoryDelivery.PullRequestPreview
+    -> IO ()
+emitPullRequestPreview callback context preview =
+    let expires = fromIntegral
+            (floor preview.pullRequestExpiresAt :: Integer)
+    in withText preview.pullRequestConfirmation \tokenPtr tokenSize ->
+    withText preview.pullRequestRepository \repositoryPtr repositorySize ->
+    withText preview.pullRequestBaseRef \basePtr baseSize ->
+    withText preview.pullRequestHeadRef \headPtr headSize ->
+    withText preview.pullRequestTitle \titlePtr titleSize ->
+        invokeRepositoryPullRequestPreviewCallback
+            callback context 0 tokenPtr tokenSize expires
+            repositoryPtr repositorySize basePtr baseSize
+            headPtr headSize titlePtr titleSize nullPtr 0
+
+emitPullRequestPreviewFailure
+    :: FunPtr RepositoryPullRequestPreviewCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitPullRequestPreviewFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryPullRequestPreviewCallback
+            callback context status nullPtr 0 0
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 errorPtr errorSize
+
+emitPullRequestResultFailure
+    :: FunPtr RepositoryPullRequestResultCallback
+    -> Ptr () -> CInt -> Text -> IO ()
+emitPullRequestResultFailure callback context status message =
+    withText message \errorPtr errorSize ->
+        invokeRepositoryPullRequestResultCallback
+            callback context status nullPtr 0 errorPtr errorSize
+
+deliveryErrorStatus :: RepositoryDelivery.DeliveryError -> CInt
+deliveryErrorStatus = \case
+    RepositoryDelivery.DeliveryStale _ -> -2
+    RepositoryDelivery.DeliveryConfirmationRejected _ -> -4
+    _ -> -1
+
+deliveryInputValid :: Ptr Word8 -> CSize -> Int -> Bool
+deliveryInputValid pointer length limit =
+    pointer /= nullPtr
+        && length > 0
+        && toInteger length <= toInteger limit
+
+deliveryPathLimit, deliveryTokenLimit, deliveryRefLimit :: Int
+deliveryPathLimit = 16 * 1024
+deliveryTokenLimit = 4 * 1024
+deliveryRefLimit = 1024
+
+deliveryTitleLimit, deliveryBodyLimit :: Int
+deliveryTitleLimit = 4 * 1024
+deliveryBodyLimit = 1024 * 1024
 
 copyRequiredText :: Ptr Word8 -> CSize -> IO (Either () Text)
 copyRequiredText pointer (CSize length)

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1025,25 +1025,14 @@ ha_repository_delivery_status pathBytes pathLength snapshotBytes snapshotLength
                         (emitDeliveryOnce terminal $
                             emitDeliveryStatusFailure callback context (-3)
                                 "repository delivery was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.repositoryDeliveryStatus
                                 (Text.unpack path)
-                                snapshot) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitDeliveryStatusFailure
-                                            callback context (-1)
-                                            "repository delivery failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitDeliveryStatusFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right status) ->
-                                        emitDeliveryOnce terminal $
-                                            emitDeliveryStatus
-                                                callback context status
+                                snapshot)
+                            (emitDeliveryStatusFailure callback context (-1)
+                                "repository delivery failed")
+                            (emitDeliveryStatusFailure callback context)
+                            (emitDeliveryStatus callback context)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1065,25 +1054,14 @@ ha_repository_push_preview pathBytes pathLength snapshotBytes snapshotLength
                         (emitDeliveryOnce terminal $
                             emitPushPreviewFailure callback context (-3)
                                 "repository push preview was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.previewRepositoryPush
                                 (Text.unpack path)
-                                snapshot) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushPreviewFailure
-                                            callback context (-1)
-                                            "repository push preview failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushPreviewFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right preview) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushPreview
-                                                callback context preview
+                                snapshot)
+                            (emitPushPreviewFailure callback context (-1)
+                                "repository push preview failed")
+                            (emitPushPreviewFailure callback context)
+                            (emitPushPreview callback context)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1105,23 +1083,14 @@ ha_repository_push_confirm pathBytes pathLength tokenBytes tokenLength
                         (emitDeliveryOnce terminal $
                             emitPushResultFailure callback context (-3)
                                 "repository push was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.confirmRepositoryPush
                                 (Text.unpack path)
-                                token) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushResultFailure
-                                            callback context (-1)
-                                            "repository push failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPushResultFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right status) ->
-                                        emitDeliveryOnce terminal $
+                                token)
+                            (emitPushResultFailure callback context (-1)
+                                "repository push failed")
+                            (emitPushResultFailure callback context)
+                            (\status ->
                                         withText status.deliverySnapshotId
                                             \snapshotPtr snapshotSize ->
                                         withText status.deliveryHeadOid
@@ -1130,7 +1099,7 @@ ha_repository_push_confirm pathBytes pathLength tokenBytes tokenLength
                                                     callback context 0
                                                     snapshotPtr snapshotSize
                                                     headPtr headSize
-                                                    nullPtr 0
+                                                    nullPtr 0)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1164,25 +1133,15 @@ ha_repository_pr_preview pathBytes pathLength snapshotBytes snapshotLength
                             emitPullRequestPreviewFailure
                                 callback context (-3)
                                 "pull-request preview was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.previewPullRequest
                                 (Text.unpack path)
-                                snapshot base title body) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestPreviewFailure
-                                            callback context (-1)
-                                            "pull-request preview failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestPreviewFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right preview) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestPreview
-                                            callback context preview
+                                snapshot base title body)
+                            (emitPullRequestPreviewFailure
+                                callback context (-1)
+                                "pull-request preview failed")
+                            (emitPullRequestPreviewFailure callback context)
+                            (emitPullRequestPreview callback context)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1204,27 +1163,18 @@ ha_repository_pr_confirm pathBytes pathLength tokenBytes tokenLength
                         (emitDeliveryOnce terminal $
                             emitPullRequestResultFailure callback context (-3)
                                 "pull-request creation was cancelled") $
-                        tryRepositorySynchronous
+                        prepareDeliveryResult terminal
                             (RepositoryDelivery.createPullRequest
                                 (Text.unpack path)
-                                token) >>= \case
-                                    Left _ ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestResultFailure
-                                            callback context (-1)
-                                            "pull-request creation failed"
-                                    Right (Left err) ->
-                                        emitDeliveryOnce terminal $
-                                            emitPullRequestResultFailure
-                                            callback context
-                                            (deliveryErrorStatus err)
-                                            (RepositoryDelivery.deliveryErrorText err)
-                                    Right (Right url) ->
-                                        emitDeliveryOnce terminal $
+                                token)
+                            (emitPullRequestResultFailure callback context (-1)
+                                "pull-request creation failed")
+                            (emitPullRequestResultFailure callback context)
+                            (\url ->
                                         withText url \urlPtr urlSize ->
                                             invokeRepositoryPullRequestResultCallback
                                                 callback context 0
-                                                urlPtr urlSize nullPtr 0
+                                                urlPtr urlSize nullPtr 0)
                     pure (if started then 0 else 3)
                 _ -> pure 2
 
@@ -1773,6 +1723,26 @@ emitDeliveryOnce terminal callback =
         shouldRun <- modifyMVar terminal \completed ->
             pure (True, not completed)
         when shouldRun callback
+
+prepareDeliveryResult
+    :: MVar Bool
+    -> IO (Either RepositoryDelivery.DeliveryError value)
+    -> IO ()
+    -> (CInt -> Text -> IO ())
+    -> (value -> IO ())
+    -> IO (IO ())
+prepareDeliveryResult terminal operation unexpectedFailure knownFailure success =
+    tryRepositorySynchronous operation >>= \case
+        Left _ ->
+            pure (emitDeliveryOnce terminal unexpectedFailure)
+        Right (Left err) ->
+            pure
+                (emitDeliveryOnce terminal $
+                    knownFailure
+                        (deliveryErrorStatus err)
+                        (RepositoryDelivery.deliveryErrorText err))
+        Right (Right value) ->
+            pure (emitDeliveryOnce terminal (success value))
 
 emitDeliveryStatus
     :: FunPtr RepositoryDeliveryStatusCallback

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -254,6 +254,70 @@ typedef void (*ha_repository_result_callback)(
     size_t error_length
 );
 
+/*
+ * Delivery APIs never invoke a shell and never return credentials, command
+ * output, or authenticated remote URLs. Preview confirmations are random,
+ * one-shot, in-memory tokens bound to the canonical repository, exact
+ * snapshot/HEAD, upstream configuration, and remote OID. They expire after
+ * ten minutes. Confirm rechecks that state immediately before mutation and
+ * never force-pushes or deletes a ref. Push targets the reviewed commit OID,
+ * and Git's ordinary fast-forward rule remains authoritative. Repository
+ * hooks are disabled for preview and confirmation.
+ *
+ * Status is 0 for success, -1 for failure, -2 for stale state, -3 for
+ * cancellation, and -4 for an invalid/expired/already-used confirmation.
+ * Every buffer is callback-scoped UTF-8. An accepted call emits exactly one
+ * callback. Delivery callbacks use the repository worker lifecycle and have
+ * the same cancellation/reentrancy rules documented below.
+ */
+typedef void (*ha_repository_delivery_status_callback)(
+    void *context, int32_t status,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    const uint8_t *head_oid, size_t head_oid_length,
+    const uint8_t *branch, size_t branch_length,
+    const uint8_t *remote, size_t remote_length,
+    const uint8_t *upstream_ref, size_t upstream_ref_length,
+    const uint8_t *upstream_oid, size_t upstream_oid_length,
+    int64_t ahead, int64_t behind,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_repository_push_preview_callback)(
+    void *context, int32_t status,
+    const uint8_t *confirmation, size_t confirmation_length,
+    int64_t expires_at_unix,
+    const uint8_t *head_oid, size_t head_oid_length,
+    const uint8_t *branch, size_t branch_length,
+    const uint8_t *remote, size_t remote_length,
+    const uint8_t *upstream_ref, size_t upstream_ref_length,
+    int64_t ahead, int64_t behind,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_repository_push_result_callback)(
+    void *context, int32_t status,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    const uint8_t *pushed_oid, size_t pushed_oid_length,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_repository_pr_preview_callback)(
+    void *context, int32_t status,
+    const uint8_t *confirmation, size_t confirmation_length,
+    int64_t expires_at_unix,
+    const uint8_t *repository, size_t repository_length,
+    const uint8_t *base_ref, size_t base_ref_length,
+    const uint8_t *head_ref, size_t head_ref_length,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *error, size_t error_length
+);
+
+typedef void (*ha_repository_pr_result_callback)(
+    void *context, int32_t status,
+    const uint8_t *url, size_t url_length,
+    const uint8_t *error, size_t error_length
+);
+
 enum ha_repository_operation {
     HA_REPOSITORY_STAGE = 0,
     HA_REPOSITORY_UNSTAGE = 1,
@@ -442,6 +506,41 @@ int32_t ha_repository_commit(
     size_t message_length,
     ha_repository_result_callback result_callback,
     void *context
+);
+
+/*
+ * Delivery input buffers are required non-empty UTF-8 and copied before the
+ * call returns. PR base/title/body are bounded to a 1 KiB base, 512-character
+ * title, and 1 MiB body. Return codes are 0 accepted, 1 null callback, 2
+ * invalid input, and 3 internal start failure.
+ */
+int32_t ha_repository_delivery_status(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    ha_repository_delivery_status_callback callback, void *context
+);
+int32_t ha_repository_push_preview(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    ha_repository_push_preview_callback callback, void *context
+);
+int32_t ha_repository_push_confirm(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *confirmation, size_t confirmation_length,
+    ha_repository_push_result_callback callback, void *context
+);
+int32_t ha_repository_pr_preview(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *snapshot_id, size_t snapshot_id_length,
+    const uint8_t *base, size_t base_length,
+    const uint8_t *title, size_t title_length,
+    const uint8_t *body, size_t body_length,
+    ha_repository_pr_preview_callback callback, void *context
+);
+int32_t ha_repository_pr_confirm(
+    const uint8_t *path, size_t path_length,
+    const uint8_t *confirmation, size_t confirmation_length,
+    ha_repository_pr_result_callback callback, void *context
 );
 
 void ha_repository_cancel_all(void);

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -259,10 +259,12 @@ typedef void (*ha_repository_result_callback)(
  * output, or authenticated remote URLs. Preview confirmations are random,
  * one-shot, in-memory tokens bound to the canonical repository, exact
  * snapshot/HEAD, upstream configuration, and remote OID. They expire after
- * ten minutes. Confirm rechecks that state immediately before mutation and
- * never force-pushes or deletes a ref. Push targets the reviewed commit OID,
- * and Git's ordinary fast-forward rule remains authoritative. Repository
- * hooks are disabled for preview and confirmation.
+ * ten minutes. Confirm rechecks that state immediately before mutation.
+ * Push targets the reviewed commit OID and uses an exact
+ * --force-with-lease=<destination>:<expected> server-side CAS only after
+ * proving expected is an ancestor of that OID. This cannot approve a history
+ * rewrite and never deletes a ref. Repository hooks are disabled for preview
+ * and confirmation.
  *
  * Status is 0 for success, -1 for failure, -2 for stale state, -3 for
  * cancellation, and -4 for an invalid/expired/already-used confirmation.

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -292,24 +292,31 @@ confirmRepositoryPush requested token =
                                                                     (DeliveryStale
                                                                         "the remote branch changed after push preview"))
                                                         | otherwise ->
-                                                            runGit
-                                                                current.deliveryRoot
-                                                                (remoteCommandPrefix previewedRemote
-                                                                <> [ "push"
-                                                                , "--porcelain"
-                                                                , "--no-verify"
-                                                                , leaseArgument current
-                                                                , "--"
-                                                                , BS8.unpack previewedRemote.validatedRemoteUrl
-                                                                , pushRefspec current
-                                                                ])
-                                                                BS.empty
-                                                                networkTimeoutMicros >>= \case
+                                                            revalidateLocalMutation
+                                                                current >>= \case
                                                                     Left err -> pure (Left err)
-                                                                    Right _ ->
-                                                                        refreshPushedStatus
-                                                                            current
-                                                                            previewedRemote
+                                                                    Right () ->
+                                                                        -- The explicit object ID prevents
+                                                                        -- any still-later local ref movement
+                                                                        -- from changing what is delivered.
+                                                                        runGit
+                                                                            current.deliveryRoot
+                                                                            (remoteCommandPrefix previewedRemote
+                                                                            <> [ "push"
+                                                                            , "--porcelain"
+                                                                            , "--no-verify"
+                                                                            , leaseArgument current
+                                                                            , "--"
+                                                                            , BS8.unpack previewedRemote.validatedRemoteUrl
+                                                                            , pushRefspec current
+                                                                            ])
+                                                                            BS.empty
+                                                                            networkTimeoutMicros >>= \case
+                                                                                Left err -> pure (Left err)
+                                                                                Right _ ->
+                                                                                    refreshPushedStatus
+                                                                                        current
+                                                                                        previewedRemote
         Right _ ->
             pure
                 (Left
@@ -444,30 +451,35 @@ createPullRequest requested token =
                                                                                     Left err ->
                                                                                         pure (Left err)
                                                                                     Right () ->
-                                                                                        runGh
-                                                                                            current.deliveryRoot
-                                                                                            [ "pr"
-                                                                                            , "create"
-                                                                                            , "--repo"
-                                                                                            , githubRepoArgument repository
-                                                                                            , "--base"
-                                                                                            , Text.unpack base
-                                                                                            , "--head"
-                                                                                            , Text.unpack current.deliveryBranch
-                                                                                            , "--title"
-                                                                                            , Text.unpack title
-                                                                                            , "--body-file"
-                                                                                            , "-"
-                                                                                            ]
-                                                                                            (TextEncoding.encodeUtf8 body)
-                                                                                            networkTimeoutMicros >>= \case
+                                                                                        revalidateLocalMutation
+                                                                                            current >>= \case
                                                                                                 Left err ->
                                                                                                     pure (Left err)
-                                                                                                Right output ->
-                                                                                                    pure
-                                                                                                        (parsePullRequestUrl
-                                                                                                            repository
-                                                                                                            output)
+                                                                                                Right () ->
+                                                                                                    runGh
+                                                                                                        current.deliveryRoot
+                                                                                                        [ "pr"
+                                                                                                        , "create"
+                                                                                                        , "--repo"
+                                                                                                        , githubRepoArgument repository
+                                                                                                        , "--base"
+                                                                                                        , Text.unpack base
+                                                                                                        , "--head"
+                                                                                                        , Text.unpack current.deliveryBranch
+                                                                                                        , "--title"
+                                                                                                        , Text.unpack title
+                                                                                                        , "--body-file"
+                                                                                                        , "-"
+                                                                                                        ]
+                                                                                                        (TextEncoding.encodeUtf8 body)
+                                                                                                        networkTimeoutMicros >>= \case
+                                                                                                            Left err ->
+                                                                                                                pure (Left err)
+                                                                                                            Right output ->
+                                                                                                                pure
+                                                                                                                    (parsePullRequestUrl
+                                                                                                                        repository
+                                                                                                                        output)
         Right _ ->
             pure
                 (Left
@@ -750,6 +762,22 @@ refreshPushedStatus pushed validatedRemote = do
                         , deliveryBehind = 0
                         }
 
+revalidateLocalMutation
+    :: DeliveryStatus
+    -> IO (Either DeliveryError ())
+revalidateLocalMutation expected =
+    repositoryDeliveryStatus
+        expected.deliveryRoot
+        expected.deliverySnapshotId >>= \case
+            Left err -> pure (Left err)
+            Right current
+                | current == expected -> pure (Right ())
+                | otherwise ->
+                    pure
+                        (Left
+                            (DeliveryStale
+                                "repository state changed immediately before delivery"))
+
 revalidatePullRequestMutation
     :: DeliveryStatus
     -> ValidatedRemote
@@ -936,38 +964,60 @@ validRemoteUrl url =
         "https://" `BS8.isPrefixOf` value
             && not (authorityContains '@' "https://" value)
             && not (containsQueryOrFragment value)
+            && not (authorityContains '%' "https://" value)
     validSsh value =
         "ssh://" `BS8.isPrefixOf` value
-            && not (userinfoContains ':' "ssh://" value)
+            && validSshAuthority value
             && not (containsQueryOrFragment value)
     validGit value =
         "git://" `BS8.isPrefixOf` value
             && not (authorityContains '@' "git://" value)
             && not (containsQueryOrFragment value)
+            && not (authorityContains '%' "git://" value)
     validFile value =
         "file://" `BS8.isPrefixOf` value
             && not (authorityContains '@' "file://" value)
             && not (containsQueryOrFragment value)
+            && not (authorityContains '%' "file://" value)
     authorityContains character prefix value =
         BS8.elem character
             (BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value))
-    userinfoContains character prefix value =
+    validSshAuthority value =
         let authority =
-                BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value)
+                BS8.takeWhile (/= '/') (BS.drop (BS.length "ssh://") value)
             (userinfo, separatorAndHost) = BS8.break (== '@') authority
-        in not (BS.null separatorAndHost)
-            && BS8.elem character userinfo
+            host = BS.drop 1 separatorAndHost
+        in not (BS.null authority)
+            && not (BS8.elem '%' authority)
+            && if BS.null separatorAndHost
+                then True
+                else validUsername userinfo
+                    && not (BS.null host)
+                    && not (BS8.elem '@' host)
+    validUsername username =
+        not (BS.null username)
+            && BS8.all
+                (\character ->
+                    isAsciiAlphaNumeric character
+                        || character `elem` ("._-" :: String))
+                username
+    isAsciiAlphaNumeric character =
+        (character >= 'a' && character <= 'z')
+            || (character >= 'A' && character <= 'Z')
+            || (character >= '0' && character <= '9')
     containsQueryOrFragment value =
         BS8.elem '?' value || BS8.elem '#' value
     validScpLike value =
         case BS8.break (== ':') value of
-            (host, path) ->
-                not (BS.null host)
-                    && BS8.elem '@' host
+            (authority, path) ->
+                let (username, separatorAndHost) = BS8.break (== '@') authority
+                    host = BS.drop 1 separatorAndHost
+                in validUsername username
+                    && not (BS.null separatorAndHost)
+                    && not (BS.null host)
+                    && not (BS8.elem '@' host)
+                    && not (BS8.elem '%' authority)
                     && BS.length path > 1
-                    -- A canonical SCP-like URL is `git@host:path`.
-                    -- Reject a second `@`, which denotes credentials in
-                    -- the authority and would be exposed in child argv.
                     && not (BS8.elem '@' path)
                     && not (containsQueryOrFragment value)
 

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -449,7 +449,7 @@ createPullRequest requested token =
                                                                                             [ "pr"
                                                                                             , "create"
                                                                                             , "--repo"
-                                                                                            , Text.unpack repository
+                                                                                            , githubRepoArgument repository
                                                                                             , "--base"
                                                                                             , Text.unpack base
                                                                                             , "--head"
@@ -815,7 +815,7 @@ ensureBaseAndNoOpenPullRequest status remote repository base =
                     [ "pr"
                     , "list"
                     , "--repo"
-                    , Text.unpack repository
+                    , githubRepoArgument repository
                     , "--head"
                     , Text.unpack status.deliveryBranch
                     , "--state"
@@ -861,7 +861,7 @@ requireGitHubCli root repository =
                 [ "repo"
                 , "view"
                 , "--repo"
-                , Text.unpack repository
+                , githubRepoArgument repository
                 , "--json"
                 , "nameWithOwner"
                 ]
@@ -884,6 +884,10 @@ requireGitHubCli root repository =
                                             "GitHub CLI returned an invalid repository identity"))
 
 newtype RepositoryIdentity = RepositoryIdentity Text
+
+githubRepoArgument :: Text -> String
+githubRepoArgument repository =
+    Text.unpack ("github.com/" <> repository)
 
 instance Aeson.FromJSON RepositoryIdentity where
     parseJSON = Aeson.withObject "RepositoryIdentity" \object ->
@@ -922,20 +926,46 @@ validRemoteUrl url =
         && BS.all (\byte -> byte >= 0x20 && byte /= 0x7f) url
         && BS8.head url /= '-'
         && (isAbsolute (BS8.unpack url)
-            || any (`BS8.isPrefixOf` url)
-                [ "https://"
-                , "ssh://"
-                , "git://"
-                , "file://"
-                ]
+            || validHttps url
+            || validSsh url
+            || validGit url
+            || validFile url
             || validScpLike url)
   where
+    validHttps value =
+        "https://" `BS8.isPrefixOf` value
+            && not (authorityContains '@' "https://" value)
+            && not (containsQueryOrFragment value)
+    validSsh value =
+        "ssh://" `BS8.isPrefixOf` value
+            && not (userinfoContains ':' "ssh://" value)
+            && not (containsQueryOrFragment value)
+    validGit value =
+        "git://" `BS8.isPrefixOf` value
+            && not (authorityContains '@' "git://" value)
+            && not (containsQueryOrFragment value)
+    validFile value =
+        "file://" `BS8.isPrefixOf` value
+            && not (authorityContains '@' "file://" value)
+            && not (containsQueryOrFragment value)
+    authorityContains character prefix value =
+        BS8.elem character
+            (BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value))
+    userinfoContains character prefix value =
+        let authority =
+                BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value)
+            (userinfo, separatorAndHost) = BS8.break (== '@') authority
+        in not (BS.null separatorAndHost)
+            && BS8.elem character userinfo
+    containsQueryOrFragment value =
+        BS8.elem '?' value || BS8.elem '#' value
     validScpLike value =
         case BS8.break (== ':') value of
             (host, path) ->
                 not (BS.null host)
                     && BS8.elem '@' host
                     && BS.length path > 1
+                    && not (containsQueryOrFragment value)
 
 remoteCommandPrefix :: ValidatedRemote -> [String]
 remoteCommandPrefix remote =
@@ -1456,6 +1486,7 @@ nonInteractiveEnvironment executable = do
             , "GCM_INTERACTIVE"
             , "GH_PROMPT_DISABLED"
             , "GH_REPO"
+            , "GH_HOST"
             , "SSH_ASKPASS_REQUIRE"
             , "GIT_DIR"
             , "GIT_WORK_TREE"

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -14,7 +14,7 @@ module Agent.CLI.RepositoryDelivery
     ) where
 
 import Control.Concurrent (forkIO, threadDelay)
-import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.Async (cancel, wait, withAsync)
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar
     ( MVar
@@ -27,6 +27,8 @@ import Control.Exception.Safe
     , bracket
     , finally
     , isAsyncException
+    , mask
+    , onException
     , throwIO
     , tryAny
     )
@@ -67,13 +69,13 @@ import System.Posix.Signals
     , sigTERM
     , signalProcessGroup
     )
+import System.Posix.Types (ProcessID)
 import System.Process
     ( CreateProcess(..)
     , ProcessHandle
     , StdStream(CreatePipe)
     , createProcess
     , getPid
-    , getProcessExitCode
     , proc
     , terminateProcess
     , waitForProcess
@@ -1285,7 +1287,7 @@ runCommand root executable arguments input timeoutMicros = do
         Right Nothing -> Left ProcessTimedOut
         Right (Just result) -> result
   where
-    start = do
+    start = mask \_ -> do
         environment <- nonInteractiveEnvironment executable
         (maybeInput, maybeOutput, maybeError, process) <-
             createProcess
@@ -1299,48 +1301,103 @@ runCommand root executable arguments input timeoutMicros = do
                     , env = Just environment
                     }
         case (maybeInput, maybeOutput, maybeError) of
-            (Just inputHandle, Just outputHandle, Just errorHandle) ->
-                pure (inputHandle, outputHandle, errorHandle, process)
+            (Just inputHandle, Just outputHandle, Just errorHandle) -> do
+                let closePipes = do
+                        closeQuietly inputHandle
+                        closeQuietly outputHandle
+                        closeQuietly errorHandle
+                    cleanupWithoutGroup = do
+                        closePipes
+                        _ <- tryAny (terminateProcess process)
+                        _ <- tryAny (waitForProcess process)
+                        pure ()
+                processGroup <- getPid process
+                    `onException` cleanupWithoutGroup
+                completed <- newIORef False
+                    `onException` do
+                        closePipes
+                        terminateProcessGroup sigKILL processGroup process
+                        _ <- tryAny (waitForProcess process)
+                        pure ()
+                pure
+                    ( inputHandle
+                    , outputHandle
+                    , errorHandle
+                    , process
+                    , processGroup
+                    , completed
+                    )
             _ -> do
                 terminateProcess process
                 _ <- waitForProcess process
                 fail "could not create command pipes"
-    stop (inputHandle, outputHandle, errorHandle, process) = do
+    stop
+        ( inputHandle
+        , outputHandle
+        , errorHandle
+        , process
+        , processGroup
+        , completed
+        ) = do
         closeQuietly inputHandle
         closeQuietly outputHandle
         closeQuietly errorHandle
-        getProcessExitCode process >>= \case
-            Just _ -> pure ()
-            Nothing -> do
-                terminateProcessGroup sigTERM process
-                threadDelay 100_000
-                getProcessExitCode process >>= \case
-                    Just _ -> pure ()
-                    Nothing -> terminateProcessGroup sigKILL process
+        finished <- readIORef completed
+        unless finished do
+            terminateProcessGroup sigTERM processGroup process
+            threadDelay 100_000
+            -- A descendant can retain the group and pipes after its leader
+            -- exits, so always escalate the captured process group.
+            terminateProcessGroup sigKILL processGroup process
         _ <- tryAny (waitForProcess process)
         pure ()
-    run (inputHandle, outputHandle, errorHandle, process) =
+    run
+        ( inputHandle
+        , outputHandle
+        , errorHandle
+        , process
+        , processGroup
+        , completed
+        ) =
         withAsync
             (BS.hPut inputHandle input `finally` closeQuietly inputHandle)
             \inputWriter ->
                 withAsync (readBounded outputHandle) \outputReader ->
                     withAsync (readBounded errorHandle) \errorReader -> do
                         exitCode <- waitForProcess process
+                        -- Do not wait for pipe EOF before terminating residual
+                        -- descendants in the leader's dedicated group.
+                        terminateProcessGroup sigKILL processGroup process
                         _ <- wait inputWriter
-                        (output, outputTruncated) <- wait outputReader
-                        (errors, errorsTruncated) <- wait errorReader
-                        let truncated = outputTruncated || errorsTruncated
-                        pure
-                            (if truncated
-                                then Left ProcessOutputExceeded
-                                else
-                                    Right
-                                        ProcessResult
-                                            { processExitCode = exitCode
-                                            , processStdout = output
-                                            , processStderr = errors
-                                            , processOutputTruncated = False
-                                            })
+                        drained <- timeout processPipeTeardownMicros
+                            ((,) <$> wait outputReader <*> wait errorReader)
+                        case drained of
+                            Nothing -> do
+                                closeQuietly outputHandle
+                                closeQuietly errorHandle
+                                cancel outputReader
+                                cancel errorReader
+                                pure (Left ProcessTimedOut)
+                            Just
+                                ( (output, outputTruncated)
+                                , (errors, errorsTruncated)
+                                ) -> do
+                                    writeIORef completed True
+                                    let truncated =
+                                            outputTruncated || errorsTruncated
+                                    pure
+                                        (if truncated
+                                            then Left ProcessOutputExceeded
+                                            else
+                                                Right
+                                                    ProcessResult
+                                                        { processExitCode =
+                                                            exitCode
+                                                        , processStdout = output
+                                                        , processStderr = errors
+                                                        , processOutputTruncated =
+                                                            False
+                                                        })
 
 readBounded :: Handle -> IO (BS.ByteString, Bool)
 readBounded handle = do
@@ -1366,10 +1423,11 @@ readBounded handle = do
 
 terminateProcessGroup
     :: Signal
+    -> Maybe ProcessID
     -> ProcessHandle
     -> IO ()
-terminateProcessGroup signal process = do
-    pid <- getPid process
+terminateProcessGroup signal processGroup process = do
+    pid <- maybe (getPid process) (pure . Just) processGroup
     case pid of
         Nothing -> do
             _ <- tryAny (terminateProcess process)
@@ -1487,6 +1545,9 @@ localTimeoutMicros = 15 * 1_000_000
 
 networkTimeoutMicros :: Int
 networkTimeoutMicros = 60 * 1_000_000
+
+processPipeTeardownMicros :: Int
+processPipeTeardownMicros = 1_000_000
 
 maxProcessOutputBytes :: Int
 maxProcessOutputBytes = 1024 * 1024

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -49,7 +49,8 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
-import Data.Word (Word8)
+import Data.Word (Word8, Word64)
+import GHC.Clock (getMonotonicTimeNSec)
 import System.Exit (ExitCode(..))
 import System.Environment (getEnvironment)
 import System.IO
@@ -146,7 +147,7 @@ instance Eq ValidatedRemote where
 
 data StoredConfirmation = StoredConfirmation
     { storedRoot :: !FilePath
-    , storedExpiresAt :: !POSIXTime
+    , storedDeadlineNanos :: !Word64
     , storedConfirmation :: !Confirmation
     }
 
@@ -1109,12 +1110,14 @@ storeConfirmation
     -> Confirmation
     -> IO (Text, POSIXTime)
 storeConfirmation root confirmation = do
-    now <- getPOSIXTime
+    wallNow <- getPOSIXTime
+    monotonicNow <- getMonotonicTimeNSec
     token <- randomToken
-    let expiresAt = now + confirmationLifetimeSeconds
+    let expiresAt = wallNow + confirmationLifetimeSeconds
+        deadline = saturatingAdd monotonicNow confirmationLifetimeNanos
     stored <- modifyMVar deliveryConfirmations \confirmations ->
         let active = Map.filter
-                (\entry -> entry.storedExpiresAt > now)
+                (\entry -> entry.storedDeadlineNanos > monotonicNow)
                 confirmations
         in if Map.size active >= maxActiveConfirmations
             || Map.member token active
@@ -1125,7 +1128,7 @@ storeConfirmation root confirmation = do
                         token
                         StoredConfirmation
                             { storedRoot = root
-                            , storedExpiresAt = expiresAt
+                            , storedDeadlineNanos = deadline
                             , storedConfirmation = confirmation
                             }
                         active
@@ -1159,10 +1162,11 @@ consumeConfirmation requested token
                         (DeliveryCommandFailed
                             "repository state could not be verified"))
             Just (Right snapshot) -> do
-                now <- getPOSIXTime
+                monotonicNow <- getMonotonicTimeNSec
                 modifyMVar deliveryConfirmations \confirmations ->
                     let pruned = Map.filter
-                            (\stored -> stored.storedExpiresAt > now)
+                            (\stored ->
+                                stored.storedDeadlineNanos > monotonicNow)
                             confirmations
                     in case Map.lookup token pruned of
                         Nothing ->
@@ -1470,6 +1474,14 @@ trySynchronous action =
 confirmationLifetimeSeconds :: POSIXTime
 confirmationLifetimeSeconds = 10 * 60
 
+confirmationLifetimeNanos :: Word64
+confirmationLifetimeNanos = 10 * 60 * 1_000_000_000
+
+saturatingAdd :: Word64 -> Word64 -> Word64
+saturatingAdd left right
+    | maxBound - left < right = maxBound
+    | otherwise = left + right
+
 localTimeoutMicros :: Int
 localTimeoutMicros = 15 * 1_000_000
 
@@ -1488,7 +1500,8 @@ deliveryConfirmations = unsafePerformIO do
     confirmations <- newMVar Map.empty
     _ <- forkIO $ forever do
         threadDelay 60_000_000
-        now <- getPOSIXTime
+        monotonicNow <- getMonotonicTimeNSec
         modifyMVar_ confirmations
-            (pure . Map.filter (\stored -> stored.storedExpiresAt > now))
+            (pure . Map.filter
+                (\stored -> stored.storedDeadlineNanos > monotonicNow))
     pure confirmations

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -15,6 +15,7 @@ module Agent.CLI.RepositoryDelivery
 
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (wait, withAsync)
+import Control.Applicative ((<|>))
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
@@ -42,6 +43,7 @@ import Data.IORef
     )
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -57,6 +59,7 @@ import System.IO
     , openBinaryFile
     )
 import System.IO.Unsafe (unsafePerformIO)
+import System.FilePath (isAbsolute)
 import System.Posix.Signals
     ( Signal
     , sigKILL
@@ -118,14 +121,28 @@ data DeliveryError
     deriving (Eq, Show)
 
 data Confirmation
-    = PushConfirmation !DeliveryStatus
+    = PushConfirmation !DeliveryStatus !ValidatedRemote
     | PullRequestConfirmation
         !DeliveryStatus
+        !ValidatedRemote
         !Text -- repository
         !Text -- base
         !Text -- title
         !Text -- body
-    deriving (Eq)
+
+data ValidatedRemote = ValidatedRemote
+    { validatedRemoteUrl :: !BS.ByteString
+    , validatedRemoteFingerprint :: !Text
+    , validatedGitHubRepository :: !(Maybe Text)
+    }
+
+instance Eq ValidatedRemote where
+    left == right =
+        left.validatedRemoteUrl == right.validatedRemoteUrl
+            && left.validatedRemoteFingerprint
+                == right.validatedRemoteFingerprint
+            && left.validatedGitHubRepository
+                == right.validatedGitHubRepository
 
 data StoredConfirmation = StoredConfirmation
     { storedRoot :: !FilePath
@@ -177,53 +194,60 @@ previewRepositoryPush
 previewRepositoryPush requested expected =
     repositoryDeliveryStatus requested expected >>= \case
         Left err -> pure (Left err)
-        Right status -> do
-            remoteHead <- queryRemoteHead status
-            case remoteHead of
+        Right status ->
+            validatedRemoteForStatus status >>= \case
                 Left err -> pure (Left err)
-                Right oid
-                    | oid /= status.deliveryUpstreamOid ->
-                        pure
-                            (Left
-                                (DeliveryStale
-                                    "the remote branch changed; fetch before previewing a push"))
-                    | status.deliveryAhead <= 0 ->
-                        pure
-                            (Left
-                                (DeliveryInvalidRequest
-                                    "the branch has no commits to push"))
-                    | status.deliveryBehind /= 0 ->
-                        pure
-                            (Left
-                                (DeliveryInvalidRequest
-                                    "the branch is behind its upstream"))
-                    | otherwise -> do
-                        dryRun <- runGit
-                            status.deliveryRoot
-                            [ "push"
-                            , "--porcelain"
-                            , "--dry-run"
-                            , "--no-verify"
-                            , "--"
-                            , Text.unpack status.deliveryRemote
-                            , pushRefspec status
-                            ]
-                            BS.empty
-                            networkTimeoutMicros
-                        case dryRun of
-                            Left err -> pure (Left err)
-                            Right _ -> do
-                                (token, expiresAt) <-
-                                    storeConfirmation
-                                        status.deliveryRoot
-                                        (PushConfirmation status)
+                Right remote ->
+                    queryRemoteHead status remote >>= \case
+                        Left err -> pure (Left err)
+                        Right oid
+                            | not (remoteMatchesExpected status oid) ->
                                 pure
-                                    (Right
-                                        PushPreview
-                                            { pushPreviewStatus = status
-                                            , pushPreviewConfirmation = token
-                                            , pushPreviewExpiresAt = expiresAt
-                                            })
+                                    (Left
+                                        (DeliveryStale
+                                            "the remote branch changed; fetch before previewing a push"))
+                            | status.deliveryAhead <= 0 ->
+                                pure
+                                    (Left
+                                        (DeliveryInvalidRequest
+                                            "the branch has no commits to push"))
+                            | status.deliveryBehind /= 0 ->
+                                pure
+                                    (Left
+                                        (DeliveryInvalidRequest
+                                            "the branch is behind its upstream"))
+                            | otherwise ->
+                                proveFastForward status >>= \case
+                                    Left err -> pure (Left err)
+                                    Right () -> do
+                                        dryRun <- runGit
+                                            status.deliveryRoot
+                                            (remoteCommandPrefix remote
+                                            <> [ "push"
+                                            , "--porcelain"
+                                            , "--dry-run"
+                                            , "--no-verify"
+                                            , leaseArgument status
+                                            , "--"
+                                            , BS8.unpack remote.validatedRemoteUrl
+                                            , pushRefspec status
+                                            ])
+                                            BS.empty
+                                            networkTimeoutMicros
+                                        case dryRun of
+                                            Left err -> pure (Left err)
+                                            Right _ -> do
+                                                (token, expiresAt) <-
+                                                    storeConfirmation
+                                                        status.deliveryRoot
+                                                        (PushConfirmation status remote)
+                                                pure
+                                                    (Right
+                                                        PushPreview
+                                                            { pushPreviewStatus = status
+                                                            , pushPreviewConfirmation = token
+                                                            , pushPreviewExpiresAt = expiresAt
+                                                            })
 
 confirmRepositoryPush
     :: FilePath
@@ -232,7 +256,7 @@ confirmRepositoryPush
 confirmRepositoryPush requested token =
     consumeConfirmation requested token >>= \case
         Left err -> pure (Left err)
-        Right (PushConfirmation previewed) ->
+        Right (PushConfirmation previewed previewedRemote) ->
             repositoryDeliveryStatus
                 requested
                 previewed.deliverySnapshotId >>= \case
@@ -244,29 +268,45 @@ confirmRepositoryPush requested token =
                                     (DeliveryStale
                                         "branch or upstream state changed after push preview"))
                         | otherwise ->
-                            queryRemoteHead current >>= \case
+                            validatedRemoteForStatus current >>= \case
                                 Left err -> pure (Left err)
-                                Right remoteOid
-                                    | remoteOid /= current.deliveryUpstreamOid ->
+                                Right currentRemote
+                                    | currentRemote /= previewedRemote ->
                                         pure
                                             (Left
                                                 (DeliveryStale
-                                                    "the remote branch changed after push preview"))
+                                                    "the remote destination changed after push preview"))
                                     | otherwise ->
-                                        runGit
-                                            current.deliveryRoot
-                                            [ "push"
-                                            , "--porcelain"
-                                            , "--no-verify"
-                                            , "--"
-                                            , Text.unpack current.deliveryRemote
-                                            , pushRefspec current
-                                            ]
-                                            BS.empty
-                                            networkTimeoutMicros >>= \case
-                                                Left err -> pure (Left err)
-                                                Right _ ->
-                                                    refreshPushedStatus current
+                                        proveFastForward current >>= \case
+                                            Left err -> pure (Left err)
+                                            Right () ->
+                                                queryRemoteHead current previewedRemote >>= \case
+                                                    Left err -> pure (Left err)
+                                                    Right remoteOid
+                                                        | not (remoteMatchesExpected current remoteOid) ->
+                                                            pure
+                                                                (Left
+                                                                    (DeliveryStale
+                                                                        "the remote branch changed after push preview"))
+                                                        | otherwise ->
+                                                            runGit
+                                                                current.deliveryRoot
+                                                                (remoteCommandPrefix previewedRemote
+                                                                <> [ "push"
+                                                                , "--porcelain"
+                                                                , "--no-verify"
+                                                                , leaseArgument current
+                                                                , "--"
+                                                                , BS8.unpack previewedRemote.validatedRemoteUrl
+                                                                , pushRefspec current
+                                                                ])
+                                                                BS.empty
+                                                                networkTimeoutMicros >>= \case
+                                                                    Left err -> pure (Left err)
+                                                                    Right _ ->
+                                                                        refreshPushedStatus
+                                                                            current
+                                                                            previewedRemote
         Right _ ->
             pure
                 (Left
@@ -293,42 +333,54 @@ previewPullRequest requested expected base title body
                             (DeliveryInvalidRequest
                                 "push the exact branch state before previewing a pull request"))
                 | otherwise ->
-                    queryRemoteHead status >>= \case
+                    validatedRemoteForStatus status >>= \case
                         Left err -> pure (Left err)
-                        Right remoteOid
-                            | remoteOid /= status.deliveryHeadOid ->
-                                pure
-                                    (Left
-                                        (DeliveryStale
-                                            "the pushed remote branch does not match HEAD"))
-                            | otherwise ->
-                                requireGitHubCli status.deliveryRoot >>= \case
-                                    Left err -> pure (Left err)
-                                    Right repository ->
-                                        ensureBaseAndNoOpenPullRequest
-                                            status repository base >>= \case
-                                                Left err -> pure (Left err)
-                                                Right () -> do
-                                                    (token, expiresAt) <-
-                                                        storeConfirmation
-                                                            status.deliveryRoot
-                                                            (PullRequestConfirmation
-                                                                status repository
-                                                                base title body)
-                                                    pure
-                                                        (Right
-                                                            PullRequestPreview
-                                                                { pullRequestRepository =
-                                                                    repository
-                                                                , pullRequestBaseRef = base
-                                                                , pullRequestHeadRef =
-                                                                    status.deliveryBranch
-                                                                , pullRequestTitle = title
-                                                                , pullRequestConfirmation =
-                                                                    token
-                                                                , pullRequestExpiresAt =
-                                                                    expiresAt
-                                                                })
+                        Right remote ->
+                            queryRemoteHead status remote >>= \case
+                                Left err -> pure (Left err)
+                                Right remoteOid
+                                    | remoteOid /= Just status.deliveryHeadOid ->
+                                        pure
+                                            (Left
+                                                (DeliveryStale
+                                                    "the pushed remote branch does not match HEAD"))
+                                    | otherwise ->
+                                        case remote.validatedGitHubRepository of
+                                            Nothing ->
+                                                pure
+                                                    (Left
+                                                        (DeliveryInvalidRequest
+                                                            "the delivery remote is not a supported GitHub repository"))
+                                            Just repository ->
+                                                requireGitHubCli
+                                                    status.deliveryRoot
+                                                    repository >>= \case
+                                                        Left err -> pure (Left err)
+                                                        Right () ->
+                                                            ensureBaseAndNoOpenPullRequest
+                                                                status remote repository base >>= \case
+                                                                    Left err -> pure (Left err)
+                                                                    Right () -> do
+                                                                        (token, expiresAt) <-
+                                                                            storeConfirmation
+                                                                                status.deliveryRoot
+                                                                                (PullRequestConfirmation
+                                                                                    status remote repository
+                                                                                    base title body)
+                                                                        pure
+                                                                            (Right
+                                                                                PullRequestPreview
+                                                                                    { pullRequestRepository =
+                                                                                        repository
+                                                                                    , pullRequestBaseRef = base
+                                                                                    , pullRequestHeadRef =
+                                                                                        status.deliveryBranch
+                                                                                    , pullRequestTitle = title
+                                                                                    , pullRequestConfirmation =
+                                                                                        token
+                                                                                    , pullRequestExpiresAt =
+                                                                                        expiresAt
+                                                                                    })
 
 createPullRequest
     :: FilePath
@@ -339,70 +391,80 @@ createPullRequest requested token =
         Left err -> pure (Left err)
         Right
             (PullRequestConfirmation
-                previewed repository base title body) ->
-                    repositoryDeliveryStatus
-                        requested
-                        previewed.deliverySnapshotId >>= \case
-                            Left err -> pure (Left err)
-                            Right current
-                                | current /= previewed ->
-                                    pure
-                                        (Left
-                                            (DeliveryStale
-                                                "branch or upstream state changed after pull-request preview"))
-                                | otherwise ->
-                                    queryRemoteHead current >>= \case
-                                        Left err -> pure (Left err)
-                                        Right remoteOid
-                                            | remoteOid
-                                                /= current.deliveryHeadOid ->
-                                                    pure
-                                                        (Left
-                                                            (DeliveryStale
-                                                                "the pushed remote branch changed after preview"))
-                                            | otherwise ->
-                                                requireGitHubCli
-                                                    current.deliveryRoot >>= \case
-                                                        Left err -> pure (Left err)
-                                                        Right currentRepository
-                                                            | currentRepository
-                                                                /= repository ->
-                                                                    pure
-                                                                        (Left
-                                                                            (DeliveryStale
-                                                                                "the GitHub repository changed after preview"))
-                                                            | otherwise ->
+                previewed previewedRemote repository base title body) ->
+            repositoryDeliveryStatus
+                requested
+                previewed.deliverySnapshotId >>= \case
+                    Left err -> pure (Left err)
+                    Right current
+                        | current /= previewed ->
+                            pure
+                                (Left
+                                    (DeliveryStale
+                                        "branch or upstream state changed after pull-request preview"))
+                        | otherwise ->
+                            validatedRemoteForStatus current >>= \case
+                                Left err -> pure (Left err)
+                                Right currentRemote
+                                    | currentRemote /= previewedRemote ->
+                                        pure
+                                            (Left
+                                                (DeliveryStale
+                                                    "the remote destination changed after preview"))
+                                    | otherwise ->
+                                        queryRemoteHead current previewedRemote >>= \case
+                                            Left err -> pure (Left err)
+                                            Right remoteOid
+                                                | remoteOid
+                                                    /= Just current.deliveryHeadOid ->
+                                                        pure
+                                                            (Left
+                                                                (DeliveryStale
+                                                                    "the pushed remote branch changed after preview"))
+                                                | otherwise ->
+                                                    requireGitHubCli
+                                                        current.deliveryRoot
+                                                        repository >>= \case
+                                                            Left err -> pure (Left err)
+                                                            Right () ->
                                                                 ensureBaseAndNoOpenPullRequest
                                                                     current
+                                                                    previewedRemote
                                                                     repository
                                                                     base >>= \case
                                                                         Left err ->
                                                                             pure (Left err)
                                                                         Right () ->
-                                                                            runGh
-                                                                                current.deliveryRoot
-                                                                                [ "pr"
-                                                                                , "create"
-                                                                                , "--repo"
-                                                                                , Text.unpack repository
-                                                                                , "--base"
-                                                                                , Text.unpack base
-                                                                                , "--head"
-                                                                                , Text.unpack current.deliveryBranch
-                                                                                , "--title"
-                                                                                , Text.unpack title
-                                                                                , "--body-file"
-                                                                                , "-"
-                                                                                ]
-                                                                                (TextEncoding.encodeUtf8 body)
-                                                                                networkTimeoutMicros >>= \case
+                                                                            revalidatePullRequestMutation
+                                                                                current
+                                                                                previewedRemote >>= \case
                                                                                     Left err ->
                                                                                         pure (Left err)
-                                                                                    Right output ->
-                                                                                        pure
-                                                                                            (parsePullRequestUrl
-                                                                                                repository
-                                                                                                output)
+                                                                                    Right () ->
+                                                                                        runGh
+                                                                                            current.deliveryRoot
+                                                                                            [ "pr"
+                                                                                            , "create"
+                                                                                            , "--repo"
+                                                                                            , Text.unpack repository
+                                                                                            , "--base"
+                                                                                            , Text.unpack base
+                                                                                            , "--head"
+                                                                                            , Text.unpack current.deliveryBranch
+                                                                                            , "--title"
+                                                                                            , Text.unpack title
+                                                                                            , "--body-file"
+                                                                                            , "-"
+                                                                                            ]
+                                                                                            (TextEncoding.encodeUtf8 body)
+                                                                                            networkTimeoutMicros >>= \case
+                                                                                                Left err ->
+                                                                                                    pure (Left err)
+                                                                                                Right output ->
+                                                                                                    pure
+                                                                                                        (parsePullRequestUrl
+                                                                                                            repository
+                                                                                                            output)
         Right _ ->
             pure
                 (Left
@@ -453,10 +515,22 @@ statusAtSnapshot snapshot =
         runGit root ["rev-parse", "--verify", "@{upstream}"] BS.empty
             localTimeoutMicros >>= \case
                 Left _ ->
-                    pure
-                        (Left
-                            (DeliveryInvalidRequest
-                                "the branch upstream is unavailable"))
+                    runGit root ["rev-list", "--count", "HEAD"] BS.empty
+                        localTimeoutMicros >>= \case
+                            Left err -> pure (Left err)
+                            Right countBytes ->
+                                case reads (BS8.unpack (stripLineEnding countBytes)) of
+                                    [(ahead, "")]
+                                        | ahead > 0 ->
+                                            finishStatus
+                                                (zeroObjectId headOid)
+                                                ahead
+                                                0
+                                    _ ->
+                                        pure
+                                            (Left
+                                                (DeliveryCommandFailed
+                                                    "Git returned an invalid commit count"))
                 Right upstreamBytes ->
                     let upstreamOid = decodeTrimmed upstreamBytes
                     in runGit
@@ -477,28 +551,27 @@ statusAtSnapshot snapshot =
                                                 (DeliveryCommandFailed
                                                     "Git returned invalid ahead/behind counts"))
                                     Just (ahead, behind) ->
-                                        readRemoteFingerprint
-                                            root remote >>= \case
-                                                Left err -> pure (Left err)
-                                                Right remoteFingerprint ->
-                                                    pure
-                                                        (Right
-                                                            DeliveryStatus
-                                                                { deliverySnapshotId =
-                                                                    snapshot.snapshotId
-                                                                , deliveryRoot = root
-                                                                , deliveryHeadOid = headOid
-                                                                , deliveryBranch = branch
-                                                                , deliveryRemote = remote
-                                                                , deliveryRemoteFingerprint =
-                                                                    remoteFingerprint
-                                                                , deliveryUpstreamRef =
-                                                                    upstreamRef
-                                                                , deliveryUpstreamOid =
-                                                                    upstreamOid
-                                                                , deliveryAhead = ahead
-                                                                , deliveryBehind = behind
-                                                                })
+                                        finishStatus upstreamOid ahead behind
+      where
+        finishStatus upstreamOid ahead behind =
+            readValidatedRemote root remote >>= \case
+                Left err -> pure (Left err)
+                Right validatedRemote ->
+                    pure
+                        (Right
+                            DeliveryStatus
+                                { deliverySnapshotId = snapshot.snapshotId
+                                , deliveryRoot = root
+                                , deliveryHeadOid = headOid
+                                , deliveryBranch = branch
+                                , deliveryRemote = remote
+                                , deliveryRemoteFingerprint =
+                                    validatedRemote.validatedRemoteFingerprint
+                                , deliveryUpstreamRef = upstreamRef
+                                , deliveryUpstreamOid = upstreamOid
+                                , deliveryAhead = ahead
+                                , deliveryBehind = behind
+                                })
 
 readUpstream
     :: FilePath
@@ -534,23 +607,34 @@ readUpstream root fullBranch =
                                 (DeliveryInvalidRequest
                                     "the branch has no configured upstream"))
 
-readRemoteFingerprint
+readValidatedRemote
     :: FilePath
     -> Text
-    -> IO (Either DeliveryError Text)
-readRemoteFingerprint root remote =
+    -> IO (Either DeliveryError ValidatedRemote)
+readValidatedRemote root remote =
     readUrls False >>= \case
         Left _ -> invalid
         Right [fetchUrl] ->
             readUrls True >>= \case
                 Right [pushUrl]
-                    | fetchUrl == pushUrl ->
-                        fmap decodeTrimmed
-                            <$> runGit
+                    | fetchUrl == pushUrl
+                        && validRemoteUrl pushUrl ->
+                            runGit
                                 root
                                 ["hash-object", "--stdin"]
                                 pushUrl
-                                localTimeoutMicros
+                                localTimeoutMicros >>= \case
+                                    Left err -> pure (Left err)
+                                    Right fingerprint ->
+                                        pure
+                                            (Right
+                                                ValidatedRemote
+                                                    { validatedRemoteUrl = pushUrl
+                                                    , validatedRemoteFingerprint =
+                                                        decodeTrimmed fingerprint
+                                                    , validatedGitHubRepository =
+                                                        githubRepositoryFromUrl pushUrl
+                                                    })
                 _ -> invalid
         _ -> invalid
   where
@@ -582,17 +666,39 @@ readRemoteFingerprint root remote =
                 (DeliveryInvalidRequest
                     "delivery requires one identical fetch and push destination"))
 
-queryRemoteHead :: DeliveryStatus -> IO (Either DeliveryError Text)
-queryRemoteHead status =
+validatedRemoteForStatus
+    :: DeliveryStatus
+    -> IO (Either DeliveryError ValidatedRemote)
+validatedRemoteForStatus status =
+    readValidatedRemote status.deliveryRoot status.deliveryRemote >>= \case
+        Left _ ->
+            pure
+                (Left
+                    (DeliveryStale
+                        "the remote destination is no longer valid"))
+        Right remote
+            | remote.validatedRemoteFingerprint
+                /= status.deliveryRemoteFingerprint ->
+                    pure
+                        (Left
+                            (DeliveryStale
+                                "the remote destination changed"))
+            | otherwise -> pure (Right remote)
+
+queryRemoteHead
+    :: DeliveryStatus
+    -> ValidatedRemote
+    -> IO (Either DeliveryError (Maybe Text))
+queryRemoteHead status remote =
     runGit
         status.deliveryRoot
-        [ "ls-remote"
-        , "--exit-code"
+        (remoteCommandPrefix remote
+        <> [ "ls-remote"
         , "--heads"
         , "--"
-        , Text.unpack status.deliveryRemote
+        , BS8.unpack remote.validatedRemoteUrl
         , Text.unpack status.deliveryUpstreamRef
-        ]
+        ])
         BS.empty
         networkTimeoutMicros >>= \case
             Left _ ->
@@ -602,11 +708,12 @@ queryRemoteHead status =
                             "could not verify the exact remote branch"))
             Right output ->
                 case BS8.words output of
+                    [] -> pure (Right Nothing)
                     [oidBytes, refBytes]
                         | decodeTrimmed refBytes
                             == status.deliveryUpstreamRef
                             && validObjectId (decodeTrimmed oidBytes) ->
-                                pure (Right (decodeTrimmed oidBytes))
+                                pure (Right (Just (decodeTrimmed oidBytes)))
                     _ ->
                         pure
                             (Left
@@ -615,44 +722,83 @@ queryRemoteHead status =
 
 refreshPushedStatus
     :: DeliveryStatus
+    -> ValidatedRemote
     -> IO (Either DeliveryError DeliveryStatus)
-refreshPushedStatus pushed = do
+refreshPushedStatus pushed validatedRemote = do
     -- A successful push does not necessarily update the local remote-tracking
     -- ref. Bind the returned result to the immutable pushed OID instead of
     -- pretending the tracking ref was refreshed.
-    remote <- queryRemoteHead
+    remoteResult <- queryRemoteHead
         pushed
             { deliveryUpstreamOid = pushed.deliveryHeadOid }
-    pure case remote of
+        validatedRemote
+    pure case remoteResult of
         Left err -> Left err
         Right oid
-            | oid /= pushed.deliveryHeadOid ->
+            | oid /= Just pushed.deliveryHeadOid ->
                 Left
                     (DeliveryStale
                         "remote verification did not match the pushed commit")
             | otherwise ->
                 Right
                     pushed
-                        { deliveryUpstreamOid = oid
+                        { deliveryUpstreamOid = pushed.deliveryHeadOid
                         , deliveryAhead = 0
                         , deliveryBehind = 0
                         }
 
+revalidatePullRequestMutation
+    :: DeliveryStatus
+    -> ValidatedRemote
+    -> IO (Either DeliveryError ())
+revalidatePullRequestMutation expected expectedRemote =
+    repositoryDeliveryStatus
+        expected.deliveryRoot
+        expected.deliverySnapshotId >>= \case
+            Left err -> pure (Left err)
+            Right current
+                | current /= expected ->
+                    pure
+                        (Left
+                            (DeliveryStale
+                                "branch or upstream state changed before pull-request creation"))
+                | otherwise ->
+                    validatedRemoteForStatus current >>= \case
+                        Left err -> pure (Left err)
+                        Right remote
+                            | remote /= expectedRemote ->
+                                pure
+                                    (Left
+                                        (DeliveryStale
+                                            "the remote destination changed before pull-request creation"))
+                            | otherwise ->
+                                queryRemoteHead current expectedRemote >>= \case
+                                    Left err -> pure (Left err)
+                                    Right oid
+                                        | oid /= Just current.deliveryHeadOid ->
+                                            pure
+                                                (Left
+                                                    (DeliveryStale
+                                                        "the pushed branch changed before pull-request creation"))
+                                        | otherwise -> pure (Right ())
+
 ensureBaseAndNoOpenPullRequest
     :: DeliveryStatus
+    -> ValidatedRemote
     -> Text
     -> Text
     -> IO (Either DeliveryError ())
-ensureBaseAndNoOpenPullRequest status repository base =
+ensureBaseAndNoOpenPullRequest status remote repository base =
     runGit
         status.deliveryRoot
-        [ "ls-remote"
+        (remoteCommandPrefix remote
+        <> [ "ls-remote"
         , "--exit-code"
         , "--heads"
         , "--"
-        , Text.unpack status.deliveryRemote
+        , BS8.unpack remote.validatedRemoteUrl
         , "refs/heads/" <> Text.unpack base
-        ]
+        ])
         BS.empty
         networkTimeoutMicros >>= \case
             Left _ ->
@@ -694,9 +840,13 @@ ensureBaseAndNoOpenPullRequest status repository base =
                                             (DeliveryCommandFailed
                                                 "GitHub CLI returned an invalid pull-request response"))
 
-requireGitHubCli :: FilePath -> IO (Either DeliveryError Text)
-requireGitHubCli root =
-    runGh root ["auth", "status"] BS.empty localTimeoutMicros >>= \case
+requireGitHubCli
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError ())
+requireGitHubCli root repository =
+    runGh root ["auth", "status", "--hostname", "github.com"]
+        BS.empty localTimeoutMicros >>= \case
         Left _ ->
             pure
                 (Left
@@ -705,7 +855,13 @@ requireGitHubCli root =
         Right _ ->
             runGh
                 root
-                ["repo", "view", "--json", "nameWithOwner"]
+                [ "repo"
+                , "view"
+                , "--repo"
+                , Text.unpack repository
+                , "--json"
+                , "nameWithOwner"
+                ]
                 BS.empty
                 networkTimeoutMicros >>= \case
                     Left _ ->
@@ -715,9 +871,9 @@ requireGitHubCli root =
                                     "GitHub repository identity is unavailable"))
                     Right output ->
                         case Aeson.decodeStrict' output of
-                            Just (RepositoryIdentity repository)
-                                | validateRepositoryName repository ->
-                                    pure (Right repository)
+                            Just (RepositoryIdentity returnedRepository)
+                                | returnedRepository == repository ->
+                                    pure (Right ())
                             _ ->
                                 pure
                                     (Left
@@ -755,6 +911,100 @@ parsePullRequestUrl repository output =
   where
     isControlOrSpace character = isSpace character
     isDigit character = character >= '0' && character <= '9'
+
+validRemoteUrl :: BS.ByteString -> Bool
+validRemoteUrl url =
+    not (BS.null url)
+        && BS.length url <= 4096
+        && BS.all (\byte -> byte >= 0x20 && byte /= 0x7f) url
+        && BS8.head url /= '-'
+        && (isAbsolute (BS8.unpack url)
+            || any (`BS8.isPrefixOf` url)
+                [ "https://"
+                , "ssh://"
+                , "git://"
+                , "file://"
+                ]
+            || validScpLike url)
+  where
+    validScpLike value =
+        case BS8.break (== ':') value of
+            (host, path) ->
+                not (BS.null host)
+                    && BS8.elem '@' host
+                    && BS.length path > 1
+
+remoteCommandPrefix :: ValidatedRemote -> [String]
+remoteCommandPrefix remote =
+    [ "-c"
+    , "url."
+        <> BS8.unpack remote.validatedRemoteUrl
+        <> ".insteadOf="
+        <> BS8.unpack remote.validatedRemoteUrl
+    ]
+
+githubRepositoryFromUrl :: BS.ByteString -> Maybe Text
+githubRepositoryFromUrl bytes
+    | not (BS.all (< 0x80) bytes) = Nothing
+    | otherwise =
+        let url = Text.pack (BS8.unpack bytes)
+        in parseHttps url
+            <|> parseSsh url
+            <|> parseScp url
+  where
+    parseHttps url =
+        Text.stripPrefix "https://github.com/" url >>= repositoryPath
+    parseSsh url =
+        (Text.stripPrefix "ssh://git@github.com/" url
+            <|> Text.stripPrefix "ssh://github.com/" url)
+            >>= repositoryPath
+    parseScp url =
+        Text.stripPrefix "git@github.com:" url >>= repositoryPath
+    repositoryPath path =
+        let withoutGit = fromMaybe path (Text.stripSuffix ".git" path)
+        in if validateRepositoryName withoutGit
+            then Just withoutGit
+            else Nothing
+
+remoteMatchesExpected :: DeliveryStatus -> Maybe Text -> Bool
+remoteMatchesExpected status =
+    (== expectedRemoteHead status)
+
+expectedRemoteHead :: DeliveryStatus -> Maybe Text
+expectedRemoteHead status
+    | Text.all (== '0') status.deliveryUpstreamOid = Nothing
+    | otherwise = Just status.deliveryUpstreamOid
+
+proveFastForward :: DeliveryStatus -> IO (Either DeliveryError ())
+proveFastForward status =
+    case expectedRemoteHead status of
+        Nothing -> pure (Right ())
+        Just expected ->
+            runGit
+                status.deliveryRoot
+                [ "merge-base"
+                , "--is-ancestor"
+                , Text.unpack expected
+                , Text.unpack status.deliveryHeadOid
+                ]
+                BS.empty
+                localTimeoutMicros >>= \case
+                    Right _ -> pure (Right ())
+                    Left _ ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "the push is not an exact fast-forward"))
+
+leaseArgument :: DeliveryStatus -> String
+leaseArgument status =
+    "--force-with-lease="
+        <> Text.unpack status.deliveryUpstreamRef
+        <> ":"
+        <> maybe
+            (Text.unpack (zeroObjectId status.deliveryHeadOid))
+            Text.unpack
+            (expectedRemoteHead status)
 
 validatePullRequestInput
     :: Text
@@ -837,6 +1087,9 @@ validateRepositoryName name =
 validObjectId :: Text -> Bool
 validObjectId oid =
     Text.length oid `elem` [40, 64] && Text.all isHexDigit oid
+
+zeroObjectId :: Text -> Text
+zeroObjectId oid = Text.replicate (Text.length oid) "0"
 
 parseAheadBehind :: BS.ByteString -> Maybe (Int, Int)
 parseAheadBehind bytes =

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -965,6 +965,10 @@ validRemoteUrl url =
                 not (BS.null host)
                     && BS8.elem '@' host
                     && BS.length path > 1
+                    -- A canonical SCP-like URL is `git@host:path`.
+                    -- Reject a second `@`, which denotes credentials in
+                    -- the authority and would be exposed in child argv.
+                    && not (BS8.elem '@' path)
                     && not (containsQueryOrFragment value)
 
 remoteCommandPrefix :: ValidatedRemote -> [String]
@@ -1395,12 +1399,34 @@ runCommand root executable arguments input timeoutMicros = do
                 withAsync (readBounded outputHandle) \outputReader ->
                     withAsync (readBounded errorHandle) \errorReader -> do
                         exitCode <- waitForProcess process
-                        -- Do not wait for pipe EOF before terminating residual
-                        -- descendants in the leader's dedicated group.
+                        inputFinished <- timeout processPipeTeardownMicros
+                            (wait inputWriter)
+                        case inputFinished of
+                            Just () -> pure ()
+                            Nothing -> do
+                                closeQuietly inputHandle
+                                cancel inputWriter
+                        let drainReaders =
+                                (,) <$> wait outputReader <*> wait errorReader
+                        -- Give ordinary buffered output a short chance to
+                        -- drain. The captured group is then terminated even
+                        -- when EOF already arrived: a descendant may close
+                        -- its pipes while continuing to run.
+                        naturallyDrained <- timeout
+                            processPipeTeardownMicros
+                            drainReaders
+                        terminateProcessGroup sigTERM processGroup process
+                        drainedAfterTerm <- case naturallyDrained of
+                            Just values -> pure (Just values)
+                            Nothing ->
+                                timeout processGroupTermGraceMicros drainReaders
+                        -- Always escalate the captured group so a descendant
+                        -- cannot outlive a successful leader.
                         terminateProcessGroup sigKILL processGroup process
-                        _ <- wait inputWriter
-                        drained <- timeout processPipeTeardownMicros
-                            ((,) <$> wait outputReader <*> wait errorReader)
+                        drained <- case drainedAfterTerm of
+                            Just values -> pure (Just values)
+                            Nothing ->
+                                timeout processPipeTeardownMicros drainReaders
                         case drained of
                             Nothing -> do
                                 closeQuietly outputHandle
@@ -1579,6 +1605,9 @@ networkTimeoutMicros = 60 * 1_000_000
 
 processPipeTeardownMicros :: Int
 processPipeTeardownMicros = 1_000_000
+
+processGroupTermGraceMicros :: Int
+processGroupTermGraceMicros = 2_000_000
 
 maxProcessOutputBytes :: Int
 maxProcessOutputBytes = 1024 * 1024

--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -1,0 +1,1241 @@
+module Agent.CLI.RepositoryDelivery
+    ( DeliveryStatus(..)
+    , PushPreview(..)
+    , PullRequestPreview(..)
+    , DeliveryError(..)
+    , repositoryDeliveryStatus
+    , previewRepositoryPush
+    , confirmRepositoryPush
+    , previewPullRequest
+    , createPullRequest
+    , deliveryErrorText
+    , validateBranchName
+    , validateRemoteName
+    ) where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newMVar
+    )
+import Control.Exception.Safe
+    ( SomeException
+    , bracket
+    , finally
+    , isAsyncException
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (forever, unless, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Char (isAlphaNum, isHexDigit, isSpace)
+import Data.IORef
+    ( modifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Text.Encoding.Error (lenientDecode)
+import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
+import Data.Word (Word8)
+import System.Exit (ExitCode(..))
+import System.Environment (getEnvironment)
+import System.IO
+    ( Handle
+    , IOMode(ReadMode)
+    , hClose
+    , openBinaryFile
+    )
+import System.IO.Unsafe (unsafePerformIO)
+import System.Posix.Signals
+    ( Signal
+    , sigKILL
+    , sigTERM
+    , signalProcessGroup
+    )
+import System.Process
+    ( CreateProcess(..)
+    , ProcessHandle
+    , StdStream(CreatePipe)
+    , createProcess
+    , getPid
+    , getProcessExitCode
+    , proc
+    , terminateProcess
+    , waitForProcess
+    )
+import System.Timeout (timeout)
+
+import Agent.CLI.RepositoryReview
+    ( RepositorySnapshot(..)
+    , repositorySnapshot
+    )
+
+data DeliveryStatus = DeliveryStatus
+    { deliverySnapshotId :: !Text
+    , deliveryRoot :: !FilePath
+    , deliveryHeadOid :: !Text
+    , deliveryBranch :: !Text
+    , deliveryRemote :: !Text
+    , deliveryRemoteFingerprint :: !Text
+    , deliveryUpstreamRef :: !Text
+    , deliveryUpstreamOid :: !Text
+    , deliveryAhead :: !Int
+    , deliveryBehind :: !Int
+    } deriving (Eq, Show)
+
+data PushPreview = PushPreview
+    { pushPreviewStatus :: !DeliveryStatus
+    , pushPreviewConfirmation :: !Text
+    , pushPreviewExpiresAt :: !POSIXTime
+    } deriving (Eq, Show)
+
+data PullRequestPreview = PullRequestPreview
+    { pullRequestRepository :: !Text
+    , pullRequestBaseRef :: !Text
+    , pullRequestHeadRef :: !Text
+    , pullRequestTitle :: !Text
+    , pullRequestConfirmation :: !Text
+    , pullRequestExpiresAt :: !POSIXTime
+    } deriving (Eq, Show)
+
+data DeliveryError
+    = DeliveryInvalidRequest !Text
+    | DeliveryStale !Text
+    | DeliveryUnavailable !Text
+    | DeliveryCommandFailed !Text
+    | DeliveryConfirmationRejected !Text
+    deriving (Eq, Show)
+
+data Confirmation
+    = PushConfirmation !DeliveryStatus
+    | PullRequestConfirmation
+        !DeliveryStatus
+        !Text -- repository
+        !Text -- base
+        !Text -- title
+        !Text -- body
+    deriving (Eq)
+
+data StoredConfirmation = StoredConfirmation
+    { storedRoot :: !FilePath
+    , storedExpiresAt :: !POSIXTime
+    , storedConfirmation :: !Confirmation
+    }
+
+data ProcessResult = ProcessResult
+    { processExitCode :: !ExitCode
+    , processStdout :: !BS.ByteString
+    , processStderr :: !BS.ByteString
+    , processOutputTruncated :: !Bool
+    }
+
+data ProcessFailure
+    = ProcessLaunchFailed
+    | ProcessTimedOut
+    | ProcessOutputExceeded
+    deriving (Eq, Show)
+
+repositoryDeliveryStatus
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError DeliveryStatus)
+repositoryDeliveryStatus requested expected =
+    timeout localTimeoutMicros (repositorySnapshot requested) >>= \case
+        Nothing ->
+            pure
+                (Left
+                    (DeliveryCommandFailed
+                        "repository snapshot verification timed out"))
+        Just (Left _) ->
+            pure
+                (Left
+                    (DeliveryCommandFailed
+                        "repository state could not be verified"))
+        Just (Right snapshot)
+            | snapshot.snapshotId /= expected ->
+                pure
+                    (Left
+                        (DeliveryStale
+                            "repository state changed"))
+            | otherwise -> statusAtSnapshot snapshot
+
+previewRepositoryPush
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError PushPreview)
+previewRepositoryPush requested expected =
+    repositoryDeliveryStatus requested expected >>= \case
+        Left err -> pure (Left err)
+        Right status -> do
+            remoteHead <- queryRemoteHead status
+            case remoteHead of
+                Left err -> pure (Left err)
+                Right oid
+                    | oid /= status.deliveryUpstreamOid ->
+                        pure
+                            (Left
+                                (DeliveryStale
+                                    "the remote branch changed; fetch before previewing a push"))
+                    | status.deliveryAhead <= 0 ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "the branch has no commits to push"))
+                    | status.deliveryBehind /= 0 ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "the branch is behind its upstream"))
+                    | otherwise -> do
+                        dryRun <- runGit
+                            status.deliveryRoot
+                            [ "push"
+                            , "--porcelain"
+                            , "--dry-run"
+                            , "--no-verify"
+                            , "--"
+                            , Text.unpack status.deliveryRemote
+                            , pushRefspec status
+                            ]
+                            BS.empty
+                            networkTimeoutMicros
+                        case dryRun of
+                            Left err -> pure (Left err)
+                            Right _ -> do
+                                (token, expiresAt) <-
+                                    storeConfirmation
+                                        status.deliveryRoot
+                                        (PushConfirmation status)
+                                pure
+                                    (Right
+                                        PushPreview
+                                            { pushPreviewStatus = status
+                                            , pushPreviewConfirmation = token
+                                            , pushPreviewExpiresAt = expiresAt
+                                            })
+
+confirmRepositoryPush
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError DeliveryStatus)
+confirmRepositoryPush requested token =
+    consumeConfirmation requested token >>= \case
+        Left err -> pure (Left err)
+        Right (PushConfirmation previewed) ->
+            repositoryDeliveryStatus
+                requested
+                previewed.deliverySnapshotId >>= \case
+                    Left err -> pure (Left err)
+                    Right current
+                        | current /= previewed ->
+                            pure
+                                (Left
+                                    (DeliveryStale
+                                        "branch or upstream state changed after push preview"))
+                        | otherwise ->
+                            queryRemoteHead current >>= \case
+                                Left err -> pure (Left err)
+                                Right remoteOid
+                                    | remoteOid /= current.deliveryUpstreamOid ->
+                                        pure
+                                            (Left
+                                                (DeliveryStale
+                                                    "the remote branch changed after push preview"))
+                                    | otherwise ->
+                                        runGit
+                                            current.deliveryRoot
+                                            [ "push"
+                                            , "--porcelain"
+                                            , "--no-verify"
+                                            , "--"
+                                            , Text.unpack current.deliveryRemote
+                                            , pushRefspec current
+                                            ]
+                                            BS.empty
+                                            networkTimeoutMicros >>= \case
+                                                Left err -> pure (Left err)
+                                                Right _ ->
+                                                    refreshPushedStatus current
+        Right _ ->
+            pure
+                (Left
+                    (DeliveryConfirmationRejected
+                        "confirmation token is for a different operation"))
+
+previewPullRequest
+    :: FilePath
+    -> Text
+    -> Text
+    -> Text
+    -> Text
+    -> IO (Either DeliveryError PullRequestPreview)
+previewPullRequest requested expected base title body
+    | Left err <- validatePullRequestInput base title body =
+        pure (Left err)
+    | otherwise =
+        repositoryDeliveryStatus requested expected >>= \case
+            Left err -> pure (Left err)
+            Right status
+                | status.deliveryAhead /= 0 || status.deliveryBehind /= 0 ->
+                    pure
+                        (Left
+                            (DeliveryInvalidRequest
+                                "push the exact branch state before previewing a pull request"))
+                | otherwise ->
+                    queryRemoteHead status >>= \case
+                        Left err -> pure (Left err)
+                        Right remoteOid
+                            | remoteOid /= status.deliveryHeadOid ->
+                                pure
+                                    (Left
+                                        (DeliveryStale
+                                            "the pushed remote branch does not match HEAD"))
+                            | otherwise ->
+                                requireGitHubCli status.deliveryRoot >>= \case
+                                    Left err -> pure (Left err)
+                                    Right repository ->
+                                        ensureBaseAndNoOpenPullRequest
+                                            status repository base >>= \case
+                                                Left err -> pure (Left err)
+                                                Right () -> do
+                                                    (token, expiresAt) <-
+                                                        storeConfirmation
+                                                            status.deliveryRoot
+                                                            (PullRequestConfirmation
+                                                                status repository
+                                                                base title body)
+                                                    pure
+                                                        (Right
+                                                            PullRequestPreview
+                                                                { pullRequestRepository =
+                                                                    repository
+                                                                , pullRequestBaseRef = base
+                                                                , pullRequestHeadRef =
+                                                                    status.deliveryBranch
+                                                                , pullRequestTitle = title
+                                                                , pullRequestConfirmation =
+                                                                    token
+                                                                , pullRequestExpiresAt =
+                                                                    expiresAt
+                                                                })
+
+createPullRequest
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError Text)
+createPullRequest requested token =
+    consumeConfirmation requested token >>= \case
+        Left err -> pure (Left err)
+        Right
+            (PullRequestConfirmation
+                previewed repository base title body) ->
+                    repositoryDeliveryStatus
+                        requested
+                        previewed.deliverySnapshotId >>= \case
+                            Left err -> pure (Left err)
+                            Right current
+                                | current /= previewed ->
+                                    pure
+                                        (Left
+                                            (DeliveryStale
+                                                "branch or upstream state changed after pull-request preview"))
+                                | otherwise ->
+                                    queryRemoteHead current >>= \case
+                                        Left err -> pure (Left err)
+                                        Right remoteOid
+                                            | remoteOid
+                                                /= current.deliveryHeadOid ->
+                                                    pure
+                                                        (Left
+                                                            (DeliveryStale
+                                                                "the pushed remote branch changed after preview"))
+                                            | otherwise ->
+                                                requireGitHubCli
+                                                    current.deliveryRoot >>= \case
+                                                        Left err -> pure (Left err)
+                                                        Right currentRepository
+                                                            | currentRepository
+                                                                /= repository ->
+                                                                    pure
+                                                                        (Left
+                                                                            (DeliveryStale
+                                                                                "the GitHub repository changed after preview"))
+                                                            | otherwise ->
+                                                                ensureBaseAndNoOpenPullRequest
+                                                                    current
+                                                                    repository
+                                                                    base >>= \case
+                                                                        Left err ->
+                                                                            pure (Left err)
+                                                                        Right () ->
+                                                                            runGh
+                                                                                current.deliveryRoot
+                                                                                [ "pr"
+                                                                                , "create"
+                                                                                , "--repo"
+                                                                                , Text.unpack repository
+                                                                                , "--base"
+                                                                                , Text.unpack base
+                                                                                , "--head"
+                                                                                , Text.unpack current.deliveryBranch
+                                                                                , "--title"
+                                                                                , Text.unpack title
+                                                                                , "--body-file"
+                                                                                , "-"
+                                                                                ]
+                                                                                (TextEncoding.encodeUtf8 body)
+                                                                                networkTimeoutMicros >>= \case
+                                                                                    Left err ->
+                                                                                        pure (Left err)
+                                                                                    Right output ->
+                                                                                        pure
+                                                                                            (parsePullRequestUrl
+                                                                                                repository
+                                                                                                output)
+        Right _ ->
+            pure
+                (Left
+                    (DeliveryConfirmationRejected
+                        "confirmation token is for a different operation"))
+
+statusAtSnapshot
+    :: RepositorySnapshot
+    -> IO (Either DeliveryError DeliveryStatus)
+statusAtSnapshot snapshot =
+    case snapshot.snapshotHead of
+        Nothing ->
+            pure
+                (Left
+                    (DeliveryInvalidRequest
+                        "delivery requires a branch with at least one commit"))
+        Just headOid ->
+            runGit root ["symbolic-ref", "--quiet", "HEAD"] BS.empty
+                localTimeoutMicros >>= \case
+                    Left _ ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "delivery requires a named local branch"))
+                    Right branchBytes ->
+                        let fullBranch = decodeTrimmed branchBytes
+                        in case Text.stripPrefix "refs/heads/" fullBranch of
+                            Nothing ->
+                                pure
+                                    (Left
+                                        (DeliveryInvalidRequest
+                                            "Git returned an invalid local branch"))
+                            Just branch
+                                | not (validateBranchName branch) ->
+                                    pure
+                                        (Left
+                                            (DeliveryInvalidRequest
+                                                "local branch name is not safe for delivery"))
+                                | otherwise ->
+                                    readUpstream root fullBranch >>= \case
+                                        Left err -> pure (Left err)
+                                        Right (remote, upstreamRef) ->
+                                            readUpstreamStatus
+                                                root headOid branch remote upstreamRef
+  where
+    root = snapshot.snapshotRoot
+    readUpstreamStatus root headOid branch remote upstreamRef =
+        runGit root ["rev-parse", "--verify", "@{upstream}"] BS.empty
+            localTimeoutMicros >>= \case
+                Left _ ->
+                    pure
+                        (Left
+                            (DeliveryInvalidRequest
+                                "the branch upstream is unavailable"))
+                Right upstreamBytes ->
+                    let upstreamOid = decodeTrimmed upstreamBytes
+                    in runGit
+                        root
+                        [ "rev-list"
+                        , "--left-right"
+                        , "--count"
+                        , "HEAD...@{upstream}"
+                        ]
+                        BS.empty
+                        localTimeoutMicros >>= \case
+                            Left err -> pure (Left err)
+                            Right counts ->
+                                case parseAheadBehind counts of
+                                    Nothing ->
+                                        pure
+                                            (Left
+                                                (DeliveryCommandFailed
+                                                    "Git returned invalid ahead/behind counts"))
+                                    Just (ahead, behind) ->
+                                        readRemoteFingerprint
+                                            root remote >>= \case
+                                                Left err -> pure (Left err)
+                                                Right remoteFingerprint ->
+                                                    pure
+                                                        (Right
+                                                            DeliveryStatus
+                                                                { deliverySnapshotId =
+                                                                    snapshot.snapshotId
+                                                                , deliveryRoot = root
+                                                                , deliveryHeadOid = headOid
+                                                                , deliveryBranch = branch
+                                                                , deliveryRemote = remote
+                                                                , deliveryRemoteFingerprint =
+                                                                    remoteFingerprint
+                                                                , deliveryUpstreamRef =
+                                                                    upstreamRef
+                                                                , deliveryUpstreamOid =
+                                                                    upstreamOid
+                                                                , deliveryAhead = ahead
+                                                                , deliveryBehind = behind
+                                                                })
+
+readUpstream
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError (Text, Text))
+readUpstream root fullBranch =
+    runGit
+        root
+        [ "for-each-ref"
+        , "--format=%(upstream:remotename)%00%(upstream:remoteref)"
+        , "--count=1"
+        , Text.unpack fullBranch
+        ]
+        BS.empty
+        localTimeoutMicros >>= \case
+            Left err -> pure (Left err)
+            Right output ->
+                case BS.split 0 (stripLineEnding output) of
+                    [remoteBytes, refBytes] ->
+                        let remote = decodeTrimmed remoteBytes
+                            upstreamRef = decodeTrimmed refBytes
+                        in if validateRemoteName remote
+                            && validateFullBranchRef upstreamRef
+                            then pure (Right (remote, upstreamRef))
+                            else
+                                pure
+                                    (Left
+                                        (DeliveryInvalidRequest
+                                            "the branch has no safe push upstream"))
+                    _ ->
+                        pure
+                            (Left
+                                (DeliveryInvalidRequest
+                                    "the branch has no configured upstream"))
+
+readRemoteFingerprint
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError Text)
+readRemoteFingerprint root remote =
+    readUrls False >>= \case
+        Left _ -> invalid
+        Right [fetchUrl] ->
+            readUrls True >>= \case
+                Right [pushUrl]
+                    | fetchUrl == pushUrl ->
+                        fmap decodeTrimmed
+                            <$> runGit
+                                root
+                                ["hash-object", "--stdin"]
+                                pushUrl
+                                localTimeoutMicros
+                _ -> invalid
+        _ -> invalid
+  where
+    readUrls push =
+        runGit
+            root
+            ( [ "remote"
+              , "get-url"
+              ]
+                <> (if push then ["--push"] else [])
+                <> [ "--all"
+                   , Text.unpack remote
+                   ]
+            )
+            BS.empty
+            localTimeoutMicros >>= \case
+                Left _ -> pure (Left ())
+                Right bytes ->
+                    pure
+                        (Right
+                            [ url
+                            | url <- map stripLineEnding (BS8.lines bytes)
+                            , not (BS.null url)
+                            , not (BS.elem 0 url)
+                            ])
+    invalid =
+        pure
+            (Left
+                (DeliveryInvalidRequest
+                    "delivery requires one identical fetch and push destination"))
+
+queryRemoteHead :: DeliveryStatus -> IO (Either DeliveryError Text)
+queryRemoteHead status =
+    runGit
+        status.deliveryRoot
+        [ "ls-remote"
+        , "--exit-code"
+        , "--heads"
+        , "--"
+        , Text.unpack status.deliveryRemote
+        , Text.unpack status.deliveryUpstreamRef
+        ]
+        BS.empty
+        networkTimeoutMicros >>= \case
+            Left _ ->
+                pure
+                    (Left
+                        (DeliveryUnavailable
+                            "could not verify the exact remote branch"))
+            Right output ->
+                case BS8.words output of
+                    [oidBytes, refBytes]
+                        | decodeTrimmed refBytes
+                            == status.deliveryUpstreamRef
+                            && validObjectId (decodeTrimmed oidBytes) ->
+                                pure (Right (decodeTrimmed oidBytes))
+                    _ ->
+                        pure
+                            (Left
+                                (DeliveryUnavailable
+                                    "the exact remote branch is unavailable"))
+
+refreshPushedStatus
+    :: DeliveryStatus
+    -> IO (Either DeliveryError DeliveryStatus)
+refreshPushedStatus pushed = do
+    -- A successful push does not necessarily update the local remote-tracking
+    -- ref. Bind the returned result to the immutable pushed OID instead of
+    -- pretending the tracking ref was refreshed.
+    remote <- queryRemoteHead
+        pushed
+            { deliveryUpstreamOid = pushed.deliveryHeadOid }
+    pure case remote of
+        Left err -> Left err
+        Right oid
+            | oid /= pushed.deliveryHeadOid ->
+                Left
+                    (DeliveryStale
+                        "remote verification did not match the pushed commit")
+            | otherwise ->
+                Right
+                    pushed
+                        { deliveryUpstreamOid = oid
+                        , deliveryAhead = 0
+                        , deliveryBehind = 0
+                        }
+
+ensureBaseAndNoOpenPullRequest
+    :: DeliveryStatus
+    -> Text
+    -> Text
+    -> IO (Either DeliveryError ())
+ensureBaseAndNoOpenPullRequest status repository base =
+    runGit
+        status.deliveryRoot
+        [ "ls-remote"
+        , "--exit-code"
+        , "--heads"
+        , "--"
+        , Text.unpack status.deliveryRemote
+        , "refs/heads/" <> Text.unpack base
+        ]
+        BS.empty
+        networkTimeoutMicros >>= \case
+            Left _ ->
+                pure
+                    (Left
+                        (DeliveryInvalidRequest
+                            "the pull-request base branch does not exist"))
+            Right _ ->
+                runGh
+                    status.deliveryRoot
+                    [ "pr"
+                    , "list"
+                    , "--repo"
+                    , Text.unpack repository
+                    , "--head"
+                    , Text.unpack status.deliveryBranch
+                    , "--state"
+                    , "open"
+                    , "--limit"
+                    , "1"
+                    , "--json"
+                    , "number"
+                    ]
+                    BS.empty
+                    networkTimeoutMicros >>= \case
+                        Left err -> pure (Left err)
+                        Right output ->
+                            case Aeson.decodeStrict' output
+                                    :: Maybe [Aeson.Value] of
+                                Just [] -> pure (Right ())
+                                Just _ ->
+                                    pure
+                                        (Left
+                                            (DeliveryInvalidRequest
+                                                "an open pull request already exists for this branch"))
+                                Nothing ->
+                                    pure
+                                        (Left
+                                            (DeliveryCommandFailed
+                                                "GitHub CLI returned an invalid pull-request response"))
+
+requireGitHubCli :: FilePath -> IO (Either DeliveryError Text)
+requireGitHubCli root =
+    runGh root ["auth", "status"] BS.empty localTimeoutMicros >>= \case
+        Left _ ->
+            pure
+                (Left
+                    (DeliveryUnavailable
+                        "GitHub CLI is unavailable or not authenticated"))
+        Right _ ->
+            runGh
+                root
+                ["repo", "view", "--json", "nameWithOwner"]
+                BS.empty
+                networkTimeoutMicros >>= \case
+                    Left _ ->
+                        pure
+                            (Left
+                                (DeliveryUnavailable
+                                    "GitHub repository identity is unavailable"))
+                    Right output ->
+                        case Aeson.decodeStrict' output of
+                            Just (RepositoryIdentity repository)
+                                | validateRepositoryName repository ->
+                                    pure (Right repository)
+                            _ ->
+                                pure
+                                    (Left
+                                        (DeliveryUnavailable
+                                            "GitHub CLI returned an invalid repository identity"))
+
+newtype RepositoryIdentity = RepositoryIdentity Text
+
+instance Aeson.FromJSON RepositoryIdentity where
+    parseJSON = Aeson.withObject "RepositoryIdentity" \object ->
+        RepositoryIdentity <$> object Aeson..: "nameWithOwner"
+
+parsePullRequestUrl :: Text -> BS.ByteString -> Either DeliveryError Text
+parsePullRequestUrl repository output =
+    case filter (not . Text.null)
+        (map Text.strip
+            (Text.lines
+                (TextEncoding.decodeUtf8With lenientDecode output))) of
+        [url]
+            | Text.length url <= 4096
+                && let prefix =
+                        "https://github.com/"
+                            <> repository
+                            <> "/pull/"
+                   in prefix `Text.isPrefixOf` url
+                        && Text.all isDigit
+                            (Text.drop (Text.length prefix) url)
+                        && Text.length url > Text.length prefix
+                && not (Text.any isControlOrSpace url) ->
+                    Right url
+        _ ->
+            Left
+                (DeliveryCommandFailed
+                    "GitHub CLI did not return one valid pull-request URL")
+  where
+    isControlOrSpace character = isSpace character
+    isDigit character = character >= '0' && character <= '9'
+
+validatePullRequestInput
+    :: Text
+    -> Text
+    -> Text
+    -> Either DeliveryError ()
+validatePullRequestInput base title body
+    | not (validateBranchName base) =
+        Left (DeliveryInvalidRequest "pull-request base branch is invalid")
+    | Text.null (Text.strip title) || Text.length title > 512 =
+        Left (DeliveryInvalidRequest "pull-request title is invalid")
+    | Text.any (== '\NUL') title =
+        Left (DeliveryInvalidRequest "pull-request title contains a NUL byte")
+    | Text.length body > 1024 * 1024 =
+        Left (DeliveryInvalidRequest "pull-request body exceeds 1 MiB")
+    | Text.any (== '\NUL') body =
+        Left (DeliveryInvalidRequest "pull-request body contains a NUL byte")
+    | otherwise = Right ()
+
+validateBranchName :: Text -> Bool
+validateBranchName branch =
+    validateFullBranchRef ("refs/heads/" <> branch)
+
+validateFullBranchRef :: Text -> Bool
+validateFullBranchRef ref =
+    not (Text.null ref)
+        && Text.length ref <= 1024
+        && "refs/heads/" `Text.isPrefixOf` ref
+        && not ("/" `Text.isSuffixOf` ref)
+        && not ("." `Text.isSuffixOf` ref)
+        && not ("." `Text.isPrefixOf` ref)
+        && not ("-" `Text.isPrefixOf` Text.drop (Text.length "refs/heads/") ref)
+        && not (".." `Text.isInfixOf` ref)
+        && not ("@{" `Text.isInfixOf` ref)
+        && not ("//" `Text.isInfixOf` ref)
+        && Text.all safeRefCharacter ref
+        && all validComponent (Text.splitOn "/" ref)
+  where
+    safeRefCharacter character =
+        not (isSpace character)
+            && character >= '\x20'
+            && character /= '\x7f'
+            && character `notElem` ("~^:?*[\\" :: String)
+    validComponent component =
+        not (Text.null component)
+            && not ("." `Text.isPrefixOf` component)
+            && component /= "."
+            && component /= ".."
+            && not (".lock" `Text.isSuffixOf` component)
+
+validateRemoteName :: Text -> Bool
+validateRemoteName remote =
+    not (Text.null remote)
+        && Text.length remote <= 255
+        && Text.head remote /= '-'
+        && Text.all
+            (\character ->
+                isAlphaNum character
+                    || character `elem` ("._/-" :: String))
+            remote
+        && not (".." `Text.isInfixOf` remote)
+        && not ("//" `Text.isInfixOf` remote)
+
+validateRepositoryName :: Text -> Bool
+validateRepositoryName name =
+    case Text.splitOn "/" name of
+        [owner, repository] ->
+            validPart owner && validPart repository
+        _ -> False
+  where
+    validPart value =
+        not (Text.null value)
+            && Text.length value <= 100
+            && Text.all
+                (\character ->
+                    isAlphaNum character
+                        || character `elem` ("-._" :: String))
+                value
+
+validObjectId :: Text -> Bool
+validObjectId oid =
+    Text.length oid `elem` [40, 64] && Text.all isHexDigit oid
+
+parseAheadBehind :: BS.ByteString -> Maybe (Int, Int)
+parseAheadBehind bytes =
+    case map (reads . BS8.unpack) (BS8.words bytes) of
+        [[ (ahead, "") ], [ (behind, "") ]]
+            | ahead >= 0 && behind >= 0 -> Just (ahead, behind)
+        _ -> Nothing
+
+pushRefspec :: DeliveryStatus -> String
+pushRefspec status =
+    Text.unpack status.deliveryHeadOid
+        <> ":"
+        <> Text.unpack status.deliveryUpstreamRef
+
+storeConfirmation
+    :: FilePath
+    -> Confirmation
+    -> IO (Text, POSIXTime)
+storeConfirmation root confirmation = do
+    now <- getPOSIXTime
+    token <- randomToken
+    let expiresAt = now + confirmationLifetimeSeconds
+    stored <- modifyMVar deliveryConfirmations \confirmations ->
+        let active = Map.filter
+                (\entry -> entry.storedExpiresAt > now)
+                confirmations
+        in if Map.size active >= maxActiveConfirmations
+            || Map.member token active
+            then pure (active, False)
+            else
+                pure
+                    ( Map.insert
+                        token
+                        StoredConfirmation
+                            { storedRoot = root
+                            , storedExpiresAt = expiresAt
+                            , storedConfirmation = confirmation
+                            }
+                        active
+                    , True
+                    )
+    unless stored (fail "repository delivery confirmation capacity exhausted")
+    pure (token, expiresAt)
+
+consumeConfirmation
+    :: FilePath
+    -> Text
+    -> IO (Either DeliveryError Confirmation)
+consumeConfirmation requested token
+    | Text.length token /= 64 || not (Text.all isHexDigit token) =
+        pure
+            (Left
+                (DeliveryConfirmationRejected
+                    "confirmation token is invalid"))
+    | otherwise = do
+        snapshotResult <- timeout localTimeoutMicros
+            (repositorySnapshot requested)
+        case snapshotResult of
+            Nothing ->
+                pure
+                    (Left
+                        (DeliveryCommandFailed
+                            "repository snapshot verification timed out"))
+            Just (Left _) ->
+                pure
+                    (Left
+                        (DeliveryCommandFailed
+                            "repository state could not be verified"))
+            Just (Right snapshot) -> do
+                now <- getPOSIXTime
+                modifyMVar deliveryConfirmations \confirmations ->
+                    let pruned = Map.filter
+                            (\stored -> stored.storedExpiresAt > now)
+                            confirmations
+                    in case Map.lookup token pruned of
+                        Nothing ->
+                            pure
+                                ( pruned
+                                , Left
+                                    (DeliveryConfirmationRejected
+                                        "confirmation token expired or was already used")
+                                )
+                        Just stored ->
+                            let remaining = Map.delete token pruned
+                            in if stored.storedRoot /= snapshot.snapshotRoot
+                                then
+                                    pure
+                                        ( remaining
+                                        , Left
+                                            (DeliveryConfirmationRejected
+                                                "confirmation token belongs to another repository")
+                                        )
+                                else
+                                    pure
+                                        ( remaining
+                                        , Right stored.storedConfirmation
+                                        )
+
+randomToken :: IO Text
+randomToken =
+    bracket
+        (openBinaryFile "/dev/urandom" ReadMode)
+        hClose
+        (\handle -> do
+            bytes <- BS.hGet handle 32
+            unless (BS.length bytes == 32)
+                (fail "could not read confirmation entropy")
+            pure (hexEncode bytes))
+
+hexEncode :: BS.ByteString -> Text
+hexEncode = Text.pack . concatMap encodeByte . BS.unpack
+  where
+    alphabet = "0123456789abcdef"
+    encodeByte :: Word8 -> String
+    encodeByte byte =
+        [ alphabet !! fromIntegral (byte `div` 16)
+        , alphabet !! fromIntegral (byte `mod` 16)
+        ]
+
+runGit
+    :: FilePath
+    -> [String]
+    -> BS.ByteString
+    -> Int
+    -> IO (Either DeliveryError BS.ByteString)
+runGit root arguments input timeoutMicros =
+    runCommand root "git" arguments input timeoutMicros >>= \case
+        Left ProcessTimedOut ->
+            pure (Left (DeliveryCommandFailed "Git command timed out"))
+        Left ProcessOutputExceeded ->
+            pure (Left (DeliveryCommandFailed "Git command output exceeded its limit"))
+        Left ProcessLaunchFailed ->
+            pure (Left (DeliveryCommandFailed "Git command could not be started"))
+        Right result -> case result.processExitCode of
+            ExitSuccess
+                | result.processOutputTruncated ->
+                    pure
+                        (Left
+                            (DeliveryCommandFailed
+                                "Git command output exceeded its limit"))
+                | otherwise -> pure (Right result.processStdout)
+            ExitFailure code ->
+                pure
+                    (Left
+                        (DeliveryCommandFailed
+                            ("Git command failed with exit code "
+                                <> Text.pack (show code))))
+
+runGh
+    :: FilePath
+    -> [String]
+    -> BS.ByteString
+    -> Int
+    -> IO (Either DeliveryError BS.ByteString)
+runGh root arguments input timeoutMicros =
+    runCommand root "gh" arguments input timeoutMicros >>= \case
+        Left _ ->
+            pure
+                (Left
+                    (DeliveryUnavailable
+                        "GitHub CLI command was unavailable"))
+        Right result -> case result.processExitCode of
+            ExitSuccess
+                | result.processOutputTruncated ->
+                    pure
+                        (Left
+                            (DeliveryCommandFailed
+                                "GitHub CLI output exceeded its limit"))
+                | otherwise -> pure (Right result.processStdout)
+            ExitFailure _ ->
+                pure
+                    (Left
+                        (DeliveryUnavailable
+                            "GitHub CLI command failed"))
+
+runCommand
+    :: FilePath
+    -> FilePath
+    -> [String]
+    -> BS.ByteString
+    -> Int
+    -> IO (Either ProcessFailure ProcessResult)
+runCommand root executable arguments input timeoutMicros = do
+    launched <- trySynchronous
+        (bracket start stop \processData ->
+            timeout timeoutMicros (run processData))
+    pure case launched of
+        Left _ -> Left ProcessLaunchFailed
+        Right Nothing -> Left ProcessTimedOut
+        Right (Just result) -> result
+  where
+    start = do
+        environment <- nonInteractiveEnvironment executable
+        (maybeInput, maybeOutput, maybeError, process) <-
+            createProcess
+                (proc executable arguments)
+                    { cwd = Just root
+                    , std_in = CreatePipe
+                    , std_out = CreatePipe
+                    , std_err = CreatePipe
+                    , close_fds = True
+                    , create_group = True
+                    , env = Just environment
+                    }
+        case (maybeInput, maybeOutput, maybeError) of
+            (Just inputHandle, Just outputHandle, Just errorHandle) ->
+                pure (inputHandle, outputHandle, errorHandle, process)
+            _ -> do
+                terminateProcess process
+                _ <- waitForProcess process
+                fail "could not create command pipes"
+    stop (inputHandle, outputHandle, errorHandle, process) = do
+        closeQuietly inputHandle
+        closeQuietly outputHandle
+        closeQuietly errorHandle
+        getProcessExitCode process >>= \case
+            Just _ -> pure ()
+            Nothing -> do
+                terminateProcessGroup sigTERM process
+                threadDelay 100_000
+                getProcessExitCode process >>= \case
+                    Just _ -> pure ()
+                    Nothing -> terminateProcessGroup sigKILL process
+        _ <- tryAny (waitForProcess process)
+        pure ()
+    run (inputHandle, outputHandle, errorHandle, process) =
+        withAsync
+            (BS.hPut inputHandle input `finally` closeQuietly inputHandle)
+            \inputWriter ->
+                withAsync (readBounded outputHandle) \outputReader ->
+                    withAsync (readBounded errorHandle) \errorReader -> do
+                        exitCode <- waitForProcess process
+                        _ <- wait inputWriter
+                        (output, outputTruncated) <- wait outputReader
+                        (errors, errorsTruncated) <- wait errorReader
+                        let truncated = outputTruncated || errorsTruncated
+                        pure
+                            (if truncated
+                                then Left ProcessOutputExceeded
+                                else
+                                    Right
+                                        ProcessResult
+                                            { processExitCode = exitCode
+                                            , processStdout = output
+                                            , processStderr = errors
+                                            , processOutputTruncated = False
+                                            })
+
+readBounded :: Handle -> IO (BS.ByteString, Bool)
+readBounded handle = do
+    chunks <- newIORef []
+    retained <- newIORef 0
+    truncated <- newIORef False
+    let drain = do
+            chunk <- BS.hGetSome handle (64 * 1024)
+            unless (BS.null chunk) do
+                current <- readIORef retained
+                let room = max 0 (maxProcessOutputBytes - current)
+                    kept = BS.take room chunk
+                unless (BS.null kept) do
+                    modifyIORef' chunks (kept :)
+                    writeIORef retained (current + BS.length kept)
+                when (BS.length kept < BS.length chunk)
+                    (writeIORef truncated True)
+                drain
+    drain `finally` closeQuietly handle
+    bytes <- BS.concat . reverse <$> readIORef chunks
+    wasTruncated <- readIORef truncated
+    pure (bytes, wasTruncated)
+
+terminateProcessGroup
+    :: Signal
+    -> ProcessHandle
+    -> IO ()
+terminateProcessGroup signal process = do
+    pid <- getPid process
+    case pid of
+        Nothing -> do
+            _ <- tryAny (terminateProcess process)
+            pure ()
+        Just processId -> do
+            _ <- tryAny (signalProcessGroup signal processId)
+            pure ()
+
+stripLineEnding :: BS.ByteString -> BS.ByteString
+stripLineEnding = BS8.dropWhileEnd (`elem` ['\r', '\n'])
+
+decodeTrimmed :: BS.ByteString -> Text
+decodeTrimmed =
+    Text.strip . TextEncoding.decodeUtf8With lenientDecode
+
+closeQuietly :: Handle -> IO ()
+closeQuietly handle = do
+    _ <- tryAny (hClose handle)
+    pure ()
+
+nonInteractiveEnvironment :: FilePath -> IO [(String, String)]
+nonInteractiveEnvironment executable = do
+    inherited <- getEnvironment
+    let blocked =
+            [ "GIT_TERMINAL_PROMPT"
+            , "GCM_INTERACTIVE"
+            , "GH_PROMPT_DISABLED"
+            , "GH_REPO"
+            , "SSH_ASKPASS_REQUIRE"
+            , "GIT_DIR"
+            , "GIT_WORK_TREE"
+            , "GIT_INDEX_FILE"
+            , "GIT_OBJECT_DIRECTORY"
+            , "GIT_ALTERNATE_OBJECT_DIRECTORIES"
+            , "GIT_COMMON_DIR"
+            , "GIT_CONFIG_COUNT"
+            , "GIT_CONFIG_KEY_0"
+            , "GIT_CONFIG_VALUE_0"
+            , "GIT_CONFIG_PARAMETERS"
+            , "GIT_SSH_COMMAND"
+            , "GIT_ASKPASS"
+            , "GIT_PROXY_COMMAND"
+            , "GIT_EXEC_PATH"
+            ]
+        sanitized = filter
+            (\(name, _) ->
+                name `notElem` blocked
+                    && not ("GIT_CONFIG_KEY_" `prefixOf` name)
+                    && not ("GIT_CONFIG_VALUE_" `prefixOf` name))
+            inherited
+        retained
+            | executable == "git" =
+                filter (\(name, _) -> name `elem` gitEnvironmentAllowlist)
+                    sanitized
+            | otherwise = sanitized
+    pure
+        ( [ ("GIT_TERMINAL_PROMPT", "0")
+          , ("GCM_INTERACTIVE", "never")
+          , ("GH_PROMPT_DISABLED", "true")
+          , ("SSH_ASKPASS_REQUIRE", "never")
+          ]
+            <> retained
+        )
+  where
+    prefixOf prefix value = take (length prefix) value == prefix
+    gitEnvironmentAllowlist =
+        [ "PATH"
+        , "HOME"
+        , "TMPDIR"
+        , "TMP"
+        , "TEMP"
+        , "LANG"
+        , "LC_ALL"
+        , "LC_CTYPE"
+        , "USER"
+        , "LOGNAME"
+        , "SSH_AUTH_SOCK"
+        , "XDG_CONFIG_HOME"
+        , "XDG_CONFIG_DIRS"
+        , "SSL_CERT_FILE"
+        , "SSL_CERT_DIR"
+        , "NIX_SSL_CERT_FILE"
+        , "TERM"
+        ]
+
+deliveryErrorText :: DeliveryError -> Text
+deliveryErrorText = \case
+    DeliveryInvalidRequest message -> message
+    DeliveryStale message -> message
+    DeliveryUnavailable message -> message
+    DeliveryCommandFailed message -> message
+    DeliveryConfirmationRejected message -> message
+
+trySynchronous :: IO value -> IO (Either SomeException value)
+trySynchronous action =
+    tryAny action >>= \case
+        Left exception
+            | isAsyncException exception -> throwIO exception
+            | otherwise -> pure (Left exception)
+        Right value -> pure (Right value)
+
+confirmationLifetimeSeconds :: POSIXTime
+confirmationLifetimeSeconds = 10 * 60
+
+localTimeoutMicros :: Int
+localTimeoutMicros = 15 * 1_000_000
+
+networkTimeoutMicros :: Int
+networkTimeoutMicros = 60 * 1_000_000
+
+maxProcessOutputBytes :: Int
+maxProcessOutputBytes = 1024 * 1024
+
+maxActiveConfirmations :: Int
+maxActiveConfirmations = 1024
+
+{-# NOINLINE deliveryConfirmations #-}
+deliveryConfirmations :: MVar (Map Text StoredConfirmation)
+deliveryConfirmations = unsafePerformIO do
+    confirmations <- newMVar Map.empty
+    _ <- forkIO $ forever do
+        threadDelay 60_000_000
+        now <- getPOSIXTime
+        modifyMVar_ confirmations
+            (pure . Map.filter (\stored -> stored.storedExpiresAt > now))
+    pure confirmations

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -1,0 +1,386 @@
+module Agent.CLI.RepositoryDeliverySpec (spec) where
+
+import Agent.CLI.RepositoryDelivery
+import Agent.CLI.RepositoryReview
+    ( RepositorySnapshot(..)
+    , repositorySnapshot
+    )
+import Control.Exception.Safe (bracket)
+import qualified Data.Text as Text
+import System.Directory
+    ( createDirectory
+    , doesFileExist
+    , getTemporaryDirectory
+    , removePathForcibly
+    )
+import System.Environment (getEnv, lookupEnv, setEnv, unsetEnv)
+import System.Exit (ExitCode(..))
+import System.IO (hClose, openTempFile)
+import System.Posix.Files
+    ( ownerExecuteMode
+    , ownerReadMode
+    , ownerWriteMode
+    , setFileMode
+    , unionFileModes
+    )
+import System.Process
+    ( CreateProcess(..)
+    , proc
+    , readCreateProcessWithExitCode
+    )
+import Test.Hspec
+
+spec :: Spec
+spec = describe "repository delivery service" do
+    it "validates branch and remote names without option/ref injection" do
+        validateBranchName "feature/safe-name" `shouldBe` True
+        validateBranchName "-force" `shouldBe` False
+        validateBranchName "bad..name" `shouldBe` False
+        validateBranchName "bad name" `shouldBe` False
+        validateBranchName ".hidden" `shouldBe` False
+        validateBranchName "topic/.hidden" `shouldBe` False
+        validateBranchName "topic.lock" `shouldBe` False
+        validateRemoteName "origin" `shouldBe` True
+        validateRemoteName "-origin" `shouldBe` False
+        validateRemoteName "origin\n--upload-pack=evil" `shouldBe` False
+
+    it "previews and confirms one exact non-force push once" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+
+            snapshot <- expectRight =<< repositorySnapshot root
+            status <- expectRight
+                =<< repositoryDeliveryStatus root snapshot.snapshotId
+            status.deliveryBranch `shouldBe` "main"
+            status.deliveryRemote `shouldBe` "origin"
+            status.deliveryAhead `shouldBe` 1
+            status.deliveryBehind `shouldBe` 0
+
+            let hookMarker = root <> "/hook-ran"
+                hook = root <> "/.git/hooks/pre-push"
+            writeFile hook
+                ("#!/bin/sh\nprintf ran > " <> shellQuote hookMarker <> "\n")
+            setFileMode hook
+                (ownerReadMode
+                    `unionFileModes` ownerWriteMode
+                    `unionFileModes` ownerExecuteMode)
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            Text.length preview.pushPreviewConfirmation `shouldBe` 64
+            pushed <- expectRight
+                =<< confirmRepositoryPush
+                    root
+                    preview.pushPreviewConfirmation
+            remoteHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            remoteHead `shouldBe` pushed.deliveryHeadOid
+            doesFileExist hookMarker `shouldReturn` False
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isConfirmationRejection
+
+    it "consumes a preview without pushing when the local snapshot changes" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            remoteBefore <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+
+            writeFile (root <> "/untracked.txt") "changes exact snapshot\n"
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isStale
+            remoteAfter <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            remoteAfter `shouldBe` remoteBefore
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isConfirmationRejection
+
+    it "rejects an externally changed remote after preview without pushing" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            initial <- Text.strip <$> git root ["rev-parse", "HEAD^"]
+            tree <- Text.strip <$> git root ["rev-parse", "HEAD^{tree}"]
+            divergent <- Text.strip
+                <$> git root
+                    [ "commit-tree"
+                    , Text.unpack tree
+                    , "-p"
+                    , Text.unpack initial
+                    , "-m"
+                    , "remote advance"
+                    ]
+            _ <- git root
+                [ "push"
+                , "-q"
+                , remote
+                , Text.unpack divergent <> ":refs/heads/main"
+                ]
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isStale
+            remoteHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            remoteHead `shouldBe` divergent
+
+    it "rejects a remote rewind observed after preview" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            _ <- git root ["push", "-q", "origin", "main"]
+            appendFile (root <> "/tracked.txt") "third\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "third"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            rewound <- Text.strip <$> git root ["rev-parse", "HEAD^^"]
+            _ <- git root
+                [ "--git-dir"
+                , remote
+                , "update-ref"
+                , "refs/heads/main"
+                , Text.unpack rewound
+                ]
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isStale
+            remoteHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            remoteHead `shouldBe` rewound
+
+    it "binds confirmation to the upstream push destination" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            let redirected = remote <> "-redirected"
+            _ <- git root ["init", "-q", "--bare", redirected]
+            _ <- git root ["remote", "set-url", "--push", "origin", redirected]
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isInvalid
+            originalHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            originalHead `shouldBe` preview.pushPreviewStatus.deliveryUpstreamOid
+
+    it "rejects malformed PR inputs before invoking GitHub CLI" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            previewPullRequest
+                root snapshot.snapshotId "-bad" "title" "body"
+                `shouldReturnSatisfying` isInvalid
+            previewPullRequest
+                root snapshot.snapshotId "main" "" "body"
+                `shouldReturnSatisfying` isInvalid
+            previewPullRequest
+                root snapshot.snapshotId "main" "title"
+                (Text.replicate (1024 * 1024 + 1) "x")
+                `shouldReturnSatisfying` isInvalid
+
+    it "previews and creates a PR through argv-only gh with a one-shot token" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \bodyCapture injectionMarker -> do
+                snapshot <- expectRight =<< repositorySnapshot root
+                let title =
+                        "Safe title $(touch "
+                            <> Text.pack injectionMarker
+                            <> ")"
+                    body = "Body is passed on stdin, not argv."
+                preview <- expectRight
+                    =<< previewPullRequest
+                        root snapshot.snapshotId "main" title body
+                preview.pullRequestRepository `shouldBe` "owner/repository"
+                preview.pullRequestHeadRef `shouldBe` "main"
+                url <- expectRight
+                    =<< createPullRequest
+                        root
+                        preview.pullRequestConfirmation
+                url `shouldBe`
+                    "https://github.com/owner/repository/pull/123"
+                readFile bodyCapture `shouldReturn` Text.unpack body
+                doesFileExist injectionMarker `shouldReturn` False
+                createPullRequest root preview.pullRequestConfirmation
+                    `shouldReturnSatisfying` isConfirmationRejection
+
+    it "rejects a gh result URL for another repository" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \_ _ -> do
+                setEnv "GH_FAKE_PR_URL"
+                    "https://github.com/attacker/repository/pull/1"
+                snapshot <- expectRight =<< repositorySnapshot root
+                preview <- expectRight
+                    =<< previewPullRequest
+                        root snapshot.snapshotId "main" "Title" "Body"
+                createPullRequest root preview.pullRequestConfirmation
+                    `shouldReturnSatisfying` isCommandFailure
+
+withDeliveryRepository :: (FilePath -> FilePath -> IO value) -> IO value
+withDeliveryRepository action =
+    withTempDirectory "repository-delivery" \container -> do
+        let root = container <> "/checkout"
+            remote = container <> "/remote.git"
+        createDirectory root
+        _ <- git container ["init", "-q", "--bare", remote]
+        _ <- git root ["init", "-q", "-b", "main"]
+        _ <- git root ["config", "user.name", "Repository Delivery Test"]
+        _ <- git root ["config", "user.email", "delivery@example.test"]
+        writeFile (root <> "/tracked.txt") "first\n"
+        _ <- git root ["add", "tracked.txt"]
+        _ <- git root ["commit", "-q", "-m", "initial"]
+        _ <- git root ["remote", "add", "origin", remote]
+        _ <- git root ["push", "-q", "-u", "origin", "main"]
+        action root remote
+
+withTempDirectory :: String -> (FilePath -> IO value) -> IO value
+withTempDirectory template action = do
+    base <- getTemporaryDirectory
+    bracket
+        (do
+            (path, handle) <- openTempFile base template
+            hClose handle
+            removePathForcibly path
+            createDirectory path
+            pure path)
+        removePathForcibly
+        action
+
+withFakeGh
+    :: FilePath
+    -> (FilePath -> FilePath -> IO value)
+    -> IO value
+withFakeGh root action = do
+    originalPath <- getEnv "PATH"
+    originalCapture <- lookupEnv "GH_BODY_CAPTURE"
+    originalFakeUrl <- lookupEnv "GH_FAKE_PR_URL"
+    withTempDirectory "repository-delivery-gh" \bin -> do
+        let executable = bin <> "/gh"
+            bodyCapture = bin <> "/body.txt"
+            injectionMarker = root <> "/shell-injection"
+        writeFile executable $ unlines
+            [ "#!/bin/sh"
+            , "set -eu"
+            , "case \"$1 $2\" in"
+            , "  'auth status') exit 0 ;;"
+            , "  'repo view') printf '%s\\n' '{\"nameWithOwner\":\"owner/repository\"}' ;;"
+            , "  'pr list') printf '%s\\n' '[]' ;;"
+            , "  'pr create')"
+            , "    cat > \"$GH_BODY_CAPTURE\""
+            , "    printf '%s\\n' \"${GH_FAKE_PR_URL:-https://github.com/owner/repository/pull/123}\""
+            , "    ;;"
+            , "  *) exit 64 ;;"
+            , "esac"
+            ]
+        setFileMode executable
+            (ownerReadMode
+                `unionFileModes` ownerWriteMode
+                `unionFileModes` ownerExecuteMode)
+        bracket
+            (do
+                setEnv "PATH" (bin <> ":" <> originalPath)
+                setEnv "GH_BODY_CAPTURE" bodyCapture)
+            (\_ -> do
+                setEnv "PATH" originalPath
+                case originalCapture of
+                    Nothing -> unsetEnv "GH_BODY_CAPTURE"
+                    Just value -> setEnv "GH_BODY_CAPTURE" value
+                case originalFakeUrl of
+                    Nothing -> unsetEnv "GH_FAKE_PR_URL"
+                    Just value -> setEnv "GH_FAKE_PR_URL" value)
+            (\_ -> action bodyCapture injectionMarker)
+
+git :: FilePath -> [String] -> IO Text.Text
+git root arguments = do
+    (exitCode, output, errors) <-
+        readCreateProcessWithExitCode
+            (proc "git" arguments) { cwd = Just root }
+            ""
+    case exitCode of
+        ExitSuccess -> pure (Text.pack output)
+        ExitFailure code ->
+            expectationFailure
+                ("git exited " <> show code <> ": " <> errors)
+                >> pure ""
+
+expectRight :: (HasCallStack, Show error) => Either error value -> IO value
+expectRight = \case
+    Left err -> expectationFailure (show err) >> fail "unreachable"
+    Right value -> pure value
+
+isInvalid :: Either DeliveryError value -> Bool
+isInvalid = \case
+    Left (DeliveryInvalidRequest _) -> True
+    _ -> False
+
+isCommandFailure :: Either DeliveryError value -> Bool
+isCommandFailure = \case
+    Left (DeliveryCommandFailed _) -> True
+    _ -> False
+
+isStale :: Either DeliveryError value -> Bool
+isStale = \case
+    Left (DeliveryStale _) -> True
+    _ -> False
+
+isConfirmationRejection :: Either DeliveryError value -> Bool
+isConfirmationRejection = \case
+    Left (DeliveryConfirmationRejected _) -> True
+    _ -> False
+
+shouldReturnSatisfying
+    :: (HasCallStack, Show value)
+    => IO value
+    -> (value -> Bool)
+    -> Expectation
+shouldReturnSatisfying action predicate =
+    action >>= (`shouldSatisfy` predicate)
+
+shellQuote :: String -> String
+shellQuote value = "'" <> concatMap escape value <> "'"
+  where
+    escape '\'' = "'\"'\"'"
+    escape character = [character]

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -10,6 +10,7 @@ import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
     , doesFileExist
+    , findExecutable
     , getTemporaryDirectory
     , removePathForcibly
     )
@@ -44,7 +45,7 @@ spec = describe "repository delivery service" do
         validateRemoteName "-origin" `shouldBe` False
         validateRemoteName "origin\n--upload-pack=evil" `shouldBe` False
 
-    it "previews and confirms one exact non-force push once" $
+    it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"
             _ <- git root ["add", "tracked.txt"]
@@ -85,6 +86,30 @@ spec = describe "repository delivery service" do
 
             confirmRepositoryPush root preview.pushPreviewConfirmation
                 `shouldReturnSatisfying` isConfirmationRejection
+
+    it "creates an unborn configured upstream using an exact nonexistence lease" $
+        withDeliveryRepository \root remote -> do
+            _ <- git root ["switch", "-q", "-c", "new-branch"]
+            _ <- git root ["config", "branch.new-branch.remote", "origin"]
+            _ <- git root
+                [ "config"
+                , "branch.new-branch.merge"
+                , "refs/heads/new-branch"
+                ]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            pushed <- expectRight
+                =<< confirmRepositoryPush
+                    root preview.pushPreviewConfirmation
+            remoteHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/new-branch"
+                    ]
+            remoteHead `shouldBe` pushed.deliveryHeadOid
 
     it "consumes a preview without pushing when the local snapshot changes" $
         withDeliveryRepository \root remote -> do
@@ -195,10 +220,37 @@ spec = describe "repository delivery service" do
                 =<< previewRepositoryPush root snapshot.snapshotId
             let redirected = remote <> "-redirected"
             _ <- git root ["init", "-q", "--bare", redirected]
-            _ <- git root ["remote", "set-url", "--push", "origin", redirected]
+            _ <- git root ["remote", "set-url", "origin", redirected]
 
             confirmRepositoryPush root preview.pushPreviewConfirmation
-                `shouldReturnSatisfying` isInvalid
+                `shouldReturnSatisfying` isStale
+            originalHead <- Text.strip
+                <$> git root
+                    [ "--git-dir"
+                    , remote
+                    , "rev-parse"
+                    , "refs/heads/main"
+                    ]
+            originalHead `shouldBe` preview.pushPreviewStatus.deliveryUpstreamOid
+
+    it "rejects an insteadOf config retarget after preview" $
+        withDeliveryRepository \root remote -> do
+            appendFile (root <> "/tracked.txt") "second\n"
+            _ <- git root ["add", "tracked.txt"]
+            _ <- git root ["commit", "-q", "-m", "second"]
+            snapshot <- expectRight =<< repositorySnapshot root
+            preview <- expectRight
+                =<< previewRepositoryPush root snapshot.snapshotId
+            let redirected = remote <> "-config-redirected"
+            _ <- git root ["init", "-q", "--bare", redirected]
+            _ <- git root
+                [ "config"
+                , "url." <> redirected <> ".insteadOf"
+                , remote
+                ]
+
+            confirmRepositoryPush root preview.pushPreviewConfirmation
+                `shouldReturnSatisfying` isStale
             originalHead <- Text.strip
                 <$> git root
                     [ "--git-dir"
@@ -259,6 +311,15 @@ spec = describe "repository delivery service" do
                 createPullRequest root preview.pullRequestConfirmation
                     `shouldReturnSatisfying` isCommandFailure
 
+    it "rejects gh repository identity that differs from the bound remote" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \_ _ -> do
+                setEnv "GH_FAKE_REPOSITORY" "attacker/repository"
+                snapshot <- expectRight =<< repositorySnapshot root
+                previewPullRequest
+                    root snapshot.snapshotId "main" "Title" "Body"
+                    `shouldReturnSatisfying` isUnavailable
+
 withDeliveryRepository :: (FilePath -> FilePath -> IO value) -> IO value
 withDeliveryRepository action =
     withTempDirectory "repository-delivery" \container -> do
@@ -297,16 +358,40 @@ withFakeGh root action = do
     originalPath <- getEnv "PATH"
     originalCapture <- lookupEnv "GH_BODY_CAPTURE"
     originalFakeUrl <- lookupEnv "GH_FAKE_PR_URL"
+    originalFakeRepository <- lookupEnv "GH_FAKE_REPOSITORY"
     withTempDirectory "repository-delivery-gh" \bin -> do
-        let executable = bin <> "/gh"
+        realGit <- maybe (fail "git not found") pure =<< findExecutable "git"
+        localRemote <- Text.unpack . Text.strip
+            <$> git root ["remote", "get-url", "origin"]
+        let githubRemote = "https://github.com/owner/repository.git"
+            executable = bin <> "/gh"
+            gitExecutable = bin <> "/git"
             bodyCapture = bin <> "/body.txt"
             injectionMarker = root <> "/shell-injection"
+        _ <- git root ["remote", "set-url", "origin", githubRemote]
+        writeFile gitExecutable $ unlines
+            [ "#!/bin/bash"
+            , "set -eu"
+            , "args=()"
+            , "for arg in \"$@\"; do"
+            , "  if [[ \"$arg\" == " <> shellQuote githubRemote <> " ]]; then"
+            , "    args+=(" <> shellQuote localRemote <> ")"
+            , "  else"
+            , "    args+=(\"$arg\")"
+            , "  fi"
+            , "done"
+            , "exec " <> shellQuote realGit <> " \"${args[@]}\""
+            ]
+        setFileMode gitExecutable
+            (ownerReadMode
+                `unionFileModes` ownerWriteMode
+                `unionFileModes` ownerExecuteMode)
         writeFile executable $ unlines
             [ "#!/bin/sh"
             , "set -eu"
             , "case \"$1 $2\" in"
             , "  'auth status') exit 0 ;;"
-            , "  'repo view') printf '%s\\n' '{\"nameWithOwner\":\"owner/repository\"}' ;;"
+            , "  'repo view') printf '{\"nameWithOwner\":\"%s\"}\\n' \"${GH_FAKE_REPOSITORY:-owner/repository}\" ;;"
             , "  'pr list') printf '%s\\n' '[]' ;;"
             , "  'pr create')"
             , "    cat > \"$GH_BODY_CAPTURE\""
@@ -330,7 +415,10 @@ withFakeGh root action = do
                     Just value -> setEnv "GH_BODY_CAPTURE" value
                 case originalFakeUrl of
                     Nothing -> unsetEnv "GH_FAKE_PR_URL"
-                    Just value -> setEnv "GH_FAKE_PR_URL" value)
+                    Just value -> setEnv "GH_FAKE_PR_URL" value
+                case originalFakeRepository of
+                    Nothing -> unsetEnv "GH_FAKE_REPOSITORY"
+                    Just value -> setEnv "GH_FAKE_REPOSITORY" value)
             (\_ -> action bodyCapture injectionMarker)
 
 git :: FilePath -> [String] -> IO Text.Text
@@ -354,6 +442,11 @@ expectRight = \case
 isInvalid :: Either DeliveryError value -> Bool
 isInvalid = \case
     Left (DeliveryInvalidRequest _) -> True
+    _ -> False
+
+isUnavailable :: Either DeliveryError value -> Bool
+isUnavailable = \case
+    Left (DeliveryUnavailable _) -> True
     _ -> False
 
 isCommandFailure :: Either DeliveryError value -> Bool

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -90,6 +90,18 @@ spec = describe "repository delivery service" do
                             Text.isInfixOf (Text.pack credentialUrl)
                 Right _ -> expectationFailure "credential URL was accepted"
 
+    it "rejects credential-bearing SCP-like URLs" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "git@owner:secret@example.test/repository.git"
+                ]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+
     it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"
@@ -359,8 +371,8 @@ spec = describe "repository delivery service" do
     it "kills a gh descendant retaining pipes after its leader exits" $
         withDeliveryRepository \root _ ->
             withFakeGh root \_ _ -> do
-                let descendantMarker = root <> "/gh-descendant-survived"
-                setEnv "GH_RETAIN_PIPE_MARKER" descendantMarker
+                let descendantPid = root <> "/gh-descendant.pid"
+                setEnv "GH_RETAIN_PIPE_MARKER" descendantPid
                 snapshot <- expectRight =<< repositorySnapshot root
                 result <- timeout 5_000_000
                     (previewPullRequest
@@ -368,8 +380,14 @@ spec = describe "repository delivery service" do
                 result `shouldSatisfy` \case
                     Just (Right _) -> True
                     _ -> False
-                threadDelay 2_500_000
-                doesFileExist descendantMarker `shouldReturn` False
+                pid <- words <$> readFile descendantPid
+                pid `shouldSatisfy` \case
+                    [_] -> True
+                    _ -> False
+                processGoneWithin
+                    3_000_000
+                    (head pid)
+                    `shouldReturn` True
 
     it "rejects a gh result URL for another repository" $
         withDeliveryRepository \root _ ->
@@ -465,7 +483,8 @@ withFakeGh root action = do
             , "set -eu"
             , "[ \"${GH_HOST:-}\" = '' ] || exit 65"
             , "if [ \"${GH_RETAIN_PIPE_MARKER:-}\" != '' ] && [ \"$1 $2\" = 'auth status' ]; then"
-            , "  (sleep 2; printf survived > \"$GH_RETAIN_PIPE_MARKER\") &"
+            , "  sleep 30 &"
+            , "  printf '%s\\n' \"$!\" > \"$GH_RETAIN_PIPE_MARKER\""
             , "  exit 0"
             , "fi"
             , "case \"$1 $2\" in"
@@ -577,6 +596,21 @@ shouldReturnSatisfying
     -> Expectation
 shouldReturnSatisfying action predicate =
     action >>= (`shouldSatisfy` predicate)
+
+processGoneWithin :: Int -> String -> IO Bool
+processGoneWithin remaining pid
+    | remaining <= 0 = fmap not processExists
+    | otherwise =
+        processExists >>= \case
+            False -> pure True
+            True -> do
+                threadDelay 100_000
+                processGoneWithin (remaining - 100_000) pid
+  where
+    processExists = do
+        (exitCode, _, _) <-
+            readCreateProcessWithExitCode (proc "kill" ["-0", pid]) ""
+        pure (exitCode == ExitSuccess)
 
 shellQuote :: String -> String
 shellQuote value = "'" <> concatMap escape value <> "'"

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -102,6 +102,26 @@ spec = describe "repository delivery service" do
             repositoryDeliveryStatus root snapshot.snapshotId
                 `shouldReturnSatisfying` isInvalid
 
+    it "rejects percent-encoded credential-bearing URLs" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "ssh://git%3Asecret@example.test/repository.git"
+                ]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "git%3Asecret@example.test:owner/repository.git"
+                ]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+
     it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -5,6 +5,8 @@ import Agent.CLI.RepositoryReview
     ( RepositorySnapshot(..)
     , repositorySnapshot
     )
+import System.Timeout (timeout)
+import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (bracket)
 import qualified Data.Text as Text
 import System.Directory
@@ -314,6 +316,21 @@ spec = describe "repository delivery service" do
                 createPullRequest root preview.pullRequestConfirmation
                     `shouldReturnSatisfying` isConfirmationRejection
 
+    it "kills a gh descendant retaining pipes after its leader exits" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \_ _ -> do
+                let descendantMarker = root <> "/gh-descendant-survived"
+                setEnv "GH_RETAIN_PIPE_MARKER" descendantMarker
+                snapshot <- expectRight =<< repositorySnapshot root
+                result <- timeout 5_000_000
+                    (previewPullRequest
+                        root snapshot.snapshotId "main" "Title" "Body")
+                result `shouldSatisfy` \case
+                    Just (Right _) -> True
+                    _ -> False
+                threadDelay 2_500_000
+                doesFileExist descendantMarker `shouldReturn` False
+
     it "rejects a gh result URL for another repository" $
         withDeliveryRepository \root _ ->
             withFakeGh root \_ _ -> do
@@ -374,6 +391,7 @@ withFakeGh root action = do
     originalCapture <- lookupEnv "GH_BODY_CAPTURE"
     originalFakeUrl <- lookupEnv "GH_FAKE_PR_URL"
     originalFakeRepository <- lookupEnv "GH_FAKE_REPOSITORY"
+    originalRetainPipeMarker <- lookupEnv "GH_RETAIN_PIPE_MARKER"
     withTempDirectory "repository-delivery-gh" \bin -> do
         realGit <- maybe (fail "git not found") pure =<< findExecutable "git"
         localRemote <- Text.unpack . Text.strip
@@ -404,6 +422,10 @@ withFakeGh root action = do
         writeFile executable $ unlines
             [ "#!/bin/sh"
             , "set -eu"
+            , "if [ \"${GH_RETAIN_PIPE_MARKER:-}\" != '' ] && [ \"$1 $2\" = 'auth status' ]; then"
+            , "  (sleep 2; printf survived > \"$GH_RETAIN_PIPE_MARKER\") &"
+            , "  exit 0"
+            , "fi"
             , "case \"$1 $2\" in"
             , "  'auth status') exit 0 ;;"
             , "  'repo view') printf '{\"nameWithOwner\":\"%s\"}\\n' \"${GH_FAKE_REPOSITORY:-owner/repository}\" ;;"
@@ -433,7 +455,10 @@ withFakeGh root action = do
                     Just value -> setEnv "GH_FAKE_PR_URL" value
                 case originalFakeRepository of
                     Nothing -> unsetEnv "GH_FAKE_REPOSITORY"
-                    Just value -> setEnv "GH_FAKE_REPOSITORY" value)
+                    Just value -> setEnv "GH_FAKE_REPOSITORY" value
+                case originalRetainPipeMarker of
+                    Nothing -> unsetEnv "GH_RETAIN_PIPE_MARKER"
+                    Just value -> setEnv "GH_RETAIN_PIPE_MARKER" value)
             (\_ -> action bodyCapture injectionMarker)
 
 git :: FilePath -> [String] -> IO Text.Text

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -62,6 +62,34 @@ spec = describe "repository delivery service" do
             repositoryDeliveryStatus root snapshot.snapshotId
                 `shouldReturnSatisfying` isInvalid
 
+    it "rejects credential-bearing URLs without echoing their secret" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "ssh://git@example.test/owner/repository.git"
+                ]
+            _ <- expectRight
+                =<< repositoryDeliveryStatus root snapshot.snapshotId
+            let secret = "delivery-secret-must-not-escape"
+                credentialUrl =
+                    "https://user:"
+                        <> secret
+                        <> "@example.test/owner/repository.git"
+            _ <- git root ["remote", "set-url", "origin", credentialUrl]
+            result <- repositoryDeliveryStatus root snapshot.snapshotId
+            result `shouldSatisfy` isInvalid
+            case result of
+                Left err -> do
+                    deliveryErrorText err
+                        `shouldNotSatisfy` Text.isInfixOf (Text.pack secret)
+                    deliveryErrorText err
+                        `shouldNotSatisfy`
+                            Text.isInfixOf (Text.pack credentialUrl)
+                Right _ -> expectationFailure "credential URL was accepted"
+
     it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"
@@ -316,6 +344,18 @@ spec = describe "repository delivery service" do
                 createPullRequest root preview.pullRequestConfirmation
                     `shouldReturnSatisfying` isConfirmationRejection
 
+    it "ignores hostile GH_HOST and binds gh operations to github.com" $
+        withDeliveryRepository \root _ ->
+            withFakeGh root \_ _ -> do
+                setEnv "GH_HOST" "attacker.example"
+                snapshot <- expectRight =<< repositorySnapshot root
+                preview <- expectRight
+                    =<< previewPullRequest
+                        root snapshot.snapshotId "main" "Title" "Body"
+                _ <- createPullRequest root preview.pullRequestConfirmation
+                    >>= expectRight
+                pure ()
+
     it "kills a gh descendant retaining pipes after its leader exits" $
         withDeliveryRepository \root _ ->
             withFakeGh root \_ _ -> do
@@ -392,6 +432,7 @@ withFakeGh root action = do
     originalFakeUrl <- lookupEnv "GH_FAKE_PR_URL"
     originalFakeRepository <- lookupEnv "GH_FAKE_REPOSITORY"
     originalRetainPipeMarker <- lookupEnv "GH_RETAIN_PIPE_MARKER"
+    originalGhHost <- lookupEnv "GH_HOST"
     withTempDirectory "repository-delivery-gh" \bin -> do
         realGit <- maybe (fail "git not found") pure =<< findExecutable "git"
         localRemote <- Text.unpack . Text.strip
@@ -422,15 +463,37 @@ withFakeGh root action = do
         writeFile executable $ unlines
             [ "#!/bin/sh"
             , "set -eu"
+            , "[ \"${GH_HOST:-}\" = '' ] || exit 65"
             , "if [ \"${GH_RETAIN_PIPE_MARKER:-}\" != '' ] && [ \"$1 $2\" = 'auth status' ]; then"
             , "  (sleep 2; printf survived > \"$GH_RETAIN_PIPE_MARKER\") &"
             , "  exit 0"
             , "fi"
             , "case \"$1 $2\" in"
-            , "  'auth status') exit 0 ;;"
-            , "  'repo view') printf '{\"nameWithOwner\":\"%s\"}\\n' \"${GH_FAKE_REPOSITORY:-owner/repository}\" ;;"
-            , "  'pr list') printf '%s\\n' '[]' ;;"
+            , "  'auth status')"
+            , "    case \" $* \" in"
+            , "      *' --hostname github.com '*) exit 0 ;;"
+            , "      *) exit 65 ;;"
+            , "    esac"
+            , "    ;;"
+            , "  'repo view')"
+            , "    case \" $* \" in"
+            , "      *' --repo github.com/owner/repository '*) ;;"
+            , "      *) exit 65 ;;"
+            , "    esac"
+            , "    printf '{\"nameWithOwner\":\"%s\"}\\n' \"${GH_FAKE_REPOSITORY:-owner/repository}\""
+            , "    ;;"
+            , "  'pr list')"
+            , "    case \" $* \" in"
+            , "      *' --repo github.com/owner/repository '*) ;;"
+            , "      *) exit 65 ;;"
+            , "    esac"
+            , "    printf '%s\\n' '[]'"
+            , "    ;;"
             , "  'pr create')"
+            , "    case \" $* \" in"
+            , "      *' --repo github.com/owner/repository '*) ;;"
+            , "      *) exit 65 ;;"
+            , "    esac"
             , "    cat > \"$GH_BODY_CAPTURE\""
             , "    printf '%s\\n' \"${GH_FAKE_PR_URL:-https://github.com/owner/repository/pull/123}\""
             , "    ;;"
@@ -458,7 +521,10 @@ withFakeGh root action = do
                     Just value -> setEnv "GH_FAKE_REPOSITORY" value
                 case originalRetainPipeMarker of
                     Nothing -> unsetEnv "GH_RETAIN_PIPE_MARKER"
-                    Just value -> setEnv "GH_RETAIN_PIPE_MARKER" value)
+                    Just value -> setEnv "GH_RETAIN_PIPE_MARKER" value
+                case originalGhHost of
+                    Nothing -> unsetEnv "GH_HOST"
+                    Just value -> setEnv "GH_HOST" value)
             (\_ -> action bodyCapture injectionMarker)
 
 git :: FilePath -> [String] -> IO Text.Text

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -45,6 +45,21 @@ spec = describe "repository delivery service" do
         validateRemoteName "-origin" `shouldBe` False
         validateRemoteName "origin\n--upload-pack=evil" `shouldBe` False
 
+    it "rejects relative paths and custom remote-helper transports" $
+        withDeliveryRepository \root _ -> do
+            snapshot <- expectRight =<< repositorySnapshot root
+            _ <- git root ["remote", "set-url", "origin", "../redirected.git"]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+            _ <- git root
+                [ "remote"
+                , "set-url"
+                , "origin"
+                , "ext::sh -c 'touch should-not-run'"
+                ]
+            repositoryDeliveryStatus root snapshot.snapshotId
+                `shouldReturnSatisfying` isInvalid
+
     it "previews and confirms one exact fast-forward lease push once" $
         withDeliveryRepository \root remote -> do
             appendFile (root <> "/tracked.txt") "second\n"

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -49,6 +49,7 @@ import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
 import qualified Agent.CLI.ProviderAvailabilitySpec as ProviderAvailabilitySpec
 import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
 import qualified Agent.CLI.RequestSpec as RequestSpec
+import qualified Agent.CLI.RepositoryDeliverySpec as RepositoryDeliverySpec
 import qualified Agent.CLI.RepositoryReviewSpec as RepositoryReviewSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
@@ -127,6 +128,7 @@ main = hspec do
     ProviderAvailabilitySpec.spec
     ProviderTransitionSpec.spec
     RequestSpec.spec
+    RepositoryDeliverySpec.spec
     RepositoryReviewSpec.spec
     RenderSpec.spec
     ReplStatusSpec.spec

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -170,6 +170,82 @@ static void repository_result_callback(
     (void)error_length;
 }
 
+static void repository_delivery_status_callback(
+        void *context, int32_t status,
+        const uint8_t *snapshot_id, size_t snapshot_id_length,
+        const uint8_t *head_oid, size_t head_oid_length,
+        const uint8_t *branch, size_t branch_length,
+        const uint8_t *remote, size_t remote_length,
+        const uint8_t *upstream_ref, size_t upstream_ref_length,
+        const uint8_t *upstream_oid, size_t upstream_oid_length,
+        int64_t ahead, int64_t behind,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)snapshot_id; (void)snapshot_id_length;
+    (void)head_oid; (void)head_oid_length;
+    (void)branch; (void)branch_length;
+    (void)remote; (void)remote_length;
+    (void)upstream_ref; (void)upstream_ref_length;
+    (void)upstream_oid; (void)upstream_oid_length;
+    (void)ahead; (void)behind; (void)error; (void)error_length;
+}
+
+static void repository_push_preview_callback(
+        void *context, int32_t status,
+        const uint8_t *confirmation, size_t confirmation_length,
+        int64_t expires_at_unix,
+        const uint8_t *head_oid, size_t head_oid_length,
+        const uint8_t *branch, size_t branch_length,
+        const uint8_t *remote, size_t remote_length,
+        const uint8_t *upstream_ref, size_t upstream_ref_length,
+        int64_t ahead, int64_t behind,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)confirmation; (void)confirmation_length; (void)expires_at_unix;
+    (void)head_oid; (void)head_oid_length;
+    (void)branch; (void)branch_length;
+    (void)remote; (void)remote_length;
+    (void)upstream_ref; (void)upstream_ref_length;
+    (void)ahead; (void)behind; (void)error; (void)error_length;
+}
+
+static void repository_push_result_callback(
+        void *context, int32_t status,
+        const uint8_t *snapshot_id, size_t snapshot_id_length,
+        const uint8_t *pushed_oid, size_t pushed_oid_length,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)snapshot_id; (void)snapshot_id_length;
+    (void)pushed_oid; (void)pushed_oid_length;
+    (void)error; (void)error_length;
+}
+
+static void repository_pr_preview_callback(
+        void *context, int32_t status,
+        const uint8_t *confirmation, size_t confirmation_length,
+        int64_t expires_at_unix,
+        const uint8_t *repository, size_t repository_length,
+        const uint8_t *base_ref, size_t base_ref_length,
+        const uint8_t *head_ref, size_t head_ref_length,
+        const uint8_t *title, size_t title_length,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)confirmation; (void)confirmation_length; (void)expires_at_unix;
+    (void)repository; (void)repository_length;
+    (void)base_ref; (void)base_ref_length;
+    (void)head_ref; (void)head_ref_length;
+    (void)title; (void)title_length;
+    (void)error; (void)error_length;
+}
+
+static void repository_pr_result_callback(
+        void *context, int32_t status,
+        const uint8_t *url, size_t url_length,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status;
+    (void)url; (void)url_length; (void)error; (void)error_length;
+}
+
 static void repository_check_output_callback(
         void *context, int32_t stream,
         const uint8_t *bytes, size_t length) {
@@ -279,6 +355,56 @@ int ha_repository_review_abi_smoke(void) {
             NULL,
             NULL) != 1) {
         return 25;
+    }
+    if (ha_repository_delivery_status(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1
+        || ha_repository_push_preview(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1
+        || ha_repository_push_confirm(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1
+        || ha_repository_pr_preview(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1
+        || ha_repository_pr_confirm(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            NULL, NULL) != 1) {
+        return 29;
+    }
+    if (ha_repository_delivery_status(
+            NULL, 0,
+            value, sizeof(value) - 1,
+            repository_delivery_status_callback, NULL) != 2
+        || ha_repository_push_preview(
+            NULL, 0,
+            value, sizeof(value) - 1,
+            repository_push_preview_callback, NULL) != 2
+        || ha_repository_push_confirm(
+            NULL, 0,
+            value, sizeof(value) - 1,
+            repository_push_result_callback, NULL) != 2
+        || ha_repository_pr_preview(
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, sizeof(value) - 1,
+            value, (size_t)1024 * 1024 + 1,
+            repository_pr_preview_callback, NULL) != 2
+        || ha_repository_pr_confirm(
+            NULL, 0,
+            value, sizeof(value) - 1,
+            repository_pr_result_callback, NULL) != 2) {
+        return 30;
     }
     void *check = NULL;
     if (ha_repository_check_start(


### PR DESCRIPTION
## Summary
- add typed branch/upstream status and bounded push/PR preview APIs
- bind monotonically expiring one-shot confirmation to the exact reviewed snapshot, HEAD, upstream, destination URL/fingerprint, and live remote OID
- pass the privately validated immutable URL directly to remote checks and push, rejecting config retargeting and unsupported transports
- prove the expected remote OID is an ancestor of exact HEAD, then use an exact `--force-with-lease=<dst>:<expected>` server-side CAS; no history rewrite or deletion is permitted
- reject credential-bearing URL authorities/query data before argv construction; derive GitHub `owner/name` from the validated URL, strip hostile `GH_HOST`, and bind auth/view/list/create explicitly to `github.com`
- use argv-only execution with bounded inputs/output/timeouts, captured process-group teardown before bounded pipe joins, close-fds, sanitized errors, and reentrant-safe exact-once callbacks

## Validation
- `nix develop -c cabal build agent-cli:agent-cli-test`
- repository-focused Hspec: 36 examples, 0 failures (including 16 delivery regressions)
- native C ABI smoke header syntax with `-Wall -Wextra -Werror`
- `git diff --check`

Stacked on #765 at `8e6b4095bc1f9896fbcf0d1d19ed11f9fb113a68`.
