### PR TITLE
Persist stable prompt epochs across session resumes

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Prompt
     ( appendMcpInstructions
     , codexEnvironmentContext
+    , mcpInstructionsForRequest
     , mcpInstructionsGuidance
     , secretInputGuidance
     , imageDisplayGuidance
@@ -247,6 +248,19 @@ appendMcpInstructions :: [(Text, Text)] -> Text -> Text
 appendMcpInstructions [] base = base
 appendMcpInstructions instructions base =
     base <> "\n\n" <> mcpInstructionsGuidance instructions
+
+-- | Progressive MCP readiness is timing-dependent: a cold fleet may have no
+-- server instructions when the request is built, while a reused fleet may
+-- already have all of them. Keep that content in the MCP conversation notice
+-- so the request prefix does not change merely because startup was faster.
+-- Blocking startup has a complete snapshot and can safely include it.
+mcpInstructionsForRequest
+    :: Bool
+    -> [(Text, Text)]
+    -> [(Text, Text)]
+mcpInstructionsForRequest progressive instructions
+    | progressive = []
+    | otherwise = instructions
 
 learnedSkillGuidance :: Set Text -> Text
 learnedSkillGuidance available

--- a/packages/agent-cli/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli/src/Agent/CLI/Request.hs
@@ -1,6 +1,8 @@
 -- | Construction of provider-neutral Responses requests.
 module Agent.CLI.Request
     ( requestParams
+    , requestPromptParts
+    , requestToolIdentities
     , setRequestInstructions
     , setRequestInstructionsAndTools
     , setRequestModel
@@ -9,7 +11,7 @@ module Agent.CLI.Request
 
 import Agent.OpenAI.ModelMetadata (isCodexResponsesLiteModel)
 import Agent.Responses.Types
-import Agent.Responses.Types.Tools (ResponseTool(..), responseToolDecoder)
+import Agent.Responses.Types.Tools (responseToolDecoder)
 import Agent.Json (RawJson, rawJsonBytes, rawJsonFromEncoding)
 import Agent.Json.Decode qualified as Hermes
 import Agent.Provider (Provider(..))
@@ -83,6 +85,38 @@ setRequestPromptCacheKey cacheKey ResponseCreateParams{..} =
         { promptCacheKey = Just cacheKey
         , ..
         }
+
+-- | Extract the provider-visible instruction/tool prefix regardless of
+-- whether the request uses conventional Responses fields or Responses Lite's
+-- ordered input template.
+requestPromptParts :: ResponseCreateParams -> (Text, [ResponseTool])
+requestPromptParts params
+    | requestUsesResponsesLite params =
+        let (instructionText, toolSchemas, _) =
+                responsesLiteTemplateParts params.input
+        in (instructionText, toolSchemas)
+    | otherwise =
+        ( fromMaybe "" params.instructions
+        , fromMaybe [] params.tools
+        )
+
+-- | Stable ordered identities used to decide whether persisted tool schemas
+-- are safe to reuse. Descriptions and JSON schemas may evolve between binary
+-- versions without invalidating a resume, while adding, removing, reordering,
+-- or renaming a tool starts a new prompt epoch.
+requestToolIdentities :: [ResponseTool] -> [Text]
+requestToolIdentities = concatMap identity
+  where
+    identity = \case
+        FunctionToolValue tool -> ["function:" <> tool.name]
+        CustomToolValue tool -> ["custom:" <> tool.name]
+        NamespaceToolValue namespace ->
+            ["namespace:" <> namespace.name <> ":begin"]
+                <> concatMap identity namespace.tools
+                <> ["namespace:" <> namespace.name <> ":end"]
+        KnownResponseTool toolType ->
+            ["known:" <> responseToolTypeText toolType]
+        UnknownResponseTool tagged -> ["unknown:" <> tagged.tag]
 
 -- | Change the wire model while keeping the request dialect coherent.
 --

--- a/packages/agent-cli/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli/src/Agent/CLI/Request.hs
@@ -70,6 +70,10 @@ requestParams provider modelName instructionText toolSchemas effort =
                 , ..
                 }
 
+-- | Route repeated requests for one durable session to the same provider-side
+-- prompt-cache bucket. This is only a routing hint, not a forced cache hit:
+-- the provider still requires an unchanged request prefix. Changed schemas or
+-- instructions naturally miss rather than reusing stale content.
 setRequestPromptCacheKey
     :: Text
     -> ResponseCreateParams

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -275,6 +275,7 @@ runAgentSession
     learnedSkillAppTools
     legacySubagentTarget
     mcpFleet
+    mcpInstructions
     mcpTools
     model
     multiCtx
@@ -335,7 +336,6 @@ runAgentSession
                         ("Failed to initialize MCP tools: " <> Text.unpack err)
                 Nothing -> pure ()
         today <- utctDay <$> getCurrentTime
-        mcpInstructions <- MCP.mcpFleetInstructions mcpFleet
         -- Catalog models provide the per-model instructions template. Full
         -- code mode remains opt-in, but code_mode_only models still route the
         -- reserved image-generation tool through exec because Responses Lite

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -62,6 +62,7 @@ import Agent.CLI.Render ( putTextLn )
 import Agent.CLI.ReplMode ()
 import Agent.CLI.Request
     ( requestParams
+    , setRequestInstructionsAndTools
     , setRequestPromptCacheKey
     )
 import Agent.CLI.Resume ( resumeNeedsGeneratedContext )
@@ -82,13 +83,15 @@ import Agent.CLI.Secret ()
 import Agent.CLI.Session
     ( addSessionUsage,
       ensureSession,
+      compatibleSessionPromptSnapshot,
       resumeHint,
       sessionTitleFromPrompt,
       sessionUsageFromTurns,
       Persistence(..),
       PersistenceState(PersistenceActive, PersistencePending),
       SessionHandle(sessionMeta, sessionDir),
-      SessionMeta(metaId, metaLastResponseId, metaTitle) )
+      SessionMeta(metaId, metaLastResponseId, metaPromptSnapshot, metaTitle),
+      SessionPromptSnapshot(..) )
 import Agent.CLI.Session.Attachments ()
 import Agent.CLI.Session.Choices ()
 import Agent.CLI.Session.History
@@ -110,7 +113,8 @@ import Agent.CLI.Session.Runtime.Types
                      ghciEnabledRef, bashEnabledRef, toolEnv, planMode, startup,
                      learnAboutUserRequested, databaseScopes, promptRequest,
                      pendingTurn, unavailableProviders, startupUnavailable, paramsRef,
-                     conversationRef, needsInitialContext, persist,
+                     conversationRef, needsInitialContext, queueInitialContext,
+                     initialGrokContext, persist,
                      contextOccupancyRef, currentContextWindow,
                      startupWindowTitle, automaticCompactionRef,
                      projectRoot, home, cwd, tokenProvider, openAiPool, startupContext,
@@ -155,7 +159,7 @@ import Agent.CLI.WebFetch ()
 import Agent.CLI.Worktree ()
 import Agent.Cancel ()
 import Agent.Claude ()
-import Agent.Dialect ()
+import Agent.Dialect (dialectId)
 import Agent.Error ()
 import Agent.GrokBuild.Dialect.Goal ()
 import Agent.GrokBuild.Dialect.Runtime ()
@@ -415,9 +419,27 @@ runAgentSession
                     <> maybe [] (.codeModeWireTools) codeModeRuntime
             baseParams = requestParams provider model instructions
                 wireSchemas effortText
-            params = maybe baseParams
-                (`setRequestPromptCacheKey` baseParams)
-                sessionId
+            compatiblePromptSnapshot =
+                compatibleSessionPromptSnapshot
+                    provider
+                    inferredTarget.targetConnectionId
+                    (dialectId dialect)
+                    cwd
+                    sessionId
+                    baseParams
+                    (resumed >>= \(meta, _) -> meta.metaPromptSnapshot)
+            params = case compatiblePromptSnapshot of
+                Just snapshot ->
+                    setRequestPromptCacheKey
+                        snapshot.promptSnapshotCacheKey
+                        (setRequestInstructionsAndTools
+                            snapshot.promptSnapshotInstructions
+                            (Just snapshot.promptSnapshotTools)
+                            baseParams)
+                Nothing ->
+                    maybe baseParams
+                        (`setRequestPromptCacheKey` baseParams)
+                        sessionId
             initialItems = maybe [] (foldSessionItems . snd) resumed
             initialTurns = maybe [] snd resumed
             resumeNeedsFreshContext =
@@ -428,6 +450,15 @@ runAgentSession
                     | resumeTargetChanged -> Nothing
                     | otherwise ->
                         resumed >>= \(meta, _) -> meta.metaLastResponseId
+            needsInitialContext =
+                resumeNeedsFreshContext
+                    || (null initialTurns && isNothing initialPrevious)
+            restoredInitialPromptSnapshot
+                | null initialTurns && isNothing initialPrevious =
+                    compatiblePromptSnapshot
+                | otherwise = Nothing
+            queueInitialContext =
+                needsInitialContext && isNothing restoredInitialPromptSnapshot
         paramsRef <- newIORef params
         policyRef <- newIORef policy
         claudeRuntimeSlot <- newClaudeSessionRuntimeSlot
@@ -516,22 +547,25 @@ runAgentSession
                     ReportAgentsContextLoaded
                 | otherwise =
                     SuppressAgentsContextLoaded
-        startupContext <-
-            loadAgentsContext
-                stderrHandle
-                fullscreen
-                agentsContextNotice
-                options
-                dialect
-                home
-                cwd
-                (if refreshDialectContext || resumeNeedsFreshContext
-                    then []
-                    else initialItems)
-                (if refreshDialectContext || resumeNeedsFreshContext
-                    then Nothing
-                    else initialPrevious)
-                environmentContextBlock
+        startupContext <- case restoredInitialPromptSnapshot of
+            Just snapshot ->
+                newIORef snapshot.promptSnapshotGeneratedContext
+            Nothing ->
+                loadAgentsContext
+                    stderrHandle
+                    fullscreen
+                    agentsContextNotice
+                    options
+                    dialect
+                    home
+                    cwd
+                    (if refreshDialectContext || resumeNeedsFreshContext
+                        then []
+                        else initialItems)
+                    (if refreshDialectContext || resumeNeedsFreshContext
+                        then Nothing
+                        else initialPrevious)
+                    environmentContextBlock
         -- Fullscreen sessions load skills after Brick has taken over the
         -- terminal, so filesystem discovery cannot delay the first frame.
         -- Minimal and one-shot sessions still initialize them synchronously
@@ -634,10 +668,11 @@ runAgentSession
                                             <|> (resolvedContextWindow
                                                 =<< codexModelInfo)
                                 , automaticCompactionRef
-                                , needsInitialContext =
-                                    resumeNeedsFreshContext
-                                        || (null initialTurns
-                                            && isNothing initialPrevious)
+                                , needsInitialContext
+                                , queueInitialContext
+                                , initialGrokContext =
+                                    restoredInitialPromptSnapshot
+                                        >>= (.promptSnapshotGrokContext)
                                 , persist
                                 , startupWindowTitle
                                 , projectRoot

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -82,7 +82,10 @@ import Agent.CLI.Plan
     ( cliPlanHooks
     , resumedPlanNeedsApproval
     )
-import Agent.CLI.Prompt ( subscriptionSubagentModelGuidance )
+import Agent.CLI.Prompt
+    ( mcpInstructionsForRequest
+    , subscriptionSubagentModelGuidance
+    )
 import Agent.CLI.PromptHooks
     ( fullscreenAwareImageHooks, fullscreenAwarePlanHooks, fullscreenAwareSecretHooks )
 import Agent.CLI.Provider.OpenAI ()
@@ -276,6 +279,7 @@ import qualified Agent.MCP as MCP
       mcpFleetInstructions,
       mcpFleetMetaTools,
       mcpFleetResourceTools,
+      mcpFleetStatuses,
       mcpFleetTools,
       releaseMcpFleetLease,
       McpFleet(mcpFleetRegistrations, mcpFleetWarnings),
@@ -741,7 +745,17 @@ runAgentTools
         (if isOneShot options || not isTty
             then Nothing
             else Just (cliMcpElicitation escPaused uiRuntimeRef))
-    let reportProgressiveMcp statuses = do
+    let enqueueMcpSnapshot statuses =
+            unless (null statuses) do
+                instructions <-
+                    readIORef mcpFleetRef
+                        >>= maybe (pure []) MCP.mcpFleetInstructions
+                enqueuePendingNotice pendingNotices PendingMcpNotice
+                    (UserMessage
+                        (formatMcpModelNoticeFor dialectId statuses
+                            <> formatMcpInstructionsNotice instructions))
+                    >>= either (reportStartupWarning startup) pure
+        reportProgressiveMcp statuses = do
             finished <- readIORef startup.startupFinished
             unless finished do
                 setStartupNotice startup.startupFullscreen
@@ -757,15 +771,7 @@ runAgentTools
             settled <-
                 atomicModifyIORef' mcpStatusPhaseRef \previous ->
                     (Just isConnecting, previous == Just True && not isConnecting)
