### PR TITLE
Fix static Nix build for provider limit events

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -572,6 +572,10 @@ uiEventLogicalBytes = \case
             TextDelta text -> logicalTextBytes text
             ReasoningDelta text -> logicalTextBytes text
             ActivityUpdated text -> logicalTextBytes text
+            ProviderLimitUpdated
+                { providerLimitText = text
+                } ->
+                logicalTextBytes text
             WarningRaised text -> logicalTextBytes text
             ResponseRestarted text -> logicalTextBytes text
             TurnStarted -> 128


### PR DESCRIPTION
## Summary
- account for `ProviderLimitUpdated` in TUI mailbox logical byte estimates
- restore exhaustive matching under the static musl build

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli` and load `Agent.CLI.TUI.App.Mailbox`
- `nix build --print-build-logs`
- `git diff --check`