### PR TITLE
Preserve native turn failure details

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -10,6 +10,7 @@ module Agent.CLI.MacOS.Bridge
     , browserToolsWhenEnabled
     , invokeBrowserCommand
     , TurnStart(..)
+    , nativeExceptionMessage
     , nativeTurnArguments
     ) where
 
@@ -21,6 +22,7 @@ import Agent.CLI.BrowserTools
 import Agent.CLI.NativeRuntime
     ( NativeProcessRuntime
     , NativeRunHooks(..)
+    , StartupFailure(..)
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
     , runNativeAgent
@@ -187,6 +189,7 @@ import Control.Exception.Safe
     ( SomeException
     , bracket
     , finally
+    , fromException
     , tryAny
     )
 import Control.Monad
@@ -1895,7 +1898,7 @@ runNativeTurn callback context processRuntime control nativeBrowserTools start i
         { turnOutcomeSessionId = sessionId
         , turnOutcomeError =
             case result of
-                Left exception -> Just (Text.pack (show exception))
+                Left exception -> Just (nativeExceptionMessage exception)
                 Right (Left err) -> Just err
                 Right (Right ())
                     | completed -> Nothing
@@ -1903,6 +1906,12 @@ runNativeTurn callback context processRuntime control nativeBrowserTools start i
                         Just
                             "turn ended without a completion event"
         }
+
+nativeExceptionMessage :: SomeException -> Text
+nativeExceptionMessage exception =
+    case fromException exception of
+        Just (StartupFailure message) -> Text.pack message
+        Nothing -> Text.pack (show exception)
 
 nativeTurnArguments :: TurnStart -> [String]
 nativeTurnArguments start =

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.NativeRuntime
     ( NativeProcessRuntime
     , NativeRunHooks(..)
+    , StartupFailure(..)
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
     , runNativeAgent
@@ -21,7 +22,7 @@ import Agent.CLI.Runtime.Orchestration.Types
     , NativeRunHooks(..)
     , nativeRunMode
     )
-import Agent.CLI.Runtime.Types (DevResult(..))
+import Agent.CLI.Runtime.Types (DevResult(..), StartupFailure(..))
 import qualified Agent.MCP as MCP
 import Control.Exception.Safe (finally, onException)
 import Data.Text (Text)

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -49,7 +49,7 @@ data ProviderTransition = ProviderTransition
 data TurnResult
     = TurnSucceeded
     | TurnCancelled
-    | TurnFailed
+    | TurnFailed !Text
     | TurnRestartRequested !Text !PendingTurn
     | TurnProviderUnavailable !ApiError !PendingTurn
 

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -141,11 +141,12 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
         if exitAfter
             then pure RunQuit
             else continuation.resumeSession env
-    TurnFailed ->
+    TurnFailed message ->
         if exitAfter
             then
                 if env.sessionBackground
-                    then throwIO (StartupFailure "agent turn failed")
+                    then
+                        throwIO (StartupFailure (Text.unpack message))
                     else exitFailure
             else do
                 case env.sessionFullscreen of

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -70,7 +70,7 @@ import Agent.Tools.Types
     , ToolEnv
     )
 import Control.Concurrent.STM (STM)
-import Control.Exception.Safe (Exception)
+import Control.Exception.Safe (Exception(..))
 import Data.IORef (IORef)
 import Data.Map.Strict (Map)
 import Data.Text (Text)
@@ -173,7 +173,8 @@ data StartupRuntime = StartupRuntime
 newtype StartupFailure = StartupFailure String
     deriving (Show)
 
-instance Exception StartupFailure
+instance Exception StartupFailure where
+    displayException (StartupFailure message) = message
 
 data StartupCancelled = StartupCancelled
     deriving (Show)

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -395,6 +395,7 @@ runOneTurnBusy env@SessionEnv
                             , pendingPlanState = planState
                             }
                 _ -> do
+                    let failureMessage = formatLoopErrorAt finishedAt err
                     restorePlanStateAfterIncomplete planMode initialPlanState
                     finishTerminal (isNothing fullscreen)
                         stdoutHandle terminal wallStarted finishedAt 1
