### PR TITLE
Keep session title requests concurrent

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionTitle.hs
@@ -11,7 +11,6 @@ module Agent.CLI.SessionTitle
     , takeSessionTitleResults
     , titleRefreshIndex
     , waitForSessionTitleResults
-    , withSessionTitleForeground
     , withSessionTitleManager
     ) where
 
@@ -28,14 +27,9 @@ import Agent.Responses.Types
     , ToolChoice(..)
     , ToolChoiceMode(..)
     )
-import Control.Concurrent.Async (race, withAsync)
+import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM
-import Control.Exception.Safe
-    ( SomeException
-    , bracket_
-    , displayException
-    , tryAny
-    )
+import Control.Exception.Safe (SomeException, displayException, tryAny)
 import Control.Monad (forever, void)
 import Control.Retry (limitRetries, retrying)
 import Data.Map.Strict (Map)
@@ -77,7 +71,6 @@ data SessionTitleManager = SessionTitleManager
     , titleResults :: !(TQueue SessionTitleResult)
     , titleRequested :: !(TVar (Set (Text, Int, Int)))
     , titleGenerations :: !(TVar (Map Text Int))
-    , titleForegroundTurns :: !(TVar Int)
     , titleBackendFactory :: !BtwBackendFactory
     , titleParams :: !(IO ResponseCreateParams)
     }
@@ -93,26 +86,15 @@ withSessionTitleManager backendFactory paramsRef onEvent action = do
     results <- newTQueueIO
     requested <- newTVarIO Set.empty
     generations <- newTVarIO Map.empty
-    foregroundTurns <- newTVarIO 0
     let manager = SessionTitleManager
             { titleJobs = jobs
             , titleResults = results
             , titleRequested = requested
             , titleGenerations = generations
-            , titleForegroundTurns = foregroundTurns
             , titleBackendFactory = backendFactory
             , titleParams = paramsRef
             }
     withAsync (titleWorker onEvent manager) \_ -> action manager
-
--- | Give foreground model turns priority over best-effort title generation.
--- Starting a foreground turn cancels an in-flight title request; the worker
--- retries that job once the foreground scope is idle again.
-withSessionTitleForeground :: SessionTitleManager -> IO a -> IO a
-withSessionTitleForeground manager =
-    bracket_
-        (atomically $ modifyTVar' manager.titleForegroundTurns (+ 1))
-        (atomically $ modifyTVar' manager.titleForegroundTurns (subtract 1))
 
 requestSessionTitle
     :: SessionTitleManager
@@ -187,27 +169,9 @@ shouldRequestSessionTitle milestone refreshIndex
 
 titleWorker :: (SessionTitleEvent -> IO ()) -> SessionTitleManager -> IO ()
 titleWorker onEvent manager = forever do
-    job <- atomically do
-        readTVar manager.titleForegroundTurns >>= check . (== 0)
-        readTQueue manager.titleJobs
-    race
-        (atomically do
-            readTVar manager.titleForegroundTurns >>= check . (> 0))
-        (generateTitleWithRetry manager job)
-        >>= \case
-            Left () ->
-                atomically (unGetTQueue manager.titleJobs job)
-            Right generated -> do
-                accepted <- acceptTitleResult manager job generated
-                mapM_ (void . tryAny . onEvent) accepted
-
-acceptTitleResult
-    :: SessionTitleManager
-    -> SessionTitleJob
-    -> Either SomeException (Either Text Text)
-    -> IO (Maybe SessionTitleEvent)
-acceptTitleResult manager job generated =
-    atomically do
+    job <- atomically (readTQueue manager.titleJobs)
+    generated <- generateTitleWithRetry manager job
+    accepted <- atomically do
         modifyTVar' manager.titleRequested
             (Set.delete
                 (job.jobSessionId, job.jobMilestone, job.jobGeneration))
@@ -242,6 +206,7 @@ acceptTitleResult manager job generated =
                                 <> Text.pack (displayException err)
                         , failureGeneration = job.jobGeneration
                         }))