-            when (settled && not (null statuses)) do
-                instructions <-
-                    readIORef mcpFleetRef
-                        >>= maybe (pure []) MCP.mcpFleetInstructions
-                enqueuePendingNotice pendingNotices PendingMcpNotice
-                    (UserMessage
-                        (formatMcpModelNoticeFor dialectId statuses
-                            <> formatMcpInstructionsNotice instructions))
-                    >>= either (reportStartupWarning startup) pure
+            when settled (enqueueMcpSnapshot statuses)
     mcpLease <-
         try @_ @SomeException
             (if progressiveMcp
@@ -794,6 +800,13 @@ runAgentTools
             Right lease -> pure lease
     let mcpFleet = mcpLease.mcpLeaseFleet
     writeIORef mcpFleetRef (Just mcpFleet)
+    when progressiveMcp $
+        MCP.mcpFleetStatuses mcpFleet >>= enqueueMcpSnapshot
+    currentMcpInstructions <- MCP.mcpFleetInstructions mcpFleet
+    let mcpInstructions =
+            mcpInstructionsForRequest
+                progressiveMcp
+                currentMcpInstructions
     mapM_ (reportStartupWarning startup) mcpFleet.mcpFleetWarnings
     setStartupNotice startup.startupFullscreen "Loading built-in tools…"
     coding <-
@@ -1054,6 +1067,7 @@ runAgentTools
         learnedSkillAppTools
         legacySubagentTarget
         mcpFleet
+        mcpInstructions
         mcpTools
         model
         multiCtx

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -70,6 +70,7 @@ import Agent.CLI.Secret ()
 import Agent.CLI.Session
     ( TranscriptEffect(TranscriptReset),
       appendTurnKeepTitleIndexed,
+      appendTurnWithPromptResetIndexed,
       createSession,
       forkSessionAt,
       loadSession,
@@ -340,24 +341,19 @@ handleSessionAction
                                 , turnProviderTelemetry = []
                                 }
                         (handle', turnIndex) <-
-                            appendTurnKeepTitleIndexed handle turn
+                            appendTurnWithPromptResetIndexed handle turn \meta ->
+                                meta
+                                    { metaLastResponseId = Nothing
+                                    , metaInputTokens = 0
+                                    , metaOutputTokens = 0
+                                    , metaCachedTokens = 0
+                                    , metaLastRecap = Nothing
+                                    , metaLastTurnSummary = Nothing
+                                    , metaLastRecapMainTurns = 0
+                                    }
                         let meta = handle'.sessionMeta
-                                { metaLastResponseId = Nothing
-                                , metaUpdatedAt = now
-                                , metaInputTokens = 0
-                                , metaOutputTokens = 0
-                                , metaCachedTokens = 0
-                                , metaLastRecap = Nothing
-                                , metaLastTurnSummary = Nothing
-                                , metaLastRecapMainTurns = 0
-                                , metaPromptSnapshot = Nothing
-                                }
-                        writeSessionMeta
-                            handle'.sessionPool
-                            handle'.sessionMetaPath
-                            meta
                         writeIORef slotRef
-                            (PersistenceActive handle'{sessionMeta = meta})
+                            (PersistenceActive handle')
                         forM_ fullscreen \runtime ->
                             commitFullscreenHistoryTurn
                                 runtime

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -90,7 +90,7 @@ import Agent.CLI.Session
       SessionMeta(metaTitle, metaLastResponseId, metaUpdatedAt,
                   metaInputTokens, metaOutputTokens, metaCachedTokens, metaLastRecap,
                   metaLastTurnSummary, metaLastRecapMainTurns, metaTransportModel,
-                  metaTitleUserTurns, metaId, metaCwd),
+                  metaTitleUserTurns, metaPromptSnapshot, metaId, metaCwd),
       SessionTransfer(transferTurns, SessionTransfer, transferMeta),
       SessionTurn(turnUsage, SessionTurn, turnAt, turnUserText,
                   turnAssistantText, turnError, turnResponseId, turnEffect,
@@ -350,6 +350,7 @@ handleSessionAction
                                 , metaLastRecap = Nothing
                                 , metaLastTurnSummary = Nothing
                                 , metaLastRecapMainTurns = 0
+                                , metaPromptSnapshot = Nothing
                                 }
                         writeSessionMeta
                             handle'.sessionPool

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -32,6 +32,7 @@ module Agent.CLI.Session
     , appendTurnIndexed
     , appendTurnWithMetaUpdate
     , appendTurnWithMetaUpdateIndexed
+    , appendTurnWithPromptResetIndexed
     , appendTurnKeepTitle
     , appendTurnKeepTitleIndexed
     , sessionRewindChoices
@@ -849,7 +850,42 @@ appendTurnWithMetaTransitionIndexed
     -> SessionTurn
     -> (SessionMeta -> SessionMeta)
     -> IO (SessionHandle, Int64)
-appendTurnWithMetaTransitionIndexed handle turn transition = do
+appendTurnWithMetaTransitionIndexed =
+    appendTurnWithMetaTransitionIndexedUsing Store.appendSessionTurnIndexed
+
+-- | Append a turn while atomically retiring the current provider-visible
+-- prompt epoch. The returned handle has no prompt snapshot, so its next
+-- request establishes a fresh stable prefix.
+appendTurnWithPromptResetIndexed
+    :: SessionHandle
+    -> SessionTurn
+    -> (SessionMeta -> SessionMeta)
+    -> IO (SessionHandle, Int64)
+appendTurnWithPromptResetIndexed handle turn transition =
+    appendTurnWithMetaTransitionIndexedUsing
+        Store.appendSessionTurnIndexedWithPromptReset
+        handle
+        turn
+        (\meta ->
+            (transition meta)
+                { metaPromptSnapshot = Nothing
+                })
+
+appendTurnWithMetaTransitionIndexedUsing
+    :: ( StorePool
+        -> Store.SessionTurn
+        -> Store.SessionMetadata
+        -> IO (Either StoreError (Maybe Int64))
+       )
+    -> SessionHandle
+    -> SessionTurn
+    -> (SessionMeta -> SessionMeta)
+    -> IO (SessionHandle, Int64)
+appendTurnWithMetaTransitionIndexedUsing
+    appendStoredTurn
+    handle
+    turn
+    transition = do
     let pool = handle.sessionPool
     now <- normalizePostgresTimestamp <$> getCurrentTime
     let meta0 = handle.sessionMeta
@@ -858,7 +894,7 @@ appendTurnWithMetaTransitionIndexed handle turn transition = do
             , metaLastResponseId = turn.turnResponseId <|> meta0.metaLastResponseId
             }
         finalMeta = transition meta
-    Store.appendSessionTurnIndexed
+    appendStoredTurn
         pool
         (toStoredTurn turn)
         (toStoredMetadata finalMeta) >>= \case
@@ -1277,6 +1313,8 @@ importSessionTransfer pool root cwd transfer = runExceptT do
             , legacyContentHash = contentFingerprint bytes
             , legacyMetadata = toStoredMetadata meta
             , legacyTurns = map toStoredTurn transfer.transferTurns
+            , legacyPromptSnapshot =
+                toStoredPromptSnapshot <$> meta.metaPromptSnapshot
             }
     lift (Store.importLegacySession pool legacy) >>= \case
         Left err -> do

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Session
     ( SessionHandle(..)
     , SessionMeta(..)
+    , SessionPromptSnapshot(..)
     , sessionMetaDecoder
     , LegacySubagentTarget(..)
     , TranscriptEffect(..)
@@ -72,7 +73,9 @@ module Agent.CLI.Session
     , sessionLegacySubagentTarget
     , sessionTitleTurnCountFromSlot
     , writeSessionMeta
+    , compatibleSessionPromptSnapshot
     , ensureSession
+    , ensureSessionWithPromptSnapshot
     , resumeHint
     , sessionUsageFromTurns
     ) where
@@ -83,9 +86,14 @@ import Agent.CLI.SessionLock
     , releaseSessionLock
     )
 import Agent.CLI.Json (decodeLazy)
+import Agent.CLI.Request
+    ( requestPromptParts
+    , requestToolIdentities
+    )
 import Agent.CLI.Session.Types
     ( SessionHandle(..)
     , SessionMeta(..)
+    , SessionPromptSnapshot(..)
     , sessionMetaDecoder
     , LegacySubagentTarget(..)
     , TranscriptEffect(..)
@@ -108,14 +116,18 @@ import Agent.CLI.Session.Codec
     , fromStoredTurn
     , importLegacySession
     , toStoredMetadata
+    , toStoredPromptSnapshot
     , toStoredTurn
     , validateSessionMeta
     )
 import Agent.CLI.Models (ModelTarget(..))
 import Agent.CLI.SessionTitle (titleRefreshIndex)
+import Agent.Dialect (DialectId)
 import Agent.Loop (TokenUsage(..))
 import Agent.OpenAI.Compaction (rewindSessionUserText)
 import Agent.OsPath (toText, unsafeToFilePath)
+import Agent.Provider (Provider)
+import Agent.Responses.Types (ResponseCreateParams(model))
 import Agent.Store.Postgres (normalizePostgresTimestamp)
 import Agent.Store.Postgres.Connection (StorePool)
 import qualified Agent.Store.Postgres.Session as Store
@@ -130,7 +142,7 @@ import Control.Exception.Safe
     , tryAny
     , tryIO
     )
-import Control.Monad (foldM, unless, when)
+import Control.Monad (foldM, guard, unless, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
@@ -216,6 +228,38 @@ instance Monoid SessionTempCleanupReport where
     mempty = SessionTempCleanupReport [] []
 
 newtype SessionTempLease = SessionTempLease FileLock.FileLock
+
+-- | Reuse an immutable provider prefix only when the runtime target and the
+-- ordered provider-visible tool identities still describe the same session.
+-- Tool documentation/schema bytes may evolve between binaries; the persisted
+-- versions remain authoritative until a tool is added, removed, reordered, or
+-- renamed.
+compatibleSessionPromptSnapshot
+    :: Provider
+    -> Text
+    -> DialectId
+    -> OsPath
+    -> Maybe Text
+    -> ResponseCreateParams
+    -> Maybe SessionPromptSnapshot
+    -> Maybe SessionPromptSnapshot
+compatibleSessionPromptSnapshot
+    provider connection dialect cwd sessionId params maybeSnapshot = do
+        cacheKey <- sessionId
+        snapshot <- maybeSnapshot
+        let currentTools = snd (requestPromptParts params)
+        guard (snapshot.promptSnapshotVersion == 1)
+        guard (snapshot.promptSnapshotProvider == provider)
+        guard (snapshot.promptSnapshotConnection == connection)
+        guard (Just snapshot.promptSnapshotModel == params.model)
+        guard (snapshot.promptSnapshotDialect == dialect)
+        guard (snapshot.promptSnapshotCwd == cwd)
+        guard (snapshot.promptSnapshotCacheKey == cacheKey)
+        guard
+            ( requestToolIdentities snapshot.promptSnapshotTools
+                == requestToolIdentities currentTools
+            )
+        pure snapshot
 
 -- | @~/.haskell-agent/sessions@ given the user's home directory.
 sessionsRoot :: OsPath -> OsPath
@@ -339,7 +383,7 @@ cleanupPendingPersistence = \case
 createSession :: SessionCreate -> IO SessionHandle
 createSession spec = do
     (sessionId, tempDir) <- allocateSessionTemp spec.createRoot
-    createReservedSession spec sessionId tempDir
+    createReservedSession spec sessionId tempDir Nothing
         `onException` removeReservedTemp spec.createRoot sessionId
 
 -- | Clone a persisted session and its durable branch artifacts under a new
@@ -475,6 +519,7 @@ forkedMetadata now sessionId requestedTitle targetCwd source =
             maybe source.metaTitleRefreshIndex
                 (const (max 2 source.metaTitleRefreshIndex))
                 normalizedTitle
+        , metaPromptSnapshot = Nothing
         }
   where
     normalizedTitle =
@@ -586,8 +631,9 @@ createReservedSession
     :: SessionCreate
     -> Text
     -> OsPath
+    -> Maybe SessionPromptSnapshot
     -> IO SessionHandle
-createReservedSession spec sessionId tempDir = do
+createReservedSession spec sessionId tempDir promptSnapshot = do
     let pool = spec.createPool
     ensurePrivateDir spec.createRoot
     dir <- either (fail . Text.unpack) pure
@@ -628,6 +674,7 @@ createReservedSession spec sessionId tempDir = do
             , metaLastRecap = Nothing
             , metaLastTurnSummary = Nothing
             , metaLastRecapMainTurns = 0
+            , metaPromptSnapshot = promptSnapshot
             }
         handle = SessionHandle
             { sessionPool = pool
@@ -637,7 +684,14 @@ createReservedSession spec sessionId tempDir = do
             , sessionTranscriptPath = dir </> unsafeEncodeUtf "transcript.jsonl"
             , sessionMeta = meta
             }
-    Store.createSession pool (toStoredMetadata meta) >>= \case
+    let createStored = case promptSnapshot of
+            Nothing -> Store.createSession pool (toStoredMetadata meta)
+            Just snapshot ->
+                Store.createSessionWithInitialPromptEpoch
+                    pool
+                    (toStoredMetadata meta)
+                    (toStoredPromptSnapshot snapshot)
+    createStored >>= \case
         Left err -> do
             _ <- tryIO (removePathForcibly dir)
             fail
@@ -655,9 +709,100 @@ ensureSession slotRef = do
     case slot of
         PersistenceActive handle -> pure handle
         PersistencePending spec sessionId tempDir -> do
-            handle <- createReservedSession spec sessionId tempDir
+            handle <- createReservedSession spec sessionId tempDir Nothing
             writeIORef slotRef (PersistenceActive handle)
             pure handle
+
+-- | Ensure the durable session exists and atomically persist the
+-- provider-visible request prefix before it can be sent. Subsequent calls only
+-- append an immutable epoch when the prefix or pending generated context
+-- actually changes.
+ensureSessionWithPromptSnapshot
+    :: IORef PersistenceState
+    -> SessionPromptSnapshot
+    -> IO SessionHandle
+ensureSessionWithPromptSnapshot slotRef candidate = do
+    slot <- readIORef slotRef
+    case slot of
+        PersistencePending spec sessionId tempDir -> do
+            handle <- createReservedSession
+                spec
+                sessionId
+                tempDir
+                (Just candidate)
+            writeIORef slotRef (PersistenceActive handle)
+            pure handle
+        PersistenceActive handle -> do
+            let snapshot =
+                    maybe candidate
+                        (`mergePromptSnapshotContext` candidate)
+                        handle.sessionMeta.metaPromptSnapshot
+            case handle.sessionMeta.metaPromptSnapshot of
+                Just previous
+                    | promptSnapshotsEquivalent previous snapshot ->
+                        pure handle
+                _ -> do
+                    Store.appendSessionPromptEpoch
+                        handle.sessionPool
+                        handle.sessionMeta.metaId
+                        (toStoredPromptSnapshot snapshot) >>= \case
+                            Left err ->
+                                fail
+                                    ("could not persist PostgreSQL prompt epoch: "
+                                        <> Text.unpack (renderStoreError err))
+                            Right Nothing ->
+                                fail
+                                    ("session not found: "
+                                        <> Text.unpack handle.sessionMeta.metaId)
+                            Right (Just _) -> do
+                                let next = handle
+                                        { sessionMeta = handle.sessionMeta
+                                            { metaPromptSnapshot = Just snapshot
+                                            }
+                                        }
+                                writeIORef slotRef (PersistenceActive next)
+                                pure next
+
+mergePromptSnapshotContext
+    :: SessionPromptSnapshot
+    -> SessionPromptSnapshot
+    -> SessionPromptSnapshot
+mergePromptSnapshotContext previous candidate
+    | promptSnapshotsSharePrefix previous candidate =
+        candidate
+            { promptSnapshotGeneratedContext =
+                candidate.promptSnapshotGeneratedContext
+                    <|> previous.promptSnapshotGeneratedContext
+            , promptSnapshotGrokContext =
+                candidate.promptSnapshotGrokContext
+                    <|> previous.promptSnapshotGrokContext
+            }
+    | otherwise = candidate
+
+promptSnapshotsSharePrefix
+    :: SessionPromptSnapshot
+    -> SessionPromptSnapshot
+    -> Bool
+promptSnapshotsSharePrefix left right =
+    left.promptSnapshotVersion == right.promptSnapshotVersion
+        && left.promptSnapshotProvider == right.promptSnapshotProvider
+        && left.promptSnapshotConnection == right.promptSnapshotConnection
+        && left.promptSnapshotModel == right.promptSnapshotModel
+        && left.promptSnapshotDialect == right.promptSnapshotDialect
+        && left.promptSnapshotCwd == right.promptSnapshotCwd
+        && left.promptSnapshotInstructions == right.promptSnapshotInstructions
+        && left.promptSnapshotTools == right.promptSnapshotTools
+        && left.promptSnapshotCacheKey == right.promptSnapshotCacheKey
+
+promptSnapshotsEquivalent
+    :: SessionPromptSnapshot
+    -> SessionPromptSnapshot
+    -> Bool
+promptSnapshotsEquivalent left right =
+    promptSnapshotsSharePrefix left right
+        && left.promptSnapshotGeneratedContext
+            == right.promptSnapshotGeneratedContext
+        && left.promptSnapshotGrokContext == right.promptSnapshotGrokContext
 
 appendTurn :: SessionHandle -> SessionTurn -> IO SessionHandle
 appendTurn handle turn =