@@ -409,7 +410,7 @@ runOneTurnBusy env@SessionEnv
                                     (UiTurnEnded BlockFailed)
                                 emitUiEvent runtime
                                     (UiErrorMessage
-                                        (formatLoopErrorAt finishedAt err
+                                        (failureMessage
                                             <> "\n"
                                             <> elapsedDetail model))
                         Nothing -> do
@@ -420,7 +421,7 @@ runOneTurnBusy env@SessionEnv
                                 (formatTurnStatus color "error" (elapsedDetail model))
                     persistIncomplete (inputOnlyTurnItems prepared)
                         (formatLoopErrorPersistedAt finishedAt err)
-                    pure TurnFailed
+                    pure (TurnFailed failureMessage)
         (Nothing, Right loopResult) -> do
             finishTerminal (isNothing fullscreen)
                 stdoutHandle terminal wallStarted finishedAt 0

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeSpec.hs
@@ -2,14 +2,22 @@ module Agent.CLI.MacOS.BridgeSpec (spec) where
 
 import Agent.CLI.MacOS.Bridge
     ( TurnStart(..)
+    , nativeExceptionMessage
     , nativeTurnArguments
     )
+import Agent.CLI.NativeRuntime (StartupFailure(..))
+import Control.Exception.Safe (displayException, toException)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Test.Hspec
 
 spec :: Spec
-spec = describe "native computer-use turn propagation" do
+spec = do
+    computerUseSpec
+    nativeFailureSpec
+
+computerUseSpec :: Spec
+computerUseSpec = describe "native computer-use turn propagation" do
     it "defaults omitted computerUse to disabled" do
         case decodeStart
             "{\"turnId\":\"t\",\"prompt\":\"p\",\"cwd\":\"/tmp\"}" of
@@ -31,6 +39,24 @@ spec = describe "native computer-use turn propagation" do
                     `shouldContain` ["--computer-use"]
                 nativeTurnArguments start
                     `shouldNotContain` ["--no-computer-use"]
+
+nativeFailureSpec :: Spec
+nativeFailureSpec =
+    describe "native turn failures" do
+        it "displays a startup failure without its constructor wrapper" do
+            displayException
+                (StartupFailure
+                    "Provider rejected the request.\nRetry the message.")
+                `shouldBe`
+                    "Provider rejected the request.\nRetry the message."
+
+        it "returns the detailed message without an exception wrapper" do
+            nativeExceptionMessage
+                (toException
+                    (StartupFailure
+                        "Provider rejected the request.\nRetry the message."))
+                `shouldBe`
+                    "Provider rejected the request.\nRetry the message."
 
 decodeStart :: String -> Either String TurnStart
 decodeStart = Aeson.eitherDecode . LBS8.pack

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -42,6 +42,15 @@ spec = do
             updated.pendingExitAfter `shouldBe` True
             updated.pendingPlanState `shouldBe` PlanActive
 
+    describe "TurnResult" do
+        it "retains the formatted failure message for background callers" do
+            case TurnFailed
+                    "Provider rejected the request.\nRetry the message." of
+                TurnFailed message ->
+                    message `shouldBe`
+                        "Provider rejected the request.\nRetry the message."
+                _ -> expectationFailure "expected a failed turn"
+
     describe "transitionCommitsImmediately" do
         it "keeps a startup automatic fallback provisional" do
             transitionCommitsImmediately (transition Nothing Nothing)


### PR DESCRIPTION
## Summary
- carry formatted loop failures through `TurnResult` for background/native callers
- surface `StartupFailure` payloads without constructor wrappers in the macOS bridge
- cover native exception rendering and turn-result payload retention

## Tests
- `nix develop path:. -c cabal test -j1 --offline agent-cli:agent-cli-test --test-option=--match --test-option="native turn failures"`
- `nix develop path:. -c cabal test -j1 --offline agent-cli:agent-cli-test --test-option=TurnResult`