### PR TITLE
Fall back from unavailable OpenAI models

### DIFF
--- a/packages/agent-cli/config/models.default.json
+++ b/packages/agent-cli/config/models.default.json
@@ -40,13 +40,15 @@
       "id": "gpt-5.6-terra",
       "connection": "openai",
       "dialect": "codex",
-      "label": "balanced"
+      "label": "balanced",
+      "fallback_priority": 1
     },
     {
       "id": "gpt-5.6-luna",
       "connection": "openai",
       "dialect": "codex",
-      "label": "fast · low cost"
+      "label": "fast · low cost",
+      "fallback_priority": 2
     },
     {
       "id": "grok-4.6",

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -118,7 +118,7 @@ import Agent.Provider
     , providerSlug
     , tokenProviderBillingMode
     )
-import Agent.Responses.Types (ResponseCreateParams)
+import Agent.Responses.Types (ResponseCreateParams(model))
 import Agent.TUI.Model (UiEvent(..))
 import Control.Monad
     ( forM_
@@ -471,6 +471,8 @@ requestAutomaticProviderFallback env apiError pending = do
         emitUiEvent runtime UiTurnRestarted
     sessionId <- ensureTransitionSessionId env.sessionPersist
     unavailable <- readIORef env.sessionUnavailableProviders
+    currentModel <-
+        fromMaybe "" . (.model) <$> readIORef env.sessionParams
     case env.sessionTokenProvider of
         Nothing -> pure Nothing
         Just tokenProvider ->
@@ -481,6 +483,7 @@ requestAutomaticProviderFallback env apiError pending = do
                 env.sessionFullscreen
                 (tokenProviderBillingMode tokenProvider)
                 env.sessionProvider
+                currentModel
                 unavailable
                 sessionId
                 pending
@@ -492,6 +495,8 @@ requestStartupProviderFallback
     -> IO (Maybe ProviderTransition)
 requestStartupProviderFallback env apiError = do
     unavailable <- readIORef env.sessionUnavailableProviders
+    currentModel <-
+        fromMaybe "" . (.model) <$> readIORef env.sessionParams
     case env.sessionTokenProvider of
         Nothing -> pure Nothing
         Just tokenProvider ->
@@ -501,6 +506,7 @@ requestStartupProviderFallback env apiError = do
                 env.sessionFullscreen
                 (tokenProviderBillingMode tokenProvider)
                 env.sessionProvider
+                currentModel
                 unavailable
                 Nothing
                 apiError
@@ -529,6 +535,7 @@ continueAutomaticFallback cwdHint stderrHandle fullscreen failed apiError =
                         fullscreen
                         billing
                         failed.transitionTarget.targetProvider
+                        failed.transitionTarget.targetModelId
                         failed.transitionUnavailableProviders
                         failed.transitionSessionId
                         pending
@@ -542,6 +549,7 @@ chooseAutomaticProviderTransition
     -> Maybe FullscreenRuntime
     -> BillingMode
     -> Provider
+    -> Text
     -> Set Provider
     -> Maybe Text
     -> PendingTurn
@@ -549,11 +557,12 @@ chooseAutomaticProviderTransition
     -> IO (Maybe ProviderTransition)
 chooseAutomaticProviderTransition
     catalog cwd stderrHandle fullscreen
-        sourceBilling current unavailable0 sessionId pending apiError =
-    tryCandidates unavailable candidates
+        sourceBilling current currentModel unavailable0 sessionId pending apiError =
+    tryCandidates unavailable0 candidates
   where
-    unavailable = markUnavailable current unavailable0
-    candidates = fallbackCandidates catalog unavailable0 current apiError
+    candidates =
+        fallbackCandidates
+            catalog unavailable0 current currentModel apiError
 
     tryCandidates unavailable = \case
         [] -> pure Nothing
@@ -561,9 +570,18 @@ chooseAutomaticProviderTransition
             choice <- resolveModelOptionDialect rawChoice
             validateAutomaticProviderTarget cwd sourceBilling choice >>= \case
                 Left err -> do
-                    let message =
+                    let failedProvider =
+                            choice.modelTarget.targetProvider
+                        unavailable' =
+                            markUnavailable failedProvider unavailable
+                        remaining =
+                            filter
+                                ((/= failedProvider)
+                                    . (.modelTarget.targetProvider))
+                                rest
+                        message =
                             "skipping "
-                            <> providerSlug choice.modelTarget.targetProvider
+                            <> providerSlug failedProvider
                             <> ": "
                             <> err
                     case fullscreen of
@@ -572,16 +590,24 @@ chooseAutomaticProviderTransition
                             putTextLn stderrHandle (roleMuted color message)
                         Just runtime ->
                             emitUiEvent runtime (UiSystemMessage message)
-                    tryCandidates
-                        (markUnavailable choice.modelTarget.targetProvider unavailable)
-                        rest
+                    tryCandidates unavailable' remaining
                 Right selected -> do
-                    let message =
-                            providerSlug current
-                            <> " unavailable; trying this turn with "
-                            <> providerSlug choice.modelTarget.targetProvider
-                            <> "/"
-                            <> choice.modelTarget.targetModelId
+                    let nextProvider = choice.modelTarget.targetProvider
+                        unavailable' =
+                            if nextProvider == current
+                                then unavailable
+                                else markUnavailable current unavailable
+                        message
+                            | nextProvider == current =
+                                currentModel
+                                    <> " unavailable; trying this turn with "
+                                    <> choice.modelTarget.targetModelId
+                            | otherwise =
+                                providerSlug current
+                                    <> " unavailable; trying this turn with "
+                                    <> providerSlug nextProvider
+                                    <> "/"
+                                    <> choice.modelTarget.targetModelId
                     case fullscreen of
                         Nothing -> do
                             color <- resolveColor stderrHandle
@@ -597,7 +623,7 @@ chooseAutomaticProviderTransition
                             (.selectedAccountId) <$> selected
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Just pending
-                        , transitionUnavailableProviders = unavailable
+                        , transitionUnavailableProviders = unavailable'
                         , transitionCause = AutomaticFallback
                         , transitionAutomaticBilling = Just sourceBilling
                         }
