### PR TITLE
Keep stale gateways from blocking local accounts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
+++ b/packages/agent-cli/src/Agent/CLI/AccountSelection.hs
@@ -26,7 +26,7 @@ import Agent.CLI.Login
 import Agent.CLI.Auth
     ( LoadedAuth(..)
     , isGatewayLoadedAuth
-    , loadAuth
+    , loadDirectOpenAiAuth
     , loadAuthForAccount
     , probeLoadedAuthCredential
     )
@@ -237,7 +237,7 @@ refreshSelectableAccount account =
   where
     refreshCredential candidate = case candidate.loginProvider of
         OpenAIProvider ->
-            loadAuth (Just OpenAIProvider) >>= \case
+            loadDirectOpenAiAuth >>= \case
                 Left err -> pure (Left err)
                 Right loaded -> case loaded.loadedOpenAiPool of
                     Nothing ->

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -24,6 +24,7 @@ module Agent.CLI.Auth
     , hasOpenAiAuth
     , loadAuth
     , loadAuthForAccount
+    , loadDirectOpenAiAuth
     , loadOpenAiDictationAuth
     , managedAuthSelectionId
     , managedGrokTokenProvider
@@ -109,6 +110,7 @@ import Agent.Provider
     , providerSlug
     , seedTokenProvider
     , tokenProvider
+    , tokenProviderBillingMode
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
 import qualified Agent.Gemini.Auth as GeminiAuth
@@ -135,33 +137,156 @@ import System.Directory.OsPath (doesFileExist, getHomeDirectory)
 import System.OsPath (unsafeEncodeUtf, (</>))
 
 loadAuth :: Maybe Provider -> IO (Either Text LoadedAuth)
-loadAuth requested =
-    if maybe True (== OpenAIProvider) requested
-        then loadGatewayCredential >>= \case
-            Left err -> pure (Left ("cannot load gateway credential: " <> err))
-            Right (Just gateway) -> pure (gatewayLoadedAuth gateway)
-            Right Nothing -> loadProvider
-        else loadProvider
+loadAuth (Just OpenAIProvider) = loadOpenAiWithGateway
+loadAuth (Just provider) = loadProvider provider
+loadAuth Nothing =
+    loadGatewayCredential >>= \case
+        Right (Just gateway) -> loadGatewayPreferredAuth gateway
+        Right Nothing -> loadDetectedProvider
+        Left gatewayErr ->
+            loadSubscriptionFallback
+                gatewayErr
+                loadDetectedSubscriptionProvider
+
+loadOpenAiWithGateway :: IO (Either Text LoadedAuth)
+loadOpenAiWithGateway =
+    loadGatewayCredential >>= \case
+        Left gatewayErr ->
+            loadSubscriptionFallback
+                gatewayErr
+                (loadProvider OpenAIProvider)
+        Right (Just gateway) -> loadGatewayPreferredAuth gateway
+        Right Nothing -> loadProvider OpenAIProvider
+
+loadSubscriptionFallback
+    :: Text
+    -> IO (Either Text LoadedAuth)
+    -> IO (Either Text LoadedAuth)
+loadSubscriptionFallback gatewayErr loadFallback =
+    loadFallback >>= \case
+        Right loaded
+            | tokenProviderBillingMode
+                loaded.loadedTokenProvider
+                == SubscriptionBilled ->
+                    pure (Right loaded)
+        Right _ ->
+            pure $ Left $
+                "cannot load gateway credential: "
+                    <> gatewayErr
+                    <> "; refusing automatic fallback to "
+                    <> "API-credit billing"
+        Left providerErr ->
+            pure $ Left $
+                "cannot load gateway credential: "
+                    <> gatewayErr
+                    <> "; "
+                    <> providerErr
+
+loadDetectedProvider :: IO (Either Text LoadedAuth)
+loadDetectedProvider =
+    runExceptT (detectProvider Nothing) >>= \case
+        Left err -> pure (Left err)
+        Right provider -> loadProvider provider
+
+loadDetectedSubscriptionProvider :: IO (Either Text LoadedAuth)
+loadDetectedSubscriptionProvider =
+    go Nothing []
+        [ OpenAIProvider
+        , XAIProvider
+        , OpenRouterProvider
+        , GeminiProvider
+        ]
   where
-    loadProvider = runExceptT do
-        provider <- detectProvider requested
-        case provider of
-            XAIProvider -> loadXai Nothing
-            OpenAIProvider -> loadOpenAi
-            OpenRouterProvider -> loadOpenRouter Nothing
-            GeminiProvider -> loadGemini Nothing
-            ClaudeCodeProvider -> loadClaudeCode
+    go firstApi errors = \case
+        [] ->
+            pure $ case firstApi of
+                Just loaded -> Right loaded
+                Nothing -> Left (Text.intercalate "; " (reverse errors))
+        provider : remaining ->
+            loadProvider provider >>= \case
+                Right loaded
+                    | tokenProviderBillingMode
+                        loaded.loadedTokenProvider
+                        == SubscriptionBilled ->
+                            pure (Right loaded)
+                    | otherwise ->
+                        go
+                            (case firstApi of
+                                Just current -> Just current
+                                Nothing -> Just loaded)
+                            errors
+                            remaining
+                Left err ->
+                    go firstApi (err : errors) remaining
+
+loadProvider :: Provider -> IO (Either Text LoadedAuth)
+loadProvider provider = runExceptT do
+    case provider of
+        XAIProvider -> loadXai Nothing
+        OpenAIProvider -> loadOpenAi
+        OpenRouterProvider -> loadOpenRouter Nothing
+        GeminiProvider -> loadGemini Nothing
+        ClaudeCodeProvider -> loadClaudeCode
+
+-- | Load local OpenAI credentials without consulting the gateway.
+--
+-- Explicit account selection and gateway failover use this entry point so a
+-- saved gateway can never shadow the user's local ChatGPT account pool.
+loadDirectOpenAiAuth :: IO (Either Text LoadedAuth)
+loadDirectOpenAiAuth =
+    runExceptT loadOpenAi
+
+loadGatewayPreferredAuth
+    :: GatewayCredential
+    -> IO (Either Text LoadedAuth)
+loadGatewayPreferredAuth gateway =
+    case gatewayLoadedAuth gateway of
+        Left gatewayErr ->
+            loadDirectOpenAiAuth >>= \case
+                Right directAuth
+                    | tokenProviderBillingMode
+                        directAuth.loadedTokenProvider
+                        == SubscriptionBilled ->
+                            pure (Right directAuth)
+                Right _ ->
+                    pure $ Left $
+                        gatewayErr
+                            <> "; refusing automatic fallback to "
+                            <> "API-credit billing"
+                Left directErr ->
+                    pure $ Left $
+                        gatewayErr <> "; direct OpenAI auth unavailable: "
+                            <> directErr
+        Right gatewayAuth ->
+            loadDirectOpenAiAuth >>= \case
+                Right directAuth
+                    | tokenProviderBillingMode
+                        directAuth.loadedTokenProvider
+                        == SubscriptionBilled -> do
+                            let gatewayCredential =
+                                    credentialForGateway gateway
+                            combined <-
+                                gatewayFallbackTokenProvider
+                                    gatewayCredential
+                                    directAuth.loadedTokenProvider
+                            pure $ Right gatewayAuth
+                                { loadedTokenProvider = combined
+                                , loadedAccountLabel = \credential ->
+                                    if credential == gatewayCredential
+                                        then pure gateway.gatewayBaseUrl
+                                        else
+                                            directAuth.loadedAccountLabel
+                                                credential
+                                , loadedOpenAiPool =
+                                    directAuth.loadedOpenAiPool
+                                }
+                _ ->
+                    pure (Right gatewayAuth)
 
 gatewayLoadedAuth :: GatewayCredential -> Either Text LoadedAuth
 gatewayLoadedAuth gateway = do
     validateGatewayWebSocketUrl gateway.gatewayWebSocketUrl
-    let credential =
-            Credential
-                { accessToken = gateway.gatewayAccessToken
-                , accountId = gateway.gatewayWebSocketUrl
-                , leaseId = Nothing
-                , provider = OpenAIProvider
-                }
+    let credential = credentialForGateway gateway
     pure LoadedAuth
             { loadedProvider = OpenAIProvider
             , loadedTokenProvider =
@@ -171,15 +296,58 @@ gatewayLoadedAuth gateway = do
             , loadedOpenAiPool = Nothing
             }
 
