### PR TITLE
fix(openai): stop auth cooldown cascades

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Error.hs
+++ b/packages/agent-cli/src/Agent/CLI/Error.hs
@@ -17,6 +17,7 @@ import Agent.CLI.Duration (formatDuration)
 import Agent.Error
     ( ApiError(..)
     , CredentialExhaustionReason(..)
+    , CredentialRefreshFailure(..)
     , ErrorType(..)
     , errorTypeText
     )
@@ -145,11 +146,30 @@ formatExhaustionReason = \case
         { exhaustionErrorType
         , exhaustionStatusCode
         } ->
-            "authentication rejected or credential refresh failed"
+            "authentication rejected"
                 <> formatReasonMetadata
                     exhaustionErrorType
                     exhaustionStatusCode
                     Nothing
+    ExhaustedByCredentialRefresh
+        { refreshFailure
+        , exhaustionErrorType
+        , exhaustionStatusCode
+        } ->
+            formatCredentialRefreshFailure refreshFailure
+                <> formatReasonMetadata
+                    exhaustionErrorType
+                    exhaustionStatusCode
+                    Nothing
+
+formatCredentialRefreshFailure :: CredentialRefreshFailure -> Text
+formatCredentialRefreshFailure = \case
+    RefreshCredentialSourceFailed ->
+        "credential source or persistence failed"
+    RefreshTransportFailed ->
+        "credential refresh transport failed"
+    RefreshProviderFailed ->
+        "credential refresh failed"
 
 formatReasonMetadata
     :: Maybe ErrorType

--- a/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ErrorSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Error
 import Agent.Error
     ( ApiError(..)
     , CredentialExhaustionReason(..)
+    , CredentialRefreshFailure(..)
     , ErrorType(..)
     , credentialsExhausted
     )
@@ -157,6 +158,11 @@ spec = do
                                 Just AuthenticationError
                             , exhaustionStatusCode = Just 401
                             }
+                        , ExhaustedByCredentialRefresh
+                            { refreshFailure = RefreshTransportFailed
+                            , exhaustionErrorType = Nothing
+                            , exhaustionStatusCode = Nothing
+                            }
                         ]
                     }
             rendered `shouldSatisfy`
@@ -164,6 +170,10 @@ spec = do
             rendered `shouldSatisfy`
                 Text.isInfixOf "type usage_limit_reached"
             rendered `shouldSatisfy` Text.isInfixOf "HTTP 401"
+            rendered `shouldSatisfy`
+                Text.isInfixOf "credential refresh transport failed"
+            rendered `shouldNotSatisfy`
+                Text.isInfixOf "authentication rejected or credential refresh failed"
 
         it "bounds and sanitizes provider detail text" do
             let rendered =
@@ -257,6 +267,10 @@ internalNames =
     , "CredentialError"
     , "ConnectionError"
     , "CredentialsExhausted"
+    , "ExhaustedByCredentialRefresh"
+    , "RefreshCredentialSourceFailed"
+    , "RefreshTransportFailed"
+    , "RefreshProviderFailed"
     , "InvalidRequestError"
     , "AuthenticationError"
     , "PermissionError"

--- a/packages/agent-core/src/Agent/Error.hs
+++ b/packages/agent-core/src/Agent/Error.hs
@@ -2,6 +2,7 @@ module Agent.Error
     ( ApiError(..)
     , ErrorType(..)
     , CredentialExhaustionReason(..)
+    , CredentialRefreshFailure(..)
     , RetryDisposition(..)
     , errorTypeFromText
     , errorTypeText
@@ -63,6 +64,23 @@ data CredentialExhaustionReason
         { exhaustionErrorType :: !(Maybe ErrorType)
         , exhaustionStatusCode :: !(Maybe Int)
         }
+    | ExhaustedByCredentialRefresh
+        { refreshFailure :: !CredentialRefreshFailure
+        , exhaustionErrorType :: !(Maybe ErrorType)
+        , exhaustionStatusCode :: !(Maybe Int)
+        }
+    deriving (Eq, Ord, Show)
+
+-- | Redacted origin of a failed credential refresh.
+--
+-- Provider response bodies, exception text, paths, and token material are
+-- deliberately excluded. The category is specific enough to distinguish an
+-- upstream rejection from failures in the local credential source or refresh
+-- transport without retaining secrets.
+data CredentialRefreshFailure
+    = RefreshCredentialSourceFailed
+    | RefreshTransportFailed
+    | RefreshProviderFailed
     deriving (Eq, Ord, Show)
 
 -- | Whether retrying can help, and which layer should own the retry.
@@ -224,20 +242,14 @@ credentialExhaustionReasonFromApiError = \case
                     , exhaustionStatusCode = Nothing
                     , exhaustionRetryAfter = retryAfter
                     }
