### PR TITLE
fix: expose computer use to Responses Lite

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -143,7 +143,7 @@ import Agent.Store.Postgres
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
-    , ToolCallKind(..)
+    , isComputerToolCallKind
     )
 import Agent.Tools.Types (AppTool)
 import Control.Concurrent (forkFinally, forkIO)
@@ -2036,7 +2036,7 @@ requestApproval
 requestApproval callback context control call = do
     alreadyAllowed <- Set.member call.name
         <$> readTVarIO control.turnControlAllowedTools
-    if alreadyAllowed && call.callKind /= ComputerCallKind
+    if alreadyAllowed && not (isComputerToolCallKind call.callKind)
       then pure (Just PermissionAllowOnce)
       else requestApprovalFromClient callback context control call
 
@@ -2084,7 +2084,7 @@ requestApprovalFromClient callback context control call = do
             (Map.delete approvalId)
     case choice of
         PermissionAllowTool
-            | call.callKind /= ComputerCallKind ->
+            | not (isComputerToolCallKind call.callKind) ->
             atomically $
                 modifyTVar'
                     control.turnControlAllowedTools

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -28,8 +28,8 @@ import Agent.JsonText (jsonTextFieldDefault)
 import Agent.OsPath (fromText)
 import Agent.ToolDispatch
     ( ToolCall(..)
-    , ToolCallKind(..)
     , canonicalToolName
+    , isComputerToolCallKind
     )
 import Agent.Tools.Dangerous (shellCommandBlocked)
 import Agent.Tools.PlanMode
@@ -170,7 +170,7 @@ approveToolDecisionWithReporterAndPersistence requestPermission report persistAl
                     if isPlanFileWrite planActive planPath call
                         then pure (Right True)
                         else do
-                            if call.callKind == ComputerCallKind
+                            if isComputerToolCallKind call.callKind
                                 then requestPermission call >>= \case
                                     Nothing -> pure (Right False)
                                     Just PermissionDeny -> pure (Right False)
@@ -277,7 +277,7 @@ childApprove _ tools call
         pure $ Left
             "Mismatched provider-native tool call kind requires parent review."
 childApprove _ _ call
-    | call.callKind == ComputerCallKind =
+    | isComputerToolCallKind call.callKind =
         pure $ Left
             "Computer use requires an explicit parent approval for every call."
 childApprove policy tools call = case policy of

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -23,7 +23,12 @@ import Agent.Responses.Types
     , SafetyCheck(..)
     , TaggedObject(..)
     )
-import Agent.ToolDispatch (ToolCall(..), noArgsTool, typedTool)
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , ToolCallKind(..)
+    , noArgsTool
+    , typedToolWithCall
+    )
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
@@ -66,12 +71,49 @@ computerUseTool = AppTool
     }
   where
     handler
-        | os == "darwin" = typedTool "computer" executeComputerCall
+        | os == "darwin" =
+            typedToolWithCall "computer" \call input ->
+                executeComputerCallWith
+                    (case call.callKind of
+                        ComputerFunctionCallKind -> ScreenshotJpeg
+                        _ -> ScreenshotPng)
+                    (computerCallFromInput call input)
         | otherwise = noArgsTool "computer"
             (pure (Left "Local computer use is currently supported only on macOS."))
 
+data ComputerToolInput = ComputerToolInput
+    { toolComputerActions :: ![ComputerAction]
+    , toolPendingSafetyChecks :: ![SafetyCheck]
+    }
+
+instance Aeson.FromJSON ComputerToolInput where
+    parseJSON = Aeson.withObject "ComputerToolInput" \object ->
+        ComputerToolInput
+            <$> object Aeson..:? "actions" Aeson..!= []
+            <*> object Aeson..:? "pending_safety_checks" Aeson..!= []
+
+computerCallFromInput :: ToolCall -> ComputerToolInput -> ComputerCall
+computerCallFromInput call input = ComputerCall
+    { computerCallItemId = Nothing
+    , computerCallId = call.callId
+    , computerActions = input.toolComputerActions
+    , pendingSafetyChecks = input.toolPendingSafetyChecks
+    , computerCallStatus = Nothing
+    , computerCallExtra = KeyMap.empty
+    }
+
 executeComputerCall :: ComputerCall -> IO (Either Text Text)
-executeComputerCall call
+executeComputerCall = executeComputerCallWith ScreenshotPng
+
+data ScreenshotEncoding
+    = ScreenshotPng
+    | ScreenshotJpeg
+
+executeComputerCallWith
+    :: ScreenshotEncoding
+    -> ComputerCall
+    -> IO (Either Text Text)
+executeComputerCallWith screenshotEncoding call
     | Left err <- validateComputerCall call = pure (Left err)
     | otherwise = do
         unlocked <- ensureUnlockedSession
@@ -99,7 +141,9 @@ executeComputerCall call
                                                 pure (Left
                                                     "The main display changed during computer use; take a fresh screenshot before continuing.")
                                             | otherwise ->
-                                                screenshotMainDisplay display
+                                                screenshotMainDisplayWith
+                                                    screenshotEncoding
+                                                    display
                                                     >>= \case
                                                         Left err ->
                                                             pure (Left err)
