### PR TITLE
ci: restore test workflow under local-actions policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,30 @@ jobs:
         experimental-features = nix-command flakes
         accept-flake-config = false
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 1
+      - name: Check out the triggering revision
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          source_dir="$RUNNER_TEMP/haskell-agent-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          printf 'SOURCE_DIR=%s\n' "$source_dir" >> "$GITHUB_ENV"
+
+          git init "$source_dir"
+          git -C "$source_dir" remote add origin \
+            https://github.com/digitallyinduced/haskell-agent.git
+          git -C "$source_dir" fetch \
+            --depth=1 \
+            --no-tags \
+            origin \
+            "$GITHUB_SHA"
+          git -C "$source_dir" checkout --detach FETCH_HEAD
 
       - name: Run Nix flake checks
         shell: bash
         run: |
           set -euo pipefail
+
+          cd "$SOURCE_DIR"
 
           nix_bin="$(command -v nix || true)"
           if [[ -z "$nix_bin" && -x /run/current-system/sw/bin/nix ]]; then
@@ -44,7 +60,7 @@ jobs:
 
           account_home=/var/lib/github-runner-haskell-agent
           credential_home="$(mktemp -d \
-            "$GITHUB_WORKSPACE/.agent-functional-credentials.XXXXXX")"
+            "$SOURCE_DIR/.agent-functional-credentials.XXXXXX")"
           chmod 700 "$credential_home"
           export AGENT_FUNCTIONAL_TEST_CREDENTIAL_HOME="$credential_home"
 


### PR DESCRIPTION
## Summary
- replace the external checkout action in the test workflow with the repository local shallow-checkout pattern
- run checks from the isolated checked-out source directory
- keep short-lived functional-test credentials in that directory for reliable cleanup

Repository Actions policy permits only local actions, so the old checkout step caused test runs to fail before a job was scheduled.

## Validation
- git diff --check
- YAML parsed successfully with PyYAML
- local smoke test of the git init, shallow fetch, and detached checkout sequence
- full CLI suite on the memory-retention branch: 1490 examples, 0 failures, 1 pending
