### PR TITLE
Make stale session cleanup idempotent

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -163,7 +163,6 @@ import System.Directory.OsPath
     , doesDirectoryExist
     , doesFileExist
     , listDirectory
-    , pathIsSymbolicLink
     , removePathForcibly
     , removeFile
     )
@@ -1394,10 +1393,15 @@ cleanupStaleSessionTemp root candidate =
             Right (Just lock) -> do
                 removed <- tryAny $
                     (do
-                        symbolic <- pathIsSymbolicLink candidate
-                        if symbolic
-                            then pure False
-                            else removePathForcibly candidate >> pure True)
+                        symbolicLinkStatusMaybe candidate >>= \case
+                            -- Another startup cleaner may have removed the
+                            -- candidate before this process acquired its
+                            -- exclusive lock.
+                            Nothing -> pure False
+                            Just status
+                                | isSymbolicLink status -> pure False
+                                | otherwise ->
+                                    removePathForcibly candidate >> pure True)
                         `finally` FileLock.unlockFile lock
                 pure case removed of
                     Left exception ->

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -26,7 +26,10 @@ import Agent.Store.Postgres
 import Agent.Store.Postgres.Managed (stopManagedPostgres)
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Types (renderStoreError)
+import Control.Concurrent (newEmptyMVar, putMVar, readMVar, takeMVar)
+import Control.Concurrent.Async (concurrently, mapConcurrently)
 import Control.Exception.Safe (bracket)
+import Control.Monad (replicateM)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -572,6 +575,28 @@ spec = describe "Agent.CLI.Session" do
                 report.tempCleanupRemoved `shouldBe` [older]
                 doesDirectoryExist older `shouldReturn` False
                 doesDirectoryExist newer `shouldReturn` True
+
+        it "tolerates concurrent stale scratch directory cleanup" $
+            withTempSessionRoot \root -> do
+                let workerCount = 32
+                    sessionId n =
+                        "2026-08-20-"
+                            <> replicate (8 - length (show n)) '0'
+                            <> show n
+                mapM_ (addSessionTemp root . sessionId) [1 .. workerCount]
+                ready <- replicateM workerCount newEmptyMVar
+                start <- newEmptyMVar
+                (reports, ()) <-
+                    concurrently
+                        (mapConcurrently
+                            (\readyVar -> do
+                                putMVar readyVar ()
+                                readMVar start
+                                cleanupStaleSessionTemps root 1 [])
+                            ready)
+                        (mapM_ takeMVar ready >> putMVar start ())
+
+                concatMap (.tempCleanupFailures) reports `shouldBe` []
 
         it "never collects scratch directories allocated today" $
             withTempSessionRoot \root -> do


### PR DESCRIPTION
## Summary
- treat a stale session scratch directory that disappears after discovery as already cleaned
- keep the symbolic-link guard while using the existing ENOENT-safe status helper
- add concurrent-cleaner regression coverage

## Validation
- loaded `agent-cli:test:agent-cli-test` through `nix develop -c cabal repl`
- regression reproduced the original `pathIsSymbolicLink:getSymbolicLinkStatus: does not exist` warning without the fix
- focused concurrent cleanup test passed 20 consecutive runs with the fix
- `git diff --check`
