### PR TITLE
Add platform gateway login to /login

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -35,7 +35,7 @@ slashCommands =
     , cmd "afk" [] "/afk [HOST:PATH]" "Move this session into tmux, locally or over SSH" True
     , cmd "worktree" [] "/worktree" "Start a fresh session in a new git worktree" False
     , cmd "rename" ["title"] "/rename <TITLE>|--auto" "Rename the current session, or restore automatic titles" True
-    , cmd "login" ["accounts"] "/login" "Manage provider credentials and usage" False
+    , cmd "login" ["accounts"] "/login" "Log in to the platform or manage provider accounts" False
     , cmd "resume" [] "/resume [ID]" "Pick a session to resume, or resume ID" True
     , cmd "home" ["welcome"] "/home" "Return to the session picker" False
     , cmd "search" [] "/search <QUERY>" "Search past conversations and resume a match" True

--- a/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
@@ -6,6 +6,7 @@ module Agent.CLI.GatewayClient
     , GatewayDeviceAuthorization(..)
     , GatewayPollResult(..)
     , connectGatewayBrowser
+    , connectGatewayBrowserWithCancel
     , defaultGatewayBaseUrl
     , gatewayAuthorizationCodeDecoder
     , gatewayAuthorizationUrl
@@ -38,6 +39,8 @@ import Agent.Json.Decode qualified as Hermes
 import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
 import Agent.OsPath (unsafeToFilePath)
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (race)
+import Control.Concurrent.STM (atomically, retry)
 import Control.Exception.Safe (bracket, bracketOnError, tryAny)
 import Control.Monad (when)
 import Crypto.Hash (Digest, SHA256, hash)
@@ -374,6 +377,23 @@ connectGatewayBrowser
     -> (Text -> IO Bool)
     -> IO (Either Text ())
 connectGatewayBrowser rawBaseUrl rawClientName present =
+    connectGatewayBrowserWithCancel
+        rawBaseUrl
+        rawClientName
+        present
+        (atomically retry)
+
+-- | Browser authorization with an explicit cancellation signal. Callers that
+-- own an interactive prompt can complete the supplied action to stop waiting
+-- for the loopback callback without waiting for the five-minute timeout.
+connectGatewayBrowserWithCancel
+    :: Text
+    -> Text
+    -> (Text -> IO Bool)
+    -> IO ()
+    -> IO (Either Text ())
+connectGatewayBrowserWithCancel
+    rawBaseUrl rawClientName present waitForCancellation =
     case validateBaseUrl rawBaseUrl of
         Left err -> pure (Left err)
         Right baseUrl -> do
@@ -410,15 +430,21 @@ connectGatewayBrowser rawBaseUrl rawClientName present =
                         callback <-
                             timeout
                                 gatewayBrowserTimeoutMicroseconds
-                                (receiveGatewayAuthorizationCallback
-                                    listener state)
+                                (race
+                                    waitForCancellation
+                                    (receiveGatewayAuthorizationCallback
+                                        listener state))
                         case callback of
                             Nothing ->
                                 pure
                                     (Left
                                         "Gateway browser authorization timed out.")
-                            Just (Left err) -> pure (Left err)
-                            Just (Right authorizationCode) ->
+                            Just (Left ()) ->
+                                pure
+                                    (Left
+                                        "Gateway browser authorization was cancelled.")
+                            Just (Right (Left err)) -> pure (Left err)
+                            Just (Right (Right authorizationCode)) ->
                                 exchangeGatewayAuthorizationCode
                                     baseUrl
                                     redirectUri

--- a/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayClient.hs
@@ -2,8 +2,18 @@
 module Agent.CLI.GatewayClient
     ( GatewayCredential(..)
     , GatewayAuthorization(..)
+    , GatewayAuthorizationCodeResponse(..)
     , GatewayDeviceAuthorization(..)
     , GatewayPollResult(..)
+    , connectGatewayBrowser
+    , defaultGatewayBaseUrl
+    , gatewayAuthorizationCodeDecoder
+    , gatewayAuthorizationUrl
+    , gatewayBrowserClientId
+    , gatewayBrowserRedirectPath
+    , gatewayPkceChallenge
+    , validateGatewayAuthorizationCallback
+    , validateGatewayAuthorizationCodeResponse
     , startGatewayAuthorization
     , pollGatewayAuthorization
     , saveGatewayCredential
@@ -28,22 +38,56 @@ import Agent.Json.Decode qualified as Hermes
 import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
 import Agent.OsPath (unsafeToFilePath)
 import Control.Concurrent (threadDelay)
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (bracket, bracketOnError, tryAny)
 import Control.Monad (when)
+import Crypto.Hash (Digest, SHA256, hash)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as AesonTypes
+import Data.ByteArray qualified as ByteArray
+import Data.ByteString qualified as BS
+import Data.ByteString.Base64.URL qualified as Base64Url
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as LBS
+import Data.Char (isDigit)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TextEncoding
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.TLS (newTlsManager)
-import Network.HTTP.Types (hContentType)
+import Network.HTTP.Types
+    ( hContentType
+    , statusCode
+    , statusIsSuccessful
+    )
+import Network.HTTP.Types.URI (parseQueryText, renderQueryText)
 import Network.URI qualified as URI
+import Network.Socket
+    ( Family(AF_INET)
+    , SockAddr(SockAddrInet)
+    , Socket
+    , SocketOption(ReuseAddr)
+    , SocketType(Stream)
+    , accept
+    , bind
+    , close
+    , defaultProtocol
+    , getSocketName
+    , listen
+    , setSocketOption
+    , socket
+    , tupleToHostAddress
+    )
+import Network.Socket.ByteString qualified as Socket
 import System.Directory.OsPath qualified as Directory
+import System.Entropy (getEntropy)
 import System.Exit (ExitCode (..))
 import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
 import System.Process (rawSystem)
+import System.Timeout (timeout)
+import Text.Read (readMaybe)
 
 data GatewayCredential = GatewayCredential
     { gatewayBaseUrl :: !Text
@@ -51,6 +95,18 @@ data GatewayCredential = GatewayCredential
     , gatewayAccessToken :: !Text
     }
     deriving (Eq)
+
+-- | The hosted gateway selected by the interactive @/login@ flow.
+defaultGatewayBaseUrl :: Text
+defaultGatewayBaseUrl = "https://platform.digitallyinduced.com"
+
+-- | Public OAuth client registered for the terminal application's loopback
+-- Authorization Code + PKCE flow.
+gatewayBrowserClientId :: Text
+gatewayBrowserClientId = "haskell-agent-cli"
+
+gatewayBrowserRedirectPath :: Text
+gatewayBrowserRedirectPath = "/oauth2callback"
 
 -- | A validated gateway base URL paired with its short-lived device flow.
 --
@@ -84,6 +140,34 @@ instance Aeson.ToJSON GatewayCredential where
             , "websocket_url" .= credential.gatewayWebSocketUrl
             , "access_token" .= credential.gatewayAccessToken
             ]
