### PR TITLE
Connect native clients to gateway accounts

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -377,7 +377,6 @@ test-suite agent-cli-test
                     , Agent.CLI.FileUriSpec
                     , Agent.CLI.GatewayBridgeSpec
                     , Agent.CLI.GatewayClientSpec
-                    , Agent.CLI.GatewayClientSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec
                     , Agent.CLI.InterruptSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -118,6 +118,7 @@ library
                     , Agent.CLI.FileUri
                     , Agent.CLI.ImagePreview
                     , Agent.CLI.GatewayBridge
+                    , Agent.CLI.GatewayClient
                     , Agent.CLI.Input
                     , Agent.CLI.Input.Types
                     , Agent.CLI.Input.Display
@@ -375,6 +376,8 @@ test-suite agent-cli-test
                     , Agent.CLI.ErrorSpec
                     , Agent.CLI.FileUriSpec
                     , Agent.CLI.GatewayBridgeSpec
+                    , Agent.CLI.GatewayClientSpec
+                    , Agent.CLI.GatewayClientSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec
                     , Agent.CLI.InterruptSpec

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -119,6 +119,7 @@ library
                     , Agent.CLI.ImagePreview
                     , Agent.CLI.GatewayBridge
                     , Agent.CLI.GatewayClient
+                    , Agent.CLI.GatewayModels
                     , Agent.CLI.Input
                     , Agent.CLI.Input.Types
                     , Agent.CLI.Input.Display
@@ -377,6 +378,7 @@ test-suite agent-cli-test
                     , Agent.CLI.FileUriSpec
                     , Agent.CLI.GatewayBridgeSpec
                     , Agent.CLI.GatewayClientSpec
+                    , Agent.CLI.GatewayModelsSpec
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.InputSpec
                     , Agent.CLI.InterruptSpec

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -69,6 +69,15 @@ import Agent.CLI.Auth
     , openaiAuthStateFromJson
     , xaiOAuthClientId
     )
+import Agent.CLI.GatewayClient
+    ( GatewayCredential(..)
+    , GatewayDeviceAuthorization(..)
+    , GatewayPollResult(..)
+    , loadGatewayCredential
+    , pollGatewayAuthorizationAndSave
+    , removeGatewayCredential
+    , startGatewayAuthorization
+    )
 import qualified Agent.OpenAI.Login as OpenAILogin
 import qualified Agent.OpenAI.Auth as OpenAIAuth
 import qualified Agent.OpenAI.Auth.Types as OpenAIAuthTypes
@@ -78,8 +87,8 @@ import Agent.CLI.ModelConfig
     ( CatalogModel(..)
     , ModelCatalog
     , catalogModelById
-    , loadModelCatalogAt
     )
+import Agent.CLI.GatewayModels (loadGatewayModelCatalogAt)
 import Agent.CLI.Database.Store
     ( applicableDatabaseScopes
     , deriveDatabaseScopes
@@ -91,6 +100,7 @@ import Agent.CLI.Models
     , defaultModelOptionFor
     , initialPickerStateResolved
     , modelCatalog
+    , resolveConfiguredModel
     , resolveModelOptionDialect
     , selectedOption
     )
@@ -287,6 +297,28 @@ type AccountOAuthStartCallback =
     -> CString -> CSize -> CString -> CSize -> CInt -> CInt
     -> CString -> CSize -> IO ()
 
+type GatewayStatusCallback =
+    Ptr () -> CInt
+    -> CString -> CSize
+    -> CString -> CSize
+    -> IO ()
+
+type GatewayConnectStartCallback =
+    Ptr () -> CInt
+    -> CString -> CSize
+    -> CString -> CSize
+    -> CString -> CSize
+    -> CString -> CSize
+    -> CInt -> CInt
+    -> CString -> CSize
+    -> IO ()
+
+type GatewayPollCallback =
+    Ptr () -> CInt -> CInt -> CString -> CSize -> IO ()
+
+type GatewayResultCallback =
+    Ptr () -> CInt -> CString -> CSize -> IO ()
+
 -- Status is 0 for a result, 1 for completion, and -1 for failure. Every
 -- pointer is callback-scoped UTF-8. A turn index of -1 denotes a metadata hit;
 -- role is 0 (metadata), 1 (user), or 2 (assistant).
@@ -342,6 +374,22 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeAccountOAuthStartCallback
         :: FunPtr AccountOAuthStartCallback -> AccountOAuthStartCallback
+
+foreign import ccall "dynamic"
+    invokeGatewayStatusCallback
+        :: FunPtr GatewayStatusCallback -> GatewayStatusCallback
+
+foreign import ccall "dynamic"
+    invokeGatewayConnectStartCallback
+        :: FunPtr GatewayConnectStartCallback -> GatewayConnectStartCallback
+
+foreign import ccall "dynamic"
+    invokeGatewayPollCallback
+        :: FunPtr GatewayPollCallback -> GatewayPollCallback
+
+foreign import ccall "dynamic"
+    invokeGatewayResultCallback
+        :: FunPtr GatewayResultCallback -> GatewayResultCallback
 
 foreign import ccall "dynamic"
     invokeSearchCallback :: FunPtr SearchCallback -> SearchCallback
@@ -584,6 +632,20 @@ foreign export ccall ha_account_set_enabled
 foreign export ccall ha_account_delete
     :: Ptr Word8 -> CSize -> FunPtr AccountResultCallback -> Ptr () -> IO CInt
 
+foreign export ccall ha_gateway_status
+    :: FunPtr GatewayStatusCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_gateway_connect_start
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr GatewayConnectStartCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_gateway_connect_poll
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr GatewayPollCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_gateway_disconnect
+    :: FunPtr GatewayResultCallback -> Ptr () -> IO CInt
+
 foreign export ccall ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
 
@@ -798,6 +860,167 @@ ha_account_delete idBytes (CSize idLength) callback context
                 Left exception -> invokeExceptionResult callback context exception
                 Right result -> invokeStoreResult callback context result
         pure 0
+
+ha_gateway_status
+    :: FunPtr GatewayStatusCallback -> Ptr () -> IO CInt
+ha_gateway_status callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        _ <- forkIO do
+            tryAny loadGatewayCredential >>= \case
+                Left exception ->
+                    invokeGatewayStatusError callback context
+                        (Text.pack (show exception))
+                Right (Left err) ->
+                    invokeGatewayStatusError callback context err
+                Right (Right Nothing) ->
+                    invokeGatewayStatusCallback callback context 1
+                        nullPtr 0 nullPtr 0
+                Right (Right (Just credential)) ->
+                    withText credential.gatewayBaseUrl $ \baseUrl baseUrlLength ->
+                        invokeGatewayStatusCallback callback context 0
+                            baseUrl baseUrlLength nullPtr 0
+        pure 0
+
+ha_gateway_connect_start
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr GatewayConnectStartCallback -> Ptr () -> IO CInt
+ha_gateway_connect_start
+    baseUrlBytes (CSize baseUrlLength)
+    clientNameBytes (CSize clientNameLength)
+    callback context
+    | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull
+        [ (baseUrlBytes, baseUrlLength)
+        , (clientNameBytes, clientNameLength)
+        ] = pure 2
+    | otherwise = do
+        baseUrl <- decodeInput baseUrlBytes baseUrlLength
+        clientName <- decodeInput clientNameBytes clientNameLength
+        _ <- forkIO do
+            tryAny (startGatewayAuthorization baseUrl clientName) >>= \case
+                Left exception ->
+                    invokeGatewayConnectStartError callback context
+                        (Text.pack (show exception))
+                Right (Left err) ->
+                    invokeGatewayConnectStartError callback context err
+                Right (Right device) ->
+                    withGatewayDeviceStrings device $
+                        invokeGatewayConnectStartCallback callback context 0
+        pure 0
+
+ha_gateway_connect_poll
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr GatewayPollCallback -> Ptr () -> IO CInt
+ha_gateway_connect_poll
+    baseUrlBytes (CSize baseUrlLength)
+    deviceCodeBytes (CSize deviceCodeLength)
+    callback context
+    | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull
+        [ (baseUrlBytes, baseUrlLength)
+        , (deviceCodeBytes, deviceCodeLength)
+        ] = pure 2
+    | otherwise = do
+        baseUrl <- decodeInput baseUrlBytes baseUrlLength
+        deviceCode <- decodeInput deviceCodeBytes deviceCodeLength
+        _ <- forkIO do
+            tryAny
+                (pollGatewayAuthorizationAndSave baseUrl deviceCode)
+                >>= \case
+                    Left exception ->
+                        invokeGatewayPollError callback context
+                            (Text.pack (show exception))
+                    Right (Left err) ->
+                        invokeGatewayPollError callback context err
+                    Right (Right result) ->
+                        invokeGatewayPollResult callback context result
+        pure 0
+
+ha_gateway_disconnect
+    :: FunPtr GatewayResultCallback -> Ptr () -> IO CInt
+ha_gateway_disconnect callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        _ <- forkIO do
+            tryAny removeGatewayCredential >>= \case
+                Left exception ->
+                    invokeGatewayResultError callback context
+                        (Text.pack (show exception))
+                Right (Left err) ->
+                    invokeGatewayResultError callback context err
+                Right (Right ()) ->
+                    invokeGatewayResultCallback callback context 0 nullPtr 0
+        pure 0
+
+invokeGatewayStatusError
+    :: FunPtr GatewayStatusCallback -> Ptr () -> Text -> IO ()
+invokeGatewayStatusError callback context err =
+    withText err $ \errorPtr errorLength ->
+        invokeGatewayStatusCallback callback context (-1)
+            nullPtr 0 errorPtr errorLength
+
+invokeGatewayConnectStartError
+    :: FunPtr GatewayConnectStartCallback -> Ptr () -> Text -> IO ()
+invokeGatewayConnectStartError callback context err =
+    withText err $ \errorPtr errorLength ->
+        invokeGatewayConnectStartCallback callback context (-1)
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            0 0 errorPtr errorLength
+
+withGatewayDeviceStrings
+    :: GatewayDeviceAuthorization
+    -> (CString -> CSize -> CString -> CSize
+        -> CString -> CSize -> CString -> CSize
+        -> CInt -> CInt -> CString -> CSize -> IO a)
+    -> IO a
+withGatewayDeviceStrings device action =
+    withText device.userCode $ \userCode userCodeLength ->
+    withText device.verificationUri $ \verificationUri verificationUriLength ->
+    withText device.verificationUriComplete $
+        \verificationComplete verificationCompleteLength ->
+    withText device.deviceCode $ \deviceCode deviceCodeLength ->
+        action
+            userCode userCodeLength
+            verificationUri verificationUriLength
+            verificationComplete verificationCompleteLength
+            deviceCode deviceCodeLength
+            (fromIntegral device.pollIntervalSeconds)
+            (fromIntegral device.expiresInSeconds)
+            nullPtr 0
+
+invokeGatewayPollResult
+    :: FunPtr GatewayPollCallback -> Ptr () -> GatewayPollResult -> IO ()
+invokeGatewayPollResult callback context = \case
+    GatewayAuthorized _ _ ->
+        invokeGatewayPollCallback callback context 0 0 nullPtr 0
+    GatewayAuthorizationPending retryInterval ->
+        invokeGatewayPollCallback callback context 1
+            (fromIntegral (fromMaybe 0 retryInterval)) nullPtr 0
+    GatewaySlowDown retryInterval ->
+        invokeGatewayPollCallback callback context 2
+            (fromIntegral (fromMaybe 0 retryInterval)) nullPtr 0
+    GatewayAccessDenied ->
+        invokeGatewayPollError callback context
+            "Gateway authorization was denied."
+    GatewayExpired ->
+        invokeGatewayPollError callback context
+            "Gateway authorization expired."
+    GatewayPollFailed code ->
+        invokeGatewayPollError callback context
+            ("Gateway authorization failed: " <> code)
+
+invokeGatewayPollError
+    :: FunPtr GatewayPollCallback -> Ptr () -> Text -> IO ()
+invokeGatewayPollError callback context err =
+    withText err $ \errorPtr errorLength ->
+        invokeGatewayPollCallback callback context (-1) 0 errorPtr errorLength
+
+invokeGatewayResultError
+    :: FunPtr GatewayResultCallback -> Ptr () -> Text -> IO ()
+invokeGatewayResultError callback context err =
+    withText err $ \errorPtr errorLength ->
+        invokeGatewayResultCallback callback context (-1) errorPtr errorLength
 
 anyNonEmptyNull :: [(Ptr Word8, Word64)] -> Bool
 anyNonEmptyNull = any \(pointer, length) ->
@@ -2003,20 +2226,29 @@ loadNativeModelCatalog store root request = do
     case contextResult of
         Left err -> pure (Left err)
         Right (cwd, maybeTarget) ->
-            loadModelCatalogAt home cwd >>= \case
+            loadGatewayModelCatalogAt home cwd >>= \case
                 Left err -> pure (Left err)
                 Right catalog -> do
