### PR TITLE
Add Gemini provider and Google account login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ cabal repl \
   agent-openai:lib:agent-openai \
   agent-xai:lib:agent-xai \
   agent-openrouter:lib:agent-openrouter \
+  agent-gemini:lib:agent-gemini \
   claude-agent-sdk-haskell:lib:claude-agent-sdk-haskell \
   agent-claude:lib:agent-claude
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ nix run "github:digitallyinduced/haskell-agent"
 - xAI (Subscription)
 - Claude (Subscription)
 - OpenRouter (API billing)
+- Google Gemini (Google account or AI Studio API billing)
 
 ## What is distinctive
 
@@ -58,9 +59,9 @@ have to be.
 
 ## Features
 
-- **Choice of models and billing:** use OpenAI/Codex, xAI/Grok, OpenRouter, or
-  Claude Code through subscriptions or API keys, and add local or hosted
-  Responses-compatible models through the user model catalog.
+- **Choice of models and billing:** use OpenAI/Codex, xAI/Grok, OpenRouter,
+  Google Gemini, or Claude Code through subscriptions or API keys, and add
+  local or hosted Responses-compatible models through the user model catalog.
 - **Interactive terminal workflow:** choose between fullscreen and inline
   interfaces with streaming Markdown, live todo progress, one-shot operation,
   and image attachments from files or the clipboard.
@@ -165,9 +166,23 @@ remote is selected from the current branch's configured remote, then
 fetch failure aborts worktree creation rather than falling back to a stale
 commit.
 
-Use `--provider openai`, `--provider xai`, `--provider openrouter`, or
-`--provider claude-code` to override automatic provider detection. Claude Code
-is selected explicitly rather than by auto-detection.
+Use `--provider openai`, `--provider xai`, `--provider openrouter`,
+`--provider gemini`, or `--provider claude-code` to override automatic
+provider detection. Claude Code is selected explicitly rather than by
+auto-detection.
+
+Open `/model` and choose a Gemini model such as `gemini-3.7-flash`. If no
+Gemini account is connected, the CLI opens Google sign-in in your browser and
+stores the OAuth credential in the same managed credential store used by the
+other providers:
+
+```console
+/model
+```
+
+No API key is required for this Google-account flow. For Google AI Studio API
+billing instead, set `GOOGLE_API_KEY` (preferred) or `GEMINI_API_KEY`, then run
+`agent-cli --provider gemini --model gemini-3.7-flash`.
 
 ### Telegram
 
@@ -203,7 +218,9 @@ defaults from a confirmed public GitHub profile. Invoke it with
 
 ### Authentication
 
-Works with your Codex, Grok, and Claude subscriptions, plus provider API keys.
+Works with your Codex, Grok, Google, and Claude accounts, plus provider API
+keys. Gemini can be connected interactively from `/model` or `/account`;
+`GOOGLE_API_KEY` (or `GEMINI_API_KEY`) remains an optional AI Studio fallback.
 
 ### Voice dictation
 
@@ -305,11 +322,11 @@ are discussed in [`IDEAS.md`](IDEAS.md).
                                |
                     canonical Responses model
                                |
-       +---------------+---------------+---------------+
-       |               |               |               |
- agent-openai      agent-xai    agent-openrouter  agent-claude
-       |               |               |               |
-OpenAI / ChatGPT       xAI          OpenRouter      Claude Code
+       +---------------+---------------+---------------+---------------+---------------+
+       |               |               |               |               |
+ agent-openai      agent-xai    agent-openrouter  agent-gemini    agent-claude
+       |               |               |               |               |
+OpenAI / ChatGPT       xAI          OpenRouter      Gemini         Claude Code
 ```
 
 The provider-neutral loop sees typed turns, tool calls, tool results, usage,
@@ -325,8 +342,9 @@ adapter.
 
 Model targets resolve independently to a provider transport and a model-facing
 dialect. OpenAI models use the Codex dialect, xAI models use the Grok Build
-dialect, and OpenRouter selects Codex, Grok Build, or a portable Responses
-dialect from the model family.
+dialect, Gemini uses the portable Responses dialect over Google's native Code
+Assist or GenerateContent API, and OpenRouter selects Codex, Grok Build, or a
+portable Responses dialect from the model family.
 
 ## Development
 

--- a/cabal.project
+++ b/cabal.project
@@ -14,6 +14,7 @@ packages:
     packages/agent-openai
     packages/agent-xai
     packages/agent-openrouter
+    packages/agent-gemini
     packages/agent-store
     packages/claude-agent-sdk-haskell
     packages/agent-claude

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,6 +1,7 @@
 # Model catalog and local models
 
-The model picker merges the shipped OpenAI, xAI, OpenRouter, and Meta catalog
+The model picker merges the shipped OpenAI, xAI, OpenRouter, Meta, and Gemini
+catalog
 with:
 
 ```text
@@ -48,6 +49,11 @@ Select it with `agent-cli --model qwen-local` or from `/model`. For an
 authenticated endpoint, set `"api_key_env": "MY_MODEL_API_KEY"` and export
 that variable. Omit `"api_key_optional": true` when a key is required.
 
+Built-in provider credentials are configured separately from the catalog.
+Selecting a Gemini entry in `/model` starts browser-based Google sign-in when
+no Gemini credential exists; no API key is required. Google AI Studio API keys
+remain available through `GOOGLE_API_KEY` or `GEMINI_API_KEY`.
+
 Set `context_window` to the endpoint's documented token limit so `/compact`
 can bound its summary request and installed snapshot. Inference works without
 this metadata, but `/compact` refuses to guess a portable model's limit.
@@ -60,8 +66,8 @@ Supported dialects are:
 
 Custom connections are selected manually and are not considered for automatic
 billing fallback. Shipped connection names (`openai`, `xai`, `openrouter`,
-`meta`, and `claude-code`) are reserved. Invalid catalogs are reported at
-startup.
+`meta`, `gemini`, and `claude-code`) are reserved. Invalid catalogs are
+reported at startup.
 
 The built-in `add-model` skill handles requests such as “use the model running
 at this URL”, “add this OpenRouter model”, or “OpenAI released a new model”.

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,17 @@
                     ];
                 };
 
+                agentGeminiSource = nix-filter.lib {
+                    root = ./packages/agent-gemini;
+                    include = [
+                        "src"
+                        "test"
+                        "agent-gemini.cabal"
+                        "README.md"
+                        "LICENSE"
+                    ];
+                };
+
                 agentProcessSource = nix-filter.lib {
                     root = ./packages/agent-process;
                     include = [
@@ -433,6 +444,9 @@
                         agent-openrouter = localPackage (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-openrouter/package.nix { }) {
                             src = agentOpenrouterSource;
                         });
+                        agent-gemini = localPackage (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-gemini/package.nix { }) {
+                            src = agentGeminiSource;
+                        });
                         claude-agent-sdk-haskell = localPackage (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/claude-agent-sdk-haskell/package.nix { }) {
                             src = claudeAgentSdkHaskellSource;
                         });
@@ -490,6 +504,7 @@
                 agentOpenaiPackage = productionHaskellPackages.agent-openai;
                 agentXaiPackage = productionHaskellPackages.agent-xai;
                 agentOpenrouterPackage = productionHaskellPackages.agent-openrouter;
+                agentGeminiPackage = productionHaskellPackages.agent-gemini;
                 claudeAgentSdkHaskellPackage = productionHaskellPackages.claude-agent-sdk-haskell;
                 agentClaudePackage = productionHaskellPackages.agent-claude;
                 agentTuiPackage = productionHaskellPackages.agent-tui;
@@ -676,6 +691,7 @@
                 packages.agent-openai = agentOpenaiPackage;
                 packages.agent-xai = agentXaiPackage;
                 packages.agent-openrouter = agentOpenrouterPackage;
+                packages.agent-gemini = agentGeminiPackage;
                 packages.claude-agent-sdk-haskell = claudeAgentSdkHaskellPackage;
                 packages.agent-claude = agentClaudePackage;
                 packages.agent-openai-login = agentOpenaiExecutables;
@@ -711,6 +727,7 @@
                         packages.agent-openai
                         packages.agent-xai
                         packages.agent-openrouter
+                        packages.agent-gemini
                         packages.claude-agent-sdk-haskell
                         packages.agent-claude
                     ];
@@ -762,6 +779,7 @@
                     agent-openai = haskellPackages.agent-openai;
                     agent-xai = haskellPackages.agent-xai;
                     agent-openrouter = haskellPackages.agent-openrouter;
+                    agent-gemini = haskellPackages.agent-gemini;
                     claude-agent-sdk-haskell =
                         haskellPackages.claude-agent-sdk-haskell;
                     agent-claude = haskellPackages.agent-claude;

--- a/nix/modules/telegram.nix
+++ b/nix/modules/telegram.nix
@@ -138,6 +138,7 @@ let
             "openai"
             "xai"
             "openrouter"
+            "gemini"
             "claude-code"
           ];
           default = "openai";

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -47,6 +47,7 @@ library
                     , Agent.CLI.AgentViewport.Status
                     , Agent.CLI.Approval.Decision
                     , Agent.CLI.Auth.Grok
+                    , Agent.CLI.Auth.Gemini
                     , Agent.CLI.Auth.OpenAI
                     , Agent.CLI.Auth.Types
                     , Agent.CLI.Command.Types
@@ -263,6 +264,7 @@ library
                     , agent-tui >= 0.1 && < 0.2
                     , agent-openai >= 0.1 && < 0.2
                     , agent-openrouter >= 0.1 && < 0.2
+                    , agent-gemini >= 0.1 && < 0.2
                     , agent-claude >= 0.1 && < 0.2
                     , agent-responses >= 0.1 && < 0.2
                     , agent-responses-types >= 0.1 && < 0.2
@@ -498,6 +500,7 @@ test-suite agent-cli-test
                     , agent-tui
                     , agent-openai
                     , agent-openrouter
+                    , agent-gemini
                     , agent-claude
                     , agent-responses
                     , agent-responses-types

--- a/packages/agent-cli/config/models.default.json
+++ b/packages/agent-cli/config/models.default.json
@@ -9,6 +9,10 @@
       "api": "builtin",
       "provider": "xai"
     },
