### PR TITLE
Bound retained native-agent state

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
@@ -564,14 +564,17 @@ alterTouched
     -> NativeAgentStore
     -> NativeAgentStore
 alterTouched identifier update store =
-    let oldBytes = maybe 0
-            nativeAgentViewBytes
-            (Map.lookup identifier store.storeAgents)
-        next = update (Map.lookup identifier store.storeAgents)
+    let previous = Map.lookup identifier store.storeAgents
+        canonicalIdentifier =
+            maybe identifier (.nativeAgentId) previous
+        oldBytes = maybe 0 nativeAgentViewBytes previous
+        next = update previous
         nextBytes = nativeAgentViewBytes next
     in store
-        { storeAgents = Map.insert identifier next store.storeAgents
-        , storeOrder = touchOrder identifier store.storeOrder
+        { storeAgents =
+            Map.insert canonicalIdentifier next store.storeAgents
+        , storeOrder =
+            touchOrder canonicalIdentifier store.storeOrder
         , storeBytes =
             saturatingNativeAdd
                 (max 0 (store.storeBytes - oldBytes))

--- a/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
@@ -229,8 +229,11 @@ restoreNativeAgents selected items current =
     normalizeStore NativeAgentStore
         { storeAgents = Map.union liveUnpersisted canonicalAgents
         , storeOrder =
-            canonicalOrder
-                <> Seq.filter (`Map.member` liveUnpersisted) current.storeOrder
+            uniqueOrder $
+                canonicalOrder
+                    <> Seq.filter
+                        (`Map.member` liveUnpersisted)
+                        current.storeOrder
         , storeSelected = selectedIdentifier
         , storeBytes =
             retainedBytes (Map.union liveUnpersisted canonicalAgents)
@@ -258,7 +261,9 @@ restoreNativeAgents selected items current =
                         case Map.lookup identifier current.storeAgents
                                 >>= (.nativeAgentParent) of
                             Nothing -> found
-                            Just parent -> Set.insert parent found)
+                            Just parent
+                                | Map.member parent canonicalAgents -> found
+                                | otherwise -> Set.insert parent found)
                     ids
                     ids
         in if Set.size withParents == Set.size ids
@@ -576,6 +581,15 @@ alterTouched identifier update store =
 touchOrder :: Text -> Seq Text -> Seq Text
 touchOrder identifier order =
     Seq.filter (/= identifier) order :|> identifier
+
+uniqueOrder :: Seq Text -> Seq Text
+uniqueOrder =
+    snd . foldl' keepFirst (Set.empty, Seq.empty)
+  where
+    keepFirst (seen, order) identifier
+        | Set.member identifier seen = (seen, order)
+        | otherwise =
+            (Set.insert identifier seen, order :|> identifier)
 
 appendOutput :: Int -> Text -> NativeOutput -> NativeOutput
 appendOutput budget chunk output

--- a/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
@@ -146,73 +146,50 @@ applyNativeAgentEvent event current =
             ResponseAttemptDiscarded ->
                 settleRunningNativeAgents NativeAgentCancelled current
             NativeAgentStarted rawIdentifier rawParent rawLabel rawModel ->
-                case boundedNativeAgentIdentifier rawIdentifier of
-                    Nothing -> current
-                    Just identifier ->
-                        let parent =
-                                rawParent >>= boundedNativeAgentIdentifier
-                            label =
-                                boundedNativeAgentText
-                                    nativeAgentPreviewBytes
-                                    rawLabel
-                            model =
-                                boundedNativeAgentText nativeAgentModelBytes
-                                    <$> rawModel
-                        in alterTouched identifier
-                            (\case
-                                Nothing ->
-                                    newNativeAgentView
-                                        NativeAgentLive
-                                        identifier
-                                        parent
-                                        label
-                                        model
-                                Just view ->
-                                    view
-                                        { nativeAgentParent = parent
-                                        , nativeAgentLabel = label
-                                        , nativeAgentModel = model
-                                        , nativeAgentStatus = "running"
-                                        , nativeAgentTerminal = Nothing
-                                        , nativeAgentOrigin = NativeAgentLive
-                                        })
-                            current
+                let parent =
+                        rawParent >>= boundedNativeAgentIdentifier
+                    label =
+                        boundedNativeAgentText
+                            nativeAgentPreviewBytes
+                            rawLabel
+                    model =
+                        boundedNativeAgentText nativeAgentModelBytes
+                            <$> rawModel
+                in alterTouched rawIdentifier
+                    (\identifier -> \case
+                        Nothing ->
+                            newNativeAgentView
+                                NativeAgentLive
+                                identifier
+                                parent
+                                label
+                                model
+                        Just view ->
+                            view
+                                { nativeAgentParent = parent
+                                , nativeAgentLabel = label
+                                , nativeAgentModel = model
+                                , nativeAgentStatus = "running"
+                                , nativeAgentTerminal = Nothing
+                                , nativeAgentOrigin = NativeAgentLive
+                                })
+                    current
             NativeAgentOutput rawIdentifier output ->
-                case boundedNativeAgentIdentifier rawIdentifier of
-                    Nothing -> current
-                    Just identifier ->
-                        alterTouched identifier
-                            (\maybeView ->
-                                let view = fromMaybe
-                                        (newNativeAgentView NativeAgentLive
-                                            identifier Nothing identifier Nothing)
-                                        maybeView
-                                in view
-                                    { nativeAgentOutput =
-                                        appendOutput
-                                            nativeAgentSelectedOutputBytes
-                                            output
-                                            view.nativeAgentOutput
-                                    , nativeAgentOrigin = NativeAgentLive
-                                    })
-                            current
+                alterNativeOutput rawIdentifier output current
             NativeAgentFinished rawIdentifier status ->
-                case boundedNativeAgentIdentifier rawIdentifier of
-                    Nothing -> current
-                    Just identifier ->
-                        alterTouched identifier
-                            (\maybeView ->
-                                (fromMaybe
-                                    (newNativeAgentView NativeAgentLive
-                                        identifier Nothing identifier Nothing)
-                                    maybeView)
-                                    { nativeAgentStatus =
-                                        nativeAgentStatusText status
-                                    , nativeAgentTerminal =
-                                        Just (nativeAgentBlockState status)
-                                    , nativeAgentOrigin = NativeAgentLive
-                                    })
-                            current
+                alterTouched rawIdentifier
+                    (\identifier maybeView ->
+                        (fromMaybe
+                            (newNativeAgentView NativeAgentLive
+                                identifier Nothing identifier Nothing)
+                            maybeView)
+                            { nativeAgentStatus =
+                                nativeAgentStatusText status
+                            , nativeAgentTerminal =
+                                Just (nativeAgentBlockState status)
+                            , nativeAgentOrigin = NativeAgentLive
+                            })
+                    current
             _ -> current
 
 -- | Materialize presentation state only for the selected row. Other rows get
@@ -597,26 +574,65 @@ nativeAgentPathSegment view =
 
 alterTouched
     :: Text
-    -> (Maybe NativeAgentView -> NativeAgentView)
+    -> (Text -> Maybe NativeAgentView -> NativeAgentView)
     -> NativeAgentStore
     -> NativeAgentStore
-alterTouched identifier update store =
-    let previous = Map.lookup identifier store.storeAgents
-        canonicalIdentifier =
-            maybe identifier (.nativeAgentId) previous
-        oldBytes = maybe 0 nativeAgentViewBytes previous
-        next = update previous
-        nextBytes = nativeAgentViewBytes next
-    in store
-        { storeAgents =
-            Map.insert canonicalIdentifier next store.storeAgents
-        , storeOrder =
-            touchOrder canonicalIdentifier store.storeOrder
-        , storeBytes =
-            saturatingNativeAdd
-                (max 0 (store.storeBytes - oldBytes))
-                nextBytes
-        }
+alterTouched rawIdentifier update =
+    alterTouchedAccounting rawIdentifier update updateBytes
+  where
+    updateBytes previous next bytes =
+        saturatingNativeAdd
+            (max 0 (bytes - maybe 0 nativeAgentViewBytes previous))
+            (nativeAgentViewBytes next)
+
+alterNativeOutput :: Text -> Text -> NativeAgentStore -> NativeAgentStore
+alterNativeOutput rawIdentifier chunk =
+    alterTouchedAccounting rawIdentifier update updateBytes
+  where
+    update identifier maybeView =
+        let view = fromMaybe
+                (newNativeAgentView NativeAgentLive
+                    identifier Nothing identifier Nothing)
+                maybeView
+        in view
+            { nativeAgentOutput =
+                appendOutput
+                    nativeAgentSelectedOutputBytes
+                    chunk
+                    view.nativeAgentOutput
+            , nativeAgentOrigin = NativeAgentLive
+            }
+    updateBytes Nothing next bytes =
+        saturatingNativeAdd bytes (nativeAgentViewBytes next)
+    updateBytes (Just previous) next bytes =
+        saturatingNativeAdd
+            (max 0
+                (bytes - previous.nativeAgentOutput.outputBytes))
+            next.nativeAgentOutput.outputBytes
+
+alterTouchedAccounting
+    :: Text
+    -> (Text -> Maybe NativeAgentView -> NativeAgentView)
+    -> (Maybe NativeAgentView -> NativeAgentView -> Int -> Int)
+    -> NativeAgentStore
+    -> NativeAgentStore
+alterTouchedAccounting rawIdentifier update updateBytes store =
+    case Map.lookup rawIdentifier store.storeAgents of
+        Just previous -> apply previous.nativeAgentId (Just previous)
+        Nothing
+            | nativeAgentIdentifierWithinLimit rawIdentifier ->
+                apply (Text.copy rawIdentifier) Nothing
+            | otherwise -> store
+  where
+    apply identifier previous =
+        let next = update identifier previous
+        in store
+            { storeAgents =
+                Map.insert identifier next store.storeAgents
+            , storeOrder =
+                touchOrder identifier store.storeOrder
+            , storeBytes = updateBytes previous next store.storeBytes
+            }
 
 touchOrder :: Text -> Seq Text -> Seq Text
 touchOrder identifier order =
@@ -722,8 +738,12 @@ outputChunkBytes text
 
 boundedNativeAgentIdentifier :: Text -> Maybe Text
 boundedNativeAgentIdentifier identifier
-    | Text.length bounded > codeUnitLimit = Nothing
+    | not (nativeAgentIdentifierWithinLimit identifier) = Nothing
     | otherwise = Just (Text.copy identifier)
+
+nativeAgentIdentifierWithinLimit :: Text -> Bool
+nativeAgentIdentifierWithinLimit identifier =
+    Text.length bounded <= codeUnitLimit
   where
     codeUnitLimit = nativeAgentIdentifierBytes `div` 4
     bounded = Text.take (codeUnitLimit + 1) identifier
@@ -834,21 +854,25 @@ compactOutputs store
     compact current identifier
         | nativeAgentStoreBytes current <= nativeAgentAggregateBytes = current
         | otherwise =
-            current
-                { storeAgents =
-                    nextAgents
-                , storeBytes = retainedBytes nextAgents
-                }
-      where
-        nextAgents =
-            Map.adjust
-                (\view -> view
-                    { nativeAgentOutput =
-                        trimOutputTo nativeAgentPreviewBytes
-                            view.nativeAgentOutput
-                    })
-                identifier
-                current.storeAgents
+            case Map.lookup identifier current.storeAgents of
+                Nothing -> current
+                Just previous ->
+                    let next = previous
+                            { nativeAgentOutput =
+                                trimOutputTo nativeAgentPreviewBytes
+                                    previous.nativeAgentOutput
+                            }
+                    in current
+                        { storeAgents =
+                            Map.insert identifier next current.storeAgents
+                        , storeBytes =
+                            saturatingNativeAdd
+                                (max 0
+                                    ( current.storeBytes
+                                        - nativeAgentViewBytes previous
+                                    ))
+                                (nativeAgentViewBytes next)
+                        }
 
 retainedBytes :: Map.Map Text NativeAgentView -> Int
 retainedBytes =

--- a/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
@@ -100,6 +100,11 @@ data NativeAgentView = NativeAgentView
     , nativeAgentOutput :: !NativeOutput
     , nativeAgentTerminal :: !(Maybe BlockState)
     , nativeAgentOrigin :: !NativeAgentOrigin
+    -- | The backend attempt that most recently produced live state for this
+    -- row. Canonical transcript items are committed only after a turn
+    -- completes, so a row from the current attempt must win over an older
+    -- canonical record when a provider reuses an identifier.
+    , nativeAgentGeneration :: !Int
     }
     deriving (Eq, Show)
 
