### PR TITLE
Fix Claude capability probing in TTY sessions

### DIFF
--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Capabilities.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Capabilities.hs
@@ -18,11 +18,12 @@ module Claude.Agent.SDK.Capabilities
     ) where
 
 import Agent.Process (terminateProcessGroup)
-import Control.Concurrent.Async (async, cancel, waitCatch)
+import Control.Concurrent.Async (withAsync, waitCatch)
 import Control.Exception.Safe
     ( SomeException
     , catchAny
     , mask
+    , onException
     , tryAny
     )
 import Control.Monad (when)
@@ -181,7 +182,12 @@ probeClaudeCapabilitiesIn executable cwd = do
     versionResult <- runProbe executable cwd ["--version"]
     case versionResult of
         Left err -> pure (Left err)
-        Right (exitCode, versionOutput, versionErr) ->
+        Right (exitCode, _, _)
+            | exitCode /= ExitSuccess ->
+                pure
+                    (Left
+                        "Claude Code --version probe exited unsuccessfully.")
+        Right (_, versionOutput, versionErr) ->
             case parseClaudeVersion (versionOutput <> "\n" <> versionErr) of
                 Nothing -> pure (Left "Unable to parse Claude Code version output.")
                 Just version -> do
@@ -191,31 +197,29 @@ probeClaudeCapabilitiesIn executable cwd = do
                         Just result -> pure (Right result)
                         Nothing -> do
                             helpResult <- runProbe executable cwd ["--help"]
-                            let result = case helpResult of
-                                    Left err -> ClaudeAgentCapabilities
-                                        { capabilityVersion = Just version
-                                        , supportedFlags = Set.empty
-                                        , permissionModes = Set.empty
-                                        , supportsStreaming = False
-                                        , supportsSafeMode = False
-                                        , warnings = [err]
-                                        }
-                                    Right (helpExit, helpOutput, helpErr) ->
-                                        let parsed = parseClaudeHelp helpOutput
-                                            failures =
-                                                [ "Claude Code --version exited unsuccessfully."
-                                                | exitCode /= ExitSuccess
-                                                ] <> [ "Claude Code --help exited unsuccessfully."
-                                                     | helpExit /= ExitSuccess
-                                                     ] <> [ "Claude Code probe stderr: " <> helpErr
-                                                           | not (Text.null (Text.strip helpErr))
-                                                           ]
-                                        in parsed
+                            case helpResult of
+                                Left err ->
+                                    pure
+                                        (Left
+                                            ("Claude Code --help probe failed: " <> err))
+                                Right (helpExit, _, _)
+                                    | helpExit /= ExitSuccess ->
+                                        pure
+                                            (Left
+                                                "Claude Code --help probe exited unsuccessfully.")
+                                Right (_, helpOutput, helpErr) -> do
+                                    let parsed = parseClaudeHelp helpOutput
+                                        failures =
+                                            [ "Claude Code probe stderr: " <> helpErr
+                                            | not (Text.null (Text.strip helpErr))
+                                            ]
+                                        result = parsed
                                             { capabilityVersion = Just version
                                             , warnings = failures <> parsed.warnings
                                             }
