### PR TITLE
Use ordinary Codex functions for macOS computer control

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -1,6 +1,7 @@
--- | Provider-native computer use backed by macOS screen capture and input.
+-- | Function-based computer use backed by macOS screen capture and input.
 module Agent.CLI.ComputerUse
     ( computerUseTool
+    , computerFunctionParameters
     , executeComputerCall
     , screenshotMacOS
     , summarizeComputerCall
@@ -40,6 +41,7 @@ import Control.Applicative ((<|>))
 import Control.Exception.Safe (finally, tryAny)
 import Control.Monad (foldM)
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as Base64
@@ -55,14 +57,13 @@ import System.IO (hClose, openBinaryTempFile)
 import System.Process (readProcessWithExitCode)
 import Text.Read (readMaybe)
 
--- | A dedicated schema constructor, rather than the name @computer@, marks
--- this as the provider-hosted computer tool. That prevents an MCP/function
--- tool with the same name from accidentally acquiring desktop control.
+-- | A dedicated internal schema marker, rather than a provider-native wire
+-- type, keeps this privileged handler separate from caller-defined functions.
 computerUseTool :: AppTool
 computerUseTool = AppTool
     { appToolName = "computer"
     , appToolDescription =
-        "Control the main macOS display using screenshots, pointer, keyboard, and scrolling."
+        "Run one or more approved actions on the main macOS display and receive a fresh screenshot. Start with screenshot when the UI state is unknown."
     , appToolSchema = HostedComputerSchema
     , appToolHandler = handler
     , appToolApproval = AlwaysPrompt
@@ -91,6 +92,114 @@ instance Aeson.FromJSON ComputerToolInput where
         ComputerToolInput
             <$> object Aeson..:? "actions" Aeson..!= []
             <*> object Aeson..:? "pending_safety_checks" Aeson..!= []
+
+-- | Strict parameters for the ordinary @computer_use@ function. Actions stay
+-- typed internally even though the provider sees a normal function call.
+computerFunctionParameters :: Aeson.Value
+computerFunctionParameters = Aeson.object
+    [ "type" Aeson..= ("object" :: Text)
+    , "properties" Aeson..= Aeson.object
+        [ "actions" Aeson..= Aeson.object
+            [ "type" Aeson..= ("array" :: Text)
+            , "description" Aeson..=
+                ("Ordered desktop actions. Coordinates are logical pixels on the main display." :: Text)
+            , "items" Aeson..= Aeson.object
+                [ "anyOf" Aeson..= computerActionSchemas ]
+            , "minItems" Aeson..= (1 :: Int)
+            , "maxItems" Aeson..= (128 :: Int)
+            ]
+        ]
+    , "required" Aeson..= ["actions" :: Text]
+    , "additionalProperties" Aeson..= False
+    ]
+
+computerActionSchemas :: [Aeson.Value]
+computerActionSchemas =
+    [ actionSchema "screenshot" []
+    , actionSchema "click"
+        [ ("x", integerProperty)
+        , ("y", integerProperty)
+        , ("button", enumProperty
+            ["left", "right", "middle", "back", "forward"])
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "double_click"
+        [ ("x", integerProperty)
+        , ("y", integerProperty)
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "scroll"
+        [ ("x", integerProperty)
+        , ("y", integerProperty)
+        , ("scroll_x", integerProperty)
+        , ("scroll_y", integerProperty)
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "move"
+        [ ("x", integerProperty)
+        , ("y", integerProperty)
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "drag"
+        [ ("path", Aeson.object
+            [ "type" Aeson..= ("array" :: Text)
+            , "items" Aeson..= Aeson.object
+                [ "type" Aeson..= ("object" :: Text)
+                , "properties" Aeson..= Aeson.object
+                    [ "x" Aeson..= integerProperty
+                    , "y" Aeson..= integerProperty
+                    ]
+                , "required" Aeson..= ["x" :: Text, "y"]
+                , "additionalProperties" Aeson..= False
+                ]
+            , "minItems" Aeson..= (2 :: Int)
+            , "maxItems" Aeson..= (1024 :: Int)
+            ])
+        , ("keys", keysProperty)
+        ]
+    , actionSchema "type"
+        [ ("text", Aeson.object
+            [ "type" Aeson..= ("string" :: Text)
+            , "maxLength" Aeson..= (8192 :: Int)
+            ])
+        ]
+    , actionSchema "keypress" [("keys", keysProperty)]
+    , actionSchema "wait" []
+    ]
+  where
+    integerProperty :: Aeson.Value
+    integerProperty = Aeson.object ["type" Aeson..= ("integer" :: Text)]
+    keysProperty :: Aeson.Value
+    keysProperty = Aeson.object
+        [ "type" Aeson..= ("array" :: Text)
+        , "items" Aeson..= Aeson.object
+            [ "type" Aeson..= ("string" :: Text)
+            , "maxLength" Aeson..= (64 :: Int)
+            ]
+        , "maxItems" Aeson..= (16 :: Int)
+        ]
+    enumProperty :: [Text] -> Aeson.Value
+    enumProperty values = Aeson.object
+        [ "type" Aeson..= ("string" :: Text)
+        , "enum" Aeson..= values
+        ]
+
+actionSchema :: Text -> [(Text, Aeson.Value)] -> Aeson.Value
+actionSchema actionType properties = Aeson.object
+    [ "type" Aeson..= ("object" :: Text)
+    , "properties" Aeson..= Aeson.Object
+        (KeyMap.fromList
+            ((Key.fromText "type", enumProperty [actionType])
+                : [(Key.fromText name, value) | (name, value) <- properties]))
+    , "required" Aeson..= ("type" : map fst properties)
+    , "additionalProperties" Aeson..= False
+    ]
+  where
+    enumProperty :: [Text] -> Aeson.Value
+    enumProperty values = Aeson.object
+        [ "type" Aeson..= ("string" :: Text)
+        , "enum" Aeson..= values
+        ]
 
 computerCallFromInput :: ToolCall -> ComputerToolInput -> ComputerCall
 computerCallFromInput call input = ComputerCall

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -86,6 +86,7 @@ systemPromptForTools
             , sessionTempGuidance sessionTmp
             , secretInputGuidance available
             , learnedSkillGuidance available
+            , browserControlGuidance available
             , ghciGuidanceForTools dialect available
             , timeContextGuidance
             ]
@@ -147,6 +148,27 @@ learnedSkillGuidance available
             , "- When the user establishes a durable preference, decision, lesson, or repeatable procedure that will help future sessions, consider promoting it with skill_create or skill_update."
             , "- Store actionable reusable guidance, not ordinary facts or transient task state. Search before creating, prefer updating an existing skill, and choose the narrowest correct scope."
             ]
+
+-- | Explain the host-provided browser surface only when its tools are
+-- registered. Tool availability is authoritative; the macOS browser pane can
+-- be shown or hidden independently by the user.
+browserControlGuidance :: [Text] -> Text
+browserControlGuidance available
+    | not (all (`elem` available) requiredBrowserTools) = ""
+    | otherwise =
+        Text.unlines
+            [ "Browser control:"
+            , "- Use the browser_* tools for websites instead of whole-desktop computer control."
+            , "- In Haskell Agent for macOS, the user can show the connected in-app browser with the browser button; it appears in the right sidebar. A configured dedicated Safari tab may be connected when that pane is hidden."
+            , "- Navigate or take a snapshot first, then use selectors returned by browser_snapshot for interaction."
+            ]
+  where
+    requiredBrowserTools =
+        [ "browser_navigate"
+        , "browser_snapshot"
+        , "browser_click"
+        , "browser_type"
+        ]
 
 -- | Prefer GHCI as the general-purpose scripting environment.
 ghciGuidance :: Text

--- a/packages/agent-cli/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli/src/Agent/CLI/Request.hs
@@ -199,9 +199,7 @@ updateResponsesLitePrefix instructionText maybeTools existingInput =
 
 -- | Convert conventional Responses tools to the Lite @additional_tools@
 -- representation. Function and custom tools share the default @functions@
--- namespace. The ChatGPT/Codex Responses Lite transport does not accept the
--- native @computer@ tool, so expose its local harness in a reserved namespace
--- whose function output can carry a screenshot back to the model.
+-- namespace; hosted tools and non-default namespaces remain top-level.
 responsesLiteToolValues :: [ResponseTool] -> [Aeson.Value]
 responsesLiteToolValues tools =
     case groupedValues of
@@ -233,137 +231,8 @@ responsesLiteToolValues tools =
                 ( firstPosition
                 , grouped
                 , description
-                , ungrouped <> [responsesLiteToolValue tool]
+                , ungrouped <> [Aeson.toJSON tool]
                 )
-
-responsesLiteToolValue :: ResponseTool -> Aeson.Value
-responsesLiteToolValue = \case
-    KnownResponseTool ToolComputer _ -> computerFunctionNamespaceValue
-    tool -> Aeson.toJSON tool
-
-computerFunctionNamespaceValue :: Aeson.Value
-computerFunctionNamespaceValue = Aeson.object
-    [ "type" Aeson..= ("namespace" :: Text)
-    , "name" Aeson..= computerFunctionNamespace
-    , "description" Aeson..=
-        ("Inspect and control the local macOS desktop. Every call returns a fresh screenshot." :: Text)
-    , "tools" Aeson..=
-        [ Aeson.object
-            [ "type" Aeson..= ("function" :: Text)
-            , "name" Aeson..= computerFunctionName
-            , "description" Aeson..=
-                ("Run one or more approved desktop actions and return a fresh screenshot. Start with screenshot when the UI state is unknown." :: Text)
-            , "parameters" Aeson..= computerFunctionParameters
-            , "strict" Aeson..= True
-            ]
-        ]
-    ]
-
-computerFunctionParameters :: Aeson.Value
-computerFunctionParameters = Aeson.object
-    [ "type" Aeson..= ("object" :: Text)
-    , "properties" Aeson..= Aeson.object
-        [ "actions" Aeson..= Aeson.object
-            [ "type" Aeson..= ("array" :: Text)
-            , "description" Aeson..=
-                ("Ordered desktop actions. Coordinates are logical pixels on the main display." :: Text)
-            , "items" Aeson..= Aeson.object
-                [ "anyOf" Aeson..= computerActionSchemas ]
-            , "minItems" Aeson..= (1 :: Int)
-            , "maxItems" Aeson..= (128 :: Int)
-            ]
-        ]
-    , "required" Aeson..= ["actions" :: Text]
-    , "additionalProperties" Aeson..= False
-    ]
-
-computerActionSchemas :: [Aeson.Value]
-computerActionSchemas =
-    [ actionSchema "screenshot" []
-    , actionSchema "click"
-        [ ("x", integerProperty)
-        , ("y", integerProperty)
-        , ("button", enumProperty
-            ["left", "right", "middle", "back", "forward"])
-        , ("keys", keysProperty)
-        ]
-    , actionSchema "double_click"
-        [ ("x", integerProperty)
-        , ("y", integerProperty)
-        , ("keys", keysProperty)
-        ]
-    , actionSchema "scroll"
-        [ ("x", integerProperty)
-        , ("y", integerProperty)
-        , ("scroll_x", integerProperty)
-        , ("scroll_y", integerProperty)
-        , ("keys", keysProperty)
-        ]
-    , actionSchema "move"
-        [ ("x", integerProperty)
-        , ("y", integerProperty)
-        , ("keys", keysProperty)
-        ]
-    , actionSchema "drag"
-        [ ("path", Aeson.object
-            [ "type" Aeson..= ("array" :: Text)
-            , "items" Aeson..= Aeson.object
-                [ "type" Aeson..= ("object" :: Text)
-                , "properties" Aeson..= Aeson.object
-                    [ "x" Aeson..= integerProperty
-                    , "y" Aeson..= integerProperty
-                    ]
-                , "required" Aeson..= ["x" :: Text, "y"]
-                , "additionalProperties" Aeson..= False
-                ]
-            , "minItems" Aeson..= (2 :: Int)
-            , "maxItems" Aeson..= (1024 :: Int)
-            ])
-        , ("keys", keysProperty)
-        ]
-    , actionSchema "type"
-        [ ("text", Aeson.object
-            [ "type" Aeson..= ("string" :: Text)
-            , "maxLength" Aeson..= (8192 :: Int)
-            ])
-        ]
-    , actionSchema "keypress" [("keys", keysProperty)]
-    , actionSchema "wait" []
-    ]
-  where
-    integerProperty :: Aeson.Value
-    integerProperty = Aeson.object ["type" Aeson..= ("integer" :: Text)]
-    keysProperty :: Aeson.Value
-    keysProperty = Aeson.object
-        [ "type" Aeson..= ("array" :: Text)
-        , "items" Aeson..= Aeson.object
-            [ "type" Aeson..= ("string" :: Text)
-            , "maxLength" Aeson..= (64 :: Int)
-            ]
-        , "maxItems" Aeson..= (16 :: Int)
-        ]
-    enumProperty :: [Text] -> Aeson.Value
-    enumProperty values = Aeson.object
-        [ "type" Aeson..= ("string" :: Text)
-        , "enum" Aeson..= values
-        ]
-
-actionSchema :: Text -> [(Text, Aeson.Value)] -> Aeson.Value
-actionSchema actionType properties = Aeson.object
-    [ "type" Aeson..= ("object" :: Text)
-    , "properties" Aeson..= Aeson.Object
-        (KeyMap.fromList
-            ((Key.fromText "type", enumProperty [actionType])
-                : [(Key.fromText name, value) | (name, value) <- properties]))
-    , "required" Aeson..= ("type" : map fst properties)
-    , "additionalProperties" Aeson..= False
-    ]
-  where
-    enumProperty :: [Text] -> Aeson.Value
-    enumProperty values = Aeson.object
-        [ "type" Aeson..= ("string" :: Text)
-        , "enum" Aeson..= values
-        ]
 
 groupedToolValues :: ResponseTool -> Maybe ([Aeson.Value], Maybe Text)
 groupedToolValues tool = case tool of
@@ -432,22 +301,12 @@ liteToolValuesToConventional = concatMap flatten
   where
     flatten value@(Aeson.Object object)
         | textField "type" object == Just "namespace"
-        , textField "name" object == Just computerFunctionNamespace
-        , any isComputerFunction (arrayField "tools" object) =
-            [knownResponseTool ToolComputer KeyMap.empty]
-        | textField "type" object == Just "namespace"
         , textField "name" object == Just "functions" =
             mapMaybe decodeTool (arrayField "tools" object)
         | otherwise = maybeToListDecoded value
     flatten value = maybeToListDecoded value
 
     maybeToListDecoded value = maybe [] pure (decodeTool value)
-
-    isComputerFunction = \case
-        Aeson.Object object ->
-            textField "type" object == Just "function"
-                && textField "name" object == Just computerFunctionName
-        _ -> False
 
 decodeTool :: Aeson.Value -> Maybe ResponseTool
 decodeTool value = case Aeson.fromJSON value of

--- a/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
@@ -66,6 +66,7 @@ import Agent.Responses.Types
     , ResponseItem(..)
     , computerFunctionName
     , computerFunctionNamespace
+    , legacyComputerFunctionName
     )
 import Agent.Store.Postgres
     ( ManagedPostgresConfig
@@ -316,8 +317,12 @@ sessionToolEvents turn =
 sessionToolEvent :: ResponseItem -> Maybe Aeson.Value
 sessionToolEvent = \case
     item@(FunctionCallItem call)
-        | call.namespace == Just computerFunctionNamespace
-        , call.name == computerFunctionName ->
+        | ( call.name == computerFunctionName
+                && call.namespace `elem` [Nothing, Just "functions"]
+          )
+            || ( call.name == legacyComputerFunctionName
+                && call.namespace == Just computerFunctionNamespace
+               ) ->
             let summary = fromMaybe "Computer action"
                     (responseItemToToolCall item
                         >>= summarizeComputerToolCall)

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Tools
     ) where
 
 import Agent.Responses.Types
+import Agent.CLI.ComputerUse (computerFunctionParameters)
 import Agent.Dialect
     ( Dialect
     , DialectId(..)
@@ -42,8 +43,17 @@ import qualified Data.Text as Text
 import System.Info (os)
 
 requireToolRegistry :: [AppTool] -> IO ToolRegistry
-requireToolRegistry tools =
-    either (ioError . userError . Text.unpack) pure (mkToolRegistry tools)
+requireToolRegistry tools
+    | any reservesComputerFunction tools =
+        ioError . userError . Text.unpack $
+            "tool name " <> computerFunctionName
+                <> " is reserved for local computer control"
+    | otherwise =
+        either (ioError . userError . Text.unpack) pure (mkToolRegistry tools)
+  where
+    reservesComputerFunction tool =
+        canonicalToolName tool.appToolName == computerFunctionName
+            && tool.appToolSchema /= HostedComputerSchema
 
 lookupAppTool :: Text -> [AppTool] -> Maybe AppTool
 lookupAppTool name =
@@ -97,11 +107,21 @@ isMultiAgentTool :: AppTool -> Bool
 isMultiAgentTool tool = tool.appToolName `elem` multiAgentToolNames
 
 schemaFromAppTool :: Dialect -> AppTool -> Maybe ResponseTool
+schemaFromAppTool _ tool
+    | canonicalToolName tool.appToolName == computerFunctionName
+    , tool.appToolSchema /= HostedComputerSchema =
+        Nothing
 schemaFromAppTool dialect tool =
     case tool.appToolSchema of
         HostedComputerSchema ->
             if os == "darwin" && dialectId dialect == CodexDialect
-                then Just (knownResponseTool ToolComputer KeyMap.empty)
+                then Just (FunctionToolValue FunctionTool
+                    { name = computerFunctionName
+                    , description = Just tool.appToolDescription
+                    , parameters = Just computerFunctionParameters
+                    , strict = Just True
+                    , extraFields = KeyMap.empty
+                    })
                 else Nothing
         JsonFunctionSchema parameters ->
             case dialectFunctionSchemaStyle dialect of

--- a/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
@@ -302,12 +302,12 @@ spec = do
             encoded `shouldSatisfy`
                 (not . ("large-private-payload" `Text.isInfixOf`))
 
-        it "redacts reserved computer function arguments and screenshot output" do
+        it "redacts ordinary computer function arguments and screenshot output" do
             let call = FunctionCall
                     { itemId = Nothing
                     , callId = "call-function"
                     , name = computerFunctionName
-                    , namespace = Just computerFunctionNamespace
+                    , namespace = Just "functions"
                     , arguments =
                         "{\"actions\":[{\"type\":\"type\",\
                         \\"text\":\"top secret\"}]}"

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -191,6 +191,44 @@ spec = describe "systemPrompt" do
             "Store actionable reusable guidance"
         withoutSkills `shouldNotSatisfy` Text.isInfixOf "Learned skills:"
 
+    it "advertises the macOS sidebar browser only when browser tools exist" do
+        let withBrowser =
+                systemPromptForTools
+                    codexDialect
+                    [ "read_file"
+                    , "browser_navigate"
+                    , "browser_snapshot"
+                    , "browser_click"
+                    , "browser_type"
+                    ]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+            withoutBrowser =
+                systemPromptForTools
+                    codexDialect
+                    ["read_file"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+            unrelatedBrowserPrefix =
+                systemPromptForTools
+                    codexDialect
+                    ["read_file", "browser_export"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+        withBrowser `shouldSatisfy` Text.isInfixOf
+            "appears in the right sidebar"
+        withBrowser `shouldSatisfy` Text.isInfixOf
+            "Use the browser_* tools for websites"
+        withoutBrowser `shouldNotSatisfy` Text.isInfixOf "Browser control:"
+        unrelatedBrowserPrefix `shouldNotSatisfy`
+            Text.isInfixOf "Browser control:"
+
     it "renders ghci-only and bash-only root prompts from registered tools" do
         let day = fromGregorian 2026 8 19
             ghciOnly =

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -85,8 +85,8 @@ spec = describe "requestParams" do
             _ -> expectationFailure
                 "expected additional_tools and base-instructions input prefix"
 
-    it "projects hosted computer into the Responses Lite function harness" do
-        let computerTool = knownResponseTool ToolComputer KeyMap.empty
+    it "groups the computer harness with ordinary Responses Lite functions" do
+        let computerTool = functionTool computerFunctionName
             params =
                 requestParams
                     OpenAIProvider
@@ -100,15 +100,14 @@ spec = describe "requestParams" do
         map toolIdentity (additionalToolValues params)
             `shouldBe`
                 [ (Just "web_search", Nothing)
-                , (Just "namespace", Just computerFunctionNamespace)
                 , (Just "namespace", Just "functions")
                 ]
-        map toolIdentity
-            (computerNamespaceTools (additionalToolValues params))
-            `shouldBe` [(Just "function", Just computerFunctionName)]
+        map (jsonTextField "name")
+            (functionsNamespaceTools (additionalToolValues params))
+            `shouldBe` map Just [computerFunctionName, "lookup"]
 
-    it "keeps hosted computer native for the standard Responses API" do
-        let computerTool = knownResponseTool ToolComputer KeyMap.empty
+    it "keeps the computer harness an ordinary standard Responses function" do
+        let computerTool = functionTool computerFunctionName
             params =
                 requestParams
                     OpenAIProvider
@@ -120,6 +119,8 @@ spec = describe "requestParams" do
         params.tools `shouldBe` Just [computerTool]
         jsonArrayField "tools" (Aeson.toJSON params)
             `shouldBe` [Aeson.toJSON computerTool]
+        map toolIdentity (jsonArrayField "tools" (Aeson.toJSON params))
+            `shouldBe` [(Just "function", Just computerFunctionName)]
 
     it "groups function and custom tools into the functions namespace" do
         let params =
@@ -155,7 +156,7 @@ spec = describe "requestParams" do
             _ -> expectationFailure "expected three top-level Lite tools"
 
     it "refreshes the Lite prefix without dropping pending input" do
-        let computerTool = knownResponseTool ToolComputer KeyMap.empty
+        let computerTool = functionTool computerFunctionName
             pending = userMessage "keep me"
             original = appendInputItem pending $
                 requestParams
@@ -179,15 +180,13 @@ spec = describe "requestParams" do
         refreshed.tools `shouldBe` Nothing
         map (jsonTextField "name")
             (functionsNamespaceTools (additionalToolValues refreshed))
-            `shouldBe` [Just "new"]
+            `shouldBe` map Just ["new", computerFunctionName]
         map toolIdentity (additionalToolValues refreshed)
-            `shouldBe`
-                [ (Just "namespace", Just "functions")
-                , (Just "namespace", Just computerFunctionNamespace)
-                ]
+            `shouldBe` [(Just "namespace", Just "functions")]
         instructionsOnly.tools `shouldBe` Nothing
-        computerNamespaceTools (additionalToolValues instructionsOnly)
-            `shouldSatisfy` (not . null)
+        map (jsonTextField "name")
+            (functionsNamespaceTools (additionalToolValues instructionsOnly))
+            `shouldBe` map Just ["new", computerFunctionName]
         case refreshed.input of
             Just (ResponseInputItems [_additional, base, suffix]) -> do
                 base `shouldSatisfy` isInstructionText "new instructions"
@@ -196,7 +195,7 @@ spec = describe "requestParams" do
                 "expected refreshed prefix followed by pending input"
 
     it "rebuilds request dialect fields when models cross the Lite boundary" do
-        let computerTool = knownResponseTool ToolComputer KeyMap.empty
+        let computerTool = functionTool computerFunctionName
             pending = userMessage "pending"
             genericText = ResponseTextConfig
                 { format = Nothing
@@ -225,8 +224,10 @@ spec = describe "requestParams" do
             `shouldBe`
                 [ (Just "web_search", Nothing)
                 , (Just "namespace", Just "functions")
-                , (Just "namespace", Just computerFunctionNamespace)
                 ]
+        map (jsonTextField "name")
+            (functionsNamespaceTools (additionalToolValues lite))
+            `shouldBe` map Just ["lookup", computerFunctionName]
         lite.parallelToolCalls `shouldBe` Just False
         fmap (.context) lite.reasoning `shouldBe` Just (Just "all_turns")
         fmap (.verbosity) lite.text `shouldBe` Just (Just "low")
@@ -351,13 +352,6 @@ functionsNamespaceTools =
         . findValue
             (\value -> toolIdentity value
                 == (Just "namespace", Just "functions"))
-
-computerNamespaceTools :: [Aeson.Value] -> [Aeson.Value]
-computerNamespaceTools =
-    maybe [] (jsonArrayField "tools")
-        . findValue
-            (\value -> toolIdentity value
-                == (Just "namespace", Just computerFunctionNamespace))
 
 findValue :: (value -> Bool) -> [value] -> Maybe value
 findValue predicate = \case

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -49,12 +49,24 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "schemasFromAppTools" do
-    it "advertises only the dedicated computer tool as a built-in" do
-        schemasFromAppTools codexDialect [computerUseTool]
-            `shouldBe`
-                [ webSearchTool
-                , knownResponseTool ToolComputer KeyMap.empty
-                ]
+    it "advertises computer use as an ordinary strict function" do
+        case schemasFromAppTools codexDialect [computerUseTool] of
+            [_, FunctionToolValue function] -> do
+                function.name `shouldBe` computerFunctionName
+                function.strict `shouldBe` Just True
+                function.parameters `shouldSatisfy` (/= Nothing)
+            other -> expectationFailure
+                ("expected ordinary computer function, got " <> show other)
+
+    it "reserves the model-facing computer_use function identity" do
+        let collision =
+                jsonAppTool computerFunctionName "Unrelated MCP function" []
+                    AlwaysPrompt
+                    (noArgsTool computerFunctionName (pure (Right "ok")))
+        schemasFromAppTools codexDialect [collision]
+            `shouldBe` [webSearchTool]
+        requireToolRegistry [computerUseTool, collision]
+            `shouldThrow` anyIOException
 
     it "keeps an unrelated function named computer as a function" do
         let computer = jsonAppTool "computer" "Unrelated MCP function" []
@@ -66,7 +78,7 @@ spec = describe "schemasFromAppTools" do
             other -> expectationFailure
                 ("expected ordinary computer function, got " <> show other)
 
-    it "advertises hosted computer only for the Codex dialect" do
+    it "advertises the local computer function only for the Codex dialect" do
         schemasFromAppTools grokBuildDialect [computerUseTool]
             `shouldBe` [webSearchTool, xSearchTool]
         schemasFromAppTools claudeCodeDialect [computerUseTool]

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -41,13 +41,12 @@ import qualified Data.Text.Encoding as TextEncoding
 data ToolCallKind
     = FunctionCallKind
     | CustomCallKind
-    -- | A provider-native computer call. Its arguments are the encoded
-    -- action list, and its result is encoded by the provider adapter as a
-    -- structured screenshot output rather than a function output string.
+    -- | A legacy provider-native computer call retained so persisted sessions
+    -- can still be resumed.
     | ComputerCallKind
-    -- | The reserved Responses Lite computer function. It uses the same local
-    -- executor and approval rules as a native computer call, but its result
-    -- must be returned as multimodal @function_call_output@ content.
+    -- | The reserved ordinary computer function. It uses the local executor
+    -- and explicit approval rules; Responses continuations pair its text
+    -- @function_call_output@ with a fresh user screenshot.
     | ComputerFunctionCallKind
     deriving (Eq, Show)
 

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -61,9 +61,9 @@ data ToolSchema
     = JsonFunctionSchema ![PropertySchema]
     | RawJsonFunctionSchema !Value
     | FreeformApplyPatchSchema
-    -- | The provider-native computer tool. Keeping this distinct prevents an
-    -- unrelated function or MCP tool named @computer@ from being projected as
-    -- a hosted desktop-control surface.
+    -- | The privileged local computer function. Keeping this distinct from
+    -- caller-defined JSON functions prevents an unrelated MCP tool from
+    -- acquiring the desktop-control handler or its output encoding.
     | HostedComputerSchema
     deriving (Eq, Show)
 
@@ -328,10 +328,9 @@ dispatchRegisteredToolCall config registry call =
                 else Nothing)
         call
 
--- | Provider-native call kinds may only reach their matching hosted handler.
--- This prevents a function/custom tool that happens to share the hosted name
--- from invoking desktop control, and prevents native calls from reaching an
--- ordinary function handler.
+-- | Privileged computer calls may only reach their dedicated handler. This
+-- prevents a caller-defined function/custom tool from acquiring desktop
+-- control, and keeps legacy native calls away from ordinary handlers.
 toolAcceptsCall :: AppTool -> ToolCall -> Bool
 toolAcceptsCall tool call =
     case (tool.appToolSchema, call.callKind) of

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -28,6 +28,7 @@ module Agent.OpenAI.LoopBackend
     , assistantTextFromResponse
     , toolResultToItem
     , withRequestInput
+    , normalizeResponseInputItems
     ) where
 
 import Agent.Error
@@ -71,8 +72,10 @@ import Agent.Responses.LoopBackend
     , toolResultToItem
     , turnInputsToItems
     , withRequestInput
+    , normalizeResponseInputItems
     )
 import Agent.Responses.Types
+import Agent.ToolDispatch (ToolCallKind(..), ToolCallResult(..))
 import qualified Agent.Transport.WebSocket as WebSocket
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (onException)
@@ -530,6 +533,22 @@ openAiBackendWithTransportFallback fallbackActive primary fallback =
         ReasoningDelta {} -> True
         _ -> False
 
+hasLegacyComputerContinuation :: [ResponseItem] -> [TurnInput] -> Bool
+hasLegacyComputerContinuation history inputs =
+    any isNativeComputerItem history
+        || any isNativeComputerResult inputs
+  where
+    isNativeComputerItem = \case
+        ComputerCallItem{} -> True
+        ComputerCallOutputItem{} -> True
+        FunctionCallItem call ->
+            call.name == legacyComputerFunctionName
+                && call.namespace == Just computerFunctionNamespace
+        _ -> False
+    isNativeComputerResult = \case
+        CompletedTool result -> result.callKind == ComputerCallKind
+        _ -> False
+
 -- | Errors that indicate the Codex Responses WebSocket transport is
 -- unavailable rather than that the logical request itself was rejected.
 isOpenAiWebSocketTransportFailure :: ApiError -> Bool
@@ -638,6 +657,8 @@ openAiBackendWithRetryPolicyAndReasoningVisibility
             fullRequest = withRequestInput baseParams (history <> newItems)
             (initialRequest, initialPrevious) =
                 case previousResponseId of
+                    _ | hasLegacyComputerContinuation history inputs ->
+                        (fullRequest, Nothing)
                     Nothing | not (null history) -> (fullRequest, Nothing)
                     _ -> (deltaRequest, previousResponseId)
         result <- sendRetrying onLoopEvent initialRequest initialPrevious
@@ -654,7 +675,9 @@ openAiBackendWithRetryPolicyAndReasoningVisibility
             Right response ->
                 pure $ Right BackendResult
                     { backendOutput = responseToTurnOutput response
-                    , backendState = history <> newItems <> response.output
+                    , backendState =
+                        normalizeResponseInputItems (history <> newItems)
+                            <> response.output
                     }
   where
     sendRetrying onLoopEvent request previousResponseId = do

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -615,6 +615,63 @@ spec = do
                 , seed <> turnInputsToItems resultInput
                 ]
 
+        it "starts a fresh ordinary-function chain for native computer history" do
+            seen <- newIORef []
+            let legacyCall = ComputerCall
+                    { computerCallItemId = Just "native-item"
+                    , computerCallId = "native-call"
+                    , computerActions = [ScreenshotAction]
+                    , pendingSafetyChecks = []
+                    , computerCallStatus = Just ItemCompleted
+                    , computerCallExtra = KeyMap.empty
+                    }
+            transcript <- newIORef [ComputerCallItem legacyCall]
+            let backend = openAiBackendWith
+                    (recordingSend seen)
+                    (pure baseParams)
+            _ <- submitWithState transcript backend (Just "resp-native")
+                [UserMessage "continue"]
+                (const (pure ()))
+            [(request, previous)] <- readIORef seen
+            previous `shouldBe` Nothing
+            case inputItems request of
+                [FunctionCallItem function, MessageItem{}] -> do
+                    function.name `shouldBe` computerFunctionName
+                    function.namespace `shouldBe` Nothing
+                other -> expectationFailure
+                    ("legacy native item reached Codex: " <> show other)
+
+        it "starts a fresh chain for the earlier Lite computer fallback" do
+            seen <- newIORef []
+            let legacyCall = FunctionCall
+                    { itemId = Just "legacy-item"
+                    , callId = "legacy-call"
+                    , name = legacyComputerFunctionName
+                    , namespace = Just computerFunctionNamespace
+                    , arguments =
+                        "{\"actions\":[{\"type\":\"screenshot\"}]}"
+                    , encryptedFunctionArgs = Nothing
+                    , status = Just ItemCompleted
+                    , extraFields = KeyMap.empty
+                    }
+            transcript <- newIORef [FunctionCallItem legacyCall]
+            let backend = openAiBackendWith
+                    (recordingSend seen)
+                    (pure baseParams)
+            _ <- submitWithState transcript backend (Just "resp-legacy-lite")
+                [UserMessage "continue"]
+                (const (pure ()))
+            [(request, previous)] <- readIORef seen
+            previous `shouldBe` Nothing
+            case inputItems request of
+                [FunctionCallItem function, MessageItem{}] -> do
+                    function.itemId `shouldBe` Nothing
+                    function.name `shouldBe` computerFunctionName
+                    function.namespace `shouldBe` Nothing
+                other -> expectationFailure
+                    ("legacy Lite computer item reached Codex: "
+                        <> show other)
+
         it "strips explicitly requested cache retention and starts a fresh chain" do
             seen <- newIORef []
             let seed = turnInputsToItems [UserMessage "old"]

--- a/packages/agent-responses-types/src/Agent/Responses/Types.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types.hs
@@ -61,6 +61,7 @@ module Agent.Responses.Types
     , FunctionTool(..)
     , computerFunctionNamespace
     , computerFunctionName
+    , legacyComputerFunctionName
 
       -- * Response
     , Response(..)

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Tools.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Tools.hs
@@ -7,6 +7,7 @@ module Agent.Responses.Types.Tools
     , FunctionTool(..)
     , computerFunctionNamespace
     , computerFunctionName
+    , legacyComputerFunctionName
     ) where
 
 import Agent.Responses.Types.Common
@@ -14,14 +15,17 @@ import Data.Aeson hiding (TaggedObject)
 import qualified Data.Aeson as Aeson
 import Data.Text (Text)
 
--- | Reserved names used when a Responses Lite transport cannot register the
--- provider-native computer tool and must expose the same harness as a
--- screenshot-returning function instead.
+-- | Legacy namespace used by sessions written by the earlier Responses Lite
+-- computer fallback.
 computerFunctionNamespace :: Text
 computerFunctionNamespace = "computer_use"
 
+-- | Ordinary function identity for the local computer harness.
 computerFunctionName :: Text
-computerFunctionName = "computer"
+computerFunctionName = "computer_use"
+
+legacyComputerFunctionName :: Text
+legacyComputerFunctionName = "computer"
 
 data ResponseToolType
     = ToolFunction

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -13,6 +13,7 @@ module Agent.Responses.LoopBackend
     , assistantTextFromResponse
     , toolResultToItem
     , withRequestInput
+    , normalizeResponseInputItems
     ) where
 
 import Agent.Error (ApiError)
@@ -44,6 +45,7 @@ import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
     , ToolCallResult(..)
+    , isComputerToolCallKind
     )
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
@@ -53,6 +55,7 @@ import Data.ByteString (ByteString)
 import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe (fromMaybe, isJust, mapMaybe, maybeToList)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -91,7 +94,9 @@ statelessResponsesBackendWithRawReasoning showRawReasoning send getParams =
             Right response ->
                 pure $ Right BackendResult
                     { backendOutput = responseToTurnOutput response
-                    , backendState = requestItems <> response.output
+                    , backendState =
+                        normalizeResponseInputItems requestItems
+                            <> response.output
                     }
 
 -- | Adapt a credentialed stateless Responses transport to the loop.
@@ -116,7 +121,7 @@ tokenProviderStatelessResponsesBackend provider send =
 withRequestInput :: ResponseCreateParams -> [ResponseItem] -> ResponseCreateParams
 withRequestInput ResponseCreateParams{..} items =
     let prefix = requestInputPrefix input
-        normalizedItems = map normalizeRequestItem items
+        normalizedItems = normalizeResponseInputItems items
         requestItems
             | any isAdditionalTools prefix =
                 map stripResponsesLiteImageDetails normalizedItems
@@ -210,15 +215,74 @@ stripInputImageDetailValue = \case
         Aeson.Array (fmap stripInputImageDetailValue values)
     value -> value
 
--- Older local compaction snapshots accidentally persisted assistant summaries
--- as input_text. Responses input accepts assistant history, but its content
--- parts must use output_text (or refusal). Repair those snapshots at the wire
--- boundary so resumed sessions recover without rewriting their session files.
-normalizeRequestItem :: ResponseItem -> ResponseItem
+-- Repair persisted compatibility shapes at the wire boundary without
+-- rewriting session files. Older assistant summaries used input_text, and
+-- older computer sessions used provider-native call/output items that Codex
+-- does not accept.
+normalizeResponseInputItems :: [ResponseItem] -> [ResponseItem]
+normalizeResponseInputItems = go Set.empty Nothing
+  where
+    go legacyFunctionCalls pendingScreenshot = \case
+        [] -> computerObservationItems pendingScreenshot
+        FunctionCallItem call : items
+            | isLegacyComputerFunctionCall call ->
+                computerObservationItems pendingScreenshot
+                    <> [FunctionCallItem
+                        (normalizeLegacyComputerFunctionCall call)]
+                    <> go
+                        (Set.insert call.callId legacyFunctionCalls)
+                        Nothing
+                        items
+        FunctionCallOutputItem output : items
+            | Set.member output.callId legacyFunctionCalls ->
+                let screenshot = legacyFunctionScreenshot output
+                in normalizeLegacyComputerFunctionOutput output screenshot
+                    : go
+                        (Set.delete output.callId legacyFunctionCalls)
+                        screenshot
+                        items
+        item : items
+            | isToolOutputItem item ->
+                normalizeRequestItem item
+                    <> go
+                        legacyFunctionCalls
+                        (updatedComputerScreenshot pendingScreenshot item)
+                        items
+            | otherwise ->
+                computerObservationItems pendingScreenshot
+                    <> normalizeRequestItem item
+                    <> go legacyFunctionCalls Nothing items
+
+    computerObservationItems =
+        maybe [] (pure . legacyComputerScreenshotObservation)
+
+-- Keep a legacy screenshot behind the complete run of tool outputs. A later
+-- incomplete computer output invalidates an earlier image rather than
+-- presenting stale pixels as the latest desktop state.
+updatedComputerScreenshot
+    :: Maybe Text
+    -> ResponseItem
+    -> Maybe Text
+updatedComputerScreenshot current = \case
+    ComputerCallOutputItem output -> legacyComputerScreenshot output
+    _ -> current
+
+isToolOutputItem :: ResponseItem -> Bool
+isToolOutputItem = \case
+    FunctionCallOutputItem{} -> True
+    CustomToolCallOutputItem{} -> True
+    ComputerCallOutputItem{} -> True
+    _ -> False
+
+normalizeRequestItem :: ResponseItem -> [ResponseItem]
 normalizeRequestItem = \case
+    ComputerCallItem call ->
+        [FunctionCallItem (legacyComputerFunctionCall call)]
+    ComputerCallOutputItem output ->
+        [legacyComputerFunctionOutput output]
     MessageItem message
         | message.role == RoleAssistant ->
-            MessageItem ResponseMessage
+            [ MessageItem ResponseMessage
                 { messageId = message.messageId
                 , content = case message.content of
                     MessageContentText text ->
@@ -232,7 +296,94 @@ normalizeRequestItem = \case
                 , passthrough = message.passthrough
                 , extraFields = message.extraFields
                 }
-    item -> item
+            ]
+    item -> [item]
+
+legacyComputerFunctionCall :: ComputerCall -> FunctionCall
+legacyComputerFunctionCall call = FunctionCall
+    { itemId = Nothing
+    , callId = call.computerCallId
+    , name = computerFunctionName
+    , namespace = Nothing
+    , arguments =
+        Text.decodeUtf8 . LBS.toStrict . Aeson.encode $
+            Aeson.object ["actions" Aeson..= call.computerActions]
+    , encryptedFunctionArgs = Nothing
+    , status = call.computerCallStatus
+    , extraFields = KeyMap.empty
+    }
+
+legacyComputerFunctionOutput :: ComputerCallOutput -> ResponseItem
+legacyComputerFunctionOutput output =
+    FunctionCallOutputItem FunctionCallOutput
+        { itemId = Nothing
+        , callId = output.computerOutputCallId
+        , name = Nothing
+        , namespace = Nothing
+        , output = Aeson.String
+            (if legacyComputerOutputCompleted output
+                then "Computer action completed."
+                else "Computer action did not complete.")
+        , status = output.computerOutputStatus
+        , extraFields = KeyMap.empty
+        }
+
+legacyComputerScreenshot :: ComputerCallOutput -> Maybe Text
+legacyComputerScreenshot output
+    | legacyComputerOutputCompleted output =
+        Just output.screenshotDataUrl
+    | otherwise = Nothing
+
+legacyComputerOutputCompleted :: ComputerCallOutput -> Bool
+legacyComputerOutputCompleted output =
+    output.computerOutputStatus `elem` [Nothing, Just ItemCompleted]
+
+normalizeLegacyComputerFunctionCall :: FunctionCall -> FunctionCall
+normalizeLegacyComputerFunctionCall call = FunctionCall
+    { itemId = Nothing
+    , callId = call.callId
+    , name = computerFunctionName
+    , namespace = Nothing
+    , arguments = call.arguments
+    , encryptedFunctionArgs = call.encryptedFunctionArgs
+    , status = call.status
+    , extraFields = KeyMap.empty
+    }
+
+normalizeLegacyComputerFunctionOutput
+    :: FunctionCallOutput
+    -> Maybe Text
+    -> ResponseItem
+normalizeLegacyComputerFunctionOutput output screenshot =
+    FunctionCallOutputItem FunctionCallOutput
+        { itemId = Nothing
+        , callId = output.callId
+        , name = Nothing
+        , namespace = Nothing
+        , output =
+            if output.status == Just ItemIncomplete
+                then Aeson.String "Computer action did not complete."
+                else case screenshot of
+                    Just _ -> Aeson.String "Computer action completed."
+                    Nothing -> output.output
+        , status = output.status
+        , extraFields = KeyMap.empty
+        }
+
+legacyFunctionScreenshot :: FunctionCallOutput -> Maybe Text
+legacyFunctionScreenshot output
+    | output.status == Just ItemIncomplete = Nothing
+    | otherwise = case output.output of
+        Aeson.Array parts ->
+            lastMaybe
+                [ imageUrl
+                | Aeson.Object part <- foldr (:) [] parts
+                , KeyMap.lookup "type" part
+                    == Just (Aeson.String "input_image")
+                , Just (Aeson.String imageUrl) <-
+                    [KeyMap.lookup "image_url" part]
+                ]
+        _ -> Nothing
 
 normalizeAssistantPart :: ResponseContentPart -> ResponseContentPart
 normalizeAssistantPart = \case
@@ -246,7 +397,10 @@ normalizeAssistantPart = \case
     part -> part
 
 turnInputsToItems :: [TurnInput] -> [ResponseItem]
-turnInputsToItems = map turnInputToItem
+turnInputsToItems inputs =
+    map turnInputToItem inputs
+        <> maybeToList
+            (computerScreenshotObservation <$> latestComputerScreenshot inputs)
 
 turnInputToItem :: TurnInput -> ResponseItem
 turnInputToItem = \case
@@ -365,48 +519,88 @@ toolResultToItem result = case result.callKind of
         , extraFields = KeyMap.empty
         }
     ComputerCallKind ->
