### PR TITLE
Backport session recovery fixes to native bridge

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -7,6 +7,7 @@ module Agent.Claude.LoopBackend
     , appendHostTranscript
     , ClaudeToolPermissionDecision(..)
     , ClaudeToolPermissionRequest(..)
+    , sdkErrorToApiError
     ) where
 
 import Agent.Claude.Options
@@ -21,6 +22,7 @@ import Agent.Claude.Internal.Messages
 import Agent.Error
     ( ApiError(..)
     , ErrorType(..)
+    , errorTypeFromText
     )
 import Agent.InterAgentMessage (renderInterAgentMessage)
 import Agent.Loop
@@ -72,7 +74,7 @@ import Data.IORef
     , readIORef
     , writeIORef
     )
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe, maybeToList)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -783,7 +785,7 @@ sdkErrorToApiError = \case
             }
     sdkError@ResultError{} ->
         ProviderError
-            { errorType = ApiErrorType
+            { errorType = classifyResultError sdkError
             , message = renderClaudeSDKError sdkError
             , retryAfter = Nothing
             }
@@ -795,6 +797,51 @@ sdkErrorToApiError = \case
             }
     sdkError ->
         ConnectionError (renderClaudeSDKError sdkError)
+
+classifyResultError :: ClaudeSDKError -> ErrorType
+classifyResultError ResultError{subtype, apiErrorStatus, errors, result} =
+    case apiErrorStatus of
+        Just 401 -> AuthenticationError
+        Just 403 -> PermissionError
+        Just 404 -> NotFoundError
+        Just 413 -> PayloadTooLargeError
+        Just 429 -> RateLimitError
+        Just status
+            | status >= 500 && status < 503 -> ServiceUnavailableError
+            | status == 503 -> ServiceUnavailableError
+            | status == 529 -> OverloadedError
+        _ ->
+            let bySubtype = errorTypeFromText (Text.toLower subtype)
+            in case bySubtype of
+                UnknownErrorType _ ->
+                    classifyResultMessage
+                        (Text.toLower (Text.intercalate " " (errors <> maybeToList result)))
+                other -> other
+classifyResultError _ = ApiErrorType
+
+classifyResultMessage :: Text -> ErrorType
+classifyResultMessage message
+    | any (`Text.isInfixOf` message)
+        [ "authentication"
+        , "failed to authenticate"
+        , "oauth session expired"
+        , "unauthorized"
+        , "invalid api key"
+        ] =
+        AuthenticationError
+    | any (`Text.isInfixOf` message) ["permission", "forbidden", "not allowed"] =
+        PermissionError
+    | any (`Text.isInfixOf` message) ["context length", "context window", "too many tokens"] =
+        ContextWindowExceeded
+    | any (`Text.isInfixOf` message) ["rate limit", "rate_limit", "too many requests"] =
+        RateLimitError
+    | any (`Text.isInfixOf` message) ["overloaded", "overload"] =
+        OverloadedError
+    | any (`Text.isInfixOf` message) ["unavailable", "temporarily down"] =
+        ServiceUnavailableError
+    | any (`Text.isInfixOf` message) ["payload too large", "request too large"] =
+        PayloadTooLargeError
+    | otherwise = ApiErrorType
 
 sdkUsageToTokenUsage :: Usage -> TokenUsage
 sdkUsageToTokenUsage usage =

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -499,7 +499,7 @@ spec = do
                                 (\_ -> pure ())
                         result `shouldSatisfy` \case
                             Just (Left ProviderError
-                                { errorType = ApiErrorType
+                                { errorType = AuthenticationError
                                 , message
                                 }) ->
                                     "login expired" `Text.isInfixOf` message
@@ -531,7 +531,7 @@ spec = do
                                     modifyIORef' events (<> [event]))
                         result `shouldSatisfy` \case
                             Just (Left ProviderError
-                                { errorType = ApiErrorType
+                                { errorType = AuthenticationError
                                 , message
                                 }) ->
                                     "non-subscription credential source"
@@ -995,7 +995,7 @@ spec = do
                                 turns
                         failed `shouldSatisfy` \case
                             Left ProviderError
-                                { errorType = ApiErrorType
+                                { errorType = AuthenticationError
                                 , message
                                 } ->
                                     "login expired"

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -3,8 +3,10 @@ module Agent.Claude.LoopBackendSpec (spec) where
 import Agent.Claude.LoopBackend
     ( appendHostTranscript
     , claudeCodeOneShotBackend
+    , sdkErrorToApiError
     , withClaudeCodeBackend
     )
+import Claude.Agent.SDK.Errors (ClaudeSDKError(..))
 import Agent.Claude.Options
     ( ClaudeCodeOptions(..)
     , ClaudeCodePermission(..)
@@ -75,6 +77,29 @@ submitBackend backend previous inputs onEvent =
 
 spec :: Spec
 spec = do
+    describe "sdkErrorToApiError" do
+        it "classifies status and subtype categories" do
+            sdkErrorToApiError
+                (ResultError "rate_limit_error" (Just 429) [] Nothing)
+                `shouldSatisfy` \case
+                    ProviderError{errorType = RateLimitError} -> True
+                    _ -> False
+            sdkErrorToApiError
+                (ResultError "permission_error" (Just 403) ["forbidden"] Nothing)
+                `shouldSatisfy` \case
+                    ProviderError{errorType = PermissionError} -> True
+                    _ -> False
+        it "classifies an expired OAuth session reported in the result" do
+            sdkErrorToApiError
+                (ResultError
+                    "error"
+                    Nothing
+                    []
+                    (Just "Failed to authenticate: OAuth session expired and could not be refreshed"))
+                `shouldSatisfy` \case
+                    ProviderError{errorType = AuthenticationError} -> True
+                    _ -> False
+
     describe "appendHostTranscript" do
         it "appends turn inputs followed by assistant text" $ do
             let history =

--- a/packages/agent-cli/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth.hs
@@ -61,6 +61,7 @@ import Agent.CLI.GatewayClient
     )
 import Agent.Error (ApiError(..))
 import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
+import Agent.Transport.WebSocket (webSocketHandshakeFailureStatus)
 import qualified Agent.Claude.Auth as ClaudeCode
 import Agent.Provider
     ( AccountFailure(..)
@@ -74,6 +75,9 @@ import Agent.Provider
     , providerSlug
     , seedTokenProvider
     , tokenProvider
+    , tokenProviderBillingMode
+    , tokenProviderWithNextToken
+    , withAccountFailureClassifier
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
 import qualified Agent.XAI.Auth as XAIAuth
@@ -97,28 +101,121 @@ import System.Directory.OsPath (doesFileExist, getHomeDirectory)
 import System.OsPath (unsafeEncodeUtf, (</>))
 
 loadAuth :: Maybe Provider -> IO (Either Text LoadedAuth)
-loadAuth requested =
+loadAuth (Just OpenAIProvider) = loadOpenAiWithGateway
+loadAuth (Just provider) = loadProvider provider
+loadAuth Nothing =
     loadGatewayCredential >>= \case
-        Left err -> pure (Left ("cannot load gateway credential: " <> err))
-        Right (Just gateway) -> pure (gatewayLoadedAuth gateway)
-        Right Nothing -> runExceptT do
-            provider <- detectProvider requested
-            case provider of
-                XAIProvider -> loadXai Nothing
-                OpenAIProvider -> loadOpenAi
-                OpenRouterProvider -> loadOpenRouter Nothing
-                ClaudeCodeProvider -> loadClaudeCode
+        Left gatewayErr ->
+            loadSubscriptionFallback gatewayErr loadDetectedProvider
+        Right (Just gateway) -> loadGatewayPreferredAuth gateway
+        Right Nothing -> loadDetectedProvider
+
+loadOpenAiWithGateway :: IO (Either Text LoadedAuth)
+loadOpenAiWithGateway =
+    loadGatewayCredential >>= \case
+        Left gatewayErr ->
+            loadSubscriptionFallback
+                gatewayErr
+                (loadProvider OpenAIProvider)
+        Right (Just gateway) -> loadGatewayPreferredAuth gateway
+        Right Nothing -> loadProvider OpenAIProvider
+
+loadSubscriptionFallback
+    :: Text
+    -> IO (Either Text LoadedAuth)
+    -> IO (Either Text LoadedAuth)
+loadSubscriptionFallback gatewayErr loadFallback =
+    loadFallback >>= \case
+        Right loaded
+            | tokenProviderBillingMode
+                loaded.loadedTokenProvider
+                == SubscriptionBilled ->
+                    pure (Right loaded)
+        Right _ ->
+            pure $ Left $
+                "cannot load gateway credential: "
+                    <> gatewayErr
+                    <> "; refusing automatic fallback to "
+                    <> "API-credit billing"
+        Left providerErr ->
+            pure $ Left $
+                "cannot load gateway credential: "
+                    <> gatewayErr
+                    <> "; "
+                    <> providerErr
+
+loadDetectedProvider :: IO (Either Text LoadedAuth)
+loadDetectedProvider =
+    runExceptT (detectProvider Nothing) >>= \case
+        Left err -> pure (Left err)
+        Right provider -> loadProvider provider
+
+loadProvider :: Provider -> IO (Either Text LoadedAuth)
+loadProvider provider = runExceptT case provider of
+    XAIProvider -> loadXai Nothing
+    OpenAIProvider -> loadOpenAi
+    OpenRouterProvider -> loadOpenRouter Nothing
+    ClaudeCodeProvider -> loadClaudeCode
+
+-- | Load local OpenAI credentials without consulting the gateway.
+--
+-- Explicit account selection and gateway failover use this entry point so a
+-- saved gateway can never shadow the user's local ChatGPT account pool.
+loadDirectOpenAiAuth :: IO (Either Text LoadedAuth)
+loadDirectOpenAiAuth =
+    runExceptT loadOpenAi
+
+loadGatewayPreferredAuth
+    :: GatewayCredential
+    -> IO (Either Text LoadedAuth)
+loadGatewayPreferredAuth gateway =
+    case gatewayLoadedAuth gateway of
+        Left gatewayErr ->
+            loadDirectOpenAiAuth >>= \case
+                Right directAuth
+                    | tokenProviderBillingMode
+                        directAuth.loadedTokenProvider
+                        == SubscriptionBilled ->
+                            pure (Right directAuth)
+                Right _ ->
+                    pure $ Left $
+                        gatewayErr
+                            <> "; refusing automatic fallback to "
+                            <> "API-credit billing"
+                Left directErr ->
+                    pure $ Left $
+                        gatewayErr <> "; direct OpenAI auth unavailable: "
+                            <> directErr
+        Right gatewayAuth ->
+            loadDirectOpenAiAuth >>= \case
+                Right directAuth
+                    | tokenProviderBillingMode
+                        directAuth.loadedTokenProvider
+                        == SubscriptionBilled -> do
+                            let gatewayCredential =
+                                    credentialForGateway gateway
+                            combined <-
+                                gatewayFallbackTokenProvider
+                                    gatewayCredential
+                                    directAuth.loadedTokenProvider
+                            pure $ Right gatewayAuth
+                                { loadedTokenProvider = combined
+                                , loadedAccountLabel = \credential ->
+                                    if credential == gatewayCredential
+                                        then pure gateway.gatewayBaseUrl
+                                        else
+                                            directAuth.loadedAccountLabel
+                                                credential
+                                , loadedOpenAiPool =
+                                    directAuth.loadedOpenAiPool
+                                }
+                _ ->
+                    pure (Right gatewayAuth)
 
 gatewayLoadedAuth :: GatewayCredential -> Either Text LoadedAuth
 gatewayLoadedAuth gateway = do
     validateGatewayWebSocketUrl gateway.gatewayWebSocketUrl
-    let credential =
-            Credential
-                { accessToken = gateway.gatewayAccessToken
-                , accountId = gateway.gatewayWebSocketUrl
-                , leaseId = Nothing
-                , provider = OpenAIProvider
-                }
+    let credential = credentialForGateway gateway
     pure LoadedAuth
             { loadedProvider = OpenAIProvider
             , loadedTokenProvider =
@@ -128,20 +225,95 @@ gatewayLoadedAuth gateway = do
             , loadedOpenAiPool = Nothing
             }
 
+credentialForGateway :: GatewayCredential -> Credential
+credentialForGateway gateway =
+    Credential
+        { accessToken = gateway.gatewayAccessToken
+        , accountId = gateway.gatewayWebSocketUrl
+        , leaseId = Nothing
+        , provider = OpenAIProvider
+        }
+
+-- | Prefer the gateway until that exact credential is rejected or exhausted,
+-- then stay on the local same-billing OpenAI pool for the rest of the session.
+--
+-- A gateway failure is not forwarded to the local pool because it describes a
+-- different credential and would otherwise cool down an unrelated account.
+gatewayFallbackTokenProvider
+    :: Credential
+    -> TokenProvider
+    -> IO TokenProvider
+gatewayFallbackTokenProvider gatewayCredential directProvider = do
+    gatewayPreferred <- newIORef True
+    pure $
+        withAccountFailureClassifier classifyGatewayFailure $
+            tokenProviderWithNextToken directProvider \failed ->
+                case failed of
+                    Nothing ->
+                        readIORef gatewayPreferred >>= \case
+                            True -> pure (Right gatewayCredential)
+                            False -> getNextToken directProvider Nothing
+                    Just reported
+                        | reported.credential == gatewayCredential -> do
+                            writeIORef gatewayPreferred False
+                            getNextToken directProvider Nothing
+                        | otherwise -> do
+                            writeIORef gatewayPreferred False
+                            getNextToken directProvider (Just reported)
+  where
+    -- A gateway WebSocket handshake 403 rejects this gateway credential
+    -- before any turn effects occur. Treat only that distinct credential as
+    -- failed so the local ChatGPT fallback becomes reachable; ordinary direct
+    -- ChatGPT 403s remain permission failures and never rotate accounts.
+    classifyGatewayFailure credential = \case
+        err
+            | credential == gatewayCredential
+            , webSocketHandshakeFailureStatus err == Just 403 ->
+                Just AccountAuthenticationRejected
+        _ -> Nothing
+
 -- | Load one specific account for providers whose HTTP backends can swap
 -- token sources without reconnecting a long-lived transport.
 loadAuthForAccount :: Provider -> Text -> IO (Either Text LoadedAuth)
 loadAuthForAccount provider selectionId =
-    loadGatewayCredential >>= \case
-        Left err -> pure (Left ("cannot load gateway credential: " <> err))
-        Right (Just gateway) -> pure (gatewayLoadedAuth gateway)
-        Right Nothing -> runExceptT case provider of
+    if provider == OpenAIProvider
+        then
+            if selectionId == "gateway"
+                then loadGatewayCredential >>= \case
+                    Left err ->
+                        pure (Left
+                            ("cannot load gateway credential: " <> err))
+                    Right (Just gateway) ->
+                        loadGatewayPreferredAuth gateway
+                    Right Nothing ->
+                        pure (Left "no gateway credential is connected")
+                else loadDirectOpenAiAccountAuth selectionId
+        else runExceptT case provider of
             XAIProvider -> loadXai (Just selectionId)
             OpenRouterProvider -> loadOpenRouter (Just selectionId)
             OpenAIProvider ->
                 throwE "OpenAI account selection is handled by the live account pool"
             ClaudeCodeProvider ->
                 throwE "Claude Code accounts are managed by `claude auth login`"
+
+loadDirectOpenAiAccountAuth :: Text -> IO (Either Text LoadedAuth)
+loadDirectOpenAiAccountAuth accountId =
+    loadDirectOpenAiAuth >>= \case
+        Left err -> pure (Left err)
+        Right loaded -> case loaded.loadedOpenAiPool of
+            Nothing ->
+                pure (Left
+                    "OpenAI account selection requires a live account pool")
+            Just pool -> do
+                preferred <- newIORef (Just accountId)
+                pure $ Right loaded
+                    { loadedTokenProvider =
+                        preferredOpenAiTokenProvider
+                            preferred
+                            pool
+                            loaded.loadedTokenProvider
+                    , loadedSelectionId = Just accountId
+                    }
 
 -- | Ask the token source whether it has a usable credential now without
 -- making a model request, preserving a successful checkout for later use.

--- a/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
@@ -34,8 +34,7 @@ import Agent.Provider
     , Provider(OpenAIProvider)
     , TokenProvider
     , getNextToken
-    , tokenProvider
-    , tokenProviderBillingMode
+    , tokenProviderWithNextToken
     )
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
@@ -74,7 +73,7 @@ preferredOpenAiTokenProvider
     -> TokenProvider
     -> TokenProvider
 preferredOpenAiTokenProvider preferredAccount pool fallback =
-    tokenProvider (tokenProviderBillingMode fallback) \failed ->
+    tokenProviderWithNextToken fallback \failed ->
         case failed of
             Just reportedFailure -> do
                 fallbackResult <-

--- a/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
@@ -15,7 +15,8 @@ import Agent.Loop
     )
 import qualified Agent.OpenAI.Client as OpenAIClient
 import Agent.OpenAI.LoopBackend
-    ( isOpenAiWebSocketTransportFailure
+    ( isOpenAiReplayUnsafeWebSocketTransportFailure
+    , isOpenAiWebSocketTransportFailure
     , openAiAuxiliaryResponseSenderReconnecting
     , openAiBackendWithReasoningVisibility
     , openAiBackendWithTransportFallback
@@ -141,6 +142,14 @@ lockedOpenAiSession gatewayOnly compactThreshold showRawReasoning wsLock fallbac
                         sendAuxiliary request Nothing (const (pure ()))
                     case result of
                         Left err
+                            | not gatewayOnly
+                            , isOpenAiReplayUnsafeWebSocketTransportFailure err -> do
+                                -- The socket is dead, so route later work over
+                                -- HTTP. Do not replay this compaction: an
+                                -- opaque checkpoint already arrived and the
+                                -- provider may have committed/billed it.
+                                writeIORef fallbackActive True
+                                pure result
                             | not gatewayOnly
                             , isOpenAiWebSocketTransportFailure err -> do
                                 writeIORef fallbackActive True

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -307,8 +307,8 @@ import Agent.Provider
       getNextToken,
       providerSlug,
       runWithTokenProvider,
-      tokenProvider,
-      tokenProviderBillingMode )
+      tokenProviderBillingMode,
+      tokenProviderWithNextToken )
 import Agent.Responses.GenericBackend
     ( genericResponsesBackendWith )
 import Agent.Responses.GenericClient ( GenericClientOptions(..) )
@@ -2822,7 +2822,7 @@ trackCredentialAccount
     -> TokenProvider
     -> TokenProvider
 trackCredentialAccount accountRef accountIdRef selectionRef resolveLabel provider =
-    tokenProvider (tokenProviderBillingMode provider) \failed ->
+    tokenProviderWithNextToken provider \failed ->
         getNextToken provider failed >>= \case
             Left err -> pure (Left err)
             Right credential -> do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -291,10 +291,11 @@ import Agent.OpenAI.WebSocketClient
     ( CodexAuthFailed(..),
       closeCodexConn,
       codexConnTurnState,
+      codexConnUsesHttpFallback,
       isGatewayWebSocketCredential,
       resetCodexTurnState,
-      withCodexWsCredential,
-      withCodexWsWithProvider )
+      withCodexWsCredentialOrHttpFallback,
+      withCodexWsWithProviderOrHttpFallback )
 import Agent.OpenRouter.LoopBackend ( openRouterBackend )
 import Agent.OsPath ( toText, unsafeToFilePath )
 import Agent.Provider
@@ -2261,15 +2262,17 @@ runAgentInitializedWithLock
                     case provider of
                     OpenAIProvider ->
                         try @_ @CodexAuthFailed
-                            (withCodexWsWithProvider tokenProvider \conn credential -> do
+                            (withCodexWsWithProviderOrHttpFallback tokenProvider \conn credential -> do
                                 wsLock <- newMVar ()
-                                initialWsHealthy <- newIORef True
+                                let startsOnHttp =
+                                        codexConnUsesHttpFallback conn
+                                initialWsHealthy <- newIORef (not startsOnHttp)
                                 activeConnectionRef <- newIORef $
                                     OpenAiPersistentConnection
                                         credential
                                         initialWsHealthy
                                         conn
-                                httpFallbackActive <- newIORef False
+                                httpFallbackActive <- newIORef startsOnHttp
                                 switchRequests <-
                                     newChan :: IO (Chan AccountSwitchRequest)
                                 let selectAccount = case loaded.loadedOpenAiPool of
@@ -2333,8 +2336,12 @@ runAgentInitializedWithLock
                                                     installConnection
                                                         newCredential
                                                         newConn = do
+                                                            let usesHttp =
+                                                                    codexConnUsesHttpFallback
+                                                                        newConn
                                                             newHealthy <-
-                                                                newIORef True
+                                                                newIORef
+                                                                    (not usesHttp)
                                                             label <-
                                                                 resolveActiveAccountLabel
                                                                     newCredential
@@ -2353,6 +2360,9 @@ runAgentInitializedWithLock
                                                             writeIORef
                                                                 activeAccountRef
                                                                 label
+                                                            writeIORef
+                                                                httpFallbackActive
+                                                                usesHttp
                                                             pure (newHealthy, label)
                                                     awaitNext newHealthy =
                                                         readChan switchRequests
@@ -2376,7 +2386,7 @@ runAgentInitializedWithLock
                                                     (Just
                                                         selectedCredential.accountId)
                                                 let connectSelected =
-                                                        withCodexWsCredential
+                                                        withCodexWsCredentialOrHttpFallback
                                                             selectedCredential
                                                             \newConn
                                                                 newCredential -> do
@@ -2423,7 +2433,7 @@ runAgentInitializedWithLock
                                                                                         , provider =
                                                                                             OpenAIProvider
                                                                                         }
-                                                                            (withCodexWsCredential
+                                                                            (withCodexWsCredentialOrHttpFallback
                                                                                 restoredCredential
                                                                                 \newConn
                                                                                     newCredential -> do

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -2,6 +2,10 @@ module Agent.CLI.AuthSpec (spec) where
 
 import Agent.CLI.Auth
 import Agent.CLI.CredentialStore
+import Agent.CLI.GatewayClient
+    ( GatewayCredential(..)
+    , saveGatewayCredentialAt
+    )
 import qualified Agent.CLI.Login as Login
 import Agent.Error
     ( ApiError(..)
@@ -19,8 +23,10 @@ import Agent.Provider
     , FailedCredential(..)
     , Provider(..)
     , getNextToken
+    , runWithTokenProvider
     , tokenProvider
     , tokenProviderBillingMode
+    , tokenProviderWithNextToken
     )
 import qualified Agent.XAI.Auth as XAIAuth
 import Control.Exception.Safe (bracket)
@@ -90,6 +96,193 @@ spec = do
                         Left err -> expectationFailure (Text.unpack err)
                         Right loaded ->
                             loaded.loadedProvider `shouldBe` OpenAIProvider
+
+        it "keeps a local ChatGPT fallback behind the preferred gateway" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccount
+                        "local-openai"
+                        "local-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just OpenAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            case loaded.loadedOpenAiPool of
+                                Nothing ->
+                                    expectationFailure
+                                        "expected local OpenAI fallback pool"
+                                Just _ -> pure ()
+                            gatewayCredential <-
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    Nothing
+                                    >>= expectRightResult
+                            gatewayCredential.accountId
+                                `shouldBe`
+                                    "wss://gateway.example/v1/responses"
+                            localCredential <-
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    (Just FailedCredential
+                                        { credential = gatewayCredential
+                                        , failure =
+                                            AccountAuthenticationRejected
+                                        , failureReason =
+                                            testAuthenticationReason
+                                        })
+                                    >>= expectRightResult
+                            localCredential.accountId
+                                `shouldBe` "local-account"
+                            getNextToken
+                                loaded.loadedTokenProvider
+                                Nothing
+                                `shouldReturn` Right localCredential
+
+        it "falls back after a gateway WebSocket handshake 403" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccount
+                        "local-openai"
+                        "local-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just OpenAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            pool <- case loaded.loadedOpenAiPool of
+                                Nothing -> do
+                                    expectationFailure
+                                        "expected local OpenAI fallback pool"
+                                    fail "missing local OpenAI fallback pool"
+                                Just pool -> pure pool
+                            preferred <- newIORef Nothing
+                            let selectableProvider =
+                                    preferredOpenAiTokenProvider
+                                        preferred
+                                        pool
+                                        loaded.loadedTokenProvider
+                                runtimeProvider =
+                                    tokenProviderWithNextToken
+                                        selectableProvider
+                                        (getNextToken selectableProvider)
+                            attempts <- newIORef ([] :: [Text])
+                            result <- runWithTokenProvider
+                                runtimeProvider
+                                \credential -> do
+                                    modifyIORef'
+                                        attempts
+                                        (<> [credential.accountId])
+                                    pure $
+                                        if credential.accountId
+                                            == "wss://gateway.example/v1/responses"
+                                            then Left $ HttpError 403
+                                                "WebSocket handshake returned HTTP 403"
+                                            else Right credential.accountId
+
+                            result `shouldBe` Right "local-account"
+                            readIORef attempts `shouldReturn`
+                                [ "wss://gateway.example/v1/responses"
+                                , "local-account"
+                                ]
+
+        it "does not replay an ordinary gateway request 403" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccount
+                        "local-openai"
+                        "local-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just OpenAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            pool <- case loaded.loadedOpenAiPool of
+                                Nothing -> do
+                                    expectationFailure
+                                        "expected local OpenAI fallback pool"
+                                    fail "missing local OpenAI fallback pool"
+                                Just pool -> pure pool
+                            preferred <- newIORef Nothing
+                            let provider =
+                                    preferredOpenAiTokenProvider
+                                        preferred
+                                        pool
+                                        loaded.loadedTokenProvider
+                                forbidden =
+                                    HttpError 403
+                                        "request forbidden after connection"
+                            attempts <- newIORef ([] :: [Text])
+                            result <- runWithTokenProvider provider
+                                \credential -> do
+                                    modifyIORef'
+                                        attempts
+                                        (<> [credential.accountId])
+                                    pure (Left forbidden :: Either ApiError Text)
+
+                            result `shouldBe` Left forbidden
+                            readIORef attempts `shouldReturn`
+                                ["wss://gateway.example/v1/responses"]
+
+        it "does not turn a rejected gateway into API-credit spending" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    saveTestGateway home
+                    storeOpenAiAccountWithBilling
+                        ApiBilled
+                        "api-openai"
+                        "api-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just OpenAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            case loaded.loadedOpenAiPool of
+                                Nothing -> pure ()
+                                Just _ ->
+                                    expectationFailure
+                                        "API-billed auth must not be an automatic gateway fallback"
+                            gatewayCredential <-
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    Nothing
+                                    >>= expectRightResult
+                            gatewayCredential.accountId
+                                `shouldBe`
+                                    "wss://gateway.example/v1/responses"
+                            getNextToken
+                                loaded.loadedTokenProvider
+                                (Just FailedCredential
+                                    { credential = gatewayCredential
+                                    , failure =
+                                        AccountAuthenticationRejected
+                                    , failureReason =
+                                        testAuthenticationReason
+                                    })
+                                `shouldReturn`
+                                    Left (CredentialError
+                                        "static credential was rejected")
+
+        it "does not let a gateway override an explicit non-OpenAI provider" $
+            withTempHome \home ->
+                withCleanGrokEnv $
+                withEnv "GROK_ACCESS_TOKEN" (Just "grok-token") do
+                    saveTestGateway home
+                    loadAuth (Just XAIProvider) >>= \case
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            loaded.loadedProvider `shouldBe` XAIProvider
+                            getNextToken
+                                loaded.loadedTokenProvider
+                                Nothing
+                                >>= \case
+                                    Left err -> expectationFailure (show err)
+                                    Right credential ->
+                                        credential.accessToken
+                                            `shouldBe` "grok-token"
 
     describe "probeLoadedAuth" do
         it "rejects auth whose accounts are currently cooling down" do
@@ -1003,6 +1196,10 @@ testAuthenticationReason = ExhaustedByAuthentication
     , exhaustionStatusCode = Just 401
     }
 
+farFutureAccessToken :: Text
+farFutureAccessToken =
+    "e30.eyJleHAiOjQxMDI0NDQ4MDB9."
+
 testRateLimitReason :: Maybe Int -> CredentialExhaustionReason
 testRateLimitReason retryAfter = ExhaustedByRateLimit
     { exhaustionErrorType = Nothing
@@ -1134,3 +1331,21 @@ withTempHome action =
         removeFile path
         createDirectory path
         pure path
+
+saveTestGateway :: OsPath -> IO ()
+saveTestGateway home =
+    saveGatewayCredentialAt
+        home
+        GatewayCredential
+            { gatewayBaseUrl = "https://gateway.example"
+            , gatewayWebSocketUrl = "wss://gateway.example/v1/responses"
+            , gatewayAccessToken = "gateway-token"
+            }
+        `shouldReturn` Right ()
+
+expectRightResult :: Show error => Either error value -> IO value
+expectRightResult = \case
+    Left err -> do
+        expectationFailure ("expected Right, got " <> show err)
+        fail "missing Right value"
+    Right value -> pure value

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -188,9 +188,7 @@ accountFailureFromApiError err = case err of
     ProviderError UsageLimitReached _ _ -> rateLimited
     ProviderError UsageBalanceExhausted _ _ -> rateLimited
     HttpError 401 _ -> authenticationRejected
-    HttpError 403 _ -> authenticationRejected
     ProviderError AuthenticationError _ _ -> authenticationRejected
-    CredentialError{} -> authenticationRejected
     _ -> Nothing
   where
     rateLimited = Just $ AccountRateLimited (apiErrorRetryAfter err)

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -4,6 +4,8 @@ module Agent.Provider
     , TokenProvider
     , tokenProviderBillingMode
     , tokenProvider
+    , tokenProviderWithNextToken
+    , withAccountFailureClassifier
     , Credential(..)
     , Provider(..)
     , providerSlug
@@ -26,6 +28,7 @@ import Agent.Error
     , apiErrorRetryAfter
     , credentialExhaustionReasonFromApiError
     )
+import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import Data.IORef
 import Data.Maybe (fromMaybe)
@@ -111,13 +114,47 @@ data TokenProvider = TokenProvider
     , runGetNextToken
         :: Maybe FailedCredential
         -> IO (Either ApiError Credential)
+    , runClassifyAccountFailure
+        :: Credential
+        -> ApiError
+        -> Maybe AccountFailure
     }
 
 tokenProvider
     :: BillingMode
     -> (Maybe FailedCredential -> IO (Either ApiError Credential))
     -> TokenProvider
-tokenProvider = TokenProvider
+tokenProvider providerBillingMode runGetNextToken = TokenProvider
+    { providerBillingMode
+    , runGetNextToken
+    , runClassifyAccountFailure =
+        \_credential -> accountFailureFromApiError
+    }
+
+-- | Replace credential acquisition while retaining the provider's billing and
+-- account-failure policy. Provider decorators should use this instead of
+-- constructing a fresh 'TokenProvider'.
+tokenProviderWithNextToken
+    :: TokenProvider
+    -> (Maybe FailedCredential -> IO (Either ApiError Credential))
+    -> TokenProvider
+tokenProviderWithNextToken provider runGetNextToken =
+    provider { runGetNextToken }
+
+-- | Add credential-source-specific failure handling while preserving the
+-- provider-neutral defaults. Classifiers added here may cause the protected
+-- action to be replayed, so they must only recognize failures that happened
+-- before the action produced externally visible effects.
+withAccountFailureClassifier
+    :: (Credential -> ApiError -> Maybe AccountFailure)
+    -> TokenProvider
+    -> TokenProvider
+withAccountFailureClassifier classifier provider =
+    provider
+        { runClassifyAccountFailure = \credential err ->
+            classifier credential err
+                <|> provider.runClassifyAccountFailure credential err
+        }
 
 tokenProviderBillingMode :: TokenProvider -> BillingMode
 tokenProviderBillingMode TokenProvider{providerBillingMode} =
@@ -132,15 +169,15 @@ getNextToken provider = provider.runGetNextToken
 seedTokenProvider :: TokenProvider -> Credential -> IO TokenProvider
 seedTokenProvider provider credential = do
     seed <- newIORef (Just credential)
-    pure TokenProvider
-        { providerBillingMode = tokenProviderBillingMode provider
-        , runGetNextToken = \failed -> case failed of
-            Just reportedFailure -> getNextToken provider (Just reportedFailure)
-            Nothing -> atomicModifyIORef'
-                seed (\current -> (Nothing, current)) >>= \case
-                    Just firstCredential -> pure (Right firstCredential)
-                    Nothing -> getNextToken provider Nothing
-        }
+    pure $
+        tokenProviderWithNextToken provider \failed ->
+            case failed of
+                Just reportedFailure ->
+                    getNextToken provider (Just reportedFailure)
+                Nothing -> atomicModifyIORef'
+                    seed (\current -> (Nothing, current)) >>= \case
+                        Just firstCredential -> pure (Right firstCredential)
+                        Nothing -> getNextToken provider Nothing
 
 runWithTokenProvider
     :: TokenProvider
@@ -169,7 +206,8 @@ runWithTokenProviderAfter provider initialFailure action =
             Left err -> pure (Left err)
             Right credential -> action credential >>= \case
                 Left err
-                    | Just failure <- accountFailureFromApiError err ->
+                    | Just failure <-
+                        provider.runClassifyAccountFailure credential err ->
                         go (attemptsLeft - 1) $ Just FailedCredential
                             { credential
                             , failure

--- a/packages/agent-core/src/Agent/Transport/WebSocket.hs
+++ b/packages/agent-core/src/Agent/Transport/WebSocket.hs
@@ -19,6 +19,7 @@ module Agent.Transport.WebSocket
     , transientWsMidRunFailureLabel
     , wsHandshakeAuthFailure
     , wsHandshakeAuthFailureStatus
+    , webSocketHandshakeFailureStatus
     ) where
 
 import Agent.Error (ApiError(..))
@@ -519,8 +520,7 @@ wsConnectExceptionRetry exception
     | Just (WS.MalformedResponse responseHead _reason) <-
         Exception.fromException exception =
             let status = WS.responseCode responseHead
-                apiError = HttpError status
-                    ("WebSocket handshake returned HTTP " <> showText status)
+                apiError = webSocketHandshakeFailure status
             in if status `elem` retryableHandshakeStatusCodes
                 then RetryException apiError
                 else StopException apiError
@@ -577,19 +577,41 @@ tlsExceptionMessage = \case
         "TLS handshake failed: " <> showText tlsException
 
 -- | Extract an authentication status from a rejected WebSocket handshake.
+--
+-- HTTP 403 is a permission or policy rejection, not proof that the bearer
+-- token is invalid. Treating every 403 as authentication failure can rotate
+-- healthy credentials and quarantine an entire account pool.
 wsHandshakeAuthFailureStatus :: Exception.SomeException -> Maybe Int
 wsHandshakeAuthFailureStatus exception = case Exception.fromException exception of
     Just (WS.MalformedResponse responseHead _reason)
-        | WS.responseCode responseHead `elem` [401, 403] ->
+        | WS.responseCode responseHead == 401 ->
             Just (WS.responseCode responseHead)
     _ -> Nothing
 
--- | Convert a raw WebSocket handshake 401/403 into the shared HTTP error
+-- | Convert a raw WebSocket handshake 401 into the shared HTTP error
 -- shape. Headers are intentionally omitted because they may contain cookies.
 wsHandshakeAuthFailure :: Exception.SomeException -> Maybe ApiError
 wsHandshakeAuthFailure exception = do
     status <- wsHandshakeAuthFailureStatus exception
-    pure (HttpError status ("WebSocket handshake returned HTTP " <> showText status))
+    pure (webSocketHandshakeFailure status)
+
+-- | Recognize the exact HTTP error shape emitted when a WebSocket handshake
+-- is rejected before a connection is established. A same-status application
+-- error must not be treated as safe to replay.
+webSocketHandshakeFailureStatus :: ApiError -> Maybe Int
+webSocketHandshakeFailureStatus = \case
+    HttpError status message
+        | message == webSocketHandshakeFailureMessage status ->
+            Just status
+    _ -> Nothing
+
+webSocketHandshakeFailure :: Int -> ApiError
+webSocketHandshakeFailure status =
+    HttpError status (webSocketHandshakeFailureMessage status)
+
+webSocketHandshakeFailureMessage :: Int -> Text
+webSocketHandshakeFailureMessage status =
+    "WebSocket handshake returned HTTP " <> showText status
 
 -- | Classify transient failures that happen during a WebSocket session.
 transientWsMidRunFailureLabel :: Exception.SomeException -> Maybe Text

--- a/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
+++ b/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
@@ -105,6 +105,25 @@ spec = describe "Agent.Transport.WebSocket" do
         wsHandshakeAuthFailure exception
             `shouldBe` Just (HttpError 401 "WebSocket handshake returned HTTP 401")
 
+    it "keeps handshake 403 as a permission failure" do
+        let exception = transientHandshakeException 403
+        wsHandshakeAuthFailureStatus exception `shouldBe` Nothing
+        wsHandshakeAuthFailure exception `shouldBe` Nothing
+        webSocketHandshakeFailureStatus
+            (HttpError 403 "WebSocket handshake returned HTTP 403")
+            `shouldBe` Just 403
+        webSocketHandshakeFailureStatus
+            (HttpError 403 "request forbidden after connection")
+            `shouldBe` Nothing
+
+        result <- retryTransientWsConnectWithPolicy
+            (constantDelay 0 <> limitRetries 3)
+            \_connected -> throwIO exception
+
+        result `shouldBe`
+            (Left (HttpError 403 "WebSocket handshake returned HTTP 403")
+                :: Either ApiError ())
+
     it "retries a transient handshake failure before the connection callback" do
         attempts <- newIORef (0 :: Int)
         let exception = TLS.HandshakeFailed $ TLS.Error_Misc

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -19,6 +19,7 @@ module Agent.OpenAI.LoopBackend
     , openAiBackendWithTransportFallback
     , withCodexTurnStateScope
     , isOpenAiWebSocketTransportFailure
+    , isOpenAiReplayUnsafeWebSocketTransportFailure
     , statelessResponsesBackend
     , turnInputsToItems
     , responseToTurnOutput
@@ -72,6 +73,7 @@ import Agent.Responses.LoopBackend
     , withRequestInput
     )
 import Agent.Responses.Types
+import qualified Agent.Transport.WebSocket as WebSocket
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (onException)
 import Control.Monad (when)
@@ -456,19 +458,35 @@ replayUnsafeError :: Text -> ApiError -> ApiError
 replayUnsafeError outputLabel err =
     if isReplayUnsafeError err
         then err
-        else ProviderError (UnknownErrorType "replay_unsafe")
+        else ProviderError replayUnsafeType
             ( "provider failed after "
                 <> outputLabel
                 <> "; refusing to replay: "
                 <> Text.pack (show err)
             )
             Nothing
+  where
+    -- Retain transport provenance in the structured error type. Auxiliary
+    -- callers must not replay a request after an opaque checkpoint arrived,
+    -- but they still need to retire the broken WebSocket for later requests.
+    replayUnsafeType
+        | isOpenAiWebSocketTransportFailure err =
+            UnknownErrorType replayUnsafeWebSocketTransportType
+        | otherwise = UnknownErrorType replayUnsafeTypeName
 
 isReplayUnsafeError :: ApiError -> Bool
 isReplayUnsafeError = \case
     ProviderError (UnknownErrorType errorType) _ _ ->
-        errorType == "replay_unsafe"
+        errorType == replayUnsafeTypeName
+            || errorType == replayUnsafeWebSocketTransportType
     _ -> False
+
+replayUnsafeTypeName :: Text
+replayUnsafeTypeName = "replay_unsafe"
+
+replayUnsafeWebSocketTransportType :: Text
+replayUnsafeWebSocketTransportType =
+    "replay_unsafe_websocket_transport"
 
 -- | Prefer a WebSocket backend, then switch this agent session permanently to
 -- a fallback transport when the socket dies before exposing model output.
@@ -515,12 +533,27 @@ openAiBackendWithTransportFallback fallbackActive primary fallback =
 -- | Errors that indicate the Codex Responses WebSocket transport is
 -- unavailable rather than that the logical request itself was rejected.
 isOpenAiWebSocketTransportFailure :: ApiError -> Bool
-isOpenAiWebSocketTransportFailure = \case
+isOpenAiWebSocketTransportFailure err = case err of
     ConnectionError {} -> True
     ProviderError WebSocketConnectionLimitReached _ _ -> True
     -- A server that does not support the Responses WebSocket protocol
     -- advertises that explicitly with HTTP 426.
     HttpError 426 _ -> True
+    -- Some direct ChatGPT accounts reject only the WebSocket upgrade while
+    -- accepting the same Responses request over HTTPS. Match the transport's
+    -- exact handshake fingerprint so an application-level 403 remains a
+    -- permission error.
+    _ -> WebSocket.webSocketHandshakeFailureStatus err == Just 403
+
+-- | A WebSocket failure whose request has already produced provider output.
+--
+-- The connection should not be reused, but the failed logical request must
+-- not be replayed: an auxiliary response may contain a billable opaque
+-- compaction checkpoint even when no text was rendered.
+isOpenAiReplayUnsafeWebSocketTransportFailure :: ApiError -> Bool
+isOpenAiReplayUnsafeWebSocketTransportFailure = \case
+    ProviderError (UnknownErrorType errorType) _ _ ->
+        errorType == replayUnsafeWebSocketTransportType
     _ -> False
 
 -- | Reset Codex sticky-routing state when a backend submission starts a new

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -1,7 +1,9 @@
 module Agent.OpenAI.WebSocketClient
     ( withCodexWs
     , withCodexWsWithProvider
+    , withCodexWsWithProviderOrHttpFallback
     , withCodexWsCredential
+    , withCodexWsCredentialOrHttpFallback
     , withCodexWsRetrying
     , withCodexWsRetryingAfter
     , sendWsRequest
@@ -33,6 +35,8 @@ module Agent.OpenAI.WebSocketClient
     , WebSocketReceiveActions(..)
     , receiveWsResponseWithActions
     , CodexConn
+    , codexConnUsesHttpFallback
+    , shouldFallbackDirectCodexHandshakeToHttp
     , closeCodexConn
     , CodexAuthFailed(..)
     ) where
@@ -106,12 +110,22 @@ newtype CodexTurnState = CodexTurnState (IORef (Maybe Text))
 data CodexConn = CodexWsConn
     !WebSocket.WebSocketSession
     !CodexTurnState
+    | CodexHttpFallback
+    !CodexTurnState
 
 newCodexTurnState :: IO CodexTurnState
 newCodexTurnState = CodexTurnState <$> newIORef Nothing
 
 codexConnTurnState :: CodexConn -> CodexTurnState
 codexConnTurnState (CodexWsConn _ turnState) = turnState
+codexConnTurnState (CodexHttpFallback turnState) = turnState
+
+-- | Whether persistent session acquisition had to bypass WebSockets. The
+-- marker still owns turn-scoped routing state so the HTTP backend can preserve
+-- the same continuation and compaction semantics as a live socket.
+codexConnUsesHttpFallback :: CodexConn -> Bool
+codexConnUsesHttpFallback CodexWsConn{} = False
+codexConnUsesHttpFallback CodexHttpFallback{} = True
 
 readCodexTurnState :: CodexTurnState -> IO (Maybe Text)
 readCodexTurnState (CodexTurnState turnState) = readIORef turnState
@@ -138,6 +152,7 @@ finishCodexTurnStateResponse turnState response
 closeCodexConn :: CodexConn -> IO ()
 closeCodexConn (CodexWsConn session _) =
     WebSocket.closeWebSocketSession session "switching account"
+closeCodexConn CodexHttpFallback{} = pure ()
 
 -- | Carry the current logical turn's sticky-routing token across a physical
 -- reconnect. Codex scopes this state to the turn rather than to the socket.
@@ -204,6 +219,28 @@ withCodexWsWithProvider provider action =
         Left err -> Exception.throwIO (CodexAuthFailed err)
         Right value -> pure value
 
+-- | Persistent-session acquisition with a direct HTTPS escape hatch.
+--
+-- Some ChatGPT accounts can use the Codex Responses API over HTTPS while the
+-- WebSocket upgrade is rejected with HTTP 403 (or 426). Convert only that exact
+-- pre-callback handshake error for a direct credential into an HTTP-fallback
+-- marker. Gateway credentials remain WebSocket-only, so their rejection is
+-- still returned to the token provider and may rotate to a direct account.
+withCodexWsWithProviderOrHttpFallback
+    :: TokenProvider
+    -> (CodexConn -> Credential -> IO a)
+    -> IO a
+withCodexWsWithProviderOrHttpFallback provider action =
+    runWithTokenProvider provider
+        (\credential ->
+            runPersistentConnectionAttempt
+                WebSocket.transientWsConnectRetryPolicy
+                credential
+                action)
+        >>= \case
+            Left err -> Exception.throwIO (CodexAuthFailed err)
+            Right value -> pure value
+
 -- | Open one exact credential for an interactive account switch. Connection
 -- retries are deliberately bounded so the selector cannot hang indefinitely.
 withCodexWsCredential
@@ -216,6 +253,49 @@ withCodexWsCredential credential action =
         credential
         (\conn activeCredential -> Right <$> action conn activeCredential)
 
+-- | Exact-credential variant of
+-- 'withCodexWsWithProviderOrHttpFallback', used by interactive account
+-- switches.
+withCodexWsCredentialOrHttpFallback
+    :: Credential
+    -> (CodexConn -> Credential -> IO a)
+    -> IO (Either ApiError a)
+withCodexWsCredentialOrHttpFallback credential =
+    runPersistentConnectionAttempt
+        (limitRetries 2 <> exponentialBackoff 500000)
+        credential
+
+runPersistentConnectionAttempt
+    :: RetryPolicyM IO
+    -> Credential
+    -> (CodexConn -> Credential -> IO a)
+    -> IO (Either ApiError a)
+runPersistentConnectionAttempt retryPolicy credential action = do
+    result <-
+        runConnectionAttemptWithPolicy
+            retryPolicy
+            credential
+            (\conn activeCredential ->
+                Right <$> action conn activeCredential)
+    case result of
+        Left err
+            | shouldFallbackDirectCodexHandshakeToHttp credential err -> do
+                turnState <- newCodexTurnState
+                Right <$> action (CodexHttpFallback turnState) credential
+        _ -> pure result
+
+-- | Recognize only the transport's exact pre-upgrade failure. A generic
+-- application-level 403 must remain a permission error, and gateways cannot
+-- use the direct ChatGPT HTTPS endpoint.
+shouldFallbackDirectCodexHandshakeToHttp
+    :: Credential
+    -> ApiError
+    -> Bool
+shouldFallbackDirectCodexHandshakeToHttp credential err =
+    credential.provider == OpenAIProvider
+        && not (isGatewayWebSocketCredential credential)
+        && WebSocket.webSocketHandshakeFailureStatus err `elem`
+            [Just 403, Just 426]
 -- | Run a replay-safe WebSocket action and automatically reacquire a
 -- credential after handshake or in-band account failures. The callback is
 -- executed again from the beginning after a 401, 403, or usage-limit error;
@@ -608,6 +688,9 @@ sendWsRequestWithEventsAndOptions
 sendWsRequestWithEventsAndOptions completion options cc request previousResponseId
         onEvent = case cc of
     CodexWsConn session turnState -> sendOverWs session turnState
+    CodexHttpFallback{} ->
+        pure $ Left $ ConnectionError
+            "OpenAI WebSocket unavailable; HTTPS fallback required"
   where
     sendOverWs session turnState = do
         turnStateValue <- readCodexTurnState turnState

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -185,10 +185,11 @@ wsPath = "/backend-api/codex/responses"
 -- The provider-neutral WebSocket transport keeps the reusable connection
 -- alive and drains control frames for the lifetime of @action@.
 --
--- A handshake HTTP 401/403 is recovered centrally: the rejected account is
+-- A handshake HTTP 401 is recovered centrally: the rejected account is
 -- force-refreshed even when its JWT has not expired, then the handshake is
 -- retried once with the rotated token. If refresh or the second handshake
 -- fails, the account is cooled down and the next configured account is tried.
+-- HTTP 403 remains a permission/policy failure and does not rotate credentials.
 -- This happens before the callback starts, so retrying cannot duplicate caller
 -- side effects.
 --
@@ -298,7 +299,8 @@ shouldFallbackDirectCodexHandshakeToHttp credential err =
             [Just 403, Just 426]
 -- | Run a replay-safe WebSocket action and automatically reacquire a
 -- credential after handshake or in-band account failures. The callback is
--- executed again from the beginning after a 401, 403, or usage-limit error;
+-- executed again from the beginning after a 401, an explicitly typed
+-- authentication error, or a usage-limit error;
 -- callers must therefore keep externally visible side effects idempotent.
 withCodexWsRetrying
     :: TokenProvider

--- a/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
@@ -53,12 +53,20 @@ spec = do
                 (ProviderError UsageBalanceExhausted "balance exhausted" (Just 3600))
                 `shouldBe` Just (AccountRateLimited (Just 3600))
 
-        it "classifies authentication failures but not connection errors" do
+        it "classifies explicit authentication failures only" do
             accountFailureFromApiError (HttpError 401 "rejected")
                 `shouldBe` Just AccountAuthenticationRejected
             accountFailureFromApiError
-                (CredentialError "credential file is invalid")
+                (ProviderError AuthenticationError "rejected" Nothing)
                 `shouldBe` Just AccountAuthenticationRejected
+            accountFailureFromApiError (HttpError 403 "model access denied")
+                `shouldBe` Nothing
+            accountFailureFromApiError
+                (ProviderError PermissionError "model access denied" Nothing)
+                `shouldBe` Nothing
+            accountFailureFromApiError
+                (CredentialError "credential file is invalid")
+                `shouldBe` Nothing
             accountFailureFromApiError (ConnectionError "offline")
                 `shouldBe` Nothing
 
@@ -98,6 +106,20 @@ spec = do
                 pure (Left (ConnectionError "offline") :: Either ApiError Text)
 
             result `shouldBe` Left (ConnectionError "offline")
+            readIORef acquisitions `shouldReturn` 1
+
+        it "does not rotate accounts after an untyped HTTP 403" do
+            acquisitions <- newIORef (0 :: Int)
+            let forbidden = HttpError 403 "WebSocket handshake returned HTTP 403"
+                provider = tokenProvider SubscriptionBilled \reported -> do
+                    reported `shouldBe` Nothing
+                    modifyIORef' acquisitions (+ 1)
+                    pure $ Right (credentialFor "acc-a")
+
+            result <- runWithTokenProvider provider \_ ->
+                pure (Left forbidden :: Either ApiError Text)
+
+            result `shouldBe` Left forbidden
             readIORef acquisitions `shouldReturn` 1
 
         it "reports an already-failed connection before choosing a replacement" do

--- a/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
@@ -65,6 +65,14 @@ spec = do
                     Nothing)
                 `shouldBe` True
 
