### PR TITLE
Update provider limit from stream events

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -473,7 +473,7 @@ updateManagedActivity event state =
                 { accumulatorKind = "activity"
                 , accumulatorMessage = nonEmpty "Working…" message
                 }
-        ProviderLimitUpdated _ _ ->
+        ProviderLimitUpdated{} ->
             state
         WarningRaised message ->
             state

--- a/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayBridge.hs
@@ -473,6 +473,8 @@ updateManagedActivity event state =
                 { accumulatorKind = "activity"
                 , accumulatorMessage = nonEmpty "Working…" message
                 }
+        ProviderLimitUpdated _ _ ->
+            state
         WarningRaised message ->
             state
                 { accumulatorKind = "warning"

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -357,6 +357,8 @@ renderEventUnlocked config = \case
             else if config.renderShowThinking
                 then startThinkingSpinnerUnlocked config
                 else putTextLn config.renderStderr (roleMuted config.renderColor activity)
+    ProviderLimitUpdated _ _ ->
+        pure ()
     WarningRaised warning -> do
         visible <- (.stateThinkingVisible) <$> readRenderState config
         when visible (stopThinkingSpinnerUnlocked config)

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -357,7 +357,7 @@ renderEventUnlocked config = \case
             else if config.renderShowThinking
                 then startThinkingSpinnerUnlocked config
                 else putTextLn config.renderStderr (roleMuted config.renderColor activity)
-    ProviderLimitUpdated _ _ ->
+    ProviderLimitUpdated{} ->
         pure ()
     WarningRaised warning -> do
         visible <- (.stateThinkingVisible) <$> readRenderState config

--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -313,6 +313,8 @@ eventWeight = \case
     TextDelta text -> Text.length text
     ReasoningDelta text -> Text.length text
     ActivityUpdated text -> Text.length text
+    ProviderLimitUpdated text warning ->
+        Text.length text + if warning then 1 else 0
     WarningRaised text -> Text.length text
     ResponseRestarted text -> Text.length text
     TurnStarted -> 1

--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -313,7 +313,10 @@ eventWeight = \case
     TextDelta text -> Text.length text
     ReasoningDelta text -> Text.length text
     ActivityUpdated text -> Text.length text
-    ProviderLimitUpdated text warning ->
+    ProviderLimitUpdated
+        { providerLimitText = text
+        , providerLimitWarning = warning
+        } ->
         Text.length text + if warning then 1 else 0
     WarningRaised text -> Text.length text
     ResponseRestarted text -> Text.length text

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -266,6 +266,8 @@ data LoopEvent
     | ReasoningDelta Text
     -- | Ephemeral transport/tool activity for the live CLI status line.
     | ActivityUpdated Text
+    -- | Latest provider-reported limit status for retained prompt chrome.
+    | ProviderLimitUpdated Text Bool
     -- | A persistent user-visible warning that must not replace live activity.
     | WarningRaised Text
     -- | A streamed response was interrupted and its provider submission is

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -267,7 +267,10 @@ data LoopEvent
     -- | Ephemeral transport/tool activity for the live CLI status line.
     | ActivityUpdated Text
     -- | Latest provider-reported limit status for retained prompt chrome.
-    | ProviderLimitUpdated Text Bool
+    | ProviderLimitUpdated
+        { providerLimitText :: !Text
+        , providerLimitWarning :: !Bool
+        }
     -- | A persistent user-visible warning that must not replace live activity.
     | WarningRaised Text
     -- | A streamed response was interrupted and its provider submission is

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1063,7 +1063,10 @@ spec = do
             reverse <$> readIORef events `shouldReturn`
                 [ WarningRaised
                     "Codex usage is low: primary 8% left. Check /usage for reset details."
-                , ProviderLimitUpdated "5h limit left: 8%" True
+                , ProviderLimitUpdated
+                    { providerLimitText = "5h limit left: 8%"
+                    , providerLimitWarning = True
+                    }
                 ]
             readIORef healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 1

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1063,6 +1063,7 @@ spec = do
             reverse <$> readIORef events `shouldReturn`
                 [ WarningRaised
                     "Codex usage is low: primary 8% left. Check /usage for reset details."
+                , ProviderLimitUpdated "5h limit left: 8%" True
                 ]
             readIORef healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 1

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -683,8 +683,10 @@ codexRateLimitsUpdate = \case
         let remaining :: Int
             remaining = max 0 (min 100 (round (100 - used)))
         in ProviderLimitUpdated
-            (label <> ": " <> Text.pack (show remaining) <> "%")
-            (remaining <= 10)
+            { providerLimitText =
+                label <> ": " <> Text.pack (show remaining) <> "%"
+            , providerLimitWarning = remaining <= 10
+            }
 
 -- | Emit an updated argument-streaming activity after this many additional
 -- streamed argument characters.

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -667,7 +667,24 @@ newStreamEventToLoopEvents showRawReasoning = do
         pure $
             maybeToList
                 (streamEventToLoopEventWithRawReasoning showRawReasoning event)
+                <> maybeToList (codexRateLimitsUpdate event)
                 <> argumentEvents
+
+codexRateLimitsUpdate :: ResponseStreamEvent -> Maybe LoopEvent
+codexRateLimitsUpdate = \case
+    ResponseCodexRateLimitsEvent { rateLimits = limits } ->
+        case limits.secondaryUsedPercent of
+            Just used -> Just (limitUpdate "Weekly limit left" used)
+            Nothing ->
+                limitUpdate "5h limit left" <$> limits.primaryUsedPercent
+    _ -> Nothing
+  where
+    limitUpdate label used =
+        let remaining :: Int
+            remaining = max 0 (min 100 (round (100 - used)))
+        in ProviderLimitUpdated
+            (label <> ": " <> Text.pack (show remaining) <> "%")
+            (remaining <= 10)
 
 -- | Emit an updated argument-streaming activity after this many additional
 -- streamed argument characters.

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -28,6 +28,7 @@ import Agent.Responses.LoopBackend
     )
 import Agent.Responses.Types
     ( MessageContent(..)
+    , CodexRateLimits(..)
     , ComputerAction(..)
     , ComputerCall(..)
     , ComputerCallOutput(..)
@@ -466,6 +467,20 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
 -- activity updates.
 streamProjectionSpec :: Spec
 streamProjectionSpec = describe "newStreamEventToLoopEvents" do
+    it "publishes Codex weekly capacity updates for retained prompt chrome" do
+        projectEvent <- newStreamEventToLoopEvents False
+        events <- projectEvent ResponseCodexRateLimitsEvent
+            { rateLimits = CodexRateLimits
+                { allowed = Just True
+                , limitReached = Just False
+                , primaryUsedPercent = Just 12
+                , secondaryUsedPercent = Just 79
+                }
+            , sequenceNumber = Nothing
+            }
+        events `shouldBe`
+            [ProviderLimitUpdated "Weekly limit left: 21%" False]
+
     it "publishes a streamed function call immediately" do
         projectEvent <- newStreamEventToLoopEvents False
         events <- projectEvent (functionCallAdded "fc-1" "call-1" "shell_command")

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -479,7 +479,11 @@ streamProjectionSpec = describe "newStreamEventToLoopEvents" do
             , sequenceNumber = Nothing
             }
         events `shouldBe`