@@ -110,11 +115,20 @@ data NativeAgentStore = NativeAgentStore
     , storeOrder :: !(Seq Text)
     , storeSelected :: !(Maybe Text)
     , storeBytes :: !Int
+    -- | Increments at each backend-attempt boundary. Native lifecycle events
+    -- use this to distinguish current live state from a previously committed
+    -- or discarded row.
+    , storeGeneration :: !Int
+    -- | Canonical transcripts commit only after their backend turn completes.
+    -- While that turn is active, its live row takes precedence over older
+    -- canonical history with the same provider-controlled identifier.
+    , storeTurnActive :: !Bool
     }
     deriving (Eq, Show)
 
 emptyNativeAgentStore :: NativeAgentStore
-emptyNativeAgentStore = NativeAgentStore Map.empty Seq.empty Nothing 0
+emptyNativeAgentStore =
+    NativeAgentStore Map.empty Seq.empty Nothing 0 0 False
 
 nativeAgentStoreSize :: NativeAgentStore -> Int
 nativeAgentStoreSize = Map.size . (.storeAgents)
@@ -139,12 +153,10 @@ applyNativeAgentEvent :: LoopEvent -> NativeAgentStore -> NativeAgentStore
 applyNativeAgentEvent event current =
     normalizeStore $
         case event of
-            TurnStarted ->
-                settleRunningNativeAgents NativeAgentCancelled current
-            ResponseRestarted _ ->
-                settleRunningNativeAgents NativeAgentCancelled current
-            ResponseAttemptDiscarded ->
-                settleRunningNativeAgents NativeAgentCancelled current
+            TurnStarted -> beginNativeAttempt current
+            TurnFinished _ -> current { storeTurnActive = False }
+            ResponseRestarted _ -> beginNativeAttempt current
+            ResponseAttemptDiscarded -> beginNativeAttempt current
             NativeAgentStarted rawIdentifier rawParent rawLabel rawModel ->
                 let parent =
                         rawParent >>= boundedNativeAgentIdentifier
@@ -158,13 +170,16 @@ applyNativeAgentEvent event current =
                 in alterTouched rawIdentifier
                     (\identifier -> \case
                         Nothing ->
-                            newNativeAgentView
-                                NativeAgentLive
+                            newLiveNativeAgentView
+                                current.storeGeneration
                                 identifier
                                 parent
                                 label
                                 model
-                        Just view ->
+                        Just view
+                            | isCurrentRunningLiveView
+                                current.storeGeneration
+                                view ->
                             view
                                 { nativeAgentParent = parent
                                 , nativeAgentLabel = label
@@ -172,22 +187,46 @@ applyNativeAgentEvent event current =
                                 , nativeAgentStatus = "running"
                                 , nativeAgentTerminal = Nothing
                                 , nativeAgentOrigin = NativeAgentLive
-                                })
+                                , nativeAgentGeneration =
+                                    current.storeGeneration
+                                }
+                            | otherwise ->
+                                newLiveNativeAgentView
+                                    current.storeGeneration
+                                    identifier
+                                    parent
+                                    label
+                                    model)
                     current
             NativeAgentOutput rawIdentifier output ->
-                alterNativeOutput rawIdentifier output current
+                alterNativeOutput
+                    current.storeGeneration
+                    rawIdentifier
+                    output
+                    current
             NativeAgentFinished rawIdentifier status ->
                 alterTouched rawIdentifier
                     (\identifier maybeView ->
-                        (fromMaybe
-                            (newNativeAgentView NativeAgentLive
-                                identifier Nothing identifier Nothing)
-                            maybeView)
+                        (case maybeView of
+                            Just view
+                                | isCurrentLiveView
+                                    current.storeGeneration
+                                    view ->
+                                    view
+                            _ ->
+                                newLiveNativeAgentView
+                                    current.storeGeneration
+                                    identifier
+                                    Nothing
+                                    identifier
+                                    Nothing)
                             { nativeAgentStatus =
                                 nativeAgentStatusText status
                             , nativeAgentTerminal =
                                 Just (nativeAgentBlockState status)
                             , nativeAgentOrigin = NativeAgentLive
+                            , nativeAgentGeneration =
+                                current.storeGeneration
                             })
                     current
             _ -> current
