### PR TITLE
Fix static Linux CLI runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ persistent `run_ghci` tool when needed:
 agent-cli --ghci
 ```
 
+The GHCi tool is optional and uses a `ghci` executable from `PATH`. Run the
+agent with a Nix-provided GHC when enabling it:
+
+```console
+nix shell nixpkgs#ghc -c agent-cli --ghci
+```
+
 For GHCi-only operation, disable Bash explicitly:
 
 ```console

--- a/flake.nix
+++ b/flake.nix
@@ -553,14 +553,17 @@
                 agentStorePackage = productionHaskellPackages.agent-store;
                 agentCliPackage = productionHaskellPackages.agent-cli;
                 agentTelegramPackage = productionHaskellPackages.agent-telegram;
-                agentCliStaticExecutable =
-                    if pkgs.stdenv.hostPlatform.isLinux then
-                        pkgs.haskell.lib.justStaticExecutables
-                            staticHaskellPackages.agent-cli
-                    else
-                        agentCliExecutable;
-                agentCliExecutable =
-                    (pkgs.haskell.lib.justStaticExecutables agentCliPackage).overrideAttrs
+                # Both installable CLI variants expose the same advertised
+                # runtime capabilities; only the harness linkage differs.
+                agentCliRuntimeTools = [
+                    pkgs.ffmpeg
+                    bun_1_4
+                    pkgs.postgresql_18
+                    pkgs.ripgrep
+                    haskellPackages.ghc
+                ];
+                wrapAgentCli = package:
+                    package.overrideAttrs
                         (old: {
                             nativeBuildInputs =
                                 (old.nativeBuildInputs or [ ])
@@ -574,16 +577,51 @@
                                     wrapProgram "$out/bin/agent-cli" \
                                         --set-default AGENT_SYNTAX_DIR \
                                             "${skylightingSyntaxDirectory}" \
+                                        --set-default AGENT_POSTGRES_BIN \
+                                            "${pkgs.postgresql_18}/bin" \
                                         --prefix PATH : \
-                                            "${pkgs.lib.makeBinPath [
-                                                pkgs.ffmpeg
-                                                bun_1_4
-                                                pkgs.postgresql_18
-                                                pkgs.ripgrep
-                                                haskellPackages.ghc
-                                            ]}"
+                                            "${pkgs.lib.makeBinPath agentCliRuntimeTools}"
                                 '';
                         });
+                agentCliStaticExecutable =
+                    if pkgs.stdenv.hostPlatform.isLinux then
+                        wrapAgentCli
+                            (pkgs.haskell.lib.justStaticExecutables
+                                staticHaskellPackages.agent-cli)
+                    else
+                        agentCliExecutable;
+                agentCliExecutable =
+                    wrapAgentCli
+                        (pkgs.haskell.lib.justStaticExecutables agentCliPackage);
+                agentCliStaticRuntimeCheck =
+                    pkgs.runCommand "agent-cli-static-runtime"
+                        { }
+                        ''
+                            home="$TMPDIR/home"
+                            mkdir -p "$home"
+
+                            run_agent() {
+                                env -i \
+                                    HOME="$home" \
+                                    PATH="${pkgs.coreutils}/bin" \
+                                    LC_ALL=C \
+                                    "${agentCliStaticExecutable}/bin/agent-cli" "$@"
+                            }
+
+                            cleanup() {
+                                run_agent storage stop || true
+                            }
+                            trap cleanup EXIT
+
+                            run_agent storage start
+                            test "$(
+                                cat "$home/.haskell-agent/postgres/data/PG_VERSION"
+                            )" = "18"
+                            run_agent storage doctor
+                            run_agent storage stop
+                            trap - EXIT
+                            touch "$out"
+                        '';
                 agentTelegramExecutable =
                     (pkgs.haskell.lib.justStaticExecutables agentTelegramPackage).overrideAttrs
                         (old: {
@@ -722,9 +760,9 @@
                 '';
             in
             {
-                # Linux users get fully static musl executables rather than
-                # the tool-bundled package's multi-gigabyte runtime closure.
-                # The native wrapped build remains available as `agent-cli`.
+                # Linux uses a statically linked musl harness, wrapped with the
+                # same runtime tools as the native build. The native build
+                # remains available as `agent-cli`.
                 packages.default = agentCliStaticExecutable;
                 packages.agent-cli-static = agentCliStaticExecutable;
                 packages.agent-cli = agentCliExecutable;
@@ -837,6 +875,7 @@
                         haskellPackages.claude-agent-sdk-haskell;
                     agent-claude = haskellPackages.agent-claude;
                 } // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+                    agent-cli-static-runtime = agentCliStaticRuntimeCheck;
                     nixos-module = import ./nix/tests/telegram-module.nix {
                         inherit self nixpkgs pkgs system;
                     };

--- a/flake.nix
+++ b/flake.nix
@@ -560,7 +560,6 @@
                     bun_1_4
                     pkgs.postgresql_18
                     pkgs.ripgrep
-                    haskellPackages.ghc
                 ];
                 wrapAgentCli = package:
                     package.overrideAttrs
@@ -568,9 +567,6 @@
                             nativeBuildInputs =
                                 (old.nativeBuildInputs or [ ])
                                 ++ [ pkgs.makeWrapper ];
-                            disallowedRequisites = pkgs.lib.remove
-                                haskellPackages.ghc
-                                (old.disallowedRequisites or [ ]);
                             postInstall =
                                 (old.postInstall or "")
                                 + ''


### PR DESCRIPTION
## Summary

- wrap the Linux musl-static `agent-cli` payload with the same packaged runtime dependencies as the native package
- centralize the CLI runtime tool list so the static/default and native outputs cannot drift
- set an overridable `AGENT_POSTGRES_BIN` default pointing at the packaged PostgreSQL 18 command suite
- keep GHC/GHCi optional instead of retaining GHC in every install, and document running `--ghci` with `nix shell nixpkgs#ghc`
- add a Linux flake check that starts the default static package's managed database in an isolated environment, verifies PostgreSQL 18, runs `storage doctor`, and stops it

## Root cause

PR #796 changed the package selected by an unqualified Linux `nix profile add` to the raw static executable. That output had no wrapper or PostgreSQL runtime dependency, so first startup tried the bare `initdb` name and failed with `posix_spawnp: does not exist`.

`nix run` continued to select the wrapped native package, which is why the install path was missed by existing smoke tests.

## Validation

- built `.#checks.x86_64-linux.agent-cli-static-runtime` on an x86_64 Linux builder
  - `storage start` succeeded
  - `PG_VERSION` was `18`
  - `storage doctor` succeeded
  - `storage stop` succeeded
- `nix flake check --no-build --no-write-lock-file`
- `nix-instantiate --parse flake.nix`
- `git diff --check`
- verified the static package directly references PostgreSQL, ripgrep, Bun, ffmpeg, syntax data, and its wrapper shell
- verified no GHC path occurs anywhere in the static package closure

The Haskell executable remains musl-static. The complete install closure is approximately 1.2 GiB without GHC, down from approximately 4.1 GiB when GHC was bundled.

Fixes #846
