### PR TITLE
Show pointer cursor for fullscreen links

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -76,6 +76,7 @@ module Agent.CLI.TUI.App
     , fullscreenSurface
     , fullscreenApp
     , wrapFullscreenKeyboardVty
+    , wrapMarkdownLinkCursorVty
     , withTrackedVtyBuilder
     , setFullscreenImagePreviews
     , setFullscreenWindowTitle

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -68,7 +68,10 @@ import Agent.CLI.Terminal ( TerminalCapabilities(..)
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
     , kittySuperVCsiBodies
+    , osc22MousePointer
     , shiftEnterCsiBodies
+    , terminalSupportsMousePointer
+    , wrapTerminalPassthrough
     )
 import qualified Agent.TUI.Theme as Theme
 import qualified Agent.CLI.TUI.Bridge as Bridge
@@ -359,7 +362,13 @@ syncMotionDemand = do
             { appMotionScheduleReset = False }
 
 handleEventInner :: BrickEvent Name AppEvent -> EventM Name AppState ()
-handleEventInner event = case event of
+handleEventInner event = do
+    when (eventClearsMarkdownLinkCursor event) $
+        setMarkdownLinkCursor False
+    handleEventInner' event
+
+handleEventInner' :: BrickEvent Name AppEvent -> EventM Name AppState ()
+handleEventInner' event = case event of
     AppEvent AppMotionTick -> do
         state <- get
         liftIO $
@@ -877,6 +886,9 @@ handleEventInner event = case event of
         keepAgentHover target
     MouseUp AgentPane Nothing _ ->
         pure ()
+    MouseUp MarkdownLink{} Nothing _ -> do
+        clearAgentHover
+        setMarkdownLinkCursor True
     MouseUp link@MarkdownLink{} (Just V.BLeft) _ -> do
         clearAgentHover
         Composer.handleControlMouseUp link (activateControl link)
@@ -947,6 +959,47 @@ handleEventInner event = case event of
                             (Nothing, Nothing, Nothing, Nothing) ->
                                 handleNormalKey vtyEvent
     _ -> pure ()
+
+eventClearsMarkdownLinkCursor :: BrickEvent Name AppEvent -> Bool
+eventClearsMarkdownLinkCursor = \case
+    -- Pointer motion is represented as a buttonless MouseUp by our
+    -- vty-unix patch. Keep the hand while Brick says that motion is inside a
+    -- Markdown link extent.
+    MouseUp MarkdownLink{} Nothing _ -> False
+    MouseDown{} -> True
+    MouseUp{} -> True
+    VtyEvent V.EvMouseDown{} -> True
+    VtyEvent V.EvMouseUp{} -> True
+    VtyEvent V.EvLostFocus -> True
+    VtyEvent V.EvResize{} -> True
+    AppEvent AppSuspend{} -> True
+    AppEvent AppAskChoice{} -> True
+    AppEvent AppAskResume{} -> True
+    AppEvent AppAskText{} -> True
+    _ -> False
+
+-- | Use OSC 22 to give Markdown links a native hand cursor even while the
+-- fullscreen UI has mouse reporting enabled. In Ghostty, mouse reporting
+-- prevents its normal Command-hover OSC 8 detection; the app still receives
+-- pointer motion, so it can set the cursor precisely for the clickable link
+-- extent.
+setMarkdownLinkCursor :: Bool -> EventM Name AppState ()
+setMarkdownLinkCursor hovered = do
+    state <- get
+    when (state.appMarkdownLinkHovered /= hovered) do
+        modify' \current ->
+            current { appMarkdownLinkHovered = hovered }
+        terminal <- liftIO (detectTerminalCapabilities stdout)
+        when (terminalSupportsMousePointer terminal.terminalKind) do
+            vty <- getVtyHandle
+            let payload =
+                    wrapTerminalPassthrough
+                        terminal.terminalInsideTmux
+                        (osc22MousePointer terminal.terminalKind hovered)
+            liftIO $
+                V.outputByteBuffer
+                    (V.outputIface vty)
+                    (TextEncoding.encodeUtf8 payload)
 
 metaConsoleToggleAvailable :: AppState -> Bool
 metaConsoleToggleAvailable state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -68,7 +68,10 @@ import Agent.CLI.Terminal ( TerminalCapabilities(..)
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
     , kittySuperVCsiBodies
+    , osc22MousePointer
     , shiftEnterCsiBodies
+    , terminalSupportsMousePointer
+    , wrapTerminalPassthrough
     )
 import qualified Agent.TUI.Theme as Theme
 import qualified Agent.CLI.TUI.Bridge as Bridge