+        it "detects lost pending function-call state" do
+            isResponseChainCompatibilityError
+                (ProviderError
+                    InvalidRequestError
+                    "No tool output found for function call call_123."
+                    Nothing)
+                `shouldBe` True
+
         it "does not classify unrelated invalid parameters as chain errors" do
             isResponseChainCompatibilityError
                 (ProviderError

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1550,11 +1550,16 @@ replayUnsafeAuxiliaryFailure failure =
 
 replayUnsafeModelFailure :: ApiError -> ApiError
 replayUnsafeModelFailure failure =
-    ProviderError (UnknownErrorType "replay_unsafe")
+    ProviderError replayUnsafeType
         ( "provider failed after model output; refusing to replay: "
             <> Text.pack (show failure)
         )
         Nothing
+  where
+    replayUnsafeType
+        | isOpenAiWebSocketTransportFailure failure =
+            UnknownErrorType "replay_unsafe_websocket_transport"
+        | otherwise = UnknownErrorType "replay_unsafe"
 
 isInputFile :: ResponseContentPart -> Bool
 isInputFile = \case

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -581,6 +581,40 @@ spec = do
                     [CompletedTool (functionResult "c1" "tool output")]
                 ]
 
+        it "replays a call and output when continuation tool state is lost" do
+            seen <- newIORef []
+            let callId = "call_lost"
+                seed =
+                    turnInputsToItems [UserMessage "old"]
+                        <> [functionCallItem callId "read_file" "{}"]
+                chainError = ProviderError
+                    InvalidRequestError
+                    "No tool output found for function call call_lost."
+                    Nothing
+                resultInput =
+                    [CompletedTool (functionResult callId "file contents")]
+            transcript <- newIORef seed
+            let send request previous onEvent = do
+                    modifyIORef' seen (++ [(request, previous)])
+                    case previous of
+                        Just _ -> pure (Left chainError)
+                        Nothing -> do
+                            onEvent (deltaEvent EventOutputTextDelta "ok")
+                            pure $ Right
+                                (testResponse "resp-fresh" [assistantItem "ok"])
+                backend = openAiBackendWith send (pure baseParams)
+            result <- submitWithState transcript backend (Just "resp-call")
+                resultInput
+                (const (pure ()))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-fresh" [] (Just "ok"))
+            requests <- readIORef seen
+            map snd requests `shouldBe` [Just "resp-call", Nothing]
+            map (inputItems . fst) requests `shouldBe`
+                [ turnInputsToItems resultInput
+                , seed <> turnInputsToItems resultInput
+                ]
+
         it "strips explicitly requested cache retention and starts a fresh chain" do
             seen <- newIORef []
             let seed = turnInputsToItems [UserMessage "old"]

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1075,6 +1075,38 @@ spec = do
                 , HttpError 503 "unavailable"
                 ]
 