@@ -220,6 +259,8 @@ restoreNativeAgents selected items current =
         , storeSelected = selectedIdentifier
         , storeBytes =
             retainedBytes (Map.union liveUnpersisted canonicalAgents)
+        , storeGeneration = current.storeGeneration
+        , storeTurnActive = current.storeTurnActive
         }
   where
     selectedIdentifier = case selected of
@@ -238,7 +279,12 @@ restoreNativeAgents selected items current =
             Map.filterWithKey
                 (\identifier view ->
                     view.nativeAgentOrigin == NativeAgentLive
-                        && Map.notMember identifier canonicalAgents)
+                        && ( Map.notMember identifier canonicalAgents
+                                || ( current.storeTurnActive
+                                        && view.nativeAgentGeneration
+                                            == current.storeGeneration
+                                   )
+                           ))
                 current.storeAgents
     closeParents ids =
         let withParents =
@@ -485,6 +531,18 @@ settleRunningNativeAgents status store =
         , storeBytes = retainedBytes agents
         }
 
+-- | A retried response remains within the same loop turn, but all streamed
+-- provider activity belongs to a fresh attempt. Advancing the generation
+-- prevents a reused child identifier from inheriting output or terminal state
+-- from the discarded attempt.
+beginNativeAttempt :: NativeAgentStore -> NativeAgentStore
+beginNativeAttempt store =
+    (settleRunningNativeAgents NativeAgentCancelled store)
+        { storeGeneration =
+            saturatingNativeAdd store.storeGeneration 1
+        , storeTurnActive = True
+        }
+
 nativeAgentBlockState :: NativeAgentStatus -> BlockState
 nativeAgentBlockState = \case
     NativeAgentRunning -> BlockRunning
@@ -509,7 +567,29 @@ newNativeAgentView origin identifier parent label model =
         , nativeAgentOutput = NativeOutput Seq.empty 0 False
         , nativeAgentTerminal = Nothing
         , nativeAgentOrigin = origin
+        , nativeAgentGeneration = 0
         }
+
+newLiveNativeAgentView
+    :: Int
+    -> Text
+    -> Maybe Text
+    -> Text
+    -> Maybe Text
+    -> NativeAgentView
+newLiveNativeAgentView generation identifier parent label model =
+    (newNativeAgentView NativeAgentLive identifier parent label model)
+        { nativeAgentGeneration = generation }
+
+isCurrentLiveView :: Int -> NativeAgentView -> Bool
+isCurrentLiveView generation view =
+    view.nativeAgentOrigin == NativeAgentLive
+        && view.nativeAgentGeneration == generation
+
+isCurrentRunningLiveView :: Int -> NativeAgentView -> Bool
+isCurrentRunningLiveView generation view =
+    isCurrentLiveView generation view
+        && view.nativeAgentStatus == "running"
 
 nativeAgentStatusText :: NativeAgentStatus -> Text
 nativeAgentStatusText = \case
@@ -601,8 +681,13 @@ alterTouched rawIdentifier update store =
                     (nativeAgentViewBytes next)
             }
 
-alterNativeOutput :: Text -> Text -> NativeAgentStore -> NativeAgentStore
-alterNativeOutput rawIdentifier chunk store =
+alterNativeOutput
+    :: Int
+    -> Text
+    -> Text
+    -> NativeAgentStore
+    -> NativeAgentStore
+alterNativeOutput generation rawIdentifier chunk store =
     case Map.lookup rawIdentifier store.storeAgents of
         Just previous -> apply previous.nativeAgentId (Just previous)
         Nothing ->
@@ -611,10 +696,17 @@ alterNativeOutput rawIdentifier chunk store =
                 Just identifier -> apply identifier Nothing
   where
     apply identifier previous =
-        let view = fromMaybe
-                (newNativeAgentView NativeAgentLive
-                    identifier Nothing identifier Nothing)
-                previous
+        let view = case previous of
+                Just previousView
+                    | isCurrentLiveView generation previousView ->
+                        previousView
+                _ ->
+                    newLiveNativeAgentView
+                        generation
+                        identifier
+                        Nothing
+                        identifier
+                        Nothing
             next = view
                 { nativeAgentOutput =
                     appendOutput
@@ -622,6 +714,7 @@ alterNativeOutput rawIdentifier chunk store =
                         chunk
                         view.nativeAgentOutput
                 , nativeAgentOrigin = NativeAgentLive
+                , nativeAgentGeneration = generation
                 }
         in store
             { storeAgents =
@@ -635,12 +728,21 @@ alterNativeOutput rawIdentifier chunk store =
                             store.storeBytes
                             (nativeAgentViewBytes next)
                     Just prior ->
-                        saturatingNativeAdd
-                            (max 0
-                                ( store.storeBytes
-                                    - prior.nativeAgentOutput.outputBytes
-                                ))
-                            next.nativeAgentOutput.outputBytes
+                        if isCurrentLiveView generation prior
+                            then
+                                saturatingNativeAdd
+                                    (max 0
+                                        ( store.storeBytes
+                                            - prior.nativeAgentOutput.outputBytes
+                                        ))
+                                    next.nativeAgentOutput.outputBytes
+                            else
+                                saturatingNativeAdd
+                                    (max 0
+                                        ( store.storeBytes
+                                            - nativeAgentViewBytes prior
+                                        ))
+                                    (nativeAgentViewBytes next)
             }
 
 touchOrder :: Text -> Seq Text -> Seq Text

--- a/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
@@ -57,6 +57,21 @@ nativeAgentAggregateBytes = 16 * 1024 * 1024
 nativeAgentSelectedBytes :: Int
 nativeAgentSelectedBytes = 8 * 1024 * 1024
 
