### PR TITLE
Integrate interactive controls with the unified macOS bridge

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1168,8 +1168,7 @@ ha_engine_stage_turn_images
     :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize -> IO CInt
 ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
     | pointer == nullPtr = pure 1
-    | turnID == nullPtr || turnIDLength == 0 = pure 2
-    | toInteger turnIDLength > maxNativeTurnIDBytes = pure 2
+    | turnID == nullPtr || not (validNativeTurnIDLength turnIDLength) = pure 2
     | imagePointer == nullPtr && imageCount > 0 = pure 4
     | toInteger imageCount > toInteger (maxBound :: Int) = pure 4
     | otherwise = do
@@ -1280,10 +1279,9 @@ enqueueSessionMutation pointer mutation callback context
 
 ha_engine_stage_turn_options
     :: Ptr () -> Ptr Word8 -> CSize -> CInt -> CInt -> IO CInt
-ha_engine_stage_turn_options pointer turnID (CSize turnIDLength) rawMode rawShell
+ha_engine_stage_turn_options pointer turnID turnIDLength rawMode rawShell
     | pointer == nullPtr = pure 1
-    | turnID == nullPtr || turnIDLength == 0 = pure 2
-    | toInteger turnIDLength > maxNativeTurnIDBytes = pure 2
+    | turnID == nullPtr || not (validNativeTurnIDLength turnIDLength) = pure 2
     | otherwise =
         case (interactionModeFromCode rawMode, shellModeFromCode rawShell) of
             (Just interactionMode, Just shellMode) -> do
@@ -1316,10 +1314,9 @@ ha_engine_stage_turn_options pointer turnID (CSize turnIDLength) rawMode rawShel
 
 ha_engine_discard_turn_staging
     :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
-ha_engine_discard_turn_staging pointer turnID (CSize turnIDLength)
+ha_engine_discard_turn_staging pointer turnID turnIDLength
     | pointer == nullPtr = pure 1
-    | turnID == nullPtr || turnIDLength == 0 = pure 2
-    | toInteger turnIDLength > maxNativeTurnIDBytes = pure 2
+    | turnID == nullPtr || not (validNativeTurnIDLength turnIDLength) = pure 2
     | otherwise = do
         result <- tryAny do
             let stable = castPtrToStablePtr pointer :: StablePtr Engine
@@ -1343,6 +1340,13 @@ ha_engine_discard_turn_staging pointer turnID (CSize turnIDLength)
 
 maxNativeTurnIDBytes :: Integer
 maxNativeTurnIDBytes = 1_024
+
+validNativeTurnIDLength :: CSize -> Bool
+validNativeTurnIDLength length =
+    let integerLength = toInteger length
+    in integerLength > 0
+        && integerLength <= toInteger (maxBound :: Int)
+        && integerLength <= maxNativeTurnIDBytes
 
 ha_engine_set_interaction_callback
     :: Ptr () -> FunPtr InteractionCallback -> Ptr () -> IO CInt

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -1,6 +1,13 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
-module Agent.CLI.MacOS.Bridge () where
+module Agent.CLI.MacOS.Bridge
+    ( NativeInteractionResolution(..)
+    , PendingInteraction(..)
+    , cancelPendingInteractions
+    , discardStagedTurn
+    , resolvePendingInteraction
+    , turnStartCleanupId
+    ) where
 
 import qualified Agent.CLI.AgentViewport as Viewport
 import Agent.CLI.NativeRuntime
@@ -146,9 +153,11 @@ import Control.Concurrent.MVar
     , newMVar
     , putMVar
     , readMVar
+    , withMVar
     )
 import Control.Concurrent.STM
