### PR TITLE
Add Grok-compatible rewind and home commands

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -341,6 +341,10 @@ parseSlash catalog raw line = case Text.words line of
                     then ReplLogin
                     else ReplCommandError "usage: /login"
             "resume" -> parseResumeCommand args
+            "home" ->
+                if null args
+                    then ReplHome
+                    else ReplCommandError "usage: /home"
             "search" ->
                 let query =
                         Text.strip (Text.drop (Text.length command) line)
@@ -352,6 +356,10 @@ parseSlash catalog raw line = case Text.words line of
                         Text.strip (Text.drop (Text.length command) line)
                 in ReplCompact
                     (if Text.null focus then Nothing else Just focus)
+            "rewind" ->
+                if null args
+                    then ReplRewind
+                    else ReplCommandError "usage: /rewind"
             "clear" ->
                 if null args
                     then ReplClear

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -37,8 +37,10 @@ slashCommands =
     , cmd "rename" ["title"] "/rename <TITLE>|--auto" "Rename the current session, or restore automatic titles" True
     , cmd "login" ["accounts"] "/login" "Manage provider credentials and usage" False
     , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or resume ID" True
+    , cmd "home" ["welcome"] "/home" "Return to the session picker" False
     , cmd "search" [] "/search <QUERY>" "Search past conversations and resume a match" True
     , cmd "compact" [] "/compact [FOCUS]" "Summarize history to free context" True
+    , cmd "rewind" ["undo"] "/rewind" "Rewind to a previous turn" False
     , cmd "clear" [] "/clear" "Reset the live conversation (same session id)" False
     , cmd "new" [] "/new" "Start a fresh persisted session id" False
     , cmd "delete" [] "/delete" "Delete the current session and start fresh" False

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -111,10 +111,14 @@ data ReplAction
     -- ^ @Nothing@ lists every command; @Just@ is a canonical name without @/@.
     | ReplResume (Maybe Text)
     -- ^ @Nothing@ opens the session picker; @Just@ is a session id.
+    | ReplHome
+    -- ^ Return to the session picker.
     | ReplSearch !Text
     -- ^ Search persisted conversation turns and open matching sessions.
     | ReplCompact (Maybe Text)
     -- ^ Optional focus note for what to keep while compacting history.
+    | ReplRewind
+      -- ^ Restore conversation state before a selected prompt.
     | ReplClear
       -- ^ Soft-reset live transcript; keep the same session id.
     | ReplNew

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -33,7 +33,8 @@ import Agent.CLI.Command
                  ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
                  ReplViewPlan, ReplQueue, ReplTranscript, ReplEditPrompt,
                  ReplContext, ReplHistory, ReplFind,
-                 ReplBtw, ReplMetaConsole, ReplRecap, ReplRetry, ReplResume, ReplSearch, ReplClear, ReplNew, ReplDelete,
+                 ReplBtw, ReplMetaConsole, ReplRecap, ReplRetry, ReplResume, ReplSearch,
+                 ReplHome, ReplRewind, ReplClear, ReplNew, ReplDelete,
                  ReplShowSession, ReplShowSessionInfo, ReplAfk, ReplWorktree,
                  ReplRename, ReplRenameAuto, ReplInit, ReplReview, ReplDiff,
                  ReplFork, ReplExport, ReplPermissions,
@@ -1113,6 +1114,8 @@ handleReplLine
                                     continue
                     action@ReplResume{} -> handleSessionAction env slashCatalog continue action
                     action@ReplSearch{} -> handleSessionAction env slashCatalog continue action