@@ -478,17 +522,32 @@ screenshotUnlockedMacOS = do
         Right display -> screenshotMainDisplay display
 
 screenshotMainDisplay :: (Int, Int) -> IO (Either Text ImageAttachment)
-screenshotMainDisplay (width, height) = do
+screenshotMainDisplay = screenshotMainDisplayWith ScreenshotPng
+
+screenshotMainDisplayWith
+    :: ScreenshotEncoding
+    -> (Int, Int)
+    -> IO (Either Text ImageAttachment)
+screenshotMainDisplayWith encoding (width, height) = do
     temporaryDirectory <- getTemporaryDirectory
     attempted <- tryAny do
+        let (suffix, format, mime, formatOptions) = case encoding of
+                ScreenshotPng ->
+                    (".png", "png", "image/png", [])
+                -- Responses Lite accounts inline image bytes against its
+                -- context. Preserve logical display dimensions while making
+                -- iterative screenshots substantially smaller.
+                ScreenshotJpeg ->
+                    (".jpg", "jpg", "image/jpeg",
+                        ["-s", "formatOptions", "80"])
         (path, handle) <- openBinaryTempFile temporaryDirectory
-            "agent-computer-use-.png"
+            ("agent-computer-use-" <> suffix)
         hClose handle
         let cleanup = removeFile path
         flip finally cleanup do
             capture <- readProcessWithExitCode
                 "/usr/sbin/screencapture"
-                ["-x", "-m", "-C", "-t", "png", path]
+                ["-x", "-m", "-C", "-t", format, path]
                 ""
             case capture of
                 (ExitFailure _, _, stderr) ->
@@ -496,7 +555,9 @@ screenshotMainDisplay (width, height) = do
                 (ExitSuccess, _, _) -> do
                     resized <- readProcessWithExitCode
                         "/usr/bin/sips"
-                        [ "-z", show height, show width, path ]
+                        ([ "-z", show height, show width ]
+                            <> formatOptions
+                            <> [path])
                         ""
                     case resized of
                         (ExitFailure _, _, stderr) ->
@@ -506,7 +567,7 @@ screenshotMainDisplay (width, height) = do
                             pure $ if BS.null bytes
                                 then Left
                                     "Screen capture returned an empty image. Grant Screen Recording permission to the terminal or agent app."
-                                else Right (ImageAttachment "image/png" bytes)
+                                else Right (ImageAttachment mime bytes)
     pure $ either (Left . Text.pack . show) id attempted
 
 mainDisplayLogicalSize :: IO (Either Text (Int, Int))
@@ -650,8 +711,9 @@ summarizeComputerToolCall call
         case Aeson.eitherDecodeStrict'
             (TextEncoding.encodeUtf8 call.arguments) of
             Left _ -> Just "Computer action"
-            Right computerCall ->
-                let detail = summarizeComputerCall computerCall
+            Right input ->
+                let computerCall = computerCallFromInput call input
+                    detail = summarizeComputerCall computerCall
                 in Just $
                     if Text.null detail
                         then "Computer action"

--- a/packages/agent-cli/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli/src/Agent/CLI/Request.hs
@@ -41,7 +41,9 @@ requestParams provider modelName instructionText toolSchemas effort =
                     if responsesLite
                         then Just
                             (ResponseInputItems
-                                (responsesLitePrefix instructionText toolSchemas))
+                                (responsesLitePrefix
+                                    instructionText
+                                    toolSchemas))
                         else Nothing
                 , include =
                     Just [ResponseInclude "reasoning.encrypted_content"]
@@ -93,7 +95,10 @@ setRequestModel provider modelName params
                     { model = Just modelName
                     , instructions = Nothing
                     , input = Just (ResponseInputItems
-                        (responsesLitePrefix instructionText toolSchemas <> suffix))
+                        (responsesLitePrefix
+                            instructionText
+                            toolSchemas
+                            <> suffix))
                     , parallelToolCalls = Just False
                     , reasoning = setReasoningContext
                         (Just "all_turns")
@@ -194,7 +199,9 @@ updateResponsesLitePrefix instructionText maybeTools existingInput =
 
 -- | Convert conventional Responses tools to the Lite @additional_tools@
 -- representation. Function and custom tools share the default @functions@
--- namespace; hosted tools and non-default namespaces remain top-level.
+-- namespace. The ChatGPT/Codex Responses Lite transport does not accept the
+-- native @computer@ tool, so expose its local harness in a reserved namespace
+-- whose function output can carry a screenshot back to the model.
 responsesLiteToolValues :: [ResponseTool] -> [Aeson.Value]
 responsesLiteToolValues tools =
     case groupedValues of
@@ -223,7 +230,140 @@ responsesLiteToolValues tools =
                 , ungrouped
                 )
             Nothing ->