-                    selectedTarget <- case maybeTarget of
-                        Just target -> pure (Just target)
-                        Nothing ->
-                            traverse
-                                (fmap (.modelTarget)
-                                    . resolveModelOptionDialect)
-                                ( defaultModelOptionFor
+                    let configuredTarget = do
+                            target <- maybeTarget
+                            option <-
+                                resolveConfiguredModel
+                                    catalog
+                                    target.targetModelId
+                            if option.modelTarget.targetConnectionId
+                                == target.targetConnectionId
+                                then Just option
+                                else Nothing
+                    selectedTarget <-
+                        traverse
+                            (fmap (.modelTarget)
+                                . resolveModelOptionDialect)
+                            ( configuredTarget
+                                <|> defaultModelOptionFor
                                     catalog
                                     OpenAIProvider
-                                    <|> listToMaybe (modelCatalog catalog)
-                                )
+                                <|> listToMaybe (modelCatalog catalog)
+                            )
                     case selectedTarget of
                         Nothing -> pure (Left "model catalog is empty")
                         Just target -> do

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -259,6 +259,75 @@ typedef void (*ha_account_oauth_start_callback)(
     const uint8_t *error,
     size_t error_length
 );
+
+/*
+ * Gateway operations are process-global and do not require an engine.
+ * Accepted operations run asynchronously on a Haskell worker thread; that
+ * thread is not the caller or the AppKit main thread. Every string is UTF-8
+ * and valid only for the duration of its callback, so callers must copy it
+ * before returning. The caller owns callback/context and must keep both valid
+ * until the callback returns. No gateway access token or WebSocket credential
+ * crosses this ABI.
+ */
+enum {
+    HA_GATEWAY_CONNECTED = 0,
+    HA_GATEWAY_DISCONNECTED = 1,
+    HA_GATEWAY_ERROR = -1
+};
+
+typedef void (*ha_gateway_status_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *base_url,
+    size_t base_url_length,
+    const uint8_t *error,
+    size_t error_length
+);
+
+/* Start status is HA_GATEWAY_CONNECTED (0) for a challenge, or -1 on error. */
+typedef void (*ha_gateway_connect_start_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *user_code,
+    size_t user_code_length,
+    const uint8_t *verification_uri,
+    size_t verification_uri_length,
+    const uint8_t *verification_uri_complete,
+    size_t verification_uri_complete_length,
+    const uint8_t *device_code,
+    size_t device_code_length,
+    int32_t poll_interval_seconds,
+    int32_t expires_in_seconds,
+    const uint8_t *error,
+    size_t error_length
+);
+
+enum {
+    HA_GATEWAY_POLL_AUTHORIZED = 0,
+    HA_GATEWAY_POLL_PENDING = 1,
+    HA_GATEWAY_POLL_SLOW_DOWN = 2,
+    HA_GATEWAY_POLL_ERROR = -1
+};
+
+/*
+ * An authorized poll has already persisted the credential inside the trusted
+ * runtime. retry_interval_seconds is zero unless the server supplied a new
+ * interval for pending/slow-down.
+ */
+typedef void (*ha_gateway_poll_callback)(
+    void *context,
+    int32_t status,
+    int32_t retry_interval_seconds,
+    const uint8_t *error,
+    size_t error_length
+);
+
+typedef void (*ha_gateway_result_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *error,
+    size_t error_length
+);
 /*
  * An image submitted for a native turn. The runtime copies both buffers
  * before this call returns; the caller retains ownership of them.
@@ -377,6 +446,36 @@ int32_t ha_account_oauth_poll(
     int32_t poll_interval_seconds,
     int32_t expires_in_seconds,
     ha_account_result_callback callback,
+    void *context
+);
+
+/*
+ * Gateway inputs are copied before return. Immediate return is 0 when the
+ * worker was accepted, 1 for a null callback, or 2 for a null pointer paired
+ * with a nonzero length. Semantic and network failures arrive asynchronously.
+ */
+int32_t ha_gateway_status(
+    ha_gateway_status_callback callback,
+    void *context
+);
+int32_t ha_gateway_connect_start(
+    const uint8_t *base_url,
+    size_t base_url_length,
+    const uint8_t *client_name,
+    size_t client_name_length,
+    ha_gateway_connect_start_callback callback,
+    void *context
+);
+int32_t ha_gateway_connect_poll(
+    const uint8_t *base_url,
+    size_t base_url_length,
+    const uint8_t *device_code,
+    size_t device_code_length,
+    ha_gateway_poll_callback callback,
+    void *context
+);
+int32_t ha_gateway_disconnect(
+    ha_gateway_result_callback callback,
     void *context
 );
 int32_t ha_account_api_key_connect(

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -55,7 +55,12 @@ import Agent.CLI.CredentialStore
     , loadManagedCredentials
     )
 import Agent.CLI.Environment (lookupNonEmpty)
+import Agent.CLI.GatewayClient
+    ( GatewayCredential (..)
+    , loadGatewayCredential
+    )
 import Agent.Error (ApiError(..))
