### PR TITLE
Recover stale OpenAI rate limits without restarting

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Auth/OpenAI.hs
@@ -30,6 +30,7 @@ import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Agent.OpenAI.Credential as OpenAICredential
 import qualified Agent.OpenAI.Login as OpenAILogin
+import qualified Agent.OpenAI.Usage as OpenAIUsage
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider
     ( BillingMode(..)
@@ -319,10 +320,20 @@ loadOpenAi = do
             filter ((== billing) . (.openAiBilling)) accounts
     refreshLock <- lift (newMVar ())
     accountSources <- lift (newIORef activeAccounts)
-    pool <- lift $ OpenAI.newDiscoveringPool
-        (map (.openAiState) activeAccounts)
-        (refreshOpenAiAccount refreshLock clientId accountSources)
-        (discoverOpenAiAccounts billing accountSources)
+    let initial = map (.openAiState) activeAccounts
+        refresh =
+            refreshOpenAiAccount refreshLock clientId accountSources
+        discover =
+            discoverOpenAiAccounts billing accountSources
+    pool <- lift $ case billing of
+        SubscriptionBilled ->
+            OpenAI.newDiscoveringPoolWithRateLimitRevalidation
+                initial
+                refresh
+                discover
+                revalidateOpenAiRateLimit
+        ApiBilled ->
+            OpenAI.newDiscoveringPool initial refresh discover
     tokenProvider <- lift
         (OpenAICredential.poolTokenProviderWithBilling billing pool)
     pure LoadedAuth
@@ -341,6 +352,22 @@ loadOpenAi = do
         , loadedSelectionId = Nothing
         , loadedOpenAiPool = Just pool
         }
+
+revalidateOpenAiRateLimit
+    :: OpenAI.AuthState
+    -> IO (Either ApiError Bool)
+revalidateOpenAiRateLimit auth =
+    fmap (fmap usageAvailable) $
+        OpenAIUsage.fetchUsage auth.accessToken auth.accountId
+  where
+    usageAvailable OpenAIUsage.UsageSnapshot{rateLimit = Nothing} = True
+    usageAvailable OpenAIUsage.UsageSnapshot
+            { rateLimit = Just OpenAIUsage.UsageLimit
+                { allowed
+                , limitReached
+                }
+            } =
+        allowed && not limitReached
 
 loadOpenAiAccounts :: IO ([Text], [OpenAiAccount])
 loadOpenAiAccounts = do

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -5,6 +5,7 @@ module Agent.CLI.ProviderTransition
     , TransitionCause(..)
     , TurnResult(..)
     , applyProviderTransition
+    , resumePendingTurnIfPresent
     , setPendingExitAfter
     , transitionCommitsImmediately
     ) where
@@ -16,6 +17,7 @@ import Agent.Loop (TurnInput)
 import Agent.Provider (BillingMode, Provider)
 import Agent.Tools.PlanMode (PlanModeState)
 import Control.Applicative ((<|>))