@@ -908,7 +1053,13 @@ loadSession
 loadSession pool root sessionId = runExceptT do
     _ <- except (sessionDirForId root sessionId)
     stored <- loadWithLegacyImport root pool sessionId Store.loadSession
-    decodeStoredSession sessionSchemaVersion isValidSessionId sessionId stored
+    storedPrompt <- loadStoredPromptEpoch pool sessionId
+    decodeStoredSession
+        sessionSchemaVersion
+        isValidSessionId
+        sessionId
+        storedPrompt
+        stored
 
 loadActiveSession
     :: StorePool
@@ -918,7 +1069,21 @@ loadActiveSession
 loadActiveSession pool root sessionId = runExceptT do
     _ <- except (sessionDirForId root sessionId)
     stored <- loadWithLegacyImport root pool sessionId Store.loadActiveSession
-    decodeStoredSession sessionSchemaVersion isValidSessionId sessionId stored
+    storedPrompt <- loadStoredPromptEpoch pool sessionId
+    decodeStoredSession
+        sessionSchemaVersion
+        isValidSessionId
+        sessionId
+        storedPrompt
+        stored
+
+loadStoredPromptEpoch
+    :: StorePool
+    -> Text
+    -> ExceptT Text IO (Maybe Store.SessionPromptEpoch)
+loadStoredPromptEpoch pool sessionId =
+    lift (Store.loadLatestSessionPromptEpoch pool sessionId)
+        >>= either (throwE . renderStoreError) pure
 
 loadSessionMeta
     :: StorePool
@@ -1057,6 +1222,7 @@ loadSessions pool root sessionIds = do
                         sessionSchemaVersion
                         isValidSessionId
                         sessionId
+                        Nothing
                         value)
         (loaded :) <$> restoreResults rest results
     restoreResults _ _ =

--- a/packages/agent-cli/src/Agent/CLI/Session/Codec.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Codec.hs
@@ -408,6 +408,8 @@ importLegacySession schemaVersion validId sessionDirForId pool sessionId = do
                         contentFingerprint (metaBytes <> transcriptBytes)
                     , legacyMetadata = toStoredMetadata meta
                     , legacyTurns = map toStoredTurn turns
+                    , legacyPromptSnapshot =
+                        toStoredPromptSnapshot <$> meta.metaPromptSnapshot
                     }
             lift (Store.importLegacySession pool legacy) >>= \case
                 Left err -> throwE (renderStoreError err)

--- a/packages/agent-cli/src/Agent/CLI/Session/Codec.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Codec.hs
@@ -6,6 +6,8 @@ module Agent.CLI.Session.Codec
     , decodeStoredSession
     , toStoredMetadata
     , fromStoredMetadata
+    , toStoredPromptSnapshot
+    , fromStoredPromptSnapshot
     , toStoredTurn
     , fromStoredTurn
     , toStoredUsage
@@ -30,6 +32,7 @@ import Agent.Provider (parseProvider, providerSlug)
 import Agent.Store.Postgres.Connection (StorePool)
 import qualified Agent.Store.Postgres.Session as Store
 import Agent.Store.Types (renderStoreError)
+import Agent.Responses.Types.Tools (responseToolDecoder)
 import Control.Monad (unless, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, except, throwE)
@@ -82,10 +85,16 @@ decodeStoredSession
     :: Int
     -> (Text -> Bool)
     -> Text
+    -> Maybe Store.SessionPromptEpoch
     -> Store.StoredSession
     -> ExceptT Text IO (SessionMeta, [SessionTurn])
-decodeStoredSession schemaVersion validId sessionId stored = do
-    meta <- except (fromStoredMetadata stored.storedMetadata)
+decodeStoredSession schemaVersion validId sessionId storedPrompt stored = do
+    baseMeta <- except (fromStoredMetadata stored.storedMetadata)
+    promptSnapshot <- except $
+        traverse
+            (fromStoredPromptSnapshot . (.sessionPromptEpochSnapshot))
+            storedPrompt
+    let meta = baseMeta { metaPromptSnapshot = promptSnapshot }
     validateSessionMeta schemaVersion validId sessionId meta
     turns <- except $
         traverse
@@ -123,6 +132,74 @@ toStoredMetadata meta = Store.SessionMetadata
     , sessionMetadataLastRecapMainTurns =
         fromIntegral meta.metaLastRecapMainTurns
     }
+
+toStoredPromptSnapshot
+    :: SessionPromptSnapshot
+    -> Store.SessionPromptSnapshot
+toStoredPromptSnapshot snapshot = Store.SessionPromptSnapshot
+    { sessionPromptVersion = fromIntegral snapshot.promptSnapshotVersion
+    , sessionPromptCreatedAt = snapshot.promptSnapshotCreatedAt
+    , sessionPromptProvider = providerSlug snapshot.promptSnapshotProvider
+    , sessionPromptConnection = snapshot.promptSnapshotConnection
+    , sessionPromptModel = snapshot.promptSnapshotModel
+    , sessionPromptDialect = dialectSlug snapshot.promptSnapshotDialect
+    , sessionPromptCwd =
+        Text.pack (unsafeToFilePath snapshot.promptSnapshotCwd)
+    , sessionPromptInstructions = snapshot.promptSnapshotInstructions
+    , sessionPromptTools =
+        TextEncoding.decodeUtf8
+            (LBS.toStrict (Aeson.encode snapshot.promptSnapshotTools))
+    , sessionPromptGeneratedContext =
+        snapshot.promptSnapshotGeneratedContext
+    , sessionPromptGrokContext = snapshot.promptSnapshotGrokContext
+    , sessionPromptCacheKey = snapshot.promptSnapshotCacheKey
+    }
+
+fromStoredPromptSnapshot
+    :: Store.SessionPromptSnapshot
+    -> Either Text SessionPromptSnapshot
+fromStoredPromptSnapshot stored = do
+    provider <- maybe
+        (Left ("unknown stored prompt provider: "
+            <> stored.sessionPromptProvider))
+        Right
+        (parseProvider stored.sessionPromptProvider)
+    dialect <- maybe
+        (Left ("unknown stored prompt dialect: "
+            <> stored.sessionPromptDialect))
+        Right
+        (parseDialect stored.sessionPromptDialect)
+    unless (providerSupportsDialect provider dialect) $
+        Left
+            ( "stored prompt dialect "
+                <> stored.sessionPromptDialect
+                <> " is incompatible with provider "
+                <> stored.sessionPromptProvider
+            )
+    tools <- case Hermes.decodeEither
+            (Hermes.list responseToolDecoder)
+            (TextEncoding.encodeUtf8 stored.sessionPromptTools) of
+        Left err ->
+            Left ("invalid stored prompt tools: "
+                <> Hermes.jsonErrorMessage err)
+        Right decoded -> Right decoded
+    pure SessionPromptSnapshot
+        { promptSnapshotVersion =
+            fromIntegral stored.sessionPromptVersion
+        , promptSnapshotCreatedAt = stored.sessionPromptCreatedAt
+        , promptSnapshotProvider = provider
+        , promptSnapshotConnection = stored.sessionPromptConnection
+        , promptSnapshotModel = stored.sessionPromptModel
+        , promptSnapshotDialect = dialect
+        , promptSnapshotCwd =
+            unsafeEncodeUtf (Text.unpack stored.sessionPromptCwd)
+        , promptSnapshotInstructions = stored.sessionPromptInstructions
+        , promptSnapshotTools = tools
+        , promptSnapshotGeneratedContext =
+            stored.sessionPromptGeneratedContext
+        , promptSnapshotGrokContext = stored.sessionPromptGrokContext
+        , promptSnapshotCacheKey = stored.sessionPromptCacheKey
+        }
 
 fromStoredMetadata :: Store.SessionMetadata -> Either Text SessionMeta
 fromStoredMetadata stored = do
@@ -173,6 +250,7 @@ fromStoredMetadata stored = do
         , metaLastTurnSummary = stored.sessionMetadataLastTurnSummary
         , metaLastRecapMainTurns =
             fromIntegral stored.sessionMetadataLastRecapMainTurns
+        , metaPromptSnapshot = Nothing
         }
 
 toStoredLegacyTarget

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -93,6 +93,7 @@ runSession
     -> IO RunResult
 runSession callbacks SessionRequest{..} SessionBackend{..} = do
   initialPrevious <- readLivePreviousResponseId conversationRef
+  grokFirstTurnContextRef <- newIORef initialGrokContext
   ioLock <- newMVar ()
   let fullscreen = startup.startupFullscreen
       terminal = startup.startupTerminal
@@ -279,7 +280,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 ( omitted
                 , max 0 (contextLength after - contextLength before)
                 )
-        installLearnedSkills context maximum =
+        installLearnedSkills context maximum queueContext =
             loadApplicableLearnedSkillsForStore
                 startup.startupDatabaseStore
                 databaseScopes >>= \case
@@ -289,10 +290,12 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                         pure []
                     Right learnedSkills -> do
                         omitted <-