@@ -204,6 +207,7 @@ runFullscreen runtime workerAction = do
                         wrapNativePreviewVty runtime vty
                             >>= wrapFullscreenKeyboardVty
                                 terminal.terminalKittyKeyboard
+                            >>= wrapMarkdownLinkCursorVty terminal
                     applyStoredFullscreenWindowTitle
                         runtime
                         (V.outputIface wrapped)
@@ -373,6 +377,31 @@ runFullscreen runtime workerAction = do
                     DictationTranscript transcript -> Right transcript
                     DictationFailed message -> Left message
 
+-- | Restore the terminal cursor before every fullscreen Vty lifecycle ends.
+-- This includes Brick suspension, which rebuilds Vty later, and protects
+-- terminals that retain OSC 22 pointer state after the alternate screen.
+wrapMarkdownLinkCursorVty
+    :: TerminalCapabilities
+    -> V.Vty
+    -> IO V.Vty
+wrapMarkdownLinkCursorVty terminal vty
+    | not (terminalSupportsMousePointer terminal.terminalKind) = pure vty
+    | otherwise =
+        pure vty
+            { V.shutdown = do
+                alreadyShutdown <- V.isShutdown vty
+                unless alreadyShutdown $
+                    V.outputByteBuffer
+                        (V.outputIface vty)
+                        ( TextEncoding.encodeUtf8
+                            ( wrapTerminalPassthrough
+                                terminal.terminalInsideTmux
+                                (osc22MousePointer terminal.terminalKind False)
+                            )
+                        )
+                        `finally` V.shutdown vty
+            }
+
 -- | Construct the retained application state shared by the live entry point
 -- and renderer tests. Generated tests should start from the same defaults as
 -- a real fullscreen session instead of assembling an approximate state.
@@ -423,6 +452,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appAgentSelected = initialAgent
         , appAgentEntries = initialAgents
         , appAgentHover = Nothing
+        , appMarkdownLinkHovered = False
         , appHoveredControl = Nothing
         , appPressedControl = Nothing
         , appWorkerStopped = False

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -338,6 +338,7 @@ data AppState = AppState
     , appAgentSelected :: !AgentTarget
     , appAgentEntries :: ![AgentEntry]
     , appAgentHover :: !(Maybe AgentHover)
+    , appMarkdownLinkHovered :: !Bool
     , appHoveredControl :: !(Maybe Name)
     , appPressedControl :: !(Maybe Name)
     , appWorkerStopped :: !Bool

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -10,6 +10,8 @@ module Agent.CLI.Terminal
     , fileUri
     , osc9Notification
     , osc52Clipboard
+    , osc22MousePointer
+    , terminalSupportsMousePointer
     , osc133PromptStart
     , osc133PromptEnd
     , osc133CommandStart
@@ -190,6 +192,33 @@ osc52Clipboard payload =
         <> TextEncoding.decodeLatin1
             (Base64.encode (TextEncoding.encodeUtf8 payload))
         <> "\ESC\\"
+
+-- | Set the terminal mouse pointer to a hand or restore its normal shape.
+--
+-- OSC 22 is implemented by Ghostty, Kitty, and recent iTerm2. It remains
+-- useful while an application has mouse reporting enabled, where the terminal
+-- cannot inspect OSC 8 hyperlinks itself to choose a link cursor. Kitty's
+-- push/pop extension restores any shape selected by the terminal;
+-- Ghostty currently supports the basic explicit-shape form.
+osc22MousePointer :: TerminalKind -> Bool -> Text
+osc22MousePointer kind pointer =
+    "\ESC]22;"
+        <> body
+        <> "\ESC\\"
+  where
+    body = case (kind, pointer) of
+        (TerminalKitty, True) -> ">pointer"
+        (TerminalKitty, False) -> "<"
+        (_, True) -> "pointer"
+        (_, False) -> "default"
+
+-- | Whether a terminal kind implements the OSC 22 mouse-pointer protocol.
+terminalSupportsMousePointer :: TerminalKind -> Bool
+terminalSupportsMousePointer = \case
+    TerminalGhostty -> True
+    TerminalKitty -> True
+    TerminalITerm -> True
+    _ -> False
 
 osc133PromptStart, osc133PromptEnd, osc133CommandStart :: Text
 osc133PromptStart = "\ESC]133;A\ESC\\"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -36,6 +36,7 @@ import Agent.CLI.TUI.App
     , newFullscreenRuntime
     , withTrackedVtyBuilder
     , wrapFullscreenKeyboardVty
