### PR TITLE
Recover from Codex WebSocket upgrade rejections

### DIFF
--- a/packages/agent-core/src/Agent/Transport/WebSocket.hs
+++ b/packages/agent-core/src/Agent/Transport/WebSocket.hs
@@ -519,11 +519,12 @@ wsConnectExceptionRetry exception
         StopException authError
     | Just (WS.MalformedResponse responseHead _reason) <-
         Exception.fromException exception =
-            let status = WS.responseCode responseHead
-                apiError = webSocketHandshakeFailure status
-            in if status `elem` retryableHandshakeStatusCodes
-                then RetryException apiError
-                else StopException apiError
+            -- This is websockets' "unexpected HTTP status" path. Like Codex,
+            -- retry every non-auth upgrade rejection before allowing the
+            -- provider layer to switch transports. No Responses payload (and
+            -- therefore no model) has been sent at this point.
+            RetryException
+                (webSocketHandshakeFailure (WS.responseCode responseHead))
     | Just WS.ConnectionTimeout <- Exception.fromException exception =
         retryConnection "WebSocket handshake timed out"
     | Just (Connection.HostNotResolved host) <-
@@ -544,7 +545,6 @@ wsConnectExceptionRetry exception
         StopException $ ConnectionError
             ("WebSocket connection failed: " <> showText exception)
   where
-    retryableHandshakeStatusCodes = [408, 425, 429, 500, 502, 503, 504]
     retryConnection = RetryException . ConnectionError
     formatNestedFailures [] = ""
     formatNestedFailures failures = " (" <> showText failures <> ")"

--- a/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
+++ b/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
@@ -105,7 +105,7 @@ spec = describe "Agent.Transport.WebSocket" do
         wsHandshakeAuthFailure exception
             `shouldBe` Just (HttpError 401 "WebSocket handshake returned HTTP 401")
 
-    it "keeps handshake 403 as a permission failure" do
+    it "retries a handshake 403 as a transport failure" do
         let exception = transientHandshakeException 403
         wsHandshakeAuthFailureStatus exception `shouldBe` Nothing
         wsHandshakeAuthFailure exception `shouldBe` Nothing
@@ -115,14 +115,33 @@ spec = describe "Agent.Transport.WebSocket" do
         webSocketHandshakeFailureStatus
             (HttpError 403 "request forbidden after connection")
             `shouldBe` Nothing
+        transientWsConnectFailureLabel exception
+            `shouldBe` Just "WebSocket handshake returned HTTP 403"
 
+        attempts <- newIORef (0 :: Int)
         result <- retryTransientWsConnectWithPolicy
             (constantDelay 0 <> limitRetries 3)
-            \_connected -> throwIO exception
+            \_connected -> do
+                modifyIORef' attempts (+ 1)
+                throwIO exception
 
         result `shouldBe`
             (Left (HttpError 403 "WebSocket handshake returned HTTP 403")
                 :: Either ApiError ())
+        readIORef attempts `shouldReturn` 4
+
+    it "retries every non-auth websocket upgrade rejection like Codex" do
+        attempts <- newIORef (0 :: Int)
+        result <- retryTransientWsConnectWithPolicy
+            (constantDelay 0 <> limitRetries 2)
+            \_connected -> do
+                modifyIORef' attempts (+ 1)
+                throwIO (transientHandshakeException 404)
+
+        result `shouldBe`
+            (Left (HttpError 404 "WebSocket handshake returned HTTP 404")
+                :: Either ApiError ())
+        readIORef attempts `shouldReturn` 3
 
     it "retries a transient handshake failure before the connection callback" do
         attempts <- newIORef (0 :: Int)

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -78,6 +78,7 @@ import Agent.Responses.LoopBackend
     , withRequestInput
     )
 import Agent.Responses.Types
+import qualified Agent.Transport.WebSocket as WebSocket
 import Control.Concurrent (threadDelay)
 import Control.Applicative ((<|>))
 import Control.Exception.Safe (onException)
@@ -552,6 +553,12 @@ openAiBackendWithTransportFallback fallbackActive primary fallback =
 isOpenAiWebSocketTransportFailure :: ApiError -> Bool
 isOpenAiWebSocketTransportFailure = \case
     ConnectionError {} -> True
+    -- Rejected WebSocket upgrades reach this exact transport-specific shape
+    -- only after bounded connection retries have been exhausted. A same-status
+    -- logical HTTP error does not match and remains a permission failure.
+    err
+        | Just status <- WebSocket.webSocketHandshakeFailureStatus err ->
+            status /= 401
     ProviderError WebSocketConnectionLimitReached _ _ -> True
     -- A server that does not support the Responses WebSocket protocol
     -- advertises that explicitly with HTTP 426.

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -180,7 +180,9 @@ wsPath = "/backend-api/codex/responses"
 -- force-refreshed even when its JWT has not expired, then the handshake is
 -- retried once with the rotated token. If refresh or the second handshake
 -- fails, the account is cooled down and the next configured account is tried.
