### PR TITLE
Close remaining shared temp path aliases

### DIFF
--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -36,7 +36,7 @@ import Agent.Codex.Dialect.Shell
     , startCodexShellCommand
     )
 import Agent.Tools.Ghci (GhciSession, runGhciTool)
-import Agent.Tools.Dangerous (blockedShellCommandReason)
+import Agent.Tools.Dangerous (blockedShellCommandReasonAt)
 import Agent.Tools.FileSystem.Grep (grepTool)
 import Agent.Tools.FileSystem.ListDir (listDirTool)
 import Agent.Tools.FileSystem.ReadFile (readFileTool)
@@ -179,8 +179,6 @@ runShell
     -> ShellCommandArgs
     -> IO (Either Text Text)
 runShell env session emitOutput args
-    | Just reason <- blockedShellCommandReason args.command =
-        pure (Left reason)
     | args.timeoutMs /= Nothing && args.yieldTimeMs /= Nothing =
         pure (Left "timeout_ms and yield_time_ms are mutually exclusive")
     | otherwise = do
@@ -189,30 +187,34 @@ runShell env session emitOutput args
             Just dir -> resolveUnderCwd env (fromText dir)
         case workdir of
             Left err -> pure (Left err)
-            Right dir -> case args.yieldTimeMs of
-                Just requestedYield -> do
-                    let yieldMs = clampMs requestedYield
-                    startCodexShellCommand
-                        session
-                        dir
-                        (Text.unpack args.command)
-                        yieldMs
-                        (\out err -> emitOutput (commandBody out err))
-                        >>= pure . fmap renderShellResult
-                Nothing -> do
-                    let timeoutMs = clampMs (fromMaybe 10000 args.timeoutMs)
-                    result <- runShellCommandStreaming
-                        env
-                        dir
-                        (Text.unpack args.command)
-                        timeoutMs
-                        (\out err -> emitOutput (commandBody out err))
-                    if result.commandCancelled
-                        then pure $ Left "Error: Command cancelled"
-                        else if result.commandTimedOut
-                        then pure $ Left $
-                            "Error: Command timed out after " <> Text.pack (show timeoutMs) <> "ms"
-                        else pure $ Right $ renderFinished result
+            Right dir
+                | Just reason <-
+                    blockedShellCommandReasonAt dir args.command ->
+                    pure (Left reason)
+                | otherwise -> case args.yieldTimeMs of
+                    Just requestedYield -> do
+                        let yieldMs = clampMs requestedYield
+                        startCodexShellCommand
+                            session
+                            dir
+                            (Text.unpack args.command)
+                            yieldMs
+                            (\out err -> emitOutput (commandBody out err))
+                            >>= pure . fmap renderShellResult
+                    Nothing -> do
+                        let timeoutMs = clampMs (fromMaybe 10000 args.timeoutMs)
+                        result <- runShellCommandStreaming
+                            env
+                            dir
+                            (Text.unpack args.command)
+                            timeoutMs
+                            (\out err -> emitOutput (commandBody out err))
+                        if result.commandCancelled
+                            then pure $ Left "Error: Command cancelled"
+                            else if result.commandTimedOut
+                            then pure $ Left $
+                                "Error: Command timed out after " <> Text.pack (show timeoutMs) <> "ms"
+                            else pure $ Right $ renderFinished result
 
 data WriteStdinArgs = WriteStdinArgs
     { sessionId :: Int

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -187,34 +187,38 @@ runShell env session emitOutput args
             Just dir -> resolveUnderCwd env (fromText dir)
         case workdir of
             Left err -> pure (Left err)
-            Right dir
-                | Just reason <-
-                    blockedShellCommandReasonAt dir args.command ->
-                    pure (Left reason)
-                | otherwise -> case args.yieldTimeMs of
-                    Just requestedYield -> do
-                        let yieldMs = clampMs requestedYield
-                        startCodexShellCommand
-                            session
-                            dir
-                            (Text.unpack args.command)
-                            yieldMs
-                            (\out err -> emitOutput (commandBody out err))
-                            >>= pure . fmap renderShellResult
-                    Nothing -> do
-                        let timeoutMs = clampMs (fromMaybe 10000 args.timeoutMs)
-                        result <- runShellCommandStreaming
-                            env
-                            dir
-                            (Text.unpack args.command)
-                            timeoutMs
-                            (\out err -> emitOutput (commandBody out err))
-                        if result.commandCancelled
-                            then pure $ Left "Error: Command cancelled"
-                            else if result.commandTimedOut
-                            then pure $ Left $
-                                "Error: Command timed out after " <> Text.pack (show timeoutMs) <> "ms"
-                            else pure $ Right $ renderFinished result
+            Right dir ->
+                blockedShellCommandReasonAt dir args.command >>= \case
+                    Just reason -> pure (Left reason)
+                    Nothing -> case args.yieldTimeMs of
+                        Just requestedYield -> do
+                            let yieldMs = clampMs requestedYield
+                            startCodexShellCommand
+                                session
+                                dir
+                                (Text.unpack args.command)
+                                yieldMs
+                                (\out err -> emitOutput (commandBody out err))
+                                >>= pure . fmap renderShellResult
+                        Nothing -> do
+                            let timeoutMs =
+                                    clampMs
+                                        (fromMaybe 10000 args.timeoutMs)
+                            result <- runShellCommandStreaming
+                                env
+                                dir
+                                (Text.unpack args.command)
+                                timeoutMs
+                                (\out err ->
+                                    emitOutput (commandBody out err))
+                            if result.commandCancelled
+                                then pure $ Left "Error: Command cancelled"
+                                else if result.commandTimedOut
+                                then pure $ Left $
+                                    "Error: Command timed out after "
+                                        <> Text.pack (show timeoutMs)
+                                        <> "ms"
+                                else pure $ Right $ renderFinished result
 
 data WriteStdinArgs = WriteStdinArgs
     { sessionId :: Int

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -49,7 +49,7 @@ import System.Directory
     , getTemporaryDirectory
     , removeDirectoryRecursive
     )
-import System.FilePath ((</>))
+import System.FilePath (makeRelative, (</>))
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
@@ -129,6 +129,27 @@ spec = describe "Codex dialect" do
                     result.output `shouldSatisfy`
                         Text.isInfixOf "Blocked hardcoded system temp path"
                     result.output `shouldSatisfy` Text.isInfixOf "$TMPDIR"
+
+    it "rejects system temp paths relative to the shell cwd" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            let relativeTmp =
+                    Text.pack (makeRelative dir "/tmp/agent-output")
+            bracket
+                (newCodexCodingTools env Nothing Nothing)
+                (.codexClose)
+                \coding -> do
+                    result <- dispatchToolCall
+                        testDispatchConfig
+                        (appToolHandlers coding.codexAppTools)
+                        (functionToolCall
+                            "shell-relative-system-tmp"
+                            "shell_command"
+                            ("{\"command\":\"cat "
+                                <> relativeTmp
+                                <> "\"}"))
+                    result.output `shouldSatisfy`
+                        Text.isInfixOf "Blocked hardcoded system temp path"
 
     it "maps a /tmp shell workdir to the private session directory" do
         withTempDir \dir -> do

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -130,6 +130,23 @@ spec = describe "Codex dialect" do
                         Text.isInfixOf "Blocked hardcoded system temp path"
                     result.output `shouldSatisfy` Text.isInfixOf "$TMPDIR"
 
+    it "rejects traversal above the private temp variables" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket
+                (newCodexCodingTools env Nothing Nothing)
+                (.codexClose)
+                \coding -> do
+                    result <- dispatchToolCall
+                        testDispatchConfig
+                        (appToolHandlers coding.codexAppTools)
+                        (functionToolCall
+                            "shell-session-tmp-traversal"
+                            "shell_command"
+                            "{\"command\":\"cat \\\"$TMPDIR/../other-session/secret\\\"\"}")
+                    result.output `shouldSatisfy`
+                        Text.isInfixOf "Blocked path traversal"
+
     it "rejects system temp paths relative to the shell cwd" do
         withTempDir \dir -> do
             env <- defaultToolEnv (unsafeEncodeUtf dir)

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -6,12 +6,15 @@
 module Agent.Tools.Dangerous
     ( shellCommandBlocked
     , blockedShellCommandReason
+    , blockedShellCommandReasonAt
     , commandLooksLikeRmRf
     , commandUsesHardcodedSystemTmp
+    , commandUsesHardcodedSystemTmpAt
     , forbiddenRmRfReason
     , hardcodedSystemTmpReason
     ) where
 
+import Agent.OsPath (toText)
 import Agent.JsonText (jsonTextField)
 import Data.Char
     ( chr
@@ -23,6 +26,7 @@ import Data.Char
     )
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.OsPath (OsPath)
 
 -- | If @toolName@ is a shell tool and @argumentsJson@ contains a forbidden
 -- command, return a rejection message for the model. Otherwise 'Nothing'.
@@ -44,6 +48,17 @@ blockedShellCommandReason command
         Just (hardcodedSystemTmpReason command)
     | otherwise = Nothing
 
+-- | Apply shell hard-denies after resolving the command's initial working
+-- directory. This additionally catches relative spellings that reach the
+-- shared system temp namespace from that directory.
+blockedShellCommandReasonAt :: OsPath -> Text -> Maybe Text
+blockedShellCommandReasonAt cwd command
+    | commandLooksLikeRmRf command =
+        Just (forbiddenRmRfReason command)
+    | commandUsesHardcodedSystemTmpAt cwd command =
+        Just (hardcodedSystemTmpReason command)
+    | otherwise = Nothing
+
 forbiddenRmRfReason :: Text -> Text
 forbiddenRmRfReason command =
     "Blocked dangerous shell command (rm -rf / recursive force delete). "
@@ -61,9 +76,22 @@ forbiddenRmRfReason command =
 -- dot/parent components, and avoids ordinary URL path components and names
 -- such as @/tmpfile@.
 commandUsesHardcodedSystemTmp :: Text -> Bool
-commandUsesHardcodedSystemTmp command =
+commandUsesHardcodedSystemTmp =
+    commandUsesHardcodedSystemTmpWithCwd Nothing
+
+-- | Like 'commandUsesHardcodedSystemTmp', but resolve relative path-shaped
+-- tokens against the shell's initial working directory.
+commandUsesHardcodedSystemTmpAt :: OsPath -> Text -> Bool
+commandUsesHardcodedSystemTmpAt cwd =
+    commandUsesHardcodedSystemTmpWithCwd (Just cwd)
+
+commandUsesHardcodedSystemTmpWithCwd :: Maybe OsPath -> Text -> Bool
+commandUsesHardcodedSystemTmpWithCwd maybeCwd command =
     go Nothing command
         || normalizedAbsolutePathTargetsTemp command
+        || maybe False
+            (\cwd -> normalizedRelativePathTargetsTemp (toText cwd) command)
+            maybeCwd
         || localFileUrlTargetsTemp command
   where
     go previous remaining
@@ -83,12 +111,19 @@ commandUsesHardcodedSystemTmp command =
                 _ -> False
 
     tempComponentAtStart remaining =
-        case Text.stripPrefix "tmp" remaining of
+        case stripPrefixCaseFold "tmp" remaining of
             Just suffix -> pathBoundaryAfter suffix
             Nothing -> False
 
+    stripPrefixCaseFold prefix text
+        | Text.toCaseFold candidate == prefix =
+            Just (Text.drop (Text.length prefix) text)
+        | otherwise = Nothing
+      where
+        candidate = Text.take (Text.length prefix) text
+
     privateTempAtStart remaining =
-        case Text.stripPrefix "private" remaining of
+        case stripPrefixCaseFold "private" remaining of
             Just afterPrivate ->
                 case Text.span (== '/') afterPrivate of
                     (slashes, afterSlashes)
@@ -115,6 +150,21 @@ commandUsesHardcodedSystemTmp command =
                 let (candidate, _) =
                         Text.span isAbsolutePathChar remaining
                 in normalizedPathTargetsTemp candidate
+                    || advance remaining
+            | otherwise = advance remaining
+          where
+            advance text =
+                scan (Just (Text.head text)) (Text.tail text)
+
+    normalizedRelativePathTargetsTemp cwd = scan Nothing
+      where
+        scan previous remaining
+            | Text.null remaining = False
+            | pathBoundaryBefore previous
+            , isPathNameChar (Text.head remaining) =
+                let (candidate, _) =
+                        Text.span isAbsolutePathChar remaining
+                in normalizedPathTargetsTemp (cwd <> "/" <> candidate)
                     || advance remaining
             | otherwise = advance remaining
           where
@@ -154,7 +204,10 @@ commandUsesHardcodedSystemTmp command =
         char == '/' || isPathNameChar char
 
     normalizedPathTargetsTemp path =
-        case reverse (foldl normalizeComponent [] (Text.splitOn "/" path)) of
+        case
+            map Text.toCaseFold $
+                reverse (foldl normalizeComponent [] (Text.splitOn "/" path))
+        of
             "tmp" : _ -> True
             "private" : "tmp" : _ -> True
             _ -> False

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -7,15 +7,20 @@ module Agent.Tools.Dangerous
     ( shellCommandBlocked
     , blockedShellCommandReason
     , blockedShellCommandReasonAt
+    , blockedShellCommandReasonIn
+    , blockedTempAccessReasonAt
     , commandLooksLikeRmRf
     , commandUsesHardcodedSystemTmp
     , commandUsesHardcodedSystemTmpAt
+    , commandEscapesSessionTempVariable
     , forbiddenRmRfReason
     , hardcodedSystemTmpReason
+    , sessionTempEscapeReason
     ) where
 
-import Agent.OsPath (toText)
 import Agent.JsonText (jsonTextField)
+import Agent.OsPath (fromText, toText, unsafeToFilePath)
+import Agent.Tools.FileSystem (pathTargetsSystemTemp)
 import Data.Char
     ( chr
     , digitToInt
@@ -24,9 +29,17 @@ import Data.Char
     , isSpace
     , toLower
     )
+import Data.List (isPrefixOf)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.OsPath (OsPath)
+import System.Directory (canonicalizePath, doesDirectoryExist)
+import System.FilePath
+    ( isAbsolute
+    , normalise
+    , splitDirectories
+    , (</>)
+    )
+import System.OsPath (OsPath, unsafeEncodeUtf)
 
 -- | If @toolName@ is a shell tool and @argumentsJson@ contains a forbidden
 -- command, return a rejection message for the model. Otherwise 'Nothing'.
@@ -44,6 +57,8 @@ blockedShellCommandReason :: Text -> Maybe Text
 blockedShellCommandReason command
     | commandLooksLikeRmRf command =
         Just (forbiddenRmRfReason command)
+    | commandEscapesSessionTempVariable command =
+        Just (sessionTempEscapeReason command)
     | commandUsesHardcodedSystemTmp command =
         Just (hardcodedSystemTmpReason command)
     | otherwise = Nothing
@@ -51,18 +66,53 @@ blockedShellCommandReason command
 -- | Apply shell hard-denies after resolving the command's initial working
 -- directory. This additionally catches relative spellings that reach the
 -- shared system temp namespace from that directory.
-blockedShellCommandReasonAt :: OsPath -> Text -> Maybe Text
+blockedShellCommandReasonAt :: OsPath -> Text -> IO (Maybe Text)
 blockedShellCommandReasonAt cwd command
     | commandLooksLikeRmRf command =
-        Just (forbiddenRmRfReason command)
-    | commandUsesHardcodedSystemTmpAt cwd command =
-        Just (hardcodedSystemTmpReason command)
-    | otherwise = Nothing
+        pure $ Just (forbiddenRmRfReason command)
+    | otherwise = blockedTempAccessReasonAt cwd command
+
+-- | Apply the shell hard-denies while also protecting an active session-temp
+-- root when the persistent shell is currently inside it.
+blockedShellCommandReasonIn
+    :: Maybe OsPath
+    -> OsPath
+    -> Text
+    -> IO (Maybe Text)
+blockedShellCommandReasonIn sessionTmp cwd command
+    | commandLooksLikeRmRf command =
+        pure $ Just (forbiddenRmRfReason command)
+    | otherwise =
+        case sessionTmp of
+            Nothing -> blockedTempAccessReasonAt cwd command
+            Just temp
+                | commandEscapesSessionTempAt temp cwd command ->
+                    pure $ Just (sessionTempEscapeReason command)
+                | otherwise -> blockedTempAccessReasonAt cwd command
+
+-- | Temp-specific deny shared by shell and GHCi tools.
+blockedTempAccessReasonAt :: OsPath -> Text -> IO (Maybe Text)
+blockedTempAccessReasonAt cwd command
+    | commandEscapesSessionTempVariable command =
+        pure $ Just (sessionTempEscapeReason command)
+    | otherwise =
+        commandUsesHardcodedSystemTmpAt cwd command >>= \usesShared ->
+            pure $
+                if usesShared
+                    then Just (hardcodedSystemTmpReason command)
+                    else Nothing
 
 forbiddenRmRfReason :: Text -> Text
 forbiddenRmRfReason command =
     "Blocked dangerous shell command (rm -rf / recursive force delete). "
         <> "Remove files more narrowly, or ask the user to run the delete outside the agent. "
+        <> "Command: "
+        <> Text.take 200 (Text.strip command)
+
+sessionTempEscapeReason :: Text -> Text
+sessionTempEscapeReason command =
+    "Blocked path traversal outside the session's private temp directory. "
+        <> "Keep $TMPDIR and $HASKELL_AGENT_TMPDIR paths within their root. "
         <> "Command: "
         <> Text.take 200 (Text.strip command)
 
@@ -77,22 +127,27 @@ forbiddenRmRfReason command =
 -- such as @/tmpfile@.
 commandUsesHardcodedSystemTmp :: Text -> Bool
 commandUsesHardcodedSystemTmp =
-    commandUsesHardcodedSystemTmpWithCwd Nothing
+    commandUsesHardcodedSystemTmpLexically True
 
 -- | Like 'commandUsesHardcodedSystemTmp', but resolve relative path-shaped
--- tokens against the shell's initial working directory.
-commandUsesHardcodedSystemTmpAt :: OsPath -> Text -> Bool
-commandUsesHardcodedSystemTmpAt cwd =
-    commandUsesHardcodedSystemTmpWithCwd (Just cwd)
+-- tokens against the shell's initial working directory. Case variants are
+-- aliases only when the host filesystem resolves them to the same directory.
+commandUsesHardcodedSystemTmpAt :: OsPath -> Text -> IO Bool
+commandUsesHardcodedSystemTmpAt cwd command = do
+    let cwdText = toText cwd
+        direct =
+            commandUsesHardcodedSystemTmpLexically False command
+    if direct
+        then pure True
+        else shellCwdMutationTargetsTemp cwdText command
 
-commandUsesHardcodedSystemTmpWithCwd :: Maybe OsPath -> Text -> Bool
-commandUsesHardcodedSystemTmpWithCwd maybeCwd command =
+commandUsesHardcodedSystemTmpLexically :: Bool -> Text -> Bool
+commandUsesHardcodedSystemTmpLexically includeNormalized command =
     go Nothing command
-        || normalizedAbsolutePathTargetsTemp command
-        || maybe False
-            (\cwd -> normalizedRelativePathTargetsTemp (toText cwd) command)
-            maybeCwd
-        || localFileUrlTargetsTemp command
+        || includeNormalized
+            && ( normalizedAbsolutePathTargetsTemp command
+                || localFileUrlTargetsTemp command
+               )
   where
     go previous remaining
         | Text.null remaining = False
@@ -111,19 +166,19 @@ commandUsesHardcodedSystemTmpWithCwd maybeCwd command =
                 _ -> False
 
     tempComponentAtStart remaining =
-        case stripPrefixCaseFold "tmp" remaining of
+        case stripPrefixAlias "tmp" remaining of
             Just suffix -> pathBoundaryAfter suffix
             Nothing -> False
 
-    stripPrefixCaseFold prefix text
-        | Text.toCaseFold candidate == prefix =
+    stripPrefixAlias prefix text
+        | candidate == prefix =
             Just (Text.drop (Text.length prefix) text)
         | otherwise = Nothing
       where
         candidate = Text.take (Text.length prefix) text
 
     privateTempAtStart remaining =
-        case stripPrefixCaseFold "private" remaining of
+        case stripPrefixAlias "private" remaining of
             Just afterPrivate ->
                 case Text.span (== '/') afterPrivate of
                     (slashes, afterSlashes)
@@ -150,21 +205,6 @@ commandUsesHardcodedSystemTmpWithCwd maybeCwd command =
                 let (candidate, _) =
                         Text.span isAbsolutePathChar remaining
                 in normalizedPathTargetsTemp candidate
-                    || advance remaining
-            | otherwise = advance remaining
-          where
-            advance text =
-                scan (Just (Text.head text)) (Text.tail text)
-
-    normalizedRelativePathTargetsTemp cwd = scan Nothing
-      where
-        scan previous remaining
-            | Text.null remaining = False
-            | pathBoundaryBefore previous
-            , isPathNameChar (Text.head remaining) =
-                let (candidate, _) =
-                        Text.span isAbsolutePathChar remaining
-                in normalizedPathTargetsTemp (cwd <> "/" <> candidate)
                     || advance remaining
             | otherwise = advance remaining
           where
@@ -205,8 +245,7 @@ commandUsesHardcodedSystemTmpWithCwd maybeCwd command =
 
     normalizedPathTargetsTemp path =
         case
-            map Text.toCaseFold $
-                reverse (foldl normalizeComponent [] (Text.splitOn "/" path))
+            reverse (foldl normalizeComponent [] (Text.splitOn "/" path))
         of
             "tmp" : _ -> True
             "private" : "tmp" : _ -> True
@@ -235,6 +274,315 @@ commandUsesHardcodedSystemTmpWithCwd maybeCwd command =
 
     isPathNameChar char =
         isAlphaNum char || char `elem` ("._-" :: String)
+
+-- | Reject lexical traversal above either environment variable's root.
+-- Ordinary normalization inside that root remains valid.
+commandEscapesSessionTempVariable :: Text -> Bool
+commandEscapesSessionTempVariable command =
+    scan Nothing command
+        || sessionTempCwdTraversal command
+  where
+    scan previous remaining
+        | Text.null remaining = False
+        | variableBoundaryBefore previous
+        , Just suffix <- sessionTempVariableSuffix remaining =
+            variableSuffixEscapes suffix || advance remaining
+        | otherwise = advance remaining
+      where
+        advance text =
+            scan (Just (Text.head text)) (Text.tail text)
+
+    sessionTempVariableSuffix text =
+        firstMatch
+            [ "${HASKELL_AGENT_TMPDIR}"
+            , "${TMPDIR}"
+            , "$HASKELL_AGENT_TMPDIR"
+            , "$TMPDIR"
+            ]
+      where
+        firstMatch [] = Nothing
+        firstMatch (prefix : prefixes)
+            | Text.isPrefixOf prefix text
+            , variableBoundaryAfter prefix text =
+                Just (Text.drop (Text.length prefix) text)
+            | otherwise = firstMatch prefixes
+
+    variableBoundaryAfter prefix text
+        | Text.isPrefixOf "${" prefix = True
+        | Text.length text == Text.length prefix = True
+        | otherwise =
+            not (isVariableNameChar (Text.index text (Text.length prefix)))
+
+    variableSuffixEscapes suffix =
+        case Text.uncons renderedSuffix of
+            Nothing -> False
+            Just ('/', path) ->
+                componentsEscape
+                    (Text.splitOn "/" path)
+            -- Concatenating onto the expansion changes the temp root itself:
+            -- e.g. @$TMPDIR-other@ names a sibling, not a child.
+            Just _ -> True
+      where
+        renderedSuffix =
+            Text.filter (not . isShellSyntax)
+                (Text.takeWhile isVariableSuffixChar suffix)
+
+    componentsEscape = goDepth (0 :: Int)
+      where
+        goDepth _ [] = False
+        goDepth depth (component : rest)
+            | Text.null component || component == "." =
+                goDepth depth rest
+            | component == ".." =
+                depth == 0 || goDepth (depth - 1) rest
+            | otherwise = goDepth (depth + 1) rest
+
+    variableBoundaryBefore = \case
+        Nothing -> True
+        Just char -> not (isVariableNameChar char)
+
+    isVariableNameChar char = isAlphaNum char || char == '_'
+    isShellSyntax char =
+        char == '\'' || char == '"' || char == '\\'
+    isVariableSuffixChar char =
+        not (isSpace char)
+            && char `notElem` (";|&()<>" :: String)
+
+sessionTempCwdTraversal :: Text -> Bool
+sessionTempCwdTraversal command =
+    shellTraversalEscapes Nothing command
+
+shellTraversalEscapes :: Maybe Int -> Text -> Bool
+shellTraversalEscapes initialDepth command =
+    go initialDepth (shellSegments command)
+  where
+    go _ [] = False
+    go depth (segment : rest)
+        | maybe False
+            (\current ->
+                any (relativeCandidateEscapes current)
+                    (relativePathCandidates segment))
+            depth =
+                True
+        | otherwise =
+            go (nextDepth depth segment) rest
+
+    nextDepth current segment =
+        case shellCdTarget segment of
+            Nothing -> current
+            Just target ->
+                case sessionVariableRelative target of
+                    Just relative -> depthAfter 0 relative
+                    Nothing
+                        | isAbsolute target -> Nothing
+                        | otherwise -> current >>= (`depthAfter` target)
+
+    sessionVariableRelative target =
+        firstMatch
+            [ "${HASKELL_AGENT_TMPDIR}"
+            , "${TMPDIR}"
+            , "$HASKELL_AGENT_TMPDIR"
+            , "$TMPDIR"
+            ]
+      where
+        text = Text.pack target
+        firstMatch [] = Nothing
+        firstMatch (prefix : prefixes)
+            | Just suffix <- Text.stripPrefix prefix text
+            , Text.isPrefixOf "${" prefix
+                || Text.null suffix
+                || not (isVariableNameChar (Text.head suffix)) =
+                Just (Text.unpack (Text.dropWhile (== '/') suffix))
+            | otherwise = firstMatch prefixes
+
+        isVariableNameChar char =
+            isAlphaNum char || char == '_'
+
+    depthAfter initial path =
+        foldDepth initial (splitDirectories path)
+
+    foldDepth depth [] = Just depth
+    foldDepth depth (component : rest)
+        | component == "." || null component = foldDepth depth rest
+        | component == ".."
+        , depth == 0 = Nothing
+        | component == ".." = foldDepth (depth - 1) rest
+        | otherwise = foldDepth (depth + 1) rest
+
+    relativeCandidateEscapes initial candidate =
+        not (Text.isPrefixOf "/" candidate)
+            && case depthAfter initial (Text.unpack candidate) of
+                Nothing -> True
+                Just _ -> False
+
+-- | A persistent shell may already be inside its private temp directory. Block
+-- relative parent traversal that would leave that root on a later call.
+commandEscapesSessionTempAt :: OsPath -> OsPath -> Text -> Bool
+commandEscapesSessionTempAt temp cwd command =
+    case depthWithin (unsafeToFilePath temp) (unsafeToFilePath cwd) of
+        Nothing -> False
+        Just initialDepth -> shellTraversalEscapes (Just initialDepth) command
+  where
+    depthWithin root path =
+        let rootComponents = splitDirectories (normalise root)
+            pathComponents = splitDirectories (normalise path)
+        in if rootComponents `isPrefixOf` pathComponents
+            then Just (length pathComponents - length rootComponents)
+            else Nothing
+
+-- | Track straightforward @cd@ commands using real filesystem resolution.
+-- This closes common multi-command aliases without pretending to be a full
+-- shell parser.
+shellCwdMutationTargetsTemp :: Text -> Text -> IO Bool
+shellCwdMutationTargetsTemp initialCwd command =
+    go (Text.unpack initialCwd) (shellSegments command)
+  where
+    go _ [] = pure False
+    go cwd (segment : rest) = do
+        targetsTemp <- anyM pathTargetsShellTemp
+            (shellPathCandidates cwd segment)
+        if targetsTemp
+            then pure True
+            else nextShellCwd cwd segment >>= \next ->
+                go next rest
+
+    pathTargetsShellTemp path = do
+        actual <- pathTargetsSystemTemp path
+        if actual
+            then pure True
+            else do
+                privateTempExists <- doesDirectoryExist "/private/tmp"
+                pure $
+                    not privateTempExists
+                        && lexicallyTargetsPrivateTemp
+                            (unsafeToFilePath path)
+
+    lexicallyTargetsPrivateTemp path =
+        case splitDirectories (normalise path) of
+            root : private : tmp : _ ->
+                root == "/"
+                    && private == "private"
+                    && tmp == "tmp"
+            _ -> False
+
+    nextShellCwd cwd segment =
+        case shellCdTarget segment of
+            Nothing -> pure cwd
+            Just target -> do
+                let requested
+                        | isAbsolute target = target
+                        | otherwise = cwd </> target
+                exists <- doesDirectoryExist requested
+                if exists
+                    then canonicalizePath requested
+                    else pure cwd
+
+shellSegments :: Text -> [Text]
+shellSegments =
+    filter (not . Text.null . Text.strip)
+        . Text.split (\char ->
+            char == ';' || char == '\n' || char == '|' || char == '&')
+
+shellCdTarget :: Text -> Maybe FilePath
+shellCdTarget segment =
+    case Text.words (Text.strip segment) of
+        ["cd", target] -> Just (Text.unpack (stripShellQuotes target))
+        ["builtin", "cd", target] ->
+            Just (Text.unpack (stripShellQuotes target))
+        _ -> Nothing
+
+stripShellQuotes :: Text -> Text
+stripShellQuotes =
+    Text.filter (\char -> char /= '"' && char /= '\'')
+
+relativePathCandidates :: Text -> [Text]
+relativePathCandidates = go Nothing
+  where
+    go previous remaining
+        | Text.null remaining = []
+        | candidateBoundaryBefore previous
+        , isCandidateChar (Text.head remaining) =
+            let (candidate, suffix) = Text.span isCandidateChar remaining
+            in candidate : continue candidate suffix
+        | otherwise =
+            go (Just (Text.head remaining)) (Text.tail remaining)
+
+    continue candidate suffix
+        | Text.null suffix = []
+        | otherwise =
+            go (Just (Text.last candidate)) suffix
+
+    candidateBoundaryBefore = \case
+        Nothing -> True
+        Just char ->
+            not (isAlphaNum char || char `elem` ("._-/:" :: String))
+
+    isCandidateChar char =
+        char == '/' || isAlphaNum char || char `elem` ("._-" :: String)
+
+shellPathCandidates :: FilePath -> Text -> [OsPath]
+shellPathCandidates cwd command =
+    map candidatePath (relativePathCandidates command)
+        <> map fromText (localFileUrlPathCandidates command)
+  where
+    candidatePath candidate
+        | Text.isPrefixOf "/" candidate = fromText candidate
+        | otherwise =
+            unsafeEncodeUtf (cwd </> Text.unpack candidate)
+
+localFileUrlPathCandidates :: Text -> [Text]
+localFileUrlPathCandidates = scan Nothing
+  where
+    scan previous remaining
+        | Text.null remaining = []
+        | pathBoundaryBefore previous
+        , "file:" == Text.toLower (Text.take 5 remaining)
+        , Just path <- fileUrlAbsolutePath (Text.drop 5 remaining) =
+            percentDecodePath
+                (Text.takeWhile isFileUrlPathChar path)
+                : advance remaining
+        | otherwise = advance remaining
+      where
+        advance text =
+            scan (Just (Text.head text)) (Text.tail text)
+
+    fileUrlAbsolutePath afterScheme
+        | Just afterAuthority <- Text.stripPrefix "//" afterScheme =
+            let (_, path) = Text.breakOn "/" afterAuthority
+            in if Text.null path then Nothing else Just path
+        | Text.isPrefixOf "/" afterScheme = Just afterScheme
+        | Text.isPrefixOf "/" (percentDecodePath afterScheme) =
+            Just afterScheme
+        | otherwise = Nothing
+
+    isFileUrlPathChar char =
+        not (isSpace char)
+            && char `notElem` ("'\";|&()?#" :: String)
+
+    pathBoundaryBefore = \case
+        Nothing -> True
+        Just char ->
+            not
+                ( isAlphaNum char
+                    || char `elem` ("._-/:" :: String)
+                )
+
+percentDecodePath :: Text -> Text
+percentDecodePath = Text.pack . decode . Text.unpack
+  where
+    decode ('%' : high : low : rest)
+        | isHexDigit high
+        , isHexDigit low =
+            chr (digitToInt high * 16 + digitToInt low) : decode rest
+    decode (char : rest) = char : decode rest
+    decode [] = []
+
+anyM :: (a -> IO Bool) -> [a] -> IO Bool
+anyM _ [] = pure False
+anyM predicate (value : rest) =
+    predicate value >>= \case
+        True -> pure True
+        False -> anyM predicate rest
 
 hardcodedSystemTmpReason :: Text -> Text
 hardcodedSystemTmpReason command =

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -19,7 +19,6 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
 import Data.IORef (readIORef)
-import Data.List (stripPrefix)
 import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Directory.OsPath
@@ -166,7 +165,7 @@ resolvePath path = do
 -- same way, while preserving @..@ and symlink semantics in the remapped path.
 systemTempRelative :: OsPath -> Maybe (OsPath, OsPath)
 systemTempRelative path =
-    firstMatch [systemTmpRoot, privateSystemTmpRoot]
+    findAlias [] components
   where
     components =
         normalizePosixRoot $
@@ -178,16 +177,48 @@ systemTempRelative path =
             , Text.all (== '/') display ->
                 posixRoot : rest
         other -> other
-    firstMatch [] = Nothing
-    firstMatch (alias : aliases) =
-        case
-            stripPrefix
-                (splitDirectories (dropTrailingPathSeparator alias))
-                components
-        of
-            Just [] -> Just (alias, currentDirectory)
-            Just relative -> Just (alias, joinPath relative)
-            Nothing -> firstMatch aliases
+    findAlias _ [] = Nothing
+    findAlias prefix (component : rest) =
+        let normalizedPrefix = appendNormalized prefix component
+        in case matchingAlias normalizedPrefix of
+            Just alias ->
+                Just
+                    ( alias
+                    , if null rest then currentDirectory else joinPath rest
+                    )
+            Nothing -> findAlias normalizedPrefix rest
+
+    -- Normalize only the components before the alias. Components after it
+    -- remain lexical so @/usr/../tmp/../outside@ is remapped and rejected as
+    -- an escape from the private root rather than being approved as @/outside@.
+    appendNormalized prefix component
+        | component == currentDirectory = prefix
+        | component == parentDirectory =
+            case prefix of
+                [] -> []
+                [root] | isAbsolute root -> prefix
+                _ -> init prefix
+        | otherwise = prefix <> [component]
+
+    matchingAlias prefix =
+        firstMatching
+            [ (systemTmpRoot, splitDirectories systemTmpRoot)
+            , (privateSystemTmpRoot, splitDirectories privateSystemTmpRoot)
+            ]
+      where
+        firstMatching [] = Nothing
+        firstMatching ((alias, aliasComponents) : aliases)
+            | componentsEqualCaseFold prefix aliasComponents = Just alias
+            | otherwise = firstMatching aliases
+
+    componentsEqualCaseFold left right =
+        length left == length right
+            && and
+                (zipWith
+                    (\a b -> Text.toCaseFold (toText a)
+                        == Text.toCaseFold (toText b))
+                    left
+                    right)
 
 -- | A preconfigured host-temp root is an explicit escape hatch from the
 -- private alias. Canonicalize only the alias root, not its descendants, so
@@ -214,6 +245,9 @@ privateSystemTmpRoot = unsafeEncodeUtf "/private/tmp"
 
 currentDirectory :: OsPath
 currentDirectory = unsafeEncodeUtf "."
+
+parentDirectory :: OsPath
+parentDirectory = unsafeEncodeUtf ".."
 
 posixRoot :: OsPath
 posixRoot = unsafeEncodeUtf "/"

--- a/packages/agent-core/src/Agent/Tools/FileSystem.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem.hs
@@ -3,6 +3,7 @@ module Agent.Tools.FileSystem
     ( deleteTextFile
     , displayPathInWorkspace
     , listDirectoryEntries
+    , pathTargetsSystemTemp
     , readTextFile
     , renameTextFile
     , resolveForRead
@@ -15,6 +16,7 @@ import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.OsPath (relativeDisplayPath, toText, unsafeToFilePath)
 import Agent.Tools.Types (ToolEnv(..), addToolAllowedRoot)
 import Control.Exception.Safe (SomeException, try, tryAny, tryIO)
+import Data.List (find)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
@@ -45,6 +47,12 @@ import System.OsPath
     , (</>)
     )
 import System.IO.Error (isDoesNotExistError)
+import System.Posix.Files
+    ( deviceID
+    , fileID
+    , getFileStatus
+    )
+import System.Posix.Types (DeviceID, FileID)
 
 -- | Resolve a model-supplied path against the tool cwd and reject anything
 -- that canonicalizes outside the cwd or an explicitly allowed root, including
@@ -119,9 +127,10 @@ resolveWithRootsAttempt env requested extraRoots = do
             | isAbsolute requested = requested
             | otherwise = absCwd </> requested
         roots = absCwd : allowedRoots
-        tempAlias
-            | isAbsolute requested = systemTempRelative combined
-            | otherwise = Nothing
+    tempAlias <-
+        if isAbsolute requested
+            then systemTempRelative combined
+            else pure Nothing
     case (canonicalSessionTmp, tempAlias) of
         (Just tempRoot, Just (aliasRoot, relative)) -> do
             explicitlyAllowed <-
@@ -159,13 +168,24 @@ resolvePath path = do
         then Right <$> canonicalizePath path
         else resolveMissing path
 
--- | Treat both common spellings of the conventional POSIX temp namespace as
--- aliases for the session-private temp root. Match components before resolving
--- the path so macOS's @/tmp@ symlink and its @/private/tmp@ target behave the
--- same way, while preserving @..@ and symlink semantics in the remapped path.
-systemTempRelative :: OsPath -> Maybe (OsPath, OsPath)
+-- | Treat existing spellings of the conventional POSIX temp namespace as
+-- aliases for the session-private temp root. Inspect each on-disk prefix so
+-- @..@ follows preceding symlinks exactly as the filesystem does. This also
+-- makes case variants aliases only on filesystems where they resolve to the
+-- same directory.
+systemTempRelative :: OsPath -> IO (Maybe (OsPath, OsPath))
 systemTempRelative path =
-    findAlias [] components
+    case directAlias components of
+        Just match -> pure (Just match)
+        Nothing -> do
+            aliases <- fmap concat $
+                mapM
+                    (\alias ->
+                        pathIdentity alias >>= \case
+                            Nothing -> pure []
+                            Just identity -> pure [(alias, identity)])
+                    [systemTmpRoot, privateSystemTmpRoot]
+            findAlias aliases [] components
   where
     components =
         normalizePosixRoot $
@@ -177,48 +197,53 @@ systemTempRelative path =
             , Text.all (== '/') display ->
                 posixRoot : rest
         other -> other
-    findAlias _ [] = Nothing
-    findAlias prefix (component : rest) =
-        let normalizedPrefix = appendNormalized prefix component
-        in case matchingAlias normalizedPrefix of
+
+    directAlias = \case
+        [root, tmp]
+            | root == posixRoot
+            , tmp == tmpComponent ->
+                Just (systemTmpRoot, currentDirectory)
+        root : tmp : rest
+            | root == posixRoot
+            , tmp == tmpComponent ->
+                Just (systemTmpRoot, joinPath rest)
+        [root, private, tmp]
+            | root == posixRoot
+            , private == privateComponent
+            , tmp == tmpComponent ->
+                Just (privateSystemTmpRoot, currentDirectory)
+        root : private : tmp : rest
+            | root == posixRoot
+            , private == privateComponent
+            , tmp == tmpComponent ->
+                Just (privateSystemTmpRoot, joinPath rest)
+        _ -> Nothing
+    findAlias _ _ [] = pure Nothing
+    findAlias aliases prefix (component : rest) = do
+        let nextPrefix = prefix <> [component]
+        candidateIdentity <- pathIdentity (joinPath nextPrefix)
+        case candidateIdentity >>= matchingAlias aliases of
             Just alias ->
-                Just
+                pure $ Just
                     ( alias
                     , if null rest then currentDirectory else joinPath rest
                     )
-            Nothing -> findAlias normalizedPrefix rest
+            Nothing -> findAlias aliases nextPrefix rest
 
-    -- Normalize only the components before the alias. Components after it
-    -- remain lexical so @/usr/../tmp/../outside@ is remapped and rejected as
-    -- an escape from the private root rather than being approved as @/outside@.
-    appendNormalized prefix component
-        | component == currentDirectory = prefix
-        | component == parentDirectory =
-            case prefix of
-                [] -> []
-                [root] | isAbsolute root -> prefix
-                _ -> init prefix
-        | otherwise = prefix <> [component]
+    matchingAlias aliases identity =
+        fst <$> find ((== identity) . snd) aliases
 
-    matchingAlias prefix =
-        firstMatching
-            [ (systemTmpRoot, splitDirectories systemTmpRoot)
-            , (privateSystemTmpRoot, splitDirectories privateSystemTmpRoot)
-            ]
-      where
-        firstMatching [] = Nothing
-        firstMatching ((alias, aliasComponents) : aliases)
-            | componentsEqualCaseFold prefix aliasComponents = Just alias
-            | otherwise = firstMatching aliases
+pathIdentity :: OsPath -> IO (Maybe (DeviceID, FileID))
+pathIdentity path =
+    tryAny (getFileStatus (unsafeToFilePath path)) >>= \case
+        Left _ -> pure Nothing
+        Right status -> pure $ Just (deviceID status, fileID status)
 
-    componentsEqualCaseFold left right =
-        length left == length right
-            && and
-                (zipWith
-                    (\a b -> Text.toCaseFold (toText a)
-                        == Text.toCaseFold (toText b))
-                    left
-                    right)
+-- | Whether the host filesystem resolves any prefix of this absolute path to
+-- the conventional shared temp directory.
+pathTargetsSystemTemp :: OsPath -> IO Bool
+pathTargetsSystemTemp path =
+    maybe False (const True) <$> systemTempRelative path
 
 -- | A preconfigured host-temp root is an explicit escape hatch from the
 -- private alias. Canonicalize only the alias root, not its descendants, so
@@ -243,11 +268,14 @@ systemTmpRoot = unsafeEncodeUtf "/tmp"
 privateSystemTmpRoot :: OsPath
 privateSystemTmpRoot = unsafeEncodeUtf "/private/tmp"
 
+tmpComponent :: OsPath
+tmpComponent = unsafeEncodeUtf "tmp"
+
+privateComponent :: OsPath
+privateComponent = unsafeEncodeUtf "private"
+
 currentDirectory :: OsPath
 currentDirectory = unsafeEncodeUtf "."
-
-parentDirectory :: OsPath
-parentDirectory = unsafeEncodeUtf ".."
 
 posixRoot :: OsPath
 posixRoot = unsafeEncodeUtf "/"

--- a/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
+++ b/packages/agent-core/src/Agent/Tools/Ghci/Runtime.hs
@@ -22,7 +22,8 @@ import Agent.Tools.Ghci.Classify
     , defaultGhciExtensions
     , typeLooksEffectful
     )