+import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
 import qualified Agent.Claude.Auth as ClaudeCode
 import Agent.Provider
     ( AccountFailure(..)
@@ -92,24 +97,51 @@ import System.Directory.OsPath (doesFileExist, getHomeDirectory)
 import System.OsPath (unsafeEncodeUtf, (</>))
 
 loadAuth :: Maybe Provider -> IO (Either Text LoadedAuth)
-loadAuth requested = runExceptT do
-    provider <- detectProvider requested
-    case provider of
-        XAIProvider -> loadXai Nothing
-        OpenAIProvider -> loadOpenAi
-        OpenRouterProvider -> loadOpenRouter Nothing
-        ClaudeCodeProvider -> loadClaudeCode
+loadAuth requested =
+    loadGatewayCredential >>= \case
+        Left err -> pure (Left ("cannot load gateway credential: " <> err))
+        Right (Just gateway) -> pure (gatewayLoadedAuth gateway)
+        Right Nothing -> runExceptT do
+            provider <- detectProvider requested
+            case provider of
+                XAIProvider -> loadXai Nothing
+                OpenAIProvider -> loadOpenAi
+                OpenRouterProvider -> loadOpenRouter Nothing
+                ClaudeCodeProvider -> loadClaudeCode
+
+gatewayLoadedAuth :: GatewayCredential -> Either Text LoadedAuth
+gatewayLoadedAuth gateway = do
+    validateGatewayWebSocketUrl gateway.gatewayWebSocketUrl
+    let credential =
+            Credential
+                { accessToken = gateway.gatewayAccessToken
+                , accountId = gateway.gatewayWebSocketUrl
+                , leaseId = Nothing
+                , provider = OpenAIProvider
+                }
+    pure LoadedAuth
+            { loadedProvider = OpenAIProvider
+            , loadedTokenProvider =
+                staticCredentialProvider SubscriptionBilled credential
+            , loadedAccountLabel = const (pure gateway.gatewayBaseUrl)
+            , loadedSelectionId = Just "gateway"
+            , loadedOpenAiPool = Nothing
+            }
 
 -- | Load one specific account for providers whose HTTP backends can swap
 -- token sources without reconnecting a long-lived transport.
 loadAuthForAccount :: Provider -> Text -> IO (Either Text LoadedAuth)
-loadAuthForAccount provider selectionId = runExceptT case provider of
-    XAIProvider -> loadXai (Just selectionId)
-    OpenRouterProvider -> loadOpenRouter (Just selectionId)
-    OpenAIProvider ->
-        throwE "OpenAI account selection is handled by the live account pool"
-    ClaudeCodeProvider ->
-        throwE "Claude Code accounts are managed by `claude auth login`"
+loadAuthForAccount provider selectionId =
+    loadGatewayCredential >>= \case
+        Left err -> pure (Left ("cannot load gateway credential: " <> err))
+        Right (Just gateway) -> pure (gatewayLoadedAuth gateway)
+        Right Nothing -> runExceptT case provider of
+            XAIProvider -> loadXai (Just selectionId)
+            OpenRouterProvider -> loadOpenRouter (Just selectionId)
+            OpenAIProvider ->
+                throwE "OpenAI account selection is handled by the live account pool"
+            ClaudeCodeProvider ->
+                throwE "Claude Code accounts are managed by `claude auth login`"
 
 -- | Ask the token source whether it has a usable credential now without
 -- making a model request, preserving a successful checkout for later use.

--- a/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
@@ -13,6 +13,7 @@ module Agent.CLI.GatewayClient
     , runGatewayCommand
     , saveGatewayCredentialAt
     , showGatewayStatus
+    , validateBaseUrl
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
@@ -277,7 +278,7 @@ validateBaseUrl :: Text -> Either Text Text
 validateBaseUrl raw
     | Text.null base = Left "Gateway URL cannot be empty."
     | "https://" `Text.isPrefixOf` lower = Right base
-    | any (`Text.isPrefixOf` lower)
+    | any localOrigin
         [ "http://127.0.0.1"
         , "http://localhost"
         , "http://[::1]"
@@ -286,6 +287,10 @@ validateBaseUrl raw
   where
     base = Text.dropWhileEnd (== '/') (Text.strip raw)
     lower = Text.toLower base
+    localOrigin origin =
+        lower == origin
+            || (origin <> ":") `Text.isPrefixOf` lower
+            || (origin <> "/") `Text.isPrefixOf` lower
 
 openBrowser :: Text -> IO Bool
 openBrowser url = do

--- a/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
@@ -6,19 +6,23 @@ module Agent.CLI.GatewayClient
     , connectGateway
     , disconnectGateway
     , gatewayCredentialPath
-    , gatewayDeviceDecoder
-    , gatewayPollDecoder
     , loadGatewayCredential
     , loadGatewayCredentialAt
+    , pollGatewayAuthorization
+    , pollGatewayAuthorizationAndSave
+    , removeGatewayCredential
     , runGatewayCommand
     , saveGatewayCredentialAt
     , showGatewayStatus
+    , startGatewayAuthorization
     , validateBaseUrl
+    , validateGatewayCredential
+    , validateGatewayDeviceAuthorization
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.CLI.Options (GatewayCommand (..))
-import Agent.Json.Decode qualified as Hermes
+import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
 import Agent.OsPath (unsafeToFilePath)
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (tryAny)
@@ -26,16 +30,19 @@ import Control.Monad (when)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as LBS
+import Data.Char (isDigit)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.TLS (newTlsManager)
 import Network.HTTP.Types (hContentType)
+import Network.URI qualified as URI
 import System.Directory.OsPath qualified as Directory
 import System.Exit (ExitCode (..))
 import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 import System.Process (rawSystem)
+import Text.Read (readMaybe)
 
 data GatewayCredential = GatewayCredential
     { gatewayBaseUrl :: !Text
@@ -48,8 +55,7 @@ instance Show GatewayCredential where
     show credential =
         "GatewayCredential { gatewayBaseUrl = "
             <> show credential.gatewayBaseUrl
-            <> ", gatewayWebSocketUrl = "
-            <> show credential.gatewayWebSocketUrl
+            <> ", gatewayWebSocketUrl = <redacted>"
             <> ", gatewayAccessToken = <redacted> }"
 
 instance Aeson.ToJSON GatewayCredential where
@@ -61,13 +67,12 @@ instance Aeson.ToJSON GatewayCredential where
             , "access_token" .= credential.gatewayAccessToken
             ]
 
-gatewayCredentialDecoder :: Hermes.Decoder GatewayCredential
-gatewayCredentialDecoder =
-    Hermes.object $
+instance Aeson.FromJSON GatewayCredential where
+    parseJSON = Aeson.withObject "GatewayCredential" \object ->
         GatewayCredential
-            <$> Hermes.atKey "base_url" Hermes.text
-            <*> Hermes.atKey "websocket_url" Hermes.text
-            <*> Hermes.atKey "access_token" Hermes.text
+            <$> object Aeson..: "base_url"
+            <*> object Aeson..: "websocket_url"
+            <*> object Aeson..: "access_token"
 
 data GatewayDeviceAuthorization = GatewayDeviceAuthorization
     { deviceCode :: !Text
@@ -77,18 +82,31 @@ data GatewayDeviceAuthorization = GatewayDeviceAuthorization
     , expiresInSeconds :: !Int
     , pollIntervalSeconds :: !Int
     }
-    deriving (Eq, Show)
+    deriving (Eq)
 
-gatewayDeviceDecoder :: Hermes.Decoder GatewayDeviceAuthorization
-gatewayDeviceDecoder =
-    Hermes.object $
+instance Show GatewayDeviceAuthorization where
+    show authorization =
+        "GatewayDeviceAuthorization"
+            <> " { deviceCode = <redacted>"
+            <> ", userCode = <redacted>"
+            <> ", verificationUri = "
+            <> show authorization.verificationUri
+            <> ", verificationUriComplete = <redacted>"
+            <> ", expiresInSeconds = "
+            <> show authorization.expiresInSeconds
+            <> ", pollIntervalSeconds = "
+            <> show authorization.pollIntervalSeconds
+            <> " }"
+
+instance Aeson.FromJSON GatewayDeviceAuthorization where
+    parseJSON = Aeson.withObject "GatewayDeviceAuthorization" \object ->
         GatewayDeviceAuthorization
-            <$> Hermes.atKey "device_code" Hermes.text
-            <*> Hermes.atKey "user_code" Hermes.text
-            <*> Hermes.atKey "verification_uri" Hermes.text
-            <*> Hermes.atKey "verification_uri_complete" Hermes.text
-            <*> Hermes.atKey "expires_in" Hermes.int
-            <*> Hermes.atKey "interval" Hermes.int
+            <$> object Aeson..: "device_code"
+            <*> object Aeson..: "user_code"
+            <*> object Aeson..: "verification_uri"
+            <*> object Aeson..: "verification_uri_complete"
+            <*> object Aeson..: "expires_in"
+            <*> object Aeson..: "interval"
 
 data GatewayPollResult
     = GatewayAuthorized !Text !Text
@@ -97,33 +115,36 @@ data GatewayPollResult
     | GatewayAccessDenied
     | GatewayExpired
     | GatewayPollFailed !Text
-    deriving (Eq, Show)
+    deriving (Eq)
 
-gatewayPollDecoder :: Hermes.Decoder GatewayPollResult
-gatewayPollDecoder =
-    Hermes.withRawJsonByteString \raw ->
-        case Hermes.decodeEither successDecoder raw of
-            Right (token, websocketUrl) ->
-                pure (GatewayAuthorized token websocketUrl)
-            Left _ -> case Hermes.decodeEither errorDecoder raw of
-                Right (code, interval) -> pure case code of
+instance Show GatewayPollResult where
+    show = \case
+        GatewayAuthorized _ _ ->
+            "GatewayAuthorized <redacted> <redacted>"
+        GatewayAuthorizationPending interval ->
+            "GatewayAuthorizationPending " <> show interval
+        GatewaySlowDown interval ->
+            "GatewaySlowDown " <> show interval
+        GatewayAccessDenied -> "GatewayAccessDenied"
+        GatewayExpired -> "GatewayExpired"
+        GatewayPollFailed code -> "GatewayPollFailed " <> show code
+
+instance Aeson.FromJSON GatewayPollResult where
+    parseJSON = Aeson.withObject "GatewayPollResult" \object -> do
+        maybeAccessToken <- object Aeson..:? "access_token"
+        case maybeAccessToken of
+            Just accessToken ->
+                GatewayAuthorized accessToken
+                    <$> object Aeson..: "websocket_url"
+            Nothing -> do
+                code <- object Aeson..: "error"
+                interval <- object Aeson..:? "interval"
+                pure case code of
                     "authorization_pending" -> GatewayAuthorizationPending interval
                     "slow_down" -> GatewaySlowDown interval
                     "access_denied" -> GatewayAccessDenied
                     "expired_token" -> GatewayExpired
                     other -> GatewayPollFailed other
-                Left err -> fail (Text.unpack (Hermes.jsonErrorMessage err))
-  where
-    successDecoder =
-        Hermes.object $
-            (,)
-                <$> Hermes.atKey "access_token" Hermes.text
-                <*> Hermes.atKey "websocket_url" Hermes.text
-    errorDecoder =
-        Hermes.object $
-            (,)
-                <$> Hermes.atKey "error" Hermes.text
-                <*> Hermes.optionalKey "interval" Hermes.int
 
 gatewayCredentialPath :: OsPath -> OsPath
 gatewayCredentialPath home =
@@ -152,9 +173,10 @@ loadGatewayCredentialAt home = do
             pure case result of
                 Left exception -> Left (Text.pack (show exception))
                 Right bytes ->
-                    case Hermes.decodeEither gatewayCredentialDecoder (LBS.toStrict bytes) of
-                        Left err -> Left (Hermes.jsonErrorMessage err)
-                        Right credential -> Right (Just credential)
+                    case Aeson.eitherDecode bytes of
+                        Left err -> Left (Text.pack err)
+                        Right credential ->
+                            Just <$> validateGatewayCredential credential
 
 saveGatewayCredentialAt :: OsPath -> GatewayCredential -> IO (Either Text ())
 saveGatewayCredentialAt home credential = do
@@ -170,21 +192,16 @@ saveGatewayCredentialAt home credential = do
 
 connectGateway :: Text -> IO ()
 connectGateway rawBaseUrl = do
-    baseUrl <- either failText pure (validateBaseUrl rawBaseUrl)
-    manager <- newTlsManager
     device <-
-        postJson manager (baseUrl <> "/api/v1/agent-connections/device")
-            (Aeson.object ["client_name" .= ("haskell-agent" :: Text)])
-            gatewayDeviceDecoder
+        startGatewayAuthorization rawBaseUrl "haskell-agent"
             >>= either failText pure
+    baseUrl <- either failText pure (validateBaseUrl rawBaseUrl)
     putStrLn ("Enter code " <> Text.unpack device.userCode <> " at:")
     putStrLn (Text.unpack device.verificationUri)
     opened <- openBrowser device.verificationUriComplete
     when (not opened) $
         putStrLn "Could not open a browser automatically."
-    credential <- pollUntilAuthorized manager baseUrl device
-    home <- Directory.getHomeDirectory
-    saveGatewayCredentialAt home credential >>= either failText pure
+    pollUntilAuthorized baseUrl device
     putStrLn "Gateway connection saved."
 
 showGatewayStatus :: IO ()
@@ -198,10 +215,7 @@ showGatewayStatus =
 
 disconnectGateway :: IO ()
 disconnectGateway = do
-    home <- Directory.getHomeDirectory
-    let path = gatewayCredentialPath home
-    exists <- Directory.doesFileExist path
-    when exists (Directory.removeFile path)
+    removeGatewayCredential >>= either failText pure
     putStrLn "Gateway connection removed."
 
 runGatewayCommand :: GatewayCommand -> IO ()
@@ -211,11 +225,10 @@ runGatewayCommand = \case
     GatewayDisconnect -> disconnectGateway
 
 pollUntilAuthorized
-    :: HTTP.Manager
-    -> Text
+    :: Text
     -> GatewayDeviceAuthorization
-    -> IO GatewayCredential
-pollUntilAuthorized manager baseUrl device =
+    -> IO ()
+pollUntilAuthorized baseUrl device =
     go device.expiresInSeconds (max 1 device.pollIntervalSeconds)
   where
     go remaining interval
@@ -223,18 +236,10 @@ pollUntilAuthorized manager baseUrl device =
         | otherwise = do
             threadDelay (interval * 1_000_000)
             result <-
-                postJson manager (baseUrl <> "/api/v1/agent-connections/token")
-                    (Aeson.object ["device_code" .= device.deviceCode])
-                    gatewayPollDecoder
+                pollGatewayAuthorizationAndSave baseUrl device.deviceCode
                     >>= either failText pure
             case result of
-                GatewayAuthorized accessToken websocketUrl ->
-                    pure
-                        GatewayCredential
-                            { gatewayBaseUrl = baseUrl
-                            , gatewayWebSocketUrl = websocketUrl
-                            , gatewayAccessToken = accessToken
-                            }
+                GatewayAuthorized _ _ -> pure ()
                 GatewayAuthorizationPending serverInterval ->
                     let next = maybe interval (max 1) serverInterval
                      in go (remaining - next) next
@@ -246,13 +251,101 @@ pollUntilAuthorized manager baseUrl device =
                 GatewayPollFailed code ->
                     failText ("Gateway authorization failed: " <> code)
 
+-- | Start device authorization without opening a browser or beginning a poll
+-- loop. This is the primitive used by native GUI clients.
+startGatewayAuthorization
+    :: Text
+    -> Text
+    -> IO (Either Text GatewayDeviceAuthorization)
+startGatewayAuthorization rawBaseUrl rawClientName =
+    case validateBaseUrl rawBaseUrl of
+        Left err -> pure (Left err)
+        Right baseUrl
+            | Text.null clientName ->
+                pure (Left "Gateway client name cannot be empty.")
+            | otherwise -> do
+                manager <- newTlsManager
+                postJson manager
+                    (baseUrl <> "/api/v1/agent-connections/device")
+                    (Aeson.object ["client_name" .= clientName])
+                    >>= \case
+                        Left err -> pure (Left err)
+                        Right authorization ->
+                            pure $
+                                validateGatewayDeviceAuthorization
+                                    baseUrl
+                                    authorization
+  where
+    clientName = Text.strip rawClientName
+
+-- | Perform one device-token poll. Callers must not expose the authorized
+-- token outside the trusted runtime; native clients should use
+-- 'pollGatewayAuthorizationAndSave' instead.
+pollGatewayAuthorization
+    :: Text
+    -> Text
+    -> IO (Either Text GatewayPollResult)
+pollGatewayAuthorization rawBaseUrl rawDeviceCode =
+    case validateBaseUrl rawBaseUrl of
+        Left err -> pure (Left err)
+        Right baseUrl
+            | Text.null deviceCode ->
+                pure (Left "Gateway device code cannot be empty.")
+            | otherwise -> do
+                manager <- newTlsManager
+                postJson manager
+                    (baseUrl <> "/api/v1/agent-connections/token")
+                    (Aeson.object ["device_code" .= deviceCode])
+  where
+    deviceCode = Text.strip rawDeviceCode
+
+-- | Poll once and atomically persist an authorized credential. The result is
+-- still useful to trusted Haskell callers, but the native ABI intentionally
+-- maps authorization to a status code and never returns either secret field.
+pollGatewayAuthorizationAndSave
+    :: Text
+    -> Text
+    -> IO (Either Text GatewayPollResult)
+pollGatewayAuthorizationAndSave rawBaseUrl deviceCode = do
+    let validatedBaseUrl = validateBaseUrl rawBaseUrl
+    case validatedBaseUrl of
+        Left err -> pure (Left err)
+        Right baseUrl ->
+            pollGatewayAuthorization baseUrl deviceCode >>= \case
+                Left err -> pure (Left err)
+                Right authorized@(GatewayAuthorized accessToken websocketUrl) ->
+                    case validateGatewayCredential GatewayCredential
+                        { gatewayBaseUrl = baseUrl
+                        , gatewayWebSocketUrl = websocketUrl
+                        , gatewayAccessToken = accessToken
+                        } of
+                        Left err -> pure (Left err)
+                        Right credential -> do
+                            home <- Directory.getHomeDirectory
+                            saveGatewayCredentialAt home credential
+                                >>= \case
+                                    Left err -> pure (Left err)
+                                    Right () -> pure (Right authorized)
+                Right result -> pure (Right result)
+
+removeGatewayCredential :: IO (Either Text ())
+removeGatewayCredential = do
+    home <- Directory.getHomeDirectory
+    let path = gatewayCredentialPath home
+    result <- tryAny do
+        exists <- Directory.doesFileExist path
+        when exists (Directory.removeFile path)
+    pure case result of
+        Left exception -> Left (Text.pack (show exception))
+        Right () -> Right ()
+
 postJson
-    :: HTTP.Manager
+    :: Aeson.FromJSON value
+    => HTTP.Manager
     -> Text
     -> Aeson.Value
-    -> Hermes.Decoder value
     -> IO (Either Text value)
-postJson manager url payload decoder = do
+postJson manager url payload = do
     parsed <- tryAny (HTTP.parseRequest (Text.unpack url))
     case parsed of
         Left exception -> pure (Left (Text.pack (show exception)))
@@ -270,27 +363,148 @@ postJson manager url payload decoder = do
             pure case response of
                 Left exception -> Left (Text.pack (show exception))
                 Right value ->
-                    case Hermes.decodeEither decoder (LBS.toStrict (HTTP.responseBody value)) of
-                        Left err -> Left (Hermes.jsonErrorMessage err)
+                    case Aeson.eitherDecode (HTTP.responseBody value) of
+                        Left err -> Left (Text.pack err)
                         Right decoded -> Right decoded
 
 validateBaseUrl :: Text -> Either Text Text
 validateBaseUrl raw
     | Text.null base = Left "Gateway URL cannot be empty."
-    | "https://" `Text.isPrefixOf` lower = Right base
-    | any localOrigin
-        [ "http://127.0.0.1"
-        , "http://localhost"
-        , "http://[::1]"
-        ] = Right base
-    | otherwise = Left "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
+    | otherwise =
+        case URI.parseURI (Text.unpack base) of
+            Just uri
+                | validUri uri
+                , scheme uri == "https:" ->
+                    Right base
+                | validUri uri
+                , scheme uri == "http:"
+                , Just authority <- URI.uriAuthority uri
+                , host authority `elem` localHosts ->
+                    Right base
+            _ -> invalid
   where
     base = Text.dropWhileEnd (== '/') (Text.strip raw)
-    lower = Text.toLower base
-    localOrigin origin =
-        lower == origin
-            || (origin <> ":") `Text.isPrefixOf` lower
-            || (origin <> "/") `Text.isPrefixOf` lower
+    invalid =
+        Left "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
+    scheme = Text.toLower . Text.pack . URI.uriScheme
+    host = Text.toLower . Text.pack . URI.uriRegName
+    localHosts = ["localhost", "127.0.0.1", "[::1]"]
+    validUri uri =
+        null (URI.uriQuery uri)
+            && null (URI.uriFragment uri)
+            && case URI.uriAuthority uri of
+                Nothing -> False
+                Just authority ->
+                    null (URI.uriUserInfo authority)
+                        && not (null (URI.uriRegName authority))
+                        && validPort (URI.uriPort authority)
+    validPort "" = True
+    validPort (':' : digits) =
+        not (null digits)
+            && all isDigit digits
+            && case readMaybe digits of
+                Just port -> port > (0 :: Int) && port <= 65535
+                Nothing -> False
+    validPort _ = False
+
+-- | Reject corrupted or tampered credential files before they affect model
+-- discovery or send a bearer token to an unrelated WebSocket origin.
+validateGatewayCredential
+    :: GatewayCredential
+    -> Either Text GatewayCredential
+validateGatewayCredential credential = do
+    baseUrl <- validateBaseUrl credential.gatewayBaseUrl
+    when
+        (Text.null (Text.strip credential.gatewayAccessToken))
+        (Left "The gateway credential contains an empty access token.")
+    validateGatewayWebSocketUrl credential.gatewayWebSocketUrl
+    baseOrigin <-
+        parseOrigin
+            "The gateway credential contains an invalid base URL."
+            baseUrl
+    websocketOrigin <-
+        parseOrigin
+            "The gateway credential contains an invalid WebSocket URL."
+            credential.gatewayWebSocketUrl
+    let expectedWebSocketScheme = case baseOrigin of
+            ("https:", _, _) -> "wss:"
+            ("http:", _, _) -> "ws:"
+            _ -> ""
+        (_, baseHost, basePort) = baseOrigin
+        (websocketScheme, websocketHost, websocketPort) = websocketOrigin
+    if websocketScheme == expectedWebSocketScheme
+        && websocketHost == baseHost
+        && websocketPort == basePort
+        then Right credential { gatewayBaseUrl = baseUrl }
+        else
+            Left
+                "The gateway credential WebSocket URL uses a different origin."
+
+-- | Ensure an authorization response cannot make a native or CLI client open
+-- an unrelated website, local file, or custom URL scheme. The verification
+-- URLs must be absolute and share the validated gateway's origin.
+validateGatewayDeviceAuthorization
+    :: Text
+    -> GatewayDeviceAuthorization
+    -> Either Text GatewayDeviceAuthorization
+validateGatewayDeviceAuthorization baseUrl authorization
+    | Text.null (Text.strip authorization.deviceCode) =
+        Left "The gateway returned an empty device code."
+    | Text.null (Text.strip authorization.userCode) =
+        Left "The gateway returned an empty user code."
+    | authorization.expiresInSeconds <= 0 =
+        Left "The gateway returned an invalid authorization expiry."
+    | authorization.pollIntervalSeconds <= 0 =
+        Left "The gateway returned an invalid polling interval."
+    | otherwise = do
+        gatewayOrigin <-
+            parseOrigin
+                "The gateway URL is invalid."
+                baseUrl
+        verificationOrigin <-
+            parseOrigin
+                "The gateway returned an invalid verification URL."
+                authorization.verificationUri
+        completeOrigin <-
+            parseOrigin
+                "The gateway returned an invalid complete verification URL."
+                authorization.verificationUriComplete
+        if verificationOrigin == gatewayOrigin
+            && completeOrigin == gatewayOrigin
+            then Right authorization
+            else
+                Left
+                    "The gateway returned a verification URL for a different origin."
+
+parseOrigin :: Text -> Text -> Either Text (Text, Text, Int)
+parseOrigin errorMessage raw = do
+    uri <- maybe (Left errorMessage) Right $
+        URI.parseURI (Text.unpack (Text.strip raw))
+    authority <- maybe (Left errorMessage) Right (URI.uriAuthority uri)
+    let scheme = Text.toLower (Text.pack (URI.uriScheme uri))
+        host = Text.toLower (Text.pack (URI.uriRegName authority))
+    if null (URI.uriUserInfo authority)
+        && not (Text.null host)
+        && null (URI.uriFragment uri)
+        then do
+            port <- originPort errorMessage scheme (URI.uriPort authority)
+            pure (scheme, host, port)
+        else Left errorMessage
+
+originPort :: Text -> Text -> String -> Either Text Int
+originPort _ "https:" "" = Right 443
+originPort _ "http:" "" = Right 80
+originPort _ "wss:" "" = Right 443
+originPort _ "ws:" "" = Right 80
+originPort _ scheme (':' : digits)
+    | scheme `elem` ["https:", "http:", "wss:", "ws:"]
+    , not (null digits)
+    , all isDigit digits
+    , Just port <- readMaybe digits
+    , port > 0
+    , port <= (65535 :: Int) =
+        Right port
+originPort errorMessage _ _ = Left errorMessage
 
 openBrowser :: Text -> IO Bool
 openBrowser url = do

--- a/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
@@ -1,0 +1,302 @@
+-- | HTTPS device authorization and restricted gateway credential storage.
+module Agent.CLI.GatewayClient
+    ( GatewayCredential(..)
+    , GatewayDeviceAuthorization(..)
+    , GatewayPollResult(..)
+    , connectGateway
+    , disconnectGateway
+    , gatewayCredentialPath
+    , gatewayDeviceDecoder
+    , gatewayPollDecoder
+    , loadGatewayCredential
+    , loadGatewayCredentialAt
+    , runGatewayCommand
+    , saveGatewayCredentialAt
+    , showGatewayStatus
+    ) where
+
+import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
+import Agent.CLI.Options (GatewayCommand (..))
+import Agent.Json.Decode qualified as Hermes
+import Agent.OsPath (unsafeToFilePath)
+import Control.Concurrent (threadDelay)
+import Control.Exception.Safe (tryAny)
+import Control.Monad (when)
+import Data.Aeson ((.=))
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Types (hContentType)
+import System.Directory.OsPath qualified as Directory
+import System.Exit (ExitCode (..))
+import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
+import System.Posix.Files (setFileMode)
+import System.Process (rawSystem)
+
+data GatewayCredential = GatewayCredential
+    { gatewayBaseUrl :: !Text
+    , gatewayWebSocketUrl :: !Text
+    , gatewayAccessToken :: !Text
+    }
+    deriving (Eq)
+
+instance Show GatewayCredential where
+    show credential =
+        "GatewayCredential { gatewayBaseUrl = "
+            <> show credential.gatewayBaseUrl
+            <> ", gatewayWebSocketUrl = "
+            <> show credential.gatewayWebSocketUrl
+            <> ", gatewayAccessToken = <redacted> }"
+
+instance Aeson.ToJSON GatewayCredential where
+    toJSON credential =
+        Aeson.object
+            [ "version" .= (1 :: Int)
+            , "base_url" .= credential.gatewayBaseUrl
+            , "websocket_url" .= credential.gatewayWebSocketUrl
+            , "access_token" .= credential.gatewayAccessToken
+            ]
+
+gatewayCredentialDecoder :: Hermes.Decoder GatewayCredential
+gatewayCredentialDecoder =
+    Hermes.object $
+        GatewayCredential
+            <$> Hermes.atKey "base_url" Hermes.text
+            <*> Hermes.atKey "websocket_url" Hermes.text
+            <*> Hermes.atKey "access_token" Hermes.text
+
+data GatewayDeviceAuthorization = GatewayDeviceAuthorization
+    { deviceCode :: !Text
+    , userCode :: !Text
+    , verificationUri :: !Text
+    , verificationUriComplete :: !Text
+    , expiresInSeconds :: !Int
+    , pollIntervalSeconds :: !Int
+    }
+    deriving (Eq, Show)
+
+gatewayDeviceDecoder :: Hermes.Decoder GatewayDeviceAuthorization
+gatewayDeviceDecoder =
+    Hermes.object $
+        GatewayDeviceAuthorization
+            <$> Hermes.atKey "device_code" Hermes.text
+            <*> Hermes.atKey "user_code" Hermes.text
+            <*> Hermes.atKey "verification_uri" Hermes.text
+            <*> Hermes.atKey "verification_uri_complete" Hermes.text
+            <*> Hermes.atKey "expires_in" Hermes.int
+            <*> Hermes.atKey "interval" Hermes.int
+
+data GatewayPollResult
+    = GatewayAuthorized !Text !Text
+    | GatewayAuthorizationPending !(Maybe Int)
+    | GatewaySlowDown !(Maybe Int)
+    | GatewayAccessDenied
+    | GatewayExpired
+    | GatewayPollFailed !Text
+    deriving (Eq, Show)
+
+gatewayPollDecoder :: Hermes.Decoder GatewayPollResult
+gatewayPollDecoder =
+    Hermes.withRawJsonByteString \raw ->
+        case Hermes.decodeEither successDecoder raw of
+            Right (token, websocketUrl) ->
+                pure (GatewayAuthorized token websocketUrl)
+            Left _ -> case Hermes.decodeEither errorDecoder raw of
+                Right (code, interval) -> pure case code of
+                    "authorization_pending" -> GatewayAuthorizationPending interval
+                    "slow_down" -> GatewaySlowDown interval
+                    "access_denied" -> GatewayAccessDenied
+                    "expired_token" -> GatewayExpired
+                    other -> GatewayPollFailed other
+                Left err -> fail (Text.unpack (Hermes.jsonErrorMessage err))
+  where
+    successDecoder =
+        Hermes.object $
+            (,)
+                <$> Hermes.atKey "access_token" Hermes.text
+                <*> Hermes.atKey "websocket_url" Hermes.text
+    errorDecoder =
+        Hermes.object $
+            (,)
+                <$> Hermes.atKey "error" Hermes.text
+                <*> Hermes.optionalKey "interval" Hermes.int
+
+gatewayCredentialPath :: OsPath -> OsPath
+gatewayCredentialPath home =
+    home
+        </> unsafeEncodeUtf ".haskell-agent"
+        </> unsafeEncodeUtf "credentials"
+        </> unsafeEncodeUtf "gateway.json"
+
+loadGatewayCredential :: IO (Either Text (Maybe GatewayCredential))
+loadGatewayCredential = do
+    home <- Directory.getHomeDirectory
+    loadGatewayCredentialAt home
+
+loadGatewayCredentialAt
+    :: OsPath
+    -> IO (Either Text (Maybe GatewayCredential))
+loadGatewayCredentialAt home = do
+    let path = gatewayCredentialPath home
+    exists <- Directory.doesFileExist path
+    if not exists
+        then pure (Right Nothing)
+        else do
+            result <-
+                retryOnFileBusy $
+                    tryAny (LBS.readFile (unsafeToFilePath path))
+            pure case result of
+                Left exception -> Left (Text.pack (show exception))
+                Right bytes ->
+                    case Hermes.decodeEither gatewayCredentialDecoder (LBS.toStrict bytes) of
+                        Left err -> Left (Hermes.jsonErrorMessage err)
+                        Right credential -> Right (Just credential)
+
+saveGatewayCredentialAt :: OsPath -> GatewayCredential -> IO (Either Text ())
+saveGatewayCredentialAt home credential = do
+    let path = gatewayCredentialPath home
+        directory = takeDirectory path
+    result <- tryAny do
+        Directory.createDirectoryIfMissing True directory
+        setFileMode (unsafeToFilePath directory) 0o700
+        writeLazyFileAtomically path 0o600 (Aeson.encode credential)
+    pure case result of
+        Left exception -> Left (Text.pack (show exception))
+        Right () -> Right ()
+
+connectGateway :: Text -> IO ()
+connectGateway rawBaseUrl = do
+    baseUrl <- either failText pure (validateBaseUrl rawBaseUrl)
+    manager <- newTlsManager
+    device <-
+        postJson manager (baseUrl <> "/api/v1/agent-connections/device")
+            (Aeson.object ["client_name" .= ("haskell-agent" :: Text)])
+            gatewayDeviceDecoder
+            >>= either failText pure
+    putStrLn ("Enter code " <> Text.unpack device.userCode <> " at:")
+    putStrLn (Text.unpack device.verificationUri)
+    opened <- openBrowser device.verificationUriComplete
+    when (not opened) $
+        putStrLn "Could not open a browser automatically."
+    credential <- pollUntilAuthorized manager baseUrl device
+    home <- Directory.getHomeDirectory
+    saveGatewayCredentialAt home credential >>= either failText pure
+    putStrLn "Gateway connection saved."
+
+showGatewayStatus :: IO ()
+showGatewayStatus =
+    loadGatewayCredential >>= \case
+        Left err -> failText err
+        Right Nothing -> putStrLn "Not connected to a gateway."
+        Right (Just credential) -> do
+            putStrLn ("Connected to " <> Text.unpack credential.gatewayBaseUrl)
+            putStrLn ("Responses WebSocket: " <> Text.unpack credential.gatewayWebSocketUrl)
+
+disconnectGateway :: IO ()
+disconnectGateway = do
+    home <- Directory.getHomeDirectory
+    let path = gatewayCredentialPath home
+    exists <- Directory.doesFileExist path
+    when exists (Directory.removeFile path)
+    putStrLn "Gateway connection removed."
+
+runGatewayCommand :: GatewayCommand -> IO ()
+runGatewayCommand = \case
+    GatewayConnect url -> connectGateway url
+    GatewayStatus -> showGatewayStatus
+    GatewayDisconnect -> disconnectGateway
+
+pollUntilAuthorized
+    :: HTTP.Manager
+    -> Text
+    -> GatewayDeviceAuthorization
+    -> IO GatewayCredential
+pollUntilAuthorized manager baseUrl device =
+    go device.expiresInSeconds (max 1 device.pollIntervalSeconds)
+  where
+    go remaining interval
+        | remaining <= 0 = failText "Gateway authorization expired."
+        | otherwise = do
+            threadDelay (interval * 1_000_000)
+            result <-
+                postJson manager (baseUrl <> "/api/v1/agent-connections/token")
+                    (Aeson.object ["device_code" .= device.deviceCode])
+                    gatewayPollDecoder
+                    >>= either failText pure
+            case result of
+                GatewayAuthorized accessToken websocketUrl ->
+                    pure
+                        GatewayCredential
+                            { gatewayBaseUrl = baseUrl
+                            , gatewayWebSocketUrl = websocketUrl
+                            , gatewayAccessToken = accessToken
+                            }
+                GatewayAuthorizationPending serverInterval ->
+                    let next = maybe interval (max 1) serverInterval
+                     in go (remaining - next) next
+                GatewaySlowDown serverInterval ->
+                    let next = maybe (interval + 5) (max (interval + 1)) serverInterval
+                     in go (remaining - next) next
+                GatewayAccessDenied -> failText "Gateway authorization was denied."
+                GatewayExpired -> failText "Gateway authorization expired."
+                GatewayPollFailed code ->
+                    failText ("Gateway authorization failed: " <> code)
+
+postJson
+    :: HTTP.Manager
+    -> Text
+    -> Aeson.Value
+    -> Hermes.Decoder value
+    -> IO (Either Text value)
+postJson manager url payload decoder = do
+    parsed <- tryAny (HTTP.parseRequest (Text.unpack url))
+    case parsed of
+        Left exception -> pure (Left (Text.pack (show exception)))
+        Right initial -> do
+            response <-
+                tryAny $
+                    HTTP.httpLbs
+                        initial
+                            { HTTP.method = "POST"
+                            , HTTP.requestHeaders = [(hContentType, "application/json")]
+                            , HTTP.requestBody = HTTP.RequestBodyLBS (Aeson.encode payload)
+                            , HTTP.checkResponse = \_ _ -> pure ()
+                            }
+                        manager
+            pure case response of
+                Left exception -> Left (Text.pack (show exception))
+                Right value ->
+                    case Hermes.decodeEither decoder (LBS.toStrict (HTTP.responseBody value)) of
+                        Left err -> Left (Hermes.jsonErrorMessage err)
+                        Right decoded -> Right decoded
+
+validateBaseUrl :: Text -> Either Text Text
+validateBaseUrl raw
+    | Text.null base = Left "Gateway URL cannot be empty."
+    | "https://" `Text.isPrefixOf` lower = Right base
+    | any (`Text.isPrefixOf` lower)
+        [ "http://127.0.0.1"
+        , "http://localhost"
+        , "http://[::1]"
+        ] = Right base
+    | otherwise = Left "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
+  where
+    base = Text.dropWhileEnd (== '/') (Text.strip raw)
+    lower = Text.toLower base
+
+openBrowser :: Text -> IO Bool
+openBrowser url = do
+    result <- tryAny (rawSystem "open" [Text.unpack url])
+    case result of
+        Right ExitSuccess -> pure True
+        _ -> do
+            fallback <- tryAny (rawSystem "xdg-open" [Text.unpack url])
+            pure case fallback of
+                Right ExitSuccess -> True
+                _ -> False
+
+failText :: Text -> IO a
+failText = ioError . userError . Text.unpack

--- a/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
@@ -1,0 +1,96 @@
+-- | Canonical model aliases exposed by the Digitally Induced LLM gateway.
+--
+-- Gateway credentials are process-wide, so the active catalog is deliberately
+-- exclusive: direct provider models disappear while connected and gateway
+-- aliases disappear while disconnected. This prevents a direct model id from
+-- being sent to the gateway (or a router alias from reaching a provider).
+module Agent.CLI.GatewayModels
+    ( catalogForGatewayState
+    , catalogUsesGateway
+    , gatewayDefaultModelId
+    , gatewayModelIds
+    , isGatewayModelId
+    , loadGatewayModelCatalogAt
+    ) where
+
+import Agent.CLI.GatewayClient (loadGatewayCredentialAt)
+import Agent.CLI.ModelConfig
+    ( CatalogModel(..)
+    , ModelCatalog(..)
+    , builtinConnectionId
+    , loadModelCatalogAt
+    )
+import Agent.Dialect (DialectId (CodexDialect))
+import Agent.Provider (Provider (OpenAIProvider))
+import Data.Text (Text)
+import System.OsPath (OsPath)
+
+gatewayDefaultModelId :: Text
+gatewayDefaultModelId = "router-default"
+
+gatewayModelIds :: [Text]
+gatewayModelIds =
+    [ gatewayDefaultModelId
+    , "router-codex"
+    , "router-grok"
+    ]
+
+isGatewayModelId :: Text -> Bool
+isGatewayModelId modelId = modelId `elem` gatewayModelIds
+
+catalogUsesGateway :: ModelCatalog -> Bool
+catalogUsesGateway catalog =
+    not (null catalog.catalogModels)
+        && all (isGatewayModelId . (.catalogModelId)) catalog.catalogModels
+
+catalogForGatewayState :: Bool -> ModelCatalog -> ModelCatalog
+catalogForGatewayState connected catalog
+    | connected = catalog { catalogModels = canonicalGatewayModels }
+    | otherwise =
+        catalog
+            { catalogModels =
+                filter
+                    (not . isGatewayModelId . (.catalogModelId))
+                    catalog.catalogModels
+            }
+
+loadGatewayModelCatalogAt
+    :: OsPath
+    -> OsPath
+    -> IO (Either Text ModelCatalog)
+loadGatewayModelCatalogAt home cwd =
+    loadModelCatalogAt home cwd >>= \case
+        Left err -> pure (Left err)
+        Right catalog ->
+            loadGatewayCredentialAt home >>= \case
+                Left err ->
+                    pure (Left ("cannot load gateway credential: " <> err))
+                Right credential ->
+                    pure
+                        (Right
+                            (catalogForGatewayState
+                                (maybe False (const True) credential)
+                                catalog))
+
+canonicalGatewayModels :: [CatalogModel]
+canonicalGatewayModels =
+    [ gatewayModel gatewayDefaultModelId "Gateway · Default" True
+    , gatewayModel "router-codex" "Gateway · Codex" False
+    , gatewayModel "router-grok" "Gateway · Grok" False
+    ]
+
+gatewayModel :: Text -> Text -> Bool -> CatalogModel
+gatewayModel modelId label isDefault =
+    CatalogModel
+        { catalogModelId = modelId
+        , catalogModelConnectionId = builtinConnectionId OpenAIProvider
+        , catalogModelWireId = modelId
+        , catalogModelDialect = CodexDialect
+        , catalogModelContextWindow = Nothing
+        , catalogModelLabel = Just label
+        , catalogModelReasoningEfforts =
+            Just ["low", "medium", "high", "xhigh", "max"]
+        , catalogModelDefaultReasoningEffort = Just "medium"
+        , catalogModelDefault = isDefault
+        , catalogModelFallbackPriority = Nothing
+        }

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -583,6 +583,8 @@ usage :: String
 usage = unlines
     [ "Usage: agent-cli [OPTIONS]"
     , "       agent-cli login"
+    , "       agent-cli gateway connect --url <https-url>"
+    , "       agent-cli gateway <status|disconnect>"
     , "       agent-cli sessions [list]"
     , "       agent-cli sessions show <session-id> [--json]"
     , "              [--limit N] [--before TURN_INDEX]"

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Options
     , ApprovalPolicy(..)
     , CliOptions(..)
     , Command(..)
+    , GatewayCommand(..)
     , ScreenMode(..)
     , SessionOutputFormat(..)
     , SessionPageRequest(..)
@@ -34,12 +35,19 @@ data Command
     = ShowHelp
     | ShowVersion
     | Login
+    | Gateway GatewayCommand
     | ListSessions SessionOutputFormat
     | ShowSession Text SessionOutputFormat (Maybe SessionPageRequest)
     | WaitSession Text
     | ImportSession (Maybe OsPath)
     | Storage StorageCommand
     | RunAgent CliOptions
+    deriving (Eq, Show)
+
+data GatewayCommand
+    = GatewayConnect Text
+    | GatewayStatus
+    | GatewayDisconnect
     deriving (Eq, Show)
 
 data SessionPageRequest
@@ -208,7 +216,7 @@ parseArgs args
 
 isRunInvocation :: [String] -> Bool
 isRunInvocation = \case
-    command : _ -> command `notElem` ["login", "sessions", "storage"]
+    command : _ -> command `notElem` ["gateway", "login", "sessions", "storage"]
     [] -> True
 
 parserPreferences :: Options.ParserPrefs
@@ -257,6 +265,9 @@ commandParser =
         ( Options.command "login"
             (Options.info (pure Login)
                 (Options.progDesc "Manage provider credentials"))
+            <> Options.command "gateway"
+                (Options.info gatewayParser
+                    (Options.progDesc "Connect this agent to an LLM gateway"))
             <> Options.command "sessions"
                 (Options.info sessionsParser
                     (Options.progDesc "Administer persisted sessions"))
@@ -265,6 +276,25 @@ commandParser =
                     (Options.progDesc "Administer managed PostgreSQL storage"))
         )
         Options.<|> (RunAgent <$> runOptionsParser)
+
+gatewayParser :: Options.Parser Command
+gatewayParser = Gateway <$> Options.hsubparser
+    ( Options.command "connect"
+        (Options.info
+            (GatewayConnect . Text.pack
+                <$> Options.strOption
+                    ( Options.long "url"
+                        <> Options.metavar "HTTPS_URL"
+                        <> Options.help "Gateway base URL"
+                    ))
+            (Options.progDesc "Authorize this installation with a gateway user"))
+    <> Options.command "status"
+        (Options.info (pure GatewayStatus)
+            (Options.progDesc "Show the connected gateway"))
+    <> Options.command "disconnect"
+        (Options.info (pure GatewayDisconnect)
+            (Options.progDesc "Remove the saved gateway credential"))
+    )
 
 sessionsParser :: Options.Parser Command
 sessionsParser =

--- a/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
@@ -53,7 +53,10 @@ data OpenAiPersistentConnection
 -- its continuation because the active WebSocket is not multiplexed and
 -- transcript mutation must not interleave between those two requests.
 lockedOpenAiSession
-    :: Maybe Int
+    :: Bool
+    -- ^ When true, every model and compaction request must remain on the
+    -- gateway WebSocket; direct provider HTTP fallback is forbidden.
+    -> Maybe Int
     -> Bool
     -> MVar ()
     -> IORef Bool
@@ -64,7 +67,7 @@ lockedOpenAiSession
     -> (TokenUsage -> IO ())
     -> IO ()
     -> (OpenAiCompactionSender, Backend)
-lockedOpenAiSession compactThreshold showRawReasoning wsLock fallbackActive
+lockedOpenAiSession gatewayOnly compactThreshold showRawReasoning wsLock fallbackActive
         provider activeConnection getParams contextTokens
         recordCompactionUsage onCompacted =
     let sendResponse request previousResponseId onEvent = do
@@ -122,20 +125,24 @@ lockedOpenAiSession compactThreshold showRawReasoning wsLock fallbackActive
                 getParams
         baseBackend =
             withConnectionRecovery $
-                openAiBackendWithTransportFallback
-                    fallbackActive
-                    websocketBackend
-                    httpFallbackBackend
+                if gatewayOnly
+                    then websocketBackend
+                    else
+                        openAiBackendWithTransportFallback
+                            fallbackActive
+                            websocketBackend
+                            httpFallbackBackend
         compactSender request = do
             active <- readIORef fallbackActive
-            if active
+            if active && not gatewayOnly
                 then sendHttpCompaction request
                 else do
                     result <-
                         sendAuxiliary request Nothing (const (pure ()))
                     case result of
                         Left err
-                            | isOpenAiWebSocketTransportFailure err -> do
+                            | not gatewayOnly
+                            , isOpenAiWebSocketTransportFailure err -> do
                                 writeIORef fallbackActive True
                                 sendHttpCompaction request
                         _ -> pure result

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -39,8 +39,8 @@ import Agent.CLI.Error
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , builtinConnectionId
-    , loadModelCatalogAt
     )
+import Agent.CLI.GatewayModels (loadGatewayModelCatalogAt)
 import Agent.CLI.Models
     ( ModelOption(..)
     , ModelTarget(..)
@@ -514,7 +514,7 @@ continueAutomaticFallback cwdHint stderrHandle fullscreen failed apiError =
         (Just billing, Just pending) -> do
             home <- getHomeDirectory
             cwd <- maybe getCurrentDirectory pure cwdHint
-            loadModelCatalogAt home cwd >>= \case
+            loadGatewayModelCatalogAt home cwd >>= \case
                 Left _ -> pure Nothing
                 Right catalog ->
                     chooseAutomaticProviderTransition

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -23,6 +23,7 @@ module Agent.CLI.Runtime.Internal
 
 import Agent.CLI.AgentSessions
     ( closeSessionThreadManager, newSessionThreadManager )
+import Agent.CLI.GatewayClient (runGatewayCommand)
 import Agent.CLI.Interrupt ( catchUserInterrupt )
 import Agent.CLI.Login ( runLoginManager )
 import Agent.CLI.McpStatus
@@ -129,6 +130,7 @@ devMainResume resumeId = do
             color <- resolveColor stderr
             runLoginManager color
             pure DevQuit
+        Right (Gateway command) -> runGatewayCommand command >> pure DevQuit
         Right (ListSessions outputFormat) ->
             runListSessions outputFormat >> pure DevQuit
         Right (ShowSession sessionId outputFormat pageRequest) ->
@@ -153,6 +155,7 @@ run = do
         Right Login -> do
             color <- resolveColor stderr
             runLoginManager color
+        Right (Gateway command) -> runGatewayCommand command
         Right (ListSessions outputFormat) ->
             runListSessions outputFormat
         Right (ShowSession sessionId outputFormat pageRequest) ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -286,6 +286,7 @@ import Agent.OpenAI.WebSocketClient
     ( CodexAuthFailed(..),
       closeCodexConn,
       codexConnTurnState,
+      isGatewayWebSocketCredential,
       resetCodexTurnState,
       withCodexWsCredential,
       withCodexWsWithProvider )
@@ -2411,12 +2412,16 @@ runAgentInitializedWithLock
                                     Just ctx ->
                                         setSubagentRunner ctx.multiRegistry $
                                             runCodexSubagent
+                                                (isGatewayWebSocketCredential
+                                                    credential)
                                                 subagentRuntime
                                                 selectableTokenProvider
                                                 ctx.multiSendToRoot
                                     Nothing -> pure ()
                                 let (compactSender, lockedBackend) =
                                         lockedOpenAiSession
+                                            (isGatewayWebSocketCredential
+                                                credential)
                                             options.optCompactThreshold
                                             options.optShowRawReasoning
                                             wsLock

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -48,6 +48,12 @@ import Agent.CLI.Dialects
       filterGhciTools )
 import Agent.CLI.Error ( formatApiErrorAt, formatException )
 import Agent.CLI.GatewayBridge ( managedGatewayTools )
+import Agent.CLI.GatewayModels
+    ( catalogUsesGateway
+    , gatewayDefaultModelId
+    , isGatewayModelId
+    , loadGatewayModelCatalogAt
+    )
 import Agent.CLI.Input ()
 import Agent.CLI.Interrupt
     ( CtrlCDecision(..),
@@ -73,8 +79,7 @@ import Agent.CLI.ModelConfig
       ResponsesConnection(..),
       builtinConnectionId,
       catalogConnection,
-      catalogContextWindowForTransport,
-      loadModelCatalogAt )
+      catalogContextWindowForTransport )
 import Agent.CLI.Models
     ( defaultModelFor,
       rawModelOption,
@@ -1060,7 +1065,7 @@ runAgentInitializedWithLock
         concurrently
             (loadProjectSettings projectRoot)
             (concurrently
-                (loadModelCatalogAt home cwd)
+                (loadGatewayModelCatalogAt home cwd)
                 (detectGitBranch cwd))
     catalog <- either
         (startupDie startup . Text.unpack)
@@ -1068,13 +1073,17 @@ runAgentInitializedWithLock
         catalogResult
     setStartupRepository fullscreen home branch cwd
     markStartupStage startup "Loading credentials…"
-    let transitionTarget = (.transitionTarget) <$> transition
+    let gatewayMode = catalogUsesGateway catalog
+        transitionTarget = (.transitionTarget) <$> transition
         pendingTurn = transition >>= (.transitionPendingTurn)
         unavailableProviders =
             maybe [] (.transitionUnavailableProviders) transition
         configuredOptionTarget =
             (.modelTarget)
                 <$> (options.optModel >>= resolveConfiguredModel catalog)
+        gatewayDefaultTarget =
+            (.modelTarget)
+                <$> resolveConfiguredModel catalog gatewayDefaultModelId
         savedTarget provider connection model transport dialect =
             case resolveConfiguredModel catalog model of
                 Just option
@@ -1095,10 +1104,14 @@ runAgentInitializedWithLock
                                 <> connection <> "/" <> model
                                 <> " is not present in ~/.haskell-agent/models.json"
         resumedTargetResult
+            | gatewayMode =
+                Right Nothing
             | isJust transitionTarget || isJust options.optModel =
                 Right Nothing
             | otherwise = case fst <$> resumed of
             Nothing -> Right Nothing
+            Just meta
+                | isGatewayModelId meta.metaModel -> Right Nothing
             Just meta ->
                 Just <$> savedTarget
                     meta.metaProvider
@@ -1107,6 +1120,8 @@ runAgentInitializedWithLock
                     meta.metaTransportModel
                     meta.metaDialect
         projectTargetResult
+            | gatewayMode =
+                Right Nothing
             | isJust transitionTarget
                 || isJust options.optModel
                 || isJust resumed =
@@ -1115,24 +1130,59 @@ runAgentInitializedWithLock
             Nothing -> Right Nothing
             Just remembered ->
                 let target = remembered.projectModelTarget
-                in
-                Just <$> savedTarget
-                    target.targetProvider
-                    target.targetConnectionId
-                    target.targetModelId
-                    (Just target.targetWireModelId)
-                    target.targetDialect
+                in if isGatewayModelId target.targetModelId
+                    then Right Nothing
+                    else
+                        Just <$> savedTarget
+                            target.targetProvider
+                            target.targetConnectionId
+                            target.targetModelId
+                            (Just target.targetWireModelId)
+                            target.targetDialect
+    when
+        ( gatewayMode
+            && isJust options.optModel
+            && isNothing configuredOptionTarget
+        ) $
+        startupDie startup
+            "the connected gateway accepts router-default, router-codex, or \
+            \router-grok; direct provider model ids are unavailable"
+    when
+        ( not gatewayMode
+            && maybe False isGatewayModelId options.optModel
+        ) $
+        startupDie startup
+            "gateway router models require an active gateway connection"
+    when
+        ( not gatewayMode
+            && maybe
+                False
+                (isGatewayModelId . (.targetModelId))
+                transitionTarget
+        ) $
+        startupDie startup
+            "the requested gateway transition is unavailable after disconnect"
     resumedTarget <-
         either (startupDie startup . Text.unpack) pure resumedTargetResult
     projectTarget <-
         either (startupDie startup . Text.unpack) pure projectTargetResult
-    let targetHint =
-            transitionTarget
-                <|> configuredOptionTarget
-                <|> resumedTarget
-                <|> if isNothing options.optModel
-                    then projectTarget
+    let gatewayTarget candidate =
+            candidate >>= \target ->
+                if isGatewayModelId target.targetModelId
+                    then Just target
                     else Nothing
+        targetHint
+            | gatewayMode =
+                gatewayTarget transitionTarget
+                    <|> configuredOptionTarget
+                    <|> gatewayDefaultTarget
+            | otherwise =
+                transitionTarget
+                    <|> configuredOptionTarget
+                    <|> resumedTarget
+                    <|> if isNothing options.optModel
+                        then projectTarget
+                        else Nothing
         requestedProvider =
             (.targetProvider) <$> targetHint
                 <|> options.optProvider
@@ -1147,7 +1197,8 @@ runAgentInitializedWithLock
                     (connection.connectionId, responses)
                 BuiltinConnection _ -> Nothing
         checkStartupUsageInBackground =
-            isJust fullscreen
+            not gatewayMode
+                && isJust fullscreen
                 && isNothing transition
                 && isNothing resumed
                 && isNothing options.optProvider
@@ -1201,6 +1252,8 @@ runAgentInitializedWithLock
     (loaded, startupAccountIds) <- case customResponses of
         Just _ -> pure (initialLoaded, Nothing)
         Nothing
+            | gatewayMode ->
+                pure (initialLoaded, Nothing)
             | Just active <- transition
             , Just selectionId <- active.transitionAccountSelectionId ->
                 pure
@@ -1268,13 +1321,15 @@ runAgentInitializedWithLock
                                             ))
     case (transitionTarget, resumed) of
         (Just target, _)
