### PR TITLE
Complete the packaged CLI upgrade fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These are important product features, but not the core differentiation.
 2. **Copy this prompt to your coding agent to install:**
 
    ```text
-   Install haskell-agent by running `nix profile add --accept-flake-config github:digitallyinduced/haskell-agent`, then verify the installation by running `agent-cli --help`.
+   Install haskell-agent by running `nix profile add --accept-flake-config github:digitallyinduced/haskell-agent`. If Nix says `haskell-agent` is already added, update it with `nix profile upgrade --refresh --accept-flake-config haskell-agent` instead. Verify the packaged runtime by running `agent-cli storage start`, `agent-cli storage doctor`, and `agent-cli storage stop`.
    ```
 
    Or install it yourself:
@@ -112,6 +112,30 @@ These are important product features, but not the core differentiation.
 
    `--accept-flake-config` enables the public IHP binary cache declared by the
    flake.
+
+### Update
+
+`nix profile add` does not replace an existing profile entry. Update an
+existing installation with:
+
+```console
+nix profile upgrade --refresh --accept-flake-config haskell-agent
+```
+
+If the profile entry cannot be upgraded, remove and reinstall it:
+
+```console
+nix profile remove haskell-agent
+nix profile add --refresh --accept-flake-config github:digitallyinduced/haskell-agent
+```
+
+Verify that the packaged PostgreSQL runtime is available:
+
+```console
+agent-cli storage start
+agent-cli storage doctor
+agent-cli storage stop
+```
 
 ## Run
 

--- a/flake.nix
+++ b/flake.nix
@@ -566,9 +566,28 @@
                         (old: {
                             nativeBuildInputs =
                                 (old.nativeBuildInputs or [ ])
-                                ++ [ pkgs.makeWrapper ];
+                                ++ [ pkgs.makeWrapper ]
+                                ++ pkgs.lib.optionals
+                                    (system == "aarch64-darwin")
+                                    [ pkgs.removeReferencesTo ];
                             postInstall =
                                 (old.postInstall or "")
+                                + pkgs.lib.optionalString
+                                    (system == "aarch64-darwin")
+                                    ''
+                                        # Darwin's linker leaves generated
+                                        # Paths_* store prefixes in otherwise
+                                        # dead constants. The packages' live
+                                        # data files use separate -data
+                                        # outputs, so remove only these package
+                                        # output references before fixup strips
+                                        # and signs the executable.
+                                        remove-references-to \
+                                            -t ${claudeAgentSdkHaskellPackage} \
+                                            -t ${agentOpenaiPackage} \
+                                            -t ${agentCorePackage} \
+                                            "$out/bin/agent-cli"
+                                    ''
                                 + ''
                                     wrapProgram "$out/bin/agent-cli" \
                                         --set-default AGENT_SYNTAX_DIR \


### PR DESCRIPTION
## Summary

- document `nix profile upgrade --refresh` for an existing `haskell-agent` profile entry, with a remove/reinstall fallback
- verify the packaged PostgreSQL runtime with `storage start`, `storage doctor`, and `storage stop` instead of only checking `--help`
- remove dead generated `Paths_*` package-output references on aarch64 Darwin before fixup, while retaining the live `agent-core` and `agent-cli` data outputs

## Context

Follow-up to #846. The Linux runtime-wrapper fix is present, but retrying `nix profile add` leaves an already-installed pre-fix profile entry unchanged. Testing the real upgrade path also exposed a separate aarch64-Darwin packaging failure: weak dead-code elimination retained package prefixes that pulled GHC into the default package's closure.

## Validation

- `git diff --check`
- `nix flake check --no-build --no-eval-cache`
- built `.#default` on aarch64 Darwin from committed revision `438e21fa`
- confirmed the Darwin closure contains no GHC and measures 906.6 MiB
- installed the Darwin output into a disposable Nix profile and passed isolated PostgreSQL 18 start/doctor/stop
- built `github:digitallyinduced/haskell-agent/438e21fa#checks.x86_64-linux.agent-cli-static-runtime` on the Linux builder; the isolated default/static runtime check passed