+        it "retains WebSocket provenance without making replay safe" do
+            let failure =
+                    replayUnsafeAuxiliaryFailure
+                        (ConnectionError
+                            "WebSocket receive error: ParseException \"not enough bytes\"")
+            isOpenAiReplayUnsafeWebSocketTransportFailure failure
+                `shouldBe` True
+            -- Callers use the ordinary predicate only when replaying the same
+            -- logical request over HTTP is safe.
+            isOpenAiWebSocketTransportFailure failure `shouldBe` False
+
+        it "does not label post-output provider failures as transport failures" do
+            let failure =
+                    replayUnsafeAuxiliaryFailure
+                        (ProviderError ApiErrorType "server error" Nothing)
+            isOpenAiReplayUnsafeWebSocketTransportFailure failure
+                `shouldBe` False
+
+    describe "isOpenAiWebSocketTransportFailure" do
+        it "recognizes an exact WebSocket handshake 403" do
+            isOpenAiWebSocketTransportFailure
+                (HttpError 403 "WebSocket handshake returned HTTP 403")
+                `shouldBe` True
+
+        it "does not hide application permission or authentication errors" do
+            isOpenAiWebSocketTransportFailure
+                (HttpError 403 "model access denied")
+                `shouldBe` False
+            isOpenAiWebSocketTransportFailure
+                (HttpError 401 "WebSocket handshake returned HTTP 401")
+                `shouldBe` False
+
     describe "openAiBackendWithTransportFallback" do
         it "switches permanently to fallback after a pre-output connection error" do
             fallbackActive <- newIORef False