-            | loaded.loadedProvider /= target.targetProvider ->
+            | not gatewayMode
+            , loaded.loadedProvider /= target.targetProvider ->
                 startupDie startup $ "provider transition requested "
                     <> Text.unpack (providerSlug target.targetProvider)
                     <> " but auth resolved "
                     <> Text.unpack (providerSlug loaded.loadedProvider)
         (Nothing, Just (meta, _))
-            | loaded.loadedProvider /= meta.metaProvider ->
+            | not gatewayMode
+            , loaded.loadedProvider /= meta.metaProvider ->
                 startupDie startup $ "session provider is "
                     <> Text.unpack (providerSlug meta.metaProvider)
                     <> " but auth resolved "
@@ -1495,14 +1550,7 @@ runAgentInitializedWithLock
             (maybe fallbackModel (.targetModelId) targetHint)
             options.optModel
         rawTarget = (rawModelOption provider model).modelTarget
-        inferredTarget0 =
-            fromMaybe rawTarget $
-                transitionTarget
-                    <|> configuredOptionTarget
-                    <|> resumedTarget
-                    <|> if isNothing options.optModel
-                        then projectTarget
-                        else Nothing
+        inferredTarget0 = fromMaybe rawTarget targetHint
         transportModel = case customResponses of
             Just _ ->
                 \name ->
