### PR TITLE
Model subagent residency explicitly

### DIFF
--- a/packages/agent-cli/benchmark/SubagentRetention.hs
+++ b/packages/agent-cli/benchmark/SubagentRetention.hs
@@ -3,7 +3,7 @@ module Main (main) where
 import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
 import Agent.CLI.Compaction (OccupancySnapshot(..), estimatedOccupancy)
 import Agent.CLI.NativeAgents
-import Agent.CLI.Subagents.Runtime (SubagentSession(..))
+import Agent.CLI.Subagents.Runtime (SubagentResidency(..), SubagentSession(..))
 import Agent.Dialect (DialectId(..))
 import Agent.Loop (LoopEvent(..), NativeAgentStatus(..))
 import Agent.Provider (Provider(..))
@@ -271,8 +271,7 @@ buildSessions agentCount itemCount payloadBytes sampleIndex =
                 ]
         transcript <- newIORef items
         contextTokens <- newIORef (Just (estimatedOccupancy itemCount payloadBytes))
-        pinned <- newIORef False
-        hydrated <- newMVar True
+        residency <- newMVar SessionResident
         pure
             ( agentIndex
             , SubagentSession
@@ -282,18 +281,17 @@ buildSessions agentCount itemCount payloadBytes sampleIndex =
                 , subSessionConnection = "openai"
                 , subSessionEffectiveModel = "gpt-5.6-luna"
                 , subSessionDialect = CodexDialect
-                , subSessionPinned = pinned
-                , subSessionHydrated = hydrated
+                , subSessionResidency = residency
                 }
             )
 
 evictSessions :: Map Int SubagentSession -> IO ()
 evictSessions sessions =
     forM_ (Map.elems sessions) \session ->
-        modifyMVar_ session.subSessionHydrated \_ -> do
+        modifyMVar_ session.subSessionResidency \_ -> do
             writeIORef session.subSessionTranscript []
             writeIORef session.subSessionContextTokens Nothing
-            pure False
+            pure SessionEvicted
 
 checksumSessions :: Map Int SubagentSession -> IO Int
 checksumSessions sessions =

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -192,7 +192,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
     restartEffortRef <- newIORef Nothing
     lastFailedTurnRef <- newIORef Nothing
     titleTurnCount <- newIORef =<< sessionTitleTurnCountFromSlot persist
-    let hydrateSelectedAgent agentId = do
+    let loadSelectedAgent agentId = do
             effectiveModel <- readIORef modelRef
             lookupOrCreateSubagentSession
                 subagentSessions
@@ -204,28 +204,19 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 effectiveModel
                 (dialectId dialect)
                 agentId
-        selectChild agentId = do
-            session <-
-                (Just <$> hydrateSelectedAgent agentId)
-                    `catchAny` \err -> do
-                        reportSessionError
-                            ("failed to load selected agent: "
-                                <> formatException err)
-                        pure Nothing
-            forM_ session \selectedSession -> do
-                withMVar selectedSession.subSessionHydrated \_ ->
-                    writeIORef selectedSession.subSessionPinned True
-                void
-                    (hydrateSelectedAgent agentId)
-                    `catchAny` \err ->
-                        reportSessionError
-                            ("failed to pin selected agent: "
-                                <> formatException err)
+        selectChild agentId =
+            (do
+                session <- loadSelectedAgent agentId
+                pinSubagentSession
+                    storeRoot agentTypes legacyTarget agentId session)
+                `catchAny` \err ->
+                    reportSessionError
+                        ("failed to select agent: "
+                            <> formatException err)
         releaseChild agentId = do
             sessions <- readIORef subagentSessions
             forM_ (Map.lookup agentId sessions) \session -> do
-                withMVar session.subSessionHydrated \_ ->
-                    writeIORef session.subSessionPinned False
+                unpinSubagentSession session
                 case multiCtx of
                     Nothing -> pure ()
                     Just ctx -> do

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -1,8 +1,10 @@
 -- | CLI-owned runtime state and provider adapters for child agents.
 module Agent.CLI.Subagents.Runtime