@@ -608,16 +634,19 @@ chooseStartupProviderTransition
     -> Maybe FullscreenRuntime
     -> BillingMode
     -> Provider
+    -> Text
     -> Set Provider
     -> Maybe Text
     -> ApiError
     -> IO (Maybe ProviderTransition)
 chooseStartupProviderTransition
-    catalog cwd fullscreen sourceBilling current unavailable0 sessionId apiError =
-    tryCandidates unavailable candidates
+    catalog cwd fullscreen sourceBilling current currentModel
+        unavailable0 sessionId apiError =
+    tryCandidates unavailable0 candidates
   where
-    unavailable = markUnavailable current unavailable0
-    candidates = fallbackCandidates catalog unavailable0 current apiError
+    candidates =
+        fallbackCandidates
+            catalog unavailable0 current currentModel apiError
 
     tryCandidates unavailable = \case
         [] -> pure Nothing
@@ -625,23 +654,40 @@ chooseStartupProviderTransition
             choice <- resolveModelOptionDialect rawChoice
             validateAutomaticProviderTarget cwd sourceBilling choice >>= \case
                 Left err -> do
-                    let message =
+                    let failedProvider =
+                            choice.modelTarget.targetProvider
+                        unavailable' =
+                            markUnavailable failedProvider unavailable
+                        remaining =
+                            filter
+                                ((/= failedProvider)
+                                    . (.modelTarget.targetProvider))
+                                rest
+                        message =
                             "skipping "
-                            <> providerSlug choice.modelTarget.targetProvider
+                            <> providerSlug failedProvider
                             <> ": "
                             <> err
                     forM_ fullscreen \runtime ->
                         emitUiEvent runtime (UiSystemMessage message)
