### PR TITLE
fix: bound list_dir traversal before rendering

### DIFF
--- a/packages/agent-core/src/Agent/Tools/FileSystem/GitIgnore.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/GitIgnore.hs
@@ -1,15 +1,44 @@
-module Agent.Tools.FileSystem.GitIgnore (isGitIgnored) where
+module Agent.Tools.FileSystem.GitIgnore
+    ( isGitIgnored
+    , ignoredPaths
+    ) where
 
 import Agent.OsPath (unsafeToFilePath)
+import qualified Data.Set as Set
 import System.Directory (findExecutable)
 import System.Exit (ExitCode(..))
 import System.OsPath (OsPath)
 import System.Process (readProcessWithExitCode)
 
 isGitIgnored :: OsPath -> OsPath -> IO Bool
-isGitIgnored cwd path = findExecutable "git" >>= \case
-    Nothing -> pure False
+isGitIgnored cwd path =
+    Set.member (unsafeToFilePath path) <$> ignoredPaths cwd [path]
+
+-- | Check a directory's immediate entries in one Git invocation.
+--
+-- @git check-ignore@ returns only ignored paths and uses exit code 1 when
+-- none match. Other non-zero codes are operational failures and are treated
+-- like the old per-path check: no path is considered ignored.
+ignoredPaths :: OsPath -> [OsPath] -> IO (Set.Set FilePath)
+ignoredPaths _ [] = pure Set.empty
+ignoredPaths cwd paths = findExecutable "git" >>= \case
+    Nothing -> pure Set.empty
     Just git -> do
-        (code, _, _) <- readProcessWithExitCode git
-            ["-C", unsafeToFilePath cwd, "check-ignore", "-q", "--", unsafeToFilePath path] ""
-        pure (code == ExitSuccess)
+        (code, output, _) <- readProcessWithExitCode git
+            ["-C", unsafeToFilePath cwd, "check-ignore", "-z", "--stdin"]
+            (concatMap (\path -> unsafeToFilePath path <> "\0") paths)
+        pure case code of
+            ExitSuccess -> parseOutput output
+            ExitFailure 1 -> parseOutput output
+            ExitFailure _ -> Set.empty
+  where
+    parseOutput = Set.fromList . filter (not . null) . splitNuls
+
+splitNuls :: String -> [String]
+splitNuls = \case
+    "" -> []
+    value ->
+        let (part, rest) = break (== '\0') value
+        in part : case rest of
+            [] -> []
+            _ : more -> splitNuls more

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
@@ -1,12 +1,14 @@
 module Agent.Tools.FileSystem.ListDir
     ( listDirTool
     , DirNode(..)
+    , ListDirOperations(..)
+    , collectDirWith
     , capNodes
     , renderTree
     ) where
 
 import Agent.Json.Decode (Decoder)
-import Agent.OsPath (fromText, toText)
+import Agent.OsPath (fromText, toText, unsafeToFilePath)
 import Agent.ToolArgs (objectArgs, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch
@@ -15,7 +17,7 @@ import Agent.ToolDispatch
     , toolArgumentsValue
     , typedTool
     )
-import Agent.Tools.FileSystem.GitIgnore (isGitIgnored)
+import Agent.Tools.FileSystem.GitIgnore (ignoredPaths)
 import Agent.Tools.IO
     ( displayPathInWorkspace
     , listDirectoryEntries
@@ -35,6 +37,7 @@ import Agent.Tools.Types
     )
 import Data.List (sortOn)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath (doesDirectoryExist, pathIsSymbolicLink)
@@ -93,11 +96,10 @@ runListDir env args = resolveForRead env (fromText args.targetDirectory) >>= \ca
             False -> pure $ Left $
                 "Error: " <> display <> " is not a valid directory"
             True ->
-                collectDir env.toolCwd path >>= \case
+                collectDir env.toolCwd maxListItems path >>= \case
                     Left err -> pure (Left err)
-                    Right entries -> do
-                        let (shown, truncated) = capNodes maxListItems entries
-                            tree = renderTree 0 shown
+                    Right (entries, truncated) -> do
+                        let tree = renderTree 0 entries
                             notice
                                 | truncated =
                                     "\nLarge directory summarized; some nested entries were omitted."
@@ -115,37 +117,136 @@ data DirNode
     | ErrorNode OsPath Text
     deriving (Eq, Show)
 
