### PR TITLE
Overlap worktree setup with account preparation

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
@@ -1,12 +1,15 @@
 -- | Usage-aware account selection for automatic startup and provider fallback.
 module Agent.CLI.AccountSelection
     ( AccountCandidate(..)
+    , PreparedProviderAccounts
     , SelectedAccount(..)
     , accountCapacity
     , loadedAuthSupportsUsageAccountSelection
+    , prepareProviderAccounts
     , providerSupportsUsageAccountSelection
     , selectCandidates
     , selectAccount
+    , selectPreparedProviderAccount
     , selectProviderAccount
     ) where
 
@@ -89,7 +92,23 @@ selectProviderAccount
     -> Maybe BillingMode
     -> Maybe (Text, Text)
     -> IO (Either Text SelectedAccount)
-selectProviderAccount provider requiredBilling remembered = do
+selectProviderAccount provider requiredBilling remembered =
+    selectPreparedProviderAccount remembered
+        <$> prepareProviderAccounts provider requiredBilling
+
+-- | Usage results prepared independently of project settings. The freshly
+-- checked-out project can apply its remembered account only after Git setup
+-- completes.
+data PreparedProviderAccounts = PreparedProviderAccounts
+    { preparedProvider :: !Provider
+    , preparedAccounts :: ![LoginAccount]
+    }
+
+prepareProviderAccounts
+    :: Provider
+    -> Maybe BillingMode
+    -> IO PreparedProviderAccounts
+prepareProviderAccounts provider requiredBilling = do
     providerAccounts <-
         filter
             ((== provider) . (.loginProvider))
@@ -106,11 +125,21 @@ selectProviderAccount provider requiredBilling remembered = do
                             providerAccounts
                 in if null subscription then providerAccounts else subscription
     checked <- mapConcurrently refreshSelectableAccount billingAccounts
-    pure $ case selectAccount remembered checked of
+    pure PreparedProviderAccounts
+        { preparedProvider = provider
+        , preparedAccounts = checked
+        }
+
+selectPreparedProviderAccount
+    :: Maybe (Text, Text)
+    -> PreparedProviderAccounts
+    -> Either Text SelectedAccount
+selectPreparedProviderAccount remembered prepared =
+    case selectAccount remembered prepared.preparedAccounts of
         Just selected -> Right selected
         Nothing -> Left $
             "no "
-                <> providerSlug provider
+                <> providerSlug prepared.preparedProvider
                 <> " account has verified available usage"
 
 -- | Prefer the remembered project account when it is usable; otherwise choose

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -72,7 +72,10 @@ import Agent.CLI.Runtime.HistorySource
 import Agent.CLI.Runtime.Orchestration.Background ()
 import Agent.CLI.Runtime.Orchestration.Concurrent ()
 import Agent.CLI.Runtime.Orchestration.Initialized
-    ( runAgentInitialized )
+    ( PreparedStartupAuth
+    , prepareStartupAuth
+    , runAgentInitialized
+    )
 import Agent.CLI.Runtime.Orchestration.Restart
     ( RestartCallbacks(..), runFullscreenRestartLoop )
 import Agent.CLI.Runtime.Orchestration.Startup
@@ -186,7 +189,7 @@ import Agent.Tools.Secret ()
 import Agent.Tools.Types ( defaultToolEnv, ToolEnv(toolCancel) )
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ( (<|>) )
-import Control.Concurrent.Async ()
+import Control.Concurrent.Async ( Async, withAsync )
 import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar
     ( newEmptyMVar, newMVar, readMVar, tryPutMVar )
@@ -199,7 +202,7 @@ import Data.Functor ()
 import Data.IORef
     ( IORef, atomicModifyIORef', newIORef, readIORef, writeIORef )
 import Data.List ()
-import Data.Maybe ( isJust )
+import Data.Maybe ( isJust, isNothing )
 import Data.Text ( Text )
 import Data.Time.Clock ( getCurrentTime )
 import System.Console.ANSI ()
@@ -709,7 +712,10 @@ prepareAgentIterationTracked
                                     page)
     writeIORef uiRuntimeRef fullscreen
     resumeLock <- readIORef resumeLockRef
