### PR TITLE
test: stabilize constrained sandbox checks

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -167,7 +167,8 @@ createWorktreeWithFetchProgress report fetchLatest source root = runExceptT do
     let day = utctDay now
         start = posixMicros now
     lift (createDirectoryIfMissing True (root </> repoName))
-    addUnique repo root repoName day start base 0
+    withGitWorktreeLock repo $
+        addUnique repo root repoName day start base 0
 
 -- | Create a worktree using the machine-wide policy under the supplied home.
 -- Configuration is read for every creation so startup, slash-command, and
@@ -195,10 +196,11 @@ createManagedWorktreeWithProgress report home source =
 removeWorktree :: OsPath -> OsPath -> IO (Either Text ())
 removeWorktree source path = runExceptT do
     repo <- gitToplevel source
-    void $ ExceptT $
-        git repo ["worktree", "remove", "--force", unsafeToFilePath path]
-    void $ ExceptT $
-        git repo ["branch", "-D", unsafeToFilePath (takeFileName path)]
+    withGitWorktreeLock repo do
+        void $ ExceptT $
+            git repo ["worktree", "remove", "--force", unsafeToFilePath path]
+        void $ ExceptT $
+            git repo ["branch", "-D", unsafeToFilePath (takeFileName path)]
 
 -- | Take a shared lease when @path@ is inside one of our managed worktrees.
 -- Cleanup takes the corresponding exclusive lock, so multiple live sessions
@@ -368,33 +370,34 @@ cleanupCandidate root candidate = do
             Right Nothing ->
                 pure mempty
             Right (Just (commonDir, branch)) ->
-                git commonDir
-                    [ "worktree"
-                    , "remove"
-                    , unsafeToFilePath candidate
-                    ] >>= \case
-                        Left err ->
-                            pure mempty
-                                { cleanupFailures = [(candidate, err)]
-                                }
-                        Right _ -> do
-                            -- The worktree is the resource governed by the
-                            -- retention policy. Branch deletion is best
-                            -- effort: @-d@ can reject a branch that is known
-                            -- to be reachable from another ref but is not
-                            -- merged into the repository's current branch.
-                            -- Retaining it is safe and should not surface as
-                            -- a startup warning.
-                            _ <- git commonDir
-                                [ "branch"
-                                , "-d"
-                                , "--"
-                                , Text.unpack branch
-                                ]
-                            pure WorktreeCleanupReport
-                                { cleanupRemoved = [candidate]
-                                , cleanupFailures = []
-                                }
+                withGitWorktreeLockAt commonDir $
+                    git commonDir
+                        [ "worktree"
+                        , "remove"
+                        , unsafeToFilePath candidate
+                        ] >>= \case
+                            Left err ->
+                                pure mempty
+                                    { cleanupFailures = [(candidate, err)]
+                                    }
+                            Right _ -> do
+                                -- The worktree is the resource governed by the
+                                -- retention policy. Branch deletion is best
+                                -- effort: @-d@ can reject a branch that is known
+                                -- to be reachable from another ref but is not
+                                -- merged into the repository's current branch.
+                                -- Retaining it is safe and should not surface as
+                                -- a startup warning.
+                                _ <- git commonDir
+                                    [ "branch"
+                                    , "-d"
+                                    , "--"
+                                    , Text.unpack branch
+                                    ]
+                                pure WorktreeCleanupReport
+                                    { cleanupRemoved = [candidate]
+                                    , cleanupFailures = []
+                                    }
 
 inspectCleanupCandidate
     :: OsPath
@@ -610,13 +613,36 @@ gitToplevel source = do
 
 gitRepositoryName :: OsPath -> ExceptT Text IO OsPath
 gitRepositoryName repo = do
-    commonDir <- ExceptT $
-        git repo ["rev-parse", "--path-format=absolute", "--git-common-dir"]
-    let path = unsafeEncodeUtf (Text.unpack (Text.strip commonDir))
+    path <- gitCommonDir repo
     pure $
         if takeFileName path == unsafeEncodeUtf ".git"
             then takeFileName (takeDirectory path)
             else takeFileName path
+
+gitCommonDir :: OsPath -> ExceptT Text IO OsPath
+gitCommonDir repo = do
+    commonDir <- ExceptT $
+        git repo ["rev-parse", "--path-format=absolute", "--git-common-dir"]
+    pure (unsafeEncodeUtf (Text.unpack (Text.strip commonDir)))
+
+-- | Serialize mutations of Git's shared worktree administration directory.
+-- Fetches use private refs and can remain concurrent, but 'git worktree add'
+-- and 'remove' update the common @.git/worktrees@ state.
+withGitWorktreeLock
+    :: OsPath
+    -> ExceptT Text IO a
+    -> ExceptT Text IO a
+withGitWorktreeLock repo action = do
+    commonDir <- gitCommonDir repo
+    ExceptT $ withGitWorktreeLockAt commonDir (runExceptT action)
+
+withGitWorktreeLockAt :: OsPath -> IO a -> IO a
+withGitWorktreeLockAt commonDir action =
+    FileLock.withFileLock
+        (unsafeToFilePath
+            (commonDir </> unsafeEncodeUtf "haskell-agent-worktree.lock"))
+        FileLock.Exclusive
+        (const action)
 
 -- | Fetch and return the commit at the selected remote's advertised default
 -- branch, or use the local @HEAD@ when the repository has no remotes. The

--- a/packages/agent-codex-dialect/agent-codex-dialect.cabal
+++ b/packages/agent-codex-dialect/agent-codex-dialect.cabal
@@ -66,6 +66,7 @@ test-suite agent-codex-dialect-test
                     , directory
                     , filepath
                     , hspec
+                    , process
                     , safe-exceptions
                     , text
                     , time

--- a/packages/agent-codex-dialect/package.nix
+++ b/packages/agent-codex-dialect/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, agent-core, agent-json, async, base, containers
-, directory, filepath, hspec, lib, safe-exceptions, text, time
-, transformers, unix
+, directory, filepath, hspec, lib, process, safe-exceptions, text
+, time, transformers, unix
 }:
 mkDerivation {
   pname = "agent-codex-dialect";
@@ -11,8 +11,8 @@ mkDerivation {
     safe-exceptions text time transformers unix
   ];
   testHaskellDepends = [
-    agent-core base directory filepath hspec safe-exceptions text time
-    unix
+    agent-core base directory filepath hspec process safe-exceptions
+    text time unix
   ];
   description = "Codex model-facing dialect for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -38,7 +38,7 @@ import Agent.Tools.Types
     , toolSchedulingPlanFor
     )
 import Control.Concurrent (threadDelay)
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, tryIO)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Calendar (fromGregorian)
@@ -49,9 +49,13 @@ import System.Directory
     , getTemporaryDirectory
     , removeDirectoryRecursive
     )
+import System.Exit (ExitCode(..))
 import System.FilePath (makeRelative, (</>))
+import System.Info (os)
+import System.IO.Error (isPermissionError)
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Temp (mkdtemp)
+import System.Process (readProcessWithExitCode)
 import Test.Hspec
 
 spec :: Spec
@@ -170,6 +174,7 @@ spec = describe "Codex dialect" do
                         Text.isInfixOf "Blocked hardcoded system temp path"
 
     it "maps a /tmp shell workdir to the private session directory" do
+        requireProcessSandbox
         withTempDir \dir -> do
             let scratch = dir </> "session-scratch"
             createDirectory scratch
@@ -191,6 +196,7 @@ spec = describe "Codex dialect" do
                         Text.isInfixOf (Text.pack canonicalScratch)
 
     it "stops retained shell commands when resetting a session" do
+        requireProcessSandbox
         withTempDir \dir -> do
             let scratch = dir </> "session-scratch"
                 output = scratch </> "retained-output"
@@ -456,6 +462,35 @@ withTempDir action = do
         (mkdtemp (tmp </> "agent-codex-dialect-XXXXXX"))
         removeDirectoryRecursive
         action
+
+requireProcessSandbox :: IO ()
+requireProcessSandbox
+    | os /= "darwin" = pure ()
+    | otherwise = do
+        doesFileExist "/usr/bin/sandbox-exec" >>= \case
+            False -> pendingWith
+                "sandbox-exec is unavailable in this test environment"
+            True -> do
+                probe <- tryIO $
+                    readProcessWithExitCode
+                        "/usr/bin/sandbox-exec"
+                        ["-p", "(version 1) (allow default)", "/usr/bin/true"]
+                        ""
+                case probe of
+                    Left err
+                        | isPermissionError err -> pendingWith
+                            "sandbox-exec is unavailable in this test environment"
+                        | otherwise -> ioError err
+                    Right (ExitSuccess, _, _) -> pure ()
+                    Right (ExitFailure 71, _, stderr)
+                        | "sandbox_apply: Operation not permitted"
+                            `Text.isInfixOf` Text.pack stderr ->
+                            pendingWith
+                                "sandbox-exec is unavailable in this test environment"
+                    Right result ->
+                        expectationFailure $
+                            "sandbox-exec capability probe failed unexpectedly: "
+                                <> show result
 
 waitForFile :: FilePath -> IO Bool
 waitForFile path = go (100 :: Int)

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -283,6 +283,7 @@ test-suite agent-core-test
                     , filepath
                     , containers
                     , hspec
