### PR TITLE
Fix queued input replacement and Meta Console overflow

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/InputBudget.hs
+++ b/packages/agent-cli/src/Agent/CLI/InputBudget.hs
@@ -18,7 +18,11 @@ import Agent.Loop
     , TurnAttachment(..)
     , TurnInput(..)
     )
-import Agent.ToolDispatch (ToolCallResult(..))
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolResultImage(..)
+    , toolCallResultImages
+    )
 import qualified Data.ByteString as ByteString
 import Data.Char (ord)
 import qualified Data.List.NonEmpty as NonEmpty
@@ -62,6 +66,14 @@ logicalTurnInputBytes = \case
     CompletedTool result ->
         logicalTextBytes result.callId
             `saturatingAdd` logicalTextBytes result.output
+            `saturatingAdd` foldBytes
+                logicalToolResultImageBytes
+                (toolCallResultImages result)
+
+logicalToolResultImageBytes :: ToolResultImage -> Int
+logicalToolResultImageBytes image =
+    logicalTextBytes image.imageUrl
+        `saturatingAdd` maybe 0 logicalTextBytes image.imageDetail
 
 logicalReplLineBytes :: ReplLine -> Int
 logicalReplLineBytes = \case

--- a/packages/agent-cli/src/Agent/CLI/PendingInputs.hs
+++ b/packages/agent-cli/src/Agent/CLI/PendingInputs.hs
@@ -102,10 +102,10 @@ enqueuePendingNotice (PendingInputs pending _) kind input =
         in case result of
             Right () -> (next, Right ())
             Left _ ->
-                ( withoutPrevious
+                ( state
                     { pendingOmissionReported = True
                     }
-                , if not withoutPrevious.pendingOmissionReported
+                , if not state.pendingOmissionReported
                     then Left pendingNoticeOmittedMessage
                     else Right ()
                 )
@@ -186,8 +186,42 @@ requeuePendingInputs :: IORef PendingState -> PendingBatch -> IO ()
 requeuePendingInputs pending (PendingBatch epoch queued _ _) =
     atomicModifyIORef' pending \state ->
         if epochOf state == epoch
-            then (state { pendingQueue = queued <> queueOf state }, ())
+            then
+                let (requeued, removedCount, removedBytes) =
+                        mergeRequeuedQueue queued (queueOf state)
+                in
+                ( state
+                    { pendingQueue = requeued
+                    , pendingRetainedCount =
+                        max 0 (state.pendingRetainedCount - removedCount)
+                    , pendingRetainedBytes =
+                        max 0 (state.pendingRetainedBytes - removedBytes)
+                    }
+                , ()
+                )
             else (state, ())
+
+-- A newer MCP snapshot may arrive while an older snapshot is in the drained
+-- in-flight batch. If that submission fails, requeue only the newest snapshot
+-- rather than exposing both stale and current state on the next attempt.
+mergeRequeuedQueue
+    :: Seq.Seq PendingEntry
+    -> Seq.Seq PendingEntry
+    -> (Seq.Seq PendingEntry, Int, Int)
+mergeRequeuedQueue drained current
+    | any ((== Just PendingMcpNotice) . (.entryNoticeKind)) current =
+        let (kept, removedCount, removedBytes) =
+                foldr removeStaleMcp (Seq.empty, 0, 0) drained
+        in (kept <> current, removedCount, removedBytes)
+    | otherwise = (drained <> current, 0, 0)
+  where
+    removeStaleMcp entry (entries, count, bytes)
+        | entry.entryNoticeKind == Just PendingMcpNotice =
+            ( entries
+            , count + 1
+            , bytes `saturatingAdd` entry.entryBytes
+            )
+        | otherwise = (entry Seq.<| entries, count, bytes)
 
 commitPendingInputs :: IORef PendingState -> PendingBatch -> IO ()
 commitPendingInputs pending (PendingBatch epoch _ count bytes) =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -898,7 +898,7 @@ submitMetaConsole = do
                 pure ()
             | otherwise -> do
                 let queued = state.appUi.uiRunning
-                liftIO $ atomically $
+                result <- liftIO $ atomically $
                     Composer.appendFullscreenInput
                         state.appRuntime.runtimeInput
                         FullscreenInput
@@ -906,16 +906,21 @@ submitMetaConsole = do
                             , fullscreenInputQueued = queued
                             , fullscreenInputDisplay = Nothing
                             }
-                if queued
-                    then
+                case result of
+                    Left message ->
                         applyLocalUiEvent $
-                            UiSetNotice $
-                                Just $
-                                    progressNotice
-                                        "Meta Console request queued for the next safe boundary."
-                    else
-                        applyLocalUiEvent (UiSetAwaitingInput False)
-                closeMetaConsole
+                            UiSetNotice (Just (warningNotice message))
+                    Right () -> do
+                        if queued
+                            then
+                                applyLocalUiEvent $
+                                    UiSetNotice $
+                                        Just $
+                                            progressNotice
+                                                "Meta Console request queued for the next safe boundary."
+                            else
+                                applyLocalUiEvent (UiSetAwaitingInput False)
+                        closeMetaConsole
 
 
 handleCtrlC :: EventM Name AppState CtrlCDecision