+credentialForGateway :: GatewayCredential -> Credential
+credentialForGateway gateway =
+    Credential
+        { accessToken = gateway.gatewayAccessToken
+        , accountId = gateway.gatewayWebSocketUrl
+        , leaseId = Nothing
+        , provider = OpenAIProvider
+        }
+
+-- | Prefer the gateway until that exact credential is rejected or exhausted,
+-- then stay on the local same-billing OpenAI pool for the rest of the session.
+--
+-- A gateway failure is not forwarded to the local pool because it describes a
+-- different credential and would otherwise cool down an unrelated account.
+gatewayFallbackTokenProvider
+    :: Credential
+    -> TokenProvider
+    -> IO TokenProvider
+gatewayFallbackTokenProvider gatewayCredential directProvider = do
+    gatewayPreferred <- newIORef True
+    pure $ tokenProvider SubscriptionBilled \failed ->
+        case failed of
+            Nothing ->
+                readIORef gatewayPreferred >>= \case
+                    True -> pure (Right gatewayCredential)
+                    False -> getNextToken directProvider Nothing
+            Just reported
+                | reported.credential == gatewayCredential -> do
+                    writeIORef gatewayPreferred False
+                    getNextToken directProvider Nothing
+                | otherwise -> do
+                    writeIORef gatewayPreferred False
+                    getNextToken directProvider (Just reported)
+
 -- | Load one specific account for providers whose HTTP backends can swap
 -- token sources without reconnecting a long-lived transport.
 loadAuthForAccount :: Provider -> Text -> IO (Either Text LoadedAuth)
 loadAuthForAccount provider selectionId =
     if provider == OpenAIProvider
-        then loadGatewayCredential >>= \case
-            Left err -> pure (Left ("cannot load gateway credential: " <> err))
-            Right (Just gateway) -> pure (gatewayLoadedAuth gateway)
-            Right Nothing -> loadProvider
+        then
+            if selectionId == gatewayAuthSelectionId
+                then loadGatewayCredential >>= \case
+                    Left err ->
+                        pure (Left
+                            ("cannot load gateway credential: " <> err))
+                    Right (Just gateway) ->
+                        -- Restore the normal preferred-gateway provider,
+                        -- including same-billing local-account failover.
+                        loadGatewayPreferredAuth gateway
+                    Right Nothing ->
+                        pure (Left "no gateway credential is connected")
+                else loadDirectOpenAiAccountAuth selectionId
         else loadProvider
   where
     loadProvider = runExceptT case provider of
@@ -190,6 +358,25 @@ loadAuthForAccount provider selectionId =
             throwE "OpenAI account selection is handled by the live account pool"
         ClaudeCodeProvider ->
             throwE "Claude Code accounts are managed by `claude auth login`"
+
+loadDirectOpenAiAccountAuth :: Text -> IO (Either Text LoadedAuth)
+loadDirectOpenAiAccountAuth accountId =
+    loadDirectOpenAiAuth >>= \case
+        Left err -> pure (Left err)
+        Right loaded -> case loaded.loadedOpenAiPool of
+            Nothing ->
+                pure (Left
+                    "OpenAI account selection requires a live account pool")
+            Just pool -> do
+                preferred <- newIORef (Just accountId)
+                pure $ Right loaded
+                    { loadedTokenProvider =
+                        preferredOpenAiTokenProvider
+                            preferred
+                            pool
+                            loaded.loadedTokenProvider
+                    , loadedSelectionId = Just accountId
+                    }
 
 -- | Ask the token source whether it has a usable credential now without
 -- making a model request, preserving a successful checkout for later use.

--- a/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
@@ -1,8 +1,14 @@
 -- | HTTPS device authorization and restricted gateway credential storage.
 module Agent.CLI.GatewayClient
     ( GatewayCredential(..)
+    , GatewayAuthorization(..)
     , GatewayDeviceAuthorization(..)
     , GatewayPollResult(..)
+    , startGatewayAuthorization
+    , pollGatewayAuthorization
+    , saveGatewayCredential
+    , removeGatewayCredential
+    , openGatewayAuthorizationPage
     , connectGateway
     , disconnectGateway
     , gatewayCredentialPath
@@ -19,6 +25,7 @@ module Agent.CLI.GatewayClient
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.CLI.Options (GatewayCommand (..))
 import Agent.Json.Decode qualified as Hermes
+import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
 import Agent.OsPath (unsafeToFilePath)
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (tryAny)
@@ -31,6 +38,7 @@ import Data.Text qualified as Text
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.TLS (newTlsManager)
 import Network.HTTP.Types (hContentType)
+import Network.URI qualified as URI
 import System.Directory.OsPath qualified as Directory
 import System.Exit (ExitCode (..))
 import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
@@ -43,6 +51,22 @@ data GatewayCredential = GatewayCredential
     , gatewayAccessToken :: !Text
     }
     deriving (Eq)
+
+-- | A validated gateway base URL paired with its short-lived device flow.
+--
+-- Keeping the normalized base URL in the value prevents UI callers from
+-- accidentally saving a different origin from the one that issued the code.
+data GatewayAuthorization = GatewayAuthorization
+    { authorizationBaseUrl :: !Text
+    , authorizationDevice :: !GatewayDeviceAuthorization
+    }
+    deriving (Eq)
+
+instance Show GatewayAuthorization where
+    show authorization =
+        "GatewayAuthorization { authorizationBaseUrl = "
+            <> show authorization.authorizationBaseUrl
+            <> ", authorizationDevice = <redacted> }"
 
 instance Show GatewayCredential where
     show credential =
@@ -77,7 +101,21 @@ data GatewayDeviceAuthorization = GatewayDeviceAuthorization
     , expiresInSeconds :: !Int
     , pollIntervalSeconds :: !Int
     }
-    deriving (Eq, Show)
+    deriving (Eq)
+
+instance Show GatewayDeviceAuthorization where
+    show device =
+        "GatewayDeviceAuthorization { deviceCode = <redacted>, userCode = "
+            <> show device.userCode
+            <> ", verificationUri = "
+            <> show device.verificationUri
+            <> ", verificationUriComplete = "
+            <> show device.verificationUriComplete
+            <> ", expiresInSeconds = "
+            <> show device.expiresInSeconds
+            <> ", pollIntervalSeconds = "
+            <> show device.pollIntervalSeconds
+            <> " }"
 
 gatewayDeviceDecoder :: Hermes.Decoder GatewayDeviceAuthorization
 gatewayDeviceDecoder =
@@ -97,7 +135,20 @@ data GatewayPollResult
     | GatewayAccessDenied
     | GatewayExpired
     | GatewayPollFailed !Text
-    deriving (Eq, Show)
+    deriving (Eq)
+
+instance Show GatewayPollResult where
+    show result = case result of
+        GatewayAuthorized _ websocketUrl ->
+            "GatewayAuthorized <redacted> " <> show websocketUrl
+        GatewayAuthorizationPending interval ->
+            "GatewayAuthorizationPending " <> show interval
+        GatewaySlowDown interval ->
+            "GatewaySlowDown " <> show interval
+        GatewayAccessDenied -> "GatewayAccessDenied"
+        GatewayExpired -> "GatewayExpired"
+        GatewayPollFailed code ->
+            "GatewayPollFailed " <> show code
 
 gatewayPollDecoder :: Hermes.Decoder GatewayPollResult
 gatewayPollDecoder =
@@ -154,37 +205,94 @@ loadGatewayCredentialAt home = do
                 Right bytes ->
                     case Hermes.decodeEither gatewayCredentialDecoder (LBS.toStrict bytes) of
                         Left err -> Left (Hermes.jsonErrorMessage err)
-                        Right credential -> Right (Just credential)
+                        Right credential ->
+                            case validateGatewayCredential credential of
+                                Left err -> Left err
+                                Right () -> Right (Just credential)
 
 saveGatewayCredentialAt :: OsPath -> GatewayCredential -> IO (Either Text ())