+import Data.IORef (IORef, atomicModifyIORef')
 import Data.Set (Set)
 import Data.Text (Text)
 
@@ -74,6 +76,20 @@ applyProviderTransition options transition =
 setPendingExitAfter :: Bool -> PendingTurn -> PendingTurn
 setPendingExitAfter exitAfter pending =
     pending { pendingExitAfter = exitAfter }
+
+-- | Atomically claim a pending turn before resuming it. This keeps one
+-- explicit recovery action from racing another, such as /retry and account
+-- refresh.
+resumePendingTurnIfPresent
+    :: IORef (Maybe PendingTurn)
+    -> (PendingTurn -> IO result)
+    -> IO result
+    -> IO result
+resumePendingTurnIfPresent pendingTurnRef resume noPendingTurn =
+    atomicModifyIORef'
+        pendingTurnRef
+        (\pending -> (Nothing, pending))
+        >>= maybe noPendingTurn resume
 
 -- | Manual selections become the project/session target immediately.
 -- Automatic fallbacks remain provisional until their replacement backend

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -124,6 +124,7 @@ import Agent.CLI.ProviderTransition
     ( PendingTurn
     , ProviderTransition
     , TurnResult(TurnProviderUnavailable)
+    , resumePendingTurnIfPresent
     )
 import Agent.CLI.Recap ( RecapKind(..), RecapRequest(..) )
 import Agent.CLI.Render
@@ -291,7 +292,7 @@ import Control.Exception.Safe
     ( displayException, finally, throwIO, tryAny, tryIO )
 import Control.Monad ( foldM, forM_, unless, when )
 import Data.Foldable ( toList )
-import Data.IORef ( atomicModifyIORef', newIORef, readIORef, writeIORef )
+import Data.IORef ( newIORef, readIORef, writeIORef )
 import Data.List ( elemIndex, findIndex )
 import Data.Maybe ( fromMaybe, isNothing )
 import Data.Text ( Text )
@@ -414,11 +415,23 @@ handleReplLine
     action@(ReplClipboardPasteOrText _ _ _) ->
         handleClipboardInput env continueWith stdoutColor action
     action@(ReplChooseModel keptDraft) ->
-        handleSelectionInput env (continueWith keptDraft) action
+        handleSelectionInput
+            env
+            (continueWith keptDraft)
+            retryPendingTurn
+            action
     action@(ReplChooseEffort keptDraft) ->
-        handleSelectionInput env (continueWith keptDraft) action
+        handleSelectionInput
+            env
+            (continueWith keptDraft)
+            retryPendingTurn
+            action
     action@(ReplChooseAccount keptDraft) ->
-        handleSelectionInput env (continueWith keptDraft) action
+        handleSelectionInput
+            env
+            (continueWith keptDraft)
+            retryPendingTurn
+            action
     ReplMeta request ->
         runMetaConsoleRequest request
     ReplRemovePendingImage keptDraft index ->
@@ -1105,16 +1118,14 @@ handleReplLine
                                 runSessionRecap True env RecapManual
                                 continue
                     ReplRetry ->
-                        atomicModifyIORef'
+                        resumePendingTurnIfPresent
                             env.sessionLastFailedTurn
-                            (\pending -> (Nothing, pending))
-                            >>= \case
-                                Just pending -> retryPendingTurn pending
-                                Nothing -> do
-                                    displayInfo
-                                        "No failed turn is available to retry."
-                                        (pure ())
-                                    continue
+                            retryPendingTurn
+                            (do
+                                displayInfo
+                                    "No failed turn is available to retry."
+                                    (pure ())
+                                continue)
                     action@ReplResume{} -> handleSessionAction env slashCatalog continue action
                     action@ReplSearch{} -> handleSessionAction env slashCatalog continue action
                     action@ReplHome -> handleSessionAction env slashCatalog continue action

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -68,7 +68,11 @@ import Agent.CLI.Provider.Switch
       requestModelTargetSwitch )
 import Agent.CLI.ProviderAvailability ()
 import Agent.CLI.ProviderFallback ()
-import Agent.CLI.ProviderTransition ()
+import Agent.CLI.ProviderTransition
+    ( PendingTurn
+    , ProviderTransition(..)
+    , resumePendingTurnIfPresent
+    )
 import Agent.CLI.Recap ()
 import Agent.CLI.Render ( clearThinking, renderEvent )
 import Agent.CLI.ReplMode ()
@@ -76,7 +80,7 @@ import Agent.CLI.Request ()
 import Agent.CLI.Runtime.HistorySource ()
 import Agent.CLI.Runtime.Persistence ()
 import Agent.CLI.Runtime.Recap ()
-import Agent.CLI.Runtime.Types ( RunResult )
+import Agent.CLI.Runtime.Types ( RunResult(..) )
 import Agent.CLI.Secret ()
 import Agent.CLI.Session ()
 import Agent.CLI.Session.Attachments ()
@@ -127,7 +131,7 @@ import Agent.OpenAI.Models.Types (ModelInfo(..), modelServiceTierForRequest)
 import Agent.OpenRouter.LoopBackend ()
 import Agent.OsPath ()
 import Agent.Provider
-    ( Provider(ClaudeCodeProvider, GeminiProvider, OpenAIProvider),
+    ( Provider(GeminiProvider, OpenAIProvider),
       providerSlug,
       tokenProviderBillingMode )
 import Agent.ReasoningEffort (reasoningEffortText)
@@ -182,18 +186,23 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ()
-import qualified Data.Text as Text ( null, stripPrefix )
+import qualified Data.Text as Text ( stripPrefix )
 import qualified Data.Text.IO as Text ( putStrLn, hPutStrLn )
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Usage as XAIUsage ()
 
-handleSelectionInput :: SessionEnv -> IO RunResult -> ReplLine -> IO RunResult
-handleSelectionInput env continue input =
-    handleSelection env continue (Left input)
+handleSelectionInput
+    :: SessionEnv
+    -> IO RunResult
+    -> (PendingTurn -> IO RunResult)
+    -> ReplLine
+    -> IO RunResult
+handleSelectionInput env continue retryPendingTurn input =
+    handleSelection env continue retryPendingTurn (Left input)
 
 handleSelectionAction :: SessionEnv -> IO RunResult -> ReplAction -> IO RunResult
 handleSelectionAction env continue action =
-    handleSelection env continue (Right action)
+    handleSelection env continue (\_ -> continue) (Right action)
 
 -- | Select an account requested by a trusted, typed Meta Console action.
 --
@@ -250,7 +259,7 @@ selectRequestedAccount env requestedProvider selector =
                                 pure (Left "Account selection was cancelled.")
                             Just index ->
                                 case atMay index options of
-                                    Just option@(AccountPickerAccount
+                                    Just (AccountPickerAccount
                                         selectedProvider
                                         selectedBilling
                                         selectedSelectionId
@@ -259,9 +268,6 @@ selectRequestedAccount env requestedProvider selector =
                                         _) ->
                                             applySelectedAccount
                                                 runtime
-                                                currentSelectionId
-                                                currentAccountId
-                                                option
                                                 selectedProvider
                                                 selectedBilling
                                                 selectedSelectionId
@@ -291,23 +297,11 @@ selectRequestedAccount env requestedProvider selector =
                 <> "'."
     applySelectedAccount
             runtime
-            currentSelectionId
-            currentAccountId
-            option
             selectedProvider
             selectedBilling
             selectedSelectionId
             selectedAccountId
             selectedLabel
-        | selectedProvider /= ClaudeCodeProvider
-        , accountPickerMatches
-            env.sessionProvider
-            currentSelectionId
-            currentAccountId
-            option = do
-                emitUiEvent runtime
-                    (UiSystemMessage ("account: " <> selectedLabel))
-                pure (Right Nothing)
         | selectedProvider == env.sessionProvider
         , Just selectedBilling
             == (tokenProviderBillingMode <$> env.sessionTokenProvider)
@@ -356,6 +350,7 @@ selectRequestedAccount env requestedProvider selector =
 handleSelection
     :: SessionEnv
     -> IO RunResult
+    -> (PendingTurn -> IO RunResult)
     -> Either ReplLine ReplAction
     -> IO RunResult
 handleSelection
@@ -377,7 +372,8 @@ handleSelection
             , sessionTokenProvider = tokenProvider
             , sessionFullscreen = fullscreen
             }
-        continue = \case
+        continue
+        retryPendingTurn = \case
     Left (ReplChooseModel keptDraft) -> do
         writeIORef draftRef keptDraft
         chooseModel continue
@@ -570,6 +566,12 @@ handleSelection
                     Text.hPutStrLn stderr (roleError color err)
                 next
             Right result -> pure result
+    attachPendingTurn result pending =
+        case result of
+            RunSwitchProvider transition ->
+                RunSwitchProvider transition
+                    { transitionPendingTurn = Just pending }
+            other -> other
     modelAuthErrorNeedsConnect targetProvider message =
         geminiAuthErrorNeedsReconnect message
             || maybe False geminiAuthErrorNeedsReconnect
@@ -616,33 +618,13 @@ handleSelection
                                         selectedSelectionId
                                         selectedAccountId
                                         selectedLabel
-                                        _
-                                            -- Claude exposes display metadata,
-                                            -- not a stable account identity.
-                                            -- Revalidate and restart even when
-                                            -- the synthetic id still matches.
-                                            | selectedProvider == provider
-                                            , selectedProvider
-                                                /= ClaudeCodeProvider
-                                            , ( not (Text.null currentSelectionId)
-                                                    && selectedSelectionId
-                                                        == currentSelectionId
-                                              )
-                                                || ( Text.null currentSelectionId
-                                                    && selectedAccountId
-                                                        == currentAccountId
-                                                   ) ->
-                                                displayInfo
-                                                    ("account: " <> selectedLabel)
-                                                    (pure ())
-                                                    >> next
-                                            | otherwise ->
-                                                chooseSelectedAccount
-                                                    selectedProvider
-                                                    selectedBilling
-                                                    selectedSelectionId
-                                                    selectedAccountId
-                                                    selectedLabel
+                                        _ ->
+                                            chooseSelectedAccount
+                                                selectedProvider
+                                                selectedBilling
+                                                selectedSelectionId
+                                                selectedAccountId
+                                                selectedLabel
                                     AccountPickerConnect selectedProvider -> do
                                         color <- resolveColor stderr
                                         connected <-
@@ -723,7 +705,10 @@ handleSelection
                                     displayInfo
                                         ("account switched to " <> label)
                                         (pure ())
-                                    next
+                                    resumePendingTurnIfPresent
+                                        env.sessionLastFailedTurn
+                                        retryPendingTurn
+                                        next
                         | otherwise =
                             readIORef paramsRef >>= \params ->
                                 requestAccountProviderSwitch
@@ -743,7 +728,10 @@ handleSelection
                                                         selectedProvider
                                                     <> ")")
                                                 (pure ())
-                                            pure result
+                                            resumePendingTurnIfPresent
+                                                env.sessionLastFailedTurn
+                                                (pure . attachPendingTurn result)
+                                                (pure result)
             Nothing -> do
                 displayError
                     "Account switching is unavailable for this session."

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -203,7 +203,8 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
             now <- getCurrentTime
             case providerRecoveryPreference
                     allowCooldownRetry now apiError of
-                RetryCurrentProviderAfter delay ->
+                RetryCurrentProviderAfter delay -> do
+                    writeIORef env.sessionLastFailedTurn (Just pending')
                     waitAndRetryPendingTurn
                         (continuation.resumeSessionWithDraft env)
                         (runPendingTurnWithCooldownRetry
@@ -217,6 +218,9 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
                         Just providerTransition ->
                             pure (RunSwitchProvider providerTransition)
                         Nothing -> do
+                            writeIORef
+                                env.sessionLastFailedTurn
+                                (Just pending')
                             if env.sessionBackground
                                 then
                                     putTextLn

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -6,6 +6,8 @@ import Agent.CLI.ProviderTransition
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (BillingMode(..), Provider(..))
 import Agent.Tools.PlanMode (PlanModeState(..))
+import Data.IORef (newIORef, readIORef)
+import Data.Maybe (isNothing)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import Test.Hspec
@@ -44,6 +46,33 @@ spec = do
             updated.pendingExitAfter `shouldBe` True
             updated.pendingPlanState `shouldBe` PlanActive
 
+    describe "resumePendingTurnIfPresent" do
+        it "atomically claims and resumes the failed turn once" do
+            failedTurnRef <- newIORef (Just pendingTurn)
+
+            result <- resumePendingTurnIfPresent
+                failedTurnRef
+                (pure . (.pendingPromptText))
+                (pure "no failed turn")
+
+            result `shouldBe` "continue the conversation"
+            fmap isNothing (readIORef failedTurnRef) `shouldReturn` True
+            resumePendingTurnIfPresent
+                failedTurnRef
+                (pure . (.pendingPromptText))
+                (pure "already claimed")
+                `shouldReturn` "already claimed"
+
+        it "continues normally when no failed turn is stored" do
+            failedTurnRef <- newIORef Nothing
+
+            result <- resumePendingTurnIfPresent
+                failedTurnRef
+                (\_ -> pure ("unexpected retry" :: Text))
+                (pure ("no failed turn" :: Text))
+
+            result `shouldBe` "no failed turn"
+
     describe "transitionCommitsImmediately" do
         it "keeps a startup automatic fallback provisional" do
             transitionCommitsImmediately (transition Nothing Nothing)
@@ -74,4 +103,13 @@ transition sessionId pending = ProviderTransition
     , transitionUnavailableProviders = Set.singleton XAIProvider
     , transitionCause = AutomaticFallback
     , transitionAutomaticBilling = Just SubscriptionBilled
+    }
+
+pendingTurn :: PendingTurn
+pendingTurn = PendingTurn
+    { pendingPromptText = "continue the conversation"
+    , pendingInputs = []
+    , pendingCheckpointed = False
+    , pendingExitAfter = False
+    , pendingPlanState = PlanInactive
     }

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -14,8 +14,10 @@ module Agent.OpenAI.Auth
       Pool
     , newPool
     , newDiscoveringPool
+    , newDiscoveringPoolWithRateLimitRevalidation
     , newUnavailableDiscoveringPool
     , getAccessToken
+    , RateLimitRevalidation
 
       -- * Cooldown management
     , reportRateLimit
@@ -64,6 +66,7 @@ import Agent.OpenAI.Auth.JWT
     )
 import Agent.OpenAI.Auth.Refresh (refreshAccessTokenHTTP)
 import Agent.OpenAI.Auth.Types (AuthState(..))
+import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.MVar
     ( MVar
     , newEmptyMVar
@@ -79,6 +82,7 @@ import Data.IORef
     , atomicModifyIORef'
     , newIORef
     , readIORef
+    , writeIORef
     )
 import Data.Containers.ListUtils (nubOrd)
 import Data.Foldable (toList)
@@ -130,6 +134,17 @@ data AccountEntry = AccountEntry
 -- after all currently known accounts are cooling down.
 type AccountDiscovery = [Text] -> IO (Either ApiError [AuthState])
 
+-- | Check whether the provider now considers an account usable. This is
+-- intentionally separate from request-side rate-limit handling: reset
+-- timestamps can become stale in a long-running process.
+type RateLimitRevalidation = AuthState -> IO (Either ApiError Bool)
+
+data RateLimitRevalidationState = RateLimitRevalidationState
+    { revalidationCallback :: !RateLimitRevalidation
+    , revalidationLock :: !(MVar ())
+    , revalidationLastAttempt :: !(IORef (Maybe UTCTime))
+    }
+
 data PoolState = PoolState
     { stateEntries :: !(Seq AccountEntry)
     , stateEmptyExhaustion
@@ -147,6 +162,7 @@ data Pool = Pool
     { poolState :: !(IORef PoolState)
     , poolRefresh :: !(AuthState -> IO (Either ApiError AuthState))
     , poolDiscovery :: !(Maybe AccountDiscovery)
+    , poolRateLimitRevalidation :: !(Maybe RateLimitRevalidationState)
     }
 
 data DiscoveryClaim
@@ -160,6 +176,11 @@ data DiscoveryClaim
 
 rateLimitCooldownSeconds :: Int
 rateLimitCooldownSeconds = 60
+
+-- | Do not call the usage endpoint on every rejected user turn while the
+-- provider still reports an account as exhausted.
+rateLimitRevalidationSeconds :: Int
+rateLimitRevalidationSeconds = 300
 
 -- | Retry window when an account returns an authentication rejection from
 -- Agent.OpenAI.
@@ -180,7 +201,8 @@ newPool
     :: [AuthState]
     -> (AuthState -> IO (Either ApiError AuthState))
     -> IO Pool
-newPool initial refresh = newPoolWithDiscovery initial refresh Nothing
+newPool initial refresh =
+    newPoolWithDiscovery initial refresh Nothing Nothing
 
 newDiscoveringPool
     :: [AuthState]
@@ -188,17 +210,36 @@ newDiscoveringPool
     -> AccountDiscovery
     -> IO Pool
 newDiscoveringPool initial refresh discover =
-    newPoolWithDiscovery initial refresh (Just discover)
+    newPoolWithDiscovery initial refresh (Just discover) Nothing
+
+-- | Build a discovering pool that can recover from stale, long-lived
+-- rate-limit reset timestamps. When every known account is cooling down, the
+-- callback is used to check current provider usage and clear only rate-limit
+-- cooldowns that have actually reset.
+newDiscoveringPoolWithRateLimitRevalidation
+    :: [AuthState]
+    -> (AuthState -> IO (Either ApiError AuthState))
+    -> AccountDiscovery
+    -> RateLimitRevalidation
+    -> IO Pool
+newDiscoveringPoolWithRateLimitRevalidation
+        initial refresh discover revalidate =
+    newPoolWithDiscovery
+        initial
+        refresh
+        (Just discover)
+        (Just revalidate)
 
 newPoolWithDiscovery
     :: [AuthState]
     -> (AuthState -> IO (Either ApiError AuthState))
     -> Maybe AccountDiscovery
+    -> Maybe RateLimitRevalidation
     -> IO Pool
-newPoolWithDiscovery initial refresh discovery = do
+newPoolWithDiscovery initial refresh discovery revalidation = do
     when (null initial) $
         error "Agent.OpenAI.Auth.newPool: called with empty account list"
-    buildPool initial Nothing refresh discovery
+    buildPool initial Nothing refresh discovery revalidation
 
 -- | Build a broker-backed pool when no account is currently available but the
 -- broker supplied the earliest reset.
@@ -208,16 +249,18 @@ newUnavailableDiscoveringPool
     -> AccountDiscovery
     -> IO Pool
 newUnavailableDiscoveringPool retryAt refresh discover =
-    buildPool [] (Just retryAt) refresh (Just discover)
+    buildPool [] (Just retryAt) refresh (Just discover) Nothing
 
 buildPool
     :: [AuthState]
     -> Maybe UTCTime
     -> (AuthState -> IO (Either ApiError AuthState))
     -> Maybe AccountDiscovery
+    -> Maybe RateLimitRevalidation
     -> IO Pool
-buildPool initial emptyRetryAt refresh discovery = do
+buildPool initial emptyRetryAt refresh discovery revalidation = do
     entries <- Seq.fromList <$> mapM mkEntry initial
+    revalidationState <- mapM mkRateLimitRevalidationState revalidation
     now <- getCurrentTime
     let offset = floor (toRational (utctDayTime now) * 1000) :: Int
     state <- newIORef PoolState
@@ -230,6 +273,19 @@ buildPool initial emptyRetryAt refresh discovery = do
         { poolState = state
         , poolRefresh = refresh
         , poolDiscovery = discovery
+        , poolRateLimitRevalidation = revalidationState
+        }
+
+mkRateLimitRevalidationState
+    :: RateLimitRevalidation
+    -> IO RateLimitRevalidationState
+mkRateLimitRevalidationState callback = do
+    lock <- newMVar ()
+    lastAttempt <- newIORef Nothing
+    pure RateLimitRevalidationState
+        { revalidationCallback = callback
+        , revalidationLock = lock
+        , revalidationLastAttempt = lastAttempt
         }
 
 mkEntry :: AuthState -> IO AccountEntry
@@ -251,13 +307,14 @@ mkEntry auth = do
 --------------------------------------------------------------------------------
 
 getAccessToken :: Pool -> IO (Either ApiError (Text, Text))
-getAccessToken pool = getAccessTokenWithDiscovery pool True
+getAccessToken pool = getAccessTokenWithRecovery pool True True
 
-getAccessTokenWithDiscovery
+getAccessTokenWithRecovery
     :: Pool
     -> Bool
+    -> Bool
     -> IO (Either ApiError (Text, Text))
-getAccessTokenWithDiscovery pool allowDiscovery = do
+getAccessTokenWithRecovery pool allowRevalidation allowDiscovery = do
     poolState <- readIORef pool.poolState
     let entries = poolState.stateEntries
         accountIdsAtCheckout = map (.entryAccountId) (toList entries)
@@ -267,23 +324,44 @@ getAccessTokenWithDiscovery pool allowDiscovery = do
             { retryAt = previousRetryAt
             , exhaustionReasons = previousReasons
             }
+            | allowRevalidation ->
+                revalidateRateLimitedAccounts pool >>= \case
+                    True ->
+                        getAccessTokenWithRecovery
+                            pool False allowDiscovery
+                    False ->
+                        finishExhausted
+                            accountIdsAtCheckout
+                            exhausted
+                            previousRetryAt
+                            previousReasons
             | allowDiscovery ->
-                discoverAdditionalAccounts pool accountIdsAtCheckout >>= \case
-                    True -> getAccessTokenWithDiscovery pool False
-                    False -> do
-                        current <- readIORef pool.poolState
-                        if Seq.null current.stateEntries
-                            then
-                                let (retryAt, reasons) =
-                                        fromMaybe
-                                            (previousRetryAt, previousReasons)
-                                            current.stateEmptyExhaustion
-                                in pure $ Left $
-                                    credentialsExhaustedWithReasons
-                                        retryAt reasons
-                            else pure (Left exhausted)
+                finishExhausted
+                    accountIdsAtCheckout
+                    exhausted
+                    previousRetryAt
+                    previousReasons
         _ -> pure result
   where
+    finishExhausted
+            accountIdsAtCheckout exhausted previousRetryAt previousReasons
+        | allowDiscovery =
+            discoverAdditionalAccounts pool accountIdsAtCheckout >>= \case
+                True -> getAccessTokenWithRecovery pool False False
+                False -> do
+                    current <- readIORef pool.poolState
+                    if Seq.null current.stateEntries
+                        then
+                            let (retryAt, reasons) =
+                                    fromMaybe
+                                        (previousRetryAt, previousReasons)
+                                        current.stateEmptyExhaustion
+                            in pure $ Left $
+                                credentialsExhaustedWithReasons
+                                    retryAt reasons
+                        else pure (Left exhausted)
+        | otherwise = pure (Left exhausted)
+
     go attemptsLeft
         | attemptsLeft <= 0 = do
             pickAccount pool >>= \case
@@ -373,6 +451,125 @@ refreshEntryWithCooldownTransition transition pool entry stale =
                     )
                 pure (Right refreshed)
         Left err -> pure (Left err)
+
+--------------------------------------------------------------------------------
+-- Rate-limit revalidation
+--------------------------------------------------------------------------------
+
+-- | Recheck active rate-limit cooldowns when the whole pool is exhausted.
+-- Failures are deliberately ignored: request-side cooldowns remain the source
+-- of truth unless the provider positively reports that capacity is available.
+revalidateRateLimitedAccounts :: Pool -> IO Bool
+revalidateRateLimitedAccounts pool =
+    case pool.poolRateLimitRevalidation of
+        Nothing -> pure False
+        Just revalidation ->
+            withMVar revalidation.revalidationLock \_ -> do
+                now <- getCurrentTime
+                lastAttempt <-
+                    readIORef revalidation.revalidationLastAttempt
+                if not (revalidationDue now lastAttempt)
+                    then hasAvailableAccount now pool
+                    else do
+                        entries <-
+                            toList . (.stateEntries)
+                                <$> readIORef pool.poolState
+                        hasActiveCooldown <-
+                            or <$> mapM
+                                (hasActiveRateLimitCooldown now)
+                                entries
+                        if not hasActiveCooldown
+                            then hasAvailableAccount now pool
+                            else do
+                                -- Record the attempt before starting network
+                                -- calls so cancellation cannot cause a probe
+                                -- storm on the next checkout.
+                                writeIORef
+                                    revalidation.revalidationLastAttempt
+                                    (Just now)
+                                recovered <- or <$> mapConcurrently
+                                    (revalidateRateLimitedAccount
+                                        pool
+                                        revalidation.revalidationCallback)
+                                    entries
+                                if recovered
+                                    then pure True
+                                    else do
+                                        nowAfterChecks <- getCurrentTime
+                                        hasAvailableAccount nowAfterChecks pool
+
+hasAvailableAccount :: UTCTime -> Pool -> IO Bool
+hasAvailableAccount now pool = do
+    entries <- toList . (.stateEntries) <$> readIORef pool.poolState
+    or <$> mapM (accountAvailable now) entries
+
+accountAvailable :: UTCTime -> AccountEntry -> IO Bool
+accountAvailable now entry =
+    atomicModifyAccount entry \current ->
+        let updated = expireCooldowns now current
+            available = case effectiveCooldown updated.accountCooldowns of
+                Nothing -> True
+                Just _ -> False
+        in (updated, available)
+
+revalidationDue :: UTCTime -> Maybe UTCTime -> Bool
+revalidationDue _ Nothing = True
+revalidationDue now (Just previous) =
+    let elapsed = diffUTCTime now previous
+    in elapsed < 0
+        || elapsed >= fromIntegral rateLimitRevalidationSeconds
+
+hasActiveRateLimitCooldown :: UTCTime -> AccountEntry -> IO Bool
+hasActiveRateLimitCooldown now entry =
+    atomicModifyAccount entry \current ->
+        let updated = expireCooldowns now current
+            active = case updated.accountCooldowns.cooldownRateLimit of
+                Just cooldown -> cooldown.cooldownUntil > now
+                Nothing -> False
+        in (updated, active)
+
+revalidateRateLimitedAccount
+    :: Pool
+    -> RateLimitRevalidation
+    -> AccountEntry
+    -> IO Bool
+revalidateRateLimitedAccount pool revalidate entry =
+    Safe.tryAny check >>= \case
+        Left _ -> pure False
+        Right available -> pure available
+  where
+    check = withMVar entry.entryRefreshLock \_ -> do
+        now <- getCurrentTime
+        state <- atomicModifyAccount entry \current ->
+            let updated = expireCooldowns now current
+            in (updated, updated)
+        case state.accountCooldowns.cooldownRateLimit of
+            Nothing -> pure False
+            Just _
+                | Just _ <- state.accountCooldowns.cooldownAuthBroken ->
+                    pure False
+                | otherwise -> do
+                    authResult <-
+                        if needsRefresh state.accountAuth now
+                            then refreshEntry pool entry state.accountAuth
+                            else pure (Right state.accountAuth)
+                    case authResult of
+                        Left _ -> pure False
+                        Right auth ->
+                            revalidate auth >>= \case
+                                Right True -> do
+                                    atomicModifyAccount entry \current ->
+                                        ( current
+                                            { accountCooldowns =
+                                                current.accountCooldowns
+                                                    { cooldownRateLimit =
+                                                        Nothing
+                                                    }
+                                            }
+                                        , ()
+                                        )
+                                    pure True
+                                _ -> pure False
 
 --------------------------------------------------------------------------------
 -- Discovery
@@ -756,30 +953,52 @@ getAccessTokenForAccount
     -> Text
     -> IO (Either ApiError (Text, Text))
 getAccessTokenForAccount pool targetAccountId =
-    findEntry pool targetAccountId >>= \case
-        Nothing ->
-            pure $ Left $ CredentialError
-                ("unknown OpenAI account " <> targetAccountId)
-        Just entry ->
-            withMVar entry.entryRefreshLock \_ -> do
-                now <- getCurrentTime
-                cooldown <- atomicModifyAccount entry \current ->
-                    let updated = expireCooldowns now current
-                    in
-                        ( updated
-                        , effectiveCooldown updated.accountCooldowns
-                        )
-                case cooldown of
-                    Just (until_, reasons) ->
-                        pure $ Left $
-                            credentialsExhaustedWithReasons until_ reasons
-                    Nothing -> do
-                        state <- (.accountAuth) <$> readIORef entry.entryState
-                        if needsRefresh state now
-                            then fmap credentialPair
-                                <$> refreshEntry pool entry state
-                            else pure (Right (credentialPair state))
+    getAccessTokenForAccountWithRecovery pool targetAccountId True
+
+getAccessTokenForAccountWithRecovery
+    :: Pool
+    -> Text
+    -> Bool
+    -> IO (Either ApiError (Text, Text))
+getAccessTokenForAccountWithRecovery
+        pool targetAccountId allowRevalidation = do
+    result <- checkout
+    case result of
+        Left CredentialsExhausted{}
+            | allowRevalidation ->
+                revalidateRateLimitedAccounts pool >>= \case
+                    True ->
+                        getAccessTokenForAccountWithRecovery
+                            pool targetAccountId False
+                    False -> pure result
+        _ -> pure result
   where
+    checkout =
+        findEntry pool targetAccountId >>= \case
+            Nothing ->
+                pure $ Left $ CredentialError
+                    ("unknown OpenAI account " <> targetAccountId)
+            Just entry ->
+                withMVar entry.entryRefreshLock \_ -> do
+                    now <- getCurrentTime
+                    cooldown <- atomicModifyAccount entry \current ->
+                        let updated = expireCooldowns now current
+                        in
+                            ( updated
+                            , effectiveCooldown updated.accountCooldowns
+                            )
+                    case cooldown of
+                        Just (until_, reasons) ->
+                            pure $ Left $
+                                credentialsExhaustedWithReasons until_ reasons
+                        Nothing -> do
+                            state <-
+                                (.accountAuth) <$> readIORef entry.entryState
+                            if needsRefresh state now
+                                then fmap credentialPair
+                                    <$> refreshEntry pool entry state
+                                else pure (Right (credentialPair state))
+
     credentialPair state = (state.accessToken, state.accountId)
 
 forceRefresh :: Pool -> Text -> IO (Either ApiError AuthState)

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -182,6 +182,12 @@ rateLimitCooldownSeconds = 60
 rateLimitRevalidationSeconds :: Int
 rateLimitRevalidationSeconds = 300
 
+-- | Usage-window revalidation must not override ordinary burst throttling.
+-- Cooldowns of one hour or less expire naturally; only suspicious long-lived
+-- reset timestamps are checked against live subscription usage.
+rateLimitRevalidationMinimumCooldownSeconds :: Int
+rateLimitRevalidationMinimumCooldownSeconds = 3600
+
 -- | Retry window when an account returns an authentication rejection from
 -- Agent.OpenAI.
 -- Authentication recovery already forces an immediate refresh; if that still
@@ -474,11 +480,11 @@ revalidateRateLimitedAccounts pool =
                         entries <-
                             toList . (.stateEntries)
                                 <$> readIORef pool.poolState
-                        hasActiveCooldown <-
+                        hasRevalidatableCooldown <-
                             or <$> mapM
-                                (hasActiveRateLimitCooldown now)
+                                (hasRevalidatableRateLimitCooldown now)
                                 entries
-                        if not hasActiveCooldown
+                        if not hasRevalidatableCooldown
                             then hasAvailableAccount now pool
                             else do
                                 -- Record the attempt before starting network
@@ -519,14 +525,24 @@ revalidationDue now (Just previous) =
     in elapsed < 0
         || elapsed >= fromIntegral rateLimitRevalidationSeconds
 
-hasActiveRateLimitCooldown :: UTCTime -> AccountEntry -> IO Bool
-hasActiveRateLimitCooldown now entry =
+hasRevalidatableRateLimitCooldown :: UTCTime -> AccountEntry -> IO Bool
+hasRevalidatableRateLimitCooldown now entry =
     atomicModifyAccount entry \current ->
         let updated = expireCooldowns now current
-            active = case updated.accountCooldowns.cooldownRateLimit of
-                Just cooldown -> cooldown.cooldownUntil > now
+            revalidatable =
+                case updated.accountCooldowns.cooldownRateLimit of
+                Just cooldown ->
+                    rateLimitCooldownCanBeRevalidated now cooldown
                 Nothing -> False
-        in (updated, active)
+        in (updated, revalidatable)
+
+rateLimitCooldownCanBeRevalidated
+    :: UTCTime
+    -> AccountCooldown
+    -> Bool
+rateLimitCooldownCanBeRevalidated now cooldown =
+    diffUTCTime cooldown.cooldownUntil now
+        > fromIntegral rateLimitRevalidationMinimumCooldownSeconds
 
 revalidateRateLimitedAccount
     :: Pool
@@ -545,8 +561,10 @@ revalidateRateLimitedAccount pool revalidate entry =
             in (updated, updated)
         case state.accountCooldowns.cooldownRateLimit of
             Nothing -> pure False
-            Just _
+            Just cooldown
                 | Just _ <- state.accountCooldowns.cooldownAuthBroken ->
+                    pure False
+                | not (rateLimitCooldownCanBeRevalidated now cooldown) ->
                     pure False
                 | otherwise -> do
                     authResult <-

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -22,6 +22,7 @@ import qualified "base64-bytestring" Data.ByteString.Base64 as B64
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
+import Data.List (find)
 import Data.Maybe (isJust, isNothing)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
@@ -336,6 +337,116 @@ spec = do
                             }
                         ]
                 other -> expectationFailure ("expected CredentialsExhausted, got " <> show other)
