### PR TITLE
fix(native): keep embedded RTS alive

### DIFF
--- a/packages/agent-cli/cbits/HaskellAgentBridgeRuntime.c
+++ b/packages/agent-cli/cbits/HaskellAgentBridgeRuntime.c
@@ -5,14 +5,16 @@
 
 static pthread_mutex_t runtime_lock = PTHREAD_MUTEX_INITIALIZER;
 static unsigned int runtime_references = 0;
+static int runtime_initialized = 0;
 
 int32_t ha_runtime_init(void) {
     pthread_mutex_lock(&runtime_lock);
-    if (runtime_references == 0) {
+    if (!runtime_initialized) {
         int argc = 1;
         char *argv[] = {"haskell-agent-macos", NULL};
         char **argv_pointer = argv;
         hs_init(&argc, &argv_pointer);
+        runtime_initialized = 1;
     }
     runtime_references += 1;
     pthread_mutex_unlock(&runtime_lock);
@@ -23,9 +25,6 @@ void ha_runtime_exit(void) {
     pthread_mutex_lock(&runtime_lock);
     if (runtime_references > 0) {
         runtime_references -= 1;
-        if (runtime_references == 0) {
-            hs_exit();
-        }
     }
     pthread_mutex_unlock(&runtime_lock);
 }


### PR DESCRIPTION
## Summary
- initialize the embedded GHC RTS once per process
- retain client reference counting without calling `hs_exit` when the last client closes
- prevent unsupported `hs_exit` → `hs_init` restart cycles in the macOS host

## Root cause
The embedded runtime was torn down when the final `EmbeddedAgentClient` shut down and later initialized again. The GHC RTS is process-lifetime state in this embedding model and is not safely restartable.

This is one half of the native crash fix; the macOS host also routes Haskell bridge entry points through a real `pthread_create` thread so GHC never detaches a libdispatch workqueue thread with `pthread_exit`.

## Validation
- `git diff --check`
- `nix develop -c cabal build agent-cli:lib:agent-cli`