### PR TITLE
Classify expired Claude OAuth sessions

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -97,7 +97,7 @@ import Data.IORef
     , readIORef
     , writeIORef
     )
-import Data.Maybe (catMaybes, fromMaybe, isJust)
+import Data.Maybe (catMaybes, fromMaybe, isJust, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -832,7 +832,7 @@ sdkErrorToApiError = \case
         ConnectionError (renderClaudeSDKError sdkError)
 
 classifyResultError :: ClaudeSDKError -> ErrorType
-classifyResultError ResultError{subtype, apiErrorStatus, errors} =
+classifyResultError ResultError{subtype, apiErrorStatus, errors, result} =
     case apiErrorStatus of
         Just 401 -> AuthenticationError
         Just 403 -> PermissionError
@@ -847,13 +847,20 @@ classifyResultError ResultError{subtype, apiErrorStatus, errors} =
             let bySubtype = errorTypeFromText (Text.toLower subtype)
             in case bySubtype of
                 UnknownErrorType _ ->
-                    classifyResultMessage (Text.toLower (Text.intercalate " " errors))
+                    classifyResultMessage
+                        (Text.toLower (Text.intercalate " " (errors <> maybeToList result)))
                 other -> other
 classifyResultError _ = ApiErrorType
 
 classifyResultMessage :: Text -> ErrorType
 classifyResultMessage message
-    | any (`Text.isInfixOf` message) ["authentication", "unauthorized", "invalid api key"] =
+    | any (`Text.isInfixOf` message)
+        [ "authentication"
+        , "failed to authenticate"
+        , "oauth session expired"
+        , "unauthorized"
+        , "invalid api key"
+        ] =
         AuthenticationError
     | any (`Text.isInfixOf` message) ["permission", "forbidden", "not allowed"] =
         PermissionError

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -125,6 +125,16 @@ spec = do
                 `shouldSatisfy` \case
                     ProviderError{errorType = PermissionError} -> True
                     _ -> False
+        it "classifies an expired OAuth session reported in the result" do
+            sdkErrorToApiError
+                (ResultError
+                    "error"
+                    Nothing
+                    []
+                    (Just "Failed to authenticate: OAuth session expired and could not be refreshed"))
+                `shouldSatisfy` \case
+                    ProviderError{errorType = AuthenticationError} -> True
+                    _ -> False
 
     describe "appendHostTranscript" do
         it "appends turn inputs followed by assistant text" $ do


### PR DESCRIPTION
## Summary
- inspect Claude SDK `ResultError.result` when classifying provider failures
- map expired/unrefreshable OAuth authentication messages to `AuthenticationError`
- add a regression test for the observed SDK payload

## Root cause
Claude CLI reports an expired OAuth session in the optional `result` field, while the classifier only inspected `subtype` and `errors`. The failure was therefore surfaced as an unknown/provider error instead of an authentication error that the session layer can handle correctly.

## Test plan
- `nix develop -c cabal test agent-claude:test:agent-claude-test --test-show-details=direct` (46 examples, 0 failures)