+
+data GatewayAuthorizationCodeResponse = GatewayAuthorizationCodeResponse
+    { authorizationAccessToken :: !Text
+    , authorizationTokenType :: !Text
+    , authorizationResponseBaseUrl :: !Text
+    , authorizationWebSocketUrl :: !Text
+    }
+    deriving (Eq)
+
+instance Show GatewayAuthorizationCodeResponse where
+    show response =
+        "GatewayAuthorizationCodeResponse"
+            <> " { authorizationAccessToken = <redacted>"
+            <> ", authorizationTokenType = "
+            <> show response.authorizationTokenType
+            <> ", authorizationResponseBaseUrl = "
+            <> show response.authorizationResponseBaseUrl
+            <> ", authorizationWebSocketUrl = <redacted> }"
+
+gatewayAuthorizationCodeDecoder
+    :: Hermes.Decoder GatewayAuthorizationCodeResponse
+gatewayAuthorizationCodeDecoder =
+    Hermes.object $
+        GatewayAuthorizationCodeResponse
+            <$> Hermes.atKey "access_token" Hermes.text
+            <*> Hermes.atKey "token_type" Hermes.text
+            <*> Hermes.atKey "base_url" Hermes.text
+            <*> Hermes.atKey "websocket_url" Hermes.text
 
 gatewayCredentialDecoder :: Hermes.Decoder GatewayCredential
 gatewayCredentialDecoder =
@@ -280,6 +364,232 @@ openGatewayAuthorizationPage =
         . (.verificationUriComplete)
         . (.authorizationDevice)
 
+-- | Complete the hosted gateway's browser OAuth flow through a loopback
+-- callback. The injected presenter normally opens the URL in the user's
+-- browser; keeping it injectable makes the network-independent contract
+-- testable and lets interactive callers choose their own presentation.
+connectGatewayBrowser
+    :: Text
+    -> Text
+    -> (Text -> IO Bool)
+    -> IO (Either Text ())
+connectGatewayBrowser rawBaseUrl rawClientName present =
+    case validateBaseUrl rawBaseUrl of
+        Left err -> pure (Left err)
+        Right baseUrl -> do
+            attempted <-
+                tryAny $
+                    bracket openGatewayCallbackSocket close $
+                        runBrowserFlow baseUrl
+            pure case attempted of
+                Left _ ->
+                    Left
+                        "Gateway browser authorization failed unexpectedly."
+                Right result -> result
+  where
+    runBrowserFlow baseUrl listener = do
+        redirectUri <- gatewayLoopbackRedirectUri listener
+        verifier <- randomUrlText 32
+        state <- randomUrlText 32
+        case
+            gatewayAuthorizationUrl
+                baseUrl
+                redirectUri
+                state
+                (gatewayPkceChallenge verifier)
+                rawClientName of
+            Left err -> pure (Left err)
+            Right authorizationUrl -> do
+                presented <- present authorizationUrl
+                if not presented
+                    then
+                        pure
+                            (Left
+                                "Could not open the gateway authorization page.")
+                    else do
+                        callback <-
+                            timeout
+                                gatewayBrowserTimeoutMicroseconds
+                                (receiveGatewayAuthorizationCallback
+                                    listener state)
+                        case callback of
+                            Nothing ->
+                                pure
+                                    (Left
+                                        "Gateway browser authorization timed out.")
+                            Just (Left err) -> pure (Left err)
+                            Just (Right authorizationCode) ->
+                                exchangeGatewayAuthorizationCode
+                                    baseUrl
+                                    redirectUri
+                                    verifier
+                                    authorizationCode
+                                    >>= \case
+                                        Left err -> pure (Left err)
+                                        Right response ->
+                                            case
+                                                validateGatewayAuthorizationCodeResponse
+                                                    baseUrl response of
+                                                Left err -> pure (Left err)
+                                                Right credential ->
+                                                    saveGatewayCredential
+                                                        credential
+
+gatewayBrowserTimeoutMicroseconds :: Int
+gatewayBrowserTimeoutMicroseconds = 5 * 60 * 1_000_000
+
+-- | Construct the registered authorization request. The redirect is accepted
+-- only when it is an IPv4 loopback URI with the exact callback path.
+gatewayAuthorizationUrl
+    :: Text
+    -> Text
+    -> Text
+    -> Text
+    -> Text
+    -> Either Text Text
+gatewayAuthorizationUrl
+    rawBaseUrl redirectUri state challenge rawClientName = do
+        baseUrl <- validateBaseUrl rawBaseUrl
+        validateGatewayLoopbackRedirectUri redirectUri
+        whenEither
+            ( Text.length state < 32
+                || Text.length state > 200
+                || not (Text.all isPkceCharacter state)
+            )
+            "Gateway OAuth state is invalid."
+        whenEither
+            ( Text.length challenge /= 43
+                || not (Text.all isBase64UrlCharacter challenge)
+            )
+            "Gateway PKCE challenge is invalid."
+        whenEither
+            (Text.null clientName || Text.length clientName > 160)
+            "Gateway client name must contain between 1 and 160 characters."
+        pure $
+            baseUrl
+                <> "/connect/agent/authorize"
+                <> query
+  where
+    clientName = Text.strip rawClientName
+    query =
+        TextEncoding.decodeUtf8 $
+            LBS.toStrict $
+                Builder.toLazyByteString $
+                    renderQueryText
+                        True
+                        [ ("response_type", Just "code")
+                        , ("client_id", Just gatewayBrowserClientId)
+                        , ("redirect_uri", Just redirectUri)
+                        , ("state", Just state)
+                        , ("code_challenge", Just challenge)
+                        , ("code_challenge_method", Just "S256")
+                        , ("client_name", Just clientName)
+                        ]
+
+gatewayPkceChallenge :: Text -> Text
+gatewayPkceChallenge =
+    TextEncoding.decodeUtf8
+        . Base64Url.encodeUnpadded
+        . ByteArray.convert
+        . (hash :: BS.ByteString -> Digest SHA256)
+        . TextEncoding.encodeUtf8
+
+-- | Validate a complete HTTP callback request and return only the one-time
+-- authorization code. Method, path, singleton state, and state value are
+-- checked before an OAuth error or code is accepted.
+validateGatewayAuthorizationCallback
+    :: Text
+    -> BS.ByteString
+    -> Either Text Text
+validateGatewayAuthorizationCallback expectedState request = do
+    target <- case BS8.words requestLine of
+        method : rawTarget : _
+            | method == "GET" -> Right rawTarget
+            | otherwise -> Left "Gateway OAuth callback must use GET."
+        _ -> Left "Gateway OAuth callback request is malformed."
+    let (path, rawQuery) = BS.break (== 63) target
+    whenEither
+        (path /= TextEncoding.encodeUtf8 gatewayBrowserRedirectPath)
+        "Gateway OAuth callback path is invalid."
+    whenEither
+        (BS.null rawQuery)
+        "Gateway OAuth callback query is missing."
+    state <- singletonParameter "state" parameters
+        >>= maybe
+            (Left "Gateway OAuth callback state is missing.")
+            Right
+    whenEither
+        (state /= expectedState)
+        "Gateway OAuth callback state mismatch."
+    case singletonParameter "error" parameters of
+        Left err -> Left err
+        Right (Just oauthError) ->
+            Left
+                ("Gateway authorization was not granted"
+                    <> safeOAuthErrorSuffix oauthError)
+        Right Nothing -> do
+            code <- singletonParameter "code" parameters
+                >>= maybe
+                    (Left
+                        "Gateway OAuth callback authorization code is missing.")
+                    Right
+            whenEither
+                (Text.null code || Text.length code > 4096)
+                "Gateway OAuth callback authorization code is invalid."
+            pure code
+  where
+    requestLine = BS8.takeWhile (/= '\r') request
+    parameters = parseQueryText (BS.drop 1 rawQueryBytes)
+    (_, rawQueryBytes) =
+        case BS8.words requestLine of
+            _ : target : _ -> BS.break (== 63) target
+            _ -> ("", "")
+
+validateGatewayAuthorizationCodeResponse
+    :: Text
+    -> GatewayAuthorizationCodeResponse
+    -> Either Text GatewayCredential
+validateGatewayAuthorizationCodeResponse rawRequestedBaseUrl response = do
+    requestedBaseUrl <- validateBaseUrl rawRequestedBaseUrl
+    responseBaseUrl <-
+        validateBaseUrl response.authorizationResponseBaseUrl
+    requestedOrigin <-
+        parseGatewayOrigin
+            "Gateway URL is invalid."
+            requestedBaseUrl
+    responseOrigin <-
+        parseGatewayOrigin
+            "The gateway returned an invalid base URL."
+            responseBaseUrl
+    whenEither
+        (response.authorizationTokenType /= "Bearer")
+        "The gateway returned an unsupported token type."
+    whenEither
+        (requestedOrigin /= responseOrigin)
+        "The gateway returned a credential for a different origin."
+    websocketOrigin <-
+        parseGatewayOrigin
+            "The gateway returned an invalid WebSocket URL."
+            response.authorizationWebSocketUrl
+    let expectedWebSocketOrigin =
+            case responseOrigin of
+                ("https:", host, port) -> ("wss:", host, port)
+                ("http:", host, port) -> ("ws:", host, port)
+                origin -> origin
+    whenEither
+        (websocketOrigin /= expectedWebSocketOrigin)
+        "The gateway returned a WebSocket URL for a different origin."
+    let credential =
+            GatewayCredential
+                { gatewayBaseUrl = responseBaseUrl
+                , gatewayWebSocketUrl =
+                    response.authorizationWebSocketUrl
+                , gatewayAccessToken =
+                    response.authorizationAccessToken
+                }
+    validateGatewayCredential credential
+    pure credential
+
 connectGateway :: Text -> IO ()
 connectGateway rawBaseUrl = do
     authorization <-
