### PR TITLE
Prioritize foreground turns over title generation

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
@@ -112,13 +112,28 @@ preferredOpenAiTokenProvider preferredAccount pool fallback =
                             selectedCredential accountId
                         Nothing ->
                             pure fallbackResult
-            Nothing ->
-                readIORef preferredAccount >>= \case
-                    Nothing ->
-                        getNextToken fallback Nothing
-                    Just accountId ->
-                        selectedCredential accountId
+            Nothing -> checkoutPreferred
   where
+    checkoutPreferred =
+        readIORef preferredAccount >>= \case
+            Nothing ->
+                getNextToken fallback Nothing
+            Just accountId ->
+                selectedCredential accountId >>= \case
+                    Left CredentialsExhausted{} ->
+                        clearStalePreference accountId
+                    result ->
+                        pure result
+
+    clearStalePreference accountId = do
+        cleared <- atomicModifyIORef' preferredAccount \current ->
+            if current == Just accountId
+                then (Nothing, True)
+                else (current, False)
+        if cleared
+            then getNextToken fallback Nothing
+            else checkoutPreferred
+
     selectedCredential accountId =
         OpenAI.getAccessTokenForAccount pool accountId >>= \case
             Right (accessToken, selectedAccountId) ->

--- a/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
@@ -11,6 +11,7 @@ module Agent.CLI.SessionTitle
     , takeSessionTitleResults
     , titleRefreshIndex
     , waitForSessionTitleResults
+    , withSessionTitleForeground
     , withSessionTitleManager
     ) where
 
@@ -27,9 +28,14 @@ import Agent.Responses.Types
     , ToolChoice(..)
     , ToolChoiceMode(..)
     )
-import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.Async (race, withAsync)
 import Control.Concurrent.STM
-import Control.Exception.Safe (SomeException, displayException, tryAny)
+import Control.Exception.Safe
+    ( SomeException
+    , bracket_
+    , displayException
+    , tryAny
+    )
 import Control.Monad (forever, void)
 import Control.Retry (limitRetries, retrying)
 import Data.Map.Strict (Map)
@@ -71,6 +77,7 @@ data SessionTitleManager = SessionTitleManager
     , titleResults :: !(TQueue SessionTitleResult)
     , titleRequested :: !(TVar (Set (Text, Int, Int)))
     , titleGenerations :: !(TVar (Map Text Int))
+    , titleForegroundTurns :: !(TVar Int)
     , titleBackendFactory :: !BtwBackendFactory
     , titleParams :: !(IO ResponseCreateParams)
     }
@@ -86,15 +93,26 @@ withSessionTitleManager backendFactory paramsRef onEvent action = do
     results <- newTQueueIO
     requested <- newTVarIO Set.empty
     generations <- newTVarIO Map.empty
+    foregroundTurns <- newTVarIO 0
     let manager = SessionTitleManager
             { titleJobs = jobs
             , titleResults = results
             , titleRequested = requested
             , titleGenerations = generations
+            , titleForegroundTurns = foregroundTurns
             , titleBackendFactory = backendFactory
             , titleParams = paramsRef
             }
     withAsync (titleWorker onEvent manager) \_ -> action manager
+
+-- | Give foreground model turns priority over best-effort title generation.
+-- Starting a foreground turn cancels an in-flight title request; the worker
+-- retries that job once the foreground scope is idle again.
+withSessionTitleForeground :: SessionTitleManager -> IO a -> IO a
+withSessionTitleForeground manager =
+    bracket_
+        (atomically $ modifyTVar' manager.titleForegroundTurns (+ 1))
+        (atomically $ modifyTVar' manager.titleForegroundTurns (subtract 1))
 
 requestSessionTitle
     :: SessionTitleManager
@@ -169,9 +187,27 @@ shouldRequestSessionTitle milestone refreshIndex
 
 titleWorker :: (SessionTitleEvent -> IO ()) -> SessionTitleManager -> IO ()
 titleWorker onEvent manager = forever do
-    job <- atomically (readTQueue manager.titleJobs)
-    generated <- generateTitleWithRetry manager job
-    accepted <- atomically do
+    job <- atomically do
+        readTVar manager.titleForegroundTurns >>= check . (== 0)
+        readTQueue manager.titleJobs
+    race
+        (atomically do
+            readTVar manager.titleForegroundTurns >>= check . (> 0))
+        (generateTitleWithRetry manager job)
+        >>= \case
+            Left () ->
+                atomically (unGetTQueue manager.titleJobs job)
+            Right generated -> do
+                accepted <- acceptTitleResult manager job generated
+                mapM_ (void . tryAny . onEvent) accepted
+
+acceptTitleResult
+    :: SessionTitleManager
+    -> SessionTitleJob
+    -> Either SomeException (Either Text Text)
+    -> IO (Maybe SessionTitleEvent)
+acceptTitleResult manager job generated =
+    atomically do
         modifyTVar' manager.titleRequested
             (Set.delete
                 (job.jobSessionId, job.jobMilestone, job.jobGeneration))
@@ -206,7 +242,6 @@ titleWorker onEvent manager = forever do
                                 <> Text.pack (displayException err)
                         , failureGeneration = job.jobGeneration
                         }))
-    mapM_ (void . tryAny . onEvent) accepted
 
 generateTitleWithRetry
     :: SessionTitleManager

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -77,6 +77,7 @@ import Agent.CLI.SessionTitle
     , shouldRequestSessionTitle
     , takeSessionTitleResults
     , titleRefreshIndex