+
+        it "recovers from a stale long cooldown without rebuilding the pool" do
+            checks <- newIORef ([] :: [Text])
+            let revalidate auth = do
+                    modifyIORef' checks (auth.accountId :)
+                    pure (Right (auth.accountId == "reset-account"))
+            pool <- newDiscoveringPoolWithRateLimitRevalidation
+                [ mkFreshAuth "still-limited"
+                , mkFreshAuth "reset-account"
+                ]
+                neverRefresh
+                noDiscovery
+                revalidate
+            reportRateLimit pool "still-limited" (Just 500_000)
+            reportRateLimit pool "reset-account" (Just 500_000)
+
+            result <- getAccessToken pool
+
+            accountIdOf result `shouldBe` "reset-account"
+            checkedAccounts <- readIORef checks
+            checkedAccounts
+                `shouldMatchList` ["still-limited", "reset-account"]
+            snapshots <- snapshotAccounts pool
+            fmap (.snapshotCooldownUntil)
+                (findSnapshot "reset-account" snapshots)
+                `shouldBe` Just Nothing
+            fmap (.snapshotCooldownUntil)
+                (findSnapshot "still-limited" snapshots)
+                `shouldSatisfy` maybe False isJust
+
+        it "revalidates an explicitly requested cooling account" do
+            pool <- newDiscoveringPoolWithRateLimitRevalidation
+                [mkFreshAuth "requested-account"]
+                neverRefresh
+                noDiscovery
+                (const (pure (Right True)))
+            reportRateLimit pool "requested-account" (Just 500_000)
+
+            getAccessTokenForAccount pool "requested-account"
+                `shouldReturn`
+                    Right
+                        ( (mkFreshAuth "requested-account").accessToken
+                        , "requested-account"
+                        )
+
+        it "refreshes an expired token before usage revalidation" do
+            refreshCalls <- newIORef (0 :: Int)
+            checkedToken <- newIORef Nothing
+            let refreshed = (mkFreshAuth "reset-account")
+                    { refreshToken = "rotated-refresh" }
+                refresh _ = do
+                    modifyIORef' refreshCalls (+ 1)
+                    pure (Right refreshed)
+                revalidate auth = do
+                    writeIORef checkedToken (Just auth.accessToken)
+                    pure (Right True)
+            pool <- newDiscoveringPoolWithRateLimitRevalidation
+                [mkExpiredAuth "reset-account"]
+                refresh
+                noDiscovery
+                revalidate
+            reportRateLimit pool "reset-account" (Just 500_000)
+
+            result <- getAccessToken pool
+
+            result `shouldBe`
+                Right (refreshed.accessToken, refreshed.accountId)
+            readIORef refreshCalls `shouldReturn` 1
+            readIORef checkedToken
+                `shouldReturn` Just refreshed.accessToken
+
+        it "throttles repeated usage revalidation while still exhausted" do
+            checks <- newIORef (0 :: Int)
+            let revalidate _ = do
+                    modifyIORef' checks (+ 1)
+                    pure (Right False)
+            pool <- newDiscoveringPoolWithRateLimitRevalidation
+                [mkFreshAuth "still-limited"]
+                neverRefresh
+                noDiscovery
+                revalidate
+            reportRateLimit pool "still-limited" (Just 500_000)
+
+            first <- getAccessToken pool
+            second <- getAccessToken pool
+
+            first `shouldSatisfy` isCredentialsExhausted
+            second `shouldSatisfy` isCredentialsExhausted
+            readIORef checks `shouldReturn` 1
+
+        it "shares recovered capacity with concurrent checkouts" do
+            checkStarted <- newEmptyMVar
+            releaseCheck <- newEmptyMVar
+            let revalidate _ = do
+                    putMVar checkStarted ()
+                    takeMVar releaseCheck
+                    pure (Right True)
+            pool <- newDiscoveringPoolWithRateLimitRevalidation
+                [mkFreshAuth "reset-account"]
+                neverRefresh
+                noDiscovery
+                revalidate
+            reportRateLimit pool "reset-account" (Just 500_000)
+
+            withAsync (getAccessToken pool) \first -> do
+                takeMVar checkStarted
+                withAsync (getAccessToken pool) \second -> do
+                    putMVar releaseCheck ()
+                    results <- sequence [wait first, wait second]
+                    results `shouldSatisfy` all isRight
 
         it "discovers a broker account that became available after startup" $ do
             discoveryCalls <- newIORef ([] :: [[Text]])