-saveGatewayCredentialAt home credential = do
-    let path = gatewayCredentialPath home
-        directory = takeDirectory path
-    result <- tryAny do
-        Directory.createDirectoryIfMissing True directory
-        setFileMode (unsafeToFilePath directory) 0o700
-        writeLazyFileAtomically path 0o600 (Aeson.encode credential)
-    pure case result of
-        Left exception -> Left (Text.pack (show exception))
-        Right () -> Right ()
+saveGatewayCredentialAt home credential =
+    case validateGatewayCredential credential of
+        Left err -> pure (Left err)
+        Right () -> do
+            let path = gatewayCredentialPath home
+                directory = takeDirectory path
+            result <- tryAny do
+                Directory.createDirectoryIfMissing True directory
+                setFileMode (unsafeToFilePath directory) 0o700
+                writeLazyFileAtomically path 0o600 (Aeson.encode credential)
+            pure case result of
+                Left exception -> Left (Text.pack (show exception))
+                Right () -> Right ()
+
+validateGatewayCredential :: GatewayCredential -> Either Text ()
+validateGatewayCredential credential = do
+    _ <- validateBaseUrl credential.gatewayBaseUrl
+    validateGatewayWebSocketUrl credential.gatewayWebSocketUrl
+    whenEither
+        (Text.null (Text.strip credential.gatewayAccessToken))
+        "Gateway access token cannot be empty."
+  where
+    whenEither condition message
+        | condition = Left message
+        | otherwise = Right ()
+
+saveGatewayCredential :: GatewayCredential -> IO (Either Text ())
+saveGatewayCredential credential =
+    tryAny Directory.getHomeDirectory >>= \case
+        Left exception -> pure (Left (Text.pack (show exception)))
+        Right home -> saveGatewayCredentialAt home credential
+
+startGatewayAuthorization
+    :: Text
+    -> IO (Either Text GatewayAuthorization)
+startGatewayAuthorization rawBaseUrl =
+    case validateBaseUrl rawBaseUrl of
+        Left err -> pure (Left err)
+        Right baseUrl -> do
+            tryAny newTlsManager >>= \case
+                Left exception ->
+                    pure (Left (Text.pack (show exception)))
+                Right manager ->
+                    fmap (GatewayAuthorization baseUrl) <$>
+                        postJson manager
+                            (baseUrl
+                                <> "/api/v1/agent-connections/device")
+                            (Aeson.object
+                                [ "client_name"
+                                    .= ("haskell-agent" :: Text)
+                                ])
+                            gatewayDeviceDecoder
+
+pollGatewayAuthorization
+    :: GatewayAuthorization
+    -> IO (Either Text GatewayPollResult)
+pollGatewayAuthorization authorization = do
+    tryAny newTlsManager >>= \case
+        Left exception ->
+            pure (Left (Text.pack (show exception)))
+        Right manager ->
+            pollGatewayAuthorizationWith manager authorization
+
+openGatewayAuthorizationPage :: GatewayAuthorization -> IO Bool
+openGatewayAuthorizationPage =
+    openBrowser
+        . (.verificationUriComplete)
+        . (.authorizationDevice)
 
 connectGateway :: Text -> IO ()
 connectGateway rawBaseUrl = do
-    baseUrl <- either failText pure (validateBaseUrl rawBaseUrl)
+    authorization <-
+        startGatewayAuthorization rawBaseUrl >>= either failText pure
     manager <- newTlsManager
-    device <-
-        postJson manager (baseUrl <> "/api/v1/agent-connections/device")
-            (Aeson.object ["client_name" .= ("haskell-agent" :: Text)])
-            gatewayDeviceDecoder
-            >>= either failText pure
+    let device = authorization.authorizationDevice
     putStrLn ("Enter code " <> Text.unpack device.userCode <> " at:")
     putStrLn (Text.unpack device.verificationUri)
-    opened <- openBrowser device.verificationUriComplete
+    opened <- openGatewayAuthorizationPage authorization
     when (not opened) $
         putStrLn "Could not open a browser automatically."
-    credential <- pollUntilAuthorized manager baseUrl device
-    home <- Directory.getHomeDirectory
-    saveGatewayCredentialAt home credential >>= either failText pure
+    credential <- pollUntilAuthorized manager authorization
+    saveGatewayCredential credential >>= either failText pure
     putStrLn "Gateway connection saved."
 
 showGatewayStatus :: IO ()
@@ -198,11 +306,19 @@ showGatewayStatus =
 
 disconnectGateway :: IO ()
 disconnectGateway = do
-    home <- Directory.getHomeDirectory
-    let path = gatewayCredentialPath home
-    exists <- Directory.doesFileExist path
-    when exists (Directory.removeFile path)
+    removeGatewayCredential >>= either failText pure
     putStrLn "Gateway connection removed."
+
+removeGatewayCredential :: IO (Either Text ())
+removeGatewayCredential = do
+    result <- tryAny do
+        home <- Directory.getHomeDirectory
+        let path = gatewayCredentialPath home
+        exists <- Directory.doesFileExist path
+        when exists (Directory.removeFile path)
+    pure case result of
+        Left exception -> Left (Text.pack (show exception))
+        Right () -> Right ()
 
 runGatewayCommand :: GatewayCommand -> IO ()
 runGatewayCommand = \case
@@ -212,20 +328,19 @@ runGatewayCommand = \case
 
 pollUntilAuthorized
     :: HTTP.Manager
-    -> Text
-    -> GatewayDeviceAuthorization
+    -> GatewayAuthorization
     -> IO GatewayCredential
-pollUntilAuthorized manager baseUrl device =
+pollUntilAuthorized manager authorization =
     go device.expiresInSeconds (max 1 device.pollIntervalSeconds)
   where
+    baseUrl = authorization.authorizationBaseUrl
+    device = authorization.authorizationDevice
     go remaining interval
         | remaining <= 0 = failText "Gateway authorization expired."
         | otherwise = do
             threadDelay (interval * 1_000_000)
             result <-
-                postJson manager (baseUrl <> "/api/v1/agent-connections/token")
-                    (Aeson.object ["device_code" .= device.deviceCode])
-                    gatewayPollDecoder
+                pollGatewayAuthorizationWith manager authorization
                     >>= either failText pure
             case result of
                 GatewayAuthorized accessToken websocketUrl ->
@@ -239,12 +354,31 @@ pollUntilAuthorized manager baseUrl device =
                     let next = maybe interval (max 1) serverInterval
                      in go (remaining - next) next
                 GatewaySlowDown serverInterval ->
-                    let next = maybe (interval + 5) (max (interval + 1)) serverInterval
+                    let next =
+                            maybe
+                                (interval + 5)
+                                (max (interval + 5))
+                                serverInterval
                      in go (remaining - next) next
                 GatewayAccessDenied -> failText "Gateway authorization was denied."
                 GatewayExpired -> failText "Gateway authorization expired."
                 GatewayPollFailed code ->
                     failText ("Gateway authorization failed: " <> code)
+
+pollGatewayAuthorizationWith
+    :: HTTP.Manager
+    -> GatewayAuthorization
+    -> IO (Either Text GatewayPollResult)
+pollGatewayAuthorizationWith manager authorization =
+    postJson
+        manager
+        (authorization.authorizationBaseUrl
+            <> "/api/v1/agent-connections/token")
+        (Aeson.object
+            [ "device_code"
+                .= authorization.authorizationDevice.deviceCode
+            ])
+        gatewayPollDecoder
 
 postJson
     :: HTTP.Manager
@@ -277,20 +411,38 @@ postJson manager url payload decoder = do
 validateBaseUrl :: Text -> Either Text Text
 validateBaseUrl raw
     | Text.null base = Left "Gateway URL cannot be empty."
-    | "https://" `Text.isPrefixOf` lower = Right base
-    | any localOrigin
-        [ "http://127.0.0.1"
-        , "http://localhost"
-        , "http://[::1]"
-        ] = Right base
-    | otherwise = Left "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
+    | otherwise = do
+        uri <- maybe
+            (Left "Gateway URL is invalid.")
+            Right
+            (URI.parseURI (Text.unpack base))
+        authority <- maybe
+            (Left "Gateway URL must include a host.")
+            Right
+            (URI.uriAuthority uri)
+        whenEither
+            (null (URI.uriRegName authority))
+            "Gateway URL must include a host."
+        whenEither
+            (not (null (URI.uriUserInfo authority))
+                || not (null (URI.uriQuery uri))
+                || not (null (URI.uriFragment uri)))
+            "Gateway URL cannot contain user info, a query, or a fragment."
+        case Text.toLower (Text.pack (URI.uriScheme uri)) of
+            "https:" -> Right base
+            "http:"
+                | localHost (URI.uriRegName authority) -> Right base
+            _ ->
+                Left
+                    "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
   where
     base = Text.dropWhileEnd (== '/') (Text.strip raw)