+nativeAgentSelectedOutputBytes :: Int
+nativeAgentSelectedOutputBytes =
+    nativeAgentSelectedBytes - 32 * 1024
+
+nativeAgentIdentifierBytes, nativeAgentModelBytes :: Int
+nativeAgentIdentifierBytes = 4 * 1024
+nativeAgentModelBytes = 4 * 1024
+
+nativeAgentArgumentsCodeUnits :: Int
+nativeAgentArgumentsCodeUnits = 64 * 1024
+
+nativeAgentEntryOverheadBytes, nativeOutputChunkOverheadBytes :: Int
+nativeAgentEntryOverheadBytes = 512
+nativeOutputChunkOverheadBytes = 256
+
 data NativeOutput = NativeOutput
     { outputChunks :: !(Seq Text)
     , outputBytes :: !Int
@@ -110,7 +125,9 @@ nativeAgentTargets =
 
 setNativeAgentSelection :: Maybe Text -> NativeAgentStore -> NativeAgentStore
 setNativeAgentSelection selected store =
-    normalizeStore store{storeSelected = selected}
+    normalizeStore store
+        { storeSelected = selected >>= boundedNativeAgentIdentifier
+        }
 
 applyNativeAgentEvent :: LoopEvent -> NativeAgentStore -> NativeAgentStore
 applyNativeAgentEvent event current =
@@ -122,49 +139,74 @@ applyNativeAgentEvent event current =
                 settleRunningNativeAgents NativeAgentCancelled current
             ResponseAttemptDiscarded ->
                 settleRunningNativeAgents NativeAgentCancelled current
-            NativeAgentStarted identifier parent label model ->
-                alterTouched identifier
-                    (\case
-                        Nothing ->
-                            newNativeAgentView
-                                NativeAgentLive identifier parent label model
-                        Just view ->
-                            view
-                                { nativeAgentParent = parent
-                                , nativeAgentLabel = label
-                                , nativeAgentModel = model
-                                , nativeAgentStatus = "running"
-                                , nativeAgentTerminal = Nothing
-                                , nativeAgentOrigin = NativeAgentLive
-                                })
-                    current
-            NativeAgentOutput identifier output ->
-                alterTouched identifier
-                    (\maybeView ->
-                        let view = fromMaybe
-                                (newNativeAgentView NativeAgentLive
-                                    identifier Nothing identifier Nothing)
-                                maybeView
-                        in view
-                            { nativeAgentOutput =
-                                appendOutput nativeAgentSelectedBytes output
-                                    view.nativeAgentOutput
-                            , nativeAgentOrigin = NativeAgentLive
-                            })
-                    current
-            NativeAgentFinished identifier status ->
-                alterTouched identifier
-                    (\maybeView ->
-                        (fromMaybe
-                            (newNativeAgentView NativeAgentLive
-                                identifier Nothing identifier Nothing)
-                            maybeView)
-                            { nativeAgentStatus = nativeAgentStatusText status
-                            , nativeAgentTerminal =
-                                Just (nativeAgentBlockState status)
-                            , nativeAgentOrigin = NativeAgentLive
-                            })
-                    current
+            NativeAgentStarted rawIdentifier rawParent rawLabel rawModel ->
+                case boundedNativeAgentIdentifier rawIdentifier of
+                    Nothing -> current
+                    Just identifier ->
+                        let parent =
+                                rawParent >>= boundedNativeAgentIdentifier
+                            label =
+                                boundedNativeAgentText
+                                    nativeAgentPreviewBytes
+                                    rawLabel
+                            model =
+                                boundedNativeAgentText nativeAgentModelBytes
+                                    <$> rawModel
+                        in alterTouched identifier
+                            (\case
+                                Nothing ->
+                                    newNativeAgentView
+                                        NativeAgentLive
+                                        identifier
+                                        parent
+                                        label
+                                        model
+                                Just view ->
+                                    view
+                                        { nativeAgentParent = parent
+                                        , nativeAgentLabel = label
+                                        , nativeAgentModel = model
+                                        , nativeAgentStatus = "running"
+                                        , nativeAgentTerminal = Nothing
+                                        , nativeAgentOrigin = NativeAgentLive
+                                        })
+                            current
+            NativeAgentOutput rawIdentifier output ->
+                case boundedNativeAgentIdentifier rawIdentifier of
+                    Nothing -> current
+                    Just identifier ->
+                        alterTouched identifier
+                            (\maybeView ->
+                                let view = fromMaybe
+                                        (newNativeAgentView NativeAgentLive
+                                            identifier Nothing identifier Nothing)
+                                        maybeView
+                                in view
+                                    { nativeAgentOutput =
+                                        appendOutput
+                                            nativeAgentSelectedOutputBytes
+                                            output
+                                            view.nativeAgentOutput
+                                    , nativeAgentOrigin = NativeAgentLive
+                                    })
+                            current
+            NativeAgentFinished rawIdentifier status ->
+                case boundedNativeAgentIdentifier rawIdentifier of
+                    Nothing -> current
+                    Just identifier ->
+                        alterTouched identifier
+                            (\maybeView ->
+                                (fromMaybe
+                                    (newNativeAgentView NativeAgentLive
+                                        identifier Nothing identifier Nothing)
+                                    maybeView)
+                                    { nativeAgentStatus =
+                                        nativeAgentStatusText status
+                                    , nativeAgentTerminal =
+                                        Just (nativeAgentBlockState status)
+                                    , nativeAgentOrigin = NativeAgentLive
+                                    })
+                            current
             _ -> current
 
 -- | Materialize presentation state only for the selected row. Other rows get
@@ -195,7 +237,7 @@ restoreNativeAgents selected items current =
         }
   where
     selectedIdentifier = case selected of
-        AgentNative identifier -> Just identifier
+        AgentNative identifier -> boundedNativeAgentIdentifier identifier
         _ -> Nothing
     (canonicalAgents, canonicalOrder) =
         canonicalNativeAgents selectedIdentifier items
@@ -241,8 +283,8 @@ canonicalNativeAgents
     :: Maybe Text
     -> [ResponseItem]
     -> (Map.Map Text NativeAgentView, Seq Text)
-canonicalNativeAgents selected =
-    go Map.empty Map.empty Seq.empty . reverse
+canonicalNativeAgents selected items =
+    go Map.empty Map.empty Seq.empty (reverse items)
   where
     go outputs agents order remaining
         | Map.size agents >= nativeAgentMaxEntries
@@ -254,31 +296,51 @@ canonicalNativeAgents selected =
                 item : rest -> case item of
                     FunctionCallOutputItem output
                         | output.provider == Just "claude-code"
-                        , Map.member output.callId outputs
+                        , Just identifier <-
+                            boundedNativeAgentIdentifier output.callId
+                        , Map.member identifier outputs
                             || Map.size outputs < nativeAgentMaxEntries
-                            || selected == Just output.callId ->
+                            || selected == Just identifier ->
                             go
-                                (Map.insert output.callId output outputs)
+                                (Map.insert identifier output outputs)
                                 agents
                                 order
                                 rest
                     FunctionCallItem call
-                        | isClaudeNativeCall call
-                        , Just output <- Map.lookup call.callId outputs ->
-                            let view = restoredView
-                                    (selected == Just output.callId)
-                                    call
-                                    output
-                                (nextAgents, nextOrder) =
-                                    insertCanonical call.callId view agents order
-                            in go
-                                (Map.delete call.callId outputs)
-                                nextAgents
-                                nextOrder
-                                rest
+                        | Just identifier <-
+                            boundedNativeAgentIdentifier call.callId ->
+                            case
+                                ( isClaudeNativeCall call
+                                , Map.lookup identifier outputs
+                                ) of
+                                (True, Just output) ->
+                                    let view = restoredView
+                                            (selected == Just identifier)
+                                            identifier
+                                            call
+                                            output
+                                        (nextAgents, nextOrder) =
+                                            insertCanonical
+                                                identifier
+                                                view
+                                                agents
+                                                order
+                                    in go
+                                        (Map.delete identifier outputs)
+                                        nextAgents
+                                        nextOrder
+                                        rest
+                                _ ->
+                                    go
+                                        (Map.delete identifier outputs)
+                                        agents
+                                        order
+                                        rest
                     _ -> go outputs agents order rest
 
     insertCanonical identifier view agents order
+        | Map.member identifier agents =
+            (agents, order)
         | Map.size agents < nativeAgentMaxEntries =
             (Map.insert identifier view agents, identifier :<| order)
         | selected == Just identifier =
@@ -298,12 +360,18 @@ canonicalNativeAgents selected =
                     else Just identifier)
             Nothing
 
-restoredView :: Bool -> FunctionCall -> FunctionCallOutput -> NativeAgentView
-restoredView selected call output =
+restoredView
+    :: Bool
+    -> Text
+    -> FunctionCall
+    -> FunctionCallOutput
+    -> NativeAgentView
+restoredView selected identifier call output =
     let outputBody
             | selected =
-                renderOutputBounded nativeAgentSelectedBytes output.output
+                renderOutputBounded nativeAgentSelectedOutputBytes output.output
             | otherwise = renderOutputPreview output.output
+        (description, model) = argumentMetadata call.arguments
         terminal = case output.status of
             Just ItemIncomplete -> BlockFailed
             Just (ItemStatusUnknown status)
@@ -313,16 +381,17 @@ restoredView selected call output =
             _ -> BlockComplete
         started = newNativeAgentView
             NativeAgentCanonical
-            call.callId
+            identifier
             Nothing
-            (fromMaybe call.name
-                (argumentText "description" call.arguments))
-            (argumentText "model" call.arguments)
+            (boundedNativeAgentText nativeAgentPreviewBytes $
+                fromMaybe call.name description)
+            (boundedNativeAgentText nativeAgentModelBytes
+                <$> model)
     in started
         { nativeAgentStatus =
             if terminal == BlockFailed then "error" else "done"
         , nativeAgentOutput =
-            appendOutput nativeAgentSelectedBytes outputBody
+            appendOutput nativeAgentSelectedOutputBytes outputBody
                 started.nativeAgentOutput
         , nativeAgentTerminal = Just terminal
         }
@@ -332,14 +401,22 @@ isClaudeNativeCall call =
     Text.toLower call.name `elem` ["agent", "task"]
         && call.provider == Just "claude-code"
 
