### PR TITLE
Clean up stale worktrees and session temp directories

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -192,6 +192,7 @@ runAgentWithRestarts options =
             home <- getHomeDirectory
             let root = sessionsRoot home
             elicitationRef <- newIORef Nothing
+            cleanupStarted <- newIORef False
             mcpSupervisor <-
                 MCP.newMcpSupervisorWith
                     MCP.defaultMcpHostHooks
@@ -202,6 +203,7 @@ runAgentWithRestarts options =
             let processRuntime = AgentProcessRuntime
                     { processMcpSupervisor = mcpSupervisor
                     , processSessionThreads = sessionThreads
+                    , processCleanupStarted = cleanupStarted
                     , processMcpElicitation = elicitationRef
                     }
             withRestoredCurrentDirectory

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -113,14 +113,20 @@ import Agent.CLI.Runtime.Types ()
 import Agent.CLI.Secret ( promptSecretLine )
 import Agent.CLI.Session
     ( allocateSessionTemp,
+      acquireSessionTempLease,
+      cleanupStaleSessionTemps,
       cleanupPendingPersistence,
+      defaultSessionTempKeepCount,
+      listSessions,
       persistenceTempDir,
+      releaseSessionTempLease,
       removeSessionTemp,
       sessionLegacySubagentTarget,
+      SessionTempCleanupReport(..),
       Persistence(PersistenceDisabled),
       SessionHandle(sessionDir, sessionMeta),
       SessionMeta(metaId, metaTransportModel, metaProvider,
-                  metaConnection, metaModel, metaDialect, metaEffort),
+                  metaConnection, metaModel, metaDialect, metaEffort, metaCwd),
       SessionTurn(turnAssistantText) )
 import Agent.CLI.Session.Attachments ( putImagePreview )
 import Agent.CLI.Session.Choices ()
@@ -165,7 +171,14 @@ import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch
     ( closeWebFetchRuntime, newWebFetchRuntime, webFetchRuntimeTool )
 import Agent.CLI.Worktree
-    ( createManagedWorktree, removeWorktree )
+    ( acquireWorktreeLease,
+      cleanupStaleWorktrees,
+      createManagedWorktree,
+      defaultWorktreeKeepCount,
+      releaseWorktreeLease,
+      removeWorktree,
+      worktreeRoot,
+      WorktreeCleanupReport(..) )
 import Agent.Cancel ()
 import Agent.Claude ()
 import Agent.Dialect
@@ -233,7 +246,7 @@ import Agent.Tools.ShowImage
 import Agent.Tools.Types ( setToolSessionTmp )
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ( (<|>) )
-import Control.Concurrent.Async ( concurrently_ )
+import Control.Concurrent.Async ( concurrently, concurrently_ )
 import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar ()
 import Control.Concurrent.STM ()
@@ -254,7 +267,6 @@ import System.Directory.OsPath (getHomeDirectory)
 import System.Environment ()
 import System.Exit ()
 import System.IO ()
-import System.OsPath ()
 import qualified Data.ByteString as BS ()
 import qualified Agent.Responses.GenericClient as GenericResponses
     ()
@@ -282,7 +294,7 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ()
-import qualified Data.Text as Text ( intercalate, unpack )
+import qualified Data.Text as Text ( intercalate, pack, unpack )
 import qualified Data.Text.IO as Text ()
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Client as XAIClient ()
@@ -621,11 +633,32 @@ runAgentTools
             imageGenerationHistory
             (foldSessionItems turns)
     home <- getHomeDirectory
-    let cleanupScratch = do
+    let cleanupAllocatedScratch = do
             cleanupPendingPersistence persist
             forM_ ephemeralSessionId \sessionId -> do
                 _ <- removeSessionTemp root sessionId
                 pure ()
+    worktreeLease <-
+        acquireWorktreeLease (worktreeRoot home) cwd >>= \case
+            Left err -> do
+                cleanupAllocatedScratch
+                startupDie startup (Text.unpack err)
+            Right lease -> pure lease
+    sessionTempLease <-
+        (acquireSessionTempLease root sessionTmp
+            `onException`
+                (mapM_ releaseWorktreeLease worktreeLease
+                    >> cleanupAllocatedScratch)) >>= \case
+                Left err -> do
+                    mapM_ releaseWorktreeLease worktreeLease
+                    cleanupAllocatedScratch
+                    startupDie startup (Text.unpack err)
+                Right lease -> pure lease
+    let cleanupScratch =
+            mapM_ releaseSessionTempLease sessionTempLease
+                `finally`
+                    (mapM_ releaseWorktreeLease worktreeLease
+                        `finally` cleanupAllocatedScratch)
         toolEnv = baseToolEnv
         mcpServerConfigs =
             [ MCP.McpServerConfig
@@ -658,6 +691,55 @@ runAgentTools
             useProgressiveMcp
                 harnessConfig.configMcpInitStrategy
                 (isOneShot options)
+    let AgentProcessRuntime
+            { processCleanupStarted = cleanupStarted
+            } = processRuntime
+    runCleanup <- atomicModifyIORef'
+        cleanupStarted
+        (\started -> (True, not started))
+    when runCleanup do
+        cleanupResult <- try @_ @SomeException do
+            (sessions, sessionWarnings) <-
+                listSessions
+                    (trustedPool startup.startupDatabaseStore)
+                    root
+            let protectedWorktrees =
+                    -- Persisted sessions must remain resumable. A worktree
+                    -- becomes collectible after its session is deleted.
+                    cwd : map (.metaCwd) sessions
+            (worktreeReport, tempReport) <- concurrently
+                (if null sessionWarnings
+                    then cleanupStaleWorktrees
+                        (worktreeRoot home)
+                        defaultWorktreeKeepCount
+                        protectedWorktrees
+                    -- A partial session catalog cannot prove that an old
+                    -- checkout is unreferenced.
+                    else pure mempty)
+                (cleanupStaleSessionTemps
+                    root
+                    defaultSessionTempKeepCount
+                    [sessionTmp])
+            pure (sessionWarnings, worktreeReport, tempReport)
+        case cleanupResult of
+            Left exception ->
+                reportStartupWarning startup
+                    ("stale resource cleanup failed: "
+                        <> formatException exception)
+            Right (sessionWarnings, worktreeReport, tempReport) -> do
+                mapM_ (reportStartupWarning startup) sessionWarnings
+                forM_ worktreeReport.cleanupFailures \(path, err) ->
+                    reportStartupWarning startup
+                        ("could not clean stale worktree "
+                            <> Text.pack (unsafeToFilePath path)
+                            <> ": "
+                            <> err)
+                forM_ tempReport.tempCleanupFailures \(path, err) ->
+                    reportStartupWarning startup
+                        ("could not clean stale session scratch directory "
+                            <> Text.pack (unsafeToFilePath path)
+                            <> ": "
+                            <> err)
     mcpStatusPhaseRef <- newIORef (Nothing :: Maybe Bool)
     mcpFleetRef <- newIORef (Nothing :: Maybe MCP.McpFleet)
     writeIORef processRuntime.processMcpElicitation
@@ -710,7 +792,8 @@ runAgentTools
                                             <> "…"))
                         mcpServerConfigs)
             >>= \case