-    lower = Text.toLower base
-    localOrigin origin =
-        lower == origin
-            || (origin <> ":") `Text.isPrefixOf` lower
-            || (origin <> "/") `Text.isPrefixOf` lower
+    localHost rawHost =
+        Text.toLower (Text.pack rawHost)
+            `elem` ["localhost", "127.0.0.1", "::1", "[::1]"]
+    whenEither condition message
+        | condition = Left message
+        | otherwise = Right ()
 
 openBrowser :: Text -> IO Bool
 openBrowser url = do

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -73,6 +73,18 @@ import Agent.CLI.Error
     , formatException
     )
 import Agent.CLI.Environment (lookupNonEmpty)
+import Agent.CLI.GatewayClient
+    ( GatewayAuthorization(..)
+    , GatewayCredential(..)
+    , GatewayDeviceAuthorization(..)
+    , GatewayPollResult(..)
+    , loadGatewayCredential
+    , openGatewayAuthorizationPage
+    , pollGatewayAuthorization
+    , removeGatewayCredential
+    , saveGatewayCredential
+    , startGatewayAuthorization
+    )
 import Agent.CLI.Input (readApprovalLine)
 import Agent.CLI.Picker
     ( PickerKey(..)
@@ -93,6 +105,7 @@ import Agent.CLI.TUI.App
     , emitUiEvent
     , requestFullscreenChoiceWithBody
     , requestFullscreenSecret
+    , requestFullscreenText
     )
 import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -223,10 +236,19 @@ runFullscreenLoginManager runtime = do
                 result <- connectFullscreenAccount runtime
                 rediscovered <- discoverLoginAccounts
                 dashboardLoop (result <|> notice) rediscovered
+            Just (LoginDashboardGateway, _) -> do
+                result <- connectFullscreenGateway runtime
+                rediscovered <- discoverLoginAccounts
+                dashboardLoop (result <|> notice) rediscovered
             Just (LoginDashboardRefreshAll, _) -> do
                 refreshed <-
                     withLoginProgress runtime "Refreshing provider usage…" $
-                        mapConcurrently refreshLoginAccountSafely accounts
+                        mapConcurrently
+                            (\account ->
+                                if isGatewayLoginAccount account
+                                    then pure account
+                                    else refreshLoginAccountSafely account)
+                            accounts
                 dashboardLoop
                     (Just (refreshAllNotice refreshed))
                     refreshed
@@ -340,8 +362,30 @@ advanceDevicePollSchedule slowedDown polledAt schedule =
         schedule.devicePollIntervalSeconds
             + if slowedDown then 5 else 0
 
+advanceGatewayPollSchedule
+    :: Bool
+    -> Maybe Int
+    -> UTCTime
+    -> DevicePollSchedule
+    -> DevicePollSchedule
+advanceGatewayPollSchedule slowedDown serverInterval polledAt schedule =
+    schedule
+        { devicePollIntervalSeconds = intervalSeconds
+        , devicePollNextAt =
+            addUTCTime (fromIntegral intervalSeconds) polledAt
+        }
+  where
+    requestedInterval =
+        maybe schedule.devicePollIntervalSeconds (max 1) serverInterval
+    intervalSeconds
+        | slowedDown =
+            max requestedInterval
+                (schedule.devicePollIntervalSeconds + 5)
+        | otherwise = requestedInterval
+
 data LoginDashboardAction
     = LoginDashboardConnect
+    | LoginDashboardGateway
     | LoginDashboardRefreshAll
     | LoginDashboardOpen !Int
 
@@ -364,6 +408,17 @@ loginDashboardEntries accounts =
         , "OpenAI, xAI / Grok, OpenRouter, Google Gemini, or Claude Code"
         )
       )
+    , ( LoginDashboardGateway
+      , if gatewayConnected
+            then
+                ( "↻ Reconnect gateway"
+                , "Replace the saved gateway authorization"
+                )
+            else
+                ( "＋ Connect gateway"
+                , "Route OpenAI requests through an agent gateway"
+                )
+      )
     ]
         <> refreshEntry
         <> zipWith
@@ -372,12 +427,19 @@ loginDashboardEntries accounts =
             [0 ..]
             accounts
   where
+    gatewayConnected = any isGatewayLoginAccount accounts
     refreshEntry
-        | null accounts = []
+        | not (any (not . isGatewayLoginAccount) accounts) = []
         | otherwise =
             [ ( LoginDashboardRefreshAll
               , ( "↻ Refresh all usage"
-                , Text.pack (show (length accounts)) <> " accounts"
+                , Text.pack
+                    (show
+                        (length
+                            (filter
+                                (not . isGatewayLoginAccount)
+                                accounts)))
+                    <> " accounts"
                 )
               )
             ]
@@ -390,12 +452,179 @@ loginDashboardAccountRow account =
         <> displayText 48 account.loginLabel
     , Text.intercalate " · " $
         [ accountIdentifier account
-        , if isJust account.loginManagedId then "managed" else "external"
+        , if account.loginSource == "gateway"
+            then "gateway"
+            else if isJust account.loginManagedId then "managed" else "external"
         , if account.loginEnabled then "enabled" else "disabled"
         , billingSummary account.loginBilling
-        , usageSummary account.loginUsage
+        , if isGatewayLoginAccount account
+            then case account.loginUsage of
+                UsageUnavailable _ -> "needs repair"
+                _ -> "connected"
+            else usageSummary account.loginUsage
         ]
     )
+
+connectFullscreenGateway :: FullscreenRuntime -> IO (Maybe LoginNotice)
+connectFullscreenGateway runtime = do
+    existing <- loadGatewayCredential
+    let initial = case existing of
+            Right (Just credential) -> credential.gatewayBaseUrl
+            _ -> ""
+    requestFullscreenText
+        runtime
+        "Connect gateway"
+        ( "Enter the HTTPS base URL of the agent gateway. The next screen "
+            <> "will show a browser link and one-time authorization code."
+        )
+        initial >>= \case
+            Nothing -> pure Nothing
+            Just rawUrl -> do
+                let url = Text.strip rawUrl
+                if Text.null url
+                    then pure Nothing
+                    else do
+                        requestedAt <- getCurrentTime
+                        requested <-
+                            withLoginProgress runtime
+                                "Starting gateway device authorization…" $
+                                    startGatewayAuthorization url
+                        case requested of
+                            Left err ->
+                                pure $ Just $
+                                    LoginNotice False
+                                        ("Gateway connection failed: " <> err)
+                            Right authorization -> do
+                                opened <-
+                                    openGatewayAuthorizationPage authorization
+                                let device =
+                                        authorization.authorizationDevice
+                                    notice
+                                        | opened = Nothing
+                                        | otherwise =
+                                            Just
+                                                "Could not open a browser automatically; use the verification link below."
+                                awaitAuthorization
+                                    authorization
+                                    (initialDevicePollSchedule
+                                        requestedAt
+                                        device.pollIntervalSeconds
+                                        device.expiresInSeconds)
+                                    notice
+  where
+    awaitAuthorization authorization schedule notice = do
+        let device = authorization.authorizationDevice
+        choice <-
+            requestFullscreenChoiceWithBody
+                runtime
+                "Connect gateway"
+                (deviceAuthorizationBody
+                    "gateway"
+                    device.verificationUriComplete
+                    device.userCode
+                    notice)
+                0
+                [ ( "Check authorization"
+                  , "Return after approving the one-time code in your browser"
+                  )
+                , ("Cancel", "Stop without changing the saved gateway")
+                ]
+        case choice of
+            Just 0 -> do
+                now <- getCurrentTime
+                case devicePollReadiness now schedule of
+                    DevicePollExpired ->
+                        gatewayTimedOut
+                    DevicePollWait seconds ->
+                        awaitAuthorization
+                            authorization
+                            schedule
+                            (Just (pollWaitNotice seconds))
+                    DevicePollReady -> do
+                        polled <-
+                            withLoginProgress runtime
+                                "Checking gateway authorization…" $
+                                    pollGatewayAuthorization authorization
+                        polledAt <- getCurrentTime
+                        case polled of
+                            Left err ->
+                                pure $ Just $
+                                    LoginNotice False
+                                        ("Gateway connection failed: " <> err)
+                            Right result ->
+                                handlePoll
+                                    authorization
+                                    schedule
+                                    polledAt
+                                    result
+            _ -> pure Nothing
+
+    handlePoll authorization schedule polledAt = \case
+        GatewayAuthorized accessToken websocketUrl
+            | devicePollReadiness polledAt schedule
+                == DevicePollExpired ->
+                    gatewayTimedOut
+            | otherwise -> do
+                saved <-
+                    saveGatewayCredential GatewayCredential
+                        { gatewayBaseUrl =
+                            authorization.authorizationBaseUrl
+                        , gatewayWebSocketUrl = websocketUrl
+                        , gatewayAccessToken = accessToken
+                        }
+                pure $ Just $ case saved of
+                    Left err ->
+                        LoginNotice False
+                            ("Could not save gateway connection: " <> err)
+                    Right () ->
+                        LoginNotice True
+                            "Gateway connected. Restart the agent to apply the new route immediately."
+        GatewayAuthorizationPending serverInterval ->
+            continuePending
+                authorization
+                polledAt
+                (advanceGatewayPollSchedule
+                    False serverInterval polledAt schedule)
+                authorizationPendingNotice
+        GatewaySlowDown serverInterval ->
+            let nextSchedule =
+                    advanceGatewayPollSchedule
+                        True serverInterval polledAt schedule
+                seconds = case devicePollReadiness polledAt nextSchedule of
+                    DevicePollWait waitSeconds -> waitSeconds
+                    _ -> 0
+            in continuePending
+                authorization
+                polledAt
+                nextSchedule
+                ( "The gateway asked this client to slow down. "
+                    <> "The next check is available in "
+                    <> Text.pack (show seconds)
+                    <> " seconds."
+                )
+        GatewayAccessDenied ->
+            pure $ Just $
+                LoginNotice False "Gateway authorization was denied."
+        GatewayExpired ->
+            gatewayTimedOut
+        GatewayPollFailed code ->
+            pure $ Just $
+                LoginNotice False
+                    ("Gateway authorization failed: " <> code)
+
+    continuePending authorization polledAt nextSchedule notice
+        | devicePollReadiness polledAt nextSchedule
+            == DevicePollExpired =
+                gatewayTimedOut
+        | otherwise =
+            awaitAuthorization
+                authorization
+                nextSchedule
+                (Just notice)
+
+    gatewayTimedOut =
+        pure $ Just $
+            LoginNotice False "Gateway device authorization timed out."
 
 accountIdentifier :: LoginAccount -> Text
 accountIdentifier account