+    , withSessionTitleForeground
     )
 import Agent.CLI.Status (formatUsageWithRate)
 import Agent.CLI.Style
@@ -188,13 +189,14 @@ runOneTurnWithContext includeTurnContext env promptText inputs = do
     -- boundary from an earlier attempt is already represented by the live and
     -- durable transcripts and must not affect this turn's suffix calculation.
     writeIORef env.sessionAutomaticCompaction Nothing
-    bracket_
-        env.sessionBeginWindowTitleBusy
-        env.sessionEndWindowTitleBusy
-        (withLiveTranscript env.sessionConversation \beforeItems ->
-            runOneTurnBusy
-                includeTurnContext env beforeItems promptText inputs)
-        `finally` writeIORef env.sessionAutomaticCompaction Nothing
+    withSessionTitleForeground env.sessionTitleManager $
+        bracket_
+            env.sessionBeginWindowTitleBusy
+            env.sessionEndWindowTitleBusy
+            (withLiveTranscript env.sessionConversation \beforeItems ->
+                runOneTurnBusy
+                    includeTurnContext env beforeItems promptText inputs)
+            `finally` writeIORef env.sessionAutomaticCompaction Nothing
 
 runOneTurnBusy
     :: Bool

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -748,6 +748,30 @@ spec = do
                             ("expected fallback account, got " <> show err)
             readIORef preferred `shouldReturn` Nothing
 
+        it "falls back when the preferred account is already cooling down" do
+            pool <- OpenAI.newPool
+                [ testAuthStateFor "acc-1"
+                , testAuthStateFor "acc-2"
+                ]
+                (pure . Right)
+            fallback <- OpenAICredential.poolTokenProvider pool
+            preferred <- newIORef (Just "acc-2")
+            let provider =
+                    preferredOpenAiTokenProvider
+                        preferred
+                        pool
+                        fallback
+
+            OpenAI.reportRateLimit pool "acc-2" (Just 60)
+
+            getNextToken provider Nothing >>= \case
+                Right credential ->
+                    credential.accountId `shouldBe` "acc-1"
+                Left err ->
+                    expectationFailure
+                        ("expected fallback account, got " <> show err)
+            readIORef preferred `shouldReturn` Nothing
+
         it "keeps the selection when another credential reports failure" do
             pool <- OpenAI.newPool
                 [ testAuthStateFor "acc-1"

--- a/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
@@ -13,6 +13,7 @@ import Control.Concurrent
     , putMVar
     , takeMVar
     , threadDelay
+    , tryTakeMVar
     )
 import Data.IORef
 import qualified Data.Text as Text
@@ -134,6 +135,44 @@ spec = describe "Agent.CLI.SessionTitle" do
                         , resultGeneration = 0
                         }
                     ]
+
+    it "cancels title generation while a foreground turn is active" do
+        attempts <- newIORef (0 :: Int)
+        started <- newEmptyMVar
+        neverFinish <- newEmptyMVar
+        notified <- newEmptyMVar
+        let backendFactory _ =
+                Backend \state _ _ _ -> do
+                    attempt <- atomicModifyIORef' attempts \count ->
+                        let next = count + 1
+                        in (next, next)
+                    if attempt == 1
+                        then do
+                            putMVar started ()
+                            _ <- takeMVar neverFinish
+                            error "cancelled title request unexpectedly resumed"
+                        else
+                            pure $ Right BackendResult
+                                { backendOutput =
+                                    emptyTurnOutput "title-response" []
+                                        (Just "Foreground-safe title")
+                                , backendState = state
+                                }
+        withSessionTitleManager backendFactory (pure defaultResponseCreateParams) (putMVar notified) \manager -> do
+            requestSessionTitle manager "session-1" 1 "conversation"
+            takeMVar started
+            withSessionTitleForeground manager do
+                threadDelay 50000
+                tryTakeMVar notified `shouldReturn` Nothing
+            takeMVar notified
+                `shouldReturn`
+                    SessionTitleGenerated SessionTitleResult
+                        { resultSessionId = "session-1"
+                        , resultMilestone = 1
+                        , resultTitle = "Foreground-safe title"
+                        , resultGeneration = 0
+                        }
+        readIORef attempts `shouldReturn` 2
 
     it "retries a failed title request once before reporting its outcome" do
         attempts <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary
- cancel and requeue best-effort session-title requests when a foreground turn starts
- resume title generation only after the foreground turn leaves its scoped activity
- clear a stale preferred OpenAI account when it is already cooling down and fall back through the shared account pool
- add regression coverage for foreground/title coordination and pre-cooled preferred accounts

## Why
Session-title generation uses the same OpenAI account pool as foreground turns. A background title request could overlap a newly submitted turn, and a preferred account that had already entered cooldown could still prevent fallback to another usable account. Foreground model work should always win over best-effort title generation.

## Validation
- `printf ':main --match "preferredOpenAiTokenProvider"\\n:main --match "Agent.CLI.SessionTitle"\\n:q\\n' | nix develop -c cabal repl agent-cli:test:agent-cli-test`
  - 3 preferred-account examples passed
  - 10 session-title examples passed
- full `agent-cli:test:agent-cli-test` suite in GHCi with a short `TMPDIR`
  - 1410 examples, 0 failures, 1 pending
- independent concurrency review: no blocking issues
