### PR TITLE
Fix OpenAI WebSocket rejection recovery

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
@@ -19,7 +19,8 @@ import Agent.Loop
     )
 import qualified Agent.OpenAI.Client as OpenAIClient
 import Agent.OpenAI.LoopBackend
-    ( isOpenAiWebSocketTransportFailure
+    ( isOpenAiReplayUnsafeWebSocketTransportFailure
+    , isOpenAiWebSocketTransportFailure
     , openAiAuxiliaryResponseSenderReconnecting
     , openAiBackendWithReasoningVisibility
     , openAiBackendWithTransportFallback
@@ -145,6 +146,14 @@ lockedOpenAiSession gatewayOnly compactThreshold showRawReasoning wsLock fallbac
                         sendAuxiliary request Nothing (const (pure ()))
                     case result of
                         Left err
+                            | not gatewayOnly
+                            , isOpenAiReplayUnsafeWebSocketTransportFailure err -> do
+                                -- The socket is dead, so route later work over
+                                -- HTTP. Do not replay this compaction: an
+                                -- opaque checkpoint already arrived and the
+                                -- provider may have committed/billed it.
+                                writeIORef fallbackActive True
+                                pure result
                             | not gatewayOnly
                             , isOpenAiWebSocketTransportFailure err -> do
                                 writeIORef fallbackActive True

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -155,10 +155,11 @@ import Agent.OpenAI.WebSocketClient
     ( CodexAuthFailed(..),
       closeCodexConn,
       codexConnTurnState,
+      codexConnUsesHttpFallback,
       isGatewayWebSocketCredential,
       resetCodexTurnState,
-      withCodexWsCredential,
-      withCodexWsWithProvider )
+      withCodexWsCredentialOrHttpFallback,
+      withCodexWsWithProviderOrHttpFallback )
 import Agent.OpenRouter.LoopBackend ( openRouterBackend )
 import Agent.OsPath ( unsafeToFilePath )
 import Agent.Provider
@@ -287,15 +288,17 @@ runAgentProviders
     = case provider of
                     OpenAIProvider ->
                         try @_ @CodexAuthFailed
-                            (withCodexWsWithProvider tokenProvider \conn credential -> do
+                            (withCodexWsWithProviderOrHttpFallback tokenProvider \conn credential -> do
                                 wsLock <- newMVar ()
-                                initialWsHealthy <- newIORef True
+                                let startsOnHttp =
+                                        codexConnUsesHttpFallback conn
+                                initialWsHealthy <- newIORef (not startsOnHttp)
                                 activeConnectionRef <- newIORef $
                                     OpenAiPersistentConnection
                                         credential
                                         initialWsHealthy
                                         conn
-                                httpFallbackActive <- newIORef False
+                                httpFallbackActive <- newIORef startsOnHttp
                                 switchRequests <-
                                     newChan :: IO (Chan AccountSwitchRequest)
                                 let selectAccount = case loaded.loadedOpenAiPool of
@@ -359,8 +362,12 @@ runAgentProviders
                                                     installConnection
                                                         newCredential
                                                         newConn = do
+                                                            let usesHttp =
+                                                                    codexConnUsesHttpFallback
+                                                                        newConn
                                                             newHealthy <-
-                                                                newIORef True
+                                                                newIORef
+                                                                    (not usesHttp)
                                                             label <-
                                                                 resolveActiveAccountLabel
                                                                     newCredential
@@ -379,6 +386,9 @@ runAgentProviders
                                                             writeIORef
                                                                 activeAccountRef
                                                                 label
+                                                            writeIORef
+                                                                httpFallbackActive
+                                                                usesHttp
                                                             pure (newHealthy, label)
                                                     awaitNext newHealthy =
                                                         readChan switchRequests
@@ -402,7 +412,7 @@ runAgentProviders
                                                     (Just
                                                         selectedCredential.accountId)
                                                 let connectSelected =
-                                                        withCodexWsCredential
+                                                        withCodexWsCredentialOrHttpFallback
                                                             selectedCredential
                                                             \newConn
                                                                 newCredential -> do
@@ -449,7 +459,7 @@ runAgentProviders
                                                                                         , provider =
                                                                                             OpenAIProvider
                                                                                         }
-                                                                            (withCodexWsCredential
+                                                                            (withCodexWsCredentialOrHttpFallback
                                                                                 restoredCredential
                                                                                 \newConn
                                                                                     newCredential -> do

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -79,6 +79,7 @@ import Agent.Responses.LoopBackend
     , withRequestInput
     )
 import Agent.Responses.Types
+import qualified Agent.Transport.WebSocket as WebSocket
 import Control.Concurrent (threadDelay)
 import Control.Applicative ((<|>))
 import Control.Exception.Safe (onException)
@@ -567,13 +568,17 @@ openAiBackendWithTransportFallback fallbackActive primary fallback =
 -- | Errors that indicate the Codex Responses WebSocket transport is
 -- unavailable rather than that the logical request itself was rejected.
 isOpenAiWebSocketTransportFailure :: ApiError -> Bool
-isOpenAiWebSocketTransportFailure = \case
+isOpenAiWebSocketTransportFailure err = case err of
     ConnectionError {} -> True
     ProviderError WebSocketConnectionLimitReached _ _ -> True
     -- A server that does not support the Responses WebSocket protocol
     -- advertises that explicitly with HTTP 426.
     HttpError 426 _ -> True
-    _ -> False
+    -- Some direct ChatGPT accounts reject only the WebSocket upgrade while
+    -- accepting the same Responses request over HTTPS. Match the transport's
+    -- exact handshake fingerprint so an application-level 403 remains a
+    -- permission error.
+    _ -> WebSocket.webSocketHandshakeFailureStatus err == Just 403
 
 -- | A WebSocket failure whose request has already produced provider output.
 --

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -21,6 +21,7 @@ module Agent.OpenAI.LoopBackend
     , openAiBackendWithTransportFallback
     , withCodexTurnStateScope
     , isOpenAiWebSocketTransportFailure
+    , isOpenAiReplayUnsafeWebSocketTransportFailure
     , statelessResponsesBackend
     , turnInputsToItems
     , responseToTurnOutput
@@ -463,19 +464,35 @@ replayUnsafeError :: Text -> ApiError -> ApiError
 replayUnsafeError outputLabel err =
     if isReplayUnsafeError err
         then err
-        else ProviderError (UnknownErrorType "replay_unsafe")
+        else ProviderError replayUnsafeType
             ( "provider failed after "
                 <> outputLabel
                 <> "; refusing to replay: "
                 <> Text.pack (show err)
             )
             Nothing
+  where
+    -- Retain transport provenance in the structured error type. Auxiliary
+    -- callers must not replay a request after an opaque checkpoint arrived,
+    -- but they still need to retire the broken WebSocket for later requests.
+    replayUnsafeType
+        | isOpenAiWebSocketTransportFailure err =
+            UnknownErrorType replayUnsafeWebSocketTransportType
+        | otherwise = UnknownErrorType replayUnsafeTypeName
 
 isReplayUnsafeError :: ApiError -> Bool
 isReplayUnsafeError = \case
     ProviderError (UnknownErrorType errorType) _ _ ->
-        errorType == "replay_unsafe"
+        errorType == replayUnsafeTypeName
+            || errorType == replayUnsafeWebSocketTransportType
     _ -> False
+
+replayUnsafeTypeName :: Text
+replayUnsafeTypeName = "replay_unsafe"
+
+replayUnsafeWebSocketTransportType :: Text
+replayUnsafeWebSocketTransportType =
+    "replay_unsafe_websocket_transport"
 
 -- | Prefer a WebSocket backend, then switch this agent session permanently to
 -- a fallback transport once the socket has failed.
@@ -556,6 +573,17 @@ isOpenAiWebSocketTransportFailure = \case
     -- A server that does not support the Responses WebSocket protocol
     -- advertises that explicitly with HTTP 426.
     HttpError 426 _ -> True
+    _ -> False
+
+-- | A WebSocket failure whose request has already produced provider output.
+--
+-- The connection should not be reused, but the failed logical request must
+-- not be replayed: an auxiliary response may contain a billable opaque
+-- compaction checkpoint even when no text was rendered.
+isOpenAiReplayUnsafeWebSocketTransportFailure :: ApiError -> Bool
+isOpenAiReplayUnsafeWebSocketTransportFailure = \case
+    ProviderError (UnknownErrorType errorType) _ _ ->
+        errorType == replayUnsafeWebSocketTransportType
     _ -> False
 
 -- | Reset Codex sticky-routing state when a backend submission starts a new

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -1,7 +1,9 @@
 module Agent.OpenAI.WebSocketClient
     ( withCodexWs
     , withCodexWsWithProvider
+    , withCodexWsWithProviderOrHttpFallback
     , withCodexWsCredential
+    , withCodexWsCredentialOrHttpFallback
     , withCodexWsCredentialUsingTurnState
     , withCodexWsRetrying
     , withCodexWsRetryingAfter
@@ -34,6 +36,8 @@ module Agent.OpenAI.WebSocketClient
     , WebSocketReceiveActions(..)
     , receiveWsResponseWithActions
     , CodexConn
+    , codexConnUsesHttpFallback
+    , shouldFallbackDirectCodexHandshakeToHttp
     , closeCodexConn
     , CodexAuthFailed(..)
     ) where
@@ -110,12 +114,22 @@ newtype CodexTurnState = CodexTurnState (IORef (Maybe Text))
 data CodexConn = CodexWsConn
     !WebSocket.WebSocketSession
     !CodexTurnState
+    | CodexHttpFallback
+    !CodexTurnState
 
 newCodexTurnState :: IO CodexTurnState
 newCodexTurnState = CodexTurnState <$> newIORef Nothing
 
 codexConnTurnState :: CodexConn -> CodexTurnState
 codexConnTurnState (CodexWsConn _ turnState) = turnState
+codexConnTurnState (CodexHttpFallback turnState) = turnState
+
+-- | Whether persistent session acquisition had to bypass WebSockets. The
+-- marker still owns turn-scoped routing state so the HTTP backend can preserve
+-- the same continuation and compaction semantics as a live socket.
+codexConnUsesHttpFallback :: CodexConn -> Bool
+codexConnUsesHttpFallback CodexWsConn{} = False
+codexConnUsesHttpFallback CodexHttpFallback{} = True
 
 readCodexTurnState :: CodexTurnState -> IO (Maybe Text)
 readCodexTurnState (CodexTurnState turnState) = readIORef turnState
@@ -144,6 +158,7 @@ finishCodexTurnStateResponse turnState response
 closeCodexConn :: CodexConn -> IO ()
 closeCodexConn (CodexWsConn session _) =
     WebSocket.closeWebSocketSession session "switching account"
+closeCodexConn CodexHttpFallback{} = pure ()
 
 -- | Carry the current logical turn's sticky-routing token across a physical
 -- reconnect. Codex scopes this state to the turn rather than to the socket.
@@ -211,6 +226,28 @@ withCodexWsWithProvider provider action =
         Left err -> Exception.throwIO (CodexAuthFailed err)
         Right value -> pure value
 
+-- | Persistent-session acquisition with a direct HTTPS escape hatch.
+--
+-- Some ChatGPT accounts can use the Codex Responses API over HTTPS while the
+-- WebSocket upgrade is rejected with HTTP 403 (or 426). Convert only that exact
+-- pre-callback handshake error for a direct credential into an HTTP-fallback
+-- marker. Gateway credentials remain WebSocket-only, so their rejection is
+-- still returned to the token provider and may rotate to a direct account.
+withCodexWsWithProviderOrHttpFallback
+    :: TokenProvider
+    -> (CodexConn -> Credential -> IO a)
+    -> IO a
+withCodexWsWithProviderOrHttpFallback provider action =
+    runWithTokenProvider provider
+        (\credential ->
+            runPersistentConnectionAttempt
+                WebSocket.transientWsConnectRetryPolicy
+                credential
+                action)
+        >>= \case
+            Left err -> Exception.throwIO (CodexAuthFailed err)
+            Right value -> pure value
+
 -- | Open one exact credential for an interactive account switch. Connection
 -- retries are deliberately bounded so the selector cannot hang indefinitely.
 withCodexWsCredential
@@ -222,6 +259,50 @@ withCodexWsCredential credential action =
         (limitRetries 2 <> exponentialBackoff 500000)
         credential
         (\conn activeCredential -> Right <$> action conn activeCredential)
+
+-- | Exact-credential variant of
+-- 'withCodexWsWithProviderOrHttpFallback', used by interactive account
+-- switches.
+withCodexWsCredentialOrHttpFallback
+    :: Credential
+    -> (CodexConn -> Credential -> IO a)
+    -> IO (Either ApiError a)
+withCodexWsCredentialOrHttpFallback credential =
+    runPersistentConnectionAttempt
+        (limitRetries 2 <> exponentialBackoff 500000)
+        credential
+
+runPersistentConnectionAttempt
+    :: RetryPolicyM IO
+    -> Credential
+    -> (CodexConn -> Credential -> IO a)
+    -> IO (Either ApiError a)
+runPersistentConnectionAttempt retryPolicy credential action = do
+    result <-
+        runConnectionAttemptWithPolicy
+            retryPolicy
+            credential
+            (\conn activeCredential ->
+                Right <$> action conn activeCredential)
+    case result of
+        Left err
+            | shouldFallbackDirectCodexHandshakeToHttp credential err -> do
+                turnState <- newCodexTurnState
+                Right <$> action (CodexHttpFallback turnState) credential
+        _ -> pure result
+
+-- | Recognize only the transport's exact pre-upgrade failure. A generic
+-- application-level 403 must remain a permission error, and gateways cannot
+-- use the direct ChatGPT HTTPS endpoint.
+shouldFallbackDirectCodexHandshakeToHttp
+    :: Credential
+    -> ApiError
+    -> Bool
+shouldFallbackDirectCodexHandshakeToHttp credential err =
+    credential.provider == OpenAIProvider
+        && not (isGatewayWebSocketCredential credential)
+        && WebSocket.webSocketHandshakeFailureStatus err `elem`
+            [Just 403, Just 426]
 
 -- | Open a disposable physical connection for an existing logical turn using
 -- one already-selected credential. Keeping credential selection outside this
@@ -632,6 +713,9 @@ sendWsRequestWithEventsAndOptions
 sendWsRequestWithEventsAndOptions completion options cc request previousResponseId
         onEvent = case cc of
     CodexWsConn session turnState -> sendOverWs session turnState
+    CodexHttpFallback{} ->
+        pure $ Left $ ConnectionError
+            "OpenAI WebSocket unavailable; HTTPS fallback required"
   where
     sendOverWs session turnState = do
         turnStateValue <- readCodexTurnState turnState

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1388,6 +1388,24 @@ spec = do
                 , HttpError 503 "unavailable"
                 ]
 
+        it "retains WebSocket provenance without making replay safe" do
+            let failure =
+                    replayUnsafeAuxiliaryFailure
+                        (ConnectionError
+                            "WebSocket receive error: ParseException \"not enough bytes\"")
+            isOpenAiReplayUnsafeWebSocketTransportFailure failure
+                `shouldBe` True
+            -- Callers use the ordinary predicate only when replaying the same
+            -- logical request over HTTP is safe.
+            isOpenAiWebSocketTransportFailure failure `shouldBe` False
+
+        it "does not label post-output provider failures as transport failures" do
+            let failure =
+                    replayUnsafeAuxiliaryFailure
+                        (ProviderError ApiErrorType "server error" Nothing)
+            isOpenAiReplayUnsafeWebSocketTransportFailure failure
+                `shouldBe` False
+
     describe "openAiBackendWithTransportFallback" do
         it "switches permanently to fallback after a pre-output connection error" do
             fallbackActive <- newIORef False
@@ -1972,11 +1990,16 @@ isAuxiliaryOutputEvent = streamOutputObserved
 
 replayUnsafeAuxiliaryFailure :: ApiError -> ApiError
 replayUnsafeAuxiliaryFailure failure =
-    ProviderError (UnknownErrorType "replay_unsafe")
+    ProviderError replayUnsafeType
         ( "provider failed after auxiliary response output; refusing to replay: "
             <> Text.pack (show failure)
         )
         Nothing
+  where
+    replayUnsafeType
+        | isOpenAiWebSocketTransportFailure failure =
+            UnknownErrorType "replay_unsafe_websocket_transport"
+        | otherwise = UnknownErrorType "replay_unsafe"
 
 isInputFile :: ResponseContentPart -> Bool
 isInputFile = \case

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1406,6 +1406,20 @@ spec = do
             isOpenAiReplayUnsafeWebSocketTransportFailure failure
                 `shouldBe` False
 
+    describe "isOpenAiWebSocketTransportFailure" do
+        it "recognizes an exact WebSocket handshake 403" do
+            isOpenAiWebSocketTransportFailure
+                (HttpError 403 "WebSocket handshake returned HTTP 403")
+                `shouldBe` True
+
+        it "does not hide application permission or authentication errors" do
+            isOpenAiWebSocketTransportFailure
+                (HttpError 403 "model access denied")
+                `shouldBe` False
+            isOpenAiWebSocketTransportFailure
+                (HttpError 401 "WebSocket handshake returned HTTP 401")
+                `shouldBe` False
+
     describe "openAiBackendWithTransportFallback" do
         it "switches permanently to fallback after a pre-output connection error" do
             fallbackActive <- newIORef False

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -124,6 +124,37 @@ spec = do
         validateGatewayWebSocketUrl "https://gateway.example/v1/responses"
             `shouldSatisfy` isLeft
 
+  describe "shouldFallbackDirectCodexHandshakeToHttp" do
+    let direct = Credential
+            { accessToken = "token"
+            , accountId = "chatgpt-account"
+            , leaseId = Nothing
+            , provider = OpenAIProvider
+            }
+        gateway = direct
+            { accountId = "wss://gateway.example/v1/responses" }
+
+    it "accepts exact direct WebSocket handshake 403 and 426 failures" do
+        shouldFallbackDirectCodexHandshakeToHttp direct
+            (HttpError 403 "WebSocket handshake returned HTTP 403")
+            `shouldBe` True
+        shouldFallbackDirectCodexHandshakeToHttp direct
+            (HttpError 426 "WebSocket handshake returned HTTP 426")
+            `shouldBe` True
+
+    it "does not hide application permission errors or authentication failures" do
+        shouldFallbackDirectCodexHandshakeToHttp direct
+            (HttpError 403 "model access denied")
+            `shouldBe` False
+        shouldFallbackDirectCodexHandshakeToHttp direct
+            (HttpError 401 "WebSocket handshake returned HTTP 401")
+            `shouldBe` False
+
+    it "keeps gateway credentials WebSocket-only" do
+        shouldFallbackDirectCodexHandshakeToHttp gateway
+            (HttpError 403 "WebSocket handshake returned HTTP 403")
+            `shouldBe` False
+
   describe "buildWsPayloadWithOptions" do
     it "forces store=false for the Codex WebSocket contract" do
         let request = sampleRequest { store = Just True }


### PR DESCRIPTION
## Summary
- fall back to the HTTPS Responses transport when a direct OpenAI WebSocket upgrade is rejected with an exact handshake 403 or 426
- preserve gateway-account rotation and avoid treating ordinary application-level permission errors as transport failures
- apply recovery to startup, account switches, reconnects, subagents, and auxiliary compaction
- retire a WebSocket after a replay-unsafe compaction failure without replaying the current opaque checkpoint

## Tests
- `nix develop -c cabal test agent-openai:test:agent-openai-test --test-show-details=direct` (331 examples, 0 failures, 1 pending live-token test)
- `nix develop -c cabal build agent-cli:lib:agent-cli`
- `git diff --check origin/master...HEAD`
