### PR TITLE
Avoid false stale worktree cleanup warnings

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -242,7 +242,8 @@ releaseWorktreeLease (WorktreeLease lock) = do
 -- untracked changes, have no active lease, and have a HEAD reachable from
 -- another local branch, remote-tracking branch, or tag. Removal deliberately
 -- omits @--force@. The generated branch is then deleted with @-d@, leaving it
--- intact whenever Git's own merged-branch check is stricter than ours.
+-- intact without treating that data-safe fallback as a cleanup failure
+-- whenever Git's own merged-branch check is stricter than ours.
 -- Worktrees created on the current UTC day are never considered stale; this
 -- also closes the interval between checkout creation and lease acquisition.
 cleanupStaleWorktrees
@@ -377,7 +378,14 @@ cleanupCandidate root candidate = do
                                 { cleanupFailures = [(candidate, err)]
                                 }
                         Right _ -> do
-                            deleted <- git commonDir
+                            -- The worktree is the resource governed by the
+                            -- retention policy. Branch deletion is best
+                            -- effort: @-d@ can reject a branch that is known
+                            -- to be reachable from another ref but is not
+                            -- merged into the repository's current branch.
+                            -- Retaining it is safe and should not surface as
+                            -- a startup warning.
+                            _ <- git commonDir
                                 [ "branch"
                                 , "-d"
                                 , "--"
@@ -385,12 +393,7 @@ cleanupCandidate root candidate = do
                                 ]
                             pure WorktreeCleanupReport
                                 { cleanupRemoved = [candidate]
-                                , cleanupFailures = case deleted of
-                                    Left err ->
-                                        [(candidate,
-                                            "worktree removed but branch retained: "
-                                                <> err)]
-                                    Right _ -> []
+                                , cleanupFailures = []
                                 }
 
 inspectCleanupCandidate

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -253,6 +253,28 @@ spec = describe "Agent.CLI.Worktree" do
                 git repo ["branch", "--list", "2026-08-20-00000001"]
                     `shouldReturn` ""
 
+        it "does not warn when Git conservatively retains the generated branch" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                    branch = "2026-08-20-00000001"
+                older <- addManagedWorktree repo root branch
+                _ <- addManagedWorktree repo root "2026-08-21-00000002"
+                writeFile
+                    (toFilePath (older </> fromFilePath "README"))
+                    "reachable elsewhere\n"
+                _ <- git older ["add", "README"]
+                _ <- git older ["commit", "-m", "reachable work"]
+                _ <- git older ["branch", "retained-copy"]
+
+                report <- cleanupStaleWorktrees root 1 []
+
+                report.cleanupRemoved `shouldBe` [older]
+                report.cleanupFailures `shouldBe` []
+                doesDirectoryExist older `shouldReturn` False
+                git repo ["branch", "--list", branch]
+                    `shouldReturn` branch
+
         it "preserves stale worktrees with uncommitted files" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do


### PR DESCRIPTION
## Summary

- stop reporting a safely retained generated branch as a stale-worktree cleanup failure after its checkout was removed
- keep conservative `git branch -d` behavior instead of force-deleting unmerged branches
- cover the mismatch between reachability from another ref and Git's current-branch merge check

## Testing

- targeted `Agent.CLI.WorktreeSpec` suite in GHCi: 21 examples, 0 failures
- `git diff --check`
- live CLI startup smoke test in tmux