-argumentText :: Text -> Text -> Maybe Text
-argumentText key raw = do
-    value <- either (const Nothing) Just $
-        Hermes.decodeEither
-            (Hermes.object (Hermes.atKey key Hermes.text))
-            (TextEncoding.encodeUtf8 raw)
-    let stripped = Text.strip value
-    if Text.null stripped then Nothing else Just stripped
+argumentMetadata :: Text -> (Maybe Text, Maybe Text)
+argumentMetadata raw
+    | Text.length raw > nativeAgentArgumentsCodeUnits = (Nothing, Nothing)
+    | otherwise =
+        either (const (Nothing, Nothing)) normalize $
+            Hermes.decodeEither decoder (TextEncoding.encodeUtf8 raw)
+  where
+    decoder = Hermes.object $
+        (,)
+            <$> Hermes.atKeyOptional "description" Hermes.text
+            <*> Hermes.atKeyOptional "model" Hermes.text
+    normalize (description, model) =
+        (nonEmpty description, nonEmpty model)
+    nonEmpty = (>>= \value ->
+        let stripped = Text.strip value
+        in if Text.null stripped then Nothing else Just stripped)
 
 renderOutput :: RawJson -> Text
 renderOutput value =
@@ -373,8 +450,7 @@ settleRunningNativeAgents
     -> NativeAgentStore
     -> NativeAgentStore
 settleRunningNativeAgents status store =
-    store
-        { storeAgents =
+    let agents =
             Map.map
                 (\view ->
                     if view.nativeAgentStatus /= "running"
@@ -385,6 +461,9 @@ settleRunningNativeAgents status store =
                                 Just (nativeAgentBlockState status)
                             })
                 store.storeAgents
+    in store
+        { storeAgents = agents
+        , storeBytes = retainedBytes agents
         }
 
 nativeAgentBlockState :: NativeAgentStatus -> BlockState
@@ -481,10 +560,10 @@ alterTouched
     -> NativeAgentStore
 alterTouched identifier update store =
     let oldBytes = maybe 0
-            ((.outputBytes) . (.nativeAgentOutput))
+            nativeAgentViewBytes
             (Map.lookup identifier store.storeAgents)
         next = update (Map.lookup identifier store.storeAgents)
-        nextBytes = next.nativeAgentOutput.outputBytes
+        nextBytes = nativeAgentViewBytes next
     in store
         { storeAgents = Map.insert identifier next store.storeAgents
         , storeOrder = touchOrder identifier store.storeOrder
@@ -510,7 +589,7 @@ appendOutput budget chunk output
                 , outputBytes =
                     saturatingNativeAdd
                         output.outputBytes
-                        (textBytes retainedChunk)
+                        (outputChunkBytes retainedChunk)
                 }
         in if chunkTruncated
             then appended { outputOmitted = True }
@@ -519,11 +598,13 @@ appendOutput budget chunk output
     -- Stream decoders may hand us a slice of a much larger event buffer.
     -- Copy only the tail which can survive the budget; copying a giant chunk
     -- in full before immediately trimming it would recreate the memory spike.
-    chunkTruncated = textBytes chunk > max 0 budget
+    chunkTruncated = outputChunkBytes chunk > max 0 budget
     retainedChunk =
         Text.copy $
             if chunkTruncated
-                then Text.takeEnd (max 0 budget `div` 4) chunk
+                then Text.takeEnd
+                    (max 0 (budget - nativeOutputChunkOverheadBytes) `div` 4)
+                    chunk
                 else chunk
 
 trimOutputTo :: Int -> NativeOutput -> NativeOutput
@@ -549,7 +630,7 @@ dropOldestTo budget = go
             case Seq.viewl chunks of
                 Seq.EmptyL -> (Seq.empty, 0)
                 chunk Seq.:< rest ->
-                    let chunkBytes = textBytes chunk
+                    let chunkBytes = outputChunkBytes chunk
                         excess = bytes - budget
                     in if chunkBytes <= excess
                         then go (bytes - chunkBytes) rest
@@ -559,7 +640,7 @@ dropOldestTo budget = go
                                 -- original backing array alive. Copy the
                                 -- retained tail so the cap is a real heap cap.
                                 suffix = Text.copy (Text.drop dropChars chunk)
-                                suffixBytes = textBytes suffix
+                                suffixBytes = outputChunkBytes suffix
                             in ( if Text.null suffix
                                     then rest
                                     else suffix :<| rest
@@ -578,6 +659,37 @@ textBytes :: Text -> Int
 textBytes text =
     let chars = Text.length text
     in if chars > maxBound `div` 4 then maxBound else chars * 4
+
+outputChunkBytes :: Text -> Int
+outputChunkBytes text
+    | Text.null text = 0
+    | otherwise =
+        saturatingNativeAdd nativeOutputChunkOverheadBytes (textBytes text)
+
+boundedNativeAgentIdentifier :: Text -> Maybe Text
+boundedNativeAgentIdentifier identifier
+    | Text.length bounded > codeUnitLimit = Nothing
+    | otherwise = Just (Text.copy identifier)
+  where
+    codeUnitLimit = nativeAgentIdentifierBytes `div` 4
+    bounded = Text.take (codeUnitLimit + 1) identifier
+
+boundedNativeAgentText :: Int -> Text -> Text
+boundedNativeAgentText budget =
+    Text.copy . Text.take (max 0 budget `div` 4)
+
+nativeAgentViewBytes :: NativeAgentView -> Int
+nativeAgentViewBytes view =
+    foldl'
+        saturatingNativeAdd
+        nativeAgentEntryOverheadBytes
+        [ textBytes view.nativeAgentId
+        , maybe 0 textBytes view.nativeAgentParent
+        , textBytes view.nativeAgentLabel
+        , maybe 0 textBytes view.nativeAgentModel
+        , textBytes view.nativeAgentStatus
+        , view.nativeAgentOutput.outputBytes
+        ]
 
 saturatingNativeAdd :: Int -> Int -> Int
 saturatingNativeAdd left right
@@ -599,10 +711,14 @@ pruneEntries store
                     { storeAgents = Map.delete identifier store.storeAgents
                     , storeOrder = Seq.filter (/= identifier) store.storeOrder
                     , storeBytes =
-                        store.storeBytes
-                            - maybe 0
-                                ((.outputBytes) . (.nativeAgentOutput))
-                                (Map.lookup identifier store.storeAgents)
+                        max 0
+                            ( store.storeBytes
+                                - maybe 0
+                                    nativeAgentViewBytes
+                                    (Map.lookup
+                                        identifier
+                                        store.storeAgents)
+                            )
                     }
   where
     protected = protectedAgentIds store
@@ -684,5 +800,5 @@ retainedBytes :: Map.Map Text NativeAgentView -> Int
 retainedBytes =
     Map.foldl'
         (\total view ->
-            saturatingNativeAdd total view.nativeAgentOutput.outputBytes)
+            saturatingNativeAdd total (nativeAgentViewBytes view))
         0

--- a/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
@@ -577,52 +577,13 @@ alterTouched
     -> (Text -> Maybe NativeAgentView -> NativeAgentView)
     -> NativeAgentStore
     -> NativeAgentStore
-alterTouched rawIdentifier update =
-    alterTouchedAccounting rawIdentifier update updateBytes
-  where
-    updateBytes previous next bytes =
-        saturatingNativeAdd
-            (max 0 (bytes - maybe 0 nativeAgentViewBytes previous))
-            (nativeAgentViewBytes next)
-
-alterNativeOutput :: Text -> Text -> NativeAgentStore -> NativeAgentStore
-alterNativeOutput rawIdentifier chunk =
-    alterTouchedAccounting rawIdentifier update updateBytes
-  where
-    update identifier maybeView =
-        let view = fromMaybe
-                (newNativeAgentView NativeAgentLive
-                    identifier Nothing identifier Nothing)
-                maybeView
-        in view
-            { nativeAgentOutput =
-                appendOutput
-                    nativeAgentSelectedOutputBytes
-                    chunk
-                    view.nativeAgentOutput
-            , nativeAgentOrigin = NativeAgentLive
-            }
-    updateBytes Nothing next bytes =
-        saturatingNativeAdd bytes (nativeAgentViewBytes next)
-    updateBytes (Just previous) next bytes =
-        saturatingNativeAdd
-            (max 0
-                (bytes - previous.nativeAgentOutput.outputBytes))
-            next.nativeAgentOutput.outputBytes
-
-alterTouchedAccounting
-    :: Text
-    -> (Text -> Maybe NativeAgentView -> NativeAgentView)
-    -> (Maybe NativeAgentView -> NativeAgentView -> Int -> Int)
-    -> NativeAgentStore
-    -> NativeAgentStore
-alterTouchedAccounting rawIdentifier update updateBytes store =
+alterTouched rawIdentifier update store =
     case Map.lookup rawIdentifier store.storeAgents of
         Just previous -> apply previous.nativeAgentId (Just previous)