-        case Aeson.eitherDecodeStrict' (Text.encodeUtf8 result.output) of
-            Right output -> ComputerCallOutputItem output
-                { computerOutputCallId = result.callId }
-            Left _ -> ComputerCallOutputItem ComputerCallOutput
-                { computerOutputItemId = Nothing
-                , computerOutputCallId = result.callId
-                , screenshotDataUrl = transparentPixelDataUrl
-                , acknowledgedChecks = []
-                , computerOutputStatus = Just ItemIncomplete
-                , computerOutputExtra = KeyMap.empty
-                }
+        FunctionCallOutputItem FunctionCallOutput
+            { itemId = Nothing
+            , callId = result.callId
+            , name = Nothing
+            , namespace = Nothing
+            , output = Aeson.String
+                (computerFunctionTextOutput result.output)
+            , status = Nothing
+            , extraFields = KeyMap.empty
+            }
     ComputerFunctionCallKind ->
         FunctionCallOutputItem FunctionCallOutput
             { itemId = Nothing
             , callId = result.callId
             , name = Nothing
             , namespace = Nothing
-            , output = computerFunctionOutput result.output
+            , output = Aeson.String
+                (computerFunctionTextOutput result.output)
             , status = Nothing
             , extraFields = KeyMap.empty
             }
 