+    "gemini": {
+      "api": "builtin",
+      "provider": "gemini"
+    },
     "openrouter": {
       "api": "builtin",
       "provider": "openrouter"
@@ -52,6 +56,29 @@
       "label": "default",
       "default": true,
       "fallback_priority": 10
+    },
+    {
+      "id": "gemini-3.7-flash",
+      "connection": "gemini",
+      "dialect": "generic-responses",
+      "context_window": 1048576,
+      "label": "default · 1M context",
+      "default": true,
+      "fallback_priority": 15
+    },
+    {
+      "id": "gemini-3.1-pro-preview",
+      "connection": "gemini",
+      "dialect": "generic-responses",
+      "context_window": 1048576,
+      "label": "1M context"
+    },
+    {
+      "id": "gemini-3.5-flash-lite",
+      "connection": "gemini",
+      "dialect": "generic-responses",
+      "context_window": 1048576,
+      "label": "1M context"
     },
     {
       "id": "stealth/ox-alpha",

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,14 +1,15 @@
 { mkDerivation, aeson, agent-claude, agent-codex-dialect
-, agent-core, agent-grok-build-dialect, agent-json, agent-mcp
-, agent-openai, agent-openrouter, agent-process, agent-responses
-, agent-responses-types, agent-store, agent-syntax, agent-tui
-, agent-xai, ansi-terminal, async, base, base64-bytestring, brick
-, bytestring, colour, containers, crypton, deepseq, directory
-, entropy, filelock, filepath, haskeline, hasql-pool, hspec
-, http-client, http-client-tls, http-types, JuicyPixels, lib
-, memory, mtl, network, network-uri, optparse-applicative, process
-, QuickCheck, retry, safe-exceptions, scientific, stm, tagsoup
-, text, time, transformers, unix, vector, vty, vty-crossplatform
+, agent-core, agent-gemini, agent-grok-build-dialect, agent-json
+, agent-mcp, agent-openai, agent-openrouter, agent-process
+, agent-responses, agent-responses-types, agent-store, agent-syntax
+, agent-tui, agent-xai, ansi-terminal, async, base
+, base64-bytestring, brick, bytestring, colour, containers, crypton
+, deepseq, directory, entropy, filelock, filepath, haskeline
+, hasql-pool, hspec, http-client, http-client-tls, http-types
+, JuicyPixels, lib, memory, mtl, network, network-uri
+, optparse-applicative, process, QuickCheck, retry, safe-exceptions
+, scientific, stm, tagsoup, text, time, transformers, unix, vector
+, vty, vty-crossplatform
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -18,7 +19,7 @@ mkDerivation {
   isExecutable = true;
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
-    aeson agent-claude agent-codex-dialect agent-core
+    aeson agent-claude agent-codex-dialect agent-core agent-gemini
     agent-grok-build-dialect agent-json agent-mcp agent-openai
     agent-openrouter agent-process agent-responses
     agent-responses-types agent-store agent-syntax agent-tui agent-xai
@@ -35,7 +36,7 @@ mkDerivation {
     text time unix
   ];
   testHaskellDepends = [
-    aeson agent-claude agent-codex-dialect agent-core
+    aeson agent-claude agent-codex-dialect agent-core agent-gemini
     agent-grok-build-dialect agent-json agent-mcp agent-openai
     agent-openrouter agent-responses agent-responses-types agent-store
     agent-tui agent-xai ansi-terminal async base brick bytestring

--- a/packages/agent-cli/src/Agent/CLI/AccountPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountPicker.hs
@@ -95,6 +95,7 @@ loadAllAccountPickerOptions currentProvider = do
                 [ OpenAIProvider
                 , XAIProvider
                 , OpenRouterProvider
+                , GeminiProvider
                 , ClaudeCodeProvider
                 ]
   where
@@ -113,7 +114,8 @@ loadAllAccountPickerOptions currentProvider = do
         OpenAIProvider -> 0 :: Int
         XAIProvider -> 1
         OpenRouterProvider -> 2
-        ClaudeCodeProvider -> 3
+        GeminiProvider -> 3
+        ClaudeCodeProvider -> 4
 
 accountBillingMode :: Provider -> AccountBilling -> BillingMode
 accountBillingMode provider = case provider of
@@ -163,10 +165,14 @@ accountPickerMatches
 accountPickerMatches currentProvider currentSelectionId currentAccountId = \case
     AccountPickerAccount optionProvider _ selectionId accountId _ _ ->
         optionProvider == currentProvider
-            && ( selectionId == currentSelectionId
-                || accountId == currentAccountId
-               )
+            && selectionMatches selectionId accountId
     AccountPickerConnect _ -> False
+  where
+    selectionMatches selectionId accountId
+        | Text.null currentSelectionId =
+            accountId == currentAccountId
+        | otherwise =
+            selectionId == currentSelectionId
 
 -- | Restrict a Meta Console account request to the requested provider and,
 -- when present, an exact case-insensitive label or id.  In particular, a
@@ -204,9 +210,7 @@ accountPickerRow currentProvider currentSelectionId currentAccountId = \case
         accountPickerLabel
         accountPickerUsage ->
             ( (if optionProvider == currentProvider
-                    && ( selectionId == currentSelectionId
-                        || accountId == currentAccountId
-                       )
+                    && selectionMatches selectionId accountId
                     then "✓ "
                     else "")
                 <> providerSlug optionProvider
@@ -216,3 +220,9 @@ accountPickerRow currentProvider currentSelectionId currentAccountId = \case
             )
     AccountPickerConnect optionProvider ->
         ("＋ Connect " <> providerSlug optionProvider <> " account", "")
+  where
+    selectionMatches selectionId accountId
+        | Text.null currentSelectionId =
+            accountId == currentAccountId
+        | otherwise =
+            selectionId == currentSelectionId

--- a/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
@@ -58,6 +58,7 @@ providerSupportsUsageAccountSelection = \case
     OpenAIProvider -> True
     XAIProvider -> True
     OpenRouterProvider -> True
+    GeminiProvider -> False
     ClaudeCodeProvider -> False
 
 -- | Whether startup may replace the loaded credential with a usage-ranked

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -2,6 +2,8 @@
 module Agent.CLI.Auth
     ( LoadedAuth(..)
     , authErrorNeedsOnboarding
+    , geminiAuthErrorNeedsReconnect
+    , geminiStartupAuthNeedsReconnect
     , GrokAuthState(..)
     , credentialAccountLabel
     , applyGrokAuthTokens
@@ -13,6 +15,10 @@ module Agent.CLI.Auth
     , grokOAuthOptionsFromAuthJson
     , gatewayAuthSelectionId
     , isGatewayLoadedAuth
+    , geminiAuthStateFromJson
+    , geminiAuthStateToJson
+    , geminiNeedsRefresh
+    , classifyGeminiRefreshFailure
     , externalAuthSelectionId
     , externalGrokTokenProvider
     , hasOpenAiAuth
@@ -21,6 +27,7 @@ module Agent.CLI.Auth
     , loadOpenAiDictationAuth
     , managedAuthSelectionId
     , managedGrokTokenProvider
+    , managedGeminiTokenProvider
     , ExternalGrokLoaded(..)
     , ExternalGrokSource(..)
     , refreshGrokLoginPayload
@@ -43,6 +50,13 @@ import Agent.CLI.Auth.Grok
     , loadExternalGrokCredentials
     , managedGrokTokenProvider
     , refreshGrokLoginPayload
+    )
+import Agent.CLI.Auth.Gemini
+    ( geminiAuthStateFromJson
+    , geminiAuthStateToJson
+    , geminiNeedsRefresh
+    , classifyGeminiRefreshFailure
+    , managedGeminiTokenProvider
     )
 import Agent.CLI.Auth.OpenAI
     ( loadOpenAi
@@ -97,7 +111,10 @@ import Agent.Provider
     , tokenProvider
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
+import qualified Agent.Gemini.Auth as GeminiAuth
+import qualified Agent.Gemini.Credential as GeminiCredential
 import qualified Agent.XAI.Auth as XAIAuth
+import Control.Applicative ((<|>))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
     ( ExceptT
@@ -132,6 +149,7 @@ loadAuth requested =
             XAIProvider -> loadXai Nothing
             OpenAIProvider -> loadOpenAi
             OpenRouterProvider -> loadOpenRouter Nothing
+            GeminiProvider -> loadGemini Nothing
             ClaudeCodeProvider -> loadClaudeCode
 
 gatewayLoadedAuth :: GatewayCredential -> Either Text LoadedAuth
@@ -167,6 +185,7 @@ loadAuthForAccount provider selectionId =
     loadProvider = runExceptT case provider of
         XAIProvider -> loadXai (Just selectionId)
         OpenRouterProvider -> loadOpenRouter (Just selectionId)
+        GeminiProvider -> loadGemini (Just selectionId)
         OpenAIProvider ->
             throwE "OpenAI account selection is handled by the live account pool"
         ClaudeCodeProvider ->
@@ -206,13 +225,16 @@ detectProvider Nothing = do
     grok <- lift hasGrokAuth
     openai <- lift hasOpenAiAuth
     openrouter <- lift hasOpenRouterAuth
+    gemini <- lift hasGeminiAuth
     if openai
         then pure OpenAIProvider
         else if grok
             then pure XAIProvider
             else if openrouter
                 then pure OpenRouterProvider
-                else throwE noAuthHint
+                else if gemini
+                    then pure GeminiProvider
+                    else throwE noAuthHint
 
 loadXai :: Maybe Text -> ExceptT Text IO LoadedAuth
 loadXai requestedSelectionId = do
@@ -260,6 +282,7 @@ loadXai requestedSelectionId = do
                     Just (managedAuthSelectionId metadata.managedId)
                 , loadedOpenAiPool = Nothing
                 }
+
         Nothing -> do
             selected <- lift $
                 selectExternalGrok
@@ -379,6 +402,114 @@ loadOpenRouter requestedSelectionId = do
                 , loadedOpenAiPool = Nothing
                 }
 
+loadGeminiCredential
+    :: Maybe Text
+    -> IO (Maybe (Text, Credential, Text))
+loadGeminiCredential requestedSelectionId = do
+    managed <- loadManagedCredential GeminiProvider requestedSelectionId
+    case managed of
+        Just (metadata, secret)
+            | metadata.managedAuthKind == ManagedBearerToken ->
+                pure $ Just
+                    ( managedAuthSelectionId metadata.managedId
+                    , (GeminiCredential.credentialFromApiKey secret.secretPayload)
+                        { accountId = metadata.managedAccountId }
+                    , metadata.managedLabel
+                    )
+        Just _ -> pure Nothing
+        Nothing -> do
+            googleKey <- lookupNonEmpty "GOOGLE_API_KEY"
+            geminiKey <- lookupNonEmpty "GEMINI_API_KEY"
+            let external = fmap
+                    (\key ->
+                        ( externalAuthSelectionId
+                            GeminiProvider
+                            "environment"
+                        , (GeminiCredential.credentialFromApiKey key)
+                            { accountId = "gemini" }
+                        , ""
+                        ))
+                    (googleKey <|> geminiKey)
+            pure $ external >>= \candidate@(selectionId, credential, _) ->
+                if matchesSelection
+                    requestedSelectionId
+                    selectionId
+                    credential
+                    then Just candidate
+                    else Nothing
+
+loadGemini :: Maybe Text -> ExceptT Text IO LoadedAuth
+loadGemini requestedSelectionId = do
+    managed <- lift
+        (loadManagedCredential GeminiProvider requestedSelectionId)
+    case managed of
+        Just (metadata, secret)
+            | metadata.managedAuthKind == ManagedGeminiAuthJson -> do
+                state <- maybe
+                    (throwE
+                        "managed Gemini OAuth credential contains invalid auth JSON; reconnect the account")
+                    pure
+                    (geminiAuthStateFromJson secret.secretPayload)
+                case state.refreshToken of
+                    Nothing ->
+                        throwE
+                            "managed Gemini OAuth credential has no refresh token; reconnect the Google account"
+                    Just _ -> pure ()
+                options <- lift GeminiAuth.oauthOptionsFromEnv
+                provider <- lift $ managedGeminiTokenProvider
+                    metadata
+                    secret
+                    state
+                    (GeminiAuth.refreshAccessToken options)
+                pure LoadedAuth
+                    { loadedProvider = GeminiProvider
+                    , loadedTokenProvider = provider
+                    , loadedAccountLabel =
+                        pure
+                            . credentialAccountLabelWith
+                                metadata.managedLabel
+                    , loadedSelectionId =
+                        Just (managedAuthSelectionId metadata.managedId)
+                    , loadedOpenAiPool = Nothing
+                    }
+            | metadata.managedAuthKind /= ManagedBearerToken ->
+                throwE "managed Gemini credential has an unsupported auth kind"
+        _ -> loadGeminiApiKey requestedSelectionId
+
+loadGeminiApiKey :: Maybe Text -> ExceptT Text IO LoadedAuth
+loadGeminiApiKey requestedSelectionId = do
+    loadedCredential <- lift (loadGeminiCredential requestedSelectionId)
+    case loadedCredential of
+        Nothing ->
+            throwE $
+                maybe noAuthHint
+                    (const
+                        (accountNotFound
+                            GeminiProvider requestedSelectionId))
+                    requestedSelectionId
+        Just (selectionId, initial, initialLabel) -> do
+            provider <- lift $ reloadableFileCredentialProvider
+                GeminiProvider
+                ApiBilled
+                initial
+                (fmap (\(_, credential, _) -> credential)
+                    <$> loadGeminiCredential (Just selectionId))
+            pure LoadedAuth
+                { loadedProvider = GeminiProvider
+                , loadedTokenProvider = provider
+                , loadedAccountLabel = \credential -> do
+                    current <- loadGeminiCredential (Just selectionId)
+                    let label = case current of
+                            Just (_, currentCredential, currentLabel)
+                                | currentCredential.accountId
+                                    == credential.accountId ->
+                                        currentLabel
+                            _ -> initialLabel
+                    pure (credentialAccountLabelWith label credential)
+                , loadedSelectionId = Just selectionId
+                , loadedOpenAiPool = Nothing
+                }
+
 loadManagedCredential
     :: Provider
     -> Maybe Text
@@ -435,6 +566,13 @@ hasOpenRouterAuth = do
     environment <- isJust <$> lookupNonEmpty "OPENROUTER_API_KEY"
     managed <- hasManagedProvider OpenRouterProvider
     pure (environment || managed)
+
+hasGeminiAuth :: IO Bool
+hasGeminiAuth = do
+    google <- isJust <$> lookupNonEmpty "GOOGLE_API_KEY"
+    gemini <- isJust <$> lookupNonEmpty "GEMINI_API_KEY"
+    managed <- hasManagedProvider GeminiProvider
+    pure (google || gemini || managed)
 
 hasManagedProvider :: Provider -> IO Bool
 hasManagedProvider provider =
@@ -499,7 +637,7 @@ reloadableFileCredentialProvider expectedProvider billing initial reload = do
                                 <> providerSlug expectedProvider)
                     | rejectedToken == Just credential.accessToken ->
                         pure $ Left $ CredentialError
-                            "reloaded credential is unchanged; refresh ~/.grok/auth.json or OPENROUTER_API_KEY and retry"
+                            "reloaded credential is unchanged; refresh the configured credential source and retry"
                     | otherwise -> do
                         writeIORef cache (Just credential)
                         pure (Right credential)
@@ -532,10 +670,37 @@ staticCredentialProvider billing credential =
 noAuthHint :: Text
 noAuthHint =
     "no credentials found. Set GROK_ACCESS_TOKEN, CODEX_ACCESS_TOKEN, \
-    \or OPENROUTER_API_KEY, place auth at ~/.grok/auth.json / ~/.codex/auth.json, \
+    \OPENROUTER_API_KEY, GOOGLE_API_KEY, or GEMINI_API_KEY, \
+    \place auth at ~/.grok/auth.json / ~/.codex/auth.json, \
+    \connect a Google account from /model or /account, \
     \or use --provider claude-code after `claude auth login`."
 
 authErrorNeedsOnboarding :: Text -> Bool
 authErrorNeedsOnboarding message =
     "no credentials found." `Text.isPrefixOf` message
         || "no valid OpenAI credentials found:" `Text.isPrefixOf` message
+
+-- | Decide whether selecting a Gemini model should offer Google sign-in.
+-- Besides a first connection, this covers malformed or rejected managed OAuth
+-- state. Network and rate-limit failures remain ordinary switch errors rather
+-- than opening a fresh browser flow.
+geminiAuthErrorNeedsReconnect :: Text -> Bool
+geminiAuthErrorNeedsReconnect message =
+    authErrorNeedsOnboarding message
+        || any (`Text.isInfixOf` message)
+            [ "managed Gemini OAuth credential contains invalid auth JSON"
+            , "managed Gemini OAuth credential has no refresh token"
+            , "managed Gemini credential has an unsupported auth kind"
+            , "Google OAuth token request failed with HTTP 400"
+            , "Google OAuth token request failed with HTTP 401"
+            ]
+
+geminiStartupAuthNeedsReconnect :: Bool -> Text -> Bool
+geminiStartupAuthNeedsReconnect targetsGemini message =
+    (geminiAuthErrorNeedsReconnect message
+        && not (authErrorNeedsOnboarding message))
+        || (targetsGemini
+            && ( authErrorNeedsOnboarding message
+                || "no enabled gemini credential"
+                    `Text.isInfixOf` Text.toLower message
+               ))

--- a/packages/agent-cli/src/Agent/CLI/Auth/Gemini.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/Gemini.hs
@@ -1,0 +1,227 @@
+module Agent.CLI.Auth.Gemini
+    ( geminiAuthStateFromJson
+    , geminiAuthStateToJson
+    , geminiNeedsRefresh
+    , classifyGeminiRefreshFailure
+    , managedGeminiTokenProvider
+    ) where
+
+import Agent.CLI.CredentialStore
+    ( ManagedAuthKind(ManagedGeminiAuthJson)
+    , ManagedCredential(..)
+    , ManagedSecret(..)
+    , loadManagedCredentials
+    , upsertManagedCredentialAfterRefresh
+    , withCredentialRefreshFileLock
+    )
+import Agent.Error (ApiError(..))
+import qualified Agent.Gemini.Auth as Gemini
+import Agent.Provider
+    ( AccountFailure(..)
+    , Credential(..)
+    , FailedCredential(..)
+    , Provider(GeminiProvider)
+    , TokenProvider
+    , credentialsExhaustedForRateLimit
+    , tokenProvider
+    )
+import Control.Applicative ((<|>))
+import Control.Concurrent.MVar (newMVar, withMVar)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Text as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Maybe (listToMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.Lazy as LazyText
+import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
+
+geminiAuthStateFromJson :: Text -> Maybe Gemini.GeminiAuthState
+geminiAuthStateFromJson =
+    Aeson.decode . LBS.fromStrict . TextEncoding.encodeUtf8
+
+geminiAuthStateToJson :: Gemini.GeminiAuthState -> Text
+geminiAuthStateToJson =
+    LazyText.toStrict . Aeson.encodeToLazyText
+
+-- | Refresh before expiry so a long streaming request does not begin with a
+-- token that is about to become invalid.
+geminiNeedsRefresh :: UTCTime -> Gemini.GeminiAuthState -> Bool
+geminiNeedsRefresh now state =
+    maybe False (<= addUTCTime 600 now) state.expiresAt
+
+managedGeminiTokenProvider
+    :: ManagedCredential
+    -> ManagedSecret
+    -> Gemini.GeminiAuthState
+    -> (Text -> IO (Either Text Gemini.OAuthTokens))
+    -> IO TokenProvider
+managedGeminiTokenProvider metadata secret initial refresh = do
+    stateRef <- newIORef initial
+    refreshLock <- newMVar ()
+    pure $ tokenProvider metadata.managedBilling \failed ->
+        withMVar refreshLock \_ ->
+            managedGeminiCredential
+                metadata secret stateRef refresh failed
+
+managedGeminiCredential
+    :: ManagedCredential
+    -> ManagedSecret
+    -> IORef Gemini.GeminiAuthState
+    -> (Text -> IO (Either Text Gemini.OAuthTokens))
+    -> Maybe FailedCredential
+    -> IO (Either ApiError Credential)
+managedGeminiCredential metadata secret stateRef refresh failed = do
+    current <- readIORef stateRef
+    case failed of
+        Just reported -> credentialsExhaustedForRateLimit reported >>= \case
+            Just err -> pure (Left err)
+            Nothing -> case reported of
+                FailedCredential
+                    { credential = rejected
+                    , failure = AccountAuthenticationRejected
+                    }
+                    | rejected.accessToken /= current.accessToken ->
+                        pure (Right (credentialFromState current))
+                    | otherwise ->
+                        refreshManagedGemini
+                            metadata secret stateRef refresh current
+                _ -> pure $ Left $ CredentialError
+                    "unsupported credential failure"
+        Nothing -> do
+            now <- getCurrentTime
+            if geminiNeedsRefresh now current
+                then refreshManagedGemini
+                    metadata secret stateRef refresh current
+                else pure (Right (credentialFromState current))
+
+refreshManagedGemini
+    :: ManagedCredential
+    -> ManagedSecret
+    -> IORef Gemini.GeminiAuthState
+    -> (Text -> IO (Either Text Gemini.OAuthTokens))
+    -> Gemini.GeminiAuthState
+    -> IO (Either ApiError Credential)
+refreshManagedGemini metadata _secret stateRef refresh stale =
+    withCredentialRefreshFileLock $
+        loadManagedCredentialById metadata.managedId >>= \case
+            Left err -> pure (Left err)
+            Right (latestMetadata, latestSecret) ->
+                case geminiAuthStateFromJson latestSecret.secretPayload of
+                    Nothing ->
+                        pure $ Left $ CredentialError
+                            "managed Gemini OAuth credential contains invalid auth JSON; reconnect the account"
+                    Just current
+                        | geminiStateChanged stale current -> do
+                            writeIORef stateRef current
+                            pure (Right (credentialFromState current))
+                        | otherwise ->
+                            refreshCurrentGemini
+                                latestMetadata latestSecret stateRef
+                                refresh current
+
+geminiStateChanged
+    :: Gemini.GeminiAuthState
+    -> Gemini.GeminiAuthState
+    -> Bool
+geminiStateChanged stale current =
+    stale.accessToken /= current.accessToken
+        || stale.refreshToken /= current.refreshToken
+        || stale.projectId /= current.projectId
+
+refreshCurrentGemini
+    :: ManagedCredential
+    -> ManagedSecret
+    -> IORef Gemini.GeminiAuthState
+    -> (Text -> IO (Either Text Gemini.OAuthTokens))
+    -> Gemini.GeminiAuthState
+    -> IO (Either ApiError Credential)
+refreshCurrentGemini metadata secret stateRef refresh state =
+    case state.refreshToken of
+        Nothing ->
+            pure $ Left $ CredentialError
+                "managed Gemini OAuth credential has no refresh token; reconnect the Google account"
+        Just refreshToken ->
+            refresh refreshToken >>= \case
+                Left err -> pure (Left (classifyGeminiRefreshFailure err))
+                Right tokens -> do
+                    now <- getCurrentTime
+                    let newState = Gemini.GeminiAuthState
+                            tokens.accessToken
+                            (tokens.refreshToken <|> state.refreshToken)
+                            ( ((`addUTCTime` now)
+                                . fromIntegral
+                                <$> tokens.expiresInSeconds)
+                                <|> state.expiresAt
+                            )
+                            state.email
+                            state.projectId
+                            state.userTier
+                        newMetadata = metadata
+                            { managedAccountId = newState.email
+                            , managedLabel = newState.email
+                            }
+                        newSecret = secret
+                            { secretPayload =
+                                geminiAuthStateToJson newState
+                            }
+                    upsertManagedCredentialAfterRefresh
+                        newMetadata newSecret >>= \case
+                            Left err ->
+                                pure (Left (ConnectionError err))
+                            Right () -> do
+                                writeIORef stateRef newState
+                                pure
+                                    (Right
+                                        (credentialFromState newState))
+
+-- The low-level OAuth helper deliberately omits token-endpoint bodies so
+-- refresh tokens cannot be echoed through errors. Its status-only failure
+-- text still lets us distinguish invalid grants from transient transport or
+-- provider failures for user-facing recovery.
+classifyGeminiRefreshFailure :: Text -> ApiError
+classifyGeminiRefreshFailure message
+    | any (`Text.isInfixOf` message)
+        [ "Google OAuth token request failed with HTTP 400"
+        , "Google OAuth token request failed with HTTP 401"
+        ] =
+            CredentialError message
+    | otherwise = ConnectionError message
+
+credentialFromState :: Gemini.GeminiAuthState -> Credential
+credentialFromState state = Credential
+    { accessToken = state.accessToken
+    , accountId = state.email
+    , leaseId = Just ("code-assist:" <> state.projectId)
+    , provider = GeminiProvider
+    }
+
+loadManagedCredentialById
+    :: Text
+    -> IO (Either ApiError (ManagedCredential, ManagedSecret))
+loadManagedCredentialById credentialId =
+    loadManagedCredentials >>= \case
+        Left err -> pure (Left (ConnectionError err))
+        Right credentials ->
+            pure $ case listToMaybe
+                (filter
+                    ((== credentialId) . (.managedId) . fst)
+                    credentials) of
+                Nothing ->
+                    Left $ CredentialError
+                        ("managed credential disappeared during refresh: "
+                            <> credentialId)
+                Just (metadata, _)
+                    | not metadata.managedEnabled ->
+                        Left $ CredentialError
+                            ("managed Gemini credential is disabled: "
+                                <> credentialId)
+                    | metadata.managedProvider /= GeminiProvider
+                        || metadata.managedAuthKind
+                            /= ManagedGeminiAuthJson ->
+                        Left $ CredentialError
+                            ("managed Gemini credential changed auth type: "
+                                <> credentialId)
+                Just credential -> Right credential

--- a/packages/agent-cli/src/Agent/CLI/Auth/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/Types.hs
@@ -89,6 +89,8 @@ credentialAccountLabel credential = case credential.provider of
             XAIAuth.emailFromToken credential.accessToken
     OpenRouterProvider ->
         fallback "OpenRouter"
+    GeminiProvider ->
+        fallback "Google Gemini"
     ClaudeCodeProvider ->
         fallback "Claude"
   where
@@ -108,6 +110,7 @@ credentialEmail credential = case credential.provider of
     OpenAIProvider -> OpenAI.deriveEmail credential.accessToken
     XAIProvider -> XAIAuth.emailFromToken credential.accessToken
     OpenRouterProvider -> Nothing
+    GeminiProvider -> Nothing
     ClaudeCodeProvider -> Nothing
 
 nonEmptyText :: Text -> Maybe Text

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -38,6 +38,8 @@ import Agent.CLI.Session.History
     , writeLiveTranscript
     )
 import Agent.Error (ApiError(..), ErrorType(..))
+import qualified Agent.Gemini.Client as Gemini
+import qualified Agent.Gemini.Options as Gemini
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
@@ -188,6 +190,21 @@ runProviderCompactWithContextWindow contextWindow openAiSender recordUsage
                         (\request ->
                             runWithTokenProvider tokens \credential ->
                                 OpenRouter.createResponseWith
+                                    options credential request)
+                        params
+                        history
+                        focus
+        GeminiProvider ->
+            case tokenProvider of
+                Nothing ->
+                    pure (compactTextFailure
+                        "gemini compact requires a token provider")
+                Just tokens -> do
+                    options <- Gemini.clientOptionsFromEnv
+                    summarizeTextAttempt
+                        (\request ->
+                            runWithTokenProvider tokens \credential ->
+                                Gemini.createResponseWith
                                     options credential request)
                         params
                         history
@@ -629,7 +646,7 @@ isPortableLocalSummaryItem :: ResponseItem -> Bool
 isPortableLocalSummaryItem = \case
     -- OpenAI checkpoints are opaque provider protocol items. Preserve them
     -- for focused OpenAI summaries, but never replay them through
-    -- xAI/OpenRouter or user-configured Responses endpoints.
+    -- xAI/OpenRouter/Gemini or user-configured Responses endpoints.
     CompactionItemValue{} -> False
     ContextCompactionItemValue{} -> False
     CompactionTriggerItemValue{} -> False

--- a/packages/agent-cli/src/Agent/CLI/Compaction/Projection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction/Projection.hs
@@ -103,6 +103,7 @@ providerLabel = \case
     OpenAIProvider -> "openai"
     XAIProvider -> "xai"
     OpenRouterProvider -> "openrouter"
+    GeminiProvider -> "gemini"
     ClaudeCodeProvider -> "claude-code"
 
 requestTooLargeError :: Text -> ApiError

--- a/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
+++ b/packages/agent-cli/src/Agent/CLI/CredentialStore.hs
@@ -50,6 +50,7 @@ data ManagedAuthKind
     = ManagedBearerToken
     | ManagedOpenAIAuthJson
     | ManagedGrokAuthJson
+    | ManagedGeminiAuthJson
     deriving (Eq, Show)
 
 data ManagedCredential = ManagedCredential
@@ -90,12 +91,14 @@ instance Aeson.ToJSON ManagedAuthKind where
         ManagedBearerToken -> "bearer"
         ManagedOpenAIAuthJson -> "openai_oauth"
         ManagedGrokAuthJson -> "grok_oauth"
+        ManagedGeminiAuthJson -> "gemini_oauth"
 
 managedAuthKindDecoder :: Hermes.Decoder ManagedAuthKind
 managedAuthKindDecoder = Hermes.withText \case
         "bearer" -> pure ManagedBearerToken
         "openai_oauth" -> pure ManagedOpenAIAuthJson
         "grok_oauth" -> pure ManagedGrokAuthJson
+        "gemini_oauth" -> pure ManagedGeminiAuthJson
         other -> fail ("unknown managed auth kind: " <> Text.unpack other)
 
 instance Aeson.ToJSON ManagedCredential where
@@ -269,7 +272,7 @@ upsertManagedCredential
 upsertManagedCredential credential secret =
     case managedCredentialEntry credential secret of
         Left err -> pure (Left err)
-        Right entry -> mutateStore (upsertStoreEntry entry)
+        Right entry -> mutateStoreSecretFirst (upsertStoreEntry entry)
 
 -- | Persist a rotated OAuth secret before derived metadata. If the process
 -- exits between writes, the new one-time refresh token is already durable.
@@ -280,23 +283,47 @@ upsertManagedCredentialAfterRefresh
 upsertManagedCredentialAfterRefresh credential secret =
     case managedCredentialEntry credential secret of
         Left err -> pure (Left err)
-        Right entry -> do
+        Right refreshedEntry -> do
             home <- getHomeDirectory
             withCredentialStoreLock home do
                 loaded <- loadManagedCredentialStoreUnlocked home
                 case loaded of
                     Left err -> pure (Left err)
-                    Right store -> do
-                        let store' = upsertStoreEntry entry store
-                        writePrivateJson
-                            (managedSecretsPath home)
-                            (secretsFile store')
-                            >>= \case
-                                Left err -> pure (Left err)
-                                Right () ->
+                    Right store ->
+                        case find
+                            ((== credential.managedId) . (.entryManagedId))
+                            store.storeEntries of
+                            Nothing ->
+                                pure $ Left
+                                    ("managed credential "
+                                        <> credential.managedId
+                                        <> " no longer exists during refresh")
+                            Just current
+                                | not current.entryCredential.managedEnabled ->
+                                    pure $ Left
+                                        ("managed credential "
+                                            <> credential.managedId
+                                            <> " is disabled")
+                                | current.entryCredential.managedProvider
+                                    /= credential.managedProvider
+                                    || current.entryCredential.managedAuthKind
+                                        /= credential.managedAuthKind ->
+                                    pure $ Left
+                                        ("managed credential "
+                                            <> credential.managedId
+                                            <> " changed auth type during refresh")
+                                | otherwise -> do
+                                    let store' =
+                                            upsertStoreEntry refreshedEntry store
                                     writePrivateJson
-                                        (managedCredentialsPath home)
-                                        (metadataFile store')
+                                        (managedSecretsPath home)
+                                        (secretsFile store')
+                                        >>= \case
+                                            Left err -> pure (Left err)
+                                            Right () ->
+                                                writePrivateJson
+                                                    (managedCredentialsPath home)
+                                                    (metadataFile store')
 
 setManagedCredentialEnabled :: Text -> Bool -> IO (Either Text ())
 setManagedCredentialEnabled credentialId enabled =
@@ -331,6 +358,31 @@ updateManagedCredentialSecret credentialId payload = do
             { entrySecret =
                 entry.entrySecret { secretPayload = payload }
             }
+
+-- New credentials must persist their secret before metadata can reference it.
+-- An interrupted first write may leave an ignored orphan secret; the reverse
+-- order can leave metadata without a secret and make the whole store unloadable.
+-- Deletes keep using 'mutateStore', where metadata-first avoids that failure.
+mutateStoreSecretFirst
+    :: (ManagedCredentialStore -> ManagedCredentialStore)
+    -> IO (Either Text ())
+mutateStoreSecretFirst update = do
+    home <- getHomeDirectory
+    withCredentialStoreLock home do
+        loaded <- loadManagedCredentialStoreUnlocked home
+        case loaded of
+            Left err -> pure (Left err)
+            Right store -> do
+                let store' = update store
+                writePrivateJson
+                    (managedSecretsPath home)
+                    (secretsFile store')
+                    >>= \case
+                        Left err -> pure (Left err)
+                        Right () ->
+                            writePrivateJson
+                                (managedCredentialsPath home)
+                                (metadataFile store')
 
 deleteManagedCredential :: Text -> IO (Either Text ())
 deleteManagedCredential credentialId =

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -21,6 +21,7 @@ module Agent.CLI.Login
     , initialLoginState
     , loginAccountActionRows
     , loginAccountDetail
+    , launchBrowserCommand
     , loginAccountSelectionId
     , loginDashboardRows
     , refreshLoginAccount
@@ -39,6 +40,10 @@ import Agent.CLI.Auth
     , openAIOAuthClientId
     , openaiAuthStateFromJson
     , xaiOAuthClientId
+    )
+import Agent.CLI.Auth.Gemini
+    ( geminiAuthStateFromJson
+    , geminiAuthStateToJson
     )
 import Agent.CLI.Auth.Grok (refreshGrokLoginPayload)
 import Agent.CLI.Login.Types
@@ -95,6 +100,7 @@ import qualified Agent.OpenAI.Login as OpenAILogin
 import Agent.OsPath (toText, unsafeToFilePath)
 import qualified Agent.OpenAI.Usage as OpenAI
 import qualified Agent.OpenRouter.Usage as OpenRouter
+import qualified Agent.Gemini.Auth as GeminiAuth
 import Agent.Provider
     ( BillingMode(..)
     , Credential(..)
@@ -115,7 +121,7 @@ import Control.Concurrent.Async
     )
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Exception.Safe (bracket, bracket_, tryAny)
-import Control.Monad (join, void)
+import Control.Monad (join, unless, void)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isControl)
@@ -142,6 +148,12 @@ import System.IO
     , hSetEcho
     , stderr
     , stdin
+    )
+import System.Process
+    ( CreateProcess(..)
+    , StdStream(NoStream)
+    , createProcess
+    , proc
     )
 
 runLoginManager :: Bool -> IO ()
@@ -348,7 +360,9 @@ loginDashboardEntries
     -> [(LoginDashboardAction, (Text, Text))]
 loginDashboardEntries accounts =
     [ ( LoginDashboardConnect
-      , ("＋ Connect account", "OpenAI, xAI / Grok, OpenRouter, or Claude Code")
+      , ( "＋ Connect account"
+        , "OpenAI, xAI / Grok, OpenRouter, Google Gemini, or Claude Code"
+        )
       )
     ]
         <> refreshEntry
@@ -658,7 +672,12 @@ discoverLoginAccounts = do
     pure (nubOrdOn loginAccountKey accounts)
   where
     loginAccountKey account =
-        (account.loginProvider, account.loginAccountId)
+        ( account.loginProvider
+        , case (account.loginProvider, account.loginManagedId) of
+            (GeminiProvider, Just managedId) ->
+                managedAuthSelectionId managedId
+            _ -> account.loginAccountId
+        )
 
 -- | Accounts that can be selected in a live session. Unlike the login
 -- dashboard, disabled managed entries do not shadow usable external sources,
@@ -688,6 +707,7 @@ discoverLoginAccountSources = do
     grokFile <- discoverGrokFile
         (home </> unsafeEncodeUtf ".grok" </> unsafeEncodeUtf "auth.json")
     openRouter <- discoverOpenRouter
+    gemini <- discoverGemini
     managed <- loadManagedCredentials
     let managedAccounts = case managed of
             Left _ -> []
@@ -700,6 +720,7 @@ discoverLoginAccountSources = do
                 , grokEnv
                 , grokFile
                 , openRouter
+                , gemini
                 ]
 
 managedLoginAccount
@@ -731,7 +752,12 @@ managedLoginAccount now (metadata, secret) =
             ManagedBearerToken ->
                 XAIAuth.emailFromToken secret.secretPayload
             ManagedOpenAIAuthJson -> Nothing
+            ManagedGeminiAuthJson -> Nothing
         OpenRouterProvider -> Nothing
+        GeminiProvider -> case metadata.managedAuthKind of
+            ManagedGeminiAuthJson ->
+                (.email) <$> geminiAuth
+            _ -> Nothing
         ClaudeCodeProvider -> Nothing
     openAIAuth = case metadata.managedAuthKind of
         ManagedOpenAIAuthJson ->
@@ -743,6 +769,10 @@ managedLoginAccount now (metadata, secret) =
         ManagedOpenAIAuthJson -> (.accessToken) <$> openAIAuth
         ManagedGrokAuthJson ->
             grokCredentialFromAuthJson secret.secretPayload
+        ManagedGeminiAuthJson ->
+            (.accessToken) <$> geminiAuth
+    geminiAuth =
+        geminiAuthStateFromJson secret.secretPayload
 
 toggleAt :: Bool -> Int -> [LoginAccount] -> IO ()
 toggleAt color index accounts =
@@ -843,13 +873,14 @@ connectAccount color =
                 (fmap (\accountId -> (provider, accountId)))
                 (connectProviderAccount color provider)
 
--- | Connect one account for the requested provider and return its provider
--- account id after it has been stored successfully.
+-- | Connect one account for the requested provider and return an identifier
+-- that selects the newly stored credential.
 connectProviderAccount :: Bool -> Provider -> IO (Maybe Text)
 connectProviderAccount color = \case
     OpenAIProvider -> connectOpenAI color
     XAIProvider -> connectXAI color
     OpenRouterProvider -> connectOpenRouter color
+    GeminiProvider -> connectGemini color
     ClaudeCodeProvider -> do
         printLoginMessage color False
             "Claude Code subscriptions are managed by `claude auth login`"
@@ -863,6 +894,7 @@ pickConnectProvider color =
         [ OpenAIProvider
         , XAIProvider
         , OpenRouterProvider
+        , GeminiProvider
         , ClaudeCodeProvider
         ]
     render index =
@@ -911,6 +943,9 @@ connectFullscreenAccount runtime = do
         , ( OpenRouterProvider
           , ("OpenRouter", "Add a masked API key and inspect credits")
           )
+        , ( GeminiProvider
+          , ("Google Gemini", "Connect a Google account with OAuth")
+          )
         , ( ClaudeCodeProvider
           , ("Claude Code", "Managed by the Claude Code CLI")
           )
@@ -924,6 +959,7 @@ connectFullscreenProvider runtime = \case
     OpenAIProvider -> connectOpenAIFullscreen runtime
     XAIProvider -> connectXAIFullscreen runtime
     OpenRouterProvider -> connectOpenRouterFullscreen runtime
+    GeminiProvider -> connectGeminiFullscreen runtime
     ClaudeCodeProvider ->
         pure $
             Just $
@@ -1211,6 +1247,60 @@ connectOpenRouterFullscreen runtime =
               where
                 apiKey = Text.strip rawKey
 
+connectGeminiFullscreen
+    :: FullscreenRuntime
+    -> IO (Maybe (Either Text Text))
+connectGeminiFullscreen runtime = do
+    oauthOptions <- GeminiAuth.oauthOptionsFromEnv
+    codeAssistOptions <- GeminiAuth.codeAssistOptionsFromEnv
+    authenticated <-
+        withLoginProgress runtime "Waiting for Google sign-in…" $
+            GeminiAuth.authenticateGoogleAccount
+                oauthOptions
+                codeAssistOptions
+                (presentGoogleLoginFullscreen runtime)
+    case authenticated of
+        Left err ->
+            pure (Just (Left ("Google sign-in failed: " <> err)))
+        Right auth
+            | Nothing <- auth.refreshToken ->
+                pure $
+                    Just $
+                        Left
+                            "Google sign-in did not return a refresh token; disconnect access for Gemini CLI in your Google account and try again"
+            | otherwise ->
+                Just <$> storeConnectedCredentialResult
+                    GeminiProvider
+                    auth.email
+                    auth.email
+                    SubscriptionBilled
+                    ManagedGeminiAuthJson
+                    (geminiAuthStateToJson auth)
+
+presentGoogleLoginFullscreen :: FullscreenRuntime -> Text -> IO ()
+presentGoogleLoginFullscreen runtime url = do
+    opened <- openBrowser url
+    choice <-
+        requestFullscreenChoiceWithBody
+            runtime
+            "Connect Google / Gemini"
+            ( Text.intercalate "\n\n" $
+                [ "[Open the Google page](" <> url <> ")."
+                , if opened
+                    then
+                        "A browser window was opened automatically. Complete the Google step, then return here."
+                    else
+                        "The browser could not be opened automatically. Use the link above, then return here."
+                ]
+            )
+            0
+            [ ("Continue", "Finish this Google step and continue")
+            , ("Cancel", "Stop without storing a credential")
+            ]
+    case choice of
+        Just 0 -> pure ()
+        _ -> fail "Google sign-in was cancelled"
+
 deviceAuthorizationBody
     :: Text
     -> Text
@@ -1369,6 +1459,79 @@ connectOpenRouter color =
                                     then Just accountId
                                     else Nothing
 
+connectGemini :: Bool -> IO (Maybe Text)
+connectGemini color = do
+    oauthOptions <- GeminiAuth.oauthOptionsFromEnv
+    codeAssistOptions <- GeminiAuth.codeAssistOptionsFromEnv
+    printLoginMessage color True
+        "Opening Google sign-in for Gemini…"
+    GeminiAuth.authenticateGoogleAccount
+        oauthOptions
+        codeAssistOptions
+        (presentGoogleLogin color) >>= \case
+            Left err -> do
+                printLoginMessage color False
+                    ("Google sign-in failed: " <> err)
+                pure Nothing
+            Right auth
+                | Nothing <- auth.refreshToken -> do
+                    printLoginMessage color False
+                        "Google sign-in did not return a refresh token; disconnect access for Gemini CLI in your Google account and try again"
+                    pure Nothing
+                | otherwise ->
+                    storeConnectedCredential color
+                        GeminiProvider
+                        auth.email
+                        auth.email
+                        SubscriptionBilled
+                        ManagedGeminiAuthJson
+                        (geminiAuthStateToJson auth)
+                        >>= \stored -> pure (if stored then Just auth.email else Nothing)
+
+presentGoogleLogin :: Bool -> Text -> IO ()
+presentGoogleLogin color url = do
+    Text.hPutStrLn stderr $
+        roleMuted color "Open "
+            <> rolePrompt color url
+    opened <- openBrowser url
+    unless opened $
+        Text.hPutStrLn stderr $
+            roleMuted color
+                "Could not launch a browser automatically; open the URL above."
+    Text.hPutStrLn stderr $
+        roleMuted color "Waiting for Google…"
+    hFlush stderr
+
+openBrowser :: Text -> IO Bool
+openBrowser url = do
+    configured <- lookupNonEmpty "BROWSER"
+    case configured of
+        Just browser ->
+            launchBrowserCommand browser url
+        Nothing -> do
+            opened <- launchBrowserCommand "open" url
+            if opened
+                then pure True
+                else launchBrowserCommand "xdg-open" url
+
+-- | Start the browser without waiting for its process to exit. Some browsers
+-- stay in the foreground for the lifetime of the window; waiting here would
+-- prevent the OAuth listener from ever accepting their callback.
+launchBrowserCommand :: Text -> Text -> IO Bool
+launchBrowserCommand command url =
+    tryAny
+        (createProcess
+            (proc (Text.unpack command) [Text.unpack url])
+                { std_in = NoStream
+                , std_out = NoStream
+                , std_err = NoStream
+                , close_fds = True
+                , create_group = True
+                , new_session = True
+                }) >>= \case
+        Right _ -> pure True
+        Left _ -> pure False
+
 storeConnectedCredential
     :: Bool
     -> Provider
@@ -1521,6 +1684,26 @@ discoverOpenRouter = do
             , loginProvider = OpenRouterProvider
             , loginAccountId = "openrouter"
             , loginLabel = "OpenRouter"
+            , loginBilling = ApiCreditsBilling
+            , loginSource = "environment"
+            , loginUsage = UsageNotChecked
+            , loginAccessToken = accessToken
+            , loginAuthKind = ManagedBearerToken
+            , loginSecretPayload = accessToken
+            , loginEnabled = True
+            }
+
+discoverGemini :: IO (Maybe LoginAccount)
+discoverGemini = do
+    googleKey <- lookupNonEmpty "GOOGLE_API_KEY"
+    geminiKey <- lookupNonEmpty "GEMINI_API_KEY"
+    pure $ do
+        accessToken <- googleKey <|> geminiKey
+        pure LoginAccount
+            { loginManagedId = Nothing
+            , loginProvider = GeminiProvider
+            , loginAccountId = "gemini"
+            , loginLabel = "Google Gemini"
             , loginBilling = ApiCreditsBilling
             , loginSource = "environment"
             , loginUsage = UsageNotChecked
@@ -1699,6 +1882,16 @@ refreshLoginAccount account
                                             <|> snapshot.keyUsage)
                                 }
                         }
+        GeminiProvider ->
+            pure account
+                { loginUsage =
+                    UsageUnavailable
+                        (case account.loginAuthKind of
+                            ManagedGeminiAuthJson ->
+                                "Gemini Code Assist usage is unavailable."
+                            _ ->
+                                "Google AI Studio does not expose account usage for API keys.")
+                }
         ClaudeCodeProvider ->
             pure account
                 { loginUsage =

--- a/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelConfig.hs
@@ -570,7 +570,7 @@ ensureUniqueModelIds source models =
 
 allBuiltinProviders :: [Provider]
 allBuiltinProviders =
-    [OpenAIProvider, XAIProvider, OpenRouterProvider]
+    [OpenAIProvider, XAIProvider, OpenRouterProvider, GeminiProvider]
 
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText value

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -181,6 +181,7 @@ defaultEffortFor = \case
     XAIProvider -> EffortHigh
     OpenAIProvider -> EffortMedium
     OpenRouterProvider -> EffortMedium
+    GeminiProvider -> EffortMedium
     ClaudeCodeProvider -> EffortXHigh
 
 isOneShot :: CliOptions -> Bool
@@ -359,7 +360,7 @@ runOptionsParser =
 optionUpdateParser :: Options.Parser OptionUpdate
 optionUpdateParser = asum
     [ optionUpdate "provider" "NAME"
-        "Provider: openai, xai, openrouter, or claude-code"
+        "Provider: openai, xai, openrouter, gemini, or claude-code"
         providerReader (\value options -> options { optProvider = Just value })
     , optionUpdate "model" "NAME" "Override the saved last model"
         textReader (\value options -> options { optModel = Just value })
@@ -496,7 +497,7 @@ providerReader = Options.eitherReader \value ->
         Just provider -> Right provider
         Nothing -> Left
             ("unknown provider: " <> value
-                <> " (use openai, xai, openrouter, or claude-code)")
+                <> " (use openai, xai, openrouter, gemini, or claude-code)")
 
 positiveIntReader :: String -> Options.ReadM Int
 positiveIntReader flag =
@@ -583,7 +584,7 @@ usage = unlines
     , ""
     , "  -p, --prompt TEXT       Run one prompt and exit"
     , "      --prompt-file FILE  Read the one-shot prompt from a file"
-    , "      --provider NAME     openai, xai, openrouter, or claude-code"
+    , "      --provider NAME     openai, xai, openrouter, gemini, or claude-code"
     , "                          (default: detect from API/OAuth auth)"
     , "      --model NAME        Override the saved last model"
     , "      --cwd DIR           Working directory for tools (default: current)"
@@ -632,7 +633,7 @@ usage = unlines
     , "Ctrl+O is the fallback when the terminal cannot distinguish Ctrl+Enter."
     , "With an empty composer, send-now promotes the oldest queued prompt."
     , "/compact [FOCUS] summarizes history (OpenAI remote compact;"
-    , "xAI/OpenRouter local summary) to free context."
+    , "xAI/OpenRouter/Gemini local summary) to free context."
     , "/plan [description] enters plan mode (read-only except plan.md);"
     , "when a plan is presented, approve (a), request changes (s), or cancel (q)."
     , "/btw <QUESTION> asks a one-shot side question without changing or"
@@ -655,7 +656,7 @@ usage = unlines
     , "drops them. Linux uses wl-paste/xclip."
     , "with an optional caption. /session prints the current session id."
     , "/clear resets the live conversation; /new starts a fresh session id."
-    , "/reload-auth forces a re-read of xAI/OpenRouter credentials;"
+    , "/reload-auth forces a re-read of xAI/OpenRouter/Gemini credentials;"
     , "auth failures also reload once and retry automatically."
     , "Ctrl-D or :q exits. Graceful exits print a --resume command when a"
     , "session has been persisted."

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -684,7 +684,7 @@ validateProviderTarget :: ModelOption -> IO (Either Text ())
 validateProviderTarget choice =
     if choice.modelTarget.targetConnectionId
         `notElem` map builtinConnectionId
-            [OpenAIProvider, XAIProvider, OpenRouterProvider]
+            [OpenAIProvider, XAIProvider, OpenRouterProvider, GeminiProvider]
     then pure (Right ())
     else fmap (() <$) $
         loadValidatedProviderTarget probeLoadedAvailability choice

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -95,7 +95,7 @@ rankedModels = sortOn modelRank . filter hasPriority . modelCatalog
         option.modelFallbackPriority /= Nothing
             -- Custom connections are deliberately manual-only.
             && option.modelTarget.targetConnectionId
-                `elem` ["openai", "xai", "openrouter"]
+                `elem` ["openai", "xai", "openrouter", "gemini"]
     modelRank = maybe maxBound id . (.modelFallbackPriority)
 
 -- | Return the best model for every provider that may still have a usable

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -147,7 +147,7 @@ import Agent.OpenRouter.LoopBackend ()
 import Agent.OsPath ()
 import Agent.Provider
     ( Provider(OpenAIProvider, XAIProvider, OpenRouterProvider,
-               ClaudeCodeProvider),
+               GeminiProvider, ClaudeCodeProvider),
       TokenProvider,
       Credential(..),
       getNextToken,
@@ -561,6 +561,7 @@ runAgentInitializedWithLock
                         let fallback = case loaded.loadedProvider of
                                 XAIProvider -> "Grok"
                                 OpenRouterProvider -> "OpenRouter"
+                                GeminiProvider -> "Google Gemini"
                                 ClaudeCodeProvider -> "Claude Code"
                             selectionId = fromMaybe "" loaded.loadedSelectionId
                         writeIORef activeAccountRef fallback

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -127,6 +127,8 @@ import Agent.GrokBuild.Dialect.Goal ()
 import Agent.GrokBuild.Dialect.Runtime ()
 import Agent.GrokBuild.Dialect.Task ()
 import Agent.GrokBuild.Dialect.Workflow ()
+import Agent.Gemini.LoopBackend
+    ( tokenProviderStatelessGeminiBackend )
 import Agent.Loop ( Backend(submitTurn, Backend) )
 import Agent.OpenAI.Compaction ()
 import Agent.OpenAI.Usage ()
@@ -142,7 +144,7 @@ import Agent.OpenRouter.LoopBackend ( openRouterBackend )
 import Agent.OsPath ( unsafeToFilePath )
 import Agent.Provider
     ( Provider(OpenRouterProvider, OpenAIProvider, XAIProvider,
-               ClaudeCodeProvider),
+               GeminiProvider, ClaudeCodeProvider),
       Credential(accountId, Credential, accessToken, leaseId, provider),
       runWithTokenProvider,
       tokenProviderBillingMode )
@@ -211,6 +213,10 @@ import qualified Agent.XAI.Client as XAIClient
     ( createResponseWith )
 import qualified Agent.XAI.Request as XAIRequest ( mapModel )
 import qualified Agent.XAI.Usage as XAIUsage ()
+import qualified Agent.Gemini.Client as GeminiClient
+    ( createResponseWith, createResponseWithEvents )
+import qualified Agent.Gemini.Options as Gemini
+    ( clientOptionsFromEnv )
 
 runAgentProviders
     modelSwitchScope
@@ -641,6 +647,85 @@ runAgentProviders
                                     then Nothing
                                     else Just selectHttpAccount)
                                 (Just . xaiContextWindow
+                                    <$> readIORef paramsRef)
+                                compactRunner)
+                            SessionBackend
+                                { backend = activeBackend
+                                , btwBackend
+                                , resetBackendState = pure ()
+                                }
+                    GeminiProvider -> do
+                        geminiOptions <- Gemini.clientOptionsFromEnv
+                        geminiOccupancy <- newIORef Nothing
+                        let geminiContextWindow =
+                                contextWindowForParams id 1_048_576
+                            makeBackend getParams =
+                                tokenProviderStatelessGeminiBackend
+                                    tokenProvider
+                                    (GeminiClient.createResponseWithEvents
+                                        geminiOptions)
+                                    getParams
+                            protectGeminiOverflow occupancy getParams backend =
+                                boundCompletedToolContinuations
+                                    geminiContextWindow
+                                    getParams
+                                    occupancy
+                                    backend
+                        case multiCtx of
+                            Just ctx ->
+                                setSubagentRunner ctx.multiRegistry $
+                                    runHttpSubagent
+                                        subagentRuntime
+                                        dialect
+                                        GeminiProvider
+                                        ctx.multiSendToRoot
+                                        (\childParams ->
+                                            protectGeminiOverflow
+                                                geminiOccupancy
+                                                (pure childParams)
+                                                (makeBackend
+                                                    (pure childParams)))
+                            Nothing -> pure ()
+                        let backend =
+                                withPendingInputs pendingNotices $
+                                    withConnectionRecovery $
+                                        protectGeminiOverflow
+                                            geminiOccupancy
+                                            (readIORef paramsRef)
+                                            (makeBackend
+                                                (readIORef paramsRef))
+                            btwBackend privateParams =
+                                makeBackend (pure privateParams)
+                            compactRunner focus = do
+                                contextWindow <-
+                                    currentModelContextWindow id
+                                historyRef <-
+                                    newIORef =<< readLiveTranscript conversationRef
+                                installLiveCompactOutcome conversationRef Nothing
+                                    (runResponsesCompactWithContextWindow
+                                        contextWindow
+                                        (\request ->
+                                            runWithTokenProvider tokenProvider
+                                                \credential ->
+                                                    GeminiClient.createResponseWith
+                                                        geminiOptions
+                                                        credential
+                                                        request)
+                                        recordCompactionUsage
+                                        paramsRef
+                                        historyRef)
+                                    focus
+                        activeBackend <-
+                            prepareTransitionBackend
+                                modelSwitchScope home projectRoot
+                                transition persist backend
+                        runSession
+                            (sessionRequest
+                                startupUnavailable
+                                (Just tokenProvider)
+                                loaded.loadedOpenAiPool
+                                (Just selectHttpAccount)
+                                (Just . geminiContextWindow
                                     <$> readIORef paramsRef)
                                 compactRunner)
                             SessionBackend

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -17,7 +17,7 @@ import Agent.CLI.AgentSessions ()
 import Agent.CLI.AgentViewport ()
 import Agent.CLI.Approval ()
 import Agent.CLI.Artifact ()
-import Agent.CLI.Auth ()
+import Agent.CLI.Auth ( geminiAuthErrorNeedsReconnect )
 import Agent.CLI.Clipboard ()
 import Agent.CLI.Command
     ( currentEffort,
@@ -127,7 +127,7 @@ import Agent.OpenAI.Models.Types (ModelInfo(..), modelServiceTierForRequest)
 import Agent.OpenRouter.LoopBackend ()
 import Agent.OsPath ()
 import Agent.Provider
-    ( Provider(ClaudeCodeProvider, OpenAIProvider),
+    ( Provider(ClaudeCodeProvider, GeminiProvider, OpenAIProvider),
       providerSlug,
       tokenProviderBillingMode )
 import Agent.ReasoningEffort (reasoningEffortText)
@@ -182,6 +182,7 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ()
+import qualified Data.Text as Text ( null, stripPrefix )
 import qualified Data.Text.IO as Text ( putStrLn, hPutStrLn )
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Usage as XAIUsage ()
@@ -445,14 +446,7 @@ handleSelection
         if modelTargetRequiresRebuild
                 connectionId provider (dialectId dialect) choice
             then
-                requestModelTargetSwitch
-                    fullscreen choice persist >>= \case
-                    Left err -> do
-                        displayError err $
-                            Text.hPutStrLn stderr
-                                (roleError color err)
-                        continue
-                    Right result -> pure result
+                switchModelTarget color choice continue
             else do
                 message <- applyModelChange
                     home projectRoot provider connectionId name
@@ -548,13 +542,43 @@ handleSelection
                                 (glyphOk <> message))
                     next
                   else
-                    requestModelTargetSwitch fullscreen choice persist >>= \case
-                        Left err -> do
-                            displayError err $
-                                Text.hPutStrLn stderr
-                                    (roleError color err)
-                            next
-                        Right result -> pure result
+                    switchModelTarget color choice next
+    switchModelTarget color choice next =
+        requestModelTargetSwitch fullscreen choice persist >>= \case
+            Left err
+                | choice.modelTarget.targetProvider == GeminiProvider
+                , modelAuthErrorNeedsConnect GeminiProvider err -> do
+                    connected <- case fullscreen of
+                        Nothing ->
+                            connectProviderAccount color GeminiProvider
+                        Just runtime ->
+                            withFullscreenSuspended runtime $
+                                connectProviderAccount color GeminiProvider
+                    case connected of
+                        Nothing -> next
+                        Just _ ->
+                            requestModelTargetSwitch
+                                fullscreen choice persist >>= \case
+                                Left retryErr -> do
+                                    displayError retryErr $
+                                        Text.hPutStrLn stderr
+                                            (roleError color retryErr)
+                                    next
+                                Right result -> pure result
+            Left err -> do
+                displayError err $
+                    Text.hPutStrLn stderr (roleError color err)
+                next
+            Right result -> pure result
+    modelAuthErrorNeedsConnect targetProvider message =
+        geminiAuthErrorNeedsReconnect message
+            || maybe False geminiAuthErrorNeedsReconnect
+                (Text.stripPrefix
+                    ( "cannot switch to "
+                        <> providerSlug targetProvider
+                        <> ": "
+                    )
+                    message)
     chooseAccount next =
         case fullscreen of
             Just runtime -> do
@@ -600,8 +624,14 @@ handleSelection
                                             | selectedProvider == provider
                                             , selectedProvider
                                                 /= ClaudeCodeProvider
-                                            , selectedAccountId
-                                                == currentAccountId ->
+                                            , ( not (Text.null currentSelectionId)
+                                                    && selectedSelectionId
+                                                        == currentSelectionId
+                                              )
+                                                || ( Text.null currentSelectionId
+                                                    && selectedAccountId
+                                                        == currentAccountId
+                                                   ) ->
                                                 displayInfo
                                                     ("account: " <> selectedLabel)
                                                     (pure ())
@@ -622,7 +652,7 @@ handleSelection
                                                     selectedProvider
                                         case connected of
                                             Nothing -> next
-                                            Just selectedAccountId -> do
+                                            Just connectedId -> do
                                                 refreshed <-
                                                     loadAllAccountPickerOptions
                                                         provider
@@ -631,14 +661,16 @@ handleSelection
                                                         | account@(AccountPickerAccount
                                                             accountProvider
                                                             _
-                                                            _
+                                                            selectionId
                                                             accountId
                                                             _
                                                             _) <- refreshed
                                                         , accountProvider
                                                             == selectedProvider
-                                                        , accountId
-                                                            == selectedAccountId
+                                                        , selectionId
+                                                            == connectedId
+                                                            || accountId
+                                                                == connectedId
                                                         ] of
                                                     Just
                                                         (AccountPickerAccount

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -256,7 +256,7 @@ accountUsageText color provider tokenProvider openAiPool = do
         _ ->
             pure $
                 roleMuted color
-                    "usage: ChatGPT Codex windows only (xAI/OpenRouter have no account usage API here)"
+                    "usage: ChatGPT Codex windows only (xAI/OpenRouter/Gemini have no account usage API here)"
 
 fetchSnapshot :: OpenAI.AccountSnapshot -> IO AccountUsageLine
 fetchSnapshot snapshot = do

--- a/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
@@ -9,9 +9,12 @@ module Agent.CLI.Startup.Auth
     ) where
 
 import Agent.CLI.Auth
