### PR TITLE
fix(openai): fall back after gateway handshake 403

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -97,6 +97,7 @@ import Agent.CLI.GatewayClient
     )
 import Agent.Error (ApiError(..))
 import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
+import Agent.Transport.WebSocket (webSocketHandshakeFailureStatus)
 import qualified Agent.Claude.Auth as ClaudeCode
 import Agent.Provider
     ( AccountFailure(..)
@@ -111,6 +112,8 @@ import Agent.Provider
     , seedTokenProvider
     , tokenProvider
     , tokenProviderBillingMode
+    , tokenProviderWithNextToken
+    , withAccountFailureClassifier
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
 import qualified Agent.Gemini.Auth as GeminiAuth
@@ -316,19 +319,32 @@ gatewayFallbackTokenProvider
     -> IO TokenProvider
 gatewayFallbackTokenProvider gatewayCredential directProvider = do
     gatewayPreferred <- newIORef True
-    pure $ tokenProvider SubscriptionBilled \failed ->
-        case failed of
-            Nothing ->
-                readIORef gatewayPreferred >>= \case
-                    True -> pure (Right gatewayCredential)
-                    False -> getNextToken directProvider Nothing
-            Just reported
-                | reported.credential == gatewayCredential -> do
-                    writeIORef gatewayPreferred False
-                    getNextToken directProvider Nothing
-                | otherwise -> do
-                    writeIORef gatewayPreferred False
-                    getNextToken directProvider (Just reported)
+    pure $
+        withAccountFailureClassifier classifyGatewayFailure $
+            tokenProviderWithNextToken directProvider \failed ->
+                case failed of
+                    Nothing ->
+                        readIORef gatewayPreferred >>= \case
+                            True -> pure (Right gatewayCredential)
+                            False -> getNextToken directProvider Nothing
+                    Just reported
+                        | reported.credential == gatewayCredential -> do
+                            writeIORef gatewayPreferred False
+                            getNextToken directProvider Nothing
+                        | otherwise -> do
+                            writeIORef gatewayPreferred False
+                            getNextToken directProvider (Just reported)
+  where
+    -- A gateway WebSocket handshake 403 rejects this gateway credential
+    -- before any turn effects occur. Treat only that distinct credential as
+    -- failed so the local ChatGPT fallback becomes reachable; ordinary direct
+    -- ChatGPT 403s remain permission failures and never rotate accounts.
+    classifyGatewayFailure credential = \case
+        err
+            | credential == gatewayCredential
+            , webSocketHandshakeFailureStatus err == Just 403 ->
+                Just AccountAuthenticationRejected
+        _ -> Nothing
 
 -- | Load one specific account for providers whose HTTP backends can swap
 -- token sources without reconnecting a long-lived transport.

--- a/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
@@ -40,6 +40,7 @@ import Agent.Provider
     , getNextToken
     , tokenProvider
     , tokenProviderBillingMode
+    , tokenProviderWithNextToken
     )
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
@@ -94,7 +95,7 @@ preferredOpenAiTokenProvider
     -> TokenProvider
     -> TokenProvider
 preferredOpenAiTokenProvider preferredAccount pool fallback =
-    tokenProvider (tokenProviderBillingMode fallback) \failed ->
+    tokenProviderWithNextToken fallback \failed ->
         case failed of
             Just reportedFailure -> do
                 fallbackResult <-

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -161,8 +161,8 @@ import Agent.Provider
       Credential(..),
       getNextToken,
       providerSlug,
-      tokenProvider,
       tokenProviderBillingMode,
+      tokenProviderWithNextToken,
       BillingMode(ApiBilled),
       FailedCredential(credential) )
 import Agent.ReasoningEffort ()
@@ -815,7 +815,7 @@ trackCredentialAccount
     -> TokenProvider
     -> TokenProvider
 trackCredentialAccount accountRef accountIdRef selectionRef resolveLabel provider =
