### PR TITLE
Build a static Linux binary by default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -281,8 +281,8 @@
                 skylightingSyntaxDirectory =
                     "${skylightingSyntaxes}/share/skylighting/xml";
 
-                mkHaskellPackages = checkLocalPackages:
-                    pkgs.haskellPackages.extend (
+                mkHaskellPackages = baseHaskellPackages: checkLocalPackages:
+                    baseHaskellPackages.extend (
                     final: previous:
                     let
                         # User-facing builds only need the statically linked
@@ -476,8 +476,14 @@
                     }
                 );
 
-                haskellPackages = mkHaskellPackages true;
-                productionHaskellPackages = mkHaskellPackages false;
+                haskellPackages = mkHaskellPackages pkgs.haskellPackages true;
+                productionHaskellPackages =
+                    mkHaskellPackages pkgs.haskellPackages false;
+                staticHaskellPackages =
+                    if pkgs.stdenv.hostPlatform.isLinux then
+                        mkHaskellPackages pkgs.pkgsStatic.haskellPackages false
+                    else
+                        null;
                 agentCorePackage = productionHaskellPackages.agent-core;
                 agentMcpPackage = productionHaskellPackages.agent-mcp;
                 agentJsonPackage = productionHaskellPackages.agent-json;
@@ -496,6 +502,12 @@
                 agentStorePackage = productionHaskellPackages.agent-store;
                 agentCliPackage = productionHaskellPackages.agent-cli;
                 agentTelegramPackage = productionHaskellPackages.agent-telegram;
+                agentCliStaticExecutable =
+                    if pkgs.stdenv.hostPlatform.isLinux then
+                        pkgs.haskell.lib.justStaticExecutables
+                            staticHaskellPackages.agent-cli
+                    else
+                        agentCliExecutable;
                 agentCliExecutable =
                     (pkgs.haskell.lib.justStaticExecutables agentCliPackage).overrideAttrs
                         (old: {
@@ -658,7 +670,11 @@
                 '';
             in
             {
-                packages.default = agentCliExecutable;
+                # Linux users get fully static musl executables rather than
+                # the tool-bundled package's multi-gigabyte runtime closure.
+                # The native wrapped build remains available as `agent-cli`.
+                packages.default = agentCliStaticExecutable;
+                packages.agent-cli-static = agentCliStaticExecutable;
                 packages.agent-cli = agentCliExecutable;
                 packages.agent-telegram = agentTelegramExecutable;
                 packages.agent-core = agentCorePackage;


### PR DESCRIPTION
## Summary

- parameterize the Haskell package overlay so it can be applied to both the native and `pkgsStatic` package sets
- make the default Linux package a fully static musl build
- retain the existing wrapped, tool-bundled build as `packages.agent-cli`
- expose the static build explicitly as `packages.agent-cli-static`
- keep the native build as the non-Linux fallback

## Validation

- `nix build --no-link --print-out-paths .#default`
- verified `file` reports both produced executables as statically linked ELF binaries
- verified `readelf` reports no interpreter, dynamic section, or `NEEDED` libraries
- verified the default output has no GHC reference and a 59.5 MiB closure
- smoke-tested `agent-cli --help`
- `git diff --check`

The first producer build currently compiles the uncached musl GHC toolchain. Consumers avoid that cost once the output is available from a binary cache or release artifact.