+                    action@ReplHome -> handleSessionAction env slashCatalog continue action
+                    action@ReplRewind -> handleSessionAction env slashCatalog continue action
                     action@ReplClear -> handleSessionAction env slashCatalog continue action
                     action@ReplNew -> handleSessionAction env slashCatalog continue action
                     action@ReplDelete -> handleSessionAction env slashCatalog continue action

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -17,7 +17,7 @@ import Agent.CLI.Command
     ( currentEffort,
       currentModel,
       ForkRequest(..),
-      ReplAction(ReplRenameAuto, ReplResume, ReplSearch, ReplClear,
+      ReplAction(ReplRenameAuto, ReplResume, ReplSearch, ReplHome, ReplRewind, ReplClear,
                  ReplNew, ReplDelete, ReplShowSession, ReplShowSessionInfo, ReplAfk,
                  ReplWorktree, ReplRename, ReplFork),
       ShellMode(ShellNone, ShellGhci, ShellBash, ShellBoth),
@@ -64,7 +64,8 @@ import Agent.CLI.Runtime.HistorySource
 import Agent.CLI.Runtime.Persistence ()
 import Agent.CLI.Runtime.Recap ()
 import Agent.CLI.Runtime.Types
-    ( RunResult(RunDeleteSession, RunForkSession, RunSwitchWorktree, RunQuit) )
+    ( RunResult(RunDeleteSession, RunForkSession, RunSwitchWorktree, RunRestart,
+                RunQuit) )
 import Agent.CLI.Secret ()
 import Agent.CLI.Session
     ( TranscriptEffect(TranscriptReset),
@@ -72,9 +73,11 @@ import Agent.CLI.Session
       createSession,
       forkSessionAt,
       loadSession,
+      rewindSession,
       removeSessionTemp,
       resetSessionTitleToAuto,
       sessionConversationText,
+      sessionRewindChoices,
       sessionsRoot,
       setManualSessionTitle,
       writeSessionMeta,
@@ -87,7 +90,7 @@ import Agent.CLI.Session
       SessionMeta(metaTitle, metaLastResponseId, metaUpdatedAt,
                   metaInputTokens, metaOutputTokens, metaCachedTokens, metaLastRecap,
                   metaLastTurnSummary, metaLastRecapMainTurns, metaTransportModel,
-                  metaId, metaCwd),
+                  metaTitleUserTurns, metaId, metaCwd),
       SessionTransfer(transferTurns, SessionTransfer, transferMeta),
       SessionTurn(turnUsage, SessionTurn, turnAt, turnUserText,
                   turnAssistantText, turnError, turnResponseId, turnEffect,
@@ -199,7 +202,8 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ( toAscList )
-import qualified Data.Text as Text ( intercalate, unlines )
+import qualified Data.Text as Text
+    ( intercalate, length, pack, strip, take, unlines, unwords, words )
 import qualified Data.Text.IO as Text ( putStrLn, hPutStrLn )
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Usage as XAIUsage ()
@@ -238,6 +242,77 @@ handleSessionAction
             databasePool fullscreen query persist >>= \case
                 Nothing -> continue
                 Just result -> pure result
+    ReplHome ->
+        handleResume databasePool fullscreen Nothing persist >>= \case
+            Nothing -> continue
+            Just result -> pure result
+    ReplRewind -> do
+        color <- resolveColor stderr
+        let unavailable message = do
+                displayError message $
+                    putTextLn stderr (roleError color message)
+                continue
+        case persist of
+            PersistenceDisabled ->
+                unavailable "/rewind requires a persisted interactive session"
+            PersistenceEnabled slotRef ->
+                readIORef slotRef >>= \case
+                    PersistencePending{} ->
+                        unavailable
+                            "/rewind is available after the first persisted turn"
+                    PersistenceActive source ->
+                        withReplActivity
+                            (\report -> do
+                                report "Loading rewind points…"
+                                loadSession
+                                    databasePool
+                                    (takeDirectory source.sessionDir)
+                                    source.sessionMeta.metaId)
+                            >>= \case
+                                Left err -> unavailable err
+                                Right (meta, turns) ->
+                                    case sessionRewindChoices turns of
+                                        [] ->
+                                            unavailable
+                                                "No prompt is available to rewind."
+                                        choices ->
+                                            chooseRewindPoint color choices >>= \case
+                                                Nothing -> continue
+                                                Just (prompt, retained) ->
+                                                    confirmRewind
+                                                        color
+                                                        prompt.turnUserText
+                                                        >>= \case
+                                                            False -> continue
+                                                            True -> mask \restore -> do
+                                                                result <-
+                                                                    restore $
+                                                                        withReplActivity \report -> do
+                                                                            report "Rewinding conversation…"
+                                                                            rewindSession
+                                                                                source
+                                                                                    { sessionMeta = meta }
+                                                                                retained
+                                                                case result of
+                                                                    Left err ->
+                                                                        restore
+                                                                            (unavailable err)
+                                                                    Right updated -> do
+                                                                        writeIORef
+                                                                            slotRef
+                                                                            (PersistenceActive updated)
+                                                                        writeIORef
+                                                                            env.sessionTitleTurnCount
+                                                                            updated.sessionMeta.metaTitleUserTurns
+                                                                        writeIORef
+                                                                            env.sessionDraft
+                                                                            prompt.turnUserText
+                                                                        invalidateSessionTitles
+                                                                            env.sessionTitleManager
+                                                                            updated.sessionMeta.metaId
+                                                                        pure
+                                                                            (RunRestart
+                                                                                updated.sessionMeta.metaId)
     ReplClear -> do
         sessionReset
         fullscreenEvent UiConversationCleared
@@ -823,6 +898,89 @@ handleSessionAction
                             Just "Use a new worktree" -> Just True
                             Just "Share current workspace" -> Just False
                             _ -> Nothing
+    chooseRewindPoint color choices =
+        let newestFirst = reverse choices
+            rows =
+                zipWith
+                    (\number (turn, _) ->
+                        ( Text.pack (show number)
+                            <> ". "
+                            <> promptPreview 72 turn.turnUserText
+                        , "Restore the conversation state before this prompt"
+                        ))
+                    [(1 :: Int) ..]
+                    newestFirst
+            labeledChoices = zip (map fst rows) newestFirst
+        in case fullscreen of
+            Just runtime ->
+                requestFullscreenChoiceWithBody
+                    runtime
+                    "Rewind conversation"
+                    ( "Choose a prompt to restore as a draft. "
+                        <> "Conversation only; files stay unchanged."
+                    )
+                    0
+                    rows
+                    >>= pure . (>>= atIndex newestFirst)
+            Nothing -> do
+                Text.hPutStrLn stderr $
+                    roleMuted color
+                        "Choose a prompt to restore as a draft. Files stay unchanged."
+                readChoiceSelectionAt
+                    0
+                    (\selected label ->
+                        if selected
+                            then rolePrompt color label
+                            else roleMuted color label)
+                    (map fst rows)
+                    >>= pure . (>>= (`lookup` labeledChoices))
+    confirmRewind color prompt =
+        case fullscreen of
+            Just runtime ->
+                requestFullscreenChoiceWithBody
+                    runtime
+                    "Rewind conversation?"
+                    ( "Restore conversation state before:\n\n"
+                        <> promptPreview 240 prompt
+                        <> "\n\nConversation only; files stay unchanged."
+                    )
+                    1
+                    [ ( "Rewind conversation"
+                      , "Remove later turns and restore this prompt as a draft"
+                      )
+                    , ( "Cancel"
+                      , "Keep the current conversation"
+                      )
+                    ]
+                    >>= pure . (== Just 0)
+            Nothing -> do
+                Text.hPutStrLn stderr $
+                    roleMuted color
+                        ( "Restore conversation state before “"
+                            <> promptPreview 120 prompt
+                            <> "”? Files stay unchanged."
+                        )
+                readChoiceSelectionAt
+                    1
+                    (\selected label ->
+                        if selected
+                            then rolePrompt color label
+                            else roleMuted color label)
+                    [ "Rewind conversation"
+                    , "Cancel"
+                    ]
+                    >>= pure . (== Just "Rewind conversation")
+    promptPreview limit prompt =
+        let oneLine = Text.unwords (Text.words (Text.strip prompt))
+        in if Text.length oneLine <= limit
+            then oneLine
+            else Text.take (max 0 (limit - 1)) oneLine <> "…"
+    atIndex values index
+        | index < 0 = Nothing
+        | otherwise =
+            case drop index values of
+                value : _ -> Just value
+                [] -> Nothing
     confirmDelete color sessionId =
         case fullscreen of
             Just runtime ->

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -33,6 +33,8 @@ module Agent.CLI.Session
     , appendTurnWithMetaUpdateIndexed
     , appendTurnKeepTitle
     , appendTurnKeepTitleIndexed
+    , sessionRewindChoices
+    , rewindSession
     , addSessionUsage
     , deleteSession
     , loadSession
@@ -110,7 +112,9 @@ import Agent.CLI.Session.Codec
     , validateSessionMeta
     )
 import Agent.CLI.Models (ModelTarget(..))
+import Agent.CLI.SessionTitle (titleRefreshIndex)
 import Agent.Loop (TokenUsage(..))
+import Agent.OpenAI.Compaction (rewindSessionUserText)
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Store.Postgres (normalizePostgresTimestamp)
 import Agent.Store.Postgres.Connection (StorePool)
@@ -815,6 +819,85 @@ appendTurnKeepTitleIndexed
     -> IO (SessionHandle, Int64)
 appendTurnKeepTitleIndexed handle turn =
     appendTurnWithMetaTransitionIndexed handle turn id
+
+-- | Prompts in the current immutable transcript branch, paired with the turns
+-- that should remain when rewinding to immediately before that prompt.
+sessionRewindChoices :: [SessionTurn] -> [(SessionTurn, [SessionTurn])]
+sessionRewindChoices turns =
+    [ (turn, take turnIndex active)
+    | (turnIndex, turn) <- zip [0 ..] active
+    , isRewindPromptTurn turn
+    ]
+  where
+    active =
+        reverse
+            (takeWhile
+                ((/= TranscriptReset) . (.turnEffect))
+                (reverse turns))
+
+-- | Publish a rewound conversation branch without mutating historical turns.
+--
+-- The reset marker and retained prefix are appended atomically. Replayed
+-- compaction checkpoints keep their replace effect, so model context resumes
+-- from the correct compacted suffix while the full visual prefix stays
+-- scrollable.
+rewindSession
+    :: SessionHandle
+    -> [SessionTurn]
+    -> IO (Either Text SessionHandle)
+rewindSession handle retained = do
+    now <- normalizePostgresTimestamp <$> getCurrentTime
+    let promptCount = length (filter isRewindPromptTurn retained)
+        meta0 = handle.sessionMeta
+        meta = meta0
+            { metaUpdatedAt = now
+            , metaLastResponseId = retainedLastResponseId retained
+            , metaTitleRefreshIndex =
+                min
+                    meta0.metaTitleRefreshIndex
+                    (titleRefreshIndex promptCount)
+            , metaTitleUserTurns = promptCount
+            , metaLastRecap = Nothing
+            , metaLastTurnSummary = Nothing
+            , metaLastRecapMainTurns = 0
+            }
+        marker = SessionTurn
+            { turnAt = now
+            , turnUserText = rewindSessionUserText
+            , turnAssistantText = Just "Conversation rewound."
+            , turnError = Nothing
+            , turnResponseId = Nothing
+            , turnEffect = TranscriptReset
+            , turnItems = []
+            , turnUsage = Nothing
+            , turnProviderTelemetry = []
+            }
+    Store.appendSessionTurns
+        handle.sessionPool
+        (map toStoredTurn (marker : retained))
+        (toStoredMetadata meta) >>= \case
+            Left err ->
+                pure
+                    (Left
+                        ("could not rewind PostgreSQL session: "
+                            <> renderStoreError err))
+            Right False ->
+                pure (Left ("session not found: " <> meta.metaId))
+            Right True ->
+                pure (Right handle { sessionMeta = meta })
+
+isRewindPromptTurn :: SessionTurn -> Bool
+isRewindPromptTurn turn =
+    turn.turnEffect == TranscriptAppend
+        && not (Text.null (Text.strip turn.turnUserText))
+
+retainedLastResponseId :: [SessionTurn] -> Maybe Text
+retainedLastResponseId = foldl' step Nothing
+  where
+    step responseId turn = case turn.turnEffect of
+        TranscriptAppend -> turn.turnResponseId <|> responseId
+        TranscriptReplace -> turn.turnResponseId
+        TranscriptReset -> turn.turnResponseId
 
 
 loadSession

--- a/packages/agent-cli/src/Agent/CLI/Session/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Types.hs
@@ -41,6 +41,7 @@ import Agent.OpenAI.Compaction
     , isClearSessionTurn
     , isCompactSessionTurn
     , isNewSessionTurn
+    , isRewindSessionTurn
     )
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (Provider, parseProvider, providerSlug)
@@ -311,7 +312,9 @@ parseTranscriptEffect = \case
 
 inferTranscriptEffect :: Text -> [ResponseItem] -> TranscriptEffect
 inferTranscriptEffect userText items
-    | isClearSessionTurn userText || isNewSessionTurn userText =
+    | isClearSessionTurn userText
+        || isNewSessionTurn userText
+        || isRewindSessionTurn userText =
         TranscriptReset
     | isCompactSessionTurn userText || hasCompactionCheckpoint items =
         TranscriptReplace

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -232,6 +232,16 @@ spec = do
             parseReplLine "/delete now"
                 `shouldBe` ReplCommandError "usage: /delete"
 
+        it "returns home or rewinds through Grok-compatible aliases" do
+            parseReplLine "/home" `shouldBe` ReplHome
+            parseReplLine "/welcome" `shouldBe` ReplHome
+            parseReplLine "/rewind" `shouldBe` ReplRewind
+            parseReplLine "/undo" `shouldBe` ReplRewind
+            parseReplLine "/home now"
+                `shouldBe` ReplCommandError "usage: /home"
+            parseReplLine "/undo now"
+                `shouldBe` ReplCommandError "usage: /rewind"
+
         it "compacts with optional focus text" do
             parseReplLine "/compact" `shouldBe` ReplCompact Nothing
             parseReplLine "/compact focus auth"
@@ -451,8 +461,10 @@ spec = do
                     , "rename"
                     , "login"
                     , "resume"
+                    , "home"
                     , "search"
                     , "compact"
+                    , "rewind"
                     , "clear"
                     , "new"
                     , "delete"
@@ -504,6 +516,10 @@ spec = do
                 `shouldBe` Just "view-plan"
             fmap (.slashName) (lookupSlashCommand "/log")
                 `shouldBe` Just "transcript"
+            fmap (.slashName) (lookupSlashCommand "/welcome")
+                `shouldBe` Just "home"
+            fmap (.slashName) (lookupSlashCommand "/undo")
+                `shouldBe` Just "rewind"
 
         it "completes command names from a leading slash" do
             slashCompletionCandidates "" "/"
@@ -513,7 +529,9 @@ spec = do
                         && "/m" `elem` xs
                         && "/agents" `elem` xs
                         && "/mcp" `elem` xs
-                        && "/btw" `elem` xs)
+                        && "/btw" `elem` xs
+                        && "/rewind" `elem` xs
+                        && "/undo" `elem` xs)
             slashCompletionCandidates "" "/mo" `shouldBe` ["/model"]
             slashCompletionCandidates "ledom/" "high" `shouldBe` []
 

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -673,6 +673,36 @@ spec = describe "Agent.CLI.Session" do
             resumeHint "it's" "id"
                 `shouldBe` "Resume this session with: 'it'\\''s' --resume id"
 