+                    , process
                     , QuickCheck >= 2.14 && < 2.16
                     , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -20,8 +20,8 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-json agent-responses-types async base base64-bytestring
     bytestring containers crypton-connection directory filepath hspec
-    QuickCheck retry safe-exceptions stm text time tls unix websockets
-    yaml
+    process QuickCheck retry safe-exceptions stm text time tls unix
+    websockets yaml
   ];
   benchmarkHaskellDepends = [
     aeson agent-json async base bytestring directory filepath process

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
@@ -67,6 +67,7 @@ import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
     , modifyMVar_
+    , modifyMVarMasked_
     , newEmptyMVar
     , newMVar
     , putMVar
@@ -615,12 +616,16 @@ monitorWorker
                             failClosed False "content received before ready"
                     Right WorkerExecSucceeded{..}
                         | hasStarted && responseId == "exec" ->
-                            do
-                                modifyMVar_ storedValues $
-                                    pure
-                                        . Map.union
+                            modifyMVarMasked_ storedValues \current -> do
+                                let updated =
+                                        Map.union
                                             (Map.map protocolValue
                                                 responseStoredValueWrites)
+                                            current
+                                -- Keep stored writes and terminal publication
+                                -- in one state-transition boundary. A later
+                                -- cell that sees these writes must also see
+                                -- this completed cell.
                                 atomically do
                                     values <- drainTQueue content
                                     void $ tryPutTMVar result $
@@ -628,17 +633,19 @@ monitorWorker
                                             (preferStreamedContent
                                                 values
                                                 (protocolValue responseValue)))
+                                pure updated
                         | otherwise ->
                             failClosed hasStarted
                                 "unexpected execution response id"
                     Right WorkerExecFailed{..}
                         | hasStarted && responseId == "exec" ->
-                            do
-                                modifyMVar_ storedValues $
-                                    pure
-                                        . Map.union
+                            modifyMVarMasked_ storedValues \current -> do
+                                let updated =
+                                        Map.union
                                             (Map.map protocolValue
                                                 responseStoredValueWrites)
+                                            current
+                                -- See the corresponding success branch.
                                 atomically do
                                     values <- drainTQueue content
                                     void $ tryPutTMVar result $
@@ -647,6 +654,7 @@ monitorWorker
                                                 values
                                                 (protocolValue responseValue))
                                             responseError)
+                                pure updated
                         | otherwise ->
                             failClosed hasStarted
                                 "unexpected execution error id"

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -28,6 +28,7 @@ import Control.Concurrent
     ( newEmptyMVar
     , putMVar
     , readMVar
+    , takeMVar
     , threadDelay
     )
 import Control.Concurrent.Async (async, cancel, wait, withAsync)
@@ -228,32 +229,38 @@ spec = describe "code-mode Bun host" do
         closeCodeModeHost host
 
     it "returns an already-observed natural completion instead of termination" do
-        let config = defaultCodeModeConfig
+        handlerStarted <- newEmptyMVar
+        releaseHandler <- newEmptyMVar
+        let handler name _
+                | name == "gate" = do
+                    putMVar handlerStarted ()
+                    readMVar releaseHandler
+                    pure (Right Null)
+                | otherwise = pure (Left "unexpected tool call")
+            config = defaultCodeModeConfig
                 "data/code-mode/worker.mjs"
-                (\_ _ -> pure $ Left "no tools")
-        host <- newCodeModeHost config
-        started <- execCodeCell
-            host
-            "await new Promise(resolve => setTimeout(resolve, 20)); text(\"done\");"
-            []
-            1
-        started `shouldBe`
-            Right CodeModeRunning
-                { cellId = "1"
-                , cellOutput = emptyContent
-                }
-        -- Bun and the host monitor share a heavily loaded CI runner with the
-        -- rest of the flake checks. Wait well beyond the 20 ms JavaScript
-        -- timer so termination tests an already-observed result rather than
-        -- racing timer scheduling.
-        threadDelay 1000000
-        terminated <- terminateCodeCell host "1"
-        terminated `shouldBe`
-            Right CodeModeFinished
-                { cellId = "1"
-                , cellValue = textContent "done"
-                }
-        closeCodeModeHost host
+                handler
+        bracket (newCodeModeHost config) closeCodeModeHost \host -> do
+            started <- execCodeCell
+                host
+                "await tools.gate({}); store(\"completion-marker\", true); text(\"done\");"
+                ["gate"]
+                1
+            started `shouldBe`
+                Right CodeModeRunning
+                    { cellId = "1"
+                    , cellOutput = emptyContent
+                    }
+            timeout 5000000 (readMVar handlerStarted) `shouldReturn` Just ()
+            putMVar releaseHandler ()
+            timeout 5000000 (waitForCompletionMarker host 100)
+                `shouldReturn` Just True
+            terminated <- terminateCodeCell host "1"
+            terminated `shouldBe`
+                Right CodeModeFinished
+                    { cellId = "1"
+                    , cellValue = textContent "done"
+                    }
 
     it "does not expose Node globals" do
         let config = defaultCodeModeConfig
@@ -304,28 +311,40 @@ spec = describe "code-mode Bun host" do
         closeCodeModeHost host
 
     it "returns output accumulated after the last timed yield on termination" do
-        let config = defaultCodeModeConfig
-                "data/code-mode/worker.mjs"
-                (\_ _ -> pure $ Left "no tools")
-        host <- newCodeModeHost config
-        started <- execCodeCell
-            host
-            "await new Promise(resolve => setTimeout(resolve, 30)); text(\"late\"); await new Promise(() => {});"
-            []
-            10
-        started `shouldBe`
-            Right CodeModeRunning
-                { cellId = "1"
-                , cellOutput = emptyContent
-                }
-        threadDelay 50000
-        terminated <- terminateCodeCell host "1"
-        terminated `shouldBe`
-            Right CodeModeTerminated
-                { cellId = "1"
-                , cellValue = textContent "late"
-                }
-        closeCodeModeHost host
+        handlerStarted <- newEmptyMVar
+        releaseHandler <- newEmptyMVar
+        notification <- newEmptyMVar
+        let handler name _
+                | name == "gate" = do
+                    putMVar handlerStarted ()
+                    readMVar releaseHandler
+                    pure (Right Null)
+                | otherwise = pure (Left "unexpected tool call")
+            config =
+                (defaultCodeModeConfig "data/code-mode/worker.mjs" handler)
+                    { notifyHandler = putMVar notification
+                    }
+        bracket (newCodeModeHost config) closeCodeModeHost \host -> do
+            started <- execCodeCell
+                host
+                "await tools.gate({}); text(\"late\"); notify(\"late-content-observed\"); await new Promise(() => {});"
+                ["gate"]
+                1
+            started `shouldBe`
+                Right CodeModeRunning
+                    { cellId = "1"
+                    , cellOutput = emptyContent
+                    }
+            timeout 5000000 (readMVar handlerStarted) `shouldReturn` Just ()
+            putMVar releaseHandler ()
+            observed <- timeout 5000000 (takeMVar notification)
+            observed `shouldBe` Just "late-content-observed"
+            terminated <- terminateCodeCell host "1"
+            terminated `shouldBe`
+                Right CodeModeTerminated
+                    { cellId = "1"
+                    , cellValue = textContent "late"
+                    }
 
     it "exposes helper content and ignores JavaScript completion values" do
         let config = defaultCodeModeConfig
@@ -828,6 +847,46 @@ textContent value = Aeson.object
             ]
         ]
     ]
+
+waitForCompletionMarker :: CodeModeHost -> Int -> IO Bool
+waitForCompletionMarker _ 0 = do
+    expectationFailure "completion-marker was never observed"
+    pure False
+waitForCompletionMarker host attempts = do
+    initial <- execCodeCell
+        host
+        "text(load(\"completion-marker\") === true ? \"ready\" : \"waiting\");"
+        []
+        3000
+    case initial of
+        Right CodeModeFinished { cellValue } ->
+            handleMarker cellValue
+        Right CodeModeRunning { cellId = identifier } -> do
+            completed <- waitCodeCell host identifier 3000
+            case completed of
+                Right CodeModeFinished { cellValue } ->
+                    handleMarker cellValue
+                unexpected -> do
+                    _ <- terminateCodeCell host identifier
+                    expectationFailure $
+                        "completion-marker probe did not finish: "
+                            <> show unexpected
+                    pure False
+        unexpected -> do
+            expectationFailure $
+                "completion-marker probe did not start: " <> show unexpected
+            pure False
+  where
+    handleMarker value
+        | value == textContent "ready" = pure True
+        | value == textContent "waiting" = do
+            threadDelay 10000
+            waitForCompletionMarker host (attempts - 1)
+        | otherwise = do
+            expectationFailure $
+                "completion-marker probe returned unexpected value: "
+                    <> show value
+            pure False
 
 withEnvironmentOverride :: String -> String -> IO a -> IO a
 withEnvironmentOverride name value action =