@@ -406,9 +635,10 @@ loginDashboardBody :: Maybe LoginNotice -> [LoginAccount] -> Text
 loginDashboardBody notice accounts =
     Text.intercalate "\n\n" $
         [ "Manage credentials and inspect provider usage without leaving the fullscreen UI."
-        , "**" <> Text.pack (show (length accounts)) <> " accounts**"
+        , "**" <> Text.pack (show (length providerAccounts)) <> " accounts**"
             <> " · " <> Text.pack (show managedCount) <> " managed"
             <> " · " <> Text.pack (show enabledCount) <> " enabled"
+        , gatewaySummary
         ]
             <> maybe [] (pure . formatLoginNotice) notice
             <> [ if null accounts
@@ -416,8 +646,16 @@ loginDashboardBody notice accounts =
                     else "Select an account for usage details, importing, enable/disable, or disconnect."
                ]
   where
-    managedCount = length (filter (isJust . (.loginManagedId)) accounts)
-    enabledCount = length (filter (.loginEnabled) accounts)
+    providerAccounts = filter (not . isGatewayLoginAccount) accounts
+    managedCount =
+        length (filter (isJust . (.loginManagedId)) providerAccounts)
+    enabledCount = length (filter (.loginEnabled) providerAccounts)
+    gatewaySummary =
+        case filter isGatewayLoginAccount accounts of
+            gateway : _ ->
+                "**Gateway:** " <> markdownText 160 gateway.loginAccountId
+            [] ->
+                "**Gateway:** not connected"
 
 loginAccountActionRows :: LoginAccount -> [(Text, Text)]
 loginAccountActionRows = map snd . loginAccountMenuEntries
@@ -426,12 +664,24 @@ loginAccountMenuEntries
     :: LoginAccount
     -> [(LoginAccountMenuAction, (Text, Text))]
 loginAccountMenuEntries account =
-    [ (LoginAccountRefresh, ("↻ Refresh usage", "Fetch the latest provider limits"))
-    ]
+    refreshEntries
         <> managementEntries
         <> [(LoginAccountBack, ("← Back to accounts", "Return to the dashboard"))]
   where