-collectDir :: OsPath -> OsPath -> IO (Either Text [DirNode])
-collectDir cwd path = do
-    listed <- listDirectoryEntries path
+data ListDirOperations = ListDirOperations
+    { readDirectoryEntries
+        :: OsPath -> IO (Either Text [(OsPath, Bool)])
+    , findIgnoredPaths
+        :: OsPath -> [OsPath] -> IO (Set.Set FilePath)
+    , isEntrySymbolicLink
+        :: OsPath -> IO Bool
+    }
+
+filesystemOperations :: ListDirOperations
+filesystemOperations = ListDirOperations
+    { readDirectoryEntries = listDirectoryEntries
+    , findIgnoredPaths = ignoredPaths
+    , isEntrySymbolicLink = pathIsSymbolicLink
+    }
+
+-- | Traverse only nodes that can appear in the result.  The old implementation
+-- built the complete tree and applied 'capNodes' afterwards, which meant a
+-- request for a large directory could scan millions of descendants despite the
+-- 200-node result limit.
+collectDir :: OsPath -> Int -> OsPath -> IO (Either Text ([DirNode], Bool))
+collectDir = collectDirWith filesystemOperations
+
+collectDirWith
+    :: ListDirOperations
+    -> OsPath
+    -> Int
+    -> OsPath
+    -> IO (Either Text ([DirNode], Bool))
+collectDirWith operations cwd budget path = do
+    visibleEntries operations cwd path >>= \case
+        Left err -> pure (Left err)
+        Right entries ->
+            Right <$> collectEntries operations cwd budget path entries
+
+visibleEntries
+    :: ListDirOperations
+    -> OsPath
+    -> OsPath
+    -> IO (Either Text [(OsPath, Bool)])
+visibleEntries operations cwd path = do
+    listed <- operations.readDirectoryEntries path
     case listed of
         Left err -> pure (Left err)
         Right raw -> do
-            let visible = sortOn fst
+            let candidates = sortOn fst
                     [ (name, isDir)
                     | (name, isDir) <- raw
                     , not ("." `Text.isPrefixOf` toText name)
                     ]
-            Right <$> (fmap concat $ mapM (toNode cwd path) visible)
+            ignored <-
+                operations.findIgnoredPaths cwd
+                    [path </> name | (name, _) <- candidates]
+            Right . foldr addVisible [] <$> traverse (classify ignored) candidates
+  where
+    classify ignored (name, isDir)
+        | Set.member (unsafeToFilePath (path </> name)) ignored = pure Nothing
+        | not isDir = pure (Just (name, False))
+        | otherwise = do
+            isLink <- operations.isEntrySymbolicLink (path </> name)
+            pure $ Just (name, not isLink)
 
-toNode :: OsPath -> OsPath -> (OsPath, Bool) -> IO [DirNode]
-toNode cwd parent (name, isDir) = do
+    addVisible (Just entry) entries = entry : entries
+    addVisible Nothing entries = entries
+
+collectEntries
+    :: ListDirOperations
+    -> OsPath
+    -> Int
+    -> OsPath
+    -> [(OsPath, Bool)]
+    -> IO ([DirNode], Bool)
+collectEntries operations cwd budget parent entries =
+    fillBounded operations cwd (max 0 budget) (length entries) parent entries
+
+-- | Preserve the existing sibling-reservation behavior while using the
+-- remaining result budget to decide whether to descend into a directory.
+fillBounded
+    :: ListDirOperations
+    -> OsPath
+    -> Int
+    -> Int
+    -> OsPath
+    -> [(OsPath, Bool)]
+    -> IO ([DirNode], Bool)
+fillBounded _ _ _ _ _ [] = pure ([], False)
+fillBounded _ _ remaining _ _ _ | remaining <= 0 = pure ([], True)
+fillBounded operations cwd remaining restCount parent (entry : rest) = do
+    let reserved = min (remaining - 1) (restCount - 1)
+        available = remaining - reserved
+    (node, nodeTruncated) <-
+        toNodeBounded operations cwd available parent entry
+    (more, restTruncated) <-
+        fillBounded operations cwd
+            (remaining - countNodes [node])
+            (restCount - 1)
+            parent
+            rest
+    pure (node : more, nodeTruncated || restTruncated)
+
+toNodeBounded
+    :: ListDirOperations
+    -> OsPath
+    -> Int
+    -> OsPath
+    -> (OsPath, Bool)
+    -> IO (DirNode, Bool)
+toNodeBounded _ _ _ _ (name, False) = pure (FileNode name, False)
+toNodeBounded operations cwd budget parent (name, True) = do
     let full = parent </> name
