### PR TITLE
Fix macOS runner workflow guard expression

### DIFF
--- a/.github/workflows/publish-binary-cache.yml
+++ b/.github/workflows/publish-binary-cache.yml
@@ -16,10 +16,7 @@ concurrency:
 jobs:
   publish:
     name: Publish ${{ matrix.system }}
-    if: >-
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/master' &&
-      github.repository == 'digitallyinduced/haskell-agent'
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'digitallyinduced/haskell-agent' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Use an explicit GitHub expression for the trusted master-push job guard. The folded implicit expression passed `actionlint`, but GitHub rejected the workflow at startup before creating jobs.

The host-side admission hook remains the primary fail-closed boundary.

Validation: `nix run nixpkgs#actionlint -- .github/workflows/publish-binary-cache.yml`