+    , wrapMarkdownLinkCursorVty
     , motionDemandFor
     , motionDemandForTerminalFocus
     , motionModeForTerminalFocus
@@ -91,7 +92,9 @@ import Agent.CLI.TUI.ImagePreview
     , TuiImagePreview(..)
     )
 import Agent.CLI.Terminal
-    ( kittyKeyboardDisambiguatePush
+    ( TerminalCapabilities(..)
+    , TerminalKind(..)
+    , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
     )
 import Agent.Loop (ImageAttachment(..), LoopEvent(..), emptyTurnOutput)
@@ -652,6 +655,36 @@ spec = do
 
             V.shutdown wrapped
             readIORef events `shouldReturn` [Right ()]
+
+    describe "fullscreen link cursor lifecycle" do
+        it "restores the Ghostty cursor before Vty shutdown" do
+            events <- newIORef
+                ([] :: [Either ByteString.ByteString ()])
+            (_, output) <- VMock.mockTerminal (80, 24)
+            vty <- mockVty
+                output
+                    { V.outputByteBuffer =
+                        \bytes ->
+                            modifyIORef' events (<> [Left bytes])
+                    }
+                (modifyIORef' events (<> [Right ()]))
+                ((Right () `elem`) <$> readIORef events)
+            let terminal = TerminalCapabilities
+                    { terminalKind = TerminalGhostty
+                    , terminalIsTty = True
+                    , terminalInsideTmux = False
+                    , terminalInlineImages = True
+                    , terminalNativeProgress = True
+                    , terminalNotifications = True
+                    , terminalSemanticPrompts = True
+                    , terminalOsc52Clipboard = True
+                    , terminalSynchronizedOutput = True
+                    , terminalKittyKeyboard = True
+                    }
+                reset = TextEncoding.encodeUtf8 "\ESC]22;default\ESC\\"
+            wrapped <- wrapMarkdownLinkCursorVty terminal vty
+            V.shutdown wrapped
+            readIORef events `shouldReturn` [Left reset, Right ()]
 
     describe "fullscreen window title" do
         it "replays the stored session title as UTF-8 OSC bytes" do

--- a/packages/agent-cli/test/Agent/CLI/TerminalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TerminalSpec.hs
@@ -19,6 +19,16 @@ spec = do
             osc52Clipboard "hello"
                 `shouldBe` "\ESC]52;c;aGVsbG8=\ESC\\"
 
+        it "uses OSC 22 to show and clear a link pointer" do
+            osc22MousePointer TerminalGhostty True
+                `shouldBe` "\ESC]22;pointer\ESC\\"
+            osc22MousePointer TerminalGhostty False
+                `shouldBe` "\ESC]22;default\ESC\\"
+            osc22MousePointer TerminalKitty True
+                `shouldBe` "\ESC]22;>pointer\ESC\\"
+            osc22MousePointer TerminalKitty False
+                `shouldBe` "\ESC]22;<\ESC\\"
+
         it "includes semantic command exit status" do
             osc133CommandFinished (Just 1)
                 `shouldBe` "\ESC]133;D;1\ESC\\"
@@ -34,6 +44,13 @@ spec = do
         it "exposes Kitty keyboard push/pop sequences" do
             Text.null kittyKeyboardPush `shouldBe` False
             Text.null kittyKeyboardPop `shouldBe` False
+
+    describe "mouse-pointer support" do
+        it "is limited to terminals with the OSC 22 protocol" do
+            terminalSupportsMousePointer TerminalGhostty `shouldBe` True
+            terminalSupportsMousePointer TerminalKitty `shouldBe` True
+            terminalSupportsMousePointer TerminalITerm `shouldBe` True
+            terminalSupportsMousePointer TerminalWezTerm `shouldBe` False
 
     describe "stripAnsi" do
         it "leaves plain text unchanged" do


### PR DESCRIPTION
## Summary
- emit a native OSC 22 hand cursor while hovering fullscreen Markdown links
- reset the cursor when leaving a link or ending/suspending the Vty lifecycle
- support Ghostty, Kitty, and recent iTerm2, including tmux passthrough

## Testing
- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-options='--match "terminal protocol encoders"'`\n- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-options='--match "fullscreen link cursor lifecycle"'`\n- `nix develop -c cabal test agent-cli:test:agent-cli-test --test-options='--match "mouse-pointer support"'`\n- live tmux smoke test with SGR pointer motion; verified tmux-wrapped OSC 22 pointer and reset output