### PR TITLE
Add /update-and-restart slash command

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -443,6 +443,10 @@ parseSlash catalog raw line = case Text.words line of
                 if null args
                     then ReplToggleAlwaysApprove
                     else ReplCommandError "usage: /always-approve"
+            "update-and-restart" ->
+                if null args
+                    then ReplUpdateAndRestart
+                    else ReplCommandError "usage: /update-and-restart"
             "quit" ->
                 if null args
                     then ReplQuit

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -65,6 +65,7 @@ slashCommands =
     , cmd "shell" [] "/shell [ghci|bash|both|none]" "Show or select the allowed shell tools" True
     , cmd "codemod" ["code-mode"] "/codemod" "Enable JavaScript code mode for this session" False
     , cmd "always-approve" ["yolo"] "/always-approve" "Toggle project auto-approve (or Shift+Tab)" False
+    , cmd "update-and-restart" [] "/update-and-restart" "Install the latest Haskell Agent and resume this session" False
     , cmd "quit" ["exit"] "/quit" "Exit the current session" False
     ]
   where

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -34,6 +34,7 @@ data CopyRequest = CopyRequest
 data ReplAction
     = ReplQuit
     | ReplReload
+    | ReplUpdateAndRestart
     | ReplPrompt Text
     | ReplExpandedPrompt !Text !Text
       -- ^ Original user-visible text and the model-visible expansion.

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -197,7 +197,7 @@ import Control.Concurrent.MVar
 import Control.Concurrent.STM ()
 import Control.Exception ()
 import Control.Exception.Safe
-    ( finally, onException, throwIO, try )
+    ( displayException, finally, onException, throwIO, try, tryAny )
 import Control.Monad ( when, forM_, void, unless )
 import Data.Functor ()
 import Data.IORef
@@ -218,6 +218,8 @@ import System.Environment ()
 import System.Exit ( die )
 import System.IO ( hIsTerminalDevice, stderr, stdin )
 import System.OsPath ( decodeFS, takeDirectory, takeFileName )
+import System.Posix.Process ( executeFile )
+import System.Process ( callProcess )
 import qualified Data.ByteString as BS ()
 import qualified Agent.Responses.GenericClient as GenericResponses
     ()
@@ -230,7 +232,7 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ( empty )
-import qualified Data.Text as Text ( unpack )
+import qualified Data.Text as Text ( pack, unpack )
 import qualified Data.Text.IO as Text ( hPutStr )
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Client as XAIClient ()
@@ -346,6 +348,21 @@ runAgentWithRuntime processRuntime runMode options = do
                 go fullscreenInputs sessionState
                     (restartSessionOptions current sessionId)
                     Nothing
+            RunUpdateAndRestart sessionId -> do
+                color <- resolveColor runMode.runStderr
+                putTextLn runMode.runStderr
+                    (roleMuted color
+                        (glyphSession <> "installing the latest Haskell Agent…"))
+                tryAny (updateAndResume sessionId) >>= \case
+                    Left err -> do
+                        putTextLn runMode.runStderr
+                            (roleError color
+                                ("update failed: "
+                                    <> Text.pack (displayException err)))
+                        go fullscreenInputs sessionState
+                            (restartSessionOptions current sessionId)
+                            Nothing
+                    Right result -> pure result
             RunEnableCodeMode sessionId ->
                 let nextOptions =
                         (restartSessionOptions current sessionId)
@@ -387,6 +404,24 @@ runAgentWithRuntime processRuntime runMode options = do
                         | otherwise -> pure DevQuit
             RunQuit -> pure DevQuit
             RunReload sessionId -> pure (DevReload sessionId)