@@ -725,6 +836,9 @@ countingRefresh ref s = do
 neverRefresh :: AuthState -> IO (Either ApiError AuthState)
 neverRefresh _ = error "neverRefresh: refresh callback should not have been invoked"
 
+noDiscovery :: [Text] -> IO (Either ApiError [AuthState])
+noDiscovery _ = pure (Right [])
+
 accountIdOf :: Either ApiError (Text, Text) -> Text
 accountIdOf (Right (_, accId)) = accId
 accountIdOf (Left err) = error ("getAccessToken failed: " <> show err)
@@ -736,6 +850,15 @@ isRight _         = False
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True
 isLeft _        = False
+
+isCredentialsExhausted :: Either ApiError value -> Bool
+isCredentialsExhausted (Left CredentialsExhausted{}) = True
+isCredentialsExhausted Right{} = False
+isCredentialsExhausted _ = False
+
+findSnapshot :: Text -> [AccountSnapshot] -> Maybe AccountSnapshot
+findSnapshot accountId =
+    find ((== accountId) . (.accountId) . (.snapshotAuth))
 
 uniq :: Eq a => [a] -> [a]
 uniq []     = []

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -367,6 +367,49 @@ spec = do
                 (findSnapshot "still-limited" snapshots)
                 `shouldSatisfy` maybe False isJust
 