@@ -2569,7 +2617,8 @@ runAgentInitializedWithLock
                                 startupUnavailable
                                 (Just tokenProvider)
                                 loaded.loadedOpenAiPool
-                                (if isJust customGenericOptions
+                                (if gatewayMode
+                                    || isJust customGenericOptions
                                     then Nothing
                                     else Just selectHttpAccount)
                                 compactRunner)

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -95,6 +95,7 @@ import Agent.OpenAI.WebSocketClient
     ( CodexTurnState
     , newCodexTurnState
     , sendWsRequestWithEvents
+    , sendWsRequestWithEventsPreservingTurnState
     , withCodexWsRetrying
     , withCodexWsRetryingUsingTurnState
     )
@@ -598,11 +599,13 @@ freshOpenAiBackendWithTurnState showRawReasoning turnState provider getParams =
 -- | Child Codex agent: per-agent transcript retained across follow-ups,
 -- independently scoped WebSocket requests, and nested multi-agent tools.
 runCodexSubagent
-    :: SubagentRuntime
+    :: Bool
+    -- ^ Gateway mode forbids every direct HTTP provider fallback.
+    -> SubagentRuntime
     -> TokenProvider
     -> Maybe (InterAgentMessage -> IO (Either Text Text))
     -> RunSubagent