-                (firstPosition, grouped, description, ungrouped <> [Aeson.toJSON tool])
+                ( firstPosition
+                , grouped
+                , description
+                , ungrouped <> [responsesLiteToolValue tool]
+                )
+
+responsesLiteToolValue :: ResponseTool -> Aeson.Value
+responsesLiteToolValue = \case
+    KnownResponseTool ToolComputer _ -> computerFunctionNamespaceValue
+    tool -> Aeson.toJSON tool
+
+computerFunctionNamespaceValue :: Aeson.Value
+computerFunctionNamespaceValue = Aeson.object
+    [ "type" Aeson..= ("namespace" :: Text)
+    , "name" Aeson..= computerFunctionNamespace
+    , "description" Aeson..=
+        ("Inspect and control the local macOS desktop. Every call returns a fresh screenshot." :: Text)
+    , "tools" Aeson..=
+        [ Aeson.object
+            [ "type" Aeson..= ("function" :: Text)
+            , "name" Aeson..= computerFunctionName
+            , "description" Aeson..=
+                ("Run one or more approved desktop actions and return a fresh screenshot. Start with screenshot when the UI state is unknown." :: Text)
+            , "parameters" Aeson..= computerFunctionParameters
+            , "strict" Aeson..= True
+            ]
+        ]
+    ]
+
+computerFunctionParameters :: Aeson.Value
+computerFunctionParameters = Aeson.object
+    [ "type" Aeson..= ("object" :: Text)
+    , "properties" Aeson..= Aeson.object
+        [ "actions" Aeson..= Aeson.object
+            [ "type" Aeson..= ("array" :: Text)
+            , "description" Aeson..=
+                ("Ordered desktop actions. Coordinates are logical pixels on the main display." :: Text)
+            , "items" Aeson..= Aeson.object
+                [ "anyOf" Aeson..= computerActionSchemas ]
+            , "minItems" Aeson..= (1 :: Int)
+            , "maxItems" Aeson..= (128 :: Int)
+            ]
+        ]
+    , "required" Aeson..= ["actions" :: Text]
+    , "additionalProperties" Aeson..= False
+    ]
+
+computerActionSchemas :: [Aeson.Value]
+computerActionSchemas =
+    [ actionSchema "screenshot" []
+    , actionSchema "click"
+        [ ("x", integerProperty)
+        , ("y", integerProperty)
+        , ("button", enumProperty
+            ["left", "right", "middle", "back", "forward"])
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "double_click"
+        [ ("x", integerProperty)
+        , ("y", integerProperty)
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "scroll"
+        [ ("x", integerProperty)
+        , ("y", integerProperty)
+        , ("scroll_x", integerProperty)
+        , ("scroll_y", integerProperty)
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "move"
+        [ ("x", integerProperty)
+        , ("y", integerProperty)
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "drag"
+        [ ("path", Aeson.object
+            [ "type" Aeson..= ("array" :: Text)
+            , "items" Aeson..= Aeson.object
+                [ "type" Aeson..= ("object" :: Text)
+                , "properties" Aeson..= Aeson.object
+                    [ "x" Aeson..= integerProperty
+                    , "y" Aeson..= integerProperty
+                    ]
+                , "required" Aeson..= ["x" :: Text, "y"]
+                , "additionalProperties" Aeson..= False
+                ]
+            , "minItems" Aeson..= (2 :: Int)
+            , "maxItems" Aeson..= (1024 :: Int)
+            ])
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "type"
+        [ ("text", Aeson.object
+            [ "type" Aeson..= ("string" :: Text)
+            , "maxLength" Aeson..= (8192 :: Int)
+            ])
+        ]
+    , actionSchema "keypress" [("keys", keysProperty)]
+    , actionSchema "wait" []
+    ]
+  where
+    integerProperty :: Aeson.Value
+    integerProperty = Aeson.object ["type" Aeson..= ("integer" :: Text)]
+    keysProperty :: Aeson.Value
+    keysProperty = Aeson.object
+        [ "type" Aeson..= ("array" :: Text)
+        , "items" Aeson..= Aeson.object
+            [ "type" Aeson..= ("string" :: Text)
+            , "maxLength" Aeson..= (64 :: Int)
+            ]
+        , "maxItems" Aeson..= (16 :: Int)
+        ]
+    enumProperty :: [Text] -> Aeson.Value
+    enumProperty values = Aeson.object
+        [ "type" Aeson..= ("string" :: Text)
+        , "enum" Aeson..= values
+        ]
+
+actionSchema :: Text -> [(Text, Aeson.Value)] -> Aeson.Value
+actionSchema actionType properties = Aeson.object
+    [ "type" Aeson..= ("object" :: Text)
+    , "properties" Aeson..= Aeson.Object
+        (KeyMap.fromList
+            ((Key.fromText "type", enumProperty [actionType])
+                : [(Key.fromText name, value) | (name, value) <- properties]))
+    , "required" Aeson..= ("type" : map fst properties)
+    , "additionalProperties" Aeson..= False
+    ]
+  where
+    enumProperty :: [Text] -> Aeson.Value
+    enumProperty values = Aeson.object
+        [ "type" Aeson..= ("string" :: Text)
+        , "enum" Aeson..= values
+        ]
 
 groupedToolValues :: ResponseTool -> Maybe ([Aeson.Value], Maybe Text)
 groupedToolValues tool = case tool of
@@ -292,12 +432,22 @@ liteToolValuesToConventional = concatMap flatten
   where
     flatten value@(Aeson.Object object)
         | textField "type" object == Just "namespace"
+        , textField "name" object == Just computerFunctionNamespace
+        , any isComputerFunction (arrayField "tools" object) =
+            [knownResponseTool ToolComputer KeyMap.empty]
+        | textField "type" object == Just "namespace"
         , textField "name" object == Just "functions" =
             mapMaybe decodeTool (arrayField "tools" object)
         | otherwise = maybeToListDecoded value
     flatten value = maybeToListDecoded value
 
     maybeToListDecoded value = maybe [] pure (decodeTool value)
+
+    isComputerFunction = \case
+        Aeson.Object object ->
+            textField "type" object == Just "function"
+                && textField "name" object == Just computerFunctionName
+        _ -> False
 
 decodeTool :: Aeson.Value -> Maybe ResponseTool
 decodeTool value = case Aeson.fromJSON value of

--- a/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
@@ -17,7 +17,10 @@ import Agent.CLI.Database.Storage
     ( postgresStorageCommandEnv
     , runStorageCommand
     )
-import Agent.CLI.ComputerUse (summarizeComputerCall)
+import Agent.CLI.ComputerUse
+    ( summarizeComputerCall
+    , summarizeComputerToolCall
+    )
 import Agent.CLI.Login
     ( AccountBilling(..)
     , LoginAccount(..)
@@ -52,6 +55,7 @@ import Agent.CLI.SessionLock
     )
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (providerSlug)
+import Agent.Responses.LoopBackend (responseItemToToolCall)
 import Agent.Responses.Types
     ( ComputerCall(..)
     , ComputerCallOutput(..)
@@ -60,6 +64,8 @@ import Agent.Responses.Types
     , FunctionCall(..)
     , FunctionCallOutput(..)
     , ResponseItem(..)
+    , computerFunctionName
+    , computerFunctionNamespace
     )
 import Agent.Store.Postgres
     ( ManagedPostgresConfig
@@ -76,10 +82,11 @@ import Control.Monad
     , when
     )
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.Int (Int64)
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -308,12 +315,29 @@ sessionToolEvents turn =
 
 sessionToolEvent :: ResponseItem -> Maybe Aeson.Value
 sessionToolEvent = \case
+    item@(FunctionCallItem call)
+        | call.namespace == Just computerFunctionNamespace
+        , call.name == computerFunctionName ->
+            let summary = fromMaybe "Computer action"
+                    (responseItemToToolCall item
+                        >>= summarizeComputerToolCall)
+            in Just $
+                toolStartedJSON
+                    call.callId
+                    "computer"
+                    (TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode $
+                        Aeson.object ["summary" Aeson..= summary])
     FunctionCallItem call ->
         Just (toolStartedJSON call.callId call.name call.arguments)
     CustomToolCallItem call ->
         Just (toolStartedJSON call.callId call.name call.input)
     FunctionCallOutputItem result ->
-        Just (toolFinishedJSON result.callId (renderToolValue result.output))
+        Just
+            (toolFinishedJSON
+                result.callId
+                (if containsInputImage result.output
+                    then "Screenshot captured"
+                    else renderToolValue result.output))
     CustomToolCallOutputItem result ->
         Just (toolFinishedJSON result.callId (renderToolValue result.output))
     ComputerCallItem call ->
@@ -331,6 +355,14 @@ sessionToolEvent = \case
                 result.computerOutputCallId
                 "Screenshot captured")
     _ -> Nothing
+
+containsInputImage :: Aeson.Value -> Bool
+containsInputImage = \case
+    Aeson.Object object ->
+        KeyMap.lookup "type" object == Just (Aeson.String "input_image")
+            || any containsInputImage object
+    Aeson.Array values -> any containsInputImage values
+    _ -> False
 
 toolStartedJSON :: Text -> Text -> Text -> Aeson.Value
 toolStartedJSON callId name arguments =

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -270,22 +270,21 @@ spec = do
             let request _ = do
                     modifyIORef' permissionRequests (+ 1)
                     pure (Just PermissionAllowTool)
-                computerCall = ToolCall
+                computerCall kind = ToolCall
                     { callId = "computer-1"
                     , name = "computer"
                     , arguments = "{}"
-                    , callKind = ComputerCallKind
+                    , callKind = kind
                     , argumentsEncrypted = False
                     }
-            approveToolDecisionWithReporter
-                request (\_ -> pure ()) policy allowed
-                (registry [mutatingTool]) plan computerCall
-                `shouldReturn` Right True
-            approveToolDecisionWithReporter
-                request (\_ -> pure ()) policy allowed
-                (registry [mutatingTool]) plan computerCall
-                `shouldReturn` Right True
-            readIORef permissionRequests `shouldReturn` 2
+                approve kind = approveToolDecisionWithReporter
+                    request (\_ -> pure ()) policy allowed
+                    (registry [mutatingTool]) plan (computerCall kind)
+            mapM_ (\kind -> do
+                approve kind `shouldReturn` Right True
+                approve kind `shouldReturn` Right True)
+                [ComputerCallKind, ComputerFunctionCallKind]
+            readIORef permissionRequests `shouldReturn` 4
             readIORef policy `shouldReturn` ApproveAll
             readIORef allowed `shouldReturn` Set.empty
 
@@ -298,22 +297,21 @@ spec = do
             let request _ = do
                     modifyIORef' permissionRequests (+ 1)
                     pure (Just PermissionAllowTool)
-                computerCall = ToolCall
+                computerCall kind = ToolCall
                     { callId = "computer-1"
                     , name = "computer"
                     , arguments = "{}"
-                    , callKind = ComputerCallKind
+                    , callKind = kind
                     , argumentsEncrypted = False
                     }
-            approveToolDecisionWithReporter
-                request (\_ -> pure ()) policy allowed
-                (registry [mutatingTool]) plan computerCall
-                `shouldReturn` Right True
-            approveToolDecisionWithReporter
-                request (\_ -> pure ()) policy allowed
-                (registry [mutatingTool]) plan computerCall
-                `shouldReturn` Right True
-            readIORef permissionRequests `shouldReturn` 2
+                approve kind = approveToolDecisionWithReporter
+                    request (\_ -> pure ()) policy allowed
+                    (registry [mutatingTool]) plan (computerCall kind)
+            mapM_ (\kind -> do
+                approve kind `shouldReturn` Right True
+                approve kind `shouldReturn` Right True)
+                [ComputerCallKind, ComputerFunctionCallKind]
+            readIORef permissionRequests `shouldReturn` 4
             readIORef allowed `shouldReturn` Set.empty
 
         it "rejects spoofed function/custom computer calls under ApproveAll" do
@@ -352,19 +350,21 @@ spec = do
                 `shouldReturn` Right True
 
         it "never lets a child bypass computer approval" do
-            let computerCall = ToolCall
+            let computerCall kind = ToolCall
                     { callId = "computer-1"
                     , name = "computer"
                     , arguments = "{}"
-                    , callKind = ComputerCallKind
+                    , callKind = kind
                     , argumentsEncrypted = False
                     }
-            childApprove ApproveAll
-                (registry [mutatingTool])
-                computerCall
-                `shouldReturn`
-                    Left
-                        "Computer use requires an explicit parent approval for every call."
+            mapM_ (\kind ->
+                childApprove ApproveAll
+                    (registry [mutatingTool])
+                    (computerCall kind)
+                    `shouldReturn`
+                        Left
+                            "Computer use requires an explicit parent approval for every call.")
+                [ComputerCallKind, ComputerFunctionCallKind]
 
         it "allows only read-only tools under DenyMutating" do
             childApprove DenyMutating (registry [readOnlyTool]) readOnlyCall

--- a/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
@@ -302,6 +302,51 @@ spec = do
             encoded `shouldSatisfy`
                 (not . ("large-private-payload" `Text.isInfixOf`))
 
+        it "redacts reserved computer function arguments and screenshot output" do
+            let call = FunctionCall
+                    { itemId = Nothing
+                    , callId = "call-function"
+                    , name = computerFunctionName
+                    , namespace = Just computerFunctionNamespace
+                    , arguments =
+                        "{\"actions\":[{\"type\":\"type\",\
+                        \\"text\":\"top secret\"}]}"
+                    , encryptedFunctionArgs = Nothing
+                    , status = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                output = FunctionCallOutput
+                    { itemId = Nothing
+                    , callId = "call-function"
+                    , name = Nothing
+                    , namespace = Nothing
+                    , output = Aeson.toJSON
+                        [ Aeson.object
+                            [ "type" Aeson..= ("input_image" :: Text.Text)
+                            , "image_url" Aeson..=
+                                ("data:image/png;base64,large-private-payload"
+                                    :: Text.Text)
+                            ]
+                        ]
+                    , status = Nothing
+                    , extraFields = KeyMap.empty
+                    }
+                encoded =
+                    TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode $
+                        [ sessionToolEvent (FunctionCallItem call)
+                        , sessionToolEvent (FunctionCallOutputItem output)
+                        ]
+            encoded `shouldSatisfy`
+                ("\"name\":\"computer\"" `Text.isInfixOf`)
+            encoded `shouldSatisfy`
+                ("type 10 characters" `Text.isInfixOf`)
+            encoded `shouldSatisfy`
+                ("\"output\":\"Screenshot captured\"" `Text.isInfixOf`)
+            encoded `shouldSatisfy`
+                (not . ("top secret" `Text.isInfixOf`))
+            encoded `shouldSatisfy`
+                (not . ("large-private-payload" `Text.isInfixOf`))
+
 toolCall :: ComputerCall -> ToolCall
 toolCall call = ToolCall
     { callId = call.computerCallId

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -85,6 +85,42 @@ spec = describe "requestParams" do
             _ -> expectationFailure
                 "expected additional_tools and base-instructions input prefix"
 
+    it "projects hosted computer into the Responses Lite function harness" do
+        let computerTool = knownResponseTool ToolComputer KeyMap.empty
+            params =
+                requestParams
+                    OpenAIProvider
+                    "gpt-5.6-sol"
+                    "base instructions"
+                    [webSearchTool, computerTool, functionTool "lookup"]
+                    "high"
+
+        params.tools `shouldBe` Nothing
+        jsonArrayField "tools" (Aeson.toJSON params) `shouldBe` []
+        map toolIdentity (additionalToolValues params)
+            `shouldBe`
+                [ (Just "web_search", Nothing)
+                , (Just "namespace", Just computerFunctionNamespace)
+                , (Just "namespace", Just "functions")
+                ]
+        map toolIdentity
+            (computerNamespaceTools (additionalToolValues params))
+            `shouldBe` [(Just "function", Just computerFunctionName)]
+
+    it "keeps hosted computer native for the standard Responses API" do
+        let computerTool = knownResponseTool ToolComputer KeyMap.empty
+            params =
+                requestParams
+                    OpenAIProvider
+                    "gpt-5.6"
+                    "base instructions"
+                    [computerTool]
+                    "high"
+
+        params.tools `shouldBe` Just [computerTool]
+        jsonArrayField "tools" (Aeson.toJSON params)
+            `shouldBe` [Aeson.toJSON computerTool]
+
     it "groups function and custom tools into the functions namespace" do
         let params =
                 requestParams
@@ -119,25 +155,39 @@ spec = describe "requestParams" do
             _ -> expectationFailure "expected three top-level Lite tools"
 
     it "refreshes the Lite prefix without dropping pending input" do
-        let pending = userMessage "keep me"
+        let computerTool = knownResponseTool ToolComputer KeyMap.empty
+            pending = userMessage "keep me"
             original = appendInputItem pending $
                 requestParams
                     OpenAIProvider
                     "gpt-5.6-sol"
                     "old instructions"
-                    [functionTool "old"]
+                    [functionTool "old", computerTool]
                     "high"
             refreshed =
                 setRequestInstructionsAndTools
                     "new instructions"
-                    (Just [functionTool "new"])
+                    (Just [functionTool "new", computerTool])
                     original
+            instructionsOnly =
+                setRequestInstructionsAndTools
+                    "newer instructions"
+                    Nothing
+                    refreshed
 
         refreshed.instructions `shouldBe` Nothing
         refreshed.tools `shouldBe` Nothing
         map (jsonTextField "name")
             (functionsNamespaceTools (additionalToolValues refreshed))
             `shouldBe` [Just "new"]
+        map toolIdentity (additionalToolValues refreshed)
+            `shouldBe`
+                [ (Just "namespace", Just "functions")
+                , (Just "namespace", Just computerFunctionNamespace)
+                ]
+        instructionsOnly.tools `shouldBe` Nothing
+        computerNamespaceTools (additionalToolValues instructionsOnly)
+            `shouldSatisfy` (not . null)
         case refreshed.input of
             Just (ResponseInputItems [_additional, base, suffix]) -> do
                 base `shouldSatisfy` isInstructionText "new instructions"
@@ -146,7 +196,8 @@ spec = describe "requestParams" do
                 "expected refreshed prefix followed by pending input"
 
     it "rebuilds request dialect fields when models cross the Lite boundary" do
-        let pending = userMessage "pending"
+        let computerTool = knownResponseTool ToolComputer KeyMap.empty
+            pending = userMessage "pending"
             genericText = ResponseTextConfig
                 { format = Nothing
                 , verbosity = Just "medium"
@@ -161,7 +212,7 @@ spec = describe "requestParams" do
                         OpenAIProvider
                         "gpt-generic"
                         "base instructions"
-                        [webSearchTool, functionTool "lookup"]
+                        [webSearchTool, functionTool "lookup", computerTool]
                         "high"
             lite =
                 setRequestModel OpenAIProvider "gpt-5.6-terra" generic
@@ -170,6 +221,12 @@ spec = describe "requestParams" do
 
         lite.instructions `shouldBe` Nothing
         lite.tools `shouldBe` Nothing
+        map toolIdentity (additionalToolValues lite)
+            `shouldBe`
+                [ (Just "web_search", Nothing)
+                , (Just "namespace", Just "functions")
+                , (Just "namespace", Just computerFunctionNamespace)
+                ]
         lite.parallelToolCalls `shouldBe` Just False
         fmap (.context) lite.reasoning `shouldBe` Just (Just "all_turns")
         fmap (.verbosity) lite.text `shouldBe` Just (Just "low")
@@ -177,7 +234,7 @@ spec = describe "requestParams" do
         restored.model `shouldBe` Just "gpt-generic-2"
         restored.instructions `shouldBe` Just "base instructions"
         restored.tools `shouldBe` Just
-            [webSearchTool, functionTool "lookup"]
+            [webSearchTool, functionTool "lookup", computerTool]
         restored.parallelToolCalls `shouldBe` Just True
         fmap (.context) restored.reasoning `shouldBe` Just Nothing
         restored.text `shouldBe` Just
@@ -294,6 +351,13 @@ functionsNamespaceTools =
         . findValue
             (\value -> toolIdentity value
                 == (Just "namespace", Just "functions"))
+
+computerNamespaceTools :: [Aeson.Value] -> [Aeson.Value]
+computerNamespaceTools =
+    maybe [] (jsonArrayField "tools")
+        . findValue
+            (\value -> toolIdentity value
+                == (Just "namespace", Just computerFunctionNamespace))
 
 findValue :: (value -> Bool) -> [value] -> Maybe value
 findValue predicate = \case

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -72,7 +72,7 @@ spec = describe "schemasFromAppTools" do
         schemasFromAppTools claudeCodeDialect [computerUseTool]
             `shouldBe` []
 
-    it "does not dispatch spoofed function/custom calls to hosted computer" do
+    it "accepts only native or reserved computer calls for the hosted handler" do
         runs <- newIORef (0 :: Int)
         let hosted = AppTool
                 { appToolName = "computer"
@@ -96,9 +96,12 @@ spec = describe "schemasFromAppTools" do
             defaultLoopDispatch registry (call FunctionCallKind)
         customResult <- dispatchRegisteredToolCall
             defaultLoopDispatch registry (call CustomCallKind)
+        computerFunctionResult <- dispatchRegisteredToolCall
+            defaultLoopDispatch registry (call ComputerFunctionCallKind)
         functionResult.output `shouldBe` "Error: Unknown tool: computer"
         customResult.output `shouldBe` "Error: Unknown tool: computer"
-        readIORef runs `shouldReturn` 0
+        computerFunctionResult.output `shouldBe` "ran"
+        readIORef runs `shouldReturn` 1
     it "enables built-in web_search ahead of app tools" do
         case schemasFromAppTools codexDialect [jsonTool] of
             KnownResponseTool ToolWebSearch tagged : _ -> do

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -3,6 +3,7 @@
 module Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
+    , isComputerToolCallKind
     , ToolCallResult(..)
     , ToolDispatchConfig(..)
     , ToolHandler
@@ -44,7 +45,17 @@ data ToolCallKind
     -- action list, and its result is encoded by the provider adapter as a
     -- structured screenshot output rather than a function output string.
     | ComputerCallKind
+    -- | The reserved Responses Lite computer function. It uses the same local
+    -- executor and approval rules as a native computer call, but its result
+    -- must be returned as multimodal @function_call_output@ content.
+    | ComputerFunctionCallKind
     deriving (Eq, Show)
+
+isComputerToolCallKind :: ToolCallKind -> Bool
+isComputerToolCallKind = \case
+    ComputerCallKind -> True
+    ComputerFunctionCallKind -> True
+    _ -> False
 
 -- | Provider-neutral function or custom tool call emitted by a model transport.
 data ToolCall = ToolCall

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -336,8 +336,10 @@ toolAcceptsCall :: AppTool -> ToolCall -> Bool
 toolAcceptsCall tool call =
     case (tool.appToolSchema, call.callKind) of
         (HostedComputerSchema, ComputerCallKind) -> True
+        (HostedComputerSchema, ComputerFunctionCallKind) -> True
         (HostedComputerSchema, _) -> False
         (_, ComputerCallKind) -> False
+        (_, ComputerFunctionCallKind) -> False
         _ -> True
 
 jsonToolParameters :: AppTool -> Maybe [PropertySchema]

--- a/packages/agent-responses-types/src/Agent/Responses/Types.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types.hs
@@ -59,6 +59,8 @@ module Agent.Responses.Types
     , responseToolTypeText
     , knownResponseTool
     , FunctionTool(..)
+    , computerFunctionNamespace
+    , computerFunctionName
 
       -- * Response
     , Response(..)

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Tools.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Tools.hs
@@ -5,12 +5,23 @@ module Agent.Responses.Types.Tools
     , responseToolTypeText
     , knownResponseTool
     , FunctionTool(..)
+    , computerFunctionNamespace
+    , computerFunctionName
     ) where
 
 import Agent.Responses.Types.Common
 import Data.Aeson hiding (TaggedObject)
 import qualified Data.Aeson as Aeson
 import Data.Text (Text)
+
+-- | Reserved names used when a Responses Lite transport cannot register the
+-- provider-native computer tool and must expose the same harness as a
+-- screenshot-returning function instead.
+computerFunctionNamespace :: Text
+computerFunctionNamespace = "computer_use"
+
+computerFunctionName :: Text
+computerFunctionName = "computer"
 
 data ResponseToolType
     = ToolFunction

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -376,6 +376,29 @@ toolResultToItem result = case result.callKind of
                 , computerOutputStatus = Just ItemIncomplete
                 , computerOutputExtra = KeyMap.empty
                 }
+    ComputerFunctionCallKind ->
+        FunctionCallOutputItem FunctionCallOutput
+            { itemId = Nothing
+            , callId = result.callId
+            , name = Nothing
+            , namespace = Nothing
+            , output = computerFunctionOutput result.output
+            , status = Nothing
+            , extraFields = KeyMap.empty
+            }
+
+computerFunctionOutput :: Text -> Aeson.Value
+computerFunctionOutput rawOutput =
+    case Aeson.eitherDecodeStrict' (Text.encodeUtf8 rawOutput) of
+        Right ComputerCallOutput{screenshotDataUrl} ->
+            Aeson.toJSON
+                [ Aeson.object
+                    [ "type" Aeson..= ("input_image" :: Text)
+                    , "image_url" Aeson..= screenshotDataUrl
+                    , "detail" Aeson..= ("original" :: Text)
+                    ]
+                ]
+        Left _ -> Aeson.String rawOutput
 
 -- A rejection or executor failure still has to satisfy the Responses protocol
 -- with a screenshot-shaped output. Successful executors return a fresh image.
@@ -407,6 +430,17 @@ tokenUsageFromResponse = maybe emptyTokenUsage \usage ->
 
 responseItemToToolCall :: ResponseItem -> Maybe ToolCall
 responseItemToToolCall = \case
+    FunctionCallItem call
+        | call.namespace == Just computerFunctionNamespace
+        , call.name == computerFunctionName ->
+            Just ToolCall
+                { callId = call.callId
+                , name = "computer"
+                , arguments = call.arguments
+                , callKind = ComputerFunctionCallKind
+                , argumentsEncrypted =
+                    computerFunctionArgumentsSensitive call.arguments
+                }
     FunctionCallItem call ->
         let toolName = namespacedToolName call.namespace call.name
         in Just ToolCall
@@ -435,6 +469,20 @@ responseItemToToolCall = \case
             call.computerActions
         }
     _ -> Nothing
+
+computerFunctionArgumentsSensitive :: Text -> Bool
+computerFunctionArgumentsSensitive rawArguments =
+    case Aeson.eitherDecodeStrict' (Text.encodeUtf8 rawArguments) of
+        Right (Aeson.Object object) ->
+            case KeyMap.lookup "actions" object of
+                Just value ->
+                    case (Aeson.fromJSON value
+                            :: Aeson.Result [ComputerAction]) of
+                        Aeson.Success actions ->
+                            any isSensitiveComputerAction actions
+                        Aeson.Error _ -> True
+                Nothing -> True
+        _ -> True
 
 isSensitiveComputerAction :: ComputerAction -> Bool
 isSensitiveComputerAction = \case

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -29,6 +29,7 @@ import Agent.Responses.Types
     , ComputerAction(..)
     , ComputerCall(..)
     , ComputerCallOutput(..)
+    , FunctionCall(..)
     , FunctionCallOutput(..)
     , InternalChatMetadata(..)
     , ItemStatus(..)
@@ -42,11 +43,14 @@ import Agent.Responses.Types
     , ResponseInput(..)
     , ResponseCreateParams(..)
     , TaggedObject(..)
+    , computerFunctionName
+    , computerFunctionNamespace
     , defaultResponseCreateParams
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Aeson.Key as Key
+import Data.Foldable (toList)
 import Data.IORef
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Text as Text
@@ -56,6 +60,59 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "tokenProviderStatelessResponsesBackend" do
+    it "routes the reserved computer function namespace to the computer harness" do
+        let call = FunctionCall
+                { itemId = Nothing
+                , callId = "call-function"
+                , name = computerFunctionName
+                , namespace = Just computerFunctionNamespace
+                , arguments =
+                    "{\"actions\":[{\"type\":\"type\",\"text\":\"secret\"}]}"
+                , encryptedFunctionArgs = Nothing
+                , status = Nothing
+                , extraFields = KeyMap.empty
+                }
+        case responseItemToToolCall (FunctionCallItem call) of
+            Just projected -> do
+                projected.name `shouldBe` "computer"
+                projected.callKind `shouldBe` ComputerFunctionCallKind
+                projected.argumentsEncrypted `shouldBe` True
+            Nothing -> expectationFailure
+                "reserved computer function was not projected"
+
+    it "returns reserved computer screenshots as multimodal function output" do
+        let encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/png;base64,AA=="
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.empty
+                    }
+            result = ToolCallResult
+                { callId = "call-function"
+                , output = encoded
+                , callKind = ComputerFunctionCallKind
+                }
+
+        case toolResultToItem result of
+            FunctionCallOutputItem output ->
+                case output.output of
+                    Aeson.Array values -> case toList values of
+                        [image] -> do
+                            jsonField "type" image
+                                `shouldBe` Just (Aeson.String "input_image")
+                            jsonField "image_url" image `shouldBe`
+                                Just (Aeson.String "data:image/png;base64,AA==")
+                            jsonField "detail" image
+                                `shouldBe` Just (Aeson.String "original")
+                        other -> expectationFailure
+                            ("expected one screenshot part, got " <> show other)
+                    other -> expectationFailure
+                        ("expected multimodal function output, got " <> show other)
+            other -> expectationFailure ("unexpected output: " <> show other)
+
     it "round-trips native computer calls through structured screenshot output" do
         let call = ComputerCall
                 { computerCallItemId = Just "item-1"


### PR DESCRIPTION
## Summary
- expose computer use to Responses Lite through a reserved computer_use.computer function while keeping the native computer tool for standard Responses
- execute fallback calls through the same macOS bridge and force per-action approval, including in global auto-approve mode
- return screenshots as redacted multimodal function output, using same-resolution JPEG to keep Lite input usage bounded
- reject lookalike ordinary function/custom calls and redact typed text plus screenshot payloads from session administration

## Verification
- nix develop -c cabal test agent-responses-test (96 examples, 0 failures)
- nix develop -c cabal test agent-openai-test (274 examples, 0 failures, 1 pending live-auth test)
- nix develop -c cabal test agent-core-test (283 examples, 0 failures)
- nix develop -c cabal test agent-cli-test (1110 examples, 0 failures, 1 pending)
- nix build .#agent-cli .#agent-native-bridge --no-link
- live Responses Lite screenshot: approval shown even with --yolo; model received and accurately described the desktop
- live deny path: model received Access was denied
- live --no-computer-use path: no tool was exposed
- real tmux smoke: approved screenshot round-trip completed in two turns