-    let action =
+    let runAction
+            :: Maybe (Async PreparedStartupAuth)
+            -> IO RunResult
+        runAction preparedAuth =
             do
                 cwd <- case resumed of
                     Just _ -> pure initialCwd
@@ -814,6 +820,21 @@ prepareAgentIterationTracked
                     resumeLock
                     cwd
                     startup
+                    preparedAuth
+        action
+            | options.optWorktree
+            , isNothing resumed
+            , isNothing transition =
+                let prepareAccountUsage =
+                        isNothing fullscreen
+                            || isJust options.optProvider
+                            || isJust options.optModel
+                in withAsync
+                    (prepareStartupAuth
+                        prepareAccountUsage
+                        options.optProvider) $
+                    runAction . Just
+            | otherwise = runAction Nothing
         cleanup = do
             writeIORef uiRuntimeRef Nothing
             writeIORef cancelToolRef (pure ())

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -1,9 +1,16 @@
-module Agent.CLI.Runtime.Orchestration.Initialized (runAgentInitialized) where
+module Agent.CLI.Runtime.Orchestration.Initialized
+    ( PreparedStartupAuth
+    , prepareStartupAuth
+    , runAgentInitialized
+    ) where
 
 import Agent.CLI.AccountPicker ()
 import Agent.CLI.AccountSelection