-    tokenProvider (tokenProviderBillingMode provider) \failed ->
+    tokenProviderWithNextToken provider \failed ->
         getNextToken provider failed >>= \case
             Left err -> pure (Left err)
             Right credential -> do

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -25,8 +25,10 @@ import Agent.Provider
     , FailedCredential(..)
     , Provider(..)
     , getNextToken
+    , runWithTokenProvider
     , tokenProvider
     , tokenProviderBillingMode
+    , tokenProviderWithNextToken
     )
 import qualified Agent.XAI.Auth as XAIAuth
 import Control.Exception.Safe (bracket)
@@ -212,6 +214,95 @@ spec = do
                                 loaded.loadedTokenProvider
                                 Nothing
                                 `shouldReturn` Right localCredential
+
+        it "falls back after a gateway WebSocket handshake 403" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccount
+                        "local-openai"
+                        "local-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just OpenAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            pool <- case loaded.loadedOpenAiPool of
+                                Nothing -> do
+                                    expectationFailure
+                                        "expected local OpenAI fallback pool"
+                                    fail "missing local OpenAI fallback pool"
+                                Just pool -> pure pool
+                            preferred <- newIORef Nothing
+                            let selectableProvider =
+                                    preferredOpenAiTokenProvider
+                                        preferred
+                                        pool
+                                        loaded.loadedTokenProvider
+                                -- The live runtime applies another acquisition
+                                -- decorator to track the active account.
+                                runtimeProvider =
+                                    tokenProviderWithNextToken
+                                        selectableProvider
+                                        (getNextToken selectableProvider)
+                            attempts <- newIORef ([] :: [Text])
+                            result <- runWithTokenProvider
+                                runtimeProvider
+                                \credential -> do
+                                    modifyIORef'
+                                        attempts
+                                        (<> [credential.accountId])
+                                    pure $
+                                        if credential.accountId
+                                            == "wss://gateway.example/v1/responses"
+                                            then Left $ HttpError 403
+                                                "WebSocket handshake returned HTTP 403"
+                                            else Right credential.accountId
+
+                            result `shouldBe` Right "local-account"
+                            readIORef attempts `shouldReturn`
+                                [ "wss://gateway.example/v1/responses"
+                                , "local-account"
+                                ]
+
+        it "does not replay an ordinary gateway request 403" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccount
+                        "local-openai"
+                        "local-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just OpenAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            pool <- case loaded.loadedOpenAiPool of
+                                Nothing -> do
+                                    expectationFailure
+                                        "expected local OpenAI fallback pool"
+                                    fail "missing local OpenAI fallback pool"
+                                Just pool -> pure pool
+                            preferred <- newIORef Nothing
+                            let provider =
+                                    preferredOpenAiTokenProvider
+                                        preferred
+                                        pool
+                                        loaded.loadedTokenProvider
+                                forbidden =
+                                    HttpError 403
+                                        "request forbidden after connection"
+                            attempts <- newIORef ([] :: [Text])
+                            result <- runWithTokenProvider provider
+                                \credential -> do
+                                    modifyIORef'
+                                        attempts
+                                        (<> [credential.accountId])
+                                    pure (Left forbidden :: Either ApiError Text)
+
+                            result `shouldBe` Left forbidden
+                            readIORef attempts `shouldReturn`
+                                ["wss://gateway.example/v1/responses"]
 
         it "does not turn a rejected gateway into API-credit spending" $
             withTempHome \home ->

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -5,6 +5,8 @@ module Agent.Provider
     , TokenProvider
     , tokenProviderBillingMode
     , tokenProvider
+    , tokenProviderWithNextToken
+    , withAccountFailureClassifier
     , Credential(..)
     , Provider(..)
     , providerSlug
@@ -27,6 +29,7 @@ import Agent.Error
     , apiErrorRetryAfter
     , credentialExhaustionReasonFromApiError
     )
+import Control.Applicative ((<|>))
 import qualified Agent.Json.Decode as Json
 import qualified Data.Aeson as Aeson
 import Data.IORef