-    ( TMVar
+    ( STM
+    , TMVar
     , TQueue
     , TVar
     , atomically
@@ -170,6 +179,7 @@ import Control.Exception.Safe
     ( SomeException
     , bracket
     , finally
+    , onException
     , tryAny
     )
 import Control.Monad
@@ -432,6 +442,30 @@ instance Aeson.FromJSON TurnStart where
             (_, _, Just _, Just _) -> pure start
             _ -> fail "provider and model must be supplied together"
 
+turnStartCleanupId :: Text -> Aeson.Value -> Text
+turnStartCleanupId requestId params =
+    fromMaybe requestId $
+        Aeson.parseMaybe
+            (Aeson.withObject "TurnStartCleanup" (.:? "turnId"))
+            params
+            >>= id
+            >>= nonBlank
+  where
+    nonBlank value
+        | Text.null (Text.strip value) = Nothing
+        | otherwise = Just value
+
+discardStagedTurn
+    :: Text
+    -> Aeson.Value
+    -> TVar (Map Text a)
+    -> TVar (Map Text b)
+    -> STM ()
+discardStagedTurn requestId params stagedImages stagedOptions = do
+    let cleanupId = turnStartCleanupId requestId params
+    modifyTVar' stagedImages (Map.delete cleanupId)
+    modifyTVar' stagedOptions (Map.delete cleanupId)
+
 data TurnReference = TurnReference
     { turnReferenceId :: !Text
     }
@@ -523,6 +557,46 @@ data PendingInteraction = PendingInteraction
     , pendingInteractionWaiter :: !(TMVar NativeInteractionResolution)
     }
 
+resolvePendingInteraction
+    :: TVar (Map (Text, Text) PendingInteraction)
+    -> (Text, Text)
+    -> NativeInteractionResolution
+    -> STM Bool
+resolvePendingInteraction pendingRef key resolution = do
+    pending <- readTVar pendingRef
+    case Map.lookup key pending of
+        Nothing -> pure False
+        Just interaction@PendingInteraction
+            { pendingInteractionOptionCount = optionCount
+            }
+            | resolution.interactionSelectedIndex < (-1)
+                || resolution.interactionSelectedIndex >= optionCount ->
+                pure False
+            | otherwise -> do
+                published <- tryPutTMVar
+                    interaction.pendingInteractionWaiter
+                    resolution
+                when published $
+                    writeTVar pendingRef (Map.delete key pending)
+                pure published
+
+cancelPendingInteractions
+    :: TVar (Map (Text, Text) PendingInteraction)
+    -> STM ()
+cancelPendingInteractions pendingRef = do
+    pending <- readTVar pendingRef
+    writeTVar pendingRef Map.empty
+    forM_ (Map.elems pending) \interaction ->
+        void $ tryPutTMVar
+            interaction.pendingInteractionWaiter
+            cancelledInteractionResolution
+
+cancelledInteractionResolution :: NativeInteractionResolution
+cancelledInteractionResolution = NativeInteractionResolution
+    { interactionSelectedIndex = -1
+    , interactionCustomText = Nothing
+    }
+
 data InteractionCallbackTarget = InteractionCallbackTarget
     { interactionTargetCallback :: !(FunPtr InteractionCallback)
     , interactionTargetContext :: !(Ptr ())
@@ -530,6 +604,7 @@ data InteractionCallbackTarget = InteractionCallbackTarget
 
 data InteractionRuntime = InteractionRuntime
     { interactionCallbackTarget :: !(TVar (Maybe InteractionCallbackTarget))
+    , interactionCallbackLock :: !(MVar ())
     , interactionPending
         :: !(TVar (Map (Text, Text) PendingInteraction))
     }
@@ -987,9 +1062,11 @@ ha_engine_create callback context
             stagedImages <- newTVarIO Map.empty
             stagedTurnOptions <- newTVarIO Map.empty
             interactionTarget <- newTVarIO Nothing
+            interactionLock <- newMVar ()
             pendingInteractions <- newTVarIO Map.empty
             let interactions = InteractionRuntime
                     { interactionCallbackTarget = interactionTarget
+                    , interactionCallbackLock = interactionLock
                     , interactionPending = pendingInteractions
                     }
             _ <- forkFinally
@@ -1229,14 +1306,19 @@ ha_engine_set_interaction_callback pointer callback callbackContext
         result <- tryAny do
             let stable = castPtrToStablePtr pointer :: StablePtr Engine
             engine <- deRefStablePtr stable
-            atomically $ writeTVar
-                engine.engineInteractions.interactionCallbackTarget
-                (if callback == nullFunPtr
-                    then Nothing
-                    else Just InteractionCallbackTarget
-                        { interactionTargetCallback = callback
-                        , interactionTargetContext = callbackContext
-                        })
+            withMVar
+                engine.engineInteractions.interactionCallbackLock
+                \_ -> atomically do
+                    writeTVar
+                        engine.engineInteractions.interactionCallbackTarget
+                        (if callback == nullFunPtr
+                            then Nothing
+                            else Just InteractionCallbackTarget
+                                { interactionTargetCallback = callback
+                                , interactionTargetContext = callbackContext
+                                })
+                    cancelPendingInteractions
+                        engine.engineInteractions.interactionPending
         pure $ either (const 3) (const 0) result
 
 ha_engine_resolve_interaction
@@ -1280,37 +1362,15 @@ ha_engine_resolve_interaction
               of
                 (Right turnIDText, Right interactionIDText, Right custom) ->
                     fmap (\published -> if published then 0 else 4) $
-                    atomically do
-                        pending <- readTVar pendingRef
-                        case Map.lookup
-                            (turnIDText, interactionIDText)
-                            pending of
-                                Nothing -> pure False
-                                Just interaction@PendingInteraction
-                                    { pendingInteractionOptionCount =
-                                        optionCount
+                        atomically $
+                            resolvePendingInteraction
+                                pendingRef
+                                (turnIDText, interactionIDText)
+                                NativeInteractionResolution
+                                    { interactionSelectedIndex =
+                                        selectedIndexValue
+                                    , interactionCustomText = custom
                                     }
-                                    | selectedIndexValue < (-1)
-                                        || selectedIndexValue >= optionCount ->
-                                        pure False
-                                    | otherwise -> do
-                                        published <- tryPutTMVar
-                                            interaction.pendingInteractionWaiter
-                                            NativeInteractionResolution
-                                                { interactionSelectedIndex =
-                                                    selectedIndexValue
-                                                , interactionCustomText =
-                                                    custom
-                                                }
-                                        when published $
-                                            writeTVar
-                                                pendingRef
-                                                (Map.delete
-                                                    ( turnIDText
-                                                    , interactionIDText
-                                                    )
-                                                    pending)
-                                        pure published
                 _ -> pure 2
         pure $ case result of
             Left _ -> 3
@@ -1402,10 +1462,11 @@ idleLoop
                 case (parseParams request
                     :: Either Text TurnStart) of
                     Left err -> do
-                        atomically $ modifyTVar' stagedImages
-                            (Map.delete request.requestId)
-                        atomically $ modifyTVar' stagedTurnOptions
-                            (Map.delete request.requestId)
+                        atomically $ discardStagedTurn
+                            request.requestId
+                            request.requestParams
+                            stagedImages
+                            stagedTurnOptions
                         sendEvent callback context
                             (failureEvent request.requestId err)
                         continue
@@ -1893,43 +1954,59 @@ requestNativeInteraction
     -> [Text]
     -> IO (Maybe NativeInteractionResolution)
 requestNativeInteraction control interactions kind prompt options = do
-    target <- readTVarIO interactions.interactionCallbackTarget
-    case target of
+    waiter <- newEmptyTMVarIO
+    registration <-
+        withMVar interactions.interactionCallbackLock \_ -> do
+            registered <- atomically do
+                target <- readTVar interactions.interactionCallbackTarget
+                case target of
+                    Nothing -> pure Nothing
+                    Just callbackTarget -> do
+                        interactionID <- register waiter
+                        pure (Just (callbackTarget, interactionID))
+            forM_ registered \(callbackTarget, interactionID) ->
+                sendNativeInteraction
+                    callbackTarget
+                    control.turnControlId
+                    interactionID
+                    kind
+                    prompt
+                    options
+                    `onException`
+                        atomically
+                            (modifyTVar'
+                                interactions.interactionPending
+                                (Map.delete
+                                    (control.turnControlId, interactionID)))
+            pure registered
+    case registration of
         Nothing -> pure Nothing
-        Just callbackTarget -> do
-            waiter <- newEmptyTMVarIO
-            interactionID <- atomically do
-                current <- readTVar control.turnControlInteractionCounter
-                let next = current + 1
-                    interactionID =
-                        control.turnControlId
-                            <> "-interaction-"
-                            <> Text.pack (show next)
-                writeTVar control.turnControlInteractionCounter next
-                modifyTVar'
-                    interactions.interactionPending
-                    (Map.insert
-                        (control.turnControlId, interactionID)
-                        PendingInteraction
-                            { pendingInteractionOptionCount =
-                                length options
-                            , pendingInteractionWaiter = waiter
-                            })
-                pure interactionID
+        Just (_, interactionID) -> do
             let cleanup =
                     atomically $ modifyTVar'
                         interactions.interactionPending
                         (Map.delete
                             (control.turnControlId, interactionID))
-            (sendNativeInteraction
-                callbackTarget
-                control.turnControlId
-                interactionID
-                kind
-                prompt
-                options
-                >> Just <$> atomically (takeTMVar waiter))
+            (Just <$> atomically (takeTMVar waiter))
                 `finally` cleanup
+  where
+    register waiter = do
+        current <- readTVar control.turnControlInteractionCounter
+        let next = current + 1
+            interactionID =
+                control.turnControlId
+                    <> "-interaction-"
+                    <> Text.pack (show next)
+        writeTVar control.turnControlInteractionCounter next
+        modifyTVar'
+            interactions.interactionPending
+            (Map.insert
+                (control.turnControlId, interactionID)
+                PendingInteraction
+                    { pendingInteractionOptionCount = length options
+                    , pendingInteractionWaiter = waiter
+                    })
+        pure interactionID
 
 sendNativeInteraction
     :: InteractionCallbackTarget
@@ -2048,10 +2125,7 @@ cancelTurn control = do
         pure (map (.pendingInteractionWaiter) (Map.elems owned))
     atomically $
         forM_ interactionWaiters \waiter ->
-            void $ tryPutTMVar waiter NativeInteractionResolution
-                { interactionSelectedIndex = -1
-                , interactionCustomText = Nothing
-                }
+            void $ tryPutTMVar waiter cancelledInteractionResolution
 
 requestApproval
     :: FunPtr EventCallback

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -5,6 +5,7 @@ module Agent.CLI.MacOS.Bridge
     , PendingInteraction(..)
     , cancelPendingInteractions
     , discardStagedTurn
+    , discardStagedTurnById
     , resolvePendingInteraction
     , turnStartCleanupId
     ) where
@@ -462,9 +463,19 @@ discardStagedTurn
     -> TVar (Map Text b)
     -> STM ()
 discardStagedTurn requestId params stagedImages stagedOptions = do
-    let cleanupId = turnStartCleanupId requestId params
-    modifyTVar' stagedImages (Map.delete cleanupId)
-    modifyTVar' stagedOptions (Map.delete cleanupId)
+    discardStagedTurnById
+        (turnStartCleanupId requestId params)
+        stagedImages
+        stagedOptions
+
+discardStagedTurnById
+    :: Text
+    -> TVar (Map Text a)
+    -> TVar (Map Text b)
+    -> STM ()
+discardStagedTurnById turnId stagedImages stagedOptions = do
+    modifyTVar' stagedImages (Map.delete turnId)
+    modifyTVar' stagedOptions (Map.delete turnId)
 
 data TurnReference = TurnReference
     { turnReferenceId :: !Text
@@ -663,6 +674,9 @@ foreign export ccall ha_engine_stage_turn_images
 
 foreign export ccall ha_engine_stage_turn_options
     :: Ptr () -> Ptr Word8 -> CSize -> CInt -> CInt -> IO CInt
+
+foreign export ccall ha_engine_discard_turn_staging
+    :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
 
 foreign export ccall ha_engine_set_interaction_callback
     :: Ptr () -> FunPtr InteractionCallback -> Ptr () -> IO CInt
@@ -1155,6 +1169,7 @@ ha_engine_stage_turn_images
 ha_engine_stage_turn_images pointer turnID turnIDLength imagePointer imageCount
     | pointer == nullPtr = pure 1
     | turnID == nullPtr || turnIDLength == 0 = pure 2
+    | toInteger turnIDLength > maxNativeTurnIDBytes = pure 2
     | imagePointer == nullPtr && imageCount > 0 = pure 4
     | toInteger imageCount > toInteger (maxBound :: Int) = pure 4
     | otherwise = do
@@ -1268,6 +1283,7 @@ ha_engine_stage_turn_options
 ha_engine_stage_turn_options pointer turnID (CSize turnIDLength) rawMode rawShell
     | pointer == nullPtr = pure 1
     | turnID == nullPtr || turnIDLength == 0 = pure 2
+    | toInteger turnIDLength > maxNativeTurnIDBytes = pure 2
     | otherwise =
         case (interactionModeFromCode rawMode, shellModeFromCode rawShell) of
             (Just interactionMode, Just shellMode) -> do
@@ -1297,6 +1313,36 @@ ha_engine_stage_turn_options pointer turnID (CSize turnIDLength) rawMode rawShel
                     Right False -> 2
                     Right True -> 0
             _ -> pure 4
+
+ha_engine_discard_turn_staging
+    :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
+ha_engine_discard_turn_staging pointer turnID (CSize turnIDLength)
+    | pointer == nullPtr = pure 1
+    | turnID == nullPtr || turnIDLength == 0 = pure 2
+    | toInteger turnIDLength > maxNativeTurnIDBytes = pure 2
+    | otherwise = do
+        result <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            bytes <- BS.packCStringLen
+                (castPtr turnID, fromIntegral turnIDLength)
+            case TextEncoding.decodeUtf8' bytes of
+                Left _ -> pure False
+                Right turnIDText
+                    | Text.null turnIDText -> pure False
+                    | otherwise -> do
+                        atomically $ discardStagedTurnById
+                            turnIDText
+                            engine.engineStagedImages
+                            engine.engineStagedTurnOptions
+                        pure True
+        pure $ case result of
+            Left _ -> 3
+            Right False -> 2
+            Right True -> 0
+
+maxNativeTurnIDBytes :: Integer
+maxNativeTurnIDBytes = 1_024
 
 ha_engine_set_interaction_callback
     :: Ptr () -> FunPtr InteractionCallback -> Ptr () -> IO CInt
@@ -1520,6 +1566,8 @@ idleLoop
                                     store
                                     root
                                     commands
+                                    stagedImages
+                                    stagedTurnOptions
                                     control
                                     running >>= \case
                                         ActiveContinue -> continue
@@ -1556,10 +1604,14 @@ activeLoop
     -> MVar (Maybe Store)
     -> OsPath
     -> TQueue EngineCommand
+    -> TVar (Map Text [ImageAttachment])
+    -> TVar (Map Text NativeTurnOptions)
     -> TurnControl
     -> Async TurnOutcome
     -> IO ActiveExit
-activeLoop callback context config store root commands control running =
+activeLoop
+        callback context config store root commands stagedImages
+        stagedTurnOptions control running =
     atomically
         ((Left <$> readTQueue commands)
             `orElse` (Right <$> waitCatchSTM running)) >>= \case
@@ -1574,12 +1626,14 @@ activeLoop callback context config store root commands control running =
             runConversationSearch
                 config store query limit searchCallback searchContext
             activeLoop
-                callback context config store root commands control running
+                callback context config store root commands stagedImages
+                stagedTurnOptions control running
         Left (EngineSessionMutation mutation resultCallback resultContext) -> do
             runSessionMutation
                 config store root mutation resultCallback resultContext
             activeLoop
-                callback context config store root commands control running
+                callback context config store root commands stagedImages
+                stagedTurnOptions control running
         Left (EngineRequest request) -> do
             if request.requestMethod == "turn.cancel"
               then
@@ -1602,7 +1656,12 @@ activeLoop callback context config store root commands control running =
                 activeAgentSnapshot control request
                     >>= sendEvent callback context
               else if request.requestMethod == "turn.start"
-              then
+              then do
+                atomically $ discardStagedTurn
+                    request.requestId
+                    request.requestParams
+                    stagedImages
+                    stagedTurnOptions
                 sendEvent callback context $
                     failureEvent request.requestId "a turn is already running"
               else
@@ -1615,6 +1674,8 @@ activeLoop callback context config store root commands control running =
                 store
                 root
                 commands
+                stagedImages
+                stagedTurnOptions
                 control
                 running
 

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -4,8 +4,10 @@ module Agent.CLI.MacOS.Bridge () where
 
 import qualified Agent.CLI.AgentViewport as Viewport
 import Agent.CLI.NativeRuntime
-    ( NativeProcessRuntime
+    ( NativeInteractionMode(..)
+    , NativeProcessRuntime
     , NativeRunHooks(..)
+    , NativeShellMode(..)
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
     , runNativeAgent
@@ -29,6 +31,7 @@ import Agent.Store.Postgres.Skill
     )
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
+    , encodeNativeUsageEvent
     )
 import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.Login
@@ -104,7 +107,13 @@ import Agent.CLI.SessionAdmin
     , managedPostgresConfigForHome
     , sessionSummaryWithStatusJSON
     )
-import Agent.Loop (ImageAttachment(..), LoopEvent(..))
+import Agent.Loop
+    ( ImageAttachment(..)
+    , LoopEvent(..)
+    , TokenUsage
+    , TurnOutput(..)
+    , emptyTokenUsage
+    )
 import Agent.Dialect (dialectSlug)
 import Agent.Provider (Provider(..), providerSlug, parseProvider, BillingMode(..))
 import Agent.Store.Postgres
@@ -117,6 +126,10 @@ import Agent.Store.Postgres
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
+    )
+import Agent.Tools.PlanMode
+    ( PlanDecision(..)
+    , PlanModeHooks(..)
     )
 import Control.Concurrent (forkFinally, forkIO)
 import Control.Concurrent.Async
@@ -162,6 +175,7 @@ import Control.Exception.Safe
 import Control.Monad
     ( forM_
     , void
+    , when
     )
 import qualified Data.Aeson as Aeson
 import Data.Aeson
@@ -172,7 +186,8 @@ import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
-    ( newIORef
+    ( modifyIORef'
+    , newIORef
     , readIORef
     , writeIORef
     )
@@ -191,6 +206,8 @@ import Foreign
     ( FunPtr
     , Ptr
     , StablePtr
+    , Storable(..)
+    , allocaArray
     , castPtr
     , castPtrToStablePtr
     , castStablePtrToPtr
@@ -201,6 +218,8 @@ import Foreign
     , nullPtr
     , plusPtr
     , peekByteOff
+    , pokeByteOff
+    , pokeElemOff
     , sizeOf
     )
 import Foreign.C.String (CString)
@@ -242,6 +261,37 @@ withOptionalText :: Maybe Text -> (CString -> CSize -> IO a) -> IO a
 withOptionalText value action = withText (fromMaybe "" value) action
 
 type EventCallback = Ptr () -> Ptr Word8 -> CSize -> IO ()
+
+data CInteractionOption = CInteractionOption
+    { cInteractionOptionLabel :: !(Ptr Word8)
+    , cInteractionOptionLabelLength :: !CSize
+    }
+
+instance Storable CInteractionOption where
+    sizeOf _ = sizeOf (nullPtr :: Ptr Word8) + sizeOf (undefined :: CSize)
+    alignment _ =
+        max
+            (alignment (nullPtr :: Ptr Word8))
+            (alignment (undefined :: CSize))
+    peek pointer =
+        CInteractionOption
+            <$> peekByteOff pointer 0
+            <*> peekByteOff pointer (sizeOf (nullPtr :: Ptr Word8))
+    poke pointer option = do
+        pokeByteOff pointer 0 option.cInteractionOptionLabel
+        pokeByteOff
+            pointer
+            (sizeOf (nullPtr :: Ptr Word8))
+            option.cInteractionOptionLabelLength
+
+type InteractionCallback =
+    Ptr ()
+    -> Ptr Word8 -> CSize -- turn id
+    -> Ptr Word8 -> CSize -- interaction id
+    -> CInt -- kind
+    -> Ptr Word8 -> CSize -- prompt/body
+    -> Ptr CInteractionOption -> CSize
+    -> IO ()
 
 type AccountListCallback =
     Ptr () -> CInt -> CString -> CSize -> CString -> CSize
@@ -290,6 +340,10 @@ type LearnedSkillsListCallback =
 
 foreign import ccall "dynamic"
     invokeEventCallback :: FunPtr EventCallback -> EventCallback
+
+foreign import ccall "dynamic"
+    invokeInteractionCallback
+        :: FunPtr InteractionCallback -> InteractionCallback
 
 foreign import ccall "dynamic"
     invokeAccountListCallback
@@ -448,6 +502,38 @@ data AccountAPIKeyRequest = AccountAPIKeyRequest
     , accountAPIKey :: !Text
     }
 
+data NativeTurnOptions = NativeTurnOptions
+    { nativeTurnInteractionMode :: !NativeInteractionMode
+    , nativeTurnShellMode :: !NativeShellMode
+    } deriving (Eq, Show)
+
+defaultNativeTurnOptions :: NativeTurnOptions
+defaultNativeTurnOptions = NativeTurnOptions
+    { nativeTurnInteractionMode = NativeAsk
+    , nativeTurnShellMode = NativeShellBash
+    }
+
+data NativeInteractionResolution = NativeInteractionResolution
+    { interactionSelectedIndex :: !Int
+    , interactionCustomText :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+data PendingInteraction = PendingInteraction
+    { pendingInteractionOptionCount :: !Int
+    , pendingInteractionWaiter :: !(TMVar NativeInteractionResolution)
+    }
+
+data InteractionCallbackTarget = InteractionCallbackTarget
+    { interactionTargetCallback :: !(FunPtr InteractionCallback)
+    , interactionTargetContext :: !(Ptr ())
+    }
+
+data InteractionRuntime = InteractionRuntime
+    { interactionCallbackTarget :: !(TVar (Maybe InteractionCallbackTarget))
+    , interactionPending
+        :: !(TVar (Map (Text, Text) PendingInteraction))
+    }
+
 data EngineCommand
     = EngineRequest !BridgeRequest
     | EngineSearch !Text !Int !(FunPtr SearchCallback) !(Ptr ())
@@ -464,6 +550,8 @@ data Engine = Engine
     { engineCommands :: !(TQueue EngineCommand)
     , engineDone :: !(MVar ())
     , engineStagedImages :: !(TVar (Map Text [ImageAttachment]))
+    , engineStagedTurnOptions :: !(TVar (Map Text NativeTurnOptions))
+    , engineInteractions :: !InteractionRuntime
     }
 
 data TurnControl = TurnControl
@@ -472,13 +560,17 @@ data TurnControl = TurnControl
     , turnControlApprovals
         :: !(TVar (Map Text (TMVar PermissionChoice)))
     , turnControlApprovalCounter :: !(TVar Int)
+    , turnControlInteractionCounter :: !(TVar Int)
     , turnControlAllowedTools :: !(TVar (Set.Set Text))
     , turnControlAgentSnapshot :: !(TVar (IO [Viewport.AgentEntry]))
+    , turnControlInteractions :: !InteractionRuntime
     }
 
 data TurnOutcome = TurnOutcome
     { turnOutcomeSessionId :: !(Maybe Text)
     , turnOutcomeError :: !(Maybe Text)
+    , turnOutcomeUsage :: !TokenUsage
+    , turnOutcomeProviderCostUSD :: !(Maybe Double)
     }
 
 data ActiveExit
@@ -493,6 +585,16 @@ foreign export ccall ha_engine_send_json
 
 foreign export ccall ha_engine_stage_turn_images
     :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize -> IO CInt
+
+foreign export ccall ha_engine_stage_turn_options
+    :: Ptr () -> Ptr Word8 -> CSize -> CInt -> CInt -> IO CInt
+
+foreign export ccall ha_engine_set_interaction_callback
+    :: Ptr () -> FunPtr InteractionCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_resolve_interaction
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> CInt -> Ptr Word8 -> CSize -> IO CInt
 
 foreign export ccall ha_engine_destroy
     :: Ptr () -> IO ()
@@ -883,6 +985,13 @@ ha_engine_create callback context
             commands <- newTQueueIO
             done <- newEmptyMVar
             stagedImages <- newTVarIO Map.empty
+            stagedTurnOptions <- newTVarIO Map.empty
+            interactionTarget <- newTVarIO Nothing
+            pendingInteractions <- newTVarIO Map.empty
+            let interactions = InteractionRuntime
+                    { interactionCallbackTarget = interactionTarget
+                    , interactionPending = pendingInteractions
+                    }
             _ <- forkFinally
                 (workerLifecycle
                     callback
@@ -890,12 +999,16 @@ ha_engine_create callback context
                     config
                     (sessionsRoot home)
                     commands
-                    stagedImages)
+                    stagedImages
+                    stagedTurnOptions
+                    interactions)
                 (const (putMVar done ()))
             stable <- newStablePtr Engine
                 { engineCommands = commands
                 , engineDone = done
                 , engineStagedImages = stagedImages
+                , engineStagedTurnOptions = stagedTurnOptions
+                , engineInteractions = interactions
                 }
             pure (castStablePtrToPtr stable)
         case created of
