### PR TITLE
Fix response body compatibility regressions

### DIFF
--- a/packages/agent-core/src/Agent/Loop/EventPump.hs
+++ b/packages/agent-core/src/Agent/Loop/EventPump.hs
@@ -334,9 +334,10 @@ reserveTailPayloadBytes pump allowInitialOversize bytes = do
         newQueuedBytes =
             saturatingPayloadAdd retainedQueuedBytes bytes
         initialOversize =
+            -- A latest-value update replaces the old tail rather than adding
+            -- another payload. Preserve the one-oversized-node progress rule.
             allowInitialOversize
-                && queuedBytes == 0
-                && oldTailBytes == 0
+                && retainedQueuedBytes == 0
     check
         ( newQueuedBytes <= eventTailPayloadBudgetBytes
             || initialOversize

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -738,12 +738,18 @@ boundLoopToolOutput output
     | Text.length output <= loopEventTailPayloadBudgetCodeUnits =
         Text.copy output
     | otherwise =
-        Text.copy (Text.take loopEventTailPayloadCodeUnits output)
-            <> "\n[tool output truncated]"
+        toolOutputOmissionMarker
+            <> Text.copy (Text.takeEnd loopEventTailPayloadCodeUnits output)
 
 loopEventTailPayloadCodeUnits :: Int
 loopEventTailPayloadCodeUnits =
-    max 0 (loopEventTailPayloadBudgetCodeUnits - 24)
+    max 0
+        ( loopEventTailPayloadBudgetCodeUnits
+            - Text.length toolOutputOmissionMarker
+        )
+
+toolOutputOmissionMarker :: Text
+toolOutputOmissionMarker = "[earlier tool output truncated]\n"
 
 loopEventTailPayloadBudgetCodeUnits :: Int
 loopEventTailPayloadBudgetCodeUnits =

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -472,7 +472,8 @@ spec = describe "runLoop" do
 
     it "bounds a single oversized live tool-output snapshot" do
         delivered <- newIORef Nothing
-        let oversized = Text.replicate (3 * 1024 * 1024) "x"
+        let oversized =
+                Text.replicate (3 * 1024 * 1024) "x" <> "newest-tail"
             backend = Backend \_state _prev _inputs onEvent -> do
                 onEvent (ToolOutputUpdated "large" oversized)
                 pure $ Right BackendResult
@@ -497,7 +498,8 @@ spec = describe "runLoop" do
             Just output -> do
                 Text.length output `shouldSatisfy` (<= 2 * 1024 * 1024)
                 output `shouldSatisfy`
-                    Text.isSuffixOf "[tool output truncated]"
+                    Text.isPrefixOf "[earlier tool output truncated]"
+                output `shouldSatisfy` Text.isSuffixOf "newest-tail"
 
     it "dispatches consecutive parallel-safe tool calls concurrently" do
         firstStarted <- newEmptyMVar

--- a/packages/agent-openai/src/Agent/OpenAI/Client.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Client.hs
@@ -336,12 +336,11 @@ responseHandler idleTimeoutMicros modelHint turnState response stream = do
     let status = getStatusCode response
     captureResponseTurnState turnState response
     if status >= 200 && status < 300
-        then
-            if responseIsEventStream response
-                then readCodexSseResponse
-                    idleTimeoutMicros modelHint stream []
-                else sniffSuccessfulResponse
-                    idleTimeoutMicros modelHint stream
+        then sniffSuccessfulResponse
+            idleTimeoutMicros
+            modelHint
+            (responseIsEventStream response)
+            stream
         else do
             bodyResult <- readBoundedBodyWithIdleTimeout
                 idleTimeoutMicros maxErrorBodyBytes stream [] 0
@@ -439,9 +438,10 @@ readBoundedBodyWithIdleTimeout idleMicros byteLimit stream =
 sniffSuccessfulResponse
     :: Int
     -> Maybe Text
+    -> Bool
     -> Streams.InputStream BS.ByteString
     -> IO (Either ApiError OpenAI.Response)
-sniffSuccessfulResponse idleMicros modelHint stream =
+sniffSuccessfulResponse idleMicros modelHint preferSse stream =
     sniff [] 0 ""
   where
     sniff reversedChunks bytesRead probe = do
@@ -449,9 +449,13 @@ sniffSuccessfulResponse idleMicros modelHint stream =
         case next of
             Nothing -> pure $ Left $ ConnectionError
                 "Codex HTTP response idle timeout"
-            Just Nothing ->
-                pure $ decodeCodexHttpBodyBytesWithModel modelHint $
-                    LBS.toStrict (LBS.fromChunks (reverse reversedChunks))
+            Just Nothing
+                | preferSse ->
+                    readCodexSseResponse
+                        idleMicros modelHint stream (reverse reversedChunks)
+                | otherwise ->
+                    pure $ decodeCodexHttpBodyBytesWithModel modelHint $
+                        LBS.toStrict (LBS.fromChunks (reverse reversedChunks))
             Just (Just chunk) -> do
                 let chunks' = chunk : reversedChunks
                     bytesRead' = bytesRead + BS.length chunk
@@ -459,7 +463,7 @@ sniffSuccessfulResponse idleMicros modelHint stream =
                         (maxResponseSniffBytes - bytesRead)
                         probe
                         chunk
-                case classifyResponseProbe probe' of
+                case classifyResponseProbe preferSse probe' of
                     Just ResponseBodySse ->
                         readCodexSseResponse
                             idleMicros modelHint stream (reverse chunks')
@@ -468,8 +472,11 @@ sniffSuccessfulResponse idleMicros modelHint stream =
                             idleMicros modelHint stream chunks' bytesRead'
                     Nothing
                         | bytesRead' >= maxResponseSniffBytes ->
-                            readSuccessfulJsonResponse
-                                idleMicros modelHint stream chunks' bytesRead'
+                            if preferSse
+                                then readCodexSseResponse
+                                    idleMicros modelHint stream (reverse chunks')
+                                else readSuccessfulJsonResponse
+                                    idleMicros modelHint stream chunks' bytesRead'
                         | otherwise -> sniff chunks' bytesRead' probe'
 
 readSuccessfulJsonResponse
@@ -595,12 +602,13 @@ advanceResponseProbe remaining current chunk
         (if BS.null current then dropAsciiSpace else id)
             (BS.take remaining chunk)
 
-classifyResponseProbe :: BS.ByteString -> Maybe ResponseBodyKind
-classifyResponseProbe probe =
+classifyResponseProbe :: Bool -> BS.ByteString -> Maybe ResponseBodyKind
+classifyResponseProbe preferSse probe =
     case BS.uncons probe of
         Nothing -> Nothing
         Just (byte, _)
             | byte == 0x7b || byte == 0x5b -> Just ResponseBodyJson
+            | preferSse -> Just ResponseBodySse
             | byte == 0x3a -> Just ResponseBodySse
             | any (`BS.isPrefixOf` probe) sseFieldPrefixes ->
                 Just ResponseBodySse

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -538,6 +538,20 @@ spec = do
                         (helloRequest "hi")
                 extractAssistantText response `shouldBe` Just "mislabeled-sse"
 
+        it "sniffs JSON from a proxy that labels it text/event-stream" do
+            recorded <- newIORef []
+            let handler _request =
+                    pure $ jsonCompletedWithContentType
+                        "text/event-stream"
+                        "mislabeled-json"
+            withMockResponses recorded handler \baseUrl -> do
+                response <- expectRight =<<
+                    createCodexMessageWithProviderAt
+                        baseUrl
+                        (staticBearerProvider "router-key")
+                        (helloRequest "hi")
+                extractAssistantText response `shouldBe` Just "mislabeled-json"
+
         it "sniffs mislabeled SSE whose first line is an id field" do
             recorded <- newIORef []
             let handler _request =
@@ -684,6 +698,13 @@ jsonCompleted text = jsonResponse
     []
     [assistantMessage text]
 
+jsonCompletedWithContentType :: BS.ByteString -> Text -> Wai.Response
+jsonCompletedWithContentType contentType text =
+    jsonResponseWithContentType
+        contentType
+        []
+        [assistantMessage text]
+
 jsonFunctionCall :: HTTP.ResponseHeaders -> Text -> Wai.Response
 jsonFunctionCall headers callId = jsonResponse
     headers
@@ -697,8 +718,16 @@ jsonFunctionCall headers callId = jsonResponse
     ]
 
 jsonResponse :: HTTP.ResponseHeaders -> [Aeson.Value] -> Wai.Response
-jsonResponse headers output = Wai.responseLBS HTTP.status200
-    (("Content-Type", "application/json") : headers)
+jsonResponse = jsonResponseWithContentType "application/json"
+
+jsonResponseWithContentType
+    :: BS.ByteString
+    -> HTTP.ResponseHeaders
+    -> [Aeson.Value]
+    -> Wai.Response
+jsonResponseWithContentType contentType headers output =
+    Wai.responseLBS HTTP.status200
+    (("Content-Type", contentType) : headers)
     (Aeson.encode (Aeson.object
         [ "id" .= ("resp-json" :: Text)
         , "created_at" .= (0 :: Int)

--- a/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
@@ -134,18 +134,15 @@ performResponsesHttpSse
                 (body, truncated) <-
                     consumeBodyBounded (HttpClient.responseBody response)
                 let decoded = Text.decodeUtf8With Text.lenientDecode body
-                    bodyText
-                        | truncated =
-                            decoded
-                                <> "\n[response body truncated after "
-                                <> Text.pack (show maxErrorBodyBytes)
-                                <> " bytes]"
-                        | otherwise = decoded
-                pure $ Left $
-                    classifyFailure status
+                    classified =
+                        classifyFailure status
                         (parseRetryAfterSeconds
                             (getResponseHeader "Retry-After" response))
-                        bodyText
+                        decoded
+                pure $ Left $
+                    if truncated
+                        then appendBodyTruncatedMessage classified
+                        else classified
 
     consumeSse body = go newSseDecoder emptyStreamAssemblyState
       where
@@ -209,3 +206,19 @@ performResponsesHttpSse
 
 maxErrorBodyBytes :: Int
 maxErrorBodyBytes = 1024 * 1024
+
+appendBodyTruncatedMessage :: ApiError -> ApiError
+appendBodyTruncatedMessage apiError =
+    let suffix =
+            "\n[response body truncated after "
+                <> Text.pack (show maxErrorBodyBytes)
+                <> " bytes]"
+    in case apiError of
+        HttpError status message -> HttpError status (message <> suffix)
+        JsonDecodeError message body ->
+            JsonDecodeError (message <> suffix) body
+        ProviderError errorType message retryAfter ->
+            ProviderError errorType (message <> suffix) retryAfter
+        ConnectionError message -> ConnectionError (message <> suffix)
+        CredentialError message -> CredentialError (message <> suffix)
+        CredentialsExhausted{} -> apiError

--- a/packages/agent-responses/test/Agent/Responses/GenericClientSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/GenericClientSpec.hs
@@ -151,6 +151,28 @@ spec = do
             readIORef recordedModels
                 `shouldReturn` [Just "provider-model", Just "provider-model"]
             readIORef recordedHeaders `shouldReturn` [True, True]
+
+        it "classifies a valid oversized error before adding truncation context" do
+            Warp.testWithApplication (pure oversizedRateLimitApp) \port -> do
+                let boundedOptions = options
+                        { baseUrl =
+                            "http://127.0.0.1:"
+                                <> show port
+                                <> "/v1"
+                        }
+                result <- createResponseWithEventsPolicy
+                    (limitRetries 0)
+                    boundedOptions
+                    defaultResponseCreateParams
+                    (const (pure ()))
+                case result of
+                    Left (ProviderError RateLimitError message Nothing) -> do
+                        message `shouldSatisfy` Text.isPrefixOf "slow down"
+                        message `shouldSatisfy` Text.isSuffixOf
+                            "[response body truncated after 1048576 bytes]"
+                    other -> expectationFailure
+                        ("expected typed truncated rate-limit error, got "
+                            <> show other)
   where
     options = GenericClientOptions
         { baseUrl = "http://localhost:8000/v1"
@@ -210,6 +232,15 @@ providerHookResponse = Wai.responseLBS HTTP.status200
             , "output" Aeson..= ([] :: [Aeson.Value])
             ]
         ]
+
+oversizedRateLimitApp :: Wai.Application
+oversizedRateLimitApp _request respond =
+    respond $ Wai.responseLBS HTTP.status429
+        [("Content-Type", "application/json")]
+        ( "{\"error\":{\"type\":\"rate_limit_error\",\
+          \\"message\":\"slow down\"}}"
+            <> LBS.replicate (1024 * 1024) 0x20
+        )
 
 expectRight :: Show error => Either error value -> IO value
 expectRight = \case


### PR DESCRIPTION
Corrective follow-up to #776.

- preserve latest oversized tool output tail
- accept JSON bodies mislabeled as SSE
- classify capped JSON error responses before appending truncation context

Validated with focused agent-core, agent-openai, and agent-responses tests.