-        Nothing
-            | nativeAgentIdentifierWithinLimit rawIdentifier ->
-                apply (Text.copy rawIdentifier) Nothing
-            | otherwise -> store
+        Nothing ->
+            case boundedNativeAgentIdentifier rawIdentifier of
+                Nothing -> store
+                Just identifier -> apply identifier Nothing
   where
     apply identifier previous =
         let next = update identifier previous
@@ -631,7 +592,55 @@ alterTouchedAccounting rawIdentifier update updateBytes store =
                 Map.insert identifier next store.storeAgents
             , storeOrder =
                 touchOrder identifier store.storeOrder
-            , storeBytes = updateBytes previous next store.storeBytes
+            , storeBytes =
+                saturatingNativeAdd
+                    (max 0
+                        ( store.storeBytes
+                            - maybe 0 nativeAgentViewBytes previous
+                        ))
+                    (nativeAgentViewBytes next)
+            }
+
+alterNativeOutput :: Text -> Text -> NativeAgentStore -> NativeAgentStore
+alterNativeOutput rawIdentifier chunk store =
+    case Map.lookup rawIdentifier store.storeAgents of
+        Just previous -> apply previous.nativeAgentId (Just previous)
+        Nothing ->
+            case boundedNativeAgentIdentifier rawIdentifier of
+                Nothing -> store
+                Just identifier -> apply identifier Nothing
+  where
+    apply identifier previous =
+        let view = fromMaybe
+                (newNativeAgentView NativeAgentLive
+                    identifier Nothing identifier Nothing)
+                previous
+            next = view
+                { nativeAgentOutput =
+                    appendOutput
+                        nativeAgentSelectedOutputBytes
+                        chunk
+                        view.nativeAgentOutput
+                , nativeAgentOrigin = NativeAgentLive
+                }
+        in store
+            { storeAgents =
+                Map.insert identifier next store.storeAgents
+            , storeOrder =
+                touchOrder identifier store.storeOrder
+            , storeBytes =
+                case previous of
+                    Nothing ->
+                        saturatingNativeAdd
+                            store.storeBytes
+                            (nativeAgentViewBytes next)
+                    Just prior ->
+                        saturatingNativeAdd
+                            (max 0
+                                ( store.storeBytes
+                                    - prior.nativeAgentOutput.outputBytes
+                                ))
+                            next.nativeAgentOutput.outputBytes
             }
 
 touchOrder :: Text -> Seq Text -> Seq Text

--- a/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeAgents.hs
@@ -82,6 +82,12 @@ data NativeOutput = NativeOutput
 data NativeAgentOrigin = NativeAgentLive | NativeAgentCanonical
     deriving (Eq, Show)
 
+data CanonicalPending
+    = CanonicalOutput !FunctionCallOutput
+    -- A newer unmatched call is a generation barrier: an older completed
+    -- pair with the same provider-controlled ID must not replace live state.
+    | CanonicalUnpairedNativeCall
+
 -- | Canonical retained state for one provider-managed agent. The streamed
 -- body is held once as append-only chunks; no UiState or duplicate transcript
 -- is retained for every tree row.
@@ -243,7 +249,10 @@ restoreNativeAgents selected items current =
         AgentNative identifier -> boundedNativeAgentIdentifier identifier
         _ -> Nothing
     (canonicalAgents, canonicalOrder) =
-        canonicalNativeAgents selectedIdentifier items
+        canonicalNativeAgents
+            selectedIdentifier
+            (Map.keysSet current.storeAgents)
+            items
     liveUnpersisted =
         Map.restrictKeys current.storeAgents liveUnpersistedIds
     liveUnpersistedIds = closeParents initialLiveIds
@@ -286,12 +295,13 @@ nativeAgentConversation view =
 
 canonicalNativeAgents
     :: Maybe Text
+    -> Set.Set Text
     -> [ResponseItem]
     -> (Map.Map Text NativeAgentView, Seq Text)
-canonicalNativeAgents selected items =
+canonicalNativeAgents selected protected items =
     go Map.empty Map.empty Seq.empty (reverse items)
   where
-    go outputs agents order remaining
+    go pending agents order remaining
         | Map.size agents >= nativeAgentMaxEntries
         , maybe True (`Map.member` agents) selected =
             (agents, order)
@@ -303,45 +313,72 @@ canonicalNativeAgents selected items =
                         | output.provider == Just "claude-code"
                         , Just identifier <-
                             boundedNativeAgentIdentifier output.callId
-                        , Map.member identifier outputs
-                            || Map.size outputs < nativeAgentMaxEntries
-                            || selected == Just identifier ->
-                            go
-                                (Map.insert identifier output outputs)
-                                agents
-                                order
-                                rest
+                        , Map.notMember identifier agents ->
+                            case Map.lookup identifier pending of
+                                Just _ ->
+                                    go pending agents order rest
+                                Nothing
+                                    | mayTrack identifier pending ->
+                                        go
+                                            (Map.insert
+                                                identifier
+                                                (CanonicalOutput output)
+                                                pending)
+                                            agents
+                                            order
+                                            rest
+                                    | otherwise ->
+                                        go pending agents order rest
                     FunctionCallItem call
                         | Just identifier <-
-                            boundedNativeAgentIdentifier call.callId ->
-                            case
-                                ( isClaudeNativeCall call
-                                , Map.lookup identifier outputs
-                                ) of
-                                (True, Just output) ->
-                                    let view = restoredView
-                                            (selected == Just identifier)
-                                            identifier
-                                            call
-                                            output
-                                        (nextAgents, nextOrder) =
-                                            insertCanonical
+                            boundedNativeAgentIdentifier call.callId
+                        , Map.notMember identifier agents ->
+                            case Map.lookup identifier pending of
+                                Just (CanonicalOutput output)
+                                    | isClaudeNativeCall call ->
+                                        let view = restoredView
+                                                (selected == Just identifier)
                                                 identifier
-                                                view
-                                                agents
-                                                order
-                                    in go
-                                        (Map.delete identifier outputs)
-                                        nextAgents
-                                        nextOrder
-                                        rest
-                                _ ->
+                                                call
+                                                output
+                                            (nextAgents, nextOrder) =
+                                                insertCanonical
+                                                    identifier
+                                                    view
+                                                    agents
+                                                    order
+                                        in go
+                                            (Map.delete identifier pending)
+                                            nextAgents
+                                            nextOrder
+                                            rest
+                                Just (CanonicalOutput _) ->
                                     go
-                                        (Map.delete identifier outputs)
+                                        (Map.delete identifier pending)
                                         agents
                                         order
                                         rest
-                    _ -> go outputs agents order rest
+                                Just CanonicalUnpairedNativeCall ->
+                                    go pending agents order rest
+                                Nothing
+                                    | isClaudeNativeCall call
+                                    , mayTrack identifier pending ->
+                                        go
+                                            (Map.insert
+                                                identifier
+                                                CanonicalUnpairedNativeCall
+                                                pending)
+                                            agents
+                                            order
+                                            rest
+                                    | otherwise ->
+                                        go pending agents order rest
+                    _ -> go pending agents order rest
+
+    mayTrack identifier pending =
+        Map.size pending < nativeAgentMaxEntries
+            || selected == Just identifier
+            || Set.member identifier protected
 
     insertCanonical identifier view agents order
         | Map.member identifier agents =

--- a/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
@@ -3,7 +3,11 @@ module Agent.CLI.NativeAgentsSpec (spec) where
 import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
 import Agent.CLI.NativeAgents
 import Agent.Json (rawJsonFromEncoding)