@@ -402,11 +712,320 @@ postJson manager url payload decoder = do
                             }
                         manager
             pure case response of
-                Left exception -> Left (Text.pack (show exception))
+                Left _ ->
+                    Left "Could not reach the gateway authorization endpoint."
                 Right value ->
                     case Hermes.decodeEither decoder (LBS.toStrict (HTTP.responseBody value)) of
                         Left err -> Left (Hermes.jsonErrorMessage err)
                         Right decoded -> Right decoded
+
+exchangeGatewayAuthorizationCode
+    :: Text
+    -> Text
+    -> Text
+    -> Text
+    -> IO (Either Text GatewayAuthorizationCodeResponse)
+exchangeGatewayAuthorizationCode
+    baseUrl redirectUri verifier authorizationCode = do
+        manager <- newTlsManager
+        postGatewayOAuthForm
+            manager
+            (baseUrl <> "/api/v1/agent-connections/oauth/token")
+            [ ("grant_type", "authorization_code")
+            , ("client_id", gatewayBrowserClientId)
+            , ("code", authorizationCode)
+            , ("code_verifier", verifier)
+            , ("redirect_uri", redirectUri)
+            ]
+
+postGatewayOAuthForm
+    :: HTTP.Manager
+    -> Text
+    -> [(Text, Text)]
+    -> IO (Either Text GatewayAuthorizationCodeResponse)
+postGatewayOAuthForm manager url fields = do
+    parsed <- tryAny (HTTP.parseRequest (Text.unpack url))
+    case parsed of
+        Left _ ->
+            pure (Left "Could not prepare the gateway token request.")
+        Right initial -> do
+            response <-
+                tryAny $
+                    HTTP.httpLbs
+                        initial
+                            { HTTP.method = "POST"
+                            , HTTP.requestHeaders =
+                                [ ( hContentType
+                                  , "application/x-www-form-urlencoded"
+                                  )
+                                ]
+                            , HTTP.requestBody =
+                                HTTP.RequestBodyLBS $
+                                    Builder.toLazyByteString $
+                                        renderQueryText
+                                            False
+                                            (fmap
+                                                (\(name, value) ->
+                                                    (name, Just value))
+                                                fields)
+                            , HTTP.checkResponse = \_ _ -> pure ()
+                            , HTTP.redirectCount = 0
+                            , HTTP.responseTimeout =
+                                HTTP.responseTimeoutMicro (30 * 1_000_000)
+                            }
+                        manager
+            pure case response of
+                Left _ ->
+                    Left "Could not reach the gateway OAuth token endpoint."
+                Right value
+                    | statusIsSuccessful (HTTP.responseStatus value) ->
+                        case Hermes.decodeEither
+                            gatewayAuthorizationCodeDecoder
+                            (LBS.toStrict (HTTP.responseBody value)) of
+                            Left _ ->
+                                Left
+                                    "The gateway returned an invalid authorization response."
+                            Right decoded -> Right decoded
+                    | otherwise ->
+                        Left $
+                            gatewayOAuthResponseError
+                                (statusCode (HTTP.responseStatus value))
+                                (HTTP.responseBody value)
+
+gatewayOAuthResponseError :: Int -> LBS.ByteString -> Text
+gatewayOAuthResponseError responseStatus body =
+    "Gateway authorization failed"
+        <> maybe
+            (" (HTTP " <> Text.pack (show responseStatus) <> ").")
+            (<> ".")
+            (safeOAuthErrorCode body)
+
+safeOAuthErrorCode :: LBS.ByteString -> Maybe Text
+safeOAuthErrorCode body = do
+    value <- Aeson.decode body
+    rawCode <- case value of
+        Aeson.Object object ->
+            AesonTypes.parseMaybe
+                (\fields -> fields Aeson..: "error")
+                object
+        _ -> Nothing
+    let code = Text.take 64 (Text.strip rawCode)
+    if Text.null code
+        || not
+            (Text.all
+                (\character ->
+                    isAsciiAlphaNumeric character
+                        || character `elem` ("_-" :: String))
+                code)
+        then Nothing
+        else Just (": " <> code)
+
+openGatewayCallbackSocket :: IO Socket
+openGatewayCallbackSocket =
+    bracketOnError
+        (socket AF_INET Stream defaultProtocol)
+        close
+        \listener -> do
+            setSocketOption listener ReuseAddr 1
+            bind listener
+                (SockAddrInet 0 (tupleToHostAddress (127, 0, 0, 1)))
+            listen listener 1
+            pure listener
+
+gatewayLoopbackRedirectUri :: Socket -> IO Text
+gatewayLoopbackRedirectUri listener =
+    getSocketName listener >>= \case
+        SockAddrInet port _ ->
+            pure
+                ("http://127.0.0.1:"
+                    <> Text.pack (show port)
+                    <> gatewayBrowserRedirectPath)
+        _ -> failText "Gateway OAuth callback did not bind IPv4 loopback."
+
+receiveGatewayAuthorizationCallback
+    :: Socket
+    -> Text
+    -> IO (Either Text Text)
+receiveGatewayAuthorizationCallback listener expectedState =
+    bracket (fst <$> accept listener) close \connection -> do
+        request <- receiveGatewayCallbackHeaders connection
+        let result =
+                request >>= validateGatewayAuthorizationCallback expectedState
+            page = gatewayCallbackPage result
+            response =
+                "HTTP/1.1 200 OK\r\n\
+                \Content-Type: text/html; charset=utf-8\r\n\
+                \Cache-Control: no-store\r\n\
+                \Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'\r\n\
+                \X-Content-Type-Options: nosniff\r\n\
+                \Connection: close\r\n\
+                \Content-Length: "
+                    <> BS8.pack (show (BS.length page))
+                    <> "\r\n\r\n"
+                    <> page
+        Socket.sendAll connection response
+        pure result
+
+receiveGatewayCallbackHeaders
+    :: Socket
+    -> IO (Either Text BS.ByteString)
+receiveGatewayCallbackHeaders connection = go BS.empty
+  where
+    maximumHeaderBytes = 16_384
+    delimiter = "\r\n\r\n"
+
+    go accumulated
+        | delimiter `BS.isInfixOf` accumulated =
+            pure (Right accumulated)
+        | BS.length accumulated >= maximumHeaderBytes =
+            pure (Left "Gateway OAuth callback headers were too large.")
+        | otherwise = do
+            chunk <-
+                Socket.recv
+                    connection
+                    (maximumHeaderBytes - BS.length accumulated)
+            if BS.null chunk
+                then
+                    pure
+                        (Left
+                            "Gateway OAuth callback closed before sending headers.")
+                else go (accumulated <> chunk)
+
+gatewayCallbackPage :: Either Text Text -> BS.ByteString
+gatewayCallbackPage result =
+    TextEncoding.encodeUtf8 $
+        "<!doctype html><html><head><meta charset=\"utf-8\">\
+        \<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\
+        \<title>Haskell Agent</title></head>\
+        \<body style=\"font-family:system-ui;margin:3rem;max-width:40rem\">\
+        \<h1>"
+            <> title
+            <> "</h1><p>"
+            <> message
+            <> "</p></body></html>"
+  where
+    (title, message) = case result of
+        Right _ ->
+            ( "Authorization received"
+            , "Return to Haskell Agent while it finishes connecting."
+            )
+        Left _ ->
+            ( "Haskell Agent could not connect"
+            , "Return to Haskell Agent to see the error and try again."
+            )
+
+validateGatewayLoopbackRedirectUri :: Text -> Either Text ()
+validateGatewayLoopbackRedirectUri raw =
+    case URI.parseURI (Text.unpack raw) of
+        Just uri
+            | URI.uriScheme uri == "http:"
+            , Just authority <- URI.uriAuthority uri
+            , null (URI.uriUserInfo authority)
+            , URI.uriRegName authority == "127.0.0.1"
+            , validPort (URI.uriPort authority)
+            , Text.pack (URI.uriPath uri) == gatewayBrowserRedirectPath
+            , null (URI.uriQuery uri)
+            , null (URI.uriFragment uri) ->
+                Right ()
+        _ -> Left "Gateway OAuth redirect URI is invalid."
+  where
+    validPort (':' : digits) =
+        not (null digits)
+            && all isDigit digits
+            && case readMaybe digits of
+                Just port -> port > (0 :: Int) && port <= 65535
+                Nothing -> False
+    validPort _ = False
+
+singletonParameter
+    :: Text
+    -> [(Text, Maybe Text)]
+    -> Either Text (Maybe Text)
+singletonParameter name parameters =
+    case [value | (key, value) <- parameters, key == name] of
+        [] -> Right Nothing
+        [Just value] -> Right (Just value)
+        _ ->
+            Left
+                ("Gateway OAuth callback contains duplicate or invalid "
+                    <> name <> " parameters.")
+
+safeOAuthErrorSuffix :: Text -> Text
+safeOAuthErrorSuffix raw =
+    let value = Text.take 64 (Text.strip raw)
+    in if Text.null value
+        || not
+            (Text.all
+                (\character ->
+                    isAsciiAlphaNumeric character
+                        || character `elem` ("_-" :: String))
+                value)
+        then "."
+        else ": " <> value <> "."
+
+randomUrlText :: Int -> IO Text
+randomUrlText byteCount =
+    TextEncoding.decodeUtf8
+        . Base64Url.encodeUnpadded
+        <$> getEntropy byteCount
+
+isAsciiAlphaNumeric :: Char -> Bool
+isAsciiAlphaNumeric character =
+    character >= 'a' && character <= 'z'
+        || character >= 'A' && character <= 'Z'
+        || character >= '0' && character <= '9'
+
+isBase64UrlCharacter :: Char -> Bool
+isBase64UrlCharacter character =
+    isAsciiAlphaNumeric character || character `elem` ("-_" :: String)
+
+isPkceCharacter :: Char -> Bool
+isPkceCharacter character =
+    isBase64UrlCharacter character
+        || character `elem` (".~" :: String)
+
+parseGatewayOrigin
+    :: Text
+    -> Text
+    -> Either Text (Text, Text, Int)
+parseGatewayOrigin errorMessage raw = do
+    uri <-
+        maybe (Left errorMessage) Right $
+            URI.parseURI (Text.unpack (Text.strip raw))
+    authority <-
+        maybe (Left errorMessage) Right (URI.uriAuthority uri)
+    let scheme = Text.toLower (Text.pack (URI.uriScheme uri))
+        host = Text.toLower (Text.pack (URI.uriRegName authority))
+    whenEither
+        ( not (null (URI.uriUserInfo authority))
+            || Text.null host
+            || not (null (URI.uriQuery uri))
+            || not (null (URI.uriFragment uri))
+        )
+        errorMessage
+    port <- gatewayOriginPort errorMessage scheme (URI.uriPort authority)
+    pure (scheme, host, port)
+
+gatewayOriginPort :: Text -> Text -> String -> Either Text Int
+gatewayOriginPort _ "https:" "" = Right 443
+gatewayOriginPort _ "http:" "" = Right 80
+gatewayOriginPort _ "wss:" "" = Right 443
+gatewayOriginPort _ "ws:" "" = Right 80
+gatewayOriginPort errorMessage scheme (':' : digits)
+    | scheme `elem` ["https:", "http:", "wss:", "ws:"]
+    , not (null digits)
+    , all isDigit digits
+    , Just port <- readMaybe digits
+    , port > 0
+    , port <= (65535 :: Int) =
+        Right port
+    | otherwise = Left errorMessage
+gatewayOriginPort errorMessage _ _ = Left errorMessage
+
+whenEither :: Bool -> Text -> Either Text ()
+whenEither condition message
+    | condition = Left message
+    | otherwise = Right ()
 
 validateBaseUrl :: Text -> Either Text Text
 validateBaseUrl raw

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Login
     , AccountUsage(..)
     , DevicePollReadiness(..)
     , DevicePollSchedule