-    HttpError status _
-        | status == 401 || status == 403 ->
-            Just ExhaustedByAuthentication
-                { exhaustionErrorType = Nothing
-                , exhaustionStatusCode = Just status
-                }
+    HttpError 401 _ ->
+        Just ExhaustedByAuthentication
+            { exhaustionErrorType = Nothing
+            , exhaustionStatusCode = Just 401
+            }
     ProviderError AuthenticationError _ _ ->
         Just ExhaustedByAuthentication
             { exhaustionErrorType = Just AuthenticationError
-            , exhaustionStatusCode = Nothing
-            }
-    CredentialError{} ->
-        Just ExhaustedByAuthentication
-            { exhaustionErrorType = Nothing
             , exhaustionStatusCode = Nothing
             }
     _ -> Nothing

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -194,9 +194,7 @@ accountFailureFromApiError err = case err of
     ProviderError UsageLimitReached _ _ -> rateLimited
     ProviderError UsageBalanceExhausted _ _ -> rateLimited
     HttpError 401 _ -> authenticationRejected
-    HttpError 403 _ -> authenticationRejected
     ProviderError AuthenticationError _ _ -> authenticationRejected
-    CredentialError{} -> authenticationRejected
     _ -> Nothing
   where
     rateLimited = Just $ AccountRateLimited (apiErrorRetryAfter err)

--- a/packages/agent-core/src/Agent/Transport/WebSocket.hs
+++ b/packages/agent-core/src/Agent/Transport/WebSocket.hs
@@ -577,14 +577,18 @@ tlsExceptionMessage = \case
         "TLS handshake failed: " <> showText tlsException
 
 -- | Extract an authentication status from a rejected WebSocket handshake.
+--
+-- HTTP 403 is a permission or policy rejection, not proof that the bearer
+-- token is invalid. Treating every 403 as authentication failure can rotate
+-- healthy credentials and quarantine an entire account pool.
 wsHandshakeAuthFailureStatus :: Exception.SomeException -> Maybe Int
 wsHandshakeAuthFailureStatus exception = case Exception.fromException exception of
     Just (WS.MalformedResponse responseHead _reason)
-        | WS.responseCode responseHead `elem` [401, 403] ->
+        | WS.responseCode responseHead == 401 ->
             Just (WS.responseCode responseHead)
     _ -> Nothing
 
--- | Convert a raw WebSocket handshake 401/403 into the shared HTTP error
+-- | Convert a raw WebSocket handshake 401 into the shared HTTP error
 -- shape. Headers are intentionally omitted because they may contain cookies.
 wsHandshakeAuthFailure :: Exception.SomeException -> Maybe ApiError
 wsHandshakeAuthFailure exception = do

--- a/packages/agent-core/test/Agent/ErrorSpec.hs
+++ b/packages/agent-core/test/Agent/ErrorSpec.hs
@@ -50,3 +50,11 @@ spec = do
                 { exhaustionErrorType = Nothing
                 , exhaustionStatusCode = Just 401
                 }
+
+    it "does not mislabel permission or local credential failures as authentication" do
+        credentialExhaustionReasonFromApiError
+            (HttpError 403 "sensitive response body")
+            `shouldBe` Nothing
+        credentialExhaustionReasonFromApiError
+            (CredentialError "sensitive local path")
+            `shouldBe` Nothing