-computerFunctionOutput :: Text -> Aeson.Value
-computerFunctionOutput rawOutput =
+computerFunctionTextOutput :: Text -> Text
+computerFunctionTextOutput rawOutput =
     case Aeson.eitherDecodeStrict' (Text.encodeUtf8 rawOutput) of
-        Right ComputerCallOutput{screenshotDataUrl} ->
-            Aeson.toJSON
-                [ Aeson.object
-                    [ "type" Aeson..= ("input_image" :: Text)
-                    , "image_url" Aeson..= screenshotDataUrl
-                    , "detail" Aeson..= ("original" :: Text)
-                    ]
-                ]
-        Left _ -> Aeson.String rawOutput
+        Right ComputerCallOutput{} ->
+            "Computer action completed."
+        Left _ -> rawOutput
 
--- A rejection or executor failure still has to satisfy the Responses protocol
--- with a screenshot-shaped output. Successful executors return a fresh image.
-transparentPixelDataUrl :: Text
-transparentPixelDataUrl =
-    "data:image/png;base64,"
-        <> "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQ"
-        <> "IHWP4z8DwHwAFgAI/ScL7WQAAAABJRU5ErkJggg=="
+latestComputerScreenshot :: [TurnInput] -> Maybe Text
+latestComputerScreenshot inputs =
+    lastMaybe
+        [ result
+        | CompletedTool result <- inputs
+        , isComputerToolCallKind result.callKind
+        ]
+        >>= \result ->
+            case Aeson.eitherDecodeStrict' (Text.encodeUtf8 result.output) of
+                Right ComputerCallOutput{screenshotDataUrl} ->
+                    Just screenshotDataUrl
+                Left _ -> Nothing
+
+computerScreenshotObservation :: Text -> ResponseItem
+computerScreenshotObservation screenshotDataUrl =
+    computerScreenshotObservationWith
+        "Current macOS desktop after the completed computer action:"
+        screenshotDataUrl
+
+legacyComputerScreenshotObservation :: Text -> ResponseItem
+legacyComputerScreenshotObservation screenshotDataUrl =
+    computerScreenshotObservationWith
+        "macOS desktop observed after the completed computer action:"
+        screenshotDataUrl
+
+computerScreenshotObservationWith :: Text -> Text -> ResponseItem
+computerScreenshotObservationWith observationText screenshotDataUrl =
+    MessageItem ResponseMessage
+        { messageId = Nothing
+        , content = MessageContentParts
+            [ InputTextPart
+                observationText
+                Nothing
+                KeyMap.empty
+            , InputImagePart
+                { detail = Just "auto"
+                , fileId = Nothing
+                , imageUrl = Just screenshotDataUrl
+                , promptCacheBreakpoint = Nothing
+                , extraFields = KeyMap.empty
+                }
+            ]
+        , role = RoleUser
+        , status = Nothing
+        , phase = Nothing
+        , passthrough = Nothing
+        , extraFields = KeyMap.empty
+        }
+
+lastMaybe :: [value] -> Maybe value
+lastMaybe = \case
+    [] -> Nothing
+    values -> Just (last values)
 
 responseToTurnOutput :: Response -> TurnOutput
 responseToTurnOutput response = TurnOutput
