### PR TITLE
Unify supervised tasks and session continuity for macOS

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,6 +15,7 @@ packages:
     packages/agent-store
     packages/claude-agent-sdk-haskell
     packages/agent-claude
+    packages/agent-runtime-daemon
 
 tests: True
 multi-repl: True

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -14,13 +14,18 @@ The first client message must be `hello`, containing a stable client ID, the
 protocol versions it supports, and optionally the sequence number of the last
 event it durably acknowledged. The daemon replies with `welcome` and the
 negotiated version, or `version_rejected` with its supported versions. Protocol
-version 1 is currently supported.
+version 2 is currently supported.
 
 A connection with no resume cursor receives a full snapshot. A reconnecting
 client receives all retained events after its cursor. If the cursor predates
 retention, it receives a fresh snapshot instead. Every event has a strictly
 increasing sequence number. Clients send `ack` after durably applying an event
 and answer `heartbeat` with `pong`.
+
+Snapshots are sent as bounded `snapshot_chunk` messages. Each chunk contains
+an independently base64-encoded slice of the snapshot JSON, plus a zero-based
+chunk index and total chunk count. Clients decode each slice and concatenate
+them in index order before decoding the snapshot JSON.
 
 Commands and command results carry client-generated command IDs. Their JSON
 payload is deliberately opaque to this package so the task supervisor can
@@ -36,6 +41,12 @@ sockets not owned by the effective user are rejected. Accepted connections are
 authenticated with the operating system's Unix peer credentials
 (`getpeereid` via `network` on macOS).
 
+A process-held exclusive lock serializes socket creation and stale-socket
+removal. Shutdown only unlinks the device/inode created by that listener, so a
+replacement path is never removed. Socket reads, writes, command execution,
+and outbound queues have deadlines; per-client event queues are bounded and an
+overflowed client is disconnected.
+
 ## Durability
 
 Task snapshots are atomically replaced and fsynced. Events are appended,
@@ -43,3 +54,8 @@ fsynced, and monotonically numbered. On startup, queued or running tasks become
 `TaskInterrupted`; the daemon never retries them automatically. Event and task
 log retention are bounded, and credential-shaped JSON fields and log lines are
 redacted before persistence.
+
+Journal directories and files must be non-symlinked and owned by the effective
+user. Corrupt snapshots, malformed or non-contiguous event suffixes, and
+oversized recovery files fail startup closed. A persistence error poisons the
+live journal so the process cannot reuse an uncertain sequence number.

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -14,7 +14,7 @@ The first client message must be `hello`, containing a stable client ID, the
 protocol versions it supports, and optionally the sequence number of the last
 event it durably acknowledged. The daemon replies with `welcome` and the
 negotiated version, or `version_rejected` with its supported versions. Protocol
-version 2 is currently supported.
+version 3 is currently supported.
 
 A connection with no resume cursor receives a full snapshot. A reconnecting
 client receives all retained events after its cursor. If the cursor predates
@@ -26,6 +26,11 @@ Snapshots are sent as bounded `snapshot_chunk` messages. Each chunk contains
 an independently base64-encoded slice of the snapshot JSON, plus a zero-based
 chunk index and total chunk count. Clients decode each slice and concatenate
 them in index order before decoding the snapshot JSON.
+
+Events that fit the negotiated frame bound use `event`. Larger events use the
+same scheme in `event_chunk` messages: clients concatenate decoded slices and
+then decode the resulting event envelope. This keeps persisted events
+deliverable without increasing the transport frame bound.
 
 Commands and command results carry client-generated command IDs. Their JSON
 payload is deliberately opaque to this package so the task supervisor can

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -81,7 +81,10 @@ and optional worktree creation. It always passes `--no-yolo`, so a noninteractiv
 task fails closed rather than implicitly approving mutating tools. Stdout and
 stderr are concurrently drained in
 bounded chunks before journal log limits are applied, total output is capped,
-and every process task has a six-hour wall-clock deadline. Log publication is
+and every process task has a six-hour wall-clock deadline. Stdin is closed.
+After the process leader exits, pipe draining has its own deadline; descendants
+that retained stdout or stderr are terminated with the same TERM/KILL
+process-group escalation rather than hanging task completion. Log publication is
 best-effort when the bounded scheduler queue is full; terminal completion uses
 a separate control queue so noisy output cannot deadlock completion or daemon
 shutdown. Embedders can supply

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -72,7 +72,10 @@ the original, unredacted input in memory. Raw prompts are deliberately not
 persisted separately from the redacted task description. After daemon restart,
 `retry` therefore fails with `task input is unavailable`; the client must
 submit the input again under a new task ID. A completed or active task cannot
-be retried.
+be retried. Input is discarded from memory as soon as a task completes; it is
+retained only for same-process failed or cancelled retries. Consequently the
+raw-input map is bounded by the durable task limit and the 8,192-character
+prompt limit, and all remaining input disappears when the daemon exits.
 
 The shipped daemon runner executes `agent-cli` directly without a shell
 (`HASKELL_AGENT_CLI` can override its path), using the real one-shot CLI flags

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -85,7 +85,8 @@ and every process task has a six-hour wall-clock deadline. Stdin is closed.
 After the process leader exits, pipe draining has its own deadline; descendants
 that retained stdout or stderr are terminated with the same TERM/KILL
 process-group escalation rather than hanging task completion. Log publication is
-best-effort when the bounded scheduler queue is full; terminal completion uses
+best-effort when the bounded scheduler queue is full; dropped chunks produce a
+durable `[output truncated: scheduler log queue was full]` marker. Terminal completion uses
 a separate control queue so noisy output cannot deadlock completion or daemon
 shutdown. Embedders can supply
 a typed `TaskRunner` while retaining the same scheduler, persistence, and wire

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -32,9 +32,40 @@ same scheme in `event_chunk` messages: clients concatenate decoded slices and
 then decode the resulting event envelope. This keeps persisted events
 deliverable without increasing the transport frame bound.
 
-Commands and command results carry client-generated command IDs. Their JSON
-payload is deliberately opaque to this package so the task supervisor can
-evolve independently of the transport.
+Commands and command results carry client-generated command IDs. The public
+task adapter accepts the following versioned command payloads. Unknown versions,
+types, invalid combinations, empty identifiers, and values beyond the
+documented bounds are rejected without changing scheduler state.
+
+```json
+{"version":1,"type":"submit","task_id":"stable-client-id","session_id":"optional-existing-session","prompt":"...","cwd":"/absolute/or/relative/path","provider":"openai","model":"gpt-5.6","effort":"high","worktree":false}
+{"version":1,"type":"cancel","task_id":"stable-client-id"}
+{"version":1,"type":"list"}
+{"version":1,"type":"set_limit","limit":4}
+{"version":1,"type":"approval","task_id":"stable-client-id","approval_id":"request-id","decision":"approve"}
+{"version":1,"type":"retry","task_id":"stable-client-id"}
+```
+
+`task_id` is a caller-generated stable identifier and cannot be reused.
+`session_id` is the stable persisted session to resume; tasks for one session
+are serialized. A missing session identifies a fresh session and does not
+conflict with other fresh tasks. `provider` and `model` must either both be
+present or both absent, and `worktree` is valid only for a fresh session.
+Task/session/approval IDs are at most 256 characters, prompts 8,192
+characters, paths 4,096 characters, and the concurrency limit is 1 through 32.
+Approval decisions are `approve`, `deny`, or `approve_session`.
+
+Successful results contain `"version": 1`; submit, cancel, and retry results
+also contain the durable task. `list` returns every retained durable task.
+Task transitions are journaled as `task_changed` events before the mutating
+command reports success. A failed, cancelled, or interrupted task is rerun
+only by an explicit `retry` command, which retains its task ID and increments
+its attempt number. A completed or active task cannot be retried.
+
+The shipped daemon runner executes `agent-cli` directly without a shell
+(`HASKELL_AGENT_CLI` can override its path). Embedders can supply a native
+`TaskRunner`, including an approval resolver, while retaining the same
+scheduler, persistence, and wire protocol.
 
 ## Local security
 

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -53,7 +53,13 @@ conflict with other fresh tasks. `provider` and `model` must either both be
 present or both absent, and `worktree` is valid only for a fresh session.
 Task/session/approval IDs are at most 256 characters, prompts 8,192
 characters, paths 4,096 characters, and the concurrency limit is 1 through 32.
-Approval decisions are `approve`, `deny`, or `approve_session`.
+Approval decisions are syntactically limited to `approve`, `deny`, or
+`approve_session`, but the current daemon runner does **not** support
+interactive approval resolution. Every `approval` command fails visibly with
+an unsupported-operation error and emits no `approval_resolved` event. Tasks
+that require an interactive approval must therefore fail or be run by an
+interactive client; clients must not present daemon approval controls as
+functional.
 
 Successful results contain `"version": 1`; submit, cancel, and retry results
 also contain the durable task. `list` returns every retained durable task.
@@ -63,9 +69,12 @@ only by an explicit `retry` command, which retains its task ID and increments
 its attempt number. A completed or active task cannot be retried.
 
 The shipped daemon runner executes `agent-cli` directly without a shell
-(`HASKELL_AGENT_CLI` can override its path). Embedders can supply a native
-`TaskRunner`, including an approval resolver, while retaining the same
-scheduler, persistence, and wire protocol.
+(`HASKELL_AGENT_CLI` can override its path), using the real one-shot CLI flags
+for prompt, session resume, cwd, provider/model/effort, session persistence,
+and optional worktree creation. Stdout and stderr are concurrently drained in
+bounded chunks before journal log limits are applied. Embedders can supply a
+typed `TaskRunner` while retaining the same scheduler, persistence, and wire
+protocol; the adapter intentionally exposes no approval-resolver hook.
 
 ## Local security
 

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -81,7 +81,10 @@ and optional worktree creation. It always passes `--no-yolo`, so a noninteractiv
 task fails closed rather than implicitly approving mutating tools. Stdout and
 stderr are concurrently drained in
 bounded chunks before journal log limits are applied, total output is capped,
-and every process task has a six-hour wall-clock deadline. Embedders can supply
+and every process task has a six-hour wall-clock deadline. Log publication is
+best-effort when the bounded scheduler queue is full; terminal completion uses
+a separate control queue so noisy output cannot deadlock completion or daemon
+shutdown. Embedders can supply
 a typed `TaskRunner` while retaining the same scheduler, persistence, and wire
 protocol; the adapter intentionally exposes no approval-resolver hook.
 

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -1,0 +1,45 @@
+# Runtime daemon protocol
+
+The runtime daemon is a per-user local service. Its Haskell package is
+`agent-runtime-daemon`; task execution is supplied separately through the
+`Supervisor` seam.
+
+## Transport and negotiation
+
+Messages are UTF-8 JSON prefixed by an unsigned 32-bit big-endian byte length.
+The daemon rejects frames larger than its configured limit (1 MiB by default)
+before allocating the body.
+
+The first client message must be `hello`, containing a stable client ID, the
+protocol versions it supports, and optionally the sequence number of the last
+event it durably acknowledged. The daemon replies with `welcome` and the
+negotiated version, or `version_rejected` with its supported versions. Protocol
+version 1 is currently supported.
+
+A connection with no resume cursor receives a full snapshot. A reconnecting
+client receives all retained events after its cursor. If the cursor predates
+retention, it receives a fresh snapshot instead. Every event has a strictly
+increasing sequence number. Clients send `ack` after durably applying an event
+and answer `heartbeat` with `pong`.
+
+Commands and command results carry client-generated command IDs. Their JSON
+payload is deliberately opaque to this package so the task supervisor can
+evolve independently of the transport.
+
+## Local security
+
+The default endpoint is
+`~/.haskell-agent/runtime/daemon.sock` and can be relocated with
+`HASKELL_AGENT_RUNTIME_DIR`. The runtime directory and socket use modes `0700`
+and `0600`. Existing non-socket paths, symlinked runtime directories, and
+sockets not owned by the effective user are rejected. Accepted connections are
+authenticated with the operating system's Unix peer credentials
+(`getpeereid` via `network` on macOS).
+
+## Durability
+
+Task snapshots are atomically replaced and fsynced. Events are appended,
+fsynced, and monotonically numbered. On startup, queued or running tasks become
+`TaskInterrupted`; the daemon never retries them automatically. Event and task
+log retention are bounded, and credential-shaped JSON fields and log lines are
+redacted before persistence.

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -65,15 +65,20 @@ Successful results contain `"version": 1`; submit, cancel, and retry results
 also contain the durable task. `list` returns every retained durable task.
 Task transitions are journaled as `task_changed` events before the mutating
 command reports success. A failed, cancelled, or interrupted task is rerun
-only by an explicit `retry` command, which retains its task ID and increments
-its attempt number. A completed or active task cannot be retried.
+only by an explicit `retry` command while the same daemon process still holds
+the original, unredacted input in memory. Raw prompts are deliberately not
+persisted separately from the redacted task description. After daemon restart,
+`retry` therefore fails with `task input is unavailable`; the client must
+submit the input again under a new task ID. A completed or active task cannot
+be retried.
 
 The shipped daemon runner executes `agent-cli` directly without a shell
 (`HASKELL_AGENT_CLI` can override its path), using the real one-shot CLI flags
 for prompt, session resume, cwd, provider/model/effort, session persistence,
 and optional worktree creation. Stdout and stderr are concurrently drained in
-bounded chunks before journal log limits are applied. Embedders can supply a
-typed `TaskRunner` while retaining the same scheduler, persistence, and wire
+bounded chunks before journal log limits are applied, total output is capped,
+and every process task has a six-hour wall-clock deadline. Embedders can supply
+a typed `TaskRunner` while retaining the same scheduler, persistence, and wire
 protocol; the adapter intentionally exposes no approval-resolver hook.
 
 ## Local security

--- a/docs/runtime-daemon-protocol.md
+++ b/docs/runtime-daemon-protocol.md
@@ -35,7 +35,9 @@ deliverable without increasing the transport frame bound.
 Commands and command results carry client-generated command IDs. The public
 task adapter accepts the following versioned command payloads. Unknown versions,
 types, invalid combinations, empty identifiers, and values beyond the
-documented bounds are rejected without changing scheduler state.
+documented bounds are rejected without changing scheduler state. Scheduler
+command admission is bounded and nonblocking: a full queue returns an immediate
+error rather than allowing an expired client request to execute later.
 
 ```json
 {"version":1,"type":"submit","task_id":"stable-client-id","session_id":"optional-existing-session","prompt":"...","cwd":"/absolute/or/relative/path","provider":"openai","model":"gpt-5.6","effort":"high","worktree":false}
@@ -75,7 +77,9 @@ be retried.
 The shipped daemon runner executes `agent-cli` directly without a shell
 (`HASKELL_AGENT_CLI` can override its path), using the real one-shot CLI flags
 for prompt, session resume, cwd, provider/model/effort, session persistence,
-and optional worktree creation. Stdout and stderr are concurrently drained in
+and optional worktree creation. It always passes `--no-yolo`, so a noninteractive
+task fails closed rather than implicitly approving mutating tools. Stdout and
+stderr are concurrently drained in
 bounded chunks before journal log limits are applied, total output is capped,
 and every process task has a six-hour wall-clock deadline. Embedders can supply
 a typed `TaskRunner` while retaining the same scheduler, persistence, and wire

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,17 @@
                     ];
                 };
 
+                agentRuntimeDaemonSource = nix-filter.lib {
+                    root = ./packages/agent-runtime-daemon;
+                    include = [
+                        "app"
+                        "src"
+                        "test"
+                        "agent-runtime-daemon.cabal"
+                        "LICENSE"
+                    ];
+                };
+
                 agentResponsesTypesSource = nix-filter.lib {
                     root = ./packages/agent-responses-types;
                     include = [
@@ -320,6 +331,11 @@
                             {
                                 src = agentProcessSource;
                             });
+                        agent-runtime-daemon = localPackage (pkgs.haskell.lib.overrideSrc
+                            (final.callPackage ./packages/agent-runtime-daemon/package.nix { })
+                            {
+                                src = agentRuntimeDaemonSource;
+                            });
                         agent-responses-types = localPackage (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-responses-types/package.nix { }) {
                             src = agentResponsesTypesSource;
                         });
@@ -392,6 +408,8 @@
                 productionHaskellPackages = mkHaskellPackages false;
                 agentCorePackage = productionHaskellPackages.agent-core;
                 agentProcessPackage = productionHaskellPackages.agent-process;
+                agentRuntimeDaemonPackage =
+                    productionHaskellPackages.agent-runtime-daemon;
                 agentCodexDialectPackage = productionHaskellPackages.agent-codex-dialect;
                 agentGrokBuildDialectPackage = productionHaskellPackages.agent-grok-build-dialect;
                 agentSyntaxPackage = productionHaskellPackages.agent-syntax;
@@ -406,6 +424,8 @@
                 agentStorePackage = productionHaskellPackages.agent-store;
                 agentCliPackage = productionHaskellPackages.agent-cli;
                 agentTelegramPackage = productionHaskellPackages.agent-telegram;
+                agentRuntimeDaemonExecutable =
+                    pkgs.haskell.lib.justStaticExecutables agentRuntimeDaemonPackage;
                 agentCliExecutable =
                     (pkgs.haskell.lib.justStaticExecutables agentCliPackage).overrideAttrs
                         (old: {
@@ -592,6 +612,7 @@
                     then "agent-native-bridge" else null} = agentNativeBridgePackage;
                 packages.agent-core = agentCorePackage;
                 packages.agent-process = agentProcessPackage;
+                packages.agent-runtime-daemon = agentRuntimeDaemonExecutable;
                 packages.agent-codex-dialect = agentCodexDialectPackage;
                 packages.agent-grok-build-dialect = agentGrokBuildDialectPackage;
                 packages.agent-syntax = agentSyntaxPackage;
@@ -615,6 +636,10 @@
                     drv = self.packages.${system}.agent-telegram;
                     exePath = "/bin/agent-telegram";
                 };
+                apps.agent-runtime-daemon = flake-utils.lib.mkApp {
+                    drv = self.packages.${system}.agent-runtime-daemon;
+                    exePath = "/bin/agent-runtime-daemon";
+                };
                 apps.agent-openai-login = flake-utils.lib.mkApp {
                     drv = self.packages.${system}.agent-openai-login;
                     exePath = "/bin/agent-openai-login";
@@ -626,6 +651,7 @@
                         packages.agent-telegram
                         packages.agent-core
                         packages.agent-process
+                        packages.agent-runtime-daemon
                         packages.agent-codex-dialect
                         packages.agent-grok-build-dialect
                         packages.agent-syntax
@@ -667,6 +693,8 @@
                     agent-telegram = haskellPackages.agent-telegram;
                     agent-core = haskellPackages.agent-core;
                     agent-process = haskellPackages.agent-process;
+                    agent-runtime-daemon =
+                        haskellPackages.agent-runtime-daemon;
                     agent-codex-dialect = haskellPackages.agent-codex-dialect;
                     agent-grok-build-dialect = haskellPackages.agent-grok-build-dialect;
                     agent-syntax = haskellPackages.agent-syntax;

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -260,13 +260,13 @@ foreign-library haskell-agent-bridge
     other-modules:    Agent.CLI.MacOS.Bridge
                     , Agent.CLI.MacOS.EngineMailbox
                     , Agent.CLI.MacOS.NativeLoopEvent
-                    , Agent.CLI.MacOS.TaskScheduler
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     includes:         HaskellAgentBridge.h
     install-includes: HaskellAgentBridge.h
     ghc-options:      -threaded
     build-depends:    agent-cli
+                    , agent-runtime-daemon
                     , agent-core >= 0.1 && < 0.2
                     , agent-store >= 0.1 && < 0.2
                     , agent-openai >= 0.1 && < 0.2
@@ -361,7 +361,6 @@ test-suite agent-cli-test
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
                     , Agent.CLI.MacOS.BridgeFFISpec
-                    , Agent.CLI.MacOS.TaskScheduler
                     , Agent.CLI.MacOS.TaskSchedulerSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
@@ -440,6 +439,7 @@ test-suite agent-cli-test
                     , Agent.CLI.WebLspSpec
                     , Agent.CLI.WorktreeSpec
     build-depends:    agent-cli
+                    , agent-runtime-daemon
                     , agent-core
                     , agent-codex-dialect
                     , agent-grok-build-dialect

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -260,6 +260,7 @@ foreign-library haskell-agent-bridge
     other-modules:    Agent.CLI.MacOS.Bridge
                     , Agent.CLI.MacOS.EngineMailbox
                     , Agent.CLI.MacOS.NativeLoopEvent
+                    , Agent.CLI.MacOS.TaskScheduler
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
     includes:         HaskellAgentBridge.h
@@ -360,6 +361,8 @@ test-suite agent-cli-test
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.BridgeHeaderSpec
                     , Agent.CLI.MacOS.BridgeFFISpec
+                    , Agent.CLI.MacOS.TaskScheduler
+                    , Agent.CLI.MacOS.TaskSchedulerSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec
@@ -473,6 +476,7 @@ test-suite agent-cli-test
     if os(darwin)
         c-sources:    test/cbits/HaskellAgentBridgeBrowserSmoke.c
                     , test/cbits/HaskellAgentBridgeImageSmoke.c
+                    , test/cbits/HaskellAgentBridgeTaskSmoke.c
                     , cbits/HaskellAgentBridgeRuntime.c
         other-modules: Agent.CLI.MacOS.Bridge
 

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -67,7 +67,7 @@ import Agent.CLI.MacOS.EngineMailbox
     , newEngineMailboxIO
     , readEngineCommand
     )
-import Agent.CLI.MacOS.TaskScheduler
+import Agent.Runtime.Daemon.TaskScheduler
     ( TaskIdentity(..)
     , selectRunnableTasks
     )

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -238,6 +238,11 @@ decodeInput pointer length
     | otherwise = TextEncoding.decodeUtf8 <$> BS.packCStringLen
         (castPtr pointer, fromIntegral length)
 
+decodeUtf8Input :: Ptr Word8 -> Word64 -> IO (Either () Text)
+decodeUtf8Input pointer length =
+    first (const ()) . TextEncoding.decodeUtf8'
+        <$> BS.packCStringLen (castPtr pointer, fromIntegral length)
+
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText value
     | Text.null value = Nothing
@@ -603,25 +608,30 @@ ha_session_load_around sessionBytes (CSize sessionLength) center radius
         callback context
     | callback == nullFunPtr = pure 2
     | sessionBytes == nullPtr || sessionLength == 0 = pure 2
+    | toInteger sessionLength > toInteger (maxBound :: Int) = pure 2
     | center < 0 || radius < 0 = pure 2
     | otherwise = do
-        sessionId <- decodeInput sessionBytes sessionLength
-        _ <- forkIO do
-            result <- tryAny $ withNativeSessionStore \pool root ->
-                loadSessionHistoryTurnsAround
-                    pool root sessionId center (fromIntegral radius)
-            case result of
-                Left exception ->
-                    sessionTurnFailure callback context
-                        (Text.pack (show exception))
-                Right (Left err) ->
-                    sessionTurnFailure callback context err
-                Right (Right page) -> do
-                    forM_ page.pageTurns \(turnIndex, turn) ->
-                        emitSessionTurn callback context turnIndex turn
-                    sessionTurnTerminal callback context
-                        page.pageHasOlder page.pageHasNewer
-        pure 0
+        decoded <- tryAny (decodeUtf8Input sessionBytes sessionLength)
+        case decoded of
+            Left _ -> pure 3
+            Right (Left ()) -> pure 2
+            Right (Right sessionId) -> do
+                _ <- forkIO do
+                    result <- tryAny $ withNativeSessionStore \pool root ->
+                        loadSessionHistoryTurnsAround
+                            pool root sessionId center (fromIntegral radius)
+                    case result of
+                        Left exception ->
+                            sessionTurnFailure callback context
+                                (Text.pack (show exception))
+                        Right (Left err) ->
+                            sessionTurnFailure callback context err
+                        Right (Right page) -> do
+                            forM_ page.pageTurns \(turnIndex, turn) ->
+                                emitSessionTurn callback context turnIndex turn
+                            sessionTurnTerminal callback context
+                                page.pageHasOlder page.pageHasNewer
+                pure 0
 
 ha_session_fork
     :: Ptr Word8 -> CSize -> Int64
@@ -629,13 +639,18 @@ ha_session_fork
 ha_session_fork sessionBytes (CSize sessionLength) throughIndex callback context
     | callback == nullFunPtr = pure 2
     | sessionBytes == nullPtr || sessionLength == 0 || throughIndex < 0 = pure 2
+    | toInteger sessionLength > toInteger (maxBound :: Int) = pure 2
     | otherwise = do
-        sessionId <- decodeInput sessionBytes sessionLength
-        _ <- forkIO do
-            result <- tryAny $ withNativeSessionStore \pool root ->
-                forkSessionAtTurn pool root sessionId throughIndex
-            completeSessionResult callback context result
-        pure 0
+        decoded <- tryAny (decodeUtf8Input sessionBytes sessionLength)
+        case decoded of
+            Left _ -> pure 3
+            Right (Left ()) -> pure 2
+            Right (Right sessionId) -> do
+                _ <- forkIO do
+                    result <- tryAny $ withNativeSessionStore \pool root ->
+                        forkSessionAtTurn pool root sessionId throughIndex
+                    completeSessionResult callback context result
+                pure 0
 
 ha_session_export
     :: Ptr Word8 -> CSize
@@ -643,22 +658,27 @@ ha_session_export
 ha_session_export sessionBytes (CSize sessionLength) callback context
     | callback == nullFunPtr = pure 2
     | sessionBytes == nullPtr || sessionLength == 0 = pure 2
+    | toInteger sessionLength > toInteger (maxBound :: Int) = pure 2
     | otherwise = do
-        sessionId <- decodeInput sessionBytes sessionLength
-        _ <- forkIO do
-            result <- tryAny $ withNativeSessionStore \pool root ->
-                streamSessionTransfer pool root sessionId
-                    (emitSessionExportChunk callback context)
-            case result of
-                Left exception ->
-                    sessionExportFailure callback context
-                        (Text.pack (show exception))
-                Right (Left err) ->
-                    sessionExportFailure callback context err
-                Right (Right ()) ->
-                    invokeSessionExportCallback callback
-                        context 1 nullPtr 0 nullPtr 0
-        pure 0
+        decoded <- tryAny (decodeUtf8Input sessionBytes sessionLength)
+        case decoded of
+            Left _ -> pure 3
+            Right (Left ()) -> pure 2
+            Right (Right sessionId) -> do
+                _ <- forkIO do
+                    result <- tryAny $ withNativeSessionStore \pool root ->
+                        streamSessionTransfer pool root sessionId
+                            (emitSessionExportChunk callback context)
+                    case result of
+                        Left exception ->
+                            sessionExportFailure callback context
+                                (Text.pack (show exception))
+                        Right (Left err) ->
+                            sessionExportFailure callback context err
+                        Right (Right ()) ->
+                            invokeSessionExportCallback callback
+                                context 1 nullPtr 0 nullPtr 0
+                pure 0
 
 ha_session_import
     :: Ptr Word8 -> CSize
@@ -671,19 +691,25 @@ ha_session_import bytes (CSize length) callback context
         payload <- BS.packCStringLen (castPtr bytes, fromIntegral length)
         _ <- forkIO do
             result <- tryAny $
-                case
-                    (Aeson.eitherDecodeStrict' payload
-                        :: Either String SessionTransferEnvelope)
-                of
-                    Left err ->
+                case TextEncoding.decodeUtf8' payload of
+                    Left _ ->
                         pure
                             (Left
-                                ("invalid session transfer: "
-                                    <> Text.pack err))
-                    Right envelope ->
-                        withNativeSessionStore \pool root ->
-                            importSessionTransferRemapped
-                                pool root Nothing envelope
+                                "invalid session transfer: invalid UTF-8")
+                    Right _ ->
+                        case
+                            (Aeson.eitherDecodeStrict' payload
+                                :: Either String SessionTransferEnvelope)
+                        of
+                            Left err ->
+                                pure
+                                    (Left
+                                        ("invalid session transfer: "
+                                            <> Text.pack err))
+                            Right envelope ->
+                                withNativeSessionStore \pool root ->
+                                    importSessionTransferRemapped
+                                        pool root Nothing envelope
             completeSessionResult callback context result
         pure 0
 

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -67,6 +67,10 @@ import Agent.CLI.MacOS.EngineMailbox
     , newEngineMailboxIO
     , readEngineCommand
     )
+import Agent.CLI.MacOS.TaskScheduler
+    ( TaskIdentity(..)
+    , selectRunnableTasks
+    )
 import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.Login
     ( AccountBilling(..)
@@ -171,10 +175,10 @@ import Agent.Tools.Types (AppTool)
 import Control.Concurrent (forkFinally, forkIO)
 import Control.Concurrent.Async
     ( Async
+    , asyncWithUnmask
     , cancel
     , mapConcurrently
-    , waitCatchSTM
-    , withAsync
+    , waitCatch
     )
 import Control.Concurrent.MVar
     ( MVar
@@ -185,6 +189,7 @@ import Control.Concurrent.MVar
     , putMVar
     , readMVar
     , withMVar
+    , takeMVar
     )
 import Control.Concurrent.STM
     ( TMVar
@@ -193,7 +198,6 @@ import Control.Concurrent.STM
     , modifyTVar'
     , newEmptyTMVarIO
     , newTVarIO
-    , orElse
     , readTVar
     , readTVarIO
     , takeTMVar
@@ -205,10 +209,13 @@ import Control.Exception.Safe
     ( SomeException
     , bracket
     , finally
+    , mask
     , tryAny
     )
 import Control.Monad
-    ( forM_
+    ( foldM
+    , filterM
+    , forM_
     , void
     )
 import qualified Data.Aeson as Aeson
@@ -225,8 +232,12 @@ import Data.IORef
     , writeIORef
     )
 import Data.Int (Int64)
+import Data.Foldable (toList)
+import Data.List (partition)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
@@ -385,6 +396,16 @@ type McpServerFieldCallback =
 type McpResultCallback =
     Ptr () -> CInt -> Word64 -> CString -> CSize -> IO ()
 
+-- Status is 0 for an active task, 1 for completion, and -1 for failure.
+-- State is 0 for queued and 1 for running. Every pointer is callback-scoped.
+type TaskSnapshotCallback =
+    Ptr () -> CInt
+    -> Ptr Word8 -> CSize -- task id
+    -> Ptr Word8 -> CSize -- session id, optional
+    -> CInt
+    -> Ptr Word8 -> CSize -- error
+    -> IO ()
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -445,6 +466,10 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeMcpResultCallback
         :: FunPtr McpResultCallback -> McpResultCallback
+
+foreign import ccall "dynamic"
+    invokeTaskSnapshotCallback
+        :: FunPtr TaskSnapshotCallback -> TaskSnapshotCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -586,6 +611,11 @@ data EngineCommand
     | EngineSessionMutation
         !SessionMutation !(FunPtr SessionResultCallback) !(Ptr ())
     | EngineMcpRestart !Word64 !Text !(FunPtr McpResultCallback) !(Ptr ())
+    | EngineCancelTask !Text
+    | EngineTaskSnapshot !(FunPtr TaskSnapshotCallback) !(Ptr ())
+    | EngineSetTaskLimit !Int
+    | EngineTaskSession !Text !Text
+    | EngineTaskFinished !Text !TaskResult
     | EngineStop
 
 data SessionMutation
@@ -611,6 +641,8 @@ newtype BrowserHost = BrowserHost
 
 data TurnControl = TurnControl
     { turnControlId :: !Text
+    , turnControlSessionId :: !(TVar (Maybe Text))
+    , turnControlCancelled :: !(TVar Bool)
     , turnControlCancel :: !(TVar (IO ()))
     , turnControlApprovals
         :: !(TVar (Map Text (TMVar PermissionChoice)))
@@ -624,9 +656,29 @@ data TurnOutcome = TurnOutcome
     , turnOutcomeError :: !(Maybe Text)
     }
 
-data ActiveExit
-    = ActiveContinue
-    | ActiveStop
+data TaskResult
+    = TaskOutcome !TurnOutcome
+    | TaskFailure !Text
+
+data PendingTurn = PendingTurn
+    { pendingTurnStart :: !TurnStart
+    , pendingTurnImages :: ![ImageAttachment]
+    }
+
+data RunningTurn = RunningTurn
+    { runningTurnControl :: !TurnControl
+    , runningTurnWorker :: !(Async ())
+    }
+
+data TaskSupervisor = TaskSupervisor
+    { supervisorLimit :: !Int
+    , supervisorPending :: !(Seq PendingTurn)
+    , supervisorRunning :: !(Map Text RunningTurn)
+    , supervisorKnownTaskIds :: !(Set.Set Text)
+    }
+
+defaultTaskLimit :: Int
+defaultTaskLimit = 3
 
 foreign export ccall ha_engine_create
     :: FunPtr EventCallback -> Ptr () -> IO (Ptr ())
@@ -639,6 +691,15 @@ foreign export ccall ha_engine_stage_turn_images
 
 foreign export ccall ha_engine_set_browser_callback
     :: Ptr () -> FunPtr BrowserCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_cancel_task
+    :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
+
+foreign export ccall ha_engine_list_tasks
+    :: Ptr () -> FunPtr TaskSnapshotCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_set_task_limit
+    :: Ptr () -> CSize -> IO CInt
 
 foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
@@ -1801,6 +1862,66 @@ enqueueSessionMutation pointer mutation callback context
             Right False -> 3
             Right True -> 0
 
+ha_engine_cancel_task
+    :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
+ha_engine_cancel_task pointer taskID (CSize taskIDLength)
+    | pointer == nullPtr = pure 1
+    | taskID == nullPtr || taskIDLength == 0 = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            taskIDBytes <- BS.packCStringLen
+                (castPtr taskID, fromIntegral taskIDLength)
+            case TextEncoding.decodeUtf8' taskIDBytes of
+                Left _ -> pure Nothing
+                Right taskIDText
+                    | Text.null taskIDText -> pure Nothing
+                    | otherwise -> Just <$> atomically
+                        (acceptEngineCommand
+                            engine.engineCommands
+                            (EngineCancelTask taskIDText))
+        pure $ case accepted of
+            Left _ -> 3
+            Right Nothing -> 2
+            Right (Just False) -> 3
+            Right (Just True) -> 0
+
+ha_engine_list_tasks
+    :: Ptr () -> FunPtr TaskSnapshotCallback -> Ptr () -> IO CInt
+ha_engine_list_tasks pointer callback context
+    | pointer == nullPtr = pure 1
+    | callback == nullFunPtr = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            atomically $ acceptEngineCommand
+                engine.engineCommands
+                (EngineTaskSnapshot callback context)
+        pure $ case accepted of
+            Left _ -> 3
+            Right False -> 3
+            Right True -> 0
+
+ha_engine_set_task_limit :: Ptr () -> CSize -> IO CInt
+ha_engine_set_task_limit pointer rawLimit
+    | pointer == nullPtr = pure 1
+    | limit < 1 || limit > 32 = pure 2
+    | otherwise = do
+        accepted <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            atomically $ acceptEngineCommand
+                engine.engineCommands
+                (EngineSetTaskLimit limit)
+        pure $ case accepted of
+            Left _ -> 3
+            Right False -> 3
+            Right True -> 0
+  where
+    limit = fromIntegral rawLimit
+
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer
     | pointer == nullPtr = pure ()
@@ -1826,10 +1947,12 @@ workerLifecycle callback context config root commands stagedImages browser =
     (do
         store <- newMVar Nothing
         processRuntime <- newNativeProcessRuntime root
+        workerRegistry <- newTVarIO Map.empty
         let cleanup =
-                closeNativeProcessRuntime processRuntime
+                shutdownRunningTurns workerRegistry
+                    `finally` closeNativeProcessRuntime processRuntime
                     `finally` closeEngineStore store
-        idleLoop
+        supervisorLoop
             callback
             context
             config
@@ -1839,6 +1962,13 @@ workerLifecycle callback context config root commands stagedImages browser =
             commands
             stagedImages
             browser
+            workerRegistry
+            TaskSupervisor
+                { supervisorLimit = defaultTaskLimit
+                , supervisorPending = Seq.empty
+                , supervisorRunning = Map.empty
+                , supervisorKnownTaskIds = Set.empty
+                }
             `finally` cleanup)
         `finally` cancelPendingMcpRestarts commands
 
@@ -1854,7 +1984,7 @@ cancelPendingMcpRestarts commands = do
                     invokeMcpResultCallback callback context (-1) expected
         _ -> pure ()
 
-idleLoop
+supervisorLoop
     :: FunPtr EventCallback
     -> Ptr ()
     -> ManagedPostgresConfig
@@ -1864,186 +1994,406 @@ idleLoop
     -> EngineMailbox EngineCommand
     -> TVar (Map Text [ImageAttachment])
     -> BrowserHost
+    -> TVar (Map Text RunningTurn)
+    -> TaskSupervisor
     -> IO ()
-idleLoop callback context config store root processRuntime commands stagedImages browser =
-    atomically (readEngineCommand commands) >>= \case
-        EngineStop -> pure ()
+supervisorLoop
+        callback context config store root processRuntime commands stagedImages browser
+        workerRegistry =
+    go
+  where
+    go supervisor0 = do
+        supervisor <- startRunnableTasks supervisor0
+        atomically (readEngineCommand commands) >>= handleCommand supervisor
+
+    handleCommand supervisor = \case
+        EngineStop ->
+            shutdownSupervisor supervisor
         EngineSearch query limit searchCallback searchContext -> do
             runConversationSearch
                 config store query limit searchCallback searchContext
-            continue
+            go supervisor
         EngineSessionMutation mutation resultCallback resultContext -> do
             runSessionMutation
                 config store root mutation resultCallback resultContext
-            continue
+            go supervisor
         EngineMcpRestart expected name resultCallback resultContext -> do
-            restarted <- tryAny do
-                home <- getHomeDirectory
-                mcpAdminTry
-                    (restartMcpAdminServer home expected name
-                        (restartNativeMcpRuntime processRuntime))
-            case restarted of
-                Left exception ->
-                    withText (Text.pack (show exception)) $
-                        invokeMcpResultCallback resultCallback
-                            resultContext (-1) expected
-                Right (Left err) ->
-                    emitMcpResult resultCallback resultContext
-                        (Left err
-                            :: Either McpAdminError (McpAdminSnapshot ()))
-                Right (Right snapshot) ->
-                    invokeMcpResultCallback resultCallback resultContext
-                        0 snapshot.mcpAdminRevision nullPtr 0
-            continue
-        EngineRequest request
-            | request.requestMethod == "turn.start" ->
-                case (parseParams request
-                    :: Either Text TurnStart) of
-                    Left err -> do
-                        atomically $ modifyTVar' stagedImages
-                            (Map.delete request.requestId)
-                        sendEvent callback context
-                            (failureEvent request.requestId err)
-                        continue
-                    Right start -> do
-                        images <- atomically $ do
-                            staged <- readTVar stagedImages
-                            writeTVar stagedImages
-                                (Map.delete start.turnStartId staged)
-                            pure (Map.findWithDefault [] start.turnStartId staged)
-                        nativeBrowserTools <- browserToolsWhenEnabled browser
-                        control <- newTurnControl start.turnStartId
-                        sendEvent callback context $
-                            successEvent request.requestId $
-                                Aeson.object
-                                    [ "turnId" Aeson..= start.turnStartId
-                                    ]
-                        sendTurnStatus
-                            callback
-                            context
-                            start.turnStartId
-                            (if start.turnStartWorktree
-                                then "Creating worktree…"
-                                else "Starting…")
-                        withAsync
-                            (runNativeTurn
-                                callback
-                                context
-                                processRuntime
-                                control
-                                nativeBrowserTools
-                                start
-                                images)
-                            \running ->
-                                activeLoop
-                                    callback
-                                    context
-                                    config
-                                    store
-                                    root
-                                    commands
-                                    control
-                                    running >>= \case
-                                        ActiveContinue -> continue
-                                        ActiveStop -> pure ()
-            | request.requestMethod `elem`
-                ["turn.cancel", "approval.resolve"] -> do
+            if Map.null supervisor.supervisorRunning
+                then do
+                    restarted <- tryAny do
+                        home <- getHomeDirectory
+                        mcpAdminTry
+                            (restartMcpAdminServer home expected name
+                                (restartNativeMcpRuntime processRuntime))
+                    case restarted of
+                        Left exception ->
+                            withText (Text.pack (show exception)) $
+                                invokeMcpResultCallback resultCallback
+                                    resultContext (-1) expected
+                        Right (Left err) ->
+                            emitMcpResult resultCallback resultContext
+                                (Left err
+                                    :: Either
+                                        McpAdminError
+                                        (McpAdminSnapshot ()))
+                        Right (Right snapshot) ->
+                            invokeMcpResultCallback
+                                resultCallback
+                                resultContext
+                                0
+                                snapshot.mcpAdminRevision
+                                nullPtr
+                                0
+                else
+                    withText "cannot restart MCP while tasks are active" $
+                        invokeMcpResultCallback resultCallback resultContext
+                            (-1) expected
+            go supervisor
+        EngineCancelTask taskId -> do
+            next <- cancelTaskById supervisor taskId
+            go next
+        EngineTaskSnapshot snapshotCallback snapshotContext -> do
+            sendTaskSnapshot snapshotCallback snapshotContext supervisor
+            go supervisor
+        EngineSetTaskLimit limit ->
+            go supervisor { supervisorLimit = limit }
+        EngineTaskSession taskId sessionId -> do
+            case Map.lookup taskId supervisor.supervisorRunning of
+                Nothing -> pure ()
+                Just running -> atomically $
+                    writeTVar
+                        running.runningTurnControl.turnControlSessionId
+                        (Just sessionId)
+            go supervisor
+        EngineTaskFinished taskId outcome -> do
+            case Map.lookup taskId supervisor.supervisorRunning of
+                Nothing -> pure ()
+                Just running -> do
+                    _ <- waitCatch running.runningTurnWorker
+                    sessionId <- readTVarIO
+                        running.runningTurnControl.turnControlSessionId
+                    cancelled <- readTVarIO
+                        running.runningTurnControl.turnControlCancelled
+                    if cancelled
+                        then do
+                            sendTaskState taskId sessionId "cancelled"
+                            sendEvent callback context $
+                                turnFailedEvent taskId "turn cancelled"
+                        else do
+                            sendTaskState
+                                taskId
+                                (taskResultSessionId sessionId outcome)
+                                (taskResultState outcome)
+                            finishTurnEvent callback context taskId outcome
+            atomically $ modifyTVar' workerRegistry (Map.delete taskId)
+            go supervisor
+                { supervisorRunning =
+                    Map.delete taskId supervisor.supervisorRunning
+                }
+        EngineRequest request ->
+            handleEngineRequest supervisor request >>= go
+
+    handleEngineRequest supervisor request
+        | request.requestMethod == "turn.start" =
+            enqueueTurn supervisor request
+        | request.requestMethod == "turn.cancel" =
+            case (parseParams request :: Either Text TurnReference) of
+                Left err -> do
+                    sendEvent callback context
+                        (failureEvent request.requestId err)
+                    pure supervisor
+                Right reference -> do
+                    let active =
+                            Map.member
+                                reference.turnReferenceId
+                                supervisor.supervisorRunning
+                        queued = any
+                            ((== reference.turnReferenceId)
+                                . (.turnStartId)
+                                . (.pendingTurnStart))
+                            supervisor.supervisorPending
+                    next <- cancelTaskById
+                        supervisor
+                        reference.turnReferenceId
                     sendEvent callback context $
-                        failureEvent
-                            request.requestId
-                            "there is no active turn"
-                    continue
-            | otherwise -> do
-                event <- handleRequest config store root request
-                sendEvent callback context event
-                continue
-  where
-    continue =
-        idleLoop
+                        if active || queued
+                            then successEvent request.requestId True
+                            else failureEvent
+                                request.requestId
+                                "turn id is not active"
+                    pure next
+        | request.requestMethod == "approval.resolve" =
+            case (parseParams request :: Either Text ApprovalResolution) of
+                Left err -> do
+                    sendEvent callback context
+                        (failureEvent request.requestId err)
+                    pure supervisor
+                Right resolution -> do
+                    matching <- filterM
+                        (approvalIsActive resolution.approvalResolutionId
+                            . (.runningTurnControl))
+                        (Map.elems supervisor.supervisorRunning)
+                    case matching of
+                        [running] ->
+                            resolveApproval running.runningTurnControl request
+                                >>= sendEvent callback context
+                        _ ->
+                            sendEvent callback context $
+                                failureEvent
+                                    request.requestId
+                                    "approval request is no longer active"
+                    pure supervisor
+        | request.requestMethod == "turn.agents" =
+            selectRunningTurn request.requestParams supervisor >>= \case
+                Left err -> do
+                    sendEvent callback context
+                        (failureEvent request.requestId err)
+                    pure supervisor
+                Right Nothing -> do
+                    sendEvent callback context $
+                        successEvent request.requestId ([] :: [Aeson.Value])
+                    pure supervisor
+                Right (Just running) ->
+                    activeAgentSnapshot running.runningTurnControl request
+                        >>= sendEvent callback context
+                        >> pure supervisor
+        | otherwise = do
+            event <- handleRequest config store root request
+            sendEvent callback context event
+            pure supervisor
+
+    selectRunningTurn params supervisor =
+        case Aeson.parseEither
+            (Aeson.withObject "turn reference" (.:? "turnId"))
+            params of
+            Left err -> pure (Left (Text.pack err))
+            Right (Just taskId) ->
+                pure $ maybe
+                    (Left "turn id is not active")
+                    (Right . Just)
+                    (Map.lookup taskId supervisor.supervisorRunning)
+            Right Nothing ->
+                pure $ case Map.elems supervisor.supervisorRunning of
+                    [running] -> Right (Just running)
+                    [] -> Right Nothing
+                    _ -> Left "turnId is required while multiple turns run"
+
+    approvalIsActive approvalId control =
+        Map.member approvalId
+            <$> readTVarIO control.turnControlApprovals
+
+    enqueueTurn supervisor request =
+        case (parseParams request :: Either Text TurnStart) of
+            Left err -> do
+                atomically $ modifyTVar' stagedImages
+                    (Map.delete request.requestId)
+                sendEvent callback context
+                    (failureEvent request.requestId err)
+                pure supervisor
+            Right start
+                | taskExists start.turnStartId supervisor -> do
+                    atomically $ modifyTVar' stagedImages
+                        (Map.delete start.turnStartId)
+                    sendEvent callback context $
+                        failureEvent request.requestId "turn id already exists"
+                    pure supervisor
+                | otherwise -> do
+                    images <- atomically $ do
+                        staged <- readTVar stagedImages
+                        writeTVar stagedImages
+                            (Map.delete start.turnStartId staged)
+                        pure
+                            (Map.findWithDefault
+                                []
+                                start.turnStartId
+                                staged)
+                    sendEvent callback context $
+                        successEvent request.requestId $
+                            Aeson.object
+                                [ "turnId" Aeson..= start.turnStartId
+                                , "state" Aeson..= ("queued" :: Text)
+                                ]
+                    sendTaskState start.turnStartId start.turnStartSessionId
+                        "queued"
+                    pure supervisor
+                        { supervisorPending =
+                            supervisor.supervisorPending
+                                Seq.|> PendingTurn start images
+                        , supervisorKnownTaskIds =
+                            Set.insert
+                                start.turnStartId
+                                supervisor.supervisorKnownTaskIds
+                        }
+
+    startRunnableTasks supervisor = do
+        sessionIds <- activeSessionIds supervisor
+        let available =
+                supervisor.supervisorLimit
+                    - Map.size supervisor.supervisorRunning
+            pending = toList supervisor.supervisorPending
+            candidates =
+                [ ( TaskIdentity
+                        pending.pendingTurnStart.turnStartId
+                        pending.pendingTurnStart.turnStartSessionId
+                  , pending
+                  )
+                | pending <- pending
+                ]
+            (selected, remaining) =
+                selectRunnableTasks available sessionIds candidates
+        running <- foldM
+            startTask
+            supervisor.supervisorRunning
+            (map snd selected)
+        pure supervisor
+            { supervisorPending = Seq.fromList (map snd remaining)
+            , supervisorRunning = running
+            }
+
+    startTask
+        :: Map Text RunningTurn
+        -> PendingTurn
+        -> IO (Map Text RunningTurn)
+    startTask running pending = do
+        let start = pending.pendingTurnStart
+        control <- newTurnControl
+            start.turnStartId
+            start.turnStartSessionId
+        sendTaskState start.turnStartId start.turnStartSessionId "running"
+        sendTurnStatus
             callback
             context
-            config
-            store
-            root
-            processRuntime
-            commands
-            stagedImages
-            browser
-
-activeLoop
-    :: FunPtr EventCallback
-    -> Ptr ()
-    -> ManagedPostgresConfig
-    -> MVar (Maybe Store)
-    -> OsPath
-    -> EngineMailbox EngineCommand
-    -> TurnControl
-    -> Async TurnOutcome
-    -> IO ActiveExit
-activeLoop callback context config store root commands control running =
-    atomically
-        ((Left <$> readEngineCommand commands)
-            `orElse` (Right <$> waitCatchSTM running)) >>= \case
-        Right outcome -> do
-            finishTurnEvent callback context control.turnControlId outcome
-            pure ActiveContinue
-        Left EngineStop -> do
-            cancelTurn control
-            cancel running
-            pure ActiveStop
-        Left (EngineSearch query limit searchCallback searchContext) -> do
-            runConversationSearch
-                config store query limit searchCallback searchContext
-            activeLoop
-                callback context config store root commands control running
-        Left (EngineSessionMutation mutation resultCallback resultContext) -> do
-            runSessionMutation
-                config store root mutation resultCallback resultContext
-            activeLoop
-                callback context config store root commands control running
-        Left (EngineMcpRestart expected _ resultCallback resultContext) -> do
-            withText "cannot restart MCP while a turn is active" $
-                invokeMcpResultCallback resultCallback resultContext (-1)
-                    expected
-            activeLoop
-                callback context config store root commands control running
-        Left (EngineRequest request) -> do
-            if request.requestMethod == "turn.cancel"
-              then
-                case (parseParams request
-                    :: Either Text TurnReference) of
-                    Right reference
-                        | reference.turnReferenceId == control.turnControlId -> do
-                            cancelTurn control
-                            cancel running
-                            sendEvent callback context $
-                                successEvent request.requestId True
-                    _ ->
-                        sendEvent callback context $
-                            failureEvent request.requestId "turn id is not active"
-              else if request.requestMethod == "approval.resolve"
-              then
-                resolveApproval control request >>= sendEvent callback context
-              else if request.requestMethod == "turn.agents"
-              then
-                activeAgentSnapshot control request
-                    >>= sendEvent callback context
-              else if request.requestMethod == "turn.start"
-              then
-                sendEvent callback context $
-                    failureEvent request.requestId "a turn is already running"
-              else
-                handleRequest config store root request
-                    >>= sendEvent callback context
-            activeLoop
+            start.turnStartId
+            (if start.turnStartWorktree
+                then "Creating worktree…"
+                else "Starting…")
+        nativeBrowserTools <- browserToolsWhenEnabled browser
+        worker <- launchTrackedWorker start.turnStartId do
+            runNativeTurn
                 callback
                 context
-                config
-                store
-                root
                 commands
+                processRuntime
                 control
-                running
+                nativeBrowserTools
+                start
+                pending.pendingTurnImages
+        let runningTurn =
+                RunningTurn
+                    { runningTurnControl = control
+                    , runningTurnWorker = worker
+                    }
+        atomically $ modifyTVar' workerRegistry $
+            Map.insert start.turnStartId runningTurn
+        pure $ Map.insert
+            start.turnStartId
+            runningTurn
+            running
+
+    launchTrackedWorker taskId action =
+        mask \_ -> do
+            gate <- newEmptyMVar
+            worker <- asyncWithUnmask \unmask -> do
+                takeMVar gate
+                outcome <- newIORef (TaskFailure "turn cancelled")
+                (tryAny (unmask action) >>= \case
+                    Left exception ->
+                        writeIORef outcome
+                            (TaskFailure (Text.pack (show exception)))
+                    Right value ->
+                        writeIORef outcome (TaskOutcome value))
+                    `finally` do
+                        result <- readIORef outcome
+                        void $ atomically $ acceptEngineCommand
+                            commands
+                            (EngineTaskFinished taskId result)
+            putMVar gate ()
+            pure worker
+
+    activeSessionIds supervisor = do
+        sessions <- mapM
+            (readTVarIO . (.turnControlSessionId) . (.runningTurnControl))
+            (Map.elems supervisor.supervisorRunning)
+        pure (Set.fromList [session | Just session <- sessions])
+
+    cancelTaskById supervisor taskId =
+        case Map.lookup taskId supervisor.supervisorRunning of
+            Just running -> do
+                cancelTurn running.runningTurnControl
+                cancel running.runningTurnWorker
+                pure supervisor
+            Nothing -> do
+                let (cancelled, retained) = partition
+                        ((== taskId)
+                            . (.turnStartId)
+                            . (.pendingTurnStart))
+                        (toList supervisor.supervisorPending)
+                forM_ cancelled \pending ->
+                    let start = pending.pendingTurnStart
+                    in do
+                        sendTaskState
+                            start.turnStartId
+                            start.turnStartSessionId
+                            "cancelled"
+                        sendEvent callback context $
+                            turnFailedEvent
+                                start.turnStartId
+                                "turn cancelled"
+                pure supervisor
+                    { supervisorPending = Seq.fromList retained }
+
+    taskExists taskId supervisor =
+        Set.member taskId supervisor.supervisorKnownTaskIds
+
+    shutdownSupervisor _ =
+        shutdownRunningTurns workerRegistry
+
+    sendTaskState :: Text -> Maybe Text -> Text -> IO ()
+    sendTaskState taskId sessionId state =
+        sendEvent callback context $
+            Aeson.object
+                [ "event" Aeson..= ("task.state" :: Text)
+                , "taskId" Aeson..= taskId
+                , "sessionId" Aeson..= sessionId
+                , "state" Aeson..= state
+                ]
+
+    sendTaskSnapshot snapshotCallback snapshotContext supervisor = do
+        forM_ supervisor.supervisorPending \pending ->
+            sendSnapshotItem
+                snapshotCallback
+                snapshotContext
+                pending.pendingTurnStart.turnStartId
+                pending.pendingTurnStart.turnStartSessionId
+                0
+        forM_ (Map.elems supervisor.supervisorRunning) \running -> do
+            sessionId <- readTVarIO
+                running.runningTurnControl.turnControlSessionId
+            sendSnapshotItem
+                snapshotCallback
+                snapshotContext
+                running.runningTurnControl.turnControlId
+                sessionId
+                1
+        invokeTaskSnapshotCallback snapshotCallback snapshotContext
+            1 nullPtr 0 nullPtr 0 0 nullPtr 0
+
+    sendSnapshotItem snapshotCallback snapshotContext taskId sessionId state =
+        withTextBytes taskId \taskPointer taskLength ->
+        withMaybeTextBytes sessionId \sessionPointer sessionLength ->
+            invokeTaskSnapshotCallback snapshotCallback snapshotContext
+                0 taskPointer taskLength sessionPointer sessionLength
+                state nullPtr 0
+
+shutdownRunningTurns :: TVar (Map Text RunningTurn) -> IO ()
+shutdownRunningTurns workerRegistry = do
+    running <- atomically do
+        current <- readTVar workerRegistry
+        writeTVar workerRegistry Map.empty
+        pure (Map.elems current)
+    forM_ running (cancelTurn . (.runningTurnControl))
+    mapM_ (cancel . (.runningTurnWorker)) running
+    mapM_ (waitCatch . (.runningTurnWorker)) running
 
 runSessionMutation
     :: ManagedPostgresConfig
@@ -2262,13 +2612,16 @@ browserStatusMessage = \case
 runNativeTurn
     :: FunPtr EventCallback
     -> Ptr ()
+    -> EngineMailbox EngineCommand
     -> NativeProcessRuntime
     -> TurnControl
     -> [AppTool]
     -> TurnStart
     -> [ImageAttachment]
     -> IO TurnOutcome
-runNativeTurn callback context processRuntime control nativeBrowserTools start images = do
+runNativeTurn
+        callback context commands processRuntime control nativeBrowserTools
+        start images = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     let hooks = NativeRunHooks
@@ -2283,6 +2636,9 @@ runNativeTurn callback context processRuntime control nativeBrowserTools start i
                             (sendEvent callback context)
             , nativeOnSessionId = \sessionId -> do
                 writeIORef sessionIdRef (Just sessionId)
+                void $ atomically $ acceptEngineCommand
+                    commands
+                    (EngineTaskSession control.turnControlId sessionId)
                 sendEvent callback context $
                     Aeson.object
                         [ "event" Aeson..= ("turn.session" :: Text)
@@ -2393,10 +2749,12 @@ withTurnImages prompt images action = do
                 BS.writeFile path image.imageBytes
                 withImageFiles directory rest (action . (path :))
 
-newTurnControl :: Text -> IO TurnControl
-newTurnControl turnId =
+newTurnControl :: Text -> Maybe Text -> IO TurnControl
+newTurnControl turnId sessionId =
     TurnControl turnId
-        <$> newTVarIO (pure ())
+        <$> newTVarIO sessionId
+        <*> newTVarIO False
+        <*> newTVarIO (pure ())
         <*> newTVarIO Map.empty
         <*> newTVarIO 0
         <*> newTVarIO Set.empty
@@ -2437,6 +2795,7 @@ agentStepStateText = \case
 
 cancelTurn :: TurnControl -> IO ()
 cancelTurn control = do
+    atomically $ writeTVar control.turnControlCancelled True
     cancelAction <- readTVarIO control.turnControlCancel
     cancelAction
     waiters <- atomically do
@@ -2558,13 +2917,13 @@ finishTurnEvent
     :: FunPtr EventCallback
     -> Ptr ()
     -> Text
-    -> Either SomeException TurnOutcome
+    -> TaskResult
     -> IO ()
 finishTurnEvent callback context turnId = \case
-    Left exception ->
+    TaskFailure message ->
         sendEvent callback context $
-            turnFailedEvent turnId (Text.pack (show exception))
-    Right outcome ->
+            turnFailedEvent turnId message
+    TaskOutcome outcome ->
         case outcome.turnOutcomeError of
             Just err ->
                 sendEvent callback context (turnFailedEvent turnId err)
@@ -2575,6 +2934,19 @@ finishTurnEvent callback context turnId = \case
                         , "turnId" Aeson..= turnId
                         , "sessionId" Aeson..= outcome.turnOutcomeSessionId
                         ]
+
+taskResultSessionId :: Maybe Text -> TaskResult -> Maybe Text
+taskResultSessionId fallback = \case
+    TaskFailure _ -> fallback
+    TaskOutcome outcome -> outcome.turnOutcomeSessionId <|> fallback
+
+taskResultState :: TaskResult -> Text
+taskResultState = \case
+    TaskFailure _ -> "failed"
+    TaskOutcome outcome ->
+        case outcome.turnOutcomeError of
+            Just _ -> "failed"
+            Nothing -> "succeeded"
 
 nativeLoopEvent :: Text -> LoopEvent -> Maybe Aeson.Value
 nativeLoopEvent turnId = \case

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -91,20 +91,28 @@ import Agent.CLI.Render
 import Agent.CLI.Options (parseEffort)
 import Agent.CLI.Session
     ( SessionMeta(..)
+    , SessionTurn(..)
+    , SessionTurnPage(..)
+    , SessionTransferEnvelope
+    , TranscriptEffect(..)
     , deleteSession
+    , forkSessionAtTurn
+    , importSessionTransferRemapped
     , listArchivedSessionIds
     , listSessions
+    , loadSessionHistoryTurnsAround
     , loadSessionMeta
     , renameSession
     , setSessionArchived
     , sessionsRoot
+    , streamSessionTransfer
     )
 import Agent.CLI.SessionAdmin
     ( loadSessionPageJSON
     , managedPostgresConfigForHome
     , sessionSummaryWithStatusJSON
     )
-import Agent.Loop (ImageAttachment(..), LoopEvent(..))
+import Agent.Loop (ImageAttachment(..), LoopEvent(..), TokenUsage(..))
 import Agent.Dialect (dialectSlug)
 import Agent.Provider (Provider(..), providerSlug, parseProvider, BillingMode(..))
 import Agent.Store.Postgres
@@ -114,6 +122,7 @@ import Agent.Store.Postgres
     , openStore
     , trustedPool
     )
+import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -288,6 +297,30 @@ type LearnedSkillsListCallback =
     -> CString -> CSize -> CString -> CSize -> CString -> CSize
     -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
 
+-- Session page status is 0 for a turn, 1 for completion, and -1 for failure.
+-- Text buffers are callback-scoped UTF-8.
+type SessionTurnCallback =
+    Ptr () -> CInt -> Int64
+    -> CString -> CSize -- occurred at
+    -> CString -> CSize -- user
+    -> CString -> CSize -- assistant
+    -> CString -> CSize -- turn error
+    -> CString -> CSize -- response id
+    -> CString -> CSize -- transcript effect
+    -> CString -> CSize -- provider-extensible response items JSON
+    -> CLLong -> CLLong -> CLLong -- usage; -1 means absent
+    -> CInt -> CInt -- has older/newer on completion
+    -> CString -> CSize -- error
+    -> IO ()
+
+-- Transfer result status is 0 for success and -1 for failure.
+type SessionTransferResultCallback =
+    Ptr () -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
+-- Export status is 0 for a chunk, 1 for completion, and -1 for failure.
+type SessionExportCallback =
+    Ptr () -> CInt -> Ptr Word8 -> CSize -> CString -> CSize -> IO ()
+
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
 
@@ -304,8 +337,8 @@ foreign import ccall "dynamic"
         :: FunPtr AccountResultCallback -> AccountResultCallback
 
 foreign import ccall "dynamic"
-    invokeSessionResultCallback
-        :: FunPtr SessionResultCallback -> SessionResultCallback
+    invokeSessionTransferResultCallback
+        :: FunPtr SessionTransferResultCallback -> SessionTransferResultCallback
 
 foreign import ccall "dynamic"
     invokeAccountOAuthStartCallback
@@ -317,6 +350,18 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeLearnedSkillsListCallback
         :: FunPtr LearnedSkillsListCallback -> LearnedSkillsListCallback
+
+foreign import ccall "dynamic"
+    invokeSessionTurnCallback
+        :: FunPtr SessionTurnCallback -> SessionTurnCallback
+
+foreign import ccall "dynamic"
+    invokeSessionResultCallback
+        :: FunPtr SessionResultCallback -> SessionResultCallback
+
+foreign import ccall "dynamic"
+    invokeSessionExportCallback
+        :: FunPtr SessionExportCallback -> SessionExportCallback
 
 data BridgeRequest = BridgeRequest
     { requestId :: !Text
@@ -509,6 +554,22 @@ foreign export ccall ha_engine_session_archive
     :: Ptr () -> Ptr Word8 -> CSize -> CInt
     -> FunPtr SessionResultCallback -> Ptr () -> IO CInt
 
+foreign export ccall ha_session_load_around
+    :: Ptr Word8 -> CSize -> Int64 -> CInt
+    -> FunPtr SessionTurnCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_session_fork
+    :: Ptr Word8 -> CSize -> Int64
+    -> FunPtr SessionTransferResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_session_export
+    :: Ptr Word8 -> CSize
+    -> FunPtr SessionExportCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_session_import
+    :: Ptr Word8 -> CSize
+    -> FunPtr SessionTransferResultCallback -> Ptr () -> IO CInt
+
 foreign export ccall ha_accounts_list
     :: FunPtr AccountListCallback -> FunPtr AccountUsageWindowCallback
     -> Ptr () -> IO CInt
@@ -534,6 +595,209 @@ foreign export ccall ha_account_delete
 
 foreign export ccall ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
+
+ha_session_load_around
+    :: Ptr Word8 -> CSize -> Int64 -> CInt
+    -> FunPtr SessionTurnCallback -> Ptr () -> IO CInt
+ha_session_load_around sessionBytes (CSize sessionLength) center radius
+        callback context
+    | callback == nullFunPtr = pure 2
+    | sessionBytes == nullPtr || sessionLength == 0 = pure 2
+    | center < 0 || radius < 0 = pure 2
+    | otherwise = do
+        sessionId <- decodeInput sessionBytes sessionLength
+        _ <- forkIO do
+            result <- tryAny $ withNativeSessionStore \pool root ->
+                loadSessionHistoryTurnsAround
+                    pool root sessionId center (fromIntegral radius)
+            case result of
+                Left exception ->
+                    sessionTurnFailure callback context
+                        (Text.pack (show exception))
+                Right (Left err) ->
+                    sessionTurnFailure callback context err
+                Right (Right page) -> do
+                    forM_ page.pageTurns \(turnIndex, turn) ->
+                        emitSessionTurn callback context turnIndex turn
+                    sessionTurnTerminal callback context
+                        page.pageHasOlder page.pageHasNewer
+        pure 0
+
+ha_session_fork
+    :: Ptr Word8 -> CSize -> Int64
+    -> FunPtr SessionTransferResultCallback -> Ptr () -> IO CInt
+ha_session_fork sessionBytes (CSize sessionLength) throughIndex callback context
+    | callback == nullFunPtr = pure 2
+    | sessionBytes == nullPtr || sessionLength == 0 || throughIndex < 0 = pure 2
+    | otherwise = do
+        sessionId <- decodeInput sessionBytes sessionLength
+        _ <- forkIO do
+            result <- tryAny $ withNativeSessionStore \pool root ->
+                forkSessionAtTurn pool root sessionId throughIndex
+            completeSessionResult callback context result
+        pure 0
+
+ha_session_export
+    :: Ptr Word8 -> CSize
+    -> FunPtr SessionExportCallback -> Ptr () -> IO CInt
+ha_session_export sessionBytes (CSize sessionLength) callback context
+    | callback == nullFunPtr = pure 2
+    | sessionBytes == nullPtr || sessionLength == 0 = pure 2
+    | otherwise = do
+        sessionId <- decodeInput sessionBytes sessionLength
+        _ <- forkIO do
+            result <- tryAny $ withNativeSessionStore \pool root ->
+                streamSessionTransfer pool root sessionId
+                    (emitSessionExportChunk callback context)
+            case result of
+                Left exception ->
+                    sessionExportFailure callback context
+                        (Text.pack (show exception))
+                Right (Left err) ->
+                    sessionExportFailure callback context err
+                Right (Right ()) ->
+                    invokeSessionExportCallback callback
+                        context 1 nullPtr 0 nullPtr 0
+        pure 0
+
+ha_session_import
+    :: Ptr Word8 -> CSize
+    -> FunPtr SessionTransferResultCallback -> Ptr () -> IO CInt
+ha_session_import bytes (CSize length) callback context
+    | callback == nullFunPtr = pure 2
+    | bytes == nullPtr || length == 0 = pure 2
+    | toInteger length > 512 * 1024 * 1024 = pure 2
+    | otherwise = do
+        payload <- BS.packCStringLen (castPtr bytes, fromIntegral length)
+        _ <- forkIO do
+            result <- tryAny $
+                case
+                    (Aeson.eitherDecodeStrict' payload
+                        :: Either String SessionTransferEnvelope)
+                of
+                    Left err ->
+                        pure
+                            (Left
+                                ("invalid session transfer: "
+                                    <> Text.pack err))
+                    Right envelope ->
+                        withNativeSessionStore \pool root ->
+                            importSessionTransferRemapped
+                                pool root Nothing envelope
+            completeSessionResult callback context result
+        pure 0
+
+withNativeSessionStore
+    :: (StorePool -> OsPath -> IO (Either Text a))
+    -> IO (Either Text a)
+withNativeSessionStore action = do
+    home <- getHomeDirectory
+    config <- managedPostgresConfigForHome home
+    openStore config >>= \case
+        Left err -> pure (Left (renderStoreError err))
+        Right opened ->
+            bracket (pure opened) closeStore \store ->
+                action (trustedPool store) (sessionsRoot home)
+
+emitSessionTurn
+    :: FunPtr SessionTurnCallback
+    -> Ptr ()
+    -> Int64
+    -> SessionTurn
+    -> IO ()
+emitSessionTurn callback context turnIndex turn =
+    withText (Text.pack (show turn.turnAt)) \occurred occurredLength ->
+    withText turn.turnUserText \user userLength ->
+    withOptionalText turn.turnAssistantText \assistant assistantLength ->
+    withOptionalText turn.turnError \turnError turnErrorLength ->
+    withOptionalText turn.turnResponseId \response responseLength ->
+    withText (transcriptEffectName turn.turnEffect) \effect effectLength ->
+    BS.useAsCStringLen
+        (LBS.toStrict (Aeson.encode turn.turnItems))
+        \(items, itemsLength) -> do
+            let (inputTokens', outputTokens', cachedTokens') =
+                    maybe (-1, -1, -1)
+                        (\usage ->
+                            ( fromIntegral usage.inputTokens
+                            , fromIntegral usage.outputTokens
+                            , fromIntegral usage.cachedTokens
+                            ))
+                        turn.turnUsage
+            invokeSessionTurnCallback callback context 0 turnIndex
+                occurred occurredLength
+                user userLength
+                assistant assistantLength
+                turnError turnErrorLength
+                response responseLength
+                effect effectLength
+                items (fromIntegral itemsLength)
+                inputTokens' outputTokens' cachedTokens'
+                0 0 nullPtr 0
+
+sessionTurnTerminal
+    :: FunPtr SessionTurnCallback -> Ptr () -> Bool -> Bool -> IO ()
+sessionTurnTerminal callback context hasOlder hasNewer =
+    invokeSessionTurnCallback callback context 1 (-1)
+        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+        (-1) (-1) (-1)
+        (if hasOlder then 1 else 0)
+        (if hasNewer then 1 else 0)
+        nullPtr 0
+
+sessionTurnFailure
+    :: FunPtr SessionTurnCallback -> Ptr () -> Text -> IO ()
+sessionTurnFailure callback context err =
+    withText err \errorPointer errorLength ->
+        invokeSessionTurnCallback callback context (-1) (-1)
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+            nullPtr 0 (-1) (-1) (-1) 0 0 errorPointer errorLength
+
+transcriptEffectName :: TranscriptEffect -> Text
+transcriptEffectName = \case
+    TranscriptAppend -> "append"
+    TranscriptReplace -> "replace"
+    TranscriptReset -> "reset"
+
+completeSessionResult
+    :: FunPtr SessionTransferResultCallback
+    -> Ptr ()
+    -> Either SomeException (Either Text Text)
+    -> IO ()
+completeSessionResult callback context = \case
+    Left exception ->
+        emitSessionResult callback context (-1) Nothing
+            (Just (Text.pack (show exception)))
+    Right (Left err) ->
+        emitSessionResult callback context (-1) Nothing (Just err)
+    Right (Right sessionId) ->
+        emitSessionResult callback context 0 (Just sessionId) Nothing
+
+emitSessionResult
+    :: FunPtr SessionTransferResultCallback
+    -> Ptr ()
+    -> CInt
+    -> Maybe Text
+    -> Maybe Text
+    -> IO ()
+emitSessionResult callback context status sessionId err =
+    withOptionalText sessionId \sessionPointer sessionLength ->
+    withOptionalText err \errorPointer errorLength ->
+        invokeSessionTransferResultCallback callback context status
+            sessionPointer sessionLength errorPointer errorLength
+
+emitSessionExportChunk
+    :: FunPtr SessionExportCallback -> Ptr () -> BS.ByteString -> IO ()
+emitSessionExportChunk callback context chunk =
+    BS.useAsCStringLen chunk \(pointer, length) ->
+        invokeSessionExportCallback callback context 0
+            (castPtr pointer) (fromIntegral length) nullPtr 0
+
+sessionExportFailure
+    :: FunPtr SessionExportCallback -> Ptr () -> Text -> IO ()
+sessionExportFailure callback context err =
+    withText err \pointer length ->
+        invokeSessionExportCallback callback context (-1)
+            nullPtr 0 pointer length
 
 ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/TaskScheduler.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/TaskScheduler.hs
@@ -1,0 +1,51 @@
+module Agent.CLI.MacOS.TaskScheduler
+    ( TaskIdentity(..)
+    , selectRunnableTasks
+    ) where
+
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+
+-- | Stable scheduling identity for one native task. A missing session id is a
+-- fresh session and therefore does not conflict with another queued task.
+data TaskIdentity = TaskIdentity
+    { taskIdentityId :: !Text
+    , taskIdentitySessionId :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+-- | Select at most @capacity@ tasks in queue order while leaving tasks for an
+-- already-active (or newly-selected) session queued. Skipping a blocked task
+-- lets unrelated sessions make progress without allowing a later turn for the
+-- same session to overtake it.
+selectRunnableTasks
+    :: Int
+    -> Set Text
+    -> [(TaskIdentity, task)]
+    -> ([(TaskIdentity, task)], [(TaskIdentity, task)])
+selectRunnableTasks rawCapacity activeSessions =
+    go (max 0 rawCapacity) activeSessions [] []
+  where
+    go _ _ selected deferred [] =
+        (reverse selected, reverse deferred)
+    go 0 _ selected deferred remaining =
+        (reverse selected, reverse deferred <> remaining)
+    go capacity sessions selected deferred (candidate@(identity, _) : rest) =
+        case identity.taskIdentitySessionId of
+            Just sessionId
+                | Set.member sessionId sessions ->
+                    go capacity sessions selected (candidate : deferred) rest
+                | otherwise ->
+                    go
+                        (capacity - 1)
+                        (Set.insert sessionId sessions)
+                        (candidate : selected)
+                        deferred
+                        rest
+            Nothing ->
+                go
+                    (capacity - 1)
+                    sessions
+                    (candidate : selected)
+                    deferred
+                    rest

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -292,8 +292,10 @@ void ha_engine_destroy(void *engine);
 /*
  * Typed session operations copy all inputs before returning and invoke exactly
  * one terminal callback after returning 0. A return of 2 rejects a null/empty
- * required input, invalid index/radius, null callback, or import larger than
- * 512 MiB; no callback follows a rejected call. Radius is clamped to 500.
+ * required input, invalid UTF-8 session id, invalid index/radius, null
+ * callback, or import larger than 512 MiB; no callback follows a rejected
+ * call. Malformed import documents, including invalid UTF-8, report callback
+ * failure after acceptance. Radius is clamped to 500.
  *
  * Fork copies through the inclusive durable turn index into a fresh session;
  * the source is immutable. Import always remaps the source id to a fresh id.

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -18,8 +18,11 @@ typedef void (*ha_event_callback)(
      * Kind 1 is reasoning text, 2 text, 3 status, 4 tool-start, and 5
      * tool-finish. Tool-start flags use bit 0 for encrypted arguments and
      * bit 1 for truncation; tool-finish uses bit 1 for truncation.
-     * The bytes are valid only for the duration of this callback; copy before
-     * returning.
+     * Turn IDs are stable task IDs for the lifetime of an engine. Events for
+     * one task are delivered in order, but callbacks for different tasks may
+     * run concurrently on runtime worker threads. The callback must be
+     * thread-safe and return promptly. The bytes are valid only for the
+     * duration of this callback; copy before returning.
      */
     const uint8_t *bytes,
     size_t length
@@ -470,6 +473,26 @@ typedef struct ha_image_attachment {
     size_t bytes_length;
 } ha_image_attachment;
 
+/*
+ * Active-task snapshots emit status 0 for each task, status 1 exactly once on
+ * completion, and status -1 for failure. state is 0 for queued or 1 for
+ * running. session_id is NULL/zero until a new task creates its session; all
+ * other item pointers are non-NULL. Error is populated only for status -1.
+ * Buffers are callback-scoped UTF-8 and must be copied before returning.
+ * Callbacks run serially on the engine command worker, not the caller thread.
+ */
+typedef void (*ha_task_snapshot_callback)(
+    void *context,
+    int32_t status,
+    const uint8_t *task_id,
+    size_t task_id_length,
+    const uint8_t *session_id,
+    size_t session_id_length,
+    int32_t state,
+    const uint8_t *error,
+    size_t error_length
+);
+
 /* Runtime calls are process-global and reference counted. */
 int32_t ha_runtime_init(void);
 void ha_runtime_exit(void);
@@ -502,6 +525,35 @@ int32_t ha_engine_send_json(
     const uint8_t *bytes,
     size_t length
 );
+/*
+ * Queue cancellation for a copied, non-empty UTF-8 task ID. Return 0 means
+ * the command was accepted, not that the task necessarily still exists.
+ * Terminal task outcome continues through ha_event_callback. Returns 1 for a
+ * null engine, 2 for an invalid task ID, and 3 for an internal failure.
+ */
+int32_t ha_engine_cancel_task(
+    void *engine,
+    const uint8_t *task_id,
+    size_t task_id_length
+);
+/*
+ * List currently queued and running tasks. Returns 0 when accepted, 1 for a
+ * null engine, 2 for a null callback, and 3 for an internal failure. An
+ * accepted request receives exactly one terminal callback unless destruction
+ * has begun. Calls must be serialized with ha_engine_destroy.
+ */
+int32_t ha_engine_list_tasks(
+    void *engine,
+    ha_task_snapshot_callback callback,
+    void *context
+);
+/*
+ * Set the engine-wide cross-session concurrency limit for future scheduling.
+ * Existing tasks are not cancelled when lowering it. Valid limits are 1...32;
+ * the default is 3. Returns 0 when accepted, 1 for a null engine, 2 for an
+ * invalid limit, and 3 for an internal failure.
+ */
+int32_t ha_engine_set_task_limit(void *engine, size_t limit);
 /*
  * Search active and archived (but not deleted) conversations. The query is
  * copied before return and limit is clamped to 1...100. Returns 0 when

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -170,6 +170,48 @@ typedef struct ha_image_attachment {
     size_t bytes_length;
 } ha_image_attachment;
 
+/*
+ * Session-page callbacks use status 0 for a turn, 1 for terminal success, and
+ * -1 for terminal failure. has_older/has_newer are meaningful only on terminal
+ * success. Missing optional strings have length zero. Usage values are all -1
+ * when a turn has no provider usage. response_items_json is the JSON array
+ * from version 1 of the full-fidelity session-transfer format; it remains JSON
+ * because provider response items are deliberately extensible. Every buffer is
+ * callback-scoped and must be copied before returning. Callbacks run serially
+ * on a background worker, never the caller or main thread.
+ */
+typedef void (*ha_session_turn_callback)(
+    void *context, int32_t status, int64_t turn_index,
+    const uint8_t *occurred_at, size_t occurred_at_length,
+    const uint8_t *user_text, size_t user_text_length,
+    const uint8_t *assistant_text, size_t assistant_text_length,
+    const uint8_t *turn_error, size_t turn_error_length,
+    const uint8_t *response_id, size_t response_id_length,
+    const uint8_t *transcript_effect, size_t transcript_effect_length,
+    const uint8_t *response_items_json, size_t response_items_json_length,
+    int64_t input_tokens, int64_t output_tokens, int64_t cached_tokens,
+    int32_t has_older, int32_t has_newer,
+    const uint8_t *error, size_t error_length
+);
+
+/* Session transfer results use status 0 for success and -1 for failure. */
+typedef void (*ha_session_transfer_result_callback)(
+    void *context, int32_t status,
+    const uint8_t *session_id, size_t session_id_length,
+    const uint8_t *error, size_t error_length
+);
+
+/*
+ * Export callbacks use status 0 for a document chunk, 1 for terminal success,
+ * and -1 for terminal failure. Chunks concatenate to one version 1
+ * haskell-agent.session-transfer JSON document. Buffers are callback-scoped.
+ */
+typedef void (*ha_session_export_callback)(
+    void *context, int32_t status,
+    const uint8_t *bytes, size_t length,
+    const uint8_t *error, size_t error_length
+);
+
 /* Runtime calls are process-global and reference counted. */
 int32_t ha_runtime_init(void);
 void ha_runtime_exit(void);
@@ -246,6 +288,34 @@ int32_t ha_engine_session_archive(
     void *context
 );
 void ha_engine_destroy(void *engine);
+
+/*
+ * Typed session operations copy all inputs before returning and invoke exactly
+ * one terminal callback after returning 0. A return of 2 rejects a null/empty
+ * required input, invalid index/radius, null callback, or import larger than
+ * 512 MiB; no callback follows a rejected call. Radius is clamped to 500.
+ *
+ * Fork copies through the inclusive durable turn index into a fresh session;
+ * the source is immutable. Import always remaps the source id to a fresh id.
+ */
+int32_t ha_session_load_around(
+    const uint8_t *session_id, size_t session_id_length,
+    int64_t center_turn_index, int32_t radius,
+    ha_session_turn_callback callback, void *context
+);
+int32_t ha_session_fork(
+    const uint8_t *session_id, size_t session_id_length,
+    int64_t through_turn_index,
+    ha_session_transfer_result_callback callback, void *context
+);
+int32_t ha_session_export(
+    const uint8_t *session_id, size_t session_id_length,
+    ha_session_export_callback callback, void *context
+);
+int32_t ha_session_import(
+    const uint8_t *bytes, size_t length,
+    ha_session_transfer_result_callback callback, void *context
+);
 
 /*
  * Account operations use typed callbacks. Callback buffers are valid only

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -20,7 +20,8 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-claude agent-codex-dialect agent-core
     agent-grok-build-dialect agent-openai agent-openrouter
-    agent-process agent-responses agent-responses-types agent-store
+    agent-process agent-responses agent-responses-types
+    agent-runtime-daemon agent-store
     agent-syntax agent-tui agent-xai ansi-terminal async base
     base64-bytestring brick bytestring colour containers directory
     filelock filepath haskeline hasql-pool http-client http-client-tls

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -1,13 +1,13 @@
 { mkDerivation, aeson, agent-claude, agent-codex-dialect
 , agent-core, agent-grok-build-dialect, agent-openai
 , agent-openrouter, agent-process, agent-responses
-, agent-responses-types, agent-store, agent-syntax, agent-tui
-, agent-xai, ansi-terminal, async, base, base64-bytestring, brick
-, bytestring, colour, containers, deepseq, directory, filelock
-, filepath, haskeline, hasql-pool, hspec, http-client
-, http-client-tls, http-types, JuicyPixels, lib, mtl, network
-, network-uri, optparse-applicative, process, QuickCheck, retry
-, safe-exceptions, scientific, stm, tagsoup, text, time
+, agent-responses-types, agent-runtime-daemon, agent-store
+, agent-syntax, agent-tui, agent-xai, ansi-terminal, async, base
+, base64-bytestring, brick, bytestring, colour, containers, deepseq
+, directory, filelock, filepath, haskeline, hasql-pool, hspec
+, http-client, http-client-tls, http-types, JuicyPixels, lib, mtl
+, network, network-uri, optparse-applicative, process, QuickCheck
+, retry, safe-exceptions, scientific, stm, tagsoup, text, time
 , transformers, unix, vector, vty, vty-crossplatform
 }:
 mkDerivation {
@@ -36,10 +36,11 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-claude agent-codex-dialect agent-core
     agent-grok-build-dialect agent-openai agent-openrouter
-    agent-responses agent-responses-types agent-store agent-tui
-    agent-xai ansi-terminal async base brick bytestring colour
-    containers directory filepath haskeline hspec JuicyPixels process
-    QuickCheck safe-exceptions stm text time transformers unix vty
+    agent-responses agent-responses-types agent-runtime-daemon
+    agent-store agent-tui agent-xai ansi-terminal async base brick
+    bytestring colour containers directory filepath haskeline hspec
+    JuicyPixels process QuickCheck safe-exceptions stm text time
+    transformers unix vty
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-responses agent-store base brick bytestring

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -954,7 +954,9 @@ loadSessionTurnsBefore
     -> IO (Either Text SessionTurnPage)
 loadSessionTurnsBefore pool root sessionId cursor limit =
     loadSessionTurnPage root pool sessionId
-        (\pool' key -> Store.loadSessionTurnsBefore pool' key cursor limit)
+        (\pool' key ->
+            Store.loadSessionTurnsBefore
+                pool' key cursor (boundedPageLimit limit))
 
 loadSessionHistoryTurnsBefore
     :: StorePool
@@ -966,7 +968,8 @@ loadSessionHistoryTurnsBefore
 loadSessionHistoryTurnsBefore pool root sessionId cursor limit =
     loadSessionTurnPage root pool sessionId
         (\pool' key ->
-            Store.loadSessionHistoryTurnsBefore pool' key cursor limit)
+            Store.loadSessionHistoryTurnsBefore
+                pool' key cursor (boundedPageLimit limit))
 
 loadSessionTurnsAfter
     :: StorePool
@@ -977,7 +980,9 @@ loadSessionTurnsAfter
     -> IO (Either Text SessionTurnPage)
 loadSessionTurnsAfter pool root sessionId cursor limit =
     loadSessionTurnPage root pool sessionId
-        (\pool' key -> Store.loadSessionTurnsAfter pool' key cursor limit)
+        (\pool' key ->
+            Store.loadSessionTurnsAfter
+                pool' key cursor (boundedPageLimit limit))
 
 loadSessionHistoryTurnsRange
     :: StorePool
@@ -989,9 +994,8 @@ loadSessionHistoryTurnsRange
 loadSessionHistoryTurnsRange pool root sessionId start limit =
     loadSessionTurnPage root pool sessionId
         (\pool' key ->
-            Store.loadSessionHistoryTurnsRange pool' key start (boundedLimit limit))
-  where
-    boundedLimit = min 1000 . max 1
+            Store.loadSessionHistoryTurnsRange
+                pool' key start (boundedPageLimit limit))
 
 loadSessionHistoryTurnsRangeBounded
     :: StorePool
@@ -1006,7 +1010,10 @@ loadSessionHistoryTurnsRangeBounded
     loadSessionTurnPage root pool sessionId
         (\pool' key ->
             Store.loadSessionHistoryTurnsRangeBounded
-                pool' key start endExclusive (min 1000 (max 1 limit)))
+                pool' key start endExclusive (boundedPageLimit limit))
+
+boundedPageLimit :: Int -> Int
+boundedPageLimit = min 1000 . max 1
 
 -- | Return a bounded full-history window centered on a durable turn index.
 -- The requested turn is included when it exists. Near either edge the result

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -9,6 +9,9 @@ module Agent.CLI.Session
     , SessionResumeStats(..)
     , SessionActivity(..)
     , SessionTransfer(..)
+    , SessionTransferEnvelope(..)
+    , sessionTransferFormatVersion
+    , validateSessionTransferEnvelope
     , SessionCreate(..)
     , Persistence(..)
     , PersistenceState(..)
@@ -39,8 +42,16 @@ module Agent.CLI.Session
     , loadSessionTurnsBefore
     , loadSessionHistoryTurnsBefore
     , loadSessionTurnsAfter
+    , loadSessionHistoryTurnsRange
+    , loadSessionHistoryTurnsRangeBounded
+    , loadSessionHistoryTurnsAround
+    , loadSessionHistorySnapshot
     , loadSessionResumeStats
     , importSessionTransfer
+    , importSessionTransferRemapped
+    , exportSessionTransfer
+    , streamSessionTransfer
+    , forkSessionAtTurn
     , loadSessionHandle
     , isValidSessionId
     , listSessions
@@ -113,11 +124,12 @@ import Control.Monad.Trans.Except
 import Data.Aeson (FromJSON(..), ToJSON(..), object, withObject, (.:), (.:?), (.!=), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString as BS
 import Data.Bits (xor)
 import Data.Int (Int64)
 import Data.IORef
 import Data.Functor ((<&>))
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -193,6 +205,77 @@ instance ToJSON SessionTransfer where
 instance FromJSON SessionTransfer where
     parseJSON = withObject "SessionTransfer" \o ->
         SessionTransfer <$> o .: "meta" <*> o .: "turns"
+
+-- | Stable interchange envelope for full-fidelity session transfers.
+--
+-- The explicit format marker prevents an arbitrary JSON object from being
+-- accepted as a session. Version changes are intentionally opt-in so importers
+-- cannot silently reinterpret provider-owned response items.
+data SessionTransferEnvelope = SessionTransferEnvelope
+    { transferFormat :: !Text
+    , transferFormatVersion :: !Int
+    , transferSession :: !SessionTransfer
+    } deriving (Eq, Show)
+
+sessionTransferFormatVersion :: Int
+sessionTransferFormatVersion = 1
+
+sessionTransferFormatName :: Text
+sessionTransferFormatName = "haskell-agent.session-transfer"
+
+instance ToJSON SessionTransferEnvelope where
+    toJSON envelope = object
+        [ "format" .= envelope.transferFormat
+        , "version" .= envelope.transferFormatVersion
+        , "session" .= envelope.transferSession
+        ]
+
+instance FromJSON SessionTransferEnvelope where
+    parseJSON = withObject "SessionTransferEnvelope" \o -> do
+        envelope <- SessionTransferEnvelope
+            <$> o .: "format"
+            <*> o .: "version"
+            <*> o .: "session"
+        either (fail . Text.unpack) pure
+            (validateSessionTransferEnvelope envelope)
+
+validateSessionTransferEnvelope
+    :: SessionTransferEnvelope
+    -> Either Text SessionTransferEnvelope
+validateSessionTransferEnvelope envelope
+    | envelope.transferFormat /= sessionTransferFormatName =
+        Left "unsupported session transfer format"
+    | envelope.transferFormatVersion /= sessionTransferFormatVersion =
+        Left
+            ("unsupported session transfer version: "
+                <> Text.pack (show envelope.transferFormatVersion))
+    | not (isValidSessionId meta.metaId) =
+        Left "invalid transferred session id"
+    | meta.metaVersion <= 0 =
+        Left "invalid transferred session schema version"
+    | length turns > maximumTransferTurns =
+        Left "session transfer contains too many turns"
+    | any invalidTurn turns =
+        Left "session transfer contains an oversized turn"
+    | otherwise = Right envelope
+  where
+    transfer = envelope.transferSession
+    meta = transfer.transferMeta
+    turns = transfer.transferTurns
+    invalidTurn turn =
+        Text.length turn.turnUserText > maximumTransferTextLength
+            || maybe False
+                ((> maximumTransferTextLength) . Text.length)
+                turn.turnAssistantText
+            || maybe False
+                ((> maximumTransferTextLength) . Text.length)
+                turn.turnError
+
+maximumTransferTurns :: Int
+maximumTransferTurns = 100000
+
+maximumTransferTextLength :: Int
+maximumTransferTextLength = 16 * 1024 * 1024
 
 -- | Durable provenance for subagent transcripts written before child target
 -- metadata was persisted. Keeping this target separate from the mutable root
@@ -896,6 +979,76 @@ loadSessionTurnsAfter pool root sessionId cursor limit =
     loadSessionTurnPage root pool sessionId
         (\pool' key -> Store.loadSessionTurnsAfter pool' key cursor limit)
 
+loadSessionHistoryTurnsRange
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either Text SessionTurnPage)
+loadSessionHistoryTurnsRange pool root sessionId start limit =
+    loadSessionTurnPage root pool sessionId
+        (\pool' key ->
+            Store.loadSessionHistoryTurnsRange pool' key start (boundedLimit limit))
+  where
+    boundedLimit = min 1000 . max 1
+
+loadSessionHistoryTurnsRangeBounded
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Int64
+    -> Int64
+    -> Int
+    -> IO (Either Text SessionTurnPage)
+loadSessionHistoryTurnsRangeBounded
+        pool root sessionId start endExclusive limit =
+    loadSessionTurnPage root pool sessionId
+        (\pool' key ->
+            Store.loadSessionHistoryTurnsRangeBounded
+                pool' key start endExclusive (min 1000 (max 1 limit)))
+
+-- | Return a bounded full-history window centered on a durable turn index.
+-- The requested turn is included when it exists. Near either edge the result
+-- is intentionally not rebalanced; callers can use the page flags to continue
+-- in either direction without an eager full-session load.
+loadSessionHistoryTurnsAround
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either Text SessionTurnPage)
+loadSessionHistoryTurnsAround pool root sessionId center radius
+    | center < 0 = pure (Left "turn index must be non-negative")
+    | radius < 0 = pure (Left "turn radius must be non-negative")
+    | otherwise =
+        loadSessionHistoryTurnsRange
+            pool
+            root
+            sessionId
+            (max 0 (center - fromIntegral boundedRadius))
+            (boundedRadius * 2 + 1)
+  where
+    boundedRadius = min 500 radius
+
+loadSessionHistorySnapshot
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> IO (Either Text (SessionMeta, Int64, Int64))
+loadSessionHistorySnapshot pool root sessionId = runExceptT do
+    _ <- except (sessionDirForId root sessionId)
+    stored <- loadWithLegacyImport
+        root pool sessionId Store.loadSessionHistorySnapshot
+    meta <- except (fromStoredMetadata stored.sessionSnapshotMetadata)
+    validateSessionMeta sessionId meta
+    pure
+        ( meta
+        , stored.sessionSnapshotStart
+        , stored.sessionSnapshotTotal
+        )
+
 loadSessionResumeStats
     :: StorePool
     -> OsPath
@@ -1047,6 +1200,177 @@ importSessionTransfer pool root cwd transfer = runExceptT do
         _ <- tryIO (removePathForcibly dir)
         _ <- removeSessionTemp root sessionId
         pure ()
+
+-- | Import a validated transfer as a new session. The source id is never
+-- reused, which makes importing the same file safe and preserves the source
+-- transcript as an immutable object.
+importSessionTransferRemapped
+    :: StorePool
+    -> OsPath
+    -> Maybe OsPath
+    -> SessionTransferEnvelope
+    -> IO (Either Text Text)
+importSessionTransferRemapped pool root cwd rawEnvelope =
+    case validateSessionTransferEnvelope rawEnvelope of
+        Left err -> pure (Left err)
+        Right envelope -> do
+            (sessionId, _) <- allocateSessionTemp root
+            now <- normalizePostgresTimestamp <$> getCurrentTime
+            let transfer = envelope.transferSession
+                sourceMeta = transfer.transferMeta
+                meta = sourceMeta
+                    { metaId = sessionId
+                    , metaCreatedAt = now
+                    , metaUpdatedAt = now
+                    }
+            importSessionTransfer pool root cwd
+                transfer { transferMeta = meta }
+
+exportSessionTransfer
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> IO (Either Text SessionTransferEnvelope)
+exportSessionTransfer pool root sessionId =
+    loadSession pool root sessionId <&> \result -> do
+        (meta, turns) <- result
+        validateSessionTransferEnvelope SessionTransferEnvelope
+            { transferFormat = sessionTransferFormatName
+            , transferFormatVersion = sessionTransferFormatVersion
+            , transferSession = SessionTransfer meta turns
+            }
+
+-- | Stream a transfer document in bounded turn pages. Callback bytes are
+-- valid only for the duration of the callback. The export captures the turn
+-- count from its first page and ignores later appends, yielding an immutable
+-- prefix without hydrating the full transcript.
+streamSessionTransfer
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> (BS.ByteString -> IO ())
+    -> IO (Either Text ())
+streamSessionTransfer pool root sessionId emit = runExceptT do
+    (meta, snapshotStart, snapshotTotal) <-
+        lift (loadSessionHistorySnapshot pool root sessionId) >>= except
+    let snapshotEnd = snapshotStart + max 0 snapshotTotal
+    lift $ emitLazy
+        ("{\"format\":\"haskell-agent.session-transfer\","
+            <> "\"version\":1,\"session\":{\"meta\":"
+            <> Aeson.encode meta
+            <> ",\"turns\":[")
+    firstPage <- lift
+        (loadSessionHistoryTurnsRangeBounded
+            pool root sessionId snapshotStart snapshotEnd 256)
+        >>= except
+    let total = max 0 snapshotTotal
+    emitted <- lift (emitPage True total 0 firstPage)
+    when (emitted < total) $
+        streamRest snapshotEnd total emitted firstPage
+    lift (emitLazy "]}}")
+  where
+    emitLazy = mapM_ emit . LBS.toChunks
+
+    emitPage first total emitted page = do
+        let remaining = max 0 (total - emitted)
+            selected = take (fromIntegral remaining) page.pageTurns
+        _ <- foldl'
+            (\action (_, turn) -> do
+                isFirst <- action
+                unless isFirst (emit ",")
+                emitLazy (Aeson.encode turn)
+                pure False)
+            (pure first)
+            selected
+        pure (emitted + fromIntegral (length selected))
+
+    streamRest snapshotEnd total emitted previous =
+        case reverse previous.pageTurns of
+            [] -> throwE "session export paging made no progress"
+            (lastIndex, _) : _ -> do
+                page <- lift
+                    (loadSessionHistoryTurnsRangeBounded
+                        pool root sessionId (lastIndex + 1) snapshotEnd 256)
+                    >>= except
+                next <- lift (emitPage False total emitted page)
+                when (next <= emitted) $
+                    throwE "session export paging made no progress"
+                when (next < total) (streamRest snapshotEnd total next page)
+
+-- | Fork a source session through an inclusive durable turn index. The source
+-- remains untouched. Transcript effects are copied verbatim, while derived
+-- usage and continuation metadata are recomputed from the selected prefix.
+forkSessionAtTurn
+    :: StorePool
+    -> OsPath
+    -> Text
+    -> Int64
+    -> IO (Either Text Text)
+forkSessionAtTurn pool root sourceId throughIndex = runExceptT do
+    when (throughIndex < 0) (throwE "turn index must be non-negative")
+    (sourceMeta, snapshotStart, snapshotTotal) <-
+        lift (loadSessionHistorySnapshot pool root sourceId) >>= except
+    let snapshotEnd = snapshotStart + max 0 snapshotTotal
+    when
+        (throughIndex < snapshotStart || throughIndex >= snapshotEnd) $
+        throwE "turn index is outside the session transcript"
+    turns <- loadPrefix snapshotStart (throughIndex + 1) id
+    let
+        usage = foldl' addUsage
+            (TokenUsage
+                { inputTokens = 0
+                , outputTokens = 0
+                , cachedTokens = 0
+                })
+            (mapMaybe (.turnUsage) turns)
+        meta = sourceMeta
+            { metaLastResponseId = continuationResponseId turns
+            , metaInputTokens = usage.inputTokens
+            , metaOutputTokens = usage.outputTokens
+            , metaCachedTokens = usage.cachedTokens
+            , metaLastRecap = Nothing
+            , metaLastTurnSummary = Nothing
+            , metaLastRecapMainTurns = 0
+            , metaTitleUserTurns =
+                length (filter (not . Text.null . Text.strip . (.turnUserText)) turns)
+            }
+        envelope = SessionTransferEnvelope
+            { transferFormat = sessionTransferFormatName
+            , transferFormatVersion = sessionTransferFormatVersion
+            , transferSession = SessionTransfer meta turns
+            }
+    lift (importSessionTransferRemapped pool root Nothing envelope) >>= except
+  where
+    loadPrefix cursor endExclusive append
+        | cursor >= endExclusive = pure (append [])
+        | otherwise = do
+            page <- lift
+                (loadSessionHistoryTurnsRangeBounded
+                    pool root sourceId cursor endExclusive 256)
+                >>= except
+            case page.pageTurns of
+                [] -> throwE "session fork paging made no progress"
+                values -> do
+                    let lastIndex = fst (last values)
+                        pageTurns = map snd values
+                    loadPrefix
+                        (lastIndex + 1)
+                        endExclusive
+                        (append . (pageTurns <>))
+
+    addUsage left right = TokenUsage
+        { inputTokens = left.inputTokens + right.inputTokens
+        , outputTokens = left.outputTokens + right.outputTokens
+        , cachedTokens = left.cachedTokens + right.cachedTokens
+        }
+
+    continuationResponseId = foldl' step Nothing
+    step previous turn =
+        let base = case turn.turnEffect of
+                TranscriptAppend -> previous
+                TranscriptReplace -> Nothing
+                TranscriptReset -> Nothing
+        in turn.turnResponseId <|> base
 
 deleteSession :: StorePool -> OsPath -> Text -> IO (Either Text ())
 deleteSession pool root sessionId = runExceptT do

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -10,6 +10,8 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 foreign import ccall "ha_image_attachment_stage_smoke"
     imageAttachmentStageSmoke :: IO CInt
 
+foreign import ccall "ha_task_supervisor_abi_smoke"
+    taskSupervisorAbiSmoke :: IO CInt
 #else
 import Test.Hspec (Spec, describe, it, pendingWith)
 #endif
@@ -19,6 +21,13 @@ spec = describe "native engine lifecycle smoke" do
     it "stages copied images and completes restart before destroy returns" do
 #ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0
+#else
+        pendingWith "the native bridge smoke test only links on macOS"
+#endif
+
+    it "controls and snapshots native tasks through the exported bridge" do
+#ifdef darwin_HOST_OS
+        taskSupervisorAbiSmoke `shouldReturn` 0
 #else
         pendingWith "the native bridge smoke test only links on macOS"
 #endif

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -17,5 +17,5 @@ spec = do
         it "preserves the documented image struct layout and ordered buffers" do
             imageAttachmentAbiSmoke `shouldReturn` 0
     describe "native session continuity ABI" do
-        it "matches callback signatures and rejects invalid synchronous inputs" do
+        it "matches callback signatures and rejects invalid UTF-8 safely" do
             sessionContinuityAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -8,7 +8,14 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 foreign import ccall "ha_image_attachment_abi_smoke"
     imageAttachmentAbiSmoke :: IO CInt
 
+foreign import ccall "ha_session_continuity_abi_smoke"
+    sessionContinuityAbiSmoke :: IO CInt
+
 spec :: Spec
-spec = describe "native image attachment ABI" do
-    it "preserves the documented image struct layout and ordered buffers" do
-        imageAttachmentAbiSmoke `shouldReturn` 0
+spec = do
+    describe "native image attachment ABI" do
+        it "preserves the documented image struct layout and ordered buffers" do
+            imageAttachmentAbiSmoke `shouldReturn` 0
+    describe "native session continuity ABI" do
+        it "matches callback signatures and rejects invalid synchronous inputs" do
+            sessionContinuityAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/TaskSchedulerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/TaskSchedulerSpec.hs
@@ -1,0 +1,71 @@
+module Agent.CLI.MacOS.TaskSchedulerSpec (spec) where
+
+import Agent.CLI.MacOS.TaskScheduler
+    ( TaskIdentity(..)
+    , selectRunnableTasks
+    )
+import qualified Data.Set as Set
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+spec :: Spec
+spec = describe "native task scheduling" do
+    it "starts distinct sessions up to the available capacity" do
+        let queued =
+                [ task "first" (Just "session-a")
+                , task "second" (Just "session-b")
+                , task "third" (Just "session-c")
+                ]
+            (selected, remaining) =
+                selectRunnableTasks 2 Set.empty queued
+        map (identityId . fst) selected
+            `shouldBe` ["first", "second"]
+        map (identityId . fst) remaining
+            `shouldBe` ["third"]
+
+    it "keeps a same-session task queued while starting unrelated work" do
+        let queued =
+                [ task "blocked" (Just "session-a")
+                , task "runnable" (Just "session-b")
+                ]
+            (selected, remaining) =
+                selectRunnableTasks 2 (Set.singleton "session-a") queued
+        map (identityId . fst) selected
+            `shouldBe` ["runnable"]
+        map (identityId . fst) remaining
+            `shouldBe` ["blocked"]
+
+    it "does not overtake an earlier task for the same queued session" do
+        let queued =
+                [ task "first-a" (Just "session-a")
+                , task "second-a" (Just "session-a")
+                , task "first-b" (Just "session-b")
+                ]
+            (selected, remaining) =
+                selectRunnableTasks 3 Set.empty queued
+        map (identityId . fst) selected
+            `shouldBe` ["first-a", "first-b"]
+        map (identityId . fst) remaining
+            `shouldBe` ["second-a"]
+
+    it "treats fresh sessions as independent tasks" do
+        let queued = [task "first" Nothing, task "second" Nothing]
+            (selected, remaining) =
+                selectRunnableTasks 2 Set.empty queued
+        map (identityId . fst) selected
+            `shouldBe` ["first", "second"]
+        remaining `shouldBe` []
+  where
+    task taskId sessionId =
+        ( TaskIdentity
+            { taskIdentityId = taskId
+            , taskIdentitySessionId = sessionId
+            }
+        , ()
+        )
+
+    identityId (TaskIdentity taskId _) = taskId

--- a/packages/agent-cli/test/Agent/CLI/MacOS/TaskSchedulerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/TaskSchedulerSpec.hs
@@ -1,6 +1,6 @@
 module Agent.CLI.MacOS.TaskSchedulerSpec (spec) where
 
-import Agent.CLI.MacOS.TaskScheduler
+import Agent.Runtime.Daemon.TaskScheduler
     ( TaskIdentity(..)
     , selectRunnableTasks
     )

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -30,6 +30,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString as BS
 import Data.IORef
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -859,6 +860,114 @@ spec = describe "Agent.CLI.Session" do
                 Directory.removeDirectoryRecursive (toFilePath dir)
                 loadSession pool root sessionId
                     `shouldReturn` Right (meta, [turn])
+
+        it "forks immutable prefixes and remaps transfer imports" $
+            withTempStore \store root -> do
+                let pool = trustedPool store
+                    turn prompt response effect usage = SessionTurn
+                        { turnAt = fixedTime
+                        , turnUserText = prompt
+                        , turnAssistantText = Just ("answer " <> prompt)
+                        , turnError = Nothing
+                        , turnResponseId = response
+                        , turnItems = []
+                        , turnUsage = usage
+                        , turnEffect = effect
+                        }
+                    first = turn "one" (Just "resp-1") TranscriptAppend
+                        (Just TokenUsage
+                            { inputTokens = 10
+                            , outputTokens = 2
+                            , cachedTokens = 1
+                            })
+                    compacted = turn "/compact" Nothing TranscriptReplace Nothing
+                    third = turn "three" (Just "resp-3") TranscriptAppend
+                        (Just TokenUsage
+                            { inputTokens = 7
+                            , outputTokens = 3
+                            , cachedTokens = 0
+                            })
+                    cleared = turn "/clear" Nothing TranscriptReset Nothing
+                    fifth = turn "five" (Just "resp-5") TranscriptAppend Nothing
+                source0 <- createSession (testCreate pool root)
+                source1 <- appendTurn source0 first
+                source2 <- appendTurnWithMetaUpdate source1 compacted
+                    \meta -> meta { metaLastResponseId = Nothing }
+                source3 <- appendTurn source2 third
+                source4 <- appendTurnWithMetaUpdate source3 cleared
+                    \meta -> meta { metaLastResponseId = Nothing }
+                _source5 <- appendTurn source4 fifth
+
+                loadSessionHistoryTurnsAround
+                    pool root source0.sessionMeta.metaId 1 1 >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right page -> do
+                            map fst page.pageTurns `shouldBe` [0, 1, 2]
+                            map snd page.pageTurns
+                                `shouldBe` [first, compacted, third]
+                            page.pageHasOlder `shouldBe` False
+                            page.pageHasNewer `shouldBe` True
+
+                forkSessionAtTurn pool root source0.sessionMeta.metaId 1
+                    >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right forkId -> do
+                            forkId `shouldNotBe` source0.sessionMeta.metaId
+                            loadSession pool root forkId >>= \case
+                                Left err -> expectationFailure (Text.unpack err)
+                                Right (meta, turns) -> do
+                                    turns `shouldBe` [first, compacted]
+                                    meta.metaLastResponseId `shouldBe` Nothing
+                                    meta.metaInputTokens `shouldBe` 10
+                                    meta.metaOutputTokens `shouldBe` 2
+                            loadSession pool root source0.sessionMeta.metaId
+                                >>= \case
+                                    Left err ->
+                                        expectationFailure (Text.unpack err)
+                                    Right (sourceMeta, sourceTurns) -> do
+                                        sourceMeta.metaId
+                                            `shouldBe` source0.sessionMeta.metaId
+                                        sourceTurns
+                                            `shouldBe`
+                                                [ first
+                                                , compacted
+                                                , third
+                                                , cleared
+                                                , fifth
+                                                ]
+
+                chunks <- newIORef []
+                streamSessionTransfer
+                    pool root source0.sessionMeta.metaId
+                    (\chunk -> modifyIORef' chunks (chunk :))
+                    `shouldReturn` Right ()
+                payload <- BS.concat . reverse <$> readIORef chunks
+                envelope <- case Aeson.eitherDecodeStrict' payload of
+                    Left err -> expectationFailure err >> fail err
+                    Right value -> pure value
+                validateSessionTransferEnvelope envelope
+                    `shouldBe` Right envelope
+                envelope.transferSession.transferTurns
+                    `shouldBe`
+                        [first, compacted, third, cleared, fifth]
+                importSessionTransferRemapped pool root Nothing envelope
+                    >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right importedId -> do
+                            importedId `shouldNotBe` source0.sessionMeta.metaId
+                            loadSession pool root importedId >>= \case
+                                Left err ->
+                                    expectationFailure (Text.unpack err)
+                                Right (importedMeta, importedTurns) -> do
+                                    importedMeta.metaId `shouldBe` importedId
+                                    importedTurns
+                                        `shouldBe`
+                                            [ first
+                                            , compacted
+                                            , third
+                                            , cleared
+                                            , fifth
+                                            ]
 
         it "keeps pending persistence lazy" $
             withTempStore \store root -> do

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -37,6 +37,7 @@ import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
 import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
 import qualified Agent.CLI.MacOS.BrowserBridgeFFISpec as BrowserBridgeFFISpec
 import qualified Agent.CLI.MacOS.BridgeSpec as BridgeSpec
+import qualified Agent.CLI.MacOS.TaskSchedulerSpec as TaskSchedulerSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.McpAdminSpec as McpAdminSpec
@@ -122,6 +123,7 @@ main = hspec do
     BridgeFFISpec.spec
     BrowserBridgeFFISpec.spec
     BridgeSpec.spec
+    TaskSchedulerSpec.spec
     MarkdownSpec.spec
     McpAdminSpec.spec
     McpManagerSpec.spec

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -1,6 +1,8 @@
 #include "HaskellAgentBridge.h"
 
 #include <stddef.h>
+#include <stdatomic.h>
+#include <unistd.h>
 
 /*
  * Keep a native compile/run smoke check next to the public ABI. This catches
@@ -140,9 +142,25 @@ static void session_export_callback(
     (void)error; (void)error_length;
 }
 
+static atomic_int invalid_import_result;
+
+static void invalid_import_callback(
+        void *context, int32_t status,
+        const uint8_t *session_id, size_t session_id_length,
+        const uint8_t *error, size_t error_length) {
+    (void)context;
+    (void)session_id; (void)session_id_length;
+    atomic_store_explicit(
+        &invalid_import_result,
+        status == -1 && error != NULL && error_length > 0 ? 1 : 2,
+        memory_order_release);
+}
+
 /* Compile every session callback signature and exercise synchronous rejects. */
 int ha_session_continuity_abi_smoke(void) {
     const uint8_t id[] = "2026-08-30-smoke";
+    const uint8_t invalid_utf8[] = {0xc3, 0x28};
+    atomic_init(&invalid_import_result, 0);
     if (ha_session_load_around(
             NULL, 0, 0, 1, session_turn_callback, NULL) != 2) {
         return 1;
@@ -163,5 +181,33 @@ int ha_session_continuity_abi_smoke(void) {
             NULL, 0, session_result_callback, NULL) != 2) {
         return 5;
     }
-    return 0;
+    if (ha_session_load_around(
+            invalid_utf8, sizeof(invalid_utf8), 0, 1,
+            session_turn_callback, NULL) != 2) {
+        return 6;
+    }
+    if (ha_session_fork(
+            invalid_utf8, sizeof(invalid_utf8), 0,
+            session_result_callback, NULL) != 2) {
+        return 7;
+    }
+    if (ha_session_export(
+            invalid_utf8, sizeof(invalid_utf8),
+            session_export_callback, NULL) != 2) {
+        return 8;
+    }
+    if (ha_session_import(
+            invalid_utf8, sizeof(invalid_utf8),
+            invalid_import_callback, NULL) != 0) {
+        return 9;
+    }
+    for (int attempt = 0; attempt < 5000; ++attempt) {
+        int result = atomic_load_explicit(
+            &invalid_import_result, memory_order_acquire);
+        if (result != 0) {
+            return result == 1 ? 0 : 10;
+        }
+        usleep(1000);
+    }
+    return 11;
 }

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -99,3 +99,69 @@ int ha_image_attachment_stage_smoke(void) {
     ha_runtime_exit();
     return status;
 }
+
+static void session_turn_callback(
+        void *context, int32_t status, int64_t turn_index,
+        const uint8_t *occurred_at, size_t occurred_at_length,
+        const uint8_t *user_text, size_t user_text_length,
+        const uint8_t *assistant_text, size_t assistant_text_length,
+        const uint8_t *turn_error, size_t turn_error_length,
+        const uint8_t *response_id, size_t response_id_length,
+        const uint8_t *transcript_effect, size_t transcript_effect_length,
+        const uint8_t *response_items_json, size_t response_items_json_length,
+        int64_t input_tokens, int64_t output_tokens, int64_t cached_tokens,
+        int32_t has_older, int32_t has_newer,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status; (void)turn_index;
+    (void)occurred_at; (void)occurred_at_length;
+    (void)user_text; (void)user_text_length;
+    (void)assistant_text; (void)assistant_text_length;
+    (void)turn_error; (void)turn_error_length;
+    (void)response_id; (void)response_id_length;
+    (void)transcript_effect; (void)transcript_effect_length;
+    (void)response_items_json; (void)response_items_json_length;
+    (void)input_tokens; (void)output_tokens; (void)cached_tokens;
+    (void)has_older; (void)has_newer; (void)error; (void)error_length;
+}
+
+static void session_result_callback(
+        void *context, int32_t status,
+        const uint8_t *session_id, size_t session_id_length,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status; (void)session_id; (void)session_id_length;
+    (void)error; (void)error_length;
+}
+
+static void session_export_callback(
+        void *context, int32_t status,
+        const uint8_t *bytes, size_t length,
+        const uint8_t *error, size_t error_length) {
+    (void)context; (void)status; (void)bytes; (void)length;
+    (void)error; (void)error_length;
+}
+
+/* Compile every session callback signature and exercise synchronous rejects. */
+int ha_session_continuity_abi_smoke(void) {
+    const uint8_t id[] = "2026-08-30-smoke";
+    if (ha_session_load_around(
+            NULL, 0, 0, 1, session_turn_callback, NULL) != 2) {
+        return 1;
+    }
+    if (ha_session_load_around(
+            id, sizeof(id) - 1, -1, 1, session_turn_callback, NULL) != 2) {
+        return 2;
+    }
+    if (ha_session_fork(
+            id, sizeof(id) - 1, -1, session_result_callback, NULL) != 2) {
+        return 3;
+    }
+    if (ha_session_export(
+            NULL, 0, session_export_callback, NULL) != 2) {
+        return 4;
+    }
+    if (ha_session_import(
+            NULL, 0, session_result_callback, NULL) != 2) {
+        return 5;
+    }
+    return 0;
+}

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeTaskSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeTaskSmoke.c
@@ -1,0 +1,90 @@
+#include "HaskellAgentBridge.h"
+
+#include <stddef.h>
+
+typedef struct task_snapshot_state {
+    int terminal_count;
+    int invalid_item;
+} task_snapshot_state;
+
+static void task_event_callback(void *context, const uint8_t *bytes,
+                                size_t length) {
+    (void)context;
+    (void)bytes;
+    (void)length;
+}
+
+static void task_snapshot_callback(void *raw_context, int32_t status,
+                                   const uint8_t *task_id,
+                                   size_t task_id_length,
+                                   const uint8_t *session_id,
+                                   size_t session_id_length,
+                                   int32_t state,
+                                   const uint8_t *error,
+                                   size_t error_length) {
+    task_snapshot_state *context = (task_snapshot_state *)raw_context;
+    (void)session_id;
+    (void)session_id_length;
+
+    if (status == 0) {
+        if (task_id == NULL || task_id_length == 0
+                || (state != 0 && state != 1)
+                || error != NULL || error_length != 0) {
+            context->invalid_item = 1;
+        }
+    } else if (status == 1) {
+        if (task_id != NULL || task_id_length != 0
+                || error != NULL || error_length != 0) {
+            context->invalid_item = 1;
+        }
+        context->terminal_count += 1;
+    } else {
+        context->invalid_item = 1;
+    }
+}
+
+/*
+ * Exercise the task-control ABI from a native caller. FIFO command handling
+ * guarantees the accepted snapshot finishes before destroy returns.
+ */
+int ha_task_supervisor_abi_smoke(void) {
+    const uint8_t missing_task[] = "missing-task";
+    task_snapshot_state state = {0, 0};
+
+    if (ha_runtime_init() != 0) {
+        return 10;
+    }
+    void *engine = ha_engine_create(task_event_callback, NULL);
+    if (engine == NULL) {
+        ha_runtime_exit();
+        return 11;
+    }
+    if (ha_engine_set_task_limit(engine, 0) != 2
+            || ha_engine_set_task_limit(engine, 33) != 2
+            || ha_engine_set_task_limit(engine, 2) != 0) {
+        ha_engine_destroy(engine);
+        ha_runtime_exit();
+        return 12;
+    }
+    if (ha_engine_cancel_task(
+            engine, missing_task, sizeof(missing_task) - 1) != 0) {
+        ha_engine_destroy(engine);
+        ha_runtime_exit();
+        return 13;
+    }
+    if (ha_engine_list_tasks(engine, task_snapshot_callback, &state) != 0) {
+        ha_engine_destroy(engine);
+        ha_runtime_exit();
+        return 14;
+    }
+    ha_engine_destroy(engine);
+    ha_runtime_exit();
+
+    if (state.invalid_item) {
+        return 15;
+    }
+    if (state.terminal_count != 1) {
+        return 16;
+    }
+    return 0;
+}

--- a/packages/agent-runtime-daemon/LICENSE
+++ b/packages/agent-runtime-daemon/LICENSE
@@ -1,0 +1,17 @@
+MIT License
+
+Copyright (c) 2026 digitally induced GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.

--- a/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
+++ b/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
@@ -1,0 +1,86 @@
+cabal-version:      3.0
+name:               agent-runtime-daemon
+version:            0.1.0.0
+synopsis:           Durable local runtime daemon foundation
+description:        Versioned local IPC, event replay, durable task state, and
+                    secure per-user Unix socket primitives for the agent runtime.
+license:            MIT
+license-file:       LICENSE
+author:             digitally induced GmbH
+maintainer:         marc@digitallyinduced.com
+copyright:          (c) 2026 digitally induced GmbH
+category:           System
+build-type:         Simple
+
+common common-options
+    default-language: GHC2021
+    default-extensions: DeriveGeneric
+                      , DerivingStrategies
+                      , DuplicateRecordFields
+                      , GeneralizedNewtypeDeriving
+                      , LambdaCase
+                      , NamedFieldPuns
+                      , NumericUnderscores
+                      , OverloadedStrings
+                      , OverloadedRecordDot
+                      , RecordWildCards
+                      , ScopedTypeVariables
+    ghc-options:      -Wall
+                      -Wcompat
+                      -Werror=incomplete-patterns
+                      -Werror=missing-fields
+
+library
+    import:           common-options
+    hs-source-dirs:   src
+    exposed-modules:  Agent.Runtime.Daemon
+                    , Agent.Runtime.Daemon.Framing
+                    , Agent.Runtime.Daemon.Journal
+                    , Agent.Runtime.Daemon.Protocol
+                    , Agent.Runtime.Daemon.Server
+                    , Agent.Runtime.Daemon.Socket
+                    , Agent.Runtime.Daemon.Supervisor
+                    , Agent.Runtime.Daemon.Task
+    build-depends:    aeson >= 2.0
+                    , async
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , containers
+                    , directory
+                    , filepath
+                    , network
+                    , safe-exceptions
+                    , stm
+                    , text >= 2.0 && < 2.2
+                    , time
+                    , unix
+
+executable agent-runtime-daemon
+    import:           common-options
+    hs-source-dirs:   app
+    main-is:          Main.hs
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N2 -M1G"
+    build-depends:    agent-runtime-daemon
+                    , base >= 4.17 && < 5
+
+test-suite agent-runtime-daemon-test
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Spec.hs
+    ghc-options:      -threaded
+    build-depends:    agent-runtime-daemon
+                    , aeson
+                    , async
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , containers
+                    , directory
+                    , filepath
+                    , hspec >= 2.11 && < 2.12
+                    , network
+                    , safe-exceptions
+                    , temporary
+                    , text
+                    , time
+                    , unix

--- a/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
+++ b/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
@@ -44,10 +44,12 @@ library
     build-depends:    aeson >= 2.0
                     , async
                     , base >= 4.17 && < 5
+                    , base64-bytestring
                     , bytestring
                     , containers
                     , directory
                     , filepath
+                    , filelock
                     , network
                     , safe-exceptions
                     , stm
@@ -80,6 +82,7 @@ test-suite agent-runtime-daemon-test
                     , hspec >= 2.11 && < 2.12
                     , network
                     , safe-exceptions
+                    , stm
                     , temporary
                     , text
                     , time

--- a/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
+++ b/packages/agent-runtime-daemon/agent-runtime-daemon.cabal
@@ -41,6 +41,8 @@ library
                     , Agent.Runtime.Daemon.Socket
                     , Agent.Runtime.Daemon.Supervisor
                     , Agent.Runtime.Daemon.Task
+                    , Agent.Runtime.Daemon.TaskAdapter
+                    , Agent.Runtime.Daemon.TaskScheduler
     build-depends:    aeson >= 2.0
                     , async
                     , base >= 4.17 && < 5
@@ -51,6 +53,7 @@ library
                     , filepath
                     , filelock
                     , network
+                    , process >= 1.6.18
                     , safe-exceptions
                     , stm
                     , text >= 2.0 && < 2.2

--- a/packages/agent-runtime-daemon/app/Main.hs
+++ b/packages/agent-runtime-daemon/app/Main.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+import Agent.Runtime.Daemon
+
+main :: IO ()
+main = do
+    config <- defaultDaemonConfig
+    runDaemon config unavailableSupervisor

--- a/packages/agent-runtime-daemon/app/Main.hs
+++ b/packages/agent-runtime-daemon/app/Main.hs
@@ -5,4 +5,5 @@ import Agent.Runtime.Daemon
 main :: IO ()
 main = do
     config <- defaultDaemonConfig
-    runDaemon config unavailableSupervisor
+    runner <- processTaskRunner
+    runTaskDaemon config runner

--- a/packages/agent-runtime-daemon/package.nix
+++ b/packages/agent-runtime-daemon/package.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, aeson, async, base, bytestring, containers
+, directory, filepath, hspec, lib, network, safe-exceptions, stm
+, temporary, text, time, unix
+}:
+mkDerivation {
+  pname = "agent-runtime-daemon";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson async base bytestring containers directory filepath network
+    safe-exceptions stm text time unix
+  ];
+  executableHaskellDepends = [ base ];
+  testHaskellDepends = [
+    aeson async base bytestring containers directory filepath hspec
+    network safe-exceptions temporary text time unix
+  ];
+  description = "Durable local runtime daemon foundation";
+  license = lib.meta.getLicenseFromSpdxId "MIT";
+  mainProgram = "agent-runtime-daemon";
+}

--- a/packages/agent-runtime-daemon/package.nix
+++ b/packages/agent-runtime-daemon/package.nix
@@ -1,6 +1,6 @@
-{ mkDerivation, aeson, async, base, bytestring, containers
-, directory, filepath, hspec, lib, network, safe-exceptions, stm
-, temporary, text, time, unix
+{ mkDerivation, aeson, async, base, base64-bytestring, bytestring
+, containers, directory, filelock, filepath, hspec, lib, network
+, safe-exceptions, stm, temporary, text, time, unix
 }:
 mkDerivation {
   pname = "agent-runtime-daemon";
@@ -9,13 +9,13 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson async base bytestring containers directory filepath network
-    safe-exceptions stm text time unix
+    aeson async base base64-bytestring bytestring containers directory
+    filelock filepath network safe-exceptions stm text time unix
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
     aeson async base bytestring containers directory filepath hspec
-    network safe-exceptions temporary text time unix
+    network safe-exceptions stm temporary text time unix
   ];
   description = "Durable local runtime daemon foundation";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-runtime-daemon/package.nix
+++ b/packages/agent-runtime-daemon/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, async, base, base64-bytestring, bytestring
 , containers, directory, filelock, filepath, hspec, lib, network
-, safe-exceptions, stm, temporary, text, time, unix
+, process, safe-exceptions, stm, temporary, text, time, unix
 }:
 mkDerivation {
   pname = "agent-runtime-daemon";
@@ -10,7 +10,8 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson async base base64-bytestring bytestring containers directory
-    filelock filepath network safe-exceptions stm text time unix
+    filelock filepath network process safe-exceptions stm text time
+    unix
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon.hs
@@ -2,11 +2,14 @@ module Agent.Runtime.Daemon
     ( DaemonConfig (..)
     , defaultDaemonConfig
     , runDaemon
+    , runTaskDaemon
     , module Agent.Runtime.Daemon.Journal
     , module Agent.Runtime.Daemon.Protocol
     , module Agent.Runtime.Daemon.Server
     , module Agent.Runtime.Daemon.Supervisor
     , module Agent.Runtime.Daemon.Task
+    , module Agent.Runtime.Daemon.TaskAdapter
+    , module Agent.Runtime.Daemon.TaskScheduler
     ) where
 
 import System.FilePath (takeDirectory, (</>))
@@ -17,6 +20,8 @@ import Agent.Runtime.Daemon.Server
 import Agent.Runtime.Daemon.Socket
 import Agent.Runtime.Daemon.Supervisor
 import Agent.Runtime.Daemon.Task
+import Agent.Runtime.Daemon.TaskAdapter
+import Agent.Runtime.Daemon.TaskScheduler
 
 data DaemonConfig = DaemonConfig
     { socket :: SocketConfig
@@ -36,3 +41,10 @@ runDaemon config supervisor =
     withUnixListener config.socket $ \listener -> do
         journal <- openJournal config.journal
         runServerOnListener listener config.server journal supervisor
+
+runTaskDaemon :: DaemonConfig -> TaskRunner -> IO ()
+runTaskDaemon config runner =
+    withUnixListener config.socket $ \listener -> do
+        journal <- openJournal config.journal
+        withTaskAdapter journal runner $
+            runServerOnListener listener config.server journal

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon.hs
@@ -1,0 +1,38 @@
+module Agent.Runtime.Daemon
+    ( DaemonConfig (..)
+    , defaultDaemonConfig
+    , runDaemon
+    , module Agent.Runtime.Daemon.Journal
+    , module Agent.Runtime.Daemon.Protocol
+    , module Agent.Runtime.Daemon.Server
+    , module Agent.Runtime.Daemon.Supervisor
+    , module Agent.Runtime.Daemon.Task
+    ) where
+
+import System.FilePath (takeDirectory, (</>))
+
+import Agent.Runtime.Daemon.Journal
+import Agent.Runtime.Daemon.Protocol
+import Agent.Runtime.Daemon.Server
+import Agent.Runtime.Daemon.Socket
+import Agent.Runtime.Daemon.Supervisor
+import Agent.Runtime.Daemon.Task
+
+data DaemonConfig = DaemonConfig
+    { socket :: SocketConfig
+    , server :: ServerConfig
+    , journal :: JournalConfig
+    }
+    deriving stock (Eq, Show)
+
+defaultDaemonConfig :: IO DaemonConfig
+defaultDaemonConfig = do
+    socket <- defaultSocketConfig
+    let journal = defaultJournalConfig (takeDirectory socket.path </> "journal")
+    pure DaemonConfig {socket, server = defaultServerConfig, journal}
+
+runDaemon :: DaemonConfig -> Supervisor -> IO ()
+runDaemon config supervisor =
+    withUnixListener config.socket $ \listener -> do
+        journal <- openJournal config.journal
+        runServerOnListener listener config.server journal supervisor

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Framing.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Framing.hs
@@ -1,0 +1,76 @@
+module Agent.Runtime.Daemon.Framing
+    ( FrameError (..)
+    , defaultMaximumFrameBytes
+    , sendJSONFrame
+    , receiveJSONFrame
+    ) where
+
+import Control.Exception.Safe (Exception, throwIO)
+import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict', encode)
+import Data.Bits ((.|.), shiftL, shiftR)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Word (Word32, Word8)
+import Network.Socket (Socket)
+import qualified Network.Socket.ByteString as Socket
+
+data FrameError
+    = FrameClosed
+    | FrameTooLarge Int Int
+    | FrameInvalidJSON String
+    deriving stock (Eq, Show)
+
+instance Exception FrameError
+
+defaultMaximumFrameBytes :: Int
+defaultMaximumFrameBytes = 1_048_576
+
+sendJSONFrame :: ToJSON value => Int -> Socket -> value -> IO ()
+sendJSONFrame maximumBytes socket value = do
+    let body = LBS.toStrict (encode value)
+        bodyLength = BS.length body
+    if bodyLength > maximumBytes
+        then throwIO (FrameTooLarge bodyLength maximumBytes)
+        else Socket.sendAll socket (encodeLength bodyLength <> body)
+
+receiveJSONFrame :: FromJSON value => Int -> Socket -> IO value
+receiveJSONFrame maximumBytes socket = do
+    header <- receiveExactly socket 4
+    let bodyLength = decodeLength header
+    if bodyLength > maximumBytes
+        then throwIO (FrameTooLarge bodyLength maximumBytes)
+        else do
+            body <- receiveExactly socket bodyLength
+            either (throwIO . FrameInvalidJSON) pure (eitherDecodeStrict' body)
+
+receiveExactly :: Socket -> Int -> IO BS.ByteString
+receiveExactly socket expected = go [] expected
+  where
+    go chunks remaining
+        | remaining == 0 = pure (BS.concat (reverse chunks))
+        | otherwise = do
+            chunk <- Socket.recv socket remaining
+            if BS.null chunk
+                then throwIO FrameClosed
+                else go (chunk : chunks) (remaining - BS.length chunk)
+
+encodeLength :: Int -> BS.ByteString
+encodeLength lengthValue =
+    let word = fromIntegral lengthValue :: Word32
+     in BS.pack
+            [ byte (word `shiftR` 24)
+            , byte (word `shiftR` 16)
+            , byte (word `shiftR` 8)
+            , byte word
+            ]
+  where
+    byte :: Word32 -> Word8
+    byte = fromIntegral
+
+decodeLength :: BS.ByteString -> Int
+decodeLength bytes =
+    fromIntegral $
+        foldl
+            (\accumulator octet -> (accumulator `shiftL` 8) .|. fromIntegral octet)
+            (0 :: Word32)
+            (BS.unpack bytes)

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -285,7 +285,7 @@ persistTask journal task =
         ensureSnapshotFits journal.config updatedSnapshot
         compacted <- persistOrPoison journal $ do
             appendEventFile journal.config event
-            writeSnapshot journal.config (snapshotAnchor updatedSnapshot updated.retainedEvents)
+            writeSnapshot journal.config updatedSnapshot
             enforceRetention journal.config updated
         publish journal event
         pure (compacted, event)
@@ -405,12 +405,6 @@ validateRecoveryOrigin snapshotExists snapshotSequence events =
                 unless (first.sequenceNumber == expected) $
                     throwIO (JournalEventGap expected first.sequenceNumber)
             | snapshotExists
-            , first.sequenceNumber < snapshotSequence ->
-                throwIO $
-                    JournalCorrupt
-                        "events.jsonl"
-                        "retained event suffix contains a stale prefix before its snapshot anchor"
-            | snapshotExists
             , lastEvent.sequenceNumber < snapshotSequence ->
                 throwIO $
                     JournalCorrupt
@@ -490,12 +484,8 @@ enforceRetention config journalState = do
                                 journalState.retainedEvents
                 byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
                 compacted = journalState {retainedEvents = byteBounded}
+            writeSnapshot config compacted.durableSnapshot
             rewriteEvents config byteBounded
-            -- The first retained event is the durable anchor for this
-            -- suffix.  Persist the rewritten events before advancing the
-            -- snapshot anchor so an interrupted compaction still leaves a
-            -- recoverable (old snapshot, new suffix) pair.
-            writeSnapshot config (snapshotAnchor compacted.durableSnapshot byteBounded)
             pure compacted
         else pure journalState
 
@@ -509,16 +499,6 @@ retainWithinBytes maximumBytes events =
         | otherwise = event : go (used + size) rest
       where
         size = BS.length (encodeLine event)
-
--- | A snapshot is valid alongside a retained suffix when its sequence is the
--- suffix's first event (the anchor), or when the suffix is empty.  The task
--- map is still the latest durable state; recovery skips the anchor event and
--- applies everything after it.
-snapshotAnchor :: JournalSnapshot -> Seq EventEnvelope -> JournalSnapshot
-snapshotAnchor saved events =
-    case Seq.lookup 0 events of
-        Nothing -> saved
-        Just first -> saved {lastSequence = first.sequenceNumber}
 
 readSnapshot :: JournalConfig -> IO (Bool, JournalSnapshot)
 readSnapshot config = do

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -1,0 +1,383 @@
+module Agent.Runtime.Daemon.Journal
+    ( Journal
+    , JournalConfig (..)
+    , JournalSnapshot (..)
+    , Replay (..)
+    , defaultJournalConfig
+    , openJournal
+    , appendEvent
+    , persistTask
+    , snapshot
+    , replayAfter
+    , subscribe
+    , subscribeReplay
+    , redactValue
+    , boundTaskLog
+    ) where
+
+import Control.Concurrent.MVar
+import Control.Concurrent.STM
+import Control.Exception.Safe (IOException, catch, onException)
+import Control.Monad (forM_)
+import Data.Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as LBS
+import Data.Char (toLower)
+import Data.Foldable (toList)
+import Data.List (isInfixOf)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import qualified Data.Sequence as Seq
+import Data.Sequence (Seq)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time (getCurrentTime)
+import GHC.Generics (Generic)
+import System.Directory
+import System.FilePath ((</>))
+import System.IO
+import System.Posix.Files (setFileMode)
+import System.Posix.IO
+    ( OpenMode (ReadOnly)
+    , closeFd
+    , defaultFileFlags
+    , openFd
+    )
+import System.Posix.Unistd (fileSynchronise)
+
+import Agent.Runtime.Daemon.Protocol
+import Agent.Runtime.Daemon.Task
+
+data JournalConfig = JournalConfig
+    { directory :: FilePath
+    , maximumEvents :: Int
+    , maximumJournalBytes :: Int
+    , maximumTaskLogLines :: Int
+    , maximumTaskLogCharacters :: Int
+    }
+    deriving stock (Eq, Show)
+
+defaultJournalConfig :: FilePath -> JournalConfig
+defaultJournalConfig directory =
+    JournalConfig
+        { directory
+        , maximumEvents = 10_000
+        , maximumJournalBytes = 16 * 1_048_576
+        , maximumTaskLogLines = 500
+        , maximumTaskLogCharacters = 256_000
+        }
+
+data JournalSnapshot = JournalSnapshot
+    { lastSequence :: Sequence
+    , tasks :: Map TaskId DurableTask
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON JournalSnapshot
+instance FromJSON JournalSnapshot
+
+data Replay
+    = ReplayEvents [EventEnvelope]
+    | ReplaySnapshot JournalSnapshot
+    deriving stock (Eq, Show)
+
+data JournalState = JournalState
+    { durableSnapshot :: JournalSnapshot
+    , retainedEvents :: Seq EventEnvelope
+    }
+
+data Journal = Journal
+    { config :: JournalConfig
+    , state :: MVar JournalState
+    , eventChannel :: TChan EventEnvelope
+    }
+
+openJournal :: JournalConfig -> IO Journal
+openJournal config = do
+    createDirectoryIfMissing True config.directory
+    setFileMode config.directory 0o700
+    savedSnapshot <- readSnapshot config
+    savedEvents <- readEvents config
+    let recoveredSnapshot = foldl recoverTask savedSnapshot (toList savedEvents)
+        lastEventSequence =
+            maybe 0 (.sequenceNumber) (Seq.lookup (Seq.length savedEvents - 1) savedEvents)
+        nextSequence = max recoveredSnapshot.lastSequence lastEventSequence
+        initialState =
+            JournalState
+                { durableSnapshot = recoveredSnapshot {lastSequence = nextSequence}
+                , retainedEvents = savedEvents
+                }
+    state <- newMVar initialState
+    eventChannel <- newBroadcastTChanIO
+    let journal = Journal {config, state, eventChannel}
+    interruptTasksFromPreviousProcess journal
+    pure journal
+
+recoverTask :: JournalSnapshot -> EventEnvelope -> JournalSnapshot
+recoverTask saved event
+    | event.sequenceNumber <= saved.lastSequence = saved
+    | event.eventType /= "task_changed" = saved
+    | otherwise =
+        case fromJSON event.payload of
+            Error _ -> saved
+            Success task ->
+                saved
+                    { lastSequence = event.sequenceNumber
+                    , tasks = Map.insert task.taskId task saved.tasks
+                    }
+
+synchronisePath :: FilePath -> IO ()
+synchronisePath path =
+    bracketFd (openFd path ReadOnly defaultFileFlags) fileSynchronise
+  where
+    bracketFd acquire use = do
+        descriptor <- acquire
+        _ <- use descriptor `onException` closeFd descriptor
+        closeFd descriptor
+
+appendEvent :: Journal -> Text -> Value -> IO EventEnvelope
+appendEvent journal eventType payload =
+    modifyMVar journal.state $ \journalState -> do
+        let nextSequence = journalState.durableSnapshot.lastSequence + 1
+            event =
+                EventEnvelope
+                    { sequenceNumber = nextSequence
+                    , eventType
+                    , payload = redactValue payload
+                    }
+            updated =
+                journalState
+                    { durableSnapshot =
+                        journalState.durableSnapshot {lastSequence = nextSequence}
+                    , retainedEvents = journalState.retainedEvents Seq.|> event
+                    }
+        appendEventFile journal.config event
+        compacted <- enforceRetention journal.config updated
+        atomically (writeTChan journal.eventChannel event)
+        pure (compacted, event)
+
+persistTask :: Journal -> DurableTask -> IO EventEnvelope
+persistTask journal task =
+    modifyMVar journal.state $ \journalState -> do
+        let boundedTask = boundTaskLog journal.config task
+            nextSequence = journalState.durableSnapshot.lastSequence + 1
+            event =
+                EventEnvelope
+                    { sequenceNumber = nextSequence
+                    , eventType = "task_changed"
+                    , payload = toJSON boundedTask
+                    }
+            updatedSnapshot =
+                JournalSnapshot
+                    { lastSequence = nextSequence
+                    , tasks = Map.insert boundedTask.taskId boundedTask journalState.durableSnapshot.tasks
+                    }
+            updated =
+                JournalState
+                    { durableSnapshot = updatedSnapshot
+                    , retainedEvents = journalState.retainedEvents Seq.|> event
+                    }
+        appendEventFile journal.config event
+        writeSnapshot journal.config updatedSnapshot
+        compacted <- enforceRetention journal.config updated
+        atomically (writeTChan journal.eventChannel event)
+        pure (compacted, event)
+
+snapshot :: Journal -> IO JournalSnapshot
+snapshot journal = durableSnapshot <$> readMVar journal.state
+
+replayAfter :: Journal -> Sequence -> IO Replay
+replayAfter journal cursor =
+    withMVar journal.state (pure . replayFromState cursor)
+
+replayFromState :: Sequence -> JournalState -> Replay
+replayFromState cursor journalState =
+    let events = toList journalState.retainedEvents
+        earliest = maybe (journalState.durableSnapshot.lastSequence + 1) (.sequenceNumber) (safeHead events)
+     in
+        if cursor > journalState.durableSnapshot.lastSequence || cursor + 1 < earliest
+            then ReplaySnapshot journalState.durableSnapshot
+            else ReplayEvents (filter ((> cursor) . (.sequenceNumber)) events)
+
+subscribe :: Journal -> IO (TChan EventEnvelope)
+subscribe journal = atomically (dupTChan journal.eventChannel)
+
+-- | Atomically with respect to appends, capture handshake state, replay, and
+-- a subscription to subsequent events.
+subscribeReplay :: Journal -> Sequence -> IO (JournalSnapshot, Replay, TChan EventEnvelope)
+subscribeReplay journal cursor =
+    withMVar journal.state $ \journalState -> do
+        channel <- atomically (dupTChan journal.eventChannel)
+        pure
+            ( journalState.durableSnapshot
+            , replayFromState cursor journalState
+            , channel
+            )
+
+redactValue :: Value -> Value
+redactValue = \case
+    Object objectValue ->
+        Object $
+            KeyMap.mapWithKey
+                (\key value ->
+                    if isSensitiveKey (Key.toText key)
+                        then String "[REDACTED]"
+                        else redactValue value
+                )
+                objectValue
+    Array values -> Array (fmap redactValue values)
+    other -> other
+
+boundTaskLog :: JournalConfig -> DurableTask -> DurableTask
+boundTaskLog config task =
+    task
+        { logTail =
+            boundCharacters config.maximumTaskLogCharacters
+                . takeLast config.maximumTaskLogLines
+                . fmap redactLogLine
+                $ task.logTail
+        }
+
+interruptTasksFromPreviousProcess :: Journal -> IO ()
+interruptTasksFromPreviousProcess journal = do
+    currentSnapshot <- snapshot journal
+    now <- getCurrentTime
+    forM_ (filter isActive (Map.elems currentSnapshot.tasks)) $ \task -> do
+        _ <- persistTask journal (interruptActive now task)
+        pure ()
+
+enforceRetention :: JournalConfig -> JournalState -> IO JournalState
+enforceRetention config journalState = do
+    journalBytes <- fileSizeOrZero (eventsPath config)
+    let tooMany = Seq.length journalState.retainedEvents > max 0 config.maximumEvents
+        tooLarge = journalBytes > fromIntegral (max 0 config.maximumJournalBytes)
+    if tooMany || tooLarge
+        then do
+            let countBounded =
+                    Seq.drop
+                        (max 0 (Seq.length journalState.retainedEvents - max 0 config.maximumEvents))
+                        journalState.retainedEvents
+                byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
+                compacted = journalState {retainedEvents = byteBounded}
+            rewriteEvents config byteBounded
+            pure compacted
+        else pure journalState
+
+retainWithinBytes :: Int -> Seq EventEnvelope -> Seq EventEnvelope
+retainWithinBytes maximumBytes events =
+    snd $
+        foldr
+            (\event (used, kept) ->
+                let size = BS.length (encodeLine event)
+                 in if used + size <= max 0 maximumBytes
+                        then (used + size, event Seq.<| kept)
+                        else (used, kept)
+            )
+            (0, Seq.empty)
+            events
+
+readSnapshot :: JournalConfig -> IO JournalSnapshot
+readSnapshot config =
+    catch
+        (do
+            bytes <- BS.readFile (snapshotPath config)
+            case eitherDecodeStrict' bytes of
+                Left _ -> pure emptySnapshot
+                Right saved -> pure saved
+        )
+        (\(_ :: IOException) -> pure emptySnapshot)
+  where
+    emptySnapshot = JournalSnapshot {lastSequence = 0, tasks = Map.empty}
+
+readEvents :: JournalConfig -> IO (Seq EventEnvelope)
+readEvents config =
+    catch
+        (do
+            bytes <- BS.readFile (eventsPath config)
+            pure . Seq.fromList $ mapMaybeDecode (BS8.lines bytes)
+        )
+        (\(_ :: IOException) -> pure Seq.empty)
+
+mapMaybeDecode :: FromJSON value => [BS.ByteString] -> [value]
+mapMaybeDecode = foldr step []
+  where
+    step bytes values =
+        case eitherDecodeStrict' bytes of
+            Left _ -> values
+            Right value -> value : values
+
+appendEventFile :: JournalConfig -> EventEnvelope -> IO ()
+appendEventFile config event =
+    withBinaryFile (eventsPath config) AppendMode $ \handle -> do
+        BS.hPut handle (encodeLine event)
+        hFlush handle
+    >> do
+        setFileMode (eventsPath config) 0o600
+        synchronisePath (eventsPath config)
+
+rewriteEvents :: JournalConfig -> Seq EventEnvelope -> IO ()
+rewriteEvents config events =
+    atomicWrite config (eventsPath config) (BS.concat (fmap encodeLine (toList events)))
+
+writeSnapshot :: JournalConfig -> JournalSnapshot -> IO ()
+writeSnapshot config savedSnapshot =
+    atomicWrite config (snapshotPath config) (LBS.toStrict (encode savedSnapshot))
+
+atomicWrite :: JournalConfig -> FilePath -> BS.ByteString -> IO ()
+atomicWrite config destination bytes = do
+    let temporary = destination <> ".tmp"
+        cleanup = removeFile temporary `catch` \(_ :: IOException) -> pure ()
+    (do
+            BS.writeFile temporary bytes
+            setFileMode temporary 0o600
+            synchronisePath temporary
+            renameFile temporary destination
+            synchronisePath config.directory
+        )
+        `onException` cleanup
+    setFileMode config.directory 0o700
+
+fileSizeOrZero :: FilePath -> IO Integer
+fileSizeOrZero path =
+    catch (getFileSize path) (\(_ :: IOException) -> pure 0)
+
+snapshotPath, eventsPath :: JournalConfig -> FilePath
+snapshotPath config = config.directory </> "snapshot.json"
+eventsPath config = config.directory </> "events.jsonl"
+
+encodeLine :: ToJSON value => value -> BS.ByteString
+encodeLine value = LBS.toStrict (encode value) <> "\n"
+
+safeHead :: [value] -> Maybe value
+safeHead = \case
+    value : _ -> Just value
+    [] -> Nothing
+
+takeLast :: Int -> [value] -> [value]
+takeLast count values = drop (max 0 (length values - max 0 count)) values
+
+boundCharacters :: Int -> [Text] -> [Text]
+boundCharacters limit = reverse . go 0 . reverse
+  where
+    go _ [] = []
+    go used (line : rest)
+        | used >= max 0 limit = []
+        | otherwise =
+            let remaining = max 0 limit - used
+                bounded = Text.take remaining line
+             in bounded : go (used + Text.length bounded) rest
+
+redactLogLine :: Text -> Text
+redactLogLine line
+    | any (`Text.isInfixOf` Text.toLower line) sensitiveFragments = "[REDACTED]"
+    | otherwise = line
+  where
+    sensitiveFragments = ["authorization:", "api_key=", "apikey=", "password=", "token=", "secret="]
+
+isSensitiveKey :: Text -> Bool
+isSensitiveKey key =
+    let lowered = fmap toLower (Text.unpack key)
+     in any (`isInfixOf` lowered) ["authorization", "password", "secret", "token", "api_key", "apikey"]

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -155,17 +155,25 @@ openJournal config = do
     savedEvents <- readEvents config
     validateEventSequence savedEvents
     validateRecoveryOrigin snapshotExists savedSnapshot.lastSequence savedEvents
-    recoveredSnapshot <- foldM (recoverTask config) savedSnapshot (toList savedEvents)
+    normalisedEvents <- traverse (normaliseRecoveredEvent config) savedEvents
+    savedTasks <- normaliseRecoveredTasks config savedSnapshot.tasks
+    let normalisedSnapshot = savedSnapshot {tasks = savedTasks}
+    recoveredSnapshot <- foldM (recoverTask config) normalisedSnapshot (toList normalisedEvents)
     recoveredTasks <- enforceTaskCapacity config recoveredSnapshot.tasks
     let boundedSnapshot = recoveredSnapshot {tasks = recoveredTasks}
         lastEventSequence =
-            maybe 0 (.sequenceNumber) (Seq.lookup (Seq.length savedEvents - 1) savedEvents)
+            maybe 0 (.sequenceNumber) (Seq.lookup (Seq.length normalisedEvents - 1) normalisedEvents)
         nextSequence = max boundedSnapshot.lastSequence lastEventSequence
         initialState =
             JournalState
                 { durableSnapshot = boundedSnapshot {lastSequence = nextSequence}
-                , retainedEvents = savedEvents
+                , retainedEvents = normalisedEvents
                 }
+    forM_ normalisedEvents (ensureEventFits config)
+    when (savedTasks /= savedSnapshot.tasks) $
+        writeSnapshot config normalisedSnapshot
+    when (normalisedEvents /= savedEvents) $
+        rewriteEvents config normalisedEvents
     state <- newMVar initialState
     subscribers <- newTVarIO Map.empty
     nextSubscriber <- newTVarIO 0
@@ -193,6 +201,23 @@ recoverTask config saved event
                     { lastSequence = event.sequenceNumber
                     , tasks = boundedTasks
                     }
+
+normaliseRecoveredEvent :: JournalConfig -> EventEnvelope -> IO EventEnvelope
+normaliseRecoveredEvent config event
+    | event.eventType /= "task_changed" =
+        pure event {payload = redactValue event.payload}
+    | otherwise =
+        case fromJSON event.payload of
+            Error message -> throwIO (JournalCorrupt "events.jsonl" message)
+            Success task ->
+                pure event {payload = toJSON (boundTaskLog config task)}
+
+normaliseRecoveredTasks ::
+    JournalConfig ->
+    Map TaskId DurableTask ->
+    IO (Map TaskId DurableTask)
+normaliseRecoveredTasks config recoveredTasks =
+    enforceTaskCapacity config (fmap (boundTaskLog config) recoveredTasks)
 
 synchronisePath :: FilePath -> IO ()
 synchronisePath path =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -21,6 +21,7 @@ import Control.Exception.Safe
     ( Exception
     , IOException
     , catch
+    , finally
     , onException
     , throwIO
     , tryIO
@@ -42,18 +43,20 @@ import Data.Sequence (Seq)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time (getCurrentTime)
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import System.Directory hiding (isSymbolicLink)
 import System.FilePath ((</>))
-import System.IO.Error (isDoesNotExistError)
+import System.IO.Error (isDoesNotExistError, isEOFError)
 import System.Posix.Files
     ( fileOwner
+    , fileSize
     , getFdStatus
     , getSymbolicLinkStatus
     , isDirectory
     , isRegularFile
     , isSymbolicLink
-    , setFileMode
+    , setFdMode
     )
 import System.Posix.User (getEffectiveUserID)
 import System.Posix.IO
@@ -63,7 +66,7 @@ import System.Posix.IO
     , defaultFileFlags
     , openFd
     )
-import System.Posix.IO.ByteString (fdWrite)
+import System.Posix.IO.ByteString (fdRead, fdWrite)
 import System.Posix.Types (Fd)
 import System.Posix.Unistd (fileSynchronise)
 
@@ -107,6 +110,7 @@ data JournalError
     | JournalFileTooLarge FilePath Integer Integer
     | JournalPoisoned String
     | JournalInsecurePath FilePath
+    | JournalSequenceExhausted Sequence
     deriving stock (Eq, Show)
 
 instance Exception JournalError
@@ -147,14 +151,11 @@ openJournal :: JournalConfig -> IO Journal
 openJournal config = do
     createDirectoryIfMissing True config.directory
     verifyPrivateDirectory config.directory
-    setFileMode config.directory 0o700
-    mapM_ verifyPrivateFileIfPresent [snapshotPath config, eventsPath config]
-    snapshotExists <- doesFileExist (snapshotPath config)
-    savedSnapshot <- readSnapshot config
+    (snapshotExists, savedSnapshot) <- readSnapshot config
     savedEvents <- readEvents config
     validateEventSequence savedEvents
-    validateRecoveryOrigin snapshotExists savedEvents
-    recoveredSnapshot <- foldM recoverTask savedSnapshot (toList savedEvents)
+    validateRecoveryOrigin snapshotExists savedSnapshot.lastSequence savedEvents
+    recoveredSnapshot <- foldM (recoverTask config) savedSnapshot (toList savedEvents)
     recoveredTasks <- enforceTaskCapacity config recoveredSnapshot.tasks
     let boundedSnapshot = recoveredSnapshot {tasks = recoveredTasks}
         lastEventSequence =
@@ -176,22 +177,28 @@ openJournal config = do
     interruptTasksFromPreviousProcess journal
     pure journal
 
-recoverTask :: JournalSnapshot -> EventEnvelope -> IO JournalSnapshot
-recoverTask saved event
+recoverTask :: JournalConfig -> JournalSnapshot -> EventEnvelope -> IO JournalSnapshot
+recoverTask config saved event
     | event.sequenceNumber <= saved.lastSequence = pure saved
     | event.eventType /= "task_changed" = pure saved
     | otherwise =
         case fromJSON event.payload of
             Error message -> throwIO (JournalCorrupt "events.jsonl" message)
-            Success task ->
+            Success task -> do
+                let boundedTask = boundTaskLog config task
+                boundedTasks <-
+                    enforceTaskCapacity config $
+                        Map.insert boundedTask.taskId boundedTask saved.tasks
                 pure saved
                     { lastSequence = event.sequenceNumber
-                    , tasks = Map.insert task.taskId task saved.tasks
+                    , tasks = boundedTasks
                     }
 
 synchronisePath :: FilePath -> IO ()
 synchronisePath path =
-    bracketFd (openFd path ReadOnly defaultFileFlags) fileSynchronise
+    bracketFd
+        (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True, directory = True})
+        fileSynchronise
   where
     bracketFd acquire use = do
         descriptor <- acquire
@@ -202,7 +209,8 @@ appendEvent :: Journal -> Text -> Value -> IO EventEnvelope
 appendEvent journal eventType payload =
     modifyMVar journal.state $ \journalState -> do
         ensureHealthy journal
-        let nextSequence = journalState.durableSnapshot.lastSequence + 1
+        nextSequence <- nextSequenceAfter journalState.durableSnapshot.lastSequence
+        let
             event =
                 EventEnvelope
                     { sequenceNumber = nextSequence
@@ -230,8 +238,8 @@ persistTask journal task =
         boundedTasks <-
             enforceTaskCapacity journal.config $
                 Map.insert boundedTask.taskId boundedTask journalState.durableSnapshot.tasks
+        nextSequence <- nextSequenceAfter journalState.durableSnapshot.lastSequence
         let
-            nextSequence = journalState.durableSnapshot.lastSequence + 1
             event =
                 EventEnvelope
                     { sequenceNumber = nextSequence
@@ -272,11 +280,18 @@ replayAfter journal cursor =
 replayFromState :: Sequence -> JournalState -> Replay
 replayFromState cursor journalState =
     let events = toList journalState.retainedEvents
-        earliest = maybe (journalState.durableSnapshot.lastSequence + 1) (.sequenceNumber) (safeHead events)
+        earliest = fmap (.sequenceNumber) (safeHead events)
+        replayGap =
+            case earliest of
+                Nothing -> cursor < journalState.durableSnapshot.lastSequence
+                Just sequenceNumber -> hasGapAfter cursor sequenceNumber
      in
-        if cursor > journalState.durableSnapshot.lastSequence || cursor + 1 < earliest
+        if cursor > journalState.durableSnapshot.lastSequence || replayGap
             then ReplaySnapshot journalState.durableSnapshot
             else ReplayEvents (filter ((> cursor) . (.sequenceNumber)) events)
+  where
+    hasGapAfter (Sequence cursorValue) (Sequence earliestValue) =
+        earliestValue > cursorValue && earliestValue - cursorValue > 1
 
 -- | Atomically with respect to appends, capture handshake state, replay, and
 -- a subscription to subsequent events.
@@ -347,38 +362,49 @@ validateEventSequence events =
             | otherwise -> go first.sequenceNumber rest
   where
     go _ [] = pure ()
-    go previous (event : remaining)
-        | event.sequenceNumber == previous + 1 =
-            go event.sequenceNumber remaining
-        | otherwise =
-            throwIO (JournalEventGap (previous + 1) event.sequenceNumber)
+    go previous (event : remaining) = do
+        expected <- nextSequenceAfter previous
+        if event.sequenceNumber == expected
+            then go event.sequenceNumber remaining
+            else throwIO (JournalEventGap expected event.sequenceNumber)
 
-validateRecoveryOrigin :: Bool -> Seq EventEnvelope -> IO ()
-validateRecoveryOrigin snapshotExists events =
-    case Seq.lookup 0 events of
-        Just first
+validateRecoveryOrigin :: Bool -> Sequence -> Seq EventEnvelope -> IO ()
+validateRecoveryOrigin snapshotExists snapshotSequence events =
+    case (Seq.lookup 0 events, Seq.lookup (Seq.length events - 1) events) of
+        (Just first, Just lastEvent)
             | not snapshotExists && first.sequenceNumber /= 1 ->
                 throwIO (JournalEventGap 1 first.sequenceNumber)
+            | snapshotExists
+            , first.sequenceNumber > snapshotSequence -> do
+                expected <- nextSequenceAfter snapshotSequence
+                unless (first.sequenceNumber == expected) $
+                    throwIO (JournalEventGap expected first.sequenceNumber)
+            | snapshotExists
+            , lastEvent.sequenceNumber < snapshotSequence ->
+                throwIO $
+                    JournalCorrupt
+                        "events.jsonl"
+                        "retained event suffix ends before the snapshot sequence"
         _ -> pure ()
 
-verifyPrivateDirectory :: FilePath -> IO ()
-verifyPrivateDirectory path = do
-    status <- getSymbolicLinkStatus path
-    effectiveUser <- getEffectiveUserID
-    unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
-        throwIO (JournalInsecurePath path)
+nextSequenceAfter :: Sequence -> IO Sequence
+nextSequenceAfter sequenceNumber@(Sequence value)
+    | value == (maxBound :: Word64) = throwIO (JournalSequenceExhausted sequenceNumber)
+    | otherwise = pure (Sequence (value + 1))
 
-verifyPrivateFileIfPresent :: FilePath -> IO ()
-verifyPrivateFileIfPresent path = do
-    tryIO (getSymbolicLinkStatus path) >>= \case
-        Left exception
-            | isDoesNotExistError exception -> pure ()
-            | otherwise -> throwIO exception
-        Right status -> do
-            effectiveUser <- getEffectiveUserID
-            unless (isRegularFile status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
-                throwIO (JournalInsecurePath path)
-            setFileMode path 0o600
+verifyPrivateDirectory :: FilePath -> IO ()
+verifyPrivateDirectory path =
+    tryIO (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True, directory = True}) >>= \case
+        Left (_ :: IOException) -> throwIO (JournalInsecurePath path)
+        Right descriptor ->
+            ( do
+                status <- getFdStatus descriptor
+                effectiveUser <- getEffectiveUserID
+                unless (isDirectory status && fileOwner status == effectiveUser) $
+                    throwIO (JournalInsecurePath path)
+                setFdMode descriptor 0o700
+            )
+                `finally` closeFd descriptor
 
 redactValue :: Value -> Value
 redactValue = \case
@@ -425,11 +451,15 @@ enforceRetention config journalState = do
     if tooMany || tooLarge
         then do
             let countBounded =
-                    Seq.drop
-                        (max 0 (Seq.length journalState.retainedEvents - max 1 config.maximumEvents))
-                        journalState.retainedEvents
+                    if config.maximumEvents <= 0
+                        then Seq.empty
+                        else
+                            Seq.drop
+                                (max 0 (Seq.length journalState.retainedEvents - config.maximumEvents))
+                                journalState.retainedEvents
                 byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
                 compacted = journalState {retainedEvents = byteBounded}
+            writeSnapshot config compacted.durableSnapshot
             rewriteEvents config byteBounded
             pure compacted
         else pure journalState
@@ -445,29 +475,23 @@ retainWithinBytes maximumBytes events =
       where
         size = BS.length (encodeLine event)
 
-readSnapshot :: JournalConfig -> IO JournalSnapshot
+readSnapshot :: JournalConfig -> IO (Bool, JournalSnapshot)
 readSnapshot config = do
-    exists <- doesFileExist (snapshotPath config)
-    if exists
-        then do
-            ensureFileSize (snapshotPath config) (fromIntegral config.maximumSnapshotBytes)
-            bytes <- BS.readFile (snapshotPath config)
+    readPrivateFile (snapshotPath config) (fromIntegral config.maximumSnapshotBytes) >>= \case
+        Just bytes ->
             case eitherDecodeStrict' bytes of
                 Left message -> throwIO (JournalCorrupt (snapshotPath config) message)
-                Right saved -> pure saved
-        else pure emptySnapshot
+                Right saved -> pure (True, saved)
+        Nothing -> pure (False, emptySnapshot)
   where
     emptySnapshot = JournalSnapshot {lastSequence = 0, tasks = Map.empty}
 
 readEvents :: JournalConfig -> IO (Seq EventEnvelope)
 readEvents config = do
-    exists <- doesFileExist (eventsPath config)
-    if exists
-        then do
-            ensureFileSize (eventsPath config) (fromIntegral config.maximumRecoveryJournalBytes)
-            bytes <- BS.readFile (eventsPath config)
+    readPrivateFile (eventsPath config) (fromIntegral config.maximumRecoveryJournalBytes) >>= \case
+        Just bytes ->
             traverse decodeLine (zip [1 :: Int ..] (BS8.lines bytes)) >>= pure . Seq.fromList
-        else pure Seq.empty
+        Nothing -> pure Seq.empty
 
 decodeLine :: FromJSON value => (Int, BS.ByteString) -> IO value
 decodeLine (lineNumber, bytes) =
@@ -475,11 +499,36 @@ decodeLine (lineNumber, bytes) =
         Left message -> throwIO (JournalCorrupt "events.jsonl" ("line " <> show lineNumber <> ": " <> message))
         Right value -> pure value
 
-ensureFileSize :: FilePath -> Integer -> IO ()
-ensureFileSize path maximumBytes = do
-    actual <- getFileSize path
+readPrivateFile :: FilePath -> Integer -> IO (Maybe BS.ByteString)
+readPrivateFile path maximumBytes =
+    tryIO (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True}) >>= \case
+        Left exception
+            | isDoesNotExistError exception -> pure Nothing
+            | otherwise -> throwIO (JournalInsecurePath path)
+        Right descriptor ->
+            Just
+                <$> ( (verifyPrivateDescriptor path descriptor >> setFdMode descriptor 0o600 >> readDescriptorBounded path maximumBytes descriptor)
+                        `finally` closeFd descriptor
+                    )
+
+readDescriptorBounded :: FilePath -> Integer -> Fd -> IO BS.ByteString
+readDescriptorBounded path maximumBytes descriptor = do
+    status <- getFdStatus descriptor
+    let actual = fromIntegral (fileSize status)
     when (maximumBytes < 0 || actual > maximumBytes) $
         throwIO (JournalFileTooLarge path actual maximumBytes)
+    go 0 []
+  where
+    go used chunks = do
+        chunk <- fdRead descriptor 65_536 `catch` \exception ->
+            if isEOFError exception then pure BS.empty else throwIO (exception :: IOException)
+        if BS.null chunk
+            then pure (BS.concat (reverse chunks))
+            else do
+                let total = used + fromIntegral (BS.length chunk)
+                when (maximumBytes < 0 || total > maximumBytes) $
+                    throwIO (JournalFileTooLarge path total maximumBytes)
+                go total (chunk : chunks)
 
 appendEventFile :: JournalConfig -> EventEnvelope -> IO ()
 appendEventFile config event = do
@@ -494,10 +543,10 @@ appendEventFile config event = do
                 , cloexec = True
                 }
     verifyPrivateDescriptor (eventsPath config) descriptor `onException` closeFd descriptor
+    setFdMode descriptor 0o600 `onException` closeFd descriptor
     writeDescriptor descriptor (encodeLine event) `onException` closeFd descriptor
     fileSynchronise descriptor `onException` closeFd descriptor
     closeFd descriptor
-    setFileMode (eventsPath config) 0o600
 
 verifyPrivateDescriptor :: FilePath -> Fd -> IO ()
 verifyPrivateDescriptor path descriptor = do
@@ -538,6 +587,7 @@ atomicWrite config destination bytes = do
                         , nofollow = True
                         , cloexec = True
                         }
+            setFdMode descriptor 0o600 `onException` closeFd descriptor
             writeDescriptor descriptor bytes `onException` closeFd descriptor
             fileSynchronise descriptor `onException` closeFd descriptor
             closeFd descriptor
@@ -545,7 +595,7 @@ atomicWrite config destination bytes = do
             synchronisePath config.directory
         )
         `onException` cleanup
-    setFileMode config.directory 0o700
+    verifyPrivateDirectory config.directory
 
 writeDescriptor :: Fd -> BS.ByteString -> IO ()
 writeDescriptor _ bytes | BS.null bytes = pure ()

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -1,5 +1,6 @@
 module Agent.Runtime.Daemon.Journal
     ( Journal
+    , JournalError (..)
     , JournalConfig (..)
     , JournalSnapshot (..)
     , Replay (..)
@@ -9,7 +10,6 @@ module Agent.Runtime.Daemon.Journal
     , persistTask
     , snapshot
     , replayAfter
-    , subscribe
     , subscribeReplay
     , redactValue
     , boundTaskLog
@@ -17,8 +17,15 @@ module Agent.Runtime.Daemon.Journal
 
 import Control.Concurrent.MVar
 import Control.Concurrent.STM
-import Control.Exception.Safe (IOException, catch, onException)
-import Control.Monad (forM_)
+import Control.Exception.Safe
+    ( Exception
+    , IOException
+    , catch
+    , onException
+    , throwIO
+    , tryIO
+    )
+import Control.Monad (foldM, forM_, unless, when)
 import Data.Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -36,16 +43,28 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time (getCurrentTime)
 import GHC.Generics (Generic)
-import System.Directory
+import System.Directory hiding (isSymbolicLink)
 import System.FilePath ((</>))
-import System.IO
-import System.Posix.Files (setFileMode)
+import System.IO.Error (isDoesNotExistError)
+import System.Posix.Files
+    ( fileOwner
+    , getFdStatus
+    , getSymbolicLinkStatus
+    , isDirectory
+    , isRegularFile
+    , isSymbolicLink
+    , setFileMode
+    )
+import System.Posix.User (getEffectiveUserID)
 import System.Posix.IO
-    ( OpenMode (ReadOnly)
+    ( OpenFileFlags (..)
+    , OpenMode (ReadOnly, WriteOnly)
     , closeFd
     , defaultFileFlags
     , openFd
     )
+import System.Posix.IO.ByteString (fdWrite)
+import System.Posix.Types (Fd)
 import System.Posix.Unistd (fileSynchronise)
 
 import Agent.Runtime.Daemon.Protocol
@@ -57,6 +76,11 @@ data JournalConfig = JournalConfig
     , maximumJournalBytes :: Int
     , maximumTaskLogLines :: Int
     , maximumTaskLogCharacters :: Int
+    , maximumTaskDescriptionCharacters :: Int
+    , maximumTasks :: Int
+    , subscriberQueueSize :: Int
+    , maximumSnapshotBytes :: Int
+    , maximumRecoveryJournalBytes :: Int
     }
     deriving stock (Eq, Show)
 
@@ -68,7 +92,24 @@ defaultJournalConfig directory =
         , maximumJournalBytes = 16 * 1_048_576
         , maximumTaskLogLines = 500
         , maximumTaskLogCharacters = 256_000
+        , maximumTaskDescriptionCharacters = 8_192
+        , maximumTasks = 1_000
+        , subscriberQueueSize = 256
+        , maximumSnapshotBytes = 64 * 1_048_576
+        , maximumRecoveryJournalBytes = 64 * 1_048_576
         }
+
+data JournalError
+    = JournalCorrupt FilePath String
+    | JournalEventGap Sequence Sequence
+    | JournalEventTooLarge Int Int
+    | JournalTaskCapacityExceeded Int
+    | JournalFileTooLarge FilePath Integer Integer
+    | JournalPoisoned String
+    | JournalInsecurePath FilePath
+    deriving stock (Eq, Show)
+
+instance Exception JournalError
 
 data JournalSnapshot = JournalSnapshot
     { lastSequence :: Sequence
@@ -92,39 +133,58 @@ data JournalState = JournalState
 data Journal = Journal
     { config :: JournalConfig
     , state :: MVar JournalState
-    , eventChannel :: TChan EventEnvelope
+    , subscribers :: TVar (Map Int Subscription)
+    , nextSubscriber :: TVar Int
+    , poisoned :: TVar (Maybe String)
+    }
+
+data Subscription = Subscription
+    { events :: TBQueue EventEnvelope
+    , overflowed :: TVar Bool
     }
 
 openJournal :: JournalConfig -> IO Journal
 openJournal config = do
     createDirectoryIfMissing True config.directory
+    verifyPrivateDirectory config.directory
     setFileMode config.directory 0o700
+    mapM_ verifyPrivateFileIfPresent [snapshotPath config, eventsPath config]
+    snapshotExists <- doesFileExist (snapshotPath config)
     savedSnapshot <- readSnapshot config
     savedEvents <- readEvents config
-    let recoveredSnapshot = foldl recoverTask savedSnapshot (toList savedEvents)
+    validateEventSequence savedEvents
+    validateRecoveryOrigin snapshotExists savedEvents
+    recoveredSnapshot <- foldM recoverTask savedSnapshot (toList savedEvents)
+    recoveredTasks <- enforceTaskCapacity config recoveredSnapshot.tasks
+    let boundedSnapshot = recoveredSnapshot {tasks = recoveredTasks}
         lastEventSequence =
             maybe 0 (.sequenceNumber) (Seq.lookup (Seq.length savedEvents - 1) savedEvents)
-        nextSequence = max recoveredSnapshot.lastSequence lastEventSequence
+        nextSequence = max boundedSnapshot.lastSequence lastEventSequence
         initialState =
             JournalState
-                { durableSnapshot = recoveredSnapshot {lastSequence = nextSequence}
+                { durableSnapshot = boundedSnapshot {lastSequence = nextSequence}
                 , retainedEvents = savedEvents
                 }
     state <- newMVar initialState
-    eventChannel <- newBroadcastTChanIO
-    let journal = Journal {config, state, eventChannel}
+    subscribers <- newTVarIO Map.empty
+    nextSubscriber <- newTVarIO 0
+    poisoned <- newTVarIO Nothing
+    let journal = Journal {config, state, subscribers, nextSubscriber, poisoned}
+    _ <- modifyMVar state $ \journalState -> do
+        compacted <- enforceRetention config journalState
+        pure (compacted, ())
     interruptTasksFromPreviousProcess journal
     pure journal
 
-recoverTask :: JournalSnapshot -> EventEnvelope -> JournalSnapshot
+recoverTask :: JournalSnapshot -> EventEnvelope -> IO JournalSnapshot
 recoverTask saved event
-    | event.sequenceNumber <= saved.lastSequence = saved
-    | event.eventType /= "task_changed" = saved
+    | event.sequenceNumber <= saved.lastSequence = pure saved
+    | event.eventType /= "task_changed" = pure saved
     | otherwise =
         case fromJSON event.payload of
-            Error _ -> saved
+            Error message -> throwIO (JournalCorrupt "events.jsonl" message)
             Success task ->
-                saved
+                pure saved
                     { lastSequence = event.sequenceNumber
                     , tasks = Map.insert task.taskId task saved.tasks
                     }
@@ -141,6 +201,7 @@ synchronisePath path =
 appendEvent :: Journal -> Text -> Value -> IO EventEnvelope
 appendEvent journal eventType payload =
     modifyMVar journal.state $ \journalState -> do
+        ensureHealthy journal
         let nextSequence = journalState.durableSnapshot.lastSequence + 1
             event =
                 EventEnvelope
@@ -154,15 +215,22 @@ appendEvent journal eventType payload =
                         journalState.durableSnapshot {lastSequence = nextSequence}
                     , retainedEvents = journalState.retainedEvents Seq.|> event
                     }
-        appendEventFile journal.config event
-        compacted <- enforceRetention journal.config updated
-        atomically (writeTChan journal.eventChannel event)
+        ensureEventFits journal.config event
+        compacted <- persistOrPoison journal $ do
+            appendEventFile journal.config event
+            enforceRetention journal.config updated
+        publish journal event
         pure (compacted, event)
 
 persistTask :: Journal -> DurableTask -> IO EventEnvelope
 persistTask journal task =
     modifyMVar journal.state $ \journalState -> do
+        ensureHealthy journal
         let boundedTask = boundTaskLog journal.config task
+        boundedTasks <-
+            enforceTaskCapacity journal.config $
+                Map.insert boundedTask.taskId boundedTask journalState.durableSnapshot.tasks
+        let
             nextSequence = journalState.durableSnapshot.lastSequence + 1
             event =
                 EventEnvelope
@@ -173,25 +241,33 @@ persistTask journal task =
             updatedSnapshot =
                 JournalSnapshot
                     { lastSequence = nextSequence
-                    , tasks = Map.insert boundedTask.taskId boundedTask journalState.durableSnapshot.tasks
+                    , tasks = boundedTasks
                     }
             updated =
                 JournalState
                     { durableSnapshot = updatedSnapshot
                     , retainedEvents = journalState.retainedEvents Seq.|> event
                     }
-        appendEventFile journal.config event
-        writeSnapshot journal.config updatedSnapshot
-        compacted <- enforceRetention journal.config updated
-        atomically (writeTChan journal.eventChannel event)
+        ensureEventFits journal.config event
+        ensureSnapshotFits journal.config updatedSnapshot
+        compacted <- persistOrPoison journal $ do
+            appendEventFile journal.config event
+            writeSnapshot journal.config updatedSnapshot
+            enforceRetention journal.config updated
+        publish journal event
         pure (compacted, event)
 
 snapshot :: Journal -> IO JournalSnapshot
-snapshot journal = durableSnapshot <$> readMVar journal.state
+snapshot journal =
+    withMVar journal.state $ \journalState -> do
+        ensureHealthy journal
+        pure journalState.durableSnapshot
 
 replayAfter :: Journal -> Sequence -> IO Replay
 replayAfter journal cursor =
-    withMVar journal.state (pure . replayFromState cursor)
+    withMVar journal.state $ \journalState -> do
+        ensureHealthy journal
+        pure (replayFromState cursor journalState)
 
 replayFromState :: Sequence -> JournalState -> Replay
 replayFromState cursor journalState =
@@ -202,20 +278,107 @@ replayFromState cursor journalState =
             then ReplaySnapshot journalState.durableSnapshot
             else ReplayEvents (filter ((> cursor) . (.sequenceNumber)) events)
 
-subscribe :: Journal -> IO (TChan EventEnvelope)
-subscribe journal = atomically (dupTChan journal.eventChannel)
-
 -- | Atomically with respect to appends, capture handshake state, replay, and
 -- a subscription to subsequent events.
-subscribeReplay :: Journal -> Sequence -> IO (JournalSnapshot, Replay, TChan EventEnvelope)
+subscribeReplay ::
+    Journal ->
+    Sequence ->
+    IO (JournalSnapshot, Replay, TBQueue EventEnvelope, TVar Bool, IO ())
 subscribeReplay journal cursor =
     withMVar journal.state $ \journalState -> do
-        channel <- atomically (dupTChan journal.eventChannel)
+        ensureHealthy journal
+        (subscriberId, subscription) <-
+            atomically $ do
+                subscriberId <- readTVar journal.nextSubscriber
+                writeTVar journal.nextSubscriber (subscriberId + 1)
+                events <- newTBQueue (fromIntegral (max 1 journal.config.subscriberQueueSize))
+                overflowed <- newTVar False
+                let subscription = Subscription {events, overflowed}
+                modifyTVar' journal.subscribers (Map.insert subscriberId subscription)
+                pure (subscriberId, subscription)
+        let unsubscribe = atomically (modifyTVar' journal.subscribers (Map.delete subscriberId))
         pure
             ( journalState.durableSnapshot
             , replayFromState cursor journalState
-            , channel
+            , subscription.events
+            , subscription.overflowed
+            , unsubscribe
             )
+
+ensureHealthy :: Journal -> IO ()
+ensureHealthy journal =
+    readTVarIO journal.poisoned >>= \case
+        Nothing -> pure ()
+        Just message -> throwIO (JournalPoisoned message)
+
+persistOrPoison :: Journal -> IO value -> IO value
+persistOrPoison journal action =
+    action `onException`
+        atomically (writeTVar journal.poisoned (Just "persistence operation failed"))
+
+publish :: Journal -> EventEnvelope -> IO ()
+publish journal event =
+    atomically $ do
+        active <- readTVar journal.subscribers
+        forM_ active $ \subscription -> do
+            full <- isFullTBQueue subscription.events
+            if full
+                then writeTVar subscription.overflowed True
+                else writeTBQueue subscription.events event
+
+ensureEventFits :: JournalConfig -> EventEnvelope -> IO ()
+ensureEventFits config event = do
+    let actual = BS.length (encodeLine event)
+        maximumBytes = config.maximumJournalBytes
+    when (maximumBytes <= 0 || actual > maximumBytes) $
+        throwIO (JournalEventTooLarge actual maximumBytes)
+
+enforceTaskCapacity :: JournalConfig -> Map TaskId DurableTask -> IO (Map TaskId DurableTask)
+enforceTaskCapacity config tasks
+    | Map.size tasks <= max 0 config.maximumTasks = pure tasks
+    | otherwise = throwIO (JournalTaskCapacityExceeded config.maximumTasks)
+
+validateEventSequence :: Seq EventEnvelope -> IO ()
+validateEventSequence events =
+    case toList events of
+        [] -> pure ()
+        first : rest
+            | first.sequenceNumber == 0 -> throwIO (JournalEventGap 1 0)
+            | otherwise -> go first.sequenceNumber rest
+  where
+    go _ [] = pure ()
+    go previous (event : remaining)
+        | event.sequenceNumber == previous + 1 =
+            go event.sequenceNumber remaining
+        | otherwise =
+            throwIO (JournalEventGap (previous + 1) event.sequenceNumber)
+
+validateRecoveryOrigin :: Bool -> Seq EventEnvelope -> IO ()
+validateRecoveryOrigin snapshotExists events =
+    case Seq.lookup 0 events of
+        Just first
+            | not snapshotExists && first.sequenceNumber /= 1 ->
+                throwIO (JournalEventGap 1 first.sequenceNumber)
+        _ -> pure ()
+
+verifyPrivateDirectory :: FilePath -> IO ()
+verifyPrivateDirectory path = do
+    status <- getSymbolicLinkStatus path
+    effectiveUser <- getEffectiveUserID
+    unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
+        throwIO (JournalInsecurePath path)
+
+verifyPrivateFileIfPresent :: FilePath -> IO ()
+verifyPrivateFileIfPresent path = do
+    tryIO (getSymbolicLinkStatus path) >>= \case
+        Left exception
+            | isDoesNotExistError exception -> pure ()
+            | otherwise -> throwIO exception
+        Right status -> do
+            effectiveUser <- getEffectiveUserID
+            unless (isRegularFile status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
+                throwIO (JournalInsecurePath path)
+            setFileMode path 0o600
 
 redactValue :: Value -> Value
 redactValue = \case
@@ -234,7 +397,10 @@ redactValue = \case
 boundTaskLog :: JournalConfig -> DurableTask -> DurableTask
 boundTaskLog config task =
     task
-        { logTail =
+        { description =
+            Text.take config.maximumTaskDescriptionCharacters $
+                redactLogLine task.description
+        , logTail =
             boundCharacters config.maximumTaskLogCharacters
                 . takeLast config.maximumTaskLogLines
                 . fmap redactLogLine
@@ -252,13 +418,15 @@ interruptTasksFromPreviousProcess journal = do
 enforceRetention :: JournalConfig -> JournalState -> IO JournalState
 enforceRetention config journalState = do
     journalBytes <- fileSizeOrZero (eventsPath config)
+    forM_ (Seq.lookup (Seq.length journalState.retainedEvents - 1) journalState.retainedEvents) $
+        ensureEventFits config
     let tooMany = Seq.length journalState.retainedEvents > max 0 config.maximumEvents
         tooLarge = journalBytes > fromIntegral (max 0 config.maximumJournalBytes)
     if tooMany || tooLarge
         then do
             let countBounded =
                     Seq.drop
-                        (max 0 (Seq.length journalState.retainedEvents - max 0 config.maximumEvents))
+                        (max 0 (Seq.length journalState.retainedEvents - max 1 config.maximumEvents))
                         journalState.retainedEvents
                 byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
                 compacted = journalState {retainedEvents = byteBounded}
@@ -268,77 +436,135 @@ enforceRetention config journalState = do
 
 retainWithinBytes :: Int -> Seq EventEnvelope -> Seq EventEnvelope
 retainWithinBytes maximumBytes events =
-    snd $
-        foldr
-            (\event (used, kept) ->
-                let size = BS.length (encodeLine event)
-                 in if used + size <= max 0 maximumBytes
-                        then (used + size, event Seq.<| kept)
-                        else (used, kept)
-            )
-            (0, Seq.empty)
-            events
+    Seq.fromList . reverse $ go 0 (reverse (toList events))
+  where
+    go _ [] = []
+    go used (event : rest)
+        | used + size > max 0 maximumBytes = []
+        | otherwise = event : go (used + size) rest
+      where
+        size = BS.length (encodeLine event)
 
 readSnapshot :: JournalConfig -> IO JournalSnapshot
-readSnapshot config =
-    catch
-        (do
+readSnapshot config = do
+    exists <- doesFileExist (snapshotPath config)
+    if exists
+        then do
+            ensureFileSize (snapshotPath config) (fromIntegral config.maximumSnapshotBytes)
             bytes <- BS.readFile (snapshotPath config)
             case eitherDecodeStrict' bytes of
-                Left _ -> pure emptySnapshot
+                Left message -> throwIO (JournalCorrupt (snapshotPath config) message)
                 Right saved -> pure saved
-        )
-        (\(_ :: IOException) -> pure emptySnapshot)
+        else pure emptySnapshot
   where
     emptySnapshot = JournalSnapshot {lastSequence = 0, tasks = Map.empty}
 
 readEvents :: JournalConfig -> IO (Seq EventEnvelope)
-readEvents config =
-    catch
-        (do
+readEvents config = do
+    exists <- doesFileExist (eventsPath config)
+    if exists
+        then do
+            ensureFileSize (eventsPath config) (fromIntegral config.maximumRecoveryJournalBytes)
             bytes <- BS.readFile (eventsPath config)
-            pure . Seq.fromList $ mapMaybeDecode (BS8.lines bytes)
-        )
-        (\(_ :: IOException) -> pure Seq.empty)
+            traverse decodeLine (zip [1 :: Int ..] (BS8.lines bytes)) >>= pure . Seq.fromList
+        else pure Seq.empty
 
-mapMaybeDecode :: FromJSON value => [BS.ByteString] -> [value]
-mapMaybeDecode = foldr step []
-  where
-    step bytes values =
-        case eitherDecodeStrict' bytes of
-            Left _ -> values
-            Right value -> value : values
+decodeLine :: FromJSON value => (Int, BS.ByteString) -> IO value
+decodeLine (lineNumber, bytes) =
+    case eitherDecodeStrict' bytes of
+        Left message -> throwIO (JournalCorrupt "events.jsonl" ("line " <> show lineNumber <> ": " <> message))
+        Right value -> pure value
+
+ensureFileSize :: FilePath -> Integer -> IO ()
+ensureFileSize path maximumBytes = do
+    actual <- getFileSize path
+    when (maximumBytes < 0 || actual > maximumBytes) $
+        throwIO (JournalFileTooLarge path actual maximumBytes)
 
 appendEventFile :: JournalConfig -> EventEnvelope -> IO ()
-appendEventFile config event =
-    withBinaryFile (eventsPath config) AppendMode $ \handle -> do
-        BS.hPut handle (encodeLine event)
-        hFlush handle
-    >> do
-        setFileMode (eventsPath config) 0o600
-        synchronisePath (eventsPath config)
+appendEventFile config event = do
+    descriptor <-
+        openFd
+            (eventsPath config)
+            WriteOnly
+            defaultFileFlags
+                { append = True
+                , creat = Just 0o600
+                , nofollow = True
+                , cloexec = True
+                }
+    verifyPrivateDescriptor (eventsPath config) descriptor `onException` closeFd descriptor
+    writeDescriptor descriptor (encodeLine event) `onException` closeFd descriptor
+    fileSynchronise descriptor `onException` closeFd descriptor
+    closeFd descriptor
+    setFileMode (eventsPath config) 0o600
+
+verifyPrivateDescriptor :: FilePath -> Fd -> IO ()
+verifyPrivateDescriptor path descriptor = do
+    status <- getFdStatus descriptor
+    effectiveUser <- getEffectiveUserID
+    unless (isRegularFile status && fileOwner status == effectiveUser) $
+        throwIO (JournalInsecurePath path)
 
 rewriteEvents :: JournalConfig -> Seq EventEnvelope -> IO ()
 rewriteEvents config events =
     atomicWrite config (eventsPath config) (BS.concat (fmap encodeLine (toList events)))
 
 writeSnapshot :: JournalConfig -> JournalSnapshot -> IO ()
-writeSnapshot config savedSnapshot =
+writeSnapshot config savedSnapshot = do
+    ensureSnapshotFits config savedSnapshot
     atomicWrite config (snapshotPath config) (LBS.toStrict (encode savedSnapshot))
+
+ensureSnapshotFits :: JournalConfig -> JournalSnapshot -> IO ()
+ensureSnapshotFits config savedSnapshot = do
+    let actual = fromIntegral (LBS.length (encode savedSnapshot))
+        maximumBytes = fromIntegral config.maximumSnapshotBytes
+    when (maximumBytes < 0 || actual > maximumBytes) $
+        throwIO (JournalFileTooLarge (snapshotPath config) actual maximumBytes)
 
 atomicWrite :: JournalConfig -> FilePath -> BS.ByteString -> IO ()
 atomicWrite config destination bytes = do
     let temporary = destination <> ".tmp"
         cleanup = removeFile temporary `catch` \(_ :: IOException) -> pure ()
+    verifyTemporaryPath temporary
     (do
-            BS.writeFile temporary bytes
-            setFileMode temporary 0o600
-            synchronisePath temporary
+            descriptor <-
+                openFd
+                    temporary
+                    WriteOnly
+                    defaultFileFlags
+                        { creat = Just 0o600
+                        , exclusive = True
+                        , nofollow = True
+                        , cloexec = True
+                        }
+            writeDescriptor descriptor bytes `onException` closeFd descriptor
+            fileSynchronise descriptor `onException` closeFd descriptor
+            closeFd descriptor
             renameFile temporary destination
             synchronisePath config.directory
         )
         `onException` cleanup
     setFileMode config.directory 0o700
+
+writeDescriptor :: Fd -> BS.ByteString -> IO ()
+writeDescriptor _ bytes | BS.null bytes = pure ()
+writeDescriptor descriptor bytes = do
+    written <- fromIntegral <$> fdWrite descriptor bytes
+    when (written <= 0) (ioError (userError "short journal write"))
+    writeDescriptor descriptor (BS.drop written bytes)
+
+verifyTemporaryPath :: FilePath -> IO ()
+verifyTemporaryPath path = do
+    tryIO (getSymbolicLinkStatus path) >>= \case
+        Left exception
+            | isDoesNotExistError exception -> pure ()
+            | otherwise -> throwIO exception
+        Right status -> do
+            effectiveUser <- getEffectiveUserID
+            unless (isRegularFile status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
+                throwIO (JournalInsecurePath path)
+            removeFile path
 
 fileSizeOrZero :: FilePath -> IO Integer
 fileSizeOrZero path =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -285,7 +285,7 @@ persistTask journal task =
         ensureSnapshotFits journal.config updatedSnapshot
         compacted <- persistOrPoison journal $ do
             appendEventFile journal.config event
-            writeSnapshot journal.config updatedSnapshot
+            writeSnapshot journal.config (snapshotAnchor updatedSnapshot updated.retainedEvents)
             enforceRetention journal.config updated
         publish journal event
         pure (compacted, event)
@@ -405,6 +405,12 @@ validateRecoveryOrigin snapshotExists snapshotSequence events =
                 unless (first.sequenceNumber == expected) $
                     throwIO (JournalEventGap expected first.sequenceNumber)
             | snapshotExists
+            , first.sequenceNumber < snapshotSequence ->
+                throwIO $
+                    JournalCorrupt
+                        "events.jsonl"
+                        "retained event suffix contains a stale prefix before its snapshot anchor"
+            | snapshotExists
             , lastEvent.sequenceNumber < snapshotSequence ->
                 throwIO $
                     JournalCorrupt
@@ -484,8 +490,12 @@ enforceRetention config journalState = do
                                 journalState.retainedEvents
                 byteBounded = retainWithinBytes config.maximumJournalBytes countBounded
                 compacted = journalState {retainedEvents = byteBounded}
-            writeSnapshot config compacted.durableSnapshot
             rewriteEvents config byteBounded
+            -- The first retained event is the durable anchor for this
+            -- suffix.  Persist the rewritten events before advancing the
+            -- snapshot anchor so an interrupted compaction still leaves a
+            -- recoverable (old snapshot, new suffix) pair.
+            writeSnapshot config (snapshotAnchor compacted.durableSnapshot byteBounded)
             pure compacted
         else pure journalState
 
@@ -499,6 +509,16 @@ retainWithinBytes maximumBytes events =
         | otherwise = event : go (used + size) rest
       where
         size = BS.length (encodeLine event)
+
+-- | A snapshot is valid alongside a retained suffix when its sequence is the
+-- suffix's first event (the anchor), or when the suffix is empty.  The task
+-- map is still the latest durable state; recovery skips the anchor event and
+-- applies everything after it.
+snapshotAnchor :: JournalSnapshot -> Seq EventEnvelope -> JournalSnapshot
+snapshotAnchor saved events =
+    case Seq.lookup 0 events of
+        Nothing -> saved
+        Just first -> saved {lastSequence = first.sequenceNumber}
 
 readSnapshot :: JournalConfig -> IO (Bool, JournalSnapshot)
 readSnapshot config = do

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
@@ -1,0 +1,145 @@
+module Agent.Runtime.Daemon.Protocol
+    ( ProtocolVersion (..)
+    , currentProtocolVersion
+    , supportedProtocolVersions
+    , Sequence (..)
+    , ClientId (..)
+    , CommandId (..)
+    , Hello (..)
+    , Welcome (..)
+    , EventEnvelope (..)
+    , ClientMessage (..)
+    , ServerMessage (..)
+    , negotiateVersion
+    ) where
+
+import Data.Aeson
+import Data.Text (Text)
+import Data.Word (Word16, Word64)
+import GHC.Generics (Generic)
+
+newtype ProtocolVersion = ProtocolVersion { unProtocolVersion :: Word16 }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (FromJSON, ToJSON)
+
+currentProtocolVersion :: ProtocolVersion
+currentProtocolVersion = ProtocolVersion 1
+
+supportedProtocolVersions :: [ProtocolVersion]
+supportedProtocolVersions = [currentProtocolVersion]
+
+newtype Sequence = Sequence { unSequence :: Word64 }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (Enum, FromJSON, Num, Real, Integral, ToJSON)
+
+newtype ClientId = ClientId { unClientId :: Text }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (FromJSON, ToJSON)
+
+newtype CommandId = CommandId { unCommandId :: Text }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (FromJSON, ToJSON)
+
+data Hello = Hello
+    { clientId :: ClientId
+    , versions :: [ProtocolVersion]
+    , resumeAfter :: Maybe Sequence
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON Hello
+instance FromJSON Hello
+
+data Welcome = Welcome
+    { version :: ProtocolVersion
+    , currentSequence :: Sequence
+    , heartbeatSeconds :: Int
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON Welcome
+instance FromJSON Welcome
+
+data EventEnvelope = EventEnvelope
+    { sequenceNumber :: Sequence
+    , eventType :: Text
+    , payload :: Value
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON EventEnvelope
+instance FromJSON EventEnvelope
+
+data ClientMessage
+    = ClientHello Hello
+    | ClientAck Sequence
+    | ClientPong Sequence
+    | ClientCommand CommandId Value
+    deriving stock (Eq, Show)
+
+instance ToJSON ClientMessage where
+    toJSON = \case
+        ClientHello hello -> object ["type" .= String "hello", "hello" .= hello]
+        ClientAck sequenceNumber -> object ["type" .= String "ack", "sequence" .= sequenceNumber]
+        ClientPong sequenceNumber -> object ["type" .= String "pong", "sequence" .= sequenceNumber]
+        ClientCommand commandId command ->
+            object ["type" .= String "command", "id" .= commandId, "command" .= command]
+
+instance FromJSON ClientMessage where
+    parseJSON = withObject "ClientMessage" $ \objectValue ->
+        objectValue .: "type" >>= \case
+            ("hello" :: Text) -> ClientHello <$> objectValue .: "hello"
+            "ack" -> ClientAck <$> objectValue .: "sequence"
+            "pong" -> ClientPong <$> objectValue .: "sequence"
+            "command" -> ClientCommand <$> objectValue .: "id" <*> objectValue .: "command"
+            unknown -> fail ("unknown client message type: " <> show unknown)
+
+data ServerMessage
+    = ServerWelcome Welcome
+    | ServerVersionRejected [ProtocolVersion]
+    | ServerSnapshot Sequence Value
+    | ServerEvent EventEnvelope
+    | ServerCommandResult CommandId (Either Text Value)
+    | ServerHeartbeat Sequence
+    deriving stock (Eq, Show)
+
+instance ToJSON ServerMessage where
+    toJSON = \case
+        ServerWelcome welcome -> object ["type" .= String "welcome", "welcome" .= welcome]
+        ServerVersionRejected versions ->
+            object ["type" .= String "version_rejected", "supported" .= versions]
+        ServerSnapshot sequenceNumber snapshot ->
+            object ["type" .= String "snapshot", "sequence" .= sequenceNumber, "snapshot" .= snapshot]
+        ServerEvent event -> object ["type" .= String "event", "event" .= event]
+        ServerCommandResult commandId result ->
+            object
+                [ "type" .= String "command_result"
+                , "id" .= commandId
+                , "ok" .= either (const False) (const True) result
+                , "error" .= either Just (const Nothing) result
+                , "result" .= either (const Nothing) Just result
+                ]
+        ServerHeartbeat sequenceNumber ->
+            object ["type" .= String "heartbeat", "sequence" .= sequenceNumber]
+
+instance FromJSON ServerMessage where
+    parseJSON = withObject "ServerMessage" $ \objectValue ->
+        objectValue .: "type" >>= \case
+            ("welcome" :: Text) -> ServerWelcome <$> objectValue .: "welcome"
+            "version_rejected" -> ServerVersionRejected <$> objectValue .: "supported"
+            "snapshot" -> ServerSnapshot <$> objectValue .: "sequence" <*> objectValue .: "snapshot"
+            "event" -> ServerEvent <$> objectValue .: "event"
+            "command_result" -> do
+                commandId <- objectValue .: "id"
+                succeeded <- objectValue .: "ok"
+                if succeeded
+                    then ServerCommandResult commandId . Right <$> objectValue .: "result"
+                    else ServerCommandResult commandId . Left <$> objectValue .: "error"
+            "heartbeat" -> ServerHeartbeat <$> objectValue .: "sequence"
+            unknown -> fail ("unknown server message type: " <> show unknown)
+
+negotiateVersion :: [ProtocolVersion] -> Maybe ProtocolVersion
+negotiateVersion offered =
+    case filter (`elem` supportedProtocolVersions) offered of
+        [] -> Nothing
+        compatible -> Just (maximum compatible)

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
@@ -23,7 +23,7 @@ newtype ProtocolVersion = ProtocolVersion { unProtocolVersion :: Word16 }
     deriving newtype (FromJSON, ToJSON)
 
 currentProtocolVersion :: ProtocolVersion
-currentProtocolVersion = ProtocolVersion 1
+currentProtocolVersion = ProtocolVersion 2
 
 supportedProtocolVersions :: [ProtocolVersion]
 supportedProtocolVersions = [currentProtocolVersion]
@@ -97,7 +97,7 @@ instance FromJSON ClientMessage where
 data ServerMessage
     = ServerWelcome Welcome
     | ServerVersionRejected [ProtocolVersion]
-    | ServerSnapshot Sequence Value
+    | ServerSnapshotChunk Sequence Int Int Text
     | ServerEvent EventEnvelope
     | ServerCommandResult CommandId (Either Text Value)
     | ServerHeartbeat Sequence
@@ -108,8 +108,14 @@ instance ToJSON ServerMessage where
         ServerWelcome welcome -> object ["type" .= String "welcome", "welcome" .= welcome]
         ServerVersionRejected versions ->
             object ["type" .= String "version_rejected", "supported" .= versions]
-        ServerSnapshot sequenceNumber snapshot ->
-            object ["type" .= String "snapshot", "sequence" .= sequenceNumber, "snapshot" .= snapshot]
+        ServerSnapshotChunk sequenceNumber chunkIndex chunkCount snapshotData ->
+            object
+                [ "type" .= String "snapshot_chunk"
+                , "sequence" .= sequenceNumber
+                , "chunk_index" .= chunkIndex
+                , "chunk_count" .= chunkCount
+                , "snapshot_data" .= snapshotData
+                ]
         ServerEvent event -> object ["type" .= String "event", "event" .= event]
         ServerCommandResult commandId result ->
             object
@@ -127,7 +133,12 @@ instance FromJSON ServerMessage where
         objectValue .: "type" >>= \case
             ("welcome" :: Text) -> ServerWelcome <$> objectValue .: "welcome"
             "version_rejected" -> ServerVersionRejected <$> objectValue .: "supported"
-            "snapshot" -> ServerSnapshot <$> objectValue .: "sequence" <*> objectValue .: "snapshot"
+            "snapshot_chunk" ->
+                ServerSnapshotChunk
+                    <$> objectValue .: "sequence"
+                    <*> objectValue .: "chunk_index"
+                    <*> objectValue .: "chunk_count"
+                    <*> objectValue .: "snapshot_data"
             "event" -> ServerEvent <$> objectValue .: "event"
             "command_result" -> do
                 commandId <- objectValue .: "id"

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Protocol.hs
@@ -23,7 +23,7 @@ newtype ProtocolVersion = ProtocolVersion { unProtocolVersion :: Word16 }
     deriving newtype (FromJSON, ToJSON)
 
 currentProtocolVersion :: ProtocolVersion
-currentProtocolVersion = ProtocolVersion 2
+currentProtocolVersion = ProtocolVersion 3
 
 supportedProtocolVersions :: [ProtocolVersion]
 supportedProtocolVersions = [currentProtocolVersion]
@@ -99,6 +99,7 @@ data ServerMessage
     | ServerVersionRejected [ProtocolVersion]
     | ServerSnapshotChunk Sequence Int Int Text
     | ServerEvent EventEnvelope
+    | ServerEventChunk Sequence Int Int Text
     | ServerCommandResult CommandId (Either Text Value)
     | ServerHeartbeat Sequence
     deriving stock (Eq, Show)
@@ -117,6 +118,14 @@ instance ToJSON ServerMessage where
                 , "snapshot_data" .= snapshotData
                 ]
         ServerEvent event -> object ["type" .= String "event", "event" .= event]
+        ServerEventChunk sequenceNumber chunkIndex chunkCount eventData ->
+            object
+                [ "type" .= String "event_chunk"
+                , "sequence" .= sequenceNumber
+                , "chunk_index" .= chunkIndex
+                , "chunk_count" .= chunkCount
+                , "event_data" .= eventData
+                ]
         ServerCommandResult commandId result ->
             object
                 [ "type" .= String "command_result"
@@ -140,6 +149,12 @@ instance FromJSON ServerMessage where
                     <*> objectValue .: "chunk_count"
                     <*> objectValue .: "snapshot_data"
             "event" -> ServerEvent <$> objectValue .: "event"
+            "event_chunk" ->
+                ServerEventChunk
+                    <$> objectValue .: "sequence"
+                    <*> objectValue .: "chunk_index"
+                    <*> objectValue .: "chunk_count"
+                    <*> objectValue .: "event_data"
             "command_result" -> do
                 commandId <- objectValue .: "id"
                 succeeded <- objectValue .: "ok"

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
@@ -7,12 +7,27 @@ module Agent.Runtime.Daemon.Server
     ) where
 
 import Control.Concurrent.Async (concurrently_, mapConcurrently_, race_)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
-import Control.Exception.Safe (bracket, catchAny, finally)
+import Control.Exception.Safe
+    ( Exception
+    , SomeException
+    , bracket
+    , catchAny
+    , finally
+    , isAsyncException
+    , throwIO
+    )
 import Control.Monad (forever)
-import Data.Aeson (toJSON)
+import Data.Aeson (FromJSON, ToJSON, encode)
+import qualified Data.ByteString as BS
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (for_)
+import qualified Data.Text.Encoding as Text
 import Network.Socket (Socket, close)
+import System.Timeout (timeout)
 
 import Agent.Runtime.Daemon.Framing
 import Agent.Runtime.Daemon.Journal
@@ -25,6 +40,8 @@ data ServerConfig = ServerConfig
     , heartbeatSeconds :: Int
     , workerCount :: Int
     , outboundQueueSize :: Int
+    , ioTimeoutSeconds :: Int
+    , supervisorTimeoutSeconds :: Int
     }
     deriving stock (Eq, Show)
 
@@ -35,7 +52,16 @@ defaultServerConfig =
         , heartbeatSeconds = 15
         , workerCount = 8
         , outboundQueueSize = 256
+        , ioTimeoutSeconds = 30
+        , supervisorTimeoutSeconds = 300
         }
+
+data ServerError
+    = ServerTimedOut String
+    | ServerSubscriberOverflow
+    deriving stock (Eq, Show)
+
+instance Exception ServerError
 
 runServer :: SocketConfig -> ServerConfig -> Journal -> Supervisor -> IO ()
 runServer socketConfig serverConfig journal supervisor =
@@ -45,7 +71,10 @@ runServer socketConfig serverConfig journal supervisor =
 runServerOnListener :: Socket -> ServerConfig -> Journal -> Supervisor -> IO ()
 runServerOnListener listener serverConfig journal supervisor = do
     accepted <- newTBQueueIO (fromIntegral (max 1 serverConfig.workerCount))
-    let acceptLoop = forever (acceptOwnedPeer listener >>= atomically . writeTBQueue accepted)
+    let acceptLoop =
+            forever $
+                (acceptOwnedPeer listener >>= atomically . writeTBQueue accepted)
+                    `catchSync` const (threadDelay 100_000)
         worker =
             forever $
                 bracket
@@ -53,7 +82,7 @@ runServerOnListener listener serverConfig journal supervisor = do
                     close
                     ( \peer ->
                         serveConnection serverConfig journal supervisor peer
-                            `catchAny` const (pure ())
+                            `catchSync` const (pure ())
                     )
         closeQueued = atomically (flushTBQueue accepted) >>= mapM_ close
     ( concurrently_ acceptLoop $
@@ -62,14 +91,14 @@ runServerOnListener listener serverConfig journal supervisor = do
 
 serveConnection :: ServerConfig -> Journal -> Supervisor -> Socket -> IO ()
 serveConnection config journal supervisor peer = do
-    receiveJSONFrame config.maximumFrameBytes peer >>= \case
+    receive config peer >>= \case
         ClientHello hello ->
             case negotiateVersion hello.versions of
                 Nothing ->
-                    sendJSONFrame config.maximumFrameBytes peer $
+                    send config peer $
                         ServerVersionRejected supportedProtocolVersions
                 Just version -> serveNegotiated config journal supervisor peer hello version
-        _ -> sendJSONFrame config.maximumFrameBytes peer $
+        _ -> send config peer $
             ServerVersionRejected supportedProtocolVersions
 
 serveNegotiated ::
@@ -82,56 +111,114 @@ serveNegotiated ::
     IO ()
 serveNegotiated config journal supervisor peer hello version = do
     let cursor = maybe 0 id hello.resumeAfter
-    (currentSnapshot, resumableReplay, eventChannel) <- subscribeReplay journal cursor
-    let replay =
-            case hello.resumeAfter of
-                Nothing -> ReplaySnapshot currentSnapshot
-                Just _ -> resumableReplay
-    sendJSONFrame config.maximumFrameBytes peer $
-        ServerWelcome
-            Welcome
-                { version
-                , currentSequence = currentSnapshot.lastSequence
-                , heartbeatSeconds = config.heartbeatSeconds
-                }
-    case replay of
-        ReplaySnapshot saved ->
-            sendJSONFrame config.maximumFrameBytes peer $
-                ServerSnapshot saved.lastSequence (toJSON saved)
-        ReplayEvents events ->
-            for_ events (sendJSONFrame config.maximumFrameBytes peer . ServerEvent)
-    outbound <- newTBQueueIO (fromIntegral (max 1 config.outboundQueueSize))
-    acknowledged <- newTVarIO cursor
-    latestSequence <- newTVarIO currentSnapshot.lastSequence
-    let enqueue message = atomically (writeTBQueue outbound message)
-        receiver =
-            forever $
-                receiveJSONFrame config.maximumFrameBytes peer >>= \case
-                    ClientAck sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
-                    ClientPong sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
-                    ClientCommand commandId command -> do
-                        result <- supervisor.handleCommand commandId command
-                        enqueue (ServerCommandResult commandId result)
-                    ClientHello _ -> pure ()
-        sender = forever $ do
-            delay <- registerDelay (max 1 config.heartbeatSeconds * 1_000_000)
-            message <-
-                atomically $
-                    (readTBQueue outbound)
-                        `orElse` (do
-                            event <- readTChan eventChannel
-                            writeTVar latestSequence event.sequenceNumber
-                            pure (ServerEvent event)
-                        )
-                        `orElse` do
-                            expired <- readTVar delay
-                            check expired
-                            sequenceNumber <- readTVar latestSequence
-                            pure (ServerHeartbeat sequenceNumber)
-            sendJSONFrame config.maximumFrameBytes peer message
-    race_ receiver sender
+    bracket
+        (subscribeReplay journal cursor)
+        (\(_, _, _, _, unsubscribe) -> unsubscribe)
+        $ \(currentSnapshot, resumableReplay, eventQueue, overflowed, _) -> do
+            let replay =
+                    case hello.resumeAfter of
+                        Nothing -> ReplaySnapshot currentSnapshot
+                        Just _ -> resumableReplay
+            send config peer $
+                ServerWelcome
+                    Welcome
+                        { version
+                        , currentSequence = currentSnapshot.lastSequence
+                        , heartbeatSeconds = config.heartbeatSeconds
+                        }
+            case replay of
+                ReplaySnapshot saved ->
+                    sendSnapshot config peer saved
+                ReplayEvents events ->
+                    for_ events (send config peer . ServerEvent)
+            outbound <- newTBQueueIO (fromIntegral (max 1 config.outboundQueueSize))
+            acknowledged <- newTVarIO cursor
+            latestSequence <- newTVarIO currentSnapshot.lastSequence
+            let enqueue message =
+                    within config.ioTimeoutSeconds "outbound queue" $
+                        atomically (writeTBQueue outbound message)
+                receiver =
+                    forever $
+                        receive config peer >>= \case
+                            ClientAck sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
+                            ClientPong sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
+                            ClientCommand commandId command -> do
+                                result <-
+                                    within config.supervisorTimeoutSeconds "supervisor command" $
+                                        supervisor.handleCommand commandId command
+                                enqueue (ServerCommandResult commandId result)
+                            ClientHello _ -> pure ()
+                sender = forever $ do
+                    delay <- registerDelay (max 1 config.heartbeatSeconds * 1_000_000)
+                    next <-
+                        atomically $
+                            (do
+                                didOverflow <- readTVar overflowed
+                                check didOverflow
+                                pure Nothing
+                            )
+                                `orElse` (Just <$> readTBQueue outbound)
+                                `orElse` (do
+                                    event <- readTBQueue eventQueue
+                                    writeTVar latestSequence event.sequenceNumber
+                                    pure (Just (ServerEvent event))
+                                )
+                                `orElse` do
+                                    expired <- readTVar delay
+                                    check expired
+                                    sequenceNumber <- readTVar latestSequence
+                                    pure (Just (ServerHeartbeat sequenceNumber))
+                    case next of
+                        Nothing -> throwIO ServerSubscriberOverflow
+                        Just message -> send config peer message
+            race_ receiver sender
   where
     acknowledge variable latest sequenceNumber =
         atomically $ do
             newest <- readTVar latest
             modifyTVar' variable (max (min sequenceNumber newest))
+
+sendSnapshot :: ServerConfig -> Socket -> JournalSnapshot -> IO ()
+sendSnapshot config peer saved = do
+    let rawChunkBytes = max 1 ((config.maximumFrameBytes - 256) * 3 `div` 4)
+        chunks = chunkBytes rawChunkBytes (LBS.toStrict (encode saved))
+        count = length chunks
+    for_ (zip [0 ..] chunks) $ \(index, bytes) ->
+        send config peer $
+            ServerSnapshotChunk
+                saved.lastSequence
+                index
+                count
+                (Text.decodeUtf8 (Base64.encode bytes))
+
+chunkBytes :: Int -> ByteString -> [ByteString]
+chunkBytes size bytes
+    | BS.null bytes = [BS.empty]
+    | otherwise =
+        let (chunk, rest) = BS.splitAt size bytes
+         in if BS.null rest
+                then [chunk]
+                else chunk : chunkBytes size rest
+
+send :: ToJSON value => ServerConfig -> Socket -> value -> IO ()
+send config peer value =
+    within config.ioTimeoutSeconds "socket write" $
+        sendJSONFrame config.maximumFrameBytes peer value
+
+receive :: FromJSON value => ServerConfig -> Socket -> IO value
+receive config peer =
+    within config.ioTimeoutSeconds "socket read" $
+        receiveJSONFrame config.maximumFrameBytes peer
+
+within :: Int -> String -> IO value -> IO value
+within seconds label action =
+    timeout (max 1 seconds * 1_000_000) action >>= \case
+        Nothing -> throwIO (ServerTimedOut label)
+        Just value -> pure value
+
+catchSync :: IO value -> (SomeException -> IO value) -> IO value
+catchSync action handler =
+    action `catchAny` \exception ->
+        if isAsyncException exception
+            then throwIO exception
+            else handler exception

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
@@ -13,6 +13,7 @@ import Control.Exception.Safe
     ( Exception
     , SomeException
     , bracket
+    , bracketOnError
     , catchAny
     , finally
     , isAsyncException
@@ -73,7 +74,10 @@ runServerOnListener listener serverConfig journal supervisor = do
     accepted <- newTBQueueIO (fromIntegral (max 1 serverConfig.workerCount))
     let acceptLoop =
             forever $
-                (acceptOwnedPeer listener >>= atomically . writeTBQueue accepted)
+                bracketOnError
+                    (acceptOwnedPeer listener)
+                    close
+                    (atomically . writeTBQueue accepted)
                     `catchSync` const (threadDelay 100_000)
         worker =
             forever $
@@ -130,7 +134,7 @@ serveNegotiated config journal supervisor peer hello version = do
                 ReplaySnapshot saved ->
                     sendSnapshot config peer saved
                 ReplayEvents events ->
-                    for_ events (send config peer . ServerEvent)
+                    for_ events (sendEvent config peer)
             outbound <- newTBQueueIO (fromIntegral (max 1 config.outboundQueueSize))
             acknowledged <- newTVarIO cursor
             latestSequence <- newTVarIO currentSnapshot.lastSequence
@@ -170,7 +174,7 @@ serveNegotiated config journal supervisor peer hello version = do
                                     pure (Just (ServerHeartbeat sequenceNumber))
                     case next of
                         Nothing -> throwIO ServerSubscriberOverflow
-                        Just message -> send config peer message
+                        Just message -> sendMessage config peer message
             race_ receiver sender
   where
     acknowledge variable latest sequenceNumber =
@@ -190,6 +194,27 @@ sendSnapshot config peer saved = do
                 index
                 count
                 (Text.decodeUtf8 (Base64.encode bytes))
+
+sendEvent :: ServerConfig -> Socket -> EventEnvelope -> IO ()
+sendEvent config peer event
+    | LBS.length (encode (ServerEvent event)) <= fromIntegral config.maximumFrameBytes =
+        send config peer (ServerEvent event)
+    | otherwise = do
+        let rawChunkBytes = max 1 ((config.maximumFrameBytes - 256) * 3 `div` 4)
+            chunks = chunkBytes rawChunkBytes (LBS.toStrict (encode event))
+            count = length chunks
+        for_ (zip [0 ..] chunks) $ \(index, bytes) ->
+            send config peer $
+                ServerEventChunk
+                    event.sequenceNumber
+                    index
+                    count
+                    (Text.decodeUtf8 (Base64.encode bytes))
+
+sendMessage :: ServerConfig -> Socket -> ServerMessage -> IO ()
+sendMessage config peer = \case
+    ServerEvent event -> sendEvent config peer event
+    message -> send config peer message
 
 chunkBytes :: Int -> ByteString -> [ByteString]
 chunkBytes size bytes

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
@@ -1,0 +1,137 @@
+module Agent.Runtime.Daemon.Server
+    ( ServerConfig (..)
+    , defaultServerConfig
+    , runServer
+    , runServerOnListener
+    , serveConnection
+    ) where
+
+import Control.Concurrent.Async (concurrently_, mapConcurrently_, race_)
+import Control.Concurrent.STM
+import Control.Exception.Safe (bracket, catchAny, finally)
+import Control.Monad (forever)
+import Data.Aeson (toJSON)
+import Data.Foldable (for_)
+import Network.Socket (Socket, close)
+
+import Agent.Runtime.Daemon.Framing
+import Agent.Runtime.Daemon.Journal
+import Agent.Runtime.Daemon.Protocol
+import Agent.Runtime.Daemon.Socket
+import Agent.Runtime.Daemon.Supervisor
+
+data ServerConfig = ServerConfig
+    { maximumFrameBytes :: Int
+    , heartbeatSeconds :: Int
+    , workerCount :: Int
+    , outboundQueueSize :: Int
+    }
+    deriving stock (Eq, Show)
+
+defaultServerConfig :: ServerConfig
+defaultServerConfig =
+    ServerConfig
+        { maximumFrameBytes = defaultMaximumFrameBytes
+        , heartbeatSeconds = 15
+        , workerCount = 8
+        , outboundQueueSize = 256
+        }
+
+runServer :: SocketConfig -> ServerConfig -> Journal -> Supervisor -> IO ()
+runServer socketConfig serverConfig journal supervisor =
+    withUnixListener socketConfig $ \listener ->
+        runServerOnListener listener serverConfig journal supervisor
+
+runServerOnListener :: Socket -> ServerConfig -> Journal -> Supervisor -> IO ()
+runServerOnListener listener serverConfig journal supervisor = do
+    accepted <- newTBQueueIO (fromIntegral (max 1 serverConfig.workerCount))
+    let acceptLoop = forever (acceptOwnedPeer listener >>= atomically . writeTBQueue accepted)
+        worker =
+            forever $
+                bracket
+                    (atomically (readTBQueue accepted))
+                    close
+                    ( \peer ->
+                        serveConnection serverConfig journal supervisor peer
+                            `catchAny` const (pure ())
+                    )
+        closeQueued = atomically (flushTBQueue accepted) >>= mapM_ close
+    ( concurrently_ acceptLoop $
+        mapConcurrently_ (const worker) [1 .. max 1 serverConfig.workerCount]
+      ) `finally` closeQueued
+
+serveConnection :: ServerConfig -> Journal -> Supervisor -> Socket -> IO ()
+serveConnection config journal supervisor peer = do
+    receiveJSONFrame config.maximumFrameBytes peer >>= \case
+        ClientHello hello ->
+            case negotiateVersion hello.versions of
+                Nothing ->
+                    sendJSONFrame config.maximumFrameBytes peer $
+                        ServerVersionRejected supportedProtocolVersions
+                Just version -> serveNegotiated config journal supervisor peer hello version
+        _ -> sendJSONFrame config.maximumFrameBytes peer $
+            ServerVersionRejected supportedProtocolVersions
+
+serveNegotiated ::
+    ServerConfig ->
+    Journal ->
+    Supervisor ->
+    Socket ->
+    Hello ->
+    ProtocolVersion ->
+    IO ()
+serveNegotiated config journal supervisor peer hello version = do
+    let cursor = maybe 0 id hello.resumeAfter
+    (currentSnapshot, resumableReplay, eventChannel) <- subscribeReplay journal cursor
+    let replay =
+            case hello.resumeAfter of
+                Nothing -> ReplaySnapshot currentSnapshot
+                Just _ -> resumableReplay
+    sendJSONFrame config.maximumFrameBytes peer $
+        ServerWelcome
+            Welcome
+                { version
+                , currentSequence = currentSnapshot.lastSequence
+                , heartbeatSeconds = config.heartbeatSeconds
+                }
+    case replay of
+        ReplaySnapshot saved ->
+            sendJSONFrame config.maximumFrameBytes peer $
+                ServerSnapshot saved.lastSequence (toJSON saved)
+        ReplayEvents events ->
+            for_ events (sendJSONFrame config.maximumFrameBytes peer . ServerEvent)
+    outbound <- newTBQueueIO (fromIntegral (max 1 config.outboundQueueSize))
+    acknowledged <- newTVarIO cursor
+    latestSequence <- newTVarIO currentSnapshot.lastSequence
+    let enqueue message = atomically (writeTBQueue outbound message)
+        receiver =
+            forever $
+                receiveJSONFrame config.maximumFrameBytes peer >>= \case
+                    ClientAck sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
+                    ClientPong sequenceNumber -> acknowledge acknowledged latestSequence sequenceNumber
+                    ClientCommand commandId command -> do
+                        result <- supervisor.handleCommand commandId command
+                        enqueue (ServerCommandResult commandId result)
+                    ClientHello _ -> pure ()
+        sender = forever $ do
+            delay <- registerDelay (max 1 config.heartbeatSeconds * 1_000_000)
+            message <-
+                atomically $
+                    (readTBQueue outbound)
+                        `orElse` (do
+                            event <- readTChan eventChannel
+                            writeTVar latestSequence event.sequenceNumber
+                            pure (ServerEvent event)
+                        )
+                        `orElse` do
+                            expired <- readTVar delay
+                            check expired
+                            sequenceNumber <- readTVar latestSequence
+                            pure (ServerHeartbeat sequenceNumber)
+            sendJSONFrame config.maximumFrameBytes peer message
+    race_ receiver sender
+  where
+    acknowledge variable latest sequenceNumber =
+        atomically $ do
+            newest <- readTVar latest
+            modifyTVar' variable (max (min sequenceNumber newest))

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
@@ -13,7 +13,16 @@ import Network.Socket
 import System.Directory hiding (isSymbolicLink)
 import System.Environment (lookupEnv)
 import System.FilePath ((</>), takeDirectory)
+import qualified System.FileLock as FileLock
 import System.Posix.Files
+import System.Posix.IO
+    ( OpenFileFlags (..)
+    , OpenMode (ReadWrite)
+    , closeFd
+    , defaultFileFlags
+    , openFd
+    )
+import System.Posix.Types (DeviceID, FileID)
 import System.Posix.User (getEffectiveUserID)
 
 data SocketConfig = SocketConfig
@@ -34,8 +43,15 @@ defaultSocketPath = do
     pure $ maybe (home </> ".haskell-agent" </> "runtime") id override </> "daemon.sock"
 
 withUnixListener :: SocketConfig -> (Socket -> IO value) -> IO value
-withUnixListener config =
-    bracket (openListener config) (closeListener config)
+withUnixListener config action = do
+    prepareSocketDirectory config
+    prepareLockFile (lockPath config)
+    result <-
+        FileLock.withTryFileLock (lockPath config) FileLock.Exclusive $ \_ ->
+            bracket (openListener config) (closeListener config) (action . (.listenerSocket))
+    case result of
+        Nothing -> throwString ("runtime daemon already owns: " <> config.path)
+        Just value -> pure value
 
 acceptOwnedPeer :: Socket -> IO Socket
 acceptOwnedPeer listener = do
@@ -50,26 +66,61 @@ verifyPeerOwner peer = do
     unless (peerUser == Just daemonUser) $
         throwString "refusing Unix socket peer owned by another user"
 
-openListener :: SocketConfig -> IO Socket
-openListener config = do
+data Listener = Listener
+    { listenerSocket :: Socket
+    , identity :: FileIdentity
+    }
+
+data FileIdentity = FileIdentity
+    { device :: DeviceID
+    , file :: FileID
+    }
+    deriving stock (Eq)
+
+prepareSocketDirectory :: SocketConfig -> IO ()
+prepareSocketDirectory config = do
     let directory = takeDirectory config.path
     createDirectoryIfMissing True directory
     verifyPrivateDirectory directory
     setFileMode directory 0o700
+
+prepareLockFile :: FilePath -> IO ()
+prepareLockFile path =
+    bracket
+        (openFd path ReadWrite defaultFileFlags {creat = Just 0o600, nofollow = True, cloexec = True})
+        closeFd
+        $ \_ -> do
+            status <- getSymbolicLinkStatus path
+            effectiveUser <- getEffectiveUserID
+            unless (isRegularFile status && fileOwner status == effectiveUser) $
+                throwString ("runtime lock is not a user-owned regular file: " <> path)
+            setFileMode path 0o600
+
+openListener :: SocketConfig -> IO Listener
+openListener config = do
     removeStaleSocket config.path
     listener <- socket AF_UNIX Stream defaultProtocol
     (do
             bind listener (SockAddrUnix config.path)
             setFileMode config.path 0o600
             listen listener config.backlog
-            pure listener
+            status <- getSymbolicLinkStatus config.path
+            pure Listener
+                { listenerSocket = listener
+                , identity = identityOf status
+                }
         )
         `onException` close listener
 
-closeListener :: SocketConfig -> Socket -> IO ()
+closeListener :: SocketConfig -> Listener -> IO ()
 closeListener config listener = do
-    close listener
-    removeFile (path config) `catch` \(_ :: IOException) -> pure ()
+    close listener.listenerSocket
+    current <- tryIO (getSymbolicLinkStatus config.path)
+    case current of
+        Right status
+            | isSocket status && identityOf status == listener.identity ->
+                removeFile config.path `catch` \(_ :: IOException) -> pure ()
+        _ -> pure ()
 
 removeStaleSocket :: FilePath -> IO ()
 removeStaleSocket path = do
@@ -97,3 +148,13 @@ verifyPrivateDirectory directory = do
     effectiveUser <- getEffectiveUserID
     unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
         throwString ("runtime socket directory is not a user-owned directory: " <> directory)
+
+identityOf :: FileStatus -> FileIdentity
+identityOf status =
+    FileIdentity
+        { device = deviceID status
+        , file = fileID status
+        }
+
+lockPath :: SocketConfig -> FilePath
+lockPath config = config.path <> ".lock"

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
@@ -1,0 +1,99 @@
+module Agent.Runtime.Daemon.Socket
+    ( SocketConfig (..)
+    , defaultSocketConfig
+    , defaultSocketPath
+    , withUnixListener
+    , acceptOwnedPeer
+    , verifyPeerOwner
+    ) where
+
+import Control.Exception.Safe (IOException, bracket, catch, onException, throwString, tryIO)
+import Control.Monad (unless, when)
+import Network.Socket
+import System.Directory hiding (isSymbolicLink)
+import System.Environment (lookupEnv)
+import System.FilePath ((</>), takeDirectory)
+import System.Posix.Files
+import System.Posix.User (getEffectiveUserID)
+
+data SocketConfig = SocketConfig
+    { path :: FilePath
+    , backlog :: Int
+    }
+    deriving stock (Eq, Show)
+
+defaultSocketConfig :: IO SocketConfig
+defaultSocketConfig = do
+    path <- defaultSocketPath
+    pure SocketConfig {path, backlog = 16}
+
+defaultSocketPath :: IO FilePath
+defaultSocketPath = do
+    home <- getHomeDirectory
+    override <- lookupEnv "HASKELL_AGENT_RUNTIME_DIR"
+    pure $ maybe (home </> ".haskell-agent" </> "runtime") id override </> "daemon.sock"
+
+withUnixListener :: SocketConfig -> (Socket -> IO value) -> IO value
+withUnixListener config =
+    bracket (openListener config) (closeListener config)
+
+acceptOwnedPeer :: Socket -> IO Socket
+acceptOwnedPeer listener = do
+    (peer, _) <- accept listener
+    verifyPeerOwner peer `onException` close peer
+    pure peer
+
+verifyPeerOwner :: Socket -> IO ()
+verifyPeerOwner peer = do
+    (_, peerUser, _) <- getPeerCredential peer
+    daemonUser <- fromIntegral <$> getEffectiveUserID
+    unless (peerUser == Just daemonUser) $
+        throwString "refusing Unix socket peer owned by another user"
+
+openListener :: SocketConfig -> IO Socket
+openListener config = do
+    let directory = takeDirectory config.path
+    createDirectoryIfMissing True directory
+    verifyPrivateDirectory directory
+    setFileMode directory 0o700
+    removeStaleSocket config.path
+    listener <- socket AF_UNIX Stream defaultProtocol
+    (do
+            bind listener (SockAddrUnix config.path)
+            setFileMode config.path 0o600
+            listen listener config.backlog
+            pure listener
+        )
+        `onException` close listener
+
+closeListener :: SocketConfig -> Socket -> IO ()
+closeListener config listener = do
+    close listener
+    removeFile (path config) `catch` \(_ :: IOException) -> pure ()
+
+removeStaleSocket :: FilePath -> IO ()
+removeStaleSocket path = do
+    exists <- fileExist path
+    when exists $ do
+        status <- getSymbolicLinkStatus path
+        effectiveUser <- getEffectiveUserID
+        if isSocket status && fileOwner status == effectiveUser
+            then do
+                active <- socketAcceptsConnections path
+                if active
+                    then throwString ("runtime daemon is already listening at: " <> path)
+                    else removeFile path
+            else throwString ("refusing to replace non-socket path: " <> path)
+
+socketAcceptsConnections :: FilePath -> IO Bool
+socketAcceptsConnections path =
+    bracket (socket AF_UNIX Stream defaultProtocol) close $ \probe ->
+        either (const False) (const True)
+            <$> tryIO (connect probe (SockAddrUnix path))
+
+verifyPrivateDirectory :: FilePath -> IO ()
+verifyPrivateDirectory directory = do
+    status <- getSymbolicLinkStatus directory
+    effectiveUser <- getEffectiveUserID
+    unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
+        throwString ("runtime socket directory is not a user-owned directory: " <> directory)

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
@@ -7,7 +7,7 @@ module Agent.Runtime.Daemon.Socket
     , verifyPeerOwner
     ) where
 
-import Control.Exception.Safe (IOException, bracket, catch, onException, throwString, tryIO)
+import Control.Exception.Safe (IOException, bracket, catch, finally, onException, throwString, tryIO)
 import Control.Monad (unless, when)
 import Network.Socket
 import System.Directory hiding (isSymbolicLink)
@@ -17,7 +17,7 @@ import qualified System.FileLock as FileLock
 import System.Posix.Files
 import System.Posix.IO
     ( OpenFileFlags (..)
-    , OpenMode (ReadWrite)
+    , OpenMode (ReadOnly, ReadWrite)
     , closeFd
     , defaultFileFlags
     , openFd
@@ -81,20 +81,32 @@ prepareSocketDirectory :: SocketConfig -> IO ()
 prepareSocketDirectory config = do
     let directory = takeDirectory config.path
     createDirectoryIfMissing True directory
-    verifyPrivateDirectory directory
-    setFileMode directory 0o700
+    descriptor <-
+        openFd
+            directory
+            ReadOnly
+            defaultFileFlags {nofollow = True, cloexec = True, directory = True}
+    (do
+            status <- getFdStatus descriptor
+            effectiveUser <- getEffectiveUserID
+            unless (isDirectory status && fileOwner status == effectiveUser) $
+                throwString ("runtime socket directory is not a user-owned directory: " <> directory)
+            setFdMode descriptor 0o700
+        )
+        `finally` closeFd descriptor
 
 prepareLockFile :: FilePath -> IO ()
-prepareLockFile path =
-    bracket
-        (openFd path ReadWrite defaultFileFlags {creat = Just 0o600, nofollow = True, cloexec = True})
-        closeFd
-        $ \_ -> do
-            status <- getSymbolicLinkStatus path
+prepareLockFile path = do
+    descriptor <-
+        openFd path ReadWrite defaultFileFlags {creat = Just 0o600, nofollow = True, cloexec = True}
+    (do
+            status <- getFdStatus descriptor
             effectiveUser <- getEffectiveUserID
             unless (isRegularFile status && fileOwner status == effectiveUser) $
                 throwString ("runtime lock is not a user-owned regular file: " <> path)
-            setFileMode path 0o600
+            setFdMode descriptor 0o600
+        )
+        `finally` closeFd descriptor
 
 openListener :: SocketConfig -> IO Listener
 openListener config = do
@@ -141,13 +153,6 @@ socketAcceptsConnections path =
     bracket (socket AF_UNIX Stream defaultProtocol) close $ \probe ->
         either (const False) (const True)
             <$> tryIO (connect probe (SockAddrUnix path))
-
-verifyPrivateDirectory :: FilePath -> IO ()
-verifyPrivateDirectory directory = do
-    status <- getSymbolicLinkStatus directory
-    effectiveUser <- getEffectiveUserID
-    unless (isDirectory status && not (isSymbolicLink status) && fileOwner status == effectiveUser) $
-        throwString ("runtime socket directory is not a user-owned directory: " <> directory)
 
 identityOf :: FileStatus -> FileIdentity
 identityOf status =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Supervisor.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Supervisor.hs
@@ -1,0 +1,21 @@
+module Agent.Runtime.Daemon.Supervisor
+    ( Supervisor (..)
+    , unavailableSupervisor
+    ) where
+
+import Data.Aeson (Value)
+import Data.Text (Text)
+
+import Agent.Runtime.Daemon.Protocol (CommandId)
+
+-- | Integration seam for the task supervisor. The daemon foundation owns
+-- transport and durability; a supervisor owns task execution and commands.
+newtype Supervisor = Supervisor
+    { handleCommand :: CommandId -> Value -> IO (Either Text Value)
+    }
+
+unavailableSupervisor :: Supervisor
+unavailableSupervisor =
+    Supervisor
+        { handleCommand = \_ _ -> pure (Left "task supervisor is not configured")
+        }

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Task.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Task.hs
@@ -6,7 +6,7 @@ module Agent.Runtime.Daemon.Task
     , interruptActive
     ) where
 
-import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.Aeson
 import Data.Text (Text)
 import Data.Time (UTCTime)
 import GHC.Generics (Generic)
@@ -29,15 +29,53 @@ instance FromJSON TaskStatus
 
 data DurableTask = DurableTask
     { taskId :: TaskId
+    , sessionId :: Maybe Text
     , status :: TaskStatus
     , description :: Text
+    , workingDirectory :: FilePath
+    , provider :: Maybe Text
+    , model :: Maybe Text
+    , effort :: Maybe Text
+    , worktree :: Bool
+    , attempt :: Int
     , updatedAt :: UTCTime
     , logTail :: [Text]
     }
     deriving stock (Eq, Show, Generic)
 
-instance ToJSON DurableTask
-instance FromJSON DurableTask
+instance ToJSON DurableTask where
+    toJSON task =
+        object
+            [ "taskId" .= task.taskId
+            , "sessionId" .= task.sessionId
+            , "status" .= task.status
+            , "description" .= task.description
+            , "workingDirectory" .= task.workingDirectory
+            , "provider" .= task.provider
+            , "model" .= task.model
+            , "effort" .= task.effort
+            , "worktree" .= task.worktree
+            , "attempt" .= task.attempt
+            , "updatedAt" .= task.updatedAt
+            , "logTail" .= task.logTail
+            ]
+
+-- Defaults keep snapshots written by the daemon foundation readable.
+instance FromJSON DurableTask where
+    parseJSON = withObject "DurableTask" $ \value ->
+        DurableTask
+            <$> value .: "taskId"
+            <*> value .:? "sessionId"
+            <*> value .: "status"
+            <*> value .: "description"
+            <*> value .:? "workingDirectory" .!= "."
+            <*> value .:? "provider"
+            <*> value .:? "model"
+            <*> value .:? "effort"
+            <*> value .:? "worktree" .!= False
+            <*> value .:? "attempt" .!= 1
+            <*> value .: "updatedAt"
+            <*> value .: "logTail"
 
 isActive :: DurableTask -> Bool
 isActive DurableTask {status} = status == TaskQueued || status == TaskRunning

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Task.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Task.hs
@@ -1,0 +1,48 @@
+module Agent.Runtime.Daemon.Task
+    ( TaskId (..)
+    , TaskStatus (..)
+    , DurableTask (..)
+    , isActive
+    , interruptActive
+    ) where
+
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import GHC.Generics (Generic)
+
+newtype TaskId = TaskId { unTaskId :: Text }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+
+data TaskStatus
+    = TaskQueued
+    | TaskRunning
+    | TaskCompleted
+    | TaskFailed
+    | TaskCancelled
+    | TaskInterrupted
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON TaskStatus
+instance FromJSON TaskStatus
+
+data DurableTask = DurableTask
+    { taskId :: TaskId
+    , status :: TaskStatus
+    , description :: Text
+    , updatedAt :: UTCTime
+    , logTail :: [Text]
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance ToJSON DurableTask
+instance FromJSON DurableTask
+
+isActive :: DurableTask -> Bool
+isActive DurableTask {status} = status == TaskQueued || status == TaskRunning
+
+interruptActive :: UTCTime -> DurableTask -> DurableTask
+interruptActive now task@DurableTask {}
+    | isActive task = task {status = TaskInterrupted, updatedAt = now}
+    | otherwise = task

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -269,10 +269,17 @@ schedulerLoopWithRegistry journal runner commands completions registry = go
                                                     <> either (\message -> [message]) (const []) result
                                             }
                                 persisted <- persistBounded journal updated
-                                pure withoutWorker
-                                    { adapterTasks =
-                                        Map.insert taskId persisted state.adapterTasks
-                                    }
+                                pure $
+                                    ( if persisted.status == TaskCompleted
+                                        then withoutWorker
+                                            { adapterInputs =
+                                                Map.delete taskId withoutWorker.adapterInputs
+                                            }
+                                        else withoutWorker
+                                    )
+                                        { adapterTasks =
+                                            Map.insert taskId persisted state.adapterTasks
+                                        }
                         _ -> pure withoutWorker
                 _ -> pure state
 
@@ -380,16 +387,20 @@ executeCommand journal registry state = \case
             Just task
                 | isActive task ->
                     pure (state, Left "active tasks cannot be retried")
-                | task.status == TaskCompleted ->
-                    pure (state, Left "completed tasks cannot be retried")
                 | Map.notMember taskId state.adapterInputs ->
                     pure
                         ( state
-                        , Left
-                            ( "task input is unavailable after daemon restart; "
-                                <> "submit a new task id"
-                            )
+                        , Left $
+                            if task.status == TaskCompleted
+                                then
+                                    "completed tasks cannot be retried; task input has been discarded"
+                                else
+                                    ( "task input is unavailable after daemon restart; "
+                                        <> "submit a new task id"
+                                    )
                         )
+                | task.status == TaskCompleted ->
+                    pure (state, Left "completed tasks cannot be retried")
                 | otherwise -> do
                     now <- getCurrentTime
                     let updated =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -131,6 +131,9 @@ defaultTaskLimit = 4
 maximumTaskLimit :: Int
 maximumTaskLimit = 32
 
+redactedTaskDescription :: Text
+redactedTaskDescription = "[task input redacted]"
+
 withTaskAdapter :: Journal -> TaskRunner -> (Supervisor -> IO value) -> IO value
 withTaskAdapter = withTaskAdapterQueueSize 1_024
 
@@ -285,12 +288,12 @@ executeCommand journal registry state = \case
             pure (state, Left "task id already exists")
         | otherwise -> do
             now <- getCurrentTime
-            let task =
+            let durableTask =
                     DurableTask
                         { taskId = submitted.submittedId
                         , sessionId = submitted.submittedSessionId
                         , status = TaskQueued
-                        , description = submitted.submittedPrompt
+                        , description = redactedTaskDescription
                         , workingDirectory = submitted.submittedWorkingDirectory
                         , provider = submitted.submittedProvider
                         , model = submitted.submittedModel
@@ -300,14 +303,16 @@ executeCommand journal registry state = \case
                         , updatedAt = now
                         , logTail = []
                         }
-            persisted <- persistBounded journal task
+                executionTask =
+                    durableTask {description = submitted.submittedPrompt}
+            persisted <- persistBounded journal durableTask
             let next =
                     state
                         { adapterPending = state.adapterPending Seq.|> persisted.taskId
                         , adapterTasks =
                             Map.insert persisted.taskId persisted state.adapterTasks
                         , adapterInputs =
-                            Map.insert persisted.taskId task state.adapterInputs
+                            Map.insert persisted.taskId executionTask state.adapterInputs
                         }
             pure (next, Right (taskResult "submitted" persisted))
     Cancel taskId ->
@@ -492,13 +497,17 @@ launchWorker commands completions runner task =
                             writeTQueue completions
                                 (TaskLogTruncated task.taskId task.attempt)
                         writeTQueue completions
-                            (TaskFinished task.taskId task.attempt outcome)
+                            (TaskFinished task.taskId task.attempt (redactFailure outcome))
                 logged line =
                     atomically $ do
                         accepted <-
                             tryWriteTBQueueCompat
                                 commands
-                                (TaskLogged task.taskId task.attempt line)
+                                ( TaskLogged
+                                    task.taskId
+                                    task.attempt
+                                    (redactTaskInput task.description line)
+                                )
                         unless accepted (writeTVar logTruncated True)
             result <-
                 tryAny
@@ -513,6 +522,14 @@ launchWorker commands completions runner task =
                 Right value -> finished value
         putMVar gate ()
         pure worker
+  where
+    redactFailure = \case
+        Left message -> Left (redactTaskInput task.description message)
+        Right () -> Right ()
+
+redactTaskInput :: Text -> Text -> Text
+redactTaskInput rawInput =
+    Text.replace rawInput redactedTaskDescription
 
 -- Equivalent to @tryWriteTBQueue@ for the pinned STM version, which does not
 -- export that helper. The fullness check and write are one transaction, so

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -109,6 +109,7 @@ data SubmitCommand = SubmitCommand
 data AdapterMessage
     = Execute !TaskCommand !(TMVar (Either Text Value)) !(TVar Bool)
     | TaskLogged !TaskId !Int !Text
+    | TaskLogTruncated !TaskId !Int
     | TaskFinished !TaskId !Int !(Either Text ())
 
 data RunningTask = RunningTask
@@ -159,14 +160,10 @@ withTaskAdapterQueueSize rawQueueSize journal runner action = do
                         Left message -> pure (Left message)
                         Right command -> do
                             active <- newTVarIO True
-                            admitted <-
-                                atomically $ do
-                                    full <- isFullTBQueue commands
-                                    if full
-                                        then pure False
-                                        else do
-                                            writeTBQueue commands (Execute command reply active)
-                                            pure True
+                            admitted <- atomically $
+                                tryWriteTBQueueCompat
+                                    commands
+                                    (Execute command reply active)
                             if admitted
                                 then
                                     atomically (takeTMVar reply)
@@ -219,6 +216,25 @@ schedulerLoopWithRegistry journal runner commands completions registry = go
                                 task
                                     { updatedAt = now
                                     , logTail = task.logTail <> [line]
+                                    }
+                        persisted <- persistBounded journal updated
+                        pure state
+                            { adapterTasks =
+                                Map.insert taskId persisted state.adapterTasks
+                            }
+                _ -> pure state
+        TaskLogTruncated taskId taskAttempt ->
+            case Map.lookup taskId state.adapterTasks of
+                Just task
+                    | task.status == TaskRunning
+                    , task.attempt == taskAttempt -> do
+                        now <- getCurrentTime
+                        let updated =
+                                task
+                                    { updatedAt = now
+                                    , logTail =
+                                        task.logTail
+                                            <> ["[output truncated: scheduler log queue was full]"]
                                     }
                         persisted <- persistBounded journal updated
                         pure state
@@ -466,18 +482,24 @@ launchWorker ::
 launchWorker commands completions runner task =
     mask $ \_ -> do
         gate <- newEmptyMVar
+        logTruncated <- newTVarIO False
         worker <- asyncWithUnmask $ \unmask -> do
             takeMVar gate
             let finished outcome =
-                    atomically $
+                    atomically $ do
+                        dropped <- readTVar logTruncated
+                        when dropped $
+                            writeTQueue completions
+                                (TaskLogTruncated task.taskId task.attempt)
                         writeTQueue completions
                             (TaskFinished task.taskId task.attempt outcome)
                 logged line =
                     atomically $ do
-                        full <- isFullTBQueue commands
-                        unless full $
-                            writeTBQueue commands
+                        accepted <-
+                            tryWriteTBQueueCompat
+                                commands
                                 (TaskLogged task.taskId task.attempt line)
+                        unless accepted (writeTVar logTruncated True)
             result <-
                 tryAny
                     ( unmask $
@@ -491,6 +513,16 @@ launchWorker commands completions runner task =
                 Right value -> finished value
         putMVar gate ()
         pure worker
+
+-- Equivalent to @tryWriteTBQueue@ for the pinned STM version, which does not
+-- export that helper. The fullness check and write are one transaction, so
+-- callers never block or enqueue after observing a full queue.
+tryWriteTBQueueCompat :: TBQueue value -> value -> STM Bool
+tryWriteTBQueueCompat queue value = do
+    full <- isFullTBQueue queue
+    if full
+        then pure False
+        else writeTBQueue queue value >> pure True
 
 shutdownRegistry :: TVar (Map TaskId RunningTask) -> IO ()
 shutdownRegistry registry = do

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -1,6 +1,8 @@
 module Agent.Runtime.Daemon.TaskAdapter
     ( TaskRunner(..)
     , processTaskRunner
+    , processTaskRunnerFor
+    , processTaskArguments
     , withTaskAdapter
     ) where
 
@@ -15,7 +17,9 @@ import Control.Concurrent.Async
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe
-    ( finally
+    ( IOException
+    , catch
+    , finally
     , isAsyncException
     , mask
     , onException
@@ -25,6 +29,7 @@ import Control.Exception.Safe
 import Control.Monad (foldM, forM_, unless, when)
 import Data.Aeson
 import Data.Aeson.Types (Parser, parseEither)
+import qualified Data.ByteString as BS
 import Data.Char (isControl)
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
@@ -34,12 +39,15 @@ import Data.Sequence (Seq)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Text.Encoding.Error (lenientDecode)
 import Data.Time (getCurrentTime)
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
-import System.IO (hIsEOF, hSetEncoding, utf8)
+import System.IO (Handle, hClose)
+import System.Posix.Signals (sigKILL, sigTERM, signalProcessGroup)
 import System.Process
+import System.Timeout (timeout)
 
 import Agent.Runtime.Daemon.Journal
 import Agent.Runtime.Daemon.Protocol (EventEnvelope (..))
@@ -49,7 +57,6 @@ import Agent.Runtime.Daemon.TaskScheduler
 
 data TaskRunner = TaskRunner
     { runTask :: DurableTask -> (Text -> IO ()) -> IO (Either Text ())
-    , resolveApproval :: TaskId -> Text -> Text -> IO (Either Text ())
     }
 
 -- | Execute a submitted turn through the installed @agent-cli@ executable.
@@ -59,12 +66,13 @@ data TaskRunner = TaskRunner
 processTaskRunner :: IO TaskRunner
 processTaskRunner = do
     executable <- maybe "agent-cli" id <$> lookupEnv "HASKELL_AGENT_CLI"
-    pure
-        TaskRunner
-            { runTask = runProcessTask executable
-            , resolveApproval = \_ _ _ ->
-                pure (Left "the process task runner cannot resolve interactive approvals")
-            }
+    pure (processTaskRunnerFor executable)
+
+processTaskRunnerFor :: FilePath -> TaskRunner
+processTaskRunnerFor executable =
+    TaskRunner
+        { runTask = runProcessTask executable
+        }
 
 data TaskCommand
     = Submit SubmitCommand
@@ -292,27 +300,16 @@ executeCommand journal runner registry state = \case
                 ( state {adapterLimit = limit}
                 , Right (object ["version" .= (1 :: Int), "limit" .= limit])
                 )
-    Approval taskId approvalId decision ->
+    Approval taskId _ _ ->
         case Map.lookup taskId state.adapterTasks of
-            Just task | task.status == TaskRunning -> do
-                result <- runner.resolveApproval taskId approvalId decision
-                case result of
-                    Left message -> pure (state, Left message)
-                    Right () -> do
-                        let response =
-                                object
-                                    [ "version" .= (1 :: Int)
-                                    , "task_id" .= taskId
-                                    , "approval_id" .= approvalId
-                                    ]
-                        _ <- appendEvent journal "approval_resolved" $
-                            object
-                                [ "version" .= (1 :: Int)
-                                , "task_id" .= taskId
-                                , "approval_id" .= approvalId
-                                , "decision" .= decision
-                                ]
-                        pure (state, Right response)
+            Just task | task.status == TaskRunning ->
+                pure
+                    ( state
+                    , Left
+                        ( "interactive approval resolution is unsupported by "
+                            <> "the daemon task adapter"
+                        )
+                    )
             _ -> pure (state, Left "task is not running")
     Retry taskId ->
         case Map.lookup taskId state.adapterTasks of
@@ -531,6 +528,7 @@ boundedString :: String -> Int -> String -> Parser String
 boundedString label maximumLength raw = do
     when (null raw) (fail (label <> " must not be empty"))
     when (length raw > maximumLength) (fail (label <> " is too long"))
+    when ('\0' `elem` raw) (fail (label <> " contains a NUL byte"))
     pure raw
 
 validDecision :: Text -> Parser Text
@@ -542,37 +540,85 @@ validDecision raw = do
 
 runProcessTask :: FilePath -> DurableTask -> (Text -> IO ()) -> IO (Either Text ())
 runProcessTask executable task logLine = do
-    let arguments =
-            ["--prompt", Text.unpack task.description, "--save-session"]
-                <> maybe [] (\value -> ["--resume", Text.unpack value]) task.sessionId
-                <> ["--cwd", task.workingDirectory]
-                <> maybe [] (\value -> ["--provider", Text.unpack value]) task.provider
-                <> maybe [] (\value -> ["--model", Text.unpack value]) task.model
-                <> maybe [] (\value -> ["--effort", Text.unpack value]) task.effort
-                <> ["--worktree" | task.worktree]
+    let arguments = processTaskArguments task
         configuration =
             (proc executable arguments)
                 { std_out = CreatePipe
                 , std_err = CreatePipe
+                , create_group = True
+                , close_fds = True
                 }
     (stdoutHandle, stderrHandle, process) <-
         createProcess configuration >>= \case
             (_, Just stdoutHandle, Just stderrHandle, process) ->
                 pure (stdoutHandle, stderrHandle, process)
             _ -> fail "failed to capture agent-cli output"
-    let terminate = terminateProcess process >> voidWait process
-        consume handle = do
-            hSetEncoding handle utf8
-            let go = do
-                    ended <- hIsEOF handle
-                    unless ended (Text.hGetLine handle >>= logLine >> go)
-            go
-    (concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
-        `onException` terminate
+    let terminate = terminateProcessGroup process
+        consume = consumeBoundedOutput logLine
+        closeHandles = hClose stdoutHandle `finally` hClose stderrHandle
+    ((concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
+        `onException` terminate)
+        `finally` closeHandles
         >>= \case
             ExitSuccess -> pure (Right ())
             ExitFailure code ->
                 pure (Left ("agent-cli exited with status " <> Text.pack (show code)))
+
+processTaskArguments :: DurableTask -> [String]
+processTaskArguments task =
+    ["--prompt", Text.unpack task.description, "--save-session"]
+        <> maybe [] (\value -> ["--resume", Text.unpack value]) task.sessionId
+        <> ["--cwd", task.workingDirectory]
+        <> maybe [] (\value -> ["--provider", Text.unpack value]) task.provider
+        <> maybe [] (\value -> ["--model", Text.unpack value]) task.model
+        <> maybe [] (\value -> ["--effort", Text.unpack value]) task.effort
+        <> ["--worktree" | task.worktree]
+
+consumeBoundedOutput :: (Text -> IO ()) -> Handle -> IO ()
+consumeBoundedOutput logChunk handle = go 0 BS.empty
+  where
+    go total pending = do
+        bytes <- BS.hGetSome handle 4_096
+        let nextTotal = total + BS.length bytes
+        when (nextTotal > maxTaskOutputBytes) $
+            ioError (userError "daemon task output exceeded 64 MiB")
+        let buffered = pending <> bytes
+        if BS.null bytes
+            then unless (BS.null buffered) (emit buffered)
+            else drain buffered >>= go nextTotal
+    drain buffered =
+        let candidate = BS.take 4_096 buffered
+         in case BS.elemIndex 10 candidate of
+                Just newline -> do
+                    emit (BS.take newline buffered)
+                    drain (BS.drop (newline + 1) buffered)
+                Nothing
+                    | BS.length buffered > 4_096 -> do
+                        emit candidate
+                        drain (BS.drop 4_096 buffered)
+                    | otherwise -> pure buffered
+    emit = logChunk . TextEncoding.decodeUtf8With lenientDecode
+
+maxTaskOutputBytes :: Int
+maxTaskOutputBytes = 64 * 1024 * 1024
+
+terminateProcessGroup :: ProcessHandle -> IO ()
+terminateProcessGroup process = do
+    signalGroup sigTERM
+    timeout 2_000_000 (waitForProcess process) >>= \case
+        Just _ -> pure ()
+        Nothing -> do
+            signalGroup sigKILL
+            voidWait process
+  where
+    signalGroup signal =
+        getPid process >>= \case
+            Just pid ->
+                signalProcessGroup signal (fromIntegral pid)
+                    `catch` \(_ :: IOException) -> pure ()
+            Nothing ->
+                terminateProcess process
+                    `catch` \(_ :: IOException) -> pure ()
 
 voidWait :: ProcessHandle -> IO ()
 voidWait process = do

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -2,6 +2,7 @@ module Agent.Runtime.Daemon.TaskAdapter
     ( TaskRunner(..)
     , processTaskRunner
     , processTaskRunnerFor
+    , processTaskRunnerForWithTimeout
     , processTaskArguments
     , withTaskAdapter
     ) where
@@ -70,9 +71,16 @@ processTaskRunner = do
 
 processTaskRunnerFor :: FilePath -> TaskRunner
 processTaskRunnerFor executable =
+    processTaskRunnerForWithTimeout defaultTaskRuntimeSeconds executable
+
+processTaskRunnerForWithTimeout :: Int -> FilePath -> TaskRunner
+processTaskRunnerForWithTimeout runtimeSeconds executable =
     TaskRunner
-        { runTask = runProcessTask executable
+        { runTask = runProcessTask runtimeSeconds executable
         }
+
+defaultTaskRuntimeSeconds :: Int
+defaultTaskRuntimeSeconds = 6 * 60 * 60
 
 data TaskCommand
     = Submit SubmitCommand
@@ -318,6 +326,14 @@ executeCommand journal registry state = \case
                     pure (state, Left "active tasks cannot be retried")
                 | task.status == TaskCompleted ->
                     pure (state, Left "completed tasks cannot be retried")
+                | Map.notMember taskId state.adapterInputs ->
+                    pure
+                        ( state
+                        , Left
+                            ( "task input is unavailable after daemon restart; "
+                                <> "submit a new task id"
+                            )
+                        )
                 | otherwise -> do
                     now <- getCurrentTime
                     let updated =
@@ -537,8 +553,8 @@ validDecision raw = do
         fail "decision must be approve, deny, or approve_session"
     pure decision
 
-runProcessTask :: FilePath -> DurableTask -> (Text -> IO ()) -> IO (Either Text ())
-runProcessTask executable task logLine = do
+runProcessTask :: Int -> FilePath -> DurableTask -> (Text -> IO ()) -> IO (Either Text ())
+runProcessTask runtimeSeconds executable task logLine = do
     let arguments = processTaskArguments task
         configuration =
             (proc executable arguments)
@@ -555,13 +571,20 @@ runProcessTask executable task logLine = do
     let terminate = terminateProcessGroup process
         consume = consumeBoundedOutput logLine
         closeHandles = hClose stdoutHandle `finally` hClose stderrHandle
-    ((concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
-        `onException` terminate)
-        `finally` closeHandles
-        >>= \case
-            ExitSuccess -> pure (Right ())
-            ExitFailure code ->
-                pure (Left ("agent-cli exited with status " <> Text.pack (show code)))
+    outcome <-
+        timeout
+            (max 1 runtimeSeconds * 1_000_000)
+            ( ((concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
+                `onException` terminate)
+                `finally` closeHandles
+            )
+    case outcome of
+        Nothing ->
+            pure
+                (Left ("agent-cli exceeded its " <> Text.pack (show runtimeSeconds) <> " second runtime limit"))
+        Just ExitSuccess -> pure (Right ())
+        Just (ExitFailure code) ->
+            pure (Left ("agent-cli exited with status " <> Text.pack (show code)))
 
 processTaskArguments :: DurableTask -> [String]
 processTaskArguments task =

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -5,6 +5,7 @@ module Agent.Runtime.Daemon.TaskAdapter
     , processTaskRunnerForWithTimeout
     , processTaskArguments
     , withTaskAdapter
+    , withTaskAdapterQueueSize
     ) where
 
 import Control.Concurrent.Async
@@ -102,7 +103,7 @@ data SubmitCommand = SubmitCommand
     }
 
 data AdapterMessage
-    = Execute !TaskCommand !(TMVar (Either Text Value))
+    = Execute !TaskCommand !(TMVar (Either Text Value)) !(TVar Bool)
     | TaskLogged !TaskId !Int !Text
     | TaskFinished !TaskId !Int !(Either Text ())
 
@@ -126,9 +127,17 @@ maximumTaskLimit :: Int
 maximumTaskLimit = 32
 
 withTaskAdapter :: Journal -> TaskRunner -> (Supervisor -> IO value) -> IO value
-withTaskAdapter journal runner action = do
+withTaskAdapter = withTaskAdapterQueueSize 1_024
+
+withTaskAdapterQueueSize ::
+    Int ->
+    Journal ->
+    TaskRunner ->
+    (Supervisor -> IO value) ->
+    IO value
+withTaskAdapterQueueSize rawQueueSize journal runner action = do
     saved <- snapshot journal
-    commands <- newTBQueueIO 1_024
+    commands <- newTBQueueIO (fromIntegral (max 1 rawQueueSize))
     let initial =
             AdapterState
                 { adapterLimit = defaultTaskLimit
@@ -144,8 +153,20 @@ withTaskAdapter journal runner action = do
                     case parseTaskCommand raw of
                         Left message -> pure (Left message)
                         Right command -> do
-                            atomically (writeTBQueue commands (Execute command reply))
-                            atomically (takeTMVar reply)
+                            active <- newTVarIO True
+                            admitted <-
+                                atomically $ do
+                                    full <- isFullTBQueue commands
+                                    if full
+                                        then pure False
+                                        else do
+                                            writeTBQueue commands (Execute command reply active)
+                                            pure True
+                            if admitted
+                                then
+                                    atomically (takeTMVar reply)
+                                        `onException` atomically (writeTVar active False)
+                                else pure (Left "task scheduler command queue is full")
                 }
     workers <- newTVarIO Map.empty
     let loop = schedulerLoopWithRegistry journal runner commands workers initial
@@ -169,11 +190,15 @@ schedulerLoopWithRegistry journal runner commands registry = go
         handleMessage state message >>= go
 
     handleMessage state = \case
-        Execute command reply -> do
-            (next, result) <-
-                executeCommand journal registry state command
-            atomically (putTMVar reply result)
-            pure next
+        Execute command reply active -> do
+            stillActive <- readTVarIO active
+            if stillActive
+                then do
+                    (next, result) <-
+                        executeCommand journal registry state command
+                    atomically (putTMVar reply result)
+                    pure next
+                else pure state
         TaskLogged taskId taskAttempt line ->
             case Map.lookup taskId state.adapterTasks of
                 Just task
@@ -588,7 +613,7 @@ runProcessTask runtimeSeconds executable task logLine = do
 
 processTaskArguments :: DurableTask -> [String]
 processTaskArguments task =
-    ["--prompt", Text.unpack task.description, "--save-session"]
+    ["--prompt", Text.unpack task.description, "--save-session", "--no-yolo"]
         <> maybe [] (\value -> ["--resume", Text.unpack value]) task.sessionId
         <> ["--cwd", task.workingDirectory]
         <> maybe [] (\value -> ["--provider", Text.unpack value]) task.provider

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -163,7 +163,7 @@ schedulerLoopWithRegistry journal runner commands registry = go
     handleMessage state = \case
         Execute command reply -> do
             (next, result) <-
-                executeCommand journal runner registry state command
+                executeCommand journal registry state command
             atomically (putTMVar reply result)
             pure next
         TaskLogged taskId taskAttempt line ->
@@ -216,12 +216,11 @@ schedulerLoopWithRegistry journal runner commands registry = go
 
 executeCommand
     :: Journal
-    -> TaskRunner
     -> TVar (Map TaskId RunningTask)
     -> AdapterState
     -> TaskCommand
     -> IO (AdapterState, Either Text Value)
-executeCommand journal runner registry state = \case
+executeCommand journal registry state = \case
     Submit submitted
         | Map.member submitted.submittedId state.adapterTasks ->
             pure (state, Left "task id already exists")

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -1,0 +1,580 @@
+module Agent.Runtime.Daemon.TaskAdapter
+    ( TaskRunner(..)
+    , processTaskRunner
+    , withTaskAdapter
+    ) where
+
+import Control.Concurrent.Async
+    ( Async
+    , asyncWithUnmask
+    , cancel
+    , concurrently_
+    , race
+    , waitCatch
+    )
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent.STM
+import Control.Exception.Safe
+    ( finally
+    , isAsyncException
+    , mask
+    , onException
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (foldM, forM_, unless, when)
+import Data.Aeson
+import Data.Aeson.Types (Parser, parseEither)
+import Data.Char (isControl)
+import Data.Foldable (toList)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import qualified Data.Sequence as Seq
+import Data.Sequence (Seq)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import Data.Time (getCurrentTime)
+import System.Environment (lookupEnv)
+import System.Exit (ExitCode (..))
+import System.IO (hIsEOF, hSetEncoding, utf8)
+import System.Process
+
+import Agent.Runtime.Daemon.Journal
+import Agent.Runtime.Daemon.Protocol (EventEnvelope (..))
+import Agent.Runtime.Daemon.Supervisor
+import Agent.Runtime.Daemon.Task
+import Agent.Runtime.Daemon.TaskScheduler
+
+data TaskRunner = TaskRunner
+    { runTask :: DurableTask -> (Text -> IO ()) -> IO (Either Text ())
+    , resolveApproval :: TaskId -> Text -> Text -> IO (Either Text ())
+    }
+
+-- | Execute a submitted turn through the installed @agent-cli@ executable.
+-- Set @HASKELL_AGENT_CLI@ to select another executable. The process receives
+-- arguments directly (never through a shell), and its bounded persisted log is
+-- populated from stdout and stderr.
+processTaskRunner :: IO TaskRunner
+processTaskRunner = do
+    executable <- maybe "agent-cli" id <$> lookupEnv "HASKELL_AGENT_CLI"
+    pure
+        TaskRunner
+            { runTask = runProcessTask executable
+            , resolveApproval = \_ _ _ ->
+                pure (Left "the process task runner cannot resolve interactive approvals")
+            }
+
+data TaskCommand
+    = Submit SubmitCommand
+    | Cancel TaskId
+    | List
+    | SetLimit Int
+    | Approval TaskId Text Text
+    | Retry TaskId
+
+data SubmitCommand = SubmitCommand
+    { submittedId :: !TaskId
+    , submittedSessionId :: !(Maybe Text)
+    , submittedPrompt :: !Text
+    , submittedWorkingDirectory :: !FilePath
+    , submittedProvider :: !(Maybe Text)
+    , submittedModel :: !(Maybe Text)
+    , submittedEffort :: !(Maybe Text)
+    , submittedWorktree :: !Bool
+    }
+
+data AdapterMessage
+    = Execute !TaskCommand !(TMVar (Either Text Value))
+    | TaskLogged !TaskId !Int !Text
+    | TaskFinished !TaskId !Int !(Either Text ())
+
+data RunningTask = RunningTask
+    { runningAttempt :: !Int
+    , runningWorker :: !(Async ())
+    }
+
+data AdapterState = AdapterState
+    { adapterLimit :: !Int
+    , adapterPending :: !(Seq TaskId)
+    , adapterRunning :: !(Map TaskId RunningTask)
+    , adapterTasks :: !(Map TaskId DurableTask)
+    , adapterInputs :: !(Map TaskId DurableTask)
+    }
+
+defaultTaskLimit :: Int
+defaultTaskLimit = 4
+
+maximumTaskLimit :: Int
+maximumTaskLimit = 32
+
+withTaskAdapter :: Journal -> TaskRunner -> (Supervisor -> IO value) -> IO value
+withTaskAdapter journal runner action = do
+    saved <- snapshot journal
+    commands <- newTBQueueIO 1_024
+    let initial =
+            AdapterState
+                { adapterLimit = defaultTaskLimit
+                , adapterPending = Seq.empty
+                , adapterRunning = Map.empty
+                , adapterTasks = saved.tasks
+                , adapterInputs = Map.empty
+                }
+        supervisor =
+            Supervisor
+                { handleCommand = \_ raw -> do
+                    reply <- newEmptyTMVarIO
+                    case parseTaskCommand raw of
+                        Left message -> pure (Left message)
+                        Right command -> do
+                            atomically (writeTBQueue commands (Execute command reply))
+                            atomically (takeTMVar reply)
+                }
+    workers <- newTVarIO Map.empty
+    let loop = schedulerLoopWithRegistry journal runner commands workers initial
+    ( race loop (action supervisor) >>= \case
+        Left () -> fail "task scheduler stopped unexpectedly"
+        Right value -> pure value
+      ) `finally` shutdownRegistry workers
+
+schedulerLoopWithRegistry
+    :: Journal
+    -> TaskRunner
+    -> TBQueue AdapterMessage
+    -> TVar (Map TaskId RunningTask)
+    -> AdapterState
+    -> IO ()
+schedulerLoopWithRegistry journal runner commands registry = go
+  where
+    go state0 = do
+        state <- startRunnable journal runner commands registry state0
+        message <- atomically (readTBQueue commands)
+        handleMessage state message >>= go
+
+    handleMessage state = \case
+        Execute command reply -> do
+            (next, result) <-
+                executeCommand journal runner registry state command
+            atomically (putTMVar reply result)
+            pure next
+        TaskLogged taskId taskAttempt line ->
+            case Map.lookup taskId state.adapterTasks of
+                Just task
+                    | task.status == TaskRunning
+                    , task.attempt == taskAttempt -> do
+                        now <- getCurrentTime
+                        let updated =
+                                task
+                                    { updatedAt = now
+                                    , logTail = task.logTail <> [line]
+                                    }
+                        persisted <- persistBounded journal updated
+                        pure state
+                            { adapterTasks =
+                                Map.insert taskId persisted state.adapterTasks
+                            }
+                _ -> pure state
+        TaskFinished taskId taskAttempt result -> do
+            case Map.lookup taskId state.adapterRunning of
+                Just running | running.runningAttempt == taskAttempt -> do
+                    _ <- waitCatch running.runningWorker
+                    atomically $ modifyTVar' registry (Map.delete taskId)
+                    let withoutWorker =
+                            state
+                                { adapterRunning =
+                                    Map.delete taskId state.adapterRunning
+                                }
+                    case Map.lookup taskId state.adapterTasks of
+                        Just task
+                            | task.status == TaskRunning
+                            , task.attempt == taskAttempt -> do
+                                now <- getCurrentTime
+                                let updated =
+                                        task
+                                            { status = either (const TaskFailed) (const TaskCompleted) result
+                                            , updatedAt = now
+                                            , logTail =
+                                                task.logTail
+                                                    <> either (\message -> [message]) (const []) result
+                                            }
+                                persisted <- persistBounded journal updated
+                                pure withoutWorker
+                                    { adapterTasks =
+                                        Map.insert taskId persisted state.adapterTasks
+                                    }
+                        _ -> pure withoutWorker
+                _ -> pure state
+
+executeCommand
+    :: Journal
+    -> TaskRunner
+    -> TVar (Map TaskId RunningTask)
+    -> AdapterState
+    -> TaskCommand
+    -> IO (AdapterState, Either Text Value)
+executeCommand journal runner registry state = \case
+    Submit submitted
+        | Map.member submitted.submittedId state.adapterTasks ->
+            pure (state, Left "task id already exists")
+        | otherwise -> do
+            now <- getCurrentTime
+            let task =
+                    DurableTask
+                        { taskId = submitted.submittedId
+                        , sessionId = submitted.submittedSessionId
+                        , status = TaskQueued
+                        , description = submitted.submittedPrompt
+                        , workingDirectory = submitted.submittedWorkingDirectory
+                        , provider = submitted.submittedProvider
+                        , model = submitted.submittedModel
+                        , effort = submitted.submittedEffort
+                        , worktree = submitted.submittedWorktree
+                        , attempt = 1
+                        , updatedAt = now
+                        , logTail = []
+                        }
+            persisted <- persistBounded journal task
+            let next =
+                    state
+                        { adapterPending = state.adapterPending Seq.|> persisted.taskId
+                        , adapterTasks =
+                            Map.insert persisted.taskId persisted state.adapterTasks
+                        , adapterInputs =
+                            Map.insert persisted.taskId task state.adapterInputs
+                        }
+            pure (next, Right (taskResult "submitted" persisted))
+    Cancel taskId ->
+        case Map.lookup taskId state.adapterTasks of
+            Nothing -> pure (state, Left "task id is unknown")
+            Just task
+                | not (isActive task) ->
+                    pure (state, Left "task is not active")
+                | otherwise -> do
+                    forM_ (Map.lookup taskId state.adapterRunning) $ \running -> do
+                        cancel running.runningWorker
+                        _ <- waitCatch running.runningWorker
+                        pure ()
+                    atomically $ modifyTVar' registry (Map.delete taskId)
+                    now <- getCurrentTime
+                    let updated = task {status = TaskCancelled, updatedAt = now}
+                        next =
+                            state
+                                { adapterPending =
+                                    Seq.filter (/= taskId) state.adapterPending
+                                , adapterRunning =
+                                    Map.delete taskId state.adapterRunning
+                                , adapterTasks =
+                                    Map.insert taskId updated state.adapterTasks
+                                }
+                    persisted <- persistBounded journal updated
+                    pure
+                        ( next
+                            { adapterTasks =
+                                Map.insert taskId persisted next.adapterTasks
+                            }
+                        , Right (taskResult "cancelled" persisted)
+                        )
+    List ->
+        pure
+            ( state
+            , Right $
+                object
+                    [ "version" .= (1 :: Int)
+                    , "tasks" .= Map.elems state.adapterTasks
+                    ]
+            )
+    SetLimit limit ->
+        do
+            _ <- appendEvent journal "scheduler_limit_changed" $
+                object ["version" .= (1 :: Int), "limit" .= limit]
+            pure
+                ( state {adapterLimit = limit}
+                , Right (object ["version" .= (1 :: Int), "limit" .= limit])
+                )
+    Approval taskId approvalId decision ->
+        case Map.lookup taskId state.adapterTasks of
+            Just task | task.status == TaskRunning -> do
+                result <- runner.resolveApproval taskId approvalId decision
+                case result of
+                    Left message -> pure (state, Left message)
+                    Right () -> do
+                        let response =
+                                object
+                                    [ "version" .= (1 :: Int)
+                                    , "task_id" .= taskId
+                                    , "approval_id" .= approvalId
+                                    ]
+                        _ <- appendEvent journal "approval_resolved" $
+                            object
+                                [ "version" .= (1 :: Int)
+                                , "task_id" .= taskId
+                                , "approval_id" .= approvalId
+                                , "decision" .= decision
+                                ]
+                        pure (state, Right response)
+            _ -> pure (state, Left "task is not running")
+    Retry taskId ->
+        case Map.lookup taskId state.adapterTasks of
+            Nothing -> pure (state, Left "task id is unknown")
+            Just task
+                | isActive task ->
+                    pure (state, Left "active tasks cannot be retried")
+                | task.status == TaskCompleted ->
+                    pure (state, Left "completed tasks cannot be retried")
+                | otherwise -> do
+                    now <- getCurrentTime
+                    let updated =
+                            task
+                                { status = TaskQueued
+                                , attempt = task.attempt + 1
+                                , updatedAt = now
+                                , logTail = []
+                                }
+                        next =
+                            state
+                                { adapterPending = state.adapterPending Seq.|> taskId
+                                , adapterTasks =
+                                    Map.insert taskId updated state.adapterTasks
+                                }
+                    persisted <- persistBounded journal updated
+                    pure
+                        ( next
+                            { adapterTasks =
+                                Map.insert taskId persisted next.adapterTasks
+                            }
+                        , Right (taskResult "queued" persisted)
+                        )
+
+startRunnable
+    :: Journal
+    -> TaskRunner
+    -> TBQueue AdapterMessage
+    -> TVar (Map TaskId RunningTask)
+    -> AdapterState
+    -> IO AdapterState
+startRunnable journal runner commands registry state = do
+    let activeSessions =
+            Set.fromList
+                [ sessionId
+                | taskId <- Map.keys state.adapterRunning
+                , Just task <- [Map.lookup taskId state.adapterTasks]
+                , Just sessionId <- [task.sessionId]
+                ]
+        candidates =
+            [ ( TaskIdentity task.taskId.unTaskId task.sessionId
+              , taskId
+              )
+            | taskId <- toList state.adapterPending
+            , Just task <- [Map.lookup taskId state.adapterTasks]
+            ]
+        capacity = state.adapterLimit - Map.size state.adapterRunning
+        (selected, remaining) =
+            selectRunnableTasks capacity activeSessions candidates
+    (tasks, running) <-
+        foldM launch (state.adapterTasks, state.adapterRunning) (map snd selected)
+    pure
+        state
+            { adapterPending = Seq.fromList (map snd remaining)
+            , adapterRunning = running
+            , adapterTasks = tasks
+            }
+  where
+    launch (tasks, running) taskId =
+        case Map.lookup taskId tasks of
+            Nothing -> pure (tasks, running)
+            Just task -> do
+                now <- getCurrentTime
+                let started = task {status = TaskRunning, updatedAt = now}
+                persisted <- persistBounded journal started
+                let executionTask =
+                        case Map.lookup taskId state.adapterInputs of
+                            Nothing -> persisted
+                            Just input ->
+                                input
+                                    { status = TaskRunning
+                                    , attempt = persisted.attempt
+                                    , updatedAt = persisted.updatedAt
+                                    , logTail = persisted.logTail
+                                    }
+                worker <- launchWorker commands runner executionTask
+                let runningTask =
+                        RunningTask
+                            { runningAttempt = persisted.attempt
+                            , runningWorker = worker
+                            }
+                atomically $ modifyTVar' registry (Map.insert taskId runningTask)
+                pure
+                    ( Map.insert taskId persisted tasks
+                    , Map.insert taskId runningTask running
+                    )
+
+launchWorker :: TBQueue AdapterMessage -> TaskRunner -> DurableTask -> IO (Async ())
+launchWorker commands runner task =
+    mask $ \_ -> do
+        gate <- newEmptyMVar
+        worker <- asyncWithUnmask $ \unmask -> do
+            takeMVar gate
+            let finished outcome =
+                    atomically $
+                        writeTBQueue commands
+                            (TaskFinished task.taskId task.attempt outcome)
+            result <-
+                tryAny
+                    ( unmask $
+                        runner.runTask task $ \line ->
+                            atomically $
+                                writeTBQueue commands
+                                    (TaskLogged task.taskId task.attempt line)
+                    )
+            case result of
+                Left exception
+                    | isAsyncException exception -> throwIO exception
+                    | otherwise ->
+                        finished (Left (Text.pack (show exception)))
+                Right value -> finished value
+        putMVar gate ()
+        pure worker
+
+shutdownRegistry :: TVar (Map TaskId RunningTask) -> IO ()
+shutdownRegistry registry = do
+    running <- atomically $ do
+        current <- readTVar registry
+        writeTVar registry Map.empty
+        pure (Map.elems current)
+    mapM_ (cancel . (.runningWorker)) running
+    mapM_ (waitCatch . (.runningWorker)) running
+
+taskResult :: Text -> DurableTask -> Value
+taskResult state task =
+    object
+        [ "version" .= (1 :: Int)
+        , "state" .= state
+        , "task" .= task
+        ]
+
+persistBounded :: Journal -> DurableTask -> IO DurableTask
+persistBounded journal task = do
+    event <- persistTask journal task
+    case fromJSON event.payload of
+        Success persisted -> pure persisted
+        Error message -> fail ("journal returned an invalid task event: " <> message)
+
+parseTaskCommand :: Value -> Either Text TaskCommand
+parseTaskCommand value =
+    case parseEither parser value of
+        Left message -> Left (Text.pack message)
+        Right command -> Right command
+  where
+    parser = withObject "daemon task command" $ \objectValue -> do
+        version <- objectValue .: "version"
+        unless (version == (1 :: Int)) (fail "unsupported task command version")
+        commandType <- objectValue .: "type"
+        case (commandType :: Text) of
+            "submit" -> Submit <$> parseSubmit objectValue
+            "cancel" -> Cancel <$> (objectValue .: "task_id" >>= validTaskId)
+            "list" -> pure List
+            "set_limit" -> do
+                limit <- objectValue .: "limit"
+                unless (limit >= 1 && limit <= maximumTaskLimit) $
+                    fail "limit must be between 1 and 32"
+                pure (SetLimit limit)
+            "approval" ->
+                Approval
+                    <$> (objectValue .: "task_id" >>= validTaskId)
+                    <*> (objectValue .: "approval_id" >>= boundedIdentifier "approval_id" 256)
+                    <*> (objectValue .: "decision" >>= validDecision)
+            "retry" -> Retry <$> (objectValue .: "task_id" >>= validTaskId)
+            _ -> fail "unknown task command type"
+
+    parseSubmit objectValue = do
+        submittedId <- objectValue .: "task_id" >>= validTaskId
+        submittedSessionId <-
+            objectValue .:? "session_id"
+                >>= traverse (boundedIdentifier "session_id" 256)
+        submittedPrompt <- objectValue .: "prompt" >>= boundedText "prompt" 8_192
+        submittedWorkingDirectory <-
+            objectValue .: "cwd" >>= boundedString "cwd" 4_096
+        submittedProvider <-
+            objectValue .:? "provider"
+                >>= traverse (boundedText "provider" 128)
+        submittedModel <-
+            objectValue .:? "model"
+                >>= traverse (boundedText "model" 256)
+        submittedEffort <-
+            objectValue .:? "effort"
+                >>= traverse (boundedText "effort" 64)
+        submittedWorktree <- objectValue .:? "worktree" .!= False
+        when (submittedWorktree && submittedSessionId /= Nothing) $
+            fail "worktree may only be used for a new session"
+        when ((submittedProvider == Nothing) /= (submittedModel == Nothing)) $
+            fail "provider and model must be supplied together"
+        pure SubmitCommand {..}
+
+validTaskId :: Text -> Parser TaskId
+validTaskId raw = TaskId <$> boundedIdentifier "task_id" 256 raw
+
+boundedIdentifier :: String -> Int -> Text -> Parser Text
+boundedIdentifier label maximumLength raw = do
+    value <- boundedText label maximumLength raw
+    when (Text.any isControl value) (fail (label <> " contains control characters"))
+    pure value
+
+boundedText :: String -> Int -> Text -> Parser Text
+boundedText label maximumLength raw = do
+    let value = Text.strip raw
+    when (Text.null value) (fail (label <> " must not be empty"))
+    when (Text.length value > maximumLength) (fail (label <> " is too long"))
+    pure value
+
+boundedString :: String -> Int -> String -> Parser String
+boundedString label maximumLength raw = do
+    when (null raw) (fail (label <> " must not be empty"))
+    when (length raw > maximumLength) (fail (label <> " is too long"))
+    pure raw
+
+validDecision :: Text -> Parser Text
+validDecision raw = do
+    decision <- boundedText "decision" 32 raw
+    unless (decision `elem` ["approve", "deny", "approve_session"]) $
+        fail "decision must be approve, deny, or approve_session"
+    pure decision
+
+runProcessTask :: FilePath -> DurableTask -> (Text -> IO ()) -> IO (Either Text ())
+runProcessTask executable task logLine = do
+    let arguments =
+            ["--prompt", Text.unpack task.description, "--save-session"]
+                <> maybe [] (\value -> ["--resume", Text.unpack value]) task.sessionId
+                <> ["--cwd", task.workingDirectory]
+                <> maybe [] (\value -> ["--provider", Text.unpack value]) task.provider
+                <> maybe [] (\value -> ["--model", Text.unpack value]) task.model
+                <> maybe [] (\value -> ["--effort", Text.unpack value]) task.effort
+                <> ["--worktree" | task.worktree]
+        configuration =
+            (proc executable arguments)
+                { std_out = CreatePipe
+                , std_err = CreatePipe
+                }
+    (stdoutHandle, stderrHandle, process) <-
+        createProcess configuration >>= \case
+            (_, Just stdoutHandle, Just stderrHandle, process) ->
+                pure (stdoutHandle, stderrHandle, process)
+            _ -> fail "failed to capture agent-cli output"
+    let terminate = terminateProcess process >> voidWait process
+        consume handle = do
+            hSetEncoding handle utf8
+            let go = do
+                    ended <- hIsEOF handle
+                    unless ended (Text.hGetLine handle >>= logLine >> go)
+            go
+    (concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
+        `onException` terminate
+        >>= \case
+            ExitSuccess -> pure (Right ())
+            ExitFailure code ->
+                pure (Left ("agent-cli exited with status " <> Text.pack (show code)))
+
+voidWait :: ProcessHandle -> IO ()
+voidWait process = do
+    _ <- waitForProcess process
+    pure ()

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -477,13 +477,27 @@ startRunnable journal runner commands completions registry state = do
                                     , updatedAt = persisted.updatedAt
                                     , logTail = persisted.logTail
                                     }
-                worker <- launchWorker commands completions runner executionTask
+                worker <-
+                    launchWorker
+                        commands
+                        completions
+                        runner
+                        executionTask
+                        $ \registered ->
+                            atomically $
+                                modifyTVar'
+                                    registry
+                                    (Map.insert
+                                        taskId
+                                        RunningTask
+                                            { runningAttempt = persisted.attempt
+                                            , runningWorker = registered
+                                            })
                 let runningTask =
                         RunningTask
                             { runningAttempt = persisted.attempt
                             , runningWorker = worker
                             }
-                atomically $ modifyTVar' registry (Map.insert taskId runningTask)
                 pure
                     ( Map.insert taskId persisted tasks
                     , Map.insert taskId runningTask running
@@ -494,8 +508,9 @@ launchWorker ::
     TQueue AdapterMessage ->
     TaskRunner ->
     DurableTask ->
+    (Async () -> IO ()) ->
     IO (Async ())
-launchWorker commands completions runner task =
+launchWorker commands completions runner task register =
     mask $ \_ -> do
         gate <- newEmptyMVar
         logTruncated <- newTVarIO False
@@ -510,16 +525,37 @@ launchWorker commands completions runner task =
                         writeTQueue completions
                             (TaskFinished task.taskId task.attempt (redactFailure outcome))
                 logged line =
-                    atomically $ do
+                    let prefixLimit =
+                            4_096
+                                + max 0 (Text.length task.description - 1)
+                        (inputPrefix, inputRemainder) =
+                            Text.splitAt prefixLimit line
+                        (redactedBytes, _) =
+                            redactSensitiveBytes
+                                (Text.null inputRemainder)
+                                (TextEncoding.encodeUtf8 task.description)
+                                (TextEncoding.encodeUtf8 inputPrefix)
+                        redactedLine =
+                            TextEncoding.decodeUtf8With
+                                lenientDecode
+                                redactedBytes
+                        boundedLine = Text.take 4_096 redactedLine
+                        lineTruncated =
+                            not (Text.null inputRemainder)
+                                || not
+                                    (Text.null
+                                        (Text.drop 4_096 redactedLine))
+                    in atomically $ do
                         accepted <-
                             tryWriteTBQueueCompat
                                 commands
                                 ( TaskLogged
                                     task.taskId
                                     task.attempt
-                                    (redactTaskInput task.description line)
+                                    boundedLine
                                 )
-                        unless accepted (writeTVar logTruncated True)
+                        when (lineTruncated || not accepted)
+                            (writeTVar logTruncated True)
             result <-
                 tryAny
                     ( unmask $
@@ -531,7 +567,8 @@ launchWorker commands completions runner task =
                     | otherwise ->
                         finished (Left (Text.pack (show exception)))
                 Right value -> finished value
-        putMVar gate ()
+        (register worker >> putMVar gate ())
+            `onException` cancel worker
         pure worker
   where
     redactFailure = \case
@@ -674,8 +711,13 @@ runProcessTask runtimeSeconds executable task logLine = do
                 pure (stdoutHandle, stderrHandle, process)
             _ -> fail "failed to capture agent-cli output"
     processGroup <- getPid process
+    totalOutputBytes <- newTVarIO 0
     let terminate = terminateProcessGroup processGroup process
-        consume = consumeBoundedOutput logLine
+        consume =
+            consumeBoundedOutput
+                totalOutputBytes
+                task.description
+                logLine
         closeHandles = hClose stdoutHandle `finally` hClose stderrHandle
         runAndDrain =
             withAsync
@@ -714,18 +756,38 @@ processTaskArguments task =
         <> maybe [] (\value -> ["--effort", Text.unpack value]) task.effort
         <> ["--worktree" | task.worktree]
 
-consumeBoundedOutput :: (Text -> IO ()) -> Handle -> IO ()
-consumeBoundedOutput logChunk handle = go 0 BS.empty
+consumeBoundedOutput
+    :: TVar Int
+    -> Text
+    -> (Text -> IO ())
+    -> Handle
+    -> IO ()
+consumeBoundedOutput totalOutputBytes sensitiveText logChunk handle =
+    go BS.empty BS.empty
   where
-    go total pending = do
+    sensitiveBytes = TextEncoding.encodeUtf8 sensitiveText
+    go redactionPending outputPending = do
         bytes <- BS.hGetSome handle 4_096
-        let nextTotal = total + BS.length bytes
-        when (nextTotal > maxTaskOutputBytes) $
-            ioError (userError "daemon task output exceeded 64 MiB")
-        let buffered = pending <> bytes
+        atomically $ do
+            total <- readTVar totalOutputBytes
+            let nextTotal = total + BS.length bytes
+            when (nextTotal > maxTaskOutputBytes) $
+                throwSTM (userError "daemon task output exceeded 64 MiB")
+            writeTVar totalOutputBytes nextTotal
         if BS.null bytes
-            then unless (BS.null buffered) (emit buffered)
-            else drain buffered >>= go nextTotal
+            then do
+                let (redacted, _) =
+                        redactSensitiveBytes True sensitiveBytes redactionPending
+                    buffered = outputPending <> redacted
+                remainder <- drain buffered
+                unless (BS.null remainder) (emit remainder)
+            else do
+                let (redacted, retained) =
+                        redactSensitiveBytes
+                            False
+                            sensitiveBytes
+                            (redactionPending <> bytes)
+                drain (outputPending <> redacted) >>= go retained
     drain buffered =
         let candidate = BS.take 4_096 buffered
          in case BS.elemIndex 10 candidate of
@@ -738,6 +800,36 @@ consumeBoundedOutput logChunk handle = go 0 BS.empty
                         drain (BS.drop 4_096 buffered)
                     | otherwise -> pure buffered
     emit = logChunk . TextEncoding.decodeUtf8With lenientDecode
+
+redactSensitiveBytes
+    :: Bool
+    -> BS.ByteString
+    -> BS.ByteString
+    -> (BS.ByteString, BS.ByteString)
+redactSensitiveBytes final sensitive = go []
+  where
+    sensitiveLength = BS.length sensitive
+    redactedBytes = TextEncoding.encodeUtf8 redactedTaskDescription
+    go chunks remaining
+        | BS.null sensitive = (remaining, BS.empty)
+        | otherwise =
+            case BS.breakSubstring sensitive remaining of
+                (prefix, suffix)
+                    | not (BS.null suffix) ->
+                        go
+                            (redactedBytes : prefix : chunks)
+                            (BS.drop sensitiveLength suffix)
+                    | final ->
+                        (BS.concat (reverse (prefix : chunks)), BS.empty)
+                    | otherwise ->
+                        let retainedLength =
+                                min
+                                    (max 0 (sensitiveLength - 1))
+                                    (BS.length prefix)
+                            emittedLength = BS.length prefix - retainedLength
+                            emitted = BS.take emittedLength prefix
+                            retained = BS.drop emittedLength prefix
+                        in (BS.concat (reverse (emitted : chunks)), retained)
 
 maxTaskOutputBytes :: Int
 maxTaskOutputBytes = 64 * 1024 * 1024

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -138,6 +138,7 @@ withTaskAdapterQueueSize ::
 withTaskAdapterQueueSize rawQueueSize journal runner action = do
     saved <- snapshot journal
     commands <- newTBQueueIO (fromIntegral (max 1 rawQueueSize))
+    completions <- newTQueueIO
     let initial =
             AdapterState
                 { adapterLimit = defaultTaskLimit
@@ -169,7 +170,9 @@ withTaskAdapterQueueSize rawQueueSize journal runner action = do
                                 else pure (Left "task scheduler command queue is full")
                 }
     workers <- newTVarIO Map.empty
-    let loop = schedulerLoopWithRegistry journal runner commands workers initial
+    let loop =
+            schedulerLoopWithRegistry
+                journal runner commands completions workers initial
     ( race loop (action supervisor) >>= \case
         Left () -> fail "task scheduler stopped unexpectedly"
         Right value -> pure value
@@ -179,14 +182,17 @@ schedulerLoopWithRegistry
     :: Journal
     -> TaskRunner
     -> TBQueue AdapterMessage
+    -> TQueue AdapterMessage
     -> TVar (Map TaskId RunningTask)
     -> AdapterState
     -> IO ()
-schedulerLoopWithRegistry journal runner commands registry = go
+schedulerLoopWithRegistry journal runner commands completions registry = go
   where
     go state0 = do
-        state <- startRunnable journal runner commands registry state0
-        message <- atomically (readTBQueue commands)
+        state <- startRunnable journal runner commands completions registry state0
+        message <-
+            atomically $
+                readTQueue completions `orElse` readTBQueue commands
         handleMessage state message >>= go
 
     handleMessage state = \case
@@ -387,10 +393,11 @@ startRunnable
     :: Journal
     -> TaskRunner
     -> TBQueue AdapterMessage
+    -> TQueue AdapterMessage
     -> TVar (Map TaskId RunningTask)
     -> AdapterState
     -> IO AdapterState
-startRunnable journal runner commands registry state = do
+startRunnable journal runner commands completions registry state = do
     let activeSessions =
             Set.fromList
                 [ sessionId
@@ -434,7 +441,7 @@ startRunnable journal runner commands registry state = do
                                     , updatedAt = persisted.updatedAt
                                     , logTail = persisted.logTail
                                     }
-                worker <- launchWorker commands runner executionTask
+                worker <- launchWorker commands completions runner executionTask
                 let runningTask =
                         RunningTask
                             { runningAttempt = persisted.attempt
@@ -446,23 +453,31 @@ startRunnable journal runner commands registry state = do
                     , Map.insert taskId runningTask running
                     )
 
-launchWorker :: TBQueue AdapterMessage -> TaskRunner -> DurableTask -> IO (Async ())
-launchWorker commands runner task =
+launchWorker ::
+    TBQueue AdapterMessage ->
+    TQueue AdapterMessage ->
+    TaskRunner ->
+    DurableTask ->
+    IO (Async ())
+launchWorker commands completions runner task =
     mask $ \_ -> do
         gate <- newEmptyMVar
         worker <- asyncWithUnmask $ \unmask -> do
             takeMVar gate
             let finished outcome =
                     atomically $
-                        writeTBQueue commands
+                        writeTQueue completions
                             (TaskFinished task.taskId task.attempt outcome)
+                logged line =
+                    atomically $ do
+                        full <- isFullTBQueue commands
+                        unless full $
+                            writeTBQueue commands
+                                (TaskLogged task.taskId task.attempt line)
             result <-
                 tryAny
                     ( unmask $
-                        runner.runTask task $ \line ->
-                            atomically $
-                                writeTBQueue commands
-                                    (TaskLogged task.taskId task.attempt line)
+                        runner.runTask task logged
                     )
             case result of
                 Left exception

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -14,8 +14,11 @@ import Control.Concurrent.Async
     , cancel
     , concurrently_
     , race
+    , wait
     , waitCatch
+    , withAsync
     )
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe
@@ -48,6 +51,7 @@ import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
 import System.IO (Handle, hClose)
 import System.Posix.Signals (sigKILL, sigTERM, signalProcessGroup)
+import System.Posix.Types (CPid)
 import System.Process
 import System.Timeout (timeout)
 
@@ -598,7 +602,8 @@ runProcessTask runtimeSeconds executable task logLine = do
     let arguments = processTaskArguments task
         configuration =
             (proc executable arguments)
-                { std_out = CreatePipe
+                { std_in = NoStream
+                , std_out = CreatePipe
                 , std_err = CreatePipe
                 , create_group = True
                 , close_fds = True
@@ -608,14 +613,27 @@ runProcessTask runtimeSeconds executable task logLine = do
             (_, Just stdoutHandle, Just stderrHandle, process) ->
                 pure (stdoutHandle, stderrHandle, process)
             _ -> fail "failed to capture agent-cli output"
-    let terminate = terminateProcessGroup process
+    processGroup <- getPid process
+    let terminate = terminateProcessGroup processGroup process
         consume = consumeBoundedOutput logLine
         closeHandles = hClose stdoutHandle `finally` hClose stderrHandle
+        runAndDrain =
+            withAsync
+                (concurrently_ (consume stdoutHandle) (consume stderrHandle))
+                $ \drainer -> do
+                    race (waitForProcess process) (wait drainer) >>= \case
+                        Right () -> waitForProcess process
+                        Left exitCode ->
+                            timeout postExitDrainMicros (wait drainer) >>= \case
+                                Just () -> pure exitCode
+                                Nothing -> do
+                                    terminate
+                                    _ <- waitCatch drainer
+                                    pure exitCode
     outcome <-
         timeout
             (max 1 runtimeSeconds * 1_000_000)
-            ( ((concurrently_ (consume stdoutHandle) (consume stderrHandle) >> waitForProcess process)
-                `onException` terminate)
+            ( (runAndDrain `onException` terminate)
                 `finally` closeHandles
             )
     case outcome of
@@ -664,17 +682,18 @@ consumeBoundedOutput logChunk handle = go 0 BS.empty
 maxTaskOutputBytes :: Int
 maxTaskOutputBytes = 64 * 1024 * 1024
 
-terminateProcessGroup :: ProcessHandle -> IO ()
-terminateProcessGroup process = do
+postExitDrainMicros :: Int
+postExitDrainMicros = 1_000_000
+
+terminateProcessGroup :: Maybe CPid -> ProcessHandle -> IO ()
+terminateProcessGroup processGroup process = do
     signalGroup sigTERM
-    timeout 2_000_000 (waitForProcess process) >>= \case
-        Just _ -> pure ()
-        Nothing -> do
-            signalGroup sigKILL
-            voidWait process
+    threadDelay 2_000_000
+    signalGroup sigKILL
+    voidWait process
   where
     signalGroup signal =
-        getPid process >>= \case
+        case processGroup of
             Just pid ->
                 signalProcessGroup signal (fromIntegral pid)
                     `catch` \(_ :: IOException) -> pure ()

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskScheduler.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskScheduler.hs
@@ -1,4 +1,4 @@
-module Agent.CLI.MacOS.TaskScheduler
+module Agent.Runtime.Daemon.TaskScheduler
     ( TaskIdentity(..)
     , selectRunnableTasks
     ) where
@@ -7,17 +7,16 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 
--- | Stable scheduling identity for one native task. A missing session id is a
--- fresh session and therefore does not conflict with another queued task.
+-- | Stable scheduling identity. Tasks belonging to the same persisted session
+-- are serialized; fresh sessions do not conflict with one another.
 data TaskIdentity = TaskIdentity
     { taskIdentityId :: !Text
     , taskIdentitySessionId :: !(Maybe Text)
     } deriving (Eq, Show)
 
--- | Select at most @capacity@ tasks in queue order while leaving tasks for an
--- already-active (or newly-selected) session queued. Skipping a blocked task
--- lets unrelated sessions make progress without allowing a later turn for the
--- same session to overtake it.
+-- | Select at most @capacity@ tasks in queue order. A task blocked by its
+-- session does not prevent an unrelated session later in the queue from
+-- running, while later work for the same session cannot overtake it.
 selectRunnableTasks
     :: Int
     -> Set Text

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -946,6 +946,43 @@ main = hspec $ do
                 BS.readFile (directory </> "events.jsonl")
                     >>= (`shouldSatisfy` (not . BS.isInfixOf rawBytes))
 
+        it "redacts repeated maximum prompts before bounding custom runner logs" $
+            withSystemTempDirectory "daemon-custom-runner-redaction" $ \directory -> do
+                let rawPrompt = Text.replicate 8_192 "x"
+                    runner =
+                        TaskRunner
+                            { runTask = \task logLine -> do
+                                logLine (task.description <> task.description)
+                                threadDelay 100_000
+                                pure (Right ())
+                            }
+                journal <- openJournal (defaultJournalConfig directory)
+                withTaskAdapter journal runner $ \supervisor -> do
+                    supervisor.handleCommand
+                        (CommandId "submit-repeated-redaction")
+                        (object
+                            [ "version" .= (1 :: Int)
+                            , "type" .= ("submit" :: Text)
+                            , "task_id" .= ("repeated-redaction" :: Text)
+                            , "prompt" .= rawPrompt
+                            , "cwd" .= ("/tmp" :: Text)
+                            ])
+                        >>= shouldSucceed
+                    waitForStatus
+                        journal
+                        (TaskId "repeated-redaction")
+                        TaskCompleted
+                saved <- snapshot journal
+                let retained =
+                        Text.concat
+                            (saved.tasks Map.! TaskId "repeated-redaction").logTail
+                retained
+                    `shouldNotSatisfy`
+                        Text.isInfixOf (Text.replicate 128 "x")
+                retained
+                    `shouldSatisfy`
+                        Text.isInfixOf "[task input redacted]"
+
         it "retains failed input for one-process retry and discards it after completion" $
             withSystemTempDirectory "daemon-task-input-lifetime" $ \directory -> do
                 received <- newTQueueIO
@@ -1042,6 +1079,23 @@ main = hspec $ do
                 captured `shouldSatisfy` (not . null)
                 map Text.length captured `shouldSatisfy` all (<= 4_096)
                 sum (map Text.length captured) `shouldBe` 20_000
+                let longPrompt =
+                        Text.replicate 500 "sensitive"
+                            <> "\n"
+                            <> Text.replicate 500 "private"
+                    longTask = task {description = longPrompt}
+                writeFile executable "#!/bin/sh\nprintf '%s\\n' \"$2\"\n"
+                redactedChunks <- newTQueueIO
+                (processTaskRunnerFor executable).runTask longTask
+                    (atomically . writeTQueue redactedChunks)
+                    `shouldReturn` Right ()
+                redacted <- Text.concat <$> atomically (flushTQueue redactedChunks)
+                redacted
+                    `shouldNotSatisfy`
+                        Text.isInfixOf (Text.replicate 500 "sensitive")
+                redacted
+                    `shouldSatisfy`
+                        Text.isInfixOf "[task input redacted]"
                 writeFile executable "#!/bin/sh\nsleep 30\n"
                 timeout
                     4_000_000
@@ -1052,6 +1106,14 @@ main = hspec $ do
                     5_000_000
                     ((processTaskRunnerForWithTimeout 10 executable).runTask task (const (pure ())))
                     `shouldReturn` Just (Right ())
+                writeFile executable $
+                    "#!/bin/sh\n"
+                        <> "dd if=/dev/zero bs=1048576 count=40 2>/dev/null\n"
+                        <> "dd if=/dev/zero bs=1048576 count=40 1>&2 2>/dev/null\n"
+                timeout
+                    20_000_000
+                    ((processTaskRunnerFor executable).runTask task (const (pure ())))
+                    `shouldThrow` anyException
 
         it "bounds task-runner output in the durable journal" $
             withSystemTempDirectory "daemon-runner-log-bound" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -6,6 +6,7 @@ import Control.Concurrent.STM
     ( TQueue
     , TMVar
     , atomically
+    , flushTQueue
     , newEmptyTMVarIO
     , newTQueueIO
     , readTQueue
@@ -37,6 +38,7 @@ import System.Posix.Files
     ( createSymbolicLink
     , fileMode
     , getFileStatus
+    , setFileMode
     )
 import System.Timeout (timeout)
 import Test.Hspec
@@ -821,13 +823,25 @@ main = hspec $ do
                             (serveConnection serverConfig firstJournal supervisor serverPeer)
                             $ \_ -> do
                                 handshake serverConfig clientPeer Nothing
+                                _ <- sendTaskCommand serverConfig clientPeer "limit" $
+                                    object
+                                        [ "version" .= (1 :: Int)
+                                        , "type" .= ("set_limit" :: Text)
+                                        , "limit" .= (1 :: Int)
+                                        ]
                                 _ <- sendTaskCommand serverConfig clientPeer "submit"
                                     (submitCommand "restart-task" "restart-session")
                                 timeout 1_000_000 (atomically (readTQueue firstStarted))
                                     `shouldReturn` Just (TaskId "restart-task")
+                                _ <- sendTaskCommand serverConfig clientPeer "submit-queued"
+                                    (submitCommand "queued-task" "queued-session")
+                                timeout 100_000 (atomically (readTQueue firstStarted))
+                                    `shouldReturn` Nothing
                 restartedJournal <- openJournal journalConfig
                 recovered <- snapshot restartedJournal
                 (.status) (recovered.tasks Map.! TaskId "restart-task")
+                    `shouldBe` TaskInterrupted
+                (.status) (recovered.tasks Map.! TaskId "queued-task")
                     `shouldBe` TaskInterrupted
                 retryGate <- newEmptyTMVarIO
                 retryStarted <- newTQueueIO
@@ -858,12 +872,91 @@ main = hspec $ do
                                         , "approval_id" .= ("approval-1" :: Text)
                                         , "decision" .= ("approve" :: Text)
                                         ])
-                                    >>= shouldSucceed
+                                    `shouldReturn` Left
+                                        "interactive approval resolution is unsupported by the daemon task adapter"
                                 running <- snapshot restartedJournal
                                 let retried =
                                         running.tasks Map.! TaskId "restart-task"
                                 retried.status `shouldBe` TaskRunning
                                 retried.attempt `shouldBe` 2
+
+        it "uses the actual agent-cli argv shape and bounds process output chunks" $
+            withSystemTempDirectory "daemon-process-runner" $ \directory -> do
+                now <- getCurrentTime
+                let executable = directory </> "agent-cli"
+                    argumentsPath = directory </> "arguments"
+                    task =
+                        DurableTask
+                            { taskId = TaskId "process"
+                            , sessionId = Just "session-id"
+                            , status = TaskRunning
+                            , description = "hello agent"
+                            , workingDirectory = "/tmp/project"
+                            , provider = Just "openai"
+                            , model = Just "gpt-5.6"
+                            , effort = Just "high"
+                            , worktree = False
+                            , attempt = 1
+                            , updatedAt = now
+                            , logTail = []
+                            }
+                    expected =
+                        [ "--prompt"
+                        , "hello agent"
+                        , "--save-session"
+                        , "--resume"
+                        , "session-id"
+                        , "--cwd"
+                        , "/tmp/project"
+                        , "--provider"
+                        , "openai"
+                        , "--model"
+                        , "gpt-5.6"
+                        , "--effort"
+                        , "high"
+                        ]
+                writeFile executable $
+                    "#!/bin/sh\n"
+                        <> "printf '%s\\n' \"$@\" > "
+                        <> show argumentsPath
+                        <> "\n"
+                        <> "dd if=/dev/zero bs=20000 count=1 2>/dev/null | tr '\\\\0' x\n"
+                setFileMode executable 0o700
+                chunks <- newTQueueIO
+                result <-
+                    (processTaskRunnerFor executable).runTask task $
+                        atomically . writeTQueue chunks
+                result `shouldBe` Right ()
+                lines <$> readFile argumentsPath `shouldReturn` expected
+                captured <- atomically (flushTQueue chunks)
+                captured `shouldSatisfy` (not . null)
+                map Text.length captured `shouldSatisfy` all (<= 4_096)
+                sum (map Text.length captured) `shouldBe` 20_000
+
+        it "bounds task-runner output in the durable journal" $
+            withSystemTempDirectory "daemon-runner-log-bound" $ \directory -> do
+                let journalConfig =
+                        (defaultJournalConfig directory)
+                            { maximumTaskLogLines = 3
+                            , maximumTaskLogCharacters = 10
+                            }
+                    runner =
+                        TaskRunner
+                            { runTask = \_ logLine -> do
+                                mapM_ logLine (replicate 8 "12345")
+                                pure (Right ())
+                            }
+                journal <- openJournal journalConfig
+                withTaskAdapter journal runner $ \supervisor -> do
+                    supervisor.handleCommand
+                        (CommandId "submit")
+                        (submitCommand "bounded-log" "bounded-session")
+                        >>= shouldSucceed
+                    waitForStatus journal (TaskId "bounded-log") TaskCompleted
+                saved <- snapshot journal
+                let retained = (.logTail) (saved.tasks Map.! TaskId "bounded-log")
+                length retained `shouldSatisfy` (<= 3)
+                sum (map Text.length retained) `shouldSatisfy` (<= 10)
 
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =
@@ -883,7 +976,6 @@ blockingRunner started gates =
             case Map.lookup task.taskId gates of
                 Nothing -> pure (Left "missing test gate")
                 Just gate -> atomically (takeTMVar gate) >> pure (Right ())
-        , resolveApproval = \_ _ _ -> pure (Right ())
         }
 
 handshake :: ServerConfig -> Socket -> Maybe Sequence -> IO ()

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -100,6 +100,23 @@ main = hspec $ do
                     ReplaySnapshot saved -> saved.lastSequence == 3
                     ReplayEvents _ -> False)
 
+        it "persists a snapshot anchor before dropping an unanchored prefix" $
+            withSystemTempDirectory "daemon-retention-anchor" $ \directory -> do
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumEvents = 1
+                            , maximumJournalBytes = 1_048_576
+                            }
+                firstProcess <- openJournal config
+                _ <- appendEvent firstProcess "one" Null
+                second <- appendEvent firstProcess "two" Null
+                secondProcess <- openJournal config
+                recovered <- snapshot secondProcess
+                recovered.lastSequence `shouldBe` 2
+                replayAfter secondProcess 1 `shouldReturn` ReplayEvents [second]
+                third <- appendEvent secondProcess "three" Null
+                third.sequenceNumber `shouldBe` 3
+
         it "redacts sensitive fields and bounds retained task logs" $
             withSystemTempDirectory "daemon-redaction" $ \directory -> do
                 now <- getCurrentTime
@@ -290,6 +307,40 @@ main = hspec $ do
                 bounded.description `shouldBe` "[REDACTED]"
                 bounded.logTail `shouldBe` []
 
+        it "applies lowered task limits to snapshots and rejects excess old tasks" $
+            withSystemTempDirectory "daemon-lowered-task-limits" $ \directory -> do
+                now <- getCurrentTime
+                let oldTask taskId =
+                        DurableTask
+                            { taskId
+                            , status = TaskCompleted
+                            , description = "password=private"
+                            , updatedAt = now
+                            , logTail = ["old", "token=private", "new"]
+                            }
+                    oldSnapshot =
+                        JournalSnapshot
+                            { lastSequence = 0
+                            , tasks = Map.singleton (TaskId "old") (oldTask (TaskId "old"))
+                            }
+                    lowered =
+                        (defaultJournalConfig directory)
+                            { maximumTaskDescriptionCharacters = 8
+                            , maximumTaskLogLines = 1
+                            , maximumTaskLogCharacters = 2
+                            }
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode oldSnapshot))
+                first <- openJournal lowered >>= snapshot
+                let bounded = first.tasks Map.! TaskId "old"
+                bounded.description `shouldBe` "[REDACTE"
+                bounded.logTail `shouldBe` ["ne"]
+                second <- openJournal lowered >>= snapshot
+                second `shouldBe` first
+                openJournal (lowered {maximumTasks = 0})
+                    `shouldThrow` \case
+                        JournalTaskCapacityExceeded 0 -> True
+                        _ -> False
+
         it "retains no events when maximumEvents is zero and preserves the sequence" $
             withSystemTempDirectory "daemon-zero-retention" $ \directory -> do
                 let config = (defaultJournalConfig directory) {maximumEvents = 0}
@@ -307,6 +358,23 @@ main = hspec $ do
                 BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode exhausted))
                 journal <- openJournal (defaultJournalConfig directory)
                 appendEvent journal "wrapped" Null
+                    `shouldThrow` \case
+                        JournalSequenceExhausted sequenceNumber ->
+                            sequenceNumber == Sequence maxBound
+                        _ -> False
+
+        it "rejects maxBound-to-zero sequence wrap during recovery" $
+            withSystemTempDirectory "daemon-recovery-sequence-wrap" $ \directory -> do
+                let event sequenceNumber =
+                        EventEnvelope {sequenceNumber, eventType = "test", payload = Null}
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    ( LBS.toStrict (encode (event (Sequence maxBound)))
+                        <> "\n"
+                        <> LBS.toStrict (encode (event 0))
+                        <> "\n"
+                    )
+                openJournal (defaultJournalConfig directory)
                     `shouldThrow` \case
                         JournalSequenceExhausted sequenceNumber ->
                             sequenceNumber == Sequence maxBound

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -1,0 +1,209 @@
+module Main (main) where
+
+import Control.Concurrent.Async (concurrently, withAsync)
+import Control.Exception.Safe (bracket)
+import Data.Aeson (Value (..), object, (.=))
+import Data.Bits ((.&.))
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import Data.Time (getCurrentTime)
+import Network.Socket
+import qualified Network.Socket.ByteString as Socket
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory, withTempDirectory)
+import System.Posix.Files (fileMode, getFileStatus)
+import Test.Hspec
+
+import Agent.Runtime.Daemon.Framing
+import Agent.Runtime.Daemon.Journal
+import Agent.Runtime.Daemon.Protocol
+import Agent.Runtime.Daemon.Server
+import Agent.Runtime.Daemon.Socket
+import Agent.Runtime.Daemon.Supervisor
+import Agent.Runtime.Daemon.Task
+
+main :: IO ()
+main = hspec $ do
+    describe "length-framed JSON IPC" $ do
+        it "round trips a typed message over a Unix stream" $
+            withSocketPair $ \(writer, reader) -> do
+                let expected = ClientAck 42
+                (_, actual) <-
+                    concurrently
+                        (sendJSONFrame defaultMaximumFrameBytes writer expected)
+                        (receiveJSONFrame defaultMaximumFrameBytes reader)
+                actual `shouldBe` expected
+
+        it "rejects an outbound frame above the configured bound" $
+            withSocketPair $ \(writer, _) ->
+                sendJSONFrame 8 writer (String "this frame is too long")
+                    `shouldThrow` \case
+                        FrameTooLarge _ 8 -> True
+                        _ -> False
+
+        it "rejects an advertised inbound length before reading its body" $
+            withSocketPair $ \(writer, reader) -> do
+                Socket.sendAll writer (BS.pack [0, 0, 1, 0])
+                (receiveJSONFrame 32 reader :: IO Value)
+                    `shouldThrow` \case
+                        FrameTooLarge 256 32 -> True
+                        _ -> False
+
+    describe "protocol negotiation" $ do
+        it "chooses the current common version" $ do
+            negotiateVersion [ProtocolVersion 99, currentProtocolVersion]
+                `shouldBe` Just currentProtocolVersion
+            negotiateVersion [ProtocolVersion 99] `shouldBe` Nothing
+
+    describe "durable journal" $ do
+        it "keeps sequence numbers monotonic and replays after a cursor" $
+            withSystemTempDirectory "daemon-journal" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                first <- appendEvent journal "one" Null
+                second <- appendEvent journal "two" Null
+                first.sequenceNumber `shouldBe` 1
+                second.sequenceNumber `shouldBe` 2
+                replayAfter journal 1 `shouldReturn` ReplayEvents [second]
+
+        it "falls back to a snapshot when retention has removed the cursor" $
+            withSystemTempDirectory "daemon-retention" $ \directory -> do
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumEvents = 2
+                            , maximumJournalBytes = 1_048_576
+                            }
+                journal <- openJournal config
+                _ <- appendEvent journal "one" Null
+                second <- appendEvent journal "two" Null
+                third <- appendEvent journal "three" Null
+                replayAfter journal 0 >>= (`shouldSatisfy` \case
+                    ReplaySnapshot saved -> saved.lastSequence == 3
+                    ReplayEvents _ -> False)
+                replayAfter journal 1 `shouldReturn` ReplayEvents [second, third]
+                replayAfter journal 99 >>= (`shouldSatisfy` \case
+                    ReplaySnapshot saved -> saved.lastSequence == 3
+                    ReplayEvents _ -> False)
+
+        it "redacts sensitive fields and bounds retained task logs" $
+            withSystemTempDirectory "daemon-redaction" $ \directory -> do
+                now <- getCurrentTime
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumTaskLogLines = 2
+                            , maximumTaskLogCharacters = 20
+                            }
+                    task =
+                        DurableTask
+                            { taskId = TaskId "task"
+                            , status = TaskRunning
+                            , description = "test"
+                            , updatedAt = now
+                            , logTail = ["old", "authorization: bearer private", "safe"]
+                            }
+                journal <- openJournal config
+                event <- appendEvent journal "credentials" (object ["token" .= ("private" :: Text)])
+                event.payload `shouldBe` object ["token" .= ("[REDACTED]" :: Text)]
+                _ <- persistTask journal task
+                saved <- snapshot journal
+                (.logTail) (saved.tasks Map.! TaskId "task")
+                    `shouldBe` ["[REDACTED]", "safe"]
+
+        it "marks active tasks interrupted on startup without retrying them" $
+            withSystemTempDirectory "daemon-recovery" $ \directory -> do
+                now <- getCurrentTime
+                let config = defaultJournalConfig directory
+                    running =
+                        DurableTask
+                            { taskId = TaskId "active"
+                            , status = TaskRunning
+                            , description = "active before crash"
+                            , updatedAt = now
+                            , logTail = []
+                            }
+                firstProcess <- openJournal config
+                _ <- persistTask firstProcess running
+                secondProcess <- openJournal config
+                recovered <- snapshot secondProcess
+                (.status) (recovered.tasks Map.! TaskId "active")
+                    `shouldBe` TaskInterrupted
+                let recoveredSequence = recovered.lastSequence
+                thirdProcess <- openJournal config
+                unchanged <- snapshot thirdProcess
+                unchanged.lastSequence `shouldBe` recoveredSequence
+                (.status) (unchanged.tasks Map.! TaskId "active")
+                    `shouldBe` TaskInterrupted
+
+    describe "secure Unix socket" $ do
+        it "uses private modes and authenticates the same-user peer" $
+            withTempDirectory "/tmp" "daemon-socket" $ \directory -> do
+                let path = directory </> "private" </> "daemon.sock"
+                    config = SocketConfig {path, backlog = 1}
+                withUnixListener config $ \listener ->
+                    withAsync
+                        (bracket (acceptOwnedPeer listener) close verifyPeerOwner)
+                        $ \_ -> do
+                            client <- socket AF_UNIX Stream defaultProtocol
+                            bracket (pure client) close $ \peer -> do
+                                connect peer (SockAddrUnix path)
+                                verifyPeerOwner peer
+                                socketStatus <- getFileStatus path
+                                directoryStatus <- getFileStatus (directory </> "private")
+                                fileMode socketStatus .&. 0o777 `shouldBe` 0o600
+                                fileMode directoryStatus .&. 0o777 `shouldBe` 0o700
+
+        it "does not unlink an active daemon socket" $
+            withTempDirectory "/tmp" "daemon-active" $ \directory -> do
+                let config =
+                        SocketConfig
+                            { path = directory </> "daemon.sock"
+                            , backlog = 1
+                            }
+                withUnixListener config $ \_ ->
+                    withUnixListener config (const (pure ()))
+                        `shouldThrow` anyException
+
+    describe "server integration" $ do
+        it "handshakes, sends a snapshot, streams events, and uses the supervisor seam" $
+            withSystemTempDirectory "daemon-server" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                let config =
+                        defaultServerConfig
+                            { heartbeatSeconds = 60
+                            , maximumFrameBytes = 4_096
+                            }
+                    supervisor =
+                        Supervisor
+                            { handleCommand = \_ command -> pure (Right command)
+                            }
+                withSocketPair $ \(serverPeer, clientPeer) ->
+                    withAsync (serveConnection config journal supervisor serverPeer) $ \_ -> do
+                        sendJSONFrame config.maximumFrameBytes clientPeer $
+                            ClientHello
+                                Hello
+                                    { clientId = ClientId "test-client"
+                                    , versions = [currentProtocolVersion]
+                                    , resumeAfter = Nothing
+                                    }
+                        welcome <- receiveJSONFrame config.maximumFrameBytes clientPeer
+                        welcome `shouldSatisfy` \case
+                            ServerWelcome accepted -> accepted.version == currentProtocolVersion
+                            _ -> False
+                        initial <- receiveJSONFrame config.maximumFrameBytes clientPeer
+                        initial `shouldSatisfy` \case
+                            ServerSnapshot 0 _ -> True
+                            _ -> False
+                        event <- appendEvent journal "changed" (object ["value" .= (1 :: Int)])
+                        receiveJSONFrame config.maximumFrameBytes clientPeer
+                            `shouldReturn` ServerEvent event
+                        sendJSONFrame config.maximumFrameBytes clientPeer $
+                            ClientCommand (CommandId "command") (String "echo")
+                        receiveJSONFrame config.maximumFrameBytes clientPeer
+                            `shouldReturn` ServerCommandResult (CommandId "command") (Right (String "echo"))
+                        sendJSONFrame config.maximumFrameBytes clientPeer (ClientAck event.sequenceNumber)
+
+withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
+withSocketPair =
+    bracket
+        (socketPair AF_UNIX Stream defaultProtocol)
+        (\(left, right) -> close left >> close right)

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -1,18 +1,32 @@
 module Main (main) where
 
-import Control.Concurrent.Async (concurrently, withAsync)
-import Control.Exception.Safe (bracket)
-import Data.Aeson (Value (..), object, (.=))
+import Control.Concurrent.Async (cancel, concurrently, waitCatch, withAsync)
+import Control.Concurrent.STM (readTVarIO)
+import Control.Exception.Safe (bracket, isAsyncException)
+import Data.Aeson (Value (..), encode, object, (.=))
 import Data.Bits ((.&.))
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time (getCurrentTime)
 import Network.Socket
 import qualified Network.Socket.ByteString as Socket
+import System.Directory
+    ( createDirectory
+    , doesFileExist
+    , removeFile
+    , renamePath
+    )
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory, withTempDirectory)
-import System.Posix.Files (fileMode, getFileStatus)
+import System.Posix.Files
+    ( createSymbolicLink
+    , fileMode
+    , getFileStatus
+    )
+import System.Timeout (timeout)
 import Test.Hspec
 
 import Agent.Runtime.Daemon.Framing
@@ -108,6 +122,8 @@ main = hspec $ do
                 saved <- snapshot journal
                 (.logTail) (saved.tasks Map.! TaskId "task")
                     `shouldBe` ["[REDACTED]", "safe"]
+                (.description) (saved.tasks Map.! TaskId "task")
+                    `shouldBe` "test"
 
         it "marks active tasks interrupted on startup without retrying them" $
             withSystemTempDirectory "daemon-recovery" $ \directory -> do
@@ -133,6 +149,114 @@ main = hspec $ do
                 unchanged.lastSequence `shouldBe` recoveredSequence
                 (.status) (unchanged.tasks Map.! TaskId "active")
                     `shouldBe` TaskInterrupted
+
+        it "fails closed on corrupt snapshots and event gaps" $
+            withSystemTempDirectory "daemon-corrupt" $ \directory -> do
+                BS.writeFile (directory </> "snapshot.json") "{broken"
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalCorrupt _ _ -> True
+                        _ -> False
+                removeFile (directory </> "snapshot.json")
+                let event sequenceNumber =
+                        EventEnvelope {sequenceNumber, eventType = "test", payload = Null}
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    (LBS.toStrict (encode (event 1)) <> "\n" <> LBS.toStrict (encode (event 3)) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalEventGap 2 3 -> True
+                        _ -> False
+
+        it "enforces contiguous startup retention and rejects an oversized newest event" $
+            withSystemTempDirectory "daemon-startup-retention" $ \directory -> do
+                original <- openJournal ((defaultJournalConfig directory) {maximumEvents = 10})
+                now <- getCurrentTime
+                _ <-
+                    persistTask original $
+                        DurableTask
+                            { taskId = TaskId "snapshot-anchor"
+                            , status = TaskCompleted
+                            , description = "anchor"
+                            , updatedAt = now
+                            , logTail = []
+                            }
+                second <- appendEvent original "two" Null
+                third <- appendEvent original "three" Null
+                reopened <- openJournal ((defaultJournalConfig directory) {maximumEvents = 2})
+                replayAfter reopened 1 `shouldReturn` ReplayEvents [second, third]
+                let tinyConfig =
+                        (defaultJournalConfig (directory </> "oversized"))
+                            { maximumJournalBytes = 4
+                            }
+                bounded <- openJournal tinyConfig
+                appendEvent bounded "large" (String "payload")
+                    `shouldThrow` \case
+                        JournalEventTooLarge _ 4 -> True
+                        _ -> False
+                saved <- snapshot bounded
+                saved.lastSequence `shouldBe` 0
+
+        it "poisons the journal after persistence I/O failure instead of reusing a sequence" $
+            withSystemTempDirectory "daemon-poison" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                _ <- appendEvent journal "first" Null
+                renamePath (directory </> "events.jsonl") (directory </> "events.saved")
+                createDirectory (directory </> "events.jsonl")
+                appendEvent journal "second" Null `shouldThrow` anyException
+                appendEvent journal "third" Null
+                    `shouldThrow` \case
+                        JournalPoisoned _ -> True
+                        _ -> False
+
+        it "redacts descriptions, bounds task count, and bounds subscriber queues" $
+            withSystemTempDirectory "daemon-bounds" $ \directory -> do
+                now <- getCurrentTime
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumTasks = 1
+                            , subscriberQueueSize = 1
+                            }
+                    task name description =
+                        DurableTask
+                            { taskId = TaskId name
+                            , status = TaskCompleted
+                            , description
+                            , updatedAt = now
+                            , logTail = []
+                            }
+                journal <- openJournal config
+                _ <- persistTask journal (task "one" "password=private")
+                saved <- snapshot journal
+                (.description) (saved.tasks Map.! TaskId "one") `shouldBe` "[REDACTED]"
+                persistTask journal (task "two" "safe")
+                    `shouldThrow` \case
+                        JournalTaskCapacityExceeded 1 -> True
+                        _ -> False
+                (_, _, _, overflowed, unsubscribe) <- subscribeReplay journal saved.lastSequence
+                _ <- appendEvent journal "a" Null
+                _ <- appendEvent journal "b" Null
+                readTVarIO overflowed `shouldReturn` True
+                unsubscribe
+
+        it "rejects symlinked journal directories and files" $
+            withSystemTempDirectory "daemon-symlink" $ \directory -> do
+                let target = directory </> "target"
+                    linked = directory </> "linked"
+                createDirectory target
+                createSymbolicLink target linked
+                openJournal (defaultJournalConfig linked)
+                    `shouldThrow` \case
+                        JournalInsecurePath _ -> True
+                        _ -> False
+                let journalDir = directory </> "journal"
+                createDirectory journalDir
+                BS.writeFile (directory </> "outside") "{}"
+                createSymbolicLink (directory </> "outside") (journalDir </> "snapshot.json")
+                openJournal (defaultJournalConfig journalDir)
+                    `shouldThrow` \case
+                        JournalInsecurePath _ -> True
+                        _ -> False
 
     describe "secure Unix socket" $ do
         it "uses private modes and authenticates the same-user peer" $
@@ -163,6 +287,15 @@ main = hspec $ do
                     withUnixListener config (const (pure ()))
                         `shouldThrow` anyException
 
+        it "only removes the socket inode created by this listener" $
+            withTempDirectory "/tmp" "daemon-identity" $ \directory -> do
+                let path = directory </> "daemon.sock"
+                    config = SocketConfig {path, backlog = 1}
+                withUnixListener config $ \_ -> do
+                    renamePath path (path <> ".replaced")
+                    BS.writeFile path "replacement"
+                doesFileExist path `shouldReturn` True
+
     describe "server integration" $ do
         it "handshakes, sends a snapshot, streams events, and uses the supervisor seam" $
             withSystemTempDirectory "daemon-server" $ \directory -> do
@@ -191,7 +324,7 @@ main = hspec $ do
                             _ -> False
                         initial <- receiveJSONFrame config.maximumFrameBytes clientPeer
                         initial `shouldSatisfy` \case
-                            ServerSnapshot 0 _ -> True
+                            ServerSnapshotChunk 0 0 1 _ -> True
                             _ -> False
                         event <- appendEvent journal "changed" (object ["value" .= (1 :: Int)])
                         receiveJSONFrame config.maximumFrameBytes clientPeer
@@ -201,6 +334,78 @@ main = hspec $ do
                         receiveJSONFrame config.maximumFrameBytes clientPeer
                             `shouldReturn` ServerCommandResult (CommandId "command") (Right (String "echo"))
                         sendJSONFrame config.maximumFrameBytes clientPeer (ClientAck event.sequenceNumber)
+
+        it "times out idle clients and preserves async cancellation" $
+            withSystemTempDirectory "daemon-timeout" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                let config = defaultServerConfig {ioTimeoutSeconds = 1}
+                withSocketPair $ \(serverPeer, _) -> do
+                    withAsync (serveConnection config journal unavailableSupervisor serverPeer) $ \server -> do
+                        result <- timeout 2_500_000 (waitCatch server)
+                        result `shouldSatisfy` \case
+                            Just (Left exception) -> not (isAsyncException exception)
+                            _ -> False
+                withTempDirectory "/tmp" "daemon-cancel" $ \socketDirectory -> do
+                    let socketConfig =
+                            SocketConfig
+                                { path = socketDirectory </> "daemon.sock"
+                                , backlog = 1
+                                }
+                    withUnixListener socketConfig $ \listener ->
+                        withAsync (runServerOnListener listener config journal unavailableSupervisor) $ \server -> do
+                            client <- socket AF_UNIX Stream defaultProtocol
+                            bracket (pure client) close $ \peer -> do
+                                connect peer (SockAddrUnix socketConfig.path)
+                                cancel server
+                                outcome <- timeout 2_000_000 (waitCatch server)
+                                outcome `shouldSatisfy` \case
+                                    Just (Left exception) -> isAsyncException exception
+                                    _ -> False
+
+        it "chunks large snapshots below the configured frame bound" $
+            withSystemTempDirectory "daemon-snapshot-chunks" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                now <- getCurrentTime
+                _ <-
+                    persistTask journal $
+                        DurableTask
+                            { taskId = TaskId "large"
+                            , status = TaskCompleted
+                            , description = "large snapshot"
+                            , updatedAt = now
+                            , logTail = [Text.replicate 2_000 "x"]
+                            }
+                let config =
+                        defaultServerConfig
+                            { maximumFrameBytes = 512
+                            , heartbeatSeconds = 60
+                            }
+                withSocketPair $ \(serverPeer, clientPeer) ->
+                    withAsync (serveConnection config journal unavailableSupervisor serverPeer) $ \_ -> do
+                        sendJSONFrame config.maximumFrameBytes clientPeer $
+                            ClientHello
+                                Hello
+                                    { clientId = ClientId "snapshot-client"
+                                    , versions = [currentProtocolVersion]
+                                    , resumeAfter = Nothing
+                                    }
+                        _ <- receiveJSONFrame config.maximumFrameBytes clientPeer :: IO ServerMessage
+                        first <- receiveJSONFrame config.maximumFrameBytes clientPeer
+                        chunkCount <-
+                            case first of
+                                ServerSnapshotChunk 1 0 count _ -> do
+                                    count `shouldSatisfy` (> 1)
+                                    pure count
+                                _ -> expectationFailure ("unexpected snapshot message: " <> show first) >> pure 0
+                        sequenceNumbers <-
+                            traverse
+                                ( \_ ->
+                                    receiveJSONFrame config.maximumFrameBytes clientPeer >>= \case
+                                        ServerSnapshotChunk 1 index count _ | count == chunkCount -> pure index
+                                        other -> expectationFailure ("unexpected snapshot chunk: " <> show other) >> pure (-1)
+                                )
+                                [1 .. chunkCount - 1]
+                        sequenceNumbers `shouldBe` [1 .. chunkCount - 1]
 
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -959,11 +959,11 @@ main = hspec $ do
                     runner =
                         TaskRunner
                             { runTask = \_ logLine -> do
-                                mapM_ logLine (replicate 8 "12345")
+                                mapM_ logLine (replicate 10_000 "12345")
                                 pure (Right ())
                             }
                 journal <- openJournal journalConfig
-                withTaskAdapter journal runner $ \supervisor -> do
+                withTaskAdapterQueueSize 1 journal runner $ \supervisor -> do
                     supervisor.handleCommand
                         (CommandId "submit")
                         (submitCommand "bounded-log" "bounded-session")

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -152,6 +152,19 @@ main = hspec $ do
                 replayAfter reopened 3 `shouldReturn` ReplayEvents [boundary, next]
                 replayAfter reopened 4 `shouldReturn` ReplayEvents [next]
 
+        it "fails closed on duplicate retained sequence numbers" $
+            withSystemTempDirectory "daemon-duplicate-boundary" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    duplicate = EventEnvelope {sequenceNumber = 4, eventType = "duplicate", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    (LBS.toStrict (encode duplicate) <> "\n" <> LBS.toStrict (encode duplicate) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalEventGap 5 4 -> True
+                        _ -> False
+
         it "redacts sensitive fields and bounds retained task logs" $
             withSystemTempDirectory "daemon-redaction" $ \directory -> do
                 now <- getCurrentTime

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -117,6 +117,26 @@ main = hspec $ do
                 third <- appendEvent secondProcess "three" Null
                 third.sequenceNumber `shouldBe` 3
 
+        it "reopens a compacted replay suffix without requiring sequence one" $
+            withSystemTempDirectory "daemon-reopen-compaction" $ \directory -> do
+                let config =
+                        (defaultJournalConfig directory)
+                            { maximumEvents = 2
+                            , maximumJournalBytes = 1_048_576
+                            }
+                firstProcess <- openJournal config
+                _ <- appendEvent firstProcess "one" Null
+                second <- appendEvent firstProcess "two" Null
+                third <- appendEvent firstProcess "three" Null
+                secondProcess <- openJournal config
+                replayAfter secondProcess 1 `shouldReturn` ReplayEvents [second, third]
+                snapshot secondProcess >>= \saved ->
+                    saved.lastSequence `shouldBe` 3
+                thirdProcess <- openJournal config
+                replayAfter thirdProcess 1 `shouldReturn` ReplayEvents [second, third]
+                fourth <- appendEvent thirdProcess "four" Null
+                fourth.sequenceNumber `shouldBe` 4
+
         it "redacts sensitive fields and bounds retained task logs" $
             withSystemTempDirectory "daemon-redaction" $ \directory -> do
                 now <- getCurrentTime

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -946,6 +946,49 @@ main = hspec $ do
                 BS.readFile (directory </> "events.jsonl")
                     >>= (`shouldSatisfy` (not . BS.isInfixOf rawBytes))
 
+        it "retains failed input for one-process retry and discards it after completion" $
+            withSystemTempDirectory "daemon-task-input-lifetime" $ \directory -> do
+                received <- newTQueueIO
+                let rawPrompt = "memory-only-retry-input"
+                    runner =
+                        TaskRunner
+                            { runTask = \task _ -> do
+                                atomically (writeTQueue received (task.attempt, task.description))
+                                pure $
+                                    if task.attempt == 1
+                                        then Left "first attempt failed"
+                                        else Right ()
+                            }
+                    retryCommand =
+                        object
+                            [ "version" .= (1 :: Int)
+                            , "type" .= ("retry" :: Text)
+                            , "task_id" .= ("retry-lifetime" :: Text)
+                            ]
+                journal <- openJournal (defaultJournalConfig directory)
+                withTaskAdapter journal runner $ \supervisor -> do
+                    supervisor.handleCommand
+                        (CommandId "submit-retry-lifetime")
+                        (object
+                            [ "version" .= (1 :: Int)
+                            , "type" .= ("submit" :: Text)
+                            , "task_id" .= ("retry-lifetime" :: Text)
+                            , "prompt" .= rawPrompt
+                            , "cwd" .= ("/tmp" :: Text)
+                            ])
+                        >>= shouldSucceed
+                    timeout 1_000_000 (atomically (readTQueue received))
+                        `shouldReturn` Just (1, rawPrompt)
+                    waitForStatus journal (TaskId "retry-lifetime") TaskFailed
+                    supervisor.handleCommand (CommandId "retry-failed") retryCommand
+                        >>= shouldSucceed
+                    timeout 1_000_000 (atomically (readTQueue received))
+                        `shouldReturn` Just (2, rawPrompt)
+                    waitForStatus journal (TaskId "retry-lifetime") TaskCompleted
+                    supervisor.handleCommand (CommandId "retry-completed") retryCommand
+                        `shouldReturn` Left
+                            "completed tasks cannot be retried; task input has been discarded"
+
         it "uses the actual agent-cli argv shape and bounds process output chunks" $
             withSystemTempDirectory "daemon-process-runner" $ \directory -> do
                 now <- getCurrentTime

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -24,6 +24,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import Data.Time (getCurrentTime)
 import Network.Socket
 import qualified Network.Socket.ByteString as Socket
@@ -889,6 +890,61 @@ main = hspec $ do
                                         unchanged.tasks Map.! TaskId "restart-task"
                                 interrupted.status `shouldBe` TaskInterrupted
                                 interrupted.attempt `shouldBe` 1
+
+        it "keeps submitted prompts out of every durable and public task representation" $
+            withSystemTempDirectory "daemon-task-input-redaction" $ \directory -> do
+                receivedPrompts <- newTQueueIO
+                let rawPrompt = "opaque-violet-7Q9-content"
+                    rawBytes = TextEncoding.encodeUtf8 rawPrompt
+                    command =
+                        object
+                            [ "version" .= (1 :: Int)
+                            , "type" .= ("submit" :: Text)
+                            , "task_id" .= ("redacted-input" :: Text)
+                            , "session_id" .= ("redacted-session" :: Text)
+                            , "prompt" .= rawPrompt
+                            , "cwd" .= ("/tmp" :: Text)
+                            ]
+                    runner =
+                        TaskRunner
+                            { runTask = \task logLine -> do
+                                atomically (writeTQueue receivedPrompts task.description)
+                                logLine ("runner echoed " <> task.description)
+                                pure (Left ("failed for " <> task.description))
+                            }
+                journal <- openJournal (defaultJournalConfig directory)
+                withTaskAdapter journal runner $ \supervisor -> do
+                    submitted <-
+                        supervisor.handleCommand (CommandId "submit-redacted") command
+                    case submitted of
+                        Left message -> expectationFailure (Text.unpack message)
+                        Right value ->
+                            LBS.toStrict (encode value)
+                                `shouldSatisfy` (not . BS.isInfixOf rawBytes)
+                    timeout 1_000_000 (atomically (readTQueue receivedPrompts))
+                        `shouldReturn` Just rawPrompt
+                    waitForStatus journal (TaskId "redacted-input") TaskFailed
+                    listed <-
+                        supervisor.handleCommand
+                            (CommandId "list-redacted")
+                            (object
+                                [ "version" .= (1 :: Int)
+                                , "type" .= ("list" :: Text)
+                                ])
+                    case listed of
+                        Left message -> expectationFailure (Text.unpack message)
+                        Right value ->
+                            LBS.toStrict (encode value)
+                                `shouldSatisfy` (not . BS.isInfixOf rawBytes)
+                saved <- snapshot journal
+                let durableTask = saved.tasks Map.! TaskId "redacted-input"
+                durableTask.description `shouldBe` "[task input redacted]"
+                Text.concat durableTask.logTail
+                    `shouldSatisfy` (not . Text.isInfixOf rawPrompt)
+                BS.readFile (directory </> "snapshot.json")
+                    >>= (`shouldSatisfy` (not . BS.isInfixOf rawBytes))
+                BS.readFile (directory </> "events.jsonl")
+                    >>= (`shouldSatisfy` (not . BS.isInfixOf rawBytes))
 
         it "uses the actual agent-cli argv shape and bounds process output chunks" $
             withSystemTempDirectory "daemon-process-runner" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -948,6 +948,11 @@ main = hspec $ do
                     4_000_000
                     ((processTaskRunnerForWithTimeout 1 executable).runTask task (const (pure ())))
                     `shouldReturn` Just (Left "agent-cli exceeded its 1 second runtime limit")
+                writeFile executable "#!/bin/sh\nsleep 30 &\nexit 0\n"
+                timeout
+                    5_000_000
+                    ((processTaskRunnerForWithTimeout 10 executable).runTask task (const (pure ())))
+                    `shouldReturn` Just (Right ())
 
         it "bounds task-runner output in the durable journal" $
             withSystemTempDirectory "daemon-runner-log-bound" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (cancel, concurrently, waitCatch, withAsync)
+import Control.Concurrent.Async (async, cancel, concurrently, wait, waitCatch, withAsync)
 import Control.Concurrent.STM
     ( TQueue
     , TMVar
@@ -9,12 +9,13 @@ import Control.Concurrent.STM
     , flushTQueue
     , newEmptyTMVarIO
     , newTQueueIO
+    , putTMVar
     , readTQueue
     , readTVarIO
     , takeTMVar
     , writeTQueue
     )
-import Control.Exception.Safe (bracket, isAsyncException)
+import Control.Exception.Safe (bracket, finally, isAsyncException, uninterruptibleMask_)
 import Data.Aeson (Result (..), Value (..), encode, fromJSON, object, toJSON, (.=))
 import Data.Bits ((.&.))
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -913,6 +914,7 @@ main = hspec $ do
                         [ "--prompt"
                         , "hello agent"
                         , "--save-session"
+                        , "--no-yolo"
                         , "--resume"
                         , "session-id"
                         , "--cwd"
@@ -971,6 +973,75 @@ main = hspec $ do
                 let retained = (.logTail) (saved.tasks Map.! TaskId "bounded-log")
                 length retained `shouldSatisfy` (<= 3)
                 sum (map Text.length retained) `shouldSatisfy` (<= 10)
+
+        it "rejects full command queues and skips requests cancelled before execution" $
+            withSystemTempDirectory "daemon-command-admission" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                runGate <- newEmptyTMVarIO
+                cleanupGate <- newEmptyTMVarIO
+                runnerStarted <- newTQueueIO
+                cleanupStarted <- newTQueueIO
+                let runner =
+                        TaskRunner
+                            { runTask = \_ _ -> do
+                                atomically (writeTQueue runnerStarted ())
+                                _ <- atomically (takeTMVar runGate)
+                                    `finally`
+                                        uninterruptibleMask_
+                                            ( do
+                                                atomically (writeTQueue cleanupStarted ())
+                                                atomically (takeTMVar cleanupGate)
+                                            )
+                                pure (Right ())
+                            }
+                    command kind fields =
+                        object
+                            ( [ "version" .= (1 :: Int)
+                              , "type" .= (kind :: Text)
+                              ]
+                                <> fields
+                            )
+                withTaskAdapterQueueSize 1 journal runner $ \supervisor -> do
+                    supervisor.handleCommand
+                        (CommandId "submit")
+                        (submitCommand "admission-task" "admission-session")
+                        >>= shouldSucceed
+                    timeout 1_000_000 (atomically (readTQueue runnerStarted))
+                        `shouldReturn` Just ()
+                    cancelling <-
+                        async $
+                            supervisor.handleCommand
+                                (CommandId "cancel")
+                                (command "cancel" ["task_id" .= ("admission-task" :: Text)])
+                    timeout 1_000_000 (atomically (readTQueue cleanupStarted))
+                        `shouldReturn` Just ()
+                    ghost <-
+                        async $
+                            supervisor.handleCommand
+                                (CommandId "ghost")
+                                (command "set_limit" ["limit" .= (1 :: Int)])
+                    threadDelay 20_000
+                    cancel ghost
+                    waitCatch ghost >>= (`shouldSatisfy` \case
+                        Left exception -> isAsyncException exception
+                        Right _ -> False)
+                    timeout
+                        200_000
+                        ( supervisor.handleCommand
+                            (CommandId "overflow")
+                            (command "list" [])
+                        )
+                        `shouldReturn` Just (Left "task scheduler command queue is full")
+                    atomically (putTMVar cleanupGate ())
+                    wait cancelling >>= shouldSucceed
+                    threadDelay 20_000
+                    afterCancel <- snapshot journal
+                    supervisor.handleCommand
+                        (CommandId "list")
+                        (command "list" [])
+                        >>= shouldSucceed
+                    afterList <- snapshot journal
+                    afterList.lastSequence `shouldBe` afterCancel.lastSequence
 
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -129,6 +129,8 @@ main = hspec $ do
                 second <- appendEvent firstProcess "two" Null
                 third <- appendEvent firstProcess "three" Null
                 secondProcess <- openJournal config
+                BS.readFile (directory </> "events.jsonl")
+                    `shouldReturn` (LBS.toStrict (encode second) <> "\n" <> LBS.toStrict (encode third) <> "\n")
                 replayAfter secondProcess 1 `shouldReturn` ReplayEvents [second, third]
                 snapshot secondProcess >>= \saved ->
                     saved.lastSequence `shouldBe` 3
@@ -136,6 +138,19 @@ main = hspec $ do
                 replayAfter thirdProcess 1 `shouldReturn` ReplayEvents [second, third]
                 fourth <- appendEvent thirdProcess "four" Null
                 fourth.sequenceNumber `shouldBe` 4
+
+        it "accepts the snapshot boundary event in a retained replay suffix" $
+            withSystemTempDirectory "daemon-snapshot-boundary" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    boundary = EventEnvelope {sequenceNumber = 4, eventType = "boundary", payload = Null}
+                    next = EventEnvelope {sequenceNumber = 5, eventType = "next", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    (LBS.toStrict (encode boundary) <> "\n" <> LBS.toStrict (encode next) <> "\n")
+                reopened <- openJournal (defaultJournalConfig directory)
+                replayAfter reopened 3 `shouldReturn` ReplayEvents [boundary, next]
+                replayAfter reopened 4 `shouldReturn` ReplayEvents [next]
 
         it "redacts sensitive fields and bounds retained task logs" $
             withSystemTempDirectory "daemon-redaction" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -2,10 +2,21 @@ module Main (main) where
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (cancel, concurrently, waitCatch, withAsync)
-import Control.Concurrent.STM (readTVarIO)
+import Control.Concurrent.STM
+    ( TQueue
+    , TMVar
+    , atomically
+    , newEmptyTMVarIO
+    , newTQueueIO
+    , readTQueue
+    , readTVarIO
+    , takeTMVar
+    , writeTQueue
+    )
 import Control.Exception.Safe (bracket, isAsyncException)
-import Data.Aeson (Value (..), encode, object, toJSON, (.=))
+import Data.Aeson (Result (..), Value (..), encode, fromJSON, object, toJSON, (.=))
 import Data.Bits ((.&.))
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
@@ -37,6 +48,7 @@ import Agent.Runtime.Daemon.Server
 import Agent.Runtime.Daemon.Socket
 import Agent.Runtime.Daemon.Supervisor
 import Agent.Runtime.Daemon.Task
+import Agent.Runtime.Daemon.TaskAdapter
 
 main :: IO ()
 main = hspec $ do
@@ -176,8 +188,15 @@ main = hspec $ do
                     task =
                         DurableTask
                             { taskId = TaskId "task"
+                            , sessionId = Nothing
                             , status = TaskRunning
                             , description = "test"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = ["old", "authorization: bearer private", "safe"]
                             }
@@ -198,8 +217,15 @@ main = hspec $ do
                     running =
                         DurableTask
                             { taskId = TaskId "active"
+                            , sessionId = Nothing
                             , status = TaskRunning
                             , description = "active before crash"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = []
                             }
@@ -264,8 +290,15 @@ main = hspec $ do
                     persistTask original $
                         DurableTask
                             { taskId = TaskId "snapshot-anchor"
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description = "anchor"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = []
                             }
@@ -308,8 +341,15 @@ main = hspec $ do
                     task name description =
                         DurableTask
                             { taskId = TaskId name
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = []
                             }
@@ -333,8 +373,15 @@ main = hspec $ do
                 let task =
                         DurableTask
                             { taskId = TaskId "recovered"
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description = "password=private"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = ["token=private"]
                             }
@@ -589,8 +636,15 @@ main = hspec $ do
                     persistTask journal $
                         DurableTask
                             { taskId = TaskId "large"
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description = "large snapshot"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = [Text.replicate 2_000 "x"]
                             }
@@ -666,8 +720,260 @@ main = hspec $ do
                                 [1 .. chunkCount - 1]
                         indices `shouldBe` [1 .. chunkCount - 1]
 
+    describe "task adapter IPC" $ do
+        it "submits, queues, cancels, lists, and replays durable task changes" $
+            withSystemTempDirectory "daemon-task-adapter" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                firstGate <- newEmptyTMVarIO
+                secondGate <- newEmptyTMVarIO
+                started <- newTQueueIO
+                let runner =
+                        blockingRunner
+                            started
+                            (Map.fromList
+                                [ (TaskId "first", firstGate)
+                                , (TaskId "second", secondGate)
+                                ])
+                    config =
+                        defaultServerConfig
+                            { heartbeatSeconds = 60
+                            , maximumFrameBytes = 16_384
+                            }
+                withTaskAdapter journal runner $ \supervisor ->
+                    withSocketPair $ \(serverPeer, clientPeer) ->
+                        withAsync (serveConnection config journal supervisor serverPeer) $ \_ -> do
+                            handshake config clientPeer Nothing
+                            sendTaskCommand config clientPeer "limit"
+                                (object
+                                    [ "version" .= (1 :: Int)
+                                    , "type" .= ("set_limit" :: Text)
+                                    , "limit" .= (1 :: Int)
+                                    ])
+                                `shouldReturn` Right
+                                    (object ["version" .= (1 :: Int), "limit" .= (1 :: Int)])
+                            sendTaskCommand config clientPeer "submit-first"
+                                (submitCommand "first" "session-a")
+                                >>= shouldSucceed
+                            timeout 1_000_000 (atomically (readTQueue started))
+                                `shouldReturn` Just (TaskId "first")
+                            sendTaskCommand config clientPeer "submit-second"
+                                (submitCommand "second" "session-b")
+                                >>= shouldSucceed
+                            timeout 100_000 (atomically (readTQueue started))
+                                `shouldReturn` Nothing
+                            sendTaskCommand config clientPeer "cancel-second"
+                                (object
+                                    [ "version" .= (1 :: Int)
+                                    , "type" .= ("cancel" :: Text)
+                                    , "task_id" .= ("second" :: Text)
+                                    ])
+                                >>= shouldSucceed
+                            sendTaskCommand config clientPeer "list"
+                                (object
+                                    [ "version" .= (1 :: Int)
+                                    , "type" .= ("list" :: Text)
+                                    ])
+                                >>= \case
+                                    Right value ->
+                                        value `shouldSatisfy` listContains
+                                            (TaskId "second") TaskCancelled
+                                    Left message ->
+                                        expectationFailure (Text.unpack message)
+                            sendTaskCommand config clientPeer "cancel-first"
+                                (object
+                                    [ "version" .= (1 :: Int)
+                                    , "type" .= ("cancel" :: Text)
+                                    , "task_id" .= ("first" :: Text)
+                                    ])
+                                >>= shouldSucceed
+                            waitForStatus journal (TaskId "first") TaskCancelled
+                saved <- snapshot journal
+                let eventCount =
+                        fromIntegral saved.lastSequence.unSequence :: Int
+                withSocketPair $ \(serverPeer, clientPeer) ->
+                    withAsync
+                        (serveConnection config journal unavailableSupervisor serverPeer)
+                        $ \_ -> do
+                            handshake config clientPeer (Just 0)
+                            replayed <- traverse
+                                (const (receiveJSONFrame config.maximumFrameBytes clientPeer))
+                                [1 .. eventCount]
+                            replayed `shouldSatisfy`
+                                any (messageHasStatus (TaskId "second") TaskCancelled)
+
+        it "interrupts in-flight work on restart and starts it only after explicit retry" $
+            withSystemTempDirectory "daemon-task-restart" $ \directory -> do
+                let journalConfig = defaultJournalConfig directory
+                    serverConfig =
+                        defaultServerConfig
+                            { heartbeatSeconds = 60
+                            , maximumFrameBytes = 16_384
+                            }
+                firstJournal <- openJournal journalConfig
+                firstGate <- newEmptyTMVarIO
+                firstStarted <- newTQueueIO
+                let firstRunner =
+                        blockingRunner firstStarted
+                            (Map.singleton (TaskId "restart-task") firstGate)
+                withTaskAdapter firstJournal firstRunner $ \supervisor ->
+                    withSocketPair $ \(serverPeer, clientPeer) ->
+                        withAsync
+                            (serveConnection serverConfig firstJournal supervisor serverPeer)
+                            $ \_ -> do
+                                handshake serverConfig clientPeer Nothing
+                                _ <- sendTaskCommand serverConfig clientPeer "submit"
+                                    (submitCommand "restart-task" "restart-session")
+                                timeout 1_000_000 (atomically (readTQueue firstStarted))
+                                    `shouldReturn` Just (TaskId "restart-task")
+                restartedJournal <- openJournal journalConfig
+                recovered <- snapshot restartedJournal
+                (.status) (recovered.tasks Map.! TaskId "restart-task")
+                    `shouldBe` TaskInterrupted
+                retryGate <- newEmptyTMVarIO
+                retryStarted <- newTQueueIO
+                let retryRunner =
+                        blockingRunner retryStarted
+                            (Map.singleton (TaskId "restart-task") retryGate)
+                withTaskAdapter restartedJournal retryRunner $ \supervisor ->
+                    withSocketPair $ \(serverPeer, clientPeer) ->
+                        withAsync
+                            (serveConnection serverConfig restartedJournal supervisor serverPeer)
+                            $ \_ -> do
+                                handshake serverConfig clientPeer Nothing
+                                timeout 100_000 (atomically (readTQueue retryStarted))
+                                    `shouldReturn` Nothing
+                                _ <- sendTaskCommand serverConfig clientPeer "retry" $
+                                    object
+                                        [ "version" .= (1 :: Int)
+                                        , "type" .= ("retry" :: Text)
+                                        , "task_id" .= ("restart-task" :: Text)
+                                        ]
+                                timeout 1_000_000 (atomically (readTQueue retryStarted))
+                                    `shouldReturn` Just (TaskId "restart-task")
+                                sendTaskCommand serverConfig clientPeer "approval"
+                                    (object
+                                        [ "version" .= (1 :: Int)
+                                        , "type" .= ("approval" :: Text)
+                                        , "task_id" .= ("restart-task" :: Text)
+                                        , "approval_id" .= ("approval-1" :: Text)
+                                        , "decision" .= ("approve" :: Text)
+                                        ])
+                                    >>= shouldSucceed
+                                running <- snapshot restartedJournal
+                                let retried =
+                                        running.tasks Map.! TaskId "restart-task"
+                                retried.status `shouldBe` TaskRunning
+                                retried.attempt `shouldBe` 2
+
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =
     bracket
         (socketPair AF_UNIX Stream defaultProtocol)
         (\(left, right) -> close left >> close right)
+
+blockingRunner
+    :: TQueue TaskId
+    -> Map.Map TaskId (TMVar ())
+    -> TaskRunner
+blockingRunner started gates =
+    TaskRunner
+        { runTask = \task logLine -> do
+            atomically (writeTQueue started task.taskId)
+            logLine "started"
+            case Map.lookup task.taskId gates of
+                Nothing -> pure (Left "missing test gate")
+                Just gate -> atomically (takeTMVar gate) >> pure (Right ())
+        , resolveApproval = \_ _ _ -> pure (Right ())
+        }
+
+handshake :: ServerConfig -> Socket -> Maybe Sequence -> IO ()
+handshake config peer resumeAfter = do
+    sendJSONFrame config.maximumFrameBytes peer $
+        ClientHello
+            Hello
+                { clientId = ClientId "task-adapter-test"
+                , versions = [currentProtocolVersion]
+                , resumeAfter
+                }
+    receiveJSONFrame config.maximumFrameBytes peer >>= \case
+        ServerWelcome _ -> pure ()
+        other -> expectationFailure ("unexpected handshake: " <> show other)
+    case resumeAfter of
+        Nothing ->
+            receiveJSONFrame config.maximumFrameBytes peer >>= \case
+                ServerSnapshotChunk _ _ _ _ -> pure ()
+                other -> expectationFailure ("unexpected snapshot: " <> show other)
+        Just _ -> pure ()
+
+sendTaskCommand
+    :: ServerConfig
+    -> Socket
+    -> Text
+    -> Value
+    -> IO (Either Text Value)
+sendTaskCommand config peer rawId command = do
+    let commandId = CommandId rawId
+    sendJSONFrame config.maximumFrameBytes peer (ClientCommand commandId command)
+    await commandId
+  where
+    await commandId =
+        receiveJSONFrame config.maximumFrameBytes peer >>= \case
+            ServerCommandResult received result
+                | received == commandId -> pure result
+            ServerEvent _ -> await commandId
+            ServerEventChunk _ _ _ _ -> await commandId
+            ServerHeartbeat sequenceNumber -> do
+                sendJSONFrame config.maximumFrameBytes peer (ClientPong sequenceNumber)
+                await commandId
+            other ->
+                expectationFailure ("unexpected command response: " <> show other)
+                    >> pure (Left "unexpected command response")
+
+shouldSucceed :: Either Text Value -> IO ()
+shouldSucceed = \case
+    Right _ -> pure ()
+    Left message -> expectationFailure (Text.unpack message)
+
+submitCommand :: Text -> Text -> Value
+submitCommand taskId sessionId =
+    object
+        [ "version" .= (1 :: Int)
+        , "type" .= ("submit" :: Text)
+        , "task_id" .= taskId
+        , "session_id" .= sessionId
+        , "prompt" .= ("test prompt" :: Text)
+        , "cwd" .= ("/tmp" :: Text)
+        ]
+
+listContains :: TaskId -> TaskStatus -> Value -> Bool
+listContains taskId status = \case
+    Object value ->
+        case KeyMap.lookup "tasks" value of
+            Just tasksValue ->
+                case fromJSON tasksValue of
+                    Success tasks ->
+                        any
+                            (\task -> task.taskId == taskId && task.status == status)
+                            (tasks :: [DurableTask])
+                    Error _ -> False
+            Nothing -> False
+    _ -> False
+
+messageHasStatus :: TaskId -> TaskStatus -> ServerMessage -> Bool
+messageHasStatus taskId status = \case
+    ServerEvent event
+        | event.eventType == "task_changed" ->
+            case (fromJSON event.payload :: Result DurableTask) of
+                Success task -> task.taskId == taskId && task.status == status
+                Error _ -> False
+    _ -> False
+
+waitForStatus :: Journal -> TaskId -> TaskStatus -> IO ()
+waitForStatus journal taskId status =
+    timeout 2_000_000 loop >>= (`shouldBe` Just ())
+  where
+    loop = do
+        saved <- snapshot journal
+        case Map.lookup taskId saved.tasks of
+            Just task | task.status == status -> pure ()
+            _ -> threadDelay 10_000 >> loop

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -208,6 +208,40 @@ main = hspec $ do
                         JournalCorrupt _ _ -> True
                         _ -> False
 
+        it "rejects a stale prefix before an otherwise current snapshot anchor" $
+            withSystemTempDirectory "daemon-stale-prefix" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    stale = EventEnvelope {sequenceNumber = 3, eventType = "test", payload = Null}
+                    anchor = EventEnvelope {sequenceNumber = 4, eventType = "test", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile
+                    (directory </> "events.jsonl")
+                    (LBS.toStrict (encode stale) <> "\n" <> LBS.toStrict (encode anchor) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalCorrupt _ _ -> True
+                        _ -> False
+
+        it "can reopen repeatedly after startup compaction" $
+            withSystemTempDirectory "daemon-reopen-compaction" $ \directory -> do
+                let originalConfig = (defaultJournalConfig directory) {maximumEvents = 10}
+                    compactedConfig = originalConfig {maximumEvents = 2}
+                original <- openJournal originalConfig
+                _ <- appendEvent original "one" Null
+                _ <- appendEvent original "two" Null
+                _ <- appendEvent original "three" Null
+                first <- openJournal compactedConfig
+                firstSnapshot <- snapshot first
+                firstSnapshot.lastSequence `shouldBe` 3
+                second <- openJournal compactedConfig
+                secondSnapshot <- snapshot second
+                secondSnapshot `shouldBe` firstSnapshot
+                fourth <- appendEvent second "four" Null
+                fourth.sequenceNumber `shouldBe` 4
+                third <- openJournal compactedConfig
+                thirdSnapshot <- snapshot third
+                thirdSnapshot.lastSequence `shouldBe` 4
+
         it "enforces contiguous startup retention and rejects an oversized newest event" $
             withSystemTempDirectory "daemon-startup-retention" $ \directory -> do
                 original <- openJournal ((defaultJournalConfig directory) {maximumEvents = 10})

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -208,40 +208,6 @@ main = hspec $ do
                         JournalCorrupt _ _ -> True
                         _ -> False
 
-        it "rejects a stale prefix before an otherwise current snapshot anchor" $
-            withSystemTempDirectory "daemon-stale-prefix" $ \directory -> do
-                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
-                    stale = EventEnvelope {sequenceNumber = 3, eventType = "test", payload = Null}
-                    anchor = EventEnvelope {sequenceNumber = 4, eventType = "test", payload = Null}
-                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
-                BS.writeFile
-                    (directory </> "events.jsonl")
-                    (LBS.toStrict (encode stale) <> "\n" <> LBS.toStrict (encode anchor) <> "\n")
-                openJournal (defaultJournalConfig directory)
-                    `shouldThrow` \case
-                        JournalCorrupt _ _ -> True
-                        _ -> False
-
-        it "can reopen repeatedly after startup compaction" $
-            withSystemTempDirectory "daemon-reopen-compaction" $ \directory -> do
-                let originalConfig = (defaultJournalConfig directory) {maximumEvents = 10}
-                    compactedConfig = originalConfig {maximumEvents = 2}
-                original <- openJournal originalConfig
-                _ <- appendEvent original "one" Null
-                _ <- appendEvent original "two" Null
-                _ <- appendEvent original "three" Null
-                first <- openJournal compactedConfig
-                firstSnapshot <- snapshot first
-                firstSnapshot.lastSequence `shouldBe` 3
-                second <- openJournal compactedConfig
-                secondSnapshot <- snapshot second
-                secondSnapshot `shouldBe` firstSnapshot
-                fourth <- appendEvent second "four" Null
-                fourth.sequenceNumber `shouldBe` 4
-                third <- openJournal compactedConfig
-                thirdSnapshot <- snapshot third
-                thirdSnapshot.lastSequence `shouldBe` 4
-
         it "enforces contiguous startup retention and rejects an oversized newest event" $
             withSystemTempDirectory "daemon-startup-retention" $ \directory -> do
                 original <- openJournal ((defaultJournalConfig directory) {maximumEvents = 10})

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -959,7 +959,7 @@ main = hspec $ do
                 let journalConfig =
                         (defaultJournalConfig directory)
                             { maximumTaskLogLines = 3
-                            , maximumTaskLogCharacters = 10
+                            , maximumTaskLogCharacters = 200
                             }
                     runner =
                         TaskRunner
@@ -977,7 +977,9 @@ main = hspec $ do
                 saved <- snapshot journal
                 let retained = (.logTail) (saved.tasks Map.! TaskId "bounded-log")
                 length retained `shouldSatisfy` (<= 3)
-                sum (map Text.length retained) `shouldSatisfy` (<= 10)
+                sum (map Text.length retained) `shouldSatisfy` (<= 200)
+                retained `shouldSatisfy`
+                    any (Text.isInfixOf "output truncated")
 
         it "rejects full command queues and skips requests cancelled before execution" $
             withSystemTempDirectory "daemon-command-admission" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -810,7 +810,7 @@ main = hspec $ do
                             replayed `shouldSatisfy`
                                 any (messageHasStatus (TaskId "second") TaskCancelled)
 
-        it "interrupts in-flight work on restart and starts it only after explicit retry" $
+        it "interrupts queued and running work and rejects unsafe retry after restart" $
             withSystemTempDirectory "daemon-task-restart" $ \directory -> do
                 let journalConfig = defaultJournalConfig directory
                     serverConfig =
@@ -840,6 +840,16 @@ main = hspec $ do
                                     (submitCommand "restart-task" "restart-session")
                                 timeout 1_000_000 (atomically (readTQueue firstStarted))
                                     `shouldReturn` Just (TaskId "restart-task")
+                                sendTaskCommand serverConfig clientPeer "approval"
+                                    (object
+                                        [ "version" .= (1 :: Int)
+                                        , "type" .= ("approval" :: Text)
+                                        , "task_id" .= ("restart-task" :: Text)
+                                        , "approval_id" .= ("approval-1" :: Text)
+                                        , "decision" .= ("approve" :: Text)
+                                        ])
+                                    `shouldReturn` Left
+                                        "interactive approval resolution is unsupported by the daemon task adapter"
                                 _ <- sendTaskCommand serverConfig clientPeer "submit-queued"
                                     (submitCommand "queued-task" "queued-session")
                                 timeout 100_000 (atomically (readTQueue firstStarted))
@@ -863,29 +873,21 @@ main = hspec $ do
                                 handshake serverConfig clientPeer Nothing
                                 timeout 100_000 (atomically (readTQueue retryStarted))
                                     `shouldReturn` Nothing
-                                _ <- sendTaskCommand serverConfig clientPeer "retry" $
-                                    object
+                                sendTaskCommand serverConfig clientPeer "retry"
+                                    (object
                                         [ "version" .= (1 :: Int)
                                         , "type" .= ("retry" :: Text)
                                         , "task_id" .= ("restart-task" :: Text)
-                                        ]
-                                timeout 1_000_000 (atomically (readTQueue retryStarted))
-                                    `shouldReturn` Just (TaskId "restart-task")
-                                sendTaskCommand serverConfig clientPeer "approval"
-                                    (object
-                                        [ "version" .= (1 :: Int)
-                                        , "type" .= ("approval" :: Text)
-                                        , "task_id" .= ("restart-task" :: Text)
-                                        , "approval_id" .= ("approval-1" :: Text)
-                                        , "decision" .= ("approve" :: Text)
                                         ])
                                     `shouldReturn` Left
-                                        "interactive approval resolution is unsupported by the daemon task adapter"
-                                running <- snapshot restartedJournal
-                                let retried =
-                                        running.tasks Map.! TaskId "restart-task"
-                                retried.status `shouldBe` TaskRunning
-                                retried.attempt `shouldBe` 2
+                                        "task input is unavailable after daemon restart; submit a new task id"
+                                timeout 100_000 (atomically (readTQueue retryStarted))
+                                    `shouldReturn` Nothing
+                                unchanged <- snapshot restartedJournal
+                                let interrupted =
+                                        unchanged.tasks Map.! TaskId "restart-task"
+                                interrupted.status `shouldBe` TaskInterrupted
+                                interrupted.attempt `shouldBe` 1
 
         it "uses the actual agent-cli argv shape and bounds process output chunks" $
             withSystemTempDirectory "daemon-process-runner" $ \directory -> do
@@ -939,6 +941,11 @@ main = hspec $ do
                 captured `shouldSatisfy` (not . null)
                 map Text.length captured `shouldSatisfy` all (<= 4_096)
                 sum (map Text.length captured) `shouldBe` 20_000
+                writeFile executable "#!/bin/sh\nsleep 30\n"
+                timeout
+                    4_000_000
+                    ((processTaskRunnerForWithTimeout 1 executable).runTask task (const (pure ())))
+                    `shouldReturn` Just (Left "agent-cli exceeded its 1 second runtime limit")
 
         it "bounds task-runner output in the durable journal" $
             withSystemTempDirectory "daemon-runner-log-bound" $ \directory -> do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -410,8 +410,15 @@ main = hspec $ do
                 let oldTask taskId =
                         DurableTask
                             { taskId
+                            , sessionId = Nothing
                             , status = TaskCompleted
                             , description = "password=private"
+                            , workingDirectory = "."
+                            , provider = Nothing
+                            , model = Nothing
+                            , effort = Nothing
+                            , worktree = False
+                            , attempt = 1
                             , updatedAt = now
                             , logTail = ["old", "token=private", "new"]
                             }

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -1,9 +1,10 @@
 module Main (main) where
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (cancel, concurrently, waitCatch, withAsync)
 import Control.Concurrent.STM (readTVarIO)
 import Control.Exception.Safe (bracket, isAsyncException)
-import Data.Aeson (Value (..), encode, object, (.=))
+import Data.Aeson (Value (..), encode, object, toJSON, (.=))
 import Data.Bits ((.&.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -168,6 +169,28 @@ main = hspec $ do
                         JournalEventGap 2 3 -> True
                         _ -> False
 
+        it "rejects a retained suffix that starts after a snapshot gap" $
+            withSystemTempDirectory "daemon-snapshot-gap" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    event = EventEnvelope {sequenceNumber = 6, eventType = "test", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile (directory </> "events.jsonl") (LBS.toStrict (encode event) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalEventGap 5 6 -> True
+                        _ -> False
+
+        it "rejects a nonempty retained suffix that ends before its snapshot" $
+            withSystemTempDirectory "daemon-stale-suffix" $ \directory -> do
+                let saved = JournalSnapshot {lastSequence = 4, tasks = Map.empty}
+                    event = EventEnvelope {sequenceNumber = 3, eventType = "test", payload = Null}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode saved))
+                BS.writeFile (directory </> "events.jsonl") (LBS.toStrict (encode event) <> "\n")
+                openJournal (defaultJournalConfig directory)
+                    `shouldThrow` \case
+                        JournalCorrupt _ _ -> True
+                        _ -> False
+
         it "enforces contiguous startup retention and rejects an oversized newest event" $
             withSystemTempDirectory "daemon-startup-retention" $ \directory -> do
                 original <- openJournal ((defaultJournalConfig directory) {maximumEvents = 10})
@@ -238,6 +261,56 @@ main = hspec $ do
                 _ <- appendEvent journal "b" Null
                 readTVarIO overflowed `shouldReturn` True
                 unsubscribe
+
+        it "applies task bounds while recovering task_changed events" $
+            withSystemTempDirectory "daemon-recovered-task-bounds" $ \directory -> do
+                now <- getCurrentTime
+                let task =
+                        DurableTask
+                            { taskId = TaskId "recovered"
+                            , status = TaskCompleted
+                            , description = "password=private"
+                            , updatedAt = now
+                            , logTail = ["token=private"]
+                            }
+                    event =
+                        EventEnvelope
+                            { sequenceNumber = 1
+                            , eventType = "task_changed"
+                            , payload = toJSON task
+                            }
+                    config =
+                        (defaultJournalConfig directory)
+                            { maximumTaskDescriptionCharacters = 64
+                            , maximumTaskLogLines = 0
+                            }
+                BS.writeFile (directory </> "events.jsonl") (LBS.toStrict (encode event) <> "\n")
+                recovered <- openJournal config >>= snapshot
+                let bounded = recovered.tasks Map.! TaskId "recovered"
+                bounded.description `shouldBe` "[REDACTED]"
+                bounded.logTail `shouldBe` []
+
+        it "retains no events when maximumEvents is zero and preserves the sequence" $
+            withSystemTempDirectory "daemon-zero-retention" $ \directory -> do
+                let config = (defaultJournalConfig directory) {maximumEvents = 0}
+                journal <- openJournal config
+                _ <- appendEvent journal "discarded" Null
+                BS.readFile (directory </> "events.jsonl") `shouldReturn` BS.empty
+                reopened <- openJournal config
+                recovered <- snapshot reopened
+                recovered.lastSequence `shouldBe` 1
+                replayAfter reopened 0 `shouldReturn` ReplaySnapshot recovered
+
+        it "refuses to wrap an exhausted sequence number" $
+            withSystemTempDirectory "daemon-sequence-overflow" $ \directory -> do
+                let exhausted = JournalSnapshot {lastSequence = Sequence maxBound, tasks = Map.empty}
+                BS.writeFile (directory </> "snapshot.json") (LBS.toStrict (encode exhausted))
+                journal <- openJournal (defaultJournalConfig directory)
+                appendEvent journal "wrapped" Null
+                    `shouldThrow` \case
+                        JournalSequenceExhausted sequenceNumber ->
+                            sequenceNumber == Sequence maxBound
+                        _ -> False
 
         it "rejects symlinked journal directories and files" $
             withSystemTempDirectory "daemon-symlink" $ \directory -> do
@@ -362,6 +435,36 @@ main = hspec $ do
                                     Just (Left exception) -> isAsyncException exception
                                     _ -> False
 
+        it "closes an accepted peer when cancellation interrupts full-queue admission" $
+            withSystemTempDirectory "daemon-admission-cancel" $ \directory ->
+                withTempDirectory "/tmp" "daemon-admission" $ \socketDirectory -> do
+                    journal <- openJournal (defaultJournalConfig directory)
+                    let socketConfig =
+                            SocketConfig
+                                { path = socketDirectory </> "daemon.sock"
+                                , backlog = 8
+                                }
+                        config =
+                            defaultServerConfig
+                                { workerCount = 1
+                                , ioTimeoutSeconds = 30
+                                }
+                    withUnixListener socketConfig $ \listener ->
+                        withAsync (runServerOnListener listener config journal unavailableSupervisor) $ \server ->
+                            bracket
+                                (traverse (const (socket AF_UNIX Stream defaultProtocol)) [1 :: Int .. 3])
+                                (mapM_ close)
+                                $ \clients -> do
+                                    mapM_ (`connect` SockAddrUnix socketConfig.path) clients
+                                    threadDelay 200_000
+                                    cancel server
+                                    _ <- waitCatch server
+                                    results <-
+                                        traverse
+                                            (\client -> timeout 1_000_000 (Socket.recv client 1))
+                                            clients
+                                    results `shouldBe` replicate 3 (Just BS.empty)
+
         it "chunks large snapshots below the configured frame bound" $
             withSystemTempDirectory "daemon-snapshot-chunks" $ \directory -> do
                 journal <- openJournal (defaultJournalConfig directory)
@@ -406,6 +509,46 @@ main = hspec $ do
                                 )
                                 [1 .. chunkCount - 1]
                         sequenceNumbers `shouldBe` [1 .. chunkCount - 1]
+
+        it "chunks events that exceed the transport frame bound" $
+            withSystemTempDirectory "daemon-event-chunks" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                event <- appendEvent journal "large" (String (Text.replicate 2_000 "x"))
+                let config =
+                        defaultServerConfig
+                            { maximumFrameBytes = 512
+                            , heartbeatSeconds = 60
+                            }
+                withSocketPair $ \(serverPeer, clientPeer) ->
+                    withAsync (serveConnection config journal unavailableSupervisor serverPeer) $ \_ -> do
+                        sendJSONFrame config.maximumFrameBytes clientPeer $
+                            ClientHello
+                                Hello
+                                    { clientId = ClientId "event-client"
+                                    , versions = [currentProtocolVersion]
+                                    , resumeAfter = Just 0
+                                    }
+                        _ <- receiveJSONFrame config.maximumFrameBytes clientPeer :: IO ServerMessage
+                        first <- receiveJSONFrame config.maximumFrameBytes clientPeer
+                        chunkCount <- case first of
+                            ServerEventChunk sequenceNumber 0 count _ ->
+                                if sequenceNumber == event.sequenceNumber && count > 1
+                                    then pure count
+                                    else expectationFailure ("unexpected event chunk: " <> show first) >> pure 0
+                            _ -> expectationFailure ("unexpected event message: " <> show first) >> pure 0
+                        indices <-
+                            traverse
+                                ( \_ ->
+                                    receiveJSONFrame config.maximumFrameBytes clientPeer >>= \case
+                                        ServerEventChunk sequenceNumber index count _
+                                            | sequenceNumber == event.sequenceNumber
+                                            , count == chunkCount ->
+                                                pure index
+                                        other ->
+                                            expectationFailure ("unexpected event chunk: " <> show other) >> pure (-1)
+                                )
+                                [1 .. chunkCount - 1]
+                        indices `shouldBe` [1 .. chunkCount - 1]
 
 withSocketPair :: ((Socket, Socket) -> IO value) -> IO value
 withSocketPair =

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -33,12 +33,16 @@ module Agent.Store.Postgres.Session
     , loadSessionMetadata
     , loadActiveSession
     , SessionTurnPage(..)
+    , SessionHistorySnapshot(..)
     , SessionResumeStats(..)
     , loadRecentSessionTurns
     , loadRecentSessionHistoryTurns
     , loadSessionTurnsBefore
     , loadSessionHistoryTurnsBefore
     , loadSessionTurnsAfter
+    , loadSessionHistoryTurnsRange
+    , loadSessionHistoryTurnsRangeBounded
+    , loadSessionHistorySnapshot
     , loadSessionResumeStats
     , loadSessionEvents
     , listSessionMetadata
@@ -83,6 +87,15 @@ data SessionLegacyTarget = SessionLegacyTarget
     , sessionLegacyConnection :: !Text
     , sessionLegacyEffectiveModel :: !Text
     , sessionLegacyDialect :: !Text
+    }
+    deriving (Eq, Show)
+
+-- | Metadata and immutable raw-history bounds observed in one repeatable-read
+-- transaction. Later appends have indexes at or above start + total.
+data SessionHistorySnapshot = SessionHistorySnapshot
+    { sessionSnapshotMetadata :: !SessionMetadata
+    , sessionSnapshotStart :: !Int64
+    , sessionSnapshotTotal :: !Int64
     }
     deriving (Eq, Show)
 
@@ -685,6 +698,64 @@ loadSessionTurnsAfter pool sessionKey cursor limit =
             (sessionKey, cursor, fromIntegral (max 1 limit + 1))
             loadTurnsAfterStatement)
         (Transaction.statement sessionKey currentGenerationStatement)
+        (max 1 limit)
+        PageAfter
+
+loadSessionHistoryTurnsRangeBounded
+    :: StorePool
+    -> Text
+    -> Int64
+    -> Int64
+    -> Int
+    -> IO (Either StoreError (Maybe SessionTurnPage))
+loadSessionHistoryTurnsRangeBounded pool sessionKey start endExclusive limit =
+    loadTurnPage pool sessionKey
+        (Transaction.statement
+            ( sessionKey
+            , max 0 start
+            , max 0 endExclusive
+            , fromIntegral (max 1 limit + 1)
+            )
+            loadHistoryTurnsRangeBoundedStatement)
+        (Transaction.statement sessionKey fullHistoryStatement)
+        (max 1 limit)
+        PageAfter
+
+loadSessionHistorySnapshot
+    :: StorePool
+    -> Text
+    -> IO (Either StoreError (Maybe SessionHistorySnapshot))
+loadSessionHistorySnapshot pool sessionKey =
+    withSession pool
+        (Transactions.transaction Transactions.RepeatableRead Transactions.Read do
+            metadata <- Transaction.statement sessionKey loadMetadataStatement
+            case metadata of
+                Nothing -> pure (Right Nothing)
+                Just value -> do
+                    (start, total) <-
+                        Transaction.statement sessionKey fullHistoryStatement
+                    pure (Right (Just SessionHistorySnapshot
+                        { sessionSnapshotMetadata = value
+                        , sessionSnapshotStart = start
+                        , sessionSnapshotTotal = total
+                        })))
+        >>= flattenDataResult
+
+-- | Load a forward page from an absolute durable turn index. Unlike the
+-- active-generation readers, this intentionally includes pre-compaction
+-- history for transcript navigation and transfer export.
+loadSessionHistoryTurnsRange
+    :: StorePool
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either StoreError (Maybe SessionTurnPage))
+loadSessionHistoryTurnsRange pool sessionKey start limit =
+    loadTurnPage pool sessionKey
+        (Transaction.statement
+            (sessionKey, max 0 start, fromIntegral (max 1 limit + 1))
+            loadHistoryTurnsRangeStatement)
+        (Transaction.statement sessionKey fullHistoryStatement)
         (max 1 limit)
         PageAfter
 
@@ -1296,6 +1367,46 @@ loadActiveTurnsStatement = mkStatement
            \ ), 0)\
            \ ORDER BY t.turn_index ASC")
     (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList turnRowDecoder)
+    True
+
+loadHistoryTurnsRangeBoundedStatement
+    :: Statement (Text, Int64, Int64, Int64) [TurnRow]
+loadHistoryTurnsRangeBoundedStatement = mkStatement
+    ( turnSelectSql
+        <> " WHERE s.session_key = $1"
+        <> " AND t.turn_index >= $2"
+        <> " AND t.turn_index < $3"
+        <> " ORDER BY t.turn_index ASC"
+        <> " LIMIT $4"
+    )
+    ( ((\(value, _, _, _) -> value)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((\(_, value, _, _) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+        <> ((\(_, _, value, _) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+        <> ((\(_, _, _, value) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
+    (Decoders.rowList turnRowDecoder)
+    True
+
+loadHistoryTurnsRangeStatement :: Statement (Text, Int64, Int64) [TurnRow]
+loadHistoryTurnsRangeStatement = mkStatement
+    ( turnSelectSql
+        <> " WHERE s.session_key = $1"
+        <> " AND t.turn_index >= $2"
+        <> " ORDER BY t.turn_index ASC"
+        <> " LIMIT $3"
+    )
+    ( ((\(value, _, _) -> value)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((\(_, value, _) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+        <> ((\(_, _, value) -> value)
+            >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+    )
     (Decoders.rowList turnRowDecoder)
     True
 


### PR DESCRIPTION
Stacks the current supervised native task/runtime-daemon chain and native session continuity onto the repository review/delivery bridge from #830. This gives the macOS app one coherent bridge SHA with the task, session, browser, gateway, and repository ABIs.

Includes the exact heads of #784 and #760 with additive conflict resolution in the bridge implementation, public header, and native smoke consumers.

Verification:
- bridge and agent test targets build
- native-focused tests: 49 examples, 0 failures
- repository-focused tests: 56 examples, 0 failures
- runtime daemon/adapter tests: 40 examples, 0 failures
- strict C compilation for runtime, browser, image/session/repository, and task consumers
- `nix build --fallback path:.#agent-native-bridge`
- installed `HaskellAgentBridge.h` byte-identical to source