### PR TITLE
Stabilize the full CI flake check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,8 @@ jobs:
 
           "$nix_bin" flake check \
             --impure \
+            --max-jobs 1 \
+            --cores 2 \
             --option sandbox relaxed \
             --no-write-lock-file \
             --print-build-logs

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -242,7 +242,11 @@ spec = describe "code-mode Bun host" do
                 { cellId = "1"
                 , cellOutput = emptyContent
                 }
-        threadDelay 50000
+        -- Bun and the host monitor share a heavily loaded CI runner with the
+        -- rest of the flake checks. Wait well beyond the 20 ms JavaScript
+        -- timer so termination tests an already-observed result rather than
+        -- racing timer scheduling.
+        threadDelay 1000000
         terminated <- terminateCodeCell host "1"
         terminated `shouldBe`
             Right CodeModeFinished


### PR DESCRIPTION
## Summary

- wait one second for a 20 ms Bun timer before asserting that termination observes natural completion
- document that the extra margin is for the heavily loaded flake-check runner
- cap the self-hosted CI invocation at one Nix job and two cores so simultaneous static/native builds stay within the persistent host's memory envelope

## Context

The repaired test workflow exposed two independent reliability problems while validating PR #857:

1. the code-mode completion test failed twice with different Hspec seeds because its fixed 50 ms sleep elapsed before Bun and the host monitor published the natural result;
2. after that assertion was stabilized, six concurrent Nix jobs exhausted the 64 GiB runner and the workflow was killed with exit 137.

## Validation

- targeted code-mode completion test passed 10/10 in the `agent-core:test:agent-core-test` GHCi session
- complete 30-example `code-mode Bun host` group passed in GHCi
- bounded `nix flake check --no-build --no-eval-cache --max-jobs 1 --cores 2` evaluation passed
- workflow YAML parsed successfully
- `git diff --check`