--- a/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
+++ b/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
@@ -105,6 +105,19 @@ spec = describe "Agent.Transport.WebSocket" do
         wsHandshakeAuthFailure exception
             `shouldBe` Just (HttpError 401 "WebSocket handshake returned HTTP 401")
 
+    it "keeps handshake 403 as a permission failure" do
+        let exception = transientHandshakeException 403
+        wsHandshakeAuthFailureStatus exception `shouldBe` Nothing
+        wsHandshakeAuthFailure exception `shouldBe` Nothing
+
+        result <- retryTransientWsConnectWithPolicy
+            (constantDelay 0 <> limitRetries 3)
+            \_connected -> throwIO exception
+
+        result `shouldBe`
+            (Left (HttpError 403 "WebSocket handshake returned HTTP 403")
+                :: Either ApiError ())
+
     it "retries a transient handshake failure before the connection callback" do
         attempts <- newIORef (0 :: Int)
         let exception = TLS.HandshakeFailed $ TLS.Error_Misc

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -24,6 +24,7 @@ module Agent.OpenAI.Auth
     , reportAuthBrokenWithReason
     , refreshAfterAuthFailure
     , recoverAfterAuthFailure
+    , recoverAfterAuthFailureWithReason
     , authFailureRetrySeconds
 
       -- * Inspection and manual refresh
@@ -51,8 +52,8 @@ module Agent.OpenAI.Auth
 import Agent.Error
     ( ApiError(..)
     , CredentialExhaustionReason(..)
+    , CredentialRefreshFailure(..)
     , ErrorType(..)
-    , credentialExhaustionReasonFromApiError
     , credentialsExhaustedWithReasons
     )
 import Agent.OpenAI.Auth.JWT
@@ -160,7 +161,8 @@ data DiscoveryClaim
 rateLimitCooldownSeconds :: Int
 rateLimitCooldownSeconds = 60
 
--- | Retry window when an account returns 401/403 from Agent.OpenAI.
+-- | Retry window when an account returns an authentication rejection from
+-- Agent.OpenAI.
 -- Authentication recovery already forces an immediate refresh; if that still
 -- fails, retry soon instead of black-holing the only configured account.
 authFailureRetrySeconds :: Int
@@ -302,11 +304,11 @@ getAccessTokenWithDiscovery pool allowDiscovery = do
                         Left err
                             | CredentialsExhausted{} <- err ->
                                 go (attemptsLeft - 1)
-                            | isAuthError err -> do
+                            | isAccountScopedRefreshFailure err -> do
                                 reportAuthBrokenWithReason
                                     pool
                                     entry.entryAccountId
-                                    (authReasonFromApiError err)
+                                    (credentialRefreshReasonFromApiError err)
                                 go (attemptsLeft - 1)
                             | otherwise -> pure (Left err)
 
@@ -623,7 +625,7 @@ refreshAfterAuthFailure pool rejectedAccountId =
                             pool
                             rejectedAccountId
                             now
-                            (authReasonFromApiError err)
+                            (credentialRefreshReasonFromApiError err)
                         pure (Left err)
 
 -- | Recover a specifically rejected token. Recovery ownership and throttling
@@ -639,6 +641,23 @@ recoverAfterAuthFailure
     -> Text
     -> IO (Either ApiError AuthState)
 recoverAfterAuthFailure pool rejectedAccountId rejectedAccessToken =
+    recoverAfterAuthFailureWithReason
+        pool
+        rejectedAccountId
+        rejectedAccessToken
+        genericAuthReason
+
+-- | Like 'recoverAfterAuthFailure', but retain the redacted reason reported by
+-- the transport if a freshly rotated token is rejected inside the recovery
+-- window.
+recoverAfterAuthFailureWithReason
+    :: Pool
+    -> Text
+    -> Text
+    -> CredentialExhaustionReason
+    -> IO (Either ApiError AuthState)
+recoverAfterAuthFailureWithReason
+        pool rejectedAccountId rejectedAccessToken rejectionReason =
     findEntry pool rejectedAccountId >>= \case
         Nothing ->
             pure $ Left $ ProviderError AuthenticationError