@@ -919,6 +1032,8 @@ ha_engine_send_json pointer bytes (CSize length)
                 :: Either String BridgeRequest) of
                 Left _ -> do
                     atomically $ writeTVar engine.engineStagedImages Map.empty
+                    atomically $
+                        writeTVar engine.engineStagedTurnOptions Map.empty
                     pure False
                 Right request -> do
                     atomically
@@ -1071,6 +1186,150 @@ enqueueSessionMutation pointer mutation callback context
             Left _ -> 3
             Right () -> 0
 
+ha_engine_stage_turn_options
+    :: Ptr () -> Ptr Word8 -> CSize -> CInt -> CInt -> IO CInt
+ha_engine_stage_turn_options pointer turnID (CSize turnIDLength) rawMode rawShell
+    | pointer == nullPtr = pure 1
+    | turnID == nullPtr || turnIDLength == 0 = pure 2
+    | otherwise =
+        case (interactionModeFromCode rawMode, shellModeFromCode rawShell) of
+            (Just interactionMode, Just shellMode) -> do
+                accepted <- tryAny do
+                    let stable =
+                            castPtrToStablePtr pointer :: StablePtr Engine
+                    engine <- deRefStablePtr stable
+                    bytes <- BS.packCStringLen
+                        (castPtr turnID, fromIntegral turnIDLength)
+                    case TextEncoding.decodeUtf8' bytes of
+                        Left _ -> pure False
+                        Right turnIDText
+                            | Text.null turnIDText -> pure False
+                            | otherwise -> do
+                                atomically $ modifyTVar'
+                                    engine.engineStagedTurnOptions
+                                    (Map.insert
+                                        turnIDText
+                                        NativeTurnOptions
+                                            { nativeTurnInteractionMode =
+                                                interactionMode
+                                            , nativeTurnShellMode = shellMode
+                                            })
+                                pure True
+                pure $ case accepted of
+                    Left _ -> 3
+                    Right False -> 2
+                    Right True -> 0
+            _ -> pure 4
+
+ha_engine_set_interaction_callback
+    :: Ptr () -> FunPtr InteractionCallback -> Ptr () -> IO CInt
+ha_engine_set_interaction_callback pointer callback callbackContext
+    | pointer == nullPtr = pure 1
+    | otherwise = do
+        result <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            atomically $ writeTVar
+                engine.engineInteractions.interactionCallbackTarget
+                (if callback == nullFunPtr
+                    then Nothing
+                    else Just InteractionCallbackTarget
+                        { interactionTargetCallback = callback
+                        , interactionTargetContext = callbackContext
+                        })
+        pure $ either (const 3) (const 0) result
+
+ha_engine_resolve_interaction
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> CInt -> Ptr Word8 -> CSize -> IO CInt
+ha_engine_resolve_interaction
+        pointer
+        turnID
+        (CSize turnIDLength)
+        interactionID
+        (CSize interactionIDLength)
+        (CInt selectedIndex)
+        customText
+        (CSize customTextLength)
+    | pointer == nullPtr = pure 1
+    | turnID == nullPtr || turnIDLength == 0 = pure 2
+    | interactionID == nullPtr || interactionIDLength == 0 = pure 2
+    | customText == nullPtr && customTextLength > 0 = pure 2
+    | otherwise = do
+        let selectedIndexValue = fromIntegral selectedIndex :: Int
+        result <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            let pendingRef =
+                    engine.engineInteractions.interactionPending
+            turnBytes <- BS.packCStringLen
+                (castPtr turnID, fromIntegral turnIDLength)
+            interactionBytes <- BS.packCStringLen
+                (castPtr interactionID, fromIntegral interactionIDLength)
+            customBytes <-
+                if customTextLength == 0
+                    then pure (Right Nothing)
+                    else fmap (fmap Just . TextEncoding.decodeUtf8')
+                        (BS.packCStringLen
+                            (castPtr customText, fromIntegral customTextLength))
+            case
+                ( TextEncoding.decodeUtf8' turnBytes
+                , TextEncoding.decodeUtf8' interactionBytes
+                , customBytes
+                )
+              of
+                (Right turnIDText, Right interactionIDText, Right custom) ->
+                    fmap (\published -> if published then 0 else 4) $
+                    atomically do
+                        pending <- readTVar pendingRef
+                        case Map.lookup
+                            (turnIDText, interactionIDText)
+                            pending of
+                                Nothing -> pure False
+                                Just interaction@PendingInteraction
+                                    { pendingInteractionOptionCount =
+                                        optionCount
+                                    }
+                                    | selectedIndexValue < (-1)
+                                        || selectedIndexValue >= optionCount ->
+                                        pure False
+                                    | otherwise -> do
+                                        published <- tryPutTMVar
+                                            interaction.pendingInteractionWaiter
+                                            NativeInteractionResolution
+                                                { interactionSelectedIndex =
+                                                    selectedIndexValue
+                                                , interactionCustomText =
+                                                    custom
+                                                }
+                                        when published $
+                                            writeTVar
+                                                pendingRef
+                                                (Map.delete
+                                                    ( turnIDText
+                                                    , interactionIDText
+                                                    )
+                                                    pending)
+                                        pure published
+                _ -> pure 2
+        pure $ case result of
+            Left _ -> 3
+            Right status -> status
+
+interactionModeFromCode :: CInt -> Maybe NativeInteractionMode
+interactionModeFromCode = \case
+    0 -> Just NativeAsk
+    1 -> Just NativePlan
+    2 -> Just NativeYolo
+    _ -> Nothing
+
+shellModeFromCode :: CInt -> Maybe NativeShellMode
+shellModeFromCode = \case
+    0 -> Just NativeShellNone
+    1 -> Just NativeShellBash
+    2 -> Just NativeShellGhci
+    3 -> Just NativeShellBoth
+    _ -> Nothing
 ha_engine_destroy :: Ptr () -> IO ()
 ha_engine_destroy pointer
     | pointer == nullPtr = pure ()
@@ -1089,8 +1348,12 @@ workerLifecycle
     -> OsPath
     -> TQueue EngineCommand
     -> TVar (Map Text [ImageAttachment])
+    -> TVar (Map Text NativeTurnOptions)
+    -> InteractionRuntime
     -> IO ()
-workerLifecycle callback context config root commands stagedImages = do
+workerLifecycle
+        callback context config root commands stagedImages stagedTurnOptions
+        interactions = do
     store <- newMVar Nothing
     processRuntime <- newNativeProcessRuntime root
     let cleanup =
@@ -1105,6 +1368,8 @@ workerLifecycle callback context config root commands stagedImages = do
         processRuntime
         commands
         stagedImages
+        stagedTurnOptions
+        interactions
         `finally` cleanup
 
 idleLoop
@@ -1116,8 +1381,12 @@ idleLoop
     -> NativeProcessRuntime
     -> TQueue EngineCommand
     -> TVar (Map Text [ImageAttachment])
+    -> TVar (Map Text NativeTurnOptions)
+    -> InteractionRuntime
     -> IO ()
-idleLoop callback context config store root processRuntime commands stagedImages =
+idleLoop
+        callback context config store root processRuntime commands stagedImages
+        stagedTurnOptions interactions =
     atomically (readTQueue commands) >>= \case
         EngineStop -> pure ()
         EngineSearch query limit searchCallback searchContext -> do
@@ -1135,16 +1404,31 @@ idleLoop callback context config store root processRuntime commands stagedImages
                     Left err -> do
                         atomically $ modifyTVar' stagedImages
                             (Map.delete request.requestId)
+                        atomically $ modifyTVar' stagedTurnOptions
+                            (Map.delete request.requestId)
                         sendEvent callback context
                             (failureEvent request.requestId err)
                         continue
                     Right start -> do
-                        images <- atomically $ do
+                        (images, turnOptions) <- atomically $ do
                             staged <- readTVar stagedImages
                             writeTVar stagedImages
                                 (Map.delete start.turnStartId staged)
-                            pure (Map.findWithDefault [] start.turnStartId staged)
-                        control <- newTurnControl start.turnStartId
+                            options <- readTVar stagedTurnOptions
+                            writeTVar stagedTurnOptions
+                                (Map.delete start.turnStartId options)
+                            pure
+                                ( Map.findWithDefault
+                                    []
+                                    start.turnStartId
+                                    staged
+                                , Map.findWithDefault
+                                    defaultNativeTurnOptions
+                                    start.turnStartId
+                                    options
+                                )
+                        control <-
+                            newTurnControl start.turnStartId interactions
                         sendEvent callback context $
                             successEvent request.requestId $
                                 Aeson.object
@@ -1164,7 +1448,9 @@ idleLoop callback context config store root processRuntime commands stagedImages
                                 processRuntime
                                 control
                                 start
-                                images)
+                                images
+                                turnOptions
+                                interactions)
                             \running ->
                                 activeLoop
                                     callback
