### PR TITLE
Improve README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,26 @@ These are important product features, but not the core differentiation.
 
 ## Install
 
-Install [Nix](https://nixos.org/download/) with flakes enabled, then install
-`haskell-agent`. `--accept-flake-config` enables the public IHP binary cache
-declared by the flake:
+1. Install [Determinate Nix](https://docs.determinate.systems/determinate-nix/):
 
-```console
-nix profile add --accept-flake-config github:digitallyinduced/haskell-agent
-```
+   ```console
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+
+2. **Copy this prompt to your coding agent to install:**
+
+   ```text
+   Install haskell-agent by running `nix profile add --accept-flake-config github:digitallyinduced/haskell-agent`, then verify the installation by running `agent-cli --help`.
+   ```
+
+   Or install it yourself:
+
+   ```console
+   nix profile add --accept-flake-config github:digitallyinduced/haskell-agent
+   ```
+
+   `--accept-flake-config` enables the public IHP binary cache declared by the
+   flake.
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,8 @@ These are important product features, but not the core differentiation.
 
 ## Install
 
-1. Install [Determinate Nix](https://docs.determinate.systems/determinate-nix/):
-
-   ```console
-   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
-   ```
+1. Install [Determinate Nix](https://docs.determinate.systems/determinate-nix/)
+   by following its platform-specific installation instructions.
 
 2. **Copy this prompt to your coding agent to install:**
 


### PR DESCRIPTION
## Summary

- link to Determinate Nix’s platform-specific installation documentation
- add a copyable prompt for installing `haskell-agent` with a coding agent
- retain the manual `nix profile add` command as an alternative

## Validation

- `git diff --check`
- verified the Determinate Nix documentation URL resolves