-runCodexSubagent runtime tokenProvider sendToRoot =
+runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
     \env previous prompt onEvent -> do
         childModel <- lookupAgentModel runtime.subagentTypes env.subId
         childEffort <- lookupAgentReasoningEffort runtime.subagentTypes env.subId
@@ -689,16 +692,31 @@ runCodexSubagent runtime tokenProvider sendToRoot =
                                         turnState tokenProvider request)
                                 (pure childParams)
                         baseBackend =
-                            openAiBackendWithTransportFallback
-                                httpFallbackActive
-                                websocketBackend
-                                httpBackend
+                            if gatewayOnly
+                                then websocketBackend
+                                else
+                                    openAiBackendWithTransportFallback
+                                        httpFallbackActive
+                                        websocketBackend
+                                        httpBackend
                         compactSender request =
-                            OpenAI.createCodexMessageWithProviderWithOptionsAndTurnState
-                                OpenAI.remoteCompactionV2RequestOptions
-                                turnState
-                                tokenProvider
-                                request
+                            if gatewayOnly
+                                then
+                                    withCodexWsRetryingUsingTurnState
+                                        tokenProvider
+                                        turnState
+                                        \conn _credential ->
+                                            sendWsRequestWithEventsPreservingTurnState
+                                                conn
+                                                request
+                                                Nothing
+                                                (const (pure ()))
+                                else
+                                    OpenAI.createCodexMessageWithProviderWithOptionsAndTurnState
+                                        OpenAI.remoteCompactionV2RequestOptions
+                                        turnState
+                                        tokenProvider
+                                        request
                         compactingBackend =
                             autoCompactOpenAiBackendWithSender
                                 runtime.subagentOptions.optCompactThreshold