--- HTTP 403 remains a permission/policy failure and does not rotate credentials.
+-- Other upgrade rejections (including HTTP 403) receive bounded connection
+-- retries. They are not generic bearer-authentication failures; after retries,
+-- the caller may switch to HTTPS or apply a credential-source-specific fallback.
 -- This happens before the callback starts, so retrying cannot duplicate caller
 -- side effects.
 --

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1578,6 +1578,59 @@ spec = do
             readIORef primaryCalls `shouldReturn` 1
             readIORef fallbackCalls `shouldReturn` 1
 
+        it "falls back after an exhausted websocket upgrade rejection" do
+            fallbackActive <- newIORef False
+            primaryCalls <- newIORef (0 :: Int)
+            fallbackCalls <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            let primary = Backend \_state _previous _inputs _onEvent -> do
+                    modifyIORef' primaryCalls (+ 1)
+                    pure (Left (HttpError 403
+                        "WebSocket handshake returned HTTP 403"))
+                fallback = Backend \state _previous _inputs _onEvent -> do
+                    modifyIORef' fallbackCalls (+ 1)
+                    pure $ Right BackendResult
+                        { backendOutput =
+                            emptyTurnOutput "resp-http" [] (Just "ok")
+                        , backendState = state
+                        }
+                backend =
+                    openAiBackendWithTransportFallback
+                        fallbackActive primary fallback
+            result <- submitWithState transcript backend Nothing
+                [UserMessage "one"] (const (pure ()))
+            result `shouldBe` Right (emptyTurnOutput "resp-http" [] (Just "ok"))
+            readIORef fallbackActive `shouldReturn` True
+            readIORef primaryCalls `shouldReturn` 1
+            readIORef fallbackCalls `shouldReturn` 1
+
+        it "does not mistake a logical HTTP 403 for a websocket upgrade failure" do
+            fallbackActive <- newIORef False
+            fallbackCalls <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            let primary = Backend \_state _previous _inputs _onEvent ->
+                    pure (Left (HttpError 403 "model access denied"))
+                fallback = Backend \state _previous _inputs _onEvent -> do
+                    modifyIORef' fallbackCalls (+ 1)
+                    pure $ Right BackendResult
+                        { backendOutput =
+                            emptyTurnOutput "resp-http" [] (Just "ok")
+                        , backendState = state
+                        }
+                backend =
+                    openAiBackendWithTransportFallback
+                        fallbackActive primary fallback
+            result <- submitWithState transcript backend Nothing
+                [UserMessage "one"] (const (pure ()))
+            result `shouldBe` Left (HttpError 403 "model access denied")
+            readIORef fallbackActive `shouldReturn` False
+            readIORef fallbackCalls `shouldReturn` 0
+
+        it "keeps websocket handshake 401 on the credential recovery path" do
+            isOpenAiWebSocketTransportFailure
+                (HttpError 401 "WebSocket handshake returned HTTP 401")
+                `shouldBe` False
+
         it "preserves non-transport provider failures" do
             fallbackActive <- newIORef False
             fallbackCalls <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary

- retry every non-auth WebSocket upgrade rejection with the existing bounded `1s, 2s, 4s, 8s, 15s` backoff, matching Codex's retry treatment for unexpected upgrade statuses
- after the retry budget is exhausted, recognize only the exact handshake-error shape as a transport failure and switch the OpenAI backend session-sticky to HTTPS
- preserve handshake `401` credential recovery, the gateway-`403` local-account fallback, and genuine logical/API `403` permission failures

## Root cause

The intermittent `403` happens during the HTTP WebSocket upgrade, before a Responses payload or model name is sent. The client previously returned that upgrade rejection as a terminal `HttpError`, so the existing HTTPS fallback was bypassed and the CLI rendered a misleading model/account permission error.

The exact upstream admission policy remains unknown because the rejected upgrade did not retain safe edge/request metadata. The confirmed client bug is the missing retry/fallback path, which this PR fixes.

## Tests

- `cabal test agent-core-test agent-openai-test --test-show-details=failures` — 491 core examples and 327 OpenAI examples, no failures (expected pending tests unchanged)
- `cabal test agent-cli-test --test-options='--match=WebSocket'` — gateway handshake fallback and WebSocket recovery tests pass
- `git diff --check`