-    ignored <- isGitIgnored cwd full
-    if ignored
-        then pure []
-        else if not isDir
-            then pure [FileNode name]
-            else do
-                isLink <- pathIsSymbolicLink full
-                if isLink
-                    then pure [FileNode name]
-                    else
-                        collectDir cwd full >>= \case
-                            Left err ->
-                                pure [ErrorNode name err]
-                            Right children ->
-                                pure [summarizeDir name children]
+    visibleEntries operations cwd full >>= \case
+        Left err -> pure (ErrorNode name err, False)
+        Right entries
+            | isLargeFlatDirectory entries ->
+                pure (summarizedDirectory name entries, False)
+            | otherwise -> do
+                (children, truncated) <-
+                    collectEntries operations cwd
+                        (max 0 (budget - 1))
+                        full
+                        entries
+                pure (DirectoryNode name children, truncated)
+
+isLargeFlatDirectory :: [(OsPath, Bool)] -> Bool
+isLargeFlatDirectory entries =
+    length entries > 20 && all (not . snd) entries
+
+summarizedDirectory :: OsPath -> [(OsPath, Bool)] -> DirNode
+summarizedDirectory name entries =
+    summarizeDir name [FileNode child | (child, _) <- entries]
 
 -- | Keep as many nodes as @budget@ allows. A directory that does not fit in
 -- full is included as a stub (and maybe a truncated child list) rather than

--- a/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/FileSystem/ListDirSpec.hs
@@ -9,12 +9,16 @@ import Agent.ToolDispatch
     )
 import Agent.Tools.FileSystem.ListDir
     ( DirNode(..)
+    , ListDirOperations(..)
     , capNodes
+    , collectDirWith
     , listDirTool
     , renderTree
     )
 import Agent.Tools.Types (AppTool(..), defaultToolEnv)
 import Control.Exception.Safe (bracket, finally)
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory
@@ -30,6 +34,7 @@ import System.Directory
     )
 import System.FilePath ((</>))
 import System.OsPath (unsafeEncodeUtf)
+import qualified System.OsPath as OsPath
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
@@ -85,6 +90,31 @@ spec = do
                 (shown, truncated) = capNodes 5 tree
             truncated `shouldBe` True
             map nodeName shown `shouldBe` ["1", "2", "3", "4", "5"]
+
+    describe "collectDirWith" do
+        it "stops opening descendants when the node budget is exhausted" do
+            visitedRef <- newIORef []
+            let root = fromText "/root"
+                child = fromText "child"
+                operations = ListDirOperations
+                    { readDirectoryEntries = \path -> do
+                        modifyIORef' visitedRef (path :)
+                        pure (Right [(child, True)])
+                    , findIgnoredPaths = \_ _ -> pure Set.empty
+                    , isEntrySymbolicLink = const (pure False)
+                    }
+                expectedTree =
+                    [ DirectoryNode child
+                        [ DirectoryNode child
+                            [DirectoryNode child []]
+                        ]
+                    ]
+                expectedVisited =
+                    take 4 (iterate (\path -> path OsPath.</> child) root)
+            result <- collectDirWith operations (fromText "/workspace") 3 root
+            visited <- reverse <$> readIORef visitedRef
+            result `shouldBe` Right (expectedTree, True)
+            visited `shouldBe` expectedVisited
 
     describe "renderTree" do
         it "does not insert blank lines after nested directories" do


### PR DESCRIPTION
## Summary

- Enforce the 200-node `list_dir` limit while recursively traversing, rather than after constructing the complete descendant tree.
- Batch `git check-ignore` for each opened directory with NUL-delimited stdin/output instead of spawning one Git process per entry.
- Add a deterministic infinite-directory-chain regression test that asserts the traversal only opens directories justified by the node budget.

## Root cause

Audit of the stuck sessions found normal tool arguments (including the pictured 49-byte request), with no NUL-padded or oversized `target_directory` values. The problem was execution-side: the previous implementation fully walked the tree, then applied its 200-item display cap, and invoked `git check-ignore` once for every descendant entry.

## Performance

Built `agent-core` with `nix develop -c cabal build lib:agent-core -O2`. The comparison uses a forced checksum, `performGC` before each sample, `+RTS -T`, and three samples per mode. The old baseline retains the complete recursive walk and singleton ignore checks; the new path uses the production bounded traversal and batched ignore checks.

| Workload | Old median | New median |
| --- | ---: | ---: |
| `packages/agent-core/src` (76 ignore checks) | 694 ms / 15.7 MB / 76 checks | 154 ms / 4.72 MB / 15 checks |
| Representative worktree (4,528 checks) | 42.3 s / 1.08 GB / 4,528 checks | 488 ms / 40.3 MB / 56 checks |

The exact broad root from the incident now completes in a 1.01 s median (60.0 MB; 111 batched checks). The current directory still has to be enumerated/classified, but recursive descendant work is bounded by the result budget.

## Validation

- `nix develop -c cabal build lib:agent-core -O2`
- Focused `agent-core-test` groups: `collectDirWith`, `capNodes`, `renderTree`, and `listDirTool` (10 examples, 0 failures)
- `git diff --check origin/master...HEAD`