--- a/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
@@ -1,0 +1,43 @@
+module Agent.CLI.GatewayClientSpec (spec) where
+
+import Agent.CLI.GatewayClient
+import Agent.Json.Decode qualified as Hermes
+import Data.Text qualified as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "gateway device authorization" do
+    it "decodes the device response contract" do
+        let payload =
+                "{\"device_code\":\"had_secret\",\"user_code\":\"ABCD-1234\",\
+                \\"verification_uri\":\"https://gateway/connect/agent\",\
+                \\"verification_uri_complete\":\"https://gateway/connect/agent?user_code=ABCD-1234\",\
+                \\"expires_in\":600,\"interval\":5}"
+        Hermes.decodeEither gatewayDeviceDecoder payload
+            `shouldBe` Right
+                GatewayDeviceAuthorization
+                    { deviceCode = "had_secret"
+                    , userCode = "ABCD-1234"
+                    , verificationUri = "https://gateway/connect/agent"
+                    , verificationUriComplete =
+                        "https://gateway/connect/agent?user_code=ABCD-1234"
+                    , expiresInSeconds = 600
+                    , pollIntervalSeconds = 5
+                    }
+
+    it "decodes pending, slow-down, and successful polls" do
+        Hermes.decodeEither gatewayPollDecoder
+            "{\"error\":\"authorization_pending\",\"interval\":5}"
+            `shouldBe` Right (GatewayAuthorizationPending (Just 5))
+        Hermes.decodeEither gatewayPollDecoder
+            "{\"error\":\"slow_down\",\"interval\":10}"
+            `shouldBe` Right (GatewaySlowDown (Just 10))
+        Hermes.decodeEither gatewayPollDecoder
+            "{\"access_token\":\"secret\",\"websocket_url\":\"wss://gateway/v1/responses\"}"
+            `shouldBe` Right
+                (GatewayAuthorized "secret" "wss://gateway/v1/responses")
+
+    it "redacts the bearer credential from Show" do
+        let credential =
+                GatewayCredential "https://gateway" "wss://gateway/v1/responses" "secret"
+        show credential `shouldSatisfy` not . Text.isInfixOf "secret" . Text.pack

--- a/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
@@ -1,8 +1,8 @@
 module Agent.CLI.GatewayClientSpec (spec) where
 
 import Agent.CLI.GatewayClient
-import Agent.Json.Decode qualified as Hermes
 import Control.Exception.Safe (bracket)
+import Data.Aeson qualified as Aeson
 import Data.Bits ((.&.))
 import Data.Text qualified as Text
 import System.Directory
@@ -24,7 +24,7 @@ spec = describe "gateway device authorization" do
                 \\"verification_uri\":\"https://gateway/connect/agent\",\
                 \\"verification_uri_complete\":\"https://gateway/connect/agent?user_code=ABCD-1234\",\
                 \\"expires_in\":600,\"interval\":5}"
-        Hermes.decodeEither gatewayDeviceDecoder payload
+        Aeson.eitherDecodeStrict' payload
             `shouldBe` Right
                 GatewayDeviceAuthorization
                     { deviceCode = "had_secret"
@@ -37,28 +37,109 @@ spec = describe "gateway device authorization" do
                     }
 
     it "decodes pending, slow-down, and successful polls" do
-        Hermes.decodeEither gatewayPollDecoder
+        Aeson.eitherDecodeStrict'
             "{\"error\":\"authorization_pending\",\"interval\":5}"
             `shouldBe` Right (GatewayAuthorizationPending (Just 5))
-        Hermes.decodeEither gatewayPollDecoder
+        Aeson.eitherDecodeStrict'
             "{\"error\":\"slow_down\",\"interval\":10}"
             `shouldBe` Right (GatewaySlowDown (Just 10))
-        Hermes.decodeEither gatewayPollDecoder
+        Aeson.eitherDecodeStrict'
             "{\"access_token\":\"secret\",\"websocket_url\":\"wss://gateway/v1/responses\"}"
             `shouldBe` Right
                 (GatewayAuthorized "secret" "wss://gateway/v1/responses")
 
-    it "redacts the bearer credential from Show" do
+    it "redacts gateway secrets from Show" do
         let credential =
                 GatewayCredential "https://gateway" "wss://gateway/v1/responses" "secret"
+            authorization =
+                GatewayDeviceAuthorization
+                    { deviceCode = "device-secret"
+                    , userCode = "USER-SECRET"
+                    , verificationUri = "https://gateway/connect/agent"
+                    , verificationUriComplete =
+                        "https://gateway/connect/agent?user_code=USER-SECRET"
+                    , expiresInSeconds = 600
+                    , pollIntervalSeconds = 5
+                    }
         show credential `shouldSatisfy` not . Text.isInfixOf "secret" . Text.pack
+        let renderedAuthorization = Text.pack (show authorization)
+            renderedPoll =
+                Text.pack $
+                    show
+                        (GatewayAuthorized
+                            "secret"
+                            "wss://gateway/v1/responses")
+        renderedAuthorization
+            `shouldSatisfy` not . Text.isInfixOf "device-secret"
+        renderedAuthorization
+            `shouldSatisfy` not . Text.isInfixOf "USER-SECRET"
+        renderedPoll `shouldSatisfy` not . Text.isInfixOf "secret"
+        renderedPoll `shouldSatisfy` not . Text.isInfixOf "wss://gateway"
 
     it "allows local HTTP development without trusting lookalike hosts" do
         validateBaseUrl "http://localhost:8080"
             `shouldBe` Right "http://localhost:8080"
+        validateBaseUrl "http://[::1]:8080"
+            `shouldBe` Right "http://[::1]:8080"
         validateBaseUrl "http://localhost.example"
             `shouldBe` Left
                 "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
+        validateBaseUrl "http://localhost:8080@evil.example"
+            `shouldBe` Left
+                "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
+        validateBaseUrl "https://gateway.example:99999"
+            `shouldBe` Left
+                "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
+
+    it "requires verification URLs to use the gateway origin" do
+        let authorization =
+                GatewayDeviceAuthorization
+                    { deviceCode = "device-secret"
+                    , userCode = "ABCD-1234"
+                    , verificationUri =
+                        "https://platform.digitallyinduced.com/connect/agent"
+                    , verificationUriComplete =
+                        "https://platform.digitallyinduced.com/connect/agent?user_code=ABCD-1234"
+                    , expiresInSeconds = 600
+                    , pollIntervalSeconds = 5
+                    }
+            validate =
+                validateGatewayDeviceAuthorization
+                    "https://platform.digitallyinduced.com"
+        validate authorization `shouldBe` Right authorization
+        validate
+            authorization
+                { verificationUriComplete = "file:///etc/passwd"
+                }
+            `shouldBe` Left
+                "The gateway returned an invalid complete verification URL."
+        validate
+            authorization
+                { verificationUri = "https://example.com/connect/agent"
+                }
+            `shouldBe` Left
+                "The gateway returned a verification URL for a different origin."
+
+    it "validates every persisted gateway credential before use" do
+        let credential =
+                GatewayCredential
+                    "https://platform.digitallyinduced.com"
+                    "wss://platform.digitallyinduced.com/v1/responses"
+                    "secret"
+        validateGatewayCredential credential `shouldBe` Right credential
+        validateGatewayCredential
+            credential
+                { gatewayAccessToken = " "
+                }
+            `shouldBe` Left
+                "The gateway credential contains an empty access token."
+        validateGatewayCredential
+            credential
+                { gatewayWebSocketUrl =
+                    "wss://example.com/v1/responses"
+                }
+            `shouldBe` Left
+                "The gateway credential WebSocket URL uses a different origin."
 
     it "round-trips credentials through a mode-0600 file" $
         withTempHome \home -> do

--- a/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
@@ -2,7 +2,18 @@ module Agent.CLI.GatewayClientSpec (spec) where
 
 import Agent.CLI.GatewayClient
 import Agent.Json.Decode qualified as Hermes
+import Control.Exception.Safe (bracket)
+import Data.Bits ((.&.))
 import Data.Text qualified as Text
+import System.Directory
+    ( createDirectory
+    , getTemporaryDirectory
+    , removeFile
+    , removePathForcibly
+    )
+import System.IO (hClose, openTempFile)
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
+import System.Posix.Files (fileMode, getFileStatus)
 import Test.Hspec
 
 spec :: Spec
@@ -48,3 +59,31 @@ spec = describe "gateway device authorization" do
         validateBaseUrl "http://localhost.example"
             `shouldBe` Left
                 "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
+
+    it "round-trips credentials through a mode-0600 file" $
+        withTempHome \home -> do
+            let credential =
+                    GatewayCredential
+                        "https://gateway"
+                        "wss://gateway/v1/responses"
+                        "secret"
+            saveGatewayCredentialAt home credential `shouldReturn` Right ()
+            loadGatewayCredentialAt home
+                `shouldReturn` Right (Just credential)
+            status <- getFileStatus
+                (either (error . show) id
+                    (decodeUtf (gatewayCredentialPath home)))
+            fileMode status .&. 0o777 `shouldBe` 0o600
+
+withTempHome :: (OsPath -> IO value) -> IO value
+withTempHome =
+    bracket create
+        (removePathForcibly . either (error . show) id . decodeUtf)
+  where
+    create = do
+        temporary <- getTemporaryDirectory
+        (path, handle) <- openTempFile temporary "agent-gateway-client"
+        hClose handle
+        removeFile path
+        createDirectory path
+        pure (unsafeEncodeUtf path)

--- a/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
@@ -41,3 +41,10 @@ spec = describe "gateway device authorization" do
         let credential =
                 GatewayCredential "https://gateway" "wss://gateway/v1/responses" "secret"
         show credential `shouldSatisfy` not . Text.isInfixOf "secret" . Text.pack
+
+    it "allows local HTTP development without trusting lookalike hosts" do
+        validateBaseUrl "http://localhost:8080"
+            `shouldBe` Right "http://localhost:8080"
+        validateBaseUrl "http://localhost.example"
+            `shouldBe` Left
+                "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."

--- a/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
@@ -1,0 +1,60 @@
+module Agent.CLI.GatewayModelsSpec (spec) where
+
+import Agent.CLI.GatewayModels
+import Agent.CLI.ModelConfig
+import Agent.Dialect (DialectId (CodexDialect))
+import Agent.Provider (Provider (OpenAIProvider))
+import Data.Map.Strict qualified as Map
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.GatewayModels" do
+    it "exposes only canonical router aliases while connected" do
+        let active = catalogForGatewayState True directCatalog
+        map (.catalogModelId) active.catalogModels
+            `shouldBe` gatewayModelIds
+        catalogUsesGateway active `shouldBe` True
+        (catalogDefaultForProvider active OpenAIProvider
+            >>= Just . (.catalogModelId))
+            `shouldBe` Just gatewayDefaultModelId
+
+    it "removes reserved router aliases while disconnected" do
+        let spoofed = directCatalog
+                { catalogModels =
+                    directCatalog.catalogModels
+                        <> [directModel
+                                { catalogModelId = gatewayDefaultModelId
+                                , catalogModelWireId = "attacker-model"
+                                }]
+                }
+            inactive = catalogForGatewayState False spoofed
+        map (.catalogModelId) inactive.catalogModels
+            `shouldBe` ["gpt-direct"]
+        catalogUsesGateway inactive `shouldBe` False
+
+directCatalog :: ModelCatalog
+directCatalog =
+    ModelCatalog
+        { catalogConnections =
+            Map.singleton "openai"
+                ModelConnection
+                    { connectionId = "openai"
+                    , connectionKind = BuiltinConnection OpenAIProvider
+                    }
+        , catalogModels = [directModel]
+        }
+
+directModel :: CatalogModel
+directModel =
+    CatalogModel
+        { catalogModelId = "gpt-direct"
+        , catalogModelConnectionId = "openai"
+        , catalogModelWireId = "gpt-direct"
+        , catalogModelDialect = CodexDialect
+        , catalogModelContextWindow = Nothing
+        , catalogModelLabel = Nothing
+        , catalogModelReasoningEfforts = Nothing
+        , catalogModelDefaultReasoningEffort = Nothing
+        , catalogModelDefault = True
+        , catalogModelFallbackPriority = Nothing
+        }

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -8,7 +8,12 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 foreign import ccall "ha_image_attachment_abi_smoke"
     imageAttachmentAbiSmoke :: IO CInt
 
+foreign import ccall "ha_gateway_abi_smoke"
+    gatewayAbiSmoke :: IO CInt
+
 spec :: Spec
 spec = describe "native image attachment ABI" do
     it "preserves the documented image struct layout and ordered buffers" do
         imageAttachmentAbiSmoke `shouldReturn` 0
+    it "preserves typed gateway callbacks and synchronous validation" do
+        gatewayAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -11,6 +11,15 @@ fromFilePath = unsafeEncodeUtf
 spec :: Spec
 spec = do
     describe "parseArgs" do