+        it "offers rewind targets from the current branch with retained prefixes" do
+            let turn effect userText responseId = SessionTurn
+                    { turnAt = fixedTime
+                    , turnUserText = userText
+                    , turnAssistantText = Just "answer"
+                    , turnError = Nothing
+                    , turnResponseId = responseId
+                    , turnItems = []
+                    , turnUsage = Nothing
+                    , turnEffect = effect
+                    , turnProviderTelemetry = []
+                    }
+                old = turn TranscriptAppend "old prompt" (Just "old")
+                reset = turn TranscriptReset "/clear" Nothing
+                first = turn TranscriptAppend "first prompt" (Just "first")
+                checkpoint =
+                    turn TranscriptReplace "/compact" Nothing
+                second = turn TranscriptAppend "second prompt" (Just "second")
+                choices =
+                    sessionRewindChoices
+                        [old, reset, first, checkpoint, second]
+            map
+                (\(prompt, retained) ->
+                    (prompt.turnUserText, map (.turnUserText) retained))
+                choices
+                `shouldBe`
+                    [ ("first prompt", [])
+                    , ("second prompt", ["first prompt", "/compact"])
+                    ]
+
         it "keeps response-item JSON codecs at the CLI storage boundary" do
             let items =
                     [ MessageItem ResponseMessage
@@ -1102,6 +1132,113 @@ spec = describe "Agent.CLI.Session" do
                     `shouldReturn`
                         Left ("session not found: " <> handle.sessionMeta.metaId)
 
+        it "publishes rewind branches while preserving checkpoints and usage" $
+            withTempStore \store root -> do
+                let
+                    pool = trustedPool store
+                    first = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "first prompt"
+                        , turnAssistantText = Just "first answer"
+                        , turnError = Nothing
+                        , turnResponseId = Just "response-first"
+                        , turnItems = []
+                        , turnUsage = Just TokenUsage
+                            { inputTokens = 10
+                            , outputTokens = 4
+                            , cachedTokens = 2
+                            }
+                        , turnEffect = TranscriptAppend
+                        , turnProviderTelemetry = []
+                        }
+                    checkpoint = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "/compact"
+                        , turnAssistantText = Just "Context compacted remotely."
+                        , turnError = Nothing
+                        , turnResponseId = Nothing
+                        , turnItems = []
+                        , turnUsage = Nothing
+                        , turnEffect = TranscriptReplace
+                        , turnProviderTelemetry = []
+                        }
+                    later = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = "later prompt"
+                        , turnAssistantText = Just "later answer"
+                        , turnError = Nothing
+                        , turnResponseId = Just "response-later"
+                        , turnItems = []
+                        , turnUsage = Just TokenUsage
+                            { inputTokens = 7
+                            , outputTokens = 3
+                            , cachedTokens = 1
+                            }
+                        , turnEffect = TranscriptAppend
+                        , turnProviderTelemetry = []
+                        }
+                initial <- createSession (testCreate pool root)
+                withFirst <- appendTurnWithMetaUpdate initial first
+                    \meta -> meta { metaTitleUserTurns = 1 }
+                withCheckpoint <-
+                    appendTurnWithMetaUpdate withFirst checkpoint
+                        \meta -> meta { metaLastResponseId = Nothing }
+                final <- appendTurnWithMetaUpdate withCheckpoint later
+                    \meta -> meta
+                        { metaTitleRefreshIndex = 2
+                        , metaTitleUserTurns = 2
+                        , metaLastRecap = Just "stale recap"
+                        , metaLastTurnSummary = Just "stale summary"
+                        , metaLastRecapMainTurns = 2
+                        }
+
+                rewound <- rewindSession final [first, checkpoint] >>= \case
+                    Left err ->
+                        expectationFailure (Text.unpack err)
+                            >> fail "rewind failed"
+                    Right handle -> pure handle
+
+                rewound.sessionMeta.metaLastResponseId `shouldBe` Nothing
+                rewound.sessionMeta.metaTitleRefreshIndex `shouldBe` 0
+                rewound.sessionMeta.metaTitleUserTurns `shouldBe` 1
+                rewound.sessionMeta.metaLastRecap `shouldBe` Nothing
+                rewound.sessionMeta.metaLastTurnSummary `shouldBe` Nothing
+                rewound.sessionMeta.metaLastRecapMainTurns `shouldBe` 0
+                rewound.sessionMeta.metaInputTokens `shouldBe` 17
+                rewound.sessionMeta.metaOutputTokens `shouldBe` 7
+                rewound.sessionMeta.metaCachedTokens `shouldBe` 3
+
+                loadSession pool root rewound.sessionMeta.metaId >>= \case
+                    Left err -> expectationFailure (Text.unpack err)
+                    Right (meta, turns) -> do
+                        meta `shouldBe` rewound.sessionMeta
+                        case turns of
+                            [ originalFirst
+                                , originalCheckpoint
+                                , originalLater
+                                , marker
+                                , replayedFirst
+                                , replayedCheckpoint
+                                ] -> do
+                                    originalFirst `shouldBe` first
+                                    originalCheckpoint `shouldBe` checkpoint
+                                    originalLater `shouldBe` later
+                                    marker.turnUserText `shouldBe` "/rewind"
+                                    marker.turnAssistantText
+                                        `shouldBe` Just "Conversation rewound."
+                                    marker.turnResponseId `shouldBe` Nothing
+                                    marker.turnEffect `shouldBe` TranscriptReset
+                                    replayedFirst `shouldBe` first
+                                    replayedCheckpoint `shouldBe` checkpoint
+                            _ ->
+                                expectationFailure
+                                    ("unexpected rewind transcript: "
+                                        <> show turns)
+
+                loadActiveSession pool root rewound.sessionMeta.metaId
+                    `shouldReturn`
+                        Right (rewound.sessionMeta, [checkpoint])
+
         it "imports a legacy meta.json and JSONL transcript once" $
             withTempStore \store root -> do
                 let