@@ -431,8 +625,7 @@ tokenUsageFromResponse = maybe emptyTokenUsage \usage ->
 responseItemToToolCall :: ResponseItem -> Maybe ToolCall
 responseItemToToolCall = \case
     FunctionCallItem call
-        | call.namespace == Just computerFunctionNamespace
-        , call.name == computerFunctionName ->
+        | isComputerFunctionCall call ->
             Just ToolCall
                 { callId = call.callId
                 , name = "computer"
@@ -469,6 +662,18 @@ responseItemToToolCall = \case
             call.computerActions
         }
     _ -> Nothing
+
+isComputerFunctionCall :: FunctionCall -> Bool
+isComputerFunctionCall call =
+    ( call.name == computerFunctionName
+        && call.namespace `elem` [Nothing, Just "functions"]
+    )
+        || isLegacyComputerFunctionCall call
+
+isLegacyComputerFunctionCall :: FunctionCall -> Bool
+isLegacyComputerFunctionCall call =
+    call.name == legacyComputerFunctionName
+        && call.namespace == Just computerFunctionNamespace
 
 computerFunctionArgumentsSensitive :: Text -> Bool
 computerFunctionArgumentsSensitive rawArguments =

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -46,11 +46,11 @@ import Agent.Responses.Types
     , computerFunctionName
     , computerFunctionNamespace
     , defaultResponseCreateParams
