### PR TITLE
Recover lost OpenAI tool continuation state

### DIFF
--- a/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
@@ -65,6 +65,14 @@ spec = do
                     Nothing)
                 `shouldBe` True
 
+        it "detects lost pending function-call state" do
+            isResponseChainCompatibilityError
+                (ProviderError
+                    InvalidRequestError
+                    "No tool output found for function call call_123."
+                    Nothing)
+                `shouldBe` True
+
         it "does not classify unrelated invalid parameters as chain errors" do
             isResponseChainCompatibilityError
                 (ProviderError

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -736,6 +736,41 @@ spec = do
                     [CompletedTool (functionResult "c1" "tool output")]
                 ]
 
+        it "replays a call and output when continuation tool state is lost" do
+            seen <- newIORef []
+            let callId = "call_lost"
+                seed =
+                    turnInputsToItems [UserMessage "old"]
+                        <> [functionCallItem callId "read_file" "{}"]
+                chainError = ProviderError
+                    InvalidRequestError
+                    "No tool output found for function call call_lost."
+                    Nothing
+                resultInput =
+                    [CompletedTool (functionResult callId "file contents")]
+            transcript <- newIORef seed
+            let send request previous onEvent = do
+                    modifyIORef' seen (++ [(request, previous)])
+                    case previous of
+                        Just _ -> pure (Left chainError)
+                        Nothing -> do
+                            onEvent (deltaEvent EventOutputTextDelta "ok")
+                            pure $ Right
+                                (testResponse "resp-fresh" [assistantItem "ok"])
+                backend = openAiBackendWith send (pure baseParams)
+            result <- submitWithState transcript backend (Just "resp-call")
+                resultInput
+                (const (pure ()))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
+            requests <- readIORef seen
+            map snd requests `shouldBe` [Just "resp-call", Nothing]
+            map (inputItems . fst) requests `shouldBe`
+                [ turnInputsToItems resultInput
+                , map stripReplayedItemStatus
+                    (seed <> turnInputsToItems resultInput)
+                ]
+
         it "strips explicitly requested cache retention and starts a fresh chain" do
             seen <- newIORef []
             let seed = turnInputsToItems [UserMessage "old"]

--- a/packages/agent-responses/src/Agent/Responses/Error.hs
+++ b/packages/agent-responses/src/Agent/Responses/Error.hs
@@ -241,12 +241,15 @@ isPreviousResponseIdError = \case
 --
 -- The Codex backend can return stored chains carrying
 -- @prompt_cache_retention@ parameter after routing a follow-up to a model that
--- no longer accepts it. Replaying the local transcript without the continuation
--- id creates a fresh chain and is safe before any model output is observed.
+-- no longer accepts it. Provider-managed continuation state can also lose a
+-- pending function call and reject its otherwise valid output. Replaying the
+-- local transcript without the continuation id creates a fresh chain and is
+-- safe before any model output is observed.
 isResponseChainCompatibilityError :: ApiError -> Bool
 isResponseChainCompatibilityError error =
     isPreviousResponseIdError error
         || apiErrorTextMatches mentionsUnsupportedPromptCacheRetention error
+        || apiErrorTextMatches mentionsMissingFunctionCallOutput error
 
 apiErrorTextMatches :: (Text -> Bool) -> ApiError -> Bool
 apiErrorTextMatches predicate = \case
@@ -273,6 +276,11 @@ mentionsUnsupportedPromptCacheRetention value =
     in "prompt_cache_retention" `Text.isInfixOf` lowered
         && ("not supported" `Text.isInfixOf` lowered
             || "unsupported" `Text.isInfixOf` lowered)
+
+mentionsMissingFunctionCallOutput :: Text -> Bool
+mentionsMissingFunctionCallOutput =
+    Text.isInfixOf "no tool output found for function call"
+        . Text.toLower
 
 orElse :: Maybe a -> Maybe a -> Maybe a
 orElse (Just value) _ = Just value


### PR DESCRIPTION
## Summary
- classify the exact missing function-call output rejection as a response-chain compatibility error
- replay the complete local call/output transcript on a fresh chain instead of terminating the session
- cover both error classification and backend recovery with regression tests

## Validation
- `nix develop -c cabal test agent-openai:agent-openai-test` (336 examples, 0 failures, 1 pending)