@@ -1200,19 +1337,23 @@ spec = describe "Agent.CLI.Session" do
                 `shouldBe` Right meta
 
         it "infers transcript effects when importing legacy JSON turns" do
-            let legacy = Aeson.object
+            let legacy userText = Aeson.object
                     [ "at" Aeson..= fixedTime
-                    , "userText" Aeson..= ("/compact focus" :: Text.Text)
+                    , "userText" Aeson..= (userText :: Text.Text)
                     , "assistantText" Aeson..= (Nothing :: Maybe Text.Text)
                     , "error" Aeson..= (Nothing :: Maybe Text.Text)
                     , "responseId" Aeson..= (Nothing :: Maybe Text.Text)
                     , "items" Aeson..= ([] :: [ResponseItem])
                     , "usage" Aeson..= (Nothing :: Maybe TokenUsage)
                     ]
-                decoded = Hermes.decodeEither sessionTurnDecoder
-                    (LBS.toStrict (Aeson.encode legacy))
-            fmap (\turn -> turn.turnEffect) decoded
+                effect userText =
+                    fmap
+                        (.turnEffect)
+                        (Hermes.decodeEither sessionTurnDecoder
+                            (LBS.toStrict (Aeson.encode (legacy userText))))
+            effect "/compact focus"
                 `shouldBe` Right TranscriptReplace
