### PR TITLE
Run tasks through the hardened runtime daemon

### DIFF
--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -81,7 +81,10 @@ and optional worktree creation. It always passes `--no-yolo`, so a noninteractiv
 task fails closed rather than implicitly approving mutating tools. Stdout and
 stderr are concurrently drained in
 bounded chunks before journal log limits are applied, total output is capped,
-and every process task has a six-hour wall-clock deadline. Log publication is
+and every process task has a six-hour wall-clock deadline. Stdin is closed.
+After the process leader exits, pipe draining has its own deadline; descendants
+that retained stdout or stderr are terminated with the same TERM/KILL
+process-group escalation rather than hanging task completion. Log publication is
 best-effort when the bounded scheduler queue is full; terminal completion uses
 a separate control queue so noisy output cannot deadlock completion or daemon
 shutdown. Embedders can supply

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -72,7 +72,10 @@ the original, unredacted input in memory. Raw prompts are deliberately not
 persisted separately from the redacted task description. After daemon restart,
 `retry` therefore fails with `task input is unavailable`; the client must
 submit the input again under a new task ID. A completed or active task cannot
-be retried.
+be retried. Input is discarded from memory as soon as a task completes; it is
+retained only for same-process failed or cancelled retries. Consequently the
+raw-input map is bounded by the durable task limit and the 8,192-character
+prompt limit, and all remaining input disappears when the daemon exits.
 
 The shipped daemon runner executes `agent-cli` directly without a shell
 (`HASKELL_AGENT_CLI` can override its path), using the real one-shot CLI flags

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -85,7 +85,8 @@ and every process task has a six-hour wall-clock deadline. Stdin is closed.
 After the process leader exits, pipe draining has its own deadline; descendants
 that retained stdout or stderr are terminated with the same TERM/KILL
 process-group escalation rather than hanging task completion. Log publication is
-best-effort when the bounded scheduler queue is full; terminal completion uses
+best-effort when the bounded scheduler queue is full; dropped chunks produce a
+durable `[output truncated: scheduler log queue was full]` marker. Terminal completion uses
 a separate control queue so noisy output cannot deadlock completion or daemon
 shutdown. Embedders can supply
 a typed `TaskRunner` while retaining the same scheduler, persistence, and wire

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -32,9 +32,40 @@ same scheme in `event_chunk` messages: clients concatenate decoded slices and
 then decode the resulting event envelope. This keeps persisted events
 deliverable without increasing the transport frame bound.
 
-Commands and command results carry client-generated command IDs. Their JSON
-payload is deliberately opaque to this package so the task supervisor can
-evolve independently of the transport.
+Commands and command results carry client-generated command IDs. The public
+task adapter accepts the following versioned command payloads. Unknown versions,
+types, invalid combinations, empty identifiers, and values beyond the
+documented bounds are rejected without changing scheduler state.
+
+```json
+{"version":1,"type":"submit","task_id":"stable-client-id","session_id":"optional-existing-session","prompt":"...","cwd":"/absolute/or/relative/path","provider":"openai","model":"gpt-5.6","effort":"high","worktree":false}
+{"version":1,"type":"cancel","task_id":"stable-client-id"}
+{"version":1,"type":"list"}
+{"version":1,"type":"set_limit","limit":4}
+{"version":1,"type":"approval","task_id":"stable-client-id","approval_id":"request-id","decision":"approve"}
+{"version":1,"type":"retry","task_id":"stable-client-id"}
+```
+
+`task_id` is a caller-generated stable identifier and cannot be reused.
+`session_id` is the stable persisted session to resume; tasks for one session
+are serialized. A missing session identifies a fresh session and does not
+conflict with other fresh tasks. `provider` and `model` must either both be
+present or both absent, and `worktree` is valid only for a fresh session.
+Task/session/approval IDs are at most 256 characters, prompts 8,192
+characters, paths 4,096 characters, and the concurrency limit is 1 through 32.
+Approval decisions are `approve`, `deny`, or `approve_session`.
+
+Successful results contain `"version": 1`; submit, cancel, and retry results
+also contain the durable task. `list` returns every retained durable task.
+Task transitions are journaled as `task_changed` events before the mutating
+command reports success. A failed, cancelled, or interrupted task is rerun
+only by an explicit `retry` command, which retains its task ID and increments
+its attempt number. A completed or active task cannot be retried.
+
+The shipped daemon runner executes `agent-cli` directly without a shell
+(`HASKELL_AGENT_CLI` can override its path). Embedders can supply a native
+`TaskRunner`, including an approval resolver, while retaining the same
+scheduler, persistence, and wire protocol.
 
 ## Local security
 

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -53,7 +53,13 @@ conflict with other fresh tasks. `provider` and `model` must either both be
 present or both absent, and `worktree` is valid only for a fresh session.
 Task/session/approval IDs are at most 256 characters, prompts 8,192
 characters, paths 4,096 characters, and the concurrency limit is 1 through 32.
-Approval decisions are `approve`, `deny`, or `approve_session`.
+Approval decisions are syntactically limited to `approve`, `deny`, or
+`approve_session`, but the current daemon runner does **not** support
+interactive approval resolution. Every `approval` command fails visibly with
+an unsupported-operation error and emits no `approval_resolved` event. Tasks
+that require an interactive approval must therefore fail or be run by an
+interactive client; clients must not present daemon approval controls as
+functional.
 
 Successful results contain `"version": 1`; submit, cancel, and retry results
 also contain the durable task. `list` returns every retained durable task.
@@ -63,9 +69,12 @@ only by an explicit `retry` command, which retains its task ID and increments
 its attempt number. A completed or active task cannot be retried.
 
 The shipped daemon runner executes `agent-cli` directly without a shell
-(`HASKELL_AGENT_CLI` can override its path). Embedders can supply a native
-`TaskRunner`, including an approval resolver, while retaining the same
-scheduler, persistence, and wire protocol.
+(`HASKELL_AGENT_CLI` can override its path), using the real one-shot CLI flags
+for prompt, session resume, cwd, provider/model/effort, session persistence,
+and optional worktree creation. Stdout and stderr are concurrently drained in
+bounded chunks before journal log limits are applied. Embedders can supply a
+typed `TaskRunner` while retaining the same scheduler, persistence, and wire
+protocol; the adapter intentionally exposes no approval-resolver hook.
 
 ## Local security
 

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -81,7 +81,10 @@ and optional worktree creation. It always passes `--no-yolo`, so a noninteractiv
 task fails closed rather than implicitly approving mutating tools. Stdout and
 stderr are concurrently drained in
 bounded chunks before journal log limits are applied, total output is capped,
-and every process task has a six-hour wall-clock deadline. Embedders can supply
+and every process task has a six-hour wall-clock deadline. Log publication is
+best-effort when the bounded scheduler queue is full; terminal completion uses
+a separate control queue so noisy output cannot deadlock completion or daemon
+shutdown. Embedders can supply
 a typed `TaskRunner` while retaining the same scheduler, persistence, and wire
 protocol; the adapter intentionally exposes no approval-resolver hook.
 

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -65,15 +65,20 @@ Successful results contain `"version": 1`; submit, cancel, and retry results
 also contain the durable task. `list` returns every retained durable task.
 Task transitions are journaled as `task_changed` events before the mutating
 command reports success. A failed, cancelled, or interrupted task is rerun
-only by an explicit `retry` command, which retains its task ID and increments
-its attempt number. A completed or active task cannot be retried.
+only by an explicit `retry` command while the same daemon process still holds
+the original, unredacted input in memory. Raw prompts are deliberately not
+persisted separately from the redacted task description. After daemon restart,
+`retry` therefore fails with `task input is unavailable`; the client must
+submit the input again under a new task ID. A completed or active task cannot
+be retried.
 
 The shipped daemon runner executes `agent-cli` directly without a shell
 (`HASKELL_AGENT_CLI` can override its path), using the real one-shot CLI flags
 for prompt, session resume, cwd, provider/model/effort, session persistence,
 and optional worktree creation. Stdout and stderr are concurrently drained in
-bounded chunks before journal log limits are applied. Embedders can supply a
-typed `TaskRunner` while retaining the same scheduler, persistence, and wire
+bounded chunks before journal log limits are applied, total output is capped,
+and every process task has a six-hour wall-clock deadline. Embedders can supply
+a typed `TaskRunner` while retaining the same scheduler, persistence, and wire
 protocol; the adapter intentionally exposes no approval-resolver hook.
 
 ## Local security

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -35,7 +35,9 @@ deliverable without increasing the transport frame bound.
 Commands and command results carry client-generated command IDs. The public
 task adapter accepts the following versioned command payloads. Unknown versions,
 types, invalid combinations, empty identifiers, and values beyond the