-    ( LoadedAuth
+    ( LoadedAuth(..)
     , authErrorNeedsOnboarding
+    , geminiStartupAuthNeedsReconnect
     , loadAuth
+    , loadAuthForAccount
+    , probeLoadedAuth
     )
 import Agent.CLI.Login (connectProviderAccount)
 import Agent.CLI.Models (ModelTarget(..))
@@ -32,6 +35,7 @@ import Agent.CLI.TUI.App
 import Agent.Provider
     ( Provider(..)
     )
+import Agent.Error (ApiError(CredentialError))
 import Agent.Store.Postgres.Skill (LearnedSkill(..))
 import Agent.TUI.Model
     ( UiEvent(..)
@@ -95,8 +99,19 @@ loadStartupAuth
     -> IO (LoadedAuth, Bool)
 loadStartupAuth startup transition requestedProvider =
     loadTransitionAuth transition requestedProvider >>= \case
-        Right loaded -> pure (loaded, False)
+        Right loaded
+            | loaded.loadedProvider == GeminiProvider
+            , Just runtime <- startup.startupFullscreen ->
+                probeLoadedAuth loaded >>= \case
+                    Left CredentialError{} ->
+                        reconnectGeminiAtStartup startup runtime
+                    Left _ -> pure (loaded, False)
+                    Right usable -> pure (usable, False)
+            | otherwise -> pure (loaded, False)
         Left err
+            | shouldReconnectGemini transition requestedProvider err
+            , Just runtime <- startup.startupFullscreen ->
+                reconnectGeminiAtStartup startup runtime
             | isNothing transition
             , authErrorNeedsOnboarding err
             , Just runtime <- startup.startupFullscreen ->
@@ -108,6 +123,34 @@ loadStartupAuth startup transition requestedProvider =
                                 (\loaded -> pure (loaded, learnAboutUser))
             | otherwise ->
                 startupDie startup (Text.unpack err)
+
+shouldReconnectGemini
+    :: Maybe ProviderTransition
+    -> Maybe Provider
+    -> Text
+    -> Bool
+shouldReconnectGemini transition requestedProvider message =
+    geminiStartupAuthNeedsReconnect
+        (targetProvider == Just GeminiProvider)
+        message
+  where
+    targetProvider = case transition of
+        Just active -> Just active.transitionTarget.targetProvider
+        Nothing -> requestedProvider
+
+reconnectGeminiAtStartup
+    :: StartupRuntime
+    -> FullscreenRuntime
+    -> IO (LoadedAuth, Bool)
+reconnectGeminiAtStartup startup runtime = do
+    markStartupStage startup "Sign in with Google…"
+    connected <- withFullscreenSuspended runtime $
+        resolveColor startup.startupStderr >>= \color ->
+            connectProviderAccount color GeminiProvider
+    selectionId <- maybe (throwIO StartupCancelled) pure connected
+    loadAuthForAccount GeminiProvider selectionId >>= either
+        (startupDie startup . Text.unpack)
+        (\loaded -> pure (loaded, False))
 
 loadTransitionAuth
     :: Maybe ProviderTransition
@@ -140,6 +183,9 @@ runCredentialOnboarding startup runtime = do
           )
         , ( OpenRouterProvider
           , ("Add an OpenRouter API key", "Use API credits")
+          )
+        , ( GeminiProvider
+          , ("Sign in with Google", "Use Gemini with your Google account")
           )
         ]
     loop =

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -563,7 +563,8 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                         (\config ->
                             runLoopInputs config previous [AgentMessage prompt])
 
--- | Child XAI/OpenRouter agent: HTTP backend, filtered tools by subagent_type.
+-- | Child xAI/OpenRouter/Gemini agent: HTTP backend, filtered tools by
+-- @subagent_type@.
 runHttpSubagent
     :: SubagentRuntime
     -> Dialect

--- a/packages/agent-cli/test/Agent/CLI/AccountSelectionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AccountSelectionSpec.hs
@@ -137,6 +137,10 @@ spec = describe "account selection" do
             (loadedAuth OpenAIProvider Nothing)
             `shouldBe` True
 
+    it "does not usage-rank Gemini API keys" do
+        providerSupportsUsageAccountSelection GeminiProvider
+            `shouldBe` False
+
     it "keeps a verified OpenRouter free-tier key usable at zero credits" do
         accountCapacity freeTierAccount `shouldBe` Just 1
 

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -16,6 +16,7 @@ import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.OpenAI.Auth (AuthState(..))
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Credential as OpenAICredential
+import qualified Agent.Gemini.Auth as Gemini
 import Agent.Provider
     ( AccountFailure(..)
     , BillingMode(..)
@@ -73,6 +74,59 @@ spec = do
                 `shouldBe` True
             authErrorNeedsOnboarding "credential store is unreadable"
                 `shouldBe` False
+
+    describe "geminiAuthErrorNeedsReconnect" do
+        it "recognizes missing, malformed, and rejected Google credentials" do
+            geminiAuthErrorNeedsReconnect
+                "no credentials found. connect a Google account"
+                `shouldBe` True
+            geminiAuthErrorNeedsReconnect
+                "cannot switch to gemini: managed Gemini OAuth credential contains invalid auth JSON; reconnect the account"
+                `shouldBe` True
+            geminiAuthErrorNeedsReconnect
+                "cannot switch to gemini: Authentication failed. Google OAuth token request failed with HTTP 400"
+                `shouldBe` True
+
+        it "does not turn connection or rate-limit failures into login" do
+            geminiAuthErrorNeedsReconnect
+                "cannot switch to gemini: Authentication failed. Google HTTP request failed"
+                `shouldBe` False
+            geminiAuthErrorNeedsReconnect
+                "cannot switch to gemini: Provider unavailable."
+                `shouldBe` False
+
+    describe "geminiStartupAuthNeedsReconnect" do
+        it "recovers stale Gemini auth without hijacking generic onboarding" do
+            geminiStartupAuthNeedsReconnect
+                False
+                "managed Gemini OAuth credential contains invalid auth JSON"
+                `shouldBe` True
+            geminiStartupAuthNeedsReconnect
+                True
+                "no credentials found. connect an account"
+                `shouldBe` True
+            geminiStartupAuthNeedsReconnect
+                False
+                "no credentials found. connect an account"
+                `shouldBe` False
+            geminiStartupAuthNeedsReconnect
+                True
+                "Google HTTP request failed"
+                `shouldBe` False
+
+    describe "classifyGeminiRefreshFailure" do
+        it "separates rejected refresh grants from transient failures" do
+            classifyGeminiRefreshFailure
+                "Google OAuth token request failed with HTTP 400"
+                `shouldBe` CredentialError
+                    "Google OAuth token request failed with HTTP 400"
+            classifyGeminiRefreshFailure
+                "Google HTTP request failed"
+                `shouldBe` ConnectionError "Google HTTP request failed"
+            classifyGeminiRefreshFailure
+                "Google OAuth token request failed with HTTP 503"
+                `shouldBe` ConnectionError
+                    "Google OAuth token request failed with HTTP 503"
 
     describe "loadAuth" do
         it "prefers OpenAI when automatic detection finds OpenAI and xAI auth" $
@@ -220,6 +274,82 @@ spec = do
                             SubscriptionBilled
                             "e30.eyJleHAiOjQxMDI0NDQ4MDB9."
                             "account-home"
+    describe "Gemini loadAuth" do
+        it "loads Google AI Studio keys with GOOGLE_API_KEY precedence" $
+            withTempHome \_ ->
+                withEnv "GOOGLE_API_KEY" (Just "google-key") $
+                withEnv "GEMINI_API_KEY" (Just "gemini-key") do
+                    loadAuth (Just GeminiProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            loaded.loadedProvider `shouldBe` GeminiProvider
+                            loaded.loadedSelectionId
+                                `shouldBe` Just
+                                    (externalAuthSelectionId
+                                        GeminiProvider
+                                        "environment")
+                            tokenProviderBillingMode
+                                loaded.loadedTokenProvider
+                                `shouldBe` ApiBilled
+                            getNextToken loaded.loadedTokenProvider Nothing
+                                >>= \case
+                                    Left apiError ->
+                                        expectationFailure (show apiError)
+                                    Right credential -> do
+                                        credential.accessToken
+                                            `shouldBe` "google-key"
+                                        credential.accountId
+                                            `shouldBe` "gemini"
+                                        credential.provider
+                                            `shouldBe` GeminiProvider
+
+        it "loads a managed Google login as subscription-billed Code Assist auth" $
+            withTempHome \_ ->
+                withEnv "GOOGLE_API_KEY" Nothing $
+                withEnv "GEMINI_API_KEY" Nothing do
+                    now <- getCurrentTime
+                    let state = Gemini.GeminiAuthState
+                            { accessToken = "google-access"
+                            , refreshToken = Just "google-refresh"
+                            , expiresAt = Just (addUTCTime 3600 now)
+                            , email = "person@example.com"
+                            , projectId = "managed-project"
+                            , userTier = "free-tier"
+                            }
+                        payload =
+                            TextEncoding.decodeUtf8
+                                (LBS.toStrict (Aeson.encode state))
+                    upsertManagedCredential
+                        ManagedCredential
+                            { managedId = "gemini-google"
+                            , managedProvider = GeminiProvider
+                            , managedAccountId = "person@example.com"
+                            , managedLabel = "person@example.com"
+                            , managedBilling = SubscriptionBilled
+                            , managedAuthKind = ManagedGeminiAuthJson
+                            , managedEnabled = True
+                            }
+                        (ManagedSecret "gemini-google" payload)
+                        `shouldReturn` Right ()
+                    loadAuth (Just GeminiProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            tokenProviderBillingMode
+                                loaded.loadedTokenProvider
+                                `shouldBe` SubscriptionBilled
+                            loaded.loadedSelectionId
+                                `shouldBe` Just
+                                    (managedAuthSelectionId "gemini-google")
+                            getNextToken loaded.loadedTokenProvider Nothing
+                                `shouldReturn`
+                                    Right Credential
+                                        { accessToken = "google-access"
+                                        , accountId = "person@example.com"
+                                        , leaseId =
+                                            Just
+                                                "code-assist:managed-project"
+                                        , provider = GeminiProvider
+                                        }
 
     describe "probeLoadedAuth" do
         it "rejects auth whose accounts are currently cooling down" do
@@ -386,6 +516,48 @@ spec = do
                                         Just
                                             (managedAuthSelectionId
                                                 "router-b")
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    Nothing
+                                    >>= \case
+                                        Left err ->
+                                            expectationFailure (show err)
+                                        Right credential ->
+                                            credential.accessToken
+                                                `shouldBe` "key-b"
+
+        it "selects duplicate Gemini API-key accounts by managed id" $
+            withTempHome \_ ->
+                withEnv "GOOGLE_API_KEY" Nothing $
+                withEnv "GEMINI_API_KEY" Nothing do
+                    storeManagedAccount
+                        ApiBilled
+                        GeminiProvider
+                        "gemini-a"
+                        "gemini"
+                        "Google Gemini"
+                        True
+                        "key-a"
+                    storeManagedAccount
+                        ApiBilled
+                        GeminiProvider
+                        "gemini-b"
+                        "gemini"
+                        "Google Gemini"
+                        True
+                        "key-b"
+                    loadAuthForAccount
+                        GeminiProvider
+                        (managedAuthSelectionId "gemini-b")
+                        >>= \case
+                            Left err ->
+                                expectationFailure (Text.unpack err)
+                            Right loaded -> do
+                                loaded.loadedSelectionId
+                                    `shouldBe`
+                                        Just
+                                            (managedAuthSelectionId
+                                                "gemini-b")
                                 getNextToken
                                     loaded.loadedTokenProvider
                                     Nothing
@@ -812,6 +984,105 @@ spec = do
             grokNeedsRefresh epoch
                 (GrokAuthState "tok" (Just "refresh") Nothing Nothing)
                 `shouldBe` False
+
+    describe "managedGeminiTokenProvider" do
+        it "refreshes an expiring Google token and persists the rotation" $
+            withTempHome \_ -> do
+                now <- getCurrentTime
+                refreshes <- newIORef (0 :: Int)
+                let metadata = ManagedCredential
+                        { managedId = "gemini-google"
+                        , managedProvider = GeminiProvider
+                        , managedAccountId = "person@example.com"
+                        , managedLabel = "person@example.com"
+                        , managedBilling = SubscriptionBilled
+                        , managedAuthKind = ManagedGeminiAuthJson
+                        , managedEnabled = True
+                        }
+                    state = Gemini.GeminiAuthState
+                        { accessToken = "stale"
+                        , refreshToken = Just "refresh-old"
+                        , expiresAt = Just (addUTCTime 60 now)
+                        , email = "person@example.com"
+                        , projectId = "managed-project"
+                        , userTier = "free-tier"
+                        }
+                    secret = ManagedSecret
+                        metadata.managedId
+                        (geminiAuthStateToJson state)
+                    refresh refreshToken = do
+                        refreshToken `shouldBe` "refresh-old"
+                        modifyIORef' refreshes (+ 1)
+                        pure $ Right Gemini.OAuthTokens
+                            { accessToken = "fresh"
+                            , refreshToken = Just "refresh-new"
+                            , expiresInSeconds = Just 3600
+                            , tokenType = Just "Bearer"
+                            , scope = Nothing
+                            }
+                    expected = Credential
+                        { accessToken = "fresh"
+                        , accountId = "person@example.com"
+                        , leaseId = Just "code-assist:managed-project"
+                        , provider = GeminiProvider
+                        }
+                upsertManagedCredential metadata secret
+                    `shouldReturn` Right ()
+                provider <- managedGeminiTokenProvider
+                    metadata secret state refresh
+                getNextToken provider Nothing `shouldReturn` Right expected
+                getNextToken provider Nothing `shouldReturn` Right expected
+                readIORef refreshes `shouldReturn` 1
+                loadManagedCredentials >>= \case
+                    Right [(_, stored)]
+                        | Just persisted <-
+                            geminiAuthStateFromJson stored.secretPayload -> do
+                                persisted.accessToken `shouldBe` "fresh"
+                                persisted.refreshToken
+                                    `shouldBe` Just "refresh-new"
+                    other ->
+                        expectationFailure
+                            ("expected persisted Gemini OAuth state, got "
+                                <> show other)
+
+        it "does not refresh a credential disabled on disk" $
+            withTempHome \_ -> do
+                now <- getCurrentTime
+                refreshes <- newIORef (0 :: Int)
+                let metadata = ManagedCredential
+                        { managedId = "gemini-disabled"
+                        , managedProvider = GeminiProvider
+                        , managedAccountId = "person@example.com"
+                        , managedLabel = "person@example.com"
+                        , managedBilling = SubscriptionBilled
+                        , managedAuthKind = ManagedGeminiAuthJson
+                        , managedEnabled = True
+                        }
+                    state = Gemini.GeminiAuthState
+                        { accessToken = "stale"
+                        , refreshToken = Just "refresh-old"
+                        , expiresAt = Just (addUTCTime 60 now)
+                        , email = "person@example.com"
+                        , projectId = "managed-project"
+                        , userTier = "free-tier"
+                        }
+                    secret = ManagedSecret
+                        metadata.managedId
+                        (geminiAuthStateToJson state)
+                    refresh _ = do
+                        modifyIORef' refreshes (+ 1)
+                        pure $ Left "refresh should not run"
+                upsertManagedCredential metadata secret
+                    `shouldReturn` Right ()
+                provider <- managedGeminiTokenProvider
+                    metadata secret state refresh
+                setManagedCredentialEnabled metadata.managedId False
+                    `shouldReturn` Right ()
+                result <- getNextToken provider Nothing
+                result `shouldBe` Left
+                    (CredentialError
+                        "managed Gemini credential is disabled: gemini-disabled")
+                readIORef refreshes `shouldReturn` 0
 
     describe "grokCredentialFromAuthJson" do
         it "accepts a plain access_token object or a nested grok CLI map" do

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -74,6 +74,8 @@ spec = do
                 `shouldReturn` Left "xai compact requires a token provider"
             runProviderCompact OpenRouterProvider Nothing params transcript Nothing
                 `shouldReturn` Left "openrouter compact requires a token provider"
+            runProviderCompact GeminiProvider Nothing params transcript Nothing
+                `shouldReturn` Left "gemini compact requires a token provider"
 
         it "short-circuits an empty transcript before using credentials" do
             params <- newIORef defaultResponseCreateParams

--- a/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CredentialStoreSpec.hs
@@ -51,6 +51,24 @@ spec =
                 LBS.unpack metadata `shouldNotSatisfy` isInfixOf "super-secret"
                 LBS.unpack secrets `shouldSatisfy` isInfixOf "super-secret"
 
+        it "round-trips managed Gemini OAuth metadata" $
+            withTempHome \_ -> do
+                let geminiAccount = account
+                        { managedId = "gemini-google"
+                        , managedProvider = GeminiProvider
+                        , managedAccountId = "person@example.com"
+                        , managedBilling = SubscriptionBilled
+                        , managedAuthKind = ManagedGeminiAuthJson
+                        }
+                    geminiSecret = secret
+                        { secretManagedId = "gemini-google"
+                        , secretPayload = "{\"access_token\":\"redacted\"}"
+                        }
+                upsertManagedCredential geminiAccount geminiSecret
+                    `shouldReturn` Right ()
+                loadManagedCredentials
+                    `shouldReturn` Right [(geminiAccount, geminiSecret)]
+
         it "writes private directories and files" $
             withTempHome \home -> do
                 upsertManagedCredential account secret `shouldReturn` Right ()
@@ -108,6 +126,28 @@ spec =
                     `shouldBe` Right [False]
                 deleteManagedCredential account.managedId
                     `shouldReturn` Right ()
+                loadManagedCredentials `shouldReturn` Right []
+
+        it "does not resurrect a credential disabled or deleted during refresh" $
+            withTempHome \_ -> do
+                let rotated = secret { secretPayload = "rotated-secret" }
+                upsertManagedCredential account secret `shouldReturn` Right ()
+                setManagedCredentialEnabled account.managedId False
+                    `shouldReturn` Right ()
+                upsertManagedCredentialAfterRefresh account rotated
+                    `shouldReturn` Left
+                        "managed credential openrouter-test is disabled"
+                loadManagedCredentials `shouldReturn`
+                    Right
+                        [ ( account { managedEnabled = False }
+                          , secret
+                          )
+                        ]
+                deleteManagedCredential account.managedId
+                    `shouldReturn` Right ()
+                upsertManagedCredentialAfterRefresh account rotated
+                    `shouldReturn` Left
+                        "managed credential openrouter-test no longer exists during refresh"
                 loadManagedCredentials `shouldReturn` Right []
 
         it "updates one secret without replacing sibling accounts" $

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -8,6 +8,7 @@ import Data.Either (isLeft)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), addUTCTime)
+import qualified System.Timeout as Timeout
 import Test.Hspec
 
 spec :: Spec
@@ -41,6 +42,12 @@ spec = do
         it "closes an empty dashboard instead of refreshing" do
             applyLoginKey PickerKeyConfirm (initialLoginState [])
                 `shouldSatisfy` isLeft
+
+    describe "launchBrowserCommand" do
+        it "does not wait for a foreground browser process to exit" do
+            result <- Timeout.timeout 1_000_000
+                (launchBrowserCommand "sleep" "2")
+            result `shouldBe` Just True
 
     describe "renderLoginFrame" do
         it "shows providers, billing modes, sources, and usage" do
@@ -109,9 +116,13 @@ spec = do
 
     describe "fullscreen login dashboard" do
         it "offers account connection before any credentials exist" do
-            let labels = map fst (loginDashboardRows [])
+            let rows = loginDashboardRows []
+                labels = map fst rows
+                rendered = Text.unlines
+                    [label <> " " <> description | (label, description) <- rows]
             labels `shouldSatisfy` any (Text.isInfixOf "Connect account")
             labels `shouldSatisfy` not . any (Text.isInfixOf "Refresh")
+            rendered `shouldSatisfy` Text.isInfixOf "Google Gemini"
 
         it "offers usage refresh and opens each discovered account" do
             let rows = loginDashboardRows [openai, openRouter]

--- a/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
@@ -32,10 +32,19 @@ spec = describe "Agent.CLI.ModelConfig" do
             (catalogDefaultForProvider catalog XAIProvider)
             `shouldBe` Just "grok-4.6"
         fmap (.catalogModelId)
+            (catalogDefaultForProvider catalog GeminiProvider)
+            `shouldBe` Just "gemini-3.7-flash"
+        fmap (.catalogModelId)
             (catalogDefaultForProvider catalog OpenRouterProvider)
             `shouldBe` Just "stealth/ox-alpha"
         catalogContextWindowFor catalog "xai" "grok-4.6"
             `shouldBe` Just 500_000
+        map (catalogContextWindowFor catalog "gemini")
+            [ "gemini-3.7-flash"
+            , "gemini-3.1-pro-preview"
+            , "gemini-3.5-flash-lite"
+            ]
+            `shouldBe` replicate 3 (Just 1_048_576)
         catalogContextWindowFor catalog "openrouter" "stealth/ox-alpha"
             `shouldBe` Just 1_048_576
         fmap (.catalogModelId)
@@ -44,6 +53,13 @@ spec = describe "Agent.CLI.ModelConfig" do
                 [ "gpt-5.6-sol"
                 , "gpt-5.6-terra"
                 , "gpt-5.6-luna"
+                ]
+        fmap (.catalogModelId)
+            (catalogModelsForConnection "gemini" catalog)
+            `shouldBe`
+                [ "gemini-3.7-flash"
+                , "gemini-3.1-pro-preview"
+                , "gemini-3.5-flash-lite"
                 ]
 
     it "adds a custom Responses connection and model" do

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -38,6 +38,8 @@ spec = do
                 `shouldBe` defaultModelFor catalog OpenAIProvider
             firstId (modelsForProvider catalog OpenRouterProvider)
                 `shouldBe` defaultModelFor catalog OpenRouterProvider
+            firstId (modelsForProvider catalog GeminiProvider)
+                `shouldBe` defaultModelFor catalog GeminiProvider
             firstId (modelsForProvider catalog ClaudeCodeProvider)
                 `shouldBe` defaultModelFor catalog ClaudeCodeProvider
 
@@ -45,6 +47,7 @@ spec = do
             modelIdsFor OpenAIProvider `shouldContain` ["gpt-5.6-sol"]
             modelIdsFor XAIProvider `shouldContain` ["grok-4.6"]
             modelIdsFor OpenRouterProvider `shouldContain` ["stealth/ox-alpha"]
+            modelIdsFor GeminiProvider `shouldContain` ["gemini-3.7-flash"]
 
         it "ships the GPT-5.6 series and each other provider frontier model" do
             modelIdsFor OpenAIProvider
@@ -56,6 +59,12 @@ spec = do
             modelIdsFor XAIProvider `shouldBe` ["grok-4.6"]
             modelIdsFor OpenRouterProvider
                 `shouldBe` ["stealth/ox-alpha", "meta/muse-spark-1.2"]
+            modelIdsFor GeminiProvider
+                `shouldBe`
+                    [ "gemini-3.7-flash"
+                    , "gemini-3.1-pro-preview"
+                    , "gemini-3.5-flash-lite"
+                    ]
             modelIdsFor ClaudeCodeProvider
                 `shouldBe` ["sonnet", "opus", "fable"]
 
@@ -96,6 +105,7 @@ spec = do
                     [ OpenAIProvider
                     , XAIProvider
                     , OpenRouterProvider
+                    , GeminiProvider
                     , ClaudeCodeProvider
                     ]
 
@@ -304,6 +314,7 @@ spec = do
                     [ OpenAIProvider
                     , XAIProvider
                     , OpenRouterProvider
+                    , GeminiProvider
                     , ClaudeCodeProvider
                     ]
 

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -93,6 +93,18 @@ spec = do
                     , optPrompt = Just "hi"
                     })
 
+        it "accepts gemini and google as provider names" do
+            parseArgs ["--provider", "gemini", "-p", "hi"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optProvider = Just GeminiProvider
+                    , optPrompt = Just "hi"
+                    })
+            parseArgs ["--provider", "google", "-p", "hi"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optProvider = Just GeminiProvider
+                    , optPrompt = Just "hi"
+                    })
+
         it "accepts claude-code and claude as provider names" do
             parseArgs ["--provider", "claude-code", "-p", "hi"]
                 `shouldBe` Right (RunAgent defaultCliOptions
@@ -357,6 +369,7 @@ spec = do
             defaultEffortFor XAIProvider `shouldBe` EffortHigh
             defaultEffortFor OpenAIProvider `shouldBe` EffortMedium
             defaultEffortFor OpenRouterProvider `shouldBe` EffortMedium
+            defaultEffortFor GeminiProvider `shouldBe` EffortMedium
             defaultEffortFor ClaudeCodeProvider `shouldBe` EffortXHigh
 
     describe "reasoningEffortsForDialect" do

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -71,6 +71,7 @@ spec = do
                 (fallbackCandidates catalog Set.empty XAIProvider exhausted)
                 `shouldBe`
                     [ (OpenAIProvider, "gpt-5.6-sol")
+                    , (GeminiProvider, "gemini-3.7-flash")
                     , (OpenRouterProvider, "stealth/ox-alpha")
                     ]
 
@@ -83,6 +84,7 @@ spec = do
                 (fallbackCandidates catalog Set.empty OpenAIProvider exhausted)
                 `shouldBe`
                     [ (XAIProvider, "grok-4.6")
+                    , (GeminiProvider, "gemini-3.7-flash")
                     , (OpenRouterProvider, "stealth/ox-alpha")
                     ]
 
@@ -96,10 +98,13 @@ spec = do
         it "skips providers already found unavailable" do
             map (.modelTarget.targetProvider)
                 (fallbackCandidates catalog (Set.singleton OpenAIProvider) XAIProvider exhausted)
-                `shouldBe` [OpenRouterProvider]
+                `shouldBe` [GeminiProvider, OpenRouterProvider]
 
         it "accepts direct usage-limit errors from every provider" do
             fallbackCandidates catalog Set.empty OpenRouterProvider
+                (ProviderError UsageLimitReached "quota exhausted" (Just 3600))
+                `shouldSatisfy` (not . null)
+            fallbackCandidates catalog Set.empty GeminiProvider
                 (ProviderError UsageLimitReached "quota exhausted" (Just 3600))
                 `shouldSatisfy` (not . null)
 
@@ -122,11 +127,11 @@ spec = do
             map (.modelTarget.targetProvider)
                 (fallbackCandidates catalog (Set.singleton XAIProvider) OpenAIProvider
                     (ProviderError AuthenticationError "rejected" Nothing))
-                `shouldBe` [OpenRouterProvider]
+                `shouldBe` [GeminiProvider, OpenRouterProvider]
             map (.modelTarget.targetProvider)
                 (fallbackCandidates catalog (Set.singleton XAIProvider) OpenAIProvider
                     (CredentialError "credential file is invalid"))
-                `shouldBe` [OpenRouterProvider]
+                `shouldBe` [GeminiProvider, OpenRouterProvider]
 
     describe "automaticCooldownRetryDelay" do
         let now = UTCTime (fromGregorian 2026 8 21) 0

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -10,8 +10,9 @@ Provider-neutral infrastructure shared by the harness transports:
   `agent-grok-build-dialect`.
 - `Agent.Loop` runs the provider-neutral tool-calling agent loop. Transport
   adapters live in `agent-openai` (`Agent.OpenAI.LoopBackend`), `agent-xai`
-  (`Agent.XAI.LoopBackend`), and `agent-openrouter`
-  (`Agent.OpenRouter.LoopBackend`).
+  (`Agent.XAI.LoopBackend`), `agent-openrouter`
+  (`Agent.OpenRouter.LoopBackend`), and `agent-gemini`
+  (`Agent.Gemini.LoopBackend`).
 - `Agent.ToolArgs` parses model-supplied JSON tool arguments.
 - `Agent.ToolDSL` owns JSON Schema fragments for function-tool parameters.
 - `Agent.ToolDispatch` decodes and runs provider-neutral application tools.
@@ -28,4 +29,5 @@ Provider-neutral infrastructure shared by the harness transports:
   unfinished exchanges poison the session so abandoned frames cannot leak
   into its successor.
 
-This package does not contain OpenAI, ChatGPT, xAI, or OpenRouter transport logic.
+This package does not contain OpenAI, ChatGPT, xAI, OpenRouter, or Gemini
+transport logic.

--- a/packages/agent-core/src/Agent/Dialect.hs
+++ b/packages/agent-core/src/Agent/Dialect.hs
@@ -210,6 +210,7 @@ dialectIdForModel :: Provider -> Text -> DialectId
 dialectIdForModel provider model = case provider of
     OpenAIProvider -> CodexDialect
     XAIProvider -> GrokBuildDialect
+    GeminiProvider -> GenericResponsesDialect
     ClaudeCodeProvider -> ClaudeCodeDialect
     OpenRouterProvider
         | "x-ai/" `Text.isPrefixOf` normalized -> GrokBuildDialect
@@ -231,6 +232,7 @@ legacyDialectIdForProvider = \case
     OpenAIProvider -> CodexDialect
     XAIProvider -> GrokBuildDialect
     OpenRouterProvider -> GrokBuildDialect
+    GeminiProvider -> GenericResponsesDialect
     ClaudeCodeProvider -> ClaudeCodeDialect
 
 -- | Whether a provider transport can carry a model-facing dialect.
@@ -242,6 +244,7 @@ providerSupportsDialect provider dialect = case provider of
     OpenAIProvider -> dialect == CodexDialect
     XAIProvider -> dialect == GrokBuildDialect
     OpenRouterProvider -> dialect /= ClaudeCodeDialect
+    GeminiProvider -> dialect == GenericResponsesDialect
     ClaudeCodeProvider -> dialect == ClaudeCodeDialect
 
 -- | Current public Grok Build names for stable internal tool identifiers.

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -38,6 +38,7 @@ data Provider
     = OpenAIProvider
     | XAIProvider
     | OpenRouterProvider
+    | GeminiProvider
     | ClaudeCodeProvider
     deriving (Eq, Ord, Show)
 
@@ -46,6 +47,7 @@ providerSlug = \case
     OpenAIProvider -> "openai"
     XAIProvider -> "xai"
     OpenRouterProvider -> "openrouter"
+    GeminiProvider -> "gemini"
     ClaudeCodeProvider -> "claude-code"
 
 parseProvider :: Text -> Maybe Provider
@@ -53,6 +55,8 @@ parseProvider = \case
     "openai" -> Just OpenAIProvider
     "xai" -> Just XAIProvider
     "openrouter" -> Just OpenRouterProvider
+    "gemini" -> Just GeminiProvider
+    "google" -> Just GeminiProvider
     "claude-code" -> Just ClaudeCodeProvider
     "claude" -> Just ClaudeCodeProvider
     _ -> Nothing

--- a/packages/agent-core/test/Agent/DialectSpec.hs
+++ b/packages/agent-core/test/Agent/DialectSpec.hs
@@ -35,6 +35,8 @@ spec = describe "Agent.Dialect" do
                 `shouldBe` CodexDialect
             dialectIdForModel XAIProvider "arbitrary-model"
                 `shouldBe` GrokBuildDialect
+            dialectIdForModel GeminiProvider "arbitrary-model"
+                `shouldBe` GenericResponsesDialect
             dialectIdForModel ClaudeCodeProvider "arbitrary-model"
                 `shouldBe` ClaudeCodeDialect
 
@@ -62,6 +64,8 @@ spec = describe "Agent.Dialect" do
             legacyDialectIdForProvider XAIProvider `shouldBe` GrokBuildDialect
             legacyDialectIdForProvider OpenRouterProvider
                 `shouldBe` GrokBuildDialect
+            legacyDialectIdForProvider GeminiProvider
+                `shouldBe` GenericResponsesDialect
             legacyDialectIdForProvider ClaudeCodeProvider
                 `shouldBe` ClaudeCodeDialect
 
@@ -74,6 +78,10 @@ spec = describe "Agent.Dialect" do
             providerSupportsDialect XAIProvider GrokBuildDialect
                 `shouldBe` True
             providerSupportsDialect XAIProvider GenericResponsesDialect
+                `shouldBe` False
+            providerSupportsDialect GeminiProvider GenericResponsesDialect
+                `shouldBe` True
+            providerSupportsDialect GeminiProvider CodexDialect
                 `shouldBe` False
             providerSupportsDialect ClaudeCodeProvider ClaudeCodeDialect
                 `shouldBe` True

--- a/packages/agent-gemini/LICENSE
+++ b/packages/agent-gemini/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 digitally induced GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-gemini/README.md
+++ b/packages/agent-gemini/README.md
@@ -1,0 +1,28 @@
+# agent-gemini
+
+Native Google Gemini transports for Code Assist and the AI Studio
+GenerateContent API.
+
+- Supports browser-based Google OAuth and Gemini Code Assist without an API
+  key. Selecting a Gemini model from `/model` starts sign-in when needed.
+- Also supports `GOOGLE_API_KEY`, with `GEMINI_API_KEY` as a fallback, for
+  Google AI Studio API billing.
+- Projects the provider-neutral Responses request model to native
+  `streamGenerateContent` requests.
+- Streams text, thoughts, thought signatures, function calls, and usage into
+  the shared agent loop.
+- Maps the portable hosted-search tool to Gemini's native Google Search and
+  adapts freeform harness tools such as `apply_patch` to function calls.
+- Preserves Gemini thought signatures across tool-call continuations.
+
+The CLI ships `gemini-3.7-flash` as the default, plus
+`gemini-3.1-pro-preview` and `gemini-3.5-flash-lite`. Each model has a
+1,048,576-token input context in the bundled catalog.
+
+```console
+/model
+```
+
+OAuth credentials are stored in haskell-agent's private managed credential
+store and refreshed automatically. API keys are supplied through the
+`x-goog-api-key` request header and are never written to the model catalog.

--- a/packages/agent-gemini/agent-gemini.cabal
+++ b/packages/agent-gemini/agent-gemini.cabal
@@ -1,0 +1,107 @@
+cabal-version:      2.2
+name:               agent-gemini
+version:            0.1.0.0
+synopsis:           Native Google Gemini transports for haskell-agent
+description:        Google OAuth and AI Studio API-key authentication,
+                    Code Assist and GenerateContent streaming transports,
+                    request projection, tool calls, and provider errors.
+license:            MIT
+license-file:       LICENSE
+author:             digitally induced GmbH
+maintainer:         marc@digitallyinduced.com
+copyright:          (c) 2026 digitally induced GmbH
+category:           Web
+build-type:         Simple
+extra-source-files: README.md
+
+common common-opts
+    default-language: Haskell2010
+    default-extensions: OverloadedStrings
+                      , OverloadedRecordDot
+                      , DuplicateRecordFields
+                      , NoFieldSelectors
+                      , LambdaCase
+                      , BlockArguments
+                      , RecordWildCards
+                      , NamedFieldPuns
+                      , NumericUnderscores
+                      , TypeApplications
+                      , ScopedTypeVariables
+                      , PackageImports
+    ghc-options:      -Wall
+                      -Werror=incomplete-patterns
+                      -Werror=incomplete-uni-patterns
+                      -Werror=missing-fields
+                      -Wno-unused-do-bind
+                      -Wno-name-shadowing
+                      -Wno-missing-signatures
+
+library
+    import:           common-opts
+    exposed-modules:  Agent.Gemini
+                    , Agent.Gemini.Auth
+                    , Agent.Gemini.Client
+                    , Agent.Gemini.Credential
+                    , Agent.Gemini.Error
+                    , Agent.Gemini.LoopBackend
+                    , Agent.Gemini.Options
+                    , Agent.Gemini.Request
+                    , Agent.Gemini.Response
+                    , Agent.Gemini.Stream
+                    , Agent.Gemini.Types
+    hs-source-dirs:   src
+    build-depends:    base                  >= 4.14 && < 5
+                    , agent-core            >= 0.1 && < 0.2
+                    , agent-json            >= 0.1 && < 0.2
+                    , agent-responses       >= 0.1 && < 0.2
+                    , agent-responses-types >= 0.1 && < 0.2
+                    , aeson                 >= 2.0
+                    , base64-bytestring
+                    , bytestring
+                    , containers
+                    , crypton
+                    , entropy
+                    , http-client
+                    , http-client-tls
+                    , http-conduit
+                    , http-types
+                    , memory
+                    , network
+                    , retry >= 0.9.3.1 && < 0.10
+                    , safe-exceptions
+                    , scientific
+                    , text
+                    , time
+
+test-suite agent-gemini-test
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Spec.hs
+    other-modules:    Agent.Gemini.AuthSpec
+                    , Agent.Gemini.ClientSpec
+                    , Agent.Gemini.CredentialSpec
+                    , Agent.Gemini.ErrorSpec
+                    , Agent.Gemini.RequestSpec
+                    , Agent.Gemini.ResponseSpec
+                    , Agent.Gemini.StreamSpec
+    ghc-options:      -threaded
+    build-depends:    base >= 4.14 && < 5
+                    , agent-core
+                    , agent-gemini
+                    , agent-json
+                    , agent-responses
+                    , agent-responses-types
+                    , aeson
+                    , async
+                    , bytestring
+                    , containers
+                    , hspec
+                    , http-conduit
+                    , http-types
+                    , network
+                    , retry
+                    , safe-exceptions
+                    , text
+                    , wai
+                    , warp

--- a/packages/agent-gemini/package.nix
+++ b/packages/agent-gemini/package.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, aeson, agent-core, agent-json, agent-responses
+, agent-responses-types, async, base, base64-bytestring, bytestring
+, containers, crypton, entropy, hspec, http-client, http-client-tls
+, http-conduit, http-types, lib, memory, network, retry
+, safe-exceptions, scientific, text, time, wai, warp
+}:
+mkDerivation {
+  pname = "agent-gemini";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson agent-core agent-json agent-responses agent-responses-types
+    base base64-bytestring bytestring containers crypton entropy
+    http-client http-client-tls http-conduit http-types memory network
+    retry safe-exceptions scientific text time
+  ];
+  testHaskellDepends = [
+    aeson agent-core agent-json agent-responses agent-responses-types
+    async base bytestring containers hspec http-conduit http-types
+    network retry safe-exceptions text wai warp
+  ];
+  description = "Native Google Gemini transports for haskell-agent";
+  license = lib.meta.getLicenseFromSpdxId "MIT";
+}