-    ( SubagentRuntime(..), SubagentSession(..), SubagentStoreRoot
+    ( SubagentResidency(..), SubagentRuntime(..), SubagentSession(..)
+    , SubagentStoreRoot
     , flushAllSubagentSnapshots, freshOpenAiBackend
     , lookupOrCreateSubagentSession, persistAndEvictSubagentSessionWithStatus
+    , pinSubagentSession, unpinSubagentSession
     , persistSubagentSnapshotWithStatus, prepareCollaborationSpawn
     , restoreAgentFromDisk, resolveChildModelAndEffort, runCodexSubagent
     , runHttpSubagent, runXaiParentSubagent, grokSpawnedChildIdentity
@@ -26,7 +28,12 @@ import Agent.CLI.SubagentStore
     , subagentDiskFields
     )
 import Agent.CLI.Subagents.Runtime.Types
-    (PreparedChild(..), SubagentRuntime(..), SubagentSession(..), SubagentStoreRoot)
+    ( PreparedChild(..)
+    , SubagentResidency(..)
+    , SubagentRuntime(..)
+    , SubagentSession(..)
+    , SubagentStoreRoot
+    )
 import Agent.CLI.Subagents.Runtime.Storage
     (flushAllSubagentSnapshots, persistAndEvictSubagentSessionWithStatus,
      persistSubagentSnapshotWithStatus, syncStoreRootFromPlan)
@@ -287,29 +294,34 @@ restoreAgentFromDisk
                                         Left err -> pure (Left err)
                                         Right () -> pure (Right ())
     restoreSession session loaded reopen =
-        modifyMVar session.subSessionHydrated \hydrated -> do
+        modifyMVar session.subSessionResidency \residency -> do
             currentStatus <- getStatus registry agentId
             case currentStatus of
-                NotFound -> finish hydrated
-                Closed -> finish hydrated
+                NotFound -> finish residency
+                Closed -> finish residency
                 _ -> do
-                    hydrated' <-
-                        ensureSubagentSessionHydratedLocked
+                    residency' <-
+                        ensureSubagentSessionResidentLocked
                             storeRootRef typesRef legacyTarget
-                            agentId session hydrated
-                    pure (hydrated', Right ())
+                            agentId session residency
+                    pure (residency', Right ())
       where
-        finish hydrated =
-            reopen hydrated >>= \case
-                Left err -> pure (hydrated, Left err)
+        finish residency =
+            reopen (isSessionResident residency) >>= \case
+                Left err -> pure (residency, Left err)
                 Right () -> do
                     case loaded of
                         Nothing -> pure ()
                         Just (items, fields) -> do
                             recordPersistedAgentSpec typesRef agentId fields
-                            unless hydrated $
+                            unless (isSessionResident residency) $
                                 writeIORef session.subSessionTranscript items
-                    pure (True, Right ())
+                    pure
+                        ( case residency of
+                            SessionPinned -> SessionPinned
+                            _ -> SessionResident
+                        , Right ()
+                        )
     reopenPersisted fields =
         case fields.diskTaskPath of
             Nothing -> restoreAt taskPathRoot
@@ -925,10 +937,31 @@ lookupOrCreateSubagentSession
     session <-
         getOrInstallSubagentSession
             sessionsRef provider connection currentEffectiveModel currentDialect agentId
-    modifyMVar_ session.subSessionHydrated $
-        ensureSubagentSessionHydratedLocked
+    modifyMVar_ session.subSessionResidency $
+        ensureSubagentSessionResidentLocked
             storeRootRef typesRef legacyTarget agentId session
     pure session
+
+-- | Ensure a session is resident and pin it against eviction in one critical
+-- section.
+pinSubagentSession
+    :: SubagentStoreRoot
+    -> GrokSubagentSpecs
+    -> Maybe LegacySubagentTarget
+    -> SubagentId
+    -> SubagentSession
+    -> IO ()
+pinSubagentSession storeRootRef typesRef legacyTarget agentId session =
+    modifyMVar_ session.subSessionResidency \residency ->
+        SessionPinned <$ ensureSubagentSessionResidentLocked
+            storeRootRef typesRef legacyTarget agentId session residency
+
+-- | Allow a pinned session to be evicted after its next successful snapshot.
+unpinSubagentSession :: SubagentSession -> IO ()
+unpinSubagentSession session =
+    modifyMVar_ session.subSessionResidency \case
+        SessionPinned -> pure SessionResident
+        residency -> pure residency
 
 getOrInstallSubagentSession
     :: IORef (Map SubagentId SubagentSession)
@@ -942,8 +975,7 @@ getOrInstallSubagentSession
         sessionsRef provider connection effectiveModel dialect agentId = do
     transcript <- newIORef []
     contextTokens <- newIORef Nothing
-    pinned <- newIORef False
-    hydrated <- newMVar False
+    residency <- newMVar SessionEvicted
     let candidate = SubagentSession
             { subSessionTranscript = transcript
             , subSessionContextTokens = contextTokens
@@ -951,25 +983,24 @@ getOrInstallSubagentSession
             , subSessionConnection = connection
             , subSessionEffectiveModel = effectiveModel
             , subSessionDialect = dialect
-            , subSessionPinned = pinned
-            , subSessionHydrated = hydrated
+            , subSessionResidency = residency
             }
     atomicModifyIORef' sessionsRef \sessions ->
         case Map.lookup agentId sessions of
             Just existing -> (sessions, existing)
             Nothing -> (Map.insert agentId candidate sessions, candidate)
 
-ensureSubagentSessionHydratedLocked
+ensureSubagentSessionResidentLocked
     :: SubagentStoreRoot
     -> GrokSubagentSpecs
     -> Maybe LegacySubagentTarget
     -> SubagentId
     -> SubagentSession
-    -> Bool
-    -> IO Bool
-ensureSubagentSessionHydratedLocked
-        storeRootRef typesRef legacyTarget agentId session hydrated
-    | hydrated = pure True
+    -> SubagentResidency
+    -> IO SubagentResidency
+ensureSubagentSessionResidentLocked
+        storeRootRef typesRef legacyTarget agentId session residency
+    | isSessionResident residency = pure residency
     | otherwise = do
         mroot <- readIORef storeRootRef
         loaded <- case mroot of
@@ -1009,7 +1040,12 @@ ensureSubagentSessionHydratedLocked
                             typesRef
                             agentId
                             (subagentDiskFields meta)
-        pure True
+        pure SessionResident
+
+isSessionResident :: SubagentResidency -> Bool
+isSessionResident = \case
+    SessionEvicted -> False
+    _ -> True
 
 recordPersistedAgentSpec
     :: GrokSubagentSpecs

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Storage.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Storage.hs
@@ -13,7 +13,8 @@ import Agent.CLI.SubagentStore
     , saveSubagentState
     )
 import Agent.CLI.Subagents.Runtime.Types
-    ( SubagentSession(..)
+    ( SubagentResidency(..)
+    , SubagentSession(..)
     , SubagentStoreRoot
     )
 import Agent.GrokBuild.Dialect.Task
@@ -81,23 +82,25 @@ persistAndEvictSubagentSessionWithStatus
     -> IO (Either Text Bool)
 persistAndEvictSubagentSessionWithStatus
         storeRootRef registry typesRef agentId status session =
-    modifyMVar session.subSessionHydrated \hydrated ->
-        if not hydrated || not (evictableStatus status)
-            then pure (hydrated, Right False)
+    modifyMVar session.subSessionResidency \residency ->
+        if residency == SessionEvicted || not (evictableStatus status)
+            then pure (residency, Right False)
             else readIORef storeRootRef >>= \case
-                Nothing -> pure (True, Right False)
+                Nothing -> pure (residency, Right False)
                 Just sessionDir ->
                     saveSubagentSnapshotWithStatus
                         sessionDir registry typesRef agentId status session >>= \case
-                            Left err -> pure (True, Left err)
-                            Right () -> do
-                                pinned <- readIORef session.subSessionPinned
-                                if pinned
-                                    then pure (True, Right False)
-                                    else do
+                            Left err -> pure (residency, Left err)
+                            Right () ->
+                                case residency of
+                                    SessionPinned ->
+                                        pure (SessionPinned, Right False)
+                                    SessionResident -> do
                                         writeIORef session.subSessionTranscript []
                                         writeIORef session.subSessionContextTokens Nothing
-                                        pure (False, Right True)
+                                        pure (SessionEvicted, Right True)
+                                    SessionEvicted ->
+                                        pure (SessionEvicted, Right False)
   where
     evictableStatus = \case
         Completed{} -> True
@@ -152,8 +155,8 @@ flushAllSubagentSnapshots storeRootRef registry sessionsRef typesRef = do
     sessions <- readIORef sessionsRef
     mapM_
         (\(agentId, session) ->
-            withMVar session.subSessionHydrated \hydrated ->
-                when hydrated do
+            withMVar session.subSessionResidency \residency ->
+                when (residency /= SessionEvicted) do
                     status <- getStatus registry agentId
                     persistSubagentSnapshotWithStatus
                         storeRootRef registry typesRef agentId status session)

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
@@ -1,6 +1,7 @@
 -- | Shared state for CLI-owned child-agent runtimes.
 module Agent.CLI.Subagents.Runtime.Types
     ( PreparedChild(..)
+    , SubagentResidency(..)
     , SubagentRuntime(..)
     , SubagentSession(..)
     , SubagentStoreRoot
@@ -23,6 +24,16 @@ import Data.Map.Strict (Map)
 import Data.Text (Text)
 import System.OsPath (OsPath)
 
+-- | Lifecycle state for an in-memory child session.
+--
+-- A pinned session is necessarily resident. Keeping these states in one
+-- lock prevents the impossible combination of an evicted, pinned session.
+data SubagentResidency
+    = SessionEvicted
+    | SessionResident
+    | SessionPinned
+    deriving (Eq, Show)
+
 data SubagentSession = SubagentSession
     { subSessionTranscript :: !(IORef [ResponseItem])
     , subSessionContextTokens :: !(IORef (Maybe OccupancySnapshot))
@@ -30,8 +41,7 @@ data SubagentSession = SubagentSession
     , subSessionConnection :: !Text
     , subSessionEffectiveModel :: !Text
     , subSessionDialect :: !DialectId
-    , subSessionPinned :: !(IORef Bool)
-    , subSessionHydrated :: !(MVar Bool)
+    , subSessionResidency :: !(MVar SubagentResidency)
     }
 
 -- | Optional on-disk root for child transcripts (@sessionDir/agents/<id>@).

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -6,14 +6,17 @@ import Agent.CLI.Session (LegacySubagentTarget(..))
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..))
 import Agent.CLI.Subagents.Runtime
-    ( SubagentSession(..)
+    ( SubagentResidency(..)
+    , SubagentSession(..)
     , flushAllSubagentSnapshots
     , lookupOrCreateSubagentSession
+    , pinSubagentSession
     , persistAndEvictSubagentSessionWithStatus
     , prepareCollaborationSpawn
     , grokSpawnedChildIdentity
     , restoreAgentFromDisk
     , resolveChildModelAndEffort
+    , unpinSubagentSession
     , usesOpenAiChildTransport
     , validatePersistedSubagentTarget
     )
@@ -516,7 +519,7 @@ spec = describe "Agent.CLI.SubagentStore" do
                                 readIORef session.subSessionTranscript
                                     `shouldReturn` marker
 
-    it "keeps the installed session across concurrent registry restores" do
+    it "keeps the installed pinned session across concurrent registry restores" do
         withTempDir \dir -> do
             let agentId = SubagentId "agent-concurrent-restore"
                 persisted = [messageItem RoleUser "persisted"]
@@ -540,6 +543,10 @@ spec = describe "Agent.CLI.SubagentStore" do
                 lookupTestSession
                     sessionsRef storeRootRef typesRef agentId
             writeIORef installed.subSessionTranscript inMemory
+            pinSubagentSession
+                storeRootRef typesRef Nothing agentId installed
+            readMVar installed.subSessionResidency
+                `shouldReturn` SessionPinned
             bracket
                 (newSubagentRegistry defaultSubagentConfig dir
                     (\_ _ _ _ -> fail "unexpected subagent runner invocation")
@@ -566,6 +573,8 @@ spec = describe "Agent.CLI.SubagentStore" do
                         Just current -> do
                             readIORef current.subSessionTranscript
                                 `shouldReturn` inMemory
+                            readMVar current.subSessionResidency
+                                `shouldReturn` SessionPinned
                             let marker = [messageItem RoleAssistant "same-ref"]
                             writeIORef current.subSessionTranscript marker
                             readIORef installed.subSessionTranscript
@@ -593,16 +602,18 @@ spec = describe "Agent.CLI.SubagentStore" do
                     (\_ _ -> pure ()))
                 closeSubagentRegistry
                 \registry -> do
-                    writeIORef session.subSessionPinned True
+                    pinSubagentSession
+                        storeRootRef typesRef Nothing agentId session
                     persistAndEvictSubagentSessionWithStatus
                         storeRootRef registry typesRef agentId
                         (Completed (Just "answer")) session
                         `shouldReturn` Right False
                     readIORef session.subSessionTranscript
                         `shouldReturn` items
-                    readMVar session.subSessionHydrated `shouldReturn` True
+                    readMVar session.subSessionResidency
+                        `shouldReturn` SessionPinned
 
-                    writeIORef session.subSessionPinned False
+                    unpinSubagentSession session
                     persistAndEvictSubagentSessionWithStatus
                         storeRootRef registry typesRef agentId
                         (Completed (Just "answer")) session
@@ -610,17 +621,23 @@ spec = describe "Agent.CLI.SubagentStore" do
                     readIORef session.subSessionTranscript `shouldReturn` []
                     readIORef session.subSessionContextTokens
                         `shouldReturn` Nothing
-                    readMVar session.subSessionHydrated `shouldReturn` False
+                    readMVar session.subSessionResidency
+                        `shouldReturn` SessionEvicted
 
+                    pinSubagentSession
+                        storeRootRef typesRef Nothing agentId session
+                    readMVar session.subSessionResidency
+                        `shouldReturn` SessionPinned
                     rehydrated <-
                         lookupTestSession
                             sessionsRef storeRootRef typesRef agentId
                     readIORef rehydrated.subSessionTranscript
                         `shouldReturn` items
-                    readMVar rehydrated.subSessionHydrated
-                        `shouldReturn` True
+                    readMVar rehydrated.subSessionResidency
+                        `shouldReturn` SessionPinned
                     writeIORef rehydrated.subSessionTranscript
                         [messageItem RoleAssistant "poison"]
+                    unpinSubagentSession rehydrated
                     persistAndEvictSubagentSessionWithStatus
                         storeRootRef registry typesRef agentId
                         (Completed (Just "answer")) rehydrated
@@ -660,7 +677,8 @@ spec = describe "Agent.CLI.SubagentStore" do
                         noStoreRef registry typesRef validId Interrupted noStore
                         `shouldReturn` Right False
                     readIORef noStore.subSessionTranscript `shouldReturn` items
-                    readMVar noStore.subSessionHydrated `shouldReturn` True
+                    readMVar noStore.subSessionResidency
+                        `shouldReturn` SessionResident
 
                     failed <-
                         lookupTestSession
@@ -673,7 +691,8 @@ spec = describe "Agent.CLI.SubagentStore" do
                             Left _ -> True
                             Right _ -> False)
                     readIORef failed.subSessionTranscript `shouldReturn` items
-                    readMVar failed.subSessionHydrated `shouldReturn` True
+                    readMVar failed.subSessionResidency
+                        `shouldReturn` SessionResident
 
 lookupTestSession sessionsRef storeRootRef typesRef agentId =
     lookupOrCreateSubagentSession


### PR DESCRIPTION
## Summary

- replace independent `subSessionHydrated` / `subSessionPinned` mutable booleans with one locked `SubagentResidency` state machine
- make load, pin, unpin, restore, persistence, and eviction transitions atomic
- remove the double-hydration selection workaround while preserving resident data on failed or unavailable persistence
- update concurrency and persistence regressions plus the subagent-retention benchmark fixture

## Validation

- rebased onto current `master`
- `agent-cli` test-suite GHCi load: 86 modules
- `Agent.CLI.SubagentStore`: 26 examples, 0 failures
- `agent viewport runtime`: 3 examples, 0 failures
- `agent-cli:bench:subagent-retention-bench` GHCi load
- `git diff --check`