@@ -1199,6 +1485,8 @@ idleLoop callback context config store root processRuntime commands stagedImages
             processRuntime
             commands
             stagedImages
+            stagedTurnOptions
+            interactions
 
 activeLoop
     :: FunPtr EventCallback
@@ -1395,14 +1683,21 @@ runNativeTurn
     -> TurnControl
     -> TurnStart
     -> [ImageAttachment]
+    -> NativeTurnOptions
+    -> InteractionRuntime
     -> IO TurnOutcome
-runNativeTurn callback context processRuntime control start images = do
+runNativeTurn
+        callback context processRuntime control start images turnOptions
+        interactions = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
+    usageRef <- newIORef emptyTokenUsage
     let hooks = NativeRunHooks
             { nativeOnLoopEvent = \event -> do
                 case event of
-                    TurnFinished _ -> writeIORef completedRef True
+                    TurnFinished output -> do
+                        writeIORef completedRef True
+                        modifyIORef' usageRef (<> output.tokenUsage)
                     _ -> pure ()
                 case encodeNativeLoopEvent control.turnControlId event of
                     Just bytes -> sendBinaryEvent callback context bytes
@@ -1423,6 +1718,11 @@ runNativeTurn callback context processRuntime control start images = do
                 atomically . writeTVar control.turnControlAgentSnapshot
             , nativeRequestApproval =
                 requestApproval callback context control
+            , nativePlanHooks =
+                nativePlanModeHooks control interactions
+            , nativeInteractionMode =
+                turnOptions.nativeTurnInteractionMode
+            , nativeShellMode = turnOptions.nativeTurnShellMode
             }
         modelArgs = case
             (start.turnStartProvider, start.turnStartModel) of
@@ -1460,6 +1760,7 @@ runNativeTurn callback context processRuntime control start images = do
                         managedFile)
     completed <- readIORef completedRef
     sessionId <- readIORef sessionIdRef
+    usage <- readIORef usageRef
     pure TurnOutcome
         { turnOutcomeSessionId = sessionId
         , turnOutcomeError =
@@ -1471,6 +1772,8 @@ runNativeTurn callback context processRuntime control start images = do
                     | otherwise ->
                         Just
                             "turn ended without a completion event"
+        , turnOutcomeUsage = usage
+        , turnOutcomeProviderCostUSD = Nothing
         }
 
 withTurnImages
@@ -1513,14 +1816,179 @@ withTurnImages prompt images action = do
                 BS.writeFile path image.imageBytes
                 withImageFiles directory rest (action . (path :))
 
-newTurnControl :: Text -> IO TurnControl
-newTurnControl turnId =
-    TurnControl turnId
-        <$> newTVarIO (pure ())
-        <*> newTVarIO Map.empty
-        <*> newTVarIO 0
-        <*> newTVarIO Set.empty
-        <*> newTVarIO (pure [])
+newTurnControl :: Text -> InteractionRuntime -> IO TurnControl
+newTurnControl turnId interactions = do
+    cancelAction <- newTVarIO (pure ())
+    approvals <- newTVarIO Map.empty
+    approvalCounter <- newTVarIO 0
+    interactionCounter <- newTVarIO 0
+    allowedTools <- newTVarIO Set.empty
+    agentSnapshot <- newTVarIO (pure [])
+    pure TurnControl
+        { turnControlId = turnId
+        , turnControlCancel = cancelAction
+        , turnControlApprovals = approvals
+        , turnControlApprovalCounter = approvalCounter
+        , turnControlInteractionCounter = interactionCounter
+        , turnControlAllowedTools = allowedTools
+        , turnControlAgentSnapshot = agentSnapshot
+        , turnControlInteractions = interactions
+        }
+
+nativePlanModeHooks
+    :: TurnControl
+    -> InteractionRuntime
+    -> PlanModeHooks
+nativePlanModeHooks control interactions = PlanModeHooks
+    { planConfirmEnter = \reason ->
+        requestNativeInteraction
+            control interactions 1 reason
+            [ "Enter plan mode"
+            , "Stay in normal mode"
+            ] >>= \case
+                Just resolution ->
+                    pure (resolution.interactionSelectedIndex == 0)
+                Nothing -> pure False
+    , planDecideExit = \planBody ->
+        requestNativeInteraction
+            control interactions 2 planBody
+            [ "Approve and implement"
+            , "Request changes"
+            , "Cancel plan"
+            ] >>= \case
+                Just resolution ->
+                    pure $ case resolution.interactionSelectedIndex of
+                        0 -> PlanApprove
+                        1 ->
+                            PlanRequestChanges
+                                (fromMaybe
+                                    "(no notes)"
+                                    (nonBlank
+                                        resolution.interactionCustomText))
+                        _ -> PlanCancel
+                Nothing -> pure PlanCancel
+    , planAskQuestion = \question options ->
+        requestNativeInteraction
+            control interactions 3 question options >>= \case
+                Nothing -> pure Nothing
+                Just resolution
+                    | resolution.interactionSelectedIndex >= 0 ->
+                        pure $
+                            atMay
+                                resolution.interactionSelectedIndex
+                                options
+                    | otherwise ->
+                        pure (nonBlank resolution.interactionCustomText)
+    }
+  where
+    nonBlank = (>>= \text ->
+        let stripped = Text.strip text
+        in if Text.null stripped then Nothing else Just stripped)
+
+requestNativeInteraction
+    :: TurnControl
+    -> InteractionRuntime
+    -> CInt
+    -> Text
+    -> [Text]
+    -> IO (Maybe NativeInteractionResolution)
+requestNativeInteraction control interactions kind prompt options = do
+    target <- readTVarIO interactions.interactionCallbackTarget
+    case target of
+        Nothing -> pure Nothing
+        Just callbackTarget -> do
+            waiter <- newEmptyTMVarIO
+            interactionID <- atomically do
+                current <- readTVar control.turnControlInteractionCounter
+                let next = current + 1
+                    interactionID =
+                        control.turnControlId
+                            <> "-interaction-"
+                            <> Text.pack (show next)
+                writeTVar control.turnControlInteractionCounter next
+                modifyTVar'
+                    interactions.interactionPending
+                    (Map.insert
+                        (control.turnControlId, interactionID)
+                        PendingInteraction
+                            { pendingInteractionOptionCount =
+                                length options
+                            , pendingInteractionWaiter = waiter
+                            })
+                pure interactionID
+            let cleanup =
+                    atomically $ modifyTVar'
+                        interactions.interactionPending
+                        (Map.delete
+                            (control.turnControlId, interactionID))
+            (sendNativeInteraction
+                callbackTarget
+                control.turnControlId
+                interactionID
+                kind
+                prompt
+                options
+                >> Just <$> atomically (takeTMVar waiter))
+                `finally` cleanup
+
+sendNativeInteraction
+    :: InteractionCallbackTarget
+    -> Text
+    -> Text
+    -> CInt
+    -> Text
+    -> [Text]
+    -> IO ()
+sendNativeInteraction target turnID interactionID kind prompt options =
+    withTextBytes turnID \turnPointer turnLength ->
+    withTextBytes interactionID
+        \interactionPointer interactionLength ->
+    withTextBytes prompt \promptPointer promptLength ->
+    withInteractionOptions options \optionPointer optionCount ->
+        invokeInteractionCallback
+            target.interactionTargetCallback
+            target.interactionTargetContext
+            turnPointer
+            turnLength
+            interactionPointer
+            interactionLength
+            kind
+            promptPointer
+            promptLength
+            optionPointer
+            optionCount
+
+withInteractionOptions
+    :: [Text]
+    -> (Ptr CInteractionOption -> CSize -> IO a)
+    -> IO a
+withInteractionOptions [] action = action nullPtr 0
+withInteractionOptions options action =
+    withEncodedOptions options \encoded ->
+        allocaArray (length encoded) \pointer -> do
+            forM_ (zip [0..] encoded) \(index, (label, labelLength)) ->
+                pokeElemOff pointer index CInteractionOption
+                    { cInteractionOptionLabel = label
+                    , cInteractionOptionLabelLength = labelLength
+                    }
+            action pointer (fromIntegral (length encoded))
+
+withEncodedOptions
+    :: [Text]
+    -> ([(Ptr Word8, CSize)] -> IO a)
+    -> IO a
+withEncodedOptions [] action = action []
+withEncodedOptions (option : rest) action =
+    withTextBytes option \pointer length ->
+        withEncodedOptions rest
+            (action . ((pointer, length) :))
+
+atMay :: Int -> [a] -> Maybe a
+atMay index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing
 
 activeAgentSnapshot :: TurnControl -> BridgeRequest -> IO Aeson.Value
 activeAgentSnapshot control request = do
