### PR TITLE
Set prompt cache key from session ID

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli/src/Agent/CLI/Request.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Request
     , setRequestInstructions
     , setRequestInstructionsAndTools
     , setRequestModel
+    , setRequestPromptCacheKey
     ) where
 
 import Agent.OpenAI.ModelMetadata (isCodexResponsesLiteModel)
@@ -68,6 +69,16 @@ requestParams provider modelName instructionText toolSchemas effort =
                     if responsesLite then Nothing else Just toolSchemas
                 , ..
                 }
+
+setRequestPromptCacheKey
+    :: Text
+    -> ResponseCreateParams
+    -> ResponseCreateParams
+setRequestPromptCacheKey cacheKey ResponseCreateParams{..} =
+    ResponseCreateParams
+        { promptCacheKey = Just cacheKey
+        , ..
+        }
 
 -- | Change the wire model while keeping the request dialect coherent.
 --

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -59,7 +59,10 @@ import Agent.CLI.ProviderTransition ()
 import Agent.CLI.Recap ()
 import Agent.CLI.Render ( putTextLn )
 import Agent.CLI.ReplMode ()
-import Agent.CLI.Request ( requestParams )
+import Agent.CLI.Request
+    ( requestParams
+    , setRequestPromptCacheKey
+    )
 import Agent.CLI.Resume ( resumeNeedsGeneratedContext )
 import Agent.CLI.Runtime.HistorySource ()
 import Agent.CLI.Runtime.Orchestration.Background ()
@@ -116,7 +119,7 @@ import Agent.CLI.Session.Runtime.Types
                      selectAccount, onPersisted, compactRunner, codeModeNestedSlot),
       StartupRuntime(startupBackground, startupDatabaseStore,
                      startupSessionState) )
-import Agent.CLI.Session.Selection ()
+import Agent.CLI.Session.Selection ( reservedSessionId )
 import Agent.CLI.SessionAdmin ()
 import Agent.CLI.SessionEnv ()
 import Agent.CLI.SessionLock ()
@@ -361,6 +364,7 @@ runAgentSession
                 Right runtime -> pure (runtime, False)
         writeIORef codeModeCloseRef
             (maybe (pure ()) (.codeModeClose) codeModeRuntime)
+        sessionId <- reservedSessionId persist
         let providerTools
                 | suppressDirectImageGeneration =
                     filter
@@ -405,8 +409,11 @@ runAgentSession
             registryTools =
                 allTools
                     <> maybe [] (.codeModeWireTools) codeModeRuntime
-            params = requestParams provider model instructions
+            baseParams = requestParams provider model instructions
                 wireSchemas effortText
+            params = maybe baseParams
+                (`setRequestPromptCacheKey` baseParams)
+                sessionId
             initialItems = maybe [] (foldSessionItems . snd) resumed
             initialTurns = maybe [] snd resumed
             resumeNeedsFreshContext =

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Request
     ( requestParams
     , setRequestInstructionsAndTools
     , setRequestModel
+    , setRequestPromptCacheKey
     )
 import Agent.CLI.Tools (webSearchTool)
 import Agent.Provider (Provider(..))
@@ -46,6 +47,16 @@ spec = describe "requestParams" do
                 reasoning.generateSummary `shouldBe` Nothing
                 reasoning.reasoningMode `shouldBe` Nothing
                 reasoning.summary `shouldBe` Just "auto"
+
+    it "sets the prompt cache key" do
+        let params = setRequestPromptCacheKey "session-123" $
+                requestParams
+                    OpenAIProvider
+                    "test-model"
+                    "test instructions"
+                    []
+                    "high"
+        params.promptCacheKey `shouldBe` Just "session-123"
 
     it "decodes Responses metadata as a string map" do
         let decoded = Hermes.decodeEither responseCreateParamsDecoder $


### PR DESCRIPTION
## Summary
- populate Responses `prompt_cache_key` from the reserved session ID
- preserve the key across request updates and omit it when persistence is disabled
- add focused request-construction coverage

## Testing
- loaded `agent-cli:lib:agent-cli` in GHCi (210 modules)
- loaded `agent-cli:test:agent-cli-test` in GHCi
- ran `Agent.CLI.RequestSpec`: 10 examples, 0 failures
- `git diff --check`