### PR TITLE
Provide setsid to Claude SDK Nix tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -471,9 +471,16 @@
                         agent-gemini = localPackage (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-gemini/package.nix { }) {
                             src = agentGeminiSource;
                         });
-                        claude-agent-sdk-haskell = localPackage (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/claude-agent-sdk-haskell/package.nix { }) {
-                            src = claudeAgentSdkHaskellSource;
-                        });
+                        claude-agent-sdk-haskell = localPackage
+                            (pkgs.haskell.lib.addTestToolDepends
+                                (pkgs.haskell.lib.overrideSrc
+                                    (final.callPackage
+                                        ./packages/claude-agent-sdk-haskell/package.nix
+                                        { })
+                                    {
+                                        src = claudeAgentSdkHaskellSource;
+                                    })
+                                [ pkgs.util-linux ]);
                         agent-claude = localPackage (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-claude/package.nix { }) {
                             src = agentClaudeSource;
                         });


### PR DESCRIPTION
## Summary
- add `util-linux` as a test-only tool dependency for `claude-agent-sdk-haskell`
- make the blocked-subprocess-write test able to resolve `setsid` in Nix CI

## Validation
- `nix build --no-link .#checks.x86_64-linux.claude-agent-sdk-haskell -L`
  - 91 examples, 0 failures

Fixes the missing-`setsid` Nix check failure after #820.
