### PR TITLE
Speed up prompt image paste

### DIFF
--- a/packages/agent-cli/benchmark/ClipboardLatency.hs
+++ b/packages/agent-cli/benchmark/ClipboardLatency.hs
@@ -5,6 +5,7 @@ import Agent.CLI.Clipboard
     , readClipboard
     , readClipboardImages
     , readClipboardImagesForPaste
+    , readClipboardImagesImageFirst
     )
 import Agent.Loop (ImageAttachment(..))
 import Control.Exception.Safe (bracket)
@@ -42,6 +43,12 @@ main = do
                 <> ", fake osascript delay=10ms")
         benchmark "old-repeat-probes" samples oldFailureProbe
         benchmark "new-single-pass" samples newFailureProbe
+        putStrLn
+            ("bitmap clipboard success path, samples=" <> show samples
+                <> ", fake file-list coercion delay=10ms")
+        setEnv "AGENT_CLIPBOARD_BENCH_IMAGE" "1"
+        benchmark "old-path-first" samples oldImagePaste
+        benchmark "new-image-first" samples newImagePaste
 
 parseSamples :: [String] -> Int
 parseSamples = \case
@@ -87,6 +94,20 @@ newFailureProbe =
         Right images -> pure (length images)
         Left err -> pure (Text.length err)
 
+oldImagePaste :: IO Int
+oldImagePaste =
+    imageResultChecksum <$> readClipboardImagesForPaste
+
+newImagePaste :: IO Int
+newImagePaste =
+    imageResultChecksum <$> readClipboardImagesImageFirst
+
+imageResultChecksum :: Either Text.Text [ImageAttachment] -> Int
+imageResultChecksum = \case
+    Left err -> Text.length err
+    Right images ->
+        sum [Text.length image.imageMime | image <- images]
+
 clipboardContentChecksum :: ClipboardContent -> Int
 clipboardContentChecksum = \case
     ClipboardImage image -> Text.length image.imageMime
@@ -105,7 +126,18 @@ withFakeClipboard action = do
             createDirectory binDir
             writeExecutable
                 (binDir </> "osascript")
-                "#!/bin/sh\n/bin/sleep 0.01\nexit 1\n"
+                "#!/bin/sh\n\
+                \case \"$2\" in\n\
+                \  *\"set theFiles\"*) /bin/sleep 0.01; exit 1 ;;\n\
+                \  *\"class PNGf\"*)\n\
+                \    if [ \"${AGENT_CLIPBOARD_BENCH_IMAGE:-}\" = 1 ]; then\n\
+                \      path=$(printf '%s\\n' \"$2\" | sed -n \
+                \'s/.*open for access POSIX file \"\\([^\"]*\\)\".*/\\1/p')\n\
+                \      printf 'benchmark-png' > \"$path\"\n\
+                \      exit 0\n\
+                \    fi ;;\n\
+                \esac\n\
+                \exit 1\n"
             writeExecutable
                 (binDir </> "pbpaste")
                 "#!/bin/sh\nprintf 'benchmark clipboard text'\n"

--- a/packages/agent-cli/src/Agent/CLI/Session/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Attachments.hs
@@ -10,7 +10,7 @@ import Agent.CLI.Clipboard
     , formatImageSize
     , pendingImageAttachmentByteLimit
     , pendingImageAttachmentCountLimit
-    , readClipboardImagesForPaste
+    , readClipboardImagesImageFirst
     )
 import Agent.CLI.ImagePreview
     ( detectImagePreviewProtocol
@@ -121,7 +121,10 @@ queueClipboardImages
     previewIdRef
     color
     showPreview = do
-    imagesResult <- readClipboardImagesForPaste
+    -- Terminal image pastes normally expose bitmap bytes directly. Avoid the
+    -- comparatively slow macOS Finder file-list coercion unless that fast
+    -- path fails.
+    imagesResult <- readClipboardImagesImageFirst
     case imagesResult of
         Right images@(_:_) ->
             Right <$> queueAttachedImages


### PR DESCRIPTION
## Summary
- use the bitmap-first clipboard reader for terminal image paste
- defer expensive macOS Finder file-list coercion until direct PNG/JPEG extraction fails
- extend the clipboard latency benchmark with old/new image-paste workloads

## Performance
Optimized benchmark (`nix develop -c cabal build --offline agent-cli:bench:clipboard-latency-bench`, 9 samples, median, simulated 10 ms Finder coercion):

| workload | elapsed | CPU |
| --- | ---: | ---: |
| old path-first | 33.568 ms | 1.306 ms |
| new image-first | 8.845 ms | 0.576 ms |

The existing text failure workload remains covered:

| workload | elapsed | CPU |
| --- | ---: |
| old repeated probes | 80.323 ms | 3.385 ms |
| new single pass | 38.022 ms | 1.851 ms |

## Validation
- `nix develop -c cabal repl agent-cli` (298 modules loaded)
- optimized clipboard benchmark build and 9-sample run
- live tmux/GHCi fullscreen smoke test with a PNG clipboard paste; attachment appeared in the composer as `image/png · 1×1 · 68 B`
- `git diff --check`