+    mapM_ (void . tryAny . onEvent) accepted
 
 generateTitleWithRetry
     :: SessionTitleManager

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -77,7 +77,6 @@ import Agent.CLI.SessionTitle
     , shouldRequestSessionTitle
     , takeSessionTitleResults
     , titleRefreshIndex
-    , withSessionTitleForeground
     )
 import Agent.CLI.Status (formatUsageWithRate)
 import Agent.CLI.Style
@@ -189,14 +188,13 @@ runOneTurnWithContext includeTurnContext env promptText inputs = do
     -- boundary from an earlier attempt is already represented by the live and
     -- durable transcripts and must not affect this turn's suffix calculation.
     writeIORef env.sessionAutomaticCompaction Nothing
-    withSessionTitleForeground env.sessionTitleManager $
-        bracket_
-            env.sessionBeginWindowTitleBusy
-            env.sessionEndWindowTitleBusy
-            (withLiveTranscript env.sessionConversation \beforeItems ->
-                runOneTurnBusy
-                    includeTurnContext env beforeItems promptText inputs)
-            `finally` writeIORef env.sessionAutomaticCompaction Nothing
+    bracket_
+        env.sessionBeginWindowTitleBusy
+        env.sessionEndWindowTitleBusy
+        (withLiveTranscript env.sessionConversation \beforeItems ->
+            runOneTurnBusy
+                includeTurnContext env beforeItems promptText inputs)
+        `finally` writeIORef env.sessionAutomaticCompaction Nothing
 
 runOneTurnBusy
     :: Bool

--- a/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionTitleSpec.hs
@@ -13,7 +13,6 @@ import Control.Concurrent
     , putMVar
     , takeMVar
     , threadDelay
-    , tryTakeMVar
     )
 import Data.IORef
 import qualified Data.Text as Text
@@ -135,44 +134,6 @@ spec = describe "Agent.CLI.SessionTitle" do
                         , resultGeneration = 0
                         }
                     ]
-
-    it "cancels title generation while a foreground turn is active" do
-        attempts <- newIORef (0 :: Int)
-        started <- newEmptyMVar
-        neverFinish <- newEmptyMVar
-        notified <- newEmptyMVar
-        let backendFactory _ =
-                Backend \state _ _ _ -> do
-                    attempt <- atomicModifyIORef' attempts \count ->
-                        let next = count + 1
-                        in (next, next)
-                    if attempt == 1
-                        then do
-                            putMVar started ()
-                            _ <- takeMVar neverFinish
-                            error "cancelled title request unexpectedly resumed"
-                        else
-                            pure $ Right BackendResult
-                                { backendOutput =
-                                    emptyTurnOutput "title-response" []
-                                        (Just "Foreground-safe title")
-                                , backendState = state
-                                }
-        withSessionTitleManager backendFactory (pure defaultResponseCreateParams) (putMVar notified) \manager -> do
-            requestSessionTitle manager "session-1" 1 "conversation"
-            takeMVar started
-            withSessionTitleForeground manager do
-                threadDelay 50000
-                tryTakeMVar notified `shouldReturn` Nothing
-            takeMVar notified
-                `shouldReturn`
-                    SessionTitleGenerated SessionTitleResult
-                        { resultSessionId = "session-1"
-                        , resultMilestone = 1
-                        , resultTitle = "Foreground-safe title"
-                        , resultGeneration = 0
-                        }
-        readIORef attempts `shouldReturn` 2
 
     it "retries a failed title request once before reporting its outcome" do
         attempts <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary
- remove foreground/title coordination introduced in #803
- allow session-title requests and foreground OpenAI requests to run concurrently
- retain cooldown-aware stale preferred-account fallback

## Why
OpenAI supports concurrent requests. Serializing or cancelling title generation was over-scoped; account selection and cooldown tracking are the correct boundary.

## Validation
- focused `SessionTitle` and `preferredOpenAiTokenProvider` GHCi specs: 12 examples, 0 failures
- full `agent-cli` GHCi suite: 1410 examples, 0 failures, 1 pending
