### PR TITLE
Exchange gateway browser OAuth codes in the native bridge

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -73,6 +73,7 @@ import Agent.CLI.GatewayClient
     ( GatewayCredential(..)
     , GatewayDeviceAuthorization(..)
     , GatewayPollResult(..)
+    , exchangeGatewayAuthorizationCode
     , loadGatewayCredential
     , pollGatewayAuthorizationAndSave
     , removeGatewayCredential
@@ -643,6 +644,12 @@ foreign export ccall ha_gateway_connect_poll
     :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
     -> FunPtr GatewayPollCallback -> Ptr () -> IO CInt
 
+foreign export ccall ha_gateway_connect_exchange
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize
+    -> FunPtr GatewayResultCallback -> Ptr () -> IO CInt
+
 foreign export ccall ha_gateway_disconnect
     :: FunPtr GatewayResultCallback -> Ptr () -> IO CInt
 
@@ -935,6 +942,51 @@ ha_gateway_connect_poll
                         invokeGatewayPollError callback context err
                     Right (Right result) ->
                         invokeGatewayPollResult callback context result
+        pure 0
+
+ha_gateway_connect_exchange
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr Word8 -> CSize
+    -> FunPtr GatewayResultCallback -> Ptr () -> IO CInt
+ha_gateway_connect_exchange
+    baseUrlBytes (CSize baseUrlLength)
+    clientIdBytes (CSize clientIdLength)
+    codeBytes (CSize codeLength)
+    verifierBytes (CSize verifierLength)
+    redirectUriBytes (CSize redirectUriLength)
+    callback context
+    | callback == nullFunPtr = pure 1
+    | anyNonEmptyNull
+        [ (baseUrlBytes, baseUrlLength)
+        , (clientIdBytes, clientIdLength)
+        , (codeBytes, codeLength)
+        , (verifierBytes, verifierLength)
+        , (redirectUriBytes, redirectUriLength)
+        ] = pure 2
+    | otherwise = do
+        baseUrl <- decodeInput baseUrlBytes baseUrlLength
+        clientId <- decodeInput clientIdBytes clientIdLength
+        code <- decodeInput codeBytes codeLength
+        verifier <- decodeInput verifierBytes verifierLength
+        redirectUri <- decodeInput redirectUriBytes redirectUriLength
+        _ <- forkIO do
+            tryAny
+                (exchangeGatewayAuthorizationCode
+                    baseUrl
+                    clientId
+                    code
+                    verifier
+                    redirectUri)
+                >>= \case
+                    Left exception ->
+                        invokeGatewayResultError callback context
+                            (Text.pack (show exception))
+                    Right (Left err) ->
+                        invokeGatewayResultError callback context err
+                    Right (Right ()) ->
+                        invokeGatewayResultCallback callback context
+                            0 nullPtr 0
         pure 0
 
 ha_gateway_disconnect

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -474,6 +474,26 @@ int32_t ha_gateway_connect_poll(
     ha_gateway_poll_callback callback,
     void *context
 );
+/*
+ * Exchanges a browser authorization code using its PKCE verifier. On success
+ * the trusted runtime has validated the returned Bearer credential and
+ * gateway origins, then atomically persisted it; no secret is returned.
+ * The result callback receives status 0 for success or -1 with an error.
+ */
+int32_t ha_gateway_connect_exchange(
+    const uint8_t *base_url,
+    size_t base_url_length,
+    const uint8_t *client_id,
+    size_t client_id_length,
+    const uint8_t *authorization_code,
+    size_t authorization_code_length,
+    const uint8_t *code_verifier,
+    size_t code_verifier_length,
+    const uint8_t *redirect_uri,
+    size_t redirect_uri_length,
+    ha_gateway_result_callback callback,
+    void *context
+);
 int32_t ha_gateway_disconnect(
     ha_gateway_result_callback callback,
     void *context

--- a/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
@@ -1,10 +1,12 @@
 -- | HTTPS device authorization and restricted gateway credential storage.
 module Agent.CLI.GatewayClient
     ( GatewayCredential(..)
+    , GatewayAuthorizationCodeResponse(..)
     , GatewayDeviceAuthorization(..)
     , GatewayPollResult(..)
     , connectGateway
     , disconnectGateway
+    , exchangeGatewayAuthorizationCode
     , gatewayCredentialPath
     , loadGatewayCredential
     , loadGatewayCredentialAt
@@ -16,6 +18,7 @@ module Agent.CLI.GatewayClient
     , showGatewayStatus
     , startGatewayAuthorization
     , validateBaseUrl
+    , validateGatewayAuthorizationCodeResponse
     , validateGatewayCredential
     , validateGatewayDeviceAuthorization
     ) where
@@ -29,13 +32,17 @@ import Control.Exception.Safe (tryAny)
 import Control.Monad (when)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as Aeson
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
-import Data.Char (isDigit)
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TextEncoding
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.TLS (newTlsManager)
-import Network.HTTP.Types (hContentType)
+import Network.HTTP.Types (hContentType, statusIsSuccessful)
+import Network.HTTP.Types.URI (renderSimpleQuery)
 import Network.URI qualified as URI
 import System.Directory.OsPath qualified as Directory
 import System.Exit (ExitCode (..))
@@ -73,6 +80,32 @@ instance Aeson.FromJSON GatewayCredential where
             <$> object Aeson..: "base_url"
             <*> object Aeson..: "websocket_url"
             <*> object Aeson..: "access_token"
+
+data GatewayAuthorizationCodeResponse = GatewayAuthorizationCodeResponse
+    { authorizationAccessToken :: !Text
+    , authorizationTokenType :: !Text
+    , authorizationBaseUrl :: !Text
+    , authorizationWebSocketUrl :: !Text
+    }
+    deriving (Eq)
+
+instance Show GatewayAuthorizationCodeResponse where
+    show response =
+        "GatewayAuthorizationCodeResponse"
+            <> " { authorizationAccessToken = <redacted>"
+            <> ", authorizationTokenType = "
+            <> show response.authorizationTokenType
+            <> ", authorizationBaseUrl = "
+            <> show response.authorizationBaseUrl
+            <> ", authorizationWebSocketUrl = <redacted> }"
+
+instance Aeson.FromJSON GatewayAuthorizationCodeResponse where
+    parseJSON = Aeson.withObject "GatewayAuthorizationCodeResponse" \object ->
+        GatewayAuthorizationCodeResponse
+            <$> object Aeson..: "access_token"
+            <*> object Aeson..: "token_type"
+            <*> object Aeson..: "base_url"
+            <*> object Aeson..: "websocket_url"
 
 data GatewayDeviceAuthorization = GatewayDeviceAuthorization
     { deviceCode :: !Text
@@ -328,6 +361,46 @@ pollGatewayAuthorizationAndSave rawBaseUrl deviceCode = do
                                     Right () -> pure (Right authorized)
                 Right result -> pure (Right result)
 
+-- | Exchange an OAuth authorization code using PKCE and atomically persist the
+-- resulting gateway credential. The code, verifier, access token, and
+-- WebSocket URL never cross the native result callback.
+exchangeGatewayAuthorizationCode
+    :: Text
+    -- ^ Gateway base URL.
+    -> Text
+    -- ^ Registered public-client identifier.
+    -> Text
+    -- ^ One-time authorization code.
+    -> Text
+    -- ^ PKCE code verifier.
+    -> Text
+    -- ^ Redirect URI used for the authorization request.
+    -> IO (Either Text ())
+exchangeGatewayAuthorizationCode
+    rawBaseUrl clientId authorizationCode codeVerifier redirectUri =
+        case validateAuthorizationCodeExchange
+            rawBaseUrl
+            clientId
+            authorizationCode
+            codeVerifier
+            redirectUri of
+            Left err -> pure (Left err)
+            Right (baseUrl, fields) -> do
+                manager <- newTlsManager
+                postForm manager
+                    (baseUrl <> "/api/v1/agent-connections/oauth/token")
+                    fields
+                    >>= \case
+                        Left err -> pure (Left err)
+                        Right response ->
+                            case validateGatewayAuthorizationCodeResponse
+                                baseUrl
+                                response of
+                                Left err -> pure (Left err)
+                                Right credential -> do
+                                    home <- Directory.getHomeDirectory
+                                    saveGatewayCredentialAt home credential
+
 removeGatewayCredential :: IO (Either Text ())
 removeGatewayCredential = do
     home <- Directory.getHomeDirectory
@@ -366,6 +439,121 @@ postJson manager url payload = do
                     case Aeson.eitherDecode (HTTP.responseBody value) of
                         Left err -> Left (Text.pack err)
                         Right decoded -> Right decoded
+
+postForm
+    :: Aeson.FromJSON value
+    => HTTP.Manager
+    -> Text
+    -> [(BS.ByteString, BS.ByteString)]
+    -> IO (Either Text value)
+postForm manager url fields = do
+    parsed <- tryAny (HTTP.parseRequest (Text.unpack url))
+    case parsed of
+        Left exception -> pure (Left (Text.pack (show exception)))
+        Right initial -> do
+            response <-
+                tryAny $
+                    HTTP.httpLbs
+                        initial
+                            { HTTP.method = "POST"
+                            , HTTP.requestHeaders =
+                                [ ( hContentType
+                                  , "application/x-www-form-urlencoded"
+                                  )
+                                ]
+                            , HTTP.requestBody =
+                                HTTP.RequestBodyBS (renderSimpleQuery False fields)
+                            , HTTP.checkResponse = \_ _ -> pure ()
+                            }
+                        manager
+            pure case response of
+                Left exception -> Left (Text.pack (show exception))
+                Right value
+                    | statusIsSuccessful
+                        (HTTP.responseStatus value) ->
+                            case Aeson.eitherDecode (HTTP.responseBody value) of
+                                Left _ ->
+                                    Left
+                                        "The gateway returned an invalid authorization response."
+                                Right decoded -> Right decoded
+                    | otherwise ->
+                        Left (gatewayOAuthError (HTTP.responseBody value))
+
+gatewayOAuthError :: LBS.ByteString -> Text
+gatewayOAuthError bytes =
+    case Aeson.decode bytes of
+        Just (Aeson.Object object) ->
+            case Aeson.parseMaybe
+                (\value ->
+                    (value Aeson..:? "error_description")
+                        >>= maybe (value Aeson..:? "error") (pure . Just))
+                object of
+                Just (Just message)
+                    | not (Text.null (Text.strip message)) ->
+                        "Gateway authorization failed: " <> message
+                _ -> fallback
+        _ -> fallback
+  where
+    fallback = "Gateway authorization failed."
+
+validateAuthorizationCodeExchange
+    :: Text
+    -> Text
+    -> Text
+    -> Text
+    -> Text
+    -> Either
+        Text
+        (Text, [(BS.ByteString, BS.ByteString)])
+validateAuthorizationCodeExchange
+    rawBaseUrl clientId authorizationCode codeVerifier redirectUri = do
+        baseUrl <- validateBaseUrl rawBaseUrl
+        when
+            (Text.null clientId || Text.length clientId > 128)
+            (Left "Gateway OAuth client ID is invalid.")
+        when
+            (Text.null authorizationCode || Text.length authorizationCode > 4096)
+            (Left "Gateway authorization code is invalid.")
+        when
+            ( Text.length codeVerifier < 43
+                || Text.length codeVerifier > 128
+                || not (Text.all isPkceCharacter codeVerifier)
+            )
+            (Left "Gateway PKCE code verifier is invalid.")
+        validateRedirectUri redirectUri
+        pure
+            ( baseUrl
+            , fmap
+                (\(name, value) ->
+                    ( TextEncoding.encodeUtf8 name
+                    , TextEncoding.encodeUtf8 value
+                    ))
+                [ ("grant_type", "authorization_code")
+                , ("client_id", clientId)
+                , ("code", authorizationCode)
+                , ("code_verifier", codeVerifier)
+                , ("redirect_uri", redirectUri)
+                ]
+            )
+  where
+    isPkceCharacter character =
+        isAsciiLower character
+            || isAsciiUpper character
+            || isDigit character
+            || character `elem` ("-._~" :: String)
+
+validateRedirectUri :: Text -> Either Text ()
+validateRedirectUri raw =
+    case URI.parseURI (Text.unpack raw) of
+        Just uri
+            | not (null (URI.uriScheme uri))
+            , null (URI.uriFragment uri)
+            , Just authority <- URI.uriAuthority uri
+            , null (URI.uriUserInfo authority)
+            , not (null (URI.uriRegName authority))
+            , not (null (URI.uriPath uri)) ->
+                Right ()
+        _ -> Left "Gateway OAuth redirect URI is invalid."
 
 validateBaseUrl :: Text -> Either Text Text
 validateBaseUrl raw
@@ -439,6 +627,39 @@ validateGatewayCredential credential = do
         else
             Left
                 "The gateway credential WebSocket URL uses a different origin."
+
+-- | Validate the token endpoint's public fields before persisting its secret.
+-- The response base URL and WebSocket URL must remain on the requested gateway
+-- origin, and the token type must be the registered Bearer scheme.
+validateGatewayAuthorizationCodeResponse
+    :: Text
+    -> GatewayAuthorizationCodeResponse
+    -> Either Text GatewayCredential
+validateGatewayAuthorizationCodeResponse requestedBaseUrl response = do
+    requestedOrigin <-
+        parseOrigin
+            "The gateway URL is invalid."
+            =<< validateBaseUrl requestedBaseUrl
+    responseBaseUrl <- validateBaseUrl response.authorizationBaseUrl
+    responseOrigin <-
+        parseOrigin
+            "The gateway returned an invalid base URL."
+            responseBaseUrl
+    if response.authorizationTokenType /= "Bearer"
+        then Left "The gateway returned an unsupported token type."
+        else
+            if responseOrigin /= requestedOrigin
+                then
+                    Left
+                        "The gateway returned a credential for a different origin."
+                else
+                    validateGatewayCredential GatewayCredential
+                        { gatewayBaseUrl = responseBaseUrl
+                        , gatewayWebSocketUrl =
+                            response.authorizationWebSocketUrl
+                        , gatewayAccessToken =
+                            response.authorizationAccessToken
+                        }
 
 -- | Ensure an authorization response cannot make a native or CLI client open
 -- an unrelated website, local file, or custom URL scheme. The verification

--- a/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
@@ -48,6 +48,54 @@ spec = describe "gateway device authorization" do
             `shouldBe` Right
                 (GatewayAuthorized "secret" "wss://gateway/v1/responses")
 
+    it "decodes and validates the authorization-code response contract" do
+        let payload =
+                "{\"access_token\":\"hag_secret\",\"token_type\":\"Bearer\",\
+                \\"base_url\":\"https://platform.digitallyinduced.com\",\
+                \\"websocket_url\":\"wss://platform.digitallyinduced.com/v1/responses\"}"
+            expectedResponse =
+                GatewayAuthorizationCodeResponse
+                    { authorizationAccessToken = "hag_secret"
+                    , authorizationTokenType = "Bearer"
+                    , authorizationBaseUrl =
+                        "https://platform.digitallyinduced.com"
+                    , authorizationWebSocketUrl =
+                        "wss://platform.digitallyinduced.com/v1/responses"
+                    }
+        Aeson.eitherDecodeStrict' payload `shouldBe` Right expectedResponse
+        validateGatewayAuthorizationCodeResponse
+            "https://platform.digitallyinduced.com"
+            expectedResponse
+            `shouldBe` Right
+                (GatewayCredential
+                    "https://platform.digitallyinduced.com"
+                    "wss://platform.digitallyinduced.com/v1/responses"
+                    "hag_secret")
+
+    it "rejects token responses for another origin or token scheme" do
+        let response =
+                GatewayAuthorizationCodeResponse
+                    { authorizationAccessToken = "hag_secret"
+                    , authorizationTokenType = "Bearer"
+                    , authorizationBaseUrl =
+                        "https://platform.digitallyinduced.com"
+                    , authorizationWebSocketUrl =
+                        "wss://platform.digitallyinduced.com/v1/responses"
+                    }
+            validate =
+                validateGatewayAuthorizationCodeResponse
+                    "https://platform.digitallyinduced.com"
+        validate response { authorizationTokenType = "bearer" }
+            `shouldBe` Left "The gateway returned an unsupported token type."
+        validate
+            response
+                { authorizationBaseUrl = "https://example.com"
+                , authorizationWebSocketUrl =
+                    "wss://example.com/v1/responses"
+                }
+            `shouldBe` Left
+                "The gateway returned a credential for a different origin."
+
     it "redacts gateway secrets from Show" do
         let credential =
                 GatewayCredential "https://gateway" "wss://gateway/v1/responses" "secret"
@@ -75,6 +123,20 @@ spec = describe "gateway device authorization" do
             `shouldSatisfy` not . Text.isInfixOf "USER-SECRET"
         renderedPoll `shouldSatisfy` not . Text.isInfixOf "secret"
         renderedPoll `shouldSatisfy` not . Text.isInfixOf "wss://gateway"
+        let renderedCodeResponse =
+                Text.pack $
+                    show
+                        GatewayAuthorizationCodeResponse
+                            { authorizationAccessToken = "oauth-secret"
+                            , authorizationTokenType = "Bearer"
+                            , authorizationBaseUrl = "https://gateway"
+                            , authorizationWebSocketUrl =
+                                "wss://gateway/v1/responses"
+                            }
+        renderedCodeResponse
+            `shouldSatisfy` not . Text.isInfixOf "oauth-secret"
+        renderedCodeResponse
+            `shouldSatisfy` not . Text.isInfixOf "wss://gateway"
 
     it "allows local HTTP development without trusting lookalike hosts" do
         validateBaseUrl "http://localhost:8080"

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -45,7 +45,7 @@ int ha_image_attachment_abi_smoke(void) {
 }
 
 /*
- * Compile the four gateway function/callback signatures as a native consumer
+ * Compile the gateway function/callback signatures as a native consumer
  * and exercise their synchronous argument validation without network or
  * credential-store access.
  */
@@ -57,6 +57,12 @@ int ha_gateway_abi_smoke(void) {
     const uint8_t base_url[] = "https://platform.digitallyinduced.com";
     const uint8_t client_name[] = "native-smoke";
     const uint8_t device_code[] = "device-code";
+    const uint8_t client_id[] = "haskell-agent-macos";
+    const uint8_t authorization_code[] = "authorization-code";
+    const uint8_t code_verifier[] =
+        "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+    const uint8_t redirect_uri[] =
+        "haskell-agent-auth://gateway/callback";
 
     if (HA_GATEWAY_CONNECTED != 0 || HA_GATEWAY_DISCONNECTED != 1
             || HA_GATEWAY_ERROR != -1 || HA_GATEWAY_POLL_AUTHORIZED != 0
@@ -79,8 +85,17 @@ int ha_gateway_abi_smoke(void) {
             poll_callback, NULL) != 1) {
         return 23;
     }
-    if (ha_gateway_disconnect(result_callback, NULL) != 1) {
+    if (ha_gateway_connect_exchange(
+            base_url, sizeof(base_url) - 1,
+            client_id, sizeof(client_id) - 1,
+            authorization_code, sizeof(authorization_code) - 1,
+            code_verifier, sizeof(code_verifier) - 1,
+            redirect_uri, sizeof(redirect_uri) - 1,
+            result_callback, NULL) != 1) {
         return 24;
+    }
+    if (ha_gateway_disconnect(result_callback, NULL) != 1) {
+        return 25;
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a typed `ha_gateway_connect_exchange` C ABI for Authorization Code + PKCE
- exchange browser authorization codes in the trusted Haskell runtime and atomically persist validated gateway credentials
- validate Bearer token responses and require returned HTTP/WebSocket origins to match the requested gateway
- extend the public header and native ABI smoke coverage

## Validation
- `agent-cli:agent-cli-test`: 1107 examples, 0 failures, 1 pending
- focused gateway tests: 9 examples, 0 failures
- `nix build --fallback path:.#agent-native-bridge`
- `nm` confirms `_ha_gateway_connect_exchange`
- `git diff --check`

## Coordination
The macOS app PR pins exact commit `5b3a1a6ffc3899e966b8cb9135ff24df27e93a1b` and keeps its copied header byte-identical.