+    , legacyComputerFunctionName
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Aeson.Key as Key
-import Data.Foldable (toList)
 import Data.IORef
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Text as Text
@@ -60,12 +60,12 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "tokenProviderStatelessResponsesBackend" do
-    it "routes the reserved computer function namespace to the computer harness" do
+    it "routes the ordinary computer function to the computer harness" do
         let call = FunctionCall
                 { itemId = Nothing
                 , callId = "call-function"
                 , name = computerFunctionName
-                , namespace = Just computerFunctionNamespace
+                , namespace = Just "functions"
                 , arguments =
                     "{\"actions\":[{\"type\":\"type\",\"text\":\"secret\"}]}"
                 , encryptedFunctionArgs = Nothing
@@ -78,9 +78,27 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
                 projected.callKind `shouldBe` ComputerFunctionCallKind
                 projected.argumentsEncrypted `shouldBe` True
             Nothing -> expectationFailure
-                "reserved computer function was not projected"
+                "computer function was not routed"
 
-    it "returns reserved computer screenshots as multimodal function output" do
+    it "routes the standard Responses computer function without a namespace" do
+        let call = FunctionCall
+                { itemId = Nothing
+                , callId = "call-standard"
+                , name = computerFunctionName
+                , namespace = Nothing
+                , arguments = "{\"actions\":[{\"type\":\"screenshot\"}]}"
+                , encryptedFunctionArgs = Nothing
+                , status = Nothing
+                , extraFields = KeyMap.empty
+                }
+        case responseItemToToolCall (FunctionCallItem call) of
+            Just projected -> do
+                projected.name `shouldBe` "computer"
+                projected.callKind `shouldBe` ComputerFunctionCallKind
+            Nothing -> expectationFailure
+                "standard computer function was not routed"
+
+    it "returns computer results as text plus a fresh user screenshot" do
         let encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
                 ComputerCallOutput
                     { computerOutputItemId = Nothing
@@ -96,24 +114,114 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
                 , callKind = ComputerFunctionCallKind
                 }
 
-        case toolResultToItem result of
-            FunctionCallOutputItem output ->
-                case output.output of
-                    Aeson.Array values -> case toList values of
-                        [image] -> do
-                            jsonField "type" image
-                                `shouldBe` Just (Aeson.String "input_image")
-                            jsonField "image_url" image `shouldBe`
-                                Just (Aeson.String "data:image/png;base64,AA==")
-                            jsonField "detail" image
-                                `shouldBe` Just (Aeson.String "original")
-                        other -> expectationFailure
-                            ("expected one screenshot part, got " <> show other)
+        case turnInputsToItems [CompletedTool result] of
+            [FunctionCallOutputItem output, MessageItem observation] -> do
+                output.output `shouldBe`
+                    Aeson.String "Computer action completed."
+                case observation.content of
+                    MessageContentParts
+                        [InputTextPart{}, InputImagePart{imageUrl, detail}] -> do
+                            imageUrl `shouldBe`
+                                Just "data:image/png;base64,AA=="
+                            detail `shouldBe` Just "auto"
                     other -> expectationFailure
-                        ("expected multimodal function output, got " <> show other)
-            other -> expectationFailure ("unexpected output: " <> show other)
+                        ("expected screenshot observation, got " <> show other)
+            other -> expectationFailure
+                ("unexpected computer continuation: " <> show other)
 
-    it "round-trips native computer calls through structured screenshot output" do
+    it "does not reuse a screenshot when the latest computer call fails" do
+        let successful = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/png;base64,STALE"
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.empty
+                    }
+            inputs =
+                [ CompletedTool ToolCallResult
+                    { callId = "call-success"
+                    , output = successful
+                    , callKind = ComputerFunctionCallKind
+                    }
+                , CompletedTool ToolCallResult
+                    { callId = "call-failed"
+                    , output = "Computer input failed after changing the UI."
+                    , callKind = ComputerFunctionCallKind
+                    }
+                ]
+        case turnInputsToItems inputs of
+            [ FunctionCallOutputItem first
+                , FunctionCallOutputItem second
+                ] -> do
+                    first.output `shouldBe`
+                        Aeson.String "Computer action completed."
+                    second.output `shouldBe`
+                        Aeson.String
+                            "Computer input failed after changing the UI."
+            other -> expectationFailure
+                ("stale screenshot was reused: " <> show other)
+
+    it "keeps computer continuation ordering in standard and Lite requests" do
+        let encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/png;base64,AA=="
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.empty
+                    }
+            inputs =
+                turnInputsToItems
+                    [ CompletedTool ToolCallResult
+                        { callId = "call-function"
+                        , output = encoded
+                        , callKind = ComputerFunctionCallKind
+                        }
+                    ]
+            standard = withRequestInput defaultResponseCreateParams inputs
+            additional = UnknownResponseItem TaggedObject
+                { tag = "additional_tools"
+                , fields = KeyMap.empty
+                }
+            lite = withRequestInput
+                defaultResponseCreateParams
+                    { input = Just (ResponseInputItems [additional])
+                    }
+                inputs
+        case standard.input of
+            Just (ResponseInputItems
+                [ FunctionCallOutputItem FunctionCallOutput{output}
+                , MessageItem ResponseMessage
+                    { role = RoleUser
+                    , content = MessageContentParts
+                        [InputTextPart{}, InputImagePart{detail}]
+                    }
+                ]) -> do
+                    output `shouldBe`
+                        Aeson.String "Computer action completed."
+                    detail `shouldBe` Just "auto"
+            other -> expectationFailure
+                ("unexpected standard continuation: " <> show other)
+        case lite.input of
+            Just (ResponseInputItems
+                [ _
+                , FunctionCallOutputItem FunctionCallOutput{output}
+                , MessageItem ResponseMessage
+                    { role = RoleUser
+                    , content = MessageContentParts
+                        [InputTextPart{}, InputImagePart{detail}]
+                    }
+                ]) -> do
+                    output `shouldBe`
+                        Aeson.String "Computer action completed."
+                    detail `shouldBe` Nothing
+            other -> expectationFailure
+                ("unexpected Lite continuation: " <> show other)
+
+    it "normalizes legacy native computer calls to ordinary function output" do
         let call = ComputerCall
                 { computerCallItemId = Just "item-1"
                 , computerCallId = "call-1"
@@ -141,27 +249,38 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
                     , computerOutputStatus = Nothing
                     , computerOutputExtra = KeyMap.empty
                     }