-            Left exception ->
+            Left exception -> do
+                cleanupScratch
                 startupDie startup
                     ("Failed to initialize MCP tools: " <> show exception)
             Right lease -> pure lease

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -31,6 +31,7 @@ data AccountSwitchRequest
 data AgentProcessRuntime = AgentProcessRuntime
     { processMcpSupervisor :: !MCP.McpSupervisor
     , processSessionThreads :: !SessionThreadManager
+    , processCleanupStarted :: !(IORef Bool)
     , processMcpElicitation
         :: !(IORef (Maybe (MCP.McpElicitRequest -> IO MCP.McpElicitResult)))
     -- ^ Interactive elicitation UI installed by the active session, shared by

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -53,6 +53,12 @@ module Agent.CLI.Session
     , allocateSessionTemp
     , ensureSessionTemp
     , removeSessionTemp
+    , cleanupStaleSessionTemps
+    , defaultSessionTempKeepCount
+    , SessionTempCleanupReport(..)
+    , SessionTempLease
+    , acquireSessionTempLease
+    , releaseSessionTempLease
     , sessionsRoot
     , sessionTitleFromPrompt
     , setGeneratedSessionTitle
@@ -112,13 +118,15 @@ import qualified Agent.Store.Postgres.Session as Store
 import Agent.Store.Types (StoreError, renderStoreError)
 import Control.Applicative ((<|>))
 import Control.Exception.Safe
-    ( displayException
+    ( SomeException
+    , displayException
     , finally
     , mask
     , onException
+    , tryAny
     , tryIO
     )
-import Control.Monad (unless, when)
+import Control.Monad (foldM, unless, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
@@ -128,15 +136,24 @@ import Control.Monad.Trans.Except
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import Data.Char (isHexDigit)
 import Data.Int (Int64)
 import Data.IORef
 import Data.Functor ((<&>))
+import Data.List (sortOn)
 import Data.Maybe (fromMaybe)
+import Data.Ord (Down(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Time.Clock (UTCTime, getCurrentTime, nominalDiffTimeToSeconds)
+import Data.Time.Calendar (Day)
+import Data.Time.Clock
+    ( UTCTime
+    , getCurrentTime
+    , nominalDiffTimeToSeconds
+    , utctDay
+    )
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
-import Data.Time.Format (defaultTimeLocale, formatTime)
+import Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
 import qualified Data.Vector as Vector
 import Numeric (showHex)
 import System.Directory.OsPath
@@ -146,10 +163,20 @@ import System.Directory.OsPath
     , doesDirectoryExist
     , doesFileExist
     , listDirectory
+    , pathIsSymbolicLink
     , removePathForcibly
     , removeFile
     )
-import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
+import qualified System.FileLock as FileLock
+import System.OsPath
+    ( OsPath
+    , equalFilePath
+    , normalise
+    , takeDirectory
+    , takeFileName
+    , unsafeEncodeUtf
+    , (</>)
+    )
 import System.IO.Error (isDoesNotExistError)
 import System.Posix.Files
     ( FileStatus
@@ -162,6 +189,30 @@ import System.Posix.Files
 
 sessionSchemaVersion :: Int
 sessionSchemaVersion = 1
+
+-- | Keep a small recent cache for session artifacts while bounding abandoned
+-- shell environments, tool outputs, and other scratch data.
+defaultSessionTempKeepCount :: Int
+defaultSessionTempKeepCount = 15
+
+data SessionTempCleanupReport = SessionTempCleanupReport
+    { tempCleanupRemoved :: ![OsPath]
+    , tempCleanupFailures :: ![(OsPath, Text)]
+    }
+    deriving (Eq, Show)
+
+instance Semigroup SessionTempCleanupReport where
+    left <> right = SessionTempCleanupReport
+        { tempCleanupRemoved =
+            left.tempCleanupRemoved <> right.tempCleanupRemoved
+        , tempCleanupFailures =
+            left.tempCleanupFailures <> right.tempCleanupFailures
+        }
+
+instance Monoid SessionTempCleanupReport where
+    mempty = SessionTempCleanupReport [] []
+
+newtype SessionTempLease = SessionTempLease FileLock.FileLock
 
 -- | @~/.haskell-agent/sessions@ given the user's home directory.
 sessionsRoot :: OsPath -> OsPath
@@ -1192,6 +1243,212 @@ allocateSessionTemp root = do
                     Right () -> do
                         setFileMode (unsafeToFilePath tempDir) 0o700
                         pure (sessionId, tempDir)
+
+-- | Take a shared lease for a session's scratch directory. Automatic cleanup
+-- requires the matching exclusive lock, so a live process cannot lose its
+-- temporary files even before its durable session lock has been acquired.
+acquireSessionTempLease
+    :: OsPath
+    -> OsPath
+    -> IO (Either Text (Maybe SessionTempLease))
+acquireSessionTempLease root path =
+    case sessionTempId root path of
+        Nothing -> pure (Right Nothing)
+        Just sessionId -> do
+            let lockPath = sessionTempLockPath root sessionId
+            result <- tryAny $
+                ensurePrivateDir (takeDirectory lockPath)
+                    >> FileLock.tryLockFile
+                        (unsafeToFilePath lockPath)
+                        FileLock.Shared
+            pure case result of
+                Left exception ->
+                    Left
+                        ("failed to lease session scratch directory "
+                            <> toText path
+                            <> ": "
+                            <> Text.pack (displayException exception))
+                Right Nothing ->
+                    Left
+                        ("session scratch directory is being cleaned up: "
+                            <> toText path)
+                Right (Just lock) ->
+                    Right (Just (SessionTempLease lock))
+
+releaseSessionTempLease :: SessionTempLease -> IO ()
+releaseSessionTempLease (SessionTempLease lock) = do
+    _ <- tryAny (FileLock.unlockFile lock)
+    pure ()
+
+-- | Remove old session scratch directories after retaining the newest entries.
+-- Only allocator-shaped names are considered, and a directory with a live
+-- shared lease is skipped. Failures are reported per path and never stop the
+-- rest of the best-effort cleanup. Directories allocated on the current UTC
+-- day are always kept, closing the startup interval before a lease is taken.
+cleanupStaleSessionTemps
+    :: OsPath
+    -> Int
+    -> [OsPath]
+    -> IO SessionTempCleanupReport
+cleanupStaleSessionTemps root requestedKeep protected = do
+    let tempRoot = sessionTempsRoot root
+    exists <- doesDirectoryExist tempRoot
+    if not exists
+        then pure mempty
+        else do
+            today <- utctDay <$> getCurrentTime
+            listed <- tryAny (listDirectory tempRoot)
+            case listed of
+                Left exception ->
+                    pure $ tempCleanupFailure tempRoot exception
+                Right entries -> do
+                    directories <- foldM
+                        (collectDirectory tempRoot)
+                        ([], [])
+                        entries
+                    case directories of
+                        (managed, discoveryFailures) -> do
+                            let candidates =
+                                    filter
+                                        (isBefore today . takeFileName)
+                                        (drop (max 1 requestedKeep) $
+                                            sortOn
+                                                (Down
+                                                    . unsafeToFilePath
+                                                    . takeFileName)
+                                                managed)
+                            cleaned <- foldM cleanupOne mempty candidates
+                            pure $
+                                cleaned
+                                    <> mempty
+                                        { tempCleanupFailures =
+                                            discoveryFailures
+                                        }
+  where
+    protectedPaths = map normalise protected
+    isBefore today path =
+        maybe False (< today) (allocatedSessionDay path)
+
+    collectDirectory tempRoot (managed, failures) entry = do
+        let path = tempRoot </> entry
+        checked <- tryAny (doesDirectoryExist path)
+        pure case checked of
+            Left exception ->
+                ( managed
+                , failures
+                    <> [(path, Text.pack (displayException exception))]
+                )
+            Right True
+                | isAllocatedSessionId entry ->
+                    (managed <> [path], failures)
+            Right _ -> (managed, failures)
+
+    cleanupOne report candidate
+        | any
+            (\protectedPath ->
+                equalFilePath protectedPath (normalise candidate))
+            protectedPaths =
+                pure report
+        | otherwise = do
+            result <- tryAny (cleanupStaleSessionTemp root candidate)
+            pure $ report <> case result of
+                Left exception ->
+                    tempCleanupFailure candidate exception
+                Right candidateReport -> candidateReport
+
+cleanupStaleSessionTemp
+    :: OsPath
+    -> OsPath
+    -> IO SessionTempCleanupReport
+cleanupStaleSessionTemp root candidate =
+    case sessionTempId root candidate of
+        Nothing -> pure mempty
+        Just sessionId -> do
+            let durableDir = root </> sessionId
+            durableExists <- doesDirectoryExist durableDir
+            durableLock <-
+                if durableExists
+                    then fmap (fmap Just) $
+                        acquireSessionLock durableDir (toText sessionId)
+                    else pure (Right Nothing)
+            case durableLock of
+                -- A running or otherwise un-lockable durable session owns the
+                -- scratch directory. Treat either case conservatively.
+                Left _ -> pure mempty
+                Right lock ->
+                    cleanupWithSessionLock sessionId
+                        `finally` mapM_ releaseSessionLock lock
+  where
+    cleanupWithSessionLock sessionId = do
+        let lockPath = sessionTempLockPath root sessionId
+        locked <- tryAny $
+            ensurePrivateDir (takeDirectory lockPath)
+                >> FileLock.tryLockFile
+                    (unsafeToFilePath lockPath)
+                    FileLock.Exclusive
+        case locked of
+            Left exception ->
+                pure $ tempCleanupFailure candidate exception
+            Right Nothing ->
+                pure mempty
+            Right (Just lock) -> do
+                removed <- tryAny $
+                    (do
+                        symbolic <- pathIsSymbolicLink candidate
+                        if symbolic
+                            then pure False
+                            else removePathForcibly candidate >> pure True)
+                        `finally` FileLock.unlockFile lock
+                pure case removed of
+                    Left exception ->
+                        tempCleanupFailure candidate exception
+                    Right True ->
+                        mempty { tempCleanupRemoved = [candidate] }
+                    Right False -> mempty
+
+sessionTempId :: OsPath -> OsPath -> Maybe OsPath
+sessionTempId root rawPath =
+    let tempRoot = normalise (sessionTempsRoot root)
+        path = normalise rawPath
+    in if equalFilePath tempRoot (takeDirectory path)
+            && isAllocatedSessionId (takeFileName path)
+        then Just (takeFileName path)
+        else Nothing
+
+sessionTempLockPath :: OsPath -> OsPath -> OsPath
+sessionTempLockPath root sessionId =
+    sessionTempsRoot root
+        </> unsafeEncodeUtf ".locks"
+        </> (sessionId <> unsafeEncodeUtf ".lock")
+
+isAllocatedSessionId :: OsPath -> Bool
+isAllocatedSessionId path = case allocatedSessionDay path of
+    Just _ -> True
+    Nothing -> False
+
+allocatedSessionDay :: OsPath -> Maybe Day
+allocatedSessionDay path =
+    case unsafeToFilePath path of
+        year1 : year2 : year3 : year4 : '-' :
+                month1 : month2 : '-' : day1 : day2 : '-' : suffix ->
+            let date =
+                    [ year1, year2, year3, year4, '-'
+                    , month1, month2, '-', day1, day2
+                    ]
+            in if length suffix == 8 && all isHexDigit suffix
+                then parseTimeM True defaultTimeLocale "%Y-%m-%d" date
+                else Nothing
+        _ -> Nothing
+
+tempCleanupFailure
+    :: OsPath
+    -> SomeException
+    -> SessionTempCleanupReport
+tempCleanupFailure path exception =
+    mempty
+        { tempCleanupFailures =
+            [(path, Text.pack (displayException exception))]
+        }
 
 ensureSessionTemp :: OsPath -> Text -> IO (Either Text OsPath)
 ensureSessionTemp root sessionId =

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -5,6 +5,12 @@ module Agent.CLI.Worktree
     , createManagedWorktree
     , createManagedWorktreeWithProgress
     , removeWorktree
+    , cleanupStaleWorktrees
+    , defaultWorktreeKeepCount
+    , WorktreeCleanupReport(..)
+    , WorktreeLease
+    , acquireWorktreeLease
+    , releaseWorktreeLease
     , isUnderWorktreeRoot
     , worktreeProgressMessage
     , worktreePath
@@ -19,8 +25,15 @@ import Agent.CLI.Config
     )
 import Agent.OsPath (unsafeToFilePath)
 import Control.Applicative ((<|>))
-import Control.Exception.Safe (finally, mask, onException, tryAny)
-import Control.Monad (void)
+import Control.Exception.Safe
+    ( SomeException
+    , displayException
+    , finally
+    , mask
+    , onException
+    , tryAny
+    )
+import Control.Monad (filterM, foldM, void)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
@@ -29,25 +42,32 @@ import Control.Monad.Trans.Except
     , withExceptT
     )
 import qualified Data.ByteString as ByteString
-import Data.List (isPrefixOf)
+import Data.Char (isHexDigit)
+import Data.List (isPrefixOf, sortOn)
 import Data.Maybe (listToMaybe)
+import Data.Ord (Down(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (Day)
 import Data.Time.Clock (UTCTime(..), getCurrentTime, nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
-import Data.Time.Format (defaultTimeLocale, formatTime)
+import Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
 import Numeric (showHex)
 import System.Directory.OsPath
     ( createDirectoryIfMissing
+    , doesDirectoryExist
     , doesPathExist
+    , listDirectory
+    , pathIsSymbolicLink
     , removePathForcibly
     )
 import System.Entropy (getEntropy)
 import System.Exit (ExitCode(..))
+import qualified System.FileLock as FileLock
 import System.OsPath
     ( OsPath
     , equalFilePath
+    , normalise
     , splitDirectories
     , takeDirectory
     , takeFileName
@@ -74,6 +94,29 @@ worktreeProgressMessage = \case
   where
     branchName ref =
         maybe ref id (Text.stripPrefix "refs/heads/" ref)
+
+-- | Match Codex Desktop's default per-repository retention. Worktrees beyond
+-- this count are only removed when they are inactive, clean, and their HEAD is
+-- reachable from another branch or tag.
+defaultWorktreeKeepCount :: Int
+defaultWorktreeKeepCount = 15
+
+data WorktreeCleanupReport = WorktreeCleanupReport
+    { cleanupRemoved :: ![OsPath]
+    , cleanupFailures :: ![(OsPath, Text)]
+    }
+    deriving (Eq, Show)
+
+instance Semigroup WorktreeCleanupReport where
+    left <> right = WorktreeCleanupReport
+        { cleanupRemoved = left.cleanupRemoved <> right.cleanupRemoved
+        , cleanupFailures = left.cleanupFailures <> right.cleanupFailures
+        }
+
+instance Monoid WorktreeCleanupReport where
+    mempty = WorktreeCleanupReport [] []
+
+newtype WorktreeLease = WorktreeLease FileLock.FileLock
 
 -- | @~/.haskell-agent/worktrees@ given the user's home directory.
 worktreeRoot :: OsPath -> OsPath
@@ -156,6 +199,353 @@ removeWorktree source path = runExceptT do
         git repo ["worktree", "remove", "--force", unsafeToFilePath path]
     void $ ExceptT $
         git repo ["branch", "-D", unsafeToFilePath (takeFileName path)]
+
+-- | Take a shared lease when @path@ is inside one of our managed worktrees.
+-- Cleanup takes the corresponding exclusive lock, so multiple live sessions
+-- may share a checkout while automatic cleanup cannot remove it.
+acquireWorktreeLease
+    :: OsPath
+    -> OsPath
+    -> IO (Either Text (Maybe WorktreeLease))
+acquireWorktreeLease root path =
+    case managedWorktreePath root path of
+        Nothing -> pure (Right Nothing)
+        Just managed -> do
+            let lockPath = worktreeLeasePath root managed
+            result <- tryAny do
+                createDirectoryIfMissing True (takeDirectory lockPath)
+                FileLock.tryLockFile
+                    (unsafeToFilePath lockPath)
+                    FileLock.Shared
+            pure case result of
+                Left exception ->
+                    Left
+                        ("failed to lease managed worktree "
+                            <> pathText managed
+                            <> ": "
+                            <> Text.pack (displayException exception))
+                Right Nothing ->
+                    Left
+                        ("managed worktree is being cleaned up: "
+                            <> pathText managed)
+                Right (Just lock) -> Right (Just (WorktreeLease lock))
+
+releaseWorktreeLease :: WorktreeLease -> IO ()
+releaseWorktreeLease (WorktreeLease lock) = do
+    _ <- tryAny (FileLock.unlockFile lock)
+    pure ()
+
+-- | Remove old managed worktrees without risking unique Git work.
+--
+-- Retention is applied per repository directory. A candidate must use our
+-- generated path and branch name, be a linked worktree with no tracked or
+-- untracked changes, have no active lease, and have a HEAD reachable from
+-- another local branch, remote-tracking branch, or tag. Removal deliberately
+-- omits @--force@. The generated branch is then deleted with @-d@, leaving it
+-- intact whenever Git's own merged-branch check is stricter than ours.
+-- Worktrees created on the current UTC day are never considered stale; this
+-- also closes the interval between checkout creation and lease acquisition.
+cleanupStaleWorktrees
+    :: OsPath
+    -> Int
+    -> [OsPath]
+    -> IO WorktreeCleanupReport
+cleanupStaleWorktrees root requestedKeep protected = do
+    exists <- doesDirectoryExist root
+    if not exists
+        then pure mempty
+        else do
+            today <- utctDay <$> getCurrentTime
+            let cleanupLockPath =
+                    root </> unsafeEncodeUtf ".cleanup.lock"
+            lockResult <- tryAny $
+                FileLock.tryLockFile
+                    (unsafeToFilePath cleanupLockPath)
+                    FileLock.Exclusive
+            case lockResult of
+                Left exception ->
+                    pure $ cleanupFailure root exception
+                Right Nothing ->
+                    -- Another process is already doing the same best-effort GC.
+                    pure mempty
+                Right (Just lock) ->
+                    runCleanup today `finally` FileLock.unlockFile lock
+  where
+    keep = max 1 requestedKeep
+    protectedManaged =
+        [ normalise path
+        | path <- protected
+        ]
+
+    runCleanup today = do
+        discovered <- discoverStaleCandidates root keep today
+        case discovered of
+            Left failures ->
+                pure mempty { cleanupFailures = failures }
+            Right (candidates, discoveryFailures) -> do
+                cleaned <- foldM cleanupOne mempty candidates
+                pure $
+                    cleaned
+                        <> mempty { cleanupFailures = discoveryFailures }
+
+    cleanupOne report candidate
+        | any (isUnderWorktreeRoot candidate) protectedManaged =
+            pure report
+        | otherwise = do
+            result <- tryAny (cleanupCandidate root candidate)
+            pure $ report <> case result of
+                Left exception -> cleanupFailure candidate exception
+                Right candidateReport -> candidateReport
+
+discoverStaleCandidates
+    :: OsPath
+    -> Int
+    -> Day
+    -> IO (Either [(OsPath, Text)] ([OsPath], [(OsPath, Text)]))
+discoverStaleCandidates root keep today = do
+    listed <- tryAny (listDirectory root)
+    case listed of
+        Left exception ->
+            pure (Left [(root, exceptionText exception)])
+        Right entries ->
+            Right <$> foldM discoverRepository ([], []) entries
+  where
+    discoverRepository (candidates, failures) entry = do
+        let repository = root </> entry
+        isDirectory <- doesDirectoryExist repository
+        if not isDirectory
+            then pure (candidates, failures)
+            else do
+                listed <- tryAny (listDirectory repository)
+                case listed of
+                    Left exception ->
+                        pure
+                            ( candidates
+                            , failures <> [(repository, exceptionText exception)]
+                            )
+                    Right children -> do
+                        directories <- filterM
+                            (doesDirectoryExist . (repository </>))
+                            children
+                        let managed =
+                                sortOn
+                                    ( Down
+                                        . unsafeToFilePath
+                                        . takeFileName
+                                        . fst
+                                    )
+                                    [ (repository </> child, day)
+                                    | child <- directories
+                                    , Just day <- [managedWorktreeDay child]
+                                    ]
+                            stale =
+                                [ path
+                                | (path, day) <- drop keep managed
+                                , day < today
+                                ]
+                        pure (candidates <> stale, failures)
+
+cleanupCandidate :: OsPath -> OsPath -> IO WorktreeCleanupReport
+cleanupCandidate root candidate = do
+    leaseResult <- tryExclusiveWorktreeLease root candidate
+    case leaseResult of
+        Left err ->
+            pure mempty
+                { cleanupFailures = [(candidate, err)]
+                }
+        Right Nothing ->
+            pure mempty
+        Right (Just lease) ->
+            cleanupWithLease `finally` releaseWorktreeLease lease
+  where
+    cleanupWithLease =
+        inspectCleanupCandidate candidate >>= \case
+            Left err ->
+                pure mempty
+                    { cleanupFailures = [(candidate, err)]
+                    }
+            Right Nothing ->
+                pure mempty
+            Right (Just (commonDir, branch)) ->
+                git commonDir
+                    [ "worktree"
+                    , "remove"
+                    , unsafeToFilePath candidate
+                    ] >>= \case
+                        Left err ->
+                            pure mempty
+                                { cleanupFailures = [(candidate, err)]
+                                }
+                        Right _ -> do
+                            deleted <- git commonDir
+                                [ "branch"
+                                , "-d"
+                                , "--"
+                                , Text.unpack branch
+                                ]
+                            pure WorktreeCleanupReport
+                                { cleanupRemoved = [candidate]
+                                , cleanupFailures = case deleted of
+                                    Left err ->
+                                        [(candidate,
+                                            "worktree removed but branch retained: "
+                                                <> err)]
+                                    Right _ -> []
+                                }
+
+inspectCleanupCandidate
+    :: OsPath
+    -> IO (Either Text (Maybe (OsPath, Text)))
+inspectCleanupCandidate candidate = runExceptT do
+    candidateLink <- lift (pathIsSymbolicLink candidate)
+    repositoryLink <- lift (pathIsSymbolicLink (takeDirectory candidate))
+    if candidateLink || repositoryLink
+        then pure Nothing
+        else do
+            topLevel <- Text.strip <$> ExceptT
+                (git candidate
+                    [ "rev-parse"
+                    , "--path-format=absolute"
+                    , "--show-toplevel"
+                    ])
+            let topLevelPath = unsafeEncodeUtf (Text.unpack topLevel)
+            if not
+                (equalFilePath
+                    (normalise candidate)
+                    (normalise topLevelPath))
+                then pure Nothing
+                else do
+                    gitDir <- Text.strip <$> ExceptT
+                        (git candidate
+                            [ "rev-parse"
+                            , "--path-format=absolute"
+                            , "--git-dir"
+                            ])
+                    commonDirText <- Text.strip <$> ExceptT
+                        (git candidate
+                            [ "rev-parse"
+                            , "--path-format=absolute"
+                            , "--git-common-dir"
+                            ])
+                    if gitDir == commonDirText
+                        then pure Nothing
+                        else do
+                            branch <- Text.strip <$> ExceptT
+                                (git candidate
+                                    ["branch", "--show-current"])
+                            let expected = Text.pack
+                                    (unsafeToFilePath
+                                        (takeFileName candidate))
+                            if Text.null branch || branch /= expected
+                                then pure Nothing
+                                else do
+                                    status <- ExceptT $
+                                        git candidate
+                                            [ "status"
+                                            , "--porcelain=v1"
+                                            , "--untracked-files=all"
+                                            , "--ignore-submodules=none"
+                                            ]
+                                    if not (Text.null status)
+                                        then pure Nothing
+                                        else do
+                                            refs <- ExceptT $
+                                                git candidate
+                                                    [ "for-each-ref"
+                                                    , "--format=%(refname)"
+                                                    , "--contains=HEAD"
+                                                    , "refs/heads"
+                                                    , "refs/remotes"
+                                                    , "refs/tags"
+                                                    ]
+                                            let ownRef =
+                                                    "refs/heads/" <> branch
+                                                otherRefs =
+                                                    filter
+                                                        (\ref ->
+                                                            not (Text.null ref)
+                                                                && ref /= ownRef)
+                                                        (Text.lines refs)
+                                            pure $
+                                                if null otherRefs
+                                                    then Nothing
+                                                    else Just
+                                                        ( unsafeEncodeUtf
+                                                            (Text.unpack
+                                                                commonDirText)
+                                                        , branch
+                                                        )
+
+tryExclusiveWorktreeLease
+    :: OsPath
+    -> OsPath
+    -> IO (Either Text (Maybe WorktreeLease))
+tryExclusiveWorktreeLease root candidate = do
+    let lockPath = worktreeLeasePath root candidate
+    result <- tryAny do
+        createDirectoryIfMissing True (takeDirectory lockPath)
+        FileLock.tryLockFile
+            (unsafeToFilePath lockPath)
+            FileLock.Exclusive
+    pure case result of
+        Left exception ->
+            Left
+                ("failed to lock stale worktree: "
+                    <> exceptionText exception)
+        Right Nothing -> Right Nothing
+        Right (Just lock) -> Right (Just (WorktreeLease lock))
+
+managedWorktreePath :: OsPath -> OsPath -> Maybe OsPath
+managedWorktreePath rawRoot rawPath =
+    let root = normalise rawRoot
+        path = normalise rawPath
+        rootParts = splitDirectories root
+        pathParts = splitDirectories path
+    in case drop (length rootParts) pathParts of
+        repository : checkout : _
+            | rootParts `isPrefixOf` pathParts
+            , isManagedWorktreeName checkout ->
+                Just (root </> repository </> checkout)
+        _ -> Nothing
+
+worktreeLeasePath :: OsPath -> OsPath -> OsPath
+worktreeLeasePath root managed =
+    root
+        </> unsafeEncodeUtf ".locks"
+        </> takeFileName (takeDirectory managed)
+        </> (takeFileName managed <> unsafeEncodeUtf ".lock")
+
+isManagedWorktreeName :: OsPath -> Bool
+isManagedWorktreeName path = case managedWorktreeDay path of
+    Just _ -> True
+    Nothing -> False
+
+managedWorktreeDay :: OsPath -> Maybe Day
+managedWorktreeDay path =
+    case unsafeToFilePath path of
+        year1 : year2 : year3 : year4 : '-' :
+                month1 : month2 : '-' : day1 : day2 : '-' : suffix ->
+            let date =
+                    [ year1, year2, year3, year4, '-'
+                    , month1, month2, '-', day1, day2
+                    ]
+            in if length suffix == 8 && all isHexDigit suffix
+                then parseTimeM True defaultTimeLocale "%Y-%m-%d" date
+                else Nothing
+        _ -> Nothing
+
+cleanupFailure :: OsPath -> SomeException -> WorktreeCleanupReport
+cleanupFailure path exception =
+    mempty
+        { cleanupFailures =
+            [(path, Text.pack (displayException exception))]
+        }
+
+exceptionText :: SomeException -> Text
+exceptionText = Text.pack . displayException
+
+pathText :: OsPath -> Text
+pathText = Text.pack . unsafeToFilePath
 
 addUnique
     :: OsPath

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.SessionSpec (spec) where
 
 import Agent.CLI.Session
+import Agent.CLI.SessionLock (acquireSessionLock, releaseSessionLock)
 import Agent.CLI.Session.StoreCodec
     ( fromStoredResponseItem
     , toStoredResponseItem
@@ -24,7 +25,7 @@ import Agent.Store.Postgres
 import Agent.Store.Postgres.Managed (stopManagedPostgres)
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Types (renderStoreError)
-import Control.Exception (bracket)
+import Control.Exception.Safe (bracket)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -32,10 +33,12 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
+import Data.Time.Clock (UTCTime(..), getCurrentTime, secondsToDiffTime)
+import Data.Time.Format (defaultTimeLocale, formatTime)
 import qualified System.Directory as Directory
 import System.Directory.OsPath
     ( createDirectory
+    , createDirectoryIfMissing
     , doesDirectoryExist
     , doesFileExist
     , listDirectory
@@ -556,6 +559,86 @@ spec = describe "Agent.CLI.Session" do
             isValidSessionId "normal-id" `shouldBe` True
             isValidSessionId "../outside" `shouldBe` False
             isValidSessionId "nested/id" `shouldBe` False
+
+        it "removes old session scratch directories beyond retention" $
+            withTempSessionRoot \root -> do
+                older <- addSessionTemp root "2026-08-20-00000001"
+                newer <- addSessionTemp root "2026-08-21-00000002"
+
+                report <- cleanupStaleSessionTemps root 1 []
+
+                report.tempCleanupFailures `shouldBe` []
+                report.tempCleanupRemoved `shouldBe` [older]
+                doesDirectoryExist older `shouldReturn` False
+                doesDirectoryExist newer `shouldReturn` True
+
+        it "never collects scratch directories allocated today" $
+            withTempSessionRoot \root -> do
+                day <- formatTime defaultTimeLocale "%Y-%m-%d"
+                    <$> getCurrentTime
+                first <- addSessionTemp root (day <> "-00000001")
+                second <- addSessionTemp root (day <> "-00000002")
+
+                report <- cleanupStaleSessionTemps root 1 []
+
+                report.tempCleanupRemoved `shouldBe` []
+                doesDirectoryExist first `shouldReturn` True
+                doesDirectoryExist second `shouldReturn` True
+
+        it "preserves old session scratch directories with a live lease" $
+            withTempSessionRoot \root -> do
+                older <- addSessionTemp root "2026-08-20-00000001"
+                _ <- addSessionTemp root "2026-08-21-00000002"
+                lease <- acquireSessionTempLease root older >>= \case
+                    Right (Just value) -> pure value
+                    _ -> expectationFailure
+                        "expected a managed session-temp lease"
+                        >> fail "missing session-temp lease"
+
+                report <- cleanupStaleSessionTemps root 1 []
+                report.tempCleanupRemoved `shouldBe` []
+                doesDirectoryExist older `shouldReturn` True
+
+                releaseSessionTempLease lease
+                second <- cleanupStaleSessionTemps root 1 []
+                second.tempCleanupRemoved `shouldBe` [older]
+                doesDirectoryExist older `shouldReturn` False
+
+        it "preserves scratch for a running durable session" $
+            withTempSessionRoot \root -> do
+                let sessionId = "2026-08-20-00000001"
+                    durableDir = root </> fromFilePath sessionId
+                older <- addSessionTemp root sessionId
+                _ <- addSessionTemp root "2026-08-21-00000002"
+                createDirectory durableDir
+                lock <- acquireSessionLock durableDir (Text.pack sessionId)
+                    >>= \case
+                        Left err ->
+                            expectationFailure (Text.unpack err)
+                                >> fail "missing durable session lock"
+                        Right value -> pure value
+
+                report <- cleanupStaleSessionTemps root 1 []
+                report.tempCleanupRemoved `shouldBe` []
+                doesDirectoryExist older `shouldReturn` True
+
+                releaseSessionLock lock
+                second <- cleanupStaleSessionTemps root 1 []
+                second.tempCleanupRemoved `shouldBe` [older]
+                doesDirectoryExist older `shouldReturn` False
+
+        it "ignores non-session directories in the scratch root" $
+            withTempSessionRoot \root -> do
+                let custom =
+                        sessionTempsRoot root
+                            </> fromFilePath "keep-custom"
+                createDirectoryIfMissing True custom
+                _ <- addSessionTemp root "2026-08-21-00000002"
+
+                report <- cleanupStaleSessionTemps root 1 []
+
+                report.tempCleanupRemoved `shouldBe` []
+                doesDirectoryExist custom `shouldReturn` True
 
         it "derives bounded titles and shell-safe resume hints" do
             sessionTitleFromPrompt
@@ -1153,6 +1236,29 @@ modeOf :: OsPath -> IO Integer
 modeOf path = do
     status <- getFileStatus (toFilePath path)
     pure (fromIntegral (fileMode status `mod` 0o1000))
+
+withTempSessionRoot :: (OsPath -> IO a) -> IO a
+withTempSessionRoot action = do
+    tmp <- Directory.getTemporaryDirectory
+    bracket
+        (mkdtemp (tmp FilePath.</> "agent-session-temp-XXXXXX"))
+        Directory.removeDirectoryRecursive
+        \basePath -> do
+            let root =
+                    fromFilePath
+                        (basePath
+                            FilePath.</> ".haskell-agent"
+                            FilePath.</> "sessions")
+            Directory.createDirectoryIfMissing True (toFilePath root)
+            action root
+
+addSessionTemp :: OsPath -> String -> IO OsPath
+addSessionTemp root sessionId = do
+    let path =
+            sessionTempsRoot root
+                </> fromFilePath sessionId
+    Directory.createDirectoryIfMissing True (toFilePath path)
+    pure path
 
 withTempStore :: (Store -> OsPath -> IO a) -> IO a
 withTempStore action = do

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -9,8 +9,14 @@ import Data.List (dropWhileEnd, isInfixOf)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (getCurrentTime)
+import Data.Time.Format (defaultTimeLocale, formatTime)
 import qualified System.Directory as Directory
-import System.Directory.OsPath (doesDirectoryExist, doesFileExist)
+import System.Directory.OsPath
+    ( createDirectoryIfMissing
+    , doesDirectoryExist
+    , doesFileExist
+    )
 import System.Exit (ExitCode(..))
 import qualified System.FilePath as FilePath
 import System.OsPath
@@ -215,6 +221,136 @@ spec = describe "Agent.CLI.Worktree" do
                 branches <- git repo ["branch", "--list", branch]
                 branches `shouldBe` ""
 
+    describe "cleanupStaleWorktrees" do
+        it "never collects worktrees created on the current UTC day" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                day <- formatTime defaultTimeLocale "%Y-%m-%d"
+                    <$> getCurrentTime
+                first <- addManagedWorktree repo root (day <> "-00000001")
+                second <- addManagedWorktree repo root (day <> "-00000002")
+
+                report <- cleanupStaleWorktrees root 1 []
+
+                report.cleanupRemoved `shouldBe` []
+                doesDirectoryExist first `shouldReturn` True
+                doesDirectoryExist second `shouldReturn` True
+
+        it "removes clean managed worktrees beyond the per-repository retention" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                older <- addManagedWorktree repo root "2026-08-20-00000001"
+                newer <- addManagedWorktree repo root "2026-08-21-00000002"
+
+                report <- cleanupStaleWorktrees root 1 []
+
+                report.cleanupFailures `shouldBe` []
+                report.cleanupRemoved `shouldBe` [older]
+                doesDirectoryExist older `shouldReturn` False
+                doesDirectoryExist newer `shouldReturn` True
+                git repo ["branch", "--list", "2026-08-20-00000001"]
+                    `shouldReturn` ""
+
+        it "preserves stale worktrees with uncommitted files" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                older <- addManagedWorktree repo root "2026-08-20-00000001"
+                _ <- addManagedWorktree repo root "2026-08-21-00000002"
+                writeFile
+                    (toFilePath (older </> fromFilePath "notes.txt"))
+                    "keep me\n"
+
+                report <- cleanupStaleWorktrees root 1 []
+
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupFailures `shouldBe` []
+                doesDirectoryExist older `shouldReturn` True
+
+        it "preserves stale worktrees whose commit is not reachable elsewhere" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                older <- addManagedWorktree repo root "2026-08-20-00000001"
+                _ <- addManagedWorktree repo root "2026-08-21-00000002"
+                writeFile
+                    (toFilePath (older </> fromFilePath "README"))
+                    "unique\n"
+                _ <- git older ["add", "README"]
+                _ <- git older ["commit", "-m", "unique work"]
+
+                report <- cleanupStaleWorktrees root 1 []
+
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupFailures `shouldBe` []
+                doesDirectoryExist older `shouldReturn` True
+
+        it "preserves stale worktrees with an active shared lease" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                older <- addManagedWorktree repo root "2026-08-20-00000001"
+                _ <- addManagedWorktree repo root "2026-08-21-00000002"
+                lease <- acquireWorktreeLease root older >>= \case
+                    Right (Just value) -> pure value
+                    _ -> expectationFailure
+                        "expected a managed worktree lease"
+                        >> fail "missing worktree lease"
+
+                fmap (.cleanupRemoved) (cleanupStaleWorktrees root 1 [])
+                    `shouldReturn` []
+                doesDirectoryExist older `shouldReturn` True
+
+                releaseWorktreeLease lease
+                fmap (.cleanupRemoved) (cleanupStaleWorktrees root 1 [])
+                    `shouldReturn` [older]
+                doesDirectoryExist older `shouldReturn` False
+
+        it "preserves explicitly protected stale worktrees" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                older <- addManagedWorktree repo root "2026-08-20-00000001"
+                _ <- addManagedWorktree repo root "2026-08-21-00000002"
+
+                report <- cleanupStaleWorktrees
+                    root
+                    1
+                    [older </> fromFilePath "nested/current-directory"]
+
+                report.cleanupRemoved `shouldBe` []
+                doesDirectoryExist older `shouldReturn` True
+
+        it "ignores symlinked managed-looking candidates" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                    parent = root </> takeFileName repo
+                    branch = "2026-08-20-00000001"
+                    candidate = parent </> fromFilePath branch
+                    actual =
+                        home
+                            </> fromFilePath "outside"
+                            </> fromFilePath branch
+                createDirectoryIfMissing True parent
+                createDirectoryIfMissing True (home </> fromFilePath "outside")
+                _ <- git repo
+                    ["worktree", "add", "-b", branch, toFilePath actual]
+                Directory.createDirectoryLink
+                    (toFilePath actual)
+                    (toFilePath candidate)
+                _ <- addManagedWorktree
+                    repo
+                    root
+                    "2026-08-21-00000002"
+
+                report <- cleanupStaleWorktrees root 1 []
+
+                report.cleanupRemoved `shouldBe` []
+                doesDirectoryExist actual `shouldReturn` True
+
 expectRight :: Either Text OsPath -> IO OsPath
 expectRight = \case
     Right path -> pure path
@@ -278,6 +414,14 @@ temporaryFetchRefs repo =
         , "--format=%(refname)"
         , "refs/haskell-agent/worktree-fetches/"
         ]
+
+addManagedWorktree :: OsPath -> OsPath -> String -> IO OsPath
+addManagedWorktree repo root name = do
+    let parent = root </> takeFileName repo
+        path = parent </> fromFilePath name
+    createDirectoryIfMissing True parent
+    _ <- git repo ["worktree", "add", "-b", name, toFilePath path]
+    pure path
 
 withTempDir :: String -> (OsPath -> IO a) -> IO a
 withTempDir prefix action = do


### PR DESCRIPTION
## Summary

- run one best-effort stale-resource cleanup per process, retaining the newest 15 resources and everything created on the current UTC day
- remove only managed worktrees that are clean, lease-free, non-symlinked, and whose HEAD is reachable from another ref; preserve every persisted session cwd
- lease live worktrees and session temp directories, coordinate scratch cleanup with durable session locks, and surface per-path failures as startup warnings

## Testing

- GHCi compiled all 210 `agent-cli` modules
- `Agent.CLI.WorktreeSpec`: 20 examples, 0 failures
- `Agent.CLI.SessionSpec` pure compatibility helpers: 13 examples, 0 failures, including 32,000 generated cases