-import Agent.Loop (LoopEvent(..), NativeAgentStatus(..))
+import Agent.Loop
+    ( LoopEvent(..)
+    , NativeAgentStatus(..)
+    , emptyTurnOutput
+    )
 import Agent.Responses.Types
     ( FunctionCall(..)
     , FunctionCallOutput(..)
@@ -69,6 +73,44 @@ spec = describe "provider-native agent tracking" do
                         (nativeAgentConversation view).uiBlocks)
         view.nativeAgentStatus `shouldBe` "cancelled"
         states `shouldSatisfy` all (/= BlockRunning)
+
+    it "does not carry reused child output across response-attempt boundaries" do
+        let beforeRetry =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    emptyNativeAgentStore
+                    [ TurnStarted
+                    , NativeAgentStarted
+                        "reused"
+                        Nothing
+                        "old live"
+                        Nothing
+                    , NativeAgentOutput "reused" "old result"
+                    ]
+            reuseAfter boundary =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    beforeRetry
+                    [ boundary
+                    , NativeAgentOutput "reused" "new result"
+                    , NativeAgentStarted
+                        "reused"
+                        Nothing
+                        "new live"
+                        Nothing
+                    ]
+            views =
+                map
+                    (lookupView "reused" . reuseAfter)
+                    [ ResponseRestarted "retrying"
+                    , ResponseAttemptDiscarded
+                    ]
+        map nativeAgentTranscript views
+            `shouldBe` [["new result"], ["new result"]]
+        map (.nativeAgentLabel) views
+            `shouldBe` ["new live", "new live"]
+        map (.nativeAgentStatus) views
+            `shouldBe` ["running", "running"]
 
     it "settles stale running children before the next turn starts" do
         let tracked =
@@ -363,6 +405,90 @@ spec = describe "provider-native agent tracking" do
             view = lookupView "reused" restored
         view.nativeAgentLabel `shouldBe` "new live"
         view.nativeAgentStatus `shouldBe` "running"
+
+    it "keeps current-turn live reuse ahead of older canonical history until turn finishes" do
+        let oldCall = FunctionCallItem FunctionCall
+                { itemId = Nothing
+                , callId = "reused"
+                , name = "Agent"
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , arguments = "{\"description\":\"old canonical\"}"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                }
+            oldOutput = FunctionCallOutputItem FunctionCallOutput
+                { itemId = Nothing
+                , callId = "reused"
+                , name = Nothing
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , output =
+                    rawJsonFromEncoding $
+                        Aeson.toEncoding ("old result" :: String)
+                , status = Just ItemCompleted
+                }
+            persisted =
+                restoreNativeAgents
+                    AgentRoot
+                    [oldCall, oldOutput]
+                    emptyNativeAgentStore
+            live =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    persisted
+                    [ TurnStarted
+                    , NativeAgentStarted
+                        "reused"
+                        Nothing
+                        "new live"
+                        Nothing
+                    , NativeAgentOutput "reused" "new result"
+                    ]
+            outputBeforeStart =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    persisted
+                    [ TurnStarted
+                    , NativeAgentOutput "reused" "new result"
+                    , NativeAgentStarted
+                        "reused"
+                        Nothing
+                        "new live"
+                        Nothing
+                    ]
+            outputFirstView = lookupView "reused" outputBeforeStart
+            finishedBeforeStart =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    persisted
+                    [ TurnStarted
+                    , NativeAgentFinished "reused" NativeAgentCompleted
+                    ]
+            finishedBeforeStartView =
+                lookupView "reused" finishedBeforeStart
+            restored =
+                restoreNativeAgents AgentRoot [oldCall, oldOutput] live
+            view = lookupView "reused" restored
+            afterFinish =
+                restoreNativeAgents
+                    AgentRoot
+                    [oldCall, oldOutput]
+                    (applyNativeAgentEvent
+                        (TurnFinished
+                            (emptyTurnOutput "root" [] Nothing))
+                        restored)
+            finishedView = lookupView "reused" afterFinish
+        view.nativeAgentLabel `shouldBe` "new live"
+        view.nativeAgentStatus `shouldBe` "running"
+        nativeAgentTranscript view `shouldBe` ["new result"]
+        outputFirstView.nativeAgentLabel `shouldBe` "new live"
+        outputFirstView.nativeAgentStatus `shouldBe` "running"
+        nativeAgentTranscript outputFirstView `shouldBe` ["new result"]
+        finishedBeforeStartView.nativeAgentStatus `shouldBe` "done"
+        nativeAgentTranscript finishedBeforeStartView `shouldBe` []
+        finishedView.nativeAgentLabel `shouldBe` "old canonical"
+        finishedView.nativeAgentStatus `shouldBe` "done"
 
     it "does not decode oversized canonical call arguments for metadata" do
         let call = FunctionCallItem FunctionCall

--- a/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
@@ -197,6 +197,121 @@ spec = describe "provider-native agent tracking" do
             `shouldSatisfy` maybe False
                 ((== "done") . (.nativeAgentStatus))
 
+    it "does not let paired non-native outputs hide an older native pair" do
+        let call name identifier = FunctionCallItem FunctionCall
+                { itemId = Nothing
+                , callId = identifier
+                , name
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , arguments = "{}"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                }
+            output identifier = FunctionCallOutputItem FunctionCallOutput
+                { itemId = Nothing
+                , callId = identifier
+                , name = Nothing
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , output =
+                    rawJsonFromEncoding
+                        (Aeson.toEncoding ("done" :: String))
+                , status = Just ItemCompleted
+                }
+            unrelated =
+                concat
+                    [ [call "Read" identifier, output identifier]
+                | index <- [1 .. nativeAgentMaxEntries + 16]
+                    , let identifier = Text.pack ("other-" <> show index)
+                    ]
+            restored =
+                restoreNativeAgents
+                    AgentRoot
+                    ([call "Agent" "native", output "native"] <> unrelated)
+                    emptyNativeAgentStore
+        nativeAgentLookup "native" restored
+            `shouldSatisfy` maybe False
+                ((== "done") . (.nativeAgentStatus))
+
+    it "keeps only the newest canonical pair for a reused call id" do
+        let pair index =
+                [ FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "reused"
+                    , name = "Agent"
+                    , namespace = Nothing
+                    , provider = Just "claude-code"
+                    , arguments =
+                        Text.pack
+                            ("{\"description\":\"revision-"
+                                <> show index
+                                <> "\"}")
+                    , encryptedFunctionArgs = Nothing
+                    , status = Just ItemCompleted
+                    }
+                , FunctionCallOutputItem FunctionCallOutput
+                    { itemId = Nothing
+                    , callId = "reused"
+                    , name = Nothing
+                    , namespace = Nothing
+                    , provider = Just "claude-code"
+                    , output =
+                        rawJsonFromEncoding $
+                            Aeson.toEncoding $
+                                Text.pack ("result-" <> show index)
+                    , status = Just ItemCompleted
+                    }
+                ]
+            pairCount = nativeAgentMaxEntries * 4
+            restored =
+                restoreNativeAgents
+                    AgentRoot
+                    (concatMap pair [1 .. pairCount])
+                    emptyNativeAgentStore
+            view = lookupView "reused" restored
+        nativeAgentStoreSize restored `shouldBe` 1
+        view.nativeAgentLabel
+            `shouldBe` Text.pack ("revision-" <> show pairCount)
+        nativeAgentTranscript view
+            `shouldBe` [Text.pack ("result-" <> show pairCount)]
+
+    it "does not decode oversized canonical call arguments for metadata" do
+        let call = FunctionCallItem FunctionCall
+                { itemId = Nothing
+                , callId = "oversized-arguments"
+                , name = "Agent"
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , arguments =
+                    "{\"description\":\"untrusted\",\"model\":\"huge\","
+                        <> "\"prompt\":\""
+                        <> Text.replicate (128 * 1024) "x"
+                        <> "\"}"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                }
+            output = FunctionCallOutputItem FunctionCallOutput
+                { itemId = Nothing
+                , callId = "oversized-arguments"
+                , name = Nothing
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , output =
+                    rawJsonFromEncoding
+                        (Aeson.toEncoding ("done" :: String))
+                , status = Just ItemCompleted
+                }
+            restored =
+                restoreNativeAgents
+                    AgentRoot
+                    [call, output]
+                    emptyNativeAgentStore
+            view = lookupView "oversized-arguments" restored
+        view.nativeAgentLabel `shouldBe` "Agent"
+        view.nativeAgentModel `shouldBe` Nothing
+        nativeAgentTranscript view `shouldBe` ["done"]
+
     it "bounds terminal rows and retained output" do
         let payload = Text.replicate (nativeAgentPreviewBytes `div` 2) "x"
             tracked =