@@ -1566,6 +2034,24 @@ cancelTurn control = do
     atomically $
         forM_ waiters \waiter ->
             void (tryPutTMVar waiter PermissionDeny)
+    interactionWaiters <- atomically do
+        current <- readTVar
+            control.turnControlInteractions.interactionPending
+        let (owned, remaining) =
+                Map.partitionWithKey
+                    (\(turnID, _) _ ->
+                        turnID == control.turnControlId)
+                    current
+        writeTVar
+            control.turnControlInteractions.interactionPending
+            remaining
+        pure (map (.pendingInteractionWaiter) (Map.elems owned))
+    atomically $
+        forM_ interactionWaiters \waiter ->
+            void $ tryPutTMVar waiter NativeInteractionResolution
+                { interactionSelectedIndex = -1
+                , interactionCustomText = Nothing
+                }
 
 requestApproval
     :: FunPtr EventCallback
@@ -1683,7 +2169,14 @@ finishTurnEvent callback context turnId = \case
     Left exception ->
         sendEvent callback context $
             turnFailedEvent turnId (Text.pack (show exception))
-    Right outcome ->
+    Right outcome -> do
+        forM_
+            (encodeNativeUsageEvent
+                True
+                turnId
+                outcome.turnOutcomeUsage
+                outcome.turnOutcomeProviderCostUSD)
+            (sendBinaryEvent callback context)
         case outcome.turnOutcomeError of
             Just err ->
                 sendEvent callback context (turnFailedEvent turnId err)
@@ -1692,7 +2185,8 @@ finishTurnEvent callback context turnId = \case
                     Aeson.object
                         [ "event" Aeson..= ("turn.completed" :: Text)
                         , "turnId" Aeson..= turnId
-                        , "sessionId" Aeson..= outcome.turnOutcomeSessionId
+                        , "sessionId" Aeson..=
+                            outcome.turnOutcomeSessionId
                         ]
 
 nativeLoopEvent :: Text -> LoopEvent -> Maybe Aeson.Value

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
@@ -2,10 +2,11 @@
 
 module Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
+    , encodeNativeUsageEvent
     ) where
 
 import Agent.CLI.Render (summarizeToolCall)
-import Agent.Loop (LoopEvent(..))
+import Agent.Loop (LoopEvent(..), TokenUsage(..), TurnOutput(..))
 import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as Builder
@@ -54,10 +55,33 @@ encodeNativeLoopEvent turnId event =
             (output, truncated) = boundedEventText result.output
             flags = if truncated then 2 else 0
             finishedFields = [Just result.callId, Just output]
+        TurnFinished output ->
+            encodeNativeUsageEvent
+                False
+                turnId
+                output.tokenUsage
+                Nothing
         _ -> Nothing
   where
     textEvent kind id text = frame kind 0 id [Just text]
     toolEvent kind flags fields = frame kind flags turnId fields
+
+encodeNativeUsageEvent
+    :: Bool
+    -> Text
+    -> TokenUsage
+    -> Maybe Double
+    -> Maybe BS.ByteString
+encodeNativeUsageEvent aggregate turnId usage providerCost =
+    frame
+        (if aggregate then 7 else 6)
+        0
+        turnId
+        [ Just (Text.pack (show usage.inputTokens))
+        , Just (Text.pack (show usage.outputTokens))
+        , Just (Text.pack (show usage.cachedTokens))
+        , Text.pack . show <$> providerCost
+        ]
 
 frame :: Word8 -> Word16 -> Text -> [Maybe Text] -> Maybe BS.ByteString
 frame kind flags turnId fields =

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -234,12 +234,14 @@ void ha_runtime_exit(void);
  */
 void *ha_engine_create(ha_event_callback callback, void *context);
 /*
- * Stage an ordered image batch for a turn before its turn.start request.
- * A later call for the same turn replaces the previous batch. Passing zero
- * images discards that turn's batch, which callers should do if they abandon
- * the request. Both image and execution-option staging are discarded when
- * turn.start parameters are rejected or a turn.start is rejected while
- * another turn is active, and are consumed by the matching valid turn.start.
+ * Stage an ordered image batch for a turn before its turn.start request. The
+ * turn ID is required, non-empty UTF-8, at most 1024 bytes, and is copied
+ * before return. A later call for the same turn replaces the previous batch.
+ * Passing zero images discards that turn's batch, which callers should do if
+ * they abandon the request. Both image and execution-option staging are
+ * discarded when turn.start parameters are rejected or a turn.start is
+ * rejected while another turn is active, and are consumed by the matching
+ * valid turn.start.
  * Returns 0 when accepted, 1 for a null engine, 2 for an invalid turn ID, 3
  * for an internal failure, and 4 for an invalid image array or UTF-8 MIME.
  */
