### PR TITLE
Bound clipboard image file reads

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -34,9 +34,10 @@ import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.Directory (doesFileExist, getFileSize)
+import System.Directory (doesFileExist)
 import System.FilePath (takeExtension)
 import System.Info (os)
+import System.IO (IOMode(ReadMode), withBinaryFile)
 
 -- | What we could usefully take from the clipboard for /paste.
 data ClipboardContent
@@ -331,24 +332,24 @@ isImageExtension ext =
 
 readImageFile :: FilePath -> IO (Either Text ImageAttachment)
 readImageFile path = do
-    sizeResult <- tryAny (getFileSize path)
-    case sizeResult of
-        Left ex -> pure (Left (formatException ex))
-        Right size
-            | size > fromIntegral singleImageAttachmentByteLimit ->
-                pure (Left (oversizedImageError (Text.pack path) size))
-            | otherwise -> do
-                result <- tryAny (BS.readFile path)
-                pure $ case result of
-                    Left ex -> Left (formatException ex)
-                    Right bytes
-                        | BS.null bytes ->
-                            Left ("empty image file: " <> Text.pack path)
-                        | otherwise ->
-                            validateImageAttachment ImageAttachment
-                                { imageMime = mimeForPath path
-                                , imageBytes = bytes
-                                }
+    result <- tryAny $
+        withBinaryFile path ReadMode \handle ->
+            BS.hGet handle (singleImageAttachmentByteLimit + 1)
+    pure $ case result of
+        Left ex -> Left (formatException ex)
+        Right bytes
+            | BS.length bytes > singleImageAttachmentByteLimit ->
+                Left
+                    (oversizedImageError
+                        (Text.pack path)
+                        (fromIntegral (BS.length bytes)))
+            | BS.null bytes ->
+                Left ("empty image file: " <> Text.pack path)
+            | otherwise ->
+                validateImageAttachment ImageAttachment
+                    { imageMime = mimeForPath path
+                    , imageBytes = bytes
+                    }
 
 readImageFilesBounded
     :: [FilePath]

--- a/packages/agent-cli/src/Agent/CLI/Clipboard/Linux.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard/Linux.hs
@@ -14,12 +14,16 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory
     ( findExecutable
-    , getFileSize
     , getTemporaryDirectory
     , removeFile
     )
 import System.Exit (ExitCode(..))
-import System.IO (hClose, openBinaryTempFile)
+import System.IO
+    ( IOMode(ReadMode)
+    , hClose
+    , openBinaryTempFile
+    , withBinaryFile
+    )
 import System.Process (readProcessWithExitCode)
 
 readLinuxClipboardImage :: IO (Either Text ImageAttachment)
@@ -123,16 +127,15 @@ runBytesCmd cmd args = do
                 ""
             case code of
                 ExitSuccess -> do
-                    size <- getFileSize path
-                    if size > maxClipboardImageBytes
+                    bytes <- withBinaryFile path ReadMode \input ->
+                        BS.hGet input (maxClipboardImageBytes + 1)
+                    if BS.length bytes > maxClipboardImageBytes
                         then pure (Left
                             "clipboard image exceeds the 20 MB limit")
-                        else do
-                            bytes <- BS.readFile path
-                            if BS.null bytes
-                                then pure (Left
-                                    "no image found on the clipboard")
-                                else pure (Right bytes)
+                        else if BS.null bytes
+                            then pure (Left
+                                "no image found on the clipboard")
+                            else pure (Right bytes)
                 ExitFailure _ ->
                     pure (Left (Text.strip (Text.pack err))))
             `finally` cleanup
@@ -140,7 +143,7 @@ runBytesCmd cmd args = do
         Left ex -> pure (Left (formatException ex))
         Right value -> pure value
 
-maxClipboardImageBytes :: Integer
+maxClipboardImageBytes :: Int
 maxClipboardImageBytes = 20 * 1024 * 1024
 
 shellQuote :: String -> String

--- a/packages/agent-cli/src/Agent/CLI/Clipboard/MacOS.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard/MacOS.hs
@@ -14,9 +14,14 @@ import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.Directory (getFileSize, getTemporaryDirectory, removeFile)
+import System.Directory (getTemporaryDirectory, removeFile)
 import System.Exit (ExitCode(..))
-import System.IO (hClose, openBinaryTempFile)
+import System.IO
+    ( IOMode(ReadMode)
+    , hClose
+    , openBinaryTempFile
+    , withBinaryFile
+    )
 import System.Process (readProcessWithExitCode)
 
 readMacClipboardImage :: IO (Either Text ImageAttachment)
@@ -103,11 +108,12 @@ readMacClipboardClass typeClass = do
                 readProcessWithExitCode "osascript" ["-e", script] ""
             case code of
                 ExitSuccess -> do
-                    size <- getFileSize path
-                    if size > maxClipboardImageBytes
+                    bytes <- withBinaryFile path ReadMode \input ->
+                        BS.hGet input (maxClipboardImageBytes + 1)
+                    if BS.length bytes > maxClipboardImageBytes
                         then pure (Left
                             "clipboard image exceeds the 20 MB limit")
-                        else Right <$> BS.readFile path
+                        else pure (Right bytes)
                 ExitFailure _ ->
                     pure (Left (clipboardErrorMessage typeClass err)))
             `finally` cleanup
@@ -115,7 +121,7 @@ readMacClipboardClass typeClass = do
         Left ex -> pure (Left (formatException ex))
         Right value -> pure value
 
-maxClipboardImageBytes :: Integer
+maxClipboardImageBytes :: Int
 maxClipboardImageBytes = 20 * 1024 * 1024
 
 clipboardErrorMessage :: String -> String -> Text

--- a/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
@@ -133,6 +133,20 @@ spec = do
                     check "quoted" quoted
                     check "file-url" filed
 
+        it "rejects an oversized path without retaining the whole file" do
+            tmp <- getTemporaryDirectory
+            bracket
+                (do
+                    (path, handle) <-
+                        openBinaryTempFile tmp "agent-paste-large-.png"
+                    BS.hPut handle (BS.replicate (20 * 1024 * 1024 + 1) 0)
+                    hClose handle
+                    pure path)
+                removeFile
+                \path -> do
+                    result <- loadImagesFromPastedText (Text.pack path)
+                    result `shouldBe` Nothing
+
 withEmptyPath :: IO a -> IO a
 withEmptyPath action = do
     tmp <- getTemporaryDirectory


### PR DESCRIPTION
Corrective follow-up to #776. Reads pasted and platform clipboard image files through the same bounded handle, closing the size-check/read race. Includes regression coverage for oversized pasted paths.