-import Agent.Tools.IO (configuredProcessEnv, terminateProcessGroup)
+import Agent.Tools.Dangerous (blockedTempAccessReasonAt)
+import Agent.Tools.IO (configuredProcess, terminateProcessGroup)
 import Agent.Tools.Types (ToolEnv(..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
@@ -204,28 +205,42 @@ closeGhciSession session =
 evalGhci :: GhciSession -> Text -> Int -> IO GhciResult
 evalGhci session expression requestedTimeout =
     withGhciRuntime session do
-        let timeoutMs = normalizeTimeout requestedTimeout
-        started <- liftIO getMonotonicTimeNSec
-        cached <- gets (.runtimeClassificationCache)
-        classification <- case cached of
-            Just (cachedExpression, cls)
-                | cachedExpression == expression -> pure cls
-            _ -> classifyGhciLocked session expression (min 15000 timeoutMs)
-        modify' \runtime ->
-            runtime { runtimeClassificationCache = Nothing }
-        remaining <- liftIO (remainingMillis started timeoutMs)
-        if remaining <= 0
-            then pure $ emptyResult GhciTimedOut classification
-                "Timed out while classifying the GHCi input."
-            else do
-                result <- evalRawGhci session expression remaining
-                pure result { ghciClass = classification }
+        blocked <- liftIO $
+            blockedTempAccessReasonAt session.ghciEnv.toolCwd expression
+        case blocked of
+            Just reason -> do
+                modify' \runtime ->
+                    runtime { runtimeClassificationCache = Nothing }
+                pure $
+                    emptyResult GhciProcessFailed GhciEffectful reason
+            Nothing -> do
+                let timeoutMs = normalizeTimeout requestedTimeout
+                started <- liftIO getMonotonicTimeNSec
+                cached <- gets (.runtimeClassificationCache)
+                classification <- case cached of
+                    Just (cachedExpression, cls)
+                        | cachedExpression == expression -> pure cls
+                    _ -> classifyGhciLocked session expression
+                        (min 15000 timeoutMs)
+                modify' \runtime ->
+                    runtime { runtimeClassificationCache = Nothing }
+                remaining <- liftIO (remainingMillis started timeoutMs)
+                if remaining <= 0
+                    then pure $ emptyResult GhciTimedOut classification
+                        "Timed out while classifying the GHCi input."
+                    else do
+                        result <- evalRawGhci session expression remaining
+                        pure result { ghciClass = classification }
 
 -- | Classify without evaluating. Fail closed on ambiguity.
 classifyGhci :: GhciSession -> Text -> IO GhciClass
 classifyGhci session expression =
     withGhciRuntime session do
-        classification <- classifyGhciLocked session expression 15000
+        blocked <- liftIO $
+            blockedTempAccessReasonAt session.ghciEnv.toolCwd expression
+        classification <- case blocked of
+            Just _ -> pure GhciEffectful
+            Nothing -> classifyGhciLocked session expression 15000
         modify' \runtime -> runtime
             { runtimeClassificationCache =
                 Just (expression, classification)
@@ -530,15 +545,14 @@ ghciArgs =
 
 spawnProcess :: ToolEnv -> IO (Either Text GhciProcess)
 spawnProcess env = do
-    processEnv <- configuredProcessEnv env
-    let spec = (proc "ghci" ghciArgs)
+    let baseSpec = (proc "ghci" ghciArgs)
             { cwd = Just (unsafeToFilePath env.toolCwd)
             , std_in = CreatePipe
             , std_out = CreatePipe
             , std_err = CreatePipe
             , create_group = True
-            , env = processEnv
             }
+    spec <- configuredProcess env baseSpec
     spawned <- try @_ @SomeException $ mask \restore -> do
         created@(_, _, _, handle) <- createProcess spec
         groupId <- getPid handle

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | Shared filesystem and process helpers for coding tools.
 module Agent.Tools.IO
     ( CommandResult(..)
@@ -18,6 +20,7 @@ module Agent.Tools.IO
     , runShellCommandStreaming
     , startShellCommand
     , startShellCommandWithInput
+    , configuredProcess
     , configuredProcessEnv
     , sessionTempProcessEnv
     , writeShellCommandInput
@@ -97,6 +100,13 @@ import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Environment (getEnvironment)
 import System.Exit (ExitCode(..))
+#if defined(darwin_HOST_OS)
+import qualified System.Directory as Directory
+import System.FilePath
+    ( takeDirectory
+    , takeFileName
+    )
+#endif
 import System.IO (Handle, hClose, hFlush)
 import System.Posix.Signals
     ( sigINT
@@ -105,6 +115,7 @@ import System.Posix.Signals
 import System.Posix.Types (ProcessGroupID)
 import System.Process
     ( CreateProcess(..)
+    , CmdSpec(..)
     , ProcessHandle
     , StdStream(..)
     , createProcess
@@ -248,16 +259,15 @@ runShellCommandStreaming
     -> IO CommandResult
 runShellCommandStreaming env workdir command timeoutMs onSnapshot =
     mask \restore -> do
-    processEnv <- configuredProcessEnv env
-    let spec = (shell command)
+    let baseSpec = (shell command)
             { cwd = Just (unsafeToFilePath workdir)
             , std_in = CreatePipe
             , std_out = CreatePipe
             , std_err = CreatePipe
             , create_group = True
-            , env = processEnv
             }
-    try @_ @SomeException (createProcess spec) >>= \case
+    try @_ @SomeException
+        (configuredProcess env baseSpec >>= createProcess) >>= \case
         Left err -> pure CommandResult
             { commandExitCode = Just 127
             , commandStdout = ""
@@ -404,25 +414,106 @@ startShellCommandWithStdin
     -> String
     -> IO (Either Text RunningCommand)
 startShellCommandWithStdin keepStdin env workdir command = do
-    processEnv <- configuredProcessEnv env
-    let spec = (shell command)
+    let baseSpec = (shell command)
             { cwd = Just (unsafeToFilePath workdir)
             , std_in = CreatePipe
             , std_out = CreatePipe
             , std_err = CreatePipe
             , create_group = True
-            , env = processEnv
             }
     try @_ @SomeException
-        (acquireRunningCommand env spec keepStdin) >>= \case
+        (configuredProcess env baseSpec >>= \spec ->
+            acquireRunningCommand env spec keepStdin) >>= \case
         Left err -> pure $ Left $ "Failed to start command: " <> Text.pack (show err)
         Right running -> pure (Right running)
 
+-- | Apply the session-private environment and, on macOS, a Seatbelt profile
+-- that denies the shared temp namespace. Managed session layouts also hide
+-- sibling scratch directories while allowing the current one.
+configuredProcess :: ToolEnv -> CreateProcess -> IO CreateProcess
+configuredProcess env spec = do
+    sessionTmp <- readIORef env.toolSessionTmp
+    processEnv <- configuredProcessEnvFor sessionTmp spec.env
+    command <- configuredCommandSpec sessionTmp spec.cmdspec
+    pure spec
+        { cmdspec = command
+        , env = case processEnv of
+            Nothing -> spec.env
+            Just values -> Just values
+        }
+
+configuredCommandSpec :: Maybe OsPath -> CmdSpec -> IO CmdSpec
+#if defined(darwin_HOST_OS)
+configuredCommandSpec sessionTmp command =
+    case sessionTmp of
+        Nothing -> pure command
+        Just temp -> do
+            let sandboxExecutable = "/usr/bin/sandbox-exec"
+            canonicalTemp <-
+                Directory.canonicalizePath (unsafeToFilePath temp)
+            let profile = sessionSandboxProfile canonicalTemp
+                wrapped = case command of
+                    RawCommand executable arguments ->
+                        executable : arguments
+                    ShellCommand script ->
+                        ["/bin/sh", "-c", script]
+            pure $
+                RawCommand sandboxExecutable
+                    (["-p", profile] <> wrapped)
+#else
+configuredCommandSpec _ command = pure command
+#endif
+
+#if defined(darwin_HOST_OS)
+sessionSandboxProfile :: FilePath -> String
+sessionSandboxProfile temp =
+    unwords $
+        [ "(version 1)"
+        , "(allow default)"
+        , "(deny file-read* file-write*"
+        , "  (subpath \"/tmp\")"
+        , "  (subpath \"/private/tmp\")"
+        ]
+        <> managedParentRule
+        <> [")"]
+        <> [ "(allow file-read* file-write*"
+           , "  (subpath " <> sandboxString temp <> "))"
+           ]
+  where
+    parent = takeDirectory temp
+    grandparent = takeDirectory parent
+    managedParentRule
+        | takeFileName parent == "sessions"
+        , takeFileName grandparent == "tmp" =
+            ["  (subpath " <> sandboxString parent <> ")"]
+        | otherwise = []
+
+sandboxString :: String -> String
+sandboxString value =
+    "\"" <> concatMap escape value <> "\""
+  where
+    escape '\\' = "\\\\"
+    escape '"' = "\\\""
+    escape '\n' = "\\n"
+    escape '\r' = "\\r"
+    escape '\t' = "\\t"
+    escape char = [char]
+#endif
+
 configuredProcessEnv :: ToolEnv -> IO (Maybe [(String, String)])
-configuredProcessEnv env = readIORef env.toolSessionTmp >>= \case
-    Nothing -> pure Nothing
-    Just temp ->
-        Just . sessionTempProcessEnv temp <$> getEnvironment
+configuredProcessEnv env =
+    readIORef env.toolSessionTmp >>= (`configuredProcessEnvFor` Nothing)
+
+configuredProcessEnvFor
+    :: Maybe OsPath
+    -> Maybe [(String, String)]
+    -> IO (Maybe [(String, String)])
+configuredProcessEnvFor sessionTmp inherited =
+    case sessionTmp of
+        Nothing -> pure inherited
+        Just temp ->
+            Just . sessionTempProcessEnv temp
+                <$> maybe getEnvironment pure inherited
 
 -- | Point a child process at one session's private scratch directory without
 -- mutating the parent process environment (several sessions may coexist).

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -3,6 +3,7 @@ module Agent.Tools.DangerousSpec (spec) where
 import Agent.Tools.Dangerous
     ( commandLooksLikeRmRf
     , commandUsesHardcodedSystemTmp
+    , commandUsesHardcodedSystemTmpAt
     , forbiddenRmRfReason
     , hardcodedSystemTmpReason
     , shellCommandBlocked
@@ -11,6 +12,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
 import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
 import Test.QuickCheck
@@ -180,6 +182,33 @@ spec = do
                 , "cat '/usr/local/../../private//tmp/input'"
                 ]
                 `shouldBe` replicate 4 True
+
+        it "resolves relative aliases against the shell working directory" do
+            let cwd = unsafeEncodeUtf "/workspace/haskell-agent"
+            map (commandUsesHardcodedSystemTmpAt cwd)
+                [ "cat ../../tmp/other-session"
+                , "cat ../../private/tmp/other-session"
+                , "cat src/../../../tmp/other-session"
+                ]
+                `shouldBe` replicate 3 True
+            map (commandUsesHardcodedSystemTmpAt cwd)
+                [ "cat ../tmp/project-file"
+                , "cat ../../tmpfile"
+                , "curl https://example.test/../../tmp/file"
+                ]
+                `shouldBe` replicate 3 False
+
+        it "matches shared temp components case-insensitively" do
+            map commandUsesHardcodedSystemTmp
+                [ "cat /TMP/other-session"
+                , "cat /PRIVATE/TMP/other-session"
+                , "cat /private/TmP/other-session"
+                , "curl file:///TMP/other-session"
+                , "cat /usr/../TmP/other-session"
+                ]
+                `shouldBe` replicate 5 True
+            commandUsesHardcodedSystemTmp "cat /TMPfile"
+                `shouldBe` False
 
         it "blocks local file URLs targeting shared temp" do
             map commandUsesHardcodedSystemTmp

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -187,16 +187,19 @@ spec = do
                 `shouldBe` replicate 4 True
 
         it "resolves relative aliases against the shell working directory" do
-            let cwd = unsafeEncodeUtf "/usr/local"
+            -- /dev exists in the Nix build sandbox, unlike /usr. Using an
+            -- existing prefix makes each parent traversal meaningful under
+            -- real filesystem semantics.
+            let cwd = unsafeEncodeUtf "/dev"
             mapM (commandUsesHardcodedSystemTmpAt cwd)
-                [ "cat ../../tmp/other-session"
-                , "cat ../../private/tmp/other-session"
-                , "cat ../local/../../tmp/other-session"
+                [ "cat ../tmp/other-session"
+                , "cat ./../tmp/other-session"
+                , "cat ../dev/../tmp/other-session"
                 ]
                 `shouldReturn` replicate 3 True
             mapM (commandUsesHardcodedSystemTmpAt cwd)
-                [ "cat ../tmp/project-file"
-                , "cat ../../tmpfile"
+                [ "cat tmp/project-file"
+                , "cat ../tmpfile"
                 , "curl https://example.test/../../tmp/file"
                 ]
                 `shouldReturn` replicate 3 False
@@ -218,9 +221,9 @@ spec = do
                 `shouldBe` False
 
         it "follows simple shell cwd changes before checking relative aliases" do
-            let cwd = unsafeEncodeUtf "/usr/local"
+            let cwd = unsafeEncodeUtf "/dev"
             commandUsesHardcodedSystemTmpAt cwd
-                "cd ../..; cat tmp/other-session"
+                "cd ..; cat tmp/other-session"
                 `shouldReturn` True
             commandUsesHardcodedSystemTmpAt cwd
                 "cd /; cat private/tmp/other-session"
@@ -232,6 +235,12 @@ spec = do
                 (unsafeEncodeUtf "/")
                 "cat /bin/../tmp/other-session"
                 `shouldReturn` aliases
+
+        it "does not normalize through a missing pre-alias component" do
+            commandUsesHardcodedSystemTmpAt
+                (unsafeEncodeUtf "/")
+                "cat /haskell-agent-missing-temp-alias-prefix/../tmp/file"
+                `shouldReturn` False
 
         it "blocks local file URLs targeting shared temp" do
             map commandUsesHardcodedSystemTmp

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -2,6 +2,7 @@ module Agent.Tools.DangerousSpec (spec) where
 
 import Agent.Tools.Dangerous
     ( commandLooksLikeRmRf
+    , commandEscapesSessionTempVariable
     , commandUsesHardcodedSystemTmp
     , commandUsesHardcodedSystemTmpAt
     , forbiddenRmRfReason
@@ -12,7 +13,9 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import Control.Exception.Safe (tryAny)
 import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Files (deviceID, fileID, getFileStatus)
 import Test.Hspec
 import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
 import Test.QuickCheck
@@ -184,31 +187,51 @@ spec = do
                 `shouldBe` replicate 4 True
 
         it "resolves relative aliases against the shell working directory" do
-            let cwd = unsafeEncodeUtf "/workspace/haskell-agent"
-            map (commandUsesHardcodedSystemTmpAt cwd)
+            let cwd = unsafeEncodeUtf "/usr/local"
+            mapM (commandUsesHardcodedSystemTmpAt cwd)
                 [ "cat ../../tmp/other-session"
                 , "cat ../../private/tmp/other-session"
-                , "cat src/../../../tmp/other-session"
+                , "cat ../local/../../tmp/other-session"
                 ]
-                `shouldBe` replicate 3 True
-            map (commandUsesHardcodedSystemTmpAt cwd)
+                `shouldReturn` replicate 3 True
+            mapM (commandUsesHardcodedSystemTmpAt cwd)
                 [ "cat ../tmp/project-file"
                 , "cat ../../tmpfile"
                 , "curl https://example.test/../../tmp/file"
                 ]
-                `shouldBe` replicate 3 False
+                `shouldReturn` replicate 3 False
 
-        it "matches shared temp components case-insensitively" do
-            map commandUsesHardcodedSystemTmp
+        it "matches case variants only when the host filesystem aliases them" do
+            aliasesCase <- pathsReferToSameFile "/tmp" "/TMP"
+            let cwd = unsafeEncodeUtf "/usr/local"
+            mapM (commandUsesHardcodedSystemTmpAt cwd)
                 [ "cat /TMP/other-session"
                 , "cat /PRIVATE/TMP/other-session"
                 , "cat /private/TmP/other-session"
                 , "curl file:///TMP/other-session"
                 , "cat /usr/../TmP/other-session"
                 ]
-                `shouldBe` replicate 5 True
+                `shouldReturn` replicate 5 aliasesCase
+            commandUsesHardcodedSystemTmp "cat /TMP/other-session"
+                `shouldBe` False
             commandUsesHardcodedSystemTmp "cat /TMPfile"
                 `shouldBe` False
+
+        it "follows simple shell cwd changes before checking relative aliases" do
+            let cwd = unsafeEncodeUtf "/usr/local"
+            commandUsesHardcodedSystemTmpAt cwd
+                "cd ../..; cat tmp/other-session"
+                `shouldReturn` True
+            commandUsesHardcodedSystemTmpAt cwd
+                "cd /; cat private/tmp/other-session"
+                `shouldReturn` True
+
+        it "preserves symlink semantics in normalized shell paths" do
+            aliases <- pathsReferToSameFile "/bin/../tmp" "/tmp"
+            commandUsesHardcodedSystemTmpAt
+                (unsafeEncodeUtf "/")
+                "cat /bin/../tmp/other-session"
+                `shouldReturn` aliases
 
         it "blocks local file URLs targeting shared temp" do
             map commandUsesHardcodedSystemTmp
@@ -251,6 +274,26 @@ spec = do
                 `shouldBe` False
             commandUsesHardcodedSystemTmp "cat /usr/../private/tmpfile"
                 `shouldBe` False
+
+        it "rejects traversal outside session temp variables" do
+            map commandEscapesSessionTempVariable
+                [ "ls \"$TMPDIR/..\""
+                , "cat ${TMPDIR}/../other-session/secret"
+                , "cat \"$HASKELL_AGENT_TMPDIR/a/../../secret\""
+                , "cat \"$TMPDIR-other-session/secret\""
+                , "cat \"${TMPDIR}\"../other-session/secret"
+                , "cd \"$TMPDIR\"; cat ../other-session/secret"
+                , "cd \"$TMPDIR\"/nested; cat ../../other-session/secret"
+                , "cd \"${HASKELL_AGENT_TMPDIR}/nested\"; cd ../.."
+                ]
+                `shouldBe` replicate 8 True
+            map commandEscapesSessionTempVariable
+                [ "cat \"$TMPDIR/result\""
+                , "cat \"$TMPDIR\"/result"
+                , "cat \"$TMPDIR/build/../result\""
+                , "cd \"$TMPDIR/nested\"; cat ../result"
+                ]
+                `shouldBe` replicate 4 False
 
     describe "shellCommandBlocked" do
         it "blocks shell tools with a clear reason" do
@@ -331,3 +374,15 @@ spec = do
         TextEncoding.decodeUtf8
             (LazyByteString.toStrict
                 (Aeson.encode (Aeson.object ["command" Aeson..= command])))
+
+pathsReferToSameFile :: FilePath -> FilePath -> IO Bool
+pathsReferToSameFile left right =
+    tryAny
+        ((,)
+            <$> getFileStatus left
+            <*> getFileStatus right) >>= \case
+        Left _ -> pure False
+        Right (leftStatus, rightStatus) ->
+            pure $
+                deviceID leftStatus == deviceID rightStatus
+                    && fileID leftStatus == fileID rightStatus

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -34,10 +34,12 @@ import Data.Either (isRight)
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
+    , createDirectoryIfMissing
     , getTemporaryDirectory
     , removeDirectoryRecursive
     )
 import System.FilePath ((</>))
+import System.Info (os)
 import System.Posix.Signals (nullSignal, signalProcess)
 import System.Posix.Temp (mkdtemp)
 import System.Posix.Types (ProcessID)
@@ -187,6 +189,56 @@ spec = describe "Agent.Tools.Ghci" do
                 result.ghciOk `shouldBe` True
                 result.ghciOutput `shouldSatisfy`
                     Text.isInfixOf (Text.pack (toFilePath env.toolCwd))
+
+    it "rejects direct and variable-based shared temp access before evaluation" do
+        withTempGhci \ghci -> do
+            direct <- evalGhci ghci
+                "readFile \"/tmp/other-session/secret\""
+                10000
+            direct.ghciOutcome `shouldBe` GhciProcessFailed
+            direct.ghciOk `shouldBe` False
+            direct.ghciOutput `shouldSatisfy`
+                Text.isInfixOf "Blocked hardcoded system temp path"
+
+            traversal <- evalGhci ghci
+                "cmd \"sh\" [\"-c\", \"cat \\\"$TMPDIR/../other-session/secret\\\"\"]"
+                10000
+            traversal.ghciOutcome `shouldBe` GhciProcessFailed
+            traversal.ghciOk `shouldBe` False
+            traversal.ghciOutput `shouldSatisfy`
+                Text.isInfixOf "Blocked path traversal"
+
+    it "isolates GHCi from managed sibling scratch directories" do
+        if os /= "darwin"
+            then pendingWith "the process-level Seatbelt boundary is macOS-only"
+            else withTempEnv \env -> do
+                let workspace = toFilePath env.toolCwd
+                    sessions =
+                        workspace
+                            </> ".haskell-agent"
+                            </> "tmp"
+                            </> "sessions"
+                    scratch = sessions </> "current"
+                    sibling = sessions </> "other"
+                    secret = sibling </> "secret"
+                mapM_ (createDirectoryIfMissing True) [scratch, sibling]
+                writeFile secret "sibling-secret"
+                setToolSessionTmp env (Just (fromFilePath scratch))
+                bracket (newGhciSession env) closeGhciSession \ghci -> do
+                    importedEnvironment <- evalGhci ghci
+                        "import System.Environment (getEnv)"
+                        10000
+                    importedEnvironment.ghciOk `shouldBe` True
+                    importedFilePath <- evalGhci ghci
+                        "import System.FilePath (takeDirectory, (</>))"
+                        10000
+                    importedFilePath.ghciOk `shouldBe` True
+                    result <- evalGhci ghci
+                        "getEnv \"TMPDIR\" >>= \\path -> readFile (takeDirectory path </> \"other\" </> \"secret\")"
+                        10000
+                    result.ghciOk `shouldBe` False
+                    result.ghciOutput `shouldNotSatisfy`
+                        Text.isInfixOf "sibling-secret"
 
     it "refreshes the private temp environment after suspension" do
         withTempEnv \env -> do

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -37,7 +37,7 @@ import Agent.Tools.Types
     )
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.MVar (readMVar)
-import Control.Exception.Safe (bracket, tryIO)
+import Control.Exception.Safe (bracket, tryAny, tryIO)
 import Control.Monad (replicateM)
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.Either (isLeft, isRight)
@@ -47,6 +47,7 @@ import qualified Data.Text as Text
 import System.Directory
     ( canonicalizePath
     , createDirectory
+    , createDirectoryIfMissing
     , createDirectoryLink
     , getTemporaryDirectory
     , listDirectory
@@ -55,7 +56,9 @@ import System.Directory
 import System.FilePath ((</>), takeFileName)
 import System.IO (IOMode(..), hClose, openFile)
 import System.IO.Error (alreadyInUseErrorType, mkIOError)
+import System.Info (os)
 import System.Posix.Temp (mkdtemp)
+import System.Posix.Files (deviceID, fileID, getFileStatus)
 import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
@@ -268,16 +271,46 @@ spec = describe "Agent.Tools.IO" do
             resolveUnderCwd env
                 (fromFilePath ("/usr/../tmp" </> relative))
                 `shouldReturn` expected
-            resolveUnderCwd env
-                (fromFilePath ("/var/../private/tmp" </> relative))
-                `shouldReturn` expected
-            resolveUnderCwd env
-                (fromFilePath ("/TMP" </> relative))
-                `shouldReturn` expected
-            resolveUnderCwd env
-                (fromFilePath ("/PRIVATE/TMP" </> relative))
-                `shouldReturn` expected
             readIORef requests `shouldReturn` []
+            varPrivateAliases <-
+                pathsReferToSameFile "/var/../private/tmp" "/private/tmp"
+            varPrivate <- resolveUnderCwd env
+                (fromFilePath ("/var/../private/tmp" </> relative))
+            if varPrivateAliases
+                then varPrivate `shouldBe` expected
+                else varPrivate `shouldSatisfy` isLeft
+            upperTmpAliases <- pathsReferToSameFile "/tmp" "/TMP"
+            upperTmp <- resolveUnderCwd env
+                (fromFilePath ("/TMP" </> relative))
+            if upperTmpAliases
+                then upperTmp `shouldBe` expected
+                else upperTmp `shouldSatisfy` isLeft
+            upperPrivateAliases <-
+                pathsReferToSameFile "/private/tmp" "/PRIVATE/TMP"
+            upperPrivate <- resolveUnderCwd env
+                (fromFilePath ("/PRIVATE/TMP" </> relative))
+            if upperPrivateAliases
+                then upperPrivate `shouldBe` expected
+                else upperPrivate `shouldSatisfy` isLeft
+
+    it "preserves symlink semantics before recognizing a normalized alias" do
+        withTempDir \dir -> do
+            let workspace = dir </> "workspace"
+                scratch = dir </> "scratch"
+                requested = "/bin/../tmp/haskell-agent-alias-probe"
+            mapM_ createDirectory [workspace, scratch]
+            env <- defaultToolEnv (fromFilePath workspace)
+            setToolSessionTmp env (Just (fromFilePath scratch))
+            aliases <- pathsReferToSameFile "/bin/../tmp" "/tmp"
+            result <- resolveUnderCwd env (fromFilePath requested)
+            if aliases
+                then do
+                    canonicalScratch <- canonicalizePath scratch
+                    result `shouldBe` Right
+                        (fromFilePath
+                            (canonicalScratch
+                                </> "haskell-agent-alias-probe"))
+                else result `shouldSatisfy` isLeft
 
     it "maps an existing host temp file unless its root was explicitly allowed" do
         withTempDir \dir ->
@@ -419,6 +452,34 @@ spec = describe "Agent.Tools.IO" do
                 5000
             result.commandStdout `shouldBe`
                 Text.pack scratch <> "\n" <> Text.pack scratch <> "\nunset"
+
+    it "isolates managed sibling scratch directories at the process boundary" do
+        if os /= "darwin"
+            then pendingWith "the process-level Seatbelt boundary is macOS-only"
+            else withTempDir \dir -> do
+                let workspace = dir </> "workspace"
+                    sessions =
+                        dir </> ".haskell-agent" </> "tmp" </> "sessions"
+                    scratch = sessions </> "current"
+                    sibling = sessions </> "other"
+                    ownFile = scratch </> "own"
+                    secret = sibling </> "secret"
+                mapM_ (createDirectoryIfMissing True)
+                    [workspace, scratch, sibling]
+                writeFile ownFile "own-scratch"
+                writeFile secret "sibling-secret"
+                env <- defaultToolEnv (fromFilePath workspace)
+                setToolSessionTmp env (Just (fromFilePath scratch))
+                ownResult <- runShellCommand env (fromFilePath workspace)
+                    "cat \"$TMPDIR/own\""
+                    5000
+                ownResult.commandExitCode `shouldBe` Just 0
+                ownResult.commandStdout `shouldBe` "own-scratch"
+                result <- runShellCommand env (fromFilePath workspace)
+                    "cat \"$TMPDIR/../other/secret\""
+                    5000
+                result.commandExitCode `shouldNotBe` Just 0
+                result.commandStdout `shouldNotBe` "sibling-secret"
 
     it "replaces inherited temp variables without exposing host temp" do
         let scratch = fromFilePath "/session/private"
@@ -657,6 +718,18 @@ checkConcurrentAppends dir = do
 startAppend path (payload, var) =
     forkIO $
         tryIO (appendLazyFileRetryingOpen path payload) >>= putMVar var
+
+pathsReferToSameFile :: FilePath -> FilePath -> IO Bool
+pathsReferToSameFile left right =
+    tryAny
+        ((,)
+            <$> getFileStatus left
+            <*> getFileStatus right) >>= \case
+        Left _ -> pure False
+        Right (leftStatus, rightStatus) ->
+            pure $
+                deviceID leftStatus == deviceID rightStatus
+                    && fileID leftStatus == fileID rightStatus
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir action = do

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -269,7 +269,7 @@ spec = describe "Agent.Tools.IO" do
                 (fromFilePath ("/private/tmp" </> relative))
                 `shouldReturn` expected
             resolveUnderCwd env
-                (fromFilePath ("/usr/../tmp" </> relative))
+                (fromFilePath ("/dev/../tmp" </> relative))
                 `shouldReturn` expected
             readIORef requests `shouldReturn` []
             varPrivateAliases <-
@@ -374,13 +374,26 @@ spec = describe "Agent.Tools.IO" do
                         "escapes the private session temp directory")
                     (const False)
             normalizedPrefixTraversal <- resolveUnderCwd env
-                (fromFilePath "/usr/../tmp/../outside.txt")
+                (fromFilePath "/dev/../tmp/../outside.txt")
             normalizedPrefixTraversal `shouldSatisfy`
                 either
                     (Text.isInfixOf
                         "escapes the private session temp directory")
                     (const False)
             readIORef requests `shouldReturn` []
+
+    it "does not normalize through a missing pre-alias component" do
+        withTempDir \dir -> do
+            let workspace = dir </> "workspace"
+                scratch = dir </> "scratch"
+                missing = "/haskell-agent-missing-temp-alias-prefix"
+                requested =
+                    missing </> ".." </> "tmp" </> "artifact.txt"
+            mapM_ createDirectory [workspace, scratch]
+            env <- defaultToolEnv (fromFilePath workspace)
+            setToolSessionTmp env (Just (fromFilePath scratch))
+            resolveUnderCwd env (fromFilePath requested)
+                >>= (`shouldSatisfy` isLeft)
 
     it "requests and remembers approval for an escaped filesystem root" do
         withTempDir \dir -> do

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -265,6 +265,18 @@ spec = describe "Agent.Tools.IO" do
             resolveUnderCwd env
                 (fromFilePath ("/private/tmp" </> relative))
                 `shouldReturn` expected
+            resolveUnderCwd env
+                (fromFilePath ("/usr/../tmp" </> relative))
+                `shouldReturn` expected
+            resolveUnderCwd env
+                (fromFilePath ("/var/../private/tmp" </> relative))
+                `shouldReturn` expected
+            resolveUnderCwd env
+                (fromFilePath ("/TMP" </> relative))
+                `shouldReturn` expected
+            resolveUnderCwd env
+                (fromFilePath ("/PRIVATE/TMP" </> relative))
+                `shouldReturn` expected
             readIORef requests `shouldReturn` []
 
     it "maps an existing host temp file unless its root was explicitly allowed" do
@@ -324,6 +336,13 @@ spec = describe "Agent.Tools.IO" do
             doubleSlashTraversal <- resolveUnderCwd env
                 (fromFilePath "//tmp/../outside.txt")
             doubleSlashTraversal `shouldSatisfy`
+                either
+                    (Text.isInfixOf
+                        "escapes the private session temp directory")
+                    (const False)
+            normalizedPrefixTraversal <- resolveUnderCwd env
+                (fromFilePath "/usr/../tmp/../outside.txt")
+            normalizedPrefixTraversal `shouldSatisfy`
                 either
                     (Text.isInfixOf
                         "escapes the private session temp directory")

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Monitor.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Monitor.hs
@@ -6,12 +6,10 @@ module Agent.GrokBuild.Dialect.Monitor
 import qualified Agent.Json.Decode as Json
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
-import Agent.Tools.Dangerous (blockedShellCommandReasonAt)
 import Agent.GrokBuild.Dialect.Common (jsonTool)
 import Agent.GrokBuild.Dialect.Json (optionalBool, optionalIntOrString)
 import Agent.GrokBuild.Dialect.Shell
     ( GrokSession
-    , currentGrokShellCwd
     , startMonitor
     )
 import Agent.Tools.Types (AppTool, ToolExecutionPolicy(..))
@@ -68,29 +66,25 @@ runMonitor session args
                 <> Text.pack (show maxMonitorTimeoutMs)
                 <> ". Set persistent=true for a session-length monitor."
     | otherwise = do
-        cwd <- currentGrokShellCwd session
-        case blockedShellCommandReasonAt cwd args.command of
-            Just reason -> pure (Left reason)
-            Nothing -> do
-                let timeout
-                        | args.persistent = Nothing
-                        | otherwise =
-                            Just
-                                (max 1
-                                    (fromMaybe
-                                        maxMonitorTimeoutMs
-                                        args.timeoutMs))
-                startMonitor session args.command timeout >>= \case
-                    Left err -> pure (Left err)
-                    Right output ->
-                        pure $ Right $
-                            output
-                                <> "\ndescription: "
-                                <> Text.strip args.description
-                                <> "\ntimeout_ms: "
-                                <> Text.pack (show (fromMaybe 0 timeout))
-                                <> "\npersistent: "
-                                <> if args.persistent then "true" else "false"
+        let timeout
+                | args.persistent = Nothing
+                | otherwise =
+                    Just
+                        (max 1
+                            (fromMaybe
+                                maxMonitorTimeoutMs
+                                args.timeoutMs))
+        startMonitor session args.command timeout >>= \case
+            Left err -> pure (Left err)
+            Right output ->
+                pure $ Right $
+                    output
+                        <> "\ndescription: "
+                        <> Text.strip args.description
+                        <> "\ntimeout_ms: "
+                        <> Text.pack (show (fromMaybe 0 timeout))
+                        <> "\npersistent: "
+                        <> if args.persistent then "true" else "false"
 
 maxMonitorTimeoutMs :: Int
 maxMonitorTimeoutMs = 36000000

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Monitor.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Monitor.hs
@@ -6,10 +6,14 @@ module Agent.GrokBuild.Dialect.Monitor
 import qualified Agent.Json.Decode as Json
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
-import Agent.Tools.Dangerous (blockedShellCommandReason)
+import Agent.Tools.Dangerous (blockedShellCommandReasonAt)
 import Agent.GrokBuild.Dialect.Common (jsonTool)
 import Agent.GrokBuild.Dialect.Json (optionalBool, optionalIntOrString)
-import Agent.GrokBuild.Dialect.Shell (GrokSession, startMonitor)
+import Agent.GrokBuild.Dialect.Shell
+    ( GrokSession
+    , currentGrokShellCwd
+    , startMonitor
+    )
 import Agent.Tools.Types (AppTool, ToolExecutionPolicy(..))
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -56,8 +60,6 @@ runMonitor :: GrokSession -> MonitorArgs -> IO (Either Text Text)
 runMonitor session args
     | Text.null (Text.strip args.description) =
         pure (Left "Missing parameter: description")
-    | Just reason <- blockedShellCommandReason args.command =
-        pure (Left reason)
     | not args.persistent
     , Just timeout <- args.timeoutMs
     , timeout > maxMonitorTimeoutMs =
@@ -66,21 +68,29 @@ runMonitor session args
                 <> Text.pack (show maxMonitorTimeoutMs)
                 <> ". Set persistent=true for a session-length monitor."
     | otherwise = do
-        let timeout
-                | args.persistent = Nothing
-                | otherwise =
-                    Just (max 1 (fromMaybe maxMonitorTimeoutMs args.timeoutMs))
-        startMonitor session args.command timeout >>= \case
-            Left err -> pure (Left err)
-            Right output ->
-                pure $ Right $
-                    output
-                        <> "\ndescription: "
-                        <> Text.strip args.description
-                        <> "\ntimeout_ms: "
-                        <> Text.pack (show (fromMaybe 0 timeout))
-                        <> "\npersistent: "
-                        <> if args.persistent then "true" else "false"
+        cwd <- currentGrokShellCwd session
+        case blockedShellCommandReasonAt cwd args.command of
+            Just reason -> pure (Left reason)
+            Nothing -> do
+                let timeout
+                        | args.persistent = Nothing
+                        | otherwise =
+                            Just
+                                (max 1
+                                    (fromMaybe
+                                        maxMonitorTimeoutMs
+                                        args.timeoutMs))
+                startMonitor session args.command timeout >>= \case
+                    Left err -> pure (Left err)
+                    Right output ->
+                        pure $ Right $
+                            output
+                                <> "\ndescription: "
+                                <> Text.strip args.description
+                                <> "\ntimeout_ms: "
+                                <> Text.pack (show (fromMaybe 0 timeout))
+                                <> "\npersistent: "
+                                <> if args.persistent then "true" else "false"
 
 maxMonitorTimeoutMs :: Int
 maxMonitorTimeoutMs = 36000000

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -9,7 +9,6 @@ module Agent.GrokBuild.Dialect.Shell
     , newGrokSession
     , resetGrokSessionTemp
     , closeGrokSession
-    , currentGrokShellCwd
     , runForegroundStreaming
     , startBackground
     , startMonitor
@@ -27,6 +26,7 @@ import Agent.ResourceScope
     , newResourceScope
     , releaseResource
     )
+import Agent.Tools.Dangerous (blockedShellCommandReasonIn)
 import Agent.Tools.IO
     ( CommandResult(..)
     , RunningCommand(..)
@@ -176,10 +176,6 @@ closeGrokSession session = do
     resetGrokBackgroundTasks session
     closeResourceScope session.grokResources
 
-currentGrokShellCwd :: GrokSession -> IO OsPath
-currentGrokShellCwd session =
-    (.shellCwd) <$> readMVar session.grokShell
-
 -- | Stop and forget background commands from the previous conversation.
 -- Preserve the id counter so stale task ids cannot alias newly started work.
 resetGrokBackgroundTasks :: GrokSession -> IO ()
@@ -195,23 +191,31 @@ resetGrokBackgroundTasks session = do
 
 runForegroundStreaming
     :: GrokSession
-    -> String
+    -> Text
     -> Int
     -> (Text -> Text -> IO ())
-    -> IO CommandResult
+    -> IO (Either Text CommandResult)
 runForegroundStreaming session command timeoutMs onSnapshot =
     modifyMVar session.grokShell \shell -> do
-        let wrapped = bashWrap (wrapScript shell True command)
-        result <- runShellCommandStreaming
-            session.grokEnv
-            session.grokEnv.toolCwd
-            wrapped
-            timeoutMs
-            onSnapshot
-        next <- if result.commandTimedOut || result.commandCancelled
-            then pure shell
-            else refreshCwd session.grokEnv shell
-        pure (next, result)
+        sessionTmp <- readIORef session.grokEnv.toolSessionTmp
+        blockedShellCommandReasonIn
+            sessionTmp shell.shellCwd command >>= \case
+                Just reason -> pure (shell, Left reason)
+                Nothing -> do
+                    let wrapped =
+                            bashWrap
+                                (wrapScript shell True (Text.unpack command))
+                    result <- runShellCommandStreaming
+                        session.grokEnv
+                        session.grokEnv.toolCwd
+                        wrapped
+                        timeoutMs
+                        onSnapshot
+                    next <- if result.commandTimedOut
+                            || result.commandCancelled
+                        then pure shell
+                        else refreshCwd session.grokEnv shell
+                    pure (next, Right result)
 
 startBackground :: GrokSession -> Text -> IO (Either Text Text)
 startBackground session command =
@@ -222,42 +226,62 @@ startMonitor session command timeoutMs =
     startBackgroundCommand session (monitorCommand command timeoutMs)
 
 startBackgroundCommand :: GrokSession -> Text -> IO (Either Text Text)
-startBackgroundCommand session command = do
-    shell <- readMVar session.grokShell
-    -- Background wrappers source cwd/env but must not write them back;
-    -- a later foreground command owns the persistent session.
-    let wrapped = bashWrap (wrapScript shell False (Text.unpack command))
-    started <- tryAny $
-        allocateResource session.grokResources
-            (startShellCommand session.grokEnv session.grokEnv.toolCwd wrapped
-                >>= either (throwIO . userError . Text.unpack) pure)
-            stopShellCommand
-    case started of
-        Left exception ->
-            pure (Left (Text.pack (show exception)))
-        Right (resource, running) -> do
-            taskId <-
-                (modifyMVar session.grokTasks \store -> do
-                    let next = store.backgroundNextId + 1
-                        taskId = "t" <> Text.pack (show next)
-                        task = BackgroundTask
-                            { backgroundId = taskId
-                            , backgroundRunning = running
-                            , backgroundResource = resource
-                            }
-                    pure
-                        ( store
-                            { backgroundNextId = next
-                            , backgroundTasks =
-                                Map.insert taskId task store.backgroundTasks
-                            }
-                        , taskId
-                        ))
-                `onException` releaseResource resource
-            pure $ Right $
-                "Command moved to background.\n\
-                \task_id: " <> taskId <> "\n\
-                \Use get_command_or_subagent_output to read output. Do not poll in a loop."
+startBackgroundCommand session command =
+    modifyMVar session.grokShell \shell -> do
+        sessionTmp <- readIORef session.grokEnv.toolSessionTmp
+        blockedShellCommandReasonIn
+            sessionTmp shell.shellCwd command >>= \case
+                Just reason -> pure (shell, Left reason)
+                Nothing -> do
+                    -- Background wrappers source cwd/env but must not write
+                    -- them back; a later foreground command owns the
+                    -- persistent session.
+                    let wrapped =
+                            bashWrap
+                                (wrapScript shell False
+                                    (Text.unpack command))
+                    started <- tryAny $
+                        allocateResource session.grokResources
+                            (startShellCommand
+                                session.grokEnv
+                                session.grokEnv.toolCwd
+                                wrapped
+                                >>= either
+                                    (throwIO . userError . Text.unpack)
+                                    pure)
+                            stopShellCommand
+                    case started of
+                        Left exception ->
+                            pure
+                                (shell, Left (Text.pack (show exception)))
+                        Right (resource, running) -> do
+                            taskId <-
+                                (modifyMVar session.grokTasks \store -> do
+                                    let next = store.backgroundNextId + 1
+                                        taskId =
+                                            "t" <> Text.pack (show next)
+                                        task = BackgroundTask
+                                            { backgroundId = taskId
+                                            , backgroundRunning = running
+                                            , backgroundResource = resource
+                                            }
+                                    pure
+                                        ( store
+                                            { backgroundNextId = next
+                                            , backgroundTasks =
+                                                Map.insert taskId task
+                                                    store.backgroundTasks
+                                            }
+                                        , taskId
+                                        ))
+                                `onException` releaseResource resource
+                            pure
+                                ( shell
+                                , Right $
+                                    "Command moved to background.\n\
+                                    \task_id: " <> taskId <> "\n\
+                                    \Use get_command_or_subagent_output to read output. Do not poll in a loop."
+                                )
 
 readTaskOutput :: GrokSession -> Text -> Maybe Int -> IO Text
 readTaskOutput session taskId timeoutMs = do

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -9,6 +9,7 @@ module Agent.GrokBuild.Dialect.Shell
     , newGrokSession
     , resetGrokSessionTemp
     , closeGrokSession
+    , currentGrokShellCwd
     , runForegroundStreaming
     , startBackground
     , startMonitor
@@ -174,6 +175,10 @@ closeGrokSession :: GrokSession -> IO ()
 closeGrokSession session = do
     resetGrokBackgroundTasks session
     closeResourceScope session.grokResources
+
+currentGrokShellCwd :: GrokSession -> IO OsPath
+currentGrokShellCwd session =
+    (.shellCwd) <$> readMVar session.grokShell
 
 -- | Stop and forget background commands from the previous conversation.
 -- Preserve the id counter so stale task ids cannot alias newly started work.

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
@@ -7,7 +7,6 @@ import Agent.ToolDispatch
     , decodeToolArguments
     , typedStreamingTool
     )
-import Agent.Tools.Dangerous (blockedShellCommandReasonAt)
 import Agent.GrokBuild.Dialect.Common (jsonTool, stripAnsi)
 import Agent.GrokBuild.Dialect.Json
     ( optionalBool
@@ -21,7 +20,6 @@ import Agent.Tools.Scheduling
 import Agent.Tools.ShellReadOnly (shellCommandIsReadOnly)
 import Agent.GrokBuild.Dialect.Shell
     ( GrokSession
-    , currentGrokShellCwd
     , hasUnwaitedBackgroundOp
     , runForegroundStreaming
     , startBackground
@@ -102,26 +100,21 @@ runTerminal
 runTerminal session emitOutput args
     | Text.null args.description =
         pure (Left "Missing parameter: description")
+    | not args.background
+    , hasUnwaitedBackgroundOp args.command =
+        pure $ Left
+            "The command contains a background '&'. Set background=true to run it as a background task, or append `wait` if you meant to wait for the children."
+    | args.background =
+        startBackground session args.command
     | otherwise = do
-        cwd <- currentGrokShellCwd session
-        case blockedShellCommandReasonAt cwd args.command of
-            Just reason -> pure (Left reason)
-            Nothing
-                | not args.background
-                , hasUnwaitedBackgroundOp args.command ->
-                    pure $ Left
-                        "The command contains a background '&'. Set background=true to run it as a background task, or append `wait` if you meant to wait for the children."
-                | args.background ->
-                    startBackground session args.command
-                | otherwise -> do
-                    let timeoutMs =
-                            min 300000
-                                (max 1 (fromMaybe 120000 args.timeout))
-                    result <- runForegroundStreaming
-                        session
-                        (Text.unpack args.command)
-                        timeoutMs
-                        (\out err ->
-                            emitOutput
-                                (stripAnsi (combineCommandOutput out err)))
-                    pure $ Right $ stripAnsi (formatCommandResult result)
+        let timeoutMs =
+                min 300000
+                    (max 1 (fromMaybe 120000 args.timeout))
+        result <- runForegroundStreaming
+            session
+            args.command
+            timeoutMs
+            (\out err ->
+                emitOutput
+                    (stripAnsi (combineCommandOutput out err)))
+        pure $ stripAnsi . formatCommandResult <$> result

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
@@ -7,7 +7,7 @@ import Agent.ToolDispatch
     , decodeToolArguments
     , typedStreamingTool
     )
-import Agent.Tools.Dangerous (blockedShellCommandReason)
+import Agent.Tools.Dangerous (blockedShellCommandReasonAt)
 import Agent.GrokBuild.Dialect.Common (jsonTool, stripAnsi)
 import Agent.GrokBuild.Dialect.Json
     ( optionalBool
@@ -21,6 +21,7 @@ import Agent.Tools.Scheduling
 import Agent.Tools.ShellReadOnly (shellCommandIsReadOnly)
 import Agent.GrokBuild.Dialect.Shell
     ( GrokSession
+    , currentGrokShellCwd
     , hasUnwaitedBackgroundOp
     , runForegroundStreaming
     , startBackground
@@ -101,18 +102,26 @@ runTerminal
 runTerminal session emitOutput args
     | Text.null args.description =
         pure (Left "Missing parameter: description")
-    | Just reason <- blockedShellCommandReason args.command =
-        pure (Left reason)
-    | not args.background && hasUnwaitedBackgroundOp args.command =
-        pure $ Left
-            "The command contains a background '&'. Set background=true to run it as a background task, or append `wait` if you meant to wait for the children."
-    | args.background = startBackground session args.command
     | otherwise = do
-        let timeoutMs = min 300000 (max 1 (fromMaybe 120000 args.timeout))
-        result <- runForegroundStreaming
-            session
-            (Text.unpack args.command)
-            timeoutMs
-            (\out err ->
-                emitOutput (stripAnsi (combineCommandOutput out err)))
-        pure $ Right $ stripAnsi (formatCommandResult result)
+        cwd <- currentGrokShellCwd session
+        case blockedShellCommandReasonAt cwd args.command of
+            Just reason -> pure (Left reason)
+            Nothing
+                | not args.background
+                , hasUnwaitedBackgroundOp args.command ->
+                    pure $ Left
+                        "The command contains a background '&'. Set background=true to run it as a background task, or append `wait` if you meant to wait for the children."
+                | args.background ->
+                    startBackground session args.command
+                | otherwise -> do
+                    let timeoutMs =
+                            min 300000
+                                (max 1 (fromMaybe 120000 args.timeout))
+                    result <- runForegroundStreaming
+                        session
+                        (Text.unpack args.command)
+                        timeoutMs
+                        (\out err ->
+                            emitOutput
+                                (stripAnsi (combineCommandOutput out err)))
+                    pure $ Right $ stripAnsi (formatCommandResult result)

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -22,12 +22,19 @@ import Agent.GrokBuild.Dialect.Runtime
 import Agent.GrokBuild.Dialect.TaskControl (validateTaskIds)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
 import Agent.OsPath (unsafeToFilePath)
-import Agent.ToolDispatch (ToolCall, functionToolCall)
+import Agent.ToolDispatch
+    ( ToolCall
+    , ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
 import Agent.Tools.Scheduling (schedulingPlansConflict)
 import Agent.Tools.IO (CommandResult(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ToolRegistry
+    , appToolHandlers
     , defaultToolEnv
     , mkToolRegistry
     , setToolSessionTmp
@@ -48,7 +55,7 @@ import System.Directory
     , doesFileExist
     , removeDirectoryRecursive
     )
-import System.FilePath ((</>), takeDirectory)
+import System.FilePath (makeRelative, takeDirectory, (</>))
 import System.IO.Temp (withSystemTempDirectory)
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Files (fileMode, getFileStatus)
@@ -94,6 +101,26 @@ spec = describe "Grok Build dialect" do
                 `shouldBe` replicate 7 True
             names `shouldNotContain` ["shell_command", "apply_patch"]
             coding.grokClose
+
+    it "rejects system temp paths relative to the persisted shell cwd" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            typesRef <- newIORef Map.empty
+            let relativeTmp =
+                    Text.pack (makeRelative dir "/tmp/agent-output")
+            bracket
+                (newGrokCodingTools env Nothing Nothing typesRef)
+                (.grokClose)
+                \coding -> do
+                    result <- dispatchToolCall
+                        testDispatchConfig
+                        (appToolHandlers coding.grokAppTools)
+                        (terminalCall
+                            "terminal-relative-system-tmp"
+                            ("cat " <> relativeTmp)
+                            False)
+                    result.output `shouldSatisfy`
+                        Text.isInfixOf "Blocked hardcoded system temp path"
 
     it "derives disjoint search_replace resources from file paths" do
         withGrokRegistry \registry close -> do
@@ -375,3 +402,13 @@ terminalCall ident command background =
 jsonString :: Text -> Text
 jsonString text =
     "\"" <> Text.replace "\"" "\\\"" text <> "\""
+
+testDispatchConfig :: ToolDispatchConfig
+testDispatchConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    , toolDispatchFinalizeOutput = \_call output -> pure output
+    }

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -274,6 +274,39 @@ spec = describe "Grok Build dialect" do
                 takeDirectory (unsafeToFilePath shell.shellEnvFile)
                     `shouldBe` scratch
 
+    it "checks temp traversal while holding the persistent shell state" do
+        withTempDir \dir -> do
+            let scratch = dir </> "session-scratch"
+            createDirectory scratch
+            createDirectory (scratch </> "nested")
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            setToolSessionTmp env (Just (unsafeEncodeUtf scratch))
+            bracket (newGrokSession env) closeGrokSession \session -> do
+                Right moved <- runForegroundStreaming
+                    session
+                    "cd \"$TMPDIR\""
+                    10000
+                    (\_ _ -> pure ())
+                moved.commandExitCode `shouldBe` Just 0
+                nestedEscape <- runForegroundStreaming
+                    session
+                    "cd nested; cat ../../other-session/secret"
+                    10000
+                    (\_ _ -> pure ())
+                nestedEscape `shouldSatisfy`
+                    either
+                        (Text.isInfixOf "Blocked path traversal")
+                        (const False)
+                escaped <- runForegroundStreaming
+                    session
+                    "cat ../other-session/secret"
+                    10000
+                    (\_ _ -> pure ())
+                escaped `shouldSatisfy`
+                    either
+                        (Text.isInfixOf "Blocked path traversal")
+                        (const False)
+
     it "recreates shell state after the session temp directory changes" do
         withTempDir \dir -> do
             let firstScratch = dir </> "first-session"
@@ -283,7 +316,7 @@ spec = describe "Grok Build dialect" do
             env <- defaultToolEnv (unsafeEncodeUtf dir)
             setToolSessionTmp env (Just (unsafeEncodeUtf firstScratch))
             bracket (newGrokSession env) closeGrokSession \session -> do
-                moved <- runForegroundStreaming
+                Right moved <- runForegroundStreaming
                     session
                     "cd \"$TMPDIR\""
                     10000
@@ -307,7 +340,7 @@ spec = describe "Grok Build dialect" do
                 unsafeToFilePath nextShell.shellCwd `shouldBe` dir
                 doesFileExist nextEnvFile `shouldReturn` True
 
-                result <- runForegroundStreaming
+                Right result <- runForegroundStreaming
                     session
                     "printf reset-ok"
                     10000


### PR DESCRIPTION
## Summary

Follow-up to #769 for review feedback that landed after the original PR merged.

- recognize shared-temp aliases by filesystem identity, preserving symlink semantics and host case sensitivity
- redirect only the matched shared-temp prefix while preserving suffix traversal for boundary enforcement
- reject `$TMPDIR`/`$HASKELL_AGENT_TMPDIR` traversal and concatenation escapes, including persistent Grok shell cwd state
- validate Grok commands while holding the shell-state lock to close cwd TOCTOU gaps
- guard GHCi shared-temp expressions and run subprocesses through a shared temp-aware process configuration
- on Darwin, enforce the boundary at process level with a fail-closed Seatbelt profile that denies shared and sibling managed temp directories while allowing the current session scratch directory

## Validation

- `agent-core`: 474 examples, 0 failures
- `agent-codex-dialect`: 15 examples, 0 failures
- `agent-grok-build-dialect`: 50 examples, 0 failures
- focused Darwin process-boundary tests cover raw shell sibling access, own scratch access, and dynamically constructed GHCi paths
- `git diff --check`