### PR TITLE
Add delete and indexed copy commands

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -1,6 +1,7 @@
 -- | Interactive REPL slash commands.
 module Agent.CLI.Command
-    ( ForkRequest(..)
+    ( CopyRequest(..)
+    , ForkRequest(..)
     , ReplAction(..)
     , ShellMode(..)
     , SkillCommand(..)
@@ -352,6 +353,10 @@ parseSlash catalog raw line = case Text.words line of
                 if null args
                     then ReplNew
                     else ReplCommandError "usage: /new"
+            "delete" ->
+                if null args
+                    then ReplDelete
+                    else ReplCommandError "usage: /delete"
             "usage" ->
                 if null args
                     then ReplUsage
@@ -371,9 +376,8 @@ parseSlash catalog raw line = case Text.words line of
                     then ReplClearAttachments
                     else ReplCommandError "usage: /clear-attachments"
             "copy" ->
-                if null args
-                    then ReplCopyLast
-                    else ReplCommandError "usage: /copy"
+                parseCopyCommand
+                    (Text.strip (Text.drop (Text.length command) line))
             "copy-code" -> parseCopyCodeCommand args
             "copy-diff" ->
                 if null args
@@ -583,6 +587,31 @@ parseForkCommand input =
                             "--worktree and --no-worktree are mutually exclusive"
                 "--at" -> Left "--at is not supported in this version"
                 _ -> finish
+
+parseCopyCommand :: Text -> ReplAction
+parseCopyCommand input
+    | Text.null stripped = copy 1 Nothing
+    | Text.all isDigit first =
+        case reads (Text.unpack first) :: [(Integer, String)] of
+            [(number, "")]
+                | number > 0
+                , number <= toInteger (maxBound :: Int) ->
+                    copy
+                        (fromInteger number)
+                        (nonEmptyText (Text.stripStart rest))
+            _ -> usage
+    | otherwise = copy 1 (Just stripped)
+  where
+    stripped = Text.strip input
+    (first, rest) = Text.break isSpace stripped
+    copy index destination =
+        ReplCopy CopyRequest
+            { copyResponseIndex = index
+            , copyDestination = destination
+            }
+    usage =
+        ReplCommandError
+            "usage: /copy [N] [PATH] where N is 1 (latest), 2, 3, ..."
 
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText value

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -41,12 +41,13 @@ slashCommands =
     , cmd "compact" [] "/compact [FOCUS]" "Summarize history to free context" True
     , cmd "clear" [] "/clear" "Reset the live conversation (same session id)" False
     , cmd "new" [] "/new" "Start a fresh persisted session id" False
+    , cmd "delete" [] "/delete" "Delete the current session and start fresh" False
     , cmd "usage" [] "/usage" "Show usage, pacing, and reset times for connected accounts" False
     , cmd "reload-auth" [] "/reload-auth" "Re-read provider credentials" False
     , cmd "paste" [] "/paste [--send] [TEXT]" "Attach a clipboard image (Cmd+V / Ctrl+V) and preview it in the terminal" True
     , cmd "attachments" [] "/attachments" "List queued clipboard images" False
     , cmd "clear-attachments" [] "/clear-attachments" "Drop queued clipboard images" False
-    , cmd "copy" ["copy-last"] "/copy" "Copy the last assistant response" False
+    , cmd "copy" ["copy-last"] "/copy [N] [PATH]" "Copy an assistant response to the clipboard or a file" True
     , cmd "copy-code" [] "/copy-code [N]" "Copy fenced code block N from the last response" True
     , cmd "copy-diff" [] "/copy-diff" "Copy the last diff block" False
     , cmd "copy-path" [] "/copy-path" "Copy the active worktree path" False

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -1,6 +1,7 @@
 -- | Data types shared by slash-command parsing and presentation.
 module Agent.CLI.Command.Types
-    ( ForkRequest(..)
+    ( CopyRequest(..)
+    , ForkRequest(..)
     , ReplAction(..)
     , ShellMode(..)
     , SkillCommand(..)
@@ -20,6 +21,13 @@ import Data.Text (Text)
 data ForkRequest = ForkRequest
     { forkWorktree :: !(Maybe Bool)
     , forkDirective :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+-- | Parsed @/copy@ selection. Responses are numbered newest-first.
+data CopyRequest = CopyRequest
+    { copyResponseIndex :: !Int
+    , copyDestination :: !(Maybe Text)
     }
     deriving (Eq, Show)
 
@@ -75,7 +83,7 @@ data ReplAction
     | ReplClearAttachments
     | ReplShowAttachments
     | ReplRemoveAttachment !Int
-    | ReplCopyLast
+    | ReplCopy !CopyRequest
     | ReplCopyCode Int
     | ReplCopyDiff
     | ReplCopyPath
@@ -111,6 +119,8 @@ data ReplAction
       -- ^ Soft-reset live transcript; keep the same session id.
     | ReplNew
       -- ^ Start a fresh persisted session id with empty history.
+    | ReplDelete
+      -- ^ Confirm deletion, then remove the current session after shutdown.
     | ReplUsage
     | ReplCommandError Text
     deriving (Eq, Show)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -90,7 +90,8 @@ import Agent.CLI.Runtime.Types
     ( DevResult(..), PreparedAgent(..), RunResult(..) )
 import Agent.CLI.Secret ()
 import Agent.CLI.Session
-    ( loadActiveSession,
+    ( deleteSession,
+      loadActiveSession,
       loadRecentSessionTurns,
       sessionDirForId,
       sessionsRoot,
@@ -122,7 +123,7 @@ import Agent.CLI.Startup.Auth
     ( recordStartupTiming, setStartupNotice )
 import Agent.CLI.StartupContext ()
 import Agent.CLI.Style
-    ( glyphSession, roleMuted, setCliWindowTitle )
+    ( glyphOk, glyphSession, roleError, roleMuted, setCliWindowTitle )
 import Agent.CLI.Subagents.Runtime ()
 import Agent.CLI.TUI.App
     ( FullscreenInputBuffer,
@@ -283,6 +284,46 @@ runAgentWithRuntime processRuntime runMode options = do
                             , optResume = Just sessionId
                             }
                         Nothing
+            RunDeleteSession sessionId cwd -> do
+                home <- getHomeDirectory
+                config <- managedPostgresConfigForHome home
+                deletion <-
+                    openStore config >>= \case
+                        Left err ->
+                            pure (Left (renderStoreError err))
+                        Right store ->
+                            deleteSession
+                                (trustedPool store)
+                                (sessionsRoot home)
+                                sessionId
+                                `finally` closeStore store
+                color <- resolveColor runMode.runStderr
+                case deletion of
+                    Left err -> do
+                        putTextLn runMode.runStderr
+                            (roleError color
+                                ("could not delete session "
+                                    <> sessionId
+                                    <> ": "
+                                    <> err))
+                        pure DevQuit
+                    Right () -> do
+                        putTextLn runMode.runStderr
+                            (roleMuted color
+                                (glyphOk
+                                    <> "deleted session "
+                                    <> sessionId))
+                        newSessionState >>= \nextState ->
+                            go fullscreenInputs nextState
+                                current
+                                    { optCwd = Just cwd
+                                    , optWorktree = False
+                                    , optPrompt = Nothing
+                                    , optPromptFile = Nothing
+                                    , optManagedTurnFile = Nothing
+                                    , optResume = Nothing
+                                    }
+                                Nothing
             RunSwitchWorktree path provider model effort ->
                 newSessionState >>= \nextState ->
                     go fullscreenInputs nextState

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -16,7 +16,8 @@ import Agent.CLI.Artifact ( fencedCodeBlock, lastDiffBlock )
 import Agent.CLI.Auth ()
 import Agent.CLI.Clipboard ( loadImagesFromPastedText )
 import Agent.CLI.Command
-    ( formatSlashHelpWithCatalog,
+    ( CopyRequest(..),
+      formatSlashHelpWithCatalog,
       parseReplLineWithCatalog,
       ReplAction(ReplCommandError, ReplQuit, ReplReload, ReplPrompt,
                  ReplExpandedPrompt, ReplInvokeSkill, ReplSkills, ReplShowShell,
@@ -24,7 +25,7 @@ import Agent.CLI.Command
                  ReplRemoveAttachment,
                  ReplShowAgentLimit, ReplSetAgentLimit, ReplAgents, ReplMcp, ReplMcpPrompt,
                  ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
-                 ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopyLast,
+                 ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopy,
                  ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
                  ReplDesktop,
                  ReplShowTerminal, ReplShowEffort, ReplSetEffort, ReplShowModel,
@@ -32,7 +33,7 @@ import Agent.CLI.Command
                  ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
                  ReplViewPlan, ReplQueue, ReplTranscript, ReplEditPrompt,
                  ReplContext, ReplHistory, ReplFind,
-                 ReplBtw, ReplMetaConsole, ReplRecap, ReplRetry, ReplResume, ReplSearch, ReplClear, ReplNew,
+                 ReplBtw, ReplMetaConsole, ReplRecap, ReplRetry, ReplResume, ReplSearch, ReplClear, ReplNew, ReplDelete,
                  ReplShowSession, ReplShowSessionInfo, ReplAfk, ReplWorktree,
                  ReplRename, ReplRenameAuto, ReplInit, ReplReview, ReplDiff,
                  ReplFork, ReplExport, ReplPermissions,
@@ -52,7 +53,8 @@ import Agent.CLI.Config
     )
 import Agent.CLI.Context ( formatContextReport )
 import Agent.CLI.Transcript
-    ( foldTranscriptTurns
+    ( assistantResponseBodies
+    , foldTranscriptTurns
     )
 import qualified Agent.CLI.Transcript as Transcript
 import Agent.CLI.Connectivity ()
@@ -222,6 +224,7 @@ import Agent.CLI.Terminal
 import Agent.CLI.TranscriptExport
     ( defaultExportFileName
     , resolveExportPath
+    , saveCopyText
     , saveTranscriptNoClobber
     )
 import qualified Agent.CLI.TranscriptExport as TranscriptExport
@@ -732,12 +735,40 @@ handleReplLine
                     action@ReplGoalSet{} -> handleWorkflowAction env submitExpandedTurn color continue action
                     action@ReplWorkflowRuns -> handleWorkflowAction env submitExpandedTurn color continue action
                     action@ReplWorkflowManage{} -> handleWorkflowAction env submitExpandedTurn color continue action
-                    ReplCopyLast -> do
-                        answer <- readIORef lastAssistantRef
-                        copyCommand
-                            "last response"
-                            "no assistant response to copy"
-                            answer
+                    ReplCopy request -> do
+                        loadAssistantResponses >>= \case
+                            Left err ->
+                                displayError err do
+                                    color <- resolveColor stderr
+                                    Text.hPutStrLn stderr
+                                        (roleError color err)
+                            Right responses ->
+                                case listAt
+                                    (request.copyResponseIndex - 1)
+                                    responses of
+                                    Nothing -> do
+                                        let available = length responses
+                                            responseNoun
+                                                | available == 1 =
+                                                    "response is"
+                                                | otherwise =
+                                                    "responses are"
+                                            message
+                                                | available == 0 =
+                                                    "no assistant response to copy"
+                                                | otherwise =
+                                                    "only "
+                                                        <> Text.pack
+                                                            (show available)
+                                                        <> " assistant "
+                                                        <> responseNoun
+                                                        <> " available to copy"
+                                        displayError message do
+                                            color <- resolveColor stderr
+                                            Text.hPutStrLn stderr
+                                                (roleError color message)
+                                    Just answer ->
+                                        copyAssistantResponse request answer
                         continue
                     ReplCopyCode index -> do
                         answer <- readIORef lastAssistantRef
@@ -1083,6 +1114,7 @@ handleReplLine
                     action@ReplSearch{} -> handleSessionAction env slashCatalog continue action
                     action@ReplClear -> handleSessionAction env slashCatalog continue action
                     action@ReplNew -> handleSessionAction env slashCatalog continue action
+                    action@ReplDelete -> handleSessionAction env slashCatalog continue action
                     action@ReplFork{} -> handleSessionAction env slashCatalog continue action
                     action@ReplShowSession -> handleSessionAction env slashCatalog continue action
                     action@ReplShowSessionInfo -> handleSessionAction env slashCatalog continue action
@@ -1750,6 +1782,58 @@ handleReplLine
             case fullscreen of
                 Nothing -> clearThinking render
                 Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
+    loadAssistantResponses =
+        loadPersistedTranscript >>= \case
+            Left err -> pure (Left err)
+            Right persisted -> do
+                latest <- readIORef lastAssistantRef
+                let responses =
+                        maybe
+                            []
+                            (assistantResponseBodies . snd)
+                            persisted
+                pure $
+                    Right $
+                        if null responses
+                            then maybe [] pure latest
+                            else responses
+    copyAssistantResponse request answer = do
+        let index = request.copyResponseIndex
+            label
+                | index == 1 = "last response"
+                | otherwise =
+                    "response " <> Text.pack (show index)
+        case request.copyDestination of
+            Nothing ->
+                copyCommand
+                    label
+                    "no assistant response to copy"
+                    (Just answer)
+            Just rawPath ->
+                resolveExportPath cwd rawPath >>= \case
+                    Left err ->
+                        displayError err do
+                            color <- resolveColor stderr
+                            Text.hPutStrLn stderr
+                                (roleError color err)
+                    Right path ->
+                        saveCopyText path answer >>= \case
+                            Left err ->
+                                displayError err do
+                                    color <- resolveColor stderr
+                                    Text.hPutStrLn stderr
+                                        (roleError color err)
+                            Right () -> do
+                                let message =
+                                        "copied "
+                                            <> label
+                                            <> " to "
+                                            <> toText path
+                                displayInfo message do
+                                    color <- resolveColor stderr
+                                    Text.hPutStrLn stderr
+                                        (roleSuccess color
+                                            (glyphOk <> message))
     copyCommand label missing payload = case payload of
         Nothing ->
             displayError missing do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -18,7 +18,7 @@ import Agent.CLI.Command
       currentModel,
       ForkRequest(..),
       ReplAction(ReplRenameAuto, ReplResume, ReplSearch, ReplClear,
-                 ReplNew, ReplShowSession, ReplShowSessionInfo, ReplAfk,
+                 ReplNew, ReplDelete, ReplShowSession, ReplShowSessionInfo, ReplAfk,
                  ReplWorktree, ReplRename, ReplFork),
       ShellMode(ShellNone, ShellGhci, ShellBash, ShellBoth),
       SlashCatalog(slashCatalogToolNames) )
@@ -30,7 +30,7 @@ import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ()
 import Agent.CLI.GatewayBridge ()
-import Agent.CLI.Input ( readChoiceSelection )
+import Agent.CLI.Input ( readChoiceSelection, readChoiceSelectionAt )
 import Agent.CLI.Interrupt ()
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
@@ -64,7 +64,7 @@ import Agent.CLI.Runtime.HistorySource
 import Agent.CLI.Runtime.Persistence ()
 import Agent.CLI.Runtime.Recap ()
 import Agent.CLI.Runtime.Types
-    ( RunResult(RunForkSession, RunSwitchWorktree, RunQuit) )
+    ( RunResult(RunDeleteSession, RunForkSession, RunSwitchWorktree, RunQuit) )
 import Agent.CLI.Secret ()
 import Agent.CLI.Session
     ( TranscriptEffect(TranscriptReset),
@@ -388,6 +388,35 @@ handleSessionAction
                         (roleMuted color
                             (glyphOk <> message))
                 continue
+    ReplDelete -> do
+        color <- resolveColor stderr
+        let unavailable message = do
+                displayError message $
+                    putTextLn stderr (roleError color message)
+                continue
+        case persist of
+            PersistenceDisabled ->
+                unavailable "/delete requires a persisted interactive session"
+            PersistenceEnabled slotRef ->
+                readIORef slotRef >>= \case
+                    PersistencePending{} ->
+                        unavailable
+                            "/delete is available after the first persisted turn"
+                    PersistenceActive handle ->
+                        confirmDelete color handle.sessionMeta.metaId >>= \case
+                            False -> continue
+                            True -> do
+                                let message =
+                                        "deleting session "
+                                            <> handle.sessionMeta.metaId
+                                            <> " after shutdown…"
+                                displayInfo message $
+                                    putTextLn stderr
+                                        (roleMuted color message)
+                                pure
+                                    (RunDeleteSession
+                                        handle.sessionMeta.metaId
+                                        cwd)
     ReplFork request -> do
         color <- resolveColor stderr
         let failFork message = do
@@ -792,5 +821,35 @@ handleSessionAction
                             Just "Use a new worktree" -> Just True
                             Just "Share current workspace" -> Just False
                             _ -> Nothing
+    confirmDelete color sessionId =
+        case fullscreen of
+            Just runtime ->
+                requestFullscreenChoiceWithBody
+                    runtime
+                    "Delete current session?"
+                    ( "This permanently removes session "
+                        <> sessionId
+                        <> " and its local artifacts, then starts a fresh conversation."
+                    )
+                    1
+                    [ ( "Delete session"
+                      , "Permanently remove its transcript and artifacts"
+                      )
+                    , ( "Cancel"
+                      , "Keep the current session"
+                      )
+                    ]
+                    >>= pure . (== Just 0)
+            Nothing ->
+                readChoiceSelectionAt
+                    1
+                    (\selected label ->
+                        if selected
+                            then rolePrompt color label
+                            else roleMuted color label)
+                    [ "Delete session permanently"
+                    , "Cancel"
+                    ]
+                    >>= pure . (== Just "Delete session permanently")
     cleanupForkWorktree source =
         mapM_ \path -> void (removeWorktree source path)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
@@ -40,6 +40,9 @@ data RunResult
       -- backend shuts down before starting the selected session.
     | RunForkSession Text (Maybe Text)
       -- ^ A newly forked session plus an optional first interactive prompt.
+    | RunDeleteSession Text OsPath
+      -- ^ Delete this session only after its backend and lock have shut down,
+      -- then return to a fresh conversation in the same working directory.
     | RunSwitchWorktree OsPath Provider Text ReasoningEffort
       -- ^ Fresh worktree path. Starts a new session after the current backend
       -- and fullscreen UI have shut down, retaining provider, model, and effort.

--- a/packages/agent-cli/src/Agent/CLI/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/Transcript.hs
@@ -4,7 +4,8 @@
 
 -- | Pure projection and Markdown rendering for persisted session history.
 module Agent.CLI.Transcript
-    ( projectTranscriptTurn
+    ( assistantResponseBodies
+    , projectTranscriptTurn
     , foldTranscriptTurns
     , renderTranscriptMarkdown
     , renderSessionTranscript
@@ -122,6 +123,16 @@ searchTranscriptBlocks rawQuery blocks
             , block.blockDetail
             , block.blockTimestamp
             ]
+
+-- | Non-empty assistant messages, newest first, for Grok-compatible @/copy N@.
+assistantResponseBodies :: [UiBlock] -> [Text]
+assistantResponseBodies =
+    reverse
+        . map (.blockBody)
+        . filter
+            (\block ->
+                block.blockKind == BlockAssistant
+                    && not (Text.null (Text.strip block.blockBody)))
 
 shown :: Show a => a -> Text
 shown = Text.pack . show

--- a/packages/agent-cli/src/Agent/CLI/TranscriptExport.hs
+++ b/packages/agent-cli/src/Agent/CLI/TranscriptExport.hs
@@ -6,6 +6,7 @@ module Agent.CLI.TranscriptExport
     ( defaultExportFileName
     , renderTranscriptMarkdown
     , resolveExportPath
+    , saveCopyText
     , saveTranscriptNoClobber
     , visibleSessionTurns
     ) where
@@ -16,6 +17,7 @@ import Agent.CLI.Session
 import Agent.CLI.Session.Types (TranscriptEffect(..))
 import Agent.CLI.TUI.History (HistoryTurn(historyTurnBlocks))
 import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn)
+import Agent.FileRetry (writeLazyFileAtomically)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.TUI.Model
     ( BlockKind(..)
@@ -27,13 +29,15 @@ import Control.Exception.Safe
     , tryAny
     )
 import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Foldable (toList)
 import Data.List (findIndex)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import System.Directory.OsPath
-    ( doesDirectoryExist
+    ( createDirectoryIfMissing
+    , doesDirectoryExist
     , getHomeDirectory
     , makeAbsolute
     , removeFile
@@ -146,3 +150,20 @@ saveTranscriptNoClobber target markdown = do
             pure $ case result of
                 Left err -> Left (Text.pack (displayException err))
                 Right () -> Right ()
+
+-- | Replace a copy target atomically, creating parents and keeping the
+-- response owner-readable only. Unlike transcript export, Grok's @/copy@
+-- file form deliberately overwrites its destination.
+saveCopyText :: OsPath -> Text -> IO (Either Text ())
+saveCopyText target value =
+    tryAny
+        (do
+            createDirectoryIfMissing True (takeDirectory target)
+            writeLazyFileAtomically
+                target
+                0o600
+                (LazyByteString.fromStrict
+                    (TextEncoding.encodeUtf8 value)))
+        >>= pure . \case
+            Left err -> Left (Text.pack (displayException err))
+            Right () -> Right ()

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -207,13 +207,16 @@ spec = do
             parseReplLine "/login openai"
                 `shouldBe` ReplCommandError "usage: /login"
 
-        it "clears or starts a new session" do
+        it "clears, starts, or deletes a session" do
             parseReplLine "/clear" `shouldBe` ReplClear
             parseReplLine "/new" `shouldBe` ReplNew
+            parseReplLine "/delete" `shouldBe` ReplDelete
             parseReplLine "/clear now"
                 `shouldBe` ReplCommandError "usage: /clear"
             parseReplLine "/new now"
                 `shouldBe` ReplCommandError "usage: /new"
+            parseReplLine "/delete now"
+                `shouldBe` ReplCommandError "usage: /delete"
 
         it "compacts with optional focus text" do
             parseReplLine "/compact" `shouldBe` ReplCompact Nothing
@@ -242,8 +245,22 @@ spec = do
             parseReplLine "/clear-attachments" `shouldBe` ReplClearAttachments
 
         it "parses terminal clipboard commands" do
-            parseReplLine "/copy" `shouldBe` ReplCopyLast
-            parseReplLine "/copy-last" `shouldBe` ReplCopyLast
+            parseReplLine "/copy"
+                `shouldBe` ReplCopy (CopyRequest 1 Nothing)
+            parseReplLine "/copy-last"
+                `shouldBe` ReplCopy (CopyRequest 1 Nothing)
+            parseReplLine "/copy 3"
+                `shouldBe` ReplCopy (CopyRequest 3 Nothing)
+            parseReplLine "/copy out.txt"
+                `shouldBe` ReplCopy (CopyRequest 1 (Just "out.txt"))
+            parseReplLine "/copy 2 ~/exports/my note.md"
+                `shouldBe`
+                    ReplCopy
+                        (CopyRequest 2 (Just "~/exports/my note.md"))
+            parseReplLine "/copy 0"
+                `shouldBe`
+                    ReplCommandError
+                        "usage: /copy [N] [PATH] where N is 1 (latest), 2, 3, ..."
             parseReplLine "/copy-code" `shouldBe` ReplCopyCode 1
             parseReplLine "/copy-code 3" `shouldBe` ReplCopyCode 3
             parseReplLine "/copy-diff" `shouldBe` ReplCopyDiff
@@ -424,6 +441,7 @@ spec = do
                     , "compact"
                     , "clear"
                     , "new"
+                    , "delete"
                     , "usage"
                     , "reload-auth"
                     , "paste"

--- a/packages/agent-cli/test/Agent/CLI/TranscriptExportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TranscriptExportSpec.hs
@@ -7,11 +7,13 @@ import Agent.CLI.TranscriptExport
     ( defaultExportFileName
     , renderTranscriptMarkdown
     , resolveExportPath
+    , saveCopyText
     , saveTranscriptNoClobber
     , visibleSessionTurns
     )
 import Agent.OsPath (unsafeToFilePath)
 import Control.Exception.Safe (bracket)
+import Data.Bits ((.&.))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as TextIO
@@ -26,6 +28,7 @@ import qualified System.Directory.OsPath as Directory
 import qualified System.FilePath as FilePath
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 import System.Posix.Temp (mkdtemp)
+import System.Posix.Files (fileMode, getFileStatus, setFileMode)
 import Test.Hspec
 
 spec :: Spec
@@ -68,6 +71,20 @@ spec = do
         it "uses a stable default filename" do
             defaultExportFileName "2026-01-01-abcd"
                 `shouldBe` "agent-session-2026-01-01-abcd.md"
+
+        it "privately overwrites copy targets and creates parent directories" $
+          withTempDir "agent-copy-spec-" \root -> do
+            let target =
+                    root
+                        `appendPath` "nested"
+                        `appendPath` "response.txt"
+            saveCopyText target "first" `shouldReturn` Right ()
+            setFileMode (unsafeToFilePath target) 0o644
+            saveCopyText target "second 🌍" `shouldReturn` Right ()
+            TextIO.readFile (unsafeToFilePath target)
+                `shouldReturn` "second 🌍"
+            status <- getFileStatus (unsafeToFilePath target)
+            fileMode status .&. 0o777 `shouldBe` 0o600
 
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True

--- a/packages/agent-cli/test/Agent/CLI/TranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TranscriptSpec.hs
@@ -9,7 +9,8 @@ import Agent.CLI.Session
     )
 import Agent.Dialect (DialectId(CodexDialect))
 import Agent.CLI.Transcript
-    ( foldTranscriptTurns
+    ( assistantResponseBodies
+    , foldTranscriptTurns
     , markdownFence
     , renderTranscriptMarkdown
     , searchTranscriptBlocks
@@ -78,6 +79,17 @@ spec = describe "Agent.CLI.Transcript" do
         searchTranscriptBlocks "ghc" blocks `shouldBe` [first]
         searchTranscriptBlocks "EXAMPLES" blocks `shouldBe` [second]
         searchTranscriptBlocks "   " blocks `shouldBe` blocks
+
+    it "selects non-empty assistant responses newest-first" do
+        let oldest = testBlock { blockBody = "oldest" }
+            tool = testBlock
+                { blockKind = BlockTool
+                , blockBody = "tool output"
+                }
+            empty = testBlock { blockBody = "  " }
+            newest = testBlock { blockBody = "newest" }
+        assistantResponseBodies [oldest, tool, empty, newest]
+            `shouldBe` ["newest", "oldest"]
 
 turn :: TranscriptEffect -> Text -> SessionTurn
 turn effect text = SessionTurn


### PR DESCRIPTION
## Summary
- add a confirmed `/delete` command that defers destructive work until the active session has shut down and then starts a fresh conversation
- extend `/copy` to support `/copy [N] [PATH]`, including reset-aware persisted history and private atomic file writes
- cover command parsing, transcript selection, UTF-8 overwrite behavior, parent creation, and file permissions

## Testing
- `nix develop -c env TMPDIR=<short-user-runtime-dir> cabal test agent-cli:test:agent-cli-test --test-show-details=direct` (1,440 examples, 0 failures)
- `printf ':quit\\n' | nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-fno-code` (210 modules loaded)
- deterministic live tmux smoke: copied the second-newest response to a mode-0600 file, verified exact contents, canceled `/delete` with the default selection, then confirmed deletion and verified the old session no longer appeared in `/resume` and its artifacts were removed