+        it "parses gateway account commands" do
+            parseArgs ["gateway", "connect", "--url", "https://gateway.example"]
+                `shouldBe` Right
+                    (Gateway (GatewayConnect "https://gateway.example"))
+            parseArgs ["gateway", "status"]
+                `shouldBe` Right (Gateway GatewayStatus)
+            parseArgs ["gateway", "disconnect"]
+                `shouldBe` Right (Gateway GatewayDisconnect)
+
         it "prints help and version without running" do
             parseArgs ["--help"] `shouldBe` Right ShowHelp
             parseArgs ["-h"] `shouldBe` Right ShowHelp

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -25,7 +25,7 @@ import qualified Agent.CLI.ErrorSpec as ErrorSpec
 import qualified Agent.CLI.FileUriSpec as FileUriSpec
 import qualified Agent.CLI.GatewayBridgeSpec as GatewayBridgeSpec
 import qualified Agent.CLI.GatewayClientSpec as GatewayClientSpec
-import qualified Agent.CLI.GatewayClientSpec as GatewayClientSpec
+import qualified Agent.CLI.GatewayModelsSpec as GatewayModelsSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
@@ -108,7 +108,7 @@ main = hspec do
     FileUriSpec.spec
     GatewayBridgeSpec.spec
     GatewayClientSpec.spec
-    GatewayClientSpec.spec
+    GatewayModelsSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec
     InterruptSpec.spec

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -24,6 +24,8 @@ import qualified Agent.CLI.EnvironmentSpec as EnvironmentSpec
 import qualified Agent.CLI.ErrorSpec as ErrorSpec
 import qualified Agent.CLI.FileUriSpec as FileUriSpec
 import qualified Agent.CLI.GatewayBridgeSpec as GatewayBridgeSpec
+import qualified Agent.CLI.GatewayClientSpec as GatewayClientSpec
+import qualified Agent.CLI.GatewayClientSpec as GatewayClientSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
@@ -105,6 +107,8 @@ main = hspec do
     ErrorSpec.spec
     FileUriSpec.spec
     GatewayBridgeSpec.spec
+    GatewayClientSpec.spec
+    GatewayClientSpec.spec
     ImagePreviewSpec.spec
     InputSpec.spec
     InterruptSpec.spec

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -44,6 +44,47 @@ int ha_image_attachment_abi_smoke(void) {
     return 0;
 }
 
+/*
+ * Compile the four gateway function/callback signatures as a native consumer
+ * and exercise their synchronous argument validation without network or
+ * credential-store access.
+ */
+int ha_gateway_abi_smoke(void) {
+    ha_gateway_status_callback status_callback = NULL;
+    ha_gateway_connect_start_callback start_callback = NULL;
+    ha_gateway_poll_callback poll_callback = NULL;
+    ha_gateway_result_callback result_callback = NULL;
+    const uint8_t base_url[] = "https://platform.digitallyinduced.com";
+    const uint8_t client_name[] = "native-smoke";
+    const uint8_t device_code[] = "device-code";
+
+    if (HA_GATEWAY_CONNECTED != 0 || HA_GATEWAY_DISCONNECTED != 1
+            || HA_GATEWAY_ERROR != -1 || HA_GATEWAY_POLL_AUTHORIZED != 0
+            || HA_GATEWAY_POLL_PENDING != 1 || HA_GATEWAY_POLL_SLOW_DOWN != 2
+            || HA_GATEWAY_POLL_ERROR != -1) {
+        return 20;
+    }
+    if (ha_gateway_status(status_callback, NULL) != 1) {
+        return 21;
+    }
+    if (ha_gateway_connect_start(
+            base_url, sizeof(base_url) - 1,
+            client_name, sizeof(client_name) - 1,
+            start_callback, NULL) != 1) {
+        return 22;
+    }
+    if (ha_gateway_connect_poll(
+            base_url, sizeof(base_url) - 1,
+            device_code, sizeof(device_code) - 1,
+            poll_callback, NULL) != 1) {
+        return 23;
+    }
+    if (ha_gateway_disconnect(result_callback, NULL) != 1) {
+        return 24;
+    }
+    return 0;
+}
+
 static void image_stage_callback(void *context, const uint8_t *bytes,
                                  size_t length) {
     (void)context;

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -15,6 +15,10 @@ module Agent.OpenAI.WebSocketClient
     , buildWsPayloadWithOptions
     , addTurnStateToPayload
     , buildCodexWsHeaders
+    , WebSocketEndpoint(..)
+    , gatewayWebSocketEndpoint
+    , isGatewayWebSocketCredential
+    , validateGatewayWebSocketUrl
     , CodexTurnState
     , newCodexTurnState
     , codexConnTurnState
@@ -85,7 +89,9 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Read as TextRead
 import qualified Network.WebSockets as WS
+import qualified Network.URI as URI
 import qualified Wuss
+import Text.Read (readMaybe)
 
 --------------------------------------------------------------------------------
 -- Connection handle
@@ -295,23 +301,125 @@ runConnectionAttemptWithPolicyAndTurnState _ _ credential _action
 runConnectionAttemptWithPolicyAndTurnState retryPolicy sharedTurnState
         credential action = do
     let headers = buildCodexWsHeaders credential
-    WebSocket.retryTransientWsConnectWithPolicy
-        retryPolicy
-        \connected ->
+    case gatewayWebSocketEndpoint credential of
+        Left err -> pure (Left (ConnectionError err))
+        Right endpoint ->
+            WebSocket.retryTransientWsConnectWithPolicy
+                retryPolicy
+                \connected ->
+                    runCredentialWebSocket endpoint headers \conn -> do
+                        connected
+                        WebSocket.withWebSocketSession
+                            WebSocket.defaultWebSocketSessionOptions
+                            conn
+                            (\session -> do
+                                turnState <- maybe newCodexTurnState pure sharedTurnState
+                                action (CodexWsConn session turnState) credential)
+
+data WebSocketEndpoint = WebSocketEndpoint
+    { endpointSecure :: !Bool
+    , endpointHost :: !String
+    , endpointPort :: !Int
+    , endpointPath :: !String
+    }
+    deriving stock (Eq, Show)
+
+-- | Parse the endpoint carried by a gateway credential. A non-WebSocket
+-- account id is an ordinary ChatGPT credential. Once the account id declares
+-- @ws://@ or @wss://@, parse failures stay errors so the gateway bearer can
+-- never fall through to the direct ChatGPT endpoint.
+gatewayWebSocketEndpoint
+    :: Credential
+    -> Either Text (Maybe WebSocketEndpoint)
+gatewayWebSocketEndpoint credential
+    | not (isGatewayWebSocketCredential credential) = Right Nothing
+    | otherwise = Just <$> parseEndpoint credential.accountId
+
+parseEndpoint :: Text -> Either Text WebSocketEndpoint
+parseEndpoint raw = do
+    uri <- maybe (Left "invalid gateway WebSocket URL") Right $
+        URI.parseURI (Text.unpack raw)
+    authority <- maybe (Left "gateway WebSocket URL has no host") Right $
+        URI.uriAuthority uri
+    secure <- case URI.uriScheme uri of
+        "wss:" -> Right True
+        "ws:"
+            | localHost (URI.uriRegName authority) -> Right False
+            | otherwise ->
+                Left "insecure gateway WebSocket URLs are allowed only for localhost"
+        _ -> Left "gateway WebSocket URL must use wss"
+    let rawHost = URI.uriRegName authority
+        host = case rawHost of
+            '[' : rest | not (null rest) && last rest == ']' -> init rest
+            _ -> rawHost
+        defaultPort = if secure then 443 else 80
+        port = case URI.uriPort authority of
+            "" -> Right defaultPort
+            ':' : portText -> case readMaybe portText of
+                Just value | value > 0 && value <= 65535 -> Right value
+                _ -> Left "gateway WebSocket URL has an invalid port"
+            _ -> Left "gateway WebSocket URL has an invalid port"
+        path = case URI.uriPath uri of
+            "" -> "/v1/responses"
+            value -> value
+    endpointPort <- port
+    if null host || not (null (URI.uriUserInfo authority))
+        || not (null (URI.uriQuery uri))
+        || not (null (URI.uriFragment uri))
+        then Left "gateway WebSocket URL contains unsupported components"
+        else Right WebSocketEndpoint
+            { endpointSecure = secure
+            , endpointHost = host
+            , endpointPort
+            , endpointPath = path
+            }
+  where
+    localHost rawHost =
+        Text.toLower (Text.pack rawHost)
+            `elem` ["localhost", "127.0.0.1", "::1", "[::1]"]
+
+isGatewayWebSocketCredential :: Credential -> Bool
+isGatewayWebSocketCredential credential =
+    let accountId = Text.toLower (Text.strip credential.accountId)
+     in "wss://" `Text.isPrefixOf` accountId
+            || "ws://" `Text.isPrefixOf` accountId
+
+validateGatewayWebSocketUrl :: Text -> Either Text ()
+validateGatewayWebSocketUrl raw =
+    parseEndpoint raw >> pure ()
+
+runCredentialWebSocket
+    :: Maybe WebSocketEndpoint
+    -> WS.Headers
+    -> (WS.Connection -> IO value)
+    -> IO value
+runCredentialWebSocket endpoint headers action =
+    case endpoint of
+        Nothing ->
             Wuss.runSecureClientWith
                 wsHost
                 443
                 wsPath
                 WS.defaultConnectionOptions
                 headers
-                \conn -> do
-                    connected
-                    WebSocket.withWebSocketSession
-                        WebSocket.defaultWebSocketSessionOptions
-                        conn
-                        (\session -> do
-                            turnState <- maybe newCodexTurnState pure sharedTurnState
-                            action (CodexWsConn session turnState) credential)
+                action
+        Just endpoint
+            | endpoint.endpointSecure ->
+                Wuss.runSecureClientWith
+                    endpoint.endpointHost
+                    (fromIntegral endpoint.endpointPort)
+                    endpoint.endpointPath
+                    WS.defaultConnectionOptions
+                    headers
+                    action
+            | otherwise ->
+                WS.runClientWith
+                    endpoint.endpointHost
+                    endpoint.endpointPort
+                    endpoint.endpointPath
+                    WS.defaultConnectionOptions
+                    headers
+                    action
 
 -- | Pure handshake-header builder exported for transport contract tests.
 buildCodexWsHeaders :: Credential -> WS.Headers
@@ -320,6 +428,7 @@ buildCodexWsHeaders credential =
     ]
     <> [ ("chatgpt-account-id", Text.encodeUtf8 credential.accountId)
        | not (Text.null credential.accountId)
+       , not (isGatewayWebSocketCredential credential)
        ]
     <> [ ("OpenAI-Beta", "responses_websockets=2026-02-06")
        , ("x-codex-beta-features", Text.encodeUtf8 remoteCompactionV2Feature)

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -11,6 +11,7 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (toList)
+import Data.Either (isLeft)
 import Data.IORef
 import Data.Text (Text)
 
@@ -53,6 +54,39 @@ spec = do
                 }
         lookup "x-codex-beta-features" (buildCodexWsHeaders credential)
             `shouldBe` Just "remote_compaction_v2"
+
+    it "recognizes gateway websocket credentials without leaking the URL as an account id" do
+        let credential = Credential
+                { accessToken = "gateway-token"
+                , accountId = "wss://gateway.example/v1/responses"
+                , leaseId = Nothing
+                , provider = OpenAIProvider
+                }
+            headers = buildCodexWsHeaders credential
+        isGatewayWebSocketCredential credential `shouldBe` True
+        lookup "Authorization" headers `shouldBe` Just "Bearer gateway-token"
+        lookup "chatgpt-account-id" headers `shouldBe` Nothing
+
+    it "accepts loopback ws gateway URLs but rejects unrelated account ids" do
+        let gateway = Credential
+                { accessToken = "token"
+                , accountId = "ws://127.0.0.1:8080/v1/responses"
+                , leaseId = Nothing
+                , provider = OpenAIProvider
+                }
+            direct = gateway { accountId = "chatgpt-account" }
+        isGatewayWebSocketCredential gateway `shouldBe` True
+        isGatewayWebSocketCredential direct `shouldBe` False
+
+    it "validates gateway endpoints before a gateway bearer can be used" do
+        validateGatewayWebSocketUrl "wss://gateway.example/v1/responses"
+            `shouldBe` Right ()
+        validateGatewayWebSocketUrl "ws://127.0.0.1:8080/v1/responses"
+            `shouldBe` Right ()
+        validateGatewayWebSocketUrl "ws://gateway.example/v1/responses"
+            `shouldSatisfy` isLeft
+        validateGatewayWebSocketUrl "https://gateway.example/v1/responses"
+            `shouldSatisfy` isLeft
 
   describe "buildWsPayloadWithOptions" do
     it "forces store=false for the Codex WebSocket contract" do


### PR DESCRIPTION
## Summary

- add secure gateway device authorization and credential persistence
- route connected native sessions through the gateway WebSocket and model catalog
- expose typed C ABI functions for gateway status, start, poll, and logout with validation and redaction

## Testing

- `nix develop -c cabal build --offline agent-cli:lib:agent-cli agent-cli:flib:haskell-agent-bridge agent-cli:test:agent-cli-test`
- focused gateway device authorization, model routing, bridge callback, ABI, and CLI parsing tests (14 examples)
- live production device-start and `authorization_pending` contract against `platform.digitallyinduced.com`