-    ( SelectedAccount(..),
+    ( PreparedProviderAccounts,
+      SelectedAccount(..),
       loadedAuthSupportsUsageAccountSelection,
+      prepareProviderAccounts,
+      selectPreparedProviderAccount,
       selectProviderAccount )
 import Agent.CLI.Afk ()
 import Agent.CLI.AgentSessions ()
@@ -14,6 +21,7 @@ import Agent.CLI.Auth
     ( LoadedAuth(loadedAccountLabel, LoadedAuth, loadedOpenAiPool,
                  loadedProvider, loadedTokenProvider, loadedSelectionId),
       preferredOpenAiTokenProvider,
+      loadAuth,
       loadAuthForAccount,
       probeLoadedAuthCredential,
       staticCredentialProvider )
@@ -118,7 +126,7 @@ import Agent.CLI.SessionState ()
 import Agent.CLI.SessionTitle ()
 import Agent.CLI.Skills ()
 import Agent.CLI.Startup.Auth
-    ( loadStartupAuth, markStartupStage, startupDie )
+    ( loadStartupAuth, loadStartupAuthFromResult, markStartupStage, startupDie )
 import Agent.CLI.StartupContext ()
 import Agent.CLI.Style ( setCliWindowTitle )
 import Agent.CLI.Subagents.Runtime ()
@@ -173,7 +181,7 @@ import Agent.Tools.Secret ()
 import Agent.Tools.Types ()
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ( (<|>) )
-import Control.Concurrent.Async ( concurrently )
+import Control.Concurrent.Async ( Async, concurrently, wait )
 import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar ( modifyMVar_, newMVar, readMVar )
 import Control.Concurrent.STM ()
@@ -212,6 +220,25 @@ import qualified Agent.XAI.Client as XAIClient ()
 import qualified Agent.XAI.Request as XAIRequest ()
 import qualified Agent.XAI.Usage as XAIUsage ()
 
+data PreparedStartupAuth = PreparedStartupAuth
+    { preparedAuthResult :: !(Either Text LoadedAuth)
+    , preparedAccountUsage :: !(Maybe PreparedProviderAccounts)
+    }
+
+prepareStartupAuth :: Bool -> Maybe Provider -> IO PreparedStartupAuth
+prepareStartupAuth prepareAccountUsage requestedProvider = do
+    authResult <- loadAuth requestedProvider
+    accountUsage <- case authResult of
+        Right loaded
+            | prepareAccountUsage
+            , loadedAuthSupportsUsageAccountSelection loaded ->
+                Just <$> prepareProviderAccounts loaded.loadedProvider Nothing
+        _ -> pure Nothing
+    pure PreparedStartupAuth
+        { preparedAuthResult = authResult
+        , preparedAccountUsage = accountUsage
+        }
+
 runAgentInitialized
     :: (AgentRunMode -> CliOptions -> IO DevResult)
     -> AgentProcessRuntime
@@ -223,11 +250,12 @@ runAgentInitialized
     -> Maybe SessionLock
     -> OsPath
     -> StartupRuntime
+    -> Maybe (Async PreparedStartupAuth)
     -> IO RunResult
 runAgentInitialized
-        runAgentChild processRuntime options transition home root resumed resumeLock cwd startup =
+        runAgentChild processRuntime options transition home root resumed resumeLock cwd startup preparedAuth =
     runAgentInitializedWithLock
-        runAgentChild processRuntime options transition home root resumed resumeLock cwd startup
+        runAgentChild processRuntime options transition home root resumed resumeLock cwd startup preparedAuth
         `onException` mapM_ releaseSessionLock resumeLock
 
 runAgentInitializedWithLock
@@ -241,10 +269,11 @@ runAgentInitializedWithLock
     -> Maybe SessionLock
     -> OsPath
     -> StartupRuntime
+    -> Maybe (Async PreparedStartupAuth)
     -> IO RunResult
 runAgentInitializedWithLock
         runAgentChild processRuntime
-        options transition home root resumed resumeLock cwd startup = do
+        options transition home root resumed resumeLock cwd startup preparedAuth = do
     let baseToolEnv = startup.startupToolEnv
         mcpSupervisor = processRuntime.processMcpSupervisor
         interrupt = startup.startupInterrupt
@@ -366,12 +395,26 @@ runAgentInitializedWithLock
                 && isNothing resumed
                 && isNothing options.optProvider
                 && isNothing options.optModel
-    ((initialLoaded, learnAboutUserRequested), customBearerToken) <-
+    ( ( initialLoaded
+      , learnAboutUserRequested
+      , preparedAccountUsage
+      )
+      , customBearerToken
+      ) <-
         case customResponses of
             Nothing -> do
-                startupAuth <-
-                    loadStartupAuth startup transition requestedProvider
-                pure (startupAuth, Nothing)
+                (startupAuth, accountUsage) <- loadPreparedOrStartupAuth
+                    preparedAuth
+                    startup
+                    transition
+                    requestedProvider
+                pure
+                    ( ( fst startupAuth
+                      , snd startupAuth
+                      , accountUsage
+                      )
+                    , Nothing
+                    )
             Just (connectionId, responses) -> do
                 token <- case responses.responsesApiKeyEnv of
                     Nothing
@@ -409,6 +452,7 @@ runAgentInitializedWithLock
                             , loadedOpenAiPool = Nothing
                             }
                       , False
+                      , Nothing
                       )
                     , if Text.null token then Nothing else Just token
                     )
@@ -457,10 +501,17 @@ runAgentInitializedWithLock
                             , account.projectAccountId
                             ))
                         (projectAccountFor provider projectSettings)
-                selectProviderAccount
-                    provider
-                    Nothing
-                    rememberedIds >>= \case
+                let selectStartupAccount = case preparedAccountUsage of
+                        Just accountUsage ->
+                            pure $ selectPreparedProviderAccount
+                                rememberedIds
+                                accountUsage
+                        Nothing ->
+                            selectProviderAccount
+                                provider
+                                Nothing
+                                rememberedIds
+                selectStartupAccount >>= \case
                         Left err ->
                             startupDie startup (Text.unpack err)
                         Right selected ->
@@ -719,6 +770,32 @@ runAgentInitializedWithLock
         transitionTarget
         uiRuntimeRef
         unavailableProviders
