### PR TITLE
Add a responsive CLI startup dashboard

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,21 @@
             system:
             let
                 pkgs = import nixpkgs { inherit system; };
+                agentBuildCommit =
+                    if self ? shortRev then self.shortRev
+                    else if self ? dirtyShortRev then self.dirtyShortRev
+                    else "development";
+                agentBuildTimestamp = self.lastModifiedDate or "";
+                # Use the source revision date rather than wall-clock build
+                # time so identical revisions produce identical binaries.
+                agentBuildDate =
+                    if builtins.stringLength agentBuildTimestamp >= 8 then
+                        builtins.substring 0 4 agentBuildTimestamp
+                        + "-"
+                        + builtins.substring 4 2 agentBuildTimestamp
+                        + "-"
+                        + builtins.substring 6 2 agentBuildTimestamp
+                    else "unknown";
                 bun_1_4 = pkgs.bun.overrideAttrs (_old: {
                     version = "1.4.0";
                     src = pkgs.fetchurl {
@@ -483,9 +498,14 @@
                                 })
                             [ pkgs.postgresql_18 ]);
                         agent-cli = localPackage (pkgs.haskell.lib.addTestToolDepends
-                            (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-cli/package.nix { }) {
+                            ((pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-cli/package.nix { }) {
                                 src = agentCliSource;
-                            })
+                            }).overrideAttrs (old: {
+                                configureFlags = (old.configureFlags or [ ]) ++ [
+                                    "--ghc-option=-DAGENT_BUILD_COMMIT=\"${agentBuildCommit}\""
+                                    "--ghc-option=-DAGENT_BUILD_DATE=\"${agentBuildDate}\""
+                                ];
+                            }))
                             [
                                 pkgs.git
                                 bun_1_4

--- a/packages/agent-cli/src/Agent/CLI.hs
+++ b/packages/agent-cli/src/Agent/CLI.hs
@@ -1,6 +1,8 @@
 -- | Public command-line entry point and compatibility façade.
 module Agent.CLI
-    ( DevResult(..)
+    ( BuildInfo(..)
+    , DevResult(..)
+    , agentBuildInfo
     , afterDev
     , accountSwitchTarget
     , applyReplMode
@@ -12,6 +14,8 @@ module Agent.CLI
     , formatMcpModelNotice
     , formatMcpModelNoticeFor
     , formatMcpProgress
+    , formatBuildInfo
+    , formatBuildInfoCompact
     , formatReplStatusLine
     , formatRepositoryPath
     , formatStartupTimings
@@ -25,7 +29,9 @@ module Agent.CLI
     ) where
 
 import Agent.CLI.Runtime
-    ( accountSwitchTarget
+    ( BuildInfo(..)
+    , accountSwitchTarget
+    , agentBuildInfo
     , afterDev
     , applyReplMode
     , buildPromptState
@@ -33,6 +39,8 @@ import Agent.CLI.Runtime
     , devArgs
     , devMain
     , devMainResume
+    , formatBuildInfo
+    , formatBuildInfoCompact
     , formatRepositoryPath
     , formatStartupTimings
     , learnAboutUserOnboardingPrompt

--- a/packages/agent-cli/src/Agent/CLI/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime.hs
@@ -1,6 +1,8 @@
 -- | Stable public facade for the command-line runtime.
 module Agent.CLI.Runtime
-    ( DevResult(..)
+    ( BuildInfo(..)
+    , DevResult(..)
+    , agentBuildInfo
     , afterDev
     , accountSwitchTarget
     , applyReplMode
@@ -12,6 +14,8 @@ module Agent.CLI.Runtime
     , formatMcpModelNotice
     , formatMcpModelNoticeFor
     , formatMcpProgress
+    , formatBuildInfo
+    , formatBuildInfoCompact
     , formatReplStatusLine
     , formatRepositoryPath
     , formatStartupTimings

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -1,6 +1,8 @@
 -- | Command-line entry point: one-shot @-p@ or an interactive REPL.
 module Agent.CLI.Runtime.Internal
-    ( DevResult(..)
+    ( BuildInfo(..)
+    , DevResult(..)
+    , agentBuildInfo
     , afterDev
     , accountSwitchTarget
     , applyReplMode
@@ -12,6 +14,8 @@ module Agent.CLI.Runtime.Internal
     , formatMcpModelNotice
     , formatMcpModelNoticeFor
     , formatMcpProgress
+    , formatBuildInfo
+    , formatBuildInfoCompact
     , formatReplStatusLine
     , formatRepositoryPath
     , formatStartupTimings
@@ -63,7 +67,13 @@ import Agent.CLI.SessionAdmin
     )
 import Agent.CLI.Startup.Auth ( learnAboutUserOnboardingPrompt )
 import Agent.CLI.Startup.Format
-    ( formatRepositoryPath, formatStartupTimings )
+    ( BuildInfo(..)
+    , agentBuildInfo
+    , formatBuildInfo
+    , formatBuildInfoCompact
+    , formatRepositoryPath
+    , formatStartupTimings
+    )
 import Agent.CLI.Status
     ( applyReplMode
     , cycleReplInteraction
@@ -137,7 +147,8 @@ devMainResume resumeId = do
     case parseArgs args of
         Left err -> die err
         Right ShowHelp -> putStr usage >> pure DevQuit
-        Right ShowVersion -> putStrLn "agent-cli 0.1.0.0" >> pure DevQuit
+        Right ShowVersion ->
+            putStrLn (Text.unpack (formatBuildInfo agentBuildInfo)) >> pure DevQuit
         Right Login -> do
             color <- resolveColor stderr
             runLoginManager color
@@ -163,7 +174,8 @@ run = do
     case parseArgs args of
         Left err -> die err
         Right ShowHelp -> putStr usage
-        Right ShowVersion -> putStrLn "agent-cli 0.1.0.0"
+        Right ShowVersion ->
+            putStrLn (Text.unpack (formatBuildInfo agentBuildInfo))
         Right Login -> do
             color <- resolveColor stderr
             runLoginManager color

--- a/packages/agent-cli/src/Agent/CLI/Startup/Format.hs
+++ b/packages/agent-cli/src/Agent/CLI/Startup/Format.hs
@@ -1,6 +1,12 @@
+{-# LANGUAGE CPP #-}
+
 -- | Pure formatting for startup diagnostics and repository chrome.
 module Agent.CLI.Startup.Format
-    ( formatRepositoryPath
+    ( BuildInfo(..)
+    , agentBuildInfo
+    , formatBuildInfo
+    , formatBuildInfoCompact
+    , formatRepositoryPath
     , formatStartupDuration
     , formatStartupTimings
     ) where
@@ -10,8 +16,52 @@ import Data.List (sortOn)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (NominalDiffTime)
+import Data.Version (showVersion)
 import System.OsPath (OsPath)
 import Text.Printf (printf)
+import qualified Paths_agent_cli as Paths
+
+#ifndef AGENT_BUILD_COMMIT
+#define AGENT_BUILD_COMMIT "development"
+#endif
+
+#ifndef AGENT_BUILD_DATE
+#define AGENT_BUILD_DATE "local"
+#endif
+
+-- | Identity embedded into an agent-cli build.
+data BuildInfo = BuildInfo
+    { buildVersion :: !Text
+    , buildCommit :: !Text
+    , buildDate :: !Text
+    } deriving (Eq, Show)
+
+agentBuildInfo :: BuildInfo
+agentBuildInfo =
+    BuildInfo
+        { buildVersion = Text.pack (showVersion Paths.version)
+        , buildCommit = Text.pack AGENT_BUILD_COMMIT
+        , buildDate = Text.pack AGENT_BUILD_DATE
+        }
+
+formatBuildInfo :: BuildInfo -> Text
+formatBuildInfo info =
+    "agent-cli "
+        <> info.buildVersion
+        <> " (commit "
+        <> info.buildCommit
+        <> ", built "
+        <> info.buildDate
+        <> ")"
+
+formatBuildInfoCompact :: BuildInfo -> Text
+formatBuildInfoCompact info =
+    "v"
+        <> info.buildVersion
+        <> " · "
+        <> info.buildCommit
+        <> " · "
+        <> info.buildDate
 
 formatStartupTimings :: [(Text, NominalDiffTime)] -> Text
 formatStartupTimings timings =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -32,6 +32,8 @@ module Agent.CLI.TUI.App
     , lambdaArtWidget
     , quickStartRows
     , quickStartVisible
+    , quickStartWideVisible
+    , startupCapabilityLines
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
     , newFullscreenInputBuffer

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -8,7 +8,9 @@ module Agent.CLI.TUI.Render.Internal
     , conversationScrollbarRenderer
     , choiceRowColumns
     , quickStartVisible
+    , quickStartWideVisible
     , quickStartRows
+    , startupCapabilityLines
     , repositoryHeaderText
     , selectedAgentConversation
     , onboardingVisibleRowIndices
@@ -317,7 +319,9 @@ import Agent.CLI.TUI.Render.Overlays
     , normalizeTextOverlayInsertion, maskedSecretText, textOverlayDisplayText
     , resumeSearchCursorColumn )
 import Agent.CLI.TUI.Render.Transcript
-    ( stickyPromptLayers, quickStartVisible, quickStartRows )
+    ( stickyPromptLayers, quickStartVisible, quickStartWideVisible
+    , quickStartRows
+    , startupCapabilityLines )
 import Agent.CLI.TUI.Render.Workspace
     ( drawWorkspace, agentPopoverLayers, agentEntryWindow, agentPaneVisible
     , agentPaneEntryLimit, conversationScrollbarRenderer

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
@@ -6,7 +6,9 @@ module Agent.CLI.TUI.Render.Transcript
     , drawEmptyConversation
     , drawConversationBlocks
     , quickStartVisible
+    , quickStartWideVisible
     , quickStartRows
+    , startupCapabilityLines
     ) where
 
 
@@ -21,10 +23,14 @@ import Agent.CLI.AgentViewport
       lookupAgentEntry )
 import Agent.CLI.Artifact ()
 import Agent.CLI.Clipboard ( formatImageSize )
-import Agent.CLI.Command ()
+import Agent.CLI.Command
+    ( SkillCommand(skillCommandName)
+    , SlashCatalog(slashCatalogSkills, slashCatalogToolNames)
+    )
 import Agent.CLI.Dictation ()
 import Agent.CLI.ImagePreview ()
-import Agent.CLI.Input ( terminalTextWidth, truncateDisplayText )
+import Agent.CLI.Input
+    ( displayEditorText, terminalTextWidth, truncateDisplayText )
 import Agent.CLI.Interrupt ()
 import Agent.CLI.Permission ()
 import Agent.CLI.Recap ()
@@ -45,6 +51,8 @@ import Agent.CLI.Resume
       resumeRelativeAge )
 import Agent.CLI.Secret ()
 import Agent.CLI.Status ( formatTokensPerSecond, formatUsageWithRate )
+import Agent.CLI.Startup.Format
+    ( agentBuildInfo, formatBuildInfoCompact )
 import Agent.CLI.Style ( motionGlyphSet )
 import Agent.CLI.TUI.History
     ( HistoryWindow(historyWindowTurns, historyWindowTotalTurns,
@@ -82,7 +90,7 @@ import Agent.CLI.TUI.Types
                appMotionElapsedMillis, appCompletionFlashes, appHoveredControl,
                appPressedControl, appAgentSelected, appConversationAnchor,
                appAgentEntries, appUi, appHistoryWindow, appAgentHover,
-               appTerminalFocus),
+               appTerminalFocus, appSlashCatalog),
       FullscreenRuntime(runtimeMotionMode, runtimeNativeImagePreviews,
                        runtimeColor, runtimeWaveTrough),
       Name(ChoiceRow, ConversationViewport, ConversationViewportExtent,
@@ -156,7 +164,6 @@ import Brick
       padBottom,
       padLeft,
       padLeftRight,
-      padRight,
       padTop,
       padTopBottom,
       reportExtent,
@@ -182,9 +189,9 @@ import Brick
       VScrollbarRenderer(..),
       ViewportType(Vertical),
       Widget(render, Widget),
-      Padding(Pad, Max) )
+      Padding(Pad) )
 import Brick.BChan ()
-import Brick.Widgets.Border ( borderWithLabel )
+import Brick.Widgets.Border ( borderWithLabel, vBorder )
 import Brick.Widgets.Border.Style ( unicodeRounded )
 import Brick.Widgets.Center ( center, centerLayer, hCenter )
 import Codec.Picture ()
@@ -237,7 +244,7 @@ import qualified Agent.CLI.TUI.Scroll as Scroll
     ( ConversationAnchor(anchorText, anchorReserveRows),
       conversationAnchorSticky )
 import qualified Data.Sequence as Seq ( (!?), length, null )
-import qualified Data.Set as Set ( Set, member )
+import qualified Data.Set as Set ( Set, member, toAscList )
 import qualified Data.Text as Text
     ( intercalate,
       isPrefixOf,
@@ -284,6 +291,7 @@ import qualified Agent.CLI.TUI.Transcript as Transcript
 import qualified Graphics.Vty as V
     ( Attr,
       Image,
+      backgroundFill,
       imageHeight,
       imageWidth,
       char,
@@ -512,17 +520,39 @@ drawEmptyConversation state =
         context <- B.getContext
         let width = context.availWidth
             height = context.availHeight
+            capabilityRows = quickStartCapabilityRows height
+            panelWidth = quickStartPanelWidth width
         B.render $
-            if quickStartVisible width height
-                then
-                    center $
-                        vBox
-                            [ vLimit
-                                (max 8 (height - quickStartReservedRows))
-                                (hCenter (lambdaArtWidget colorEnabled frame))
-                            , hCenter (drawQuickStartPanel state)
-                            ]
-                else center (lambdaArtWidget colorEnabled frame)
+            if not (quickStartVisible width height)
+                then center (lambdaArtWidget colorEnabled frame)
+                else
+                    if quickStartWideVisible width height
+                        then
+                            center $
+                                drawQuickStartDashboard
+                                    state
+                                    panelWidth
+                                    height
+                                    colorEnabled
+                                    frame
+                        else
+                            center $
+                                vBox
+                                    [ vLimit
+                                        (max 8
+                                            (height
+                                                - quickStartReservedRows
+                                                    capabilityRows))
+                                        (hCenter
+                                            (lambdaArtWidget
+                                                colorEnabled
+                                                frame))
+                                    , hCenter
+                                        (drawQuickStartPanel
+                                            state
+                                            panelWidth
+                                            capabilityRows)
+                                    ]
   where
     colorEnabled = state.appRuntime.runtimeColor
     frame
@@ -535,12 +565,26 @@ drawEmptyConversation state =
                 MotionReduced -> 0
                 MotionOff -> 0
 
-quickStartReservedRows :: Int
-quickStartReservedRows = 9
+quickStartReservedRows :: Int -> Int
+quickStartReservedRows capabilityRows =
+    11 + 2 * capabilityRows
+
+quickStartCapabilityRows :: Int -> Int
+quickStartCapabilityRows height
+    | height >= 34 = 2
+    | otherwise = 1
+
+quickStartPanelWidth :: Int -> Int
+quickStartPanelWidth width =
+    max 44 (width - 4)
 
 quickStartVisible :: Int -> Int -> Bool
 quickStartVisible width height =
-    width >= 48 && height >= 20
+    width >= 48 && height >= 22
+
+quickStartWideVisible :: Int -> Int -> Bool
+quickStartWideVisible width height =
+    width >= 104 && height >= 29
 
 quickStartRows :: [(Name, Text, Text)]
 quickStartRows =
@@ -550,18 +594,217 @@ quickStartRows =
     , (QuickStartModel, "Manage models", "/model")
     ]
 
-drawQuickStartPanel :: AppState -> Widget Name
-drawQuickStartPanel state =
-    hLimit 44 $
+drawQuickStartDashboard
+    :: AppState
+    -> Int
+    -> Int
+    -> Bool
+    -> Int
+    -> Widget Name
+drawQuickStartDashboard
+    state
+    panelWidth
+    availableHeight
+    colorEnabled
+    frame =
+    vLimit dashboardHeight $
+        hLimit panelWidth $
+            withBorderStyle unicodeRounded $
+                borderWithLabel
+                    (withAttr Theme.headingAttr (txt " haskell-agent ")) $
+                    padAll 1 $
+                        hBox
+                            [ hLimit leftWidth $
+                                vBox
+                                    [ vLimit artHeight $
+                                        hCenter
+                                            (lambdaArtWidget
+                                                colorEnabled
+                                                frame)
+                                    , withAttr Theme.mutedAttr $
+                                        hCenter
+                                            (txt
+                                                (formatBuildInfoCompact
+                                                    agentBuildInfo))
+                                    , padTop (Pad 1) $
+                                        hCenter $
+                                            hLimit leftWidth
+                                                (drawQuickStartActions state)
+                                    ]
+                            , withAttr Border.borderAttr vBorder
+                            , padLeft (Pad 2) $
+                                hLimit capabilityWidth $
+                                    padRightWithBackground $
+                                        drawDashboardCapabilities
+                                            capabilityWidth
+                                            toolRows
+                                            skillRows
+                                            toolNames
+                                            skillNames
+                            ]
+  where
+    innerWidth = max 1 (panelWidth - 4)
+    leftWidth =
+        min 48 (max 38 (innerWidth `div` 3))
+    capabilityWidth =
+        max 1 (innerWidth - leftWidth - 3)
+    artHeight
+        | availableHeight >= 35 = 21
+        | otherwise = 16
+    dashboardHeight
+        | availableHeight >= 35 = 32
+        | otherwise = 27
+    toolRows
+        | availableHeight >= 38 = 7
+        | otherwise = 5
+    skillRows
+        | availableHeight >= 38 = 5
+        | otherwise = 3
+    toolNames = startupToolNames state
+    skillNames = startupSkillNames state
+
+-- | Make a widget greedily occupy its available width without painting a
+-- rectangle of explicit space glyphs. Some terminals expose those glyphs as
+-- dotted whitespace; Vty background cells remain visually blank while still
+-- giving the surrounding border the intended width.
+padRightWithBackground :: Widget n -> Widget n
+padRightWithBackground widget@(Widget _ verticalSize _) =
+    Widget Greedy verticalSize do
+        context <- getContext
+        result <- render (hLimit context.availWidth widget)
+        let missingWidth =
+                max 0 (context.availWidth - V.imageWidth result.image)
+            padding =
+                V.backgroundFill
+                    missingWidth
+                    (V.imageHeight result.image)
+        pure result
+            { image = V.horizCat [result.image, padding]
+            }
+
+drawDashboardCapabilities
+    :: Int
+    -> Int
+    -> Int
+    -> [Text]
+    -> [Text]
+    -> Widget Name
+drawDashboardCapabilities
+    width
+    toolRows
+    skillRows
+    toolNames
+    skillNames =
+    vBox
+        [ drawSection
+            Theme.toolAttr
+            "Available Tools"
+            toolRows
+            toolNames
+        , padTop (Pad 1) $
+            drawSection
+                Theme.controlLinkAttr
+                "Available Skills"
+                skillRows
+                skillNames
+        , padTop (Pad 1) $
+            withAttr Theme.mutedAttr $
+                txt $
+                    truncateDisplayText width $
+                        Text.pack (show (length toolNames))
+                            <> " tools · "
+                            <> Text.pack (show (length skillNames))
+                            <> " skills · Type / to browse all."
+        ]
+  where
+    drawSection valueAttr label maxRows names =
+        vBox
+            [ withAttr Theme.strongAttr $
+                txt
+                    (label
+                        <> " ("
+                        <> Text.pack (show (length names))
+                        <> ")")
+            , padTop (Pad 1) $
+                padLeft (Pad 2) $
+                    vBox
+                        (map
+                            (withAttr valueAttr . txt)
+                            (startupCapabilityLines
+                                (max 1 (width - 2))
+                                maxRows
+                                names))
+            ]
+
+drawQuickStartPanel :: AppState -> Int -> Int -> Widget Name
+drawQuickStartPanel state panelWidth capabilityRows =
+    hLimit panelWidth $
         vBox
             [ withAttr Theme.headingAttr $
-                hCenter (txt "What would you like to do?")
+                hCenter (txt "haskell-agent")
+            , withAttr Theme.mutedAttr $
+                hCenter (txt (formatBuildInfoCompact agentBuildInfo))
             , padTop (Pad 1) $
-                vBox (map drawQuickStartRow quickStartRows)
+                vBox
+                    [ drawCapability
+                        Theme.toolAttr
+                        "Tools"
+                        toolNames
+                    , drawCapability
+                        Theme.controlLinkAttr
+                        "Skills"
+                        skillNames
+                    ]
+            , padTop (Pad 1) $
+                hCenter $
+                    hLimit 44 $
+                        drawQuickStartActions state
             , padTop (Pad 1) $
                 withAttr Theme.mutedAttr $
                     hCenter (txt "Tip: Type / to browse commands and skills.")
             ]
+  where
+    toolNames = startupToolNames state
+    skillNames = startupSkillNames state
+    capabilityLabelWidth = 14
+    capabilityTextWidth = max 1 (panelWidth - capabilityLabelWidth)
+
+    drawCapability valueAttr label names =
+        vBox $
+            zipWith
+                (drawCapabilityLine valueAttr heading)
+                [0 :: Int ..]
+                (startupCapabilityLines
+                    capabilityTextWidth
+                    capabilityRows
+                    names)
+      where
+        heading =
+            label <> " (" <> Text.pack (show (length names)) <> ")"
+
+    drawCapabilityLine valueAttr heading lineIndex line =
+        hBox
+            [ hLimit capabilityLabelWidth $
+                if lineIndex == 0
+                    then
+                        withAttr Theme.strongAttr $
+                            txt $
+                                Text.justifyLeft capabilityLabelWidth ' ' $
+                                    truncateDisplayText
+                                        capabilityLabelWidth
+                                        heading
+                    else fill ' '
+            , hLimit capabilityTextWidth $
+                withAttr valueAttr (txt line)
+            ]
+
+drawQuickStartActions :: AppState -> Widget Name
+drawQuickStartActions state =
+    vBox
+        [ withAttr Theme.headingAttr $
+            hCenter (txt "What would you like to do?")
+        , vBox (map drawQuickStartRow quickStartRows)
+        ]
   where
     drawQuickStartRow (name, label, command) =
         clickable name $
@@ -576,3 +819,84 @@ drawQuickStartPanel state =
                 , withAttr Theme.mutedAttr (txt command)
                 , txt "  "
                 ]
+
+startupToolNames :: AppState -> [Text]
+startupToolNames state =
+    sanitizeCapabilityNames
+        (Set.toAscList state.appSlashCatalog.slashCatalogToolNames)
+
+startupSkillNames :: AppState -> [Text]
+startupSkillNames state =
+    map ("/" <>)
+        (sanitizeCapabilityNames
+            (map
+                (.skillCommandName)
+                state.appSlashCatalog.slashCatalogSkills))
+
+startupCapabilityLines :: Int -> Int -> [Text] -> [Text]
+startupCapabilityLines width maxRows rawNames
+    | width <= 0 || maxRows <= 0 = []
+    | null names = [truncateDisplayText width "none"]
+    | otherwise = layout maxRows names
+  where
+    names = sanitizeCapabilityNames rawNames
+
+    layout _ [] = []
+    layout 1 remaining = [finalCapabilityLine width remaining]
+    layout rows remaining =
+        let (shown, rest) = takeCapabilityLine width remaining
+            line = Text.intercalate capabilitySeparator shown
+        in line :
+            if null rest
+                then []
+                else layout (rows - 1) rest
+
+sanitizeCapabilityNames :: [Text] -> [Text]
+sanitizeCapabilityNames =
+    filter (not . Text.null)
+        . map (displayEditorText . Text.strip)
+
+capabilitySeparator :: Text
+capabilitySeparator = " · "
+
+takeCapabilityLine :: Int -> [Text] -> ([Text], [Text])
+takeCapabilityLine _ [] = ([], [])
+takeCapabilityLine width (first : rest)
+    | terminalTextWidth first > width =
+        ([truncateDisplayText width first], rest)
+    | otherwise = go [first] rest
+  where
+    go shown [] = (shown, [])
+    go shown remaining@(next : remainingTail)
+        | terminalTextWidth candidate <= width =
+            go (shown <> [next]) remainingTail
+        | otherwise = (shown, remaining)
+      where
+        candidate =
+            Text.intercalate capabilitySeparator (shown <> [next])
+
+finalCapabilityLine :: Int -> [Text] -> Text
+finalCapabilityLine width [name] =
+    truncateDisplayText width name
+finalCapabilityLine width names
+    | terminalTextWidth complete <= width = complete
+    | otherwise = choose (length names - 1)
+  where
+    complete = Text.intercalate capabilitySeparator names
+    total = length names
+
+    choose shownCount
+        | shownCount <= 0 =
+            truncateDisplayText width (omissionText total)
+        | terminalTextWidth candidate <= width = candidate
+        | otherwise = choose (shownCount - 1)
+      where
+        omitted = total - shownCount
+        candidate =
+            Text.intercalate capabilitySeparator (take shownCount names)
+                <> capabilitySeparator
+                <> omissionText omitted
+
+omissionText :: Int -> Text
+omissionText omitted =
+    "… +" <> Text.pack (show omitted)

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -1,8 +1,10 @@
 module Agent.CLI.ReplStatusSpec (spec) where
 
 import Agent.CLI
-    ( DevResult(..)
+    ( BuildInfo(..)
+    , DevResult(..)
     , accountSwitchTarget
+    , agentBuildInfo
     , afterDev
     , applyReplMode
     , buildPromptState
@@ -11,6 +13,8 @@ import Agent.CLI
     , formatMcpModelNotice
     , formatMcpModelNoticeFor
     , formatMcpProgress
+    , formatBuildInfo
+    , formatBuildInfoCompact
     , formatReplStatusLine
     , formatRepositoryPath
     , formatStartupTimings
@@ -300,6 +304,26 @@ spec = do
                 ]
                 `shouldBe`
                     "startup: first frame 42ms · Loading tools… 400ms · ready 1.25s"
+
+    describe "build identity" do
+        let info =
+                BuildInfo
+                    { buildVersion = "1.2.3"
+                    , buildCommit = "abc1234"
+                    , buildDate = "2026-08-30"
+                    }
+
+        it "formats full and compact build metadata consistently" do
+            formatBuildInfo info
+                `shouldBe`
+                    "agent-cli 1.2.3 (commit abc1234, built 2026-08-30)"
+            formatBuildInfoCompact info
+                `shouldBe` "v1.2.3 · abc1234 · 2026-08-30"
+
+        it "embeds a package version, commit, and build date" do
+            agentBuildInfo.buildVersion `shouldNotBe` ""
+            agentBuildInfo.buildCommit `shouldNotBe` ""
+            agentBuildInfo.buildDate `shouldNotBe` ""
 
     describe "formatRepositoryPath" do
         it "abbreviates paths below the home directory" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -42,6 +42,8 @@ import Agent.CLI.TUI.App
     , lambdaArtWidget
     , quickStartRows
     , quickStartVisible
+    , quickStartWideVisible
+    , startupCapabilityLines
     , nativeProgressKeepaliveDue
     , nextMotionSchedule
     , onboardingVisibleRowIndices
@@ -744,7 +746,12 @@ spec = do
         it "shows quick-start actions only when the empty pane has room" do
             quickStartVisible 100 30 `shouldBe` True
             quickStartVisible 47 30 `shouldBe` False
-            quickStartVisible 100 19 `shouldBe` False
+            quickStartVisible 100 21 `shouldBe` False
+
+        it "uses the two-column dashboard only in wide render contexts" do
+            quickStartWideVisible 140 35 `shouldBe` True
+            quickStartWideVisible 103 35 `shouldBe` False
+            quickStartWideVisible 140 28 `shouldBe` False
 
         it "surfaces the existing high-value startup commands" do
             quickStartRows
@@ -754,6 +761,37 @@ spec = do
                     , (QuickStartCommands, "Browse commands", "/")
                     , (QuickStartModel, "Manage models", "/model")
                     ]
+
+        it "packs capability names into bounded startup rows" do
+            let lines' =
+                    startupCapabilityLines
+                        20
+                        2
+                        [ "read_file"
+                        , "grep"
+                        , "shell_command"
+                        , "apply_patch"
+                        ]
+            lines'
+                `shouldBe`
+                    [ "read_file · grep"
+                    , "shell_command · … +1"
+                    ]
+            map terminalTextWidth lines'
+                `shouldSatisfy` all (<= 20)
+
+        it "summarizes omitted capabilities and handles an empty catalog" do
+            startupCapabilityLines
+                20
+                1
+                ["read_file", "grep", "shell_command", "apply_patch"]
+                `shouldBe` ["read_file · … +3"]
+            startupCapabilityLines 20 2 []
+                `shouldBe` ["none"]
+
+        it "renders untrusted capability names without terminal controls" do
+            startupCapabilityLines 40 1 ["  safe\nname\ESC[31m  "]
+                `shouldBe` ["safe↵name␛[31m"]
 
         it "paints an exact terminal-sized backing surface" do
             let image =


### PR DESCRIPTION
## Summary

- add a responsive two-column startup dashboard with build identity, available tools and skills, and quick-start actions
- retain compact and art-only fallbacks for smaller terminal sizes
- sanitize and width-bound capability names, including explicit omitted-item counts
- embed reproducible commit and source-date metadata in Nix builds and use the same identity for `--version`
- reserve dashboard width with visually blank Vty background cells

## Validation

- `nix develop -c cabal repl agent-cli:lib:agent-cli` (210 modules loaded)
- `nix develop -c cabal build agent-cli:exe:agent-cli agent-cli:test:agent-cli-test`
- focused bounded-rendering suite: 10 examples, 0 failures
- live fullscreen smoke checks in tmux at 140×46 and 180×50, including loading and populated capability states
