### PR TITLE
Expose read-only data browser bridge

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -92,9 +92,14 @@ import Agent.CLI.ModelConfig
     , catalogModelById
     )
 import Agent.CLI.GatewayModels (loadGatewayModelCatalogAt)
+import Agent.CLI.Database (DatabaseScope(..))
 import Agent.CLI.Database.Store
-    ( applicableDatabaseScopes
+    ( DatabaseBrowsePage(..)
+    , DatabaseScopes
+    , applicableDatabaseScopes
     , deriveDatabaseScopes
+    , listDatabaseObjects
+    , loadDatabaseRows
     )
 import Agent.CLI.Models
     ( ModelOption(..)
@@ -141,6 +146,11 @@ import Agent.Store.Postgres
     , closeStore
     , openStore
     , trustedPool
+    )
+import Agent.Store.Postgres.Custom
+    ( CatalogColumn(..)
+    , CatalogDefinition(..)
+    , CatalogObject(..)
     )
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
@@ -347,6 +357,17 @@ type LearnedSkillsListCallback =
     -> CString -> CSize -> CString -> CSize -> CString -> CSize
     -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
 
+type DataCatalogCallback =
+    Ptr () -> CInt -> CInt -> CInt
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CInt
+    -> CString -> CSize -> CString -> CSize -> IO ()
+
+type DataRowsCallback =
+    Ptr () -> CInt -> Int64 -> Int64 -> CInt -> CInt
+    -> CString -> CSize -> Int64 -> CInt
+    -> CString -> CSize -> IO ()
+
 type BrowserCallback =
     Ptr () -> CInt
     -> Ptr Word8 -> CSize
@@ -401,6 +422,14 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeLearnedSkillsListCallback
         :: FunPtr LearnedSkillsListCallback -> LearnedSkillsListCallback
+
+foreign import ccall "dynamic"
+    invokeDataCatalogCallback
+        :: FunPtr DataCatalogCallback -> DataCatalogCallback
+
+foreign import ccall "dynamic"
+    invokeDataRowsCallback
+        :: FunPtr DataRowsCallback -> DataRowsCallback
 
 foreign import ccall "dynamic"
     invokeBrowserCallback :: FunPtr BrowserCallback -> BrowserCallback
@@ -659,6 +688,13 @@ foreign export ccall ha_gateway_disconnect
 foreign export ccall ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
 
+foreign export ccall ha_data_catalog_list
+    :: Ptr Word8 -> CSize -> FunPtr DataCatalogCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_data_rows_load
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize
+    -> Int64 -> CInt -> FunPtr DataRowsCallback -> Ptr () -> IO CInt
+
 ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
 ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
@@ -699,6 +735,245 @@ ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
                                 <$> listAllLearnedSkills
                                     (trustedPool store)
                                     (applicableDatabaseScopes databaseScopes)
+
+ha_data_catalog_list
+    :: Ptr Word8 -> CSize -> FunPtr DataCatalogCallback -> Ptr () -> IO CInt
+ha_data_catalog_list cwdBytes (CSize cwdLength) callback context
+    | callback == nullFunPtr = pure 1
+    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
+    | otherwise = do
+        cwd <- decodeInput cwdBytes cwdLength
+        _ <- forkIO do
+            tryAny (loadDataCatalogFor (Text.unpack cwd)) >>= \case
+                Left exception ->
+                    withText (Text.pack (show exception)) \errorPtr errorLength ->
+                        dataCatalogTerminal
+                            callback context (-1) errorPtr errorLength
+                Right (Left err) ->
+                    withText err \errorPtr errorLength ->
+                        dataCatalogTerminal
+                            callback context (-1) errorPtr errorLength
+                Right (Right scopedObjects) -> do
+                    forM_ scopedObjects \(scope, objects) ->
+                        forM_ objects (emitDataCatalogObject callback context scope)
+                    dataCatalogTerminal callback context 2 nullPtr 0
+        pure 0
+
+ha_data_rows_load
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize
+    -> Int64 -> CInt -> FunPtr DataRowsCallback -> Ptr () -> IO CInt
+ha_data_rows_load
+    cwdBytes
+    (CSize cwdLength)
+    rawScope
+    objectBytes
+    (CSize objectLength)
+    offset
+    rawLimit
+    callback
+    context
+    | callback == nullFunPtr = pure 1
+    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
+    | objectBytes == nullPtr && objectLength > 0 = pure 2
+    | offset /= 0 = pure 3
+    | rawLimit < 1 || rawLimit > 500 = pure 3
+    | Nothing <- dataScopeFromCode rawScope = pure 3
+    | otherwise = do
+        cwd <- decodeInput cwdBytes cwdLength
+        objectName <- decodeInput objectBytes objectLength
+        if Text.null objectName
+            then pure 3
+            else do
+                let Just scope = dataScopeFromCode rawScope
+                    limit = fromIntegral rawLimit
+                _ <- forkIO do
+                    tryAny
+                        (loadDataPageFor
+                            (Text.unpack cwd)
+                            scope
+                            objectName
+                            offset
+                            limit)
+                        >>= \case
+                            Left exception ->
+                                withText
+                                    (Text.pack (show exception))
+                                    \errorPtr errorLength ->
+                                        dataRowsTerminal
+                                            callback context (-1) offset 0 False
+                                            errorPtr errorLength
+                            Right (Left err) ->
+                                withText err \errorPtr errorLength ->
+                                    dataRowsTerminal
+                                        callback context (-1) offset 0 False
+                                        errorPtr errorLength
+                            Right (Right page) -> do
+                                forM_
+                                    (zip [0 :: Int64 ..] page.databaseBrowseRows)
+                                    \(rowIndex, row) ->
+                                        forM_
+                                            (zip [0 :: Int ..] row)
+                                            \(columnIndex, value) ->
+                                                withDataValue value
+                                                    \kind valuePtr valueLength ->
+                                                        invokeDataRowsCallback
+                                                            callback context 0
+                                                            offset rowIndex
+                                                            (fromIntegral columnIndex)
+                                                            kind
+                                                            valuePtr valueLength
+                                                            0 0 nullPtr 0
+                                dataRowsTerminal
+                                    callback
+                                    context
+                                    1
+                                    offset
+                                    (fromIntegral
+                                        (length page.databaseBrowseRows))
+                                    page.databaseBrowseHasMore
+                                    nullPtr
+                                    0
+                pure 0
+
+loadDataCatalogFor
+    :: FilePath
+    -> IO (Either Text [(CInt, [CatalogObject])])
+loadDataCatalogFor cwd =
+    withDatabaseStoreFor cwd \store scopes -> do
+        results <- mapM
+            (\(scopeCode, scope) ->
+                fmap (fmap ((,) scopeCode)) $
+                    listDatabaseObjects store scopes scope)
+            [ (0, DatabaseUserScope)
+            , (1, DatabaseRepositoryScope)
+            , (2, DatabaseCheckoutScope)
+            ]
+        pure (sequence results)
+
+loadDataPageFor
+    :: FilePath
+    -> DatabaseScope
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either Text DatabaseBrowsePage)
+loadDataPageFor cwd selected objectName offset limit =
+    withDatabaseStoreFor cwd \store scopes ->
+        loadDatabaseRows store scopes selected objectName offset limit
+
+withDatabaseStoreFor
+    :: FilePath
+    -> (Store -> DatabaseScopes -> IO (Either Text value))
+    -> IO (Either Text value)
+withDatabaseStoreFor cwd action = do
+    home <- getHomeDirectory
+    projectRoot <- resolveProjectRoot (unsafeEncodeUtf cwd)
+    stateDirectory <- decodeFS (takeDirectory (sessionsRoot home))
+    projectRootPath <- decodeFS projectRoot
+    deriveDatabaseScopes stateDirectory projectRootPath >>= \case
+        Left err -> pure (Left err)
+        Right scopes -> do
+            config <- managedPostgresConfigForHome home
+            openStore config >>= \case
+                Left err -> pure (Left (renderStoreError err))
+                Right opened ->
+                    bracket (pure opened) closeStore \store ->
+                        action store scopes
+
+emitDataCatalogObject
+    :: FunPtr DataCatalogCallback
+    -> Ptr ()
+    -> CInt
+    -> CatalogObject
+    -> IO ()
+emitDataCatalogObject callback context scope object =
+    withText object.catalogObjectName \objectPtr objectLength ->
+    withOptionalText definition.definitionComment \commentPtr commentLength -> do
+        invokeDataCatalogCallback callback context
+            0 scope kind
+            objectPtr objectLength
+            commentPtr commentLength
+            nullPtr 0 nullPtr 0 0 nullPtr 0 nullPtr 0
+        forM_ definition.definitionColumns \column ->
+            withText column.columnName \columnPtr columnLength ->
+            withText column.columnType \typePtr typeLength ->
+            withOptionalText column.columnComment
+                \columnCommentPtr columnCommentLength ->
+                    invokeDataCatalogCallback callback context
+                        1 scope kind
+                        objectPtr objectLength
+                        nullPtr 0
+                        columnPtr columnLength
+                        typePtr typeLength
+                        (if column.columnNullable then 1 else 0)
+                        columnCommentPtr columnCommentLength
+                        nullPtr 0
+  where
+    definition = object.catalogObjectDefinition
+    kind = dataObjectKind object.catalogObjectKind
+
+dataObjectKind :: Text -> CInt
+dataObjectKind = \case
+    "view" -> 1
+    "materialized_view" -> 1
+    _ -> 0
+
+dataScopeFromCode :: CInt -> Maybe DatabaseScope
+dataScopeFromCode = \case
+    0 -> Just DatabaseUserScope
+    1 -> Just DatabaseRepositoryScope
+    2 -> Just DatabaseCheckoutScope
+    _ -> Nothing
+
+dataCatalogTerminal
+    :: FunPtr DataCatalogCallback
+    -> Ptr ()
+    -> CInt
+    -> CString
+    -> CSize
+    -> IO ()
+dataCatalogTerminal callback context status errorPtr errorLength =
+    invokeDataCatalogCallback callback context
+        status 0 0
+        nullPtr 0 nullPtr 0
+        nullPtr 0 nullPtr 0 0
+        nullPtr 0 errorPtr errorLength
+
+withDataValue
+    :: Aeson.Value
+    -> (CInt -> CString -> CSize -> IO value)
+    -> IO value
+withDataValue value action =
+    case value of
+        Aeson.Null -> action 0 nullPtr 0
+        Aeson.String text -> withText text (action 1)
+        Aeson.Number _ -> withEncoded 2
+        Aeson.Bool True -> withText "true" (action 3)
+        Aeson.Bool False -> withText "false" (action 3)
+        Aeson.Array _ -> withEncoded 4
+        Aeson.Object _ -> withEncoded 4
+  where
+    withEncoded kind =
+        withText
+            (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode value)))
+            (action kind)
+
+dataRowsTerminal
+    :: FunPtr DataRowsCallback
+    -> Ptr ()
+    -> CInt
+    -> Int64
+    -> Int64
+    -> Bool
+    -> CString
+    -> CSize
+    -> IO ()
+dataRowsTerminal
+    callback context status offset rowCount hasMore errorPtr errorLength =
+        invokeDataRowsCallback callback context
+            status offset (-1) (-1) (-1)
+            nullPtr 0 rowCount (if hasMore then 1 else 0)
+            errorPtr errorLength
 
 type LearnedSkillItemCallback =
     CString -> CSize -> CString -> CSize -> CLLong