-        case toolResultToItem ToolCallResult
-                { callId = "call-1"
-                , output = encoded
-                , callKind = ComputerCallKind
-                } of
-            ComputerCallOutputItem output -> do
-                output.computerOutputCallId `shouldBe` "call-1"
-                output.screenshotDataUrl `shouldBe` "data:image/png;base64,AA=="
-            other -> expectationFailure ("unexpected output: " <> show other)
+        case turnInputsToItems
+                [ CompletedTool ToolCallResult
+                    { callId = "call-1"
+                    , output = encoded
+                    , callKind = ComputerCallKind
+                    }
+                ] of
+            [FunctionCallOutputItem output, MessageItem observation] -> do
+                output.callId `shouldBe` "call-1"
+                output.output `shouldBe`
+                    Aeson.String "Computer action completed."
+                case observation.content of
+                    MessageContentParts
+                        [InputTextPart{}, InputImagePart{imageUrl}] ->
+                            imageUrl `shouldBe`
+                                Just "data:image/png;base64,AA=="
+                    other -> expectationFailure
+                        ("expected legacy screenshot observation, got "
+                            <> show other)
+            other -> expectationFailure
+                ("unexpected normalized output: " <> show other)
 
-    it "marks rejected or failed computer calls incomplete" do
+    it "returns rejected legacy computer calls as ordinary text output" do
         case toolResultToItem ToolCallResult
                 { callId = "call-failed"
                 , output = "Tool call rejected by user."
                 , callKind = ComputerCallKind
                 } of
