### PR TITLE
Skip skill detection for pasted prompts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -194,7 +194,10 @@ import Agent.CLI.SessionEnv ( SessionEnv(..) )
 import Agent.CLI.SessionLock ()
 import Agent.CLI.SessionState ()
 import Agent.CLI.SessionTitle ()
-import Agent.CLI.Skills ( formatSkillsListing )
+import Agent.CLI.Skills
+    ( formatSkillsListing
+    , resolvePromptSkillMentions
+    )
 import Agent.CLI.Startup.Auth ()
 import Agent.CLI.Startup.Format ()
 import Agent.CLI.StartupContext ()
@@ -259,7 +262,6 @@ import Agent.Skills
     ( SkillInvocation(invocationSkill),
       formatSkillActivation,
       resolveSkillInvocation,
-      resolveSkillMentions,
       Skill(skillName) )
 import Agent.Store.Postgres ()
 import Agent.Store.Types ()
@@ -498,7 +500,7 @@ handleReplLine
                                                 ImageAttachmentItem
                                                 pendingImages)
                                         ]
-                                preparePromptSkillInputs env text turnInputs >>= \case
+                                preparePromptSkillInputsWithPaste env pasted text turnInputs >>= \case
                                     Left err -> do
                                         displayError err $
                                             Text.hPutStrLn stderr
@@ -509,8 +511,8 @@ handleReplLine
                                         result <- runOneTurn env text skillInputs
                                         finishTurn False result
                     ReplExpandedPrompt original expanded ->
-                        submitExpandedTurn
-                            continue color original expanded
+                        submitExpandedTurnWithPaste
+                            pasted continue color original expanded
                     ReplInit -> do
                         let guidePath = cwd </> unsafeEncodeUtf "AGENTS.md"
                         tryIO
@@ -1183,7 +1185,8 @@ handleReplLine
                         displayError err $
                             Text.hPutStrLn stderr (roleError color err)
                         continue
-    submitExpandedTurn next color original expanded = do
+    submitExpandedTurn = submitExpandedTurnWithPaste False
+    submitExpandedTurnWithPaste pasted next color original expanded = do
         pendingImages <-
             modifyLiveAttachments conversationRef \imgs -> ([], imgs)
         forM_ fullscreen \runtime ->
@@ -1193,7 +1196,7 @@ handleReplLine
                     expanded
                     (map ImageAttachmentItem pendingImages)
                 ]
-        preparePromptSkillInputs env original turnInputs >>= \case
+        preparePromptSkillInputsWithPaste env pasted original turnInputs >>= \case
             Left err -> do
                 displayError err $
                     Text.hPutStrLn stderr (roleError color err)
@@ -2145,10 +2148,18 @@ preparePromptSkillInputs
     -> Text
     -> [TurnInput]
     -> IO (Either Text [TurnInput])
-preparePromptSkillInputs env prompt inputs = do
+preparePromptSkillInputs env = preparePromptSkillInputsWithPaste env False
+
+preparePromptSkillInputsWithPaste
+    :: SessionEnv
+    -> Bool
+    -> Text
+    -> [TurnInput]
+    -> IO (Either Text [TurnInput])
+preparePromptSkillInputsWithPaste env pasted prompt inputs = do
     invocations <- readIORef env.sessionSkillInvocations
     pure do
-        selected <- resolveSkillMentions invocations prompt
+        selected <- resolvePromptSkillMentions pasted invocations prompt
         let activations =
                 [ UserMessage (formatSkillActivation invocation prompt)
                 | invocation <- selected

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Skills
     , queueSkillCatalogContext
     , queueSkillCatalogContextWithOmissions
     , reservedSlashNames
+    , resolvePromptSkillMentions
     , skillInvocationCommand
     ) where
 
@@ -47,6 +48,15 @@ reservedSlashNames =
     concatMap
         (\command -> command.slashName : command.slashAliases)
         slashCommands
+
+resolvePromptSkillMentions
+    :: Bool
+    -> [SkillInvocation]
+    -> Text
+    -> Either Text [SkillInvocation]
+resolvePromptSkillMentions pasted invocations prompt
+    | pasted = Right []
+    | otherwise = resolveSkillMentions invocations prompt
 
 loadSkillsCatalog
     :: CliOptions

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -144,6 +144,16 @@ spec = describe "Agent.CLI.Skills" do
                     [invocation]
         listing `shouldSatisfy` Text.isInfixOf "$deploy, /deploy"
 
+    it "does not interpret dollar-prefixed SQL parameters in pasted prompts" do
+        let invocations = [SkillInvocation "deploy" fakeSkill True]
+            pastedSql = "WHERE listings.agent_id = $1"
+        resolvePromptSkillMentions True invocations pastedSql
+            `shouldBe` Right []
+        resolvePromptSkillMentions False invocations pastedSql
+            `shouldSatisfy` isLeft
+        resolvePromptSkillMentions False invocations "please $deploy"
+            `shouldBe` Right invocations
+
     it "installs a deferred catalog, invocations, and startup context together" do
         context <- newIORef (Just "agents")
         catalogRef <- newIORef (SkillCatalog [] [])


### PR DESCRIPTION
## Summary
- preserve paste provenance through normal and expanded prompt submission
- skip dollar-prefixed skill mention resolution for pasted messages
- keep typed skill mention behavior unchanged

## Validation
- `git diff --check`
- `cabal repl agent-cli:test:agent-cli-test` with focused HSpec match: 1 example, 0 failures
- loaded all 211 `agent-cli` library modules in GHCi
- launched the live CLI in tmux and confirmed the real TTY startup path renders correctly