@@ -117,13 +120,47 @@ data TokenProvider = TokenProvider
     , runGetNextToken
         :: Maybe FailedCredential
         -> IO (Either ApiError Credential)
+    , runClassifyAccountFailure
+        :: Credential
+        -> ApiError
+        -> Maybe AccountFailure
     }
 
 tokenProvider
     :: BillingMode
     -> (Maybe FailedCredential -> IO (Either ApiError Credential))
     -> TokenProvider
-tokenProvider = TokenProvider
+tokenProvider providerBillingMode runGetNextToken = TokenProvider
+    { providerBillingMode
+    , runGetNextToken
+    , runClassifyAccountFailure =
+        \_credential -> accountFailureFromApiError
+    }
+
+-- | Replace credential acquisition while retaining the provider's billing and
+-- account-failure policy. Provider decorators should use this instead of
+-- constructing a fresh 'TokenProvider'.
+tokenProviderWithNextToken
+    :: TokenProvider
+    -> (Maybe FailedCredential -> IO (Either ApiError Credential))
+    -> TokenProvider
+tokenProviderWithNextToken provider runGetNextToken =
+    provider { runGetNextToken }
+
+-- | Add credential-source-specific failure handling while preserving the
+-- provider-neutral defaults. Classifiers added here may cause the protected
+-- action to be replayed, so they must only recognize failures that happened
+-- before the action produced externally visible effects.
+withAccountFailureClassifier
+    :: (Credential -> ApiError -> Maybe AccountFailure)
+    -> TokenProvider
+    -> TokenProvider
+withAccountFailureClassifier classifier provider =
+    provider
+        { runClassifyAccountFailure = \credential err ->
+            classifier credential err
+                <|> provider.runClassifyAccountFailure credential err
+        }
 
 tokenProviderBillingMode :: TokenProvider -> BillingMode
 tokenProviderBillingMode TokenProvider{providerBillingMode} =
@@ -138,15 +175,15 @@ getNextToken provider = provider.runGetNextToken
 seedTokenProvider :: TokenProvider -> Credential -> IO TokenProvider
 seedTokenProvider provider credential = do
     seed <- newIORef (Just credential)
-    pure TokenProvider
-        { providerBillingMode = tokenProviderBillingMode provider
-        , runGetNextToken = \failed -> case failed of
-            Just reportedFailure -> getNextToken provider (Just reportedFailure)
-            Nothing -> atomicModifyIORef'
-                seed (\current -> (Nothing, current)) >>= \case
-                    Just firstCredential -> pure (Right firstCredential)
-                    Nothing -> getNextToken provider Nothing
-        }
+    pure $
+        tokenProviderWithNextToken provider \failed ->
+            case failed of
+                Just reportedFailure ->
+                    getNextToken provider (Just reportedFailure)
+                Nothing -> atomicModifyIORef'
+                    seed (\current -> (Nothing, current)) >>= \case
+                        Just firstCredential -> pure (Right firstCredential)
+                        Nothing -> getNextToken provider Nothing
 
 runWithTokenProvider
     :: TokenProvider
@@ -175,7 +212,8 @@ runWithTokenProviderAfter provider initialFailure action =
             Left err -> pure (Left err)
             Right credential -> action credential >>= \case
                 Left err
-                    | Just failure <- accountFailureFromApiError err ->
+                    | Just failure <-
+                        provider.runClassifyAccountFailure credential err ->
                         go (attemptsLeft - 1) $ Just FailedCredential
                             { credential
                             , failure

--- a/packages/agent-core/src/Agent/Transport/WebSocket.hs
+++ b/packages/agent-core/src/Agent/Transport/WebSocket.hs
@@ -19,6 +19,7 @@ module Agent.Transport.WebSocket
     , transientWsMidRunFailureLabel
     , wsHandshakeAuthFailure
     , wsHandshakeAuthFailureStatus
+    , webSocketHandshakeFailureStatus
     ) where
 
 import Agent.Error (ApiError(..))
