### PR TITLE
Add Grok session navigation commands

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -1,6 +1,7 @@
 -- | Interactive REPL slash commands.
 module Agent.CLI.Command
-    ( ReplAction(..)
+    ( ForkRequest(..)
+    , ReplAction(..)
     , ShellMode(..)
     , SkillCommand(..)
     , SlashCatalog(..)
@@ -228,13 +229,20 @@ parseSlash catalog raw line = case Text.words line of
                     then ReplDiff
                     else ReplCommandError "usage: /diff"
             "fork" ->
-                let name = Text.strip (Text.drop (Text.length command) line)
-                in ReplFork
-                    (if Text.null name then Nothing else Just name)
+                parseForkCommand
+                    (Text.strip (Text.drop (Text.length command) line))
             "export" ->
                 let path = Text.strip (Text.drop (Text.length command) line)
                 in ReplExport
                     (if Text.null path then Nothing else Just path)
+            "history" ->
+                if null args
+                    then ReplHistory
+                    else ReplCommandError "usage: /history"
+            "find" ->
+                ReplFind
+                    (nonEmptyText
+                        (Text.strip (Text.drop (Text.length command) line)))
             "permissions" ->
                 if null args
                     then ReplPermissions
@@ -542,6 +550,40 @@ parseDeepResearchCommand original query
     | otherwise =
         ReplExpandedPrompt original (deepResearchInstruction query)
 
+parseForkCommand :: Text -> ReplAction
+parseForkCommand input =
+    either ReplCommandError ReplFork (go Nothing (Text.stripStart input))
+  where
+    go worktree rest
+        | Text.null rest =
+            Right ForkRequest
+                { forkWorktree = worktree
+                , forkDirective = Nothing
+                }
+        | otherwise =
+            let (token, suffix) = Text.break isSpace rest
+                remaining = Text.stripStart suffix
+                finish =
+                    Right ForkRequest
+                        { forkWorktree = worktree
+                        , forkDirective = nonEmptyText (Text.strip rest)
+                        }
+            in case token of
+                "--worktree" -> case worktree of
+                    Nothing -> go (Just True) remaining
+                    Just True -> Left "--worktree specified twice"
+                    Just False ->
+                        Left
+                            "--worktree and --no-worktree are mutually exclusive"
+                "--no-worktree" -> case worktree of
+                    Nothing -> go (Just False) remaining
+                    Just False -> Left "--no-worktree specified twice"
+                    Just True ->
+                        Left
+                            "--worktree and --no-worktree are mutually exclusive"
+                "--at" -> Left "--at is not supported in this version"
+                _ -> finish
+
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText value
     | Text.null value = Nothing
@@ -816,6 +858,7 @@ argCompletions catalog spec = case spec.slashName of
         map (.slashName) catalog.slashCatalogCommands
             <> map (.skillCommandName) catalog.slashCatalogSkills
     "rename" -> ["--auto"]
+    "fork" -> ["--worktree", "--no-worktree"]
     "paste" -> ["--send"]
     "goal" -> ["status", "pause", "resume", "clear"]
     "workflow" -> ["runs"]

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -11,8 +11,10 @@ slashCommands =
     , cmd "init" [] "/init" "Create an AGENTS.md contributor guide" False
     , cmd "review" [] "/review [INSTRUCTIONS]" "Review current changes and find issues" True
     , cmd "diff" [] "/diff" "Show Git diff, including untracked files" False
-    , cmd "fork" [] "/fork [NAME]" "Fork the current chat into a new session" True
+    , cmd "fork" [] "/fork [--worktree|--no-worktree] [DIRECTIVE]" "Fork the current chat into a peer session" True
     , cmd "export" [] "/export [PATH]" "Export the conversation as Markdown" True
+    , cmd "history" [] "/history" "Search prompt history and reuse a prompt" False
+    , cmd "find" [] "/find [TEXT]" "Search this conversation in a pager" True
     , cmd "permissions" [] "/permissions" "Choose the tool approval policy" False
     , cmd "model" ["m"] "/model [NAME]" "Open the model picker, or set a model" True
     , cmd "effort" [] "/effort [none|low|medium|high|xhigh|max]" "Show or set reasoning effort" True

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -1,6 +1,7 @@
 -- | Data types shared by slash-command parsing and presentation.
 module Agent.CLI.Command.Types
-    ( ReplAction(..)
+    ( ForkRequest(..)
+    , ReplAction(..)
     , ShellMode(..)
     , SkillCommand(..)
     , SlashCatalog(..)
@@ -15,6 +16,13 @@ import Data.Map.Strict (Map)
 import Data.Set (Set)
 import Data.Text (Text)
 
+-- | Parsed @/fork@ options. A missing worktree choice asks interactively.
+data ForkRequest = ForkRequest
+    { forkWorktree :: !(Maybe Bool)
+    , forkDirective :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
 data ReplAction
     = ReplQuit
     | ReplReload
@@ -24,7 +32,7 @@ data ReplAction
     | ReplInit
     | ReplReview (Maybe Text)
     | ReplDiff
-    | ReplFork (Maybe Text)
+    | ReplFork !ForkRequest
     | ReplExport (Maybe Text)
     | ReplPermissions
     | ReplShowEffort
@@ -41,6 +49,8 @@ data ReplAction
     | ReplTranscript
     | ReplEditPrompt
     | ReplContext
+    | ReplHistory
+    | ReplFind !(Maybe Text)
     | ReplBtw Text
     -- ^ Ask an isolated one-shot question over the current context.
     | ReplMetaConsole Text

--- a/packages/agent-cli/src/Agent/CLI/Input/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/History.hs
@@ -7,6 +7,7 @@ module Agent.CLI.Input.History
     , trySetMode
     ) where
 
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Control.Exception.Safe (catchIO)
 import Data.Char (isSpace)
 import Data.Text (Text)
@@ -22,6 +23,7 @@ import System.Directory (createDirectoryIfMissing, getHomeDirectory)
 import System.FilePath (takeDirectory, (</>))
 import System.Posix.Files (setFileMode)
 import System.Posix.Types (FileMode)
+import System.OsPath (unsafeEncodeUtf)
 
 replHistoryPath :: FilePath -> FilePath
 replHistoryPath home = home </> ".haskell-agent" </> "history"
@@ -31,8 +33,9 @@ readReplHistory = do
     home <- getHomeDirectory
     let path = replHistoryPath home
     ensureHistoryParent path
-    history <- readHistory path `catchIO` \_ -> pure emptyHistory
-    pure (map Text.pack (historyLines history))
+    withHistoryLock path do
+        history <- readHistory path `catchIO` \_ -> pure emptyHistory
+        pure (map Text.pack (historyLines history))
 
 appendReplHistory :: Text -> IO ()
 appendReplHistory text
@@ -41,9 +44,19 @@ appendReplHistory text
         home <- getHomeDirectory
         let path = replHistoryPath home
         ensureHistoryParent path
-        history <- readHistory path `catchIO` \_ -> pure emptyHistory
-        writeHistory path (addHistory (Text.unpack text) history)
-            `catchIO` \_ -> pure ()
+        withHistoryLock path do
+            history <- readHistory path `catchIO` \_ -> pure emptyHistory
+            writeHistory path (addHistory (Text.unpack text) history)
+                `catchIO` \_ -> pure ()
+            trySetMode path 0o600
+
+-- Haskeline rewrites history in place. Fullscreen input publication and
+-- command handling run concurrently, so serialize reads with that rewrite to
+-- avoid observing the temporary truncated file. The lock also coordinates
+-- independent harness processes sharing the same history.
+withHistoryLock :: FilePath -> IO a -> IO a
+withHistoryLock path =
+    withPrivateFileLock (unsafeEncodeUtf (path <> ".lock"))
 
 ensureHistoryParent :: FilePath -> IO ()
 ensureHistoryParent path = do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -265,6 +265,21 @@ runAgentWithRuntime processRuntime runMode options = do
                             , optResume = Just sessionId
                             }
                         Nothing
+            RunForkSession sessionId directive ->
+                newSessionState >>= \nextState -> do
+                    writeIORef nextState.sessionInitialPrompt directive
+                    go fullscreenInputs nextState
+                        current
+                            { optProvider = Nothing
+                            , optModel = Nothing
+                            , optCwd = Nothing
+                            , optWorktree = False
+                            , optEffort = Nothing
+                            , optPrompt = Nothing
+                            , optPromptFile = Nothing
+                            , optResume = Just sessionId
+                            }
+                        Nothing
             RunSwitchWorktree path provider model effort ->
                 newSessionState >>= \nextState ->
                     go fullscreenInputs nextState

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -31,7 +31,7 @@ import Agent.CLI.Command
                  ReplSetModel, ReplToggleFast, ReplEnableCodeMode,
                  ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
                  ReplViewPlan, ReplQueue, ReplTranscript, ReplEditPrompt,
-                 ReplContext,
+                 ReplContext, ReplHistory, ReplFind,
                  ReplBtw, ReplMetaConsole, ReplRecap, ReplRetry, ReplResume, ReplSearch, ReplClear, ReplNew,
                  ReplShowSession, ReplShowSessionInfo, ReplAfk, ReplWorktree,
                  ReplRename, ReplRenameAuto, ReplInit, ReplReview, ReplDiff,
@@ -76,9 +76,12 @@ import Agent.CLI.GitDiff
 import Agent.CLI.Input
     ( formatPasteChip,
       readApprovalLine,
+      readChoiceSelection,
       readChoiceSelectionAt,
+      readReplHistory,
       readModalText,
       submissionPromptText,
+      truncateDisplayText,
       ReplLine(ReplText, ReplMeta, ReplEof, ReplQuitInterrupt, ReplCycleMode,
                ReplClipboardPaste, ReplClipboardPasteOrText, ReplChooseModel,
                ReplChooseEffort, ReplChooseAccount, ReplRemovePendingImage,
@@ -200,6 +203,7 @@ import Agent.CLI.TUI.App
       commitFullscreenHistoryTurn,
       emitUiEvent,
       requestFullscreenChoiceWithBody,
+      requestFullscreenFilterChoice,
       requestFullscreenSecret,
       requestFullscreenText,
       queuedFullscreenInputDisplays,
@@ -314,7 +318,7 @@ import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text
-    ( intercalate, map, null, pack, replace, strip, toLower )
+    ( intercalate, map, null, pack, replace, strip, toCaseFold, toLower )
 import qualified Data.Text.IO as Text ( putStrLn, hPutStrLn, readFile )
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Usage as XAIUsage ()
@@ -932,6 +936,39 @@ handleReplLine
                                     activeTools
                         displayInfo message (Text.putStrLn message)
                         continue
+                    ReplHistory -> do
+                        prompts <-
+                            filter
+                                ((/= "/history")
+                                    . Text.toCaseFold
+                                    . Text.strip)
+                                <$> readReplHistory
+                        case prompts of
+                            [] -> do
+                                let message =
+                                        "No prompt history is available."
+                                displayInfo message (Text.putStrLn message)
+                                continue
+                            _ -> do
+                                selected <- case fullscreen of
+                                    Just runtime ->
+                                        requestFullscreenFilterChoice
+                                            runtime
+                                            "Prompt history"
+                                            0
+                                            [ (historyLabel prompt, "")
+                                            | prompt <- prompts
+                                            ]
+                                            >>= pure . (>>= (`listAt` prompts))
+                                    Nothing ->
+                                        readChoiceSelection
+                                            (\active prompt ->
+                                                (if active
+                                                    then roleSuccess color
+                                                    else roleMuted color)
+                                                    (historyLabel prompt))
+                                            prompts
+                                maybe continue continueWith selected
                     ReplTranscript -> do
                         outcome <- case persist of
                             PersistenceDisabled ->
@@ -972,6 +1009,45 @@ handleReplLine
                                 | otherwise ->
                                     displayInfo message (Text.putStrLn message)
                         continue
+                    ReplFind maybeQuery ->
+                        loadPersistedTranscript >>= \case
+                            Left err -> do
+                                displayError err $
+                                    Text.hPutStrLn stderr
+                                        (roleError color err)
+                                continue
+                            Right Nothing -> do
+                                let message =
+                                        "No conversation transcript is available yet."
+                                displayInfo message (Text.putStrLn message)
+                                continue
+                            Right (Just (meta, blocks)) -> do
+                                let query = fromMaybe "" maybeQuery
+                                    matches =
+                                        Transcript.searchTranscriptBlocks
+                                            query
+                                            blocks
+                                if null matches
+                                    then do
+                                        let message =
+                                                "No transcript blocks matched “"
+                                                    <> query
+                                                    <> "”."
+                                        displayInfo message
+                                            (Text.putStrLn message)
+                                    else
+                                        legacy
+                                            (openPager
+                                                (Transcript.renderTranscriptMarkdown
+                                                    meta
+                                                    matches))
+                                            >>= \case
+                                                Left err ->
+                                                    displayError err $
+                                                        Text.hPutStrLn stderr
+                                                            (roleError color err)
+                                                Right () -> pure ()
+                                continue
                     ReplEditPrompt -> do
                         legacy editPrompt >>= \case
                             Left err -> do
@@ -1719,6 +1795,26 @@ handleReplLine
                     )
             Right result -> result
 
+    loadPersistedTranscript =
+        case persist of
+            PersistenceDisabled -> pure (Right Nothing)
+            PersistenceEnabled slotRef ->
+                readIORef slotRef >>= \case
+                    PersistencePending{} -> pure (Right Nothing)
+                    PersistenceActive handle ->
+                        loadSession
+                            databasePool
+                            (sessionsRoot home)
+                            handle.sessionMeta.metaId
+                            >>= pure . fmap
+                                (\(meta, turns) ->
+                                    let blocks =
+                                            foldTranscriptTurns
+                                                (zip [0 ..] turns)
+                                    in if null blocks
+                                        then Nothing
+                                        else Just (meta, blocks))
+
     openPager markdown = do
         outcome <- tryAny do
             resolveExternalProgram
@@ -1737,6 +1833,15 @@ handleReplLine
                         <> Text.pack (show exception)
                     )
             Right result -> result
+
+    historyLabel =
+        truncateDisplayText 120 . Text.replace "\n" " ↵ "
+
+    listAt index values
+        | index < 0 = Nothing
+        | otherwise = case drop index values of
+            value : _ -> Just value
+            [] -> Nothing
 
 formatQueuedPrompts :: [Text] -> Text
 formatQueuedPrompts [] = "No prompts are queued."

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -16,6 +16,7 @@ import Agent.CLI.Clipboard ()
 import Agent.CLI.Command
     ( currentEffort,
       currentModel,
+      ForkRequest(..),
       ReplAction(ReplRenameAuto, ReplResume, ReplSearch, ReplClear,
                  ReplNew, ReplShowSession, ReplShowSessionInfo, ReplAfk,
                  ReplWorktree, ReplRename, ReplFork),
@@ -29,7 +30,7 @@ import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ()
 import Agent.CLI.GatewayBridge ()
-import Agent.CLI.Input ()
+import Agent.CLI.Input ( readChoiceSelection )
 import Agent.CLI.Interrupt ()
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
@@ -63,14 +64,13 @@ import Agent.CLI.Runtime.HistorySource
 import Agent.CLI.Runtime.Persistence ()
 import Agent.CLI.Runtime.Recap ()
 import Agent.CLI.Runtime.Types
-    ( RunResult(RunSwitchWorktree, RunQuit) )
+    ( RunResult(RunForkSession, RunSwitchWorktree, RunQuit) )
 import Agent.CLI.Secret ()
 import Agent.CLI.Session
     ( TranscriptEffect(TranscriptReset),
       appendTurnKeepTitleIndexed,
       createSession,
-      deleteSession,
-      forkSession,
+      forkSessionAt,
       loadSession,
       removeSessionTemp,
       resetSessionTitleToAuto,
@@ -87,17 +87,14 @@ import Agent.CLI.Session
       SessionMeta(metaTitle, metaLastResponseId, metaUpdatedAt,
                   metaInputTokens, metaOutputTokens, metaCachedTokens, metaLastRecap,
                   metaLastTurnSummary, metaLastRecapMainTurns, metaTransportModel,
-                  metaId, metaCwd, metaTitleUserTurns),
+                  metaId, metaCwd),
       SessionTransfer(transferTurns, SessionTransfer, transferMeta),
       SessionTurn(turnUsage, SessionTurn, turnAt, turnUserText,
                   turnAssistantText, turnError, turnResponseId, turnEffect,
                   turnItems) )
 import Agent.CLI.Session.Attachments ()
 import Agent.CLI.Session.Choices ()
-import Agent.CLI.Session.History
-    ( durableTranscriptCheckpoint
-    , retargetLiveTranscript
-    )
+import Agent.CLI.Session.History ()
 import Agent.CLI.Session.Interaction ()
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types ()
@@ -115,10 +112,13 @@ import Agent.CLI.Startup.Format ()
 import Agent.CLI.StartupContext ()
 import Agent.CLI.Status ( formatTokenUsageOrZero )
 import Agent.CLI.Style
-    ( cliWindowTitle, glyphOk, glyphSession, roleError, roleMuted )
+    ( cliWindowTitle, glyphOk, glyphSession, roleError, roleMuted, rolePrompt )
 import Agent.CLI.Subagents.Runtime ()
 import Agent.CLI.TUI.App
-    ( commitFullscreenHistoryTurn, emitUiEvent )
+    ( commitFullscreenHistoryTurn
+    , emitUiEvent
+    , requestFullscreenChoiceWithBody
+    )
 import Agent.CLI.TUI.SessionHistory ( sessionHistoryTurn )
 import Agent.CLI.TUI.Types ( HistoryCommit(..) )
 import Agent.CLI.Terminal ( resolveColor )
@@ -127,7 +127,10 @@ import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch ()
 import Agent.CLI.Worktree
-    ( createManagedWorktreeWithProgress, worktreeProgressMessage )
+    ( createManagedWorktreeWithProgress
+    , removeWorktree
+    , worktreeProgressMessage
+    )
 import Agent.Cancel ()
 import Agent.Claude ()
 import Agent.Dialect ( dialectId, dialectSlug )
@@ -169,9 +172,8 @@ import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar ()
 import Control.Concurrent.STM ()
 import Control.Exception ()
-import Control.Exception.Safe
-    ( displayException, finally, mask_, tryAny )
-import Control.Monad ( forM_ )
+import Control.Exception.Safe ( finally, mask, onException )
+import Control.Monad ( forM_, void )
 import Data.IORef ( readIORef, writeIORef )
 import Data.List ()
 import Data.Maybe ( fromMaybe )
@@ -197,7 +199,7 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ( toAscList )
-import qualified Data.Text as Text ( intercalate, pack, unlines )
+import qualified Data.Text as Text ( intercalate, unlines )
 import qualified Data.Text.IO as Text ( putStrLn, hPutStrLn )
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Usage as XAIUsage ()
@@ -386,69 +388,90 @@ handleSessionAction
                         (roleMuted color
                             (glyphOk <> message))
                 continue
-    ReplFork requestedTitle -> do
+    ReplFork request -> do
         color <- resolveColor stderr
-        case persist of
-            PersistenceDisabled -> do
-                let message =
-                        "session forking requires a persisted session"
+        let failFork message = do
                 displayError message $
-                    Text.hPutStrLn stderr
-                        (roleError color message)
+                    putTextLn stderr (roleError color message)
                 continue
+        case persist of
+            PersistenceDisabled ->
+                failFork "/fork requires a persisted interactive session"
             PersistenceEnabled slotRef ->
                 readIORef slotRef >>= \case
-                    PersistencePending{} -> do
-                        let message =
-                                "a session must contain at least one turn before it can be forked"
-                        displayError message $
-                            Text.hPutStrLn stderr
-                                (roleError color message)
-                        continue
-                    PersistenceActive source -> do
-                        let root = takeDirectory source.sessionDir
-                        result <-
-                            withReplActivity \report -> do
-                                report "Forking session…"
-                                loadSession
-                                    databasePool
-                                    root
-                                    source.sessionMeta.metaId >>= \case
-                                        Left err ->
-                                            pure (Left err)
-                                        Right (meta, turns) ->
-                                            forkSession
-                                                root
-                                                source { sessionMeta = meta }
-                                                turns
-                                                requestedTitle
-                        case result of
-                            Left err -> do
-                                displayError err $
-                                    Text.hPutStrLn stderr
-                                        (roleError color err)
-                                continue
-                            Right forked -> do
-                                installed <-
-                                    installFork
-                                        slotRef
-                                        source
-                                        forked
-                                case installed of
-                                    Left err -> do
-                                        displayError err $
-                                            Text.hPutStrLn stderr
-                                                (roleError color err)
-                                        continue
-                                    Right () -> do
-                                        let message =
-                                                "forked session: "
-                                                    <> forked.sessionMeta.metaId
-                                        displayInfo message $
-                                            Text.hPutStrLn stderr
-                                                (roleMuted color
-                                                    (glyphOk <> message))
-                                        continue
+                    PersistencePending{} ->
+                        failFork
+                            "/fork is available after the first persisted turn"
+                    PersistenceActive source ->
+                        chooseForkWorktree color request.forkWorktree >>= \case
+                            Nothing -> continue
+                            Just useWorktree -> mask \restore -> do
+                                destination <-
+                                    restore $
+                                        if useWorktree
+                                            then
+                                                withReplActivity \report ->
+                                                    createManagedWorktreeWithProgress
+                                                        (report
+                                                            . worktreeProgressMessage)
+                                                        env.sessionHome
+                                                        source.sessionMeta.metaCwd
+                                                    >>= pure . fmap
+                                                        (\path ->
+                                                            (path, Just path))
+                                            else
+                                                pure
+                                                    (Right
+                                                        ( source.sessionMeta.metaCwd
+                                                        , Nothing
+                                                        ))
+                                case destination of
+                                    Left err -> failFork err
+                                    Right (newCwd, worktreePath) -> do
+                                        let root =
+                                                takeDirectory source.sessionDir
+                                            cleanup =
+                                                cleanupForkWorktree
+                                                    source.sessionMeta.metaCwd
+                                                    worktreePath
+                                        result <-
+                                            restore
+                                                (withReplActivity \report -> do
+                                                    report "Forking session…"
+                                                    loadSession
+                                                        databasePool
+                                                        root
+                                                        source.sessionMeta.metaId
+                                                        >>= \case
+                                                            Left err ->
+                                                                pure (Left err)
+                                                            Right (meta, turns) ->
+                                                                forkSessionAt
+                                                                    root
+                                                                    source
+                                                                        { sessionMeta =
+                                                                            meta
+                                                                        }
+                                                                    turns
+                                                                    Nothing
+                                                                    newCwd)
+                                                `onException` cleanup
+                                        case result of
+                                            Left err -> do
+                                                cleanup
+                                                failFork err
+                                            Right forked -> do
+                                                let message =
+                                                        "forked session: "
+                                                            <> forked.sessionMeta.metaId
+                                                displayInfo message $
+                                                    putTextLn stderr
+                                                        (roleMuted color
+                                                            (glyphOk <> message))
+                                                pure
+                                                    (RunForkSession
+                                                        forked.sessionMeta.metaId
+                                                        request.forkDirective)
     ReplShowSession -> do
         color <- resolveColor stdout
         case persist of
@@ -709,69 +732,6 @@ handleSessionAction
         continue
     _ -> error "handleSessionAction: unsupported action"
   where
-    installFork slotRef source forked = mask_ do
-        prepared <- tryAny do
-            env.sessionSetTempDir forked.sessionTempDir
-            forM_ fullscreen \runtime ->
-                reloadFullscreenHistoryForHandle runtime forked
-            retargetLiveTranscript
-                env.sessionConversation
-                (durableTranscriptCheckpoint
-                    databasePool
-                    (takeDirectory forked.sessionDir)
-                    forked.sessionMeta.metaId)
-        case prepared of
-            Left err -> rollbackBeforeClaim err
-            Right () ->
-                tryAny (env.sessionOnPersisted forked) >>= \case
-                    Left err -> rollbackBeforeClaim err
-                    Right () -> do
-                        -- With the new lock held, all remaining state changes
-                        -- are non-blocking IORef swaps. Keep the live
-                        -- conversation and response parent unchanged.
-                        writeIORef slotRef (PersistenceActive forked)
-                        writeIORef planMode.planSessionDir
-                            (Just forked.sessionDir)
-                        writeIORef storeRoot (Just forked.sessionDir)
-                        writeIORef
-                            env.sessionTitleTurnCount
-                            forked.sessionMeta.metaTitleUserTurns
-                        _ <- tryAny $
-                            setWindowTitle
-                                (cliWindowTitle
-                                    forked.sessionMeta.metaCwd
-                                    (Just forked.sessionMeta.metaTitle))
-                        pure (Right ())
-      where
-        rollbackBeforeClaim err = do
-            _ <- tryAny
-                (env.sessionSetTempDir source.sessionTempDir)
-            _ <- tryAny $
-                forM_ fullscreen \runtime ->
-                    reloadFullscreenHistoryForHandle runtime source
-            _ <- tryAny $
-                retargetLiveTranscript
-                    env.sessionConversation
-                    (durableTranscriptCheckpoint
-                        databasePool
-                        (takeDirectory source.sessionDir)
-                        source.sessionMeta.metaId)
-            cleanup <-
-                deleteSession
-                    databasePool
-                    (takeDirectory forked.sessionDir)
-                    forked.sessionMeta.metaId
-            let base =
-                    "could not activate forked session: "
-                        <> Text.pack (displayException err)
-            pure $
-                Left $
-                    case cleanup of
-                        Right () -> base
-                        Left cleanupErr ->
-                            base
-                                <> "; cleanup also failed: "
-                                <> cleanupErr
     fullscreenEvent event = case fullscreen of
         Nothing -> pure ()
         Just runtime -> emitUiEvent runtime event
@@ -798,3 +758,39 @@ handleSessionAction
         case fullscreen of
             Nothing -> clearThinking render
             Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
+    chooseForkWorktree color = \case
+        Just value -> pure (Just value)
+        Nothing ->
+            case fullscreen of
+                Just runtime ->
+                    requestFullscreenChoiceWithBody
+                        runtime
+                        "Fork session"
+                        "Should the peer conversation use a fresh git worktree?"
+                        0
+                        [ ( "Use a new worktree"
+                          , "Create an isolated branch and working directory"
+                          )
+                        , ( "Share current workspace"
+                          , "Keep both conversations in the current checkout"
+                          )
+                        ]
+                        >>= pure . \case
+                            Just 0 -> Just True
+                            Just 1 -> Just False
+                            _ -> Nothing
+                Nothing ->
+                    readChoiceSelection
+                        (\selected label ->
+                            if selected
+                                then rolePrompt color label
+                                else roleMuted color label)
+                        [ "Use a new worktree"
+                        , "Share current workspace"
+                        ]
+                        >>= pure . \case
+                            Just "Use a new worktree" -> Just True
+                            Just "Share current workspace" -> Just False
+                            _ -> Nothing
+    cleanupForkWorktree source =
+        mapM_ \path -> void (removeWorktree source path)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
@@ -38,6 +38,8 @@ data RunResult
     | RunResumeSession Text
       -- ^ Persisted session id. Consumed after the current provider-specific
       -- backend shuts down before starting the selected session.
+    | RunForkSession Text (Maybe Text)
+      -- ^ A newly forked session plus an optional first interactive prompt.
     | RunSwitchWorktree OsPath Provider Text ReasoningEffort
       -- ^ Fresh worktree path. Starts a new session after the current backend
       -- and fullscreen UI have shut down, retaining provider, model, and effort.

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -26,6 +26,7 @@ module Agent.CLI.Session
     , cleanupPendingPersistence
     , createSession
     , forkSession
+    , forkSessionAt
     , appendTurn
     , appendTurnIndexed
     , appendTurnWithMetaUpdate
@@ -296,7 +297,25 @@ forkSession
     -> [SessionTurn]
     -> Maybe Text
     -> IO (Either Text SessionHandle)
-forkSession root source turns requestedTitle
+forkSession root source turns requestedTitle =
+    forkSessionAt
+        root
+        source
+        turns
+        requestedTitle
+        source.sessionMeta.metaCwd
+
+-- | Clone a persisted session while selecting the fork's working directory.
+-- This is used by @/fork --worktree@; ordinary callers retain the source cwd
+-- through 'forkSession'.
+forkSessionAt
+    :: OsPath
+    -> SessionHandle
+    -> [SessionTurn]
+    -> Maybe Text
+    -> OsPath
+    -> IO (Either Text SessionHandle)
+forkSessionAt root source turns requestedTitle targetCwd
     | not (any substantiveTurn (activeTranscriptTurns turns)) =
         pure (Left "a session must contain at least one turn before it can be forked")
     | otherwise = mask \restore -> do
@@ -311,8 +330,13 @@ forkSession root source turns requestedTitle
                         pure (Left err)
                     Right dir -> do
                         now <- normalizePostgresTimestamp <$> getCurrentTime
-                        let meta = forkedMetadata now sessionId requestedTitle
-                                source.sessionMeta
+                        let meta =
+                                forkedMetadata
+                                    now
+                                    sessionId
+                                    requestedTitle
+                                    targetCwd
+                                    source.sessionMeta
                             storedMeta = toStoredMetadata meta
                             handle = SessionHandle
                                 { sessionPool = source.sessionPool
@@ -381,13 +405,15 @@ forkedMetadata
     :: UTCTime
     -> Text
     -> Maybe Text
+    -> OsPath
     -> SessionMeta
     -> SessionMeta
-forkedMetadata now sessionId requestedTitle source =
+forkedMetadata now sessionId requestedTitle targetCwd source =
     source
         { metaId = sessionId
         , metaCreatedAt = now
         , metaUpdatedAt = now
+        , metaCwd = targetCwd
         , metaTitle = title
         , metaTitleIsManual =
             maybe source.metaTitleIsManual (const True) normalizedTitle

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -881,32 +881,38 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                                     pure
                         result <- runOneTurn env request.managedTurnText skillInputs
                         callbacks.runnerFinishTurn env True result
-                    Nothing ->
-                        case learnAboutUserOnboardingPrompt learnedSkills of
-                            Just onboardingPrompt
-                                | learnAboutUserRequested
-                                , isNothing initialPrevious -> do
-                                    skillInputs <-
-                                        callbacks.runnerPreparePromptSkillInputs
-                                            env
-                                            onboardingPrompt
-                                            [UserMessage onboardingPrompt]
-                                            >>= either
-                                                (startupDie startup . Text.unpack)
-                                                pure
-                                    forM_ fullscreen \runtime ->
-                                        emitUiEvent runtime
-                                            (UiUserSubmitted onboardingPrompt)
-                                    result <-
-                                        runOneTurn
-                                            env
-                                            onboardingPrompt
-                                            skillInputs
-                                    callbacks.runnerFinishTurn env False result
-                            _ ->
-                                readIORef
-                                    startup.startupSessionState.sessionDraft
-                                    >>= callbacks.runnerReplWithDraft env
+                    Nothing -> do
+                        initialPrompt <-
+                            atomicModifyIORef'
+                                startup.startupSessionState.sessionInitialPrompt
+                                (\pending -> (Nothing, pending))
+                        case initialPrompt of
+                            Just text -> runInteractiveInitialPrompt env text
+                            Nothing ->
+                                case learnAboutUserOnboardingPrompt learnedSkills of
+                                    Just onboardingPrompt
+                                        | learnAboutUserRequested
+                                        , isNothing initialPrevious ->
+                                            runInteractiveInitialPrompt
+                                                env
+                                                onboardingPrompt
+                                    _ ->
+                                        readIORef
+                                            startup.startupSessionState.sessionDraft
+                                            >>= callbacks.runnerReplWithDraft env
+        runInteractiveInitialPrompt env text = do
+            skillInputs <-
+                callbacks.runnerPreparePromptSkillInputs
+                    env
+                    text
+                    [UserMessage text]
+                    >>= either
+                        (startupDie startup . Text.unpack)
+                        pure
+            forM_ fullscreen \runtime ->
+                emitUiEvent runtime (UiUserSubmitted text)
+            result <- runOneTurn env text skillInputs
+            callbacks.runnerFinishTurn env False result
         btwWorker = do
             question <- readChan btwRequests
             runBtwQuestion False env question

--- a/packages/agent-cli/src/Agent/CLI/SessionState.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionState.hs
@@ -17,6 +17,10 @@ import Data.Text (Text)
 -- but they must keep this state object alive.
 data SessionState = SessionState
     { sessionDraft :: !(IORef Text)
+    -- | A prompt submitted as the first interactive turn after rebuilding a
+    -- session (for example a @/fork@ directive). Unlike 'CliOptions.optPrompt',
+    -- this does not turn the invocation into one-shot mode.
+    , sessionInitialPrompt :: !(IORef (Maybe Text))
     , sessionConversation :: !(IORef LiveConversation)
     , sessionPreviewId :: !(IORef Int)
     }
@@ -24,10 +28,12 @@ data SessionState = SessionState
 newSessionState :: IO SessionState
 newSessionState = do
     draft <- newIORef ""
+    initialPrompt <- newIORef Nothing
     conversation <- newIORef =<< newConversationStore Nothing [] []
     previewId <- newIORef 1
     pure SessionState
         { sessionDraft = draft
+        , sessionInitialPrompt = initialPrompt
         , sessionConversation = conversation
         , sessionPreviewId = previewId
         }

--- a/packages/agent-cli/src/Agent/CLI/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/Transcript.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Transcript
     , foldTranscriptTurns
     , renderTranscriptMarkdown
     , renderSessionTranscript
+    , searchTranscriptBlocks
     , markdownFence
     ) where
 
@@ -103,6 +104,24 @@ renderTranscriptMarkdown meta blocks =
                 | Text.null (Text.strip detail) = []
                 | otherwise = ["", "**Details**", "", markdownFence detail]
         in bodyLines <> detailLines <> stateLine
+
+-- | Match transcript blocks case-insensitively across their visible fields.
+-- An empty query deliberately returns the complete transcript so @/find@
+-- can hand search control to the pager.
+searchTranscriptBlocks :: Text -> [UiBlock] -> [UiBlock]
+searchTranscriptBlocks rawQuery blocks
+    | Text.null query = blocks
+    | otherwise = filter matches blocks
+  where
+    query = Text.toCaseFold (Text.strip rawQuery)
+    matches block =
+        any
+            (Text.isInfixOf query . Text.toCaseFold)
+            [ block.blockTitle
+            , block.blockBody
+            , block.blockDetail
+            , block.blockTimestamp
+            ]
 
 shown :: Show a => a -> Text
 shown = Text.pack . show

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -78,12 +78,44 @@ spec = do
             parseReplLine "/diff" `shouldBe` ReplDiff
             parseReplLine "/diff now"
                 `shouldBe` ReplCommandError "usage: /diff"
-            parseReplLine "/fork" `shouldBe` ReplFork Nothing
+            parseReplLine "/fork"
+                `shouldBe` ReplFork (ForkRequest Nothing Nothing)
             parseReplLine "/fork   experiment branch  "
-                `shouldBe` ReplFork (Just "experiment branch")
+                `shouldBe`
+                    ReplFork
+                        (ForkRequest Nothing (Just "experiment branch"))
+            parseReplLine "/fork --worktree fix the tests"
+                `shouldBe`
+                    ReplFork
+                        (ForkRequest (Just True) (Just "fix the tests"))
+            parseReplLine "/fork --no-worktree"
+                `shouldBe` ReplFork (ForkRequest (Just False) Nothing)
+            parseReplLine "/fork --unknown stays a directive"
+                `shouldBe`
+                    ReplFork
+                        (ForkRequest
+                            Nothing
+                            (Just "--unknown stays a directive"))
+            parseReplLine "/fork --worktree --no-worktree"
+                `shouldBe`
+                    ReplCommandError
+                        "--worktree and --no-worktree are mutually exclusive"
+            parseReplLine "/fork --worktree --worktree"
+                `shouldBe`
+                    ReplCommandError "--worktree specified twice"
+            parseReplLine "/fork --at 3"
+                `shouldBe`
+                    ReplCommandError
+                        "--at is not supported in this version"
             parseReplLine "/export" `shouldBe` ReplExport Nothing
             parseReplLine "/export  notes/session.md  "
                 `shouldBe` ReplExport (Just "notes/session.md")
+            parseReplLine "/history" `shouldBe` ReplHistory
+            parseReplLine "/history now"
+                `shouldBe` ReplCommandError "usage: /history"
+            parseReplLine "/find" `shouldBe` ReplFind Nothing
+            parseReplLine "/find   exact  phrase"
+                `shouldBe` ReplFind (Just "exact  phrase")
             parseReplLine "/permissions" `shouldBe` ReplPermissions
             parseReplLine "/permissions now"
                 `shouldBe` ReplCommandError "usage: /permissions"
@@ -364,6 +396,8 @@ spec = do
                     , "diff"
                     , "fork"
                     , "export"
+                    , "history"
+                    , "find"
                     , "permissions"
                     , "model"
                     , "effort"
@@ -479,6 +513,8 @@ spec = do
                 `shouldBe` ["qwen-local"]
             slashCompletionCandidates "emaner/" "-"
                 `shouldBe` ["--auto"]
+            slashCompletionCandidates "krof/" "-"
+                `shouldBe` ["--worktree", "--no-worktree"]
             slashCompletionCandidates "llehs/" "b"
                 `shouldBe` ["bash", "both"]
 

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -722,7 +722,13 @@ spec = describe "Agent.CLI.Session" do
                 LBS.writeFile (toFilePath childPath) "child"
                 LBS.writeFile (toFilePath ignoredPath) "runtime log"
 
-                forkSession root source [sourceTurn] (Just "Fork title") >>= \case
+                let forkCwd = root </> unsafeEncodeUtf "fork-worktree"
+                forkSessionAt
+                    root
+                    source
+                    [sourceTurn]
+                    (Just "Fork title")
+                    forkCwd >>= \case
                     Left err -> expectationFailure (Text.unpack err)
                     Right forked -> do
                         forked.sessionMeta.metaId
@@ -733,6 +739,7 @@ spec = describe "Agent.CLI.Session" do
                             `shouldBe` forked.sessionMeta.metaCreatedAt
                         forked.sessionMeta.metaTitle `shouldBe` "Fork title"
                         forked.sessionMeta.metaTitleIsManual `shouldBe` True
+                        forked.sessionMeta.metaCwd `shouldBe` forkCwd
                         forked.sessionMeta.metaLastResponseId
                             `shouldBe` Just "response-parent"
                         forked.sessionMeta.metaLastRecap `shouldBe` Just "recap"

--- a/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
@@ -21,6 +21,9 @@ spec =
 
             -- Replacing a backend reuses this same provider-independent state.
             readIORef state.sessionDraft `shouldReturn` "unfinished prompt"
+            writeIORef state.sessionInitialPrompt (Just "fork directive")
+            readIORef state.sessionInitialPrompt
+                `shouldReturn` Just "fork directive"
             readLiveAttachments state.sessionConversation `shouldReturn` [image]
             readIORef state.sessionPreviewId `shouldReturn` 42
 
@@ -40,5 +43,6 @@ spec =
         it "starts a new user session with empty composer state" do
             state <- newSessionState
             readIORef state.sessionDraft `shouldReturn` ""
+            readIORef state.sessionInitialPrompt `shouldReturn` Nothing
             readLiveAttachments state.sessionConversation `shouldReturn` []
             readIORef state.sessionPreviewId `shouldReturn` 1

--- a/packages/agent-cli/test/Agent/CLI/TranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TranscriptSpec.hs
@@ -12,6 +12,7 @@ import Agent.CLI.Transcript
     ( foldTranscriptTurns
     , markdownFence
     , renderTranscriptMarkdown
+    , searchTranscriptBlocks
     )
 import Agent.Provider (Provider(..))
 import Agent.TUI.Model
@@ -63,6 +64,20 @@ spec = describe "Agent.CLI.Transcript" do
         let block = testBlock { blockBody = "answer ``` with output" }
             output = renderTranscriptMarkdown testMeta [block]
         output `shouldSatisfy` Text.isInfixOf "````\nanswer ``` with output\n````"
+
+    it "searches visible transcript fields case-insensitively" do
+        let first = testBlock
+                { blockTitle = "Compiler"
+                , blockBody = "GHC loaded the module"
+                }
+            second = testBlock
+                { blockTitle = "Tests"
+                , blockDetail = "1300 examples passed"
+                }
+            blocks = [first, second]
+        searchTranscriptBlocks "ghc" blocks `shouldBe` [first]
+        searchTranscriptBlocks "EXAMPLES" blocks `shouldBe` [second]
+        searchTranscriptBlocks "   " blocks `shouldBe` blocks
 
 turn :: TranscriptEffect -> Text -> SessionTurn
 turn effect text = SessionTurn


### PR DESCRIPTION
## Summary
- add searchable `/history` and persisted-transcript `/find` commands
- extend transactional `/fork` with interactive worktree selection, `--worktree` / `--no-worktree`, and an optional first-turn directive
- keep directive-driven forks interactive after their first response and clean up interrupted worktree creation safely
- serialize prompt-history reads and writes so fullscreen `/history` cannot race persistence
- add parser, catalog, completion, transcript-search, session-state, and fork metadata coverage

## Validation
- GHCi loaded all 209 modules
- `TMPDIR=/tmp nix develop -c cabal test agent-cli:test:agent-cli-test --test-show-details=direct` — 1,392 examples, 0 failures
- real tmux smoke test covering `/history` selection/prefill, `/find` filtering, `/fork --no-worktree` with an automatic directive followed by continued interaction, and `/export`