-            ComputerCallOutputItem output -> do
-                output.computerOutputCallId `shouldBe` "call-failed"
-                output.computerOutputStatus `shouldBe` Just ItemIncomplete
-                output.screenshotDataUrl `shouldSatisfy`
-                    ("data:image/png;base64," `Text.isPrefixOf`)
+            FunctionCallOutputItem output -> do
+                output.callId `shouldBe` "call-failed"
+                output.output `shouldBe`
+                    Aeson.String "Tool call rejected by user."
             other -> expectationFailure ("unexpected output: " <> show other)
 
     it "uses the durationless computer wait action shape" do
@@ -212,15 +331,22 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
                     , computerOutputStatus = Nothing
                     , computerOutputExtra = KeyMap.empty
                     }
-        case toolResultToItem ToolCallResult
-                { callId = "call-large"
-                , output = encoded
-                , callKind = ComputerCallKind
-                } of
-            ComputerCallOutputItem output -> do
-                output.computerOutputCallId `shouldBe` "call-large"
-                output.screenshotDataUrl `shouldBe` screenshot
-            other -> expectationFailure ("unexpected output: " <> show other)
+        case turnInputsToItems
+                [ CompletedTool ToolCallResult
+                    { callId = "call-large"
+                    , output = encoded
+                    , callKind = ComputerCallKind
+                    }
+                ] of
+            [FunctionCallOutputItem{}, MessageItem observation] ->
+                case observation.content of
+                    MessageContentParts
+                        [InputTextPart{}, InputImagePart{imageUrl}] ->
+                            imageUrl `shouldBe` Just screenshot
+                    other -> expectationFailure
+                        ("expected large screenshot, got " <> show other)
+            other -> expectationFailure
+                ("unexpected large continuation: " <> show other)
 
     it "encodes file attachments as input_file parts" do
         let image = ImageAttachment "image/png" "png-bytes"