--- a/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/DangerousSpec.hs
@@ -13,7 +13,8 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LazyByteString
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (tryIO)
+import System.IO.Error (isDoesNotExistError, isPermissionError)
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Files (deviceID, fileID, getFileStatus)
 import Test.Hspec
@@ -187,16 +188,25 @@ spec = do
                 `shouldBe` replicate 4 True
 
         it "resolves relative aliases against the shell working directory" do
-            -- /dev exists in the Nix build sandbox, unlike /usr. Using an
-            -- existing prefix makes each parent traversal meaningful under
-            -- real filesystem semantics.
+            -- Using an existing prefix makes each parent traversal meaningful
+            -- under real filesystem semantics. Some nested macOS sandboxes
+            -- prohibit inspecting the resulting /tmp path.
             let cwd = unsafeEncodeUtf "/dev"
-            mapM (commandUsesHardcodedSystemTmpAt cwd)
-                [ "cat ../tmp/other-session"
-                , "cat ./../tmp/other-session"
-                , "cat ../dev/../tmp/other-session"
-                ]
-                `shouldReturn` replicate 3 True
+            devTmpAliases <- pathsReferToSameFile "/dev/../tmp" "/tmp"
+            if devTmpAliases
+                then
+                    mapM (commandUsesHardcodedSystemTmpAt cwd)
+                        [ "cat ../tmp/other-session"
+                        , "cat ./../tmp/other-session"
+                        , "cat ../dev/../tmp/other-session"
+                        ]
+                        `shouldReturn` replicate 3 True
+                else
+                    pendingWith
+                        "the test environment cannot inspect the /tmp alias"
+
+        it "does not classify unrelated relative path candidates as temp aliases" do
+            let cwd = unsafeEncodeUtf "/dev"
             mapM (commandUsesHardcodedSystemTmpAt cwd)
                 [ "cat tmp/project-file"
                 , "cat ../tmpfile"
@@ -386,11 +396,15 @@ spec = do
 
 pathsReferToSameFile :: FilePath -> FilePath -> IO Bool
 pathsReferToSameFile left right =
-    tryAny
+    tryIO
         ((,)
             <$> getFileStatus left
             <*> getFileStatus right) >>= \case
-        Left _ -> pure False
+        Left err
+            | isPermissionError err || isDoesNotExistError err ->
+                pure False
+            | otherwise ->
+                ioError err
         Right (leftStatus, rightStatus) ->
             pure $
                 deviceID leftStatus == deviceID rightStatus

--- a/packages/agent-core/test/Agent/Tools/GhciSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/GhciSpec.hs
@@ -29,20 +29,24 @@ import Agent.Tools.Types
     )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (mapConcurrently, wait, withAsync)
-import Control.Exception.Safe (SomeException, bracket, try)
+import Control.Exception.Safe (SomeException, bracket, try, tryIO)
 import Data.Either (isRight)
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
     , createDirectoryIfMissing
+    , doesFileExist
     , getTemporaryDirectory
     , removeDirectoryRecursive
     )
+import System.Exit (ExitCode(..))
 import System.FilePath ((</>))
 import System.Info (os)
+import System.IO.Error (isPermissionError)
 import System.Posix.Signals (nullSignal, signalProcess)
 import System.Posix.Temp (mkdtemp)
 import System.Posix.Types (ProcessID)
+import System.Process (readProcessWithExitCode)
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -212,6 +216,7 @@ spec = describe "Agent.Tools.Ghci" do
         if os /= "darwin"
             then pendingWith "the process-level Seatbelt boundary is macOS-only"
             else withTempEnv \env -> do
+                requireProcessSandbox
                 let workspace = toFilePath env.toolCwd
                     sessions =
                         workspace
@@ -241,6 +246,7 @@ spec = describe "Agent.Tools.Ghci" do
                         Text.isInfixOf "sibling-secret"
 
     it "refreshes the private temp environment after suspension" do
+        requireProcessSandbox
         withTempEnv \env -> do
             let firstScratch = toFilePath env.toolCwd </> "first-session"
                 nextScratch = toFilePath env.toolCwd </> "next-session"
@@ -474,6 +480,35 @@ waitForProcessDeath pid = go (200 :: Int)
 processAlive :: ProcessID -> IO Bool
 processAlive pid =
     isRight <$> try @_ @SomeException (signalProcess nullSignal pid)
+
+requireProcessSandbox :: IO ()
+requireProcessSandbox
+    | os /= "darwin" = pure ()
+    | otherwise = do
+        doesFileExist "/usr/bin/sandbox-exec" >>= \case
+            False -> pendingWith
+                "sandbox-exec is unavailable in this test environment"
+            True -> do
+                probe <- tryIO $
+                    readProcessWithExitCode
+                        "/usr/bin/sandbox-exec"
+                        ["-p", "(version 1) (allow default)", "/usr/bin/true"]
+                        ""
+                case probe of
+                    Left err
+                        | isPermissionError err -> pendingWith
+                            "sandbox-exec is unavailable in this test environment"
+                        | otherwise -> ioError err
+                    Right (ExitSuccess, _, _) -> pure ()
+                    Right (ExitFailure 71, _, stderr)
+                        | "sandbox_apply: Operation not permitted"
+                            `Text.isInfixOf` Text.pack stderr ->
+                            pendingWith
+                                "sandbox-exec is unavailable in this test environment"
+                    Right result ->
+                        expectationFailure $
+                            "sandbox-exec capability probe failed unexpectedly: "
+                                <> show result
 
 withTempEnv :: (ToolEnv -> IO a) -> IO a
 withTempEnv action =

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -37,7 +37,7 @@ import Agent.Tools.Types
     )
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.MVar (readMVar)
-import Control.Exception.Safe (bracket, tryAny, tryIO)
+import Control.Exception.Safe (bracket, tryIO)
 import Control.Monad (replicateM)
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.Either (isLeft, isRight)
@@ -49,16 +49,24 @@ import System.Directory
     , createDirectory
     , createDirectoryIfMissing
     , createDirectoryLink
+    , doesFileExist
     , getTemporaryDirectory
     , listDirectory
     , removeDirectoryRecursive
     )
+import System.Exit (ExitCode(..))
 import System.FilePath ((</>), takeFileName)
 import System.IO (IOMode(..), hClose, openFile)
-import System.IO.Error (alreadyInUseErrorType, mkIOError)
+import System.IO.Error
+    ( alreadyInUseErrorType
+    , isDoesNotExistError
+    , isPermissionError
+    , mkIOError
+    )
 import System.Info (os)
 import System.Posix.Temp (mkdtemp)
 import System.Posix.Files (deviceID, fileID, getFileStatus)
+import System.Process (readProcessWithExitCode)
 import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
@@ -268,9 +276,12 @@ spec = describe "Agent.Tools.IO" do
             resolveUnderCwd env
                 (fromFilePath ("/private/tmp" </> relative))
                 `shouldReturn` expected
-            resolveUnderCwd env
+            devTmpAliases <- pathsReferToSameFile "/dev/../tmp" "/tmp"
+            devTmp <- resolveUnderCwd env
                 (fromFilePath ("/dev/../tmp" </> relative))
-                `shouldReturn` expected
+            if devTmpAliases
+                then devTmp `shouldBe` expected
+                else devTmp `shouldSatisfy` isLeft
             readIORef requests `shouldReturn` []
             varPrivateAliases <-
                 pathsReferToSameFile "/var/../private/tmp" "/private/tmp"
@@ -375,11 +386,16 @@ spec = describe "Agent.Tools.IO" do
                     (const False)
             normalizedPrefixTraversal <- resolveUnderCwd env
                 (fromFilePath "/dev/../tmp/../outside.txt")
-            normalizedPrefixTraversal `shouldSatisfy`
-                either
-                    (Text.isInfixOf
-                        "escapes the private session temp directory")
-                    (const False)
+            normalizedPrefixTraversal `shouldSatisfy` isLeft
+            devTmpAliases <- pathsReferToSameFile "/dev/../tmp" "/tmp"
+            if devTmpAliases
+                then
+                    normalizedPrefixTraversal `shouldSatisfy`
+                        either
+                            (Text.isInfixOf
+                                "escapes the private session temp directory")
+                            (const False)
+                else pure ()
             readIORef requests `shouldReturn` []
 
     it "does not normalize through a missing pre-alias component" do
@@ -451,6 +467,7 @@ spec = describe "Agent.Tools.IO" do
             result `shouldSatisfy` isLeft
 
     it "sets the private temp environment for shell commands" do
+        requireProcessSandbox
         withTempDir \dir -> do
             let workspace = dir </> "workspace"
                 scratch = dir </> "scratch"
