### PR TITLE
Restrict macOS runner to trusted master pushes

### DIFF
--- a/.github/workflows/publish-binary-cache.yml
+++ b/.github/workflows/publish-binary-cache.yml
@@ -3,7 +3,6 @@ name: Publish binary cache
 on:
   push:
     branches: [master]
-  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -17,6 +16,10 @@ concurrency:
 jobs:
   publish:
     name: Publish ${{ matrix.system }}
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      github.repository == 'digitallyinduced/haskell-agent'
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/ci/authorize-macos-runner-job.sh
+++ b/scripts/ci/authorize-macos-runner-job.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+expected_repository="digitallyinduced/haskell-agent"
+expected_event="push"
+expected_ref="refs/heads/master"
+expected_workflow_ref="${expected_repository}/.github/workflows/publish-binary-cache.yml@${expected_ref}"
+
+deny() {
+    printf 'Refusing self-hosted macOS job: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ "${GITHUB_REPOSITORY:-}" == "$expected_repository" ]] ||
+    deny "unexpected repository '${GITHUB_REPOSITORY:-unset}'"
+[[ "${GITHUB_EVENT_NAME:-}" == "$expected_event" ]] ||
+    deny "unexpected event '${GITHUB_EVENT_NAME:-unset}'"
+[[ "${GITHUB_REF:-}" == "$expected_ref" ]] ||
+    deny "unexpected ref '${GITHUB_REF:-unset}'"
+[[ "${GITHUB_WORKFLOW_REF:-}" == "$expected_workflow_ref" ]] ||
+    deny "unexpected workflow '${GITHUB_WORKFLOW_REF:-unset}'"
+
+printf 'Authorized %s from %s on %s\n' \
+    "$GITHUB_WORKFLOW_REF" "$GITHUB_EVENT_NAME" "$GITHUB_REF"


### PR DESCRIPTION
## Summary

- remove manual dispatch from the binary-cache workflow
- gate the publish job on a push to this repository's `master` branch
- check in the fail-closed host admission hook deployed on the macOS runner

The runner host is configured with `ACTIONS_RUNNER_HOOK_JOB_STARTED` pointing to a copy outside the Actions workspace, so pull requests and other workflows are rejected before job steps execute.

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/publish-binary-cache.yml`
- `bash -n scripts/ci/authorize-macos-runner-job.sh`
- positive host-hook test for the permitted master push
- negative host-hook test for a pull-request event
- runner confirmed online with the expected labels and Nix path