### PR TITLE
Add Codex-compatible view_image tool

### DIFF
--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -16,6 +16,7 @@ import Agent.ToolDSL
     , PropertyType(..)
     , parametersObjectLoose
     )
+import Agent.Tools.ViewImage (viewImageTool)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
@@ -87,6 +88,7 @@ codexTools
 codexTools env shellSession ghci planMode multi =
     pure $
         [ runGhciTool ghci
+        , viewImageTool env
         , readFileTool env
         , grepTool env
         , listDirTool env

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -87,10 +87,11 @@ spec = describe "Codex dialect" do
             map (`elem` names)
                 [ "shell_command"
                 , "apply_patch"
+                , "view_image"
                 , "update_plan"
                 , "write_plan"
                 ]
-                `shouldBe` replicate 4 True
+                `shouldBe` replicate 5 True
             names `shouldNotContain` ["run_terminal_cmd", "search_replace"]
             coding.codexClose
 

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -91,6 +91,7 @@ library
                     , Agent.Tools.ShowImage
                     , Agent.Tools.ShellReadOnly
                     , Agent.Tools.Types
+                    , Agent.Tools.ViewImage
                     , Agent.Transport.WebSocket
     other-modules:    Agent.Loop.EventPump
                     , Agent.Loop.Internal
@@ -115,6 +116,7 @@ library
                     , crypton-connection
                     , directory
                     , filepath
+                    , JuicyPixels
                     , process
                     , retry >= 0.9.3.1 && < 0.10
                     , resourcet
@@ -267,6 +269,7 @@ test-suite agent-core-test
                     , Agent.Tools.PlanModeSpec
                     , Agent.Tools.SecretSpec
                     , Agent.Tools.ShowImageSpec
+                    , Agent.Tools.ViewImageSpec
                     , Agent.ToolDSLSpec
                     , Agent.Transport.WebSocketSpec
     build-depends:    base >= 4.14 && < 5

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,9 +1,9 @@
 { mkDerivation, aeson, agent-json, agent-process
 , agent-responses-types, async, base, base64-bytestring, bytestring
-, containers, crypton-connection, directory, filepath, hspec, lib
-, process, QuickCheck, resourcet, retry, safe-exceptions, stm
-, template-haskell, text, text-builder, time, tls, transformers
-, unix, vector, websockets, yaml
+, containers, crypton-connection, directory, filepath, hspec
+, JuicyPixels, lib, process, QuickCheck, resourcet, retry
+, safe-exceptions, stm, template-haskell, text, text-builder, time
+, tls, transformers, unix, vector, websockets, yaml
 }:
 mkDerivation {
   pname = "agent-core";
@@ -13,9 +13,9 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-json agent-process agent-responses-types async base
     base64-bytestring bytestring containers crypton-connection
-    directory filepath process resourcet retry safe-exceptions stm
-    template-haskell text time tls transformers unix vector websockets
-    yaml
+    directory filepath JuicyPixels process resourcet retry
+    safe-exceptions stm template-haskell text time tls transformers
+    unix vector websockets yaml
   ];
   testHaskellDepends = [
     aeson agent-json agent-responses-types async base base64-bytestring

--- a/packages/agent-core/src/Agent/Tools/ViewImage.hs
+++ b/packages/agent-core/src/Agent/Tools/ViewImage.hs
@@ -1,0 +1,184 @@
+-- | Model-facing local image inspection.
+--
+-- Unlike 'Agent.Tools.ShowImage', this tool puts the selected image in the
+-- next provider request so a vision-capable model can inspect it.
+module Agent.Tools.ViewImage
+    ( viewImageTool
+    , viewImageToolName
+    ) where
+
+import Agent.Json.Decode (Decoder)
+import Agent.OsPath (fromText, unsafeToFilePath)
+import Agent.ToolArgs (objectArgs, optText, reqText)
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , ToolHandlerResult(..)
+    , ToolResultImage(..)
+    , decodeToolArguments
+    , toolArgumentsValue
+    , typedRichToolWithCall
+    )
+import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
+import Agent.Tools.FileSystem (displayPathInWorkspace, resolveForRead)
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    )
+import Agent.Tools.Types
+    ( AppTool
+    , ToolEnv
+    , ToolExecutionPolicy(..)
+    , jsonTool
+    , withToolResourceClaims
+    )
+import Codec.Picture (decodeGifImages, decodeImage)
+import Control.Exception.Safe (tryIO)
+import Data.Bits ((.|.), shiftL)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as Base64
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import System.Directory.OsPath (doesFileExist)
+import System.IO (IOMode(ReadMode), withBinaryFile)
+
+viewImageToolName :: Text
+viewImageToolName = "view_image"
+
+-- | Keep individual image results bounded even though the upstream API permits
+-- a larger aggregate request. The model may call this tool repeatedly in one
+-- turn, and tool-result images remain in the conversation history.
+maxViewImageBytes :: Int
+maxViewImageBytes = 20 * 1024 * 1024
+
+data ViewImageArgs = ViewImageArgs
+    { path :: !Text
+    , detail :: !(Maybe Text)
+    }
+
+viewImageArgsDecoder :: Decoder ViewImageArgs
+viewImageArgsDecoder = objectArgs \object ->
+    ViewImageArgs
+        <$> reqText object "path"
+        <*> optText object "detail"
+
+viewImageTool :: ToolEnv -> AppTool
+viewImageTool env =
+    withToolResourceClaims (viewImageClaims env) $
+        jsonTool viewImageToolName viewImageDescription
+            [ PropertySchema "path" PropertyString True $ Just
+                "Local filesystem path to an image file."
+            ]
+            True
+            ParallelSafe
+            (typedRichToolWithCall viewImageToolName viewImageArgsDecoder
+                (runViewImage env))
+
+viewImageDescription :: Text
+viewImageDescription =
+    "View a local image file from the filesystem when visual inspection is needed. \
+    \Use this for images already available on disk. The image is added to your context."
+
+viewImageClaims
+    :: ToolEnv
+    -> ToolCall
+    -> IO (Either Text [ToolResourceClaim])
+viewImageClaims env call =
+    case decodeToolArguments viewImageArgsDecoder (toolArgumentsValue call.arguments) of
+        Left err -> pure (Left err)
+        Right args ->
+            resolveForRead env (fromText args.path)
+                >>= pure . fmap (\path -> [ToolResourceClaim ToolRead (ToolPath path)])
+
+runViewImage
+    :: ToolEnv
+    -> ToolCall
+    -> ViewImageArgs
+    -> IO (Either Text ToolHandlerResult)
+runViewImage env _call args =
+    case args.detail of
+        Just detail | detail /= "high" ->
+            pure . Left $
+                "view_image.detail only supports `high` for this model, got `"
+                    <> detail <> "`"
+        _ ->
+            resolveForRead env (fromText args.path) >>= \case
+                Left err -> pure (Left err)
+                Right imagePath -> do
+                    display <- displayPathInWorkspace env imagePath
+                    doesFileExist imagePath >>= \case
+                        False -> pure (Left ("File not found: " <> display))
+                        True -> readAndEncode display imagePath
+  where
+    readAndEncode display imagePath =
+        tryIO
+            (withBinaryFile (unsafeToFilePath imagePath) ReadMode
+                (\handle -> BS.hGet handle (maxViewImageBytes + 1))) >>= \case
+            Left err ->
+                pure . Left $
+                    "Failed to read " <> display <> ": " <> Text.pack (show err)
+            Right bytes | BS.length bytes > maxViewImageBytes ->
+                pure . Left $
+                    "Image is too large to view (the limit is "
+                        <> Text.pack (show maxViewImageBytes)
+                        <> " bytes). Downscale it first."
+            Right bytes ->
+                case supportedImageMime bytes of
+                    Nothing ->
+                        pure . Left $
+                            display <> " is not a supported image. Supported formats: PNG, JPEG, WebP, non-animated GIF."
+                    Just mime
+                        | not (validImage mime bytes) ->
+                            pure . Left $ "Unable to process image: invalid or unsupported image data"
+                        | otherwise ->
+                            pure . Right $ ToolHandlerResult
+                                { resultText = "Viewed image file: " <> display
+                                , resultImages =
+                                    [ ToolResultImage
+                                        { imageUrl =
+                                            "data:" <> mime <> ";base64,"
+                                                <> TextEncoding.decodeUtf8 (Base64.encode bytes)
+                                        , imageDetail = Just "high"
+                                        }
+                                    ]
+                                }
+
+-- | Image types supported by the Responses image-input API. We inspect magic
+-- bytes rather than extensions; the full decoder check above rejects corrupt
+-- data that happens to have one of these prefixes.
+supportedImageMime :: BS.ByteString -> Maybe Text
+supportedImageMime bytes
+    | prefix [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] = Just "image/png"
+    | prefix [0xff, 0xd8, 0xff] = Just "image/jpeg"
+    | prefix [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]
+        || prefix [0x47, 0x49, 0x46, 0x38, 0x39, 0x61] = Just "image/gif"
+    | BS.length bytes >= 12
+        && BS.take 4 bytes == "RIFF"
+        && BS.take 4 (BS.drop 8 bytes) == "WEBP" = Just "image/webp"
+    | otherwise = Nothing
+  where
+    prefix = (`BS.isPrefixOf` bytes) . BS.pack
+
+validImage :: Text -> BS.ByteString -> Bool
+validImage "image/webp" = validWebP
+validImage "image/gif" =
+    either (const False) ((== 1) . length) . decodeGifImages
+validImage _ = either (const False) (const True) . decodeImage
+
+-- JuicyPixels does not decode WebP. Validate its RIFF envelope and require a
+-- standard WebP payload chunk; the provider performs the full pixel decode.
+validWebP :: BS.ByteString -> Bool
+validWebP bytes =
+    BS.length bytes >= 20
+        && BS.take 4 bytes == "RIFF"
+        && BS.take 4 (BS.drop 8 bytes) == "WEBP"
+        && riffSize bytes + 8 == BS.length bytes
+        && BS.take 4 (BS.drop 12 bytes) `elem` ["VP8 ", "VP8L", "VP8X"]
+
+riffSize :: BS.ByteString -> Int
+riffSize bytes =
+    fromIntegral (BS.index bytes 4)
+        .|. (fromIntegral (BS.index bytes 5) `shiftL` 8)
+        .|. (fromIntegral (BS.index bytes 6) `shiftL` 16)
+        .|. (fromIntegral (BS.index bytes 7) `shiftL` 24)