--- a/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
@@ -6,6 +6,7 @@ import Agent.CLI.PendingInputs
     , enqueuePendingInput
     , enqueuePendingNotice
     , newPendingInputs
+    , pendingInputByteLimit
     , pendingInputCountLimit
     , withPendingInputs
     )
@@ -222,6 +223,59 @@ spec = do
                         , backendState = state
                         }
         _ <- backend.submitTurn [] Nothing [] (const (pure ()))
+        readIORef seen `shouldReturn` [UserMessage "settled"]
+
+    it "keeps the previous MCP snapshot when its replacement is rejected" do
+        pending <- newPendingInputs
+        enqueuePendingNotice pending PendingMcpNotice
+            (UserMessage "settled")
+            `shouldReturn` Right ()
+        enqueuePendingNotice pending PendingMcpNotice
+            (UserMessage (Text.replicate (pendingInputByteLimit + 1) "x"))
+            `shouldReturn`
+                Left
+                    "Root input queue is full; one or more background notices were omitted."
+        seen <- newIORef []
+        let backend = withPendingInputs pending $ Backend
+                \state _ inputs _ -> do
+                    writeIORef seen inputs
+                    pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "ok" [] Nothing
+                        , backendState = state
+                        }
+        _ <- backend.submitTurn [] Nothing [] (const (pure ()))
+        readIORef seen `shouldReturn` [UserMessage "settled"]
+
+    it "drops a stale drained MCP snapshot after an in-flight failure" do
+        pending <- newPendingInputs
+        enqueuePendingNotice pending PendingMcpNotice
+            (UserMessage "connecting")
+            `shouldReturn` Right ()
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        let failing = withPendingInputs pending $ Backend
+                \_ _ _ _ -> do
+                    putMVar entered ()
+                    takeMVar release
+                    pure (Left (ConnectionError "offline"))
+        done <- newEmptyMVar
+        _ <- forkIO $
+            failing.submitTurn [] Nothing [] (const (pure ())) >>= putMVar done
+        takeMVar entered
+        enqueuePendingNotice pending PendingMcpNotice
+            (UserMessage "settled")
+            `shouldReturn` Right ()
+        putMVar release ()
+        _ <- takeMVar done
+        seen <- newIORef []
+        let retry = withPendingInputs pending $ Backend
+                \state _ inputs _ -> do
+                    writeIORef seen inputs
+                    pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "ok" [] Nothing
+                        , backendState = state
+                        }
+        _ <- retry.submitTurn [] Nothing [] (const (pure ()))
         readIORef seen `shouldReturn` [UserMessage "settled"]
 
     it "reports synthetic overflow once without exceeding the queue bound" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -125,6 +125,7 @@ import Control.Concurrent.STM
     , newTChanIO
     , retry
     )
+import Control.Monad (replicateM_)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (find, toList)
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
@@ -393,6 +394,46 @@ spec = do
         it "submits immediately at an idle REPL boundary" do
             (_, inputs) <- runMetaConsoleSubmission False
             map (.fullscreenInputQueued) inputs `shouldBe` [False]
+
+        it "keeps the request open when the prompt queue is full" do
+            let running = reduceUi (UiLoop TurnStarted) initialUiState
+            runtime <- newScriptRuntime running
+            atomically $
+                replicateM_ Composer.fullscreenInputCountLimit do
+                    result <- Composer.appendFullscreenInput
+                        runtime.runtimeInput
+                        FullscreenInput
+                            { fullscreenInputLine = ReplEof
+                            , fullscreenInputQueued = True
+                            , fullscreenInputDisplay = Nothing
+                            }
+                    case result of
+                        Left message -> error (Text.unpack message)
+                        Right () -> pure ()
+            let request = "connect my Grok account"
+                initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+                script =
+                    [ FullscreenScriptVty
+                        (V.EvKey (V.KChar 'k') [V.MMeta])
+                    , FullscreenScriptVty
+                        (V.EvPaste (encoded request))
+                    , FullscreenScriptVty
+                        (V.EvKey V.KEnter [])
+                    , FullscreenScriptHalt
+                    ]
+            (_, finalState) <-
+                runFullscreenScriptWithState initialState script
+            (.metaConsoleDraft) <$> finalState.appMetaConsole
+                `shouldBe` Just request
+            (.noticeText) <$> finalState.appUi.uiNotice
+                `shouldBe`
+                    Just
+                        "Prompt queue is full; wait for a queued prompt to be consumed."
+            inputs <- atomically $
+                Composer.readFullscreenInputs runtime.runtimeInput
+            Seq.length inputs
+                `shouldBe` Composer.fullscreenInputCountLimit
 
     describe "choice overlay lifecycle" do
         it "closes a running-turn choice on success or cancellation" do


### PR DESCRIPTION
Corrective follow-up to #776.

- preserve a queued MCP snapshot if a newer one cannot fit
- discard a stale drained MCP snapshot after a failed submit
- keep the Meta Console open when its input buffer is full
- account rich tool-result images in queued input budgets

Validated by focused CLI regression tests and a live tmux UI launch/smoke test.