-            [ProviderLimitUpdated "Weekly limit left: 21%" False]
+            [ ProviderLimitUpdated
+                { providerLimitText = "Weekly limit left: 21%"
+                , providerLimitWarning = False
+                }
+            ]
 
     it "publishes a streamed function call immediately" do
         projectEvent <- newStreamEventToLoopEvents False

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -374,7 +374,10 @@ reduceLoop event state = case event of
                 }
     ActivityUpdated activity ->
         state { uiActivity = activity }
-    ProviderLimitUpdated text warning ->
+    ProviderLimitUpdated
+        { providerLimitText = text
+        , providerLimitWarning = warning
+        } ->
         state
             { uiPrompt =
                 state.uiPrompt

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -374,6 +374,17 @@ reduceLoop event state = case event of
                 }
     ActivityUpdated activity ->
         state { uiActivity = activity }
+    ProviderLimitUpdated text warning ->
+        state
+            { uiPrompt =
+                state.uiPrompt
+                    { promptLimitStatus =
+                        Just PromptLimitStatus
+                            { promptLimitText = text
+                            , promptLimitWarning = warning
+                            }
+                    }
+            }
     WarningRaised warning ->
         state
             { uiNotice = Just (warningNotice warning)

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -232,6 +232,19 @@ spec = describe "fullscreen UI reducer" do
                     (warningNotice
                         "Codex usage is low: primary 8% left.")
 
+    it "updates provider capacity in the prompt chrome" do
+        let state =
+                apply
+                    [ UiLoop
+                        (ProviderLimitUpdated "Weekly limit left: 8%" True)
+                    ]
+        state.uiPrompt.promptLimitStatus
+            `shouldBe`
+                Just PromptLimitStatus
+                    { promptLimitText = "Weekly limit left: 8%"
+                    , promptLimitWarning = True
+                    }
+
     it "separates a partial response from its automatic retry" do
         let message =
                 "Connection interrupted the response; restarting automatically."

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -236,7 +236,10 @@ spec = describe "fullscreen UI reducer" do
         let state =
                 apply
                     [ UiLoop
-                        (ProviderLimitUpdated "Weekly limit left: 8%" True)
+                        ProviderLimitUpdated
+                            { providerLimitText = "Weekly limit left: 8%"
+                            , providerLimitWarning = True
+                            }
                     ]
         state.uiPrompt.promptLimitStatus
             `shouldBe`


### PR DESCRIPTION
## Summary
- project OpenAI `codex.rate_limits` stream events into loop events
- update retained prompt limit chrome immediately from primary or weekly usage
- preserve existing low-limit warnings and ignore the chrome-only event in append-only renderers

## Validation
- multi-package GHCi typecheck (agent-cli, agent-core, agent-responses, agent-tui)
- targeted agent-responses projection test
- targeted agent-tui reducer test
- targeted agent-openai recovery test
- live tmux OpenAI turn; footer updated from 19% before the turn to 4% afterward