-                    tryCandidates
-                        (markUnavailable choice.modelTarget.targetProvider unavailable)
-                        rest
+                    tryCandidates unavailable' remaining
                 Right selected -> do
-                    let message =
-                            providerSlug current
-                            <> " account unavailable; switched to "
-                            <> providerSlug choice.modelTarget.targetProvider
-                            <> "/"
-                            <> choice.modelTarget.targetModelId
+                    let nextProvider = choice.modelTarget.targetProvider
+                        unavailable' =
+                            if nextProvider == current
+                                then unavailable
+                                else markUnavailable current unavailable
+                        message
+                            | nextProvider == current =
+                                currentModel
+                                    <> " unavailable; switched to "
+                                    <> choice.modelTarget.targetModelId
+                            | otherwise =
+                                providerSlug current
+                                    <> " account unavailable; switched to "
+                                    <> providerSlug nextProvider
+                                    <> "/"
+                                    <> choice.modelTarget.targetModelId
                     forM_ fullscreen \runtime ->
                         emitUiEvent runtime (UiSystemMessage message)
                     pure $ Just ProviderTransition
@@ -652,7 +698,7 @@ chooseStartupProviderTransition
                             (.selectedAccountId) <$> selected
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Nothing
-                        , transitionUnavailableProviders = unavailable
+                        , transitionUnavailableProviders = unavailable'
                         , transitionCause = AutomaticFallback
                         , transitionAutomaticBilling = Just sourceBilling
                         }

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -84,10 +84,11 @@ automaticRetryCountdownText rawSeconds =
 
 -- | Curated models ordered from strongest to weakest for automatic selection.
 --
--- Availability is account-level: once a provider reports that all of its
--- credentials are exhausted, trying a weaker model on the same account would
--- only loop. 'fallbackCandidates' therefore keeps the highest-ranked model for
--- each still-eligible provider.
+-- Account and quota failures are provider-wide, so trying a weaker model on
+-- the same account would only loop. Model-access failures are different: new
+-- models are often rolled out gradually. In that case 'fallbackCandidates'
+-- first walks down the ranked models for the current provider, then keeps the
+-- highest-ranked model for every other eligible provider.
 rankedModels :: ModelCatalog -> [ModelOption]
 rankedModels = sortOn modelRank . filter hasPriority . modelCatalog
   where
@@ -98,19 +99,43 @@ rankedModels = sortOn modelRank . filter hasPriority . modelCatalog
                 `elem` ["openai", "xai", "openrouter", "gemini"]
     modelRank = maybe maxBound id . (.modelFallbackPriority)
 
--- | Return the best model for every provider that may still have a usable
--- account. Providers already observed as exhausted, including the provider
--- that produced this error, are excluded.
+-- | Return ordered recovery targets for an unavailable model or provider.
+-- Providers already observed as exhausted are excluded. A structured
+-- model-access failure may keep the current provider long enough to try its
+-- lower-ranked models.
 fallbackCandidates
     :: ModelCatalog
     -> Set Provider
     -> Provider
+    -> Text
     -> ApiError
     -> [ModelOption]
-fallbackCandidates catalog unavailable current err
+fallbackCandidates catalog unavailable current currentModel err
     | current == ClaudeCodeProvider = []
     | not (isProviderUnavailable err) = []
-    | otherwise =
+    | otherwise = sameProviderFallbacks <> otherProviderFallbacks
+  where
+    ranked = rankedModels catalog
+    sameProviderFallbacks
+        | isModelUnavailable err =
+            case currentPriority of
+                Nothing -> []
+                Just priority ->
+                    filter
+                        (\option ->
+                            option.modelTarget.targetProvider == current
+                                && option.modelTarget.targetModelId /= currentModel
+                                && option.modelFallbackPriority > Just priority)
+                        ranked
+        | otherwise = []
+    currentPriority =
+        (.modelFallbackPriority) =<< safeHead
+            (filter
+                (\option ->
+                    option.modelTarget.targetProvider == current
+                        && option.modelTarget.targetModelId == currentModel)
+                ranked)
+    otherProviderFallbacks =
         filter
             (\option ->
                 option.modelTarget.targetProvider /= current
@@ -118,7 +143,20 @@ fallbackCandidates catalog unavailable current err
                         /= ClaudeCodeProvider
                     && option.modelTarget.targetProvider
                         `Set.notMember` unavailable)