@@ -368,6 +494,163 @@ spec = describe "tokenProviderStatelessResponsesBackend" do
                 first `shouldBe` prefix
                 second `shouldSatisfy` isUserMessage
             _ -> expectationFailure "expected preserved input prefix"
+
+    it "never re-emits legacy native computer history on the wire" do
+        let call = ComputerCall
+                { computerCallItemId = Just "native-item"
+                , computerCallId = "native-call"
+                , computerActions = [ScreenshotAction]
+                , pendingSafetyChecks = []
+                , computerCallStatus = Just ItemCompleted
+                , computerCallExtra = KeyMap.empty
+                }
+            output = ComputerCallOutput
+                { computerOutputItemId = Just "native-output"
+                , computerOutputCallId = "native-call"
+                , screenshotDataUrl = "data:image/png;base64,AA=="
+                , acknowledgedChecks = []
+                , computerOutputStatus = Just ItemCompleted
+                , computerOutputExtra = KeyMap.empty
+                }
+            request = withRequestInput defaultResponseCreateParams
+                [ComputerCallItem call, ComputerCallOutputItem output]
+        case request.input of
+            Just (ResponseInputItems
+                [ FunctionCallItem function
+                , FunctionCallOutputItem functionOutput
+                , MessageItem ResponseMessage
+                    { role = RoleUser
+                    , content = MessageContentParts
+                        [InputTextPart{}, InputImagePart{imageUrl}]
+                    }
+                ]) -> do
+                    function.itemId `shouldBe` Nothing
+                    function.name `shouldBe` computerFunctionName
+                    function.namespace `shouldBe` Nothing
+                    function.callId `shouldBe` "native-call"
+                    functionOutput.itemId `shouldBe` Nothing
+                    functionOutput.callId `shouldBe` "native-call"
+                    functionOutput.output `shouldBe`
+                        Aeson.String "Computer action completed."
+                    imageUrl `shouldBe` Just "data:image/png;base64,AA=="
+            other -> expectationFailure
+                ("legacy computer history reached the wire: " <> show other)
+
+    it "normalizes the earlier Lite computer fallback history" do
+        let call = FunctionCall
+                { itemId = Just "legacy-function-item"
+                , callId = "legacy-function-call"
+                , name = legacyComputerFunctionName
+                , namespace = Just computerFunctionNamespace
+                , arguments = "{\"actions\":[{\"type\":\"screenshot\"}]}"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                , extraFields = KeyMap.empty
+                }
+            output = FunctionCallOutput
+                { itemId = Just "legacy-output-item"
+                , callId = "legacy-function-call"
+                , name = Nothing
+                , namespace = Nothing
+                , output = Aeson.toJSON
+                    [ Aeson.object
+                        [ "type" Aeson..= ("input_image" :: Text.Text)
+                        , "image_url" Aeson..=
+                            ("data:image/jpeg;base64,LITE" :: Text.Text)
+                        , "detail" Aeson..= ("original" :: Text.Text)
+                        ]
+                    ]
+                , status = Nothing
+                , extraFields = KeyMap.empty
+                }
+            request = withRequestInput defaultResponseCreateParams
+                [FunctionCallItem call, FunctionCallOutputItem output]
+        case request.input of
+            Just (ResponseInputItems
+                [ FunctionCallItem function
+                , FunctionCallOutputItem functionOutput
+                , MessageItem ResponseMessage
+                    { role = RoleUser
+                    , content = MessageContentParts
+                        [InputTextPart{}, InputImagePart{imageUrl}]
+                    }
+                ]) -> do
+                    function.itemId `shouldBe` Nothing
+                    function.name `shouldBe` computerFunctionName
+                    function.namespace `shouldBe` Nothing
+                    functionOutput.itemId `shouldBe` Nothing
+                    functionOutput.output `shouldBe`
+                        Aeson.String "Computer action completed."
+                    imageUrl `shouldBe`
+                        Just "data:image/jpeg;base64,LITE"
+            other -> expectationFailure
+                ("legacy Lite computer history reached the wire: "
+                    <> show other)
+
+    it "keeps incomplete legacy computer output incomplete and image-free" do
+        let output = ComputerCallOutput
+                { computerOutputItemId = Just "native-output"
+                , computerOutputCallId = "native-call"
+                , screenshotDataUrl = "data:image/png;base64,PLACEHOLDER"
+                , acknowledgedChecks = []
+                , computerOutputStatus = Just ItemIncomplete
+                , computerOutputExtra = KeyMap.empty
+                }
+            request = withRequestInput defaultResponseCreateParams
+                [ComputerCallOutputItem output]
+        case request.input of
+            Just (ResponseInputItems [FunctionCallOutputItem functionOutput]) -> do
+                functionOutput.status `shouldBe` Just ItemIncomplete
+                functionOutput.output `shouldBe`
+                    Aeson.String "Computer action did not complete."
+            other -> expectationFailure
+                ("incomplete legacy output became an observation: " <> show other)
+
+    it "places all legacy function outputs before the final observation" do
+        let call callId = ComputerCall
+                { computerCallItemId = Nothing
+                , computerCallId = callId
+                , computerActions = [ScreenshotAction]
+                , pendingSafetyChecks = []
+                , computerCallStatus = Just ItemCompleted
+                , computerCallExtra = KeyMap.empty
+                }
+            output callId screenshot = ComputerCallOutput
+                { computerOutputItemId = Nothing
+                , computerOutputCallId = callId
+                , screenshotDataUrl = screenshot
+                , acknowledgedChecks = []
+                , computerOutputStatus = Just ItemCompleted
+                , computerOutputExtra = KeyMap.empty
+                }
+            request = withRequestInput defaultResponseCreateParams
+                [ ComputerCallItem (call "call-1")
+                , ComputerCallItem (call "call-2")
+                , ComputerCallOutputItem
+                    (output "call-1" "data:image/png;base64,FIRST")
+                , ComputerCallOutputItem
+                    (output "call-2" "data:image/png;base64,LATEST")
+                ]
+        case request.input of
+            Just (ResponseInputItems
+                [ FunctionCallItem firstCall
+                , FunctionCallItem secondCall
+                , FunctionCallOutputItem firstOutput
+                , FunctionCallOutputItem secondOutput
+                , MessageItem ResponseMessage
+                    { role = RoleUser
+                    , content = MessageContentParts
+                        [InputTextPart{}, InputImagePart{imageUrl}]
+                    }
+                ]) -> do
+                    firstCall.callId `shouldBe` "call-1"
+                    secondCall.callId `shouldBe` "call-2"
+                    firstOutput.callId `shouldBe` "call-1"
+                    secondOutput.callId `shouldBe` "call-2"
+                    imageUrl `shouldBe`
+                        Just "data:image/png;base64,LATEST"
+            other -> expectationFailure
+                ("legacy outputs were interleaved: " <> show other)
 
     it "replaces arbitrary prior input instead of replaying it as a prefix" do
         let stale = turnInputsToItems [UserMessage "stale"]


### PR DESCRIPTION
## Summary
- expose local macOS computer control to Codex as the ordinary strict `computer_use` function in both standard Responses and Responses Lite
- return ordinary `function_call_output` text, followed by a normal user image observation containing the fresh screenshot
- keep explicit per-call computer approval, sensitive-argument redaction, privileged-handler isolation, and macOS action validation unchanged
- tell agents when the native app's connected browser tools are available and that the browser can be opened from the right sidebar

## Compatibility
- no gateway-specific model or endpoint checks; the gateway remains a generic function-call transport
- no provider-native `computer`, `computer_call`, or `computer_call_output` is emitted for new turns
- persisted native-computer and earlier namespaced-Lite sessions are normalized to ordinary function history and restarted on a fresh response chain
- failed or incomplete actions cannot reuse a stale screenshot

The abandoned gateway adapter was reverted and [haskell-agent-gateway#25](https://github.com/digitallyinduced/haskell-agent-gateway/pull/25) is closed. The native runtime pin is updated in [haskell-agent-macos#106](https://github.com/digitallyinduced/haskell-agent-macos/pull/106).

## Validation
- `agent-responses`: 59 examples, 0 failures
- `agent-openai`: 285 examples, 0 failures, 1 credential-gated pending test
- `agent-cli`: affected browser/request/computer/approval/tool tests pass; full suite passed 1216 examples in a clean-temp run (a later repeat hit one unrelated `McpAdmin` concurrency flake, which passed immediately in isolation)
- live direct Codex `gpt-5.6-sol`: ordinary `read_file` function round trip passed
- live direct Codex `gpt-5.6-sol`: `computer_use` was emitted, reached explicit approval, was denied safely, and continued through a normal function output
- final read-only review: no remaining correctness or security findings