@@ -1505,11 +1537,16 @@ isAuxiliaryOutputEvent = streamOutputObserved
 
 replayUnsafeAuxiliaryFailure :: ApiError -> ApiError
 replayUnsafeAuxiliaryFailure failure =
-    ProviderError (UnknownErrorType "replay_unsafe")
+    ProviderError replayUnsafeType
         ( "provider failed after auxiliary response output; refusing to replay: "
             <> Text.pack (show failure)
         )
         Nothing
+  where
+    replayUnsafeType
+        | isOpenAiWebSocketTransportFailure failure =
+            UnknownErrorType "replay_unsafe_websocket_transport"
+        | otherwise = UnknownErrorType "replay_unsafe"
 
 replayUnsafeModelFailure :: ApiError -> ApiError
 replayUnsafeModelFailure failure =

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -88,6 +88,37 @@ spec = do
         validateGatewayWebSocketUrl "https://gateway.example/v1/responses"
             `shouldSatisfy` isLeft
 
+  describe "shouldFallbackDirectCodexHandshakeToHttp" do
+    let direct = Credential
+            { accessToken = "token"
+            , accountId = "chatgpt-account"
+            , leaseId = Nothing
+            , provider = OpenAIProvider
+            }
+        gateway = direct
+            { accountId = "wss://gateway.example/v1/responses" }
+
+    it "accepts exact direct WebSocket handshake 403 and 426 failures" do
+        shouldFallbackDirectCodexHandshakeToHttp direct
+            (HttpError 403 "WebSocket handshake returned HTTP 403")
+            `shouldBe` True
+        shouldFallbackDirectCodexHandshakeToHttp direct
+            (HttpError 426 "WebSocket handshake returned HTTP 426")
+            `shouldBe` True
+
+    it "does not hide application permission errors or authentication failures" do
+        shouldFallbackDirectCodexHandshakeToHttp direct
+            (HttpError 403 "model access denied")
+            `shouldBe` False
+        shouldFallbackDirectCodexHandshakeToHttp direct
+            (HttpError 401 "WebSocket handshake returned HTTP 401")
+            `shouldBe` False
+
+    it "keeps gateway credentials WebSocket-only" do
+        shouldFallbackDirectCodexHandshakeToHttp gateway
+            (HttpError 403 "WebSocket handshake returned HTTP 403")
+            `shouldBe` False
+
   describe "buildWsPayloadWithOptions" do
     it "forces store=false for the Codex WebSocket contract" do
         let request = sampleRequest { store = Just True }