+
+loadPreparedOrStartupAuth
+    :: Maybe (Async PreparedStartupAuth)
+    -> StartupRuntime
+    -> Maybe ProviderTransition
+    -> Maybe Provider
+    -> IO ((LoadedAuth, Bool), Maybe PreparedProviderAccounts)
+loadPreparedOrStartupAuth prepared startup transition requestedProvider =
+    case prepared of
+        Nothing ->
+            (, Nothing)
+                <$> loadStartupAuth startup transition requestedProvider
+        Just worker ->
+            wait worker >>= \case
+                preparedResult
+                    | Right loaded <- preparedResult.preparedAuthResult
+                    , maybe True (== loaded.loadedProvider) requestedProvider ->
+                        (, preparedResult.preparedAccountUsage)
+                            <$> loadStartupAuthFromResult
+                                startup
+                                transition
+                                requestedProvider
+                                preparedResult.preparedAuthResult
+                _ ->
+                    (, Nothing)
+                        <$> loadStartupAuth startup transition requestedProvider
 
 trackCredentialAccount
     :: IORef Text

--- a/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Startup.Auth
     ( learnAboutUserOnboardingPrompt
     , loadStartupAuth
+    , loadStartupAuthFromResult
     , markStartupStage
     , recordStartupTiming
     , setStartupNotice
@@ -98,7 +99,16 @@ loadStartupAuth
     -> Maybe Provider
     -> IO (LoadedAuth, Bool)
 loadStartupAuth startup transition requestedProvider =
-    loadTransitionAuth transition requestedProvider >>= \case
+    loadTransitionAuth transition requestedProvider >>=
+        loadStartupAuthFromResult startup transition requestedProvider
+
+loadStartupAuthFromResult
+    :: StartupRuntime
+    -> Maybe ProviderTransition
+    -> Maybe Provider
+    -> Either Text LoadedAuth
+    -> IO (LoadedAuth, Bool)
+loadStartupAuthFromResult startup transition requestedProvider = \case
         Right loaded
             | loaded.loadedProvider == GeminiProvider
             , Just runtime <- startup.startupFullscreen ->


### PR DESCRIPTION
## Summary

- overlap fresh `--worktree` Git setup with credential and account preparation
- split account discovery/refresh from final selection so freshly fetched project settings remain authoritative
- reuse speculative auth/account results only when the resolved provider matches, otherwise fall back to the existing startup path
- scope the worker with `withAsync` so Git/setup failures cancel and join background work

Resume and provider-transition flows are unchanged. Default fullscreen startup speculates auth only because its account usage probe already runs in the background; non-fullscreen or explicit provider/model startup also overlaps usage refresh.

## Validation

Focused account-selection tests in GHCi:

```console
$ printf ':main --match "account selection"\n:quit\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test
17 examples, 0 failures
```

The `agent-cli` library also loaded successfully in GHCi (210 modules).

A full GHCi suite run reached 1,408 examples with 31 failures and 1 pending. All 31 failures were existing PostgreSQL/session tests unable to create a socket because the environment path was too long (`PostgreSQL socket directory is too long: ...`); no other tests failed.

`git diff --check` passes.

## Benchmark

Controlled startup-orchestration benchmark compiled inside `nix develop` with GHC `-O2 -threaded`. The representative workload models a 220 ms Git/worktree phase and a 160 ms account-preparation phase, compares the old sequential composition with the new structured `withAsync` composition, warms each path once, and averages 15 samples:

```console
$ nix develop -c ghc -O2 -threaded agent-startup-concurrency-bench.hs -o agent-startup-concurrency-bench
$ ./agent-startup-concurrency-bench
sequential_mean_ms=381.61
concurrent_mean_ms=221.06
speedup=1.73x
reduction=42.1%
```

This is a controlled I/O orchestration benchmark rather than a claim that every real startup will improve by exactly 42%; real savings depend on Git and provider latency.
