### PR TITLE
Run stale resource cleanup in background

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -84,7 +84,9 @@ import Agent.CLI.Status
     )
 import Agent.CLI.Terminal ( resolveColor )
 import Agent.CLI.Worktree ( isUnderWorktreeRoot, worktreeRoot )
-import Control.Exception.Safe ( finally, onException )
+import Control.Concurrent.Async ( withAsync )
+import Control.Concurrent.MVar ( newEmptyMVar, putMVar, takeMVar )
+import Control.Exception.Safe ( finally, mask_, onException )
 import Data.Text ( Text )
 import System.Directory.OsPath
     ( getCurrentDirectory, getHomeDirectory, makeAbsolute )
@@ -93,7 +95,7 @@ import System.Exit ( die )
 import System.IO ( stderr )
 
 import qualified Agent.MCP as MCP
-import Data.IORef (newIORef, readIORef)
+import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import qualified Data.Text as Text
 
 -- | GHCi @:cmd@ helper: on 'DevReload', reload modules and resume that exact
@@ -205,24 +207,36 @@ runAgentWithRestarts options =
             let root = sessionsRoot home
             elicitationRef <- newIORef Nothing
             cleanupStarted <- newIORef False
-            mcpSupervisor <-
-                MCP.newMcpSupervisorWith
-                    MCP.defaultMcpHostHooks
-                        { MCP.mcpHostElicit = readIORef elicitationRef }
-            sessionThreads <-
-                newSessionThreadManager root
-                    `onException` MCP.closeMcpSupervisor mcpSupervisor
-            let processRuntime = AgentProcessRuntime
-                    { processMcpSupervisor = mcpSupervisor
-                    , processSessionThreads = sessionThreads
-                    , processCleanupStarted = cleanupStarted
-                    , processMcpElicitation = elicitationRef
-                    }
-            withRestoredCurrentDirectory
-                (runAgentWithRuntime processRuntime foregroundRunMode options)
-                `finally`
-                    (closeSessionThreadManager sessionThreads
-                        `finally` MCP.closeMcpSupervisor mcpSupervisor))
+            cleanupRequest <- newEmptyMVar
+            -- Cleanup is intentionally process-scoped rather than
+            -- session-scoped: provider restarts must not rescan every
+            -- worktree. 'withAsync' owns and joins the worker on shutdown.
+            withAsync (takeMVar cleanupRequest >>= id) \_ -> do
+                mcpSupervisor <-
+                    MCP.newMcpSupervisorWith
+                        MCP.defaultMcpHostHooks
+                            { MCP.mcpHostElicit = readIORef elicitationRef }
+                sessionThreads <-
+                    newSessionThreadManager root
+                        `onException` MCP.closeMcpSupervisor mcpSupervisor
+                let startCleanup action = mask_ do
+                        shouldStart <- atomicModifyIORef'
+                            cleanupStarted
+                            (\started -> (True, not started))
+                        if shouldStart
+                            then putMVar cleanupRequest action
+                            else pure ()
+                    processRuntime = AgentProcessRuntime
+                        { processMcpSupervisor = mcpSupervisor
+                        , processSessionThreads = sessionThreads
+                        , processStartCleanup = startCleanup
+                        , processMcpElicitation = elicitationRef
+                        }
+                withRestoredCurrentDirectory
+                    (runAgentWithRuntime processRuntime foregroundRunMode options)
+                    `finally`
+                        (closeSessionThreadManager sessionThreads
+                            `finally` MCP.closeMcpSupervisor mcpSupervisor))
         (pure DevQuit)
 
 loginMcpWithScopes :: [Text] -> Text -> IO ()

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -100,7 +100,8 @@ import Agent.CLI.Runtime.Orchestration.Tools ( runAgentTools )
 import Agent.CLI.Runtime.Orchestration.Types
     ( ActiveHttpAuth(activeHttpGeneration, ActiveHttpAuth,
                      activeHttpAccountId, activeHttpProvider, activeHttpResolveLabel),
-      AgentProcessRuntime(processSessionThreads, processMcpSupervisor, processMcpElicitation),
+      AgentProcessRuntime(processSessionThreads, processMcpSupervisor,
+                          processStartCleanup, processMcpElicitation),
       AgentRunMode )
 import Agent.CLI.Runtime.Persistence ()
 import Agent.CLI.Runtime.Recap ()

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -105,7 +105,6 @@ import Agent.CLI.Runtime.Orchestration.Restart ()
 import Agent.CLI.Runtime.Orchestration.Session ( runAgentSession )
 import Agent.CLI.Runtime.Orchestration.Startup
     ( reportStartupWarning )
