### PR TITLE
Add Apple Foundation Models to macOS model pickers

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -98,6 +98,7 @@ library
                     , Agent.CLI.Artifact
                     , Agent.CLI.Afk
                     , Agent.CLI.Auth
+                    , Agent.CLI.AppleFoundationModels
                     , Agent.CLI.Btw
                     , Agent.CLI.CancelWatch
                     , Agent.CLI.Clipboard
@@ -156,6 +157,7 @@ library
                     , Agent.CLI.Render
                     , Agent.CLI.ReplMode
                     , Agent.CLI.Resume
+                    , Agent.CLI.RuntimeModel
                     , Agent.CLI.Session
                     , Agent.CLI.Session.History
                     , Agent.CLI.Session.StoreCodec

--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -15,6 +15,10 @@ module Agent.CLI.MacOS.Bridge
     ) where
 
 import qualified Agent.CLI.AgentViewport as Viewport
+import Agent.CLI.AppleFoundationModels
+    ( appleFoundationModelId
+    , withAppleFoundationModelRuntime
+    )
 import Agent.CLI.BrowserTools
     ( BrowserCommand(..)
     , browserTools
@@ -90,6 +94,10 @@ import Agent.CLI.ModelConfig
     ( CatalogModel(..)
     , ModelCatalog
     , catalogModelById
+    )
+import Agent.CLI.RuntimeModel
+    ( RuntimeResponsesModel
+    , applyRuntimeResponsesModel
     )
 import Agent.CLI.GatewayModels (loadGatewayModelCatalogAt)
 import Agent.CLI.Database (DatabaseScope(..))
@@ -1719,23 +1727,26 @@ workerLifecycle
     -> TVar (Map Text [ImageAttachment])
     -> BrowserHost
     -> IO ()
-workerLifecycle callback context config root commands stagedImages browser = do
-    store <- newMVar Nothing
-    processRuntime <- newNativeProcessRuntime root
-    let cleanup =
-            closeNativeProcessRuntime processRuntime
-                `finally` closeEngineStore store
-    idleLoop
-        callback
-        context
-        config
-        store
-        root
-        processRuntime
-        commands
-        stagedImages
-        browser
-        `finally` cleanup
+workerLifecycle
+        callback context config root commands stagedImages browser =
+    withAppleFoundationModelRuntime \runtimeResponsesModel -> do
+        store <- newMVar Nothing
+        processRuntime <- newNativeProcessRuntime root
+        let cleanup =
+                closeNativeProcessRuntime processRuntime
+                    `finally` closeEngineStore store
+        idleLoop
+            callback
+            context
+            config
+            store
+            root
+            processRuntime
+            commands
+            stagedImages
+            browser
+            runtimeResponsesModel
+            `finally` cleanup
 
 idleLoop
     :: FunPtr EventCallback
@@ -1747,8 +1758,11 @@ idleLoop
     -> TQueue EngineCommand
     -> TVar (Map Text [ImageAttachment])
     -> BrowserHost
+    -> IO (Maybe RuntimeResponsesModel)
     -> IO ()
-idleLoop callback context config store root processRuntime commands stagedImages browser =
+idleLoop
+        callback context config store root processRuntime commands stagedImages
+        browser runtimeResponsesModel =
     atomically (readTQueue commands) >>= \case
         EngineStop -> pure ()
         EngineSearch query limit searchCallback searchContext -> do
@@ -1770,46 +1784,24 @@ idleLoop callback context config store root processRuntime commands stagedImages
                             (failureEvent request.requestId err)
                         continue
                     Right start -> do
-                        images <- atomically $ do
-                            staged <- readTVar stagedImages
-                            writeTVar stagedImages
-                                (Map.delete start.turnStartId staged)
-                            pure (Map.findWithDefault [] start.turnStartId staged)
-                        nativeBrowserTools <- browserToolsWhenEnabled browser
-                        control <- newTurnControl start.turnStartId
-                        sendEvent callback context $
-                            successEvent request.requestId $
-                                Aeson.object
-                                    [ "turnId" Aeson..= start.turnStartId
-                                    ]
-                        sendTurnStatus
-                            callback
-                            context
-                            start.turnStartId
-                            (if start.turnStartWorktree
-                                then "Creating worktree…"
-                                else "Starting…")
-                        withAsync
-                            (runNativeTurn
-                                callback
-                                context
-                                processRuntime
-                                control
-                                nativeBrowserTools
-                                start
-                                images)
-                            \running ->
-                                activeLoop
-                                    callback
-                                    context
-                                    config
-                                    store
-                                    root
-                                    commands
-                                    control
-                                    running >>= \case
-                                        ActiveContinue -> continue
-                                        ActiveStop -> pure ()
+                        selectedRuntimeModel <-
+                            validatedRuntimeModel runtimeResponsesModel
+                        case selectedRuntimeModel of
+                            Nothing
+                                | start.turnStartModel
+                                    == Just appleFoundationModelId -> do
+                                        atomically $ modifyTVar' stagedImages
+                                            (Map.delete start.turnStartId)
+                                        sendEvent callback context $
+                                            failureEvent
+                                                request.requestId
+                                                "Apple Intelligence is no longer available"
+                                        continue
+                            _ ->
+                                launchTurn
+                                    request.requestId
+                                    start
+                                    selectedRuntimeModel
             | request.requestMethod `elem`
                 ["turn.cancel", "approval.resolve"] -> do
                     sendEvent callback context $
@@ -1818,10 +1810,55 @@ idleLoop callback context config store root processRuntime commands stagedImages
                             "there is no active turn"
                     continue
             | otherwise -> do
-                event <- handleRequest config store root request
+                event <- handleRequest
+                    config store root runtimeResponsesModel request
                 sendEvent callback context event
                 continue
   where
+    launchTurn startRequestId start selectedRuntimeModel = do
+        images <- atomically $ do
+            staged <- readTVar stagedImages
+            writeTVar stagedImages
+                (Map.delete start.turnStartId staged)
+            pure (Map.findWithDefault [] start.turnStartId staged)
+        nativeBrowserTools <- browserToolsWhenEnabled browser
+        control <- newTurnControl start.turnStartId
+        sendEvent callback context $
+            successEvent startRequestId $
+                Aeson.object
+                    [ "turnId" Aeson..= start.turnStartId
+                    ]
+        sendTurnStatus
+            callback
+            context
+            start.turnStartId
+            (if start.turnStartWorktree
+                then "Creating worktree…"
+                else "Starting…")
+        withAsync
+            (runNativeTurn
+                callback
+                context
+                processRuntime
+                selectedRuntimeModel
+                control
+                nativeBrowserTools
+                start
+                images)
+            \running ->
+                activeLoop
+                    callback
+                    context
+                    config
+                    store
+                    root
+                    commands
+                    control
+                    runtimeResponsesModel
+                    running >>= \case
+                        ActiveContinue -> continue
+                        ActiveStop -> pure ()
+
     continue =
         idleLoop
             callback
@@ -1833,6 +1870,7 @@ idleLoop callback context config store root processRuntime commands stagedImages
             commands
             stagedImages
             browser
+            runtimeResponsesModel
 
 activeLoop
     :: FunPtr EventCallback
@@ -1842,9 +1880,12 @@ activeLoop
     -> OsPath
     -> TQueue EngineCommand
     -> TurnControl
+    -> IO (Maybe RuntimeResponsesModel)
     -> Async TurnOutcome
     -> IO ActiveExit
-activeLoop callback context config store root commands control running =
+activeLoop
+        callback context config store root commands control runtimeResponsesModel
+        running =
     atomically
         ((Left <$> readTQueue commands)
             `orElse` (Right <$> waitCatchSTM running)) >>= \case
@@ -1859,12 +1900,14 @@ activeLoop callback context config store root commands control running =
             runConversationSearch
                 config store query limit searchCallback searchContext
             activeLoop
-                callback context config store root commands control running
+                callback context config store root commands control
+                    runtimeResponsesModel running
         Left (EngineSessionMutation mutation resultCallback resultContext) -> do
             runSessionMutation
                 config store root mutation resultCallback resultContext
             activeLoop
-                callback context config store root commands control running
+                callback context config store root commands control
+                    runtimeResponsesModel running
         Left (EngineRequest request) -> do
             if request.requestMethod == "turn.cancel"
               then
@@ -1891,7 +1934,8 @@ activeLoop callback context config store root commands control running =
                 sendEvent callback context $
                     failureEvent request.requestId "a turn is already running"
               else
-                handleRequest config store root request
+                handleRequest
+                    config store root runtimeResponsesModel request
                     >>= sendEvent callback context
             activeLoop
                 callback
@@ -1901,6 +1945,7 @@ activeLoop callback context config store root commands control running =
                 root
                 commands
                 control
+                runtimeResponsesModel
                 running
 
 runSessionMutation
@@ -2121,12 +2166,15 @@ runNativeTurn
     :: FunPtr EventCallback
     -> Ptr ()
     -> NativeProcessRuntime
+    -> Maybe RuntimeResponsesModel
     -> TurnControl
     -> [AppTool]
     -> TurnStart
     -> [ImageAttachment]
     -> IO TurnOutcome
-runNativeTurn callback context processRuntime control nativeBrowserTools start images = do
+runNativeTurn
+        callback context processRuntime runtimeResponsesModel control
+        nativeBrowserTools start images = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     let hooks = NativeRunHooks
@@ -2161,6 +2209,7 @@ runNativeTurn callback context processRuntime control nativeBrowserTools start i
             withFile "/dev/null" WriteMode \output ->
                 runNativeAgent
                     processRuntime
+                    runtimeResponsesModel
                     output
                     (unsafeEncodeUtf start.turnStartCwd)
                     hooks
@@ -2476,9 +2525,10 @@ handleRequest
     :: ManagedPostgresConfig
     -> MVar (Maybe Store)
     -> OsPath
+    -> IO (Maybe RuntimeResponsesModel)
     -> BridgeRequest
     -> IO Aeson.Value
-handleRequest config store root request = do
+handleRequest config store root runtimeResponsesModel request = do
     result <- tryAny (handleMethod request)
     pure $ either
         (failureEvent request.requestId . Text.pack . show)
@@ -2534,9 +2584,12 @@ handleRequest config store root request = do
                         pure (failureEvent current.requestId err)
                     Right parameters -> do
                         activeStore <- acquireStore config store
+                        runtimeModel <-
+                            validatedRuntimeModel runtimeResponsesModel
                         catalogResult <- loadNativeModelCatalog
                             activeStore
                             root
+                            runtimeModel
                             parameters
                         pure $ either
                             (failureEvent current.requestId)
@@ -2546,12 +2599,18 @@ handleRequest config store root request = do
                 pure $ failureEvent current.requestId
                     ("unknown method: " <> method)
 
+validatedRuntimeModel
+    :: IO (Maybe RuntimeResponsesModel)
+    -> IO (Maybe RuntimeResponsesModel)
+validatedRuntimeModel = id
+
 loadNativeModelCatalog
     :: Store
     -> OsPath
+    -> Maybe RuntimeResponsesModel
     -> ModelsListRequest
     -> IO (Either Text Aeson.Value)
-loadNativeModelCatalog store root request = do
+loadNativeModelCatalog store root runtimeResponsesModel request = do
     let home = takeDirectory (takeDirectory root)
         requestedCwd = unsafeEncodeUtf request.modelsListCwd
     contextResult <- currentModelContext
@@ -2564,7 +2623,11 @@ loadNativeModelCatalog store root request = do
         Right (cwd, maybeTarget) ->
             loadGatewayModelCatalogAt home cwd >>= \case
                 Left err -> pure (Left err)
-                Right catalog -> do
+                Right loadedCatalog -> do
+                    let catalog = maybe
+                            loadedCatalog
+                            (`applyRuntimeResponsesModel` loadedCatalog)
+                            runtimeResponsesModel
                     let configuredTarget = do
                             target <- maybeTarget
                             option <-

--- a/packages/agent-cli/src/Agent/CLI/AppleFoundationModels.hs
+++ b/packages/agent-cli/src/Agent/CLI/AppleFoundationModels.hs
@@ -1,0 +1,583 @@
+-- | Scoped supervision for the optional Apple on-device model helper.
+--
+-- The private macOS application embeds @apfel@ under @Contents/Helpers@. The
+-- public runtime owns the child process so its bearer token never enters the
+-- app or any tool subprocess environment.
+module Agent.CLI.AppleFoundationModels
+    ( appleFoundationModelId
+    , appleFoundationModelRuntimeAvailable
+    , withAppleFoundationModelRuntime
+    ) where
+
+import Agent.CLI.RuntimeModel
+    ( RuntimeResponsesModel
+    , appleFoundationModelsModelId
+    , mkAppleFoundationModelsRuntime
+    )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newMVar
+    )
+import Control.Exception.Safe
+    ( bracket
+    , mask
+    , onException
+    , throwIO
+    , tryAny
+    )
+import Control.Monad (forM_, unless, void)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.:), withObject)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64.URL as Base64Url
+import Data.Char (isDigit)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Time.Clock
+    ( UTCTime
+    , addUTCTime
+    , diffUTCTime
+    , getCurrentTime
+    )
+import qualified Network.HTTP.Client as Http
+import Network.HTTP.Types.Status (statusCode)
+import qualified Network.Socket as Socket
+import System.Directory
+    ( canonicalizePath
+    , doesFileExist
+    , executable
+    , getPermissions
+    )
+import System.Environment
+    ( getEnvironment
+    , getExecutablePath
+    , lookupEnv
+    )
+import System.Exit (ExitCode(ExitSuccess))
+import qualified System.FilePath as FilePath
+import System.Info (arch, os)
+import System.IO
+    ( IOMode(ReadMode, WriteMode)
+    , withBinaryFile
+    , withFile
+    )
+import System.Posix.Signals (sigKILL, signalProcess)
+import System.Process
+    ( CreateProcess(..)
+    , ProcessHandle
+    , StdStream(NoStream, UseHandle)
+    , createProcess
+    , getPid
+    , getProcessExitCode
+    , proc
+    , readProcess
+    , readProcessWithExitCode
+    , terminateProcess
+    , waitForProcess
+    )
+import System.Timeout (timeout)
+import System.IO.Unsafe (unsafePerformIO)
+
+appleFoundationModelId :: Text
+appleFoundationModelId = appleFoundationModelsModelId
+
+data ManagedAppleModel = ManagedAppleModel
+    { managedRuntime :: !RuntimeResponsesModel
+    , managedProcess :: !ProcessHandle
+    , managedPort :: !Int
+    , managedContextWindow :: !Int
+    , managedHttpManager :: !Http.Manager
+    , managedHealthPendingSince :: !(Maybe UTCTime)
+    }
+
+data SharedAppleModel
+    = AppleModelNotStarted
+    | AppleModelUnavailable !UTCTime
+    | AppleModelRunning !ManagedAppleModel !Int
+
+data AppleModelLease
+    = UnavailableLease
+    | RunningLease !RuntimeResponsesModel
+
+data AppleModelStart
+    = AppleModelStarted !ManagedAppleModel
+    | AppleModelStartUnavailable
+    | AppleModelStartRetryable
+
+data ManagedAppleModelHealth
+    = ManagedAppleModelHealthy
+    | ManagedAppleModelPending
+    | ManagedAppleModelUnhealthy
+
+{-# NOINLINE sharedAppleModel #-}
+sharedAppleModel :: MVar SharedAppleModel
+sharedAppleModel = unsafePerformIO (newMVar AppleModelNotStarted)
+
+data HealthResponse = HealthResponse
+    { healthStatus :: !Text
+    , healthModelAvailable :: !Bool
+    , healthModel :: !Text
+    , healthContextWindow :: !Int
+    }
+
+instance Aeson.FromJSON HealthResponse where
+    parseJSON = withObject "apfel health response" \object ->
+        HealthResponse
+            <$> object .: "status"
+            <*> object .: "model_available"
+            <*> object .: "model"
+            <*> object .: "context_window"
+
+withAppleFoundationModelRuntime
+    :: (IO (Maybe RuntimeResponsesModel) -> IO value)
+    -> IO value
+withAppleFoundationModelRuntime action =
+    bracket
+        acquireAppleModelClient
+        releaseAppleModelClient
+        (action . refreshAppleModelClient)
+
+acquireAppleModelClient :: IO (MVar AppleModelLease)
+acquireAppleModelClient =
+    mask \_ -> acquireAppleModel >>= newMVar
+
+releaseAppleModelClient :: MVar AppleModelLease -> IO ()
+releaseAppleModelClient leaseVariable =
+    modifyMVar_ leaseVariable \lease -> do
+        releaseAppleModel lease
+        pure UnavailableLease
+
+refreshAppleModelClient
+    :: MVar AppleModelLease
+    -> IO (Maybe RuntimeResponsesModel)
+refreshAppleModelClient leaseVariable =
+    modifyMVar leaseVariable \lease ->
+        case lease of
+            UnavailableLease -> replaceLease lease
+            RunningLease runtime ->
+                appleFoundationModelRuntimeAvailable runtime >>= \case
+                    True -> pure (lease, Just runtime)
+                    False -> replaceLease lease
+  where
+    replaceLease lease =
+        mask \_ -> do
+            releaseAppleModel lease
+            replacement <- acquireAppleModel
+            pure (replacement, leaseRuntime replacement)
+    leaseRuntime = \case
+        UnavailableLease -> Nothing
+        RunningLease runtime -> Just runtime
+
+acquireAppleModel :: IO AppleModelLease
+acquireAppleModel =
+    modifyMVar sharedAppleModel \case
+        AppleModelRunning managed references ->
+            refreshManagedAppleModel managed >>= \case
+                Just refreshed ->
+                    pure
+                        ( AppleModelRunning refreshed (references + 1)
+                        , RunningLease refreshed.managedRuntime
+                        )
+                Nothing -> do
+                    stopAppleModel managed
+                    startLease
+        unavailable@(AppleModelUnavailable retryAfter) -> do
+            now <- getCurrentTime
+            if now < retryAfter
+                then pure (unavailable, UnavailableLease)
+                else startLease
+        AppleModelNotStarted -> startLease
+  where
+    startLease =
+        tryAny discoverAndStartAppleModel >>= \case
+            Left _ -> cacheUnavailable
+            Right (Just managed) ->
+                pure
+                    ( AppleModelRunning managed 1
+                    , RunningLease managed.managedRuntime
+                    )
+            Right Nothing -> cacheUnavailable
+    cacheUnavailable = do
+        retryAfter <- addUTCTime 30 <$> getCurrentTime
+        pure (AppleModelUnavailable retryAfter, UnavailableLease)
+
+releaseAppleModel :: AppleModelLease -> IO ()
+releaseAppleModel = \case
+    UnavailableLease -> pure ()
+    RunningLease runtime ->
+        modifyMVar_ sharedAppleModel \case
+            AppleModelRunning managed references
+                | managed.managedRuntime == runtime
+                    && references <= 1 -> do
+                        stopAppleModel managed
+                        pure AppleModelNotStarted
+                | managed.managedRuntime == runtime ->
+                    pure (AppleModelRunning managed (references - 1))
+            state -> pure state
+
+-- | Revalidate that the shared helper behind a runtime descriptor is still
+-- the live owner of its loopback listener.
+appleFoundationModelRuntimeAvailable
+    :: RuntimeResponsesModel
+    -> IO Bool
+appleFoundationModelRuntimeAvailable runtime =
+    modifyMVar sharedAppleModel \case
+        AppleModelRunning managed references
+            | managed.managedRuntime == runtime ->
+                refreshManagedAppleModel managed >>= \case
+                    Just refreshed ->
+                        pure
+                            ( AppleModelRunning refreshed references
+                            , True
+                            )
+                    Nothing -> do
+                        stopAppleModel managed
+                        pure (AppleModelNotStarted, False)
+        state -> pure (state, False)
+
+discoverAndStartAppleModel :: IO (Maybe ManagedAppleModel)
+discoverAndStartAppleModel =
+    findApfelExecutable >>= \case
+        Nothing -> pure Nothing
+        Just executablePath -> startWithRetries 3 executablePath
+  where
+    startWithRetries :: Int -> FilePath -> IO (Maybe ManagedAppleModel)
+    startWithRetries remaining executablePath =
+        startAppleModel executablePath >>= \case
+            AppleModelStarted managed -> pure (Just managed)
+            AppleModelStartUnavailable -> pure Nothing
+            AppleModelStartRetryable
+                | remaining > 1 ->
+                    startWithRetries (remaining - 1) executablePath
+                | otherwise -> pure Nothing
+
+findApfelExecutable :: IO (Maybe FilePath)
+findApfelExecutable
+    | os /= "darwin" || arch /= "aarch64" = pure Nothing
+    | otherwise =
+        macOSSupportsFoundationModels >>= \case
+            False -> pure Nothing
+            True -> do
+                executablePath <- getExecutablePath
+                let directory = FilePath.takeDirectory executablePath
+                    bundledPath =
+                        directory FilePath.</> ".."
+                            FilePath.</> "Helpers"
+                            FilePath.</> "apfel"
+                    isApplicationBundle =
+                        FilePath.takeFileName directory == "MacOS"
+                            && FilePath.takeFileName
+                                (FilePath.takeDirectory directory)
+                                == "Contents"
+                if isApplicationBundle
+                    then firstExecutable [bundledPath]
+                    else do
+                        configured <-
+                            lookupEnv "HASKELL_AGENT_APFEL_EXECUTABLE"
+                        firstExecutable $
+                            [bundledPath, directory FilePath.</> "apfel"]
+                                <> maybe
+                                    []
+                                    (\path ->
+                                        [path | not (null path)])
+                                    configured
+
+macOSSupportsFoundationModels :: IO Bool
+macOSSupportsFoundationModels =
+    tryAny (readProcess "/usr/bin/sw_vers" ["-productVersion"] "") >>= \case
+        Left _ -> pure False
+        Right version ->
+            pure $ case reads (takeWhile isDigit version) of
+                [(major, "")] -> (major :: Int) >= 26
+                _ -> False
+
+firstExecutable :: [FilePath] -> IO (Maybe FilePath)
+firstExecutable = \case
+    [] -> pure Nothing
+    candidate : rest ->
+        doesFileExist candidate >>= \case
+            False -> firstExecutable rest
+            True -> do
+                permissions <- getPermissions candidate
+                if executable permissions
+                    then Just <$> canonicalizePath candidate
+                    else firstExecutable rest
+
+startAppleModel :: FilePath -> IO AppleModelStart
+startAppleModel executablePath = mask \restore -> do
+    port <- reserveLoopbackPort
+    token <- randomBearerToken
+    inherited <- getEnvironment
+    let childEnvironment =
+            setChildEnvironment "NO_COLOR" "1"
+                (setChildEnvironment "APFEL_TOKEN" (Text.unpack token) inherited)
+        process =
+            (proc executablePath
+                [ "--serve"
+                , "--host", "127.0.0.1"
+                , "--port", show port
+                , "--max-concurrent", "1"
+                ])
+                { env = Just childEnvironment
+                , std_in = NoStream
+                , std_out = NoStream
+                , std_err = NoStream
+                }
+    (_, _, _, processHandle) <-
+        withFile "/dev/null" WriteMode \nullHandle ->
+            createProcess process
+                { std_out = UseHandle nullHandle
+                , std_err = UseHandle nullHandle
+                }
+    let cleanup = stopProcess processHandle
+    restore
+        (do
+            manager <- Http.newManager Http.defaultManagerSettings
+            awaitAppleModel manager processHandle port >>= \case
+                HealthReady contextWindow -> do
+                    listenerOwnedByProcess processHandle port >>= \case
+                        False -> do
+                            cleanup
+                            pure AppleModelStartRetryable
+                        True -> do
+                            runtime <-
+                                either
+                                    (throwIO . userError . Text.unpack)
+                                    pure
+                                    (mkAppleFoundationModelsRuntime
+                                        ("http://127.0.0.1:"
+                                            <> Text.pack (show port)
+                                            <> "/v1")
+                                        token
+                                        contextWindow)
+                            pure $ AppleModelStarted ManagedAppleModel
+                                { managedRuntime = runtime
+                                , managedProcess = processHandle
+                                , managedPort = port
+                                , managedContextWindow = contextWindow
+                                , managedHttpManager = manager
+                                , managedHealthPendingSince = Nothing
+                                }
+                HealthUnavailable -> do
+                    cleanup
+                    pure AppleModelStartUnavailable
+                HealthFailed -> do
+                    cleanup
+                    pure AppleModelStartRetryable
+                HealthPending -> do
+                    cleanup
+                    pure AppleModelStartRetryable)
+        `onException` cleanup
+
+setChildEnvironment
+    :: String
+    -> String
+    -> [(String, String)]
+    -> [(String, String)]
+setChildEnvironment name value inherited =
+    (name, value) : filter ((/= name) . fst) inherited
+
+reserveLoopbackPort :: IO Int
+reserveLoopbackPort =
+    Socket.withSocketsDo $
+        bracket
+            (Socket.socket Socket.AF_INET Socket.Stream Socket.defaultProtocol)
+            Socket.close
+            \socket -> do
+                Socket.bind socket
+                    (Socket.SockAddrInet
+                        0
+                        (Socket.tupleToHostAddress (127, 0, 0, 1)))
+                Socket.getSocketName socket >>= \case
+                    Socket.SockAddrInet port _ ->
+                        pure (fromIntegral port)
+                    _ -> throwIO (userError "could not reserve an IPv4 port")
+
+randomBearerToken :: IO Text
+randomBearerToken = do
+    bytes <- withBinaryFile "/dev/urandom" ReadMode (`BS.hGet` 32)
+    unless (BS.length bytes == 32) $
+        throwIO (userError "could not read bearer-token entropy")
+    pure $ TextEncoding.decodeUtf8 (Base64Url.encodeUnpadded bytes)
+
+awaitAppleModel :: Http.Manager -> ProcessHandle -> Int -> IO HealthStatus
+awaitAppleModel manager processHandle port =
+    timeout 3_000_000 (go (30 :: Int)) >>= \case
+        Just status -> pure status
+        Nothing -> pure HealthFailed
+  where
+    go 0 = pure HealthFailed
+    go remaining =
+        getProcessExitCode processHandle >>= \case
+            Just _ -> pure HealthFailed
+            Nothing ->
+                checkHealth manager port >>= \case
+                    HealthReady contextWindow ->
+                        pure (HealthReady contextWindow)
+                    HealthUnavailable -> pure HealthUnavailable
+                    HealthFailed -> pure HealthFailed
+                    HealthPending -> do
+                        threadDelay 100_000
+                        go (remaining - 1)
+
+data HealthStatus
+    = HealthReady !Int
+    | HealthUnavailable
+    | HealthPending
+    | HealthFailed
+
+checkHealth :: Http.Manager -> Int -> IO HealthStatus
+checkHealth manager port =
+    timeout 750_000 (tryAny request) >>= \case
+        Just (Right (responseStatus, Just responseBody))
+            | statusCode responseStatus /= 200 ->
+                pure HealthPending
+            | otherwise ->
+                case
+                    (Aeson.eitherDecodeStrict' responseBody
+                        :: Either String HealthResponse) of
+                    Left _ -> pure HealthPending
+                    Right health
+                        | health.healthStatus == "ok"
+                            && health.healthModelAvailable
+                            && health.healthModel == appleFoundationModelId
+                            && health.healthContextWindow
+                                `elem` [4096, 8192] ->
+                                pure
+                                    (HealthReady
+                                        health.healthContextWindow)
+                        | otherwise -> pure HealthUnavailable
+        _ -> pure HealthPending
+  where
+    request = do
+        requestWithoutToken <- Http.parseRequest
+            ("http://127.0.0.1:" <> show port <> "/health")
+        let bounded = requestWithoutToken
+                { Http.responseTimeout =
+                    Http.responseTimeoutMicro 500_000
+                }
+        Http.withResponse bounded manager \response -> do
+            body <- readBoundedResponseBody 16_384
+                (Http.responseBody response)
+            pure (Http.responseStatus response, body)
+
+readBoundedResponseBody
+    :: Int
+    -> Http.BodyReader
+    -> IO (Maybe BS.ByteString)
+readBoundedResponseBody limit = go [] 0
+  where
+    go chunks size reader = do
+        chunk <- Http.brRead reader
+        if BS.null chunk
+            then pure (Just (BS.concat (reverse chunks)))
+            else
+                let nextSize = size + BS.length chunk
+                in if nextSize > limit
+                    then pure Nothing
+                    else go (chunk : chunks) nextSize reader
+
+managedAppleModelHealth
+    :: ManagedAppleModel
+    -> IO ManagedAppleModelHealth
+managedAppleModelHealth managed =
+    getProcessExitCode managed.managedProcess >>= \case
+        Just _ -> do
+            void (waitForProcess managed.managedProcess)
+            pure ManagedAppleModelUnhealthy
+        Nothing ->
+            listenerOwnedByProcess
+                managed.managedProcess
+                managed.managedPort >>= \case
+                    False -> pure ManagedAppleModelUnhealthy
+                    True ->
+                        checkHealth
+                            managed.managedHttpManager
+                            managed.managedPort >>= \case
+                                HealthReady contextWindow
+                                    | contextWindow
+                                        == managed.managedContextWindow ->
+                                            pure ManagedAppleModelHealthy
+                                    | otherwise ->
+                                        pure ManagedAppleModelUnhealthy
+                                HealthPending ->
+                                    pure ManagedAppleModelPending
+                                HealthUnavailable ->
+                                    pure ManagedAppleModelUnhealthy
+                                HealthFailed ->
+                                    pure ManagedAppleModelUnhealthy
+
+refreshManagedAppleModel
+    :: ManagedAppleModel
+    -> IO (Maybe ManagedAppleModel)
+refreshManagedAppleModel managed =
+    tryAny (managedAppleModelHealth managed) >>= \case
+        Left _ -> pure Nothing
+        Right ManagedAppleModelUnhealthy -> pure Nothing
+        Right ManagedAppleModelHealthy ->
+            pure $ Just managed
+                { managedHealthPendingSince = Nothing
+                }
+        Right ManagedAppleModelPending -> do
+            now <- getCurrentTime
+            case managed.managedHealthPendingSince of
+                Nothing ->
+                    pure $ Just managed
+                        { managedHealthPendingSince = Just now
+                        }
+                Just pendingSince
+                    | diffUTCTime now pendingSince < 5 ->
+                        pure (Just managed)
+                    | otherwise -> pure Nothing
+
+listenerOwnedByProcess :: ProcessHandle -> Int -> IO Bool
+listenerOwnedByProcess processHandle port =
+    getPid processHandle >>= \case
+        Nothing -> pure False
+        Just processId ->
+            timeout 1_000_000
+                (tryAny
+                    (readProcessWithExitCode
+                        "/usr/sbin/lsof"
+                        [ "-nP"
+                        , "-a"
+                        , "-p", show processId
+                        , "-iTCP@127.0.0.1:" <> show port
+                        , "-sTCP:LISTEN"
+                        , "-Fp"
+                        ]
+                        "")) >>= \case
+                            Just (Right (ExitSuccess, output, _)) ->
+                                pure $
+                                    ("p" <> show processId)
+                                        `elem` lines output
+                            _ -> pure False
+
+stopAppleModel :: ManagedAppleModel -> IO ()
+stopAppleModel = stopProcess . (.managedProcess)
+
+stopProcess :: ProcessHandle -> IO ()
+stopProcess processHandle =
+    tryAny (getProcessExitCode processHandle) >>= \case
+        Right (Just _) -> reap
+        _ -> do
+            processId <-
+                tryAny (getPid processHandle) >>= \case
+                    Right result -> pure result
+                    Left _ -> pure Nothing
+            void $ tryAny (terminateProcess processHandle)
+            timeout 2_000_000 (tryAny (waitForProcess processHandle))
+                >>= \case
+                    Just (Right _) -> pure ()
+                    _ -> do
+                        forM_ processId \pid ->
+                            void $ tryAny (signalProcess sigKILL pid)
+                        void $
+                            timeout 2_000_000
+                                (tryAny (waitForProcess processHandle))
+  where
+    reap = void $ tryAny (waitForProcess processHandle)

--- a/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
@@ -1,9 +1,9 @@
 -- | Canonical model aliases exposed by the Digitally Induced LLM gateway.
 --
--- Gateway credentials are process-wide, so the active catalog is deliberately
--- exclusive: direct provider models disappear while connected and gateway
--- aliases disappear while disconnected. This prevents a direct model id from
--- being sent to the gateway (or a router alias from reaching a provider).
+-- Gateway credentials are process-wide. Built-in direct-provider models are
+-- hidden while connected, but explicitly configured custom Responses
+-- connections remain available because they carry independent authentication
+-- and transport.
 module Agent.CLI.GatewayModels
     ( catalogForGatewayState
     , catalogUsesGateway
@@ -16,12 +16,15 @@ module Agent.CLI.GatewayModels
 import Agent.CLI.GatewayClient (loadGatewayCredentialAt)
 import Agent.CLI.ModelConfig
     ( CatalogModel(..)
+    , ConnectionKind(..)
     , ModelCatalog(..)
+    , ModelConnection(..)
     , builtinConnectionId
     , loadModelCatalogAt
     )
 import Agent.Dialect (DialectId (CodexDialect))
 import Agent.Provider (Provider (OpenAIProvider))
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import System.OsPath (OsPath)
 
@@ -40,12 +43,22 @@ isGatewayModelId modelId = modelId `elem` gatewayModelIds
 
 catalogUsesGateway :: ModelCatalog -> Bool
 catalogUsesGateway catalog =
-    not (null catalog.catalogModels)
-        && all (isGatewayModelId . (.catalogModelId)) catalog.catalogModels
+    any (isGatewayModelId . (.catalogModelId)) catalog.catalogModels
 
 catalogForGatewayState :: Bool -> ModelCatalog -> ModelCatalog
 catalogForGatewayState connected catalog
-    | connected = catalog { catalogModels = canonicalGatewayModels }
+    | connected =
+        catalog
+            { catalogModels =
+                canonicalGatewayModels
+                    <> filter
+                        (\model ->
+                            usesCustomConnection catalog model
+                                && not
+                                    (isGatewayModelId
+                                        model.catalogModelId))
+                        catalog.catalogModels
+            }
     | otherwise =
         catalog
             { catalogModels =
@@ -53,6 +66,15 @@ catalogForGatewayState connected catalog
                     (not . isGatewayModelId . (.catalogModelId))
                     catalog.catalogModels
             }
+
+usesCustomConnection :: ModelCatalog -> CatalogModel -> Bool
+usesCustomConnection catalog model =
+    case Map.lookup
+        model.catalogModelConnectionId
+        catalog.catalogConnections of
+        Just ModelConnection
+            { connectionKind = CustomResponsesConnection _ } -> True
+        _ -> False
 
 loadGatewayModelCatalogAt
     :: OsPath

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -12,6 +12,7 @@ import Agent.CLI.AgentSessions
     , closeSessionThreadManager
     , newSessionThreadManager
     )
+import Agent.CLI.RuntimeModel ( RuntimeResponsesModel )
 import Agent.CLI.Options
     ( Command(..)
     , parseArgs
@@ -53,12 +54,13 @@ closeNativeProcessRuntime runtime =
 
 runNativeAgent
     :: NativeProcessRuntime
+    -> Maybe RuntimeResponsesModel
     -> Handle
     -> OsPath
     -> NativeRunHooks
     -> [String]
     -> IO (Either Text ())
-runNativeAgent runtime output cwd hooks args =
+runNativeAgent runtime runtimeModel output cwd hooks args =
     case parseArgs args of
         Left err -> pure (Left (Text.pack err))
         Right (RunAgent options) ->
@@ -66,6 +68,7 @@ runNativeAgent runtime output cwd hooks args =
                 AgentProcessRuntime
                     { processMcpSupervisor = runtime.nativeMcpSupervisor
                     , processSessionThreads = runtime.nativeSessionThreads
+                    , processRuntimeResponsesModel = runtimeModel
                     }
                 (nativeRunMode output cwd hooks)
                 options >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Prompt
     , subscriptionSubagentModelGuidance
     , sessionTempGuidance
     , systemPrompt
+    , systemPromptForAvailableTools
     , systemPromptForTools
     ) where
 
@@ -78,8 +79,24 @@ systemPromptForTools
     -> Day
     -> Bool
     -> Text
-systemPromptForTools
-        dialect toolNames cwd sessionTmp today isNonInteractive =
+systemPromptForTools dialect toolNames =
+    systemPromptForAvailableTools
+        dialect
+        (hostedSearchToolNames dialect ++ toolNames)
+
+-- | Render a prompt from the exact set of names exposed by the wire
+-- transport. Unlike 'systemPromptForTools', this does not assume hosted
+-- search is available.
+systemPromptForAvailableTools
+    :: Dialect
+    -> [Text]
+    -> OsPath
+    -> Maybe OsPath
+    -> Day
+    -> Bool
+    -> Text
+systemPromptForAvailableTools
+        dialect available cwd sessionTmp today isNonInteractive =
     Text.intercalate "\n\n" $
         filter (not . Text.null)
             [ base
@@ -90,7 +107,6 @@ systemPromptForTools
             , timeContextGuidance
             ]
   where
-    available = hostedSearchToolNames dialect ++ toolNames
     base = case dialectPromptStyle dialect of
         GrokBuildPromptStyle ->
             grokSystemPromptForTools

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -23,6 +23,8 @@ module Agent.CLI.Runtime.Internal
 
 import Agent.CLI.AgentSessions
     ( closeSessionThreadManager, newSessionThreadManager )
+import Agent.CLI.AppleFoundationModels
+    ( withAppleFoundationModelRuntime )
 import Agent.CLI.GatewayClient (runGatewayCommand)
 import Agent.CLI.Interrupt ( catchUserInterrupt )
 import Agent.CLI.Login ( runLoginManager )
@@ -176,7 +178,8 @@ run = do
 runAgentWithRestarts :: CliOptions -> IO DevResult
 runAgentWithRestarts options =
     catchUserInterrupt
-        (do
+        (withAppleFoundationModelRuntime \getRuntimeResponsesModel -> do
+            runtimeResponsesModel <- getRuntimeResponsesModel
             home <- getHomeDirectory
             let root = sessionsRoot home
             mcpSupervisor <- MCP.newMcpSupervisor
@@ -186,6 +189,8 @@ runAgentWithRestarts options =
             let processRuntime = AgentProcessRuntime
                     { processMcpSupervisor = mcpSupervisor
                     , processSessionThreads = sessionThreads
+                    , processRuntimeResponsesModel =
+                        runtimeResponsesModel
                     }
             withRestoredCurrentDirectory
                 (runAgentWithRuntime processRuntime foregroundRunMode options)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration.hs
@@ -112,7 +112,9 @@ import Agent.CLI.Project
       resolveProjectRoot,
       saveProjectModel )
 import Agent.CLI.Prompt
-    ( subscriptionSubagentModelGuidance, systemPromptForTools )
+    ( subscriptionSubagentModelGuidance
+    , systemPromptForAvailableTools
+    )
 import Agent.CLI.PromptHooks
     ( fullscreenAwarePlanHooks, fullscreenAwareSecretHooks )
 import Agent.CLI.Provider.OpenAI
@@ -139,6 +141,12 @@ import Agent.CLI.Render ( putTextLn )
 import Agent.CLI.ReplMode ()
 import Agent.CLI.Request ( requestParams )
 import Agent.CLI.Runtime.Persistence ( preparePersistence )
+import Agent.CLI.RuntimeModel
+    ( RuntimeModelTransport(..)
+    , RuntimeResponsesModel(..)
+    , applyRuntimeResponsesModel
+    , runtimeResponsesModelMatches
+    )
 import Agent.CLI.Runtime.Recap
     ( runSessionRecap, runSessionTurnSummary )
 import Agent.CLI.Runtime.Repl
@@ -253,7 +261,11 @@ import Agent.CLI.Terminal
       reportTerminalCwd,
       resolveColor,
       TerminalCapabilities(terminalNativeProgress) )
-import Agent.CLI.Tools ( schemasFromAppTools )
+import Agent.CLI.Tools
+    ( functionSchemasFromAppTools
+    , responseToolNames
+    , schemasFromAppTools
+    )
 import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch
@@ -421,6 +433,12 @@ import qualified Agent.Responses.GenericClient as GenericResponses
     ( GenericClientOptions(model),
       createResponseWith,
       createResponseWithEvents )
+import qualified Agent.Responses.ChatCompletions as ChatCompletions
+    ( ChatCompletionsOptions(..)
+    , createChatCompletionWith
+    , createChatCompletionWithEvents
+    , reinforceFunctionSchemas
+    )
 import qualified Agent.MCP as MCP
     ( acquireMcpFleetProgressive,
       acquireMcpFleetWithProgress,
@@ -1070,11 +1088,14 @@ runAgentInitializedWithLock
                 (detectGitBranch cwd))
     catalog <- either
         (startupDie startup . Text.unpack)
-        pure
+        (pure . maybe
+            id
+            applyRuntimeResponsesModel
+            processRuntime.processRuntimeResponsesModel)
         catalogResult
     setStartupRepository fullscreen home branch cwd
     markStartupStage startup "Loading credentials…"
-    let gatewayMode = catalogUsesGateway catalog
+    let gatewayAvailable = catalogUsesGateway catalog
         transitionTarget = (.transitionTarget) <$> transition
         pendingTurn = transition >>= (.transitionPendingTurn)
         unavailableProviders =
@@ -1085,12 +1106,34 @@ runAgentInitializedWithLock
         gatewayDefaultTarget =
             (.modelTarget)
                 <$> resolveConfiguredModel catalog gatewayDefaultModelId
+        gatewayCompatibleTarget target =
+            case resolveConfiguredModel catalog target.targetModelId of
+                Just option
+                    | option.modelTarget == target ->
+                        isGatewayModelId target.targetModelId
+                            || case catalogConnection
+                                catalog
+                                target.targetConnectionId of
+                                Just ModelConnection
+                                    { connectionKind =
+                                        CustomResponsesConnection _ } ->
+                                            True
+                                _ -> False
+                _ -> False
         savedTarget provider connection model transport dialect =
             case resolveConfiguredModel catalog model of
                 Just option
                     | option.modelTarget.targetConnectionId == connection ->
                         Right option.modelTarget
                 _
+                    | isGatewayModelId model ->
+                        Left
+                            "gateway router models require an active gateway connection"
+                    | gatewayAvailable ->
+                        Left $
+                            "saved direct-provider model "
+                                <> connection <> "/" <> model
+                                <> " is unavailable while the gateway is connected"
                     | connection == builtinConnectionId provider ->
                         Right ModelTarget
                             { targetProvider = provider
@@ -1105,14 +1148,10 @@ runAgentInitializedWithLock
                                 <> connection <> "/" <> model
                                 <> " is not present in ~/.haskell-agent/models.json"
         resumedTargetResult
-            | gatewayMode =
-                Right Nothing
             | isJust transitionTarget || isJust options.optModel =
                 Right Nothing
             | otherwise = case fst <$> resumed of
             Nothing -> Right Nothing
-            Just meta
-                | isGatewayModelId meta.metaModel -> Right Nothing
             Just meta ->
                 Just <$> savedTarget
                     meta.metaProvider
@@ -1121,8 +1160,6 @@ runAgentInitializedWithLock
                     meta.metaTransportModel
                     meta.metaDialect
         projectTargetResult
-            | gatewayMode =
-                Right Nothing
             | isJust transitionTarget
                 || isJust options.optModel
                 || isJust resumed =
@@ -1131,31 +1168,36 @@ runAgentInitializedWithLock
             Nothing -> Right Nothing
             Just remembered ->
                 let target = remembered.projectModelTarget
-                in if isGatewayModelId target.targetModelId
-                    then Right Nothing
-                    else
-                        Just <$> savedTarget
-                            target.targetProvider
-                            target.targetConnectionId
-                            target.targetModelId
-                            (Just target.targetWireModelId)
-                            target.targetDialect
+                in Just <$> savedTarget
+                    target.targetProvider
+                    target.targetConnectionId
+                    target.targetModelId
+                    (Just target.targetWireModelId)
+                    target.targetDialect
     when
-        ( gatewayMode
+        ( gatewayAvailable
             && isJust options.optModel
             && isNothing configuredOptionTarget
         ) $
         startupDie startup
-            "the connected gateway accepts router-default, router-codex, or \
-            \router-grok; direct provider model ids are unavailable"
+            "the requested model is unavailable while the gateway is connected"
     when
-        ( not gatewayMode
+        ( gatewayAvailable
+            && maybe
+                False
+                (not . gatewayCompatibleTarget)
+                transitionTarget
+        ) $
+        startupDie startup
+            "the requested provider transition is unavailable while the gateway is connected"
+    when
+        ( not gatewayAvailable
             && maybe False isGatewayModelId options.optModel
         ) $
         startupDie startup
             "gateway router models require an active gateway connection"
     when
-        ( not gatewayMode
+        ( not gatewayAvailable
             && maybe
                 False
                 (isGatewayModelId . (.targetModelId))
@@ -1167,23 +1209,18 @@ runAgentInitializedWithLock
         either (startupDie startup . Text.unpack) pure resumedTargetResult
     projectTarget <-
         either (startupDie startup . Text.unpack) pure projectTargetResult
-    let gatewayTarget candidate =
-            candidate >>= \target ->
-                if isGatewayModelId target.targetModelId
-                    then Just target
+    let targetHint =
+            transitionTarget
+                <|> configuredOptionTarget
+                <|> resumedTarget
+                <|> if isNothing options.optModel
+                    then projectTarget <|> gatewayDefaultTarget
                     else Nothing
-        targetHint
-            | gatewayMode =
-                gatewayTarget transitionTarget
-                    <|> configuredOptionTarget
-                    <|> gatewayDefaultTarget
-            | otherwise =
-                transitionTarget
-                    <|> configuredOptionTarget
-                    <|> resumedTarget
-                    <|> if isNothing options.optModel
-                        then projectTarget
-                        else Nothing
+        gatewayMode =
+            maybe
+                False
+                (isGatewayModelId . (.targetModelId))
+                targetHint
         requestedProvider =
             (.targetProvider) <$> targetHint
                 <|> options.optProvider
@@ -1197,6 +1234,16 @@ runAgentInitializedWithLock
                 CustomResponsesConnection responses -> Just
                     (connection.connectionId, responses)
                 BuiltinConnection _ -> Nothing
+        selectedRuntimeModel =
+            case
+                (processRuntime.processRuntimeResponsesModel, targetHint) of
+                (Just runtime, Just target)
+                    | runtimeResponsesModelMatches
+                        runtime
+                        target.targetConnectionId
+                        target.targetModelId ->
+                            Just runtime
+                _ -> Nothing
         checkStartupUsageInBackground =
             not gatewayMode
                 && isJust fullscreen
@@ -1211,26 +1258,29 @@ runAgentInitializedWithLock
                     loadStartupAuth startup transition requestedProvider
                 pure (startupAuth, Nothing)
             Just (connectionId, responses) -> do
-                token <- case responses.responsesApiKeyEnv of
-                    Nothing
-                        | responses.responsesApiKeyOptional -> pure ""
-                        | otherwise ->
-                            startupDie startup $
-                                "custom connection "
-                                    <> Text.unpack connectionId
-                                    <> " requires api_key_env or api_key_optional=true"
-                    Just envName ->
-                        lookupEnv (Text.unpack envName) >>= \case
-                            Just value
-                                | not (null value) -> pure (Text.pack value)
-                            _
-                                | responses.responsesApiKeyOptional -> pure ""
-                                | otherwise ->
-                                    startupDie startup $
-                                        "custom connection "
-                                            <> Text.unpack connectionId
-                                            <> " requires environment variable "
-                                            <> Text.unpack envName
+                token <- case selectedRuntimeModel of
+                    Just runtime ->
+                        pure runtime.runtimeResponsesBearerToken
+                    _ -> case responses.responsesApiKeyEnv of
+                        Nothing
+                            | responses.responsesApiKeyOptional -> pure ""
+                            | otherwise ->
+                                startupDie startup $
+                                    "custom connection "
+                                        <> Text.unpack connectionId
+                                        <> " requires api_key_env or api_key_optional=true"
+                        Just envName ->
+                            lookupEnv (Text.unpack envName) >>= \case
+                                Just value
+                                    | not (null value) -> pure (Text.pack value)
+                                _
+                                    | responses.responsesApiKeyOptional -> pure ""
+                                    | otherwise ->
+                                        startupDie startup $
+                                            "custom connection "
+                                                <> Text.unpack connectionId
+                                                <> " requires environment variable "
+                                                <> Text.unpack envName
                 let credential = Credential
                         { accessToken = token
                         , accountId = connectionId
@@ -1579,6 +1629,12 @@ runAgentInitializedWithLock
                 }
         customGenericOptions = do
             (_, responses) <- customResponses
+            case selectedRuntimeModel of
+                Just runtime
+                    | runtime.runtimeResponsesTransport
+                        == RuntimeChatCompletionsTransport ->
+                            Nothing
+                _ -> pure ()
             pure GenericClientOptions
                 { baseUrl = Text.unpack responses.responsesBaseUrl
                 , model = inferredTarget.targetWireModelId
@@ -1586,6 +1642,57 @@ runAgentInitializedWithLock
                 , requestTimeoutSeconds =
                     responses.responsesRequestTimeoutSeconds
                 }
+        customChatOptions = do
+            (_, responses) <- customResponses
+            runtime <- selectedRuntimeModel
+            if runtime.runtimeResponsesTransport
+                == RuntimeChatCompletionsTransport
+                then pure ChatCompletions.ChatCompletionsOptions
+                    { ChatCompletions.chatBaseUrl =
+                        Text.unpack responses.responsesBaseUrl
+                    , ChatCompletions.chatModel =
+                        inferredTarget.targetWireModelId
+                    , ChatCompletions.chatBearerToken = customBearerToken
+                    , ChatCompletions.chatRequestTimeoutSeconds =
+                        responses.responsesRequestTimeoutSeconds
+                    }
+                else Nothing
+        customCreateResponseWithEvents =
+            case customChatOptions of
+                Just chatOptions ->
+                    Just \request onEvent ->
+                        ChatCompletions.createChatCompletionWithEvents
+                            chatOptions
+                            request
+                            onEvent
+                Nothing -> do
+                    genericOptions <- customGenericOptions
+                    pure \request onEvent ->
+                        GenericResponses.createResponseWithEvents
+                            genericOptions
+                                { GenericResponses.model =
+                                    transportModel
+                                        (fromMaybe model request.model)
+                                }
+                            request
+                            onEvent
+        customCreateResponse =
+            case customChatOptions of
+                Just chatOptions ->
+                    Just \request ->
+                        ChatCompletions.createChatCompletionWith
+                            chatOptions
+                            request
+                Nothing -> do
+                    genericOptions <- customGenericOptions
+                    pure \request ->
+                        GenericResponses.createResponseWith
+                            genericOptions
+                                { GenericResponses.model =
+                                    transportModel
+                                        (fromMaybe model request.model)
+                                }
+                            request
         persistedTarget = case fst <$> resumed of
             Just meta ->
                 Just
@@ -1988,27 +2095,38 @@ runAgentInitializedWithLock
             , provider == OpenAIProvider
             , os == "darwin"
             ]
+        runtimeToolNames =
+            selectedRuntimeModel >>= (.runtimeResponsesAllowedTools)
+        filterRuntimeTools candidates =
+            case runtimeToolNames of
+                Nothing -> candidates
+                Just allowed ->
+                    filter ((`elem` allowed) . (.appToolName)) candidates
         allTools =
-            coding.codingAppTools
-                ++ extraTools
-                ++ mcpTools
-                ++ sessionTools
-                ++ gatewayTools
-                ++ databaseAppTools
-                ++ learnedSkillAppTools
-                ++ nativeAppTools
-                ++ computerTools
+            filterRuntimeTools
+                ( coding.codingAppTools
+                    ++ extraTools
+                    ++ mcpTools
+                    ++ sessionTools
+                    ++ gatewayTools
+                    ++ databaseAppTools
+                    ++ learnedSkillAppTools
+                    ++ nativeAppTools
+                    ++ computerTools
+                )
         tools =
-            filterGhciTools options.optGhci
-                (filterBashTools options.optBash coding.codingAppTools)
-                ++ extraTools
-                ++ mcpTools
-                ++ sessionTools
-                ++ gatewayTools
-                ++ databaseAppTools
-                ++ learnedSkillAppTools
-                ++ nativeAppTools
-                ++ computerTools
+            filterRuntimeTools
+                ( filterGhciTools options.optGhci
+                    (filterBashTools options.optBash coding.codingAppTools)
+                    ++ extraTools
+                    ++ mcpTools
+                    ++ sessionTools
+                    ++ gatewayTools
+                    ++ databaseAppTools
+                    ++ learnedSkillAppTools
+                    ++ nativeAppTools
+                    ++ computerTools
+                )
         planMode = coding.codingPlanMode
         -- Keep planSessionDir and subagent store root in sync.
         noteSessionDir dir = do
@@ -2053,16 +2171,35 @@ runAgentInitializedWithLock
                         ("Failed to initialize MCP tools: " <> Text.unpack err)
                 Nothing -> pure ()
         today <- utctDay <$> getCurrentTime
-        let instructions =
-                systemPromptForTools
+        let projectToolSchemas = case selectedRuntimeModel of
+                Just runtime
+                    | runtime.runtimeResponsesTransport
+                        == RuntimeChatCompletionsTransport ->
+                            functionSchemasFromAppTools dialect
+                _ -> schemasFromAppTools dialect
+            projectTools candidates =
+                let schemas = projectToolSchemas candidates
+                in (responseToolNames schemas, schemas)
+            (promptToolNames, toolSchemas) = projectTools tools
+            instructions =
+                systemPromptForAvailableTools
                     dialect
-                    (map (.appToolName) tools)
+                    promptToolNames
                     cwd
                     (Just sessionTmp)
                     today
                     (isOneShot options)
-            params = requestParams provider model instructions
-                (schemasFromAppTools dialect tools) effort
+            finalizeRequestParams =
+                case selectedRuntimeModel of
+                    Just runtime
+                        | runtime.runtimeResponsesTransport
+                            == RuntimeChatCompletionsTransport ->
+                                ChatCompletions.reinforceFunctionSchemas
+                    _ -> id
+            params =
+                finalizeRequestParams
+                    (requestParams provider model instructions
+                        toolSchemas effort)
             initialItems = maybe [] (foldSessionItems . snd) resumed
             initialTurns = maybe [] snd resumed
             resumeNeedsFreshContext =
@@ -2193,6 +2330,8 @@ runAgentInitializedWithLock
                                 , dialect
                                 , policy
                                 , allTools
+                                , projectTools
+                                , finalizeRequestParams
                                 , suspendGhci = coding.codingSuspendGhci
                                 , grokRuntime = coding.codingGrokRuntime
                                 , mcpRegistrations =
@@ -2717,20 +2856,10 @@ runAgentInitializedWithLock
                                 pure result
                     OpenRouterProvider -> do
                         let makeBackend params =
-                                case customGenericOptions of
-                                    Just genericOptions ->
+                                case customCreateResponseWithEvents of
+                                    Just createResponse ->
                                         genericResponsesBackendWith
-                                            (\request onEvent ->
-                                                GenericResponses.createResponseWithEvents
-                                                    genericOptions
-                                                        { GenericResponses.model =
-                                                            transportModel
-                                                                (fromMaybe
-                                                                    model
-                                                                    request.model)
-                                                        }
-                                                    request
-                                                    onEvent)
+                                            createResponse
                                             params
                                     Nothing ->
                                         openRouterBackend openRouterOptions
@@ -2761,20 +2890,11 @@ runAgentInitializedWithLock
                                 historyRef <-
                                     newIORef =<< readLiveTranscript conversationRef
                                 installLiveCompactOutcome conversationRef Nothing
-                                    (case customGenericOptions of
-                                        Just genericOptions ->
+                                    (case customCreateResponse of
+                                        Just createResponse ->
                                             runResponsesCompactWithContextWindow
                                                 contextWindow
-                                                (\request ->
-                                                    GenericResponses.createResponseWith
-                                                        genericOptions
-                                                            { GenericResponses.model =
-                                                                transportModel
-                                                                    (fromMaybe
-                                                                        model
-                                                                        request.model)
-                                                            }
-                                                        request)
+                                                createResponse
                                                 recordCompactionUsage
                                                 paramsRef
                                                 historyRef

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Runtime.Orchestration.Types
 import Agent.CLI.AgentSessions ( SessionThreadManager )
 import Agent.CLI.AgentViewport ( AgentEntry )
 import Agent.CLI.Permission ( PermissionChoice )
+import Agent.CLI.RuntimeModel ( RuntimeResponsesModel )
 import Agent.Error ( ApiError )
 import Agent.Loop ( LoopEvent )
 import Agent.Provider ( Credential, TokenProvider )
@@ -37,6 +38,9 @@ data AccountSwitchRequest
 data AgentProcessRuntime = AgentProcessRuntime
     { processMcpSupervisor :: !MCP.McpSupervisor
     , processSessionThreads :: !SessionThreadManager
+    -- | An ephemeral model endpoint supplied by a trusted native host. It is
+    -- never read from or written to the user model catalog.
+    , processRuntimeResponsesModel :: !(Maybe RuntimeResponsesModel)
     }
 
 data NativeRunHooks = NativeRunHooks

--- a/packages/agent-cli/src/Agent/CLI/RuntimeModel.hs
+++ b/packages/agent-cli/src/Agent/CLI/RuntimeModel.hs
@@ -1,0 +1,155 @@
+-- | Ephemeral model connections supplied by a trusted runtime host.
+--
+-- These models are deliberately separate from the persisted catalog: bearer
+-- tokens stay in memory, and a host-provided connection cannot be redefined by
+-- a user overlay.
+module Agent.CLI.RuntimeModel
+    ( RuntimeModelTransport(..)
+    , RuntimeResponsesModel(..)
+    , appleFoundationModelsConnectionId
+    , appleFoundationModelsModelId
+    , mkAppleFoundationModelsRuntime
+    , applyRuntimeResponsesModel
+    , runtimeResponsesModelMatches
+    ) where
+
+import Agent.CLI.ModelConfig
+    ( CatalogModel(..)
+    , ConnectionKind(..)
+    , ModelCatalog(..)
+    , ModelConnection(..)
+    , ResponsesConnection(..)
+    )
+import Agent.Dialect (DialectId(GenericResponsesDialect))
+import Control.Monad (unless)
+import Data.Char (isDigit)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | Wire protocol used by a host-managed local model.
+data RuntimeModelTransport
+    = RuntimeResponsesTransport
+    | RuntimeChatCompletionsTransport
+    deriving (Eq, Show)
+
+data RuntimeResponsesModel = RuntimeResponsesModel
+    { runtimeResponsesConnectionId :: !Text
+    , runtimeResponsesConnection :: !ResponsesConnection
+    , runtimeResponsesCatalogModel :: !CatalogModel
+    , runtimeResponsesTransport :: !RuntimeModelTransport
+    , runtimeResponsesBearerToken :: !Text
+    , runtimeResponsesAllowedTools :: !(Maybe [Text])
+    }
+    deriving (Eq)
+
+appleFoundationModelsConnectionId :: Text
+appleFoundationModelsConnectionId = "apple-foundationmodels"
+
+appleFoundationModelsModelId :: Text
+appleFoundationModelsModelId = "apple-foundationmodel"
+
+-- | Build the one host-managed Apple Intelligence model. The endpoint is
+-- deliberately restricted to an authenticated IPv4 loopback server; the
+-- native app supplies the random port and in-memory bearer token.
+mkAppleFoundationModelsRuntime
+    :: Text
+    -> Text
+    -> Int
+    -> Either Text RuntimeResponsesModel
+mkAppleFoundationModelsRuntime rawBaseUrl rawBearerToken contextWindow = do
+    baseUrl <- validateLoopbackBaseUrl rawBaseUrl
+    let bearerToken = Text.strip rawBearerToken
+    unless (not (Text.null bearerToken)) $
+        Left "Apple Foundation Models requires a bearer token"
+    unless (contextWindow `elem` [4096, 8192]) $
+        Left "Apple Foundation Models reported an unsupported context window"
+    pure RuntimeResponsesModel
+        { runtimeResponsesConnectionId = appleFoundationModelsConnectionId
+        , runtimeResponsesConnection = ResponsesConnection
+            { responsesBaseUrl = baseUrl
+            , responsesApiKeyEnv = Nothing
+            , responsesApiKeyOptional = False
+            , responsesRequestTimeoutSeconds = 600
+            }
+        , runtimeResponsesCatalogModel = CatalogModel
+            { catalogModelId = appleFoundationModelsModelId
+            , catalogModelConnectionId = appleFoundationModelsConnectionId
+            , catalogModelWireId = appleFoundationModelsModelId
+            , catalogModelDialect = GenericResponsesDialect
+            , catalogModelContextWindow = Just contextWindow
+            , catalogModelLabel =
+                Just "Apple Intelligence · On-device (Experimental)"
+            -- An explicit empty list makes the native picker offer Default
+            -- only: Foundation Models has no reasoning-effort control.
+            , catalogModelReasoningEfforts = Just []
+            , catalogModelDefaultReasoningEffort = Nothing
+            , catalogModelDefault = False
+            , catalogModelFallbackPriority = Nothing
+            }
+        , runtimeResponsesTransport = RuntimeChatCompletionsTransport
+        , runtimeResponsesBearerToken = bearerToken
+        , runtimeResponsesAllowedTools =
+            Just
+                [ "read_file"
+                , "list_dir"
+                , "grep"
+                , "search_replace"
+                , "run_terminal_cmd"
+                ]
+        }
+
+-- | Add one trusted runtime model, replacing anything that attempts to reuse
+-- its connection or stable model id.
+applyRuntimeResponsesModel
+    :: RuntimeResponsesModel
+    -> ModelCatalog
+    -> ModelCatalog
+applyRuntimeResponsesModel runtime catalog =
+    let connectionId = runtime.runtimeResponsesConnectionId
+        model = runtime.runtimeResponsesCatalogModel
+        retained =
+            filter
+                (\candidate ->
+                    candidate.catalogModelId /= model.catalogModelId
+                        && candidate.catalogModelConnectionId /= connectionId)
+                catalog.catalogModels
+    in ModelCatalog
+        { catalogConnections =
+            Map.insert
+                connectionId
+                ModelConnection
+                    { connectionId
+                    , connectionKind =
+                        CustomResponsesConnection
+                            runtime.runtimeResponsesConnection
+                    }
+                catalog.catalogConnections
+        , catalogModels = retained <> [model]
+        }
+
+runtimeResponsesModelMatches
+    :: RuntimeResponsesModel
+    -> Text
+    -> Text
+    -> Bool
+runtimeResponsesModelMatches runtime connectionId modelId =
+    runtime.runtimeResponsesConnectionId == connectionId
+        && runtime.runtimeResponsesCatalogModel.catalogModelId == modelId
+
+validateLoopbackBaseUrl :: Text -> Either Text Text
+validateLoopbackBaseUrl raw =
+    case Text.stripPrefix "http://127.0.0.1:" normalized of
+        Nothing -> Left "Apple Foundation Models must use a 127.0.0.1 endpoint"
+        Just portAndPath ->
+            let (port, path) = Text.breakOn "/" portAndPath
+            in if
+                Text.null port
+                    || not (Text.all isDigit port)
+                    || path /= "/v1"
+               then
+                    Left
+                        "Apple Foundation Models endpoint must end in /v1"
+               else Right normalized
+  where
+    normalized = Text.dropWhileEnd (== '/') (Text.strip raw)

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner.hs
@@ -71,7 +71,7 @@ import Agent.CLI.Project
     , saveProjectMaxConcurrentAgents
     )
 import Agent.CLI.Prompt
-    ( systemPromptForTools )
+    ( systemPromptForAvailableTools )
 import Agent.CLI.Resume (resumeNeedsGeneratedContext)
 import Agent.CLI.ProviderTransition
     ( PendingTurn(..)
@@ -127,11 +127,7 @@ import Agent.CLI.Terminal
     , resolveColor
     )
 import Agent.CLI.Request (setRequestInstructionsAndTools)
-import Agent.CLI.Tools
-    ( hostedSearchToolNames
-    , requireToolRegistry
-    , schemasFromAppTools
-    )
+import Agent.CLI.Tools (requireToolRegistry)
 import Agent.CLI.Dialects
     ( filterBashTools
     , filterGhciTools
@@ -161,13 +157,7 @@ import Agent.CLI.WindowTitle
 import Agent.CLI.Turn (applyPendingSessionTitles, runOneTurn)
 import Agent.Cancel (requestCancel)
 import Agent.Loop
-import Agent.Dialect
-    ( DialectId(..)
-    , ToolLayout(..)
-    , dialectId
-    , dialectToolLayout
-    , grokBuildPublicToolName
-    )
+import Agent.Dialect (dialectId)
 import Agent.Skills
     ( SkillCatalog(..)
     , SkillWarning(..)
@@ -190,15 +180,11 @@ import Agent.ToolDispatch
     ( ToolCall(..)
     , canonicalToolName
     )
-import Agent.Tools.MultiAgents
-    ( MultiAgentContext(..)
-    , multiAgentToolNames
-    )
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Tools.PlanMode
     ( PlanModeEnv(..) )
 import Agent.Tools.Types
-    ( AppTool(..)
-    , ToolEnv(..)
+    ( ToolEnv(..)
     , setToolSessionTmp
     )
 import Agent.OsPath (toText)
@@ -831,32 +817,10 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
         currentActiveToolNames = do
             ghciEnabled <- readIORef ghciEnabledRef
             bashEnabled <- readIORef bashEnabledRef
-            let active =
-                    activeShellTools ghciEnabled bashEnabled
-                internalNames = map (.appToolName) active
-                projectedNames =
-                    case dialectToolLayout dialect of
-                        NoHostToolLayout -> []
-                        FlatToolLayout
-                            | dialectId dialect
-                                == GrokBuildDialect ->
-                                    map
-                                        grokBuildPublicToolName
-                                        internalNames
-                            | otherwise -> internalNames
-                        CollaborationNamespaceLayout ->
-                            filter
-                                (`notElem` multiAgentToolNames)
-                                internalNames
-                                <> if any
-                                    (`elem` multiAgentToolNames)
-                                    internalNames
-                                    then ["collaboration"]
-                                    else []
             pure $
-                case dialectToolLayout dialect of
-                    NoHostToolLayout -> []
-                    _ -> hostedSearchToolNames dialect ++ projectedNames
+                fst
+                    (projectTools
+                        (activeShellTools ghciEnabled bashEnabled))
         shellModeFlags = \case
             ShellGhci -> (True, False)
             ShellBash -> (False, True)
@@ -871,19 +835,22 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             sessionTmp <- readIORef toolEnv.toolSessionTmp
             today <- utctDay <$> getCurrentTime
             let enabledTools = activeShellTools ghciEnabled bashEnabled
+                (promptToolNames, toolSchemas) =
+                    projectTools enabledTools
                 instructionText =
-                    systemPromptForTools
+                    systemPromptForAvailableTools
                         dialect
-                        (map (.appToolName) enabledTools)
+                        promptToolNames
                         cwd
                         sessionTmp
                         today
                         (isOneShot options)
-                toolSchemas = schemasFromAppTools dialect enabledTools
             modifyIORef' paramsRef
-                (setRequestInstructionsAndTools
-                    instructionText
-                    (Just toolSchemas))
+                ( finalizeRequestParams
+                    . setRequestInstructionsAndTools
+                        instructionText
+                        (Just toolSchemas)
+                )
         setShellMode mode = do
             let (ghciEnabled, bashEnabled) = shellModeFlags mode
             writeIORef ghciEnabledRef ghciEnabled

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -53,7 +53,7 @@ import Agent.Provider
     , Provider
     , TokenProvider
     )
-import Agent.Responses.Types (ResponseCreateParams)
+import Agent.Responses.Types (ResponseCreateParams, ResponseTool)
 import Agent.Skills
     ( SkillCatalog
     , SkillInvocation
@@ -95,6 +95,8 @@ data SessionRequest = SessionRequest
     , dialect :: !Dialect
     , policy :: !ApprovalPolicy
     , allTools :: ![AppTool]
+    , projectTools :: !([AppTool] -> ([Text], [ResponseTool]))
+    , finalizeRequestParams :: !(ResponseCreateParams -> ResponseCreateParams)
     , suspendGhci :: !(IO ())
     , grokRuntime :: !(Maybe GrokRuntimeControl)
     , mcpRegistrations :: ![MCP.McpToolRegistration]

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -2,6 +2,8 @@
 module Agent.CLI.Tools
     ( requireToolRegistry
     , lookupAppTool
+    , functionSchemasFromAppTools
+    , responseToolNames
     , schemasFromAppTools
     , hostedSearchToolNames
     , hostedSearchToolCollisions
@@ -92,6 +94,33 @@ schemasFromAppTools dialect tools = case dialectToolLayout dialect of
         hostedSearchTools dialect ++ mapMaybe (schemaFromAppTool dialect) tools
     NoHostToolLayout ->
         []
+
+-- | Project only ordinary function tools for transports, such as local Chat
+-- Completions servers, that cannot execute provider-hosted or custom tools.
+functionSchemasFromAppTools :: Dialect -> [AppTool] -> [ResponseTool]
+functionSchemasFromAppTools dialect =
+    filter isFunctionTool . schemasFromAppTools dialect
+  where
+    isFunctionTool = \case
+        FunctionToolValue _ -> True
+        _ -> False
+
+-- | Model-facing names corresponding exactly to the projected wire schemas.
+responseToolNames :: [ResponseTool] -> [Text]
+responseToolNames = map responseToolName
+  where
+    responseToolName = \case
+        FunctionToolValue function -> function.name
+        KnownResponseTool toolType tagged ->
+            taggedName
+                (responseToolTypeText toolType)
+                tagged.fields
+        UnknownResponseTool tagged ->
+            taggedName tagged.tag tagged.fields
+    taggedName fallback fields =
+        case KeyMap.lookup "name" fields of
+            Just (Aeson.String name) -> name
+            _ -> fallback
 
 isMultiAgentTool :: AppTool -> Bool
 isMultiAgentTool tool = tool.appToolName `elem` multiAgentToolNames

--- a/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
@@ -2,6 +2,11 @@ module Agent.CLI.GatewayModelsSpec (spec) where
 
 import Agent.CLI.GatewayModels
 import Agent.CLI.ModelConfig
+import Agent.CLI.RuntimeModel
+    ( appleFoundationModelsModelId
+    , applyRuntimeResponsesModel
+    , mkAppleFoundationModelsRuntime
+    )
 import Agent.Dialect (DialectId (CodexDialect))
 import Agent.Provider (Provider (OpenAIProvider))
 import Data.Map.Strict qualified as Map
@@ -31,6 +36,56 @@ spec = describe "Agent.CLI.GatewayModels" do
         map (.catalogModelId) inactive.catalogModels
             `shouldBe` ["gpt-direct"]
         catalogUsesGateway inactive `shouldBe` False
+
+    it "does not retain custom models that reuse reserved router aliases" do
+        let customConnectionId = "custom"
+            spoofed = directCatalog
+                { catalogConnections =
+                    Map.insert
+                        customConnectionId
+                        ModelConnection
+                            { connectionId = customConnectionId
+                            , connectionKind =
+                                CustomResponsesConnection ResponsesConnection
+                                    { responsesBaseUrl =
+                                        "http://127.0.0.1:8000/v1"
+                                    , responsesApiKeyEnv = Nothing
+                                    , responsesApiKeyOptional = True
+                                    , responsesRequestTimeoutSeconds = 60
+                                    }
+                            }
+                        directCatalog.catalogConnections
+                , catalogModels =
+                    directCatalog.catalogModels
+                        <> [directModel
+                                { catalogModelId = gatewayDefaultModelId
+                                , catalogModelConnectionId =
+                                    customConnectionId
+                                , catalogModelWireId = "attacker-model"
+                                }]
+                }
+            active = catalogForGatewayState True spoofed
+        map (.catalogModelId) active.catalogModels
+            `shouldBe` gatewayModelIds
+
+    it "keeps independently authenticated runtime models while connected" do
+        runtime <- expectRight
+            (mkAppleFoundationModelsRuntime
+                "http://127.0.0.1:49152/v1"
+                "ephemeral-token"
+                4096)
+        let active =
+                catalogForGatewayState True
+                    (applyRuntimeResponsesModel runtime directCatalog)
+        map (.catalogModelId) active.catalogModels
+            `shouldBe` gatewayModelIds <> [appleFoundationModelsModelId]
+
+expectRight :: Show err => Either err value -> IO value
+expectRight = \case
+    Left err -> do
+        expectationFailure (show err)
+        fail "expected Right"
+    Right value -> pure value
 
 directCatalog :: ModelCatalog
 directCatalog =

--- a/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelConfigSpec.hs
@@ -1,6 +1,14 @@
 module Agent.CLI.ModelConfigSpec (spec) where
 
 import Agent.CLI.ModelConfig
+import Agent.CLI.RuntimeModel
+    ( RuntimeModelTransport(..)
+    , RuntimeResponsesModel(..)
+    , appleFoundationModelsConnectionId
+    , appleFoundationModelsModelId
+    , applyRuntimeResponsesModel
+    , mkAppleFoundationModelsRuntime
+    )
 import Agent.Dialect (DialectId(..))
 import Agent.OsPath (fromText, unsafeToFilePath)
 import Agent.Provider (Provider(..))
@@ -114,6 +122,58 @@ spec = describe "Agent.CLI.ModelConfig" do
             `shouldBe` [GenericResponsesDialect]
         fmap (.catalogModelContextWindow) custom
             `shouldBe` [Just 32_768]
+
+    it "adds the authenticated on-device Apple model only at runtime" do
+        defaults <- readPackagedDefaults
+        catalog <- expectRight (decodeModelConfig "models.default.json" defaults)
+        runtime <- expectRight $
+            mkAppleFoundationModelsRuntime
+                "http://127.0.0.1:49152/v1/"
+                "ephemeral-token"
+                4096
+        let augmented = applyRuntimeResponsesModel runtime catalog
+        runtime.runtimeResponsesBearerToken `shouldBe` "ephemeral-token"
+        runtime.runtimeResponsesTransport
+            `shouldBe` RuntimeChatCompletionsTransport
+        fmap (.catalogModelId)
+            (catalogModelById augmented appleFoundationModelsModelId)
+            `shouldBe` Just appleFoundationModelsModelId
+        fmap (.catalogModelContextWindow)
+            (catalogModelById augmented appleFoundationModelsModelId)
+            `shouldBe` Just (Just 4096)
+        nextRuntime <- expectRight $
+            mkAppleFoundationModelsRuntime
+                "http://127.0.0.1:49153/v1"
+                "ephemeral-token"
+                8192
+        nextRuntime.runtimeResponsesCatalogModel.catalogModelContextWindow
+            `shouldBe` Just 8192
+        fmap (.catalogModelReasoningEfforts)
+            (catalogModelById augmented appleFoundationModelsModelId)
+            `shouldBe` Just (Just [])
+        Map.lookup appleFoundationModelsConnectionId
+            augmented.catalogConnections
+            `shouldBe`
+                Just ModelConnection
+                    { connectionId = appleFoundationModelsConnectionId
+                    , connectionKind =
+                        CustomResponsesConnection ResponsesConnection
+                            { responsesBaseUrl =
+                                "http://127.0.0.1:49152/v1"
+                            , responsesApiKeyEnv = Nothing
+                            , responsesApiKeyOptional = False
+                            , responsesRequestTimeoutSeconds = 600
+                            }
+                    }
+        case mkAppleFoundationModelsRuntime
+            "https://example.invalid/v1"
+            "ephemeral-token"
+            4096 of
+            Left err ->
+                err `shouldSatisfy` Text.isInfixOf "127.0.0.1"
+            Right _ ->
+                expectationFailure
+                    "expected a non-loopback Apple runtime URL to be rejected"
 
     it "uses the effective configured wire model after a transport remap" do
         defaults <- readPackagedDefaults

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -138,6 +138,18 @@ spec = describe "systemPrompt" do
         prompt `shouldNotSatisfy` Text.isInfixOf "Prefer ghci for scripting"
         prompt `shouldNotSatisfy` Text.isInfixOf "Use ask_secret"
 
+    it "does not invent hosted search for an exact local tool set" do
+        let prompt =
+                systemPromptForAvailableTools
+                    genericResponsesDialect
+                    ["read_file", "list_dir", "grep"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+        prompt `shouldSatisfy` Text.isInfixOf "read_file"
+        prompt `shouldNotSatisfy` Text.isInfixOf "web_search"
+
     it "adds secret guidance only when ask_secret is registered" do
         let withSecret =
                 systemPromptForTools

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -109,6 +109,16 @@ spec = describe "schemasFromAppTools" do
                 tagged.fields `shouldBe` KeyMap.empty
             other -> expectationFailure ("expected web_search first, got " <> show other)
 
+    it "can project function-only schemas for local transports" do
+        let schemas =
+                functionSchemasFromAppTools
+                    codexDialect
+                    [jsonTool, computerUseTool]
+        schemas `shouldSatisfy` \case
+            [FunctionToolValue tool] -> tool.name == "read_file"
+            _ -> False
+        responseToolNames schemas `shouldBe` ["read_file"]
+
     it "builds a strict function tool for OpenAI JSON tools" do
         case schemasFromAppTools codexDialect [jsonTool] of
             [_, FunctionToolValue tool] -> do

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
@@ -40,7 +40,7 @@ listDirTool :: ToolEnv -> AppTool
 listDirTool env = withToolResourceClaims (listDirClaims env) $
     jsonTool "list_dir" listDirDescription
     [ PropertySchema "target_directory" PropertyString True $ Just
-        "Path to a directory within an allowed filesystem root. Relative paths use the workspace root; absolute paths may resolve within the workspace or session temp directory."
+        "Path to a directory within an allowed filesystem root. Relative paths use the workspace root; absolute paths may resolve within the workspace or session temp directory. If the user does not specify a directory, use \".\"."
     ]
     True
     ParallelSafe

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -45,6 +45,7 @@ library
     import:           common-opts
     exposed-modules:  Agent.Responses.Codec
                     , Agent.Responses.Client
+                    , Agent.Responses.ChatCompletions
                     , Agent.Responses.Error
                     , Agent.Responses.GenericBackend
                     , Agent.Responses.GenericClient
@@ -77,6 +78,7 @@ test-suite agent-responses-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Agent.Responses.ClientSpec
+                    , Agent.Responses.ChatCompletionsSpec
                     , Agent.Responses.LoopBackendSpec
                     , Agent.Responses.GenericClientSpec
                     , Agent.Responses.ResponseMergeSpec

--- a/packages/agent-responses/src/Agent/Responses/ChatCompletions.hs
+++ b/packages/agent-responses/src/Agent/Responses/ChatCompletions.hs
@@ -1,0 +1,654 @@
+-- | Stateless OpenAI Chat Completions adapter for local tool-capable models.
+--
+-- The harness keeps its canonical transcript as Responses items. This module
+-- projects that transcript to Chat Completions messages, then normalizes each
+-- completion back into a Responses-shaped result so the normal tool loop,
+-- persistence, and compaction machinery remain shared.
+module Agent.Responses.ChatCompletions
+    ( ChatCompletionsOptions(..)
+    , buildChatRequest
+    , createChatCompletionWith
+    , createChatCompletionWithEvents
+    , normalizeChatCompletion
+    , reinforceFunctionSchemas
+    ) where
+
+import Agent.Error (ApiError(..), ErrorType(InvalidRequestError))
+import Agent.Responses.GenericClient
+    ( classifyFailure
+    , retryTransientResultWithPolicy
+    )
+import qualified Agent.Responses.HttpSSE as Http
+import Agent.Responses.LoopBackend (assistantTextFromResponse)
+import Agent.Responses.Types
+import Control.Exception.Safe (tryAny)
+import Control.Monad (foldM, unless)
+import Control.Retry
+    ( RetryPolicyM
+    , exponentialBackoff
+    , limitRetries
+    )
+import qualified Data.Aeson as Aeson
+import Data.Aeson
+    ( (.:)
+    , (.:?)
+    , (.!=)
+    , withObject
+    )
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import Data.Maybe (fromMaybe, isNothing, mapMaybe, maybeToList)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Network.HTTP.Simple hiding (Response)
+
+data ChatCompletionsOptions = ChatCompletionsOptions
+    { chatBaseUrl :: !String
+      -- ^ API prefix including any version segment, but not
+      -- @/chat/completions@.
+    , chatModel :: !Text
+      -- ^ Exact model identifier sent to the endpoint.
+    , chatBearerToken :: !(Maybe Text)
+      -- ^ Optional bearer token. 'Nothing' omits the Authorization header.
+    , chatRequestTimeoutSeconds :: !Int
+      -- ^ Full non-streaming request timeout.
+    }
+    deriving (Eq)
+
+-- | Project a canonical Responses request to the Chat Completions subset
+-- understood by apfel and similar local servers.
+buildChatRequest
+    :: ChatCompletionsOptions
+    -> ResponseCreateParams
+    -> Either ApiError Aeson.Value
+buildChatRequest options rawRequest = do
+    let request = reinforceFunctionSchemas rawRequest
+    let responseTools = fromMaybe [] request.tools
+    chatTools <- traverse chatTool responseTools
+    messages <- responseInputMessages request.instructions request.input
+    pure $ Aeson.object $
+        [ "model" Aeson..= options.chatModel
+        , "messages" Aeson..= messages
+        , "stream" Aeson..= False
+        -- apfel executes one Foundation Models request at a time and reports
+        -- a single tool-call sequence, so make that contract explicit.
+        , "parallel_tool_calls" Aeson..= False
+        ]
+            <> maybeToList
+                (("max_tokens" Aeson..=) <$> request.maxOutputTokens)
+            <> maybeToList
+                (("temperature" Aeson..=) <$> request.temperature)
+            <> maybeToList
+                (("top_p" Aeson..=) <$> request.topP)
+            <> maybeToList
+                (("tool_choice" Aeson..=) . chatToolChoice
+                    <$> request.toolChoice)
+            <> ["tools" Aeson..= chatTools | not (null chatTools)]
+  where
+    responseInputMessages instructionText inputItems =
+        (maybeToList (systemMessage <$> instructionText) <>)
+            <$> projectResponseInput inputItems
+
+-- | Apple Intelligence is substantially more reliable at producing object
+-- arguments when the OpenAI function schemas also appear in its instruction
+-- text. The native Foundation Models tool definitions alone can otherwise
+-- yield positional payloads such as @[]@ even for object schemas.
+--
+-- Apply this to the canonical params before context sizing. 'buildChatRequest'
+-- also applies it defensively for direct callers.
+reinforceFunctionSchemas :: ResponseCreateParams -> ResponseCreateParams
+reinforceFunctionSchemas request =
+    case functionSchemaInstructions (fromMaybe [] request.tools) of
+        Nothing -> request
+        Just schemas -> case request of
+            ResponseCreateParams{..} ->
+                ResponseCreateParams
+                { instructions =
+                    appendInstructionsOnce instructions schemas
+                , ..
+                }
+
+functionSchemaInstructions :: [ResponseTool] -> Maybe Text
+functionSchemaInstructions tools =
+    case mapMaybe functionSchema tools of
+        [] -> Nothing
+        schemas ->
+            Just $
+                "## Function Argument Schemas\n\
+                \When calling a function, function.arguments must be a \
+                \JSON-encoded object matching that function's schema. Never \
+                \use an array as the top-level arguments value. Include every \
+                \required field.\n"
+                    <> Text.decodeUtf8
+                        (LBS.toStrict (Aeson.encode schemas))
+  where
+    functionSchema = \case
+        FunctionToolValue function ->
+            Just $ Aeson.object $
+                [ "name" Aeson..= function.name ]
+                    <> maybeToList
+                        (("parameters" Aeson..=) <$> function.parameters)
+        _ -> Nothing
+
+appendInstructionsOnce :: Maybe Text -> Text -> Maybe Text
+appendInstructionsOnce base addition =
+    case base of
+        Nothing -> Just addition
+        Just current
+            | Text.null (Text.strip current) -> Just addition
+            | addition `Text.isSuffixOf` current -> Just current
+            | otherwise -> Just (current <> "\n\n" <> addition)
+
+createChatCompletionWith
+    :: ChatCompletionsOptions
+    -> ResponseCreateParams
+    -> IO (Either ApiError Response)
+createChatCompletionWith options request =
+    createChatCompletionWithEvents options request (const (pure ()))
+
+-- | Send one non-streaming completion while adapting final assistant text to
+-- the usual Responses delta callback consumed by the UI.
+createChatCompletionWithEvents
+    :: ChatCompletionsOptions
+    -> ResponseCreateParams
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+createChatCompletionWithEvents options request onEvent =
+    retryTransientResultWithPolicy
+        transientResultPolicy
+        performOnce
+        onEvent
+  where
+    performOnce emit = do
+        case buildChatRequest options request of
+            Left err -> pure (Left err)
+            Right requestBody -> do
+                result <- Http.performChatCompletionsHttpJson
+                    Http.HttpJsonConfig
+                        { Http.jsonExceptionPrefix =
+                            "Chat Completions request failed"
+                        , Http.jsonClassifyFailure = classifyFailure
+                        }
+                    options.chatBaseUrl
+                    options.chatRequestTimeoutSeconds
+                    (Aeson.encode requestBody)
+                    configureRequest
+                case result >>= chatCompletionToResponse of
+                    Left err -> pure (Left err)
+                    Right response ->
+                        emitNonStreamingText emit response >>= \case
+                            Left err -> pure (Left err)
+                            Right () -> pure (Right response)
+
+    configureRequest =
+        maybe
+            id
+            (\token ->
+                setRequestHeader
+                    "Authorization"
+                    ["Bearer " <> Text.encodeUtf8 token])
+            (nonEmptyText options.chatBearerToken)
+            . setRequestHeader "User-Agent" ["haskell-agent"]
+
+data ChatCompletion = ChatCompletion
+    { chatCompletionId :: !Text
+    , chatCompletionCreated :: !Aeson.Value
+    , chatCompletionModel :: !Text
+    , chatCompletionChoices :: ![ChatChoice]
+    , chatCompletionUsage :: !(Maybe ChatUsage)
+    }
+
+instance Aeson.FromJSON ChatCompletion where
+    parseJSON = withObject "ChatCompletion" \object ->
+        ChatCompletion
+            <$> object .: "id"
+            <*> object .: "created"
+            <*> object .: "model"
+            <*> object .: "choices"
+            <*> object .:? "usage"
+
+data ChatChoice = ChatChoice
+    { chatChoiceMessage :: !ChatMessage
+    , chatChoiceFinishReason :: !(Maybe Text)
+    }
+
+instance Aeson.FromJSON ChatChoice where
+    parseJSON = withObject "ChatChoice" \object ->
+        ChatChoice
+            <$> object .: "message"
+            <*> object .:? "finish_reason"
+
+data ChatMessage = ChatMessage
+    { chatMessageRole :: !Text
+    , chatMessageContent :: !(Maybe Text)
+    , chatMessageToolCalls :: ![ChatToolCall]
+    }
+
+instance Aeson.FromJSON ChatMessage where
+    parseJSON = withObject "ChatMessage" \object ->
+        ChatMessage
+            <$> object .: "role"
+            <*> object .:? "content"
+            <*> object .:? "tool_calls" .!= []
+
+data ChatToolCall = ChatToolCall
+    { chatToolCallId :: !Text
+    , chatToolCallType :: !Text
+    , chatToolCallFunction :: !ChatFunction
+    }
+
+instance Aeson.FromJSON ChatToolCall where
+    parseJSON = withObject "ChatToolCall" \object ->
+        ChatToolCall
+            <$> object .: "id"
+            <*> object .: "type"
+            <*> object .: "function"
+
+data ChatFunction = ChatFunction
+    { chatFunctionName :: !Text
+    , chatFunctionArguments :: !Text
+    }
+
+instance Aeson.FromJSON ChatFunction where
+    parseJSON = withObject "ChatFunction" \object ->
+        ChatFunction
+            <$> object .: "name"
+            <*> object .:? "arguments" .!= "{}"
+
+data ChatUsage = ChatUsage
+    { chatPromptTokens :: !(Maybe Int)
+    , chatCompletionTokens :: !(Maybe Int)
+    , chatTotalTokens :: !(Maybe Int)
+    }
+
+instance Aeson.FromJSON ChatUsage where
+    parseJSON = withObject "ChatUsage" \object ->
+        ChatUsage
+            <$> object .:? "prompt_tokens"
+            <*> object .:? "completion_tokens"
+            <*> object .:? "total_tokens"
+
+chatCompletionToResponse :: ChatCompletion -> Either ApiError Response
+chatCompletionToResponse completion = do
+    unless (isNonEmpty completion.chatCompletionId) $
+        Left (invalidRequest
+            "Chat Completions response contained an empty id")
+    unless (isNonEmpty completion.chatCompletionModel) $
+        Left (invalidRequest
+            "Chat Completions response contained an empty model")
+    choice <- case completion.chatCompletionChoices of
+        first : _ -> Right first
+        [] -> Left (ConnectionError
+            "Chat Completions response did not contain a choice")
+    unless (choice.chatChoiceMessage.chatMessageRole == "assistant") $
+        Left (invalidRequest
+            "Chat Completions response message was not from the assistant")
+    case choice.chatChoiceFinishReason of
+        Nothing -> pure ()
+        Just "stop" -> pure ()
+        Just "tool_calls" -> pure ()
+        Just "length" ->
+            Left (invalidRequest
+                "Apple Intelligence stopped at its output-token limit")
+        Just reason ->
+            Left (invalidRequest
+                ("Apple Intelligence returned unsupported finish_reason "
+                    <> reason))
+    let message = choice.chatChoiceMessage
+    validateChatToolCalls message.chatMessageToolCalls
+    let
+        output =
+            maybeToList
+                (assistantTextItem <$> nonEmptyText message.chatMessageContent)
+                <> map chatToolCallItem message.chatMessageToolCalls
+    if null output
+        then Left (ConnectionError
+            "Chat Completions response contained neither text nor tool calls")
+        else decodeResponse completion output
+
+-- | Normalize a decoded Chat Completions payload into the canonical Responses
+-- value consumed by the shared loop.
+normalizeChatCompletion :: Aeson.Value -> Either ApiError Response
+normalizeChatCompletion value =
+    case Aeson.fromJSON value of
+        Aeson.Error err ->
+            Left (ConnectionError
+                ("Chat Completions response could not be decoded: "
+                    <> Text.pack err))
+        Aeson.Success completion ->
+            chatCompletionToResponse completion
+
+validateChatToolCalls :: [ChatToolCall] -> Either ApiError ()
+validateChatToolCalls = go Set.empty
+  where
+    go _ [] = pure ()
+    go seen (call : rest) = do
+        unless (call.chatToolCallType == "function") $
+            Left (invalidRequest
+                "Chat Completions returned a non-function tool call")
+        unless (isNonEmpty call.chatToolCallId) $
+            Left (invalidRequest
+                "Chat Completions returned a tool call with an empty id")
+        unless (isNonEmpty call.chatToolCallFunction.chatFunctionName) $
+            Left (invalidRequest
+                "Chat Completions returned a tool call with an empty name")
+        unless (Set.notMember call.chatToolCallId seen) $
+            Left (invalidRequest
+                "Chat Completions returned duplicate tool-call ids")
+        go (Set.insert call.chatToolCallId seen) rest
+
+decodeResponse
+    :: ChatCompletion
+    -> [ResponseItem]
+    -> Either ApiError Response
+decodeResponse completion output =
+    case Aeson.fromJSON payload of
+        Aeson.Error err ->
+            Left (ConnectionError
+                ("Chat Completions response could not be normalized: "
+                    <> Text.pack err))
+        Aeson.Success response -> Right response
+  where
+    payload = Aeson.object $
+        [ "id" Aeson..= completion.chatCompletionId
+        , "created_at" Aeson..= completion.chatCompletionCreated
+        , "model" Aeson..= completion.chatCompletionModel
+        , "status" Aeson..= ("completed" :: Text)
+        , "output" Aeson..= output
+        ]
+            <> maybeToList
+                (chatUsageField <$> completion.chatCompletionUsage)
+
+chatUsageField usage =
+    "usage" Aeson..= Aeson.object
+        [ "input_tokens" Aeson..= fromMaybe 0 usage.chatPromptTokens
+        , "output_tokens" Aeson..= fromMaybe 0 usage.chatCompletionTokens
+        , "total_tokens" Aeson..= fromMaybe 0 usage.chatTotalTokens
+        ]
+
+assistantTextItem :: Text -> ResponseItem
+assistantTextItem text = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentParts
+        [ OutputTextPart
+            { text
+            , annotations = Nothing
+            , logprobs = Nothing
+            , extraFields = KeyMap.empty
+            }
+        ]
+    , role = RoleAssistant
+    , status = Just ItemCompleted
+    , phase = Nothing
+    , passthrough = Nothing
+    , extraFields = KeyMap.empty
+    }
+
+chatToolCallItem :: ChatToolCall -> ResponseItem
+chatToolCallItem call = FunctionCallItem FunctionCall
+    { itemId = Nothing
+    , callId = call.chatToolCallId
+    , name = call.chatToolCallFunction.chatFunctionName
+    , namespace = Nothing
+    , arguments = call.chatToolCallFunction.chatFunctionArguments
+    , encryptedFunctionArgs = Nothing
+    , status = Just ItemCompleted
+    , extraFields = KeyMap.empty
+    }
+
+systemMessage :: Text -> Aeson.Value
+systemMessage text =
+    Aeson.object
+        [ "role" Aeson..= ("system" :: Text)
+        , "content" Aeson..= text
+        ]
+
+projectResponseInput
+    :: Maybe ResponseInput
+    -> Either ApiError [Aeson.Value]
+projectResponseInput = \case
+    Nothing -> pure []
+    Just (ResponseInputText text) ->
+        pure [Aeson.object
+            [ "role" Aeson..= ("user" :: Text)
+            , "content" Aeson..= text
+            ]
+        ]
+    Just (ResponseInputItems items) -> responseItemsToChatMessages items
+
+responseItemsToChatMessages
+    :: [ResponseItem]
+    -> Either ApiError [Aeson.Value]
+responseItemsToChatMessages = go Set.empty
+  where
+    go outstanding = \case
+        []
+            | Set.null outstanding -> pure []
+            | otherwise ->
+                Left (invalidRequest
+                    "Apple Intelligence history contains a tool call without a result")
+        MessageItem message : rest
+            | not (Set.null outstanding) ->
+                Left (invalidRequest
+                    "Apple Intelligence history contains a message before the preceding tool result")
+            | message.role == RoleAssistant ->
+                let (calls, remaining) = spanFunctionCalls rest
+                in if null calls
+                    then do
+                        value <- chatMessage message
+                        (value :) <$> go outstanding rest
+                    else do
+                        nextOutstanding <-
+                            registerFunctionCalls outstanding calls
+                        let value = assistantToolCallMessage
+                                (nonEmptyText
+                                    (Just
+                                        (messageContentText
+                                            message.content)))
+                                calls
+                        (value :) <$> go nextOutstanding remaining
+            | otherwise -> do
+                value <- chatMessage message
+                (value :) <$> go outstanding rest
+        first@(FunctionCallItem _) : rest ->
+            if not (Set.null outstanding)
+                then Left (invalidRequest
+                    "Apple Intelligence history contains overlapping tool calls")
+                else
+                    let (calls, remaining) =
+                            spanFunctionCalls (first : rest)
+                    in do
+                        nextOutstanding <-
+                            registerFunctionCalls outstanding calls
+                        let value =
+                                assistantToolCallMessage Nothing calls
+                        (value :) <$> go nextOutstanding remaining
+        FunctionCallOutputItem call : rest -> do
+            unless (isNonEmpty call.callId) $
+                Left (invalidRequest
+                    "Apple Intelligence history contains an empty tool-call id")
+            unless (Set.member call.callId outstanding) $
+                Left (invalidRequest
+                    "Apple Intelligence history contains an orphaned tool result")
+            let value =
+                    Aeson.object
+                        [ "role" Aeson..= ("tool" :: Text)
+                        , "tool_call_id" Aeson..= call.callId
+                        , "content" Aeson..=
+                            nonEmptyToolOutput call.output
+                        ]
+            (value :) <$> go (Set.delete call.callId outstanding) rest
+        _ ->
+            Left (invalidRequest
+                "Apple Intelligence cannot continue this session because its history contains an unsupported item")
+
+spanFunctionCalls :: [ResponseItem] -> ([FunctionCall], [ResponseItem])
+spanFunctionCalls = go []
+  where
+    go reversed = \case
+        FunctionCallItem call : rest -> go (call : reversed) rest
+        rest -> (reverse reversed, rest)
+
+registerFunctionCalls
+    :: Set.Set Text
+    -> [FunctionCall]
+    -> Either ApiError (Set.Set Text)
+registerFunctionCalls = foldM step
+  where
+    step outstanding call = do
+        unless (isNonEmpty call.callId) $
+            Left (invalidRequest
+                "Apple Intelligence history contains an empty tool-call id")
+        unless (isNonEmpty call.name) $
+            Left (invalidRequest
+                "Apple Intelligence history contains an empty tool name")
+        unless (isNothing call.namespace) $
+            Left (invalidRequest
+                "Apple Intelligence does not support namespaced tool history")
+        unless (Set.notMember call.callId outstanding) $
+            Left (invalidRequest
+                "Apple Intelligence history contains duplicate tool-call ids")
+        pure (Set.insert call.callId outstanding)
+
+chatMessage :: ResponseMessage -> Either ApiError Aeson.Value
+chatMessage message = do
+    role <- chatRole message.role
+    pure $ Aeson.object
+        [ "role" Aeson..= role
+        , "content" Aeson..= messageContentText message.content
+        ]
+
+assistantToolCallMessage
+    :: Maybe Text
+    -> [FunctionCall]
+    -> Aeson.Value
+assistantToolCallMessage content calls =
+    Aeson.object
+        [ "role" Aeson..= ("assistant" :: Text)
+        , "content" Aeson..= maybe Aeson.Null Aeson.String content
+        , "tool_calls" Aeson..= map functionCallValue calls
+        ]
+
+functionCallValue :: FunctionCall -> Aeson.Value
+functionCallValue call =
+    Aeson.object
+        [ "id" Aeson..= call.callId
+        , "type" Aeson..= ("function" :: Text)
+        , "function" Aeson..= Aeson.object
+            [ "name" Aeson..= call.name
+            , "arguments" Aeson..= call.arguments
+            ]
+        ]
+
+chatTool :: ResponseTool -> Either ApiError Aeson.Value
+chatTool = \case
+    FunctionToolValue function -> do
+        unless (isNonEmpty function.name) $
+            Left (invalidRequest
+                "Apple Intelligence received a function tool with an empty name")
+        pure $ Aeson.object
+            [ "type" Aeson..= ("function" :: Text)
+            , "function" Aeson..= Aeson.object
+                ( [ "name" Aeson..= function.name ]
+                    <> maybeToList
+                        (("description" Aeson..=) <$> function.description)
+                    <> maybeToList
+                        (("parameters" Aeson..=) <$> function.parameters)
+                    <> maybeToList
+                        (("strict" Aeson..=) <$> function.strict)
+                )
+            ]
+    _ ->
+        Left (invalidRequest
+            "Apple Intelligence supports function tools only")
+
+chatToolChoice :: ToolChoice -> Aeson.Value
+chatToolChoice choice = case choice of
+    ToolChoiceObject tagged
+        | tagged.tag == "function"
+        , Just name <- KeyMap.lookup "name" tagged.fields ->
+            Aeson.object
+                [ "type" Aeson..= ("function" :: Text)
+                , "function" Aeson..= Aeson.object ["name" Aeson..= name]
+                ]
+    _ -> Aeson.toJSON choice
+
+chatRole :: ResponseRole -> Either ApiError Text
+chatRole = \case
+    RoleAssistant -> pure "assistant"
+    RoleSystem -> pure "system"
+    RoleDeveloper -> pure "system"
+    RoleUser -> pure "user"
+    RoleUnknown _ ->
+        Left (invalidRequest
+            "Apple Intelligence history contains an unsupported message role")
+
+messageContentText :: MessageContent -> Text
+messageContentText = \case
+    MessageContentText text -> text
+    MessageContentParts parts -> Text.concat (map contentPartText parts)
+
+contentPartText :: ResponseContentPart -> Text
+contentPartText = \case
+    InputTextPart{text} -> text
+    OutputTextPart{text} -> text
+    PlainTextPart{text} -> text
+    RefusalPart{refusal} -> refusal
+    ReasoningTextPart{text} -> text
+    SummaryTextPart{text} -> text
+    InputImagePart{} -> "\n[image omitted by the local chat adapter]\n"
+    InputFilePart{} -> "\n[file omitted by the local chat adapter]\n"
+    InputAudioPart{} -> "\n[audio omitted by the local chat adapter]\n"
+    EncryptedContentPart{} -> ""
+    UnknownContentPart{} -> ""
+
+renderToolOutput :: Aeson.Value -> Text
+renderToolOutput = \case
+    Aeson.String text -> text
+    value -> Text.decodeUtf8 (LBS.toStrict (Aeson.encode value))
+
+nonEmptyToolOutput :: Aeson.Value -> Text
+nonEmptyToolOutput value =
+    let rendered = renderToolOutput value
+    in if Text.null (Text.strip rendered)
+        then "(no output)"
+        else rendered
+
+emitNonStreamingText
+    :: (ResponseStreamEvent -> IO ())
+    -> Response
+    -> IO (Either ApiError ())
+emitNonStreamingText emit response =
+    tryAny
+        (mapM_
+            (\text ->
+                emit OtherResponseStreamEvent
+                    { otherEventType = EventOutputTextDelta
+                    , sequenceNumber = Nothing
+                    , eventExtraFields =
+                        KeyMap.singleton "delta" (Aeson.String text)
+                    })
+            (assistantTextFromResponse response)) >>= \case
+                Left exception ->
+                    pure $ Left $ ConnectionError
+                        ( "Chat Completions callback failed: "
+                            <> Text.pack (show exception)
+                        )
+                Right () -> pure (Right ())
+
+nonEmptyText :: Maybe Text -> Maybe Text
+nonEmptyText (Just value)
+    | not (Text.null (Text.strip value)) = Just value
+nonEmptyText _ = Nothing
+
+isNonEmpty :: Text -> Bool
+isNonEmpty = not . Text.null . Text.strip
+
+invalidRequest :: Text -> ApiError
+invalidRequest message =
+    ProviderError InvalidRequestError message Nothing
+
+transientResultPolicy :: RetryPolicyM IO
+transientResultPolicy = exponentialBackoff 1_000_000 <> limitRetries 3

--- a/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
@@ -1,7 +1,9 @@
--- | Provider-neutral HTTP transport for streaming Responses endpoints.
+-- | Provider-neutral HTTP transports for Responses endpoints.
 module Agent.Responses.HttpSSE
-    ( HttpSseConfig(..)
+    ( HttpJsonConfig(..)
+    , HttpSseConfig(..)
     , StreamEventCallback
+    , performChatCompletionsHttpJson
     , performResponsesHttpSse
     ) where
 
@@ -21,6 +23,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
+import qualified Data.Aeson as Aeson
 import qualified Network.HTTP.Client as HttpClient
 import qualified Network.HTTP.Client.TLS as HttpTls
 import Network.HTTP.Simple hiding (Response)
@@ -36,6 +39,79 @@ data HttpSseConfig = HttpSseConfig
     , buildResponse :: !([ResponseStreamEvent] -> Either ApiError Response)
       -- ^ Assemble retained terminal events into the provider response.
     }
+
+data HttpJsonConfig = HttpJsonConfig
+    { jsonExceptionPrefix :: !Text
+      -- ^ Prefix used when request setup or transport code throws.
+    , jsonClassifyFailure :: !(Int -> Maybe Int -> Text -> ApiError)
+      -- ^ Classify a non-success status, optional @Retry-After@, and body.
+    }
+
+-- | POST one non-streaming Chat Completions request and decode its JSON
+-- response. This shares failure and timeout behavior with the Responses
+-- transport while using the endpoint's distinct path.
+performChatCompletionsHttpJson
+    :: Aeson.FromJSON response
+    => HttpJsonConfig
+    -> String
+    -> Int
+    -> LBS.ByteString
+    -> (Request -> Request)
+    -> IO (Either ApiError response)
+performChatCompletionsHttpJson = performHttpJson "/chat/completions"
+
+performHttpJson
+    :: Aeson.FromJSON response
+    => String
+    -> HttpJsonConfig
+    -> String
+    -> Int
+    -> LBS.ByteString
+    -> (Request -> Request)
+    -> IO (Either ApiError response)
+performHttpJson
+    endpoint
+    HttpJsonConfig{jsonExceptionPrefix, jsonClassifyFailure}
+    baseUrl
+    timeoutSeconds
+    requestBody
+    configureRequest =
+        tryAny performRequest >>= \case
+            Left exception -> pure $ Left $ ConnectionError
+                (jsonExceptionPrefix <> ": " <> Text.pack (show exception))
+            Right result -> pure result
+  where
+    performRequest = do
+        baseRequest <- parseRequest
+            ("POST " <> trimTrailingSlash baseUrl <> endpoint)
+        response <- httpLBS
+            ( setRequestBodyLBS requestBody
+            $ configureRequest
+            $ setRequestHeader "Content-Type" ["application/json"]
+            $ setRequestHeader "Accept" ["application/json"]
+            $ setRequestResponseTimeout
+                (HttpClient.responseTimeoutMicro
+                    (timeoutSeconds * 1_000_000))
+                baseRequest
+            )
+        let status = getResponseStatusCode response
+            body = getResponseBody response
+        if status >= 200 && status < 300
+            then case Aeson.eitherDecode' body of
+                Left err -> pure $ Left $ ConnectionError
+                    ( jsonExceptionPrefix
+                        <> ": invalid JSON response: "
+                        <> Text.pack err
+                    )
+                Right decoded -> pure (Right decoded)
+            else do
+                let bodyText = Text.decodeUtf8With Text.lenientDecode
+                        (LBS.toStrict body)
+                pure $ Left $
+                    jsonClassifyFailure status
+                        (parseRetryAfterSeconds
+                            (getResponseHeader "Retry-After" response))
+                        bodyText
 
 -- | POST one streaming Responses request and deliver decoded events in wire
 -- order. The request modifier supplies provider-specific authentication and

--- a/packages/agent-responses/test/Agent/Responses/ChatCompletionsSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/ChatCompletionsSpec.hs
@@ -1,0 +1,326 @@
+module Agent.Responses.ChatCompletionsSpec (spec) where
+
+import Agent.Error (ApiError(..), ErrorType(InvalidRequestError))
+import Agent.Responses.ChatCompletions
+import Agent.Responses.Types
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Foldable (toList)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "buildChatRequest" do
+    it "projects instructions, text input, and function tools" do
+        let tool = FunctionToolValue FunctionTool
+                { name = "read_file"
+                , description = Just "Read a file"
+                , parameters = Just $ Aeson.object
+                    [ "type" Aeson..= ("object" :: String)
+                    ]
+                , strict = Just True
+                , extraFields = KeyMap.empty
+                }
+            request = defaultResponseCreateParams
+                { model = Just "must-not-escape"
+                , instructions = Just "Be concise."
+                , input = Just (ResponseInputText "Read README.md")
+                , tools = Just [tool]
+                , store = Just True
+                , previousResponseId = Just "resp_previous"
+                }
+        buildChatRequest options request `shouldBe` Right (Aeson.object
+            [ "model" Aeson..= ("apple-foundationmodel" :: String)
+            , "messages" Aeson..=
+                [ Aeson.object
+                    [ "role" Aeson..= ("system" :: String)
+                    , "content" Aeson..= expectedInstructions
+                    ]
+                , Aeson.object
+                    [ "role" Aeson..= ("user" :: String)
+                    , "content" Aeson..= ("Read README.md" :: String)
+                    ]
+                ]
+            , "stream" Aeson..= False
+            , "parallel_tool_calls" Aeson..= False
+            , "tools" Aeson..=
+                [ Aeson.object
+                    [ "type" Aeson..= ("function" :: String)
+                    , "function" Aeson..= Aeson.object
+                        [ "name" Aeson..= ("read_file" :: String)
+                        , "description" Aeson..= ("Read a file" :: String)
+                        , "parameters" Aeson..= Aeson.object
+                            ["type" Aeson..= ("object" :: String)]
+                        , "strict" Aeson..= True
+                        ]
+                    ]
+                ]
+            ])
+
+    it "reinforces object arguments when no base instructions are present" do
+        let tool = FunctionToolValue FunctionTool
+                { name = "list_dir"
+                , description = Just "List a directory"
+                , parameters = Just $ Aeson.object
+                    [ "type" Aeson..= ("object" :: String)
+                    , "properties" Aeson..= Aeson.object
+                        [ "target_directory" Aeson..= Aeson.object
+                            [ "type" Aeson..= ("string" :: String)
+                            ]
+                        ]
+                    , "required" Aeson..= (["target_directory"] :: [Text])
+                    ]
+                , strict = Just True
+                , extraFields = KeyMap.empty
+                }
+            request = defaultResponseCreateParams
+                { input = Just (ResponseInputText "call list_dir")
+                , tools = Just [tool]
+                }
+            reinforced = reinforceFunctionSchemas request
+        reinforced.instructions `shouldSatisfy`
+            maybe False (Text.isInfixOf "Never use an array")
+        reinforceFunctionSchemas reinforced `shouldBe` reinforced
+        case buildChatRequest options request of
+            Right (Aeson.Object object)
+                | Just (Aeson.Array messages) <- KeyMap.lookup "messages" object
+                , Aeson.Object system : _ <- toList messages
+                , Just (Aeson.String content) <- KeyMap.lookup "content" system -> do
+                    content `shouldSatisfy`
+                        Text.isInfixOf "Never use an array"
+                    content `shouldSatisfy`
+                        Text.isInfixOf "\"name\":\"list_dir\""
+                    content `shouldSatisfy`
+                        Text.isInfixOf
+                            "\"required\":[\"target_directory\"]"
+            result ->
+                expectationFailure
+                    ("expected schema instructions, got " <> show result)
+
+    it "replays function calls and outputs as Chat Completions messages" do
+        let request = case defaultResponseCreateParams of
+                ResponseCreateParams{..} -> ResponseCreateParams
+                    { input = Just $ ResponseInputItems
+                        [ messageItem RoleUser "Use the tool."
+                        , FunctionCallItem FunctionCall
+                            { itemId = Nothing
+                            , callId = "call_1"
+                            , name = "read_file"
+                            , namespace = Nothing
+                            , arguments = "{\"path\":\"README.md\"}"
+                            , encryptedFunctionArgs = Nothing
+                            , status = Just ItemCompleted
+                            , extraFields = KeyMap.empty
+                            }
+                        , FunctionCallOutputItem FunctionCallOutput
+                            { itemId = Nothing
+                            , callId = "call_1"
+                            , name = Just "read_file"
+                            , namespace = Nothing
+                            , output = Aeson.String "contents"
+                            , status = Just ItemCompleted
+                            , extraFields = KeyMap.empty
+                            }
+                        ]
+                    , ..
+                    }
+            expected = Aeson.toJSON
+                [ Aeson.object
+                    [ "role" Aeson..= ("user" :: String)
+                    , "content" Aeson..= ("Use the tool." :: String)
+                    ]
+                , Aeson.object
+                    [ "role" Aeson..= ("assistant" :: String)
+                    , "content" Aeson..= Aeson.Null
+                    , "tool_calls" Aeson..=
+                        [ Aeson.object
+                            [ "id" Aeson..= ("call_1" :: String)
+                            , "type" Aeson..= ("function" :: String)
+                            , "function" Aeson..= Aeson.object
+                                [ "name" Aeson..= ("read_file" :: String)
+                                , "arguments" Aeson..=
+                                    ("{\"path\":\"README.md\"}" :: String)
+                                ]
+                            ]
+                        ]
+                    ]
+                , Aeson.object
+                    [ "role" Aeson..= ("tool" :: String)
+                    , "tool_call_id" Aeson..= ("call_1" :: String)
+                    , "content" Aeson..= ("contents" :: String)
+                    ]
+                ]
+        case buildChatRequest options request of
+            Right (Aeson.Object object) ->
+                KeyMap.lookup "messages" object `shouldBe` Just expected
+            result ->
+                expectationFailure
+                    ("expected a JSON request object, got " <> show result)
+
+    it "replaces empty tool output with a non-empty sentinel" do
+        let request = case defaultResponseCreateParams of
+                ResponseCreateParams{..} -> ResponseCreateParams
+                    { input = Just $ ResponseInputItems
+                        [ FunctionCallItem FunctionCall
+                            { itemId = Nothing
+                            , callId = "call_empty"
+                            , name = "run_terminal_cmd"
+                            , namespace = Nothing
+                            , arguments = "{}"
+                            , encryptedFunctionArgs = Nothing
+                            , status = Just ItemCompleted
+                            , extraFields = KeyMap.empty
+                            }
+                        , FunctionCallOutputItem FunctionCallOutput
+                            { itemId = Nothing
+                            , callId = "call_empty"
+                            , name = Just "run_terminal_cmd"
+                            , namespace = Nothing
+                            , output = Aeson.String "  "
+                            , status = Just ItemCompleted
+                            , extraFields = KeyMap.empty
+                            }
+                        ]
+                    , ..
+                    }
+            expected = Aeson.toJSON
+                [ Aeson.object
+                    [ "role" Aeson..= ("assistant" :: String)
+                    , "content" Aeson..= Aeson.Null
+                    , "tool_calls" Aeson..=
+                        [ Aeson.object
+                            [ "id" Aeson..= ("call_empty" :: String)
+                            , "type" Aeson..= ("function" :: String)
+                            , "function" Aeson..= Aeson.object
+                                [ "name" Aeson..=
+                                    ("run_terminal_cmd" :: String)
+                                , "arguments" Aeson..= ("{}" :: String)
+                                ]
+                            ]
+                        ]
+                    ]
+                , Aeson.object
+                    [ "role" Aeson..= ("tool" :: String)
+                    , "tool_call_id" Aeson..= ("call_empty" :: String)
+                    , "content" Aeson..= ("(no output)" :: String)
+                    ]
+                ]
+        case buildChatRequest options request of
+            Right (Aeson.Object object) ->
+                KeyMap.lookup "messages" object `shouldBe` Just expected
+            result ->
+                expectationFailure
+                    ("expected a JSON request object, got " <> show result)
+
+    it "rejects messages inserted before a pending tool result" do
+        let request = case defaultResponseCreateParams of
+                ResponseCreateParams{..} -> ResponseCreateParams
+                    { input = Just $ ResponseInputItems
+                        [ FunctionCallItem FunctionCall
+                            { itemId = Nothing
+                            , callId = "call_pending"
+                            , name = "read_file"
+                            , namespace = Nothing
+                            , arguments = "{}"
+                            , encryptedFunctionArgs = Nothing
+                            , status = Just ItemCompleted
+                            , extraFields = KeyMap.empty
+                            }
+                        , messageItem RoleUser "skip the result"
+                        ]
+                    , ..
+                    }
+        case buildChatRequest options request of
+            Left (ProviderError{errorType = InvalidRequestError}) ->
+                pure ()
+            result ->
+                expectationFailure
+                    ("expected invalid tool ordering, got " <> show result)
+
+    it "normalizes function calls into canonical Responses items" do
+        let message = Aeson.object
+                [ "role" Aeson..= ("assistant" :: String)
+                , "content" Aeson..= Aeson.Null
+                , "tool_calls" Aeson..=
+                    [ Aeson.object
+                        [ "id" Aeson..= ("call_42" :: String)
+                        , "type" Aeson..= ("function" :: String)
+                        , "function" Aeson..= Aeson.object
+                            [ "name" Aeson..= ("read_file" :: String)
+                            , "arguments" Aeson..=
+                                ("{\"path\":\"README.md\"}" :: String)
+                            ]
+                        ]
+                    ]
+                ]
+        case normalizeChatCompletion
+            (chatPayload "tool_calls" message) of
+            Left err ->
+                expectationFailure
+                    ("expected a normalized response, got " <> show err)
+            Right response ->
+                case response.output of
+                    [FunctionCallItem call] ->
+                        (call.callId, call.name, call.arguments)
+                            `shouldBe`
+                                ( "call_42"
+                                , "read_file"
+                                , "{\"path\":\"README.md\"}"
+                                )
+                    output ->
+                        expectationFailure
+                            ("expected one function call, got " <> show output)
+
+    it "rejects output truncated by the local model" do
+        let message = Aeson.object
+                [ "role" Aeson..= ("assistant" :: String)
+                , "content" Aeson..= ("partial" :: String)
+                ]
+        normalizeChatCompletion (chatPayload "length" message)
+            `shouldBe`
+                Left
+                    (ProviderError
+                        InvalidRequestError
+                        "Apple Intelligence stopped at its output-token limit"
+                        Nothing)
+  where
+    expectedInstructions :: Text
+    expectedInstructions =
+        "Be concise.\n\n\
+        \## Function Argument Schemas\n\
+        \When calling a function, function.arguments must be a JSON-encoded \
+        \object matching that function's schema. Never use an array as the \
+        \top-level arguments value. Include every required field.\n\
+        \[{\"name\":\"read_file\",\"parameters\":{\"type\":\"object\"}}]"
+    options = ChatCompletionsOptions
+        { chatBaseUrl = "http://127.0.0.1:8000/v1"
+        , chatModel = "apple-foundationmodel"
+        , chatBearerToken = Nothing
+        , chatRequestTimeoutSeconds = 60
+        }
+
+chatPayload :: String -> Aeson.Value -> Aeson.Value
+chatPayload finishReason message =
+    Aeson.object
+        [ "id" Aeson..= ("chatcmpl_test" :: String)
+        , "created" Aeson..= (1 :: Int)
+        , "model" Aeson..= ("apple-foundationmodel" :: String)
+        , "choices" Aeson..=
+            [ Aeson.object
+                [ "finish_reason" Aeson..= finishReason
+                , "message" Aeson..= message
+                ]
+            ]
+        ]
+
+messageItem :: ResponseRole -> Text -> ResponseItem
+messageItem role value = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentText value
+    , role
+    , status = Just ItemCompleted
+    , phase = Nothing
+    , passthrough = Nothing
+    , extraFields = KeyMap.empty
+    }

--- a/packages/agent-responses/test/Spec.hs
+++ b/packages/agent-responses/test/Spec.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Test.Hspec (hspec)
 
 import qualified Agent.Responses.ClientSpec as ClientSpec
+import qualified Agent.Responses.ChatCompletionsSpec as ChatCompletionsSpec
 import qualified Agent.Responses.GenericClientSpec as GenericClientSpec
 import qualified Agent.Responses.LoopBackendSpec as LoopBackendSpec
 import qualified Agent.Responses.ResponseMergeSpec as ResponseMergeSpec
@@ -12,6 +13,7 @@ import qualified Agent.Responses.StreamAssemblySpec as StreamAssemblySpec
 main :: IO ()
 main = hspec do
     ClientSpec.spec
+    ChatCompletionsSpec.spec
     GenericClientSpec.spec
     LoopBackendSpec.spec
     ResponseMergeSpec.spec


### PR DESCRIPTION
## Summary

- expose Apple Intelligence as an experimental runtime-only model when a macOS host can start and validate the embedded `apfel` helper
- support the model in both the native macOS picker and the direct CLI picker
- supervise a bearer-authenticated loopback helper with shared leases, bounded health checks, listener ownership verification, automatic recovery, and 4K/8K runtime context metadata
- adapt the shared Responses tool loop to `apfel`'s non-streaming Chat Completions endpoint while forcing the selected wire model and limiting Apple turns to supported local function tools
- reinforce function argument schemas in canonical instructions so Foundation Models emits JSON objects, while keeping the added schema tokens inside context-budget estimation
- preserve exact function-only tool and prompt projections across `/new` and shell/session refreshes, without advertising unavailable hosted search
- preserve independently authenticated custom models in gateway mode without allowing reserved router-id collisions

## Packaging

- dependent private macOS packaging PR: digitallyinduced/haskell-agent-macos#104

## Validation

- agent-responses: 59 examples, 0 failures
- focused prompt projection tests: 15 examples, 0 failures
- focused gateway catalog tests: 4 examples, 0 failures
- focused runtime model catalog tests: 12 examples, 0 failures
- function-tool schema tests: 17 examples, 0 failures
- agent-cli library and native bridge: 148 modules compiled after rebasing onto `feature/native-bridge`
- live direct-CLI tmux smoke: selected `apple-foundationmodel`, ran `/new`, and completed `list_dir` with persisted arguments `{"target_directory":"."}`
- live `apfel` supervisor smoke: shared leases, process recovery, 4096-token health, and no orphaned helper
- synthetic macOS 27 health smoke: 8192-token context propagated to the runtime catalog
- exact-pin private bundle: `nix build --option builders '' --option max-jobs 1 'path:.#agent-macos'`
- bundled helper inspected as a real arm64 Mach-O linked against `FoundationModels.framework`
- independent follow-up review: no remaining P0-P2 findings