+    , GatewayLoginFlow(..)
     , LoginAccount(..)
     , LoginAction(..)
     , LoginState(..)
@@ -28,6 +29,7 @@ module Agent.CLI.Login
     , renderLoginFrame
     , runFullscreenLoginManager
     , runLoginManager
+    , selectGatewayLoginFlow
     ) where
 
 import Agent.CLI.Auth
@@ -78,8 +80,10 @@ import Agent.CLI.GatewayClient
     , GatewayCredential(..)
     , GatewayDeviceAuthorization(..)
     , GatewayPollResult(..)
+    , connectGateway
+    , connectGatewayBrowser
+    , defaultGatewayBaseUrl
     , loadGatewayCredential
-    , openGatewayAuthorizationPage
     , pollGatewayAuthorization
     , removeGatewayCredential
     , saveGatewayCredential
@@ -105,7 +109,6 @@ import Agent.CLI.TUI.App
     , emitUiEvent
     , requestFullscreenChoiceWithBody
     , requestFullscreenSecret
-    , requestFullscreenText
     )
 import Agent.FileRetry (retryOnFileBusy)
 import qualified Agent.OpenAI.Auth as OpenAI
@@ -163,6 +166,7 @@ import System.IO
     , stderr
     , stdin
     )
+import qualified System.Info as SystemInfo
 import System.Process
     ( CreateProcess(..)
     , StdStream(NoStream)
@@ -199,6 +203,9 @@ runLoginManager color = do
                 loop [index] state'
             Just (LoginAdd, _) -> do
                 void (connectAccount color)
+                rediscover
+            Just (LoginGateway, _) -> do
+                connectTerminalGateway color
                 rediscover
             Just (LoginToggle index, state') -> do
                 toggleAt color index state'.loginAccounts
@@ -314,6 +321,31 @@ data DevicePollReadiness
     | DevicePollExpired
     deriving (Eq, Show)
 
+-- | The interactive gateway authorization appropriate for the current host.
+-- A macOS process reached through SSH is headless from the user's point of
+-- view, so it uses the same device flow as a remote Linux server.
+data GatewayLoginFlow
+    = GatewayBrowserOAuth
+    | GatewayDeviceFlow
+    deriving (Eq, Show)
+
+selectGatewayLoginFlow :: String -> Bool -> GatewayLoginFlow
+selectGatewayLoginFlow operatingSystem remoteSession
+    | operatingSystem == "darwin" && not remoteSession =
+        GatewayBrowserOAuth
+    | otherwise =
+        GatewayDeviceFlow
+
+currentGatewayLoginFlow :: IO GatewayLoginFlow
+currentGatewayLoginFlow = do
+    sshConnection <- lookupNonEmpty "SSH_CONNECTION"
+    sshClient <- lookupNonEmpty "SSH_CLIENT"
+    sshTty <- lookupNonEmpty "SSH_TTY"
+    pure $
+        selectGatewayLoginFlow
+            SystemInfo.os
+            (any isJust [sshConnection, sshClient, sshTty])
+
 -- | Start a bounded device-code flow. The first explicit check is allowed
 -- immediately; every pending response schedules the next permitted check.
 initialDevicePollSchedule
@@ -412,12 +444,12 @@ loginDashboardEntries accounts =
     , ( LoginDashboardGateway
       , if gatewayConnected
             then
-                ( "↻ Reconnect gateway"
-                , "Replace the saved gateway authorization"
+                ( "↻ Reconnect platform gateway"
+                , "Replace the saved platform.digitallyinduced.com authorization"
                 )
             else
-                ( "＋ Connect gateway"
-                , "Route OpenAI requests through an agent gateway"
+                ( "＋ Log in to platform gateway"
+                , "Route requests through platform.digitallyinduced.com"
                 )
       )
     ]
@@ -468,50 +500,85 @@ loginDashboardAccountRow account =
 
 connectFullscreenGateway :: FullscreenRuntime -> IO (Maybe LoginNotice)
 connectFullscreenGateway runtime = do
-    existing <- loadGatewayCredential
-    let initial = case existing of
-            Right (Just credential) -> credential.gatewayBaseUrl
-            _ -> ""
-    requestFullscreenText
-        runtime
-        "Connect gateway"
-        ( "Enter the HTTPS base URL of the agent gateway. The next screen "
-            <> "will show a browser link and one-time authorization code."
-        )
-        initial >>= \case
-            Nothing -> pure Nothing
-            Just rawUrl -> do
-                let url = Text.strip rawUrl
-                if Text.null url
-                    then pure Nothing
-                    else do
-                        requestedAt <- getCurrentTime
-                        requested <-
-                            withLoginProgress runtime
-                                "Starting gateway device authorization…" $
-                                    startGatewayAuthorization url
-                        case requested of
-                            Left err ->
-                                pure $ Just $
-                                    LoginNotice False
-                                        ("Gateway connection failed: " <> err)
-                            Right authorization -> do
-                                opened <-
-                                    openGatewayAuthorizationPage authorization
-                                let device =
-                                        authorization.authorizationDevice
-                                    notice
-                                        | opened = Nothing
-                                        | otherwise =
-                                            Just
-                                                "Could not open a browser automatically; use the verification link below."
-                                awaitAuthorization
-                                    authorization
-                                    (initialDevicePollSchedule
-                                        requestedAt
-                                        device.pollIntervalSeconds
-                                        device.expiresInSeconds)
-                                    notice
+    currentGatewayLoginFlow >>= \case
+        GatewayBrowserOAuth ->
+            connectFullscreenGatewayBrowser runtime
+        GatewayDeviceFlow ->
+            connectFullscreenGatewayDevice runtime
+
+connectFullscreenGatewayBrowser
+    :: FullscreenRuntime
+    -> IO (Maybe LoginNotice)
+connectFullscreenGatewayBrowser runtime = do
+    result <-
+        withLoginProgress runtime "Waiting for platform gateway login…" $
+            connectGatewayBrowser
+                defaultGatewayBaseUrl
+                "Haskell Agent CLI"
+                (presentGatewayBrowserLoginFullscreen runtime)
+    pure $
+        Just $
+            case result of
+                Left err ->
+                    LoginNotice False
+                        ("Gateway connection failed: " <> err)
+                Right () ->
+                    LoginNotice True
+                        "Platform gateway connected. Restart the agent to apply the new route immediately."
+
+presentGatewayBrowserLoginFullscreen
+    :: FullscreenRuntime
+    -> Text
+    -> IO Bool
+presentGatewayBrowserLoginFullscreen runtime authorizationUrl = do
+    opened <- openBrowser authorizationUrl
+    if opened
+        then pure True
+        else do
+            choice <-
+                requestFullscreenChoiceWithBody
+                    runtime
+                    "Log in to platform gateway"
+                    ( "The browser could not be opened automatically. "
+                        <> "[Open the platform login page]("
+                        <> authorizationUrl
+                        <> "), then return here."
+                    )
+                    0
+                    [ ( "Wait for browser login"
+                      , "Continue waiting for the secure local callback"
+                      )
+                    , ("Cancel", "Stop without changing the saved gateway")
+                    ]
+            pure (choice == Just 0)
+
+connectFullscreenGatewayDevice
+    :: FullscreenRuntime
+    -> IO (Maybe LoginNotice)
+connectFullscreenGatewayDevice runtime = do
+    requestedAt <- getCurrentTime
+    requested <-
+        withLoginProgress runtime
+            "Starting gateway device authorization…" $
+                startGatewayAuthorization defaultGatewayBaseUrl
+    case requested of
+        Left err ->
+            pure $ Just $
+                LoginNotice False
+                    ("Gateway connection failed: " <> err)
+        Right authorization -> do
+            let device =
+                    authorization.authorizationDevice
+                notice =
+                    Just
+                        "Open the verification link in a browser on your local computer."
+            awaitAuthorization
+                authorization
+                (initialDevicePollSchedule
+                    requestedAt
+                    device.pollIntervalSeconds
+                    device.expiresInSeconds)
+                notice
   where
     awaitAuthorization authorization schedule notice = do
         let device = authorization.authorizationDevice
@@ -1195,6 +1262,44 @@ accountAt index accounts =
     case drop index accounts of
         account : _ -> Just account
         [] -> Nothing
+
+connectTerminalGateway :: Bool -> IO ()
+connectTerminalGateway color = do
+    currentGatewayLoginFlow >>= \case
+        GatewayBrowserOAuth -> do
+            result <-
+                connectGatewayBrowser
+                    defaultGatewayBaseUrl
+                    "Haskell Agent CLI"
+                    \authorizationUrl -> do
+                        Text.hPutStrLn stderr $
+                            roleMuted color "Open "
+                                <> rolePrompt color authorizationUrl
+                        opened <- openBrowser authorizationUrl
+                        unless opened $
+                            Text.hPutStrLn stderr $
+                                roleMuted color
+                                    "Could not launch a browser automatically; open the URL above."
+                        Text.hPutStrLn stderr $
+                            roleMuted color
+                                "Waiting for platform gateway authorization…"
+                        hFlush stderr
+                        -- Printing the complete link is a valid presentation
+                        -- fallback even when automatic browser launch fails.
+                        pure True
+            printLoginResult color $
+                fmap
+                    (const
+                        "Platform gateway connected. Restart the agent to apply the new route immediately.")
+                    result
+        GatewayDeviceFlow ->
+            tryAny (connectGateway defaultGatewayBaseUrl) >>= \case
+                Left exception ->
+                    printLoginMessage color False
+                        ("Gateway connection failed: "
+                            <> formatException exception)
+                Right () ->
+                    pure ()
 
 connectAccount :: Bool -> IO (Maybe (Provider, Text))
 connectAccount color =
@@ -2289,14 +2394,14 @@ renderLoginFrame color state =
         ]
             <> body
             <> [ roleMuted color
-                    "↑↓/jk or scroll · click/enter refresh · a add · i import · e enable/disable · d disconnect · esc/q"
+                    "↑↓/jk or scroll · click/enter refresh · a add · g gateway · i import · e enable/disable · d disconnect · esc/q"
                ]
   where
     body
         | null state.loginAccounts =
             [ roleWarn color "No credentials found."
             , roleMuted color
-                "Set provider credentials or import an existing Codex/Grok login."
+                "Press g to log in to platform.digitallyinduced.com, or a to connect a provider account."
             ]
         | otherwise =
             concat $

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -81,7 +81,7 @@ import Agent.CLI.GatewayClient
     , GatewayDeviceAuthorization(..)
     , GatewayPollResult(..)
     , connectGateway
-    , connectGatewayBrowser
+    , connectGatewayBrowserWithCancel
     , defaultGatewayBaseUrl
     , loadGatewayCredential
     , pollGatewayAuthorization
@@ -131,13 +131,22 @@ import qualified Agent.XAI.Auth as XAIAuth
 import qualified Agent.XAI.Usage as XAI
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async
-    ( mapConcurrently
+    ( Async
+    , mapConcurrently
     , mapConcurrently_
+    , poll
     , race
+    , wait
     , withAsync
     )
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
-import Control.Exception.Safe (bracket, bracket_, tryAny)
+import Control.Concurrent.MVar
+    ( MVar
+    , newEmptyMVar
+    , putMVar
+    , takeMVar
+    )
+import Control.Exception.Safe (bracket, bracket_, onException, tryAny)
 import Control.Monad (join, unless, void)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
@@ -512,45 +521,117 @@ connectFullscreenGatewayBrowser
 connectFullscreenGatewayBrowser runtime = do
     result <-
         withLoginProgress runtime "Waiting for platform gateway login…" $
-            connectGatewayBrowser
-                defaultGatewayBaseUrl
-                "Haskell Agent CLI"
-                (presentGatewayBrowserLoginFullscreen runtime)
+            runFullscreenGatewayBrowser runtime
     pure $
-        Just $
-            case result of
-                Left err ->
-                    LoginNotice False
-                        ("Gateway connection failed: " <> err)
-                Right () ->
+        case result of
+            Left err
+                | gatewayBrowserAuthorizationCancelled err ->
+                    Nothing
+                | otherwise ->
+                    Just $
+                        LoginNotice False
+                            ("Gateway connection failed: " <> err)
+            Right () ->
+                Just $
                     LoginNotice True
                         "Platform gateway connected. Restart the agent to apply the new route immediately."
 
-presentGatewayBrowserLoginFullscreen
+runFullscreenGatewayBrowser
     :: FullscreenRuntime
+    -> IO (Either Text ())
+runFullscreenGatewayBrowser runtime = do
+    presentation <- newEmptyMVar
+    cancellation <- newEmptyMVar
+    withAsync
+        (connectGatewayBrowserWithCancel
+            defaultGatewayBaseUrl
+            "Haskell Agent CLI"
+            (presentGatewayBrowserLogin presentation)
+            (takeMVar cancellation))
+        \authorization ->
+            race
+                (takeMVar presentation)
+                (waitGatewayBrowserAuthorization authorization)
+                >>= \case
+                    Left details ->
+                        awaitFullscreenGatewayBrowser
+                            runtime
+                            authorization
+                            cancellation
+                            details
+                    Right result -> pure result
+
+presentGatewayBrowserLogin
+    :: MVar (Text, Bool)
     -> Text
     -> IO Bool
-presentGatewayBrowserLoginFullscreen runtime authorizationUrl = do
+presentGatewayBrowserLogin presentation authorizationUrl = do
     opened <- openBrowser authorizationUrl
-    if opened
-        then pure True
-        else do
-            choice <-
-                requestFullscreenChoiceWithBody
-                    runtime
-                    "Log in to platform gateway"
-                    ( "The browser could not be opened automatically. "
-                        <> "[Open the platform login page]("
-                        <> authorizationUrl
-                        <> "), then return here."
-                    )
-                    0
-                    [ ( "Wait for browser login"
-                      , "Continue waiting for the secure local callback"
-                      )
-                    , ("Cancel", "Stop without changing the saved gateway")
-                    ]
-            pure (choice == Just 0)
+    putMVar presentation (authorizationUrl, opened)
+    pure True
+
+awaitFullscreenGatewayBrowser
+    :: FullscreenRuntime
+    -> Async (Either Text ())
+    -> MVar ()
+    -> (Text, Bool)
+    -> IO (Either Text ())
+awaitFullscreenGatewayBrowser
+    runtime authorization cancellation (authorizationUrl, opened) =
+        pollGatewayBrowserAuthorization authorization >>= \case
+            Just result -> pure result
+            Nothing -> do
+                choice <-
+                    requestFullscreenChoiceWithBody
+                        runtime
+                        "Log in to platform gateway"
+                        (Text.intercalate "\n\n"
+                            [ if opened
+                                then
+                                    "A browser window was opened automatically. Approve access there, then return here."
+                                else
+                                    "The browser could not be opened automatically. [Open the platform login page]("
+                                        <> authorizationUrl
+                                        <> "), then return here."
+                            , "Select Check connection after approving. Cancel or Esc stops waiting for the local callback."
+                            ])
+                        0
+                        [ ( "Check connection"
+                          , "See whether browser authorization completed"
+                          )
+                        , ( "Cancel"
+                          , "Stop without changing the saved gateway"
+                          )
+                        ]
+                case choice of
+                    Just 0 ->
+                        awaitFullscreenGatewayBrowser
+                            runtime
+                            authorization
+                            cancellation
+                            (authorizationUrl, opened)
+                    _ -> do
+                        putMVar cancellation ()
+                        waitGatewayBrowserAuthorization authorization
+
+pollGatewayBrowserAuthorization
+    :: Async (Either Text ())
+    -> IO (Maybe (Either Text ()))
+pollGatewayBrowserAuthorization authorization =
+    poll authorization >>= \case
+        Nothing -> pure Nothing
+        Just (Left _) ->
+            pure $
+                Just $
+                    Left
+                        "Gateway browser authorization failed unexpectedly."
+        Just (Right result) -> pure (Just result)
+
+waitGatewayBrowserAuthorization
+    :: Async (Either Text ())
+    -> IO (Either Text ())
+waitGatewayBrowserAuthorization authorization =
+    wait authorization
 
 connectFullscreenGatewayDevice
     :: FullscreenRuntime
@@ -1268,10 +1349,10 @@ connectTerminalGateway color = do
     currentGatewayLoginFlow >>= \case
         GatewayBrowserOAuth -> do
             result <-
-                connectGatewayBrowser
+                connectGatewayBrowserWithCancel
                     defaultGatewayBaseUrl
                     "Haskell Agent CLI"
-                    \authorizationUrl -> do
+                    (\authorizationUrl -> do
                         Text.hPutStrLn stderr $
                             roleMuted color "Open "
                                 <> rolePrompt color authorizationUrl
@@ -1286,12 +1367,20 @@ connectTerminalGateway color = do
                         hFlush stderr
                         -- Printing the complete link is a valid presentation
                         -- fallback even when automatic browser launch fails.
-                        pure True
-            printLoginResult color $
-                fmap
-                    (const
-                        "Platform gateway connected. Restart the agent to apply the new route immediately.")
-                    result
+                        pure True)
+                    (waitForTerminalGatewayBrowserCancellation color)
+            case result of
+                Left err
+                    | gatewayBrowserAuthorizationCancelled err ->
+                        Text.hPutStrLn stderr $
+                            roleMuted color
+                                "Gateway authorization cancelled."
+                _ ->
+                    printLoginResult color $
+                        fmap
+                            (const
+                                "Platform gateway connected. Restart the agent to apply the new route immediately.")
+                            result
         GatewayDeviceFlow ->
             tryAny (connectGateway defaultGatewayBaseUrl) >>= \case
                 Left exception ->
@@ -1300,6 +1389,25 @@ connectTerminalGateway color = do
                             <> formatException exception)
                 Right () ->
                     pure ()
+
+waitForTerminalGatewayBrowserCancellation :: Bool -> IO ()
+waitForTerminalGatewayBrowserCancellation color =
+    loop `onException` Text.hPutStrLn stderr ""
+  where
+    loop =
+        readApprovalLine
+            (roleMuted color
+                "Press Esc or q to cancel gateway authorization. ")
+            >>= \case
+                Nothing -> pure ()
+                Just answer
+                    | Text.toLower answer `elem` ["q", "\ESC"] ->
+                        pure ()
+                    | otherwise -> loop
+
+gatewayBrowserAuthorizationCancelled :: Text -> Bool
+gatewayBrowserAuthorizationCancelled =
+    (== "Gateway browser authorization was cancelled.")
 
 connectAccount :: Bool -> IO (Maybe (Provider, Text))
 connectAccount color =

--- a/packages/agent-cli/src/Agent/CLI/Login/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login/Types.hs
@@ -84,6 +84,7 @@ data LoginAction
     = LoginClose
     | LoginRefresh !Int
     | LoginAdd
+    | LoginGateway
     | LoginToggle !Int
     | LoginDelete !Int
     | LoginImport !Int
@@ -103,6 +104,8 @@ applyLoginKey key state = case key of
     PickerKeyChar 'R' -> refresh
     PickerKeyChar 'a' -> Left LoginAdd
     PickerKeyChar 'A' -> Left LoginAdd
+    PickerKeyChar 'g' -> Left LoginGateway
+    PickerKeyChar 'G' -> Left LoginGateway
     PickerKeyChar 'e' -> selected LoginToggle
     PickerKeyChar 'E' -> selected LoginToggle
     PickerKeyChar 'd' -> selected LoginDelete

--- a/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
@@ -52,6 +52,152 @@ spec = describe "gateway device authorization" do
             `shouldBe` Right
                 (GatewayAuthorized "secret" "wss://gateway/v1/responses")
 
+    it "builds the registered loopback Authorization Code + PKCE request" do
+        gatewayAuthorizationUrl
+            defaultGatewayBaseUrl
+            "http://127.0.0.1:54321/oauth2callback"
+            "0123456789abcdefghijklmnopqrstuvwxyz"
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+            "Marc's Mac"
+            `shouldBe` Right
+                "https://platform.digitallyinduced.com/connect/agent/authorize\
+                \?response_type=code\
+                \&client_id=haskell-agent-cli\
+                \&redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Foauth2callback\
+                \&state=0123456789abcdefghijklmnopqrstuvwxyz\
+                \&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM\
+                \&code_challenge_method=S256\
+                \&client_name=Marc%27s%20Mac"
+        gatewayPkceChallenge
+            "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+            `shouldBe`
+                "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+    it "accepts only the exact IPv4 loopback redirect contract" do
+        let authorize redirect =
+                gatewayAuthorizationUrl
+                    defaultGatewayBaseUrl
+                    redirect
+                    "0123456789abcdefghijklmnopqrstuvwxyz"
+                    "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+                    "Haskell Agent CLI"
+        authorize "http://127.0.0.1:1/oauth2callback"
+            `shouldSatisfy` not . isLeft
+        authorize "http://localhost:54321/oauth2callback"
+            `shouldBe` Left "Gateway OAuth redirect URI is invalid."
+        authorize "http://127.0.0.1:54321/other"
+            `shouldBe` Left "Gateway OAuth redirect URI is invalid."
+        authorize "https://127.0.0.1:54321/oauth2callback"
+            `shouldBe` Left "Gateway OAuth redirect URI is invalid."
+        map authorize
+            [ "http://127.0.0.1:0/oauth2callback"
+            , "http://127.0.0.1:65536/oauth2callback"
+            , "http://127.0.0.1:not-a-port/oauth2callback"
+            , "http://127.0.0.1:54321/oauth2callback?next=evil"
+            , "http://127.0.0.1:54321/oauth2callback#fragment"
+            , "http://user@127.0.0.1:54321/oauth2callback"
+            , "http://127.0.0.1.example:54321/oauth2callback"
+            ]
+            `shouldSatisfy` all isLeft
+
+    it "validates callback method, path, singleton state, and errors" do
+        let state = "0123456789abcdefghijklmnopqrstuvwxyz"
+            callback target =
+                validateGatewayAuthorizationCallback
+                    state
+                    ("GET " <> target <> " HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        callback
+            "/oauth2callback?code=hac_secret&state=0123456789abcdefghijklmnopqrstuvwxyz"
+            `shouldBe` Right "hac_secret"
+        callback
+            "/oauth2callback?code=hac_secret&state=wrong"
+            `shouldBe` Left "Gateway OAuth callback state mismatch."
+        callback
+            "/other?code=hac_secret&state=0123456789abcdefghijklmnopqrstuvwxyz"
+            `shouldBe` Left "Gateway OAuth callback path is invalid."
+        validateGatewayAuthorizationCallback
+            state
+            "POST /oauth2callback?code=hac_secret&state=0123456789abcdefghijklmnopqrstuvwxyz HTTP/1.1\r\n\r\n"
+            `shouldBe` Left "Gateway OAuth callback must use GET."
+        callback
+            "/oauth2callback?error=access_denied&state=0123456789abcdefghijklmnopqrstuvwxyz"
+            `shouldBe` Left
+                "Gateway authorization was not granted: access_denied."
+        callback
+            "/oauth2callback?code=hac_secret&state=0123456789abcdefghijklmnopqrstuvwxyz&state=0123456789abcdefghijklmnopqrstuvwxyz"
+            `shouldBe` Left
+                "Gateway OAuth callback contains duplicate or invalid state parameters."
+        callback
+            "/oauth2callback?code=first&code=second&state=0123456789abcdefghijklmnopqrstuvwxyz"
+            `shouldBe` Left
+                "Gateway OAuth callback contains duplicate or invalid code parameters."
+        callback
+            "/oauth2callback?error=%3Cscript%3E&state=0123456789abcdefghijklmnopqrstuvwxyz"
+            `shouldBe` Left "Gateway authorization was not granted."
+
+    it "decodes and validates a same-origin bearer response" do
+        let payload =
+                "{\"access_token\":\"hag_secret\",\"token_type\":\"Bearer\",\
+                \\"base_url\":\"https://platform.digitallyinduced.com\",\
+                \\"websocket_url\":\"wss://platform.digitallyinduced.com/v1/responses\"}"
+            response =
+                GatewayAuthorizationCodeResponse
+                    { authorizationAccessToken = "hag_secret"
+                    , authorizationTokenType = "Bearer"
+                    , authorizationResponseBaseUrl =
+                        "https://platform.digitallyinduced.com"
+                    , authorizationWebSocketUrl =
+                        "wss://platform.digitallyinduced.com/v1/responses"
+                    }
+        Hermes.decodeEither
+            gatewayAuthorizationCodeDecoder
+            payload
+            `shouldBe` Right response
+        validateGatewayAuthorizationCodeResponse
+            defaultGatewayBaseUrl response
+            `shouldBe` Right
+                GatewayCredential
+                    { gatewayBaseUrl =
+                        "https://platform.digitallyinduced.com"
+                    , gatewayWebSocketUrl =
+                        "wss://platform.digitallyinduced.com/v1/responses"
+                    , gatewayAccessToken = "hag_secret"
+                    }
+
+    it "rejects OAuth responses with the wrong scheme or origin" do
+        let response =
+                GatewayAuthorizationCodeResponse
+                    { authorizationAccessToken = "hag_secret"
+                    , authorizationTokenType = "Bearer"
+                    , authorizationResponseBaseUrl =
+                        "https://platform.digitallyinduced.com"
+                    , authorizationWebSocketUrl =
+                        "wss://platform.digitallyinduced.com/v1/responses"
+                    }
+            validate =
+                validateGatewayAuthorizationCodeResponse
+                    defaultGatewayBaseUrl
+        validate response { authorizationTokenType = "bearer" }
+            `shouldBe`
+                Left "The gateway returned an unsupported token type."
+        validate
+            response
+                { authorizationResponseBaseUrl = "https://example.com"
+                , authorizationWebSocketUrl =
+                    "wss://example.com/v1/responses"
+                }
+            `shouldBe`
+                Left
+                    "The gateway returned a credential for a different origin."
+        validate
+            response
+                { authorizationWebSocketUrl =
+                    "wss://example.com/v1/responses"
+                }
+            `shouldBe`
+                Left
+                    "The gateway returned a WebSocket URL for a different origin."
+
     it "redacts the bearer credential from Show" do
         let credential =
                 GatewayCredential "https://gateway" "wss://gateway/v1/responses" "secret"
@@ -66,6 +212,15 @@ spec = describe "gateway device authorization" do
                 600
                 5)
             `shouldSatisfy` not . Text.isInfixOf "device-secret" . Text.pack
+        let browserResponse =
+                GatewayAuthorizationCodeResponse
+                    "oauth-secret"
+                    "Bearer"
+                    "https://gateway"
+                    "wss://gateway/secret-websocket"
+            rendered = Text.pack (show browserResponse)
+        rendered `shouldSatisfy` not . Text.isInfixOf "oauth-secret"
+        rendered `shouldSatisfy` not . Text.isInfixOf "secret-websocket"
 
     it "allows local HTTP development without trusting lookalike hosts" do
         validateBaseUrl "http://localhost:8080"

--- a/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayClientSpec.hs
@@ -73,6 +73,15 @@ spec = describe "gateway device authorization" do
             `shouldBe`
                 "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
+    it "allows an interactive caller to cancel the callback wait" do
+        connectGatewayBrowserWithCancel
+            defaultGatewayBaseUrl
+            "Haskell Agent CLI"
+            (const (pure True))
+            (pure ())
+            `shouldReturn`
+                Left "Gateway browser authorization was cancelled."
+
     it "accepts only the exact IPv4 loopback redirect contract" do
         let authorize redirect =
                 gatewayAuthorizationUrl

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -28,10 +28,12 @@ spec = do
             applyLoginKey (PickerKeyChar 'r') state
                 `shouldBe` Left (LoginRefresh 1)
 
-        it "opens add, toggle, and delete actions" do
+        it "opens provider, gateway, toggle, and delete actions" do
             let state = initialLoginState [openai]
             applyLoginKey (PickerKeyChar 'a') state
                 `shouldBe` Left LoginAdd
+            applyLoginKey (PickerKeyChar 'g') state
+                `shouldBe` Left LoginGateway
             applyLoginKey (PickerKeyChar 'e') state
                 `shouldBe` Left (LoginToggle 0)
             applyLoginKey (PickerKeyChar 'd') state
@@ -48,6 +50,15 @@ spec = do
             result <- Timeout.timeout 1_000_000
                 (launchBrowserCommand "sleep" "2")
             result `shouldBe` Just True
+
+    describe "gateway login flow selection" do
+        it "uses browser OAuth only on a local macOS session" do
+            selectGatewayLoginFlow "darwin" False
+                `shouldBe` GatewayBrowserOAuth
+            selectGatewayLoginFlow "darwin" True
+                `shouldBe` GatewayDeviceFlow
+            selectGatewayLoginFlow "linux" False
+                `shouldBe` GatewayDeviceFlow
 
     describe "renderLoginFrame" do
         it "shows providers, billing modes, sources, and usage" do
@@ -125,7 +136,7 @@ spec = do
                 rendered = Text.unlines
                     [label <> " " <> description | (label, description) <- rows]
             labels `shouldSatisfy` any (Text.isInfixOf "Connect account")
-            labels `shouldSatisfy` any (Text.isInfixOf "Connect gateway")
+            labels `shouldSatisfy` any (Text.isInfixOf "platform gateway")
             labels `shouldSatisfy` not . any (Text.isInfixOf "Refresh")
             rendered `shouldSatisfy` Text.isInfixOf "Google Gemini"
 
@@ -135,7 +146,7 @@ spec = do
                 actionLabels =
                     map fst (loginAccountActionRows gateway)
             dashboardLabels
-                `shouldSatisfy` any (Text.isInfixOf "Reconnect gateway")
+                `shouldSatisfy` any (Text.isInfixOf "Reconnect platform gateway")
             dashboardLabels
                 `shouldSatisfy` not . any (Text.isInfixOf "Refresh all")
             actionLabels


### PR DESCRIPTION
## Summary

- add a platform gateway action to `/login`, targeting `https://platform.digitallyinduced.com`
- use browser Authorization Code + PKCE with an ephemeral loopback callback on local macOS
- use the existing device-token flow on Linux and SSH/remote macOS sessions
- validate callback state, token/base/WebSocket origins, and persist the resulting bearer credential with existing restricted storage

## Gateway dependency

Requires digitallyinduced/haskell-agent-gateway#24 to be merged and deployed before the production browser flow accepts the `haskell-agent-cli` client.

## Testing

- focused `agent-cli-test` specs — 23 examples, 0 failures
- GHCi library/test targets loaded successfully through `nix develop`
- live fullscreen `/login` exercised in tmux; verified the platform gateway row and terminal keybinding