+            effect "/rewind" `shouldBe` Right TranscriptReset
 
 testCreate :: StorePool -> OsPath -> SessionCreate
 testCreate pool root = SessionCreate

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -29,10 +29,12 @@ module Agent.OpenAI.Compaction
     , isCompactSessionTurn
     , isClearSessionTurn
     , isNewSessionTurn
+    , isRewindSessionTurn
     , isTranscriptResetTurn
     , compactSessionUserText
     , clearSessionUserText
     , newSessionUserText
+    , rewindSessionUserText
     ) where
 
 import Agent.OpenAI.Compaction.Request
@@ -48,8 +50,10 @@ import Agent.OpenAI.Compaction.Commands
     , isClearSessionTurn
     , isCompactSessionTurn
     , isNewSessionTurn
+    , isRewindSessionTurn
     , isTranscriptResetTurn
     , newSessionUserText
+    , rewindSessionUserText
     )
 import Agent.Responses.Types
 import Agent.Json (RawJson, rawJsonFromEncoding)

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction/Commands.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction/Commands.hs
@@ -4,8 +4,10 @@ module Agent.OpenAI.Compaction.Commands
     , isCompactSessionTurn
     , clearSessionUserText
     , newSessionUserText
+    , rewindSessionUserText
     , isClearSessionTurn
     , isNewSessionTurn