-            (nubOrdOn (.modelTarget.targetProvider) (rankedModels catalog))
+            (nubOrdOn (.modelTarget.targetProvider) ranked)
+
+    safeHead = \case
+        [] -> Nothing
+        value : _ -> Just value
+
+-- | A structured provider response that says the selected model or feature is
+-- unavailable. Unlike a bare HTTP 403, this is safe to recover from by trying
+-- a lower-ranked model on the same account.
+isModelUnavailable :: ApiError -> Bool
+isModelUnavailable = \case
+    ProviderError PermissionError _ _ -> True
+    ProviderError UsageNotIncluded _ _ -> True
+    _ -> False
 
 isUsageExhausted :: ApiError -> Bool
 isUsageExhausted = \case

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -588,6 +588,7 @@ runAgentProviders
                                                     (tokenProviderBillingMode
                                                         tokenProvider)
                                                     provider
+                                                    model
                                                     unavailableProviders
                                                     Nothing
                                                     err >>= \case

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -68,7 +68,8 @@ spec = do
                     ( model.modelTarget.targetProvider
                     , model.modelTarget.targetModelId
                     ))
-                (fallbackCandidates catalog Set.empty XAIProvider exhausted)
+                (fallbackCandidates catalog Set.empty XAIProvider
+                    "grok-4.6" exhausted)
                 `shouldBe`
                     [ (OpenAIProvider, "gpt-5.6-sol")
                     , (GeminiProvider, "gemini-3.7-flash")
@@ -81,7 +82,8 @@ spec = do
                     ( model.modelTarget.targetProvider
                     , model.modelTarget.targetModelId
                     ))
-                (fallbackCandidates catalog Set.empty OpenAIProvider exhausted)
+                (fallbackCandidates catalog Set.empty OpenAIProvider
+                    "gpt-5.6-sol" exhausted)
                 `shouldBe`
                     [ (XAIProvider, "grok-4.6")
                     , (GeminiProvider, "gemini-3.7-flash")
@@ -89,28 +91,34 @@ spec = do
                     ]
 
         it "never automatically enters or leaves the Claude Code provider" do
-            fallbackCandidates catalog Set.empty ClaudeCodeProvider exhausted
+            fallbackCandidates catalog Set.empty ClaudeCodeProvider
+                "sonnet" exhausted
                 `shouldBe` []
             map (.modelTarget.targetProvider)
-                (fallbackCandidates catalog Set.empty OpenAIProvider exhausted)
+                (fallbackCandidates catalog Set.empty OpenAIProvider
+                    "gpt-5.6-sol" exhausted)
                 `shouldSatisfy` (ClaudeCodeProvider `notElem`)
 
         it "skips providers already found unavailable" do
             map (.modelTarget.targetProvider)
-                (fallbackCandidates catalog (Set.singleton OpenAIProvider) XAIProvider exhausted)
+                (fallbackCandidates catalog (Set.singleton OpenAIProvider)
+                    XAIProvider "grok-4.6" exhausted)
                 `shouldBe` [GeminiProvider, OpenRouterProvider]
 
         it "accepts direct usage-limit errors from every provider" do
             fallbackCandidates catalog Set.empty OpenRouterProvider
+                "stealth/ox-alpha"
                 (ProviderError UsageLimitReached "quota exhausted" (Just 3600))
                 `shouldSatisfy` (not . null)
             fallbackCandidates catalog Set.empty GeminiProvider
+                "gemini-3.7-flash"
                 (ProviderError UsageLimitReached "quota exhausted" (Just 3600))
                 `shouldSatisfy` (not . null)
 
         it "accepts other definitive account and billing exhaustion errors" do
             map