@@ -655,10 +674,10 @@ recoverAfterAuthFailure pool rejectedAccountId rejectedAccessToken =
                         pure (Right current)
                     AuthRecoveryCoolingDown retryAt -> do
                         setAuthBrokenCooldownAt
-                            pool rejectedAccountId now genericAuthReason
+                            pool rejectedAccountId now rejectionReason
                         pure $ Left $
                             credentialsExhaustedWithReasons
-                                retryAt [genericAuthReason]
+                                retryAt [rejectionReason]
                     AuthRecoveryOwner stale ->
                         refreshEntryAfterAuthFailure
                             pool entry stale >>= \case
@@ -669,7 +688,7 @@ recoverAfterAuthFailure pool rejectedAccountId rejectedAccessToken =
                                     pool
                                     rejectedAccountId
                                     now
-                                    (authReasonFromApiError err)
+                                    (credentialRefreshReasonFromApiError err)
                                 pure (Left err)
 
 data AuthRecoveryDecision
@@ -870,14 +889,48 @@ genericAuthReason = ExhaustedByAuthentication
     , exhaustionStatusCode = Nothing
     }
 
-authReasonFromApiError :: ApiError -> CredentialExhaustionReason
-authReasonFromApiError err =
-    fromMaybe genericAuthReason
-        (credentialExhaustionReasonFromApiError err)
+-- | Failures from the refresh callback that identify an unusable account.
+-- The HTTP cases are deliberately scoped to the OAuth token endpoint; raw
+-- 403 responses from ordinary provider requests are permission failures and
+-- never reach this classifier.
+isAccountScopedRefreshFailure :: ApiError -> Bool
+isAccountScopedRefreshFailure (HttpError status _) =
+    status `elem` [400, 401, 403]
+isAccountScopedRefreshFailure
+    (ProviderError AuthenticationError _ _) = True
+isAccountScopedRefreshFailure CredentialError{} = True
+isAccountScopedRefreshFailure _ = False
 
-isAuthError :: ApiError -> Bool
-isAuthError (HttpError 401 _) = True
-isAuthError (HttpError 403 _) = True
-isAuthError (ProviderError AuthenticationError _ _) = True
-isAuthError CredentialError{} = True
-isAuthError _ = False
+-- | Retain a token-safe description of a failure that happened while rotating
+-- a credential. This is deliberately contextual: a 'CredentialError' returned
+-- by an arbitrary provider action is not itself proof that the checked-out
+-- account was rejected, while the same error from this pool's refresh callback
+-- identifies a failed credential source or persistence step.
+credentialRefreshReasonFromApiError
+    :: ApiError
+    -> CredentialExhaustionReason
+credentialRefreshReasonFromApiError = \case
+    CredentialError{} ->
+        refreshFailureReason RefreshCredentialSourceFailed Nothing Nothing
+    ConnectionError{} ->
+        refreshFailureReason RefreshTransportFailed Nothing Nothing
+    HttpError status _ ->
+        refreshFailureReason RefreshProviderFailed Nothing (Just status)
+    ProviderError errorType _ _ ->
+        refreshFailureReason RefreshProviderFailed (Just errorType) Nothing
+    JsonDecodeError{} ->
+        refreshFailureReason RefreshProviderFailed Nothing Nothing
+    CredentialsExhausted{} ->
+        refreshFailureReason RefreshProviderFailed Nothing Nothing
+
+refreshFailureReason
+    :: CredentialRefreshFailure
+    -> Maybe ErrorType
+    -> Maybe Int
+    -> CredentialExhaustionReason
+refreshFailureReason refreshFailure exhaustionErrorType exhaustionStatusCode =
+    ExhaustedByCredentialRefresh
+        { refreshFailure
+        , exhaustionErrorType
+        , exhaustionStatusCode
+        }