-                            atomicModifyIORef' capabilityCache \m -> (Map.insert key result m, ())
-                            pure (Right result)
+                                    atomicModifyIORef' capabilityCache
+                                        \m -> (Map.insert key result m, ())
+                                    pure (Right result)
 capabilityCache :: IORef (Map.Map String ClaudeAgentCapabilities)
 capabilityCache = unsafePerformIO (newIORef Map.empty)
 {-# NOINLINE capabilityCache #-}
@@ -226,6 +230,11 @@ runProbe executable cwd args =
         created <- tryAny $ createProcess
             (proc executable args)
                 { cwd = Just cwd
+                -- Claude Code inspects inherited terminals even for
+                -- non-interactive version/help commands.  Inheriting the
+                -- agent TUI's raw-mode stdin can make `claude --help` block
+                -- without producing output, so provide immediate EOF.
+                , std_in = CreatePipe
                 , std_out = CreatePipe
                 , std_err = CreatePipe
                 , close_fds = True
@@ -234,31 +243,74 @@ runProbe executable cwd args =
                 }
         case created of
             Left exception -> pure (Left (Text.pack (show (exception :: SomeException))))
-            Right (Nothing, Nothing, Nothing, _) ->
-                pure (Left "Claude Code probe did not provide output handles.")
-            Right (Nothing, Just output, Just error, processHandle) -> do
-                outputReader <- async (readBounded output)
-                errorReader <- async (readBounded error)
-                groupId <- getPid processHandle
-                outcome <- restore (timeout probeTimeoutMicros (waitForProcess processHandle))
-                    `catchAny` \_ -> pure Nothing
-                when (outcome == Nothing) do
-                    terminateProcessGroup groupId processHandle
-                outputText <- waitBounded outputReader
-                errorText <- waitBounded errorReader
-                case outcome of
-                    Nothing -> pure (Left "Claude Code capability probe timed out.")
-                    Just exitCode -> pure (Right (exitCode, outputText, errorText))
-            Right (_, _, _, processHandle) -> do
+            Right (Just input, Just output, Just error, processHandle) -> do
+                voidClose input
+                withAsync (readBounded output) \outputReader ->
+                    withAsync (readBounded error) \errorReader -> do
+                        groupId <- getPid processHandle
+                        outcome <-
+                            ( restore
+                                (timeout
+                                    probeTimeoutMicros
+                                    (waitForProcess processHandle))
+                                `catchAny` \_ -> pure Nothing
+                            ) `onException`
+                                terminateProcessGroup groupId processHandle
+                        when (outcome == Nothing) do
+                            terminateProcessGroup groupId processHandle
+                        outputResult <-
+                            waitBounded "stdout" outputReader
+                        errorResult <-
+                            waitBounded "stderr" errorReader
+                        case outcome of
+                            Nothing ->
+                                pure
+                                    (Left
+                                        "Claude Code capability probe timed out.")
+                            Just exitCode ->
+                                case (outputResult, errorResult) of
+                                    (Left message, _) -> do
+                                        terminateProcessGroup
+                                            groupId
+                                            processHandle
+                                        pure (Left message)
+                                    (_, Left message) -> do
+                                        terminateProcessGroup
+                                            groupId
+                                            processHandle
+                                        pure (Left message)
+                                    (Right outputText, Right errorText) ->
+                                        pure
+                                            (Right
+                                                ( exitCode
+                                                , outputText
+                                                , errorText
+                                                ))
+            Right (input, output, error, processHandle) -> do
+                mapM_
+                    (maybe (pure ()) voidClose)
+                    [input, output, error]
                 terminateProcessGroup Nothing processHandle
                 pure (Left "Claude Code probe returned incomplete output handles.")
   where
     probeTimeoutMicros = 3_000_000
-    waitBounded reader = do
+    waitBounded stream reader = do
         result <- timeout 1_000_000 (waitCatch reader)
         case result of
-            Just (Right text) -> pure text
-            _ -> cancel reader >> pure ""
+            Nothing ->
+                pure
+                    (Left
+                        ("Claude Code capability probe "
+                            <> stream
+                            <> " read timed out."))
+            Just (Left exception) ->
+                pure
+                    (Left
+                        ("Claude Code capability probe "
+                            <> stream
+                            <> " read failed: "
+                            <> Text.pack (show exception)))
+            Just (Right text) -> pure (Right text)
 
 readBounded :: Handle -> IO Text
 readBounded handle = do

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/CapabilitiesSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/CapabilitiesSpec.hs
@@ -3,8 +3,20 @@
 module Claude.Agent.SDK.CapabilitiesSpec (spec) where
 
 import Claude.Agent.SDK.Capabilities
+import Claude.Agent.SDK.TestSupport
+    ( withFakeClaude )
+import Control.Exception.Safe (bracket, finally, onException)
+import Control.Monad (void)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.Posix.IO
+    ( closeFd
+    , createPipe
+    , dup
+    , dupTo
+    , stdInput
+    )
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -26,6 +38,37 @@ spec = describe "Claude Code capabilities" do
             ["-p", "--input-format", "stream-json", "--output-format", "stream-json", "--verbose"]
             `shouldSatisfy` isLeft
 
+    it "does not inherit caller stdin for capability subprocesses" $
+        withFakeClaude stdinReadingProbeScript \directory executable -> do
+            result <-
+                withBlockedStandardInput $
+                    timeout 5_000_000 $
+                        probeClaudeCapabilitiesIn executable directory
+            result `shouldSatisfy` \case
+                Just (Right capabilities) ->
+                    capabilities.supportsStreaming
+                _ -> False
+
+    it "does not cache a failed capability probe" $
+        withFakeClaude failFirstHelpProbeScript \directory executable -> do
+            first <- probeClaudeCapabilitiesIn executable directory
+            first `shouldSatisfy` isLeft
+            second <- probeClaudeCapabilitiesIn executable directory
+            second `shouldSatisfy` \case
+                Right capabilities ->
+                    capabilities.supportsStreaming
+                Left _ -> False
+
+    it "fails the probe when a descendant keeps stdout open" $
+        withFakeClaude heldOpenHelpOutputScript \directory executable -> do
+            result <-
+                timeout 3_000_000 $
+                    probeClaudeCapabilitiesIn executable directory
+            result `shouldSatisfy` \case
+                Just (Left message) ->
+                    "stdout read timed out" `Text.isInfixOf` message
+                _ -> False
+
 fixtureHelp :: Text
 fixtureHelp = Text.unlines
     [ "Usage: claude [options]"
@@ -37,6 +80,98 @@ fixtureHelp = Text.unlines
     , "  --strict-mcp-config"
     , "  --permission-mode <mode> (choices: acceptEdits, auto, bypassPermissions, manual, dontAsk, plan)"
     ]
+
+stdinReadingProbeScript :: String
+stdinReadingProbeScript =
+    unlines
+        [ "#!/bin/sh"
+        , "IFS= read -r _input"
+        , "case \"$1\" in"
+        , "  --version)"
+        , "    printf '%s\\n' '2.1.251 (Claude Code)'"
+        , "    ;;"
+        , "  --help)"
+        , "    printf '%s\\n' \\"
+        , "      'Usage: claude [options]' \\"
+        , "      '  -p, --print' \\"
+        , "      '  --input-format <format> (choices: text, stream-json)' \\"
+        , "      '  --output-format <format> (choices: text, json, stream-json)' \\"
+        , "      '  --verbose' \\"
+        , "      '  --safe-mode' \\"
+        , "      '  --strict-mcp-config' \\"
+        , "      '  --permission-mode <mode> (choices: acceptEdits, auto, bypassPermissions, manual, dontAsk, plan)'"
+        , "    ;;"
+        , "esac"
+        ]
+
+heldOpenHelpOutputScript :: String
+heldOpenHelpOutputScript =
+    unlines
+        [ "#!/bin/sh"
+        , "case \"$1\" in"
+        , "  --version)"
+        , "    printf '%s\\n' '2.1.253 (Claude Code)'"
+        , "    ;;"
+        , "  --help)"
+        , "    sleep 2 2>/dev/null &"
+        , "    printf '%s\\n' \\"
+        , "      'Usage: claude [options]' \\"
+        , "      '  -p, --print' \\"
+        , "      '  --input-format <format> (choices: text, stream-json)' \\"
+        , "      '  --output-format <format> (choices: text, json, stream-json)' \\"
+        , "      '  --verbose'"
+        , "    ;;"
+        , "esac"
+        ]
+
+failFirstHelpProbeScript :: String
+failFirstHelpProbeScript =
+    unlines
+        [ "#!/bin/sh"
+        , "case \"$1\" in"
+        , "  --version)"
+        , "    printf '%s\\n' '2.1.252 (Claude Code)'"
+        , "    ;;"
+        , "  --help)"
+        , "    if [ ! -e \"$0.help-probed\" ]; then"
+        , "      printf 'failed' > \"$0.help-probed\""
+        , "      exit 1"
+        , "    fi"
+        , "    printf '%s\\n' \\"
+        , "      'Usage: claude [options]' \\"
+        , "      '  -p, --print' \\"
+        , "      '  --input-format <format> (choices: text, stream-json)' \\"
+        , "      '  --output-format <format> (choices: text, json, stream-json)' \\"
+        , "      '  --verbose' \\"
+        , "      '  --safe-mode' \\"
+        , "      '  --strict-mcp-config' \\"
+        , "      '  --permission-mode <mode> (choices: acceptEdits, auto, bypassPermissions, manual, dontAsk, plan)'"
+        , "    ;;"
+        , "esac"
+        ]
+
+-- | Replace stdin with a pipe whose writer stays open. A child that inherits
+-- stdin blocks in @read@, while a child with a private closed stdin receives
+-- EOF immediately.
+withBlockedStandardInput :: IO a -> IO a
+withBlockedStandardInput action =
+    bracket acquire release (const action)
+  where
+    acquire = do
+        original <- dup stdInput
+        (reader, writer) <- createPipe
+        let cleanup = do
+                closeFd original
+                closeFd reader
+                closeFd writer
+        (do
+            _ <- dupTo reader stdInput
+            closeFd reader
+            pure (original, writer)
+            ) `onException` cleanup
+    release (original, writer) =
+        (void (dupTo original stdInput) `finally` closeFd original)
+            `finally` closeFd writer
 
 isLeft :: Either a b -> Bool
 isLeft = \case


### PR DESCRIPTION
## Summary

- give Claude Code capability probes a private closed stdin instead of the agent TUI's raw terminal
- report and avoid caching transient, non-zero, or incomplete probe failures
- scope probe output readers and clean up subprocess groups on cancellation/read failure
- add regressions for inherited blocked stdin, retry after a failed probe, and held-open output pipes

## Root cause

In a live tmux agent, `claude --help` inherited the raw-mode TTY on stdin and blocked without emitting output. The three-second timeout was then converted to `supportsStreaming = False` and cached, producing the misleading stream-json validation error.

## Validation

- `TMPDIR="$PWD/dist-newstyle/tmp" nix develop -c sh -c "printf 'main\\n:q\\n' | cabal repl claude-agent-sdk-haskell:test:claude-agent-sdk-haskell-test --repl-options=-v0"` — 94 examples, 0 failures
- raw-TTY capability probe in tmux against Claude Code 2.1.251 — `supportsStreaming = True`
- source-loaded `agent-cli` in tmux with unshimmed `claude-code/sonnet` — created and ran `Verify.hs`, output `3628800`