--- a/packages/agent-responses/src/Agent/Responses/Error.hs
+++ b/packages/agent-responses/src/Agent/Responses/Error.hs
@@ -263,12 +263,15 @@ isPreviousResponseIdError = \case
 --
 -- The Codex backend can return stored chains carrying
 -- @prompt_cache_retention@ parameter after routing a follow-up to a model that
--- no longer accepts it. Replaying the local transcript without the continuation
--- id creates a fresh chain and is safe before any model output is observed.
+-- no longer accepts it. Provider-managed continuation state can also lose a
+-- pending function call and reject its otherwise valid output. Replaying the
+-- local transcript without the continuation id creates a fresh chain and is
+-- safe before any model output is observed.
 isResponseChainCompatibilityError :: ApiError -> Bool
 isResponseChainCompatibilityError error =
     isPreviousResponseIdError error
         || apiErrorTextMatches mentionsUnsupportedPromptCacheRetention error
+        || apiErrorTextMatches mentionsMissingFunctionCallOutput error
 
 apiErrorTextMatches :: (Text -> Bool) -> ApiError -> Bool
 apiErrorTextMatches predicate = \case
@@ -295,6 +298,11 @@ mentionsUnsupportedPromptCacheRetention value =
     in "prompt_cache_retention" `Text.isInfixOf` lowered
         && ("not supported" `Text.isInfixOf` lowered
             || "unsupported" `Text.isInfixOf` lowered)
+
+mentionsMissingFunctionCallOutput :: Text -> Bool
+mentionsMissingFunctionCallOutput =
+    Text.isInfixOf "no tool output found for function call"
+        . Text.toLower
 
 orElse :: Maybe a -> Maybe a -> Maybe a
 orElse (Just value) _ = Just value


### PR DESCRIPTION
## Summary

- fall back from rejected direct OpenAI WebSockets to HTTPS without replaying turns after output
- rotate an exact gateway handshake 403 to the local subscription-backed ChatGPT pool while keeping application 403s and API-credit accounts non-replayable
- recover OpenAI continuations whose pending tool state was lost
- classify expired Claude OAuth sessions as authentication failures
- preserve the embedded native runtime lifetime fix already merged on this feature branch

## Validation

- agent-cli: 1,115 examples, 0 failures, 1 intentional pending live test
- agent-openai: 283 examples, 0 failures, 1 intentional pending live test
- agent-claude: 32 examples, 0 failures
- focused gateway/auth tests after rebase: 12 examples, 0 failures
- nix build path:.#agent-native-bridge
- independent code review: no blocking findings