+    , isRewindSessionTurn
     , isTranscriptResetTurn
     ) where
 
@@ -36,14 +38,21 @@ clearSessionUserText = "/clear"
 newSessionUserText :: Text
 newSessionUserText = "/new"
 
+rewindSessionUserText :: Text
+rewindSessionUserText = "/rewind"
+
 isClearSessionTurn :: Text -> Bool
 isClearSessionTurn text = Text.strip text == clearSessionUserText
 
 isNewSessionTurn :: Text -> Bool
 isNewSessionTurn text = Text.strip text == newSessionUserText
 
+isRewindSessionTurn :: Text -> Bool
+isRewindSessionTurn text = Text.strip text == rewindSessionUserText
+
 isTranscriptResetTurn :: Text -> Bool
 isTranscriptResetTurn text =
     isCompactSessionTurn text
         || isClearSessionTurn text
         || isNewSessionTurn text
+        || isRewindSessionTurn text

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -1193,12 +1193,15 @@ spec = do
             isCompactSessionTurn "/compact focus auth" `shouldBe` True
             isCompactSessionTurn "hello" `shouldBe` False
 
-    describe "clear/new session markers" do
-        it "recognizes /clear and /new as transcript resets" do
+    describe "session reset markers" do
+        it "recognizes /clear, /new, and /rewind as transcript resets" do
             isClearSessionTurn "/clear" `shouldBe` True
             isNewSessionTurn "/new" `shouldBe` True