--- a/packages/agent-core/test/Agent/Tools/ViewImageSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/ViewImageSpec.hs
@@ -1,0 +1,174 @@
+module Agent.Tools.ViewImageSpec (spec) where
+
+import Agent.ToolDispatch
+    ( ToolCallResult(..)
+    , ToolResultImage(..)
+    , ToolDispatchConfig(..)
+    , dispatchToolCall
+    , functionToolCall
+    )
+import Agent.ToolDSL (PropertySchema(..))
+import Agent.Tools.Scheduling
+    ( ToolAccess(..)
+    , ToolResource(..)
+    , ToolResourceClaim(..)
+    , ToolSchedulingPlan(..)
+    )
+import Agent.Tools.Types
+    ( AppTool(..)
+    , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
+    , defaultToolEnv
+    , jsonToolParameters
+    , mkToolRegistry
+    , setToolSessionTmp
+    , toolSchedulingPlanFor
+    )
+import Agent.Tools.ViewImage (viewImageTool)
+import Control.Exception.Safe (bracket)
+import qualified Data.ByteString as BS
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as Text
+import System.Directory
+    ( canonicalizePath
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
+import System.FilePath ((</>))
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Tools.ViewImage" do
+    it "advertises a read-only, parallel-safe model-facing tool" do
+        withTool \_ tool -> do
+            tool.appToolName `shouldBe` "view_image"
+            map (.propertyName) (fromMaybe [] (jsonToolParameters tool))
+                `shouldBe` ["path"]
+            case tool.appToolApproval of
+                AlwaysReadOnly -> pure ()
+                _ -> expectationFailure "view_image should not require approval"
+            tool.appToolExecution `shouldBe` ParallelSafe
+
+    it "returns a data-url image result for the model" do
+        withTool \workspace tool -> do
+            BS.writeFile (workspace </> "error.png") pngBytes
+            result <- runTool tool "{\"path\":\"error.png\"}"
+            case result of
+                ToolCallResultWithImages{output, toolResultImages = [image]} -> do
+                    output `shouldBe` "Viewed image file: error.png"
+                    image.imageDetail `shouldBe` Just "high"
+                    image.imageUrl `shouldSatisfy`
+                        Text.isPrefixOf "data:image/png;base64,"
+                _ -> expectationFailure ("expected image result, got " <> show result)
+
+    it "accepts a structurally valid WebP image" do
+        withTool \workspace tool -> do
+            BS.writeFile (workspace </> "error.webp") webpBytes
+            result <- runTool tool "{\"path\":\"error.webp\"}"
+            case result of
+                ToolCallResultWithImages{toolResultImages = [image]} ->
+                    image.imageUrl `shouldSatisfy`
+                        Text.isPrefixOf "data:image/webp;base64,"
+                _ -> expectationFailure ("expected WebP image result, got " <> show result)
+
+    it "rejects unsupported detail hints" do
+        withTool \workspace tool -> do
+            BS.writeFile (workspace </> "error.png") pngBytes
+            result <- runTool tool "{\"path\":\"error.png\",\"detail\":\"original\"}"
+            result.output `shouldSatisfy`
+                Text.isInfixOf "only supports `high` for this model"
+
+    it "rejects invalid detail and non-image input" do
+        withTool \workspace tool -> do
+            BS.writeFile (workspace </> "notes.txt") "not an image"
+            invalidDetail <- runTool tool "{\"path\":\"notes.txt\",\"detail\":\"low\"}"
+            invalidDetail.output `shouldSatisfy`
+                Text.isInfixOf "only supports `high` for this model"
+            invalidImage <- runTool tool "{\"path\":\"notes.txt\"}"
+            invalidImage.output `shouldSatisfy` Text.isInfixOf "not a supported image"
+
+    it "rejects corrupt image data after recognizing its magic bytes" do
+        withTool \workspace tool -> do
+            BS.writeFile (workspace </> "broken.png")
+                (BS.take 8 pngBytes <> "not-a-png")
+            result <- runTool tool "{\"path\":\"broken.png\"}"
+            result.output `shouldSatisfy`
+                Text.isInfixOf "invalid or unsupported image data"
+
+    it "reports missing files and refuses paths outside the workspace" do
+        withTool \_ tool -> do
+            missing <- runTool tool "{\"path\":\"missing.png\"}"
+            missing.output `shouldSatisfy`
+                Text.isInfixOf "File not found: missing.png"
+            outside <- runTool tool "{\"path\":\"/etc/hosts\"}"
+            case outside of
+                ToolCallResultWithImages{} ->
+                    expectationFailure "outside path returned an image"
+                ToolCallResult{output} ->
+                    output `shouldNotSatisfy` Text.isPrefixOf "Viewed"
+
+    it "claims a read on the resolved image path" do
+        withTool \workspace tool -> do
+            BS.writeFile (workspace </> "error.png") pngBytes
+            registry <- either (fail . Text.unpack) pure (mkToolRegistry [tool])
+            plan <- toolSchedulingPlanFor registry
+                (functionToolCall "view-2" "view_image" "{\"path\":\"error.png\"}")
+            canonical <- canonicalizePath (workspace </> "error.png")
+            plan `shouldBe`
+                ToolResourceClaims
+                    [ ToolResourceClaim ToolRead
+                        (ToolPath (unsafeEncodeUtf canonical))
+                    ]
+
+pngBytes :: BS.ByteString
+pngBytes = BS.pack
+    [ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a
+    , 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52
+    , 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01
+    , 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde
+    , 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54
+    , 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00
+    , 0x03, 0x01, 0x01, 0x00, 0x18, 0xdd, 0x8d, 0xb0
+    , 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44
+    , 0xae, 0x42, 0x60, 0x82
+    ]
+
+-- | A minimal valid 1×1 lossy WebP.
+webpBytes :: BS.ByteString
+webpBytes = BS.pack
+    [ 0x52, 0x49, 0x46, 0x46, 0x22, 0x00, 0x00, 0x00
+    , 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38, 0x20
+    , 0x16, 0x00, 0x00, 0x00, 0x30, 0x01, 0x00, 0x9d
+    , 0x01, 0x2a, 0x01, 0x00, 0x01, 0x00, 0x0e, 0xc0
+    , 0xfe, 0x25, 0xa4, 0x00, 0x03, 0x70, 0x00, 0x00
+    , 0x00, 0x00
+    ]
+
+withTool :: (FilePath -> AppTool -> IO a) -> IO a
+withTool action = do
+    root <- getTemporaryDirectory
+    bracket
+        (mkdtemp (root </> "agent-view-image-test-"))
+        removeDirectoryRecursive
+        \workspace -> do
+            temp <- mkdtemp (workspace </> "session-tmp-")
+            env <- defaultToolEnv (unsafeEncodeUtf workspace)
+            setToolSessionTmp env (Just (unsafeEncodeUtf temp))
+            action workspace (viewImageTool env)
+
+runTool :: AppTool -> Text.Text -> IO ToolCallResult
+runTool tool arguments =
+    dispatchToolCall testDispatchConfig [tool.appToolHandler]
+        (functionToolCall "view-1" "view_image" arguments)
+
+testDispatchConfig :: ToolDispatchConfig
+testDispatchConfig = ToolDispatchConfig
+    { toolDispatchUnknownTool = \name -> "unknown:" <> name
+    , toolDispatchFormatResult = either ("ERR " <>) id
+    , toolDispatchFormatException = \name _ -> "EX " <> name
+    , toolDispatchOnException = \_ _ -> pure ()
+    , toolDispatchOnOutput = \_ _ -> pure ()
+    , toolDispatchFinalizeOutput = \_ output -> pure output
+    }

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -34,6 +34,7 @@ import qualified Agent.Tools.OutputArtifactSpec as OutputArtifactSpec
 import qualified Agent.Tools.PlanModeSpec as PlanModeSpec
 import qualified Agent.Tools.SecretSpec as SecretSpec
 import qualified Agent.Tools.ShowImageSpec as ShowImageSpec
+import qualified Agent.Tools.ViewImageSpec as ViewImageSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
 import Test.Hspec (hspec)
 
@@ -70,6 +71,7 @@ main = hspec do
     PlanModeSpec.spec
     SecretSpec.spec
     ShowImageSpec.spec
+    ViewImageSpec.spec
     CodeModeHostSpec.spec
     CodeModeProtocolSpec.spec
     DangerousSpec.spec


### PR DESCRIPTION
## Summary

- add a Codex-compatible `view_image` tool that attaches local images to the model context
- validate and bound PNG, JPEG, WebP, and non-animated GIF inputs before returning a rich image tool result
- register the tool on the Codex surface and add focused coverage for schemas, path safety, image validation, WebP, and rich result propagation

## Validation

- `cabal repl --offline agent-core:lib:agent-core agent-codex-dialect:lib:agent-codex-dialect` (71 modules loaded)
- `cabal test --offline agent-core:agent-core-test --test-options='--match=Agent.Tools.ViewImage'` (8 examples, 0 failures)
- Codex tool-surface test (1 example, 0 failures)
- Responses rich function-output serialization test (1 example, 0 failures)
- `git diff --check`

## Live smoke check

A tmux launch reached the development GHCi entry point, but the host currently returns `Operation not permitted` for `~/.haskell-agent/tmp/sessions`, so the live agent cannot allocate its session temp directory. The focused dispatcher and provider serialization paths pass independently.

## Broader test note

The full `agent-core` suite built and ran, but has existing host-environment failures around session-temp isolation and project-instruction discovery caused by the same inaccessible `~/.haskell-agent/tmp/sessions` path; the new `view_image` tests all pass.