@@ -470,6 +487,7 @@ spec = describe "Agent.Tools.IO" do
         if os /= "darwin"
             then pendingWith "the process-level Seatbelt boundary is macOS-only"
             else withTempDir \dir -> do
+                requireProcessSandbox
                 let workspace = dir </> "workspace"
                     sessions =
                         dir </> ".haskell-agent" </> "tmp" </> "sessions"
@@ -640,6 +658,7 @@ checkForegroundOutputCap dir = do
     result.commandStdout `shouldSatisfy` Text.isInfixOf "[truncated"
 
 checkBackgroundOutputArtifact dir = do
+    requireProcessSandbox
     let osDir = fromFilePath dir
     base <- defaultToolEnv osDir
     setToolSessionTmp base (Just osDir)
@@ -656,6 +675,7 @@ checkBackgroundOutputArtifact dir = do
                 Right output -> Text.length output `shouldBe` 131072
 
 checkForegroundOutputArtifact dir = do
+    requireProcessSandbox
     let osDir = fromFilePath dir
     base <- defaultToolEnv osDir
     setToolSessionTmp base (Just osDir)
@@ -697,6 +717,35 @@ checkBackgroundOutputCap dir = do
     Text.length result.commandStdout `shouldSatisfy` (< 128)
     result.commandStdout `shouldSatisfy` Text.isInfixOf "[truncated"
 
+requireProcessSandbox :: IO ()
+requireProcessSandbox
+    | os /= "darwin" = pure ()
+    | otherwise = do
+        doesFileExist "/usr/bin/sandbox-exec" >>= \case
+            False -> pendingWith
+                "sandbox-exec is unavailable in this test environment"
+            True -> do
+                probe <- tryIO $
+                    readProcessWithExitCode
+                        "/usr/bin/sandbox-exec"
+                        ["-p", "(version 1) (allow default)", "/usr/bin/true"]
+                        ""
+                case probe of
+                    Left err
+                        | isPermissionError err -> pendingWith
+                            "sandbox-exec is unavailable in this test environment"
+                        | otherwise -> ioError err
+                    Right (ExitSuccess, _, _) -> pure ()
+                    Right (ExitFailure 71, _, stderr)
+                        | "sandbox_apply: Operation not permitted"
+                            `Text.isInfixOf` Text.pack stderr ->
+                            pendingWith
+                                "sandbox-exec is unavailable in this test environment"
+                    Right result ->
+                        expectationFailure $
+                            "sandbox-exec capability probe failed unexpectedly: "
+                                <> show result
+
 checkConcurrentAtomicWrites :: FilePath -> IO ()
 checkConcurrentAtomicWrites dir = do
     let path = fromFilePath (dir </> "state.json")
@@ -734,11 +783,15 @@ startAppend path (payload, var) =
 
 pathsReferToSameFile :: FilePath -> FilePath -> IO Bool
 pathsReferToSameFile left right =
-    tryAny
+    tryIO
         ((,)
             <$> getFileStatus left
             <*> getFileStatus right) >>= \case
-        Left _ -> pure False
+        Left err
+            | isPermissionError err || isDoesNotExistError err ->
+                pure False
+            | otherwise ->
+                ioError err
         Right (leftStatus, rightStatus) ->
             pure $
                 deviceID leftStatus == deviceID rightStatus
@@ -752,8 +805,16 @@ withTempDir action = do
         removeDirectoryRecursive
         action
 
-withSystemTempDir :: (FilePath -> IO a) -> IO a
-withSystemTempDir =
-    bracket
-        (mkdtemp "/tmp/agent-io-host-XXXXXX")
-        removeDirectoryRecursive
+withSystemTempDir :: (FilePath -> IO ()) -> IO ()
+withSystemTempDir action =
+    tryIO (mkdtemp "/tmp/agent-io-host-XXXXXX") >>= \case
+        Left err
+            | isPermissionError err ->
+            pendingWith
+                "the test environment cannot create a directory under /tmp"
+            | otherwise -> ioError err
+        Right dir ->
+            bracket
+                (pure dir)
+                removeDirectoryRecursive
+                action

--- a/packages/agent-gemini/agent-gemini.cabal
+++ b/packages/agent-gemini/agent-gemini.cabal
@@ -85,6 +85,7 @@ test-suite agent-gemini-test
                     , Agent.Gemini.RequestSpec
                     , Agent.Gemini.ResponseSpec
                     , Agent.Gemini.StreamSpec
+                    , Agent.Gemini.TestSupport
     ghc-options:      -threaded
     build-depends:    base >= 4.14 && < 5
                     , agent-core

--- a/packages/agent-gemini/test/Agent/Gemini/AuthSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/AuthSpec.hs
@@ -1,6 +1,7 @@
 module Agent.Gemini.AuthSpec (spec) where
 
 import Agent.Gemini.Auth
+import Agent.Gemini.TestSupport (withLoopbackApplication)
 import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.Async (concurrently)
 import Control.Exception.Safe (bracket)
@@ -17,7 +18,7 @@ import Network.HTTP.Types
 import qualified Network.Socket as Net
 import qualified Network.Socket.ByteString as Net
 import Network.Wai
-import Network.Wai.Handler.Warp
+import Network.Wai.Handler.Warp (Port)
 import qualified System.Timeout as Timeout
 import Test.Hspec
 import Text.Read (readMaybe)
@@ -59,7 +60,7 @@ spec = do
 
         it "accepts a callback request split across TCP reads" do
             recorded <- newIORef []
-            testWithApplication (pure (tokenApp recorded)) \port -> do
+            withLoopbackApplication (pure (tokenApp recorded)) \port -> do
                 presentedUrl <- newEmptyMVar
                 let options = (testOAuthOptions port) { timeoutSeconds = 5 }
                 (result, ()) <- concurrently
@@ -75,7 +76,7 @@ spec = do
 
         it "exchanges a code and refreshes without losing the refresh token" do
             recorded <- newIORef []
-            testWithApplication (pure (tokenApp recorded)) \port -> do
+            withLoopbackApplication (pure (tokenApp recorded)) \port -> do
                 let options = testOAuthOptions port
                 exchangeAuthorizationCode
                     options
@@ -104,12 +105,12 @@ spec = do
                     any (Text.isInfixOf "refresh_token=refresh-old")
 
         it "fetches the account email with a bearer token" do
-            testWithApplication (pure userInfoApp) \port ->
+            withLoopbackApplication (pure userInfoApp) \port ->
                 fetchUserEmail (testOAuthOptions port) "secret-access"
                     `shouldReturn` Right "person@example.com"
 
         it "bounds authenticated endpoint waits" do
-            testWithApplication (pure slowApp) \port -> do
+            withLoopbackApplication (pure slowApp) \port -> do
                 let options = (testOAuthOptions port) { timeoutSeconds = 1 }
                 result <- Timeout.timeout 2_000_000
                     (fetchUserEmail options "secret-access")
@@ -128,7 +129,7 @@ spec = do
                 `shouldNotContain` Text.unpack defaultOAuthOptions.clientSecret
 
         it "does not expose token-form secrets in endpoint errors" do
-            testWithApplication (pure echoingTokenErrorApp) \port -> do
+            withLoopbackApplication (pure echoingTokenErrorApp) \port -> do
                 result <- refreshAccessToken
                     (testOAuthOptions port)
                     "refresh-must-stay-secret"
@@ -136,7 +137,7 @@ spec = do
                 show result `shouldNotContain` "server-echoed-sensitive-body"
 
         it "redacts bearer tokens echoed by authenticated endpoints" do
-            testWithApplication (pure echoingBearerErrorApp) \port -> do
+            withLoopbackApplication (pure echoingBearerErrorApp) \port -> do
                 result <- fetchUserEmail
                     (testOAuthOptions port)
                     "access-must-stay-secret"
@@ -145,9 +146,9 @@ spec = do
 
         it "never forwards OAuth credentials or token forms across redirects" do
             redirected <- newIORef []
-            testWithApplication (pure (redirectTargetApp redirected))
+            withLoopbackApplication (pure (redirectTargetApp redirected))
                 \targetPort ->
-                    testWithApplication
+                    withLoopbackApplication
                         (pure (redirectingApp targetPort))
                         \originPort -> do
                             refreshAccessToken
@@ -181,7 +182,7 @@ spec = do
     describe "Code Assist setup" do
         it "uses an existing Code Assist project without onboarding" do
             calls <- newIORef []