+            isRewindSessionTurn "/rewind" `shouldBe` True
+            isRewindSessionTurn "/undo" `shouldBe` False
             isTranscriptResetTurn "/clear" `shouldBe` True
             isTranscriptResetTurn "/new" `shouldBe` True
+            isTranscriptResetTurn "/rewind" `shouldBe` True
             isTranscriptResetTurn "/compact" `shouldBe` True
             isTranscriptResetTurn "hello" `shouldBe` False
 

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -18,6 +18,7 @@ module Agent.Store.Postgres.Session
     , replaceSessionMetadata
     , appendSessionTurn
     , appendSessionTurnIndexed
+    , appendSessionTurns
     , loadSession
     , loadSessionWithImplementation
     , loadSessions

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
@@ -10,6 +10,7 @@ module Agent.Store.Postgres.Session.Write
     , replaceSessionMetadata
     , appendSessionTurn
     , appendSessionTurnIndexed
+    , appendSessionTurns
     , deleteSession
     , importLegacySession
     , withSessionAdvisoryLock
@@ -158,6 +159,36 @@ appendSessionTurnIndexed pool turn metadata =
                         insertTurnStatement
                     insertResponseItems turnId turn.sessionTurnItems
                     pure (Just turnIndex)
+
+-- | Append a sequence of turns as one atomic transcript transition.
+--
+-- This is used when an immutable transcript needs to publish a reset marker
+-- and a replayed prefix together: readers observe either the entire new branch
+-- or none of it.
+appendSessionTurns
+    :: StorePool
+    -> [SessionTurn]
+    -> SessionMetadata
+    -> IO (Either StoreError Bool)
+appendSessionTurns pool turns metadata =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write do
+            _ <- Transaction.statement
+                metadata.sessionMetadataKey
+                blockingAdvisoryLockStatement
+            case turns of
+                [] ->
+                    Transaction.statement
+                        metadata.sessionMetadataKey
+                        sessionExistsStatement
+                _ -> appendAll turns
+  where
+    appendAll [] = pure True
+    appendAll (turn : rest) = do
+        appended <- appendTurnTransaction turn metadata
+        if appended
+            then appendAll rest
+            else Transaction.condemn >> pure False
 
 deleteSession
     :: StorePool

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -123,10 +123,20 @@ spec = describe "PostgreSQL session schema" do
                                     }
                             createSession pool metadata2
                                 `shouldReturn` Right True