@@ -519,8 +520,7 @@ wsConnectExceptionRetry exception
     | Just (WS.MalformedResponse responseHead _reason) <-
         Exception.fromException exception =
             let status = WS.responseCode responseHead
-                apiError = HttpError status
-                    ("WebSocket handshake returned HTTP " <> showText status)
+                apiError = webSocketHandshakeFailure status
             in if status `elem` retryableHandshakeStatusCodes
                 then RetryException apiError
                 else StopException apiError
@@ -593,7 +593,25 @@ wsHandshakeAuthFailureStatus exception = case Exception.fromException exception 
 wsHandshakeAuthFailure :: Exception.SomeException -> Maybe ApiError
 wsHandshakeAuthFailure exception = do
     status <- wsHandshakeAuthFailureStatus exception
-    pure (HttpError status ("WebSocket handshake returned HTTP " <> showText status))
+    pure (webSocketHandshakeFailure status)
+
+-- | Recognize the exact HTTP error shape emitted when a WebSocket handshake
+-- is rejected before a connection is established. A same-status application
+-- error must not be treated as safe to replay.
+webSocketHandshakeFailureStatus :: ApiError -> Maybe Int
+webSocketHandshakeFailureStatus = \case
+    HttpError status message
+        | message == webSocketHandshakeFailureMessage status ->
+            Just status
+    _ -> Nothing
+
+webSocketHandshakeFailure :: Int -> ApiError
+webSocketHandshakeFailure status =
+    HttpError status (webSocketHandshakeFailureMessage status)
+
+webSocketHandshakeFailureMessage :: Int -> Text
+webSocketHandshakeFailureMessage status =
+    "WebSocket handshake returned HTTP " <> showText status
 
 -- | Classify transient failures that happen during a WebSocket session.
 transientWsMidRunFailureLabel :: Exception.SomeException -> Maybe Text

--- a/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
+++ b/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
@@ -109,6 +109,12 @@ spec = describe "Agent.Transport.WebSocket" do
         let exception = transientHandshakeException 403
         wsHandshakeAuthFailureStatus exception `shouldBe` Nothing
         wsHandshakeAuthFailure exception `shouldBe` Nothing
+        webSocketHandshakeFailureStatus
+            (HttpError 403 "WebSocket handshake returned HTTP 403")
+            `shouldBe` Just 403
+        webSocketHandshakeFailureStatus
+            (HttpError 403 "request forbidden after connection")
+            `shouldBe` Nothing
 
         result <- retryTransientWsConnectWithPolicy
             (constantDelay 0 <> limitRetries 3)


### PR DESCRIPTION
## Summary
- Treat the exact pre-connection gateway WebSocket handshake 403 as a failure of the gateway credential and fall back to the local same-billing ChatGPT pool.
- Preserve credential-specific account-failure policy through OpenAI preference, runtime tracking, and seeding decorators.
- Keep ordinary/in-band 403 responses non-rotating, so a submitted turn is never replayed across accounts.

## Root cause
A saved gateway credential was selected ahead of direct ChatGPT auth. The gateway rejected its WebSocket handshake with HTTP 403, but generic 403s intentionally do not rotate credentials because they can be policy failures after a request has begun. That left the local same-billing fallback unreachable. This is not a `gpt-5.6-sol` model-retirement issue.

## Validation
- `printf "main\n:quit\n" | nix develop -c cabal repl agent-core:test:agent-core-test` — 479 examples, 0 failures
- `printf ":set args --match \"loadAuth\"\nmain\n:quit\n" | nix develop -c cabal repl agent-cli:test:agent-cli-test --ghc-option=-Wno-error=incomplete-patterns` — 23 examples, 0 failures
- `git diff --check`

## Note
The focused CLI GHCi run demotes an unrelated existing `Mailbox.hs` incomplete-pattern warning; the new code compiles and its tests pass.