--- a/packages/agent-openai/src/Agent/OpenAI/Auth/Refresh.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth/Refresh.hs
@@ -50,12 +50,10 @@ refreshAccessTokenHTTP oauthClientId state = do
         Right response -> do
             let status = getResponseStatusCode response
             if status < 200 || status >= 300
-                then pure $ Left $ ProviderError AuthenticationError
-                    ("Codex token refresh failed with HTTP "
-                        <> Text.pack (show status) <> ": "
-                        <> Text.decodeUtf8With Text.lenientDecode
-                            (LBS.toStrict (LBS.take 500 (getResponseBody response))))
-                    Nothing
+                then pure $ Left $ HttpError status
+                    (Text.decodeUtf8With Text.lenientDecode
+                        (LBS.toStrict
+                            (LBS.take 500 (getResponseBody response))))
                 else case decodeRefreshResponse (getResponseBody response) of
                     Left err -> pure (Left err)
                     Right RefreshResponse{..} -> do

--- a/packages/agent-openai/src/Agent/OpenAI/Credential.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Credential.hs
@@ -40,10 +40,11 @@ poolTokenProviderWithBilling billing pool =
                             then rejectStaticCredential
                                 pool credential.accountId failureReason
                             else do
-                                Auth.recoverAfterAuthFailure
+                                Auth.recoverAfterAuthFailureWithReason
                                     pool
                                     credential.accountId
-                                    credential.accessToken >>= \case
+                                    credential.accessToken
+                                    failureReason >>= \case
                                         Right refreshed ->
                                             pure $ Right $
                                                 credentialFromAuthState refreshed

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -176,10 +176,11 @@ wsPath = "/backend-api/codex/responses"
 -- The provider-neutral WebSocket transport keeps the reusable connection
 -- alive and drains control frames for the lifetime of @action@.
 --
--- A handshake HTTP 401/403 is recovered centrally: the rejected account is
+-- A handshake HTTP 401 is recovered centrally: the rejected account is
 -- force-refreshed even when its JWT has not expired, then the handshake is
 -- retried once with the rotated token. If refresh or the second handshake
 -- fails, the account is cooled down and the next configured account is tried.
+-- HTTP 403 remains a permission/policy failure and does not rotate credentials.
 -- This happens before the callback starts, so retrying cannot duplicate caller
 -- side effects.
 --
@@ -236,7 +237,8 @@ withCodexWsCredentialUsingTurnState =
 
 -- | Run a replay-safe WebSocket action and automatically reacquire a
 -- credential after handshake or in-band account failures. The callback is