+        it "does not revalidate a short server-directed cooldown" do
+            checks <- newIORef (0 :: Int)
+            let revalidate _ = do
+                    modifyIORef' checks (+ 1)
+                    pure (Right True)
+            pool <- newDiscoveringPoolWithRateLimitRevalidation
+                [mkFreshAuth "burst-limited"]
+                neverRefresh
+                noDiscovery
+                revalidate
+            reportRateLimit pool "burst-limited" (Just 60)
+
+            result <- getAccessToken pool
+
+            result `shouldSatisfy` isCredentialsExhausted
+            readIORef checks `shouldReturn` 0
+            [snapshot] <- snapshotAccounts pool
+            snapshot.snapshotCooldownUntil `shouldSatisfy` isJust
+
+        it "preserves short cooldowns while revalidating long windows" do
+            checks <- newIORef ([] :: [Text])
+            let revalidate auth = do
+                    modifyIORef' checks (auth.accountId :)
+                    pure (Right True)
+            pool <- newDiscoveringPoolWithRateLimitRevalidation
+                [ mkFreshAuth "window-reset"
+                , mkFreshAuth "burst-limited"
+                ]
+                neverRefresh
+                noDiscovery
+                revalidate
+            reportRateLimit pool "window-reset" (Just 500_000)
+            reportRateLimit pool "burst-limited" (Just 60)
+
+            result <- getAccessToken pool
+
+            accountIdOf result `shouldBe` "window-reset"
+            readIORef checks `shouldReturn` ["window-reset"]
+            snapshots <- snapshotAccounts pool
+            fmap (.snapshotCooldownUntil)
+                (findSnapshot "burst-limited" snapshots)
+                `shouldSatisfy` maybe False isJust
+
         it "revalidates an explicitly requested cooling account" do
             pool <- newDiscoveringPoolWithRateLimitRevalidation
                 [mkFreshAuth "requested-account"]