--- a/packages/agent-gemini/src/Agent/Gemini.hs
+++ b/packages/agent-gemini/src/Agent/Gemini.hs
@@ -1,0 +1,16 @@
+-- | Native Google Gemini transports and account authentication.
+module Agent.Gemini
+    ( module Agent.Gemini.Auth
+    , module Agent.Gemini.Client
+    , module Agent.Gemini.Credential
+    , module Agent.Gemini.LoopBackend
+    , module Agent.Gemini.Options
+    , module Agent.Gemini.Request
+    ) where
+
+import Agent.Gemini.Auth
+import Agent.Gemini.Client
+import Agent.Gemini.Credential
+import Agent.Gemini.LoopBackend
+import Agent.Gemini.Options
+import Agent.Gemini.Request

--- a/packages/agent-gemini/src/Agent/Gemini/Auth.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Auth.hs
@@ -1,0 +1,874 @@
+-- | Google OAuth and Gemini Code Assist account setup.
+--
+-- The embedded client credentials are the public installed-application
+-- credentials used by the official Gemini CLI. Installed-app client secrets
+-- are application identifiers rather than confidential secrets. Deployments
+-- can override the endpoints and client credentials through the environment.
+module Agent.Gemini.Auth
+    ( OAuthOptions(..)
+    , defaultOAuthOptions
+    , oauthOptionsFromEnv
+    , OAuthTokens(..)
+    , GeminiAuthState(..)
+    , CodeAssistOptions(..)
+    , defaultCodeAssistOptions
+    , codeAssistOptionsFromEnv
+    , CodeAssistUser(..)
+    , runLoopbackOAuth
+    , exchangeAuthorizationCode
+    , refreshAccessToken
+    , fetchUserEmail
+    , setupCodeAssist
+    , setupCodeAssistWithValidation
+    , authenticateGoogleAccount
+    , authorizationUrl
+    , validateOAuthCallback
+    , pkceChallenge
+    ) where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception.Safe
+    ( IOException
+    , SomeException
+    , bracket
+    , fromException
+    , tryAny
+    )
+import Crypto.Hash (Digest, SHA256, hash)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.:), (.:?), (.!=))
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64.URL as Base64Url
+import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as LBS
+import Data.Bifunctor (first)
+import Data.List (find)
+import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
+import Network.HTTP.Simple
+import Network.HTTP.Types.URI (parseQueryText, renderQueryText)
+import qualified Network.HTTP.Client as HttpClient
+import qualified Network.Socket as Net
+import qualified Network.Socket.ByteString as Net
+import System.Environment (lookupEnv)
+import System.Entropy (getEntropy)
+import System.IO.Error (ioeGetErrorString)
+import System.Timeout (timeout)
+
+data OAuthOptions = OAuthOptions
+    { authorizationEndpoint :: !String
+    , tokenEndpoint :: !String
+    , userInfoEndpoint :: !String
+    , clientId :: !Text
+    , clientSecret :: !Text
+    , scopes :: ![Text]
+    , timeoutSeconds :: !Int
+    } deriving (Eq)
+
+instance Show OAuthOptions where
+    show options =
+        "OAuthOptions { authorizationEndpoint = "
+            <> show options.authorizationEndpoint
+            <> ", tokenEndpoint = " <> show options.tokenEndpoint
+            <> ", userInfoEndpoint = " <> show options.userInfoEndpoint
+            <> ", clientId = " <> show options.clientId
+            <> ", clientSecret = <redacted>, scopes = " <> show options.scopes
+            <> ", timeoutSeconds = " <> show options.timeoutSeconds <> " }"
+
+-- | Public installed-app OAuth client from the official Gemini CLI.
+defaultOAuthOptions :: OAuthOptions
+defaultOAuthOptions = OAuthOptions
+    { authorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+    , tokenEndpoint = "https://oauth2.googleapis.com/token"
+    , userInfoEndpoint = "https://www.googleapis.com/oauth2/v2/userinfo"
+    , clientId =
+        "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com"
+    , clientSecret = "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"
+    , scopes =
+        [ "https://www.googleapis.com/auth/cloud-platform"
+        , "https://www.googleapis.com/auth/userinfo.email"
+        , "https://www.googleapis.com/auth/userinfo.profile"
+        ]
+    , timeoutSeconds = 5 * 60
+    }
+
+oauthOptionsFromEnv :: IO OAuthOptions
+oauthOptionsFromEnv = do
+    authorizationEndpoint <- envString
+        "GEMINI_OAUTH_AUTHORIZATION_ENDPOINT"
+        defaultOAuthOptions.authorizationEndpoint
+    tokenEndpoint <- envString
+        "GEMINI_OAUTH_TOKEN_ENDPOINT"
+        defaultOAuthOptions.tokenEndpoint
+    userInfoEndpoint <- envString
+        "GEMINI_OAUTH_USERINFO_ENDPOINT"
+        defaultOAuthOptions.userInfoEndpoint
+    clientId <- envText "GEMINI_OAUTH_CLIENT_ID" defaultOAuthOptions.clientId
+    clientSecret <- envText
+        "GEMINI_OAUTH_CLIENT_SECRET"
+        defaultOAuthOptions.clientSecret
+    pure defaultOAuthOptions
+        { authorizationEndpoint
+        , tokenEndpoint
+        , userInfoEndpoint
+        , clientId
+        , clientSecret
+        }
+
+data OAuthTokens = OAuthTokens
+    { accessToken :: !Text
+    , refreshToken :: !(Maybe Text)
+    , expiresInSeconds :: !(Maybe Int)
+    , tokenType :: !(Maybe Text)
+    , scope :: !(Maybe Text)
+    } deriving (Eq)
+
+instance Show OAuthTokens where
+    show tokens =
+        "OAuthTokens { accessToken = <redacted>, refreshToken = "
+            <> maybe "Nothing" (const "Just <redacted>") tokens.refreshToken
+            <> ", expiresInSeconds = " <> show tokens.expiresInSeconds
+            <> ", tokenType = " <> show tokens.tokenType
+            <> ", scope = " <> show tokens.scope <> " }"
+
+instance Aeson.FromJSON OAuthTokens where
+    parseJSON = Aeson.withObject "OAuthTokens" \object -> OAuthTokens
+        <$> object .: "access_token"
+        <*> object .:? "refresh_token"
+        <*> object .:? "expires_in"
+        <*> object .:? "token_type"
+        <*> object .:? "scope"
+
+-- | Persisted Google credentials and Code Assist routing metadata.
+data GeminiAuthState = GeminiAuthState
+    { accessToken :: !Text
+    , refreshToken :: !(Maybe Text)
+    , expiresAt :: !(Maybe UTCTime)
+    , email :: !Text
+    , projectId :: !Text
+    , userTier :: !Text
+    } deriving (Eq)
+
+instance Show GeminiAuthState where
+    show state =
+        "GeminiAuthState { accessToken = <redacted>, refreshToken = "
+            <> maybe "Nothing" (const "Just <redacted>") state.refreshToken
+            <> ", expiresAt = " <> show state.expiresAt
+            <> ", email = " <> show state.email
+            <> ", projectId = " <> show state.projectId
+            <> ", userTier = " <> show state.userTier <> " }"
+
+instance Aeson.ToJSON GeminiAuthState where
+    toJSON state = Aeson.object
+        [ "access_token" Aeson..= state.accessToken
+        , "refresh_token" Aeson..= state.refreshToken
+        , "expires_at" Aeson..= state.expiresAt
+        , "email" Aeson..= state.email
+        , "project_id" Aeson..= state.projectId
+        , "user_tier" Aeson..= state.userTier
+        ]
+
+instance Aeson.FromJSON GeminiAuthState where
+    parseJSON = Aeson.withObject "GeminiAuthState" \object -> GeminiAuthState
+        <$> object .: "access_token"
+        <*> object .:? "refresh_token"
+        <*> object .:? "expires_at"
+        <*> object .: "email"
+        <*> object .: "project_id"
+        <*> object .: "user_tier"
+
+data CodeAssistOptions = CodeAssistOptions
+    { baseUrl :: !String
+    , configuredProject :: !(Maybe Text)
+    , pollIntervalMicros :: !Int
+    , maxPollAttempts :: !Int
+    , requestTimeoutSeconds :: !Int
+    } deriving (Eq, Show)
+
+defaultCodeAssistOptions :: CodeAssistOptions
+defaultCodeAssistOptions = CodeAssistOptions
+    { baseUrl = "https://cloudcode-pa.googleapis.com/v1internal"
+    , configuredProject = Nothing
+    , pollIntervalMicros = 5 * 1_000_000
+    , maxPollAttempts = 60
+    , requestTimeoutSeconds = 60
+    }
+
+codeAssistOptionsFromEnv :: IO CodeAssistOptions
+codeAssistOptionsFromEnv = do
+    baseUrl <- envString
+        "GEMINI_CODE_ASSIST_BASE_URL"
+        defaultCodeAssistOptions.baseUrl
+    googleCloudProject <- nonEmptyEnv "GOOGLE_CLOUD_PROJECT"
+    googleCloudProjectId <- nonEmptyEnv "GOOGLE_CLOUD_PROJECT_ID"
+    let configuredProject = googleCloudProject `orElse` googleCloudProjectId
+    pure defaultCodeAssistOptions { baseUrl, configuredProject }
+
+data CodeAssistUser = CodeAssistUser
+    { projectId :: !Text
+    , userTier :: !Text
+    , userTierName :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+-- | Start a PKCE-S256 loopback flow and exchange the callback code.
+runLoopbackOAuth
+    :: OAuthOptions
+    -> (Text -> IO ())
+    -> IO (Either Text OAuthTokens)
+runLoopbackOAuth options presentAuthorizationUrl = safely $
+    bracket openLoopbackSocket Net.close \listener -> do
+        redirectUri <- loopbackRedirectUri listener
+        state <- randomUrlText 32
+        verifier <- randomUrlText 32
+        presentAuthorizationUrl
+            (authorizationUrl options redirectUri state (pkceChallenge verifier))
+        callback <- timeout
+            (max 1 options.timeoutSeconds * 1_000_000)
+            (receiveOAuthCallback listener state)
+        code <- case callback of
+            Nothing -> fail
+                ("Google OAuth authorization timed out after "
+                    <> show options.timeoutSeconds <> " seconds")
+            Just (Left err) -> fail (Text.unpack err)
+            Just (Right value) -> pure value
+        exchangeAuthorizationCode options redirectUri verifier code >>= \case
+            Left err -> fail (Text.unpack err)
+            Right tokens -> pure tokens
+
+authorizationUrl :: OAuthOptions -> Text -> Text -> Text -> Text
+authorizationUrl options redirectUri state challenge =
+    Text.pack options.authorizationEndpoint
+        <> TextEncoding.decodeUtf8
+            (LBS.toStrict
+                (Builder.toLazyByteString
+                    (renderQueryText True
+                        [ ("client_id", Just options.clientId)
+                        , ("redirect_uri", Just redirectUri)
+                        , ("response_type", Just "code")
+                        , ("scope", Just (Text.unwords options.scopes))
+                        , ("access_type", Just "offline")
+                        , ("prompt", Just "consent")
+                        , ("state", Just state)
+                        , ("code_challenge", Just challenge)
+                        , ("code_challenge_method", Just "S256")
+                        ])))
+
+validateOAuthCallback :: Text -> BS.ByteString -> Either Text Text
+validateOAuthCallback expectedState requestTarget = do
+    let (_, queryWithQuestion) = BS8.break (== '?') requestTarget
+        parameters = parseQueryText (BS.drop 1 queryWithQuestion)
+        parameter key = lookup key parameters >>= id
+    actualState <- maybe
+        (Left "Google OAuth callback did not include state")
+        Right
+        (parameter "state")
+    if actualState /= expectedState
+        then Left "Google OAuth state mismatch; authorization was rejected"
+        else do
+            case parameter "error" of
+                Just oauthError ->
+                    Left ("Google OAuth rejected authorization: " <> oauthError
+                        <> maybe "" (": " <>)
+                            (parameter "error_description"))
+                Nothing -> pure ()
+            maybe
+                (Left
+                    "Google OAuth callback did not include an authorization code")
+                Right
+                (parameter "code")
+
+pkceChallenge :: Text -> Text
+pkceChallenge verifier =
+    TextEncoding.decodeUtf8
+        (Base64Url.encodeUnpadded
+            (BA.convert
+                (hash (TextEncoding.encodeUtf8 verifier) :: Digest SHA256)))
+
+exchangeAuthorizationCode
+    :: OAuthOptions
+    -> Text
+    -> Text
+    -> Text
+    -> IO (Either Text OAuthTokens)
+exchangeAuthorizationCode options redirectUri verifier code =
+    postTokenForm options
+        [ ("grant_type", "authorization_code")
+        , ("code", TextEncoding.encodeUtf8 code)
+        , ("redirect_uri", TextEncoding.encodeUtf8 redirectUri)
+        , ("code_verifier", TextEncoding.encodeUtf8 verifier)
+        , ("client_id", TextEncoding.encodeUtf8 options.clientId)
+        , ("client_secret", TextEncoding.encodeUtf8 options.clientSecret)
+        ]
+
+-- | Refresh, retaining the old refresh token if Google does not rotate it.
+refreshAccessToken :: OAuthOptions -> Text -> IO (Either Text OAuthTokens)
+refreshAccessToken options oldRefreshToken = do
+    result <- postTokenForm options
+        [ ("grant_type", "refresh_token")
+        , ("refresh_token", TextEncoding.encodeUtf8 oldRefreshToken)
+        , ("client_id", TextEncoding.encodeUtf8 options.clientId)
+        , ("client_secret", TextEncoding.encodeUtf8 options.clientSecret)
+        ]
+    pure $ fmap
+        (\(tokens :: OAuthTokens) -> OAuthTokens
+            { accessToken = tokens.accessToken
+            , refreshToken =
+                tokens.refreshToken `orElse` Just oldRefreshToken
+            , expiresInSeconds = tokens.expiresInSeconds
+            , tokenType = tokens.tokenType
+            , scope = tokens.scope
+            })
+        result
+
+fetchUserEmail :: OAuthOptions -> Text -> IO (Either Text Text)
+fetchUserEmail options bearerToken = safely do
+    request <- parseRequest options.userInfoEndpoint
+    response <- httpLBS
+        $ setRequestHeader "Authorization"
+            ["Bearer " <> TextEncoding.encodeUtf8 bearerToken]
+        $ setRequestHeader "Accept" ["application/json"]
+        $ withResponseTimeout options.timeoutSeconds
+        $ withoutRedirects request
+    ensureSuccess bearerToken "Google userinfo request" response
+    userInfo <-
+        (decodeBody "Google userinfo response" response :: IO UserInfo)
+    let email = Text.strip userInfo.email
+    if Text.null email
+        then fail "Google userinfo response contained an empty email"
+        else pure email
+
+setupCodeAssist
+    :: CodeAssistOptions
+    -> Text
+    -> IO (Either Text CodeAssistUser)
+setupCodeAssist options bearerToken =
+    setupCodeAssistWithValidation options bearerToken Nothing
+
+-- | Set up Code Assist, optionally presenting Google's one-time account
+-- validation page and polling until validation completes.
+setupCodeAssistWithValidation
+    :: CodeAssistOptions
+    -> Text
+    -> Maybe (Text -> Text -> IO ())
+    -> IO (Either Text CodeAssistUser)
+setupCodeAssistWithValidation options bearerToken validationPresenter =
+    first (redactSecret bearerToken) <$> safely do
+    validateConfiguredProject options.configuredProject
+    loadResponse <- loadCodeAssistWithValidation
+        options bearerToken validationPresenter
+    case loadResponse.currentTier of
+        Just tier -> do
+            project <- requireProject loadResponse options.configuredProject
+            let paidTierId = loadResponse.paidTier >>= (.tierId)
+                paidTierName = loadResponse.paidTier >>= (.name)
+            pure CodeAssistUser
+                { projectId = project
+                , userTier =
+                    fromMaybe "standard-tier"
+                        (paidTierId `orElse` tier.tierId)
+                , userTierName = paidTierName `orElse` tier.name
+                }
+        Nothing -> do
+            let tier = fromMaybe legacyTier
+                    (find (.isDefault) loadResponse.allowedTiers)
+                onboardProject
+                    | tier.tierId == Just "free-tier" = Nothing
+                    | otherwise = options.configuredProject
+            operation <- postCodeAssist
+                options bearerToken ":onboardUser"
+                (OnboardRequest tier onboardProject)
+            completed <- awaitOperation options bearerToken operation
+            project <- case completed.response >>= (.project) >>= (.projectId) of
+                Just value | not (Text.null (Text.strip value)) -> pure value
+                _ -> do
+                    rejectIneligible loadResponse
+                    requireProject loadResponse options.configuredProject
+            pure CodeAssistUser
+                { projectId = project
+                , userTier = fromMaybe "standard-tier" tier.tierId
+                , userTierName = tier.name
+                }
+
+authenticateGoogleAccount
+    :: OAuthOptions
+    -> CodeAssistOptions
+    -> (Text -> IO ())
+    -> IO (Either Text GeminiAuthState)
+authenticateGoogleAccount oauthOptions codeAssistOptions presentUrl =
+    timeout
+        (max 1 oauthOptions.timeoutSeconds * 1_000_000)
+        authenticate >>= \case
+            Nothing ->
+                pure $ Left
+                    ("Google sign-in timed out after "
+                        <> Text.pack (show oauthOptions.timeoutSeconds)
+                        <> " seconds")
+            Just result -> pure result
+  where
+    authenticate = runLoopbackOAuth oauthOptions presentUrl >>= \case
+        Left err -> pure (Left err)
+        Right tokens -> fetchUserEmail oauthOptions tokens.accessToken >>= \case
+            Left err -> pure (Left err)
+            Right email -> setupCodeAssistWithValidation
+                codeAssistOptions
+                tokens.accessToken
+                (Just (\url _description -> presentUrl url)) >>= \case
+                    Left err -> pure (Left err)
+                    Right user -> do
+                        now <- getCurrentTime
+                        pure $ Right GeminiAuthState
+                            { accessToken = tokens.accessToken
+                            , refreshToken = tokens.refreshToken
+                            , expiresAt =
+                                (`addUTCTime` now)
+                                    . fromIntegral
+                                    <$> tokens.expiresInSeconds
+                            , email
+                            , projectId = user.projectId
+                            , userTier = user.userTier
+                            }
+
+--------------------------------------------------------------------------------
+-- Loopback listener
+--------------------------------------------------------------------------------
+
+openLoopbackSocket :: IO Net.Socket
+openLoopbackSocket = do
+    socket <- Net.socket Net.AF_INET Net.Stream Net.defaultProtocol
+    Net.setSocketOption socket Net.ReuseAddr 1
+    Net.bind socket
+        (Net.SockAddrInet 0 (Net.tupleToHostAddress (127, 0, 0, 1)))
+    Net.listen socket 1
+    pure socket
+
+loopbackRedirectUri :: Net.Socket -> IO Text
+loopbackRedirectUri socket = Net.getSocketName socket >>= \case
+    Net.SockAddrInet port _ ->
+        pure ("http://127.0.0.1:" <> Text.pack (show port) <> "/oauth2callback")
+    _ -> fail "Google OAuth loopback listener did not bind an IPv4 address"
+
+receiveOAuthCallback :: Net.Socket -> Text -> IO (Either Text Text)
+receiveOAuthCallback listener expectedState =
+    bracket (Net.accept listener) (Net.close . fst) \(connection, _) -> do
+        received <- receiveRequestHeaders connection
+        let result = case received of
+                Left err -> Left err
+                Right bytes ->
+                    case BS8.words (BS8.takeWhile (/= '\r') bytes) of
+                        _method : target : _ ->
+                            validateOAuthCallback expectedState target
+                        _ ->
+                            Left
+                                "Malformed HTTP request received by Google OAuth callback"
+            location = case result of
+                Right _ ->
+                    "https://developers.google.com/gemini-code-assist/auth_success_gemini"
+                Left _ ->
+                    "https://developers.google.com/gemini-code-assist/auth_failure_gemini"
+        Net.sendAll connection
+            ("HTTP/1.1 302 Found\r\nLocation: " <> location
+                <> "\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        pure result
+
+receiveRequestHeaders :: Net.Socket -> IO (Either Text BS.ByteString)
+receiveRequestHeaders connection = go BS.empty
+  where
+    maxHeaderBytes = 16_384
+    delimiter = "\r\n\r\n"
+
+    go accumulated
+        | delimiter `BS.isInfixOf` accumulated = pure (Right accumulated)
+        | BS.length accumulated >= maxHeaderBytes =
+            pure (Left "Google OAuth callback request headers were too large")
+        | otherwise = do
+            chunk <- Net.recv connection
+                (maxHeaderBytes - BS.length accumulated)
+            if BS.null chunk
+                then pure
+                    (Left
+                        "Google OAuth callback connection closed before the request headers completed")
+                else go (accumulated <> chunk)
+
+--------------------------------------------------------------------------------
+-- HTTP and Code Assist JSON
+--------------------------------------------------------------------------------
+
+postTokenForm
+    :: OAuthOptions
+    -> [(BS.ByteString, BS.ByteString)]
+    -> IO (Either Text OAuthTokens)
+postTokenForm options form = safely do
+    request <- parseRequest ("POST " <> options.tokenEndpoint)
+    response <- httpLBS
+        $ setRequestHeader "Content-Type" ["application/x-www-form-urlencoded"]
+        $ setRequestBodyURLEncoded form
+        $ withResponseTimeout options.timeoutSeconds
+        $ withoutRedirects request
+    ensureSuccessWithoutBody "Google OAuth token request" response
+    decodeBody "Google OAuth token response" response
+
+postCodeAssist
+    :: (Aeson.ToJSON request, Aeson.FromJSON response)
+    => CodeAssistOptions
+    -> Text
+    -> String
+    -> request
+    -> IO response
+postCodeAssist options token suffix body = do
+    request <- parseRequest ("POST " <> trimSlash options.baseUrl <> suffix)
+    response <- httpLBS
+        $ setRequestHeader "Authorization"
+            ["Bearer " <> TextEncoding.encodeUtf8 token]
+        $ setRequestHeader "Content-Type" ["application/json"]
+        $ setRequestBodyJSON body
+        $ withResponseTimeout options.requestTimeoutSeconds
+        $ withoutRedirects request
+    ensureSuccess token ("Gemini Code Assist " <> suffix) response
+    decodeBody ("Gemini Code Assist " <> suffix <> " response") response
+
+getCodeAssist
+    :: Aeson.FromJSON response
+    => CodeAssistOptions
+    -> Text
+    -> Text
+    -> IO response
+getCodeAssist options token operationName = do
+    request <- parseRequest
+        (trimSlash options.baseUrl <> "/" <> Text.unpack operationName)
+    response <- httpLBS
+        $ setRequestHeader "Authorization"
+            ["Bearer " <> TextEncoding.encodeUtf8 token]
+        $ withResponseTimeout options.requestTimeoutSeconds
+        $ withoutRedirects request
+    ensureSuccess token "Gemini Code Assist operation poll" response
+    decodeBody "Gemini Code Assist operation response" response
+
+awaitOperation
+    :: CodeAssistOptions
+    -> Text
+    -> Operation
+    -> IO Operation
+awaitOperation options token = go 0
+  where
+    go :: Int -> Operation -> IO Operation
+    go attempt operation
+        | Just operationError <- operation.operationError =
+            fail (Text.unpack (renderOperationError operationError))
+        | operation.done = pure operation
+        | attempt >= max 0 options.maxPollAttempts =
+            fail "Gemini Code Assist onboarding timed out"
+        | otherwise = case operation.name of
+            Nothing -> fail
+                "Gemini Code Assist onboarding returned an unfinished operation without a name"
+            Just name -> do
+                threadDelay (max 0 options.pollIntervalMicros)
+                next <- getCodeAssist options token name
+                go (attempt + 1) next
+
+data UserInfo = UserInfo { email :: !Text }
+instance Aeson.FromJSON UserInfo where
+    parseJSON = Aeson.withObject "UserInfo" \object ->
+        UserInfo <$> object .: "email"
+
+data ClientMetadata = ClientMetadata
+instance Aeson.ToJSON ClientMetadata where
+    toJSON _ = Aeson.object
+        [ "ideType" Aeson..= ("IDE_UNSPECIFIED" :: Text)
+        , "platform" Aeson..= ("PLATFORM_UNSPECIFIED" :: Text)
+        , "pluginType" Aeson..= ("GEMINI" :: Text)
+        ]
+
+newtype LoadRequest = LoadRequest (Maybe Text)
+instance Aeson.ToJSON LoadRequest where
+    toJSON (LoadRequest project) = Aeson.object $
+        maybe [] (\value -> ["cloudaicompanionProject" Aeson..= value]) project
+        <> [ "metadata" Aeson..= Aeson.object
+                ( [ "ideType" Aeson..= ("IDE_UNSPECIFIED" :: Text)
+                  , "platform" Aeson..= ("PLATFORM_UNSPECIFIED" :: Text)
+                  , "pluginType" Aeson..= ("GEMINI" :: Text)
+                  ]
+                  <> maybe [] (\value -> ["duetProject" Aeson..= value]) project
+                )
+           ]
+
+data Tier = Tier
+    { tierId :: !(Maybe Text)
+    , name :: !(Maybe Text)
+    , isDefault :: !Bool
+    }
+instance Aeson.FromJSON Tier where
+    parseJSON = Aeson.withObject "Tier" \object -> Tier
+        <$> object .:? "id"
+        <*> object .:? "name"
+        <*> object .:? "isDefault" .!= False
+
+legacyTier :: Tier
+legacyTier = Tier (Just "legacy-tier") Nothing True
+
+data IneligibleTier = IneligibleTier
+    { reasonMessage :: !(Maybe Text)
+    , reasonCode :: !(Maybe Text)
+    , validationUrl :: !(Maybe Text)
+    }
+instance Aeson.FromJSON IneligibleTier where
+    parseJSON = Aeson.withObject "IneligibleTier" \object -> IneligibleTier
+        <$> object .:? "reasonMessage"
+        <*> object .:? "reasonCode"
+        <*> object .:? "validationUrl"
+
+data LoadResponse = LoadResponse
+    { currentTier :: !(Maybe Tier)
+    , paidTier :: !(Maybe Tier)
+    , allowedTiers :: ![Tier]
+    , ineligibleTiers :: ![IneligibleTier]
+    , cloudaicompanionProject :: !(Maybe Text)
+    }
+instance Aeson.FromJSON LoadResponse where
+    parseJSON = Aeson.withObject "LoadResponse" \object -> LoadResponse
+        <$> object .:? "currentTier"
+        <*> object .:? "paidTier"
+        <*> object .:? "allowedTiers" .!= []
+        <*> object .:? "ineligibleTiers" .!= []
+        <*> object .:? "cloudaicompanionProject"
+
+data OnboardRequest = OnboardRequest !Tier !(Maybe Text)
+instance Aeson.ToJSON OnboardRequest where
+    toJSON (OnboardRequest tier project) = Aeson.object $
+        maybe [] (\value -> ["tierId" Aeson..= value]) tier.tierId
+        <> maybe [] (\value -> ["cloudaicompanionProject" Aeson..= value]) project
+        <> [ "metadata" Aeson..= case project of
+                Nothing -> Aeson.toJSON ClientMetadata
+                Just value -> Aeson.object
+                    [ "ideType" Aeson..= ("IDE_UNSPECIFIED" :: Text)
+                    , "platform" Aeson..= ("PLATFORM_UNSPECIFIED" :: Text)
+                    , "pluginType" Aeson..= ("GEMINI" :: Text)
+                    , "duetProject" Aeson..= value
+                    ]
+           ]
+
+data Project = Project { projectId :: !(Maybe Text) }
+instance Aeson.FromJSON Project where
+    parseJSON = Aeson.withObject "Project" \object ->
+        Project <$> object .:? "id"
+
+newtype OnboardResponse = OnboardResponse { project :: Maybe Project }
+instance Aeson.FromJSON OnboardResponse where
+    parseJSON = Aeson.withObject "OnboardResponse" \object ->
+        OnboardResponse <$> object .:? "cloudaicompanionProject"
+
+data OperationError = OperationError
+    { code :: !(Maybe Int)
+    , message :: !(Maybe Text)
+    }
+instance Aeson.FromJSON OperationError where
+    parseJSON = Aeson.withObject "OperationError" \object -> OperationError
+        <$> object .:? "code"
+        <*> object .:? "message"
+
+data Operation = Operation
+    { name :: !(Maybe Text)
+    , done :: !Bool
+    , response :: !(Maybe OnboardResponse)
+    , operationError :: !(Maybe OperationError)
+    }
+instance Aeson.FromJSON Operation where
+    parseJSON = Aeson.withObject "Operation" \object -> Operation
+        <$> object .:? "name"
+        <*> object .:? "done" .!= False
+        <*> object .:? "response"
+        <*> object .:? "error"
+
+renderOperationError :: OperationError -> Text
+renderOperationError operationError =
+    "Gemini Code Assist onboarding failed"
+        <> maybe "" (\code -> " (code " <> Text.pack (show code) <> ")")
+            operationError.code
+        <> maybe "" (": " <>) operationError.message
+
+requireProject :: LoadResponse -> Maybe Text -> IO Text
+requireProject response configured = case
+    response.cloudaicompanionProject `orElse` configured of
+        Just project | not (Text.null (Text.strip project)) -> pure project
+        _ -> fail
+            "This Google account requires GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID"
+
+rejectIneligible :: LoadResponse -> IO ()
+rejectIneligible response = case listToMaybe response.ineligibleTiers of
+    Nothing -> pure ()
+    Just tier -> fail . Text.unpack $
+        fromMaybe "This Google account is not eligible for Gemini Code Assist"
+            tier.reasonMessage
+        <> maybe "" ("\nValidate the account at: " <>) tier.validationUrl
+
+rejectValidationRequired :: LoadResponse -> IO ()
+rejectValidationRequired response =
+    case find
+        (\tier ->
+            tier.reasonCode == Just "VALIDATION_REQUIRED"
+                && maybe False (not . Text.null . Text.strip)
+                    tier.validationUrl)
+        response.ineligibleTiers of
+        Nothing -> pure ()
+        Just tier -> fail . Text.unpack $
+            fromMaybe "Google account validation is required"
+                tier.reasonMessage
+            <> maybe "" ("\nValidate the account at: " <>) tier.validationUrl
+
+loadCodeAssistWithValidation
+    :: CodeAssistOptions
+    -> Text
+    -> Maybe (Text -> Text -> IO ())
+    -> IO LoadResponse
+loadCodeAssistWithValidation options token presenter = go 0 Nothing
+  where
+    go attempts lastPresentedUrl = do
+        response <- postCodeAssist
+            options token ":loadCodeAssist"
+            (LoadRequest options.configuredProject)
+        case validationRequirement response of
+            Nothing -> pure response
+            Just (url, description) -> case presenter of
+                Nothing -> rejectValidationRequired response >> pure response
+                Just present -> do
+                    validationUrl <- requireHttpsValidationUrl url
+                    if Just validationUrl == lastPresentedUrl
+                        then pure ()
+                        else present validationUrl description
+                    if attempts >= max 0 options.maxPollAttempts
+                        then fail
+                            "Google account validation did not complete before the retry limit"
+                        else do
+                            threadDelay (max 0 options.pollIntervalMicros)
+                            go (attempts + 1) (Just validationUrl)
+
+validationRequirement :: LoadResponse -> Maybe (Text, Text)
+validationRequirement response = do
+    Nothing <- pure response.currentTier
+    tier <- find
+        (\candidate ->
+            candidate.reasonCode == Just "VALIDATION_REQUIRED"
+                && maybe False (not . Text.null . Text.strip)
+                    candidate.validationUrl)
+        response.ineligibleTiers
+    url <- Text.strip <$> tier.validationUrl
+    pure
+        ( url
+        , fromMaybe "Google account validation is required"
+            tier.reasonMessage
+        )
+
+requireHttpsValidationUrl :: Text -> IO Text
+requireHttpsValidationUrl url
+    | "https://" `Text.isPrefixOf` Text.toLower url
+    , not (Text.null (Text.drop 8 url)) =
+        pure url
+    | otherwise =
+        fail "Google account validation returned an invalid non-HTTPS URL"
+
+validateConfiguredProject :: Maybe Text -> IO ()
+validateConfiguredProject = \case
+    Just project
+        | not (Text.null project) && Text.all (`elem` ['0'..'9']) project ->
+            fail ("GOOGLE_CLOUD_PROJECT must be a project ID, not numeric project number: "
+                <> Text.unpack project)
+    _ -> pure ()
+
+ensureSuccess :: Text -> String -> Response LBS.ByteString -> IO ()
+ensureSuccess secret label response = do
+    let status = getResponseStatusCode response
+    if status >= 200 && status < 300
+        then pure ()
+        else fail (label <> " failed with HTTP " <> show status <> ": "
+            <> Text.unpack bodyText)
+  where
+    bodyText =
+        Text.take 500
+            (redactSecret secret
+                (TextEncoding.decodeUtf8With
+                    (\_ _ -> Just '\xfffd')
+                    (LBS.toStrict (getResponseBody response))))
+
+redactSecret :: Text -> Text -> Text
+redactSecret secret text
+    | Text.null secret = text
+    | otherwise = Text.replace secret "<redacted>" text
+
+decodeBody
+    :: Aeson.FromJSON value
+    => String
+    -> Response LBS.ByteString
+    -> IO value
+decodeBody label response = case Aeson.eitherDecode (getResponseBody response) of
+    Left err -> fail (label <> " was invalid JSON: " <> err)
+    Right value -> pure value
+
+safely :: IO value -> IO (Either Text value)
+safely action = tryAny action >>= \case
+    Left exception -> pure (Left (safeExceptionText exception))
+    Right value -> pure (Right value)
+
+-- Never render an HTTP request here. Token-exchange request bodies contain
+-- authorization codes, refresh tokens, and the installed-app client secret.
+safeExceptionText :: SomeException -> Text
+safeExceptionText exception =
+    case fromException exception :: Maybe HttpClient.HttpException of
+        Just (HttpClient.InvalidUrlException url reason) ->
+            "invalid Google endpoint URL "
+                <> Text.pack url <> ": " <> Text.pack reason
+        Just HttpClient.HttpExceptionRequest{} ->
+            "Google HTTP request failed"
+        Nothing -> case fromException exception :: Maybe IOException of
+            Just ioError -> Text.pack (ioeGetErrorString ioError)
+            Nothing -> Text.pack (show exception)
+
+ensureSuccessWithoutBody
+    :: String
+    -> Response LBS.ByteString
+    -> IO ()
+ensureSuccessWithoutBody label response = do
+    let status = getResponseStatusCode response
+    if status >= 200 && status < 300
+        then pure ()
+        else fail (label <> " failed with HTTP " <> show status)
+
+-- Credential-bearing API requests must never follow redirects. http-client's
+-- default redirect policy can preserve custom Authorization/API-key headers,
+-- and 307/308 redirects can also replay OAuth token form bodies.
+withoutRedirects :: Request -> Request
+withoutRedirects request = request { HttpClient.redirectCount = 0 }
+
+withResponseTimeout :: Int -> Request -> Request
+withResponseTimeout timeoutSeconds request =
+    request
+        { HttpClient.responseTimeout =
+            HttpClient.responseTimeoutMicro
+                (max 1 timeoutSeconds * 1_000_000)
+        }
+
+randomUrlText :: Int -> IO Text
+randomUrlText bytes =
+    TextEncoding.decodeUtf8 . Base64Url.encodeUnpadded <$> getEntropy bytes
+
+trimSlash :: String -> String
+trimSlash = reverse . dropWhile (== '/') . reverse
+
+orElse :: Maybe value -> Maybe value -> Maybe value
+orElse (Just value) _ = Just value
+orElse Nothing right = right
+
+nonEmptyEnv :: String -> IO (Maybe Text)
+nonEmptyEnv key = lookupEnv key >>= \case
+    Just value | not (Text.null (Text.strip (Text.pack value))) ->
+        pure (Just (Text.strip (Text.pack value)))
+    _ -> pure Nothing
+
+envString :: String -> String -> IO String
+envString key fallback = maybe fallback Text.unpack <$> nonEmptyEnv key
+
+envText :: String -> Text -> IO Text
+envText key fallback = fromMaybe fallback <$> nonEmptyEnv key

--- a/packages/agent-gemini/src/Agent/Gemini/Client.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Client.hs
@@ -1,0 +1,351 @@
+-- | Native streaming GenerateContent client for the Gemini Developer and
+-- Gemini Code Assist APIs.
+module Agent.Gemini.Client
+    ( StreamEventCallback
+    , createResponse
+    , createResponseWith
+    , createResponseWithEvents
+    , createResponseWithEventsPolicy
+    , retryTransientGeminiResultWithPolicy
+    ) where
+
+import Agent.Error
+    ( ApiError(..)
+    , ErrorType(..)
+    , isInlineRetryableProviderError
+    )
+import Agent.Gemini.Error (classifyFailure)
+import Agent.Gemini.Options
+import Agent.Gemini.Request
+import Agent.Gemini.Response
+import Agent.Gemini.Stream
+import Agent.Http.Header (parseRetryAfterSeconds)
+import Agent.Http.Url (trimTrailingSlash)
+import Agent.Provider (Credential(..), Provider(..))
+import Agent.Responses.Client (retryStreamingResultWithPolicy)
+import Agent.Responses.Types
+import Control.Exception.Safe
+    ( Exception
+    , SomeException
+    , fromException
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (foldM)
+import Control.Retry
+    ( RetryPolicyM
+    , exponentialBackoff
+    , limitRetries
+    )
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.Encoding.Error as TextEncoding (lenientDecode)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Network.HTTP.Client as HttpClient
+import qualified Network.HTTP.Client.TLS as HttpTls
+import Network.HTTP.Simple hiding (Response)
+import qualified Network.HTTP.Types.URI as Uri
+import qualified System.Timeout as Timeout
+
+type StreamEventCallback = GeminiStreamEvent -> IO ()
+
+data GeminiTransport
+    = DeveloperApi
+    | CodeAssist !Text
+
+newtype StreamStalled = StreamStalled Int
+
+instance Show StreamStalled where
+    show (StreamStalled seconds) =
+        "Gemini streaming response stalled: no data received for "
+            <> show seconds
+            <> "s"
+
+instance Exception StreamStalled
+
+-- | Send one request using environment-derived client options.
+createResponse
+    :: Credential
+    -> ResponseCreateParams
+    -> IO (Either ApiError Response)
+createResponse credential request = do
+    options <- clientOptionsFromEnv
+    createResponseWith options credential request
+
+-- | Send one request using explicit client options.
+createResponseWith
+    :: ClientOptions
+    -> Credential
+    -> ResponseCreateParams
+    -> IO (Either ApiError Response)
+createResponseWith options credential request =
+    createResponseWithEvents options credential request (const (pure ()))
+
+-- | Send one request and deliver text, reasoning, and complete function calls
+-- incrementally in wire order.
+createResponseWithEvents
+    :: ClientOptions
+    -> Credential
+    -> ResponseCreateParams
+    -> StreamEventCallback
+    -> IO (Either ApiError Response)
+createResponseWithEvents =
+    createResponseWithEventsPolicy transientResultPolicy
+
+-- | Variant with an injectable retry policy. A transient failure is retried
+-- only before the first callback, so consumers never observe replayed output.
+createResponseWithEventsPolicy
+    :: RetryPolicyM IO
+    -> ClientOptions
+    -> Credential
+    -> ResponseCreateParams
+    -> StreamEventCallback
+    -> IO (Either ApiError Response)
+createResponseWithEventsPolicy policy options credential request onEvent
+    | credential.provider /= GeminiProvider =
+        pure $ Left $ ProviderError ApiErrorType
+            "agent-gemini requires a Gemini credential"
+            Nothing
+    | Text.null (Text.strip credential.accessToken) =
+        pure $ Left $ CredentialError $ case credentialTransport credential of
+            DeveloperApi -> "Gemini API key is empty"
+            CodeAssist _ -> "Gemini access token is empty"
+    | otherwise =
+        case buildRequest options.defaultModel request of
+            Left err -> pure (Left err)
+            Right nativeRequest ->
+                retryTransientGeminiResultWithPolicy
+                    policy
+                    (performOnce nativeRequest)
+                    onEvent
+  where
+    performOnce nativeRequest =
+        performGeminiRequest
+            options
+            credential
+            request
+            nativeRequest
+
+retryTransientGeminiResultWithPolicy
+    :: RetryPolicyM IO
+    -> ((event -> IO ()) -> IO (Either ApiError value))
+    -> (event -> IO ())
+    -> IO (Either ApiError value)
+retryTransientGeminiResultWithPolicy policy request onEvent =
+    retryStreamingResultWithPolicy
+        policy
+        isInlineRetryableProviderError
+        request
+        (Just onEvent)
+
+transientResultPolicy :: RetryPolicyM IO
+transientResultPolicy =
+    exponentialBackoff 1_000_000 <> limitRetries 3
+
+maxErrorBodyBytes :: Int
+maxErrorBodyBytes = 1024 * 1024
+
+performGeminiRequest
+    :: ClientOptions
+    -> Credential
+    -> ResponseCreateParams
+    -> GeminiRequest
+    -> StreamEventCallback
+    -> IO (Either ApiError Response)
+performGeminiRequest options credential canonical nativeRequest emit =
+    tryAny performRequest >>= \case
+        Left exception -> pure $ Left $ ConnectionError
+            ( "Gemini request failed: "
+                <> safeExceptionText credential.accessToken exception
+            )
+        Right result -> pure result
+  where
+    performRequest = do
+        fallbackId <- freshResponseId nativeRequest.requestModel
+        baseRequest <- parseRequest
+            ("POST " <> generateContentUrl
+                options
+                transport
+                nativeRequest.requestModel)
+        manager <- HttpTls.getGlobalManager
+        HttpClient.withResponse
+            ( setRequestBodyLBS
+                (Aeson.encode
+                    (transportRequestBody
+                        transport
+                        fallbackId
+                        nativeRequest))
+            $ applyCredential transport credential.accessToken
+            $ setRequestHeader "Content-Type" ["application/json"]
+            $ setRequestHeader "Accept" ["text/event-stream"]
+            $ setRequestHeader "User-Agent" ["haskell-agent"]
+            $ withTimeout options.requestTimeoutSeconds
+            $ withoutRedirects baseRequest
+            )
+            manager
+            (handleResponse fallbackId)
+
+    transport = credentialTransport credential
+
+    handleResponse fallbackId response = do
+        let status = getResponseStatusCode response
+            body = HttpClient.responseBody response
+        if status >= 200 && status < 300
+            then consumeSse fallbackId body
+            else do
+                failureBody <- consumeBody body
+                let bodyText = TextEncoding.decodeUtf8With
+                        TextEncoding.lenientDecode
+                        (LBS.toStrict failureBody)
+                pure $ Left $
+                    classifyFailure
+                        status
+                        (parseRetryAfterSeconds
+                            (getResponseHeader "Retry-After" response))
+                        (redactSecret credential.accessToken bodyText)
+
+    consumeSse fallbackId body =
+        go
+            newSseDecoder
+            (initialStreamStateWithCustomTools
+                nativeRequest.requestModel
+                fallbackId
+                nativeRequest.requestCustomToolNames)
+      where
+        go decoder state = do
+            chunk <- readChunkWithin options.requestTimeoutSeconds body
+            if BS.null chunk
+                then case finishSseDecoder decoder of
+                    Left err -> pure (Left err)
+                    Right trailing -> do
+                        finalState <- foldM deliver state trailing
+                        if streamReachedTerminal finalState
+                            then pure $ Right
+                                (buildResponse canonical finalState)
+                            else pure $ Left $ ConnectionError
+                                "Gemini stream ended before a terminal finish reason"
+                else case feedSseDecoder decoder chunk of
+                    Left err -> pure (Left err)
+                    Right (nextDecoder, responses) -> do
+                        nextState <- foldM deliver state responses
+                        go nextDecoder nextState
+
+        deliver state response = do
+            let (nextState, events) = applyChunk state response
+            mapM_ emit events
+            pure nextState
+
+    consumeBody body =
+        LBS.fromChunks <$> readChunks maxErrorBodyBytes []
+      where
+        readChunks remaining reversedChunks
+            | remaining <= 0 = pure (reverse reversedChunks)
+        readChunks remaining reversedChunks = do
+            chunk <- readChunkWithin options.requestTimeoutSeconds body
+            if BS.null chunk
+                then pure (reverse reversedChunks)
+                else
+                    let kept = BS.take remaining chunk
+                    in readChunks
+                        (remaining - BS.length kept)
+                        (kept : reversedChunks)
+
+withTimeout :: Int -> Request -> Request
+withTimeout timeoutSeconds request =
+    request
+        { HttpClient.responseTimeout =
+            HttpClient.responseTimeoutMicro
+                (timeoutSeconds * 1_000_000)
+        }
+
+withoutRedirects :: Request -> Request
+withoutRedirects request = request { HttpClient.redirectCount = 0 }
+
+readChunkWithin
+    :: Int
+    -> HttpClient.BodyReader
+    -> IO BS.ByteString
+readChunkWithin timeoutSeconds body
+    | timeoutSeconds <= 0 = HttpClient.brRead body
+    | otherwise =
+        Timeout.timeout
+            (timeoutSeconds * 1_000_000)
+            (HttpClient.brRead body) >>= \case
+                Just chunk -> pure chunk
+                Nothing -> throwIO (StreamStalled timeoutSeconds)
+
+credentialTransport :: Credential -> GeminiTransport
+credentialTransport credential =
+    case credential.leaseId >>= Text.stripPrefix "code-assist:" of
+        Just project -> CodeAssist project
+        Nothing -> DeveloperApi
+
+applyCredential :: GeminiTransport -> Text -> Request -> Request
+applyCredential transport token =
+    setRequestHeader headerName [headerValue]
+  where
+    encoded = TextEncoding.encodeUtf8 token
+    (headerName, headerValue) = case transport of
+        DeveloperApi -> ("x-goog-api-key", encoded)
+        CodeAssist _ -> ("Authorization", "Bearer " <> encoded)
+
+transportRequestBody :: GeminiTransport -> Text -> GeminiRequest -> Aeson.Value
+transportRequestBody DeveloperApi _ nativeRequest =
+    nativeRequest.requestBody
+transportRequestBody (CodeAssist project) promptId nativeRequest =
+    Aeson.object
+        [ "model" Aeson..= nativeRequest.requestModel
+        , "project" Aeson..= project
+        , "user_prompt_id" Aeson..= promptId
+        , "request" Aeson..= nativeRequest.requestBody
+        ]
+
+generateContentUrl :: ClientOptions -> GeminiTransport -> Text -> String
+generateContentUrl options transport model = case transport of
+    DeveloperApi ->
+        trimTrailingSlash options.baseUrl
+            <> "/models/"
+            <> BS8.unpack
+                (Uri.urlEncode True (TextEncoding.encodeUtf8 model))
+            <> ":streamGenerateContent?alt=sse"
+    CodeAssist _ ->
+        trimTrailingSlash options.codeAssistBaseUrl
+            <> ":streamGenerateContent?alt=sse"
+
+freshResponseId :: Text -> IO Text
+freshResponseId model = do
+    now <- getPOSIXTime
+    let micros = round (now * 1_000_000) :: Integer
+        modelTag = Text.map sanitize model
+    pure ("gemini-" <> modelTag <> "-" <> Text.pack (show micros))
+  where
+    sanitize character
+        | character >= 'a' && character <= 'z' = character
+        | character >= 'A' && character <= 'Z' = character
+        | character >= '0' && character <= '9' = character
+        | character == '-' = character
+        | otherwise = '-'
+
+-- Rendering a complete 'HttpExceptionRequest' would include custom headers;
+-- unlike Authorization, @x-goog-api-key@ is not guaranteed to be redacted by
+-- http-client. Keep the useful failure content while deliberately dropping
+-- the request and its credential-bearing headers.
+safeExceptionText :: Text -> SomeException -> Text
+safeExceptionText secret exception =
+    redactSecret secret $ case
+        fromException exception :: Maybe HttpClient.HttpException of
+        Just (HttpClient.HttpExceptionRequest _ content) ->
+            Text.pack (show content)
+        Just (HttpClient.InvalidUrlException url reason) ->
+            "invalid URL " <> Text.pack url <> ": " <> Text.pack reason
+        Nothing -> Text.pack (show exception)
+
+redactSecret :: Text -> Text -> Text
+redactSecret secret text
+    | Text.null secret = text
+    | otherwise = Text.replace secret "<redacted>" text

--- a/packages/agent-gemini/src/Agent/Gemini/Credential.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Credential.hs
@@ -1,0 +1,54 @@
+-- | Static Google AI Studio API-key credentials.
+module Agent.Gemini.Credential
+    ( staticApiKeyProvider
+    , credentialFromApiKey
+    , credentialFromEnv
+    ) where
+
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Provider
+import Control.Applicative ((<|>))
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (addUTCTime, getCurrentTime)
+import System.Environment (lookupEnv)
+
+-- | A single Gemini API key with no refresh flow.
+staticApiKeyProvider :: Text -> TokenProvider
+staticApiKeyProvider apiKey = tokenProvider ApiBilled \failed -> case failed of
+    Nothing -> pure $ Right (credentialFromApiKey apiKey)
+    Just FailedCredential
+        { failure = AccountRateLimited { retryAfterSeconds }
+        , failureReason
+        } -> do
+        now <- getCurrentTime
+        let seconds = max 1 (fromMaybe 60 retryAfterSeconds)
+        pure $ Left $ CredentialsExhausted
+            { retryAt = addUTCTime (fromIntegral seconds) now
+            , exhaustionReasons = [failureReason]
+            }
+    Just FailedCredential { failure = AccountAuthenticationRejected } ->
+        pure $ Left $ ProviderError AuthenticationError
+            "static Gemini API key was rejected"
+            Nothing
+
+credentialFromApiKey :: Text -> Credential
+credentialFromApiKey apiKey = Credential
+    { accessToken = apiKey
+    , accountId = "gemini"
+    , leaseId = Nothing
+    , provider = GeminiProvider
+    }
+
+-- | Read the standard Gemini SDK environment variables. When both are set,
+-- @GOOGLE_API_KEY@ takes precedence, matching Google's SDKs.
+credentialFromEnv :: IO (Maybe Credential)
+credentialFromEnv = do
+    googleKey <- nonEmpty <$> lookupEnv "GOOGLE_API_KEY"
+    geminiKey <- nonEmpty <$> lookupEnv "GEMINI_API_KEY"
+    pure $ credentialFromApiKey . Text.pack <$> (googleKey <|> geminiKey)
+  where
+    nonEmpty = \case
+        Just value | not (null value) -> Just value
+        _ -> Nothing

--- a/packages/agent-gemini/src/Agent/Gemini/Error.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Error.hs
@@ -1,0 +1,108 @@
+-- | Normalization of Google API error envelopes into the shared error model.
+module Agent.Gemini.Error
+    ( classifyFailure
+    ) where
+
+import Agent.Error (ApiError(..), ErrorType(..))
+import Data.Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+
+data GoogleErrorEnvelope = GoogleErrorEnvelope
+    { googleErrorMessage :: !Text
+    , googleErrorStatus :: !(Maybe Text)
+    }
+
+instance FromJSON GoogleErrorEnvelope where
+    parseJSON = withObject "Google API error envelope" \object ->
+        object .: "error" >>= withObject "Google API error" \err ->
+            GoogleErrorEnvelope
+                <$> err .:? "message" .!= ""
+                <*> err .:? "status"
+
+-- | Classify a non-success HTTP response. Only the provider's short message is
+-- retained; error details may contain request material and are deliberately
+-- omitted from diagnostics.
+classifyFailure :: Int -> Maybe Int -> Text -> ApiError
+classifyFailure httpStatus retryAfterHeader body =
+    ProviderError errorType message retryAfter
+  where
+    envelope = decodeEnvelope body
+    upstreamStatus = envelope >>= (.googleErrorStatus)
+    upstreamMessage = maybe "" (.googleErrorMessage) envelope
+    message
+        | Text.null (Text.strip upstreamMessage) = preview body
+        | otherwise = upstreamMessage
+    errorType
+        | looksLikeApiKeyFailure message = AuthenticationError
+        | otherwise = errorTypeFromGoogle httpStatus upstreamStatus
+    retryAfter
+        | errorType `elem`
+            [ RateLimitError
+            , OverloadedError
+            , ServiceUnavailableError
+            , ApiErrorType
+            ] = retryAfterHeader
+        | otherwise = Nothing
+
+decodeEnvelope :: Text -> Maybe GoogleErrorEnvelope
+decodeEnvelope body =
+    decode
+        (LBS.fromStrict (TextEncoding.encodeUtf8 body))
+
+errorTypeFromGoogle :: Int -> Maybe Text -> ErrorType
+errorTypeFromGoogle httpStatus upstreamStatus =
+    case Text.toUpper . Text.strip <$> upstreamStatus of
+        Just "UNAUTHENTICATED" -> AuthenticationError
+        Just "PERMISSION_DENIED" -> PermissionError
+        Just "RESOURCE_EXHAUSTED" -> RateLimitError
+        Just "NOT_FOUND" -> NotFoundError
+        Just "INVALID_ARGUMENT" -> InvalidRequestError
+        Just "FAILED_PRECONDITION" -> InvalidRequestError
+        Just "ALREADY_EXISTS" -> InvalidRequestError
+        Just "OUT_OF_RANGE" -> InvalidRequestError
+        Just "CANCELLED" -> ServiceUnavailableError
+        Just "DEADLINE_EXCEEDED" -> ServiceUnavailableError
+        Just "ABORTED" -> ServiceUnavailableError
+        Just "UNAVAILABLE" -> ServiceUnavailableError
+        Just "INTERNAL" -> ApiErrorType
+        Just "DATA_LOSS" -> ApiErrorType
+        Just "UNKNOWN" -> ApiErrorType
+        _ -> errorTypeFromStatus httpStatus
+
+errorTypeFromStatus :: Int -> ErrorType
+errorTypeFromStatus = \case
+    400 -> InvalidRequestError
+    401 -> AuthenticationError
+    403 -> PermissionError
+    404 -> NotFoundError
+    408 -> ServiceUnavailableError
+    409 -> ServiceUnavailableError
+    413 -> PayloadTooLargeError
+    425 -> ServiceUnavailableError
+    429 -> RateLimitError
+    500 -> ApiErrorType
+    502 -> ServiceUnavailableError
+    503 -> OverloadedError
+    504 -> ServiceUnavailableError
+    status
+        | status >= 400 && status < 500 -> InvalidRequestError
+        | otherwise -> ApiErrorType
+
+looksLikeApiKeyFailure :: Text -> Bool
+looksLikeApiKeyFailure message =
+    any (`Text.isInfixOf` normalized)
+        [ "api key not valid"
+        , "invalid api key"
+        , "api_key_invalid"
+        , "api key was reported as leaked"
+        ]
+  where
+    normalized = Text.toLower message
+
+preview :: Text -> Text
+preview body
+    | Text.null (Text.strip body) = "Gemini request failed"
+    | otherwise = Text.take 500 body

--- a/packages/agent-gemini/src/Agent/Gemini/LoopBackend.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/LoopBackend.hs
@@ -1,0 +1,76 @@
+-- | Adapter from native Gemini streaming events to the provider-neutral loop.
+module Agent.Gemini.LoopBackend
+    ( statelessGeminiBackend
+    , tokenProviderStatelessGeminiBackend
+    , geminiStreamEventToLoopEvent
+    ) where
+
+import Agent.Error (ApiError)
+import Agent.Gemini.Response (GeminiStreamEvent(..))
+import Agent.Loop (Backend(..), BackendResult(..), LoopEvent(..))
+import Agent.Provider
+    ( Credential
+    , TokenProvider
+    , runWithTokenProvider
+    )
+import Agent.Responses.LoopBackend
+    ( responseItemToToolCall
+    , responseToTurnOutput
+    , turnInputsToItems
+    , withRequestInput
+    )
+import Agent.Responses.Types
+    ( FunctionCall
+    , Response(..)
+    , ResponseCreateParams
+    , ResponseItem(..)
+    )
+import Agent.ToolDispatch (ToolCall)
+
+statelessGeminiBackend
+    :: (ResponseCreateParams
+        -> (GeminiStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> Backend
+statelessGeminiBackend send getParams =
+    Backend \history _previousResponseId inputs onEvent -> do
+        baseParams <- getParams
+        let newItems = turnInputsToItems inputs
+            requestItems = history <> newItems
+            request = withRequestInput baseParams requestItems
+        result <- send request \event ->
+            maybe (pure ()) onEvent (geminiStreamEventToLoopEvent event)
+        case result of
+            Left err -> pure (Left err)
+            Right response ->
+                pure $ Right BackendResult
+                    { backendOutput = responseToTurnOutput response
+                    , backendState = requestItems <> response.output
+                    }
+
+tokenProviderStatelessGeminiBackend
+    :: TokenProvider
+    -> (Credential
+        -> ResponseCreateParams
+        -> (GeminiStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> IO ResponseCreateParams
+    -> Backend
+tokenProviderStatelessGeminiBackend provider send =
+    statelessGeminiBackend \params onEvent ->
+        runWithTokenProvider provider \credential ->
+            send credential params onEvent
+
+geminiStreamEventToLoopEvent
+    :: GeminiStreamEvent
+    -> Maybe LoopEvent
+geminiStreamEventToLoopEvent = \case
+    GeminiTextDelta text -> Just (TextDelta text)
+    GeminiReasoningDelta text -> Just (ReasoningDelta text)
+    GeminiFunctionCallReady call ->
+        ToolStarted <$> functionCallToToolCall call
+
+functionCallToToolCall :: FunctionCall -> Maybe ToolCall
+functionCallToToolCall =
+    responseItemToToolCall . FunctionCallItem

--- a/packages/agent-gemini/src/Agent/Gemini/Options.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Options.hs
@@ -1,0 +1,50 @@
+-- | Configuration for the native Gemini GenerateContent transports.
+module Agent.Gemini.Options
+    ( ClientOptions(..)
+    , defaultClientOptions
+    , clientOptionsFromEnv
+    ) where
+
+import Agent.Provider.Options (lookupIntEnv, lookupNonEmptyEnv)
+import qualified Data.Maybe as Maybe
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data ClientOptions = ClientOptions
+    { baseUrl :: !String
+      -- ^ Google Generative Language API prefix, including @/v1beta@.
+    , codeAssistBaseUrl :: !String
+      -- ^ Gemini Code Assist API prefix, including @/v1internal@.
+    , defaultModel :: !Text
+      -- ^ Model used when a request omits its model.
+    , requestTimeoutSeconds :: !Int
+      -- ^ Header and per-stream-read timeout.
+    } deriving (Eq, Show)
+
+defaultClientOptions :: ClientOptions
+defaultClientOptions = ClientOptions
+    { baseUrl = "https://generativelanguage.googleapis.com/v1beta"
+    , codeAssistBaseUrl = "https://cloudcode-pa.googleapis.com/v1internal"
+    , defaultModel = "gemini-3.7-flash"
+    , requestTimeoutSeconds = 600
+    }
+
+-- | Load optional endpoint, model, and timeout overrides.
+clientOptionsFromEnv :: IO ClientOptions
+clientOptionsFromEnv = do
+    baseUrl <- lookupNonEmptyEnv "GEMINI_BASE_URL"
+    codeAssistBaseUrl <-
+        lookupNonEmptyEnv "GEMINI_CODE_ASSIST_BASE_URL"
+    defaultModel <- lookupNonEmptyEnv "GEMINI_DEFAULT_MODEL"
+    timeoutSeconds <- lookupIntEnv "GEMINI_TIMEOUT_SECONDS"
+    pure ClientOptions
+        { baseUrl = Maybe.fromMaybe defaultClientOptions.baseUrl baseUrl
+        , codeAssistBaseUrl = Maybe.fromMaybe
+            defaultClientOptions.codeAssistBaseUrl
+            codeAssistBaseUrl
+        , defaultModel =
+            maybe defaultClientOptions.defaultModel Text.pack defaultModel
+        , requestTimeoutSeconds =
+            Maybe.fromMaybe defaultClientOptions.requestTimeoutSeconds
+                timeoutSeconds
+        }

--- a/packages/agent-gemini/src/Agent/Gemini/Request.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Request.hs
@@ -1,0 +1,573 @@
+-- | Projection from the harness' canonical Responses-shaped transcript to
+-- Gemini's native GenerateContent request.
+module Agent.Gemini.Request
+    ( GeminiRequest(..)
+    , buildRequest
+    , normalizeModelId
+    ) where
+
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Responses.Types
+import Control.Applicative ((<|>))
+import Control.Monad (foldM)
+import Data.Aeson
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import qualified Data.Foldable as Foldable
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+
+data GeminiRequest = GeminiRequest
+    { requestModel :: !Text
+    , requestBody :: !Value
+    , requestCustomToolNames :: !(Set Text)
+    } deriving (Eq, Show)
+
+-- | Build one native request. The caller supplies the fallback model so this
+-- pure projection can also be used by side requests such as compaction.
+buildRequest
+    :: Text
+    -> ResponseCreateParams
+    -> Either ApiError GeminiRequest
+buildRequest fallbackModel params = do
+    (tools, customToolNames) <-
+        projectTools (enabledTools params.toolChoice params.tools)
+    projection <- projectInput customToolNames params.input
+    let model = normalizeModelId
+            (fromMaybe fallbackModel params.model)
+        systemTexts =
+            maybe projection.systemTexts
+                (: projection.systemTexts)
+                (params.instructions >>= nonEmptyText)
+        bodyFields =
+            [ Just ("contents" .= projection.contents)
+            , ("systemInstruction" .=)
+                <$> systemInstruction systemTexts
+            , ("generationConfig" .=)
+                <$> generationConfig model params
+            , ("tools" .=) <$> tools
+            , ("toolConfig" .=) <$> (tools >> toolConfig params.toolChoice)
+            ]
+    if Text.null model
+        then Left $ ProviderError InvalidRequestError
+            "Gemini model id must not be empty"
+            Nothing
+        else pure GeminiRequest
+            { requestModel = model
+            , requestBody = object (catMaybes bodyFields)
+            , requestCustomToolNames = customToolNames
+            }
+
+normalizeModelId :: Text -> Text
+normalizeModelId raw =
+    fromMaybe stripped (Text.stripPrefix "models/" stripped)
+  where
+    stripped = Text.strip raw
+
+enabledTools
+    :: Maybe ToolChoice
+    -> Maybe [ResponseTool]
+    -> Maybe [ResponseTool]
+enabledTools (Just (ToolChoiceMode ToolChoiceNone)) _ = Nothing
+enabledTools _ tools = tools
+
+data Projection = Projection
+    { systemTexts :: ![Text]
+    , contents :: ![Value]
+    , callNames :: !(Map Text Text)
+    , pendingThoughtSignature :: !(Maybe Text)
+    , customToolNames :: !(Set Text)
+    }
+
+emptyProjection :: Set Text -> Projection
+emptyProjection customToolNames = Projection
+    { systemTexts = []
+    , contents = []
+    , callNames = Map.empty
+    , pendingThoughtSignature = Nothing
+    , customToolNames
+    }
+
+projectInput :: Set Text -> Maybe ResponseInput -> Either ApiError Projection
+projectInput customToolNames = \case
+    Nothing -> pure (emptyProjection customToolNames)
+    Just (ResponseInputText text) ->
+        pure $ appendContent "user" [textPart text]
+            (emptyProjection customToolNames)
+    Just (ResponseInputItems items) ->
+        foldM projectItem (emptyProjection customToolNames) items
+
+projectItem :: Projection -> ResponseItem -> Either ApiError Projection
+projectItem projection = \case
+    MessageItem message ->
+        projectMessage projection message.role message.content
+    AgentMessageItem message ->
+        projectMessage projection RoleUser
+            (MessageContentParts message.content)
+    ReasoningItemValue reasoning ->
+        pure (projectReasoning projection reasoning)
+    FunctionCallItem call ->
+        pure (projectFunctionCall projection call)
+    FunctionCallOutputItem callOutput ->
+        pure (projectFunctionOutput projection callOutput)
+    CustomToolCallItem call ->
+        pure (projectCustomToolCall projection call)
+    CustomToolCallOutputItem callOutput ->
+        pure (projectCustomToolOutput projection callOutput)
+    -- Local compaction snapshots are represented by ordinary messages. The
+    -- remaining Responses-only control/hosted-tool items have no native
+    -- GenerateContent equivalent and are intentionally not replayed.
+    ComputerCallItem{} -> unsupportedItem "computer calls"
+    ComputerCallOutputItem{} -> unsupportedItem "computer outputs"
+    AdditionalToolsItemValue{} -> pure projection
+    ItemReferenceValue{} -> pure projection
+    LocalShellCallItem{} -> pure projection
+    ToolSearchCallItem{} -> pure projection
+    ToolSearchOutputItem{} -> pure projection
+    WebSearchCallItem{} -> pure projection
+    ImageGenerationCallItem{} -> pure projection
+    CompactionItemValue{} -> pure projection
+    CompactionTriggerItemValue{} -> pure projection
+    ContextCompactionItemValue{} -> pure projection
+    KnownResponseItem{} -> pure projection
+    UnknownResponseItem{} -> pure projection
+  where
+    unsupportedItem label = Left $ ProviderError InvalidRequestError
+        ("Gemini does not support replaying " <> label)
+        Nothing
+
+projectMessage
+    :: Projection
+    -> ResponseRole
+    -> MessageContent
+    -> Either ApiError Projection
+projectMessage projection role content =
+    let parts = messageParts content
+    in case role of
+        RoleSystem -> pure projection
+            { systemTexts =
+                projection.systemTexts <> textFromMessage content
+            }
+        RoleDeveloper -> pure projection
+            { systemTexts =
+                projection.systemTexts <> textFromMessage content
+            }
+        RoleAssistant ->
+            pure (appendModelParts parts projection)
+        RoleUnknown "model" ->
+            pure (appendModelParts parts projection)
+        RoleUnknown _ ->
+            pure (appendContent "user" parts projection)
+        RoleUser ->
+            pure (appendContent "user" parts projection)
+
+appendModelParts :: [Value] -> Projection -> Projection
+appendModelParts [] projection = projection
+appendModelParts parts projection =
+    appendContent "model" signedParts projection
+        { pendingThoughtSignature = Nothing }
+  where
+    signedParts = attachSignature
+        projection.pendingThoughtSignature
+        parts
+
+projectReasoning :: Projection -> ReasoningItem -> Projection
+projectReasoning projection reasoning
+    | Just text <- nonEmptyText (reasoningItemText reasoning) =
+        appendContent "model"
+            [ object $
+                [ "text" .= text
+                , "thought" .= True
+                ]
+                <> maybe []
+                    (\signature -> ["thoughtSignature" .= signature])
+                    signature
+            ]
+            projection
+                { pendingThoughtSignature = Nothing }
+    | Just encrypted <- reasoning.encryptedContent =
+        projection { pendingThoughtSignature = Just encrypted }
+    | otherwise = projection
+  where
+    signature =
+        reasoning.encryptedContent
+            <|> projection.pendingThoughtSignature
+
+projectFunctionCall :: Projection -> FunctionCall -> Projection
+projectFunctionCall projection call =
+    appendContent "model" [part] projection
+        { callNames = Map.insert call.callId call.name projection.callNames
+        , pendingThoughtSignature = Nothing
+        }
+  where
+    args
+        | call.name `Set.member` projection.customToolNames =
+            object ["input" .= call.arguments]
+        | otherwise =
+            case Aeson.eitherDecodeStrict' (encodeUtf8 call.arguments) of
+                Right value -> value
+                Left _ -> Object KeyMap.empty
+    functionCall = object
+        [ "id" .= call.callId
+        , "name" .= call.name
+        , "args" .= args
+        ]
+    part = object $
+        ["functionCall" .= functionCall]
+            <> maybe []
+                (\signature -> ["thoughtSignature" .= signature])
+                projection.pendingThoughtSignature
+
+projectCustomToolCall :: Projection -> CustomToolCall -> Projection
+projectCustomToolCall projection call =
+    projectFunctionCall projection FunctionCall
+        { itemId = call.itemId
+        , callId = call.callId
+        , name = call.name
+        , namespace = call.namespace
+        , provider = Just "gemini"
+        , arguments = call.input
+        , encryptedFunctionArgs = Nothing
+        , status = call.status
+        }
+
+projectCustomToolOutput
+    :: Projection
+    -> CustomToolCallOutput
+    -> Projection
+projectCustomToolOutput projection callOutput =
+    projectFunctionOutput projection FunctionCallOutput
+        { itemId = callOutput.itemId
+        , callId = callOutput.callId
+        , name = callOutput.name
+        , namespace = Nothing
+        , provider = Just "gemini"
+        , output = callOutput.output
+        , status = callOutput.status
+        }
+
+projectFunctionOutput :: Projection -> FunctionCallOutput -> Projection
+projectFunctionOutput projection callOutput =
+    appendContent "user" [part] projection
+  where
+    callName = fromMaybe "tool"
+        (callOutput.name
+            <|> Map.lookup callOutput.callId projection.callNames)
+    result = toJSON callOutput.output
+    responseObject = case result of
+        Object objectValue -> Object objectValue
+        value -> object ["result" .= value]
+    part = object
+        [ "functionResponse" .= object
+            [ "id" .= callOutput.callId
+            , "name" .= callName
+            , "response" .= responseObject
+            ]
+        ]
+
+appendContent :: Text -> [Value] -> Projection -> Projection
+appendContent _ [] projection = projection
+appendContent role parts projection =
+    projection { contents = appendOrMerge projection.contents }
+  where
+    next = object ["role" .= role, "parts" .= parts]
+    appendOrMerge [] = [next]
+    appendOrMerge values =
+        case unsnoc values of
+            Just (prefix, Object lastContent)
+                | Just (String lastRole) <- KeyMap.lookup "role" lastContent
+                , lastRole == role
+                , Just (Array lastParts) <- KeyMap.lookup "parts" lastContent ->
+                    prefix
+                        <> [Object (KeyMap.insert "parts"
+                                (toJSON (toList lastParts <> parts))
+                                lastContent)]
+            _ -> values <> [next]
+
+attachSignature :: Maybe Text -> [Value] -> [Value]
+attachSignature Nothing parts = parts
+attachSignature _ [] = []
+attachSignature (Just signature) (Object first : rest) =
+    Object (KeyMap.insert "thoughtSignature" (String signature) first) : rest
+attachSignature _ parts = parts
+
+messageParts :: MessageContent -> [Value]
+messageParts = \case
+    MessageContentText text -> [textPart text]
+    MessageContentParts parts -> concatMap contentPart parts
+
+textFromMessage :: MessageContent -> [Text]
+textFromMessage = \case
+    MessageContentText text -> maybe [] pure (nonEmptyText text)
+    MessageContentParts parts ->
+        mapMaybe contentPartText parts
+
+contentPart :: ResponseContentPart -> [Value]
+contentPart = \case
+    InputTextPart{text} -> [textPart text]
+    OutputTextPart{text} -> [textPart text]
+    PlainTextPart{text} -> [textPart text]
+    ReasoningTextPart{text} -> [textPart text]
+    SummaryTextPart{text} -> [textPart text]
+    RefusalPart{refusal} -> [textPart refusal]
+    InputImagePart{imageUrl = Just url} ->
+        [dataOrFilePart Nothing url]
+    InputFilePart{fileData = Just fileData} ->
+        [dataOrFilePart Nothing fileData]
+    InputFilePart{fileUrl = Just fileUrl} ->
+        [dataOrFilePart Nothing fileUrl]
+    -- File ids belong to Responses' upload API and cannot be dereferenced by
+    -- Google's API. Encrypted/unknown parts are provider-private.
+    InputImagePart{} -> []
+    InputFilePart{} -> []
+    InputAudioPart{} -> []
+    EncryptedContentPart{} -> []
+    UnknownContentPart{} -> []
+
+contentPartText :: ResponseContentPart -> Maybe Text
+contentPartText = \case
+    InputTextPart{text} -> nonEmptyText text
+    OutputTextPart{text} -> nonEmptyText text
+    PlainTextPart{text} -> nonEmptyText text
+    ReasoningTextPart{text} -> nonEmptyText text
+    SummaryTextPart{text} -> nonEmptyText text
+    RefusalPart{refusal} -> nonEmptyText refusal
+    InputImagePart{} -> Nothing
+    InputFilePart{} -> Nothing
+    InputAudioPart{} -> Nothing
+    EncryptedContentPart{} -> Nothing
+    UnknownContentPart{} -> Nothing
+
+dataOrFilePart :: Maybe Text -> Text -> Value
+dataOrFilePart fallbackMime source =
+    case parseDataUrl source of
+        Just (mime, payload) -> object
+            [ "inlineData" .= object
+                [ "mimeType" .= mime
+                , "data" .= payload
+                ]
+            ]
+        Nothing -> object
+            [ "fileData" .= object
+                [ "mimeType" .= fromMaybe "application/octet-stream" fallbackMime
+                , "fileUri" .= source
+                ]
+            ]
+
+parseDataUrl :: Text -> Maybe (Text, Text)
+parseDataUrl source = do
+    remainder <- Text.stripPrefix "data:" source
+    let (header, withComma) = Text.breakOn "," remainder
+    payload <- Text.stripPrefix "," withComma
+    mime <- Text.stripSuffix ";base64" header
+    if Text.null mime || Text.null payload
+        then Nothing
+        else Just (mime, payload)
+
+reasoningItemText :: ReasoningItem -> Text
+reasoningItemText reasoning =
+    Text.concat selected
+  where
+    summaries =
+        mapMaybe (\part -> part.text) reasoning.summary
+    contentTexts =
+        maybe [] (mapMaybe contentPartText) reasoning.content
+    selected
+        | null summaries = contentTexts
+        | otherwise = summaries
+
+textPart :: Text -> Value
+textPart text = object ["text" .= text]
+
+systemInstruction :: [Text] -> Maybe Value
+systemInstruction values = do
+    text <- nonEmptyText (Text.intercalate "\n\n" values)
+    pure $ object ["parts" .= [textPart text]]
+
+generationConfig :: Text -> ResponseCreateParams -> Maybe Value
+generationConfig model params
+    | null fields = Nothing
+    | otherwise = Just (object fields)
+  where
+    fields = catMaybes
+        [ ("maxOutputTokens" .=) <$> params.maxOutputTokens
+        , ("temperature" .=) <$> params.temperature
+        , ("topP" .=) <$> params.topP
+        , ("thinkingConfig" .=) <$> thinkingConfig model params.reasoning
+        , ("responseMimeType" .=) <$> responseMimeType params.text
+        , ("responseJsonSchema" .=) <$> responseJsonSchema params.text
+        ]
+
+thinkingConfig :: Text -> Maybe ReasoningConfig -> Maybe Value
+thinkingConfig model reasoning = do
+    effort <- reasoning >>= (.effort) >>= nonEmptyText
+    let normalized = Text.toLower (Text.strip effort)
+    pure $ object
+        [ "thinkingLevel" .= thinkingLevel model effort
+        , "includeThoughts" .= (normalized /= "none")
+        ]
+
+thinkingLevel :: Text -> Text -> Text
+thinkingLevel model effort = case Text.toLower (Text.strip effort) of
+    "none" -> minimumThinkingLevel model
+    "minimal" -> minimumThinkingLevel model
+    "low" -> "LOW"
+    "medium" -> "MEDIUM"
+    "high" -> "HIGH"
+    "xhigh" -> "HIGH"
+    _ -> "MEDIUM"
+
+-- Gemini's lowest accepted thinking level is model-specific. In particular,
+-- Gemini 3.7 Flash and 3.1 Pro reject MINIMAL, while 3.5 Flash-Lite accepts it.
+-- LOW is the safest minimum for unknown text models.
+minimumThinkingLevel :: Text -> Text
+minimumThinkingLevel model
+    | normalizeModelId model `Set.member` minimalThinkingModels = "MINIMAL"
+    | otherwise = "LOW"
+  where
+    minimalThinkingModels = Set.fromList
+        [ "gemini-3.5-flash-lite"
+        , "gemini-3.5-flash"
+        , "gemini-3.6-flash"
+        , "gemini-3-flash-preview"
+        ]
+
+responseMimeType :: Maybe ResponseTextConfig -> Maybe Text
+responseMimeType config = config >>= (.format) >>= \case
+    ResponseFormatText -> Nothing
+    ResponseFormatJsonObject -> Just "application/json"
+    ResponseFormatJsonSchema{} -> Just "application/json"
+    ResponseFormatUnknown{} -> Nothing
+
+responseJsonSchema :: Maybe ResponseTextConfig -> Maybe Value
+responseJsonSchema config = config >>= (.format) >>= \case
+    ResponseFormatJsonSchema{formatSchema} -> Just (toJSON formatSchema)
+    ResponseFormatText -> Nothing
+    ResponseFormatJsonObject -> Nothing
+    ResponseFormatUnknown{} -> Nothing
+
+projectTools
+    :: Maybe [ResponseTool]
+    -> Either ApiError (Maybe [Value], Set Text)
+projectTools Nothing = pure (Nothing, Set.empty)
+projectTools (Just []) = pure (Nothing, Set.empty)
+projectTools (Just tools) = do
+    projected <- traverse projectTool tools
+    let declarations = concatMap fst projected
+        nativeTools = concatMap (fst . snd) projected
+        customToolNames =
+            Set.unions (map (snd . snd) projected)
+        functionTools = case declarations of
+            [] -> []
+            values ->
+                [object ["functionDeclarations" .= values]]
+        allTools = functionTools <> nativeTools
+    pure $ case allTools of
+        [] -> (Nothing, customToolNames)
+        values -> (Just values, customToolNames)
+
+projectTool
+    :: ResponseTool
+    -> Either ApiError ([Value], ([Value], Set Text))
+projectTool = \case
+    FunctionToolValue tool ->
+        pure
+            ( [object (catMaybes
+                [ Just ("name" .= tool.name)
+                , ("description" .=) <$> tool.description
+                , ("parametersJsonSchema" .=)
+                    . toJSON <$> tool.parameters
+                ])]
+            , ([], Set.empty)
+            )
+    NamespaceToolValue namespace ->
+        combineProjected <$> traverse projectTool namespace.tools
+    CustomToolValue tool ->
+        pure
+            ( [object
+                [ "name" .= tool.name
+                , "description" .= customToolDescription tool
+                , "parametersJsonSchema" .= customToolSchema
+                ]]
+            , ([], Set.singleton tool.name)
+            )
+    KnownResponseTool ToolWebSearch ->
+        pure
+            ( []
+            , ([object ["googleSearch" .= object []]], Set.empty)
+            )
+    KnownResponseTool ToolWebSearchPreview ->
+        pure
+            ( []
+            , ([object ["googleSearch" .= object []]], Set.empty)
+            )
+    KnownResponseTool toolType ->
+        unsupported (responseToolTypeText toolType)
+    UnknownResponseTool{} -> unsupported "unknown"
+  where
+    unsupported kind = Left $ ProviderError InvalidRequestError
+        ("Gemini does not support tool type " <> kind)
+        Nothing
+
+    combineProjected values =
+        ( concatMap fst values
+        , ( concatMap (fst . snd) values
+          , Set.unions (map (snd . snd) values)
+          )
+        )
+
+customToolDescription :: CustomTool -> Text
+customToolDescription tool =
+    fromMaybe ("Run " <> tool.name) tool.description
+        <> "\n\nPass the tool's complete raw input in the `input` field."
+
+customToolSchema :: Value
+customToolSchema = object
+    [ "type" .= ("object" :: Text)
+    , "properties" .= object
+        [ "input" .= object
+            [ "type" .= ("string" :: Text)
+            , "description" .=
+                ("Complete raw input for the custom tool." :: Text)
+            ]
+        ]
+    , "required" .= ["input" :: Text]
+    , "additionalProperties" .= False
+    ]
+
+toolConfig :: Maybe ToolChoice -> Maybe Value
+toolConfig choice = choice >>= \case
+    ToolChoiceMode mode -> Just $ object
+        [ "functionCallingConfig" .= object
+            ["mode" .= modeText mode]
+        ]
+    ToolChoiceObject{} -> Nothing
+  where
+    modeText = \case
+        ToolChoiceNone -> ("NONE" :: Text)
+        ToolChoiceAuto -> "AUTO"
+        ToolChoiceRequired -> "ANY"
+        ToolChoiceModeUnknown value -> Text.toUpper value
+
+nonEmptyText :: Text -> Maybe Text
+nonEmptyText value
+    | Text.null stripped = Nothing
+    | otherwise = Just stripped
+  where
+    stripped = Text.strip value
+
+encodeUtf8 :: Text -> BS.ByteString
+encodeUtf8 = TextEncoding.encodeUtf8
+
+unsnoc :: [a] -> Maybe ([a], a)
+unsnoc [] = Nothing
+unsnoc values = Just (init values, last values)
+
+toList = Foldable.toList

--- a/packages/agent-gemini/src/Agent/Gemini/Response.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Response.hs
@@ -1,0 +1,390 @@
+-- | Incremental projection of native Gemini chunks into the harness' common
+-- response model.
+module Agent.Gemini.Response
+    ( GeminiStreamEvent(..)
+    , StreamState
+    , initialStreamState
+    , initialStreamStateWithCustomTools
+    , applyChunk
+    , buildResponse
+    , streamReachedTerminal
+    ) where
+
+import Agent.Gemini.Types
+import Agent.Responses.Types
+import Control.Applicative ((<|>))
+import Data.Aeson (Value(..), encode)
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (find)
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+
+data GeminiStreamEvent
+    = GeminiTextDelta !Text
+    | GeminiReasoningDelta !Text
+    | GeminiFunctionCallReady !FunctionCall
+    deriving (Eq, Show)
+
+data StreamState = StreamState
+    { fallbackResponseId :: !Text
+    , requestedModel :: !Text
+    , observedResponseId :: !(Maybe Text)
+    , observedModelVersion :: !(Maybe Text)
+    , responseOutputRev :: ![ResponseItem]
+    , pendingAssistantTextRev :: ![Text]
+    , responseUsage :: !(Maybe UsageMetadata)
+    , responseFinishReason :: !(Maybe Text)
+    , responsePromptBlockReason :: !(Maybe Text)
+    , nextFunctionCallIndex :: !Int
+    , responseCustomToolNames :: !(Set Text)
+    }
+
+initialStreamState :: Text -> Text -> StreamState
+initialStreamState model fallbackId =
+    initialStreamStateWithCustomTools model fallbackId Set.empty
+
+initialStreamStateWithCustomTools
+    :: Text
+    -> Text
+    -> Set Text
+    -> StreamState
+initialStreamStateWithCustomTools model fallbackId customToolNames = StreamState
+    { fallbackResponseId = fallbackId
+    , requestedModel = model
+    , observedResponseId = Nothing
+    , observedModelVersion = Nothing
+    , responseOutputRev = []
+    , pendingAssistantTextRev = []
+    , responseUsage = Nothing
+    , responseFinishReason = Nothing
+    , responsePromptBlockReason = Nothing
+    , nextFunctionCallIndex = 0
+    , responseCustomToolNames = customToolNames
+    }
+
+applyChunk
+    :: StreamState
+    -> GenerateContentResponse
+    -> (StreamState, [GeminiStreamEvent])
+applyChunk initial chunk =
+    foldl' applyPart (withMetadata, []) parts
+  where
+    candidate = primaryCandidate chunk.nativeCandidates
+    parts = maybe [] (.contentParts)
+        (candidate >>= (.candidateContent))
+    withMetadata = initial
+        { observedResponseId =
+            chunk.nativeResponseId <|> initial.observedResponseId
+        , observedModelVersion =
+            chunk.nativeModelVersion <|> initial.observedModelVersion
+        , responseUsage =
+            chunk.nativeUsageMetadata <|> initial.responseUsage
+        , responseFinishReason =
+            mergeFinishReason
+                initial.responseFinishReason
+                (candidate >>= (.candidateFinishReason))
+        , responsePromptBlockReason =
+            mergePromptBlockReason
+                initial.responsePromptBlockReason
+                chunk.nativePromptBlockReason
+        }
+
+primaryCandidate :: [Candidate] -> Maybe Candidate
+primaryCandidate candidates =
+    find ((== Just 0) . (.candidateIndex)) candidates
+        <|> case candidates of
+            first : _ -> Just first
+            [] -> Nothing
+
+applyPart
+    :: (StreamState, [GeminiStreamEvent])
+    -> Part
+    -> (StreamState, [GeminiStreamEvent])
+applyPart (state, events) part =
+    ( withOutput
+        { nextFunctionCallIndex =
+            withOutput.nextFunctionCallIndex + functionCallCount
+        }
+    , events <> partEvents
+    )
+  where
+    withOutput = foldl' appendOutputItem state outputItems
+    text = part.partText >>= nonEmptyDelta
+    functionCall = canonicalFunctionCall state <$> part.partFunctionCall
+    functionCallCount = maybe 0 (const 1) functionCall
+    signatureItems
+        | part.partThought = []
+        | otherwise = maybe [] (pure . signatureItem)
+            part.partThoughtSignature
+    textItems = case text of
+        Just value
+            | part.partThought ->
+                [reasoningItem value part.partThoughtSignature]
+            | otherwise ->
+                [assistantMessageItem value]
+        Nothing
+            | part.partThought
+            , Just signature <- part.partThoughtSignature ->
+                [signatureItem signature]
+            | otherwise -> []
+    callItems = maybe [] (pure . FunctionCallItem) functionCall
+    outputItems = signatureItems <> textItems <> callItems
+    partEvents =
+        maybe [] (\value ->
+            [ if part.partThought
+                then GeminiReasoningDelta value
+                else GeminiTextDelta value
+            ])
+            text
+        <> maybe [] (pure . GeminiFunctionCallReady) functionCall
+
+canonicalFunctionCall
+    :: StreamState
+    -> NativeFunctionCall
+    -> FunctionCall
+canonicalFunctionCall state native = FunctionCall
+    { itemId = Just callId
+    , callId
+    , name = native.functionCallName
+    , namespace = Nothing
+    , provider = Just "gemini"
+    , arguments
+    , encryptedFunctionArgs = Nothing
+    , status = Just ItemCompleted
+    }
+  where
+    callId = fromMaybe syntheticId
+        (native.functionCallId >>= nonEmptyText)
+    syntheticId =
+        effectiveResponseId state
+            <> "-call-"
+            <> Text.pack (show state.nextFunctionCallIndex)
+    arguments
+        | native.functionCallName
+            `Set.member` state.responseCustomToolNames =
+            customToolInput native.functionCallArgs
+        | otherwise = jsonText native.functionCallArgs
+
+customToolInput :: Value -> Text
+customToolInput = \case
+    Object arguments
+        | Just (String input) <- KeyMap.lookup "input" arguments ->
+            input
+    value -> jsonText value
+
+assistantMessageItem :: Text -> ResponseItem
+assistantMessageItem text = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentParts
+        [OutputTextPart text Nothing Nothing]
+    , role = RoleAssistant
+    , status = Just ItemCompleted
+    , phase = Nothing
+    , passthrough = Nothing
+    }
+
+-- Gemini emits answer text as wire deltas, while a canonical Responses
+-- message stores the complete text. Accumulate adjacent chunks in reverse and
+-- flatten once, both preserving token-boundary whitespace and avoiding a
+-- repeated strict-Text append for every network frame.
+appendOutputItem :: StreamState -> ResponseItem -> StreamState
+appendOutputItem state = \case
+    MessageItem message
+        | message.role == RoleAssistant
+        , MessageContentParts [OutputTextPart text Nothing Nothing] <-
+            message.content ->
+            state
+                { pendingAssistantTextRev =
+                    text : state.pendingAssistantTextRev
+                }
+    item ->
+        let flushed = flushAssistantText state
+        in flushed
+            { responseOutputRev = item : flushed.responseOutputRev }
+
+flushAssistantText :: StreamState -> StreamState
+flushAssistantText state = case state.pendingAssistantTextRev of
+    [] -> state
+    chunksRev ->
+        state
+            { responseOutputRev =
+                assistantMessageItem (Text.concat (reverse chunksRev))
+                    : state.responseOutputRev
+            , pendingAssistantTextRev = []
+            }
+
+assembledOutput :: StreamState -> [ResponseItem]
+assembledOutput state =
+    let flushed = flushAssistantText state
+    in reverse flushed.responseOutputRev
+
+reasoningItem :: Text -> Maybe Text -> ResponseItem
+reasoningItem text signature = ReasoningItemValue ReasoningItem
+    { itemId = Nothing
+    , summary = [ReasoningSummaryPart "summary_text" (Just text)]
+    , content = Nothing
+    , encryptedContent = signature
+    , status = Just ItemCompleted
+    }
+
+signatureItem :: Text -> ResponseItem
+signatureItem signature = ReasoningItemValue ReasoningItem
+    { itemId = Nothing
+    , summary = []
+    , content = Nothing
+    , encryptedContent = Just signature
+    , status = Just ItemCompleted
+    }
+
+buildResponse :: ResponseCreateParams -> StreamState -> Response
+buildResponse request state = Response
+    { responseId = effectiveResponseId state
+    , createdAt = 0
+    , error = Nothing
+    , incompleteDetails =
+        IncompleteDetails <$> incompleteReason
+    , instructions = Nothing
+    , metadata = request.metadata
+    , model = fromMaybe state.requestedModel state.observedModelVersion
+    , object = "response"
+    , output = assembledOutput state
+    , parallelToolCalls = request.parallelToolCalls
+    , temperature = request.temperature
+    , toolChoice = request.toolChoice
+    , tools = request.tools
+    , topP = request.topP
+    , background = Nothing
+    , completedAt = Just 0
+    , conversation = Nothing
+    , maxOutputTokens = request.maxOutputTokens
+    , maxToolCalls = request.maxToolCalls
+    , moderation = Nothing
+    , previousResponseId = Nothing
+    , prompt = Nothing
+    , promptCacheKey = request.promptCacheKey
+    , promptCacheOptions = request.promptCacheOptions
+    , promptCacheRetention = request.promptCacheRetention
+    , reasoning = request.reasoning
+    , safetyIdentifier = request.safetyIdentifier
+    , serviceTier = Nothing
+    , status = maybe ResponseCompleted
+        (const ResponseIncomplete)
+        incompleteReason
+    , text = request.text
+    , topLogprobs = Nothing
+    , truncation = request.truncation
+    , usage = responseUsage <$> state.responseUsage
+    , user = request.user
+    }
+  where
+    incompleteReason =
+        (blockedReason <$> state.responsePromptBlockReason)
+            <|> (state.responseFinishReason >>= finishReason)
+
+-- A clean HTTP EOF is only a complete Gemini response after the provider has
+-- supplied a candidate finish reason or a prompt-block reason. Without one,
+-- EOF can mean that the streaming connection was truncated.
+streamReachedTerminal :: StreamState -> Bool
+streamReachedTerminal state =
+    maybe False isTerminalFinishReason state.responseFinishReason
+        || maybe False isTerminalPromptBlockReason
+            state.responsePromptBlockReason
+
+mergeFinishReason :: Maybe Text -> Maybe Text -> Maybe Text
+mergeFinishReason previous current = case current of
+    Just reason
+        | isTerminalFinishReason reason -> Just reason
+    _ -> previous
+
+isTerminalFinishReason :: Text -> Bool
+isTerminalFinishReason raw =
+    let normalized = Text.toUpper (Text.strip raw)
+    in not (Text.null normalized)
+        && normalized /= "FINISH_REASON_UNSPECIFIED"
+
+mergePromptBlockReason :: Maybe Text -> Maybe Text -> Maybe Text
+mergePromptBlockReason previous current = case current of
+    Just reason
+        | isTerminalPromptBlockReason reason -> Just reason
+    _ -> previous
+
+isTerminalPromptBlockReason :: Text -> Bool
+isTerminalPromptBlockReason raw =
+    let normalized = Text.toUpper (Text.strip raw)
+    in not (Text.null normalized)
+        && normalized /= "BLOCK_REASON_UNSPECIFIED"
+
+effectiveResponseId :: StreamState -> Text
+effectiveResponseId state =
+    fromMaybe state.fallbackResponseId state.observedResponseId
+
+finishReason :: Text -> Maybe Text
+finishReason raw = case Text.toUpper (Text.strip raw) of
+    "" -> Nothing
+    "STOP" -> Nothing
+    "FINISH_REASON_UNSPECIFIED" -> Nothing
+    "MAX_TOKENS" -> Just "max_output_tokens"
+    "MALFORMED_FUNCTION_CALL" -> Just "invalid_tool_call"
+    "UNEXPECTED_TOOL_CALL" -> Just "invalid_tool_call"
+    reason -> Just (blockedReason reason)
+
+blockedReason :: Text -> Text
+blockedReason reason
+    | Text.toUpper reason `elem` filterReasons = "content_filter"
+    | otherwise = Text.toLower reason
+  where
+    filterReasons =
+        [ "SAFETY"
+        , "RECITATION"
+        , "BLOCKLIST"
+        , "PROHIBITED_CONTENT"
+        , "SPII"
+        , "IMAGE_SAFETY"
+        , "IMAGE_PROHIBITED_CONTENT"
+        ]
+
+responseUsage :: UsageMetadata -> ResponseUsage
+responseUsage usage = ResponseUsage
+    { inputTokens = promptTokens
+    , inputTokensDetails = Just TokenDetails
+        { cachedTokens = usage.cachedContentTokenCount
+        , reasoningTokens = Nothing
+        }
+    , outputTokens = outputTokens
+    , outputTokensDetails = Just TokenDetails
+        { cachedTokens = Nothing
+        , reasoningTokens = usage.thoughtsTokenCount
+        }
+    , totalTokens =
+        fromMaybe (promptTokens + outputTokens) usage.totalTokenCount
+    }
+  where
+    promptTokens = fromMaybe 0 usage.promptTokenCount
+    -- Google reports candidate and thought tokens separately; its documented
+    -- total is prompt + thoughts + response candidates.
+    outputTokens =
+        fromMaybe 0 usage.candidatesTokenCount
+            + fromMaybe 0 usage.thoughtsTokenCount
+
+jsonText :: Value -> Text
+jsonText =
+    TextEncoding.decodeUtf8 . LBS.toStrict . encode
+
+nonEmptyText :: Text -> Maybe Text
+nonEmptyText value
+    | Text.null stripped = Nothing
+    | otherwise = Just stripped
+  where
+    stripped = Text.strip value
+
+-- Streamed text is a byte-for-byte delta. Trimming individual chunks would
+-- collapse token-boundary spaces (for example, @"hello "@ <> @"world"@).
+nonEmptyDelta :: Text -> Maybe Text
+nonEmptyDelta value
+    | Text.null value = Nothing
+    | otherwise = Just value

--- a/packages/agent-gemini/src/Agent/Gemini/Stream.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Stream.hs
@@ -1,0 +1,227 @@
+-- | Incremental decoding of Gemini's server-sent GenerateContent responses.
+module Agent.Gemini.Stream
+    ( SseDecoder
+    , newSseDecoder
+    , feedSseDecoder
+    , finishSseDecoder
+    , parseSseResponses
+    , parseSseResponsesBytes
+    ) where
+
+import Agent.Error (ApiError(..))
+import Agent.Gemini.Types (GenerateContentResponse)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.Maybe as Maybe
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.Encoding.Error as TextEncoding (lenientDecode)
+import Data.Word (Word8)
+
+-- | Incomplete lines and event blocks remain chunked until a terminating
+-- newline arrives. This avoids repeatedly copying a large JSON frame when the
+-- HTTP client splits it across many small chunks.
+data SseDecoder = SseDecoder
+    { decoderLineChunksRev :: ![BS.ByteString]
+    , decoderBlockLinesRev :: ![BS.ByteString]
+    , decoderEventBytes :: !Int
+    }
+
+newSseDecoder :: SseDecoder
+newSseDecoder = SseDecoder
+    { decoderLineChunksRev = []
+    , decoderBlockLinesRev = []
+    , decoderEventBytes = 0
+    }
+
+feedSseDecoder
+    :: SseDecoder
+    -> BS.ByteString
+    -> Either ApiError (SseDecoder, [GenerateContentResponse])
+feedSseDecoder decoder chunk =
+    decodeAvailable decoder chunk []
+  where
+    decodeAvailable current bytes responses
+        | BS.null bytes = Right (current, reverse responses)
+        | otherwise =
+            let (linePart, restWithNewline) = BS.break (== lineFeed) bytes
+            in if BS.null restWithNewline
+                then do
+                    next <- appendLinePart current linePart
+                    Right (next, reverse responses)
+                else do
+                    withPart <- appendLinePart current linePart
+                    withNewline <- addEventBytes 1 withPart
+                    let line = completeLine withNewline
+                        afterLine =
+                            withNewline { decoderLineChunksRev = [] }
+                    (next, decoded) <- consumeLine afterLine line
+                    decodeAvailable
+                        next
+                        (BS.tail restWithNewline)
+                        (maybe responses (: responses) decoded)
+
+-- | Finish a stream, accepting a final event without a blank-line delimiter.
+finishSseDecoder
+    :: SseDecoder
+    -> Either ApiError [GenerateContentResponse]
+finishSseDecoder decoder = do
+    (afterLine, lineResponse) <-
+        if null decoder.decoderLineChunksRev
+            then Right (decoder, Nothing)
+            else
+                let line = completeLine decoder
+                    withoutLine = decoder { decoderLineChunksRev = [] }
+                in consumeLine withoutLine line
+    blockResponse <-
+        parseBlockLines (reverse afterLine.decoderBlockLinesRev)
+    pure (Maybe.catMaybes [lineResponse, blockResponse])
+
+parseSseResponses
+    :: Text
+    -> Either ApiError [GenerateContentResponse]
+parseSseResponses =
+    parseSseResponsesBytes . TextEncoding.encodeUtf8
+
+parseSseResponsesBytes
+    :: BS.ByteString
+    -> Either ApiError [GenerateContentResponse]
+parseSseResponsesBytes bytes = do
+    (decoder, responses) <- feedSseDecoder newSseDecoder bytes
+    trailing <- finishSseDecoder decoder
+    pure (responses <> trailing)
+
+appendLinePart
+    :: SseDecoder
+    -> BS.ByteString
+    -> Either ApiError SseDecoder
+appendLinePart decoder chunk
+    | BS.null chunk = Right decoder
+    | otherwise = do
+        withBytes <- addEventBytes (BS.length chunk) decoder
+        pure withBytes
+            { decoderLineChunksRev =
+                chunk : withBytes.decoderLineChunksRev
+            }
+
+addEventBytes :: Int -> SseDecoder -> Either ApiError SseDecoder
+addEventBytes amount decoder
+    | amount <= maxSseEventBytes - decoder.decoderEventBytes =
+        Right decoder
+            { decoderEventBytes = decoder.decoderEventBytes + amount }
+    | otherwise = Left $ JsonDecodeError
+        ( "Gemini SSE event exceeds "
+            <> Text.pack (show maxSseEventBytes)
+            <> " bytes"
+        )
+        (decoderPreview decoder)
+
+completeLine :: SseDecoder -> BS.ByteString
+completeLine =
+    dropTrailingCarriageReturn
+        . BS.concat
+        . reverse
+        . (.decoderLineChunksRev)
+
+consumeLine
+    :: SseDecoder
+    -> BS.ByteString
+    -> Either
+        ApiError
+        (SseDecoder, Maybe GenerateContentResponse)
+consumeLine decoder line
+    | BS.null line = do
+        decoded <-
+            parseBlockLines (reverse decoder.decoderBlockLinesRev)
+        pure (newSseDecoder, decoded)
+    | otherwise =
+        Right
+            ( decoder
+                { decoderBlockLinesRev =
+                    line : decoder.decoderBlockLinesRev
+                }
+            , Nothing
+            )
+
+parseBlockLines
+    :: [BS.ByteString]
+    -> Either ApiError (Maybe GenerateContentResponse)
+parseBlockLines [] = Right Nothing
+parseBlockLines lines =
+    parseBlockBytes (BS.intercalate "\n" lines)
+
+parseBlockBytes
+    :: BS.ByteString
+    -> Either ApiError (Maybe GenerateContentResponse)
+parseBlockBytes bytes =
+    case TextEncoding.decodeUtf8' bytes of
+        Left err -> Left $ JsonDecodeError
+            ("Invalid UTF-8 in Gemini SSE event: " <> Text.pack (show err))
+            (Text.take 2000
+                (TextEncoding.decodeUtf8With TextEncoding.lenientDecode bytes))
+        Right _ -> parseBlock bytes
+
+parseBlock
+    :: BS.ByteString
+    -> Either ApiError (Maybe GenerateContentResponse)
+parseBlock block
+    | BS.null dataBytes = Right Nothing
+    | isDonePayload dataBytes = Right Nothing
+    | otherwise =
+        case Aeson.eitherDecodeStrict' dataBytes of
+            Left err -> Left $ JsonDecodeError
+                ("Invalid Gemini SSE JSON: " <> Text.pack err)
+                (Text.take 2000
+                    (TextEncoding.decodeUtf8With
+                        TextEncoding.lenientDecode
+                        dataBytes))
+            Right response -> Right (Just response)
+  where
+    blockLines = map dropTrailingCarriageReturn (BS8.lines block)
+    dataBytes = BS.intercalate "\n"
+        [ stripOptionalSpace (BS.drop 5 line)
+        | line <- blockLines
+        , "data:" `BS.isPrefixOf` line
+        ]
+    stripOptionalSpace line =
+        Maybe.fromMaybe line (BS.stripPrefix " " line)
+
+isDonePayload :: BS.ByteString -> Bool
+isDonePayload bytes =
+    Text.strip
+        (TextEncoding.decodeUtf8With TextEncoding.lenientDecode bytes)
+        == "[DONE]"
+
+dropTrailingCarriageReturn :: BS.ByteString -> BS.ByteString
+dropTrailingCarriageReturn bytes =
+    case BS.unsnoc bytes of
+        Just (prefix, byte)
+            | byte == carriageReturn -> prefix
+        _ -> bytes
+
+decoderPreview :: SseDecoder -> Text
+decoderPreview decoder =
+    TextEncoding.decodeUtf8With TextEncoding.lenientDecode
+        $ BS.concat
+        $ takeByteChunks 2000
+        $ reverse decoder.decoderBlockLinesRev
+            <> reverse decoder.decoderLineChunksRev
+
+takeByteChunks :: Int -> [BS.ByteString] -> [BS.ByteString]
+takeByteChunks remaining _
+    | remaining <= 0 = []
+takeByteChunks _ [] = []
+takeByteChunks remaining (chunk : rest) =
+    let kept = BS.take remaining chunk
+    in kept : takeByteChunks (remaining - BS.length kept) rest
+
+lineFeed :: Word8
+lineFeed = 0x0a
+
+carriageReturn :: Word8
+carriageReturn = 0x0d
+
+maxSseEventBytes :: Int
+maxSseEventBytes = 64 * 1024 * 1024

--- a/packages/agent-gemini/src/Agent/Gemini/Types.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Types.hs
@@ -1,0 +1,140 @@
+-- | Minimal native Gemini response types used by the streaming adapter.
+module Agent.Gemini.Types
+    ( GenerateContentResponse(..)
+    , Candidate(..)
+    , Content(..)
+    , Part(..)
+    , NativeFunctionCall(..)
+    , UsageMetadata(..)
+    ) where
+
+import Control.Applicative ((<|>))
+import Data.Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.Types (Parser)
+import Data.Text (Text)
+
+data NativeFunctionCall = NativeFunctionCall
+    { functionCallId :: !(Maybe Text)
+    , functionCallName :: !Text
+    , functionCallArgs :: !Value
+    } deriving (Eq, Show)
+
+instance FromJSON NativeFunctionCall where
+    parseJSON = withObject "Gemini FunctionCall" \object ->
+        NativeFunctionCall
+            <$> object .:? "id"
+            <*> object .: "name"
+            <*> object .:? "args" .!= Object KeyMap.empty
+
+data Part = Part
+    { partText :: !(Maybe Text)
+    , partThought :: !Bool
+    , partThoughtSignature :: !(Maybe Text)
+    , partFunctionCall :: !(Maybe NativeFunctionCall)
+    } deriving (Eq, Show)
+
+instance FromJSON Part where
+    parseJSON = withObject "Gemini Part" \object ->
+        Part
+            <$> object .:? "text"
+            <*> object .:? "thought" .!= False
+            <*> object .:? "thoughtSignature"
+            <*> object .:? "functionCall"
+
+data Content = Content
+    { contentRole :: !(Maybe Text)
+    , contentParts :: ![Part]
+    } deriving (Eq, Show)
+
+instance FromJSON Content where
+    parseJSON = withObject "Gemini Content" \object ->
+        Content
+            <$> object .:? "role"
+            <*> object .:? "parts" .!= []
+
+data Candidate = Candidate
+    { candidateContent :: !(Maybe Content)
+    , candidateFinishReason :: !(Maybe Text)
+    , candidateIndex :: !(Maybe Int)
+    } deriving (Eq, Show)
+
+instance FromJSON Candidate where
+    parseJSON = withObject "Gemini Candidate" \object ->
+        Candidate
+            <$> object .:? "content"
+            <*> object .:? "finishReason"
+            <*> object .:? "index"
+
+data UsageMetadata = UsageMetadata
+    { promptTokenCount :: !(Maybe Int)
+    , candidatesTokenCount :: !(Maybe Int)
+    , cachedContentTokenCount :: !(Maybe Int)
+    , thoughtsTokenCount :: !(Maybe Int)
+    , totalTokenCount :: !(Maybe Int)
+    } deriving (Eq, Show)
+
+instance FromJSON UsageMetadata where
+    parseJSON = withObject "Gemini UsageMetadata" \object ->
+        UsageMetadata
+            <$> object .:? "promptTokenCount"
+            <*> object .:? "candidatesTokenCount"
+            <*> object .:? "cachedContentTokenCount"
+            <*> object .:? "thoughtsTokenCount"
+            <*> object .:? "totalTokenCount"
+
+data GenerateContentResponse = GenerateContentResponse
+    { nativeResponseId :: !(Maybe Text)
+    , nativeModelVersion :: !(Maybe Text)
+    , nativeCandidates :: ![Candidate]
+    , nativeUsageMetadata :: !(Maybe UsageMetadata)
+    , nativePromptBlockReason :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+instance FromJSON GenerateContentResponse where
+    parseJSON = withObject "Gemini GenerateContentResponse" \object -> do
+        traceId <- object .:? "traceId"
+        case KeyMap.lookup "response" object of
+            Just Null -> pure (emptyCodeAssistResponse traceId)
+            Just responseValue -> do
+                response <- parseJSON responseValue
+                pure response
+                    { nativeResponseId =
+                        response.nativeResponseId <|> traceId
+                    }
+            Nothing
+                | any (`KeyMap.member` object)
+                    ["traceId", "consumedCredits", "remainingCredits"] ->
+                    pure (emptyCodeAssistResponse traceId)
+                | otherwise -> parseNativeResponse object
+
+emptyCodeAssistResponse :: Maybe Text -> GenerateContentResponse
+emptyCodeAssistResponse responseId = GenerateContentResponse
+    { nativeResponseId = responseId
+    , nativeModelVersion = Nothing
+    , nativeCandidates = []
+    , nativeUsageMetadata = Nothing
+    , nativePromptBlockReason = Nothing
+    }
+
+parseNativeResponse :: Object -> Parser GenerateContentResponse
+parseNativeResponse object = do
+    if any (`KeyMap.member` object)
+        [ "responseId"
+        , "modelVersion"
+        , "candidates"
+        , "usageMetadata"
+        , "promptFeedback"
+        ]
+        then pure ()
+        else fail "Gemini stream object has no response fields"
+    promptFeedback <- object .:? "promptFeedback" :: Parser (Maybe Value)
+    blockReason <- case promptFeedback of
+        Just (Object feedback) -> feedback .:? "blockReason"
+        _ -> pure Nothing
+    GenerateContentResponse
+        <$> object .:? "responseId"
+        <*> object .:? "modelVersion"
+        <*> object .:? "candidates" .!= []
+        <*> object .:? "usageMetadata"
+        <*> pure blockReason

--- a/packages/agent-gemini/test/Agent/Gemini/AuthSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/AuthSpec.hs
@@ -1,0 +1,576 @@
+module Agent.Gemini.AuthSpec (spec) where
+
+import Agent.Gemini.Auth
+import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay)
+import Control.Concurrent.Async (concurrently)
+import Control.Exception.Safe (bracket)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as LBS
+import Data.Either (isLeft)
+import Data.IORef
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Network.HTTP.Types
+import qualified Network.Socket as Net
+import qualified Network.Socket.ByteString as Net
+import Network.Wai
+import Network.Wai.Handler.Warp
+import qualified System.Timeout as Timeout
+import Test.Hspec
+import Text.Read (readMaybe)
+
+spec :: Spec
+spec = do
+    describe "Google OAuth" do
+        it "builds an offline PKCE-S256 authorization URL" do
+            let url = authorizationUrl
+                    defaultOAuthOptions
+                    "http://127.0.0.1:43127/oauth2callback"
+                    "state-value"
+                    "challenge-value"
+            url `shouldSatisfy` Text.isInfixOf "access_type=offline"
+            url `shouldSatisfy` Text.isInfixOf "code_challenge=challenge-value"
+            url `shouldSatisfy` Text.isInfixOf "code_challenge_method=S256"
+            url `shouldSatisfy` Text.isInfixOf "cloud-platform"
+
+        it "computes the RFC 7636 S256 test vector" do
+            pkceChallenge
+                "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+                `shouldBe` "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+        it "validates state and extracts the callback code" do
+            validateOAuthCallback
+                "expected"
+                "/oauth2callback?code=abc123&state=expected"
+                `shouldBe` Right "abc123"
+            validateOAuthCallback
+                "expected"
+                "/oauth2callback?code=abc123&state=attacker"
+                `shouldBe` Left
+                    "Google OAuth state mismatch; authorization was rejected"
+            validateOAuthCallback
+                "expected"
+                "/oauth2callback?error=access_denied&state=attacker"
+                `shouldBe` Left
+                    "Google OAuth state mismatch; authorization was rejected"
+
+        it "accepts a callback request split across TCP reads" do
+            recorded <- newIORef []
+            testWithApplication (pure (tokenApp recorded)) \port -> do
+                presentedUrl <- newEmptyMVar
+                let options = (testOAuthOptions port) { timeoutSeconds = 5 }
+                (result, ()) <- concurrently
+                    (runLoopbackOAuth options (putMVar presentedUrl))
+                    (takeMVar presentedUrl >>= sendSplitOAuthCallback)
+                result `shouldBe` Right OAuthTokens
+                    { accessToken = "access-initial"
+                    , refreshToken = Just "refresh-initial"
+                    , expiresInSeconds = Just 3600
+                    , tokenType = Just "Bearer"
+                    , scope = Nothing
+                    }
+
+        it "exchanges a code and refreshes without losing the refresh token" do
+            recorded <- newIORef []
+            testWithApplication (pure (tokenApp recorded)) \port -> do
+                let options = testOAuthOptions port
+                exchangeAuthorizationCode
+                    options
+                    "http://127.0.0.1/callback"
+                    "verifier"
+                    "code"
+                    `shouldReturn` Right OAuthTokens
+                        { accessToken = "access-initial"
+                        , refreshToken = Just "refresh-initial"
+                        , expiresInSeconds = Just 3600
+                        , tokenType = Just "Bearer"
+                        , scope = Nothing
+                        }
+                refreshAccessToken options "refresh-old"
+                    `shouldReturn` Right OAuthTokens
+                        { accessToken = "access-refreshed"
+                        , refreshToken = Just "refresh-old"
+                        , expiresInSeconds = Just 1800
+                        , tokenType = Nothing
+                        , scope = Nothing
+                        }
+                forms <- readIORef recorded
+                forms `shouldSatisfy`
+                    any (Text.isInfixOf "code_verifier=verifier")
+                forms `shouldSatisfy`
+                    any (Text.isInfixOf "refresh_token=refresh-old")
+
+        it "fetches the account email with a bearer token" do
+            testWithApplication (pure userInfoApp) \port ->
+                fetchUserEmail (testOAuthOptions port) "secret-access"
+                    `shouldReturn` Right "person@example.com"
+
+        it "bounds authenticated endpoint waits" do
+            testWithApplication (pure slowApp) \port -> do
+                let options = (testOAuthOptions port) { timeoutSeconds = 1 }
+                result <- Timeout.timeout 2_000_000
+                    (fetchUserEmail options "secret-access")
+                result `shouldSatisfy` \case
+                    Just (Left err) ->
+                        "Google HTTP request failed" `Text.isInfixOf` err
+                    _ -> False
+
+        it "redacts tokens and the installed client secret from Show" do
+            let renderedTokens = show
+                    (OAuthTokens "access-secret" (Just "refresh-secret")
+                        Nothing Nothing Nothing)
+            renderedTokens `shouldNotContain` "access-secret"
+            renderedTokens `shouldNotContain` "refresh-secret"
+            show defaultOAuthOptions
+                `shouldNotContain` Text.unpack defaultOAuthOptions.clientSecret
+
+        it "does not expose token-form secrets in endpoint errors" do
+            testWithApplication (pure echoingTokenErrorApp) \port -> do
+                result <- refreshAccessToken
+                    (testOAuthOptions port)
+                    "refresh-must-stay-secret"
+                show result `shouldNotContain` "refresh-must-stay-secret"
+                show result `shouldNotContain` "server-echoed-sensitive-body"
+
+        it "redacts bearer tokens echoed by authenticated endpoints" do
+            testWithApplication (pure echoingBearerErrorApp) \port -> do
+                result <- fetchUserEmail
+                    (testOAuthOptions port)
+                    "access-must-stay-secret"
+                show result `shouldNotContain` "access-must-stay-secret"
+                show result `shouldContain` "<redacted>"
+
+        it "never forwards OAuth credentials or token forms across redirects" do
+            redirected <- newIORef []
+            testWithApplication (pure (redirectTargetApp redirected))
+                \targetPort ->
+                    testWithApplication
+                        (pure (redirectingApp targetPort))
+                        \originPort -> do
+                            refreshAccessToken
+                                (testOAuthOptions originPort)
+                                "refresh-must-stay-secret"
+                                >>= (`shouldSatisfy` isLeft)
+                            fetchUserEmail
+                                (testOAuthOptions originPort)
+                                "access-must-stay-secret"
+                                >>= (`shouldSatisfy` isLeft)
+                            setupCodeAssist
+                                (testCodeAssistOptions originPort)
+                                "access-must-stay-secret"
+                                >>= (`shouldSatisfy` isLeft)
+            readIORef redirected `shouldReturn` []
+
+    describe "GeminiAuthState" do
+        it "round-trips through JSON and redacts credentials from Show" do
+            let state = GeminiAuthState
+                    { accessToken = "access-secret"
+                    , refreshToken = Just "refresh-secret"
+                    , expiresAt = Nothing
+                    , email = "person@example.com"
+                    , projectId = "managed-project"
+                    , userTier = "free-tier"
+                    }
+            Aeson.eitherDecode (Aeson.encode state) `shouldBe` Right state
+            show state `shouldNotContain` "access-secret"
+            show state `shouldNotContain` "refresh-secret"
+
+    describe "Code Assist setup" do
+        it "uses an existing Code Assist project without onboarding" do
+            calls <- newIORef []
+            testWithApplication (pure (existingUserApp calls)) \port -> do
+                result <- setupCodeAssist (testCodeAssistOptions port) "bearer"
+                result `shouldBe` Right CodeAssistUser
+                    { projectId = "managed-project"
+                    , userTier = "free-tier"
+                    , userTierName = Just "Gemini Code Assist"
+                    }
+                readIORef calls `shouldReturn`
+                    ["/v1internal:loadCodeAssist"]
+
+        it "prefers paid-tier metadata for an existing account" do
+            testWithApplication (pure paidUserApp) \port ->
+                setupCodeAssist (testCodeAssistOptions port) "bearer"
+                    `shouldReturn` Right CodeAssistUser
+                        { projectId = "paid-project"
+                        , userTier = "paid-tier"
+                        , userTierName = Just "Google AI plan"
+                        }
+
+        it "fills missing paid-tier fields from the current tier" do
+            testWithApplication (pure partialPaidUserApp) \port ->
+                setupCodeAssist (testCodeAssistOptions port) "bearer"
+                    `shouldReturn` Right CodeAssistUser
+                        { projectId = "paid-project"
+                        , userTier = "standard-tier"
+                        , userTierName = Just "Google AI plan"
+                        }
+
+        it "presents one-time account validation and retries setup" do
+            calls <- newIORef (0 :: Int)
+            presented <- newIORef []
+            testWithApplication (pure (validationRequiredApp calls)) \port -> do
+                result <- setupCodeAssistWithValidation
+                    (testCodeAssistOptions port)
+                    "bearer"
+                    (Just (\url description ->
+                        modifyIORef' presented (<> [(url, description)])))
+                result `shouldBe` Right CodeAssistUser
+                    { projectId = "validated-project"
+                    , userTier = "free-tier"
+                    , userTierName = Just "Validated"
+                    }
+                readIORef calls `shouldReturn` 2
+                readIORef presented `shouldReturn`
+                    [("https://accounts.example.test/validate", "Verify please")]
+
+        it "includes the configured project for standard-tier onboarding" do
+            bodies <- newIORef []
+            testWithApplication (pure (standardOnboardingApp bodies)) \port -> do
+                let options = (testCodeAssistOptions port)
+                        { configuredProject = Just "billing-project" }
+                setupCodeAssist options "bearer"
+                    `shouldReturn` Right CodeAssistUser
+                        { projectId = "billing-project"
+                        , userTier = "standard-tier"
+                        , userTierName = Just "Standard"
+                        }
+                onboardBody <- lookup "/v1internal:onboardUser"
+                    <$> readIORef bodies
+                onboardBody `shouldSatisfy` maybe False
+                    (BS.isInfixOf "\"cloudaicompanionProject\":\"billing-project\"")
+                onboardBody `shouldSatisfy` maybe False
+                    (BS.isInfixOf "\"duetProject\":\"billing-project\"")
+
+        it "rejects a failed onboarding operation even with a configured project" do
+            testWithApplication (pure failedOnboardingApp) \port -> do
+                let options = (testCodeAssistOptions port)
+                        { configuredProject = Just "billing-project" }
+                setupCodeAssist options "bearer"
+                    `shouldReturn` Left
+                        "Gemini Code Assist onboarding failed (code 9): precondition failed"
+
+        it "redacts bearer tokens from decoded setup errors" do
+            testWithApplication (pure echoingOnboardingErrorApp) \port -> do
+                let options = (testCodeAssistOptions port)
+                        { configuredProject = Just "billing-project" }
+                result <- setupCodeAssist options "secret-bearer"
+                show result `shouldNotContain` "secret-bearer"
+                show result `shouldContain` "<redacted>"
+
+        it "onboards the default free tier and polls the operation" do
+            calls <- newIORef []
+            bodies <- newIORef []
+            testWithApplication (pure (onboardingApp calls bodies)) \port -> do
+                result <- setupCodeAssist (testCodeAssistOptions port) "bearer"
+                result `shouldBe` Right CodeAssistUser
+                    { projectId = "new-managed-project"
+                    , userTier = "free-tier"
+                    , userTierName = Just "Free"
+                    }
+                readIORef calls `shouldReturn`
+                    [ "/v1internal:loadCodeAssist"
+                    , "/v1internal:onboardUser"
+                    , "/v1internal/operations/onboarding"
+                    ]
+                requestBodies <- readIORef bodies
+                let loadBody = lookup "/v1internal:loadCodeAssist" requestBodies
+                    onboardBody = lookup "/v1internal:onboardUser" requestBodies
+                loadBody `shouldSatisfy` maybe False
+                    (not . BS.isInfixOf "cloudaicompanionProject")
+                loadBody `shouldSatisfy` maybe False
+                    (not . BS.isInfixOf "duetProject")
+                onboardBody `shouldSatisfy` maybe False
+                    (not . BS.isInfixOf "cloudaicompanionProject")
+                onboardBody `shouldSatisfy` maybe False
+                    (not . BS.isInfixOf "duetProject")
+
+tokenApp :: IORef [Text] -> Application
+tokenApp recorded request respond = do
+    body <- strictRequestBody request
+    let textBody = TextEncoding.decodeUtf8 (LBS.toStrict body)
+    modifyIORef' recorded (<> [textBody])
+    let refreshing = "refresh_token=refresh-old" `Text.isInfixOf` textBody
+        response
+            | refreshing = Aeson.object
+                [ "access_token" Aeson..= ("access-refreshed" :: Text)
+                , "expires_in" Aeson..= (1800 :: Int)
+                ]
+            | otherwise = Aeson.object
+                [ "access_token" Aeson..= ("access-initial" :: Text)
+                , "refresh_token" Aeson..= ("refresh-initial" :: Text)
+                , "expires_in" Aeson..= (3600 :: Int)
+                , "token_type" Aeson..= ("Bearer" :: Text)
+                ]
+    respond (jsonResponse status200 response)
+
+userInfoApp :: Application
+userInfoApp request respond
+    | lookup "Authorization" (requestHeaders request)
+        == Just "Bearer secret-access" =
+            respond (jsonResponse status200
+                (Aeson.object
+                    ["email" Aeson..= ("person@example.com" :: Text)]))
+    | otherwise = respond (responseLBS status401 [] "")
+
+slowApp :: Application
+slowApp _request respond = do
+    threadDelay 3_000_000
+    respond (responseLBS status200 [] "")
+
+echoingTokenErrorApp :: Application
+echoingTokenErrorApp request respond = do
+    _ <- strictRequestBody request
+    respond
+        (responseLBS status400 [("Content-Type", "text/plain")]
+            "server-echoed-sensitive-body")
+
+echoingBearerErrorApp :: Application
+echoingBearerErrorApp _request respond =
+    respond
+        (responseLBS status401 [("Content-Type", "text/plain")]
+            "rejected access-must-stay-secret")
+
+redirectingApp :: Port -> Application
+redirectingApp targetPort _request respond =
+    respond
+        (responseLBS status307
+            [("Location", BS8.pack (localBaseUrl targetPort <> "/captured"))]
+            "")
+
+redirectTargetApp :: IORef [BS.ByteString] -> Application
+redirectTargetApp requests request respond = do
+    _ <- strictRequestBody request
+    modifyIORef' requests (<> [rawPathInfo request])
+    respond (responseLBS status200 [] "")
+
+existingUserApp :: IORef [Text] -> Application
+existingUserApp calls request respond = do
+    modifyIORef' calls (<> [TextEncoding.decodeUtf8 (rawPathInfo request)])
+    respond (jsonResponse status200 (Aeson.object
+        [ "currentTier" Aeson..= Aeson.object
+            [ "id" Aeson..= ("free-tier" :: Text)
+            , "name" Aeson..= ("Gemini Code Assist" :: Text)
+            ]
+        , "cloudaicompanionProject" Aeson..= ("managed-project" :: Text)
+        ]))
+
+paidUserApp :: Application
+paidUserApp _request respond =
+    respond (jsonResponse status200 (Aeson.object
+        [ "currentTier" Aeson..= Aeson.object
+            ["id" Aeson..= ("standard-tier" :: Text)]
+        , "paidTier" Aeson..= Aeson.object
+            [ "id" Aeson..= ("paid-tier" :: Text)
+            , "name" Aeson..= ("Google AI plan" :: Text)
+            ]
+        , "cloudaicompanionProject" Aeson..= ("paid-project" :: Text)
+        ]))
+
+partialPaidUserApp :: Application
+partialPaidUserApp _request respond =
+    respond (jsonResponse status200 (Aeson.object
+        [ "currentTier" Aeson..= Aeson.object
+            [ "id" Aeson..= ("standard-tier" :: Text)
+            , "name" Aeson..= ("Standard" :: Text)
+            ]
+        , "paidTier" Aeson..= Aeson.object
+            ["name" Aeson..= ("Google AI plan" :: Text)]
+        , "cloudaicompanionProject" Aeson..= ("paid-project" :: Text)
+        ]))
+
+validationRequiredApp :: IORef Int -> Application
+validationRequiredApp calls _request respond = do
+    attempt <- atomicModifyIORef' calls \value ->
+        let next = value + 1
+        in (next, next)
+    if attempt == 1
+        then respond (jsonResponse status200 (Aeson.object
+            [ "ineligibleTiers" Aeson..=
+                [ Aeson.object
+                    [ "reasonCode" Aeson..= ("VALIDATION_REQUIRED" :: Text)
+                    , "reasonMessage" Aeson..= ("Verify please" :: Text)
+                    , "validationUrl" Aeson..=
+                        ("https://accounts.example.test/validate" :: Text)
+                    ]
+                ]
+            ]))
+        else respond (jsonResponse status200 (Aeson.object
+            [ "currentTier" Aeson..= Aeson.object
+                [ "id" Aeson..= ("free-tier" :: Text)
+                , "name" Aeson..= ("Validated" :: Text)
+                ]
+            , "cloudaicompanionProject" Aeson..=
+                ("validated-project" :: Text)
+            ]))
+
+standardOnboardingApp
+    :: IORef [(BS.ByteString, BS.ByteString)]
+    -> Application
+standardOnboardingApp bodies request respond = do
+    body <- LBS.toStrict <$> strictRequestBody request
+    let path = rawPathInfo request
+    modifyIORef' bodies (<> [(path, body)])
+    case path of
+        "/v1internal:loadCodeAssist" ->
+            respond (jsonResponse status200 (Aeson.object
+                [ "allowedTiers" Aeson..=
+                    [ Aeson.object
+                        [ "id" Aeson..= ("standard-tier" :: Text)
+                        , "name" Aeson..= ("Standard" :: Text)
+                        , "isDefault" Aeson..= True
+                        ]
+                    ]
+                ]))
+        "/v1internal:onboardUser" ->
+            respond (jsonResponse status200 (Aeson.object
+                [ "done" Aeson..= True
+                , "response" Aeson..= Aeson.object []
+                ]))
+        _ -> respond (responseLBS status404 [] "")
+
+failedOnboardingApp :: Application
+failedOnboardingApp request respond =
+    case rawPathInfo request of
+        "/v1internal:loadCodeAssist" ->
+            respond (jsonResponse status200 (Aeson.object
+                [ "allowedTiers" Aeson..=
+                    [ Aeson.object
+                        [ "id" Aeson..= ("standard-tier" :: Text)
+                        , "isDefault" Aeson..= True
+                        ]
+                    ]
+                ]))
+        "/v1internal:onboardUser" ->
+            respond (jsonResponse status200 (Aeson.object
+                [ "done" Aeson..= True
+                , "error" Aeson..= Aeson.object
+                    [ "code" Aeson..= (9 :: Int)
+                    , "message" Aeson..= ("precondition failed" :: Text)
+                    ]
+                ]))
+        _ -> respond (responseLBS status404 [] "")
+
+echoingOnboardingErrorApp :: Application
+echoingOnboardingErrorApp request respond =
+    case rawPathInfo request of
+        "/v1internal:loadCodeAssist" ->
+            respond (jsonResponse status200 (Aeson.object
+                [ "allowedTiers" Aeson..=
+                    [ Aeson.object
+                        [ "id" Aeson..= ("standard-tier" :: Text)
+                        , "isDefault" Aeson..= True
+                        ]
+                    ]
+                ]))
+        "/v1internal:onboardUser" ->
+            respond (jsonResponse status200 (Aeson.object
+                [ "done" Aeson..= True
+                , "error" Aeson..= Aeson.object
+                    [ "message" Aeson..=
+                        ("rejected secret-bearer" :: Text)
+                    ]
+                ]))
+        _ -> respond (responseLBS status404 [] "")
+
+onboardingApp :: IORef [Text] -> IORef [(BS.ByteString, BS.ByteString)] -> Application
+onboardingApp calls bodies request respond = do
+    body <- LBS.toStrict <$> strictRequestBody request
+    let path = rawPathInfo request
+    modifyIORef' calls (<> [TextEncoding.decodeUtf8 path])
+    modifyIORef' bodies (<> [(path, body)])
+    case rawPathInfo request of
+        "/v1internal:loadCodeAssist" ->
+            respond (jsonResponse status200 (Aeson.object
+                [ "allowedTiers" Aeson..=
+                    [ Aeson.object
+                        [ "id" Aeson..= ("free-tier" :: Text)
+                        , "name" Aeson..= ("Free" :: Text)
+                        , "isDefault" Aeson..= True
+                        ]
+                    ]
+                ]))
+        "/v1internal:onboardUser" ->
+            respond (jsonResponse status200 (Aeson.object
+                [ "name" Aeson..= ("operations/onboarding" :: Text)
+                , "done" Aeson..= False
+                ]))
+        "/v1internal/operations/onboarding" ->
+            respond (jsonResponse status200 (Aeson.object
+                [ "done" Aeson..= True
+                , "response" Aeson..= Aeson.object
+                    [ "cloudaicompanionProject" Aeson..= Aeson.object
+                        ["id" Aeson..= ("new-managed-project" :: Text)]
+                    ]
+                ]))
+        _ -> respond (responseLBS status404 [] "")
+
+testOAuthOptions :: Port -> OAuthOptions
+testOAuthOptions port = defaultOAuthOptions
+    { tokenEndpoint = localBaseUrl port <> "/token"
+    , userInfoEndpoint = localBaseUrl port <> "/userinfo"
+    , clientId = "test-client"
+    , clientSecret = "test-secret"
+    }
+
+testCodeAssistOptions :: Port -> CodeAssistOptions
+testCodeAssistOptions port = defaultCodeAssistOptions
+    { baseUrl = localBaseUrl port <> "/v1internal"
+    , pollIntervalMicros = 0
+    , maxPollAttempts = 2
+    }
+
+localBaseUrl :: Port -> String
+localBaseUrl port = "http://127.0.0.1:" <> show port
+
+sendSplitOAuthCallback :: Text -> IO ()
+sendSplitOAuthCallback authorization = do
+    redirect <- maybe
+        (expectationFailure "authorization URL has no redirect_uri" >> pure "")
+        pure
+        (queryParameter "redirect_uri" authorization)
+    state <- maybe
+        (expectationFailure "authorization URL has no state" >> pure "")
+        pure
+        (queryParameter "state" authorization)
+    port <- maybe
+        (expectationFailure "redirect_uri has no loopback port" >> pure 0)
+        pure
+        (loopbackPort redirect)
+    bracket
+        (Net.socket Net.AF_INET Net.Stream Net.defaultProtocol)
+        Net.close
+        \socket -> do
+            Net.connect socket
+                (Net.SockAddrInet
+                    (fromIntegral port)
+                    (Net.tupleToHostAddress (127, 0, 0, 1)))
+            Net.sendAll socket
+                "GET /oauth2callback?code=split"
+            threadDelay 100_000
+            Net.sendAll socket $
+                "-code&state="
+                    <> TextEncoding.encodeUtf8 state
+                    <> " HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"
+            _ <- Net.recv socket 4096
+            pure ()
+
+queryParameter :: Text -> Text -> Maybe Text
+queryParameter key url = do
+    query <- Text.stripPrefix "?" (snd (Text.breakOn "?" url))
+    lookup key (parseQueryText (TextEncoding.encodeUtf8 query)) >>= id
+
+loopbackPort :: Text -> Maybe Int
+loopbackPort redirect = do
+    remainder <- Text.stripPrefix "http://127.0.0.1:" redirect
+    let (port, _) = Text.breakOn "/" remainder
+    readMaybe (Text.unpack port)
+
+jsonResponse :: Status -> Aeson.Value -> Response
+jsonResponse status value =
+    responseLBS status
+        [("Content-Type", "application/json")]
+        (Aeson.encode value)

--- a/packages/agent-gemini/test/Agent/Gemini/ClientSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/ClientSpec.hs
@@ -1,0 +1,395 @@
+module Agent.Gemini.ClientSpec (spec) where
+
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Gemini.Client (createResponseWithEventsPolicy)
+import Agent.Gemini.Options (ClientOptions(..), defaultClientOptions)
+import Agent.Gemini.Response (GeminiStreamEvent(..))
+import Agent.Provider (Credential(..), Provider(..))
+import Agent.Responses.Types
+    ( Response(..)
+    , ResponseContentPart(..)
+    , ResponseCreateParams(..)
+    , ResponseInput(..)
+    , ResponseItem(..)
+    , MessageContent(..)
+    , ResponseMessage(..)
+    , ResponseRole(..)
+    , defaultResponseCreateParams
+    )
+import Control.Retry (limitRetries)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as LBS
+import Data.Either (isLeft)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Network.HTTP.Types as HTTP
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Gemini client validation" do
+    it "rejects credentials belonging to another provider without networking" do
+        let credential = Credential "secret" "account" Nothing OpenAIProvider
+        createResponseWithEventsPolicy
+            (limitRetries 0)
+            defaultClientOptions
+            credential
+            defaultResponseCreateParams
+            (const (pure ()))
+            `shouldReturn`
+                Left
+                    (ProviderError
+                        ApiErrorType
+                        "agent-gemini requires a Gemini credential"
+                        Nothing)
+
+    it "rejects an empty Gemini API key without networking" do
+        let credential = Credential "" "gemini" Nothing GeminiProvider
+        createResponseWithEventsPolicy
+            (limitRetries 0)
+            defaultClientOptions
+            credential
+            defaultResponseCreateParams
+            (const (pure ()))
+            `shouldReturn` Left (CredentialError "Gemini API key is empty")
+
+    it "uses the native streaming endpoint and x-goog-api-key header" do
+        recorded <- newIORef Nothing
+        let app request respond = do
+                body <- Wai.strictRequestBody request
+                writeIORef recorded $ Just
+                    ( Wai.rawPathInfo request
+                    , Wai.rawQueryString request
+                    , lookup "x-goog-api-key" (Wai.requestHeaders request)
+                    , body
+                    )
+                respond $ Wai.responseLBS HTTP.status200
+                    [("Content-Type", "text/event-stream")]
+                    geminiSse
+        Warp.testWithApplication (pure app) \port -> do
+            let options = defaultClientOptions
+                    { baseUrl = "http://127.0.0.1:"
+                        <> show port <> "/v1beta"
+                    , requestTimeoutSeconds = 10
+                    }
+                credential =
+                    Credential "google-key" "gemini" Nothing GeminiProvider
+                request = defaultResponseCreateParams
+                    { model = Just "gemini-test"
+                    , instructions = Just "Be concise"
+                    , input = Just (ResponseInputText "hello")
+                    }
+            result <- createResponseWithEventsPolicy
+                (limitRetries 0)
+                options
+                credential
+                request
+                (const (pure ()))
+            case result of
+                Left err ->
+                    expectationFailure
+                        ("expected Gemini response, got " <> show err)
+                Right response -> do
+                    response.responseId `shouldBe` "resp-1"
+                    assistantText response `shouldBe` Just "hello back"
+        readIORef recorded >>= \case
+            Nothing -> expectationFailure "mock server received no request"
+            Just (path, query, apiKey, body) -> do
+                path `shouldBe`
+                    "/v1beta/models/gemini-test:streamGenerateContent"
+                query `shouldBe` "?alt=sse"
+                apiKey `shouldBe` Just "google-key"
+                Aeson.decode body `shouldBe` Just expectedRequestBody
+
+    it "uses bearer auth and the wrapped Code Assist streaming endpoint" do
+        recorded <- newIORef Nothing
+        let app request respond = do
+                body <- Wai.strictRequestBody request
+                writeIORef recorded $ Just
+                    ( Wai.rawPathInfo request
+                    , Wai.rawQueryString request
+                    , lookup "Authorization" (Wai.requestHeaders request)
+                    , lookup "x-goog-api-key" (Wai.requestHeaders request)
+                    , body
+                    )
+                respond $ Wai.responseLBS HTTP.status200
+                    [("Content-Type", "text/event-stream")]
+                    codeAssistSse
+        Warp.testWithApplication (pure app) \port -> do
+            let options = defaultClientOptions
+                    { codeAssistBaseUrl = "http://127.0.0.1:"
+                        <> show port <> "/v1internal"
+                    , requestTimeoutSeconds = 10
+                    }
+                credential = Credential
+                    "oauth-token"
+                    "account@example.com"
+                    (Just "code-assist:project-123")
+                    GeminiProvider
+                request = defaultResponseCreateParams
+                    { model = Just "gemini-test"
+                    , instructions = Just "Be concise"
+                    , input = Just (ResponseInputText "hello")
+                    }
+            result <- createResponseWithEventsPolicy
+                (limitRetries 0)
+                options
+                credential
+                request
+                (const (pure ()))
+            case result of
+                Left err ->
+                    expectationFailure
+                        ("expected Code Assist response, got " <> show err)
+                Right response -> do
+                    response.responseId `shouldBe` "trace-1"
+                    assistantText response `shouldBe` Just "hello back"
+        readIORef recorded >>= \case
+            Nothing -> expectationFailure "mock server received no request"
+            Just (path, query, authorization, apiKey, body) -> do
+                path `shouldBe`
+                    "/v1internal:streamGenerateContent"
+                query `shouldBe` "?alt=sse"
+                authorization `shouldBe` Just "Bearer oauth-token"
+                apiKey `shouldBe` Nothing
+                case Aeson.decode body of
+                    Just (Aeson.Object object) -> do
+                        KeyMap.lookup "model" object
+                            `shouldBe` Just (Aeson.String "gemini-test")
+                        KeyMap.lookup "project" object
+                            `shouldBe` Just (Aeson.String "project-123")
+                        KeyMap.lookup "request" object
+                            `shouldBe` Just expectedRequestBody
+                        case KeyMap.lookup "user_prompt_id" object of
+                            Just (Aeson.String promptId) ->
+                                promptId `shouldSatisfy`
+                                    Text.isPrefixOf "gemini-gemini-test-"
+                            _ -> expectationFailure
+                                "Code Assist request has no user_prompt_id"
+                    value -> expectationFailure
+                        ("invalid Code Assist request: " <> show value)
+
+    it "rejects an empty successful stream" do
+        withGeminiServer "" \options -> do
+            result <- createResponseWithEventsPolicy
+                (limitRetries 0)
+                options
+                geminiCredential
+                defaultResponseCreateParams
+                (const (pure ()))
+            result `shouldBe` Left
+                (ConnectionError
+                    "Gemini stream ended before a terminal finish reason")
+
+    it "does not treat an unspecified prompt block as terminal" do
+        withGeminiServer unspecifiedPromptBlockSse \options -> do
+            result <- createResponseWithEventsPolicy
+                (limitRetries 0)
+                options
+                geminiCredential
+                defaultResponseCreateParams
+                (const (pure ()))
+            result `shouldBe` Left
+                (ConnectionError
+                    "Gemini stream ended before a terminal finish reason")
+
+    it "does not let unspecified reasons mask a terminal reason" do
+        withGeminiServer unspecifiedAroundTerminalSse \options -> do
+            result <- createResponseWithEventsPolicy
+                (limitRetries 0)
+                options
+                geminiCredential
+                defaultResponseCreateParams
+                (const (pure ()))
+            result `shouldSatisfy` \case
+                Right _ -> True
+                Left _ -> False
+
+    it "does not treat an unspecified finish reason as terminal" do
+        withGeminiServer unspecifiedFinishSse \options -> do
+            result <- createResponseWithEventsPolicy
+                (limitRetries 0)
+                options
+                geminiCredential
+                defaultResponseCreateParams
+                (const (pure ()))
+            result `shouldBe` Left
+                (ConnectionError
+                    "Gemini stream ended before a terminal finish reason")
+
+    it "reports a truncated stream after preserving its emitted delta" do
+        events <- newIORef []
+        withGeminiServer truncatedGeminiSse \options -> do
+            result <- createResponseWithEventsPolicy
+                (limitRetries 0)
+                options
+                geminiCredential
+                defaultResponseCreateParams
+                (\event -> writeIORef events . (<> [event])
+                    =<< readIORef events)
+            result `shouldBe` Left
+                (ConnectionError
+                    "Gemini stream ended before a terminal finish reason")
+        readIORef events `shouldReturn`
+            [GeminiTextDelta "partial "]
+
+    it "classifies non-success Google error envelopes" do
+        withGeminiHttpResponse
+            HTTP.status400
+            [("Content-Type", "application/json")]
+            invalidKeyBody
+            \options -> do
+                result <- createResponseWithEventsPolicy
+                    (limitRetries 0)
+                    options
+                    geminiCredential
+                    defaultResponseCreateParams
+                    (const (pure ()))
+                result `shouldBe` Left
+                    (ProviderError
+                        AuthenticationError
+                        "API key not valid. Please pass a valid API key."
+                        Nothing)
+
+    it "redacts an API key echoed by an error response" do
+        withGeminiHttpResponse
+            HTTP.status400
+            [("Content-Type", "text/plain")]
+            "rejected google-key"
+            \options -> do
+                result <- createResponseWithEventsPolicy
+                    (limitRetries 0)
+                    options
+                    geminiCredential
+                    defaultResponseCreateParams
+                    (const (pure ()))
+                show result `shouldNotContain` "google-key"
+                show result `shouldContain` "<redacted>"
+
+    it "never forwards an API key across redirects" do
+        redirected <- newIORef (Nothing :: Maybe HTTP.RequestHeaders)
+        Warp.testWithApplication
+            (pure \request respond -> do
+                writeIORef redirected
+                    (Just (Wai.requestHeaders request))
+                respond (Wai.responseLBS HTTP.status200 [] ""))
+            \targetPort ->
+                Warp.testWithApplication
+                    (pure \_ respond ->
+                        respond
+                            (Wai.responseLBS HTTP.status307
+                                [ ( "Location"
+                                  , BS8.pack
+                                        ("http://127.0.0.1:"
+                                            <> show targetPort
+                                            <> "/captured")
+                                  )
+                                ]
+                                ""))
+                    \originPort -> do
+                        let options = defaultClientOptions
+                                { baseUrl =
+                                    "http://127.0.0.1:"
+                                        <> show originPort
+                                        <> "/v1beta"
+                                }
+                        result <- createResponseWithEventsPolicy
+                            (limitRetries 0)
+                            options
+                            geminiCredential
+                            defaultResponseCreateParams
+                            (const (pure ()))
+                        result `shouldSatisfy` isLeft
+        readIORef redirected `shouldReturn` Nothing
+
+geminiSse :: LBS.ByteString
+geminiSse =
+    "data: {\"responseId\":\"resp-1\",\"modelVersion\":\"gemini-test\",\"candidates\":[{\"index\":0,\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"hello back\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":3,\"totalTokenCount\":5}}\n\n"
+
+codeAssistSse :: LBS.ByteString
+codeAssistSse =
+    "data: {\"response\":{\"modelVersion\":\"gemini-test\",\"candidates\":[{\"index\":0,\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"hello back\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":3,\"totalTokenCount\":5}},\"traceId\":\"trace-1\"}\n\n"
+
+truncatedGeminiSse :: LBS.ByteString
+truncatedGeminiSse =
+    "data: {\"candidates\":[{\"index\":0,\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"partial \"}]}}]}\n\n"
+
+unspecifiedFinishSse :: LBS.ByteString
+unspecifiedFinishSse =
+    "data: {\"candidates\":[{\"index\":0,\"finishReason\":\"FINISH_REASON_UNSPECIFIED\"}]}\n\n"
+
+unspecifiedPromptBlockSse :: LBS.ByteString
+unspecifiedPromptBlockSse =
+    "data: {\"promptFeedback\":{\"blockReason\":\"BLOCK_REASON_UNSPECIFIED\"}}\n\n"
+
+unspecifiedAroundTerminalSse :: LBS.ByteString
+unspecifiedAroundTerminalSse =
+    "data: {\"candidates\":[{\"index\":0,\"finishReason\":\"FINISH_REASON_UNSPECIFIED\"}]}\n\n\
+    \data: {\"candidates\":[{\"index\":0,\"finishReason\":\"STOP\"}]}\n\n\
+    \data: {\"candidates\":[{\"index\":0,\"finishReason\":\"FINISH_REASON_UNSPECIFIED\"}]}\n\n"
+
+invalidKeyBody :: LBS.ByteString
+invalidKeyBody =
+    "{\"error\":{\"code\":400,\"message\":\"API key not valid. Please pass a valid API key.\",\"status\":\"INVALID_ARGUMENT\"}}"
+
+geminiCredential :: Credential
+geminiCredential =
+    Credential "google-key" "gemini" Nothing GeminiProvider
+
+withGeminiServer
+    :: LBS.ByteString
+    -> (ClientOptions -> IO result)
+    -> IO result
+withGeminiServer =
+    withGeminiHttpResponse
+        HTTP.status200
+        [("Content-Type", "text/event-stream")]
+
+withGeminiHttpResponse
+    :: HTTP.Status
+    -> HTTP.ResponseHeaders
+    -> LBS.ByteString
+    -> (ClientOptions -> IO result)
+    -> IO result
+withGeminiHttpResponse status headers body action =
+    Warp.testWithApplication
+        (pure \_ respond ->
+            respond $ Wai.responseLBS status headers body)
+        \port ->
+            action defaultClientOptions
+                { baseUrl = "http://127.0.0.1:"
+                    <> show port <> "/v1beta"
+                , defaultModel = "gemini-test"
+                , requestTimeoutSeconds = 10
+                }
+
+expectedRequestBody :: Aeson.Value
+expectedRequestBody = Aeson.object
+    [ "contents" Aeson..=
+        [ Aeson.object
+            [ "role" Aeson..= ("user" :: Text)
+            , "parts" Aeson..=
+                [Aeson.object ["text" Aeson..= ("hello" :: Text)]]
+            ]
+        ]
+    , "systemInstruction" Aeson..= Aeson.object
+        [ "parts" Aeson..=
+            [Aeson.object ["text" Aeson..= ("Be concise" :: Text)]]
+        ]
+    ]
+
+assistantText :: Response -> Maybe Text
+assistantText response = case
+    [ text
+    | MessageItem message <- response.output
+    , message.role == RoleAssistant
+    , OutputTextPart{text} <- case message.content of
+        MessageContentParts parts -> parts
+        MessageContentText _ -> []
+    ] of
+        text : _ -> Just text
+        [] -> Nothing

--- a/packages/agent-gemini/test/Agent/Gemini/CredentialSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/CredentialSpec.hs
@@ -1,0 +1,15 @@
+module Agent.Gemini.CredentialSpec (spec) where
+
+import Agent.Gemini.Credential
+import Agent.Provider (Provider(..))
+import Agent.Provider (Credential(..))
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Gemini credentials" do
+    it "creates a static API-key credential" do
+        let credential = credentialFromApiKey "secret"
+        let Credential{accessToken, accountId, provider} = credential
+        provider `shouldBe` GeminiProvider
+        accessToken `shouldBe` "secret"
+        accountId `shouldBe` "gemini"

--- a/packages/agent-gemini/test/Agent/Gemini/ErrorSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/ErrorSpec.hs
@@ -1,0 +1,25 @@
+module Agent.Gemini.ErrorSpec (spec) where
+
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Gemini.Error (classifyFailure)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Gemini error classification" do
+    it "recognizes invalid API keys even when Google returns HTTP 400" do
+        classifyFailure
+            400
+            Nothing
+            "{\"error\":{\"code\":400,\"message\":\"API key not valid. Please pass a valid API key.\",\"status\":\"INVALID_ARGUMENT\"}}"
+            `shouldBe`
+                ProviderError
+                    AuthenticationError
+                    "API key not valid. Please pass a valid API key."
+                    Nothing
+
+    it "preserves retry timing for resource exhaustion" do
+        classifyFailure
+            429
+            (Just 17)
+            "{\"error\":{\"code\":429,\"message\":\"quota exhausted\",\"status\":\"RESOURCE_EXHAUSTED\"}}"
+            `shouldBe` ProviderError RateLimitError "quota exhausted" (Just 17)

--- a/packages/agent-gemini/test/Agent/Gemini/RequestSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/RequestSpec.hs
@@ -1,0 +1,201 @@
+module Agent.Gemini.RequestSpec (spec) where
+
+import Agent.Gemini.Request
+import Agent.Responses.Types
+import Data.Aeson (Value(..), object, (.=))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Set as Set
+import Data.Text (Text)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Gemini request projection" do
+    it "projects instructions, user text, and model normalization" do
+        let params = defaultResponseCreateParams
+                { model = Just " models/gemini-test "
+                , instructions = Just "Be concise"
+                , input = Just (ResponseInputItems [message RoleUser "hello"])
+                }
+        buildRequest "fallback" params `shouldBe`
+            Right (GeminiRequest "gemini-test"
+                (object
+                    [ "contents" .=
+                        [object
+                            [ "role" .= ("user" :: Text)
+                            , "parts" .= [object ["text" .= ("hello" :: Text)]]
+                            ]]
+                    , "systemInstruction" .= object
+                        [ "parts" .= [object ["text" .= ("Be concise" :: Text)]] ]
+                    ])
+                Set.empty)
+
+    it "emits function declarations and thinking config" do
+        let tool = FunctionToolValue FunctionTool
+                { name = "lookup"
+                , description = Just "Look up a value"
+                , parameters = Nothing
+                , strict = Nothing
+                }
+            params :: ResponseCreateParams
+            params = defaultResponseCreateParams
+                { input = Just (ResponseInputText "use lookup")
+                , tools = Just [tool]
+                , reasoning = Just ReasoningConfig
+                    { context = Nothing, effort = Just "high"
+                    , summary = Nothing, generateSummary = Nothing
+                    , reasoningMode = Nothing
+                    }
+                }
+        case buildRequest "gemini-test" params of
+            Right GeminiRequest{requestBody = Object body} -> do
+                body `shouldSatisfy` member "tools"
+                body `shouldSatisfy` member "generationConfig"
+            other -> expectationFailure ("unexpected request: " <> show other)
+
+    it "maps the portable hosted search tool to native Google Search" do
+        let params :: ResponseCreateParams
+            params = withTools
+                (Just [KnownResponseTool ToolWebSearch])
+                defaultResponseCreateParams
+        fmap (.requestBody) (buildRequest "gemini-3.7-flash" params)
+            `shouldBe`
+                Right
+                    (object
+                        [ "contents" .= ([] :: [Value])
+                        , "tools" .=
+                            [object ["googleSearch" .= object []]]
+                        ])
+
+    it "omits every native tool when tool choice is none" do
+        let params :: ResponseCreateParams
+            params = withToolChoice
+                (Just (ToolChoiceMode ToolChoiceNone))
+                (withTools
+                    (Just [KnownResponseTool ToolWebSearch])
+                    defaultResponseCreateParams)
+        fmap (.requestBody) (buildRequest "gemini-test" params)
+            `shouldBe`
+                Right (object ["contents" .= ([] :: [Value])])
+
+    it "adapts freeform custom tools and preserves raw replay input" do
+        let patch = "*** Begin Patch\n*** End Patch"
+            custom = CustomToolValue CustomTool
+                { name = "apply_patch"
+                , description = Just "Apply a patch."
+                , format = Nothing
+                }
+            call = FunctionCallItem FunctionCall
+                { itemId = Just "item-1"
+                , callId = "call-1"
+                , name = "apply_patch"
+                , namespace = Nothing
+                , provider = Just "gemini"
+                , arguments = patch
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                }
+            params = defaultResponseCreateParams
+                { tools = Just [custom]
+                , input = Just (ResponseInputItems [call])
+                }
+        case buildRequest "gemini-test" params of
+            Left err -> expectationFailure
+                ("unexpected request error: " <> show err)
+            Right request -> do
+                request.requestCustomToolNames
+                    `shouldBe` Set.singleton "apply_patch"
+                request.requestBody `shouldBe` object
+                    [ "contents" .=
+                        [ object
+                            [ "role" .= ("model" :: Text)
+                            , "parts" .=
+                                [ object
+                                    [ "functionCall" .= object
+                                        [ "id" .= ("call-1" :: Text)
+                                        , "name" .= ("apply_patch" :: Text)
+                                        , "args" .= object
+                                            ["input" .= (patch :: Text)]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    , "tools" .=
+                        [ object
+                            [ "functionDeclarations" .=
+                                [ object
+                                    [ "name" .= ("apply_patch" :: Text)
+                                    , "description" .=
+                                        ( "Apply a patch.\n\nPass the tool's complete raw input in the `input` field."
+                                            :: Text
+                                        )
+                                    , "parametersJsonSchema" .= object
+                                        [ "type" .= ("object" :: Text)
+                                        , "properties" .= object
+                                            [ "input" .= object
+                                                [ "type" .= ("string" :: Text)
+                                                , "description" .=
+                                                    ( "Complete raw input for the custom tool."
+                                                        :: Text
+                                                    )
+                                                ]
+                                            ]
+                                        , "required" .= ["input" :: Text]
+                                        , "additionalProperties" .= False
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+
+    it "maps disabled reasoning to the model's minimum thinking level" do
+        let params :: ResponseCreateParams
+            params = withReasoning
+                (Just ReasoningConfig
+                    { context = Nothing, effort = Just "none"
+                    , summary = Nothing, generateSummary = Nothing
+                    , reasoningMode = Nothing
+                    })
+                defaultResponseCreateParams
+        fmap (.requestBody) (buildRequest "gemini-test" params)
+            `shouldBe`
+                Right
+                    (object
+                        [ "contents" .= ([] :: [Value])
+                        , "generationConfig" .= object
+                            [ "thinkingConfig" .= object
+                                [ "thinkingLevel" .= ("LOW" :: Text)
+                                , "includeThoughts" .= False
+                                ]
+                            ]
+                        ])
+        fmap (.requestBody) (buildRequest "gemini-3.5-flash-lite" params)
+            `shouldBe`
+                Right
+                    (object
+                        [ "contents" .= ([] :: [Value])
+                        , "generationConfig" .= object
+                            [ "thinkingConfig" .= object
+                                [ "thinkingLevel" .= ("MINIMAL" :: Text)
+                                , "includeThoughts" .= False
+                                ]
+                            ]
+                        ])
+  where
+    message role text = MessageItem ResponseMessage
+        { messageId = Nothing, role = role
+        , content = MessageContentText text, status = Nothing
+        , phase = Nothing, passthrough = Nothing
+        }
+    member key objectValue = KeyMap.member (Key.fromText key) objectValue
+
+    withTools value ResponseCreateParams{..} =
+        ResponseCreateParams { tools = value, .. }
+
+    withToolChoice value ResponseCreateParams{..} =
+        ResponseCreateParams { toolChoice = value, .. }
+
+    withReasoning value ResponseCreateParams{..} =
+        ResponseCreateParams { reasoning = value, .. }

--- a/packages/agent-gemini/test/Agent/Gemini/ResponseSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/ResponseSpec.hs
@@ -1,0 +1,118 @@
+module Agent.Gemini.ResponseSpec (spec) where
+
+import Agent.Gemini.Response
+import Agent.Gemini.Types
+import Agent.Responses.Types
+import qualified Data.Aeson
+import qualified Data.Set as Set
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Gemini response assembly" do
+    it "assembles text, thoughts, signatures, calls, and usage" do
+        let thought = Part (Just "thinking") True (Just "sig") Nothing
+            text = Part (Just "hello") False Nothing Nothing
+            call = Part Nothing False Nothing
+                (Just (NativeFunctionCall (Just "call-1") "lookup" (objectValue)))
+            usage = UsageMetadata (Just 3) (Just 4) Nothing (Just 1) (Just 8)
+            chunk = GenerateContentResponse (Just "resp-1") (Just "gemini-test")
+                [Candidate (Just (Content (Just "model") [thought, text, call]))
+                    (Just "STOP") (Just 0)]
+                (Just usage) Nothing
+            (state, events) = applyChunk
+                (initialStreamState "gemini-test" "fallback") chunk
+            response = buildResponse defaultResponseCreateParams state
+        events `shouldSatisfy` (not . null)
+        response.responseId `shouldBe` "resp-1"
+        length response.output `shouldBe` 3
+        fmap (.inputTokens) response.usage `shouldBe` Just 3
+        fmap (.outputTokens) response.usage `shouldBe` Just 5
+        fmap (.totalTokens) response.usage `shouldBe` Just 8
+        (response.usage >>= (.outputTokensDetails)
+            >>= (.reasoningTokens))
+            `shouldBe` Just 1
+
+    it "preserves whitespace in streamed text deltas" do
+        let parts =
+                [ Part (Just "hello ") False Nothing Nothing
+                , Part (Just " ") False Nothing Nothing
+                , Part (Just "world") False Nothing Nothing
+                ]
+            chunk = GenerateContentResponse Nothing Nothing
+                [Candidate (Just (Content (Just "model") parts))
+                    Nothing (Just 0)]
+                Nothing Nothing
+            (_, events) = applyChunk
+                (initialStreamState "gemini-test" "fallback") chunk
+        events `shouldBe`
+            [ GeminiTextDelta "hello "
+            , GeminiTextDelta " "
+            , GeminiTextDelta "world"
+            ]
+
+    it "assembles adjacent wire deltas into one canonical assistant message" do
+        let first = GenerateContentResponse Nothing Nothing
+                [Candidate
+                    (Just (Content (Just "model")
+                        [Part (Just "hello ") False Nothing Nothing]))
+                    Nothing
+                    (Just 0)]
+                Nothing Nothing
+            second = GenerateContentResponse Nothing Nothing
+                [Candidate
+                    (Just (Content (Just "model")
+                        [Part (Just "world") False Nothing Nothing]))
+                    (Just "STOP")
+                    (Just 0)]
+                Nothing Nothing
+            (afterFirst, _) = applyChunk
+                (initialStreamState "gemini-test" "fallback")
+                first
+            (afterSecond, _) = applyChunk afterFirst second
+            response = buildResponse defaultResponseCreateParams afterSecond
+        response.output `shouldBe`
+            [ MessageItem ResponseMessage
+                { messageId = Nothing
+                , content = MessageContentParts
+                    [OutputTextPart "hello world" Nothing Nothing]
+                , role = RoleAssistant
+                , status = Just ItemCompleted
+                , phase = Nothing
+                , passthrough = Nothing
+                }
+            ]
+
+    it "unwraps raw input from adapted custom tool calls" do
+        let nativeCall = NativeFunctionCall
+                (Just "call-1")
+                "apply_patch"
+                (Data.Aeson.object
+                    ["input" Data.Aeson..= ("*** Begin Patch" :: String)])
+            chunk = GenerateContentResponse Nothing Nothing
+                [ Candidate
+                    (Just (Content (Just "model")
+                        [Part Nothing False Nothing (Just nativeCall)]))
+                    (Just "STOP")
+                    (Just 0)
+                ]
+                Nothing Nothing
+            (_, events) = applyChunk
+                (initialStreamStateWithCustomTools
+                    "gemini-test"
+                    "fallback"
+                    (Set.singleton "apply_patch"))
+                chunk
+        events `shouldBe`
+            [ GeminiFunctionCallReady FunctionCall
+                { itemId = Just "call-1"
+                , callId = "call-1"
+                , name = "apply_patch"
+                , namespace = Nothing
+                , provider = Just "gemini"
+                , arguments = "*** Begin Patch"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                }
+            ]
+  where
+    objectValue = Data.Aeson.object ["q" Data.Aeson..= ("x" :: String)]

--- a/packages/agent-gemini/test/Agent/Gemini/StreamSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/StreamSpec.hs
@@ -1,0 +1,28 @@
+module Agent.Gemini.StreamSpec (spec) where
+
+import Agent.Gemini.Stream
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Gemini SSE decoder" do
+    it "handles CRLF and arbitrary chunk boundaries" do
+        let payload = "data: {\"responseId\":\"r\",\"candidates\":[]}\r\n\r\n"
+            chunks = ["data: {\"response", "Id\":\"r\",\"candidates\":[]}\r\n", "\r\n"]
+            result = do
+                (decoder, first) <- feedSseDecoder newSseDecoder (chunks !! 0)
+                (decoder2, second) <- feedSseDecoder decoder (chunks !! 1)
+                trailing <- finishSseDecoder decoder2
+                pure (first <> second <> trailing)
+        result `shouldBe` parseSseResponses payload
+        result `shouldSatisfy` either (const False) ((== 1) . length)
+
+    it "rejects malformed JSON" do
+        parseSseResponses "data: {not-json}\n\n" `shouldSatisfy` isLeft
+
+    it "does not silently accept an error envelope as an empty response" do
+        parseSseResponses
+            "data: {\"error\":{\"message\":\"stream failed\"}}\n\n"
+            `shouldSatisfy` isLeft
+  where
+    isLeft (Left _) = True
+    isLeft _ = False

--- a/packages/agent-gemini/test/Spec.hs
+++ b/packages/agent-gemini/test/Spec.hs
@@ -1,0 +1,20 @@
+module Main (main) where
+
+import Test.Hspec (hspec)
+import qualified Agent.Gemini.AuthSpec as AuthSpec
+import qualified Agent.Gemini.ClientSpec as ClientSpec
+import qualified Agent.Gemini.CredentialSpec as CredentialSpec
+import qualified Agent.Gemini.ErrorSpec as ErrorSpec
+import qualified Agent.Gemini.RequestSpec as RequestSpec
+import qualified Agent.Gemini.ResponseSpec as ResponseSpec
+import qualified Agent.Gemini.StreamSpec as StreamSpec
+
+main :: IO ()
+main = hspec do
+    AuthSpec.spec
+    ClientSpec.spec
+    CredentialSpec.spec
+    ErrorSpec.spec
+    RequestSpec.spec
+    ResponseSpec.spec
+    StreamSpec.spec

--- a/packages/agent-openai/src/Agent/OpenAI/Client.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Client.hs
@@ -245,6 +245,9 @@ createCodexMessageWithProviderAtWithOptionsInternal options turnState
             OpenRouterProvider -> pure $ Left $ ProviderError ApiErrorType
                 "OpenRouter credentials must be used through agent-openrouter"
                 Nothing
+            GeminiProvider -> pure $ Left $ ProviderError ApiErrorType
+                "Gemini credentials must be used through agent-gemini"
+                Nothing
             ClaudeCodeProvider -> pure $ Left $ ProviderError ApiErrorType
                 "Claude Code subscription sessions must use agent-claude"
                 Nothing

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -1,5 +1,5 @@
 -- | Conversation compaction helpers shared by OpenAI remote compact and
--- xAI/OpenRouter local summarization.
+-- xAI/OpenRouter/Gemini local summarization.
 module Agent.OpenAI.Compaction
     ( summaryPrefix
     , summarizationPrompt

--- a/packages/agent-openai/src/Agent/OpenAI/Models/Client.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Models/Client.hs
@@ -136,6 +136,9 @@ listModelsWithCredentialAt baseUrl clientVersion knownEtag credential =
         OpenRouterProvider -> pure $ Left $ ProviderError ApiErrorType
             "OpenRouter credentials must be used through agent-openrouter"
             Nothing
+        GeminiProvider -> pure $ Left $ ProviderError ApiErrorType
+            "Gemini credentials must be used through agent-gemini"
+            Nothing
         ClaudeCodeProvider -> pure $ Left $ ProviderError ApiErrorType
             "Claude Code credentials must be used through agent-claude"
             Nothing
@@ -203,6 +206,7 @@ modelsCacheKeyForCredential baseUrl credential = ModelsCacheKey
         OpenAIProvider -> "openai"
         XAIProvider -> "xai"
         OpenRouterProvider -> "openrouter"
+        GeminiProvider -> "gemini"
         ClaudeCodeProvider -> "claude-code"
     , baseUrl
     , accountId =

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -313,6 +313,10 @@ runConnectionAttemptWithPolicyAndTurnState _ _ credential _action
         "OpenRouter credentials must be used through agent-openrouter"
         Nothing
 runConnectionAttemptWithPolicyAndTurnState _ _ credential _action
+    | credential.provider == GeminiProvider = pure $ Left $ ProviderError ApiErrorType
+        "Gemini credentials must be used through agent-gemini"
+        Nothing
+runConnectionAttemptWithPolicyAndTurnState _ _ credential _action
     | credential.provider == ClaudeCodeProvider = pure $ Left $ ProviderError ApiErrorType
         "Claude Code subscription sessions must use agent-claude"
         Nothing

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/App.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/App.hs
@@ -267,7 +267,7 @@ telegramUsage = unlines
     , "       agent-telegram users list|add ID|remove ID"
     , ""
     , "Setup options:"
-    , "  --provider NAME       openai, xai, or openrouter"
+    , "  --provider NAME       openai, xai, openrouter, gemini, or claude-code"
     , "  --model NAME          optional model override"
     , "  --cwd PATH            agent working directory"
     , "  --effort LEVEL        optional reasoning effort"


### PR DESCRIPTION
## Summary

- add a native Gemini provider with Google AI Studio and Gemini Code Assist streaming
- connect a Google account automatically when a Gemini model is selected in `/model`, without requiring an API key
- persist and refresh managed Google OAuth credentials, while retaining `GOOGLE_API_KEY` / `GEMINI_API_KEY` as optional fallbacks
- integrate Gemini across the model catalog, account UI, compaction, subagents, and Telegram

## Validation

- loaded all 437 multi-package GHCi modules after rebasing onto current `master`
- `nix build path:.#checks.x86_64-linux.agent-gemini --no-link`
- `nix build path:.#checks.x86_64-linux.agent-cli --no-link`
- live tmux smoke of `/model` with mocked local Google OAuth
- live tmux smoke of the fullscreen `/login` Google Gemini picker

No real Google model request or billable API call was made during validation.