@@ -230,6 +345,62 @@ spec = describe "provider-native agent tracking" do
             (Text.pack ("running-" <> show (nativeAgentMaxEntries + 16)))
             tracked
             `shouldSatisfy` maybe False (const True)
+
+    it "bounds and accounts provider-controlled lifecycle metadata" do
+        let huge = Text.replicate (2 * 1024 * 1024) "x"
+            tracked =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    emptyNativeAgentStore
+                    [ NativeAgentStarted
+                        identifier
+                        Nothing
+                        (huge <> Text.pack (show index))
+                        (Just huge)
+                    | index <- [1 .. nativeAgentMaxEntries]
+                    , let identifier = Text.pack ("metadata-" <> show index)
+                    ]
+            views =
+                [ view
+                | identifier <- nativeAgentTargets tracked
+                , AgentNative nativeId <- [identifier]
+                , Just view <- [nativeAgentLookup nativeId tracked]
+                ]
+        nativeAgentStoreSize tracked `shouldBe` nativeAgentMaxEntries
+        nativeAgentStoreBytes tracked `shouldSatisfy` (> 0)
+        nativeAgentStoreBytes tracked
+            `shouldSatisfy` (<= nativeAgentAggregateBytes)
+        views `shouldSatisfy`
+            all
+                (\view ->
+                    Text.length view.nativeAgentLabel
+                        <= nativeAgentPreviewBytes `div` 4
+                        && maybe True
+                            ((<= nativeAgentPreviewBytes `div` 4) . Text.length)
+                            view.nativeAgentModel)
+
+    it "ignores identifiers too large to retain as map keys" do
+        let hugeIdentifier = Text.replicate (2 * 1024 * 1024) "x"
+            tracked =
+                applyNativeAgentEvent
+                    (NativeAgentStarted
+                        hugeIdentifier
+                        Nothing
+                        "untrusted"
+                        Nothing)
+                    emptyNativeAgentStore
+        nativeAgentStoreSize tracked `shouldBe` 0
+        nativeAgentStoreBytes tracked `shouldBe` 0
+
+    it "charges per-delta overhead for fragmented output" do
+        let deltas = replicate 1024 (NativeAgentOutput "fragmented" "x")
+            tracked =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    emptyNativeAgentStore
+                    deltas
+        nativeAgentStoreBytes tracked
+            `shouldSatisfy` (> 1024 * 4)
 
     it "retains only a bounded tail of one oversized native output" do
         let suffix = "newest-tail"

--- a/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
@@ -324,6 +324,46 @@ spec = describe "provider-native agent tracking" do
         nativeAgentTranscript view
             `shouldBe` [Text.pack ("result-" <> show pairCount)]
 
+    it "keeps a newer live reuse when its canonical call is still unpaired" do
+        let call description = FunctionCallItem FunctionCall
+                { itemId = Nothing
+                , callId = "reused"
+                , name = "Agent"
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , arguments =
+                    "{\"description\":\"" <> description <> "\"}"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                }
+            oldOutput = FunctionCallOutputItem FunctionCallOutput
+                { itemId = Nothing
+                , callId = "reused"
+                , name = Nothing
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , output =
+                    rawJsonFromEncoding $
+                        Aeson.toEncoding ("old result" :: String)
+                , status = Just ItemCompleted
+                }
+            live =
+                applyNativeAgentEvent
+                    (NativeAgentStarted
+                        "reused"
+                        Nothing
+                        "new live"
+                        Nothing)
+                    emptyNativeAgentStore
+            restored =
+                restoreNativeAgents
+                    AgentRoot
+                    [call "old canonical", oldOutput, call "new canonical"]
+                    live
+            view = lookupView "reused" restored
+        view.nativeAgentLabel `shouldBe` "new live"
+        view.nativeAgentStatus `shouldBe` "running"
+
     it "does not decode oversized canonical call arguments for metadata" do
         let call = FunctionCallItem FunctionCall
                 { itemId = Nothing

--- a/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeAgentsSpec.hs
@@ -129,6 +129,54 @@ spec = describe "provider-native agent tracking" do
         view.nativeAgentStatus `shouldBe` "done"
         nativeAgentTranscript view `shouldBe` ["review complete"]
 
+    it "replaces live parent snapshots with canonical state on every restore" do
+        let live =
+                foldl
+                    (flip applyNativeAgentEvent)
+                    emptyNativeAgentStore
+                    [ NativeAgentStarted
+                        "parent" Nothing "Live parent" Nothing
+                    , NativeAgentStarted
+                        "child" (Just "parent") "Child" Nothing
+                    ]
+            call = FunctionCallItem FunctionCall
+                { itemId = Nothing
+                , callId = "parent"
+                , name = "Agent"
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , arguments =
+                    "{\"description\":\"Persisted parent\"}"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                }
+            output = FunctionCallOutputItem FunctionCallOutput
+                { itemId = Nothing
+                , callId = "parent"
+                , name = Nothing
+                , namespace = Nothing
+                , provider = Just "claude-code"
+                , output =
+                    rawJsonFromEncoding $
+                        Aeson.toEncoding ("persisted" :: String)
+                , status = Just ItemCompleted
+                }
+            restore =
+                restoreNativeAgents AgentRoot [call, output]
+            restored =
+                iterate restore live
+                    !! (nativeAgentMaxEntries * 4)
+            parent = lookupView "parent" restored
+            child =
+                find
+                    ((== AgentNative "child") . (.agentTarget))
+                    (nativeAgentEntries AgentRoot restored)
+        nativeAgentStoreSize restored `shouldBe` 2
+        parent.nativeAgentLabel `shouldBe` "Persisted parent"
+        parent.nativeAgentStatus `shouldBe` "done"
+        (.agentPath) <$> child
+            `shouldBe` Just "/native/Persisted parent/Child"
+
     it "does not restore unpaired or non-Claude canonical calls" do
         let call identifier provider = FunctionCallItem FunctionCall
                 { itemId = Nothing


### PR DESCRIPTION
Corrective follow-up to #776.

Caps and accounts provider-controlled native-agent identifiers, labels, models, output fragments, and canonical restore metadata. The restore scanner treats a newer unpaired reused call ID as a generation barrier, so stale completed history cannot overwrite the currently live generation. Native-output accounting and aggregate compaction use exact incremental byte deltas rather than rescanning all retained rows.

Validation:
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-show-details=direct --test-option=--match --test-option='provider-native agent tracking'` — 21 examples, 0 failures.
- `nix develop -c cabal build --offline --enable-optimization=2 agent-cli:bench:subagent-retention-bench` for both base `d52ef547` and this head, on Apple Silicon / GHC 9.10.3.
- Equivalent `bounded-native` workloads, 9-sample CPU medians (ms); 8x16 KiB and 64x16 KiB rows were additionally repeated as five alternating 15-sample runs:

| agents × outputs × payload | base CPU | candidate CPU | base allocation | candidate allocation |
| --- | ---: | ---: | ---: | ---: |
| 8 × 64 × 1 KiB | 0.313 | 0.321 | 2,637,712 | 2,603,344 |
| 8 × 64 × 16 KiB* | 2.355 | 2.353 | 26,268,032 | 26,235,920 |
| 32 × 64 × 1 KiB | 2.342 | 2.329 | 13,660,984 | 13,523,880 |
| 32 × 64 × 16 KiB | 8.737 | 8.078 | 108,382,936 | 108,272,856 |
| 64 × 64 × 1 KiB | 6.292 | 5.551 | 35,628,376 | 35,389,512 |
| 64 × 64 × 16 KiB* | 16.391 | 16.461 | 225,725,680 | 225,554,672 |

\* Repeated alternating median. The 0.4% CPU difference at the highest payload is within run noise; allocation is 0.08% lower. No representative workload materially regressed.

The earlier CI failure was an infrastructure failure (private Nix cache 502s followed by a Nix daemon disconnect), not a source/test failure. The fresh check and one retry reached the external live OpenAI test and failed only because no configured account had verified available usage; all unit suites completed before that gate.