-                            queueLearnedSkillContextWithOmissions
-                                maximum
-                                context
-                                learnedSkills
+                            if queueContext
+                                then queueLearnedSkillContextWithOmissions
+                                    maximum
+                                    context
+                                    learnedSkills
+                                else pure 0
                         when (omitted > 0) $
                             reportLearnedSkillWarning
                                 ("learned skills: "
@@ -319,6 +322,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             void $ installLearnedSkills
                 freshAgents
                 defaultLearnedSkillContextMaxChars
+                True
             fresh <- readIORef freshAgents
             writeIORef startupContext fresh
         sessionReset = do
@@ -331,6 +335,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             modifyIORef' renderStateRef clearRenderTokenRate
             writeIORef lastAssistantRef Nothing
             writeIORef subagentSessions Map.empty
+            writeIORef grokFirstTurnContextRef Nothing
             resetAgentViewport agentViewportRuntime
             case multiCtx of
                 Just ctx -> resetSubagentRegistry ctx.multiRegistry
@@ -786,6 +791,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionTokenProvider = tokenProvider
             , sessionOpenAiPool = openAiPool
             , sessionStartupContext = startupContext
+            , sessionGrokFirstTurnContext = grokFirstTurnContextRef
             , sessionSkills = skillsRef
             , sessionSkillInvocations = skillInvocationsRef
             , sessionRefreshSkills = refreshSkills
@@ -864,7 +870,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             skills <- loadSkillsCatalogQuiet
                 options home projectRoot cwd
             (omitted, _) <- installSkills startupContext
-                needsInitialContext
+                queueInitialContext
                 skills
             reportSkillCatalog (isNothing fullscreen) skills omitted
             learnedSkills <-
@@ -872,6 +878,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                     then installLearnedSkills
                         startupContext
                         defaultLearnedSkillContextMaxChars
+                        queueInitialContext
                     else pure []
             callbacks.runnerFinishStartup startup
             pure learnedSkills

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -138,6 +138,8 @@ data SessionRequest = SessionRequest
     , automaticCompactionRef
         :: !(IORef (Maybe AutomaticCompactionBoundary))
     , needsInitialContext :: !Bool
+    , queueInitialContext :: !Bool
+    , initialGrokContext :: !(Maybe Text)
     , persist :: !Persistence
     , startupWindowTitle :: !Text
     , projectRoot :: !OsPath

--- a/packages/agent-cli/src/Agent/CLI/Session/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Types.hs
@@ -2,6 +2,8 @@
 module Agent.CLI.Session.Types
     ( SessionMeta(..)
     , sessionMetaDecoder
+    , SessionPromptSnapshot(..)
+    , sessionPromptSnapshotDecoder
     , SessionTransfer(..)
     , sessionTransferDecoder
     , LegacySubagentTarget(..)
@@ -47,6 +49,7 @@ import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (Provider, parseProvider, providerSlug)
 import Agent.Responses.Types (ResponseItem)
 import Agent.Responses.Types.Items (responseItemDecoder)
+import Agent.Responses.Types.Tools (ResponseTool, responseToolDecoder)
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Postgres.Session (TranscriptEffect(..))
 import Control.Monad (unless, when)
@@ -83,7 +86,79 @@ data SessionMeta = SessionMeta
     , metaLastRecap :: !(Maybe Text)
     , metaLastTurnSummary :: !(Maybe Text)
     , metaLastRecapMainTurns :: !Int
+    , metaPromptSnapshot :: !(Maybe SessionPromptSnapshot)
     } deriving (Eq, Show)
+
+-- | Immutable provider-visible prefix for the latest prompt epoch.
+--
+-- Generated context is retained for the crash window before its first
+-- transcript turn becomes durable. It is not blindly re-appended once the
+-- transcript proves that context was consumed.
+data SessionPromptSnapshot = SessionPromptSnapshot
+    { promptSnapshotVersion :: !Int
+    , promptSnapshotCreatedAt :: !UTCTime
+    , promptSnapshotProvider :: !Provider
+    , promptSnapshotConnection :: !Text
+    , promptSnapshotModel :: !Text
+    , promptSnapshotDialect :: !DialectId
+    , promptSnapshotCwd :: !OsPath
+    , promptSnapshotInstructions :: !Text
+    , promptSnapshotTools :: ![ResponseTool]
+    , promptSnapshotGeneratedContext :: !(Maybe Text)
+    , promptSnapshotGrokContext :: !(Maybe Text)
+    , promptSnapshotCacheKey :: !Text
+    } deriving (Eq, Show)
+
+instance ToJSON SessionPromptSnapshot where
+    toJSON snapshot = object
+        [ "version" .= snapshot.promptSnapshotVersion
+        , "createdAt" .= snapshot.promptSnapshotCreatedAt
+        , "provider" .= providerSlug snapshot.promptSnapshotProvider
+        , "connection" .= snapshot.promptSnapshotConnection
+        , "model" .= snapshot.promptSnapshotModel
+        , "dialect" .= dialectSlug snapshot.promptSnapshotDialect
+        , "cwd" .= Text.pack (unsafeToFilePath snapshot.promptSnapshotCwd)
+        , "instructions" .= snapshot.promptSnapshotInstructions
+        , "tools" .= snapshot.promptSnapshotTools
+        , "generatedContext" .= snapshot.promptSnapshotGeneratedContext
+        , "grokContext" .= snapshot.promptSnapshotGrokContext
+        , "promptCacheKey" .= snapshot.promptSnapshotCacheKey
+        ]
+
+sessionPromptSnapshotDecoder :: Hermes.Decoder SessionPromptSnapshot
+sessionPromptSnapshotDecoder = Hermes.object do
+    version <- Hermes.atKey "version" Hermes.int
+    providerText <- Hermes.atKey "provider" Hermes.text
+    provider <- maybe
+        (fail ("unknown prompt snapshot provider: "
+            <> Text.unpack providerText))
+        pure
+        (parseProvider providerText)
+    dialectText <- Hermes.atKey "dialect" Hermes.text
+    dialect <- maybe
+        (fail ("unknown prompt snapshot dialect: "
+            <> Text.unpack dialectText))
+        pure
+        (parseDialect dialectText)
+    unless (providerSupportsDialect provider dialect) $
+        fail
+            ( "prompt snapshot dialect "
+                <> Text.unpack dialectText
+                <> " is incompatible with provider "
+                <> Text.unpack providerText
+            )
+    SessionPromptSnapshot version
+        <$> Hermes.atKey "createdAt" Hermes.utcTime
+        <*> pure provider
+        <*> Hermes.atKey "connection" Hermes.text
+        <*> Hermes.atKey "model" Hermes.text
+        <*> pure dialect
+        <*> (unsafeEncodeUtf . Text.unpack <$> Hermes.atKey "cwd" Hermes.text)
+        <*> Hermes.atKey "instructions" Hermes.text
+        <*> Hermes.atKey "tools" (Hermes.list responseToolDecoder)
+        <*> optionalKey "generatedContext" Hermes.text
+        <*> optionalKey "grokContext" Hermes.text
+        <*> Hermes.atKey "promptCacheKey" Hermes.text
 
 data SessionTransfer = SessionTransfer
     { transferMeta :: !SessionMeta
@@ -177,6 +252,7 @@ instance ToJSON SessionMeta where
         , "lastRecap" .= meta.metaLastRecap
         , "lastTurnSummary" .= meta.metaLastTurnSummary
         , "lastRecapMainTurns" .= meta.metaLastRecapMainTurns
+        , "promptSnapshot" .= meta.metaPromptSnapshot
         ]
 
 sessionMetaDecoder :: Hermes.Decoder SessionMeta
@@ -227,6 +303,7 @@ sessionMetaDecoder = Hermes.object do
             <*> optionalKey "lastRecap" Hermes.text
             <*> optionalKey "lastTurnSummary" Hermes.text
             <*> Hermes.defaultKey 0 "lastRecapMainTurns" Hermes.int
+            <*> optionalKey "promptSnapshot" sessionPromptSnapshotDecoder
 
 data SessionTurn = SessionTurn
     { turnAt :: !UTCTime

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -77,6 +77,7 @@ data SessionEnv = SessionEnv
     , sessionTokenProvider :: !(Maybe TokenProvider)
     , sessionOpenAiPool :: !(Maybe OpenAI.Pool)
     , sessionStartupContext :: !(IORef (Maybe Text))
+    , sessionGrokFirstTurnContext :: !(IORef (Maybe Text))
     , sessionSkills :: !(IORef SkillCatalog)
     , sessionSkillInvocations :: !(IORef [SkillInvocation])
     , sessionRefreshSkills :: !(Bool -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -7,6 +7,7 @@ module Agent.CLI.Turn
     , restorePlanStateAfterIncomplete
     , retryCheckpointedTurn
     , runOneTurn
+    , takeGrokFirstTurnContext
     ) where
 
 import Agent.Cancel (resetCancel)
@@ -18,6 +19,7 @@ import Agent.CLI.ProviderTransition
     ( PendingTurn(..)
     , TurnResult(..)
     )
+import Agent.CLI.Request (requestPromptParts)
 import Agent.CLI.TUI.App
     ( commitFullscreenHistoryTurn
     , emitUiEvent
@@ -48,6 +50,7 @@ import Agent.CLI.Render
 import Agent.CLI.Session
     ( SessionHandle(..)
     , SessionMeta(..)
+    , SessionPromptSnapshot(..)
     , SessionTurn(..)
     , SessionTurnPage(..)
     , TranscriptEffect(..)
@@ -55,6 +58,7 @@ import Agent.CLI.Session
     , PersistenceState(..)
     , appendTurnWithMetaUpdateIndexed
     , ensureSession
+    , ensureSessionWithPromptSnapshot
     , loadRecentSessionTurns
     , sessionConversationText
     , sessionsRoot
@@ -123,7 +127,11 @@ import Agent.Loop
     , turnInputImages
     )
 import Agent.Provider (Provider(..))
-import Agent.Responses.Types (ResponseItem)
+import Agent.Responses.Types
+    ( ResponseCreateParams(model, promptCacheKey)
+    , ResponseItem
+    )
+import Agent.Store.Postgres (normalizePostgresTimestamp)
 import Agent.Tools.PlanMode
     ( PlanDecision(..)
     , PlanCompletion(..)
@@ -141,7 +149,8 @@ import Agent.OsPath (toText, unsafeToFilePath)
 import Control.Monad (forM_, when)
 import Control.Exception.Safe (bracket_, finally, onException, tryAny)
 import Data.IORef
-    ( atomicModifyIORef'
+    ( IORef
+    , atomicModifyIORef'
     , readIORef
     , writeIORef
     )
@@ -210,6 +219,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
     , sessionPersist = persist
     , sessionPlanMode = planMode
     , sessionStartupContext = startupContext
+    , sessionGrokFirstTurnContext = grokFirstTurnContext
     , sessionBackground = background
     , sessionEscPaused = escPaused
     , sessionInterrupt = interrupt
@@ -237,35 +247,6 @@ runOneTurnBusy includeTurnContext env@SessionEnv
     applyPendingSessionTitles env
     initialPlanState <- readIORef planMode.planStateRef
     when (initialPlanState == PlanPending) (activatePlanMode planMode)
-    -- Create the session directory before tools run so first-turn subagents
-    -- can persist under agents/<id>/ as they complete.
-    case persist of
-        PersistenceEnabled slotRef -> do
-            created <- isPendingPersistence <$> readIORef slotRef
-            handle <- ensureSession slotRef
-            onPersisted handle
-            writeIORef planMode.planSessionDir (Just handle.sessionDir)
-            writeIORef storeRoot (Just handle.sessionDir)
-            when
-                ( handle.sessionMeta.metaTitle == "untitled"
-                    && not (Text.null (Text.strip promptText))
-                )
-                (setWindowTitle
-                    (cliWindowTitle handle.sessionMeta.metaCwd
-                        (Just (sessionTitleFromPrompt promptText))))
-            when created do
-                case fullscreen of
-                    Just runtime ->
-                        emitUiEvent runtime
-                            (UiSystemMessage
-                                ("session: " <> handle.sessionMeta.metaId))
-                    Nothing -> do
-                        color <- resolveColor stderrHandle
-                        putTextLn stderrHandle
-                            (roleMuted color
-                                (glyphSession <> "session: "
-                                    <> handle.sessionMeta.metaId))
-        PersistenceDisabled -> pure ()
     prev <- readLivePreviousResponseId conversationRef
     when includeTurnContext $
         env.sessionRecordImageGenerationInputs
@@ -294,20 +275,97 @@ runOneTurnBusy includeTurnContext env@SessionEnv
         turnInputs0 =
             turnInputsWithContext planReminder pendingStartup inputs
     stampedInputs <- stampTurnInputs turnInputs0
-    turnInputs <-
+    sentStartupContext <- case pendingStartup of
+        Nothing -> pure Nothing
+        Just _ ->
+            case drop (if isJust planReminder then 1 else 0) stampedInputs of
+                UserMessage context : _ -> pure (Just context)
+                _ -> fail "startup context did not produce a user message"
+    (turnInputs, pendingGrokContext) <-
         if dialectId env.sessionDialect == GrokBuildDialect
             then do
                 let framed = grokFrameLastUserInput stampedInputs
                     firstTurn = null beforeItems && prev == Nothing
                 if firstTurn
                     then do
-                        prefix <- loadGrokFirstTurnPrefix env.sessionCwd
-                        pure (UserMessage prefix : framed)
-                    else pure framed
-            else pure stampedInputs
+                        prefix <-
+                            takeGrokFirstTurnContext
+                                grokFirstTurnContext
+                                (loadGrokFirstTurnPrefix env.sessionCwd)
+                        pure (UserMessage prefix : framed, Just prefix)
+                    else pure (framed, Nothing)
+            else pure (stampedInputs, Nothing)
+    let restoreConsumedPromptContext = do
+            forM_ sentStartupContext \consumed ->
+                atomicModifyIORef' startupContext \current ->
+                    (restoreStartupContext consumed current, ())
+            forM_ pendingGrokContext \consumed ->
+                atomicModifyIORef' grokFirstTurnContext \current ->
+                    (case current of
+                        Nothing -> Just consumed
+                        Just _ -> current
+                    , ())
+        persistPromptSnapshot = case persist of
+            PersistenceDisabled -> pure ()
+            PersistenceEnabled slotRef -> do
+                created <- isPendingPersistence <$> readIORef slotRef
+                params <- readIORef env.sessionParams
+                modelName <- maybe
+                    (fail "provider request is missing a model")
+                    pure
+                    params.model
+                cacheKey <- maybe
+                    (fail "persistent provider request is missing a cache key")
+                    pure
+                    params.promptCacheKey
+                now <- normalizePostgresTimestamp <$> getCurrentTime
+                let (instructionText, toolSchemas) =
+                        requestPromptParts params
+                    snapshot = SessionPromptSnapshot
+                        { promptSnapshotVersion = 1
+                        , promptSnapshotCreatedAt = now
+                        , promptSnapshotProvider = env.sessionProvider
+                        , promptSnapshotConnection = env.sessionConnection
+                        , promptSnapshotModel = modelName
+                        , promptSnapshotDialect = dialectId env.sessionDialect
+                        , promptSnapshotCwd = env.sessionCwd
+                        , promptSnapshotInstructions = instructionText
+                        , promptSnapshotTools = toolSchemas
+                        , promptSnapshotGeneratedContext = sentStartupContext
+                        , promptSnapshotGrokContext = pendingGrokContext
+                        , promptSnapshotCacheKey = cacheKey
+                        }
+                -- Persist the exact provider-visible prefix before it can be
+                -- sent. Pending sessions create metadata and epoch atomically.
+                handle <-
+                    ensureSessionWithPromptSnapshot slotRef snapshot
+                onPersisted handle
+                writeIORef planMode.planSessionDir (Just handle.sessionDir)
+                writeIORef storeRoot (Just handle.sessionDir)
+                when
+                    ( handle.sessionMeta.metaTitle == "untitled"
+                        && not (Text.null (Text.strip promptText))
+                    )
+                    (setWindowTitle
+                        (cliWindowTitle handle.sessionMeta.metaCwd
+                            (Just (sessionTitleFromPrompt promptText))))
+                when created do
+                    case fullscreen of
+                        Just runtime ->
+                            emitUiEvent runtime
+                                (UiSystemMessage
+                                    ("session: "
+                                        <> handle.sessionMeta.metaId))
+                        Nothing -> do
+                            color <- resolveColor stderrHandle
+                            putTextLn stderrHandle
+                                (roleMuted color
+                                    (glyphSession <> "session: "
+                                        <> handle.sessionMeta.metaId))
+    persistPromptSnapshot `onException` restoreConsumedPromptContext
     let prepared = PreparedTurn
             { preparedBeforeItems = beforeItems
-            , preparedConsumedStartup = pendingStartup
+            , preparedConsumedStartup = sentStartupContext
             , preparedTurnInputs = turnInputs
             }
         commitConversationPatch patch = do
@@ -716,6 +774,15 @@ loadGrokFirstTurnPrefix cwd = do
     today <- localDay . zonedTimeToLocalTime <$> getZonedTime
     status <- loadGitStatus cwd
     pure (grokFirstTurnPrefix osVersion shell cwd today status)
+
+-- | Consume a persisted first-turn prefix before consulting the live
+-- environment. The persisted value keeps a resumed request byte-for-byte
+-- stable across the crash window before its first transcript turn commits.
+takeGrokFirstTurnContext :: IORef (Maybe Text) -> IO Text -> IO Text
+takeGrokFirstTurnContext contextRef loadFresh = do
+    restored <-
+        atomicModifyIORef' contextRef (\pending -> (Nothing, pending))
+    maybe loadFresh pure restored
 
 loadOperatingSystem :: IO Text
 loadOperatingSystem = do

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -101,6 +101,7 @@ import Agent.CLI.TurnState
     ( ConversationOutcome(..)
     , ConversationPatch(..)
     , FieldUpdate(..)
+    , GrokContextUpdate(..)
     , PreparedTurn(..)
     , StartupUpdate(..)
     , TurnAbort(..)
@@ -366,6 +367,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
     let prepared = PreparedTurn
             { preparedBeforeItems = beforeItems
             , preparedConsumedStartup = sentStartupContext
+            , preparedConsumedGrokContext = pendingGrokContext
             , preparedTurnInputs = turnInputs
             }
         commitConversationPatch patch = do
@@ -380,6 +382,15 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                 RestoreStartup consumed ->
                     atomicModifyIORef' startupContext \current ->
                         (restoreStartupContext consumed current, ())
+            case patch.patchGrokFirstTurnContext of
+                KeepGrokContext -> pure ()
+                RestoreGrokContext consumed ->
+                    atomicModifyIORef' grokFirstTurnContext \current ->
+                        ( case current of
+                            Nothing -> Just consumed
+                            Just _ -> current
+                        , ()
+                        )
             atomicModifyIORef' usageRef \current ->
                 (addTokenUsage current patch.patchUsageDelta, ())
             case patch.patchLastAssistant of

--- a/packages/agent-cli/src/Agent/CLI/TurnState.hs
+++ b/packages/agent-cli/src/Agent/CLI/TurnState.hs
@@ -3,6 +3,7 @@ module Agent.CLI.TurnState
     ( ConversationState(..)
     , FieldUpdate(..)
     , StartupUpdate(..)
+    , GrokContextUpdate(..)
     , ConversationPatch(..)
     , PreparedTurn(..)
     , ConversationOutcome(..)
@@ -62,6 +63,7 @@ data ConversationState = ConversationState
     { conversationPreviousResponseId :: !(Maybe Text)
     , conversationTranscript :: ![ResponseItem]
     , conversationStartupContext :: !(Maybe Text)
+    , conversationGrokFirstTurnContext :: !(Maybe Text)
     , conversationUsage :: !TokenUsage
     , conversationLastAssistant :: !(Maybe Text)
     } deriving (Eq, Show)
@@ -76,6 +78,11 @@ data StartupUpdate
     | RestoreStartup !Text
     deriving (Eq, Show)
 
+data GrokContextUpdate
+    = KeepGrokContext
+    | RestoreGrokContext !Text
+    deriving (Eq, Show)
+
 -- | A description of the conversation mutations owned by a turn.
 -- Usage is a delta so automatic compaction can add usage concurrently without
 -- a later whole-state write losing it. Startup restoration is a merge for the
@@ -84,6 +91,7 @@ data ConversationPatch = ConversationPatch
     { patchPreviousResponseId :: !(FieldUpdate (Maybe Text))
     , patchTranscript :: !(FieldUpdate [ResponseItem])
     , patchStartupContext :: !StartupUpdate
+    , patchGrokFirstTurnContext :: !GrokContextUpdate
     , patchUsageDelta :: !TokenUsage
     , patchLastAssistant :: !(FieldUpdate (Maybe Text))
     } deriving (Eq, Show)
@@ -91,6 +99,7 @@ data ConversationPatch = ConversationPatch
 data PreparedTurn = PreparedTurn
     { preparedBeforeItems :: ![ResponseItem]
     , preparedConsumedStartup :: !(Maybe Text)
+    , preparedConsumedGrokContext :: !(Maybe Text)
     , preparedTurnInputs :: ![TurnInput]
     } deriving (Eq, Show)
 
@@ -286,6 +295,7 @@ rebasePreparedTurn boundary prepared =
                 { preparedBeforeItems =
                     committed.automaticCompactionHistory
                 , preparedConsumedStartup = Nothing
+                , preparedConsumedGrokContext = Nothing
                 , preparedTurnInputs =
                     committed.automaticCompactionPendingInputs
                 }
@@ -298,12 +308,13 @@ finishConversation prepared = \case
             , patchStartupContext =
                 maybe KeepStartup RestoreStartup
                     prepared.preparedConsumedStartup
+            , patchGrokFirstTurnContext = grokContextUpdate
             }
     ConversationCancelled retained -> retainItems retained
     ConversationFailed retained -> retainItems retained
-    ConversationInterrupted -> restoreStartup
+    ConversationInterrupted -> restorePromptContext
     ConversationProviderUnavailable ->
-        restoreStartup
+        restorePromptContext
     ConversationCompleted _responseId usage assistant ->
         basePatch
             { patchUsageDelta = usage
@@ -314,6 +325,7 @@ finishConversation prepared = \case
         { patchPreviousResponseId = KeepField
         , patchTranscript = KeepField
         , patchStartupContext = KeepStartup
+        , patchGrokFirstTurnContext = KeepGrokContext
         , patchUsageDelta = emptyTokenUsage
         , patchLastAssistant = KeepField
         }
@@ -325,12 +337,16 @@ finishConversation prepared = \case
             , patchTranscript =
                 SetField (prepared.preparedBeforeItems <> retained)
             }
-    restoreStartup =
+    restorePromptContext =
         basePatch
             { patchStartupContext =
                 maybe KeepStartup RestoreStartup
                     prepared.preparedConsumedStartup
+            , patchGrokFirstTurnContext = grokContextUpdate
             }
+    grokContextUpdate =
+        maybe KeepGrokContext RestoreGrokContext
+            prepared.preparedConsumedGrokContext
 
 applyConversationPatch
     :: ConversationPatch
@@ -346,6 +362,9 @@ applyConversationPatch patch state =
         , conversationStartupContext =
             applyStartup patch.patchStartupContext
                 state.conversationStartupContext
+        , conversationGrokFirstTurnContext =
+            applyGrokContext patch.patchGrokFirstTurnContext
+                state.conversationGrokFirstTurnContext
         , conversationUsage =
             addTokenUsage state.conversationUsage patch.patchUsageDelta
         , conversationLastAssistant =
@@ -377,3 +396,10 @@ applyStartup :: StartupUpdate -> Maybe Text -> Maybe Text
 applyStartup update current = case update of
     KeepStartup -> current
     RestoreStartup consumed -> restoreStartupContext consumed current
+
+applyGrokContext :: GrokContextUpdate -> Maybe Text -> Maybe Text
+applyGrokContext update current = case update of
+    KeepGrokContext -> current
+    RestoreGrokContext consumed -> case current of
+        Nothing -> Just consumed
+        Just _ -> current

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -218,6 +218,30 @@ spec = describe "systemPrompt" do
             "Store actionable reusable guidance"
         withoutSkills `shouldNotSatisfy` Text.isInfixOf "Learned skills:"
 
+    it "keeps progressive MCP readiness out of the request prefix" do
+        let base = "stable base instructions"
+            configured =
+                [("example", "Readiness-dependent server instructions")]
+            discovered =
+                mcpInstructionsForRequest True configured
+            cold =
+                appendMcpInstructions
+                    (mcpInstructionsForRequest True [])
+                    base
+            warm =
+                appendMcpInstructions
+                    discovered
+                    base
+            blocking =
+                appendMcpInstructions
+                    (mcpInstructionsForRequest False configured)
+                    base
+        discovered `shouldBe` []
+        warm `shouldBe` cold
+        warm `shouldBe` base
+        blocking `shouldSatisfy` Text.isInfixOf
+            "Readiness-dependent server instructions"
+
     it "renders ghci-only and bash-only root prompts from registered tools" do
         let day = fromGregorian 2026 8 19
             ghciOnly =

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -2,6 +2,8 @@ module Agent.CLI.RequestSpec (spec) where
 
 import Agent.CLI.Request
     ( requestParams
+    , requestPromptParts
+    , requestToolIdentities
     , setRequestInstructionsAndTools
     , setRequestModel
     , setRequestPromptCacheKey
@@ -178,6 +180,68 @@ spec = describe "requestParams" do
             _ -> expectationFailure
                 "expected refreshed prefix followed by pending input"
 
+    it "restores an exact persisted Lite instruction/tool prefix" do
+        let original =
+                requestParams
+                    OpenAIProvider
+                    "gpt-5.6-sol"
+                    "persisted instructions"
+                    [ webSearchTool
+                    , functionTool "lookup"
+                    , customTool "exec"
+                    , namespaceTool "editor" Nothing [functionTool "edit"]
+                    ]
+                    "high"
+            persisted@(instructionText, toolSchemas) =
+                requestPromptParts original
+            regenerated =
+                requestParams
+                    OpenAIProvider
+                    "gpt-5.6-sol"
+                    "new binary instructions"
+                    [ webSearchTool
+                    , documentedFunctionTool
+                        "lookup"
+                        "new description"
+                    , customTool "exec"
+                    , namespaceTool "editor" Nothing [functionTool "edit"]
+                    ]
+                    "high"
+            restored =
+                setRequestInstructionsAndTools
+                    instructionText
+                    (Just toolSchemas)
+                    regenerated
+
+        requestToolIdentities toolSchemas
+            `shouldBe`
+                requestToolIdentities
+                    (snd (requestPromptParts regenerated))
+        requestPromptParts restored `shouldBe` persisted
+
+    it "treats tool identity and order changes as new prompt epochs" do
+        let old =
+                [ functionTool "lookup"
+                , customTool "exec"
+                ]
+            descriptionOnly =
+                [ documentedFunctionTool
+                    "lookup"
+                    "updated documentation"
+                , customTool "exec"
+                ]
+            reordered = reverse old
+            renamed =
+                [ functionTool "search"
+                , customTool "exec"
+                ]
+        requestToolIdentities descriptionOnly
+            `shouldBe` requestToolIdentities old
+        requestToolIdentities reordered
+            `shouldNotBe` requestToolIdentities old
+        requestToolIdentities renamed
+            `shouldNotBe` requestToolIdentities old
+
     it "rebuilds request dialect fields when models cross the Lite boundary" do
         let pending = userMessage "pending"
             genericText = ResponseTextConfig
@@ -257,6 +321,15 @@ functionTool toolName = FunctionToolValue FunctionTool
     , parameters = Nothing
     , strict = Just True
     }
+
+documentedFunctionTool :: Text -> Text -> ResponseTool
+documentedFunctionTool toolName documentation =
+    FunctionToolValue FunctionTool
+        { name = toolName
+        , description = Just documentation
+        , parameters = Nothing
+        , strict = Just True
+        }
 
 customTool :: Text -> ResponseTool
 customTool toolName = CustomToolValue CustomTool

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -340,4 +340,5 @@ sampleMeta sid title =
         , metaLastRecap = Nothing
         , metaLastTurnSummary = Nothing
         , metaLastRecapMainTurns = 0
+        , metaPromptSnapshot = Nothing
         }

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.SessionSpec (spec) where
 
 import Agent.CLI.Session
 import Agent.CLI.SessionLock (acquireSessionLock, releaseSessionLock)
+import Agent.CLI.Request (requestParams)
 import Agent.CLI.Session.StoreCodec
     ( fromStoredResponseItem
     , toStoredResponseItem
@@ -25,6 +26,7 @@ import Agent.Store.Postgres
     )
 import Agent.Store.Postgres.Managed (stopManagedPostgres)
 import Agent.Store.Postgres.Connection (StorePool)
+import qualified Agent.Store.Postgres.Session as Store
 import Agent.Store.Types (renderStoreError)
 import Control.Concurrent (newEmptyMVar, putMVar, readMVar, takeMVar)
 import Control.Concurrent.Async (concurrently, mapConcurrently)
@@ -457,6 +459,57 @@ contentPartKind = \case
 spec :: Spec
 spec = describe "Agent.CLI.Session" do
     describe "pure compatibility helpers" do
+        it "reuses prompt bytes only for the same target and tool identities" do
+            let sessionId = "session-prompt"
+                snapshot =
+                    (testPromptSnapshot sessionId)
+                        { promptSnapshotTools =
+                            [promptFunctionTool "lookup" "old documentation"]
+                        }
+                regenerated =
+                    requestParams
+                        XAIProvider
+                        "grok-4"
+                        "new binary instructions"
+                        [promptFunctionTool "lookup" "new documentation"]
+                        "low"
+                renamed =
+                    requestParams
+                        XAIProvider
+                        "grok-4"
+                        "new binary instructions"
+                        [promptFunctionTool "search" "new documentation"]
+                        "low"
+                compatible params cwd cacheKey =
+                    compatibleSessionPromptSnapshot
+                        XAIProvider
+                        "xai"
+                        GrokBuildDialect
+                        cwd
+                        cacheKey
+                        params
+                        (Just snapshot)
+            compatible
+                regenerated
+                (fromFilePath "/tmp/work")
+                (Just sessionId)
+                `shouldBe` Just snapshot
+            compatible
+                renamed
+                (fromFilePath "/tmp/work")
+                (Just sessionId)
+                `shouldBe` Nothing
+            compatible
+                regenerated
+                (fromFilePath "/tmp/other")
+                (Just sessionId)
+                `shouldBe` Nothing
+            compatible
+                regenerated
+                (fromFilePath "/tmp/work")
+                (Just "other-session")
+                `shouldBe` Nothing
+
         it "round-trips typed computer calls through storage" do
             let items =
                     [ ComputerCallItem ComputerCall
@@ -1288,6 +1341,61 @@ spec = describe "Agent.CLI.Session" do
                 PersistenceActive again <- readIORef slot
                 again.sessionMeta.metaId `shouldBe` handle.sessionMeta.metaId
 
+        it "creates and advances immutable prompt epochs before first use" $
+            withTempStore \store root -> do
+                let pool = trustedPool store
+                PersistenceEnabled slot <-
+                    newPendingPersistence (testCreate pool root)
+                PersistencePending _ reservedId _ <- readIORef slot
+                let initial = testPromptSnapshot reservedId
+                handle <-
+                    ensureSessionWithPromptSnapshot slot initial
+                handle.sessionMeta.metaPromptSnapshot
+                    `shouldBe` Just initial
+                initialEpoch <-
+                    Store.loadLatestSessionPromptEpoch pool reservedId
+                fmap (fmap (.sessionPromptEpochIndex)) initialEpoch
+                    `shouldBe` Right (Just 0)
+
+                -- Consuming the one-shot generated context does not create a
+                -- new epoch; the original value remains available to repair
+                -- a crash before the first transcript turn is durable.
+                unchanged <-
+                    ensureSessionWithPromptSnapshot
+                        slot
+                        initial
+                            { promptSnapshotGeneratedContext = Nothing
+                            , promptSnapshotGrokContext = Nothing
+                            }
+                unchanged.sessionMeta.metaPromptSnapshot
+                    `shouldBe` Just initial
+                unchangedEpoch <-
+                    Store.loadLatestSessionPromptEpoch pool reservedId
+                fmap (fmap (.sessionPromptEpochIndex)) unchangedEpoch
+                    `shouldBe` Right (Just 0)
+
+                let advanced = initial
+                        { promptSnapshotInstructions =
+                            "updated persisted instructions"
+                        , promptSnapshotGeneratedContext = Nothing
+                        , promptSnapshotGrokContext = Nothing
+                        }
+                latest <-
+                    ensureSessionWithPromptSnapshot slot advanced
+                latest.sessionMeta.metaPromptSnapshot
+                    `shouldBe` Just advanced
+                advancedEpoch <-
+                    Store.loadLatestSessionPromptEpoch pool reservedId
+                fmap (fmap (.sessionPromptEpochIndex)) advancedEpoch
+                    `shouldBe` Right (Just 1)
+                loadSession pool root reservedId >>= \case
+                    Right (loadedMeta, []) ->
+                        loadedMeta.metaPromptSnapshot
+                            `shouldBe` Just advanced
+                    result ->
+                        expectationFailure
+                            ("unexpected prompt session: " <> show result)
+
         it "cleans scratch space for a pending session that never persists" $
             withTempStore \store root -> do
                 let pool = trustedPool store
@@ -1402,7 +1510,33 @@ testMeta sessionId = SessionMeta
     , metaLastRecap = Nothing
     , metaLastTurnSummary = Nothing
     , metaLastRecapMainTurns = 0
+    , metaPromptSnapshot = Nothing
     }
+
+testPromptSnapshot :: Text.Text -> SessionPromptSnapshot
+testPromptSnapshot sessionId = SessionPromptSnapshot
+    { promptSnapshotVersion = 1
+    , promptSnapshotCreatedAt = fixedTime
+    , promptSnapshotProvider = XAIProvider
+    , promptSnapshotConnection = "xai"
+    , promptSnapshotModel = "grok-4"
+    , promptSnapshotDialect = GrokBuildDialect
+    , promptSnapshotCwd = fromFilePath "/tmp/work"
+    , promptSnapshotInstructions = "persisted instructions"
+    , promptSnapshotTools = []
+    , promptSnapshotGeneratedContext = Just "project and skill context"
+    , promptSnapshotGrokContext = Just "grok first-turn context"
+    , promptSnapshotCacheKey = sessionId
+    }
+
+promptFunctionTool :: Text.Text -> Text.Text -> ResponseTool
+promptFunctionTool toolName documentation =
+    FunctionToolValue FunctionTool
+        { name = toolName
+        , description = Just documentation
+        , parameters = Nothing
+        , strict = Just True
+        }
 
 fixedTime :: UTCTime
 fixedTime = UTCTime (fromGregorian 2026 8 19) (secondsToDiffTime 0)

--- a/packages/agent-cli/test/Agent/CLI/TranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TranscriptSpec.hs
@@ -129,6 +129,7 @@ testMeta = SessionMeta
     , metaLastRecap = Nothing
     , metaLastTurnSummary = Nothing
     , metaLastRecapMainTurns = 0
+    , metaPromptSnapshot = Nothing
     }
 
 testBlock :: UiBlock

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.Turn
     , grokFrameLastUserInput
     , grokUserQuery
     , restorePlanStateAfterIncomplete
+    , takeGrokFirstTurnContext
     )
 import Agent.CLI.TurnState
 import Agent.CLI.Compaction (AutomaticCompactionBoundary(..))
@@ -43,7 +44,7 @@ import Agent.Tools.PlanMode
     , activatePlanMode
     , newPlanModeEnv
     )
-import Data.IORef (readIORef, writeIORef)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -451,6 +452,15 @@ spec = do
             prefix `shouldSatisfy` Text.isInfixOf "Prefer using relative paths"
             prefix `shouldSatisfy` Text.isInfixOf "<git_status>"
             prefix `shouldSatisfy` Text.isInfixOf " M src/Main.hs"
+
+        it "consumes persisted first-turn context before loading it fresh" do
+            contextRef <- newIORef (Just "persisted environment")
+            takeGrokFirstTurnContext
+                contextRef
+                (expectationFailure "loaded fresh context" >> pure "fresh")
+                `shouldReturn` "persisted environment"
+            takeGrokFirstTurnContext contextRef (pure "fresh environment")
+                `shouldReturn` "fresh environment"
 
 history :: [ResponseItem]
 history = turnInputsToItems [UserMessage "earlier"]

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -73,6 +73,8 @@ spec = do
             final.conversationTranscript `shouldBe` history
             final.conversationStartupContext
                 `shouldBe` Just "startup instructions\n\nnewer skills"
+            final.conversationGrokFirstTurnContext
+                `shouldBe` Just "grok environment"
             final.conversationUsage `shouldBe` priorUsage
             final.conversationLastAssistant `shouldBe` Just "old answer"
 
@@ -93,6 +95,7 @@ spec = do
             final.conversationPreviousResponseId `shouldBe` Nothing
             final.conversationTranscript `shouldBe` history <> retained
             final.conversationStartupContext `shouldBe` Just "newer skills"
+            final.conversationGrokFirstTurnContext `shouldBe` Nothing
             final.conversationUsage `shouldBe` priorUsage
             final.conversationLastAssistant `shouldBe` Just "old answer"
 
@@ -107,6 +110,7 @@ spec = do
                 multimodalPrepared = PreparedTurn
                     { preparedBeforeItems = history
                     , preparedConsumedStartup = Nothing
+                    , preparedConsumedGrokContext = Nothing
                     , preparedTurnInputs =
                         [ userMessageWithAttachments
                             "inspect this"
@@ -128,7 +132,7 @@ spec = do
                                 [ImageAttachmentItem image]
                             ]
 
-        it "restores startup without changing conversation state for retry" do
+        it "restores one-shot context without changing conversation state for retry" do
             let final = applyConversationPatch
                     (finishConversation
                         prepared
@@ -138,8 +142,23 @@ spec = do
             final.conversationTranscript `shouldBe` mutatedTranscript
             final.conversationStartupContext
                 `shouldBe` Just "startup instructions\n\nnewer skills"
+            final.conversationGrokFirstTurnContext
+                `shouldBe` Just "grok environment"
             final.conversationUsage `shouldBe` priorUsage
             final.conversationLastAssistant `shouldBe` Just "old answer"
+
+        it "does not overwrite newer Grok context while restoring a retry" do
+            let state = runningState
+                    { conversationGrokFirstTurnContext =
+                        Just "newer environment"
+                    }
+                final = applyConversationPatch
+                    (finishConversation
+                        prepared
+                        ConversationProviderUnavailable)
+                    state
+            final.conversationGrokFirstTurnContext
+                `shouldBe` Just "newer environment"
 
         it "commits successful metadata without rewriting backend state" do
             let usage = TokenUsage
@@ -157,6 +176,7 @@ spec = do
             final.conversationPreviousResponseId `shouldBe` Just "resp-newer"
             final.conversationTranscript `shouldBe` mutatedTranscript
             final.conversationStartupContext `shouldBe` Just "newer skills"
+            final.conversationGrokFirstTurnContext `shouldBe` Nothing
             final.conversationUsage `shouldBe` TokenUsage
                 { inputTokens = 17
                 , outputTokens = 7
@@ -207,6 +227,7 @@ spec = do
             cancelled.conversationTranscript `shouldBe` expected
             failed.conversationTranscript `shouldBe` expected
             inputOnlyTurnItems committed `shouldBe` []
+            committed.preparedConsumedGrokContext `shouldBe` Nothing
 
         it "persists only the post-checkpoint suffix after success" do
             let checkpoint =
@@ -480,6 +501,7 @@ prepared :: PreparedTurn
 prepared = PreparedTurn
     { preparedBeforeItems = history
     , preparedConsumedStartup = Just "startup instructions"
+    , preparedConsumedGrokContext = Just "grok environment"
     , preparedTurnInputs =
         [ UserMessage "startup instructions [2026-08-23 13:10 CEST]"
         , UserMessage "build failed [2026-08-23 13:10 CEST]"
@@ -491,6 +513,7 @@ runningState = ConversationState
     { conversationPreviousResponseId = Just "resp-newer"
     , conversationTranscript = mutatedTranscript
     , conversationStartupContext = Just "newer skills"
+    , conversationGrokFirstTurnContext = Nothing
     , conversationUsage = priorUsage
     , conversationLastAssistant = Just "old answer"
     }

--- a/packages/agent-store/benchmark/RealSessionLoad.hs
+++ b/packages/agent-store/benchmark/RealSessionLoad.hs
@@ -9,11 +9,14 @@ import Agent.Store.Postgres
     )
 import Agent.Store.Postgres.Session
     ( SessionMetadata(..)
+    , SessionPromptEpoch(..)
+    , SessionPromptSnapshot(..)
     , SessionReadImplementation(..)
     , SessionTurn(..)
     , StoredSession(..)
     , StoredTurn(..)
     , loadActiveSessionWithImplementation
+    , loadLatestSessionPromptEpoch
     , loadSessionWithImplementation
     )
 import Agent.Store.SessionItem
@@ -24,6 +27,7 @@ import Data.List (sort)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Vector as Vector
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
 import System.CPUTime (getCPUTime)
@@ -32,7 +36,10 @@ import System.Exit (die)
 import System.Mem (performGC)
 import Text.Printf (printf)
 
-data Workload = Active | Full
+data Workload
+    = Active
+    | ActiveWithPrompt
+    | Full
 
 data Sample = Sample
     { elapsedMillis :: !Double
@@ -55,6 +62,7 @@ main = do
                 value -> die ("unknown implementation: " <> value)
             workload <- case workloadArg of
                 "active" -> pure Active
+                "active-prompt" -> pure ActiveWithPrompt
                 "full" -> pure Full
                 value -> die ("unknown workload: " <> value)
             sampleCount <- parsePositive sampleCountArg
@@ -86,7 +94,7 @@ main = do
             die $
                 "usage: real-session-load-bench "
                     <> "(per-item|adaptive) STATE_DIRECTORY "
-                    <> "(active|full) SESSION_KEY SAMPLES\n"
+                    <> "(active|active-prompt|full) SESSION_KEY SAMPLES\n"
                     <> "output: implementation,workload,session_key,"
                     <> "elapsed_ms,cpu_ms,allocated_bytes,checksum"
 
@@ -102,26 +110,38 @@ loadWorkload
     -> Workload
     -> Store
     -> Text
-    -> IO (Either StoreError StoredSession)
+    -> IO
+        (Either StoreError (StoredSession, Maybe SessionPromptEpoch))
 loadWorkload implementation workload store sessionKey =
     loader (trustedPool store) sessionKey >>= \case
         Left err -> pure (Left err)
         Right Nothing ->
             die ("session not found: " <> Text.unpack sessionKey)
-        Right (Just session) -> pure (Right session)
+        Right (Just session) -> case workload of
+            ActiveWithPrompt ->
+                loadLatestSessionPromptEpoch
+                    (trustedPool store)
+                    sessionKey >>= \case
+                        Left err -> pure (Left err)
+                        Right prompt -> pure (Right (session, prompt))
+            _ -> pure (Right (session, Nothing))
   where
     loader = case workload of
         Active -> loadActiveSessionWithImplementation implementation
+        ActiveWithPrompt ->
+            loadActiveSessionWithImplementation implementation
         Full -> loadSessionWithImplementation implementation
 
-measure :: IO (Either StoreError StoredSession) -> IO Sample
+measure
+    :: IO (Either StoreError (StoredSession, Maybe SessionPromptEpoch))
+    -> IO Sample
 measure action = do
     performGC
     beforeStats <- getRTSStats
     beforeCpu <- getCPUTime
     beforeElapsed <- getMonotonicTimeNSec
-    stored <- action >>= requireStore "load session"
-    forced <- pure $! checksumSession stored
+    (stored, prompt) <- action >>= requireStore "load session"
+    forced <- pure $! checksumSession stored + maybe 0 checksumPrompt prompt
     afterElapsed <- getMonotonicTimeNSec
     afterCpu <- getCPUTime
     performGC
@@ -149,6 +169,24 @@ checksumSession stored =
         checksumTurn
         (Text.length stored.storedMetadata.sessionMetadataTitle)
         stored.storedTurns
+
+checksumPrompt :: SessionPromptEpoch -> Int
+checksumPrompt epoch =
+    let snapshot = epoch.sessionPromptEpochSnapshot
+    in fromIntegral epoch.sessionPromptEpochIndex
+        + fromIntegral snapshot.sessionPromptVersion
+        + floor
+            (utcTimeToPOSIXSeconds snapshot.sessionPromptCreatedAt)
+        + Text.length snapshot.sessionPromptProvider
+        + Text.length snapshot.sessionPromptConnection
+        + Text.length snapshot.sessionPromptModel
+        + Text.length snapshot.sessionPromptDialect
+        + Text.length snapshot.sessionPromptCwd
+        + Text.length snapshot.sessionPromptInstructions
+        + Text.length snapshot.sessionPromptTools
+        + maybeText snapshot.sessionPromptGeneratedContext
+        + maybeText snapshot.sessionPromptGrokContext
+        + Text.length snapshot.sessionPromptCacheKey
 
 checksumTurn :: Int -> StoredTurn -> Int
 checksumTurn total stored =

--- a/packages/agent-store/benchmark/RealSessionLoad.md
+++ b/packages/agent-store/benchmark/RealSessionLoad.md
@@ -11,13 +11,16 @@ bin=$(nix develop -c cabal list-bin \
   agent-store:bench:real-session-load-bench)
 "$bin" per-item "$HOME/.haskell-agent" active SESSION_KEY 11 +RTS -T
 "$bin" adaptive "$HOME/.haskell-agent" active SESSION_KEY 11 +RTS -T
+"$bin" adaptive "$HOME/.haskell-agent" active-prompt SESSION_KEY 11 +RTS -T
 ```
 
 Use `active` to measure the inference context loaded when resuming a session,
-starting at its latest replacement/reset checkpoint. Use `full` to load every
-persisted turn. The `per-item` implementation is the executable baseline that
-issues the original child-row point reads; `adaptive` selects the production
-implementation.
+starting at its latest replacement/reset checkpoint. Use `active-prompt` to
+include the bounded latest-prompt-epoch lookup performed by a cache-stable
+resume, while retaining `active` as its same-binary baseline. Use `full` to
+load every persisted turn. The `per-item` implementation is the executable
+baseline that issues the original child-row point reads; `adaptive` selects
+the production implementation.
 
 Inputs are read from the local managed PostgreSQL store. The store must already
 contain the selected session. The first load is discarded as a warm-up; the

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -194,6 +194,15 @@ coreMigrations =
                  \ ON harness.session_prompt_epochs TO ha_runtime"
                ]
         }
+    , Migration
+        { migrationVersion = 104
+        , migrationName = "prompt epoch invalidation markers"
+        , migrationStatements =
+            [ "ALTER TABLE IF EXISTS harness.session_prompt_epochs\
+              \ ADD COLUMN IF NOT EXISTS is_active boolean\
+              \ NOT NULL DEFAULT TRUE"
+            ]
+        }
     ]
 
 -- Version 1 shipped only on the in-development PostgreSQL branch. Empty

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -33,6 +33,7 @@ import Agent.Store.Postgres.Scope (customSchemaStatements)
 import Agent.Store.Postgres.Session
     ( sessionSchemaStatements
     , sessionSearchIndexStatements
+    , sessionPromptEpochSchemaStatements
     )
 import Agent.Store.Postgres.Skill
     ( learnedSkillRuntimeGrantStatements
@@ -183,6 +184,15 @@ coreMigrations =
             [ "ALTER TABLE IF EXISTS harness.session_turns\
               \ ADD COLUMN IF NOT EXISTS provider_telemetry_json text"
             ]
+        }
+    , Migration
+        { migrationVersion = 103
+        , migrationName = "immutable session prompt epochs"
+        , migrationStatements =
+            sessionPromptEpochSchemaStatements
+            <> [ "GRANT SELECT, INSERT\
+                 \ ON harness.session_prompt_epochs TO ha_runtime"
+               ]
         }
     ]
 
@@ -497,6 +507,8 @@ sessionRuntimeGrantStatements =
       \ ON harness.session_tagged_items TO ha_runtime"
     , "GRANT SELECT, INSERT\
       \ ON harness.session_response_content_parts TO ha_runtime"
+    , "GRANT SELECT, INSERT\
+      \ ON harness.session_prompt_epochs TO ha_runtime"
     ]
 
 runCoreMigrations :: StorePool -> IO (Either StoreError ())

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -2,6 +2,8 @@
 module Agent.Store.Postgres.Session
     ( SessionMetadata(..)
     , SessionLegacyTarget(..)
+    , SessionPromptSnapshot(..)
+    , SessionPromptEpoch(..)
     , TranscriptEffect(..)
     , SessionTurn(..)
     , SessionUsage(..)
@@ -13,9 +15,12 @@ module Agent.Store.Postgres.Session
     , SessionReadImplementation(..)
     , sessionSchemaStatements
     , sessionSearchIndexStatements
+    , sessionPromptEpochSchemaStatements
     , createSession
+    , createSessionWithInitialPromptEpoch
     , createSessionFromSnapshot
     , replaceSessionMetadata
+    , appendSessionPromptEpoch
     , appendSessionTurn
     , appendSessionTurnIndexed
     , appendSessionTurns
@@ -23,6 +28,7 @@ module Agent.Store.Postgres.Session
     , loadSessionWithImplementation
     , loadSessions
     , loadSessionMetadata
+    , loadLatestSessionPromptEpoch
     , loadActiveSession
     , loadActiveSessionWithImplementation
     , SessionTurnPage(..)

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -23,6 +23,7 @@ module Agent.Store.Postgres.Session
     , appendSessionPromptEpoch
     , appendSessionTurn
     , appendSessionTurnIndexed
+    , appendSessionTurnIndexedWithPromptReset
     , appendSessionTurns
     , loadSession
     , loadSessionWithImplementation

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
@@ -15,6 +15,7 @@ module Agent.Store.Postgres.Session.Read
     , loadSessionWithImplementation
     , loadSessions
     , loadSessionMetadata
+    , loadLatestSessionPromptEpoch
     , loadActiveSession
     , loadActiveSessionWithImplementation
     , loadRecentSessionTurns
@@ -153,6 +154,15 @@ loadSessionMetadata pool sessionKey =
     withSession pool $
         Transactions.transaction Transactions.RepeatableRead Transactions.Read $
             Transaction.statement sessionKey loadMetadataStatement
+
+loadLatestSessionPromptEpoch
+    :: StorePool
+    -> Text
+    -> IO (Either StoreError (Maybe SessionPromptEpoch))
+loadLatestSessionPromptEpoch pool sessionKey =
+    withSession pool $
+        Transactions.transaction Transactions.RepeatableRead Transactions.Read $
+            Transaction.statement sessionKey loadLatestPromptEpochStatement
 
 loadActiveSession
     :: StorePool
@@ -406,6 +416,39 @@ loadMetadataManyStatement = mkStatement
            \ ORDER BY array_position($1::text[], session_key)")
     textArrayParams
     (Decoders.rowVector metadataRow)
+    True
+
+loadLatestPromptEpochStatement
+    :: Statement Text (Maybe SessionPromptEpoch)
+loadLatestPromptEpochStatement = mkStatement
+    "SELECT epoch.epoch_index, epoch.prompt_version, epoch.created_at,\
+    \ epoch.provider, epoch.connection_id, epoch.model_id, epoch.dialect,\
+    \ epoch.cwd_text, epoch.instructions_text, epoch.tools_text,\
+    \ epoch.generated_context_text, epoch.grok_context_text,\
+    \ epoch.prompt_cache_key\
+    \ FROM harness.session_prompt_epochs epoch\
+    \ JOIN harness.sessions session\
+    \   ON session.session_id = epoch.session_id\
+    \ WHERE session.session_key = $1 AND session.deleted_at IS NULL\
+    \ ORDER BY epoch.epoch_index DESC\
+    \ LIMIT 1"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowMaybe $
+        SessionPromptEpoch
+            <$> Decoders.column (Decoders.nonNullable Decoders.int8)
+            <*> (SessionPromptSnapshot
+                <$> Decoders.column (Decoders.nonNullable Decoders.int4)
+                <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)))
     True
 
 loadMetadataStatement :: Statement Text (Maybe SessionMetadata)

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
@@ -421,17 +421,21 @@ loadMetadataManyStatement = mkStatement
 loadLatestPromptEpochStatement
     :: Statement Text (Maybe SessionPromptEpoch)
 loadLatestPromptEpochStatement = mkStatement
-    "SELECT epoch.epoch_index, epoch.prompt_version, epoch.created_at,\
-    \ epoch.provider, epoch.connection_id, epoch.model_id, epoch.dialect,\
-    \ epoch.cwd_text, epoch.instructions_text, epoch.tools_text,\
-    \ epoch.generated_context_text, epoch.grok_context_text,\
-    \ epoch.prompt_cache_key\
-    \ FROM harness.session_prompt_epochs epoch\
-    \ JOIN harness.sessions session\
-    \   ON session.session_id = epoch.session_id\
-    \ WHERE session.session_key = $1 AND session.deleted_at IS NULL\
-    \ ORDER BY epoch.epoch_index DESC\
-    \ LIMIT 1"
+    "SELECT latest.epoch_index, latest.prompt_version, latest.created_at,\
+    \ latest.provider, latest.connection_id, latest.model_id, latest.dialect,\
+    \ latest.cwd_text, latest.instructions_text, latest.tools_text,\
+    \ latest.generated_context_text, latest.grok_context_text,\
+    \ latest.prompt_cache_key\
+    \ FROM (\
+    \   SELECT epoch.*\
+    \   FROM harness.session_prompt_epochs epoch\
+    \   JOIN harness.sessions session\
+    \     ON session.session_id = epoch.session_id\
+    \   WHERE session.session_key = $1 AND session.deleted_at IS NULL\
+    \   ORDER BY epoch.epoch_index DESC\
+    \   LIMIT 1\
+    \ ) latest\
+    \ WHERE latest.is_active"
     (Encoders.param (Encoders.nonNullable Encoders.text))
     (Decoders.rowMaybe $
         SessionPromptEpoch

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Schema.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Schema.hs
@@ -161,6 +161,7 @@ sessionPromptEpochSchemaStatements =
       \ session_id uuid NOT NULL\
       \   REFERENCES harness.sessions(session_id),\
       \ epoch_index bigint NOT NULL CHECK (epoch_index >= 0),\
+      \ is_active boolean NOT NULL DEFAULT TRUE,\
       \ prompt_version integer NOT NULL CHECK (prompt_version > 0),\
       \ created_at timestamptz NOT NULL,\
       \ provider text NOT NULL CHECK (length(btrim(provider)) > 0),\

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Schema.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Schema.hs
@@ -3,6 +3,7 @@
 module Agent.Store.Postgres.Session.Schema
     ( sessionSchemaStatements
     , sessionSearchIndexStatements
+    , sessionPromptEpochSchemaStatements
     ) where
 
 import Data.ByteString (ByteString)
@@ -152,6 +153,35 @@ sessionSchemaStatements =
        \ BEFORE UPDATE OR DELETE ON harness.session_turns\
        \ FOR EACH ROW EXECUTE FUNCTION harness.reject_session_fact_mutation()"
        ]
+    <> sessionPromptEpochSchemaStatements
+
+sessionPromptEpochSchemaStatements :: [ByteString]
+sessionPromptEpochSchemaStatements =
+    [ "CREATE TABLE IF NOT EXISTS harness.session_prompt_epochs (\
+      \ session_id uuid NOT NULL\
+      \   REFERENCES harness.sessions(session_id),\
+      \ epoch_index bigint NOT NULL CHECK (epoch_index >= 0),\
+      \ prompt_version integer NOT NULL CHECK (prompt_version > 0),\
+      \ created_at timestamptz NOT NULL,\
+      \ provider text NOT NULL CHECK (length(btrim(provider)) > 0),\
+      \ connection_id text NOT NULL CHECK (length(btrim(connection_id)) > 0),\
+      \ model_id text NOT NULL CHECK (length(btrim(model_id)) > 0),\
+      \ dialect text NOT NULL CHECK (length(btrim(dialect)) > 0),\
+      \ cwd_text text NOT NULL CHECK (length(btrim(cwd_text)) > 0),\
+      \ instructions_text text NOT NULL,\
+      \ tools_text text NOT NULL,\
+      \ generated_context_text text,\
+      \ grok_context_text text,\
+      \ prompt_cache_key text NOT NULL\
+      \   CHECK (length(btrim(prompt_cache_key)) > 0),\
+      \ PRIMARY KEY (session_id, epoch_index)\
+      \ )"
+    , "DROP TRIGGER IF EXISTS session_prompt_epochs_immutable\
+      \ ON harness.session_prompt_epochs"
+    , "CREATE TRIGGER session_prompt_epochs_immutable\
+      \ BEFORE UPDATE OR DELETE ON harness.session_prompt_epochs\
+      \ FOR EACH ROW EXECUTE FUNCTION harness.reject_session_fact_mutation()"
+    ]
 
 -- | Trigram indexes that make the substring branches of conversation search
 -- indexable. Without them the @ILIKE@ fallbacks in 'searchTurnsStatement'

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
@@ -172,5 +172,6 @@ data LegacySession = LegacySession
     , legacyContentHash :: !Text
     , legacyMetadata :: !SessionMetadata
     , legacyTurns :: ![SessionTurn]
+    , legacyPromptSnapshot :: !(Maybe SessionPromptSnapshot)
     }
     deriving (Eq, Show)

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
@@ -3,6 +3,8 @@
 module Agent.Store.Postgres.Session.Types
     ( SessionMetadata(..)
     , SessionLegacyTarget(..)
+    , SessionPromptSnapshot(..)
+    , SessionPromptEpoch(..)
     , TranscriptEffect(..)
     , SessionTurn(..)
     , SessionUsage(..)
@@ -27,6 +29,35 @@ data SessionLegacyTarget = SessionLegacyTarget
     , sessionLegacyConnection :: !Text
     , sessionLegacyEffectiveModel :: !Text
     , sessionLegacyDialect :: !Text
+    }
+    deriving (Eq, Show)
+
+-- | Provider-visible request prefix captured before a turn can be sent.
+--
+-- Tool schemas are stored as canonical JSON text by the caller. Keeping the
+-- store representation opaque avoids coupling persistence to a provider's
+-- evolving tool sum type while preserving schema order exactly.
+data SessionPromptSnapshot = SessionPromptSnapshot
+    { sessionPromptVersion :: !Int32
+    , sessionPromptCreatedAt :: !UTCTime
+    , sessionPromptProvider :: !Text
+    , sessionPromptConnection :: !Text
+    , sessionPromptModel :: !Text
+    , sessionPromptDialect :: !Text
+    , sessionPromptCwd :: !Text
+    , sessionPromptInstructions :: !Text
+    , sessionPromptTools :: !Text
+    , sessionPromptGeneratedContext :: !(Maybe Text)
+    , sessionPromptGrokContext :: !(Maybe Text)
+    , sessionPromptCacheKey :: !Text
+    }
+    deriving (Eq, Show)
+
+-- | One immutable prompt epoch. A session gets a new epoch only when its
+-- provider-visible prefix or pending generated context intentionally changes.
+data SessionPromptEpoch = SessionPromptEpoch
+    { sessionPromptEpochIndex :: !Int64
+    , sessionPromptEpochSnapshot :: !SessionPromptSnapshot
     }
     deriving (Eq, Show)
 

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
@@ -6,8 +6,10 @@
 -- | PostgreSQL write operations for harness sessions.
 module Agent.Store.Postgres.Session.Write
     ( createSession
+    , createSessionWithInitialPromptEpoch
     , createSessionFromSnapshot
     , replaceSessionMetadata
+    , appendSessionPromptEpoch
     , appendSessionTurn
     , appendSessionTurnIndexed
     , appendSessionTurns
@@ -63,6 +65,55 @@ createSession pool metadata =
                             }
                         insertEventStatement
                     pure True
+
+-- | Create the session and its first provider-visible prompt epoch in one
+-- transaction, so a resumable session can never exist without that prefix.
+createSessionWithInitialPromptEpoch
+    :: StorePool
+    -> SessionMetadata
+    -> SessionPromptSnapshot
+    -> IO (Either StoreError Bool)
+createSessionWithInitialPromptEpoch pool metadata snapshot =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write do
+            let sessionKey = metadata.sessionMetadataKey
+            _ <- Transaction.statement sessionKey blockingAdvisoryLockStatement
+            exists <- Transaction.statement sessionKey sessionExistsStatement
+            if exists
+                then pure False
+                else do
+                    sessionId <- Transaction.statement metadata insertSessionStatement
+                    epoch <- Transaction.statement
+                        (sessionKey, snapshot)
+                        insertPromptEpochStatement
+                    case epoch of
+                        Just 0 -> pure ()
+                        _ -> Transaction.condemn
+                    _ <- Transaction.statement
+                        EventInsert
+                            { eventInsertSessionId = sessionId
+                            , eventInsertSequence = 0
+                            , eventInsertKind = "session.created"
+                            , eventInsertOccurredAt =
+                                metadata.sessionMetadataCreatedAt
+                            }
+                        insertEventStatement
+                    pure True
+
+-- | Append an immutable prompt epoch, assigning the next per-session index
+-- while holding the same advisory lock used by other session writes.
+appendSessionPromptEpoch
+    :: StorePool
+    -> Text
+    -> SessionPromptSnapshot
+    -> IO (Either StoreError (Maybe Int64))
+appendSessionPromptEpoch pool sessionKey snapshot =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write do
+            _ <- Transaction.statement sessionKey blockingAdvisoryLockStatement
+            Transaction.statement
+                (sessionKey, snapshot)
+                insertPromptEpochStatement
 
 -- | Atomically create a session from an already-materialized transcript.
 --
@@ -344,6 +395,56 @@ sessionExistsStatement = mkStatement
     (Encoders.param (Encoders.nonNullable Encoders.text))
     (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
     True
+
+insertPromptEpochStatement
+    :: Statement (Text, SessionPromptSnapshot) (Maybe Int64)
+insertPromptEpochStatement = mkStatement
+    "INSERT INTO harness.session_prompt_epochs (\
+    \ session_id, epoch_index, prompt_version, created_at,\
+    \ provider, connection_id, model_id, dialect, cwd_text,\
+    \ instructions_text, tools_text,\
+    \ generated_context_text, grok_context_text, prompt_cache_key\
+    \ )\
+    \ SELECT session.session_id,\
+    \   COALESCE((\
+    \     SELECT max(existing.epoch_index) + 1\
+    \     FROM harness.session_prompt_epochs existing\
+    \     WHERE existing.session_id = session.session_id\
+    \   ), 0),\
+    \   $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13\
+    \ FROM harness.sessions session\
+    \ WHERE session.session_key = $1 AND session.deleted_at IS NULL\
+    \ RETURNING epoch_index"
+    ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snapshotField (.sessionPromptVersion)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int4))
+        <> (snapshotField (.sessionPromptCreatedAt)
+            >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
+        <> (snapshotField (.sessionPromptProvider)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snapshotField (.sessionPromptConnection)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snapshotField (.sessionPromptModel)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snapshotField (.sessionPromptDialect)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snapshotField (.sessionPromptCwd)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snapshotField (.sessionPromptInstructions)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snapshotField (.sessionPromptTools)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snapshotField (.sessionPromptGeneratedContext)
+            >$< Encoders.param (Encoders.nullable Encoders.text))
+        <> (snapshotField (.sessionPromptGrokContext)
+            >$< Encoders.param (Encoders.nullable Encoders.text))
+        <> (snapshotField (.sessionPromptCacheKey)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text))
+    )
+    (Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.int8)))
+    True
+  where
+    snapshotField field = field . snd
 
 insertSessionStatement :: Statement SessionMetadata Text
 insertSessionStatement = mkStatement

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
@@ -12,13 +12,14 @@ module Agent.Store.Postgres.Session.Write
     , appendSessionPromptEpoch
     , appendSessionTurn
     , appendSessionTurnIndexed
+    , appendSessionTurnIndexedWithPromptReset
     , appendSessionTurns
     , deleteSession
     , importLegacySession
     , withSessionAdvisoryLock
     ) where
 
-import Control.Monad (forM_, unless)
+import Control.Monad (forM_, unless, when)
 import Data.Functor.Contravariant ((>$<))
 import Data.Int (Int64)
 import Data.Text (Text)
@@ -181,7 +182,26 @@ appendSessionTurnIndexed
     -> SessionTurn
     -> SessionMetadata
     -> IO (Either StoreError (Maybe Int64))
-appendSessionTurnIndexed pool turn metadata =
+appendSessionTurnIndexed =
+    appendSessionTurnIndexedInternal False
+
+-- | Append a turn and retire the current provider-visible prompt prefix in
+-- the same transaction. The next request must establish a new prompt epoch.
+appendSessionTurnIndexedWithPromptReset
+    :: StorePool
+    -> SessionTurn
+    -> SessionMetadata
+    -> IO (Either StoreError (Maybe Int64))
+appendSessionTurnIndexedWithPromptReset =
+    appendSessionTurnIndexedInternal True
+
+appendSessionTurnIndexedInternal
+    :: Bool
+    -> StorePool
+    -> SessionTurn
+    -> SessionMetadata
+    -> IO (Either StoreError (Maybe Int64))
+appendSessionTurnIndexedInternal resetPrompt pool turn metadata =
     withSession pool $
         Transactions.transaction Transactions.Serializable Transactions.Write do
             _ <- Transaction.statement
@@ -209,6 +229,13 @@ appendSessionTurnIndexed pool turn metadata =
                             }
                         insertTurnStatement
                     insertResponseItems turnId turn.sessionTurnItems
+                    when resetPrompt do
+                        _ <- Transaction.statement
+                            ( metadata.sessionMetadataKey
+                            , turn.sessionTurnOccurredAt
+                            )
+                            invalidatePromptEpochStatement
+                        pure ()
                     pure (Just turnIndex)
 
 -- | Append a sequence of turns as one atomic transcript transition.
@@ -284,6 +311,13 @@ importLegacySession pool legacy =
                         "legacy.import_completed"
                         metadata
                         legacy.legacyTurns
+                    forM_ legacy.legacyPromptSnapshot \snapshot -> do
+                        epoch <- Transaction.statement
+                            (sessionKey, snapshot)
+                            insertPromptEpochStatement
+                        case epoch of
+                            Just 0 -> pure ()
+                            _ -> Transaction.condemn
                     Transaction.statement
                         ( legacy.legacySourcePath
                         , legacy.legacyContentHash
@@ -400,7 +434,7 @@ insertPromptEpochStatement
     :: Statement (Text, SessionPromptSnapshot) (Maybe Int64)
 insertPromptEpochStatement = mkStatement
     "INSERT INTO harness.session_prompt_epochs (\
-    \ session_id, epoch_index, prompt_version, created_at,\
+    \ session_id, epoch_index, is_active, prompt_version, created_at,\
     \ provider, connection_id, model_id, dialect, cwd_text,\
     \ instructions_text, tools_text,\
     \ generated_context_text, grok_context_text, prompt_cache_key\
@@ -411,7 +445,7 @@ insertPromptEpochStatement = mkStatement
     \     FROM harness.session_prompt_epochs existing\
     \     WHERE existing.session_id = session.session_id\
     \   ), 0),\
-    \   $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13\
+    \   TRUE, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13\
     \ FROM harness.sessions session\
     \ WHERE session.session_key = $1 AND session.deleted_at IS NULL\
     \ RETURNING epoch_index"
@@ -445,6 +479,40 @@ insertPromptEpochStatement = mkStatement
     True
   where
     snapshotField field = field . snd
+
+invalidatePromptEpochStatement
+    :: Statement (Text, UTCTime) (Maybe Int64)
+invalidatePromptEpochStatement = mkStatement
+    "WITH latest AS (\
+    \ SELECT epoch.*\
+    \ FROM harness.session_prompt_epochs epoch\
+    \ JOIN harness.sessions session\
+    \   ON session.session_id = epoch.session_id\
+    \ WHERE session.session_key = $1 AND session.deleted_at IS NULL\
+    \ ORDER BY epoch.epoch_index DESC\
+    \ LIMIT 1\
+    \ )\
+    \ INSERT INTO harness.session_prompt_epochs (\
+    \ session_id, epoch_index, is_active, prompt_version, created_at,\
+    \ provider, connection_id, model_id, dialect, cwd_text,\
+    \ instructions_text, tools_text,\
+    \ generated_context_text, grok_context_text, prompt_cache_key\
+    \ )\
+    \ SELECT latest.session_id, latest.epoch_index + 1, FALSE,\
+    \   latest.prompt_version, $2, latest.provider, latest.connection_id,\
+    \   latest.model_id, latest.dialect, latest.cwd_text,\
+    \   latest.instructions_text, latest.tools_text,\
+    \   latest.generated_context_text, latest.grok_context_text,\
+    \   latest.prompt_cache_key\
+    \ FROM latest\
+    \ WHERE latest.is_active\
+    \ RETURNING epoch_index"
+    ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snd
+            >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz))
+    )
+    (Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.int8)))
+    True
 
 insertSessionStatement :: Statement SessionMetadata Text
 insertSessionStatement = mkStatement

--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -280,7 +280,8 @@ legacyTranscriptEffectMigrations =
         { migrationVersion = 1
         , migrationName = "initial harness storage"
         , migrationStatements =
-            [ "CREATE TABLE harness.session_turns (\
+            legacyPromptEpochPrerequisiteStatements
+            <> [ "CREATE TABLE harness.session_turns (\
               \ turn_id uuid PRIMARY KEY,\
               \ session_id uuid NOT NULL,\
               \ turn_index bigint NOT NULL,\
@@ -301,13 +302,6 @@ legacyTranscriptEffectMigrations =
               \ response_item_id uuid NOT NULL,\
               \ text_value text\
               \ )"
-            , "CREATE OR REPLACE FUNCTION\
-              \ harness.reject_session_fact_mutation()\
-              \ RETURNS trigger\
-              \ LANGUAGE plpgsql\
-              \ AS $$ BEGIN\
-              \ RAISE EXCEPTION 'session events and turns are immutable';\
-              \ END $$"
             , "CREATE TRIGGER session_turns_immutable\
               \ BEFORE UPDATE OR DELETE ON harness.session_turns\
               \ FOR EACH ROW EXECUTE FUNCTION\
@@ -341,7 +335,7 @@ legacyTranscriptEffectMigrations =
     , Migration
         { migrationVersion = 2
         , migrationName = "restricted harness runtime role"
-        , migrationStatements = []
+        , migrationStatements = legacyRuntimeRoleStatements
         }
     , Migration
         { migrationVersion = 3
@@ -371,7 +365,8 @@ legacyOpaqueFieldMigrations =
         { migrationVersion = 1
         , migrationName = "initial harness storage"
         , migrationStatements =
-            [ "CREATE TABLE harness.session_messages (\
+            legacyPromptEpochPrerequisiteStatements
+            <> [ "CREATE TABLE harness.session_messages (\
               \ response_item_id uuid PRIMARY KEY,\
               \ extra_fields jsonb NOT NULL DEFAULT '{}'::jsonb\
               \   CONSTRAINT provider_fields_are_objects\
@@ -411,11 +406,7 @@ legacyOpaqueFieldMigrations =
     , Migration
         { migrationVersion = 2
         , migrationName = "restricted harness runtime role"
-        , migrationStatements =
-            [ "CREATE ROLE ha_runtime LOGIN\
-              \ NOSUPERUSER NOCREATEDB NOCREATEROLE\
-              \ NOINHERIT NOREPLICATION NOBYPASSRLS"
-            ]
+        , migrationStatements = legacyRuntimeRoleStatements
         }
     , Migration
         { migrationVersion = 3
@@ -440,7 +431,8 @@ legacyTypedToolOutputMigrations =
         { migrationVersion = 1
         , migrationName = "initial harness storage"
         , migrationStatements =
-            [ "CREATE TABLE harness.session_function_call_outputs (\
+            legacyPromptEpochPrerequisiteStatements
+            <> [ "CREATE TABLE harness.session_function_call_outputs (\
               \ response_item_id uuid PRIMARY KEY,\
               \ output jsonb NOT NULL\
               \ )"
@@ -460,17 +452,34 @@ legacyTypedToolOutputMigrations =
     , Migration
         { migrationVersion = 2
         , migrationName = "restricted harness runtime role"
-        , migrationStatements =
-            [ "CREATE ROLE ha_runtime LOGIN\
-              \ NOSUPERUSER NOCREATEDB NOCREATEROLE\
-              \ NOINHERIT NOREPLICATION NOBYPASSRLS"
-            ]
+        , migrationStatements = legacyRuntimeRoleStatements
         }
     , Migration
         { migrationVersion = 3
         , migrationName = "typed relational session storage"
         , migrationStatements = []
         }
+    ]
+
+legacyPromptEpochPrerequisiteStatements :: [ByteString]
+legacyPromptEpochPrerequisiteStatements =
+    [ "CREATE TABLE harness.sessions (\
+      \ session_id uuid PRIMARY KEY\
+      \ )"
+    , "CREATE OR REPLACE FUNCTION\
+      \ harness.reject_session_fact_mutation()\
+      \ RETURNS trigger\
+      \ LANGUAGE plpgsql\
+      \ AS $$ BEGIN\
+      \ RAISE EXCEPTION 'session events and turns are immutable';\
+      \ END $$"
+    ]
+
+legacyRuntimeRoleStatements :: [ByteString]
+legacyRuntimeRoleStatements =
+    [ "CREATE ROLE ha_runtime LOGIN\
+      \ NOSUPERUSER NOCREATEDB NOCREATEROLE\
+      \ NOINHERIT NOREPLICATION NOBYPASSRLS"
     ]
 
 legacySessionSchemaStatements :: [ByteString]

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -69,6 +69,9 @@ spec = describe "PostgreSQL session schema" do
         ddl `shouldContainBytes` "USING gin (assistant_text gin_trgm_ops)"
         ddl `shouldContainBytes` "session_events_immutable"
         ddl `shouldContainBytes` "session_turns_immutable"
+        ddl `shouldContainBytes`
+            "CREATE TABLE IF NOT EXISTS harness.session_prompt_epochs"
+        ddl `shouldContainBytes` "session_prompt_epochs_immutable"
 
     it "tracks restart-safe legacy imports" do
         let ddl = ByteString.intercalate "\n" sessionSchemaStatements
@@ -94,6 +97,41 @@ spec = describe "PostgreSQL session schema" do
                                 now = read "2026-08-23 12:00:00 UTC"
                                 metadata = testMetadata now
                                 turn = testTurn now
+                                promptMetadata = metadata
+                                    { sessionMetadataKey = "session-prompt"
+                                    }
+                                promptSnapshot = testPromptSnapshot now
+                            createSessionWithInitialPromptEpoch
+                                pool promptMetadata promptSnapshot
+                                `shouldReturn` Right True
+                            createSessionWithInitialPromptEpoch
+                                pool promptMetadata promptSnapshot
+                                `shouldReturn` Right False
+                            loadLatestSessionPromptEpoch
+                                pool "session-prompt"
+                                `shouldReturn`
+                                    Right
+                                        (Just SessionPromptEpoch
+                                            { sessionPromptEpochIndex = 0
+                                            , sessionPromptEpochSnapshot =
+                                                promptSnapshot
+                                            })
+                            let nextPrompt = promptSnapshot
+                                    { sessionPromptInstructions =
+                                        "updated instructions"
+                                    }
+                            appendSessionPromptEpoch
+                                pool "session-prompt" nextPrompt
+                                `shouldReturn` Right (Just 1)
+                            loadLatestSessionPromptEpoch
+                                pool "session-prompt"
+                                `shouldReturn`
+                                    Right
+                                        (Just SessionPromptEpoch
+                                            { sessionPromptEpochIndex = 1
+                                            , sessionPromptEpochSnapshot =
+                                                nextPrompt
+                                            })
                             createSession pool metadata
                                 `shouldReturn` Right True
                             appendSessionTurn pool turn metadata
@@ -502,6 +540,22 @@ testMetadata now = SessionMetadata
     , sessionMetadataLastRecap = Nothing
     , sessionMetadataLastTurnSummary = Nothing
     , sessionMetadataLastRecapMainTurns = 0
+    }
+
+testPromptSnapshot :: UTCTime -> SessionPromptSnapshot
+testPromptSnapshot now = SessionPromptSnapshot
+    { sessionPromptVersion = 1
+    , sessionPromptCreatedAt = now
+    , sessionPromptProvider = "openai"
+    , sessionPromptConnection = "openai"
+    , sessionPromptModel = "gpt-test"
+    , sessionPromptDialect = "openai"
+    , sessionPromptCwd = "/tmp/project"
+    , sessionPromptInstructions = "persisted instructions"
+    , sessionPromptTools = "[{\"type\":\"function\",\"name\":\"lookup\"}]"
+    , sessionPromptGeneratedContext = Just "project context"
+    , sessionPromptGrokContext = Nothing
+    , sessionPromptCacheKey = "session-prompt"
     }
 
 testTurn :: UTCTime -> SessionTurn

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -71,6 +71,7 @@ spec = describe "PostgreSQL session schema" do
         ddl `shouldContainBytes` "session_turns_immutable"
         ddl `shouldContainBytes`
             "CREATE TABLE IF NOT EXISTS harness.session_prompt_epochs"
+        ddl `shouldContainBytes` "is_active boolean NOT NULL DEFAULT TRUE"
         ddl `shouldContainBytes` "session_prompt_epochs_immutable"
 
     it "tracks restart-safe legacy imports" do
@@ -131,6 +132,72 @@ spec = describe "PostgreSQL session schema" do
                                             { sessionPromptEpochIndex = 1
                                             , sessionPromptEpochSnapshot =
                                                 nextPrompt
+                                            })
+                            let resetTurn = turn
+                                    { sessionTurnUserText = "/clear"
+                                    , sessionTurnAssistantText =
+                                        Just "Conversation cleared."
+                                    , sessionTurnResponseId = Nothing
+                                    , sessionTurnEffect = TranscriptReset
+                                    , sessionTurnItems = []
+                                    , sessionTurnUsage = Nothing
+                                    , sessionTurnProviderTelemetry = Nothing
+                                    }
+                            appendSessionTurnIndexedWithPromptReset
+                                pool resetTurn promptMetadata
+                                `shouldReturn` Right (Just 0)
+                            loadLatestSessionPromptEpoch
+                                pool "session-prompt"
+                                `shouldReturn` Right Nothing
+                            let reactivatedPrompt = nextPrompt
+                                    { sessionPromptGeneratedContext = Nothing
+                                    }
+                            appendSessionPromptEpoch
+                                pool "session-prompt" reactivatedPrompt
+                                `shouldReturn` Right (Just 3)
+                            appendSessionTurn
+                                pool
+                                resetTurn
+                                    { sessionTurnUserText = "/rewind"
+                                    }
+                                promptMetadata
+                                `shouldReturn` Right True
+                            loadLatestSessionPromptEpoch
+                                pool "session-prompt"
+                                `shouldReturn`
+                                    Right
+                                        (Just SessionPromptEpoch
+                                            { sessionPromptEpochIndex = 3
+                                            , sessionPromptEpochSnapshot =
+                                                reactivatedPrompt
+                                            })
+                            let importedMetadata = promptMetadata
+                                    { sessionMetadataKey =
+                                        "session-imported-prompt"
+                                    }
+                                importedPrompt = promptSnapshot
+                                    { sessionPromptCacheKey =
+                                        "session-imported-prompt"
+                                    }
+                                legacy = LegacySession
+                                    { legacySourcePath =
+                                        "afk:session-imported-prompt"
+                                    , legacyContentHash = "transfer-hash"
+                                    , legacyMetadata = importedMetadata
+                                    , legacyTurns = []
+                                    , legacyPromptSnapshot =
+                                        Just importedPrompt
+                                    }
+                            importLegacySession pool legacy
+                                `shouldReturn` Right True
+                            loadLatestSessionPromptEpoch
+                                pool "session-imported-prompt"
+                                `shouldReturn`
+                                    Right
+                                        (Just SessionPromptEpoch
+                                            { sessionPromptEpochIndex = 0
+                                            , sessionPromptEpochSnapshot =
+                                                importedPrompt
                                             })
                             createSession pool metadata
                                 `shouldReturn` Right True


### PR DESCRIPTION
## Summary

- persist the exact provider-visible instructions, ordered tools, prompt-cache key, generated startup context, and Grok first-turn context as immutable PostgreSQL prompt epochs before a request can be sent
- restore that prefix on compatible resume while keeping current tool implementations live; append a new epoch when the provider target or tool topology changes
- preserve prompt snapshots across legacy imports and `/afk` transfers, and restore consumed Grok context when a turn must be retried
- invalidate the saved prefix atomically on `/clear` with an append-only marker while preserving it across `/rewind`
- keep readiness-dependent progressive MCP server instructions out of the system prefix, bootstrap older sessions on their next request, and keep forks independent

## Why

`prompt_cache_key` is only a routing hint. A provider cache hit still requires a byte-stable request prefix. Rebuilding prompts and tool schemas on resume can change that prefix because of binary updates, timestamps, or MCP readiness timing.

## Storage and performance

- migration 103 adds append-only `harness.session_prompt_epochs`; migration 104 adds active/inactive epoch markers
- initial session metadata and epoch are created atomically; later epochs and reset markers use the session advisory lock
- selected-session resume adds one bounded latest-epoch query
- measured median: 0.628 ms -> 0.759 ms (+0.131 ms, +26,696 allocated bytes)

## Validation

- isolated Nix check: `agent-store`
- clean isolated Cabal build of `agent-cli-test` in the Nix development environment
- GHCi: all 259 modules loaded
- `agent-store-test`: 35 examples, 0 failures
- `agent-cli-test`: 1487 examples, 0 failures, 1 pending
- independent edge-case review: no correctness regression found
- `git diff --check`

GitHub Actions run 33336404848 ended with `startup_failure` before scheduling a job (zero jobs and no logs); the local checks above cover the pushed head.