-                (not . null . fallbackCandidates catalog Set.empty XAIProvider)
+                (not . null . fallbackCandidates catalog Set.empty XAIProvider
+                    "grok-4.6")
                 [ ProviderError UsageBalanceExhausted "balance exhausted" Nothing
                 , ProviderError QuotaExceeded "quota exhausted" Nothing
                 , ProviderError UsageNotIncluded "not included" Nothing
@@ -119,19 +127,51 @@ spec = do
                 `shouldBe` replicate 4 True
 
         it "does not switch for transient capacity failures" do
-            fallbackCandidates catalog Set.empty XAIProvider
+            fallbackCandidates catalog Set.empty XAIProvider "grok-4.6"
                 (ProviderError OverloadedError "busy" (Just 30))
                 `shouldBe` []
 
         it "can continue past a replacement provider with rejected auth" do
             map (.modelTarget.targetProvider)
-                (fallbackCandidates catalog (Set.singleton XAIProvider) OpenAIProvider
+                (fallbackCandidates catalog (Set.singleton XAIProvider)
+                    OpenAIProvider "gpt-5.6-sol"
                     (ProviderError AuthenticationError "rejected" Nothing))
                 `shouldBe` [GeminiProvider, OpenRouterProvider]
             map (.modelTarget.targetProvider)
-                (fallbackCandidates catalog (Set.singleton XAIProvider) OpenAIProvider
+                (fallbackCandidates catalog (Set.singleton XAIProvider)
+                    OpenAIProvider "gpt-5.6-sol"
                     (CredentialError "credential file is invalid"))
                 `shouldBe` [GeminiProvider, OpenRouterProvider]
+
+        it "steps down through same-provider models on model access errors" do
+            map (.modelTarget.targetModelId)
+                (fallbackCandidates catalog Set.empty OpenAIProvider
+                    "gpt-5.6-sol"
+                    (ProviderError PermissionError "not available" Nothing))
+                `shouldBe`
+                    [ "gpt-5.6-terra"
+                    , "gpt-5.6-luna"
+                    , "grok-4.6"
+                    , "gemini-3.7-flash"
+                    , "stealth/ox-alpha"
+                    ]
+            map (.modelTarget.targetModelId)
+                (fallbackCandidates catalog Set.empty OpenAIProvider
+                    "gpt-5.6-terra"
+                    (ProviderError UsageNotIncluded "not included" Nothing))
+                `shouldBe`
+                    [ "gpt-5.6-luna"
+                    , "grok-4.6"
+                    , "gemini-3.7-flash"
+                    , "stealth/ox-alpha"
+                    ]
+
+        it "does not retry the same provider for untyped HTTP permission failures" do
+            map (.modelTarget.targetProvider)
+                (fallbackCandidates catalog Set.empty OpenAIProvider
+                    "gpt-5.6-sol" (HttpError 403 "forbidden"))
+                `shouldBe`
+                    [XAIProvider, GeminiProvider, OpenRouterProvider]
 
     describe "automaticCooldownRetryDelay" do
         let now = UTCTime (fromGregorian 2026 8 21) 0


### PR DESCRIPTION
## Summary

- distinguish model-specific access errors from provider-wide account failures
- try lower-ranked OpenAI models before crossing to another provider
- preserve direct cross-provider fallback for raw HTTP 403 and account-wide failures
- show model-specific fallback messages in the CLI

## Verification

- `nix develop -c cabal repl agent-cli:test:agent-cli-test --ghc-option=-Wno-error=incomplete-patterns`
  - `:main --match fallbackCandidates` — 10 examples, 0 failures
  - `:main --match rankedModels` — 1 example, 0 failures
- `git diff --check`
- live tmux smoke with `nix develop -c repl`; fullscreen prompt opened and `/model` showed sol → terra → luna

The warning override is needed because current master has an unrelated incomplete-pattern warning in `Agent.CLI.TUI.App.Mailbox` for `ProviderLimitUpdated`.