-import Agent.CLI.Runtime.Orchestration.Types (AgentProcessRuntime(..))
 import Agent.CLI.Runtime.Persistence ( preparePersistence )
 import Agent.CLI.Runtime.Recap ()
 import Agent.CLI.Runtime.Repl ()
@@ -253,7 +252,7 @@ import Control.Concurrent.STM ()
 import Control.Exception ()
 import Control.Exception.Safe
     ( SomeException, finally, onException, throwIO, try )
-import Control.Monad ( join, when, forM_, unless )
+import Control.Monad ( forM_, join, unless, when )
 import Data.Functor ()
 import Data.IORef
     ( atomicModifyIORef', newIORef, readIORef, writeIORef )
@@ -691,13 +690,9 @@ runAgentTools
             useProgressiveMcp
                 harnessConfig.configMcpInitStrategy
                 (isOneShot options)
-    let AgentProcessRuntime
-            { processCleanupStarted = cleanupStarted
-            } = processRuntime
-    runCleanup <- atomicModifyIORef'
-        cleanupStarted
-        (\started -> (True, not started))
-    when runCleanup do
+    -- Housekeeping may inspect hundreds of worktrees and invoke Git for each
+    -- candidate. It must never delay interactive startup.
+    _ <- processRuntime.processStartCleanup do
         cleanupResult <- try @_ @SomeException do
             (sessions, sessionWarnings) <-
                 listSessions

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -11,12 +11,12 @@ import Agent.CLI.AgentSessions ( SessionThreadManager )
 import Agent.Error ( ApiError )
 import Agent.Provider ( Credential, TokenProvider )
 import Control.Concurrent.MVar ( MVar )
+import Data.IORef ( IORef )
 import Data.Text ( Text )
 import System.IO ( Handle, stderr, stdout )
 import System.OsPath ( OsPath )
 
 import qualified Agent.MCP as MCP
-import Data.IORef (IORef)
 
 data ActiveHttpAuth = ActiveHttpAuth
     { activeHttpGeneration :: !Int
@@ -31,7 +31,9 @@ data AccountSwitchRequest
 data AgentProcessRuntime = AgentProcessRuntime
     { processMcpSupervisor :: !MCP.McpSupervisor
     , processSessionThreads :: !SessionThreadManager
-    , processCleanupStarted :: !(IORef Bool)
+    -- | Starts the process-scoped stale-resource cleanup exactly once. Its
+    -- owner joins it when the process runtime closes.
+    , processStartCleanup :: !(IO () -> IO ())
     , processMcpElicitation
         :: !(IORef (Maybe (MCP.McpElicitRequest -> IO MCP.McpElicitResult)))
     -- ^ Interactive elicitation UI installed by the active session, shared by


### PR DESCRIPTION
## Summary
- move stale worktree and session-temp cleanup off the interactive startup path
- schedule cleanup once per process, even across provider restarts
- keep the worker structured so runtime shutdown cancels and joins it

## Performance
Measured in a real tmux TTY with an optimized build and 409 managed worktrees:
- installed baseline median ready time: **16.37s** (18.40s, 16.37s, 14.05s)
- patched median ready time: **0.863s** (2.05s, 0.863s, 0.794s)

On the final rebased build, startup timing reported credentials at 113ms and tools at 115ms, so the tool stage took about 2ms before proceeding.

## Testing
- `TMPDIR=$HOME/.haskell-agent/t nix develop -c cabal test --offline agent-cli:agent-cli-test` (1455 examples, 0 failures, 1 pending)
- `nix develop -c cabal build --offline agent-cli:exe:agent-cli`
- real-terminal tmux startup and shutdown smoke test
