### PR TITLE
Fix Darwin agent-cli profile installation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -578,7 +578,17 @@
                                         --prefix PATH : \
                                             "${pkgs.lib.makeBinPath agentCliRuntimeTools}"
                                 '';
-                        });
+                        } // pkgs.lib.optionalAttrs
+                            pkgs.stdenv.hostPlatform.isDarwin {
+                                # Darwin retains GHC as a requisite of the
+                                # wrapped justStaticExecutables output. GHC is
+                                # deliberately not added to PATH, so code mode
+                                # still uses an independently installed
+                                # compiler when one is available.
+                                disallowedRequisites = pkgs.lib.remove
+                                    haskellPackages.ghc
+                                    (old.disallowedRequisites or [ ]);
+                            });
                 agentCliStaticExecutable =
                     if pkgs.stdenv.hostPlatform.isLinux then
                         wrapAgentCli
@@ -850,6 +860,9 @@
                 };
 
                 checks = {
+                    # The package check does not exercise the wrapped
+                    # justStaticExecutables output or its requisite assertions.
+                    agent-cli-executable = agentCliExecutable;
                     agent-cli = haskellPackages.agent-cli;
                     agent-telegram = haskellPackages.agent-telegram;
                     agent-core = haskellPackages.agent-core;


### PR DESCRIPTION
## Summary

- allow the GHC store reference retained by the wrapped `justStaticExecutables` output on Darwin
- keep GHC out of the packaged CLI runtime `PATH`
- add a flake check for the wrapped installable CLI output, not just its underlying Haskell package

## Root cause

The packaged Darwin executable retains a reference to the GHC derivation. After the prior GHC exemption was removed from `disallowedRequisites`, `nix profile add github:digitallyinduced/haskell-agent` failed during fixup even though GHC was no longer injected into the wrapper's `PATH`.

The exemption is now Darwin-only, preserving the stricter no-GHC-reference assertion on Linux.

## Validation

- `git diff --check`
- `nix build --no-link .#checks.x86_64-linux.agent-cli-executable`
- ran the resulting `agent-cli --version`
- verified the Linux output has no GHC store reference
- `nix flake check --no-build --show-trace`

Native `aarch64-darwin` validation is left to the repository's Darwin builder.