-                            appendSessionTurn pool turn2 metadata2
+                            appendSessionTurns pool [turn2, turn3] metadata2
                                 `shouldReturn` Right True
-                            appendSessionTurn pool turn3 metadata2
+                            appendSessionTurns
+                                pool
+                                []
+                                metadata2
                                 `shouldReturn` Right True
+                            appendSessionTurns
+                                pool
+                                []
+                                metadata2
+                                    { sessionMetadataKey = "missing"
+                                    }
+                                `shouldReturn` Right False
                             loadSessions pool [] `shouldReturn` []
                             loadSessions pool
                                 [ "session-2"


### PR DESCRIPTION
## Summary
- add Grok-compatible `/rewind` (`/undo`) with prompt selection, safe confirmation, selected-prompt draft restoration, and explicit conversation-only semantics
- publish rewinds atomically in the append-only PostgreSQL transcript as a reset marker plus retained branch, preserving compaction checkpoints, cumulative usage, and historical turns while clearing stale response/recap state
- add `/home` (`/welcome`) as the local equivalent of Grok's welcome action by opening the existing session picker
- recognize legacy persisted `/rewind` markers as transcript resets and centralize the canonical marker in `agent-openai`

## Testing
- `TMPDIR=/run/user/$(id -u) cabal test agent-store:test:agent-store-test agent-openai:test:agent-openai-test agent-cli:test:agent-cli-test`
  - `agent-store`: 34 examples, 0 failures
  - `agent-openai`: 324 examples, 0 failures, 1 pre-existing pending
  - `agent-cli`: 1,466 examples, 0 failures
- `printf ':load Agent.CLI.Runtime.Repl.Session\n:quit\n' | cabal repl agent-cli --repl-options=-fno-code` (300 modules loaded before the optimized suites)
- deterministic live tmux smoke on the built fullscreen CLI:
  - `/help rewind` rendered `/rewind (/undo)` and its summary
  - `/rewind` and `/undo` reached the safe no-persisted-turn path
  - `/help home` rendered `/home (/welcome)` and its summary
  - `/home` and `/welcome` opened the two-pane Resume session picker; Escape returned to the composer
  - `/session` remained pending, confirming the smoke created no persisted session