--- executed again from the beginning after a 401, 403, or usage-limit error;
+-- executed again from the beginning after a 401, an explicitly typed
+-- authentication error, or a usage-limit error;
 -- callers must therefore keep externally visible side effects idempotent.
 withCodexWsRetrying
     :: TokenProvider

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -5,6 +5,7 @@ import Agent.OpenAI.Auth.Refresh (RefreshResponse(RefreshResponse), decodeRefres
 import Agent.Error
     ( ApiError(..)
     , CredentialExhaustionReason(..)
+    , CredentialRefreshFailure(..)
     , ErrorType(..)
     , credentialsExhausted
     )
@@ -282,6 +283,26 @@ spec = do
                     accountIdOf result `shouldBe` second
                 _ -> expectationFailure
                     ("expected two refresh attempts, got " <> show tried)
+
+        it "retains a token-endpoint rejection without its response body" do
+            let secretBody = "TOP_SECRET_REFRESH_RESPONSE"
+                refresh _ = pure $ Left $ HttpError 403 secretBody
+            pool <- newPool [mkExpiredAuth "acc-broken"] refresh
+
+            result <- getAccessToken pool
+
+            case result of
+                Left CredentialsExhausted{exhaustionReasons} ->
+                    exhaustionReasons `shouldBe`
+                        [ ExhaustedByCredentialRefresh
+                            { refreshFailure = RefreshProviderFailed
+                            , exhaustionErrorType = Nothing
+                            , exhaustionStatusCode = Just 403
+                            }
+                        ]
+                other -> expectationFailure
+                    ("expected CredentialsExhausted, got " <> show other)
+            show result `shouldNotContain` "TOP_SECRET_REFRESH_RESPONSE"
 
     describe "reportRateLimit" $ do
         it "skips rate-limited accounts on subsequent picks" $ do
@@ -620,6 +641,28 @@ spec = do
             outcome `shouldSatisfy` isLeft
             ids <- mapM (const (accountIdOf <$> getAccessToken pool)) [1 .. 3 :: Int]
             ids `shouldSatisfy` all (== "healthy")
+
+        it "retains transport provenance when forced refresh fails" do
+            let refreshError =
+                    ConnectionError "TOP_SECRET_REFRESH_EXCEPTION"
+                refresh _ = pure (Left refreshError)
+            pool <- newPool [mkFreshAuth "broken"] refresh
+
+            refreshAfterAuthFailure pool "broken" >>= \case
+                Left err -> err `shouldBe` refreshError
+                Right _ -> expectationFailure
+                    "expected forced refresh to fail"
+            getAccessToken pool >>= \case
+                Left CredentialsExhausted{exhaustionReasons} ->
+                    exhaustionReasons `shouldBe`
+                        [ ExhaustedByCredentialRefresh
+                            { refreshFailure = RefreshTransportFailed
+                            , exhaustionErrorType = Nothing
+                            , exhaustionStatusCode = Nothing
+                            }
+                        ]
+                other -> expectationFailure
+                    ("expected CredentialsExhausted, got " <> show other)
 
     describe "allAccountIds + readAccountState" $ do
         it "lists every account currently in the pool" $ do

--- a/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
@@ -6,6 +6,7 @@ import Agent.OpenAI.Credential
 import Agent.Error
     ( ApiError(..)
     , CredentialExhaustionReason(..)
+    , CredentialRefreshFailure(..)
     , ErrorType(..)
     )
 import Agent.Provider
@@ -53,12 +54,20 @@ spec = do
                 (ProviderError UsageBalanceExhausted "balance exhausted" (Just 3600))
                 `shouldBe` Just (AccountRateLimited (Just 3600))
 
-        it "classifies authentication failures but not connection errors" do
+        it "classifies explicit authentication failures only" do
             accountFailureFromApiError (HttpError 401 "rejected")
                 `shouldBe` Just AccountAuthenticationRejected
             accountFailureFromApiError
-                (CredentialError "credential file is invalid")
+                (ProviderError AuthenticationError "rejected" Nothing)
                 `shouldBe` Just AccountAuthenticationRejected
+            accountFailureFromApiError (HttpError 403 "model access denied")
+                `shouldBe` Nothing
+            accountFailureFromApiError
+                (ProviderError PermissionError "model access denied" Nothing)
+                `shouldBe` Nothing
+            accountFailureFromApiError
+                (CredentialError "credential file is invalid")
+                `shouldBe` Nothing
             accountFailureFromApiError (ConnectionError "offline")
                 `shouldBe` Nothing
 
@@ -98,6 +107,20 @@ spec = do
                 pure (Left (ConnectionError "offline") :: Either ApiError Text)
 
             result `shouldBe` Left (ConnectionError "offline")
+            readIORef acquisitions `shouldReturn` 1
+
+        it "does not rotate accounts after an untyped HTTP 403" do
+            acquisitions <- newIORef (0 :: Int)
+            let forbidden = HttpError 403 "WebSocket handshake returned HTTP 403"
+                provider = tokenProvider SubscriptionBilled \reported -> do
+                    reported `shouldBe` Nothing
+                    modifyIORef' acquisitions (+ 1)
+                    pure $ Right (credentialFor "acc-a")
+
+            result <- runWithTokenProvider provider \_ ->
+                pure (Left forbidden :: Either ApiError Text)
+
+            result `shouldBe` Left forbidden
             readIORef acquisitions `shouldReturn` 1
 
         it "reports an already-failed connection before choosing a replacement" do
@@ -204,6 +227,36 @@ spec = do
             rotated.accessToken `shouldNotBe` initial.accessToken
             readIORef refreshCalls `shouldReturn` 1
 
+        it "reports refresh-source failures separately from provider rejection" do
+            let refresh _ =
+                    pure $ Left (CredentialError "credential store unavailable")
+                rejectionReason = ExhaustedByAuthentication
+                    { exhaustionErrorType = Nothing
+                    , exhaustionStatusCode = Just 401
+                    }
+            provider <- localProvider ["acc-a", "acc-b"] refresh
+            first <- expectCredential =<< getNextToken provider Nothing
+            second <- expectCredential =<< getNextToken provider
+                (failedWithReason
+                    first AccountAuthenticationRejected rejectionReason)
+
+            exhausted <- getNextToken provider
+                (failedWithReason
+                    second AccountAuthenticationRejected rejectionReason)
+
+            case exhausted of
+                Left CredentialsExhausted{exhaustionReasons} ->
+                    exhaustionReasons `shouldBe`
+                        [ ExhaustedByCredentialRefresh
+                            { refreshFailure =
+                                RefreshCredentialSourceFailed
+                            , exhaustionErrorType = Nothing
+                            , exhaustionStatusCode = Nothing
+                            }
+                        ]
+                other -> expectationFailure
+                    ("expected CredentialsExhausted, got " <> show other)
+
         it "shares auth recovery across token providers for one pool" do
             refreshCalls <- newIORef (0 :: Int)
             refreshStarted <- newEmptyMVar
@@ -250,14 +303,21 @@ spec = do
                         { Auth.accessToken = freshToken ("rotated-" <> showText call) }
             provider <- localProvider ["acc-a"] refresh
             initial <- expectCredential =<< getNextToken provider Nothing
+            let rejectionReason = ExhaustedByAuthentication
+                    { exhaustionErrorType = Nothing
+                    , exhaustionStatusCode = Just 401
+                    }
             rotated <- expectCredential =<< getNextToken provider
-                (failed initial AccountAuthenticationRejected)
+                (failedWithReason
+                    initial AccountAuthenticationRejected rejectionReason)
 
             exhausted <- getNextToken provider
-                (failed rotated AccountAuthenticationRejected)
+                (failedWithReason
+                    rotated AccountAuthenticationRejected rejectionReason)
 
             case exhausted of
-                Left CredentialsExhausted{} -> pure ()
+                Left CredentialsExhausted{exhaustionReasons} ->
+                    exhaustionReasons `shouldBe` [rejectionReason]
                 other -> expectationFailure ("expected CredentialsExhausted, got " <> show other)
             readIORef refreshCalls `shouldReturn` 1
 
@@ -403,6 +463,14 @@ failed credential failure = Just FailedCredential
                 , exhaustionStatusCode = Nothing
                 }
     }
+
+failedWithReason
+    :: Credential
+    -> AccountFailure
+    -> CredentialExhaustionReason
+    -> Maybe FailedCredential
+failedWithReason credential failure failureReason =
+    Just FailedCredential { credential, failure, failureReason }
 
 credentialFor :: Text -> Credential
 credentialFor accountId = Credential


### PR DESCRIPTION
## Summary
- treat only HTTP 401 and explicit authentication errors as account rejection; keep raw 403 and local credential failures out of the auth failover loop
- keep WebSocket handshake 403 as a permission failure so it cannot refresh or quarantine the whole account pool
- retain token-safe authentication and refresh provenance (source, transport, provider status/type) through cooldown errors

## Root cause
A raw WebSocket HTTP 403 flowed through the handshake error path and was treated as an account authentication rejection. That triggered forced refresh and cooldown account-by-account until every account was quarantined for 60 seconds. Sessions then received the misleading generic CredentialsExhausted error even though the OpenAI credentials were valid.

## Verification
- multi-package GHCi: 391 modules loaded
- agent-core-test: 473 examples, 0 failures
- agent-openai-test: 324 examples, 0 failures (1 pending)
- agent-cli-test: 1,408 examples, 0 failures (1 pending)