-    managementEntries = case account.loginManagedId of
+    refreshEntries
+        | isGatewayLoginAccount account = []
+        | otherwise =
+            [ ( LoginAccountRefresh
+              , ("↻ Refresh usage", "Fetch the latest provider limits")
+              )
+            ]
+    managementEntries
+        | isGatewayLoginAccount account =
+            [ ( LoginAccountDisconnect
+              , ("− Disconnect gateway", "Stop routing OpenAI requests through the gateway")
+              )
+            ]
+        | otherwise = case account.loginManagedId of
         Just _ ->
             [ ( LoginAccountToggle
               , ( if account.loginEnabled
@@ -467,6 +717,23 @@ loginAccountBody notice account =
             <> [loginAccountDetail account]
 
 loginAccountDetail :: LoginAccount -> Text
+loginAccountDetail account
+    | isGatewayLoginAccount account =
+        Text.intercalate "\n"
+            [ "**" <> markdownText 100 account.loginLabel <> "**"
+            , ""
+            , "Gateway URL: "
+                <> markdownText 160 account.loginAccountId
+            , "Status: " <> gatewayStatus
+            , ""
+            , "The gateway is preferred for OpenAI requests. If its saved "
+                <> "authorization is rejected, compatible local ChatGPT "
+                <> "accounts remain available as fallbacks."
+            ]
+      where
+        gatewayStatus = case account.loginUsage of
+            UsageUnavailable _ -> "saved credential is unreadable"
+            _ -> "saved"
 loginAccountDetail account =
     Text.intercalate "\n" $
         [ "**" <> markdownText 100 account.loginLabel <> "**"
@@ -529,6 +796,9 @@ usageBar usedPercent =
 
 accountHealthGlyph :: LoginAccount -> Text
 accountHealthGlyph account
+    | isGatewayLoginAccount account = case account.loginUsage of
+        UsageUnavailable _ -> "✗ "
+        _ -> "✓ "
     | not account.loginEnabled = "○ "
     | otherwise = case account.loginUsage of
         UsageNotChecked -> "◌ "
@@ -553,6 +823,10 @@ usageSummary = \case
             [] -> case usage.creditsRemaining of
                 Just remaining -> remaining <> " remaining"
                 Nothing -> maybe "usage available" id usage.usagePlan
+
+isGatewayLoginAccount :: LoginAccount -> Bool
+isGatewayLoginAccount account =
+    account.loginSource == "gateway"
 
 displayText :: Int -> Text -> Text
 displayText limit =
@@ -595,10 +869,11 @@ refreshAllNotice accounts
             ("Usage refreshed; " <> Text.pack (show unavailable)
                 <> " of " <> count <> " accounts were unavailable.")
   where
-    count = Text.pack (show (length accounts))
+    providerAccounts = filter (not . isGatewayLoginAccount) accounts
+    count = Text.pack (show (length providerAccounts))
     unavailable = length
         [()
-        | account <- accounts
+        | account <- providerAccounts
         , UsageUnavailable _ <- [account.loginUsage]
         ]
 
@@ -629,12 +904,17 @@ confirmFullscreenDisconnect runtime account = do
         requestFullscreenChoiceWithBody
             runtime
             "Disconnect credential?"
-            ( "Delete **" <> markdownText 100 account.loginLabel
-                <> "** from the managed credential store?\n\n"
-                <> "This cannot be undone."
+            ( if account.loginSource == "gateway"
+                then "Disconnect **" <> markdownText 100 account.loginLabel
+                    <> "**?\n\nThe saved gateway credential will be removed."
+                else "Delete **" <> markdownText 100 account.loginLabel
+                    <> "** from the managed credential store?\n\n"
+                    <> "This cannot be undone."
             )
             1
-            [ ("Disconnect", "Delete the stored credential")
+            [ ("Disconnect", if account.loginSource == "gateway"
+                then "Remove the saved gateway connection"
+                else "Delete the stored credential")
             , ("Keep credential", "Return without changing anything")
             ]
     pure (choice == Just 0)
@@ -684,7 +964,12 @@ discoverLoginAccounts = do
 -- and distinct managed credentials remain separately addressable.
 discoverSelectableLoginAccounts :: IO [LoginAccount]
 discoverSelectableLoginAccounts = do
-    accounts <- filter (.loginEnabled) <$> discoverLoginAccountSources
+    accounts <-
+        filter
+            (\account ->
+                account.loginEnabled
+                    && not (isGatewayLoginAccount account))
+            <$> discoverLoginAccountSources
     pure (nubOrdOn loginAccountSelectionId accounts)
 
 loginAccountSelectionId :: LoginAccount -> Text
@@ -709,11 +994,12 @@ discoverLoginAccountSources = do
     openRouter <- discoverOpenRouter
     gemini <- discoverGemini
     managed <- loadManagedCredentials
+    gateway <- loadGatewayLoginAccount
     let managedAccounts = case managed of
             Left _ -> []
             Right entries -> map (managedLoginAccount now) entries
     pure $
-        managedAccounts
+        maybe managedAccounts (:managedAccounts) gateway
             <> catMaybes
                 [ openaiEnv
                 , openaiFile
@@ -722,6 +1008,39 @@ discoverLoginAccountSources = do
                 , openRouter
                 , gemini
                 ]
+
+loadGatewayLoginAccount :: IO (Maybe LoginAccount)
+loadGatewayLoginAccount =
+    loadGatewayCredential >>= \case
+        Right (Just credential) ->
+            pure $ Just LoginAccount
+                { loginManagedId = Nothing
+                , loginProvider = OpenAIProvider
+                , loginAccountId = credential.gatewayBaseUrl
+                , loginLabel = "Gateway · " <> credential.gatewayBaseUrl
+                , loginBilling = SubscriptionBilling Nothing
+                , loginSource = "gateway"
+                , loginUsage = UsageNotChecked
+                , loginAccessToken = ""
+                , loginAuthKind = ManagedOpenAIAuthJson
+                , loginSecretPayload = ""
+                , loginEnabled = True
+                }
+        Left err ->
+            pure $ Just LoginAccount
+                { loginManagedId = Nothing
+                , loginProvider = OpenAIProvider
+                , loginAccountId = "(invalid saved credential)"
+                , loginLabel = "Gateway connection needs repair"
+                , loginBilling = SubscriptionBilling Nothing
+                , loginSource = "gateway"
+                , loginUsage = UsageUnavailable err
+                , loginAccessToken = ""
+                , loginAuthKind = ManagedOpenAIAuthJson
+                , loginSecretPayload = ""
+                , loginEnabled = True
+                }
+        Right Nothing -> pure Nothing
 
 managedLoginAccount
     :: UTCTime
@@ -801,20 +1120,32 @@ deleteAt color index accounts =
     case accountAt index accounts of
         Nothing -> pure ()
         Just account -> case account.loginManagedId of
+            Nothing
+                | isGatewayLoginAccount account ->
+                    confirmDisconnect account
             Nothing ->
                 disconnectLoginAccount account >>= printLoginResult color
-            Just _ ->
-                readApprovalLine
-                    ("Disconnect " <> account.loginLabel <> "? [y/N] ")
-                    >>= \case
-                        Just answer
-                            | Text.toLower (Text.strip answer) `elem` ["y", "yes"] ->
-                                disconnectLoginAccount account
-                                    >>= printLoginResult color
-                        _ -> pure ()
+            Just _ -> confirmDisconnect account
+  where
+    confirmDisconnect account =
+        readApprovalLine
+            ("Disconnect " <> account.loginLabel <> "? [y/N] ")
+            >>= \case
+                Just answer
+                    | Text.toLower (Text.strip answer) `elem` ["y", "yes"] ->
+                        disconnectLoginAccount account
+                            >>= printLoginResult color
+                _ -> pure ()
 
 disconnectLoginAccount :: LoginAccount -> IO (Either Text Text)
 disconnectLoginAccount account = case account.loginManagedId of
+    Nothing
+        | isGatewayLoginAccount account ->
+            fmap
+                (fmap
+                    (const
+                        "Gateway disconnected. Restart the agent to apply the route change immediately."))
+                removeGatewayCredential
     Nothing ->
         pure (Left
             "external credentials are read-only; remove them from their source")
@@ -1786,6 +2117,7 @@ prepareGrokLoginAccount account
 
 refreshLoginAccount :: LoginAccount -> IO LoginAccount
 refreshLoginAccount account
+    | isGatewayLoginAccount account = pure account
     | Text.null account.loginAccessToken = pure case account.loginUsage of
         UsageNotChecked ->
             account
@@ -1973,6 +2305,9 @@ renderAccount color selected index account =
   where
     cursor = if selected == index then roleWarn color "› " else "  "
     health
+        | isGatewayLoginAccount account = case account.loginUsage of
+            UsageUnavailable _ -> roleError color glyphErr
+            _ -> roleSuccess color glyphOk
         | not account.loginEnabled = roleWarn color "○ "
         | otherwise = case account.loginUsage of
             UsageNotChecked -> roleMuted color "◌ "
@@ -1990,15 +2325,26 @@ renderAccount color selected index account =
     accountId
         | Text.null account.loginAccountId = "(unknown account)"
         | otherwise = Text.take 24 account.loginAccountId
-    usageLines = case account.loginUsage of
-        UsageNotChecked ->
-            ["    " <> roleMuted color "checking usage…"]
-        UsageUnavailable err ->
-            ["    " <> roleError color ("usage unavailable · " <> Text.take 100 err)]
-        UsageAvailable usage ->
-            map ("    " <>) $
-                map (roleMuted color . formatWindow) usage.usageWindows
-                    <> creditLines usage
+    usageLines
+        | isGatewayLoginAccount account = case account.loginUsage of
+            UsageUnavailable err ->
+                [ "    "
+                    <> roleError color
+                        ("gateway needs repair · " <> Text.take 100 err)
+                ]
+            _ -> ["    " <> roleMuted color "gateway connected"]
+        | otherwise = case account.loginUsage of
+            UsageNotChecked ->
+                ["    " <> roleMuted color "checking usage…"]
+            UsageUnavailable err ->
+                [ "    "
+                    <> roleError color
+                        ("usage unavailable · " <> Text.take 100 err)
+                ]
+            UsageAvailable usage ->
+                map ("    " <>) $
+                    map (roleMuted color . formatWindow) usage.usageWindows
+                        <> creditLines usage
 
 formatWindow :: UsageWindow -> Text
 formatWindow window =

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -28,6 +28,7 @@ import Agent.CLI.Session.History
 import Agent.CLI.Auth
     ( LoadedAuth(..)
     , loadAuth
+    , loadDirectOpenAiAuth
     , loadAuthForAccount
     , preferredOpenAiTokenProvider
     )
@@ -162,7 +163,7 @@ loadSelectedAccountAuth
 loadSelectedAccountAuth provider selectionId accountId =
     case provider of
         OpenAIProvider ->
-            loadAuth (Just OpenAIProvider) >>= \case
+            loadDirectOpenAiAuth >>= \case
                 Left err -> pure (Left err)
                 Right loaded -> case loaded.loadedOpenAiPool of
                     Nothing ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -20,6 +20,7 @@ import Agent.CLI.Artifact ()
 import Agent.CLI.Auth
     ( LoadedAuth(loadedAccountLabel, LoadedAuth, loadedOpenAiPool,
                  loadedProvider, loadedTokenProvider, loadedSelectionId),
+      gatewayAuthSelectionId,
       preferredOpenAiTokenProvider,
       loadAuth,
       loadAuthForAccount,
@@ -701,6 +702,15 @@ runAgentInitializedWithLock
                                 Right (credential, usable) -> do
                                     label <-
                                         usable.loadedAccountLabel credential
+                                    when
+                                        (loaded.loadedProvider
+                                            == OpenAIProvider) $
+                                        writeIORef
+                                            preferredOpenAiAccountRef
+                                            (if selectedSelectionId
+                                                    == gatewayAuthSelectionId
+                                                then Nothing
+                                                else Just credential.accountId)
                                     let selectionId =
                                             fromMaybe
                                                 selectedSelectionId

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Auth
 import Agent.CLI.CredentialStore
 import Agent.CLI.GatewayClient
     ( GatewayCredential(..)
+    , gatewayCredentialPath
     , saveGatewayCredentialAt
     )
 import qualified Agent.CLI.Login as Login
@@ -61,6 +62,13 @@ fromFilePath = unsafeEncodeUtf
 
 toFilePath :: OsPath -> FilePath
 toFilePath path = either (error . show) id (decodeUtf path)
+
+expectRightResult :: Show err => Either err value -> IO value
+expectRightResult = \case
+    Left err -> do
+        expectationFailure ("expected Right, got " <> show err)
+        fail "unreachable after expectation failure"
+    Right value -> pure value
 
 spec :: Spec
 spec = do
@@ -161,6 +169,178 @@ spec = do
                         loaded.loadedProvider `shouldBe` OpenAIProvider
                         loaded.loadedSelectionId
                             `shouldBe` Just gatewayAuthSelectionId
+
+        it "falls back from a rejected gateway to local ChatGPT auth" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccount
+                        "local-openai"
+                        "local-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just OpenAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            case loaded.loadedOpenAiPool of
+                                Nothing ->
+                                    expectationFailure
+                                        "expected local OpenAI fallback pool"
+                                Just _ -> pure ()
+                            gatewayCredential <-
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    Nothing
+                                    >>= expectRightResult
+                            gatewayCredential.accountId
+                                `shouldBe`
+                                    "wss://gateway.example/v1/responses"
+                            localCredential <-
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    (Just FailedCredential
+                                        { credential = gatewayCredential
+                                        , failure =
+                                            AccountAuthenticationRejected
+                                        , failureReason =
+                                            testAuthenticationReason
+                                        })
+                                    >>= expectRightResult
+                            localCredential.accountId
+                                `shouldBe` "local-account"
+                            getNextToken
+                                loaded.loadedTokenProvider
+                                Nothing
+                                `shouldReturn` Right localCredential
+
+        it "does not turn a rejected gateway into API-credit spending" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccountWithBilling
+                        ApiBilled
+                        "api-openai"
+                        "api-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just OpenAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            case loaded.loadedOpenAiPool of
+                                Nothing -> pure ()
+                                Just _ ->
+                                    expectationFailure
+                                        "API-credit pool must not be attached"
+                            gatewayCredential <-
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    Nothing
+                                    >>= expectRightResult
+                            getNextToken
+                                loaded.loadedTokenProvider
+                                (Just FailedCredential
+                                    { credential = gatewayCredential
+                                    , failure =
+                                        AccountAuthenticationRejected
+                                    , failureReason =
+                                        testAuthenticationReason
+                                    })
+                                >>= \case
+                                    Left (CredentialError _) -> pure ()
+                                    other ->
+                                        expectationFailure $
+                                            "expected gateway rejection, got "
+                                                <> show other
+
+        it "uses local OpenAI auth when the gateway file is invalid" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    let path = toFilePath (gatewayCredentialPath home)
+                    createDirectoryIfMissing True
+                        (toFilePath home </> ".haskell-agent"
+                            </> "credentials")
+                    LBS.writeFile path "{not-json"
+                    storeOpenAiAccount
+                        "local-openai"
+                        "local-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just OpenAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            loaded.loadedSelectionId `shouldBe` Nothing
+                            getNextToken
+                                loaded.loadedTokenProvider
+                                Nothing
+                                >>= \case
+                                    Left err ->
+                                        expectationFailure (show err)
+                                    Right credential ->
+                                        credential.accountId
+                                            `shouldBe` "local-account"
+
+        it "does not turn an invalid gateway into API-credit spending" $
+            withTempHome \home ->
+                withCleanOpenAiEnv $
+                withCleanGrokEnv do
+                    let path = toFilePath (gatewayCredentialPath home)
+                    createDirectoryIfMissing True
+                        (toFilePath home </> ".haskell-agent"
+                            </> "credentials")
+                    LBS.writeFile path "{not-json"
+                    storeOpenAiAccountWithBilling
+                        ApiBilled
+                        "api-openai"
+                        "api-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth Nothing >>= \case
+                        Left err ->
+                            err `shouldSatisfy`
+                                Text.isInfixOf
+                                    "refusing automatic fallback to API-credit billing"
+                        Right _ ->
+                            expectationFailure
+                                "expected invalid gateway to preserve the billing boundary"
+
+        it "uses another subscription provider when the gateway file is invalid" $
+            withTempHome \home ->
+                withCleanOpenAiEnv $
+                withCleanGrokEnv $
+                withEnv "GROK_ACCESS_TOKEN" (Just "xai-token") do
+                    let path = toFilePath (gatewayCredentialPath home)
+                    createDirectoryIfMissing True
+                        (toFilePath home </> ".haskell-agent"
+                            </> "credentials")
+                    LBS.writeFile path "{not-json"
+                    loadAuth Nothing >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded ->
+                            loaded.loadedProvider `shouldBe` XAIProvider
+
+        it "skips API-credit auth to use another subscription provider" $
+            withTempHome \home ->
+                withCleanOpenAiEnv $
+                withCleanGrokEnv $
+                withEnv "GROK_ACCESS_TOKEN" (Just "xai-token") do
+                    let path = toFilePath (gatewayCredentialPath home)
+                    createDirectoryIfMissing True
+                        (toFilePath home </> ".haskell-agent"
+                            </> "credentials")
+                    LBS.writeFile path "{not-json"
+                    storeOpenAiAccountWithBilling
+                        ApiBilled
+                        "api-openai"
+                        "api-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth Nothing >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            loaded.loadedProvider `shouldBe` XAIProvider
+                            tokenProviderBillingMode
+                                loaded.loadedTokenProvider
+                                `shouldBe` SubscriptionBilled
 
         it "does not let a gateway override an explicit non-OpenAI provider" $
             withTempHome \home ->
@@ -394,6 +574,74 @@ spec = do
                         `shouldReturn` Right second
 
     describe "loadAuthForAccount" do
+        it "keeps local fallback when the gateway route is selected" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccount
+                        "local-openai"
+                        "local-account"
+                        True
+                        farFutureAccessToken
+                    loadAuthForAccount
+                        OpenAIProvider
+                        gatewayAuthSelectionId
+                        >>= \case
+                            Left err ->
+                                expectationFailure (Text.unpack err)
+                            Right loaded -> do
+                                gatewayCredential <-
+                                    getNextToken
+                                        loaded.loadedTokenProvider
+                                        Nothing
+                                        >>= expectRightResult
+                                localCredential <-
+                                    getNextToken
+                                        loaded.loadedTokenProvider
+                                        (Just FailedCredential
+                                            { credential = gatewayCredential
+                                            , failure =
+                                                AccountAuthenticationRejected
+                                            , failureReason =
+                                                testAuthenticationReason
+                                            })
+                                        >>= expectRightResult
+                                localCredential.accountId
+                                    `shouldBe` "local-account"
+
+        it "loads the selected local OpenAI account while a gateway is connected" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccount
+                        "local-openai-a"
+                        "local-account-a"
+                        True
+                        farFutureAccessToken
+                    storeOpenAiAccount
+                        "local-openai-b"
+                        "local-account-b"
+                        True
+                        farFutureAccessToken
+                    loadAuthForAccount
+                        OpenAIProvider
+                        "local-account-b"
+                        >>= \case
+                            Left err ->
+                                expectationFailure (Text.unpack err)
+                            Right loaded -> do
+                                loaded.loadedSelectionId
+                                    `shouldBe` Just "local-account-b"
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    Nothing
+                                    >>= \case
+                                        Left err ->
+                                            expectationFailure (show err)
+                                        Right credential ->
+                                            credential.accountId
+                                                `shouldBe` "local-account-b"
+
         it "does not let a gateway override a selected non-OpenAI account" $
             withTempHome \home ->
                 withCleanGrokEnv $
@@ -647,6 +895,41 @@ spec = do
                                     `shouldReturn` Right "openrouter"
 
     describe "discoverSelectableLoginAccounts" do
+        it "shows a gateway in login management but not account selection" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccount
+                        "local-openai"
+                        "local-account"
+                        True
+                        farFutureAccessToken
+                    managed <- Login.discoverLoginAccounts
+                    selectable <- Login.discoverSelectableLoginAccounts
+                    map (.loginSource) managed
+                        `shouldSatisfy` elem "gateway"
+                    map (.loginSource) selectable
+                        `shouldSatisfy` not . elem "gateway"
+
+        it "keeps an unreadable gateway visible so it can be disconnected" $
+            withTempHome \home -> do
+                createDirectoryIfMissing True
+                    (toFilePath home </> ".haskell-agent"
+                        </> "credentials")
+                LBS.writeFile
+                    (toFilePath (gatewayCredentialPath home))
+                    "{not-json"
+                accounts <- Login.discoverLoginAccounts
+                case filter ((== "gateway") . (.loginSource)) accounts of
+                    [gateway] ->
+                        gateway.loginUsage
+                            `shouldSatisfy` \case
+                                Login.UsageUnavailable _ -> True
+                                _ -> False
+                    _ ->
+                        expectationFailure
+                            "expected one repairable gateway entry"
+
         it "does not let a disabled managed account shadow an external source" $
             withTempHome \_ ->
                 withCleanGrokEnv $
@@ -1637,6 +1920,10 @@ testAuthenticationReason = ExhaustedByAuthentication
     { exhaustionErrorType = Nothing
     , exhaustionStatusCode = Just 401
     }
+
+farFutureAccessToken :: Text
+farFutureAccessToken =
+    "e30.eyJleHAiOjQxMDI0NDQ4MDB9."
 
 testRateLimitReason :: Maybe Int -> CredentialExhaustionReason
 testRateLimitReason retryAfter = ExhaustedByRateLimit

--- a/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
@@ -4,13 +4,17 @@ import Agent.CLI.GatewayClient
 import Agent.Json.Decode qualified as Hermes
 import Control.Exception.Safe (bracket)
 import Data.Bits ((.&.))
+import Data.ByteString.Lazy qualified as LBS
+import Data.Either (isLeft)
 import Data.Text qualified as Text
 import System.Directory
     ( createDirectory
+    , createDirectoryIfMissing
     , getTemporaryDirectory
     , removeFile
     , removePathForcibly
     )
+import System.FilePath (takeDirectory)
 import System.IO (hClose, openTempFile)
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import System.Posix.Files (fileMode, getFileStatus)
@@ -52,6 +56,16 @@ spec = describe "gateway device authorization" do
         let credential =
                 GatewayCredential "https://gateway" "wss://gateway/v1/responses" "secret"
         show credential `shouldSatisfy` not . Text.isInfixOf "secret" . Text.pack
+        show (GatewayAuthorized "secret" "wss://gateway/v1/responses")
+            `shouldSatisfy` not . Text.isInfixOf "secret" . Text.pack
+        show (GatewayDeviceAuthorization
+                "device-secret"
+                "USER-CODE"
+                "https://gateway/connect"
+                "https://gateway/connect?code=USER-CODE"
+                600
+                5)
+            `shouldSatisfy` not . Text.isInfixOf "device-secret" . Text.pack
 
     it "allows local HTTP development without trusting lookalike hosts" do
         validateBaseUrl "http://localhost:8080"
@@ -59,6 +73,11 @@ spec = describe "gateway device authorization" do
         validateBaseUrl "http://localhost.example"
             `shouldBe` Left
                 "Gateway URL must use HTTPS (HTTP is allowed only for localhost development)."
+        validateBaseUrl "https://" `shouldSatisfy` isLeft
+        validateBaseUrl "https://user@gateway.example"
+            `shouldSatisfy` isLeft
+        validateBaseUrl "https://gateway.example?token=secret"
+            `shouldSatisfy` isLeft
 
     it "round-trips credentials through a mode-0600 file" $
         withTempHome \home -> do
@@ -74,6 +93,39 @@ spec = describe "gateway device authorization" do
                 (either (error . show) id
                     (decodeUtf (gatewayCredentialPath home)))
             fileMode status .&. 0o777 `shouldBe` 0o600
+
+    it "rejects invalid gateway endpoints before persisting them" $
+        withTempHome \home -> do
+            saveGatewayCredentialAt
+                home
+                (GatewayCredential
+                    "https://gateway"
+                    "https://not-a-websocket.example"
+                    "secret")
+                `shouldReturn`
+                    Left "gateway WebSocket URL must use wss"
+            saveGatewayCredentialAt
+                home
+                (GatewayCredential
+                    "https://gateway"
+                    "wss://gateway/v1/responses"
+                    "")
+                `shouldReturn`
+                    Left "Gateway access token cannot be empty."
+
+    it "rejects decoded credentials that fail validation" $
+        withTempHome \home -> do
+            let path =
+                    either (error . show) id
+                        (decodeUtf (gatewayCredentialPath home))
+            createDirectoryIfMissing True (takeDirectory path)
+            LBS.writeFile path
+                "{\"version\":1,\"base_url\":\"https://gateway\",\
+                \\"websocket_url\":\"wss://gateway/v1/responses\",\
+                \\"access_token\":\"\"}"
+            loadGatewayCredentialAt home
+                `shouldReturn`
+                    Left "Gateway access token cannot be empty."
 
 withTempHome :: (OsPath -> IO value) -> IO value
 withTempHome =

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -94,6 +94,10 @@ spec = do
             renderLoginFrame False (initialLoginState [openai])
                 `shouldSatisfy` (not . Text.isInfixOf "secret-openai")
 
+        it "shows gateway routing status instead of a usage spinner" do
+            renderLoginFrame False (initialLoginState [gateway])
+                `shouldSatisfy` Text.isInfixOf "gateway connected"
+
         it "shows unchecked usage as an in-progress refresh" do
             renderLoginFrame False (initialLoginState [openai])
                 `shouldSatisfy` Text.isInfixOf "checking usage"
@@ -121,8 +125,25 @@ spec = do
                 rendered = Text.unlines
                     [label <> " " <> description | (label, description) <- rows]
             labels `shouldSatisfy` any (Text.isInfixOf "Connect account")
+            labels `shouldSatisfy` any (Text.isInfixOf "Connect gateway")
             labels `shouldSatisfy` not . any (Text.isInfixOf "Refresh")
             rendered `shouldSatisfy` Text.isInfixOf "Google Gemini"
+
+        it "shows a saved gateway with reconnect and disconnect controls" do
+            let dashboardLabels =
+                    map fst (loginDashboardRows [gateway])
+                actionLabels =
+                    map fst (loginAccountActionRows gateway)
+            dashboardLabels
+                `shouldSatisfy` any (Text.isInfixOf "Reconnect gateway")
+            dashboardLabels
+                `shouldSatisfy` not . any (Text.isInfixOf "Refresh all")
+            actionLabels
+                `shouldSatisfy` any (Text.isInfixOf "Disconnect gateway")
+            actionLabels
+                `shouldSatisfy` not . any (Text.isInfixOf "Refresh usage")
+            loginAccountDetail gateway
+                `shouldSatisfy` Text.isInfixOf "preferred"
 
         it "offers usage refresh and opens each discovered account" do
             let rows = loginDashboardRows [openai, openRouter]
@@ -259,6 +280,21 @@ openRouter = LoginAccount
     , loginAccessToken = "secret-openrouter"
     , loginAuthKind = ManagedBearerToken
     , loginSecretPayload = "secret-openrouter"
+    , loginEnabled = True
+    }
+
+gateway :: LoginAccount
+gateway = LoginAccount
+    { loginManagedId = Nothing
+    , loginProvider = OpenAIProvider
+    , loginAccountId = "https://gateway.example"
+    , loginLabel = "Gateway · https://gateway.example"
+    , loginBilling = SubscriptionBilling Nothing
+    , loginSource = "gateway"
+    , loginUsage = UsageNotChecked
+    , loginAccessToken = ""
+    , loginAuthKind = ManagedBearerToken
+    , loginSecretPayload = ""
     , loginEnabled = True
     }
 


### PR DESCRIPTION
## Summary
- treat the gateway as a preferred OpenAI route instead of letting a stale gateway block other accounts
- fall back only to local subscription-billed OpenAI auth on gateway authentication or rate-limit failures, without silently spending API credits
- add connect, reconnect, repair, and disconnect controls for the gateway to the fullscreen `/login` dashboard
- validate persisted gateway endpoints and credentials, preserve old credentials on failed reconnects, and redact authorization secrets from diagnostics
- keep explicit provider and exact account selections from being overridden by the gateway

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --offline`
  - `--match loadAuth`: 21 examples, 0 failures
  - `--match "gateway device authorization"`: 7 examples, 0 failures
  - `--match "fullscreen login dashboard"`: 6 examples, 0 failures
- live tmux smoke: `/login` → Connect gateway → URL prompt → cancel
- `git diff --check origin/master...HEAD`

The live smoke did not create or modify a real gateway credential.