-documented bounds are rejected without changing scheduler state.
+documented bounds are rejected without changing scheduler state. Scheduler
+command admission is bounded and nonblocking: a full queue returns an immediate
+error rather than allowing an expired client request to execute later.
 
 ```json
 {"version":1,"type":"submit","task_id":"stable-client-id","session_id":"optional-existing-session","prompt":"...","cwd":"/absolute/or/relative/path","provider":"openai","model":"gpt-5.6","effort":"high","worktree":false}
@@ -75,7 +77,9 @@ be retried.
 The shipped daemon runner executes `agent-cli` directly without a shell
 (`HASKELL_AGENT_CLI` can override its path), using the real one-shot CLI flags
 for prompt, session resume, cwd, provider/model/effort, session persistence,
-and optional worktree creation. Stdout and stderr are concurrently drained in
+and optional worktree creation. It always passes `--no-yolo`, so a noninteractive
+task fails closed rather than implicitly approving mutating tools. Stdout and
+stderr are concurrently drained in
 bounded chunks before journal log limits are applied, total output is capped,
 and every process task has a six-hour wall-clock deadline. Embedders can supply
 a typed `TaskRunner` while retaining the same scheduler, persistence, and wire

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -260,13 +260,13 @@ foreign-library haskell-agent-bridge
     other-modules:    Agent.CLI.MacOS.Bridge
                     , Agent.CLI.MacOS.EngineMailbox
                     , Agent.CLI.MacOS.NativeLoopEvent
-                    , Agent.CLI.MacOS.TaskScheduler
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     includes:         HaskellAgentBridge.h
     install-includes: HaskellAgentBridge.h
     ghc-options:      -threaded
     build-depends:    agent-cli
+                    , agent-runtime-daemon
                     , agent-core >= 0.1 && < 0.2
                     , agent-store >= 0.1 && < 0.2
                     , agent-openai >= 0.1 && < 0.2
@@ -361,7 +361,6 @@ test-suite agent-cli-test
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
                     , Agent.CLI.MacOS.BridgeFFISpec
-                    , Agent.CLI.MacOS.TaskScheduler
                     , Agent.CLI.MacOS.TaskSchedulerSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
@@ -440,6 +439,7 @@ test-suite agent-cli-test
                     , Agent.CLI.WebLspSpec
                     , Agent.CLI.WorktreeSpec
     build-depends:    agent-cli
+                    , agent-runtime-daemon
                     , agent-core
                     , agent-codex-dialect
                     , agent-grok-build-dialect

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -67,7 +67,7 @@ import Agent.CLI.MacOS.EngineMailbox
     , newEngineMailboxIO
     , readEngineCommand
     )
-import Agent.CLI.MacOS.TaskScheduler
+import Agent.Runtime.Daemon.TaskScheduler
     ( TaskIdentity(..)
     , selectRunnableTasks
     )

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -20,7 +20,8 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-claude agent-codex-dialect agent-core
     agent-grok-build-dialect agent-openai agent-openrouter
-    agent-process agent-responses agent-responses-types agent-store
+    agent-process agent-responses agent-responses-types
+    agent-runtime-daemon agent-store
     agent-syntax agent-tui agent-xai ansi-terminal async base
     base64-bytestring brick bytestring colour containers directory
     filelock filepath haskeline hasql-pool http-client http-client-tls

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,13 +1,13 @@
 { mkDerivation, aeson, agent-claude, agent-codex-dialect
 , agent-core, agent-grok-build-dialect, agent-openai
 , agent-openrouter, agent-process, agent-responses
-, agent-responses-types, agent-store, agent-syntax, agent-tui
-, agent-xai, ansi-terminal, async, base, base64-bytestring, brick
-, bytestring, colour, containers, deepseq, directory, filelock
-, filepath, haskeline, hasql-pool, hspec, http-client
-, http-client-tls, http-types, JuicyPixels, lib, mtl, network
-, network-uri, optparse-applicative, process, QuickCheck, retry
-, safe-exceptions, scientific, stm, tagsoup, text, time
+, agent-responses-types, agent-runtime-daemon, agent-store
+, agent-syntax, agent-tui, agent-xai, ansi-terminal, async, base
+, base64-bytestring, brick, bytestring, colour, containers, deepseq
+, directory, filelock, filepath, haskeline, hasql-pool, hspec
+, http-client, http-client-tls, http-types, JuicyPixels, lib, mtl
+, network, network-uri, optparse-applicative, process, QuickCheck
+, retry, safe-exceptions, scientific, stm, tagsoup, text, time
 , transformers, unix, vector, vty, vty-crossplatform
 }:
 mkDerivation {
@@ -36,10 +36,11 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-claude agent-codex-dialect agent-core
     agent-grok-build-dialect agent-openai agent-openrouter
-    agent-responses agent-responses-types agent-store agent-tui
-    agent-xai ansi-terminal async base brick bytestring colour
-    containers directory filepath haskeline hspec JuicyPixels process
-    QuickCheck safe-exceptions stm text time transformers unix vty
+    agent-responses agent-responses-types agent-runtime-daemon
+    agent-store agent-tui agent-xai ansi-terminal async base brick
+    bytestring colour containers directory filepath haskeline hspec
+    JuicyPixels process QuickCheck safe-exceptions stm text time
+    transformers unix vty
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-responses agent-store base brick bytestring

--- a/packages/agent-cli/test/Agent/CLI/MacOS/TaskSchedulerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/TaskSchedulerSpec.hs
@@ -1,6 +1,6 @@
 module Agent.CLI.MacOS.TaskSchedulerSpec (spec) where
 
-import Agent.CLI.MacOS.TaskScheduler
+import Agent.Runtime.Daemon.TaskScheduler
     ( TaskIdentity(..)
     , selectRunnableTasks
     )

--- a/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
+++ b/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
@@ -41,6 +41,8 @@ library
                     , Agent.Runtime.Daemon.Socket
                     , Agent.Runtime.Daemon.Supervisor
                     , Agent.Runtime.Daemon.Task
+                    , Agent.Runtime.Daemon.TaskAdapter
+                    , Agent.Runtime.Daemon.TaskScheduler
     build-depends:    aeson >= 2.0
                     , async
                     , base >= 4.17 && < 5
@@ -51,6 +53,7 @@ library
                     , filepath
                     , filelock
                     , network
+                    , process >= 1.6.18
                     , safe-exceptions
                     , stm
                     , text >= 2.0 && < 2.2

--- a/packages/agent-runtime-daemon/app/Main.hs
+++ b/packages/agent-runtime-daemon/app/Main.hs
@@ -5,4 +5,5 @@ import Agent.Runtime.Daemon
 main :: IO ()
 main = do
     config <- defaultDaemonConfig
-    runDaemon config unavailableSupervisor
+    runner <- processTaskRunner
+    runTaskDaemon config runner

--- a/packages/agent-runtime-daemon/package.nix
+++ b/packages/agent-runtime-daemon/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, async, base, base64-bytestring, bytestring
 , containers, directory, filelock, filepath, hspec, lib, network
-, safe-exceptions, stm, temporary, text, time, unix
+, process, safe-exceptions, stm, temporary, text, time, unix
 }:
 mkDerivation {
   pname = "agent-runtime-daemon";
@@ -10,7 +10,8 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson async base base64-bytestring bytestring containers directory
-    filelock filepath network safe-exceptions stm text time unix
+    filelock filepath network process safe-exceptions stm text time
+    unix
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon.hs
@@ -2,11 +2,14 @@ module Agent.Runtime.Daemon
     ( DaemonConfig (..)
     , defaultDaemonConfig
     , runDaemon
+    , runTaskDaemon
     , module Agent.Runtime.Daemon.Journal
     , module Agent.Runtime.Daemon.Protocol
     , module Agent.Runtime.Daemon.Server
     , module Agent.Runtime.Daemon.Supervisor
     , module Agent.Runtime.Daemon.Task
+    , module Agent.Runtime.Daemon.TaskAdapter
+    , module Agent.Runtime.Daemon.TaskScheduler
     ) where
 
 import System.FilePath (takeDirectory, (</>))
@@ -17,6 +20,8 @@ import Agent.Runtime.Daemon.Server
 import Agent.Runtime.Daemon.Socket
 import Agent.Runtime.Daemon.Supervisor
 import Agent.Runtime.Daemon.Task
+import Agent.Runtime.Daemon.TaskAdapter
+import Agent.Runtime.Daemon.TaskScheduler
 
 data DaemonConfig = DaemonConfig
     { socket :: SocketConfig
@@ -36,3 +41,10 @@ runDaemon config supervisor =
     withUnixListener config.socket $ \listener -> do
         journal <- openJournal config.journal
         runServerOnListener listener config.server journal supervisor
+
+runTaskDaemon :: DaemonConfig -> TaskRunner -> IO ()
+runTaskDaemon config runner =
+    withUnixListener config.socket $ \listener -> do
+        journal <- openJournal config.journal
+        withTaskAdapter journal runner $
+            runServerOnListener listener config.server journal

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Task.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Task.hs
@@ -6,7 +6,7 @@ module Agent.Runtime.Daemon.Task
     , interruptActive
     ) where
 
-import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.Aeson
 import Data.Text (Text)
 import Data.Time (UTCTime)
 import GHC.Generics (Generic)
@@ -29,15 +29,53 @@ instance FromJSON TaskStatus
 
 data DurableTask = DurableTask
     { taskId :: TaskId
+    , sessionId :: Maybe Text
     , status :: TaskStatus
     , description :: Text
+    , workingDirectory :: FilePath
+    , provider :: Maybe Text
+    , model :: Maybe Text
+    , effort :: Maybe Text
+    , worktree :: Bool
+    , attempt :: Int
     , updatedAt :: UTCTime
     , logTail :: [Text]
     }
     deriving stock (Eq, Show, Generic)
 
-instance ToJSON DurableTask
-instance FromJSON DurableTask
+instance ToJSON DurableTask where
+    toJSON task =
+        object
+            [ "taskId" .= task.taskId
+            , "sessionId" .= task.sessionId
+            , "status" .= task.status
+            , "description" .= task.description
+            , "workingDirectory" .= task.workingDirectory
+            , "provider" .= task.provider
+            , "model" .= task.model
+            , "effort" .= task.effort
+            , "worktree" .= task.worktree
+            , "attempt" .= task.attempt
+            , "updatedAt" .= task.updatedAt
+            , "logTail" .= task.logTail
+            ]
+
+-- Defaults keep snapshots written by the daemon foundation readable.
+instance FromJSON DurableTask where
+    parseJSON = withObject "DurableTask" $ \value ->
+        DurableTask
+            <$> value .: "taskId"
+            <*> value .:? "sessionId"
+            <*> value .: "status"
+            <*> value .: "description"
+            <*> value .:? "workingDirectory" .!= "."
+            <*> value .:? "provider"
+            <*> value .:? "model"
+            <*> value .:? "effort"
+            <*> value .:? "worktree" .!= False
+            <*> value .:? "attempt" .!= 1
+            <*> value .: "updatedAt"
+            <*> value .: "logTail"
 
 isActive :: DurableTask -> Bool
 isActive DurableTask {status} = status == TaskQueued || status == TaskRunning

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -269,10 +269,17 @@ schedulerLoopWithRegistry journal runner commands completions registry = go
                                                     <> either (\message -> [message]) (const []) result
                                             }
                                 persisted <- persistBounded journal updated
-                                pure withoutWorker
-                                    { adapterTasks =
-                                        Map.insert taskId persisted state.adapterTasks
-                                    }
+                                pure $
+                                    ( if persisted.status == TaskCompleted
+                                        then withoutWorker
+                                            { adapterInputs =
+                                                Map.delete taskId withoutWorker.adapterInputs
+                                            }
+                                        else withoutWorker
+                                    )
+                                        { adapterTasks =
+                                            Map.insert taskId persisted state.adapterTasks
+                                        }
                         _ -> pure withoutWorker
                 _ -> pure state
 
@@ -380,16 +387,20 @@ executeCommand journal registry state = \case
             Just task
                 | isActive task ->
                     pure (state, Left "active tasks cannot be retried")
-                | task.status == TaskCompleted ->
-                    pure (state, Left "completed tasks cannot be retried")
                 | Map.notMember taskId state.adapterInputs ->
                     pure
                         ( state
-                        , Left
-                            ( "task input is unavailable after daemon restart; "
-                                <> "submit a new task id"
-                            )
+                        , Left $
+                            if task.status == TaskCompleted
+                                then
+                                    "completed tasks cannot be retried; task input has been discarded"
+                                else
+                                    ( "task input is unavailable after daemon restart; "
+                                        <> "submit a new task id"
+                                    )
                         )
+                | task.status == TaskCompleted ->
+                    pure (state, Left "completed tasks cannot be retried")
                 | otherwise -> do
                     now <- getCurrentTime
                     let updated =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -131,6 +131,9 @@ defaultTaskLimit = 4
 maximumTaskLimit :: Int
 maximumTaskLimit = 32
 
+redactedTaskDescription :: Text
+redactedTaskDescription = "[task input redacted]"
+
 withTaskAdapter :: Journal -> TaskRunner -> (Supervisor -> IO value) -> IO value
 withTaskAdapter = withTaskAdapterQueueSize 1_024
 
@@ -285,12 +288,12 @@ executeCommand journal registry state = \case
             pure (state, Left "task id already exists")
         | otherwise -> do
             now <- getCurrentTime
-            let task =
+            let durableTask =
                     DurableTask
                         { taskId = submitted.submittedId
                         , sessionId = submitted.submittedSessionId
                         , status = TaskQueued
-                        , description = submitted.submittedPrompt
+                        , description = redactedTaskDescription
                         , workingDirectory = submitted.submittedWorkingDirectory
                         , provider = submitted.submittedProvider
                         , model = submitted.submittedModel
@@ -300,14 +303,16 @@ executeCommand journal registry state = \case
                         , updatedAt = now
                         , logTail = []
                         }
-            persisted <- persistBounded journal task
+                executionTask =
+                    durableTask {description = submitted.submittedPrompt}
+            persisted <- persistBounded journal durableTask
             let next =
                     state
                         { adapterPending = state.adapterPending Seq.|> persisted.taskId
                         , adapterTasks =
                             Map.insert persisted.taskId persisted state.adapterTasks
                         , adapterInputs =
-                            Map.insert persisted.taskId task state.adapterInputs
+                            Map.insert persisted.taskId executionTask state.adapterInputs
                         }
             pure (next, Right (taskResult "submitted" persisted))
     Cancel taskId ->
@@ -492,13 +497,17 @@ launchWorker commands completions runner task =
                             writeTQueue completions
                                 (TaskLogTruncated task.taskId task.attempt)
                         writeTQueue completions
-                            (TaskFinished task.taskId task.attempt outcome)
+                            (TaskFinished task.taskId task.attempt (redactFailure outcome))
                 logged line =
                     atomically $ do
                         accepted <-
                             tryWriteTBQueueCompat
                                 commands
-                                (TaskLogged task.taskId task.attempt line)
+                                ( TaskLogged
+                                    task.taskId
+                                    task.attempt
+                                    (redactTaskInput task.description line)
+                                )
                         unless accepted (writeTVar logTruncated True)
             result <-
                 tryAny
@@ -513,6 +522,14 @@ launchWorker commands completions runner task =
                 Right value -> finished value
         putMVar gate ()
         pure worker
+  where
+    redactFailure = \case
+        Left message -> Left (redactTaskInput task.description message)
+        Right () -> Right ()
+
+redactTaskInput :: Text -> Text -> Text
+redactTaskInput rawInput =
+    Text.replace rawInput redactedTaskDescription
 
 -- Equivalent to @tryWriteTBQueue@ for the pinned STM version, which does not
 -- export that helper. The fullness check and write are one transaction, so

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -109,6 +109,7 @@ data SubmitCommand = SubmitCommand
 data AdapterMessage
     = Execute !TaskCommand !(TMVar (Either Text Value)) !(TVar Bool)
     | TaskLogged !TaskId !Int !Text
+    | TaskLogTruncated !TaskId !Int
     | TaskFinished !TaskId !Int !(Either Text ())
 
 data RunningTask = RunningTask
@@ -159,14 +160,10 @@ withTaskAdapterQueueSize rawQueueSize journal runner action = do
                         Left message -> pure (Left message)
                         Right command -> do
                             active <- newTVarIO True
-                            admitted <-
-                                atomically $ do
-                                    full <- isFullTBQueue commands
-                                    if full
-                                        then pure False
-                                        else do
-                                            writeTBQueue commands (Execute command reply active)
-                                            pure True
+                            admitted <- atomically $
+                                tryWriteTBQueueCompat
+                                    commands
+                                    (Execute command reply active)
                             if admitted
                                 then
                                     atomically (takeTMVar reply)
@@ -219,6 +216,25 @@ schedulerLoopWithRegistry journal runner commands completions registry = go
                                 task
                                     { updatedAt = now
                                     , logTail = task.logTail <> [line]
+                                    }
+                        persisted <- persistBounded journal updated
+                        pure state
+                            { adapterTasks =
+                                Map.insert taskId persisted state.adapterTasks
+                            }
+                _ -> pure state
+        TaskLogTruncated taskId taskAttempt ->
+            case Map.lookup taskId state.adapterTasks of
+                Just task
+                    | task.status == TaskRunning
+                    , task.attempt == taskAttempt -> do
+                        now <- getCurrentTime
+                        let updated =
+                                task
+                                    { updatedAt = now
+                                    , logTail =
+                                        task.logTail
+                                            <> ["[output truncated: scheduler log queue was full]"]
                                     }
                         persisted <- persistBounded journal updated
                         pure state
@@ -466,18 +482,24 @@ launchWorker ::
 launchWorker commands completions runner task =
     mask $ \_ -> do
         gate <- newEmptyMVar
+        logTruncated <- newTVarIO False
         worker <- asyncWithUnmask $ \unmask -> do
             takeMVar gate
             let finished outcome =
-                    atomically $
+                    atomically $ do
+                        dropped <- readTVar logTruncated
+                        when dropped $
+                            writeTQueue completions
+                                (TaskLogTruncated task.taskId task.attempt)
                         writeTQueue completions
                             (TaskFinished task.taskId task.attempt outcome)
                 logged line =
                     atomically $ do
-                        full <- isFullTBQueue commands
-                        unless full $
-                            writeTBQueue commands
+                        accepted <-
+                            tryWriteTBQueueCompat
+                                commands
                                 (TaskLogged task.taskId task.attempt line)
+                        unless accepted (writeTVar logTruncated True)
             result <-
                 tryAny
                     ( unmask $
@@ -491,6 +513,16 @@ launchWorker commands completions runner task =
                 Right value -> finished value
         putMVar gate ()
         pure worker
+
+-- Equivalent to @tryWriteTBQueue@ for the pinned STM version, which does not
+-- export that helper. The fullness check and write are one transaction, so
+-- callers never block or enqueue after observing a full queue.
+tryWriteTBQueueCompat :: TBQueue value -> value -> STM Bool
+tryWriteTBQueueCompat queue value = do
+    full <- isFullTBQueue queue
+    if full
+        then pure False
+        else writeTBQueue queue value >> pure True
 
 shutdownRegistry :: TVar (Map TaskId RunningTask) -> IO ()
 shutdownRegistry registry = do

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -1,6 +1,8 @@
 module Agent.Runtime.Daemon.TaskAdapter
     ( TaskRunner(..)
     , processTaskRunner
+    , processTaskRunnerFor
+    , processTaskArguments
     , withTaskAdapter
     ) where
 
@@ -15,7 +17,9 @@ import Control.Concurrent.Async
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe
-    ( finally
+    ( IOException
+    , catch
+    , finally
     , isAsyncException
     , mask
     , onException
@@ -25,6 +29,7 @@ import Control.Exception.Safe
 import Control.Monad (foldM, forM_, unless, when)
 import Data.Aeson
 import Data.Aeson.Types (Parser, parseEither)
+import qualified Data.ByteString as BS
 import Data.Char (isControl)
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
@@ -34,12 +39,15 @@ import Data.Sequence (Seq)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Text.Encoding.Error (lenientDecode)
 import Data.Time (getCurrentTime)
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
-import System.IO (hIsEOF, hSetEncoding, utf8)
+import System.IO (Handle, hClose)
+import System.Posix.Signals (sigKILL, sigTERM, signalProcessGroup)
 import System.Process
+import System.Timeout (timeout)
 
 import Agent.Runtime.Daemon.Journal
 import Agent.Runtime.Daemon.Protocol (EventEnvelope (..))
@@ -49,7 +57,6 @@ import Agent.Runtime.Daemon.TaskScheduler
 
 data TaskRunner = TaskRunner
     { runTask :: DurableTask -> (Text -> IO ()) -> IO (Either Text ())
-    , resolveApproval :: TaskId -> Text -> Text -> IO (Either Text ())
     }
 
 -- | Execute a submitted turn through the installed @agent-cli@ executable.
@@ -59,12 +66,13 @@ data TaskRunner = TaskRunner
 processTaskRunner :: IO TaskRunner
 processTaskRunner = do
     executable <- maybe "agent-cli" id <$> lookupEnv "HASKELL_AGENT_CLI"
-    pure
-        TaskRunner
-            { runTask = runProcessTask executable
-            , resolveApproval = \_ _ _ ->
-                pure (Left "the process task runner cannot resolve interactive approvals")
-            }
+    pure (processTaskRunnerFor executable)
+
+processTaskRunnerFor :: FilePath -> TaskRunner
+processTaskRunnerFor executable =
+    TaskRunner
+        { runTask = runProcessTask executable
+        }
 
 data TaskCommand
     = Submit SubmitCommand
@@ -292,27 +300,16 @@ executeCommand journal runner registry state = \case
                 ( state {adapterLimit = limit}
                 , Right (object ["version" .= (1 :: Int), "limit" .= limit])
                 )
-    Approval taskId approvalId decision ->
+    Approval taskId _ _ ->
         case Map.lookup taskId state.adapterTasks of
-            Just task | task.status == TaskRunning -> do
-                result <- runner.resolveApproval taskId approvalId decision
-                case result of
-                    Left message -> pure (state, Left message)
-                    Right () -> do
-                        let response =
-                                object
-                                    [ "version" .= (1 :: Int)
-                                    , "task_id" .= taskId
-                                    , "approval_id" .= approvalId
-                                    ]
-                        _ <- appendEvent journal "approval_resolved" $
-                            object
-                                [ "version" .= (1 :: Int)
-                                , "task_id" .= taskId
-                                , "approval_id" .= approvalId
-                                , "decision" .= decision
-                                ]
-                        pure (state, Right response)
+            Just task | task.status == TaskRunning ->
+                pure
+                    ( state
+                    , Left
+                        ( "interactive approval resolution is unsupported by "
+                            <> "the daemon task adapter"
+                        )
+                    )
             _ -> pure (state, Left "task is not running")
     Retry taskId ->
         case Map.lookup taskId state.adapterTasks of
@@ -531,6 +528,7 @@ boundedString :: String -> Int -> String -> Parser String
 boundedString label maximumLength raw = do
     when (null raw) (fail (label <> " must not be empty"))
     when (length raw > maximumLength) (fail (label <> " is too long"))
+    when ('\0' `elem` raw) (fail (label <> " contains a NUL byte"))
     pure raw
 
 validDecision :: Text -> Parser Text
@@ -542,37 +540,85 @@ validDecision raw = do
 
 runProcessTask :: FilePath -> DurableTask -> (Text -> IO ()) -> IO (Either Text ())
 runProcessTask executable task logLine = do
-    let arguments =
-            ["--prompt", Text.unpack task.description, "--save-session"]
-                <> maybe [] (\value -> ["--resume", Text.unpack value]) task.sessionId
-                <> ["--cwd", task.workingDirectory]
-                <> maybe [] (\value -> ["--provider", Text.unpack value]) task.provider
-                <> maybe [] (\value -> ["--model", Text.unpack value]) task.model
-                <> maybe [] (\value -> ["--effort", Text.unpack value]) task.effort
-                <> ["--worktree" | task.worktree]
+    let arguments = processTaskArguments task
         configuration =
             (proc executable arguments)
                 { std_out = CreatePipe
                 , std_err = CreatePipe
+                , create_group = True
+                , close_fds = True
                 }
     (stdoutHandle, stderrHandle, process) <-
         createProcess configuration >>= \case
             (_, Just stdoutHandle, Just stderrHandle, process) ->
                 pure (stdoutHandle, stderrHandle, process)
             _ -> fail "failed to capture agent-cli output"
-    let terminate = terminateProcess process >> voidWait process
-        consume handle = do
-            hSetEncoding handle utf8
-            let go = do
-                    ended <- hIsEOF handle
-                    unless ended (Text.hGetLine handle >>= logLine >> go)
-            go
-    (concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
-        `onException` terminate
+    let terminate = terminateProcessGroup process
+        consume = consumeBoundedOutput logLine
+        closeHandles = hClose stdoutHandle `finally` hClose stderrHandle
+    ((concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
+        `onException` terminate)
+        `finally` closeHandles
         >>= \case
             ExitSuccess -> pure (Right ())
             ExitFailure code ->
                 pure (Left ("agent-cli exited with status " <> Text.pack (show code)))
+
+processTaskArguments :: DurableTask -> [String]
+processTaskArguments task =
+    ["--prompt", Text.unpack task.description, "--save-session"]
+        <> maybe [] (\value -> ["--resume", Text.unpack value]) task.sessionId
+        <> ["--cwd", task.workingDirectory]
+        <> maybe [] (\value -> ["--provider", Text.unpack value]) task.provider
+        <> maybe [] (\value -> ["--model", Text.unpack value]) task.model
+        <> maybe [] (\value -> ["--effort", Text.unpack value]) task.effort
+        <> ["--worktree" | task.worktree]
+
+consumeBoundedOutput :: (Text -> IO ()) -> Handle -> IO ()
+consumeBoundedOutput logChunk handle = go 0 BS.empty
+  where
+    go total pending = do
+        bytes <- BS.hGetSome handle 4_096
+        let nextTotal = total + BS.length bytes
+        when (nextTotal > maxTaskOutputBytes) $
+            ioError (userError "daemon task output exceeded 64 MiB")
+        let buffered = pending <> bytes
+        if BS.null bytes
+            then unless (BS.null buffered) (emit buffered)
+            else drain buffered >>= go nextTotal
+    drain buffered =
+        let candidate = BS.take 4_096 buffered
+         in case BS.elemIndex 10 candidate of
+                Just newline -> do
+                    emit (BS.take newline buffered)
+                    drain (BS.drop (newline + 1) buffered)
+                Nothing
+                    | BS.length buffered > 4_096 -> do
+                        emit candidate
+                        drain (BS.drop 4_096 buffered)
+                    | otherwise -> pure buffered
+    emit = logChunk . TextEncoding.decodeUtf8With lenientDecode
+
+maxTaskOutputBytes :: Int
+maxTaskOutputBytes = 64 * 1024 * 1024
+
+terminateProcessGroup :: ProcessHandle -> IO ()
+terminateProcessGroup process = do
+    signalGroup sigTERM
+    timeout 2_000_000 (waitForProcess process) >>= \case
+        Just _ -> pure ()
+        Nothing -> do
+            signalGroup sigKILL
+            voidWait process
+  where
+    signalGroup signal =
+        getPid process >>= \case
+            Just pid ->
+                signalProcessGroup signal (fromIntegral pid)
+                    `catch` \(_ :: IOException) -> pure ()
+            Nothing ->
+                terminateProcess process
+                    `catch` \(_ :: IOException) -> pure ()
 
 voidWait :: ProcessHandle -> IO ()
 voidWait process = do

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -2,6 +2,7 @@ module Agent.Runtime.Daemon.TaskAdapter
     ( TaskRunner(..)
     , processTaskRunner
     , processTaskRunnerFor
+    , processTaskRunnerForWithTimeout
     , processTaskArguments
     , withTaskAdapter
     ) where
@@ -70,9 +71,16 @@ processTaskRunner = do
 
 processTaskRunnerFor :: FilePath -> TaskRunner
 processTaskRunnerFor executable =
+    processTaskRunnerForWithTimeout defaultTaskRuntimeSeconds executable
+
+processTaskRunnerForWithTimeout :: Int -> FilePath -> TaskRunner
+processTaskRunnerForWithTimeout runtimeSeconds executable =
     TaskRunner
-        { runTask = runProcessTask executable
+        { runTask = runProcessTask runtimeSeconds executable
         }
+
+defaultTaskRuntimeSeconds :: Int
+defaultTaskRuntimeSeconds = 6 * 60 * 60
 
 data TaskCommand
     = Submit SubmitCommand
@@ -318,6 +326,14 @@ executeCommand journal registry state = \case
                     pure (state, Left "active tasks cannot be retried")
                 | task.status == TaskCompleted ->
                     pure (state, Left "completed tasks cannot be retried")
+                | Map.notMember taskId state.adapterInputs ->
+                    pure
+                        ( state
+                        , Left
+                            ( "task input is unavailable after daemon restart; "
+                                <> "submit a new task id"
+                            )
+                        )
                 | otherwise -> do
                     now <- getCurrentTime
                     let updated =
@@ -537,8 +553,8 @@ validDecision raw = do
         fail "decision must be approve, deny, or approve_session"
     pure decision
 
-runProcessTask :: FilePath -> DurableTask -> (Text -> IO ()) -> IO (Either Text ())
-runProcessTask executable task logLine = do
+runProcessTask :: Int -> FilePath -> DurableTask -> (Text -> IO ()) -> IO (Either Text ())
+runProcessTask runtimeSeconds executable task logLine = do
     let arguments = processTaskArguments task
         configuration =
             (proc executable arguments)
@@ -555,13 +571,20 @@ runProcessTask executable task logLine = do
     let terminate = terminateProcessGroup process
         consume = consumeBoundedOutput logLine
         closeHandles = hClose stdoutHandle `finally` hClose stderrHandle
-    ((concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
-        `onException` terminate)
-        `finally` closeHandles
-        >>= \case
-            ExitSuccess -> pure (Right ())
-            ExitFailure code ->
-                pure (Left ("agent-cli exited with status " <> Text.pack (show code)))
+    outcome <-
+        timeout
+            (max 1 runtimeSeconds * 1_000_000)
+            ( ((concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
+                `onException` terminate)
+                `finally` closeHandles
+            )
+    case outcome of
+        Nothing ->
+            pure
+                (Left ("agent-cli exceeded its " <> Text.pack (show runtimeSeconds) <> " second runtime limit"))
+        Just ExitSuccess -> pure (Right ())
+        Just (ExitFailure code) ->
+            pure (Left ("agent-cli exited with status " <> Text.pack (show code)))
 
 processTaskArguments :: DurableTask -> [String]
 processTaskArguments task =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -5,6 +5,7 @@ module Agent.Runtime.Daemon.TaskAdapter
     , processTaskRunnerForWithTimeout
     , processTaskArguments
     , withTaskAdapter
+    , withTaskAdapterQueueSize
     ) where
 
 import Control.Concurrent.Async
@@ -102,7 +103,7 @@ data SubmitCommand = SubmitCommand
     }
 
 data AdapterMessage
-    = Execute !TaskCommand !(TMVar (Either Text Value))
+    = Execute !TaskCommand !(TMVar (Either Text Value)) !(TVar Bool)
     | TaskLogged !TaskId !Int !Text
     | TaskFinished !TaskId !Int !(Either Text ())
 
@@ -126,9 +127,17 @@ maximumTaskLimit :: Int
 maximumTaskLimit = 32
 
 withTaskAdapter :: Journal -> TaskRunner -> (Supervisor -> IO value) -> IO value
-withTaskAdapter journal runner action = do
+withTaskAdapter = withTaskAdapterQueueSize 1_024
+
+withTaskAdapterQueueSize ::
+    Int ->
+    Journal ->
+    TaskRunner ->
+    (Supervisor -> IO value) ->
+    IO value
+withTaskAdapterQueueSize rawQueueSize journal runner action = do
     saved <- snapshot journal
-    commands <- newTBQueueIO 1_024
+    commands <- newTBQueueIO (fromIntegral (max 1 rawQueueSize))
     let initial =
             AdapterState
                 { adapterLimit = defaultTaskLimit
@@ -144,8 +153,20 @@ withTaskAdapter journal runner action = do
                     case parseTaskCommand raw of
                         Left message -> pure (Left message)
                         Right command -> do
-                            atomically (writeTBQueue commands (Execute command reply))
-                            atomically (takeTMVar reply)
+                            active <- newTVarIO True
+                            admitted <-
+                                atomically $ do
+                                    full <- isFullTBQueue commands
+                                    if full
+                                        then pure False
+                                        else do
+                                            writeTBQueue commands (Execute command reply active)
+                                            pure True
+                            if admitted
+                                then
+                                    atomically (takeTMVar reply)
+                                        `onException` atomically (writeTVar active False)
+                                else pure (Left "task scheduler command queue is full")
                 }
     workers <- newTVarIO Map.empty
     let loop = schedulerLoopWithRegistry journal runner commands workers initial
@@ -169,11 +190,15 @@ schedulerLoopWithRegistry journal runner commands registry = go
         handleMessage state message >>= go
 
     handleMessage state = \case
-        Execute command reply -> do
-            (next, result) <-
-                executeCommand journal registry state command
-            atomically (putTMVar reply result)
-            pure next
+        Execute command reply active -> do
+            stillActive <- readTVarIO active
+            if stillActive
+                then do
+                    (next, result) <-
+                        executeCommand journal registry state command
+                    atomically (putTMVar reply result)
+                    pure next
+                else pure state
         TaskLogged taskId taskAttempt line ->
             case Map.lookup taskId state.adapterTasks of
                 Just task
@@ -588,7 +613,7 @@ runProcessTask runtimeSeconds executable task logLine = do
 
 processTaskArguments :: DurableTask -> [String]
 processTaskArguments task =
-    ["--prompt", Text.unpack task.description, "--save-session"]
+    ["--prompt", Text.unpack task.description, "--save-session", "--no-yolo"]
         <> maybe [] (\value -> ["--resume", Text.unpack value]) task.sessionId
         <> ["--cwd", task.workingDirectory]
         <> maybe [] (\value -> ["--provider", Text.unpack value]) task.provider

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -163,7 +163,7 @@ schedulerLoopWithRegistry journal runner commands registry = go
     handleMessage state = \case
         Execute command reply -> do
             (next, result) <-
-                executeCommand journal runner registry state command
+                executeCommand journal registry state command
             atomically (putTMVar reply result)
             pure next
         TaskLogged taskId taskAttempt line ->
@@ -216,12 +216,11 @@ schedulerLoopWithRegistry journal runner commands registry = go
 
 executeCommand
     :: Journal
-    -> TaskRunner
     -> TVar (Map TaskId RunningTask)
     -> AdapterState
     -> TaskCommand
     -> IO (AdapterState, Either Text Value)
-executeCommand journal runner registry state = \case
+executeCommand journal registry state = \case
     Submit submitted
         | Map.member submitted.submittedId state.adapterTasks ->
             pure (state, Left "task id already exists")

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -1,0 +1,580 @@
+module Agent.Runtime.Daemon.TaskAdapter
+    ( TaskRunner(..)
+    , processTaskRunner
+    , withTaskAdapter
+    ) where
+
+import Control.Concurrent.Async
+    ( Async
+    , asyncWithUnmask
+    , cancel
+    , concurrently_
+    , race
+    , waitCatch
+    )
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent.STM
+import Control.Exception.Safe
+    ( finally
+    , isAsyncException
+    , mask
+    , onException
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (foldM, forM_, unless, when)
+import Data.Aeson
+import Data.Aeson.Types (Parser, parseEither)
+import Data.Char (isControl)
+import Data.Foldable (toList)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import qualified Data.Sequence as Seq
+import Data.Sequence (Seq)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import Data.Time (getCurrentTime)
+import System.Environment (lookupEnv)
+import System.Exit (ExitCode (..))
+import System.IO (hIsEOF, hSetEncoding, utf8)
+import System.Process
+
+import Agent.Runtime.Daemon.Journal
+import Agent.Runtime.Daemon.Protocol (EventEnvelope (..))
+import Agent.Runtime.Daemon.Supervisor
+import Agent.Runtime.Daemon.Task
+import Agent.Runtime.Daemon.TaskScheduler
+
+data TaskRunner = TaskRunner
+    { runTask :: DurableTask -> (Text -> IO ()) -> IO (Either Text ())
+    , resolveApproval :: TaskId -> Text -> Text -> IO (Either Text ())
+    }
+
+-- | Execute a submitted turn through the installed @agent-cli@ executable.
+-- Set @HASKELL_AGENT_CLI@ to select another executable. The process receives
+-- arguments directly (never through a shell), and its bounded persisted log is
+-- populated from stdout and stderr.
+processTaskRunner :: IO TaskRunner
+processTaskRunner = do
+    executable <- maybe "agent-cli" id <$> lookupEnv "HASKELL_AGENT_CLI"
+    pure
+        TaskRunner
+            { runTask = runProcessTask executable
+            , resolveApproval = \_ _ _ ->
+                pure (Left "the process task runner cannot resolve interactive approvals")
+            }
+
+data TaskCommand
+    = Submit SubmitCommand
+    | Cancel TaskId
+    | List
+    | SetLimit Int
+    | Approval TaskId Text Text
+    | Retry TaskId
+
+data SubmitCommand = SubmitCommand
+    { submittedId :: !TaskId
+    , submittedSessionId :: !(Maybe Text)
+    , submittedPrompt :: !Text
+    , submittedWorkingDirectory :: !FilePath
+    , submittedProvider :: !(Maybe Text)
+    , submittedModel :: !(Maybe Text)
+    , submittedEffort :: !(Maybe Text)
+    , submittedWorktree :: !Bool
+    }
+
+data AdapterMessage
+    = Execute !TaskCommand !(TMVar (Either Text Value))
+    | TaskLogged !TaskId !Int !Text
+    | TaskFinished !TaskId !Int !(Either Text ())
+
+data RunningTask = RunningTask
+    { runningAttempt :: !Int
+    , runningWorker :: !(Async ())
+    }
+
+data AdapterState = AdapterState
+    { adapterLimit :: !Int
+    , adapterPending :: !(Seq TaskId)
+    , adapterRunning :: !(Map TaskId RunningTask)
+    , adapterTasks :: !(Map TaskId DurableTask)
+    , adapterInputs :: !(Map TaskId DurableTask)
+    }
+
+defaultTaskLimit :: Int
+defaultTaskLimit = 4
+
+maximumTaskLimit :: Int
+maximumTaskLimit = 32
+
+withTaskAdapter :: Journal -> TaskRunner -> (Supervisor -> IO value) -> IO value
+withTaskAdapter journal runner action = do
+    saved <- snapshot journal
+    commands <- newTBQueueIO 1_024
+    let initial =
+            AdapterState
+                { adapterLimit = defaultTaskLimit
+                , adapterPending = Seq.empty
+                , adapterRunning = Map.empty
+                , adapterTasks = saved.tasks
+                , adapterInputs = Map.empty
+                }
+        supervisor =
+            Supervisor
+                { handleCommand = \_ raw -> do
+                    reply <- newEmptyTMVarIO
+                    case parseTaskCommand raw of
+                        Left message -> pure (Left message)
+                        Right command -> do
+                            atomically (writeTBQueue commands (Execute command reply))
+                            atomically (takeTMVar reply)
+                }
+    workers <- newTVarIO Map.empty
+    let loop = schedulerLoopWithRegistry journal runner commands workers initial
+    ( race loop (action supervisor) >>= \case
+        Left () -> fail "task scheduler stopped unexpectedly"
+        Right value -> pure value
+      ) `finally` shutdownRegistry workers
+
+schedulerLoopWithRegistry
+    :: Journal
+    -> TaskRunner
+    -> TBQueue AdapterMessage
+    -> TVar (Map TaskId RunningTask)
+    -> AdapterState
+    -> IO ()
+schedulerLoopWithRegistry journal runner commands registry = go
+  where
+    go state0 = do
+        state <- startRunnable journal runner commands registry state0
+        message <- atomically (readTBQueue commands)
+        handleMessage state message >>= go
+
+    handleMessage state = \case
+        Execute command reply -> do
+            (next, result) <-
+                executeCommand journal runner registry state command
+            atomically (putTMVar reply result)
+            pure next
+        TaskLogged taskId taskAttempt line ->
+            case Map.lookup taskId state.adapterTasks of
+                Just task
+                    | task.status == TaskRunning
+                    , task.attempt == taskAttempt -> do
+                        now <- getCurrentTime
+                        let updated =
+                                task
+                                    { updatedAt = now
+                                    , logTail = task.logTail <> [line]
+                                    }
+                        persisted <- persistBounded journal updated
+                        pure state
+                            { adapterTasks =
+                                Map.insert taskId persisted state.adapterTasks
+                            }
+                _ -> pure state
+        TaskFinished taskId taskAttempt result -> do
+            case Map.lookup taskId state.adapterRunning of
+                Just running | running.runningAttempt == taskAttempt -> do
+                    _ <- waitCatch running.runningWorker
+                    atomically $ modifyTVar' registry (Map.delete taskId)
+                    let withoutWorker =
+                            state
+                                { adapterRunning =
+                                    Map.delete taskId state.adapterRunning
+                                }
+                    case Map.lookup taskId state.adapterTasks of
+                        Just task
+                            | task.status == TaskRunning
+                            , task.attempt == taskAttempt -> do
+                                now <- getCurrentTime
+                                let updated =
+                                        task
+                                            { status = either (const TaskFailed) (const TaskCompleted) result
+                                            , updatedAt = now
+                                            , logTail =
+                                                task.logTail
+                                                    <> either (\message -> [message]) (const []) result
+                                            }
+                                persisted <- persistBounded journal updated
+                                pure withoutWorker
+                                    { adapterTasks =
+                                        Map.insert taskId persisted state.adapterTasks
+                                    }
+                        _ -> pure withoutWorker
+                _ -> pure state
+
+executeCommand
+    :: Journal
+    -> TaskRunner
+    -> TVar (Map TaskId RunningTask)
+    -> AdapterState
+    -> TaskCommand
+    -> IO (AdapterState, Either Text Value)
+executeCommand journal runner registry state = \case
+    Submit submitted
+        | Map.member submitted.submittedId state.adapterTasks ->
+            pure (state, Left "task id already exists")
+        | otherwise -> do
+            now <- getCurrentTime
+            let task =
+                    DurableTask
+                        { taskId = submitted.submittedId
+                        , sessionId = submitted.submittedSessionId
+                        , status = TaskQueued
+                        , description = submitted.submittedPrompt
+                        , workingDirectory = submitted.submittedWorkingDirectory
+                        , provider = submitted.submittedProvider
+                        , model = submitted.submittedModel
+                        , effort = submitted.submittedEffort
+                        , worktree = submitted.submittedWorktree
+                        , attempt = 1
+                        , updatedAt = now
+                        , logTail = []
+                        }
+            persisted <- persistBounded journal task
+            let next =
+                    state
+                        { adapterPending = state.adapterPending Seq.|> persisted.taskId
+                        , adapterTasks =
+                            Map.insert persisted.taskId persisted state.adapterTasks
+                        , adapterInputs =
+                            Map.insert persisted.taskId task state.adapterInputs
+                        }
+            pure (next, Right (taskResult "submitted" persisted))
+    Cancel taskId ->
+        case Map.lookup taskId state.adapterTasks of
+            Nothing -> pure (state, Left "task id is unknown")
+            Just task
+                | not (isActive task) ->
+                    pure (state, Left "task is not active")
+                | otherwise -> do
+                    forM_ (Map.lookup taskId state.adapterRunning) $ \running -> do
+                        cancel running.runningWorker
+                        _ <- waitCatch running.runningWorker
+                        pure ()
+                    atomically $ modifyTVar' registry (Map.delete taskId)
+                    now <- getCurrentTime
+                    let updated = task {status = TaskCancelled, updatedAt = now}
+                        next =
+                            state
+                                { adapterPending =
+                                    Seq.filter (/= taskId) state.adapterPending
+                                , adapterRunning =
+                                    Map.delete taskId state.adapterRunning
+                                , adapterTasks =
+                                    Map.insert taskId updated state.adapterTasks
+                                }
+                    persisted <- persistBounded journal updated
+                    pure
+                        ( next
+                            { adapterTasks =
+                                Map.insert taskId persisted next.adapterTasks
+                            }
+                        , Right (taskResult "cancelled" persisted)
+                        )
+    List ->
+        pure
+            ( state
+            , Right $
+                object
+                    [ "version" .= (1 :: Int)
+                    , "tasks" .= Map.elems state.adapterTasks
+                    ]
+            )
+    SetLimit limit ->
+        do
+            _ <- appendEvent journal "scheduler_limit_changed" $
+                object ["version" .= (1 :: Int), "limit" .= limit]
+            pure
+                ( state {adapterLimit = limit}
+                , Right (object ["version" .= (1 :: Int), "limit" .= limit])
+                )
+    Approval taskId approvalId decision ->
+        case Map.lookup taskId state.adapterTasks of
+            Just task | task.status == TaskRunning -> do
+                result <- runner.resolveApproval taskId approvalId decision
+                case result of
+                    Left message -> pure (state, Left message)
+                    Right () -> do
+                        let response =
+                                object
+                                    [ "version" .= (1 :: Int)
+                                    , "task_id" .= taskId
+                                    , "approval_id" .= approvalId
+                                    ]
+                        _ <- appendEvent journal "approval_resolved" $
+                            object
+                                [ "version" .= (1 :: Int)
+                                , "task_id" .= taskId
+                                , "approval_id" .= approvalId
+                                , "decision" .= decision
+                                ]
+                        pure (state, Right response)
+            _ -> pure (state, Left "task is not running")
+    Retry taskId ->
+        case Map.lookup taskId state.adapterTasks of
+            Nothing -> pure (state, Left "task id is unknown")
+            Just task
+                | isActive task ->
+                    pure (state, Left "active tasks cannot be retried")
+                | task.status == TaskCompleted ->
+                    pure (state, Left "completed tasks cannot be retried")
+                | otherwise -> do
+                    now <- getCurrentTime
+                    let updated =
+                            task
+                                { status = TaskQueued
+                                , attempt = task.attempt + 1
+                                , updatedAt = now
+                                , logTail = []
+                                }
+                        next =
+                            state
+                                { adapterPending = state.adapterPending Seq.|> taskId
+                                , adapterTasks =
+                                    Map.insert taskId updated state.adapterTasks
+                                }
+                    persisted <- persistBounded journal updated
+                    pure
+                        ( next
+                            { adapterTasks =
+                                Map.insert taskId persisted next.adapterTasks
+                            }
+                        , Right (taskResult "queued" persisted)
+                        )
+
+startRunnable
+    :: Journal
+    -> TaskRunner
+    -> TBQueue AdapterMessage
+    -> TVar (Map TaskId RunningTask)
+    -> AdapterState
+    -> IO AdapterState
+startRunnable journal runner commands registry state = do
+    let activeSessions =
+            Set.fromList
+                [ sessionId
+                | taskId <- Map.keys state.adapterRunning
+                , Just task <- [Map.lookup taskId state.adapterTasks]
+                , Just sessionId <- [task.sessionId]
+                ]
+        candidates =
+            [ ( TaskIdentity task.taskId.unTaskId task.sessionId
+              , taskId
+              )
+            | taskId <- toList state.adapterPending
+            , Just task <- [Map.lookup taskId state.adapterTasks]
+            ]
+        capacity = state.adapterLimit - Map.size state.adapterRunning
+        (selected, remaining) =
+            selectRunnableTasks capacity activeSessions candidates
+    (tasks, running) <-
+        foldM launch (state.adapterTasks, state.adapterRunning) (map snd selected)
+    pure
+        state
+            { adapterPending = Seq.fromList (map snd remaining)
+            , adapterRunning = running
+            , adapterTasks = tasks
+            }
+  where
+    launch (tasks, running) taskId =
+        case Map.lookup taskId tasks of
+            Nothing -> pure (tasks, running)
+            Just task -> do
+                now <- getCurrentTime
+                let started = task {status = TaskRunning, updatedAt = now}
+                persisted <- persistBounded journal started
+                let executionTask =
+                        case Map.lookup taskId state.adapterInputs of
+                            Nothing -> persisted
+                            Just input ->
+                                input
+                                    { status = TaskRunning
+                                    , attempt = persisted.attempt
+                                    , updatedAt = persisted.updatedAt
+                                    , logTail = persisted.logTail
+                                    }
+                worker <- launchWorker commands runner executionTask
+                let runningTask =
+                        RunningTask
+                            { runningAttempt = persisted.attempt
+                            , runningWorker = worker
+                            }
+                atomically $ modifyTVar' registry (Map.insert taskId runningTask)
+                pure
+                    ( Map.insert taskId persisted tasks
+                    , Map.insert taskId runningTask running
+                    )
+
+launchWorker :: TBQueue AdapterMessage -> TaskRunner -> DurableTask -> IO (Async ())
+launchWorker commands runner task =
+    mask $ \_ -> do
+        gate <- newEmptyMVar
+        worker <- asyncWithUnmask $ \unmask -> do
+            takeMVar gate
+            let finished outcome =
+                    atomically $
+                        writeTBQueue commands
+                            (TaskFinished task.taskId task.attempt outcome)
+            result <-
+                tryAny
+                    ( unmask $
+                        runner.runTask task $ \line ->
+                            atomically $
+                                writeTBQueue commands
+                                    (TaskLogged task.taskId task.attempt line)
+                    )
+            case result of
+                Left exception
+                    | isAsyncException exception -> throwIO exception
+                    | otherwise ->
+                        finished (Left (Text.pack (show exception)))
+                Right value -> finished value
+        putMVar gate ()
+        pure worker
+
+shutdownRegistry :: TVar (Map TaskId RunningTask) -> IO ()
+shutdownRegistry registry = do
+    running <- atomically $ do
+        current <- readTVar registry
+        writeTVar registry Map.empty
+        pure (Map.elems current)
+    mapM_ (cancel . (.runningWorker)) running
+    mapM_ (waitCatch . (.runningWorker)) running
+
+taskResult :: Text -> DurableTask -> Value
+taskResult state task =
+    object
+        [ "version" .= (1 :: Int)
+        , "state" .= state
+        , "task" .= task
+        ]
+
+persistBounded :: Journal -> DurableTask -> IO DurableTask
+persistBounded journal task = do
+    event <- persistTask journal task
+    case fromJSON event.payload of
+        Success persisted -> pure persisted
+        Error message -> fail ("journal returned an invalid task event: " <> message)
+
+parseTaskCommand :: Value -> Either Text TaskCommand
+parseTaskCommand value =
+    case parseEither parser value of
+        Left message -> Left (Text.pack message)
+        Right command -> Right command
+  where
+    parser = withObject "daemon task command" $ \objectValue -> do
+        version <- objectValue .: "version"
+        unless (version == (1 :: Int)) (fail "unsupported task command version")
+        commandType <- objectValue .: "type"
+        case (commandType :: Text) of
+            "submit" -> Submit <$> parseSubmit objectValue
+            "cancel" -> Cancel <$> (objectValue .: "task_id" >>= validTaskId)
+            "list" -> pure List
+            "set_limit" -> do
+                limit <- objectValue .: "limit"
+                unless (limit >= 1 && limit <= maximumTaskLimit) $
+                    fail "limit must be between 1 and 32"
+                pure (SetLimit limit)
+            "approval" ->
+                Approval
+                    <$> (objectValue .: "task_id" >>= validTaskId)
+                    <*> (objectValue .: "approval_id" >>= boundedIdentifier "approval_id" 256)
+                    <*> (objectValue .: "decision" >>= validDecision)
+            "retry" -> Retry <$> (objectValue .: "task_id" >>= validTaskId)
+            _ -> fail "unknown task command type"
+
+    parseSubmit objectValue = do
+        submittedId <- objectValue .: "task_id" >>= validTaskId
+        submittedSessionId <-
+            objectValue .:? "session_id"
+                >>= traverse (boundedIdentifier "session_id" 256)
+        submittedPrompt <- objectValue .: "prompt" >>= boundedText "prompt" 8_192
+        submittedWorkingDirectory <-
+            objectValue .: "cwd" >>= boundedString "cwd" 4_096
+        submittedProvider <-
+            objectValue .:? "provider"
+                >>= traverse (boundedText "provider" 128)
+        submittedModel <-
+            objectValue .:? "model"
+                >>= traverse (boundedText "model" 256)
+        submittedEffort <-
+            objectValue .:? "effort"
+                >>= traverse (boundedText "effort" 64)
+        submittedWorktree <- objectValue .:? "worktree" .!= False
+        when (submittedWorktree && submittedSessionId /= Nothing) $
+            fail "worktree may only be used for a new session"
+        when ((submittedProvider == Nothing) /= (submittedModel == Nothing)) $
+            fail "provider and model must be supplied together"
+        pure SubmitCommand {..}
+
+validTaskId :: Text -> Parser TaskId
+validTaskId raw = TaskId <$> boundedIdentifier "task_id" 256 raw
+
+boundedIdentifier :: String -> Int -> Text -> Parser Text
+boundedIdentifier label maximumLength raw = do
+    value <- boundedText label maximumLength raw
+    when (Text.any isControl value) (fail (label <> " contains control characters"))
+    pure value
+
+boundedText :: String -> Int -> Text -> Parser Text
+boundedText label maximumLength raw = do
+    let value = Text.strip raw
+    when (Text.null value) (fail (label <> " must not be empty"))
+    when (Text.length value > maximumLength) (fail (label <> " is too long"))
+    pure value
+
+boundedString :: String -> Int -> String -> Parser String
+boundedString label maximumLength raw = do
+    when (null raw) (fail (label <> " must not be empty"))
+    when (length raw > maximumLength) (fail (label <> " is too long"))
+    pure raw
+
+validDecision :: Text -> Parser Text
+validDecision raw = do
+    decision <- boundedText "decision" 32 raw
+    unless (decision `elem` ["approve", "deny", "approve_session"]) $
+        fail "decision must be approve, deny, or approve_session"
+    pure decision
+
+runProcessTask :: FilePath -> DurableTask -> (Text -> IO ()) -> IO (Either Text ())
+runProcessTask executable task logLine = do
+    let arguments =
+            ["--prompt", Text.unpack task.description, "--save-session"]
+                <> maybe [] (\value -> ["--resume", Text.unpack value]) task.sessionId
+                <> ["--cwd", task.workingDirectory]
+                <> maybe [] (\value -> ["--provider", Text.unpack value]) task.provider
+                <> maybe [] (\value -> ["--model", Text.unpack value]) task.model
+                <> maybe [] (\value -> ["--effort", Text.unpack value]) task.effort
+                <> ["--worktree" | task.worktree]
+        configuration =
+            (proc executable arguments)
+                { std_out = CreatePipe
+                , std_err = CreatePipe
+                }
+    (stdoutHandle, stderrHandle, process) <-
+        createProcess configuration >>= \case
+            (_, Just stdoutHandle, Just stderrHandle, process) ->
+                pure (stdoutHandle, stderrHandle, process)
+            _ -> fail "failed to capture agent-cli output"
+    let terminate = terminateProcess process >> voidWait process
+        consume handle = do
+            hSetEncoding handle utf8
+            let go = do
+                    ended <- hIsEOF handle
+                    unless ended (Text.hGetLine handle >>= logLine >> go)
+            go
+    (concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
+        `onException` terminate
+        >>= \case
+            ExitSuccess -> pure (Right ())
+            ExitFailure code ->
+                pure (Left ("agent-cli exited with status " <> Text.pack (show code)))
+
+voidWait :: ProcessHandle -> IO ()
+voidWait process = do
+    _ <- waitForProcess process
+    pure ()

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -477,13 +477,27 @@ startRunnable journal runner commands completions registry state = do
                                     , updatedAt = persisted.updatedAt
                                     , logTail = persisted.logTail
                                     }
-                worker <- launchWorker commands completions runner executionTask
+                worker <-
+                    launchWorker
+                        commands
+                        completions
+                        runner
+                        executionTask
+                        $ \registered ->
+                            atomically $
+                                modifyTVar'
+                                    registry
+                                    (Map.insert
+                                        taskId
+                                        RunningTask
+                                            { runningAttempt = persisted.attempt
+                                            , runningWorker = registered
+                                            })
                 let runningTask =
                         RunningTask
                             { runningAttempt = persisted.attempt
                             , runningWorker = worker
                             }
-                atomically $ modifyTVar' registry (Map.insert taskId runningTask)
                 pure
                     ( Map.insert taskId persisted tasks
                     , Map.insert taskId runningTask running
@@ -494,8 +508,9 @@ launchWorker ::
     TQueue AdapterMessage ->
     TaskRunner ->
     DurableTask ->
+    (Async () -> IO ()) ->
     IO (Async ())
-launchWorker commands completions runner task =
+launchWorker commands completions runner task register =
     mask $ \_ -> do
         gate <- newEmptyMVar
         logTruncated <- newTVarIO False
@@ -510,16 +525,37 @@ launchWorker commands completions runner task =
                         writeTQueue completions
                             (TaskFinished task.taskId task.attempt (redactFailure outcome))
                 logged line =
-                    atomically $ do
+                    let prefixLimit =
+                            4_096
+                                + max 0 (Text.length task.description - 1)
+                        (inputPrefix, inputRemainder) =
+                            Text.splitAt prefixLimit line
+                        (redactedBytes, _) =
+                            redactSensitiveBytes
+                                (Text.null inputRemainder)
+                                (TextEncoding.encodeUtf8 task.description)
+                                (TextEncoding.encodeUtf8 inputPrefix)
+                        redactedLine =
+                            TextEncoding.decodeUtf8With
+                                lenientDecode
+                                redactedBytes
+                        boundedLine = Text.take 4_096 redactedLine
+                        lineTruncated =
+                            not (Text.null inputRemainder)
+                                || not
+                                    (Text.null
+                                        (Text.drop 4_096 redactedLine))
+                    in atomically $ do
                         accepted <-
                             tryWriteTBQueueCompat
                                 commands
                                 ( TaskLogged
                                     task.taskId
                                     task.attempt
-                                    (redactTaskInput task.description line)
+                                    boundedLine
                                 )
-                        unless accepted (writeTVar logTruncated True)
+                        when (lineTruncated || not accepted)
+                            (writeTVar logTruncated True)
             result <-
                 tryAny
                     ( unmask $
@@ -531,7 +567,8 @@ launchWorker commands completions runner task =
                     | otherwise ->
                         finished (Left (Text.pack (show exception)))
                 Right value -> finished value
-        putMVar gate ()
+        (register worker >> putMVar gate ())
+            `onException` cancel worker
         pure worker
   where
     redactFailure = \case
@@ -674,8 +711,13 @@ runProcessTask runtimeSeconds executable task logLine = do
                 pure (stdoutHandle, stderrHandle, process)
             _ -> fail "failed to capture agent-cli output"
     processGroup <- getPid process
+    totalOutputBytes <- newTVarIO 0
     let terminate = terminateProcessGroup processGroup process
-        consume = consumeBoundedOutput logLine
+        consume =
+            consumeBoundedOutput
+                totalOutputBytes
+                task.description
+                logLine
         closeHandles = hClose stdoutHandle `finally` hClose stderrHandle
         runAndDrain =
             withAsync
@@ -714,18 +756,38 @@ processTaskArguments task =
         <> maybe [] (\value -> ["--effort", Text.unpack value]) task.effort
         <> ["--worktree" | task.worktree]
 
-consumeBoundedOutput :: (Text -> IO ()) -> Handle -> IO ()
-consumeBoundedOutput logChunk handle = go 0 BS.empty
+consumeBoundedOutput
+    :: TVar Int
+    -> Text
+    -> (Text -> IO ())
+    -> Handle
+    -> IO ()
+consumeBoundedOutput totalOutputBytes sensitiveText logChunk handle =
+    go BS.empty BS.empty
   where
-    go total pending = do
+    sensitiveBytes = TextEncoding.encodeUtf8 sensitiveText
+    go redactionPending outputPending = do
         bytes <- BS.hGetSome handle 4_096
-        let nextTotal = total + BS.length bytes
-        when (nextTotal > maxTaskOutputBytes) $
-            ioError (userError "daemon task output exceeded 64 MiB")
-        let buffered = pending <> bytes
+        atomically $ do
+            total <- readTVar totalOutputBytes
+            let nextTotal = total + BS.length bytes
+            when (nextTotal > maxTaskOutputBytes) $
+                throwSTM (userError "daemon task output exceeded 64 MiB")
+            writeTVar totalOutputBytes nextTotal
         if BS.null bytes
-            then unless (BS.null buffered) (emit buffered)
-            else drain buffered >>= go nextTotal
+            then do
+                let (redacted, _) =
+                        redactSensitiveBytes True sensitiveBytes redactionPending
+                    buffered = outputPending <> redacted
+                remainder <- drain buffered
+                unless (BS.null remainder) (emit remainder)
+            else do
+                let (redacted, retained) =
+                        redactSensitiveBytes
+                            False
+                            sensitiveBytes
+                            (redactionPending <> bytes)
+                drain (outputPending <> redacted) >>= go retained
     drain buffered =
         let candidate = BS.take 4_096 buffered
          in case BS.elemIndex 10 candidate of
@@ -738,6 +800,36 @@ consumeBoundedOutput logChunk handle = go 0 BS.empty
                         drain (BS.drop 4_096 buffered)
                     | otherwise -> pure buffered
     emit = logChunk . TextEncoding.decodeUtf8With lenientDecode
+
+redactSensitiveBytes
+    :: Bool
+    -> BS.ByteString
+    -> BS.ByteString
+    -> (BS.ByteString, BS.ByteString)
+redactSensitiveBytes final sensitive = go []
+  where
+    sensitiveLength = BS.length sensitive
+    redactedBytes = TextEncoding.encodeUtf8 redactedTaskDescription
+    go chunks remaining
+        | BS.null sensitive = (remaining, BS.empty)
+        | otherwise =
+            case BS.breakSubstring sensitive remaining of
+                (prefix, suffix)
+                    | not (BS.null suffix) ->
+                        go
+                            (redactedBytes : prefix : chunks)
+                            (BS.drop sensitiveLength suffix)
+                    | final ->
+                        (BS.concat (reverse (prefix : chunks)), BS.empty)
+                    | otherwise ->
+                        let retainedLength =
+                                min
+                                    (max 0 (sensitiveLength - 1))
+                                    (BS.length prefix)
+                            emittedLength = BS.length prefix - retainedLength
+                            emitted = BS.take emittedLength prefix
+                            retained = BS.drop emittedLength prefix
+                        in (BS.concat (reverse (emitted : chunks)), retained)
 
 maxTaskOutputBytes :: Int
 maxTaskOutputBytes = 64 * 1024 * 1024

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -138,6 +138,7 @@ withTaskAdapterQueueSize ::
 withTaskAdapterQueueSize rawQueueSize journal runner action = do
     saved <- snapshot journal
     commands <- newTBQueueIO (fromIntegral (max 1 rawQueueSize))
+    completions <- newTQueueIO
     let initial =
             AdapterState
                 { adapterLimit = defaultTaskLimit
@@ -169,7 +170,9 @@ withTaskAdapterQueueSize rawQueueSize journal runner action = do
                                 else pure (Left "task scheduler command queue is full")
                 }
     workers <- newTVarIO Map.empty
-    let loop = schedulerLoopWithRegistry journal runner commands workers initial
+    let loop =
+            schedulerLoopWithRegistry
+                journal runner commands completions workers initial
     ( race loop (action supervisor) >>= \case
         Left () -> fail "task scheduler stopped unexpectedly"
         Right value -> pure value
@@ -179,14 +182,17 @@ schedulerLoopWithRegistry
     :: Journal
     -> TaskRunner
     -> TBQueue AdapterMessage
+    -> TQueue AdapterMessage
     -> TVar (Map TaskId RunningTask)
     -> AdapterState
     -> IO ()
-schedulerLoopWithRegistry journal runner commands registry = go
+schedulerLoopWithRegistry journal runner commands completions registry = go
   where
     go state0 = do
-        state <- startRunnable journal runner commands registry state0
-        message <- atomically (readTBQueue commands)
+        state <- startRunnable journal runner commands completions registry state0
+        message <-
+            atomically $
+                readTQueue completions `orElse` readTBQueue commands
         handleMessage state message >>= go
 
     handleMessage state = \case
@@ -387,10 +393,11 @@ startRunnable
     :: Journal
     -> TaskRunner
     -> TBQueue AdapterMessage
+    -> TQueue AdapterMessage
     -> TVar (Map TaskId RunningTask)
     -> AdapterState
     -> IO AdapterState
-startRunnable journal runner commands registry state = do
+startRunnable journal runner commands completions registry state = do
     let activeSessions =
             Set.fromList
                 [ sessionId
@@ -434,7 +441,7 @@ startRunnable journal runner commands registry state = do
                                     , updatedAt = persisted.updatedAt
                                     , logTail = persisted.logTail
                                     }
-                worker <- launchWorker commands runner executionTask
+                worker <- launchWorker commands completions runner executionTask
                 let runningTask =
                         RunningTask
                             { runningAttempt = persisted.attempt
@@ -446,23 +453,31 @@ startRunnable journal runner commands registry state = do
                     , Map.insert taskId runningTask running
                     )
 
-launchWorker :: TBQueue AdapterMessage -> TaskRunner -> DurableTask -> IO (Async ())
-launchWorker commands runner task =
+launchWorker ::
+    TBQueue AdapterMessage ->
+    TQueue AdapterMessage ->
+    TaskRunner ->
+    DurableTask ->
+    IO (Async ())
+launchWorker commands completions runner task =
     mask $ \_ -> do
         gate <- newEmptyMVar
         worker <- asyncWithUnmask $ \unmask -> do
             takeMVar gate
             let finished outcome =
                     atomically $
-                        writeTBQueue commands
+                        writeTQueue completions
                             (TaskFinished task.taskId task.attempt outcome)
+                logged line =
+                    atomically $ do
+                        full <- isFullTBQueue commands
+                        unless full $
+                            writeTBQueue commands
+                                (TaskLogged task.taskId task.attempt line)
             result <-
                 tryAny
                     ( unmask $
-                        runner.runTask task $ \line ->
-                            atomically $
-                                writeTBQueue commands
-                                    (TaskLogged task.taskId task.attempt line)
+                        runner.runTask task logged
                     )
             case result of
                 Left exception

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -14,8 +14,11 @@ import Control.Concurrent.Async
     , cancel
     , concurrently_
     , race
+    , wait
     , waitCatch
+    , withAsync
     )
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe
@@ -48,6 +51,7 @@ import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
 import System.IO (Handle, hClose)
 import System.Posix.Signals (sigKILL, sigTERM, signalProcessGroup)
+import System.Posix.Types (CPid)
 import System.Process
 import System.Timeout (timeout)
 
@@ -598,7 +602,8 @@ runProcessTask runtimeSeconds executable task logLine = do
     let arguments = processTaskArguments task
         configuration =
             (proc executable arguments)
-                { std_out = CreatePipe
+                { std_in = NoStream
+                , std_out = CreatePipe
                 , std_err = CreatePipe
                 , create_group = True
                 , close_fds = True
@@ -608,14 +613,27 @@ runProcessTask runtimeSeconds executable task logLine = do
             (_, Just stdoutHandle, Just stderrHandle, process) ->
                 pure (stdoutHandle, stderrHandle, process)
             _ -> fail "failed to capture agent-cli output"
-    let terminate = terminateProcessGroup process
+    processGroup <- getPid process
+    let terminate = terminateProcessGroup processGroup process
         consume = consumeBoundedOutput logLine
         closeHandles = hClose stdoutHandle `finally` hClose stderrHandle
+        runAndDrain =
+            withAsync
+                (concurrently_ (consume stdoutHandle) (consume stderrHandle))
+                $ \drainer -> do
+                    race (waitForProcess process) (wait drainer) >>= \case
+                        Right () -> waitForProcess process
+                        Left exitCode ->
+                            timeout postExitDrainMicros (wait drainer) >>= \case
+                                Just () -> pure exitCode
+                                Nothing -> do
+                                    terminate
+                                    _ <- waitCatch drainer
+                                    pure exitCode
     outcome <-
         timeout
             (max 1 runtimeSeconds * 1_000_000)
-            ( ((concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
-                `onException` terminate)
+            ( (runAndDrain `onException` terminate)
                 `finally` closeHandles
             )
     case outcome of
@@ -664,17 +682,18 @@ consumeBoundedOutput logChunk handle = go 0 BS.empty
 maxTaskOutputBytes :: Int
 maxTaskOutputBytes = 64 * 1024 * 1024
 
-terminateProcessGroup :: ProcessHandle -> IO ()
-terminateProcessGroup process = do
+postExitDrainMicros :: Int
+postExitDrainMicros = 1_000_000
+
+terminateProcessGroup :: Maybe CPid -> ProcessHandle -> IO ()
+terminateProcessGroup processGroup process = do
     signalGroup sigTERM
-    timeout 2_000_000 (waitForProcess process) >>= \case
-        Just _ -> pure ()
-        Nothing -> do
-            signalGroup sigKILL
-            voidWait process
+    threadDelay 2_000_000
+    signalGroup sigKILL
+    voidWait process
   where
     signalGroup signal =
-        getPid process >>= \case
+        case processGroup of
             Just pid ->
                 signalProcessGroup signal (fromIntegral pid)
                     `catch` \(_ :: IOException) -> pure ()

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskScheduler.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskScheduler.hs
@@ -1,4 +1,4 @@
-module Agent.CLI.MacOS.TaskScheduler
+module Agent.Runtime.Daemon.TaskScheduler
     ( TaskIdentity(..)
     , selectRunnableTasks
     ) where
@@ -7,17 +7,16 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 
--- | Stable scheduling identity for one native task. A missing session id is a
--- fresh session and therefore does not conflict with another queued task.
+-- | Stable scheduling identity. Tasks belonging to the same persisted session
+-- are serialized; fresh sessions do not conflict with one another.
 data TaskIdentity = TaskIdentity
     { taskIdentityId :: !Text
     , taskIdentitySessionId :: !(Maybe Text)
     } deriving (Eq, Show)
 
--- | Select at most @capacity@ tasks in queue order while leaving tasks for an
--- already-active (or newly-selected) session queued. Skipping a blocked task
--- lets unrelated sessions make progress without allowing a later turn for the
--- same session to overtake it.
+-- | Select at most @capacity@ tasks in queue order. A task blocked by its
+-- session does not prevent an unrelated session later in the queue from
+-- running, while later work for the same session cannot overtake it.
 selectRunnableTasks
     :: Int
     -> Set Text

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -946,6 +946,43 @@ main = hspec $ do
                 BS.readFile (directory </> "events.jsonl")
                     >>= (`shouldSatisfy` (not . BS.isInfixOf rawBytes))
 
+        it "redacts repeated maximum prompts before bounding custom runner logs" $
+            withSystemTempDirectory "daemon-custom-runner-redaction" $ \directory -> do
+                let rawPrompt = Text.replicate 8_192 "x"
+                    runner =
+                        TaskRunner
+                            { runTask = \task logLine -> do
+                                logLine (task.description <> task.description)
+                                threadDelay 100_000
+                                pure (Right ())
+                            }
+                journal <- openJournal (defaultJournalConfig directory)
+                withTaskAdapter journal runner $ \supervisor -> do
+                    supervisor.handleCommand
+                        (CommandId "submit-repeated-redaction")
+                        (object
+                            [ "version" .= (1 :: Int)
+                            , "type" .= ("submit" :: Text)
+                            , "task_id" .= ("repeated-redaction" :: Text)
+                            , "prompt" .= rawPrompt
+                            , "cwd" .= ("/tmp" :: Text)
+                            ])
+                        >>= shouldSucceed
+                    waitForStatus
+                        journal
+                        (TaskId "repeated-redaction")
+                        TaskCompleted
+                saved <- snapshot journal
+                let retained =
+                        Text.concat
+                            (saved.tasks Map.! TaskId "repeated-redaction").logTail
+                retained
+                    `shouldNotSatisfy`
+                        Text.isInfixOf (Text.replicate 128 "x")
+                retained
+                    `shouldSatisfy`
+                        Text.isInfixOf "[task input redacted]"
+
         it "retains failed input for one-process retry and discards it after completion" $
             withSystemTempDirectory "daemon-task-input-lifetime" $ \directory -> do
                 received <- newTQueueIO
@@ -1042,6 +1079,23 @@ main = hspec $ do
                 captured `shouldSatisfy` (not . null)
                 map Text.length captured `shouldSatisfy` all (<= 4_096)
                 sum (map Text.length captured) `shouldBe` 20_000
+                let longPrompt =
+                        Text.replicate 500 "sensitive"
+                            <> "\n"
+                            <> Text.replicate 500 "private"
+                    longTask = task {description = longPrompt}
+                writeFile executable "#!/bin/sh\nprintf '%s\\n' \"$2\"\n"
+                redactedChunks <- newTQueueIO
+                (processTaskRunnerFor executable).runTask longTask
+                    (atomically . writeTQueue redactedChunks)
+                    `shouldReturn` Right ()
+                redacted <- Text.concat <$> atomically (flushTQueue redactedChunks)
+                redacted
+                    `shouldNotSatisfy`
+                        Text.isInfixOf (Text.replicate 500 "sensitive")
+                redacted
+                    `shouldSatisfy`
+                        Text.isInfixOf "[task input redacted]"
                 writeFile executable "#!/bin/sh\nsleep 30\n"
                 timeout
                     4_000_000
@@ -1052,6 +1106,14 @@ main = hspec $ do
                     5_000_000
                     ((processTaskRunnerForWithTimeout 10 executable).runTask task (const (pure ())))
                     `shouldReturn` Just (Right ())
+                writeFile executable $
+                    "#!/bin/sh\n"
+                        <> "dd if=/dev/zero bs=1048576 count=40 2>/dev/null\n"
+                        <> "dd if=/dev/zero bs=1048576 count=40 1>&2 2>/dev/null\n"
+                timeout
+                    20_000_000
+                    ((processTaskRunnerFor executable).runTask task (const (pure ())))
+                    `shouldThrow` anyException
 
         it "bounds task-runner output in the durable journal" $
             withSystemTempDirectory "daemon-runner-log-bound" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -6,6 +6,7 @@ import Control.Concurrent.STM
     ( TQueue
     , TMVar
     , atomically
+    , flushTQueue
     , newEmptyTMVarIO
     , newTQueueIO
     , readTQueue
@@ -37,6 +38,7 @@ import System.Posix.Files
     ( createSymbolicLink
     , fileMode
     , getFileStatus
+    , setFileMode
     )
 import System.Timeout (timeout)
 import Test.Hspec
@@ -821,13 +823,25 @@ main = hspec $ do
                             (serveConnection serverConfig firstJournal supervisor serverPeer)
                             $ \_ -> do
                                 handshake serverConfig clientPeer Nothing
+                                _ <- sendTaskCommand serverConfig clientPeer "limit" $
+                                    object
+                                        [ "version" .= (1 :: Int)
+                                        , "type" .= ("set_limit" :: Text)
+                                        , "limit" .= (1 :: Int)
+                                        ]
                                 _ <- sendTaskCommand serverConfig clientPeer "submit"
                                     (submitCommand "restart-task" "restart-session")
                                 timeout 1_000_000 (atomically (readTQueue firstStarted))
                                     `shouldReturn` Just (TaskId "restart-task")
+                                _ <- sendTaskCommand serverConfig clientPeer "submit-queued"
+                                    (submitCommand "queued-task" "queued-session")
+                                timeout 100_000 (atomically (readTQueue firstStarted))
+                                    `shouldReturn` Nothing
                 restartedJournal <- openJournal journalConfig
                 recovered <- snapshot restartedJournal
                 (.status) (recovered.tasks Map.! TaskId "restart-task")
+                    `shouldBe` TaskInterrupted
+                (.status) (recovered.tasks Map.! TaskId "queued-task")
                     `shouldBe` TaskInterrupted
                 retryGate <- newEmptyTMVarIO
                 retryStarted <- newTQueueIO
@@ -858,12 +872,91 @@ main = hspec $ do
                                         , "approval_id" .= ("approval-1" :: Text)
                                         , "decision" .= ("approve" :: Text)
                                         ])
-                                    >>= shouldSucceed
+                                    `shouldReturn` Left
+                                        "interactive approval resolution is unsupported by the daemon task adapter"
                                 running <- snapshot restartedJournal
                                 let retried =
                                         running.tasks Map.! TaskId "restart-task"
                                 retried.status `shouldBe` TaskRunning
                                 retried.attempt `shouldBe` 2
+
+        it "uses the actual agent-cli argv shape and bounds process output chunks" $
+            withSystemTempDirectory "daemon-process-runner" $ \directory -> do
+                now <- getCurrentTime
+                let executable = directory </> "agent-cli"
+                    argumentsPath = directory </> "arguments"
+                    task =
+                        DurableTask
+                            { taskId = TaskId "process"
+                            , sessionId = Just "session-id"
+                            , status = TaskRunning
+                            , description = "hello agent"
+                            , workingDirectory = "/tmp/project"
+                            , provider = Just "openai"
+                            , model = Just "gpt-5.6"
+                            , effort = Just "high"
+                            , worktree = False
+                            , attempt = 1
+                            , updatedAt = now
+                            , logTail = []
+                            }
+                    expected =
+                        [ "--prompt"
+                        , "hello agent"
+                        , "--save-session"
+                        , "--resume"
+                        , "session-id"
+                        , "--cwd"
+                        , "/tmp/project"
+                        , "--provider"
+                        , "openai"
+                        , "--model"
+                        , "gpt-5.6"
+                        , "--effort"
+                        , "high"
+                        ]
+                writeFile executable $
+                    "#!/bin/sh\n"
+                        <> "printf '%s\\n' \"$@\" > "
+                        <> show argumentsPath
+                        <> "\n"
+                        <> "dd if=/dev/zero bs=20000 count=1 2>/dev/null | tr '\\\\0' x\n"
+                setFileMode executable 0o700
+                chunks <- newTQueueIO
+                result <-
+                    (processTaskRunnerFor executable).runTask task $
+                        atomically . writeTQueue chunks
+                result `shouldBe` Right ()
+                lines <$> readFile argumentsPath `shouldReturn` expected
+                captured <- atomically (flushTQueue chunks)
+                captured `shouldSatisfy` (not . null)
+                map Text.length captured `shouldSatisfy` all (<= 4_096)
+                sum (map Text.length captured) `shouldBe` 20_000
+
+        it "bounds task-runner output in the durable journal" $
+            withSystemTempDirectory "daemon-runner-log-bound" $ \directory -> do
+                let journalConfig =
+                        (defaultJournalConfig directory)
+                            { maximumTaskLogLines = 3
+                            , maximumTaskLogCharacters = 10
+                            }
+                    runner =
+                        TaskRunner
+                            { runTask = \_ logLine -> do
+                                mapM_ logLine (replicate 8 "12345")
+                                pure (Right ())
+                            }
+                journal <- openJournal journalConfig
+                withTaskAdapter journal runner $ \supervisor -> do
+                    supervisor.handleCommand
+                        (CommandId "submit")
+                        (submitCommand "bounded-log" "bounded-session")
+                        >>= shouldSucceed
+                    waitForStatus journal (TaskId "bounded-log") TaskCompleted
+                saved <- snapshot journal
+                let retained = (.logTail) (saved.tasks Map.! TaskId "bounded-log")
+                length retained `shouldSatisfy` (<= 3)
+                sum (map Text.length retained) `shouldSatisfy` (<= 10)
 
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =
@@ -883,7 +976,6 @@ blockingRunner started gates =
             case Map.lookup task.taskId gates of
                 Nothing -> pure (Left "missing test gate")
                 Just gate -> atomically (takeTMVar gate) >> pure (Right ())
-        , resolveApproval = \_ _ _ -> pure (Right ())
         }
 
 handshake :: ServerConfig -> Socket -> Maybe Sequence -> IO ()

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -959,11 +959,11 @@ main = hspec $ do
                     runner =
                         TaskRunner
                             { runTask = \_ logLine -> do
-                                mapM_ logLine (replicate 8 "12345")
+                                mapM_ logLine (replicate 10_000 "12345")
                                 pure (Right ())
                             }
                 journal <- openJournal journalConfig
-                withTaskAdapter journal runner $ \supervisor -> do
+                withTaskAdapterQueueSize 1 journal runner $ \supervisor -> do
                     supervisor.handleCommand
                         (CommandId "submit")
                         (submitCommand "bounded-log" "bounded-session")

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -946,6 +946,49 @@ main = hspec $ do
                 BS.readFile (directory </> "events.jsonl")
                     >>= (`shouldSatisfy` (not . BS.isInfixOf rawBytes))
 
+        it "retains failed input for one-process retry and discards it after completion" $
+            withSystemTempDirectory "daemon-task-input-lifetime" $ \directory -> do
+                received <- newTQueueIO
+                let rawPrompt = "memory-only-retry-input"
+                    runner =
+                        TaskRunner
+                            { runTask = \task _ -> do
+                                atomically (writeTQueue received (task.attempt, task.description))
+                                pure $
+                                    if task.attempt == 1
+                                        then Left "first attempt failed"
+                                        else Right ()
+                            }
+                    retryCommand =
+                        object
+                            [ "version" .= (1 :: Int)
+                            , "type" .= ("retry" :: Text)
+                            , "task_id" .= ("retry-lifetime" :: Text)
+                            ]
+                journal <- openJournal (defaultJournalConfig directory)
+                withTaskAdapter journal runner $ \supervisor -> do
+                    supervisor.handleCommand
+                        (CommandId "submit-retry-lifetime")
+                        (object
+                            [ "version" .= (1 :: Int)
+                            , "type" .= ("submit" :: Text)
+                            , "task_id" .= ("retry-lifetime" :: Text)
+                            , "prompt" .= rawPrompt
+                            , "cwd" .= ("/tmp" :: Text)
+                            ])
+                        >>= shouldSucceed
+                    timeout 1_000_000 (atomically (readTQueue received))
+                        `shouldReturn` Just (1, rawPrompt)
+                    waitForStatus journal (TaskId "retry-lifetime") TaskFailed
+                    supervisor.handleCommand (CommandId "retry-failed") retryCommand
+                        >>= shouldSucceed
+                    timeout 1_000_000 (atomically (readTQueue received))
+                        `shouldReturn` Just (2, rawPrompt)
+                    waitForStatus journal (TaskId "retry-lifetime") TaskCompleted
+                    supervisor.handleCommand (CommandId "retry-completed") retryCommand
+                        `shouldReturn` Left
+                            "completed tasks cannot be retried; task input has been discarded"
+
         it "uses the actual agent-cli argv shape and bounds process output chunks" $
             withSystemTempDirectory "daemon-process-runner" $ \directory -> do
                 now <- getCurrentTime

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -24,6 +24,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Data.Time (getCurrentTime)
 import Network.Socket
 import qualified Network.Socket.ByteString as Socket
@@ -889,6 +890,61 @@ main = hspec $ do
                                         unchanged.tasks Map.! TaskId "restart-task"
                                 interrupted.status `shouldBe` TaskInterrupted
                                 interrupted.attempt `shouldBe` 1
+
+        it "keeps submitted prompts out of every durable and public task representation" $
+            withSystemTempDirectory "daemon-task-input-redaction" $ \directory -> do
+                receivedPrompts <- newTQueueIO
+                let rawPrompt = "opaque-violet-7Q9-content"
+                    rawBytes = TextEncoding.encodeUtf8 rawPrompt
+                    command =
+                        object
+                            [ "version" .= (1 :: Int)
+                            , "type" .= ("submit" :: Text)
+                            , "task_id" .= ("redacted-input" :: Text)
+                            , "session_id" .= ("redacted-session" :: Text)
+                            , "prompt" .= rawPrompt
+                            , "cwd" .= ("/tmp" :: Text)
+                            ]
+                    runner =
+                        TaskRunner
+                            { runTask = \task logLine -> do
+                                atomically (writeTQueue receivedPrompts task.description)
+                                logLine ("runner echoed " <> task.description)
+                                pure (Left ("failed for " <> task.description))
+                            }
+                journal <- openJournal (defaultJournalConfig directory)
+                withTaskAdapter journal runner $ \supervisor -> do
+                    submitted <-
+                        supervisor.handleCommand (CommandId "submit-redacted") command
+                    case submitted of
+                        Left message -> expectationFailure (Text.unpack message)
+                        Right value ->
+                            LBS.toStrict (encode value)
+                                `shouldSatisfy` (not . BS.isInfixOf rawBytes)
+                    timeout 1_000_000 (atomically (readTQueue receivedPrompts))
+                        `shouldReturn` Just rawPrompt
+                    waitForStatus journal (TaskId "redacted-input") TaskFailed
+                    listed <-
+                        supervisor.handleCommand
+                            (CommandId "list-redacted")
+                            (object
+                                [ "version" .= (1 :: Int)
+                                , "type" .= ("list" :: Text)
+                                ])
+                    case listed of
+                        Left message -> expectationFailure (Text.unpack message)
+                        Right value ->
+                            LBS.toStrict (encode value)
+                                `shouldSatisfy` (not . BS.isInfixOf rawBytes)
+                saved <- snapshot journal
+                let durableTask = saved.tasks Map.! TaskId "redacted-input"
+                durableTask.description `shouldBe` "[task input redacted]"
+                Text.concat durableTask.logTail
+                    `shouldSatisfy` (not . Text.isInfixOf rawPrompt)
+                BS.readFile (directory </> "snapshot.json")
+                    >>= (`shouldSatisfy` (not . BS.isInfixOf rawBytes))
+                BS.readFile (directory </> "events.jsonl")
+                    >>= (`shouldSatisfy` (not . BS.isInfixOf rawBytes))
 
         it "uses the actual agent-cli argv shape and bounds process output chunks" $
             withSystemTempDirectory "daemon-process-runner" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -948,6 +948,11 @@ main = hspec $ do
                     4_000_000
                     ((processTaskRunnerForWithTimeout 1 executable).runTask task (const (pure ())))
                     `shouldReturn` Just (Left "agent-cli exceeded its 1 second runtime limit")
+                writeFile executable "#!/bin/sh\nsleep 30 &\nexit 0\n"
+                timeout
+                    5_000_000
+                    ((processTaskRunnerForWithTimeout 10 executable).runTask task (const (pure ())))
+                    `shouldReturn` Just (Right ())
 
         it "bounds task-runner output in the durable journal" $
             withSystemTempDirectory "daemon-runner-log-bound" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (cancel, concurrently, waitCatch, withAsync)
+import Control.Concurrent.Async (async, cancel, concurrently, wait, waitCatch, withAsync)
 import Control.Concurrent.STM
     ( TQueue
     , TMVar
@@ -9,12 +9,13 @@ import Control.Concurrent.STM
     , flushTQueue
     , newEmptyTMVarIO
     , newTQueueIO
+    , putTMVar
     , readTQueue
     , readTVarIO
     , takeTMVar
     , writeTQueue
     )
-import Control.Exception.Safe (bracket, isAsyncException)
+import Control.Exception.Safe (bracket, finally, isAsyncException, uninterruptibleMask_)
 import Data.Aeson (Result (..), Value (..), encode, fromJSON, object, toJSON, (.=))
 import Data.Bits ((.&.))
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -913,6 +914,7 @@ main = hspec $ do
                         [ "--prompt"
                         , "hello agent"
                         , "--save-session"
+                        , "--no-yolo"
                         , "--resume"
                         , "session-id"
                         , "--cwd"
@@ -971,6 +973,75 @@ main = hspec $ do
                 let retained = (.logTail) (saved.tasks Map.! TaskId "bounded-log")
                 length retained `shouldSatisfy` (<= 3)
                 sum (map Text.length retained) `shouldSatisfy` (<= 10)
+
+        it "rejects full command queues and skips requests cancelled before execution" $
+            withSystemTempDirectory "daemon-command-admission" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                runGate <- newEmptyTMVarIO
+                cleanupGate <- newEmptyTMVarIO
+                runnerStarted <- newTQueueIO
+                cleanupStarted <- newTQueueIO
+                let runner =
+                        TaskRunner
+                            { runTask = \_ _ -> do
+                                atomically (writeTQueue runnerStarted ())
+                                _ <- atomically (takeTMVar runGate)
+                                    `finally`
+                                        uninterruptibleMask_
+                                            ( do
+                                                atomically (writeTQueue cleanupStarted ())
+                                                atomically (takeTMVar cleanupGate)
+                                            )
+                                pure (Right ())
+                            }
+                    command kind fields =
+                        object
+                            ( [ "version" .= (1 :: Int)
+                              , "type" .= (kind :: Text)
+                              ]
+                                <> fields
+                            )
+                withTaskAdapterQueueSize 1 journal runner $ \supervisor -> do
+                    supervisor.handleCommand
+                        (CommandId "submit")
+                        (submitCommand "admission-task" "admission-session")
+                        >>= shouldSucceed
+                    timeout 1_000_000 (atomically (readTQueue runnerStarted))
+                        `shouldReturn` Just ()
+                    cancelling <-
+                        async $
+                            supervisor.handleCommand
+                                (CommandId "cancel")
+                                (command "cancel" ["task_id" .= ("admission-task" :: Text)])
+                    timeout 1_000_000 (atomically (readTQueue cleanupStarted))
+                        `shouldReturn` Just ()
+                    ghost <-
+                        async $
+                            supervisor.handleCommand
+                                (CommandId "ghost")
+                                (command "set_limit" ["limit" .= (1 :: Int)])
+                    threadDelay 20_000
+                    cancel ghost
+                    waitCatch ghost >>= (`shouldSatisfy` \case
+                        Left exception -> isAsyncException exception
+                        Right _ -> False)
+                    timeout
+                        200_000
+                        ( supervisor.handleCommand
+                            (CommandId "overflow")
+                            (command "list" [])
+                        )
+                        `shouldReturn` Just (Left "task scheduler command queue is full")
+                    atomically (putTMVar cleanupGate ())
+                    wait cancelling >>= shouldSucceed
+                    threadDelay 20_000
+                    afterCancel <- snapshot journal
+                    supervisor.handleCommand
+                        (CommandId "list")
+                        (command "list" [])
+                        >>= shouldSucceed
+                    afterList <- snapshot journal
+                    afterList.lastSequence `shouldBe` afterCancel.lastSequence
 
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -2,10 +2,21 @@ module Main (main) where
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (cancel, concurrently, waitCatch, withAsync)
-import Control.Concurrent.STM (readTVarIO)
+import Control.Concurrent.STM
+    ( TQueue
+    , TMVar
+    , atomically
+    , newEmptyTMVarIO
+    , newTQueueIO
+    , readTQueue
+    , readTVarIO
+    , takeTMVar
+    , writeTQueue
+    )
 import Control.Exception.Safe (bracket, isAsyncException)
-import Data.Aeson (Value (..), encode, object, toJSON, (.=))
+import Data.Aeson (Result (..), Value (..), encode, fromJSON, object, toJSON, (.=))
 import Data.Bits ((.&.))
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
@@ -37,6 +48,7 @@ import Agent.Runtime.Daemon.Server
 import Agent.Runtime.Daemon.Socket
 import Agent.Runtime.Daemon.Supervisor
 import Agent.Runtime.Daemon.Task
+import Agent.Runtime.Daemon.TaskAdapter
 
 main :: IO ()
 main = hspec $ do
@@ -176,8 +188,15 @@ main = hspec $ do
                     task =
                         DurableTask
                             { taskId = TaskId "task"
+                            , sessionId = Nothing
                             , status = TaskRunning
                             , description = "test"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = ["old", "authorization: bearer private", "safe"]
                             }
@@ -198,8 +217,15 @@ main = hspec $ do
                     running =
                         DurableTask
                             { taskId = TaskId "active"
+                            , sessionId = Nothing
                             , status = TaskRunning
                             , description = "active before crash"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = []
                             }
@@ -264,8 +290,15 @@ main = hspec $ do
                     persistTask original $
                         DurableTask
                             { taskId = TaskId "snapshot-anchor"
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description = "anchor"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = []
                             }
@@ -308,8 +341,15 @@ main = hspec $ do
                     task name description =
                         DurableTask
                             { taskId = TaskId name
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = []
                             }
@@ -333,8 +373,15 @@ main = hspec $ do
                 let task =
                         DurableTask
                             { taskId = TaskId "recovered"
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description = "password=private"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = ["token=private"]
                             }
@@ -589,8 +636,15 @@ main = hspec $ do
                     persistTask journal $
                         DurableTask
                             { taskId = TaskId "large"
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description = "large snapshot"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = [Text.replicate 2_000 "x"]
                             }
@@ -666,8 +720,260 @@ main = hspec $ do
                                 [1 .. chunkCount - 1]
                         indices `shouldBe` [1 .. chunkCount - 1]
 
+    describe "task adapter IPC" $ do
+        it "submits, queues, cancels, lists, and replays durable task changes" $
+            withSystemTempDirectory "daemon-task-adapter" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                firstGate <- newEmptyTMVarIO
+                secondGate <- newEmptyTMVarIO
+                started <- newTQueueIO
+                let runner =
+                        blockingRunner
+                            started
+                            (Map.fromList
+                                [ (TaskId "first", firstGate)
+                                , (TaskId "second", secondGate)
+                                ])
+                    config =
+                        defaultServerConfig
+                            { heartbeatSeconds = 60
+                            , maximumFrameBytes = 16_384
+                            }
+                withTaskAdapter journal runner $ \supervisor ->
+                    withSocketPair $ \(serverPeer, clientPeer) ->
+                        withAsync (serveConnection config journal supervisor serverPeer) $ \_ -> do
+                            handshake config clientPeer Nothing
+                            sendTaskCommand config clientPeer "limit"
+                                (object
+                                    [ "version" .= (1 :: Int)
+                                    , "type" .= ("set_limit" :: Text)
+                                    , "limit" .= (1 :: Int)
+                                    ])
+                                `shouldReturn` Right
+                                    (object ["version" .= (1 :: Int), "limit" .= (1 :: Int)])
+                            sendTaskCommand config clientPeer "submit-first"
+                                (submitCommand "first" "session-a")
+                                >>= shouldSucceed
+                            timeout 1_000_000 (atomically (readTQueue started))
+                                `shouldReturn` Just (TaskId "first")
+                            sendTaskCommand config clientPeer "submit-second"
+                                (submitCommand "second" "session-b")
+                                >>= shouldSucceed
+                            timeout 100_000 (atomically (readTQueue started))
+                                `shouldReturn` Nothing
+                            sendTaskCommand config clientPeer "cancel-second"
+                                (object
+                                    [ "version" .= (1 :: Int)
+                                    , "type" .= ("cancel" :: Text)
+                                    , "task_id" .= ("second" :: Text)
+                                    ])
+                                >>= shouldSucceed
+                            sendTaskCommand config clientPeer "list"
+                                (object
+                                    [ "version" .= (1 :: Int)
+                                    , "type" .= ("list" :: Text)
+                                    ])
+                                >>= \case
+                                    Right value ->
+                                        value `shouldSatisfy` listContains
+                                            (TaskId "second") TaskCancelled
+                                    Left message ->
+                                        expectationFailure (Text.unpack message)
+                            sendTaskCommand config clientPeer "cancel-first"
+                                (object
+                                    [ "version" .= (1 :: Int)
+                                    , "type" .= ("cancel" :: Text)
+                                    , "task_id" .= ("first" :: Text)
+                                    ])
+                                >>= shouldSucceed
+                            waitForStatus journal (TaskId "first") TaskCancelled
+                saved <- snapshot journal
+                let eventCount =
+                        fromIntegral saved.lastSequence.unSequence :: Int
+                withSocketPair $ \(serverPeer, clientPeer) ->
+                    withAsync
+                        (serveConnection config journal unavailableSupervisor serverPeer)
+                        $ \_ -> do
+                            handshake config clientPeer (Just 0)
+                            replayed <- traverse
+                                (const (receiveJSONFrame config.maximumFrameBytes clientPeer))
+                                [1 .. eventCount]
+                            replayed `shouldSatisfy`
+                                any (messageHasStatus (TaskId "second") TaskCancelled)
+
+        it "interrupts in-flight work on restart and starts it only after explicit retry" $
+            withSystemTempDirectory "daemon-task-restart" $ \directory -> do
+                let journalConfig = defaultJournalConfig directory
+                    serverConfig =
+                        defaultServerConfig
+                            { heartbeatSeconds = 60
+                            , maximumFrameBytes = 16_384
+                            }
+                firstJournal <- openJournal journalConfig
+                firstGate <- newEmptyTMVarIO
+                firstStarted <- newTQueueIO
+                let firstRunner =
+                        blockingRunner firstStarted
+                            (Map.singleton (TaskId "restart-task") firstGate)
+                withTaskAdapter firstJournal firstRunner $ \supervisor ->
+                    withSocketPair $ \(serverPeer, clientPeer) ->
+                        withAsync
+                            (serveConnection serverConfig firstJournal supervisor serverPeer)
+                            $ \_ -> do
+                                handshake serverConfig clientPeer Nothing
+                                _ <- sendTaskCommand serverConfig clientPeer "submit"
+                                    (submitCommand "restart-task" "restart-session")
+                                timeout 1_000_000 (atomically (readTQueue firstStarted))
+                                    `shouldReturn` Just (TaskId "restart-task")
+                restartedJournal <- openJournal journalConfig
+                recovered <- snapshot restartedJournal
+                (.status) (recovered.tasks Map.! TaskId "restart-task")
+                    `shouldBe` TaskInterrupted
+                retryGate <- newEmptyTMVarIO
+                retryStarted <- newTQueueIO
+                let retryRunner =
+                        blockingRunner retryStarted
+                            (Map.singleton (TaskId "restart-task") retryGate)
+                withTaskAdapter restartedJournal retryRunner $ \supervisor ->
+                    withSocketPair $ \(serverPeer, clientPeer) ->
+                        withAsync
+                            (serveConnection serverConfig restartedJournal supervisor serverPeer)
+                            $ \_ -> do
+                                handshake serverConfig clientPeer Nothing
+                                timeout 100_000 (atomically (readTQueue retryStarted))
+                                    `shouldReturn` Nothing
+                                _ <- sendTaskCommand serverConfig clientPeer "retry" $
+                                    object
+                                        [ "version" .= (1 :: Int)
+                                        , "type" .= ("retry" :: Text)
+                                        , "task_id" .= ("restart-task" :: Text)
+                                        ]
+                                timeout 1_000_000 (atomically (readTQueue retryStarted))
+                                    `shouldReturn` Just (TaskId "restart-task")
+                                sendTaskCommand serverConfig clientPeer "approval"
+                                    (object
+                                        [ "version" .= (1 :: Int)
+                                        , "type" .= ("approval" :: Text)
+                                        , "task_id" .= ("restart-task" :: Text)
+                                        , "approval_id" .= ("approval-1" :: Text)
+                                        , "decision" .= ("approve" :: Text)
+                                        ])
+                                    >>= shouldSucceed
+                                running <- snapshot restartedJournal
+                                let retried =
+                                        running.tasks Map.! TaskId "restart-task"
+                                retried.status `shouldBe` TaskRunning
+                                retried.attempt `shouldBe` 2
+
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =
     bracket
         (socketPair AF_UNIX Stream defaultProtocol)
         (\(left, right) -> close left >> close right)
+
+blockingRunner
+    :: TQueue TaskId
+    -> Map.Map TaskId (TMVar ())
+    -> TaskRunner
+blockingRunner started gates =
+    TaskRunner
+        { runTask = \task logLine -> do
+            atomically (writeTQueue started task.taskId)
+            logLine "started"
+            case Map.lookup task.taskId gates of
+                Nothing -> pure (Left "missing test gate")
+                Just gate -> atomically (takeTMVar gate) >> pure (Right ())
+        , resolveApproval = \_ _ _ -> pure (Right ())
+        }
+
+handshake :: ServerConfig -> Socket -> Maybe Sequence -> IO ()
+handshake config peer resumeAfter = do
+    sendJSONFrame config.maximumFrameBytes peer $
+        ClientHello
+            Hello
+                { clientId = ClientId "task-adapter-test"
+                , versions = [currentProtocolVersion]
+                , resumeAfter
+                }
+    receiveJSONFrame config.maximumFrameBytes peer >>= \case
+        ServerWelcome _ -> pure ()
+        other -> expectationFailure ("unexpected handshake: " <> show other)
+    case resumeAfter of
+        Nothing ->
+            receiveJSONFrame config.maximumFrameBytes peer >>= \case
+                ServerSnapshotChunk _ _ _ _ -> pure ()
+                other -> expectationFailure ("unexpected snapshot: " <> show other)
+        Just _ -> pure ()
+
+sendTaskCommand
+    :: ServerConfig
+    -> Socket
+    -> Text
+    -> Value
+    -> IO (Either Text Value)
+sendTaskCommand config peer rawId command = do
+    let commandId = CommandId rawId
+    sendJSONFrame config.maximumFrameBytes peer (ClientCommand commandId command)
+    await commandId
+  where
+    await commandId =
+        receiveJSONFrame config.maximumFrameBytes peer >>= \case
+            ServerCommandResult received result
+                | received == commandId -> pure result
+            ServerEvent _ -> await commandId
+            ServerEventChunk _ _ _ _ -> await commandId
+            ServerHeartbeat sequenceNumber -> do
+                sendJSONFrame config.maximumFrameBytes peer (ClientPong sequenceNumber)
+                await commandId
+            other ->
+                expectationFailure ("unexpected command response: " <> show other)
+                    >> pure (Left "unexpected command response")
+
+shouldSucceed :: Either Text Value -> IO ()
+shouldSucceed = \case
+    Right _ -> pure ()
+    Left message -> expectationFailure (Text.unpack message)
+
+submitCommand :: Text -> Text -> Value
+submitCommand taskId sessionId =
+    object
+        [ "version" .= (1 :: Int)
+        , "type" .= ("submit" :: Text)
+        , "task_id" .= taskId
+        , "session_id" .= sessionId
+        , "prompt" .= ("test prompt" :: Text)
+        , "cwd" .= ("/tmp" :: Text)
+        ]
+
+listContains :: TaskId -> TaskStatus -> Value -> Bool
+listContains taskId status = \case
+    Object value ->
+        case KeyMap.lookup "tasks" value of
+            Just tasksValue ->
+                case fromJSON tasksValue of
+                    Success tasks ->
+                        any
+                            (\task -> task.taskId == taskId && task.status == status)
+                            (tasks :: [DurableTask])
+                    Error _ -> False
+            Nothing -> False
+    _ -> False
+
+messageHasStatus :: TaskId -> TaskStatus -> ServerMessage -> Bool
+messageHasStatus taskId status = \case
+    ServerEvent event
+        | event.eventType == "task_changed" ->
+            case (fromJSON event.payload :: Result DurableTask) of
+                Success task -> task.taskId == taskId && task.status == status
+                Error _ -> False
+    _ -> False
+
+waitForStatus :: Journal -> TaskId -> TaskStatus -> IO ()
+waitForStatus journal taskId status =
+    timeout 2_000_000 loop >>= (`shouldBe` Just ())
+  where
+    loop = do
+        saved <- snapshot journal
+        case Map.lookup taskId saved.tasks of
+            Just task | task.status == status -> pure ()
+            _ -> threadDelay 10_000 >> loop

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -959,7 +959,7 @@ main = hspec $ do
                 let journalConfig =
                         (defaultJournalConfig directory)
                             { maximumTaskLogLines = 3
-                            , maximumTaskLogCharacters = 10
+                            , maximumTaskLogCharacters = 200
                             }
                     runner =
                         TaskRunner
@@ -977,7 +977,9 @@ main = hspec $ do
                 saved <- snapshot journal
                 let retained = (.logTail) (saved.tasks Map.! TaskId "bounded-log")
                 length retained `shouldSatisfy` (<= 3)
-                sum (map Text.length retained) `shouldSatisfy` (<= 10)
+                sum (map Text.length retained) `shouldSatisfy` (<= 200)
+                retained `shouldSatisfy`
+                    any (Text.isInfixOf "output truncated")
 
         it "rejects full command queues and skips requests cancelled before execution" $
             withSystemTempDirectory "daemon-command-admission" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -810,7 +810,7 @@ main = hspec $ do
                             replayed `shouldSatisfy`
                                 any (messageHasStatus (TaskId "second") TaskCancelled)
 
-        it "interrupts in-flight work on restart and starts it only after explicit retry" $
+        it "interrupts queued and running work and rejects unsafe retry after restart" $
             withSystemTempDirectory "daemon-task-restart" $ \directory -> do
                 let journalConfig = defaultJournalConfig directory
                     serverConfig =
@@ -840,6 +840,16 @@ main = hspec $ do
                                     (submitCommand "restart-task" "restart-session")
                                 timeout 1_000_000 (atomically (readTQueue firstStarted))
                                     `shouldReturn` Just (TaskId "restart-task")
+                                sendTaskCommand serverConfig clientPeer "approval"
+                                    (object
+                                        [ "version" .= (1 :: Int)
+                                        , "type" .= ("approval" :: Text)
+                                        , "task_id" .= ("restart-task" :: Text)
+                                        , "approval_id" .= ("approval-1" :: Text)
+                                        , "decision" .= ("approve" :: Text)
+                                        ])
+                                    `shouldReturn` Left
+                                        "interactive approval resolution is unsupported by the daemon task adapter"
                                 _ <- sendTaskCommand serverConfig clientPeer "submit-queued"
                                     (submitCommand "queued-task" "queued-session")
                                 timeout 100_000 (atomically (readTQueue firstStarted))
@@ -863,29 +873,21 @@ main = hspec $ do
                                 handshake serverConfig clientPeer Nothing
                                 timeout 100_000 (atomically (readTQueue retryStarted))
                                     `shouldReturn` Nothing
-                                _ <- sendTaskCommand serverConfig clientPeer "retry" $
-                                    object
+                                sendTaskCommand serverConfig clientPeer "retry"
+                                    (object
                                         [ "version" .= (1 :: Int)
                                         , "type" .= ("retry" :: Text)
                                         , "task_id" .= ("restart-task" :: Text)
-                                        ]
-                                timeout 1_000_000 (atomically (readTQueue retryStarted))
-                                    `shouldReturn` Just (TaskId "restart-task")
-                                sendTaskCommand serverConfig clientPeer "approval"
-                                    (object
-                                        [ "version" .= (1 :: Int)
-                                        , "type" .= ("approval" :: Text)
-                                        , "task_id" .= ("restart-task" :: Text)
-                                        , "approval_id" .= ("approval-1" :: Text)
-                                        , "decision" .= ("approve" :: Text)
                                         ])
                                     `shouldReturn` Left
-                                        "interactive approval resolution is unsupported by the daemon task adapter"
-                                running <- snapshot restartedJournal
-                                let retried =
-                                        running.tasks Map.! TaskId "restart-task"
-                                retried.status `shouldBe` TaskRunning
-                                retried.attempt `shouldBe` 2
+                                        "task input is unavailable after daemon restart; submit a new task id"
+                                timeout 100_000 (atomically (readTQueue retryStarted))
+                                    `shouldReturn` Nothing
+                                unchanged <- snapshot restartedJournal
+                                let interrupted =
+                                        unchanged.tasks Map.! TaskId "restart-task"
+                                interrupted.status `shouldBe` TaskInterrupted
+                                interrupted.attempt `shouldBe` 1
 
         it "uses the actual agent-cli argv shape and bounds process output chunks" $
             withSystemTempDirectory "daemon-process-runner" $ \directory -> do
@@ -939,6 +941,11 @@ main = hspec $ do
                 captured `shouldSatisfy` (not . null)
                 map Text.length captured `shouldSatisfy` all (<= 4_096)
                 sum (map Text.length captured) `shouldBe` 20_000
+                writeFile executable "#!/bin/sh\nsleep 30\n"
+                timeout
+                    4_000_000
+                    ((processTaskRunnerForWithTimeout 1 executable).runTask task (const (pure ())))
+                    `shouldReturn` Just (Left "agent-cli exceeded its 1 second runtime limit")
 
         it "bounds task-runner output in the durable journal" $
             withSystemTempDirectory "daemon-runner-log-bound" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -410,8 +410,15 @@ main = hspec $ do
                 let oldTask taskId =
                         DurableTask
                             { taskId
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description = "password=private"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = ["old", "token=private", "new"]
                             }


### PR DESCRIPTION
## Summary
- add a typed, durable task adapter backed by noninteractive `agent-cli` process tasks
- persist and replay bounded task state while interrupting queued/running work on restart without automatic retry
- fail closed for unavailable recovered input and unsupported interactive approvals
- bound command admission, child output, runtime, and process-group shutdown

## Validation
- `nix develop -c cabal test agent-runtime-daemon-test --offline --test-show-details=direct` (34 examples)
- `nix develop -c cabal build agent-runtime-daemon:exe:agent-runtime-daemon --offline`
- `git diff --check`

Stacked on #767.