### PR DESCRIPTION
## Summary

- revalidate exhausted ChatGPT subscription accounts against the live Codex usage endpoint instead of trusting stale multi-day reset timestamps indefinitely
- serialize and throttle usage probes, refresh expired access tokens first, and clear only rate-limit cooldowns that are definitively available
- retain provider-unavailable turns so manual account recovery can resume the interrupted conversation
- make the fullscreen account picker revalidate even the active account, then atomically retry the retained turn or transfer it across a provider switch
- add regression coverage for stale cooldown recovery, token refresh, throttling, concurrent waiters, and single-claim pending-turn recovery

## Root cause

The OpenAI account pool stored the provider's complete `resets_in_seconds` value as an in-memory cooldown. Once all configured accounts were exhausted, token checkout only consulted those timestamps. A long-running process therefore remained blocked by a stale reset even after provider capacity returned, while restarting rebuilt the pool without those cooldowns.

The fullscreen account selector also treated the active account as a no-op, and provider-unavailable turns were not retained as retry candidates. Even when selecting an account refreshed its usage display, the interrupted conversation had no restart path.

## Testing

- focused `agent-openai-test` rate-limit suite — 17 examples, 0 failures
- complete `agent-openai-test` suite — 343 examples, 0 failures, 1 live test pending by design
- `cabal repl agent-cli:lib:agent-cli` in the Nix shell — 211 modules loaded
- focused `agent-cli-test` pending-turn recovery tests in GHCi — 2 examples, 0 failures
- live fullscreen tmux smoke — bottom-right account control opened the Accounts overlay; active-account selection refreshed usage, switched the live account, and updated the footer
- `git diff --check`

