### PR TITLE
Recognize bare exit aliases in interactive prompts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -179,7 +179,7 @@ parseReplLineWithSkills skills =
 parseReplLineWithCatalog :: SlashCatalog -> Text -> ReplAction
 parseReplLineWithCatalog catalog raw =
     let line = Text.strip raw
-    in if line == ":q" || line == ":quit"
+    in if isExitAlias line
         then ReplQuit
         else if line == ":reload"
             then ReplReload
@@ -189,6 +189,13 @@ parseReplLineWithCatalog catalog raw =
                     | otherwise -> parseSlash catalog raw line
                 Just (':', _) -> parseColon raw
                 _ -> ReplPrompt raw
+
+-- | Bare shell- and Vim-style input that exits the interactive session.
+-- Keep this exact so ordinary prompts such as @exiting@ still reach the model.
+isExitAlias :: Text -> Bool
+isExitAlias raw =
+    Text.toLower (Text.strip raw)
+        `elem` ["exit", "quit", ":q", ":q!", ":quit", ":wq", ":wq!"]
 
 -- Absolute paths share slash commands' leading slash. A path with at least
 -- one further separator is unambiguously path-like, so leave it as prompt

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -12,12 +12,26 @@ import Test.Hspec
 spec :: Spec
 spec = do
     describe "parseReplLine" do
-        it "keeps :q and :quit as quit" do
-            parseReplLine ":q" `shouldBe` ReplQuit
-            parseReplLine ":quit" `shouldBe` ReplQuit
-            parseReplLine "  :quit  " `shouldBe` ReplQuit
+        it "recognizes bare shell- and Vim-style exit aliases" do
+            map parseReplLine
+                [ "exit"
+                , "quit"
+                , "EXIT"
+                , " Quit "
+                , ":q"
+                , ":Q!"
+                , ":quit"
+                , ":wq"
+                , ":WQ!"
+                ]
+                `shouldBe` replicate 9 ReplQuit
             parseReplLine "/quit" `shouldBe` ReplQuit
             parseReplLine "/exit" `shouldBe` ReplQuit
+
+        it "does not exit for near matches" do
+            map parseReplLine ["exiting", "quite", "q", "wq", ":w", ":x"]
+                `shouldBe`
+                    map ReplPrompt ["exiting", "quite", "q", "wq", ":w", ":x"]
 
         it "treats :reload as a GHCi reload request" do
             parseReplLine ":reload" `shouldBe` ReplReload


### PR DESCRIPTION
## Summary
- recognize bare `exit` and `quit` before sending prompt text to the model
- support Grok Build-style Vim aliases (`:q!`, `:wq`, and `:wq!`) case-insensitively
- preserve existing `/quit`, `/exit`, and `:quit` behavior and keep near matches as ordinary prompts

## Validation
- `nix develop -c cabal repl agent-cli:test:agent-cli-test`, then `:main --match "parseReplLine"` (44 examples, 0 failures)
- live tmux smoke test through `cabal repl agent-cli:lib:agent-cli`: typed `exit` in the fullscreen composer and confirmed a clean return to GHCi without a model turn
- `git diff --check origin/master...HEAD`