--- a/packages/agent-cli/include/HaskellAgentBridge.h
+++ b/packages/agent-cli/include/HaskellAgentBridge.h
@@ -195,6 +195,107 @@ int32_t ha_learned_skills_list(
     ha_learned_skills_list_callback callback, void *context
 );
 
+enum {
+    HA_DATA_SCOPE_USER = 0,
+    HA_DATA_SCOPE_REPOSITORY = 1,
+    HA_DATA_SCOPE_CHECKOUT = 2
+};
+
+enum {
+    HA_DATA_CATALOG_OBJECT = 0,
+    HA_DATA_CATALOG_COLUMN = 1,
+    HA_DATA_CATALOG_COMPLETE = 2,
+    HA_DATA_CATALOG_ERROR = -1
+};
+
+enum {
+    HA_DATA_OBJECT_TABLE = 0,
+    HA_DATA_OBJECT_VIEW = 1
+};
+
+enum {
+    HA_DATA_ROWS_VALUE = 0,
+    HA_DATA_ROWS_COMPLETE = 1,
+    HA_DATA_ROWS_ERROR = -1
+};
+
+enum {
+    HA_DATA_VALUE_NULL = 0,
+    HA_DATA_VALUE_TEXT = 1,
+    HA_DATA_VALUE_NUMBER = 2,
+    HA_DATA_VALUE_BOOLEAN = 3,
+    HA_DATA_VALUE_JSON = 4
+};
+
+/*
+ * Read-only catalog callbacks first emit an object and then its columns.
+ * status is HA_DATA_CATALOG_COMPLETE exactly once on success or
+ * HA_DATA_CATALOG_ERROR exactly once on failure. Optional comments have zero
+ * length when absent. column_nullable is 0 or 1 for column items.
+ *
+ * All strings are UTF-8 and callback-scoped; copy them before returning.
+ * Callbacks run serially on a runtime worker, never the caller or AppKit main
+ * thread. The host owns callback/context and must keep them alive through the
+ * terminal callback.
+ */
+typedef void (*ha_data_catalog_callback)(
+    void *context,
+    int32_t status,
+    int32_t scope,
+    int32_t object_kind,
+    const uint8_t *object_name, size_t object_name_length,
+    const uint8_t *object_comment, size_t object_comment_length,
+    const uint8_t *column_name, size_t column_name_length,
+    const uint8_t *column_type, size_t column_type_length,
+    int32_t column_nullable,
+    const uint8_t *column_comment, size_t column_comment_length,
+    const uint8_t *error, size_t error_length
+);
+
+/*
+ * Value callbacks identify a zero-based row and column within one bounded
+ * preview. Text is unquoted UTF-8; numbers use JSON number syntax; booleans are
+ * "true" or "false"; JSON arrays/objects are encoded as UTF-8 JSON; null has
+ * no value bytes. The terminal success item supplies offset, row_count, and
+ * has_more. Failure supplies only error.
+ *
+ * Buffers, threading, ownership, and terminal-callback guarantees match the
+ * catalog callback above. The operation is strictly read-only and queries
+ * only an object resolved through the selected custom-scope catalog.
+ */
+typedef void (*ha_data_rows_callback)(
+    void *context,
+    int32_t status,
+    int64_t offset,
+    int64_t row_index,
+    int32_t column_index,
+    int32_t value_kind,
+    const uint8_t *value, size_t value_length,
+    int64_t row_count,
+    int32_t has_more,
+    const uint8_t *error, size_t error_length
+);
+
+/*
+ * Return 0 when accepted, 1 for a null callback, 2 for an invalid pointer/
+ * length pair, or 3 for invalid scope, object name, offset, or limit. An
+ * accepted request receives exactly one terminal callback. offset must be zero
+ * so every result comes from one statement snapshot; limit is 1...500.
+ */
+int32_t ha_data_catalog_list(
+    const uint8_t *cwd, size_t cwd_length,
+    ha_data_catalog_callback callback, void *context
+);
+
+int32_t ha_data_rows_load(
+    const uint8_t *cwd, size_t cwd_length,
+    int32_t scope,
+    const uint8_t *object_name, size_t object_name_length,
+    int64_t offset,
+    int32_t limit,
+    ha_data_rows_callback callback, void *context
+);
+
 /*
  * Account list callbacks use status 0 for an item, 1 for end-of-list, and
  * -1 for an error. Item strings include disabled managed credentials and

--- a/packages/agent-cli/src/Agent/CLI/Database/Store.hs
+++ b/packages/agent-cli/src/Agent/CLI/Database/Store.hs
@@ -1,10 +1,13 @@
 -- | Adapter from the CLI database tools to the Hasql-backed PostgreSQL store.
 module Agent.CLI.Database.Store
     ( DatabaseScopes
+    , DatabaseBrowsePage(..)
     , deriveDatabaseScopes
     , scopeForDatabase
     , applicableDatabaseScopes
     , databaseToolsEnvForStore
+    , listDatabaseObjects
+    , loadDatabaseRows
     ) where
 
 import Agent.CLI.Database
@@ -27,6 +30,7 @@ import Agent.Store.Postgres.Custom
     , CustomAuditContext(..)
     , CustomExecutionResult(..)
     , CustomQueryResult(..)
+    , QueryLimits(..)
     , defaultQueryLimits
     , executeCustom
     , inspectCustomSchema
@@ -41,6 +45,7 @@ import Agent.Store.Postgres.Scope
     , ScopeDatabase(..)
     , ScopeId
     , ScopeKind(..)
+    , lookupScopeDatabase
     , mkScopeId
     , provisionScope
     )
@@ -48,8 +53,13 @@ import Agent.Store.Types (renderStoreError)
 import Control.Exception.Safe (SomeException, try)
 import Data.Aeson (Value, toJSON)
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Aeson.KeyMap as AesonKeyMap
 import Data.Bits (xor)
 import qualified Data.ByteString as ByteString
+import Data.Int (Int64)
+import Data.List (find)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -64,6 +74,12 @@ data DatabaseScopes = DatabaseScopes
     { userScope :: !Scope
     , repositoryScope :: !Scope
     , checkoutScope :: !Scope
+    }
+    deriving (Eq, Show)
+
+data DatabaseBrowsePage = DatabaseBrowsePage
+    { databaseBrowseRows :: ![[Value]]
+    , databaseBrowseHasMore :: !Bool
     }
     deriving (Eq, Show)
 
@@ -128,6 +144,106 @@ databaseToolsEnvForStore store scopes currentSessionId = DatabaseToolsEnv
             Left err -> pure (Left (renderStoreError err))
             Right results -> pure $ Right $ toJSON (map searchResultValue results)
     }
+
+-- | List the table-like objects exposed by one user-defined scope. Sequences
+-- are intentionally omitted from the native data browser.
+listDatabaseObjects
+    :: Store
+    -> DatabaseScopes
+    -> DatabaseScope
+    -> IO (Either Text [CatalogObject])
+listDatabaseObjects store scopes selected =
+    withExistingScopeDatabase
+        store
+        (scopeForDatabase scopes selected)
+        (Right [])
+        \database pool ->
+            fmap (filter isBrowseableObject)
+                <$> inspectCustomSchema pool database
+
+-- | Load one bounded preview in catalog column order. A preview is read by one
+-- PostgreSQL statement, rather than multiple OFFSET queries whose snapshots can
+-- drift while a table is changing. The object name must first resolve through
+-- the isolated custom-schema catalog, so quoting cannot expose harness-owned
+-- or sibling-scope relations.
+loadDatabaseRows
+    :: Store
+    -> DatabaseScopes
+    -> DatabaseScope
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either Text DatabaseBrowsePage)
+loadDatabaseRows store scopes selected objectName offset limit
+    | offset /= 0 = pure (Left "data preview offset must be zero")
+    | limit <= 0 || limit > 500 =
+        pure (Left "data page size must be between 1 and 500")
+    | otherwise =
+        withExistingScopeDatabase
+            store
+            (scopeForDatabase scopes selected)
+            (Left "the selected data table no longer exists")
+            \database pool ->
+                inspectCustomSchema pool database >>= \case
+                    Left err -> pure (Left err)
+                    Right catalog ->
+                        case find matchesObject catalog of
+                            Nothing ->
+                                pure (Left "the selected data table no longer exists")
+                            Just object -> do
+                                let columns =
+                                        object.catalogObjectDefinition.definitionColumns
+                                    requested = fromIntegral limit + 1
+                                    limits = defaultQueryLimits
+                                        { queryMaxRows = requested
+                                        , queryMaxOutputBytes = 8 * 1024 * 1024
+                                        }
+                                    sql =
+                                        "select * from "
+                                            <> quoteBrowseIdentifier objectName
+                                            <> " limit " <> Text.pack (show requested)
+                                queryCustom pool database limits sql >>= \case
+                                    Left err -> pure (Left err)
+                                    Right result ->
+                                        pure $ do
+                                            rows <- decodeBrowseRows
+                                                columns
+                                                result.customQueryRows
+                                            pure DatabaseBrowsePage
+                                                { databaseBrowseRows =
+                                                    take limit rows
+                                                , databaseBrowseHasMore =
+                                                    length rows > limit
+                                                }
+  where
+    matchesObject object =
+        object.catalogObjectName == objectName
+            && isBrowseableObject object
+
+isBrowseableObject :: CatalogObject -> Bool
+isBrowseableObject object =
+    object.catalogObjectKind
+        `elem` ["table", "partitioned_table", "view", "materialized_view"]
+
+decodeBrowseRows :: [CatalogColumn] -> Text -> Either Text [[Value]]
+decodeBrowseRows columns encoded =
+    case Aeson.eitherDecodeStrict' (Text.encodeUtf8 encoded) of
+        Left err -> Left ("database rows: " <> Text.pack err)
+        Right values -> traverse rowValues (values :: [Value])
+  where
+    rowValues (Aeson.Object object) =
+        Right
+            [ fromMaybe Aeson.Null $
+                AesonKeyMap.lookup
+                    (AesonKey.fromText column.columnName)
+                    object
+            | column <- columns
+            ]
+    rowValues _ = Left "database rows did not have the expected shape"
+
+quoteBrowseIdentifier :: Text -> Text
+quoteBrowseIdentifier value =
+    "\"" <> Text.replace "\"" "\"\"" value <> "\""
 
 queryResultValue :: CustomQueryResult -> Either Text Value
 queryResultValue result = do
@@ -209,12 +325,30 @@ searchResultValue result = Aeson.object
 withScopeDatabase
     :: Store
     -> Scope
-    -> (ScopeDatabase -> HasqlPool -> IO (Either Text Value))
-    -> IO (Either Text Value)
+    -> (ScopeDatabase -> HasqlPool -> IO (Either Text value))
+    -> IO (Either Text value)
 withScopeDatabase store scope action =
     provisionScope (storePool (provisioningPool store)) scope >>= \case
         Left err -> pure (Left err)
         Right database ->
+            scopePool store database.scopeDatabaseRole >>= \case
+                Left err -> pure (Left (renderStoreError err))
+                Right pool -> action database (storePool pool)
+
+-- | Run a native browser read only when the scope already exists. Unlike the
+-- agent database tools, merely opening Data must not create a role, schema, or
+-- scope-registry row.
+withExistingScopeDatabase
+    :: Store
+    -> Scope
+    -> Either Text value
+    -> (ScopeDatabase -> HasqlPool -> IO (Either Text value))
+    -> IO (Either Text value)
+withExistingScopeDatabase store scope missing action =
+    lookupScopeDatabase (storePool (provisioningPool store)) scope >>= \case
+        Left err -> pure (Left err)
+        Right Nothing -> pure missing
+        Right (Just database) ->
             scopePool store database.scopeDatabaseRole >>= \case
                 Left err -> pure (Left (renderStoreError err))
                 Right pool -> action database (storePool pool)

--- a/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
@@ -2,8 +2,40 @@ module Agent.CLI.DatabaseSpec (spec) where
 
 import Agent.CLI.Database
 import Agent.CLI.Database.Storage
-import Agent.CLI.Database.Store (deriveDatabaseScopes)
+import Agent.CLI.Database.Store
+    ( DatabaseBrowsePage(..)
+    , deriveDatabaseScopes
+    , listDatabaseObjects
+    , loadDatabaseRows
+    , scopeForDatabase
+    )
 import Agent.CLI.Options (StorageCommand(..))
+import Agent.Store.Postgres
+    ( ManagedPostgresConfig(..)
+    , ManagedPostgresPaths(..)
+    , Store
+    , closeStore
+    , defaultManagedPostgresConfig
+    , openStore
+    , provisioningPool
+    , scopePool
+    , trustedPool
+    )
+import Agent.Store.Postgres.Connection (StorePool, storePool)
+import Agent.Store.Postgres.Custom
+    ( CustomAuditContext(..)
+    , CatalogColumn(..)
+    , CatalogDefinition(..)
+    , CatalogObject(..)
+    , defaultQueryLimits
+    , executeCustom
+    )
+import Agent.Store.Postgres.Managed (stopManagedPostgres)
+import Agent.Store.Postgres.Scope
+    ( ScopeDatabase(..)
+    , lookupScopeDatabase
+    , provisionScope
+    )
 import Agent.ToolDispatch
     ( ToolCallResult(..)
     , ToolDispatchConfig(..)
@@ -13,12 +45,20 @@ import Agent.Tools.Types
     ( appToolHandlers
     )
 import Agent.ToolDispatch (dispatchToolCall)
-import Control.Exception.Safe (displayException)
+import Control.Exception.Safe (displayException, finally, onException)
 import Data.Aeson (object, (.=))
 import qualified Data.Aeson as Aeson
 import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.Directory
+    ( createDirectory
+    , getCurrentDirectory
+    , getTemporaryDirectory
+    , removePathForcibly
+    )
+import System.FilePath ((</>))
+import System.Posix.Process (getProcessID)
 import Test.Hspec
 
 spec :: Spec
@@ -104,6 +144,31 @@ spec = do
                     "{\"query\":\"nothing\"}")
             result.output `shouldBe` "(no matching conversations)"
 
+    describe "native data browser store" do
+        it "does not provision on browse and returns typed table rows" $
+            withBrowserDirectories \stateDirectory socketDirectory -> do
+                let
+                    baseConfig =
+                        defaultManagedPostgresConfig stateDirectory ""
+                    config = baseConfig
+                        { postgresPaths = baseConfig.postgresPaths
+                            { postgresSocketDirectory = socketDirectory
+                            }
+                        }
+                    cleanup = do
+                        _ <- stopManagedPostgres config
+                        pure ()
+                (openStore config >>= \case
+                    Left err ->
+                        expectationFailure (
+                            "could not open store: " <> show err
+                        )
+                    Right store ->
+                        finally
+                            (exerciseDataBrowser store stateDirectory)
+                            (closeStore store)
+                    ) `finally` cleanup
+
     describe "runStorageCommand" do
         it "dispatches each administrative command to its store action" do
             let env = StorageCommandEnv
@@ -137,6 +202,146 @@ spec = do
                 "/tmp/haskell-agent-state"
                 "/tmp/haskell-agent-checkout-b"
             first `shouldNotBe` second
+
+withBrowserDirectories
+    :: (FilePath -> FilePath -> IO value)
+    -> IO value
+withBrowserDirectories action = do
+    currentDirectory <- getCurrentDirectory
+    temporaryDirectory <- getTemporaryDirectory
+    processId <- getProcessID
+    let
+        suffix = show processId
+        stateDirectory = currentDirectory </> (".ha-db-" <> suffix)
+        socketDirectory = temporaryDirectory </> ("s" <> suffix)
+    createDirectory stateDirectory
+    createDirectory socketDirectory
+        `onException` removePathForcibly stateDirectory
+    action stateDirectory socketDirectory
+        `finally`
+            (removePathForcibly stateDirectory
+                `finally` removePathForcibly socketDirectory)
+
+exerciseDataBrowser :: Store -> FilePath -> IO ()
+exerciseDataBrowser store stateDirectory =
+    deriveDatabaseScopes stateDirectory stateDirectory >>= \case
+        Left err ->
+            expectationFailure (
+                "could not derive database scopes: " <> Text.unpack err
+            )
+        Right scopes -> do
+            let
+                scope =
+                    scopeForDatabase scopes DatabaseRepositoryScope
+                provisionPool = storePool (provisioningPool store)
+            lookupScopeDatabase provisionPool scope
+                `shouldReturn` Right Nothing
+            listDatabaseObjects
+                store scopes DatabaseRepositoryScope
+                `shouldReturn` Right []
+            lookupScopeDatabase provisionPool scope
+                `shouldReturn` Right Nothing
+
+            provisionScope provisionPool scope >>= \case
+                Left err ->
+                    expectationFailure (
+                        "could not provision scope: " <> Text.unpack err
+                    )
+                Right database ->
+                    scopePool store database.scopeDatabaseRole >>= \case
+                        Left err ->
+                            expectationFailure (
+                                "could not open scope pool: " <> show err
+                            )
+                        Right scoped -> do
+                            let
+                                audit = CustomAuditContext
+                                    { customAuditSessionId = Nothing
+                                    , customAuditAgentId = Nothing
+                                    }
+                            seedBrowserTable store scoped database audit
+
+                            objects <- listDatabaseObjects
+                                store scopes DatabaseRepositoryScope
+                            assertBrowserCatalog objects
+
+                            loadDatabaseRows
+                                store
+                                scopes
+                                DatabaseRepositoryScope
+                                "notes"
+                                0
+                                500
+                                >>= assertDataPage
+                            loadDatabaseRows
+                                store
+                                scopes
+                                DatabaseRepositoryScope
+                                "notes"
+                                1
+                                500
+                                `shouldReturn`
+                                    Left "data preview offset must be zero"
+
+seedBrowserTable
+    :: Store
+    -> StorePool
+    -> ScopeDatabase
+    -> CustomAuditContext
+    -> IO ()
+seedBrowserTable store scoped database audit =
+    executeCustom
+        (storePool (trustedPool store))
+        (storePool scoped)
+        database
+        audit
+        defaultQueryLimits
+        "test native data browser"
+        "CREATE TABLE notes (\
+        \ id bigint PRIMARY KEY,\
+        \ title text NOT NULL,\
+        \ done boolean NOT NULL,\
+        \ metadata jsonb);\
+        \ INSERT INTO notes VALUES\
+        \ (1, 'first', true, '{\"priority\":2}'::jsonb)"
+        >>= \case
+            Left err ->
+                expectationFailure (
+                    "could not seed browser table: " <> Text.unpack err
+                )
+            Right _ -> pure ()
+
+assertBrowserCatalog :: Either Text [CatalogObject] -> IO ()
+assertBrowserCatalog = \case
+    Left err ->
+        expectationFailure (
+            "could not list browser tables: " <> Text.unpack err
+        )
+    Right [object] -> do
+        object.catalogObjectName `shouldBe` "notes"
+        map (.columnName)
+            object.catalogObjectDefinition.definitionColumns
+            `shouldBe` ["id", "title", "done", "metadata"]
+    Right unexpected ->
+        expectationFailure (
+            "unexpected browser catalog: " <> show unexpected
+        )
+
+assertDataPage :: Either Text DatabaseBrowsePage -> IO ()
+assertDataPage = \case
+    Left err ->
+        expectationFailure (
+            "could not load browser rows: " <> Text.unpack err
+        )
+    Right page -> do
+        page.databaseBrowseHasMore `shouldBe` False
+        page.databaseBrowseRows `shouldBe`
+            [ [ Aeson.Number 1
+              , Aeson.String "first"
+              , Aeson.Bool True
+              , object ["priority" .= (2 :: Int)]
+              ]
+            ]
 
 testEnv :: DatabaseToolsEnv
 testEnv = DatabaseToolsEnv

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -11,9 +11,14 @@ foreign import ccall "ha_image_attachment_abi_smoke"
 foreign import ccall "ha_gateway_abi_smoke"
     gatewayAbiSmoke :: IO CInt
 
+foreign import ccall "ha_data_browser_abi_smoke"
+    dataBrowserAbiSmoke :: IO CInt
+
 spec :: Spec
 spec = describe "native image attachment ABI" do
     it "preserves the documented image struct layout and ordered buffers" do
         imageAttachmentAbiSmoke `shouldReturn` 0
     it "preserves typed gateway callbacks and synchronous validation" do
         gatewayAbiSmoke `shouldReturn` 0
+    it "preserves typed data-browser callbacks and synchronous validation" do
+        dataBrowserAbiSmoke `shouldReturn` 0

--- a/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-cli/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -100,6 +100,66 @@ int ha_gateway_abi_smoke(void) {
     return 0;
 }
 
+/*
+ * Compile the typed data-browser callbacks and validate that both entry points
+ * reject a missing callback and non-zero preview offsets synchronously,
+ * without opening PostgreSQL.
+ */
+static void data_rows_callback(
+        void *context, int32_t status, int64_t offset, int64_t row_index,
+        int32_t column_index, int32_t value_kind, const uint8_t *value,
+        size_t value_length, int64_t row_count, int32_t has_more,
+        const uint8_t *error, size_t error_length) {
+    (void)context;
+    (void)status;
+    (void)offset;
+    (void)row_index;
+    (void)column_index;
+    (void)value_kind;
+    (void)value;
+    (void)value_length;
+    (void)row_count;
+    (void)has_more;
+    (void)error;
+    (void)error_length;
+}
+
+int ha_data_browser_abi_smoke(void) {
+    ha_data_catalog_callback catalog_callback = NULL;
+    ha_data_rows_callback rows_callback = NULL;
+    const uint8_t object_name[] = "example";
+
+    if (HA_DATA_SCOPE_USER != 0 || HA_DATA_SCOPE_REPOSITORY != 1
+            || HA_DATA_SCOPE_CHECKOUT != 2
+            || HA_DATA_CATALOG_OBJECT != 0
+            || HA_DATA_CATALOG_COLUMN != 1
+            || HA_DATA_CATALOG_COMPLETE != 2
+            || HA_DATA_CATALOG_ERROR != -1
+            || HA_DATA_OBJECT_TABLE != 0 || HA_DATA_OBJECT_VIEW != 1
+            || HA_DATA_ROWS_VALUE != 0 || HA_DATA_ROWS_COMPLETE != 1
+            || HA_DATA_ROWS_ERROR != -1
+            || HA_DATA_VALUE_NULL != 0 || HA_DATA_VALUE_TEXT != 1
+            || HA_DATA_VALUE_NUMBER != 2 || HA_DATA_VALUE_BOOLEAN != 3
+            || HA_DATA_VALUE_JSON != 4) {
+        return 30;
+    }
+    if (ha_data_catalog_list(NULL, 0, catalog_callback, NULL) != 1) {
+        return 31;
+    }
+    if (ha_data_rows_load(
+            NULL, 0, HA_DATA_SCOPE_USER, NULL, 0, 0, 100,
+            rows_callback, NULL) != 1) {
+        return 32;
+    }
+    if (ha_data_rows_load(
+            NULL, 0, HA_DATA_SCOPE_USER,
+            object_name, sizeof(object_name) - 1, 1, 100,
+            data_rows_callback, NULL) != 3) {
+        return 33;
+    }
+    return 0;
+}
+
 static void image_stage_callback(void *context, const uint8_t *bytes,
                                  size_t length) {
     (void)context;


### PR DESCRIPTION
## Summary

- add narrow typed native callbacks for listing database objects and loading table/view rows
- keep browsing read-only, catalog-resolved, and bounded to a 500-row preview
- return typed null, text, number, boolean, and JSON values without provisioning missing scopes
- cover the Postgres behavior and C callback ABI

## Verification

- native data browser store: 1 example, 0 failures
- native browser callback ABI: 7 examples, 0 failures
- native image/data callback ABI smoke tests: 3 examples, 0 failures