@@ -252,11 +254,11 @@ int32_t ha_engine_stage_turn_images(
 );
 /*
  * Stage execution and shell modes for one turn. The turn ID is required,
- * non-empty UTF-8 and is copied before return. A later call for the same turn
- * replaces the previous options; the matching valid turn.start consumes them.
- * Unstaged turns default to ASK + BASH. Returns 0 when accepted, 1 for a null
- * engine, 2 for an invalid turn ID, 3 for an internal failure, and 4 for an
- * unknown mode code.
+ * non-empty UTF-8, at most 1024 bytes, and is copied before return. A later
+ * call for the same turn replaces the previous options; the matching valid
+ * turn.start consumes them. Unstaged turns default to ASK + BASH. Returns 0
+ * when accepted, 1 for a null engine, 2 for an invalid turn ID, 3 for an
+ * internal failure, and 4 for an unknown mode code.
  */
 int32_t ha_engine_stage_turn_options(
     void *engine,
@@ -268,9 +270,10 @@ int32_t ha_engine_stage_turn_options(
 /*
  * Atomically discard both the staged image batch and staged execution options
  * for one turn. The turn ID pointer must be non-NULL, its length must be
- * non-zero, and its bytes must be valid non-empty UTF-8; the ID is copied
- * before return. The operation is idempotent and safe while the engine command
- * worker is running, but must be serialized with ha_engine_destroy.
+ * between 1 and 1024 bytes, and its bytes must be valid non-empty UTF-8; the ID
+ * is copied before return. The operation is idempotent and safe while the
+ * engine command worker is running, but must be serialized with
+ * ha_engine_destroy.
  *
  * Returns 0 after discarding (including when nothing was staged), 1 for a null
  * engine, 2 for an invalid turn ID pointer/length/UTF-8, and 3 for an internal

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -15,9 +15,15 @@ typedef void (*ha_event_callback)(
      * binary HAEV frame:
      *   magic "HAEV" (4), version (u8), kind (u8), flags (u16 BE),
      *   turn-id and kind-specific fields as u32-BE length-prefixed UTF-8.
-     * Kind 1 is reasoning text, 2 text, 3 status, 4 tool-start, and 5
-     * tool-finish. Tool-start flags use bit 0 for encrypted arguments and
-     * bit 1 for truncation; tool-finish uses bit 1 for truncation.
+     * Kind 1 is reasoning text, 2 text, 3 status, 4 tool-start, 5
+     * tool-finish, 6 one provider response's usage, and 7 aggregate user-turn
+     * usage. Kind 7 is terminal and, when a turn outcome is available,
+     * precedes turn.completed or turn.failed. Usage fields are decimal UTF-8
+     * input, output, and cached token counts followed by optional
+     * provider-reported USD cost; the cost field is absent when unavailable
+     * and is never a local estimate.
+     * Tool-start flags use bit 0 for encrypted arguments and bit 1 for
+     * truncation; tool-finish uses bit 1 for truncation.
      * The bytes are valid only for the duration of this callback; copy before
      * returning.
      */
@@ -170,6 +176,52 @@ typedef struct ha_image_attachment {
     size_t bytes_length;
 } ha_image_attachment;
 
+enum {
+    HA_INTERACTION_MODE_ASK = 0,
+    HA_INTERACTION_MODE_PLAN = 1,
+    HA_INTERACTION_MODE_YOLO = 2
+};
+
+enum {
+    HA_SHELL_MODE_NONE = 0,
+    HA_SHELL_MODE_BASH = 1,
+    HA_SHELL_MODE_GHCI = 2,
+    HA_SHELL_MODE_BOTH = 3
+};
+
+enum {
+    HA_INTERACTION_PLAN_ENTER = 1,
+    HA_INTERACTION_PLAN_EXIT = 2,
+    HA_INTERACTION_QUESTION = 3
+};
+
+typedef struct ha_interaction_option {
+    const uint8_t *label;
+    size_t label_length;
+} ha_interaction_option;
+
+/*
+ * Interactive callbacks run synchronously on the native turn worker thread.
+ * turn_id, interaction_id, prompt, the options array, and every option label
+ * are borrowed and valid only until the callback returns; copy them before
+ * returning and dispatch UI work to the main thread. options is NULL exactly
+ * when option_count is zero. kind is one of HA_INTERACTION_* above.
+ * PLAN_ENTER's prompt is the reason and its options are enter/stay; PLAN_EXIT's
+ * prompt is the plan markdown and its options are approve/request changes/
+ * cancel; QUESTION's prompt and options come from ask_user_question.
+ *
+ * Returning from this callback does not answer it. The turn remains paused
+ * until ha_engine_resolve_interaction is called or the turn is cancelled.
+ */
+typedef void (*ha_interaction_callback)(
+    void *context,
+    const uint8_t *turn_id, size_t turn_id_length,
+    const uint8_t *interaction_id, size_t interaction_id_length,
+    int32_t kind,
+    const uint8_t *prompt, size_t prompt_length,
+    const ha_interaction_option *options, size_t option_count
+);
+
 /* Runtime calls are process-global and reference counted. */
 int32_t ha_runtime_init(void);
 void ha_runtime_exit(void);
@@ -196,6 +248,56 @@ int32_t ha_engine_stage_turn_images(
     size_t turn_id_length,
     const ha_image_attachment *images,
     size_t image_count
+);
+/*
+ * Stage execution and shell modes for one turn. The turn ID is required,
+ * non-empty UTF-8 and is copied before return. A later call for the same turn
+ * replaces the previous options; the matching valid turn.start consumes them.
+ * Unstaged turns default to ASK + BASH. Returns 0 when accepted, 1 for a null
+ * engine, 2 for an invalid turn ID, 3 for an internal failure, and 4 for an
+ * unknown mode code.
+ */
+int32_t ha_engine_stage_turn_options(
+    void *engine,
+    const uint8_t *turn_id,
+    size_t turn_id_length,
+    int32_t interaction_mode,
+    int32_t shell_mode
+);
+/*
+ * Install or replace the engine's interactive callback. Passing NULL clears
+ * it; future interaction requests then use safe decline/cancel defaults.
+ * The callback and context must remain valid until replaced, cleared, or
+ * ha_engine_destroy returns. Replacement, clearing, and destruction must be
+ * serialized with callback execution; do not release callback storage until
+ * an in-flight callback has returned. Returns 0 on success, 1 for a null
+ * engine, and 3 for an internal failure.
+ */
+int32_t ha_engine_set_interaction_callback(
+    void *engine,
+    ha_interaction_callback callback,
+    void *context
+);
+/*
+ * Resolve a currently pending interaction. selected_index is a zero-based
+ * option index, or -1 for custom text/cancel. custom_text may be NULL only
+ * when custom_text_length is zero and is copied before return. For a free-text
+ * question use -1 with non-empty custom text; use -1 with empty text to
+ * cancel. Plan-exit option 1 uses custom text as change-request notes.
+ *
+ * Returns 0 when published, 1 for a null engine, 2 for invalid pointers/UTF-8,
+ * 3 for an internal failure, and 4 when the interaction is absent, already
+ * resolved, or selected_index is out of range.
+ */
+int32_t ha_engine_resolve_interaction(
+    void *engine,
+    const uint8_t *turn_id,
+    size_t turn_id_length,
+    const uint8_t *interaction_id,
+    size_t interaction_id_length,
+    int32_t selected_index,
+    const uint8_t *custom_text,
+    size_t custom_text_length
 );
 int32_t ha_engine_send_json(
     void *engine,

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -237,8 +237,9 @@ void *ha_engine_create(ha_event_callback callback, void *context);
  * Stage an ordered image batch for a turn before its turn.start request.
  * A later call for the same turn replaces the previous batch. Passing zero
  * images discards that turn's batch, which callers should do if they abandon
- * the request. Staging is also discarded when a request envelope or turn.start
- * parameters are rejected, and is consumed by the matching valid turn.start.
+ * the request. Both image and execution-option staging are discarded when
+ * turn.start parameters are rejected or a turn.start is rejected while
+ * another turn is active, and are consumed by the matching valid turn.start.
  * Returns 0 when accepted, 1 for a null engine, 2 for an invalid turn ID, 3
  * for an internal failure, and 4 for an invalid image array or UTF-8 MIME.
  */
@@ -263,6 +264,22 @@ int32_t ha_engine_stage_turn_options(
     size_t turn_id_length,
     int32_t interaction_mode,
     int32_t shell_mode
+);
+/*
+ * Atomically discard both the staged image batch and staged execution options
+ * for one turn. The turn ID pointer must be non-NULL, its length must be
+ * non-zero, and its bytes must be valid non-empty UTF-8; the ID is copied
+ * before return. The operation is idempotent and safe while the engine command
+ * worker is running, but must be serialized with ha_engine_destroy.
+ *
+ * Returns 0 after discarding (including when nothing was staged), 1 for a null
+ * engine, 2 for an invalid turn ID pointer/length/UTF-8, and 3 for an internal
+ * failure.
+ */
+int32_t ha_engine_discard_turn_staging(
+    void *engine,
+    const uint8_t *turn_id,
+    size_t turn_id_length
 );
 /*
  * Install or replace the engine's interactive callback. Passing NULL clears

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -267,11 +267,11 @@ int32_t ha_engine_stage_turn_options(
 /*
  * Install or replace the engine's interactive callback. Passing NULL clears
  * it; future interaction requests then use safe decline/cancel defaults.
- * The callback and context must remain valid until replaced, cleared, or
- * ha_engine_destroy returns. Replacement, clearing, and destruction must be
- * serialized with callback execution; do not release callback storage until
- * an in-flight callback has returned. Returns 0 on success, 1 for a null
- * engine, and 3 for an internal failure.
+ * Replacing or clearing waits for an in-flight callback to return, cancels all
+ * interactions still awaiting answers, and then makes the old callback/context
+ * safe to release. Do not call this function reentrantly from the callback.
+ * Engine destruction must still be serialized with all API calls. Returns 0
+ * on success, 1 for a null engine, and 3 for an internal failure.
  */
 int32_t ha_engine_set_interaction_callback(
     void *engine,

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -1,5 +1,7 @@
 module Agent.CLI.NativeRuntime
     ( NativeProcessRuntime
+    , NativeInteractionMode(..)
+    , NativeShellMode(..)
     , NativeRunHooks(..)
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
@@ -13,11 +15,14 @@ import Agent.CLI.AgentSessions
     )
 import Agent.CLI.Options
     ( Command(..)
+    , CliOptions(..)
     , parseArgs
     )
 import Agent.CLI.Runtime.Orchestration (runAgentWithRuntime)
 import Agent.CLI.Runtime.Orchestration.Types
     ( AgentProcessRuntime(..)
+    , NativeInteractionMode(..)
+    , NativeShellMode(..)
     , NativeRunHooks(..)
     , nativeRunMode
     )
@@ -67,10 +72,27 @@ runNativeAgent runtime output cwd hooks args =
                     , processSessionThreads = runtime.nativeSessionThreads
                     }
                 (nativeRunMode output cwd hooks)
-                options >>= \case
+                options
+                    { optGhci = nativeGhciEnabled hooks.nativeShellMode
+                    , optBash = nativeBashEnabled hooks.nativeShellMode
+                    } >>= \case
                     DevQuit -> pure (Right ())
                     DevReload _ ->
                         pure (Left
                             "native turn unexpectedly requested a reload")
         Right _ -> pure (Left
             "native turn arguments did not select an agent")
+
+nativeGhciEnabled :: NativeShellMode -> Bool
+nativeGhciEnabled = \case
+    NativeShellGhci -> True
+    NativeShellBoth -> True
+    NativeShellNone -> False
+    NativeShellBash -> False
+
+nativeBashEnabled :: NativeShellMode -> Bool
+nativeBashEnabled = \case
+    NativeShellBash -> True
+    NativeShellBoth -> True
+    NativeShellNone -> False
+    NativeShellGhci -> False

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -83,7 +83,7 @@ import Agent.CLI.Models
       ModelTarget(targetProvider, ModelTarget, targetModelId,
                   targetDialect, targetWireModelId, targetConnectionId) )
 import Agent.CLI.Options
-    ( ApprovalPolicy(PromptMutating),
+    ( ApprovalPolicy(ApproveAll, PromptMutating),
       defaultEffortFor,
       isOneShot,
       resolveApprovalPolicy,
@@ -334,10 +334,11 @@ import Agent.TUI.Motion ( nativeProgressAnimationEnabled )
 import Agent.Tools.MultiAgents
     ( MultiAgentContext(..), SubagentWorktree(..) )
 import Agent.Tools.PlanMode
-    ( PlanModeEnv(planSessionDir),
+    ( PlanModeEnv(planSessionDir, planStateRef),
       PlanModeHooks(planAskQuestion, PlanModeHooks, planConfirmEnter,
                     planDecideExit),
-      PlanDecision(PlanCancel) )
+      PlanDecision(PlanCancel),
+      PlanModeState(PlanPending) )
 import Agent.Tools.Secret
     ( SecretPrompt(..), SecretPromptHooks(..) )
 import Agent.Tools.Types
@@ -446,7 +447,7 @@ import qualified Agent.XAI.Usage as XAIUsage ()
 
 import Agent.CLI.Runtime.Orchestration.Types
     ( ActiveHttpAuth(..), AccountSwitchRequest(..), AgentProcessRuntime(..),
-      AgentRunMode(..), NativeRunHooks(..) )
+      AgentRunMode(..), NativeInteractionMode(..), NativeRunHooks(..) )
 import Agent.CLI.Runtime.Orchestration.Restart
     ( RestartCallbacks(..), runFullscreenRestartLoop )
 import Agent.CLI.Runtime.Orchestration.Background
@@ -1465,6 +1466,8 @@ runAgentInitializedWithLock
             Left err -> startupDie startup (Text.unpack err)
             Right config -> pure config
     let basePlanHooks
+            | Just hooks <- startup.startupNativeHooks =
+                hooks.nativePlanHooks
             | startup.startupBackground =
                 PlanModeHooks
                     { planConfirmEnter = \_ -> pure False
@@ -1587,13 +1590,21 @@ runAgentInitializedWithLock
             (maybe (defaultEffortFor provider) (.metaEffort) (fst <$> resumed))
             options.optEffort
         policy = case startup.startupNativeHooks of
-            Just _ -> PromptMutating
+            Just hooks -> case hooks.nativeInteractionMode of
+                NativeYolo -> ApproveAll
+                NativeAsk -> PromptMutating
+                NativePlan -> PromptMutating
             Nothing ->
                 resolveApprovalPolicy options isTty
                     projectSettings.settingsAutoApprove
         claudeBypassEnabled =
-            not options.optNoYolo
-                && (options.optYolo || projectSettings.settingsAutoApprove)
+            case startup.startupNativeHooks of
+                Just hooks ->
+                    hooks.nativeInteractionMode == NativeYolo
+                Nothing ->
+                    not options.optNoYolo
+                        && (options.optYolo
+                            || projectSettings.settingsAutoApprove)
     -- Provider transitions commit their selection separately: manual switches
     -- immediately, automatic fallbacks only after the replacement succeeds.
     when (isNothing transition) $
@@ -1792,6 +1803,9 @@ runAgentInitializedWithLock
             agentTypesRef
             `onException`
                 (MCP.releaseMcpFleetLease mcpLease >> cleanupScratch)
+    forM_ startup.startupNativeHooks \hooks ->
+        when (hooks.nativeInteractionMode == NativePlan) $
+            writeIORef coding.codingPlanMode.planStateRef PlanPending
     let closeBeforeSession =
             coding.codingClose
                 `finally`

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -3,6 +3,8 @@ module Agent.CLI.Runtime.Orchestration.Types
     , AccountSwitchRequest(..)
     , AgentProcessRuntime(..)
     , AgentRunMode(..)
+    , NativeInteractionMode(..)
+    , NativeShellMode(..)
     , NativeRunHooks(..)
     , foregroundRunMode
     , backgroundRunMode
@@ -16,6 +18,7 @@ import Agent.Error ( ApiError )
 import Agent.Loop ( LoopEvent )
 import Agent.Provider ( Credential, TokenProvider )
 import Agent.ToolDispatch ( ToolCall )
+import Agent.Tools.PlanMode ( PlanModeHooks )
 import Control.Concurrent.MVar ( MVar )
 import Data.Text ( Text )
 import System.IO ( Handle, stderr, stdout )
@@ -38,12 +41,31 @@ data AgentProcessRuntime = AgentProcessRuntime
     , processSessionThreads :: !SessionThreadManager
     }
 
+data NativeInteractionMode
+    = NativeAsk
+    -- ^ Prompt before mutating tools.
+    | NativePlan
+    -- ^ Begin this turn with plan mode active.
+    | NativeYolo
+    -- ^ Auto-approve mutating tools.
+    deriving (Eq, Show)
+
+data NativeShellMode
+    = NativeShellNone
+    | NativeShellBash
+    | NativeShellGhci
+    | NativeShellBoth
+    deriving (Eq, Show)
+
 data NativeRunHooks = NativeRunHooks
     { nativeOnLoopEvent :: !(LoopEvent -> IO ())
     , nativeOnSessionId :: !(Text -> IO ())
     , nativeRegisterCancel :: !(IO () -> IO ())
     , nativeRegisterAgentSnapshot :: !(IO [AgentEntry] -> IO ())
     , nativeRequestApproval :: !(ToolCall -> IO (Maybe PermissionChoice))
+    , nativePlanHooks :: !PlanModeHooks
+    , nativeInteractionMode :: !NativeInteractionMode
+    , nativeShellMode :: !NativeShellMode
     }
 
 data AgentRunMode = AgentRunMode

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -9,15 +9,25 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 
 foreign import ccall "ha_image_attachment_stage_smoke"
     imageAttachmentStageSmoke :: IO CInt
+
+foreign import ccall "ha_native_turn_options_stage_smoke"
+    nativeTurnOptionsStageSmoke :: IO CInt
 #else
 import Test.Hspec (Spec, describe, it, pendingWith)
 #endif
 
 spec :: Spec
-spec = describe "native image attachment staging" do
+spec = describe "native bridge FFI" do
     it "accepts copied image buffers through the exported bridge" do
 #ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0
+#else
+        pendingWith "the native bridge smoke test only links on macOS"
+#endif
+
+    it "stages typed turn options and validates interaction resolution" do
+#ifdef darwin_HOST_OS
+        nativeTurnOptionsStageSmoke `shouldReturn` 0
 #else
         pendingWith "the native bridge smoke test only links on macOS"
 #endif

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -9,6 +9,7 @@ import Agent.CLI.MacOS.Bridge
     , PendingInteraction(..)
     , cancelPendingInteractions
     , discardStagedTurn
+    , discardStagedTurnById
     , resolvePendingInteraction
     , turnStartCleanupId
     )
@@ -37,6 +38,9 @@ foreign import ccall "ha_image_attachment_stage_smoke"
 
 foreign import ccall "ha_native_turn_options_stage_smoke"
     nativeTurnOptionsStageSmoke :: IO CInt
+
+foreign import ccall "ha_turn_staging_discard_smoke"
+    turnStagingDiscardSmoke :: IO CInt
 #else
 import Test.Hspec (Spec, describe, it, pendingWith)
 #endif
@@ -46,6 +50,13 @@ spec = describe "native bridge FFI" do
     it "accepts copied image buffers through the exported bridge" do
 #ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0
+#else
+        pendingWith "the native bridge smoke test only links on macOS"
+#endif
+
+    it "discards staged turns through the C ABI and destroys cleanly" do
+#ifdef darwin_HOST_OS
+        turnStagingDiscardSmoke `shouldReturn` 0
 #else
         pendingWith "the native bridge smoke test only links on macOS"
 #endif
@@ -72,6 +83,27 @@ spec = describe "native bridge FFI" do
             `shouldReturn` Map.singleton "request-1" 2
         readTVarIO stagedOptions
             `shouldReturn` Map.singleton "request-1" 2
+
+    it "atomically discards options-only, images-only, both, and repeatedly" do
+        stagedImages <- newTVarIO $ Map.fromList
+            [("images-only", 1 :: Int), ("both", 2)]
+        stagedOptions <- newTVarIO $ Map.fromList
+            [("options-only", 1 :: Int), ("both", 2)]
+        atomically $ discardStagedTurnById
+            "options-only" stagedImages stagedOptions
+        readTVarIO stagedImages `shouldReturn` Map.fromList
+            [("images-only", 1), ("both", 2)]
+        readTVarIO stagedOptions `shouldReturn` Map.singleton "both" 2
+        atomically $ discardStagedTurnById
+            "images-only" stagedImages stagedOptions
+        readTVarIO stagedImages `shouldReturn` Map.singleton "both" 2
+        readTVarIO stagedOptions `shouldReturn` Map.singleton "both" 2
+        atomically $ discardStagedTurnById
+            "both" stagedImages stagedOptions
+        atomically $ discardStagedTurnById
+            "both" stagedImages stagedOptions
+        (Map.null <$> readTVarIO stagedImages) `shouldReturn` True
+        (Map.null <$> readTVarIO stagedOptions) `shouldReturn` True
 
     it "resolves a pending callback answer exactly once" do
         waiter <- newEmptyTMVarIO

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -4,8 +4,33 @@
 module Agent.CLI.MacOS.BridgeFFISpec (spec) where
 
 #ifdef darwin_HOST_OS
+import Agent.CLI.MacOS.Bridge
+    ( NativeInteractionResolution(..)
+    , PendingInteraction(..)
+    , cancelPendingInteractions
+    , discardStagedTurn
+    , resolvePendingInteraction
+    , turnStartCleanupId
+    )
+import Control.Concurrent.Async (concurrently)
+import Control.Concurrent.STM
+    ( atomically
+    , newEmptyTMVarIO
+    , newTVarIO
+    , readTMVar
+    , readTVarIO
+    )
+import qualified Data.Aeson as Aeson
+import qualified Data.Map.Strict as Map
 import Foreign.C.Types (CInt(..))
-import Test.Hspec (Spec, describe, it, shouldReturn)
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldReturn
+    , shouldSatisfy
+    )
 
 foreign import ccall "ha_image_attachment_stage_smoke"
     imageAttachmentStageSmoke :: IO CInt
@@ -23,6 +48,78 @@ spec = describe "native bridge FFI" do
         imageAttachmentStageSmoke `shouldReturn` 0
 #else
         pendingWith "the native bridge smoke test only links on macOS"
+#endif
+
+#ifdef darwin_HOST_OS
+    it "cleans malformed turn.start staging by turnId, not request id" do
+        let malformed = Aeson.object
+                [ "turnId" Aeson..= ("turn-1" :: String)
+                , "prompt" Aeson..= (17 :: Int)
+                ]
+        turnStartCleanupId "request-1" malformed `shouldBe` "turn-1"
+        turnStartCleanupId "request-1" (Aeson.object [])
+            `shouldBe` "request-1"
+        stagedImages <- newTVarIO $ Map.fromList
+            [("turn-1", 1 :: Int), ("request-1", 2)]
+        stagedOptions <- newTVarIO $ Map.fromList
+            [("turn-1", 1 :: Int), ("request-1", 2)]
+        atomically $ discardStagedTurn
+            "request-1"
+            malformed
+            stagedImages
+            stagedOptions
+        readTVarIO stagedImages
+            `shouldReturn` Map.singleton "request-1" 2
+        readTVarIO stagedOptions
+            `shouldReturn` Map.singleton "request-1" 2
+
+    it "resolves a pending callback answer exactly once" do
+        waiter <- newEmptyTMVarIO
+        pending <- newTVarIO $ Map.singleton
+            ("turn", "question")
+            PendingInteraction
+                { pendingInteractionOptionCount = 2
+                , pendingInteractionWaiter = waiter
+                }
+        let resolution = NativeInteractionResolution
+                { interactionSelectedIndex = 1
+                , interactionCustomText = Just "notes"
+                }
+        atomically (resolvePendingInteraction
+            pending
+            ("turn", "question")
+            resolution) `shouldReturn` True
+        atomically (readTMVar waiter) `shouldReturn` resolution
+        atomically (resolvePendingInteraction
+            pending
+            ("turn", "question")
+            resolution) `shouldReturn` False
+        (Map.null <$> readTVarIO pending) `shouldReturn` True
+
+    it "cancels callback replacement races without stranding a waiter" do
+        waiter <- newEmptyTMVarIO
+        pending <- newTVarIO $ Map.singleton
+            ("turn", "question")
+            PendingInteraction
+                { pendingInteractionOptionCount = 1
+                , pendingInteractionWaiter = waiter
+                }
+        let resolution = NativeInteractionResolution
+                { interactionSelectedIndex = 0
+                , interactionCustomText = Nothing
+                }
+        _ <- concurrently
+            (atomically $ resolvePendingInteraction
+                pending
+                ("turn", "question")
+                resolution)
+            (atomically $ cancelPendingInteractions pending)
+        result <- atomically (readTMVar waiter)
+        result `shouldSatisfy` (`elem`
+            [ resolution
+            , NativeInteractionResolution (-1) Nothing
+            ])
+        (Map.null <$> readTVarIO pending) `shouldReturn` True
 #endif
 
     it "stages typed turn options and validates interaction resolution" do

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -8,7 +8,13 @@ import Test.Hspec (Spec, describe, it, shouldReturn)
 foreign import ccall "ha_image_attachment_abi_smoke"
     imageAttachmentAbiSmoke :: IO CInt
 
+foreign import ccall "ha_interaction_option_abi_smoke"
+    interactionOptionAbiSmoke :: IO CInt
+
 spec :: Spec
-spec = describe "native image attachment ABI" do
+spec = describe "native bridge struct ABI" do
     it "preserves the documented image struct layout and ordered buffers" do
         imageAttachmentAbiSmoke `shouldReturn` 0
+
+    it "preserves the documented interaction option layout" do
+        interactionOptionAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
@@ -1,7 +1,15 @@
 module Agent.CLI.MacOS.NativeLoopEventSpec (spec) where
 
-import Agent.CLI.MacOS.NativeLoopEvent (encodeNativeLoopEvent)
-import Agent.Loop (LoopEvent(..))
+import Agent.CLI.MacOS.NativeLoopEvent
+    ( encodeNativeLoopEvent
+    , encodeNativeUsageEvent
+    )
+import Agent.Loop
+    ( LoopEvent(..)
+    , TokenUsage(..)
+    , TurnOutput(..)
+    , emptyTurnOutput
+    )
 import Agent.ToolDispatch (ToolCall(..), ToolCallKind(..), ToolCallResult(..))
 import qualified Data.ByteString as BS
 import qualified Data.Text as Text
@@ -47,7 +55,28 @@ spec = describe "native loop event binary encoding" do
             Nothing -> expectationFailure "native tool event failed to encode"
             Just encoded -> BS.take 8 encoded `shouldBe` header 5 2
 
-    it "does not encode lifecycle events as native loop frames" do
+    it "encodes terminal provider token usage without inventing cost" do
+        let output =
+                (emptyTurnOutput "response" [] Nothing)
+                    { tokenUsage = TokenUsage 120 34 56 }
+        encodeNativeLoopEvent "turn" (TurnFinished output)
+            `shouldBe`
+                Just
+                    (frame 6 0 ["turn", "120", "34", "56"]
+                        <> word32BE maxBound)
+
+    it "encodes aggregate usage and exact provider-reported cost" do
+        encodeNativeUsageEvent
+            True
+            "turn"
+            (TokenUsage 200 50 80)
+            (Just 0.0125)
+            `shouldBe`
+                Just
+                    (frame 7 0
+                        ["turn", "200", "50", "80", "1.25e-2"])
+
+    it "does not encode turn-start lifecycle events as native loop frames" do
         encodeNativeLoopEvent "turn" TurnStarted `shouldBe` Nothing
 
 frame :: Word8 -> Word8 -> [String] -> BS.ByteString

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -44,6 +44,40 @@ int ha_image_attachment_abi_smoke(void) {
     return 0;
 }
 
+static void interaction_callback(
+        void *context,
+        const uint8_t *turn_id,
+        size_t turn_id_length,
+        const uint8_t *interaction_id,
+        size_t interaction_id_length,
+        int32_t kind,
+        const uint8_t *prompt,
+        size_t prompt_length,
+        const ha_interaction_option *options,
+        size_t option_count) {
+    (void)context;
+    (void)turn_id;
+    (void)turn_id_length;
+    (void)interaction_id;
+    (void)interaction_id_length;
+    (void)kind;
+    (void)prompt;
+    (void)prompt_length;
+    (void)options;
+    (void)option_count;
+}
+
+int ha_interaction_option_abi_smoke(void) {
+    if (offsetof(ha_interaction_option, label) != 0
+            || offsetof(ha_interaction_option, label_length)
+                != sizeof(const uint8_t *)
+            || sizeof(ha_interaction_option)
+                != sizeof(const uint8_t *) + sizeof(size_t)) {
+        return 1;
+    }
+    return 0;
+}
+
 static void image_stage_callback(void *context, const uint8_t *bytes,
                                  size_t length) {
     (void)context;
@@ -94,6 +128,86 @@ int ha_image_attachment_stage_smoke(void) {
     if (status == 0) {
         status = ha_engine_stage_turn_images(
             engine, turn_id, sizeof(turn_id) - 1, NULL, 0);
+    }
+    ha_engine_destroy(engine);
+    ha_runtime_exit();
+    return status;
+}
+
+int ha_native_turn_options_stage_smoke(void) {
+    const uint8_t turn_id[] = "native-options-turn";
+    const uint8_t interaction_id[] = "not-active";
+    const int32_t interaction_modes[] = {
+        HA_INTERACTION_MODE_ASK,
+        HA_INTERACTION_MODE_PLAN,
+        HA_INTERACTION_MODE_YOLO
+    };
+    const int32_t shell_modes[] = {
+        HA_SHELL_MODE_NONE,
+        HA_SHELL_MODE_BASH,
+        HA_SHELL_MODE_GHCI,
+        HA_SHELL_MODE_BOTH
+    };
+    if (ha_runtime_init() != 0) {
+        return 10;
+    }
+    void *engine = ha_engine_create(image_stage_callback, NULL);
+    if (engine == NULL) {
+        ha_runtime_exit();
+        return 11;
+    }
+    int32_t status = ha_engine_set_interaction_callback(
+        engine, interaction_callback, NULL);
+    for (size_t mode_index = 0;
+            status == 0
+                && mode_index
+                    < sizeof(interaction_modes) / sizeof(interaction_modes[0]);
+            ++mode_index) {
+        for (size_t shell_index = 0;
+                status == 0
+                    && shell_index
+                        < sizeof(shell_modes) / sizeof(shell_modes[0]);
+                ++shell_index) {
+            status = ha_engine_stage_turn_options(
+                engine,
+                turn_id,
+                sizeof(turn_id) - 1,
+                interaction_modes[mode_index],
+                shell_modes[shell_index]);
+        }
+    }
+    if (status == 0
+            && ha_engine_stage_turn_options(
+                engine,
+                turn_id,
+                sizeof(turn_id) - 1,
+                99,
+                HA_SHELL_MODE_BOTH) != 4) {
+        status = 12;
+    }
+    if (status == 0
+            && ha_engine_stage_turn_options(
+                engine,
+                turn_id,
+                sizeof(turn_id) - 1,
+                HA_INTERACTION_MODE_ASK,
+                99) != 4) {
+        status = 14;
+    }
+    if (status == 0
+            && ha_engine_resolve_interaction(
+                engine,
+                turn_id,
+                sizeof(turn_id) - 1,
+                interaction_id,
+                sizeof(interaction_id) - 1,
+                0,
+                NULL,
+                0) != 4) {
+        status = 13;
+    }
+    if (status == 0) {
+        status = ha_engine_set_interaction_callback(engine, NULL, NULL);
     }
     ha_engine_destroy(engine);
     ha_runtime_exit();

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -134,6 +134,105 @@ int ha_image_attachment_stage_smoke(void) {
     return status;
 }
 
+int ha_turn_staging_discard_smoke(void) {
+    const uint8_t options_only[] = "options-only";
+    const uint8_t images_only[] = "images-only";
+    const uint8_t both[] = "both";
+    const uint8_t rejected[] = "rejected";
+    const uint8_t invalid_utf8[] = {0xff};
+    const uint8_t mime[] = "image/png";
+    const uint8_t bytes[] = {0x89, 0x50, 0x4e, 0x47};
+    const ha_image_attachment image = {
+        .mime = mime,
+        .mime_length = sizeof(mime) - 1,
+        .bytes = bytes,
+        .bytes_length = sizeof(bytes),
+    };
+    const uint8_t malformed_start[] =
+        "{\"id\":\"request-id\",\"method\":\"turn.start\","
+        "\"params\":{\"turnId\":\"rejected\"}}";
+    if (ha_runtime_init() != 0) {
+        return 20;
+    }
+    void *engine = ha_engine_create(image_stage_callback, NULL);
+    if (engine == NULL) {
+        ha_runtime_exit();
+        return 21;
+    }
+    int32_t status = ha_engine_stage_turn_options(
+        engine, options_only, sizeof(options_only) - 1,
+        HA_INTERACTION_MODE_ASK, HA_SHELL_MODE_BASH);
+    if (status == 0) {
+        status = ha_engine_discard_turn_staging(
+            engine, options_only, sizeof(options_only) - 1);
+    }
+    if (status == 0) {
+        status = ha_engine_stage_turn_images(
+            engine, images_only, sizeof(images_only) - 1, &image, 1);
+    }
+    if (status == 0) {
+        status = ha_engine_discard_turn_staging(
+            engine, images_only, sizeof(images_only) - 1);
+    }
+    if (status == 0) {
+        status = ha_engine_stage_turn_images(
+            engine, both, sizeof(both) - 1, &image, 1);
+    }
+    if (status == 0) {
+        status = ha_engine_stage_turn_options(
+            engine, both, sizeof(both) - 1,
+            HA_INTERACTION_MODE_PLAN, HA_SHELL_MODE_BOTH);
+    }
+    if (status == 0) {
+        status = ha_engine_discard_turn_staging(
+            engine, both, sizeof(both) - 1);
+    }
+    if (status == 0) {
+        status = ha_engine_discard_turn_staging(
+            engine, both, sizeof(both) - 1);
+    }
+    if (status == 0
+            && ha_engine_discard_turn_staging(engine, NULL, 1) != 2) {
+        status = 22;
+    }
+    if (status == 0
+            && ha_engine_discard_turn_staging(
+                engine, invalid_utf8, sizeof(invalid_utf8)) != 2) {
+        status = 23;
+    }
+    if (status == 0
+            && ha_engine_discard_turn_staging(engine, both, SIZE_MAX) != 2) {
+        status = 24;
+    }
+    if (status == 0
+            && ha_engine_stage_turn_images(
+                engine, both, SIZE_MAX, &image, 1) != 2) {
+        status = 25;
+    }
+    if (status == 0
+            && ha_engine_stage_turn_options(
+                engine, both, SIZE_MAX,
+                HA_INTERACTION_MODE_ASK, HA_SHELL_MODE_NONE) != 2) {
+        status = 26;
+    }
+    if (status == 0) {
+        status = ha_engine_stage_turn_images(
+            engine, rejected, sizeof(rejected) - 1, &image, 1);
+    }
+    if (status == 0) {
+        status = ha_engine_stage_turn_options(
+            engine, rejected, sizeof(rejected) - 1,
+            HA_INTERACTION_MODE_YOLO, HA_SHELL_MODE_NONE);
+    }
+    if (status == 0) {
+        status = ha_engine_send_json(
+            engine, malformed_start, sizeof(malformed_start) - 1);
+    }
+    ha_engine_destroy(engine);
+    ha_runtime_exit();
+    return status;
+}
+
 int ha_native_turn_options_stage_smoke(void) {
     const uint8_t turn_id[] = "native-options-turn";
     const uint8_t interaction_id[] = "not-active";

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -140,6 +140,7 @@ int ha_turn_staging_discard_smoke(void) {
     const uint8_t both[] = "both";
     const uint8_t rejected[] = "rejected";
     const uint8_t invalid_utf8[] = {0xff};
+    const uint8_t *unreadable_turn_id = (const uint8_t *)(uintptr_t)1;
     const uint8_t mime[] = "image/png";
     const uint8_t bytes[] = {0x89, 0x50, 0x4e, 0x47};
     const ha_image_attachment image = {
@@ -214,6 +215,22 @@ int ha_turn_staging_discard_smoke(void) {
                 engine, both, SIZE_MAX,
                 HA_INTERACTION_MODE_ASK, HA_SHELL_MODE_NONE) != 2) {
         status = 26;
+    }
+    if (status == 0
+            && ha_engine_discard_turn_staging(
+                engine, unreadable_turn_id, 1025) != 2) {
+        status = 27;
+    }
+    if (status == 0
+            && ha_engine_stage_turn_images(
+                engine, unreadable_turn_id, 1025, &image, 1) != 2) {
+        status = 28;
+    }
+    if (status == 0
+            && ha_engine_stage_turn_options(
+                engine, unreadable_turn_id, 1025,
+                HA_INTERACTION_MODE_ASK, HA_SHELL_MODE_NONE) != 2) {
+        status = 29;
     }
     if (status == 0) {
         status = ha_engine_stage_turn_images(


### PR DESCRIPTION
## Summary
- layer the exact interactive-control implementation from #758 onto the unified native bridge
- preserve concurrent task scheduling, repository review/delivery, session continuity, and typed usage events
- stage turn options and image inputs atomically and resolve/cancel host interactions without stranding waiters

## Verification
- `cabal build agent-cli:flib:haskell-agent-bridge agent-cli:test:agent-cli-test`
- 58 native tests, 4 interaction-focused tests, and 56 repository tests
- strict C11 compilation of runtime/browser/image/task bridge consumers
- `nix build --fallback path:.#agent-native-bridge`
- installed header is byte-identical to the checked-in authoritative header

Source implementation: #758

## Dependency

Stacked on #833.