+
+    updateAndResume sessionId = do
+        callProcess "nix"
+            [ "profile"
+            , "remove"
+            , "haskell-agent"
+            ]
+        callProcess "nix"
+            [ "profile"
+            , "add"
+            , "--accept-flake-config"
+            , "github:digitallyinduced/haskell-agent"
+            ]
+        executeFile
+            "agent-cli"
+            True
+            ["--resume", Text.unpack sessionId]
+            Nothing
 
 -- | Restore the process cwd after an action succeeds or throws. Cabal gives
 -- GHCi relative source paths, so returning from an agent session in its cwd

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -19,8 +19,9 @@ import Agent.CLI.Command
     ( CopyRequest(..),
       formatSlashHelpWithCatalog,
       parseReplLineWithCatalog,
-      ReplAction(ReplCommandError, ReplQuit, ReplReload, ReplPrompt,
-                 ReplExpandedPrompt, ReplInvokeSkill, ReplSkills, ReplShowShell,
+      ReplAction(ReplCommandError, ReplQuit, ReplReload,
+                 ReplUpdateAndRestart, ReplPrompt, ReplExpandedPrompt,
+                 ReplInvokeSkill, ReplSkills, ReplShowShell,
                  ReplSetShell, ReplPaste, ReplShowAttachments, ReplClearAttachments,
                  ReplRemoveAttachment,
                  ReplShowAgentLimit, ReplSetAgentLimit, ReplAgents, ReplMcp, ReplMcpPrompt,
@@ -161,8 +162,8 @@ import Agent.CLI.Runtime.Repl.Selection
 import Agent.CLI.Runtime.Repl.Session ( handleSessionAction )
 import Agent.CLI.Runtime.Repl.Workflow ( handleWorkflowAction )
 import Agent.CLI.Runtime.Types
-    ( RunResult(RunEnableCodeMode, RunRestart, RunSwitchProvider, RunReload,
-                RunQuit) )
+    ( RunResult(RunEnableCodeMode, RunRestart, RunUpdateAndRestart,
+                RunSwitchProvider, RunReload, RunQuit) )
 import Agent.CLI.Secret ( promptSecretLine )
 import Agent.CLI.Session
     ( TranscriptEffect(TranscriptReplace),
@@ -448,6 +449,8 @@ handleReplLine
                 case parseReplLineWithCatalog slashCatalog promptLine of
                     ReplQuit -> pure RunQuit
                     ReplReload -> requestReload fullscreen persist
+                    ReplUpdateAndRestart ->
+                        requestUpdateAndRestart fullscreen persist
                     ReplMetaConsole request ->
                         runMetaConsoleRequest request
                     ReplPrompt text -> do
@@ -1971,6 +1974,37 @@ requestReload fullscreen persist = do
             handle <- ensureSession slotRef
             reportInfo ("reloading; session " <> handle.sessionMeta.metaId)
             pure (RunReload handle.sessionMeta.metaId)
+
+requestUpdateAndRestart
+    :: Maybe FullscreenRuntime
+    -> Persistence
+    -> IO RunResult
+requestUpdateAndRestart fullscreen persist = do
+    color <- resolveColor stderr
+    let reportInfo message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
+        reportError message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr (roleError color message)
+                Just runtime ->
+                    emitUiEvent runtime (UiErrorMessage message)
+    case persist of
+        PersistenceDisabled -> do
+            reportError "/update-and-restart needs a persisted session"
+            pure RunQuit
+        PersistenceEnabled slotRef -> do
+            handle <- ensureSession slotRef
+            reportInfo
+                ("updating Haskell Agent; session "
+                    <> handle.sessionMeta.metaId
+                    <> " will resume")
+            pure (RunUpdateAndRestart handle.sessionMeta.metaId)
 
 requestMcpRestart
     :: Maybe FullscreenRuntime

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Types.hs
@@ -31,6 +31,7 @@ data DevResult
 data RunResult
     = RunQuit
     | RunRestart Text
+    | RunUpdateAndRestart Text
     | RunEnableCodeMode Text
     | RunReload Text
     | RunSwitchProvider ProviderTransition

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -37,6 +37,13 @@ spec = do
             parseReplLine ":reload" `shouldBe` ReplReload
             parseReplLine "  :reload  " `shouldBe` ReplReload
 
+        it "parses update-and-restart without arguments" do
+            parseReplLine "/update-and-restart"
+                `shouldBe` ReplUpdateAndRestart
+            parseReplLine "/update-and-restart now"
+                `shouldBe`
+                    ReplCommandError "usage: /update-and-restart"
+
         it "parses exact-turn retry" do
             parseReplLine "/retry" `shouldBe` ReplRetry
             parseReplLine "/retry now"
@@ -489,6 +496,7 @@ spec = do
                     , "shell"
                     , "codemod"
                     , "always-approve"
+                    , "update-and-restart"
                     , "quit"
                     ]
 


### PR DESCRIPTION
## Summary

- add `/update-and-restart` to slash-command parsing, help, and completion
- gracefully stop the active backend before replacing the Nix profile installation
- resume the same persisted session with the newly installed `agent-cli`
- recover into the existing session when the update fails

## Validation

- loaded the full `agent-cli` library in GHCi
- focused parser test: `--match update-and-restart`
- slash catalog test: `--match "contains every static slash spec"`
- exercised the inline editor through a real tmux TTY

The destructive profile remove/add sequence was intentionally not executed during testing.