-            testWithApplication (pure (existingUserApp calls)) \port -> do
+            withLoopbackApplication (pure (existingUserApp calls)) \port -> do
                 result <- setupCodeAssist (testCodeAssistOptions port) "bearer"
                 result `shouldBe` Right CodeAssistUser
                     { projectId = "managed-project"
@@ -192,7 +193,7 @@ spec = do
                     ["/v1internal:loadCodeAssist"]
 
         it "prefers paid-tier metadata for an existing account" do
-            testWithApplication (pure paidUserApp) \port ->
+            withLoopbackApplication (pure paidUserApp) \port ->
                 setupCodeAssist (testCodeAssistOptions port) "bearer"
                     `shouldReturn` Right CodeAssistUser
                         { projectId = "paid-project"
@@ -201,7 +202,7 @@ spec = do
                         }
 
         it "fills missing paid-tier fields from the current tier" do
-            testWithApplication (pure partialPaidUserApp) \port ->
+            withLoopbackApplication (pure partialPaidUserApp) \port ->
                 setupCodeAssist (testCodeAssistOptions port) "bearer"
                     `shouldReturn` Right CodeAssistUser
                         { projectId = "paid-project"
@@ -212,7 +213,7 @@ spec = do
         it "presents one-time account validation and retries setup" do
             calls <- newIORef (0 :: Int)
             presented <- newIORef []
-            testWithApplication (pure (validationRequiredApp calls)) \port -> do
+            withLoopbackApplication (pure (validationRequiredApp calls)) \port -> do
                 result <- setupCodeAssistWithValidation
                     (testCodeAssistOptions port)
                     "bearer"
@@ -229,7 +230,7 @@ spec = do
 
         it "includes the configured project for standard-tier onboarding" do
             bodies <- newIORef []
-            testWithApplication (pure (standardOnboardingApp bodies)) \port -> do
+            withLoopbackApplication (pure (standardOnboardingApp bodies)) \port -> do
                 let options = (testCodeAssistOptions port)
                         { configuredProject = Just "billing-project" }
                 setupCodeAssist options "bearer"
@@ -246,7 +247,7 @@ spec = do
                     (BS.isInfixOf "\"duetProject\":\"billing-project\"")
 
         it "rejects a failed onboarding operation even with a configured project" do
-            testWithApplication (pure failedOnboardingApp) \port -> do
+            withLoopbackApplication (pure failedOnboardingApp) \port -> do
                 let options = (testCodeAssistOptions port)
                         { configuredProject = Just "billing-project" }
                 setupCodeAssist options "bearer"
@@ -254,7 +255,7 @@ spec = do
                         "Gemini Code Assist onboarding failed (code 9): precondition failed"
 
         it "redacts bearer tokens from decoded setup errors" do
-            testWithApplication (pure echoingOnboardingErrorApp) \port -> do
+            withLoopbackApplication (pure echoingOnboardingErrorApp) \port -> do
                 let options = (testCodeAssistOptions port)
                         { configuredProject = Just "billing-project" }
                 result <- setupCodeAssist options "secret-bearer"
@@ -264,7 +265,7 @@ spec = do
         it "onboards the default free tier and polls the operation" do
             calls <- newIORef []
             bodies <- newIORef []
-            testWithApplication (pure (onboardingApp calls bodies)) \port -> do
+            withLoopbackApplication (pure (onboardingApp calls bodies)) \port -> do
                 result <- setupCodeAssist (testCodeAssistOptions port) "bearer"
                 result `shouldBe` Right CodeAssistUser
                     { projectId = "new-managed-project"

--- a/packages/agent-gemini/test/Agent/Gemini/ClientSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/ClientSpec.hs
@@ -4,6 +4,7 @@ import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Gemini.Client (createResponseWithEventsPolicy)
 import Agent.Gemini.Options (ClientOptions(..), defaultClientOptions)
 import Agent.Gemini.Response (GeminiStreamEvent(..))
+import Agent.Gemini.TestSupport (withLoopbackApplication)
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.Responses.Types
     ( Response(..)
@@ -27,7 +28,6 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import Test.Hspec
 
 spec :: Spec
@@ -70,7 +70,7 @@ spec = describe "Gemini client validation" do
                 respond $ Wai.responseLBS HTTP.status200
                     [("Content-Type", "text/event-stream")]
                     geminiSse
-        Warp.testWithApplication (pure app) \port -> do
+        withLoopbackApplication (pure app) \port -> do
             let options = defaultClientOptions
                     { baseUrl = "http://127.0.0.1:"
                         <> show port <> "/v1beta"
@@ -119,7 +119,7 @@ spec = describe "Gemini client validation" do
                 respond $ Wai.responseLBS HTTP.status200
                     [("Content-Type", "text/event-stream")]
                     codeAssistSse
-        Warp.testWithApplication (pure app) \port -> do
+        withLoopbackApplication (pure app) \port -> do
             let options = defaultClientOptions
                     { codeAssistBaseUrl = "http://127.0.0.1:"
                         <> show port <> "/v1internal"
@@ -272,13 +272,13 @@ spec = describe "Gemini client validation" do
 
     it "never forwards an API key across redirects" do
         redirected <- newIORef (Nothing :: Maybe HTTP.RequestHeaders)
-        Warp.testWithApplication
+        withLoopbackApplication
             (pure \request respond -> do
                 writeIORef redirected
                     (Just (Wai.requestHeaders request))
                 respond (Wai.responseLBS HTTP.status200 [] ""))
             \targetPort ->
-                Warp.testWithApplication
+                withLoopbackApplication
                     (pure \_ respond ->
                         respond
                             (Wai.responseLBS HTTP.status307
@@ -356,7 +356,7 @@ withGeminiHttpResponse
     -> (ClientOptions -> IO result)
     -> IO result
 withGeminiHttpResponse status headers body action =
-    Warp.testWithApplication
+    withLoopbackApplication
         (pure \_ respond ->
             respond $ Wai.responseLBS status headers body)
         \port ->

--- a/packages/agent-gemini/test/Agent/Gemini/TestSupport.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/TestSupport.hs
@@ -1,0 +1,32 @@
+module Agent.Gemini.TestSupport
+    ( withLoopbackApplication
+    ) where
+
+import Control.Exception (IOException, try)
+import Network.HTTP.Types (status200)
+import Network.Wai (Application, responseLBS)
+import Network.Wai.Handler.Warp (testWithApplication)
+import System.IO.Error (isPermissionError)
+import Test.Hspec (pendingWith)
+
+-- | Run a loopback-server test when the enclosing sandbox permits an
+-- ephemeral listener. Other listener startup errors remain test failures.
+withLoopbackApplication application action = do
+    requireLoopbackListener
+    testWithApplication application action
+
+requireLoopbackListener :: IO ()
+requireLoopbackListener = do
+    result <- (try $ testWithApplication (pure probeApplication)
+        (const $ pure ())) :: IO (Either IOException ())
+    case result of
+        Right () -> pure ()
+        Left err
+            | isPermissionError err ->
+                pendingWith
+                    "the test environment cannot bind a loopback listener"
+            | otherwise -> ioError err
+
+probeApplication :: Application
+probeApplication _ respond =
+    respond $ responseLBS status200 [] ""

--- a/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
+++ b/packages/agent-grok-build-dialect/agent-grok-build-dialect.cabal
@@ -105,6 +105,7 @@ test-suite agent-grok-build-dialect-test
                     , directory
                     , filepath
                     , hspec
+                    , process
                     , safe-exceptions
                     , text
                     , temporary

--- a/packages/agent-grok-build-dialect/package.nix
+++ b/packages/agent-grok-build-dialect/package.nix
@@ -12,7 +12,7 @@ mkDerivation {
     unix
   ];
   testHaskellDepends = [
-    agent-core async base containers directory filepath hspec
+    agent-core async base containers directory filepath hspec process
     safe-exceptions temporary text time unix
   ];
   benchmarkHaskellDepends = [

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -42,7 +42,7 @@ import Agent.Tools.Types
     )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar (readMVar)
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, tryIO)
 import Data.Bits ((.&.))
 import Data.IORef (newIORef)
 import qualified Data.Map.Strict as Map
@@ -55,10 +55,14 @@ import System.Directory
     , doesFileExist
     , removeDirectoryRecursive
     )
+import System.Exit (ExitCode(..))
 import System.FilePath (makeRelative, takeDirectory, (</>))
 import System.IO.Temp (withSystemTempDirectory)
+import System.Info (os)
+import System.IO.Error (isPermissionError)
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Files (fileMode, getFileStatus)
+import System.Process (readProcessWithExitCode)
 import Test.Hspec
 
 spec :: Spec
@@ -275,6 +279,7 @@ spec = describe "Grok Build dialect" do
                     `shouldBe` scratch
 
     it "checks temp traversal while holding the persistent shell state" do
+        requireProcessSandbox
         withTempDir \dir -> do
             let scratch = dir </> "session-scratch"
             createDirectory scratch
@@ -308,6 +313,7 @@ spec = describe "Grok Build dialect" do
                         (const False)
 
     it "recreates shell state after the session temp directory changes" do
+        requireProcessSandbox
         withTempDir \dir -> do
             let firstScratch = dir </> "first-session"
                 nextScratch = dir </> "next-session"
@@ -349,6 +355,7 @@ spec = describe "Grok Build dialect" do
                 result.commandStdout `shouldBe` "reset-ok"
 
     it "stops background tasks when the session temp directory changes" do
+        requireProcessSandbox
         withTempDir \dir -> do
             let firstScratch = dir </> "first-session"
                 nextScratch = dir </> "next-session"
@@ -393,6 +400,35 @@ spec = describe "Grok Build dialect" do
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir = withSystemTempDirectory "agent-grok-build-dialect"
+
+requireProcessSandbox :: IO ()
+requireProcessSandbox
+    | os /= "darwin" = pure ()
+    | otherwise = do
+        doesFileExist "/usr/bin/sandbox-exec" >>= \case
+            False -> pendingWith
+                "sandbox-exec is unavailable in this test environment"
+            True -> do
+                probe <- tryIO $
+                    readProcessWithExitCode
+                        "/usr/bin/sandbox-exec"
+                        ["-p", "(version 1) (allow default)", "/usr/bin/true"]
+                        ""
+                case probe of
+                    Left err
+                        | isPermissionError err -> pendingWith
+                            "sandbox-exec is unavailable in this test environment"
+                        | otherwise -> ioError err
+                    Right (ExitSuccess, _, _) -> pure ()
+                    Right (ExitFailure 71, _, stderr)
+                        | "sandbox_apply: Operation not permitted"
+                            `Text.isInfixOf` Text.pack stderr ->
+                            pendingWith
+                                "sandbox-exec is unavailable in this test environment"
+                    Right result ->
+                        expectationFailure $
+                            "sandbox-exec capability probe failed unexpectedly: "
+                                <> show result
 
 waitForFile :: FilePath -> IO Bool
 waitForFile path = go (100 :: Int)

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
@@ -28,6 +28,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
@@ -93,37 +94,39 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             `shouldBe` ["grok-4.6", "grok-4.5", lunaSubagentModel]
 
     it "advertises the Grok-root allowlist and records Luna at high effort" do
-        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
-            (\_ _ prompt _ -> pure $ Right LoopResult
-                { finalResponseId = "c"
-                , finalText = Just ("done:" <> interAgentMessagePayload prompt)
-                , turnsUsed = 1
-                , tokenUsage = emptyTokenUsage
-                })
-            (\_ _ -> pure ())
-        typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing Nothing
-                (Just (grokRootChildModels True))
-            tool = taskTool (fromFilePath "/tmp") ctx typesRef
-        tool.appToolDescription `shouldSatisfy`
-            Text.isInfixOf "gpt-5.6-luna"
-        tool.appToolDescription `shouldSatisfy`
-            Text.isInfixOf "ONLY use model slugs"
-        tool.appToolDescription `shouldSatisfy`
-            Text.isInfixOf "Do not use Luna as a blanket default"
-        tool.appToolDescription `shouldSatisfy`
-            Text.isInfixOf "Inherit the parent for ambiguous"
-        result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
-            (functionToolCall "c1" "task"
-                "{\"prompt\":\"hello\",\"description\":\"luna child\",\"model\":\"luna\"}")
-        result.output `shouldSatisfy` Text.isInfixOf "Subagent started in background"
-        specs <- Map.elems <$> readIORef typesRef
-        map (\entry -> entry.modelOverride) specs
-            `shouldBe` [Just lunaSubagentModel]
-        map (\entry -> entry.reasoningEffortOverride) specs
-            `shouldBe` [Just lunaSubagentEffort]
-        closeSubagentRegistry registry
+        withSystemTempDirectory "agent-grok-task" \dir -> do
+            let cwd = fromFilePath dir
+            registry <- newSubagentRegistry defaultSubagentConfig cwd
+                (\_ _ prompt _ -> pure $ Right LoopResult
+                    { finalResponseId = "c"
+                    , finalText = Just ("done:" <> interAgentMessagePayload prompt)
+                    , turnsUsed = 1
+                    , tokenUsage = emptyTokenUsage
+                    })
+                (\_ _ -> pure ())
+            typesRef <- newIORef Map.empty
+            let ctx = MultiAgentContext registry cwd Nothing 0 taskPathRoot
+                    (pure Nothing) Nothing Nothing Nothing Nothing Nothing
+                    (Just (grokRootChildModels True))
+                tool = taskTool cwd ctx typesRef
+            tool.appToolDescription `shouldSatisfy`
+                Text.isInfixOf "gpt-5.6-luna"
+            tool.appToolDescription `shouldSatisfy`
+                Text.isInfixOf "ONLY use model slugs"
+            tool.appToolDescription `shouldSatisfy`
+                Text.isInfixOf "Do not use Luna as a blanket default"
+            tool.appToolDescription `shouldSatisfy`
+                Text.isInfixOf "Inherit the parent for ambiguous"
+            result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+                (functionToolCall "c1" "task"
+                    "{\"prompt\":\"hello\",\"description\":\"luna child\",\"model\":\"luna\"}")
+            result.output `shouldSatisfy` Text.isInfixOf "Subagent started in background"
+            specs <- Map.elems <$> readIORef typesRef
+            map (\entry -> entry.modelOverride) specs
+                `shouldBe` [Just lunaSubagentModel]
+            map (\entry -> entry.reasoningEffortOverride) specs
+                `shouldBe` [Just lunaSubagentEffort]
+            closeSubagentRegistry registry
 
     it "rejects grok-4-1-fast when a Grok-root allowlist is set" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
@@ -143,40 +146,44 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         closeSubagentRegistry registry
 
     it "defaults run_in_background and spawns a background agent" do
-        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
-            (\_ _ prompt _ -> pure $ Right LoopResult
-                { finalResponseId = "c"
-                , finalText = Just ("done:" <> interAgentMessagePayload prompt)
-                , turnsUsed = 1
-                , tokenUsage = emptyTokenUsage
-                })
-            (\_ _ -> pure ())
-        typesRef <- newIORef Map.empty
-        let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
-            tool = taskTool (fromFilePath "/tmp") ctx typesRef
-        result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
-            (functionToolCall "c1" "task"
-                "{\"prompt\":\"hello\",\"description\":\"test task\",\"model\":\"grok-4.5-mini\"}")
-        result.output `shouldSatisfy` Text.isInfixOf "Subagent started in background"
-        result.output `shouldSatisfy` Text.isInfixOf "subagent_id: agent-"
-        specs <- Map.elems <$> readIORef typesRef
-        map (\entry -> entry.modelOverride) specs `shouldBe` [Just "grok-4.5-mini"]
-        closeSubagentRegistry registry
+        withSystemTempDirectory "agent-grok-task" \dir -> do
+            let cwd = fromFilePath dir
+            registry <- newSubagentRegistry defaultSubagentConfig cwd
+                (\_ _ prompt _ -> pure $ Right LoopResult
+                    { finalResponseId = "c"
+                    , finalText = Just ("done:" <> interAgentMessagePayload prompt)
+                    , turnsUsed = 1
+                    , tokenUsage = emptyTokenUsage
+                    })
+                (\_ _ -> pure ())
+            typesRef <- newIORef Map.empty
+            let ctx = MultiAgentContext registry cwd Nothing 0 taskPathRoot
+                    (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
+                tool = taskTool cwd ctx typesRef
+            result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+                (functionToolCall "c1" "task"
+                    "{\"prompt\":\"hello\",\"description\":\"test task\",\"model\":\"grok-4.5-mini\"}")
+            result.output `shouldSatisfy` Text.isInfixOf "Subagent started in background"
+            result.output `shouldSatisfy` Text.isInfixOf "subagent_id: agent-"
+            specs <- Map.elems <$> readIORef typesRef
+            map (\entry -> entry.modelOverride) specs `shouldBe` [Just "grok-4.5-mini"]
+            closeSubagentRegistry registry
 
     it "records overrides before the child supervisor starts" do
-        typesRef <- newIORef Map.empty
-        observed <- newEmptyMVar
-        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
-            (observeSpec typesRef observed)
-            (\_ _ -> pure ())
-        let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
-                (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
-            tool = taskTool (fromFilePath "/tmp") ctx typesRef
-        _ <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
-            (functionToolCall "c1" "task" raceArgs)
-        takeMVar observed `shouldReturn` (Just "explore", Just "grok-4.5-mini")
-        closeSubagentRegistry registry
+        withSystemTempDirectory "agent-grok-task" \dir -> do
+            let cwd = fromFilePath dir
+            typesRef <- newIORef Map.empty
+            observed <- newEmptyMVar
+            registry <- newSubagentRegistry defaultSubagentConfig cwd
+                (observeSpec typesRef observed)
+                (\_ _ -> pure ())
+            let ctx = MultiAgentContext registry cwd Nothing 0 taskPathRoot
+                    (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
+                tool = taskTool cwd ctx typesRef
+            _ <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+                (functionToolCall "c1" "task" raceArgs)
+            takeMVar observed `shouldReturn` (Just "explore", Just "grok-4.5-mini")
+            closeSubagentRegistry registry
 
     it "updates an agent type without discarding its overrides" do
         specsRef <- newIORef Map.empty

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -139,6 +139,7 @@ test-suite agent-openai-test
                     , Agent.OpenAI.ModelsTypesSpec
                     , Agent.OpenAI.CompactionSpec
                     , Agent.OpenAI.ToolDSLSpec
+                    , Agent.OpenAI.TestSupport
                     , Agent.OpenAI.TranscriptionSpec
                     , Agent.OpenAI.UsageSpec
                     , Agent.OpenAI.WebSocketClientSpec

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -7,6 +7,7 @@ import qualified Agent.Responses.Codec as ResponsesCodec
 import Agent.OpenAI.Credential (staticBearerProvider)
 import Agent.Error
 import Agent.OpenAI.Http
+import Agent.OpenAI.TestSupport (withLoopbackApplication)
 import Agent.OpenAI.WebSocketClient
     ( newCodexTurnState
     , readCodexTurnState
@@ -30,7 +31,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import Test.Hspec
 
 spec :: Spec
@@ -672,7 +672,7 @@ withMockResponses
     -> (Text -> IO a)
     -> IO a
 withMockResponses recorded handler action =
-    Warp.testWithApplication (pure app) \port ->
+    withLoopbackApplication (pure app) \port ->
         action ("http://127.0.0.1:" <> Text.pack (show port) <> "/v1")
   where
     app waiRequest respond = do

--- a/packages/agent-openai/test/Agent/OpenAI/ImageGenerationSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ImageGenerationSpec.hs
@@ -4,6 +4,7 @@ import Agent.Loop
     ( ImageAttachment(..)
     , defaultLoopDispatch
     )
+import Agent.OpenAI.TestSupport (withLoopbackApplication)
 import Agent.OpenAI.ImageGeneration
     ( imageGenerationToolAt
     , newImageGenerationHistory
@@ -53,7 +54,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
@@ -221,7 +221,7 @@ withImageServer
     -> (Text -> IO a)
     -> IO a
 withImageServer recorded imageBytes action =
-    Warp.testWithApplication (pure app) \port ->
+    withLoopbackApplication (pure app) \port ->
         action ("http://127.0.0.1:" <> Text.pack (show port))
   where
     app request respond = do

--- a/packages/agent-openai/test/Agent/OpenAI/ModelsClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ModelsClientSpec.hs
@@ -3,6 +3,7 @@ module Agent.OpenAI.ModelsClientSpec (spec) where
 import Agent.OpenAI.Models.Client
 import Agent.OpenAI.Models.Cache (ModelsCacheKey(..))
 import Agent.OpenAI.Models.Types (ModelInfo(..), ModelsResponse(..))
+import Agent.OpenAI.TestSupport (withLoopbackApplication)
 import Agent.Provider
     ( BillingMode(..)
     , Credential(..)
@@ -18,7 +19,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import Test.Hspec
 
 spec :: Spec
@@ -152,7 +152,7 @@ withModelsServer
     -> (Text -> IO value)
     -> IO value
 withModelsServer recorded response action =
-    Warp.testWithApplication (pure app) \port ->
+    withLoopbackApplication (pure app) \port ->
         action ("http://127.0.0.1:" <> Text.pack (show port) <> "/v1")
   where
     app request respond = do

--- a/packages/agent-openai/test/Agent/OpenAI/TestSupport.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TestSupport.hs
@@ -1,0 +1,33 @@
+module Agent.OpenAI.TestSupport
+    ( requireLoopbackListener
+    , withLoopbackApplication
+    ) where
+
+import Control.Exception (IOException, try)
+import Network.HTTP.Types (status200)
+import Network.Wai (Application, responseLBS)
+import Network.Wai.Handler.Warp (testWithApplication)
+import System.IO.Error (isPermissionError)
+import Test.Hspec (pendingWith)
+
+-- | Run a loopback-server test when the enclosing sandbox permits an
+-- ephemeral listener. Other listener startup errors remain test failures.
+withLoopbackApplication application action = do
+    requireLoopbackListener
+    testWithApplication application action
+
+requireLoopbackListener :: IO ()
+requireLoopbackListener = do
+    result <- (try $ testWithApplication (pure probeApplication)
+        (const $ pure ())) :: IO (Either IOException ())
+    case result of
+        Right () -> pure ()
+        Left err
+            | isPermissionError err ->
+                pendingWith
+                    "the test environment cannot bind a loopback listener"
+            | otherwise -> ioError err
+
+probeApplication :: Application
+probeApplication _ respond =
+    respond $ responseLBS status200 [] ""

--- a/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
@@ -2,6 +2,10 @@ module Agent.OpenAI.TranscriptionSpec (spec) where
 
 import Agent.Error (ApiError(..))
 import Agent.OpenAI.Transcription
+import Agent.OpenAI.TestSupport
+    ( requireLoopbackListener
+    , withLoopbackApplication
+    )
 import Agent.Provider
     ( BillingMode(..)
     , Credential(..)
@@ -29,7 +33,6 @@ import qualified Data.Text.Encoding as TextEncoding
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Socket as Socket
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.WebSockets as WS
 import qualified System.Timeout as Timeout
 import Test.Hspec
@@ -277,7 +280,7 @@ spec = describe "OpenAI transcription" do
                                         [ "text" .=
                                             ("hello from oauth" :: Text)
                                         ]))
-        Warp.testWithApplication (pure app) \port -> do
+        withLoopbackApplication (pure app) \port -> do
             let baseUrl =
                     "http://127.0.0.1:"
                         <> Text.pack (show port)
@@ -331,6 +334,7 @@ withWebSocketServer
     -> (Int -> IO value)
     -> IO value
 withWebSocketServer server action =
+    requireLoopbackListener >>
     bracket
         (WS.makeListenSocket "127.0.0.1" 0)
         Socket.close

--- a/packages/agent-openrouter/agent-openrouter.cabal
+++ b/packages/agent-openrouter/agent-openrouter.cabal
@@ -77,6 +77,7 @@ test-suite agent-openrouter-test
                     , Agent.OpenRouter.FunctionalSpec
                     , Agent.OpenRouter.ModelsSpec
                     , Agent.OpenRouter.RequestSpec
+                    , Agent.OpenRouter.TestSupport
                     , Agent.OpenRouter.UsageSpec
     ghc-options:      -threaded
     build-depends:    base >= 4.14 && < 5

--- a/packages/agent-openrouter/test/Agent/OpenRouter/ClientSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/ClientSpec.hs
@@ -4,6 +4,7 @@ module Agent.OpenRouter.ClientSpec (spec) where
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.OpenRouter.Client
 import Agent.OpenRouter.Options
+import Agent.OpenRouter.TestSupport (withLoopbackApplication)
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.Responses.Types
 import qualified Agent.Json.Decode as Json
@@ -20,7 +21,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -207,7 +207,7 @@ withMockOpenRouter
     -> (ClientOptions -> IO a)
     -> IO a
 withMockOpenRouter recorded handler action =
-    Warp.testWithApplication (pure app) \port ->
+    withLoopbackApplication (pure app) \port ->
         action defaultClientOptions
             { baseUrl = "http://127.0.0.1:" <> show port <> "/v1"
             , requestTimeoutSeconds = 10

--- a/packages/agent-openrouter/test/Agent/OpenRouter/ModelsSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/ModelsSpec.hs
@@ -2,6 +2,7 @@ module Agent.OpenRouter.ModelsSpec (spec) where
 
 import Agent.OpenRouter.Models
 import Agent.OpenRouter.Options
+import Agent.OpenRouter.TestSupport (withLoopbackApplication)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.CaseInsensitive as CI
 import Data.IORef (IORef, newIORef, readIORef, atomicModifyIORef')
@@ -10,7 +11,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import Test.Hspec
 
 spec :: Spec
@@ -161,7 +161,7 @@ withMockModels
     -> (ClientOptions -> IO a)
     -> IO a
 withMockModels requests response action =
-    Warp.testWithApplication (pure app) \port ->
+    withLoopbackApplication (pure app) \port ->
         action defaultClientOptions
             { baseUrl = "http://127.0.0.1:" <> show port <> "/v1"
             , requestTimeoutSeconds = 10

--- a/packages/agent-openrouter/test/Agent/OpenRouter/TestSupport.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/TestSupport.hs
@@ -1,0 +1,32 @@
+module Agent.OpenRouter.TestSupport
+    ( withLoopbackApplication
+    ) where
+
+import Control.Exception (IOException, try)
+import Network.HTTP.Types (status200)
+import Network.Wai (Application, responseLBS)
+import Network.Wai.Handler.Warp (testWithApplication)
+import System.IO.Error (isPermissionError)
+import Test.Hspec (pendingWith)
+
+-- | Run a loopback-server test when the enclosing sandbox permits an
+-- ephemeral listener. Other listener startup errors remain test failures.
+withLoopbackApplication application action = do
+    requireLoopbackListener
+    testWithApplication application action
+
+requireLoopbackListener :: IO ()
+requireLoopbackListener = do
+    result <- (try $ testWithApplication (pure probeApplication)
+        (const $ pure ())) :: IO (Either IOException ())
+    case result of
+        Right () -> pure ()
+        Left err
+            | isPermissionError err ->
+                pendingWith
+                    "the test environment cannot bind a loopback listener"
+            | otherwise -> ioError err
+
+probeApplication :: Application
+probeApplication _ respond =
+    respond $ responseLBS status200 [] ""

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -86,6 +86,7 @@ test-suite agent-responses-test
                     , Agent.Responses.ResponseMergeSpec
                     , Agent.Responses.SSESpec
                     , Agent.Responses.StreamAssemblySpec
+                    , Agent.Responses.TestSupport
     build-depends:    base >= 4.14 && < 5
                     , agent-core
                     , agent-json

--- a/packages/agent-responses/test/Agent/Responses/GenericClientSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/GenericClientSpec.hs
@@ -5,6 +5,7 @@ import Agent.Json (rawJsonBytes, rawJsonFromEncoding)
 import qualified Agent.Responses.Codec as Codec
 import Agent.Responses.GenericClient
 import Agent.Responses.Request (setResponseModel)
+import Agent.Responses.TestSupport (requireLoopbackListener)
 import Agent.Responses.Types
 import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson as Aeson
@@ -133,6 +134,7 @@ spec = do
 
     describe "createResponseWithProviderPolicy" do
         it "applies provider hooks through the shared transport and retry path" do
+            requireLoopbackListener
             attempts <- newIORef (0 :: Int)
             recordedModels <- newIORef []
             recordedHeaders <- newIORef []
@@ -153,6 +155,7 @@ spec = do
             readIORef recordedHeaders `shouldReturn` [True, True]
 
         it "classifies a valid oversized error before adding truncation context" do
+            requireLoopbackListener
             Warp.testWithApplication (pure oversizedRateLimitApp) \port -> do
                 let boundedOptions = options
                         { baseUrl =

--- a/packages/agent-responses/test/Agent/Responses/HttpSSESpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/HttpSSESpec.hs
@@ -3,6 +3,7 @@ module Agent.Responses.HttpSSESpec (spec) where
 import Agent.Error (ApiError(..))
 import Agent.Responses.HttpSSE
 import Agent.Responses.StreamAssembly
+import Agent.Responses.TestSupport (requireLoopbackListener)
 import Agent.Responses.Types
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as Builder
@@ -18,6 +19,7 @@ import Test.Hspec
 spec :: Spec
 spec = describe "performResponsesHttpSse" do
     it "assembles events online, emits in wire order, and stops at terminal" do
+        requireLoopbackListener
         seen <- newIORef []
         testWithApplication (pure streamApplication) \port -> do
             result <- performResponsesHttpSse
@@ -43,6 +45,7 @@ spec = describe "performResponsesHttpSse" do
                 ] `shouldBe` ["{\"path\":\"README.md\"}"]
 
     it "caps oversized non-success response bodies with a truthful marker" do
+        requireLoopbackListener
         testWithApplication (pure oversizedFailureApplication) \port -> do
             result <- performResponsesHttpSse
                 testConfig

--- a/packages/agent-responses/test/Agent/Responses/TestSupport.hs
+++ b/packages/agent-responses/test/Agent/Responses/TestSupport.hs
@@ -1,0 +1,28 @@
+module Agent.Responses.TestSupport
+    ( requireLoopbackListener
+    ) where
+
+import Control.Exception (IOException, try)
+import Network.HTTP.Types (status200)
+import Network.Wai (Application, responseLBS)
+import Network.Wai.Handler.Warp (testWithApplication)
+import System.IO.Error (isPermissionError)
+import Test.Hspec (pendingWith)
+
+-- | Skip listener-backed integration tests only when an enclosing sandbox
+-- denies binding an ephemeral loopback port.
+requireLoopbackListener :: IO ()
+requireLoopbackListener = do
+    result <- (try $ testWithApplication (pure probeApplication)
+        (const $ pure ())) :: IO (Either IOException ())
+    case result of
+        Right () -> pure ()
+        Left err
+            | isPermissionError err ->
+                pendingWith
+                    "the test environment cannot bind a loopback listener"
+            | otherwise -> ioError err
+
+probeApplication :: Application
+probeApplication _ respond =
+    respond $ responseLBS status200 [] ""

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -78,6 +78,7 @@ test-suite agent-xai-test
                     , Agent.XAI.ClientSpec
                     , Agent.XAI.FunctionalSpec
                     , Agent.XAI.ResponsesSpec
+                    , Agent.XAI.TestSupport
                     , Agent.XAI.TranscriptionSpec
                     , Agent.XAI.UsageSpec
     ghc-options:      -threaded

--- a/packages/agent-xai/test/Agent/XAI/AuthSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/AuthSpec.hs
@@ -3,6 +3,7 @@ module Agent.XAI.AuthSpec (spec) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.XAI.Auth
+import Agent.XAI.TestSupport (withLoopbackApplication)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64.URL as Base64Url
@@ -13,7 +14,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import Test.Hspec
 
 spec :: Spec
@@ -197,7 +197,7 @@ withMockAuth
     -> (OAuthOptions -> IO a)
     -> IO a
 withMockAuth recorded handler action =
-    Warp.testWithApplication (pure app) \port ->
+    withLoopbackApplication (pure app) \port ->
         action (defaultOAuthOptions testClientId)
             { issuer = "http://127.0.0.1:" <> show port }
   where

--- a/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
@@ -4,6 +4,7 @@ module Agent.XAI.ClientSpec (spec) where
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.XAI.Client
 import Agent.XAI.Options
+import Agent.XAI.TestSupport (withLoopbackApplication)
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.Responses.Types
 import qualified Agent.Json.Decode as Json
@@ -22,7 +23,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -303,7 +303,7 @@ withMockGrokTimeout
     -> (ClientOptions -> IO a)
     -> IO a
 withMockGrokTimeout timeoutSecs recorded handler action =
-    Warp.testWithApplication (pure app) \port ->
+    withLoopbackApplication (pure app) \port ->
         action defaultClientOptions
             { baseUrl = "http://127.0.0.1:" <> show port <> "/v1"
             , requestTimeoutSeconds = timeoutSecs

--- a/packages/agent-xai/test/Agent/XAI/TestSupport.hs
+++ b/packages/agent-xai/test/Agent/XAI/TestSupport.hs
@@ -1,0 +1,32 @@
+module Agent.XAI.TestSupport
+    ( withLoopbackApplication
+    ) where
+
+import Control.Exception (IOException, try)
+import Network.HTTP.Types (status200)
+import Network.Wai (Application, responseLBS)
+import Network.Wai.Handler.Warp (testWithApplication)
+import System.IO.Error (isPermissionError)
+import Test.Hspec (pendingWith)
+
+-- | Run a loopback-server test when the enclosing sandbox permits an
+-- ephemeral listener. Other listener startup errors remain test failures.
+withLoopbackApplication application action = do
+    requireLoopbackListener
+    testWithApplication application action
+
+requireLoopbackListener :: IO ()
+requireLoopbackListener = do
+    result <- (try $ testWithApplication (pure probeApplication)
+        (const $ pure ())) :: IO (Either IOException ())
+    case result of
+        Right () -> pure ()
+        Left err
+            | isPermissionError err ->
+                pendingWith
+                    "the test environment cannot bind a loopback listener"
+            | otherwise -> ioError err
+
+probeApplication :: Application
+probeApplication _ respond =
+    respond $ responseLBS status200 [] ""

--- a/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/UsageSpec.hs
@@ -7,6 +7,7 @@ import Agent.XAI.Options
     , grokUserAgent
     )
 import Agent.XAI.Usage
+import Agent.XAI.TestSupport (withLoopbackApplication)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.CaseInsensitive as CI
@@ -14,7 +15,6 @@ import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
 import Test.Hspec
 
 spec :: Spec
@@ -69,7 +69,7 @@ spec = do
     describe "fetchGrokUsageFrom" do
         it "uses the current Grok CLI proxy authentication contract" do
             headersSeen <- newEmptyMVar
-            Warp.testWithApplication
+            withLoopbackApplication
                 (pure (billingApp headersSeen))
                 \port -> do
                     result <- fetchGrokUsageFrom


### PR DESCRIPTION
## Summary
- capability-gate listener and macOS Seatbelt integration tests only when the enclosing sandbox denies those capabilities
- replace CodeMode completion timing sleeps with deterministic synchronization and atomic state publication
- serialize Git worktree add, removal, and retention cleanup by common Git directory while keeping isolated upstream fetches concurrent
- use writable temporary directories in Grok task tests and regenerate Nix metadata for new test dependencies

## Validation
- `nix flake check --impure --option sandbox relaxed --no-write-lock-file --max-jobs 1` (before the clean rebase)
- `nix develop -c cabal repl agent-core:test:agent-core-test` (post-rebase; all 37 test modules loaded)
- focused concurrent-worktree test, repeated 50 times
- `nix develop -c cabal test agent-cli:agent-cli-test` (1,498 examples)
- `git diff --check`