### PR TITLE
Add integrated model and reasoning effort picker

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -832,6 +832,7 @@ runCreateAgentSession env args
                         , targetWireModelId = env.toolsTransportModel
                         , targetDialect = env.toolsDialect
                         }
+                    , modelContextWindow = Nothing
                     , modelLabel = Nothing
                     , modelFallbackPriority = Nothing
                     }
@@ -845,6 +846,7 @@ runCreateAgentSession env args
                         , targetDialect =
                             dialectIdForModel env.toolsProvider model
                         }
+                    , modelContextWindow = Nothing
                     , modelLabel = Nothing
                     , modelFallbackPriority = Nothing
                     }

--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -1,31 +1,71 @@
 -- | Interactive TTY model picker for bare @/model@.
 module Agent.CLI.ModelPicker
-    ( pickModel
+    ( ModelPickerSelection(..)
+    , ModelPickerState(..)
+    , pickModel
     , pickModelWithOptions
+    , pickModelWithEffort
     , formatCatalogListing
+    , initialModelPickerState
+    , applyModelPickerEvent
+    , modelEffortOptions
+    , initialModelEffort
+    , renderEffortIndicator
     , renderPickerFrame
+    , renderModelPickerFrame
     , decodePickerKey
     ) where
 
-import Agent.CLI.Models
 import Agent.CLI.ModelConfig (ModelCatalog)
+import Agent.CLI.Models
+import Agent.CLI.Options
+    ( defaultEffortFor
+    , normalizeReasoningEffortForDialect
+    , reasoningEffortsForDialect
+    )
 import Agent.CLI.Picker (PickerKey(..), runOverlayWithDecoder)
 import qualified Agent.CLI.Picker as Picker
-import Agent.Dialect (DialectId, dialectSlug)
 import Agent.CLI.Style
     ( glyphOk
     , roleMuted
     , rolePrompt
+    , roleSelected
     , roleSuccess
     , roleWarn
     )
+import Agent.Dialect (DialectId, dialectSlug)
 import Agent.Provider (Provider)
+import Agent.ReasoningEffort
+    ( ReasoningEffort
+    , reasoningEffortText
+    )
+import Agent.TUI.TextWidth (displayTerminalText)
 import Control.Monad (join)
 import Data.Char (isPrint)
+import Data.List (elemIndex)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import System.IO (hFlush, hIsTerminalDevice, stderr, stdin)
+
+-- | A confirmed model and the reasoning effort chosen alongside it.
+data ModelPickerSelection = ModelPickerSelection
+    { modelPickerOption :: !ModelOption
+    , modelPickerEffort :: !ReasoningEffort
+    }
+    deriving (Eq, Show)
+
+-- | Search/navigation state plus an independent effort choice for every model.
+-- Keeping choices per model means moving through the list does not discard an
+-- adjustment the user made before comparing another model.
+data ModelPickerState = ModelPickerState
+    { modelPickerModels :: !PickerState
+    , modelPickerEfforts
+        :: !(Map.Map (Text, Text, DialectId) ReasoningEffort)
+    }
+    deriving (Eq, Show)
 
 -- | Decode one keypress (including CSI arrow sequences) into a picker event.
 decodePickerKey :: String -> Maybe PickerEvent
@@ -41,6 +81,8 @@ toEvent :: PickerKey -> PickerEvent
 toEvent = \case
     PickerKeyUp -> PickerUp
     PickerKeyDown -> PickerDown
+    PickerKeyLeft -> PickerLeft
+    PickerKeyRight -> PickerRight
     PickerKeyConfirm -> PickerConfirm
     PickerKeyCancel -> PickerCancel
     PickerKeyBackspace -> PickerBackspace
@@ -57,7 +99,7 @@ pickModel
     -> Text
     -> DialectId
     -> IO (Maybe ModelOption)
-pickModel catalog color connectionId provider current currentDialect = do
+pickModel catalog color connectionId provider current currentDialect =
     pickModelWithOptions
         catalog
         []
@@ -67,8 +109,8 @@ pickModel catalog color connectionId provider current currentDialect = do
         current
         currentDialect
 
--- | Open the picker with extra runtime-discovered entries appended to the
--- configured catalog.
+-- | Compatibility entry point for callers that only need the model. The
+-- provider default seeds the integrated effort control.
 pickModelWithOptions
     :: ModelCatalog
     -> [ModelOption]
@@ -79,28 +121,120 @@ pickModelWithOptions
     -> DialectId
     -> IO (Maybe ModelOption)
 pickModelWithOptions
-        catalog discovered color connectionId provider current currentDialect = do
+        catalog discovered color connectionId provider current currentDialect =
+    fmap (fmap (.modelPickerOption)) $
+        pickModelWithEffort
+            catalog
+            discovered
+            color
+            connectionId
+            provider
+            current
+            currentDialect
+            (defaultEffortFor provider)
+
+-- | Open the integrated model/effort picker with runtime-discovered entries.
+pickModelWithEffort
+    :: ModelCatalog
+    -> [ModelOption]
+    -> Bool
+    -> Text
+    -> Provider
+    -> Text
+    -> DialectId
+    -> ReasoningEffort
+    -> IO (Maybe ModelPickerSelection)
+pickModelWithEffort
+        catalog
+        discovered
+        color
+        connectionId
+        provider
+        current
+        currentDialect
+        currentEffort = do
     isTty <- hIsTerminalDevice stdin
-    state0 <-
+    models <-
         initialPickerStateResolvedWith
             catalog discovered connectionId provider current currentDialect
+    let state0 = initialModelPickerState currentEffort models
     if not isTty
         then do
             Text.hPutStrLn stderr
                 (formatCatalogListingState
-                    color current currentDialect state0)
+                    color current currentDialect models)
             hFlush stderr
             pure Nothing
         else do
             result <-
                 runOverlayWithDecoder
                     decodeModelPickerKey
-                    (renderPickerFrame color)
-                    step
+                    (renderModelPickerFrame color)
+                    (\key -> applyModelPickerEvent (toEvent key))
                     state0
             pure (join result)
-  where
-    step key state = applyPickerEvent (toEvent key) state
+
+-- | Seed each row with the active effort for the current model and the target
+-- provider's normalized default for every other model.
+initialModelPickerState
+    :: ReasoningEffort
+    -> PickerState
+    -> ModelPickerState
+initialModelPickerState currentEffort models =
+    ModelPickerState
+        { modelPickerModels = models
+        , modelPickerEfforts =
+            Map.fromList
+                [ (modelIdentity option, initialModelEffort models currentEffort option)
+                | option <- models.pickerAll
+                ]
+        }
+
+-- | Efforts supported by a model-facing dialect.
+modelEffortOptions :: ModelOption -> [ReasoningEffort]
+modelEffortOptions =
+    reasoningEffortsForDialect . (.modelTarget.targetDialect)
+
+-- | Initial effort for one row in a picker.
+initialModelEffort
+    :: PickerState
+    -> ReasoningEffort
+    -> ModelOption
+    -> ReasoningEffort
+initialModelEffort models currentEffort option =
+    normalizeReasoningEffortForDialect
+        option.modelTarget.targetDialect
+        ( if isCurrent
+                models.pickerConnectionId
+                models.pickerCurrent
+                models.pickerCurrentDialect
+                option
+            then currentEffort
+            else defaultEffortFor option.modelTarget.targetProvider
+        )
+
+-- | Apply navigation, search, confirmation, or a horizontal effort change.
+applyModelPickerEvent
+    :: PickerEvent
+    -> ModelPickerState
+    -> Either (Maybe ModelPickerSelection) ModelPickerState
+applyModelPickerEvent event state = case event of
+    PickerCancel -> Left Nothing
+    PickerConfirm ->
+        Left $
+            fmap
+                (\option ->
+                    ModelPickerSelection
+                        { modelPickerOption = option
+                        , modelPickerEffort = effortForOption state option
+                        })
+                (selectedOption state.modelPickerModels)
+    PickerLeft -> Right (adjustSelectedEffort (-1) state)
+    PickerRight -> Right (adjustSelectedEffort 1 state)
+    _ ->
+        case applyPickerEvent event state.modelPickerModels of
+            Right models -> Right state { modelPickerModels = models }
+            Left _ -> Right state
 
 formatCatalogListing
     :: ModelCatalog
@@ -129,9 +263,9 @@ formatCatalogListingState color current currentDialect state =
             roleMuted color
                 (glyphSessionLike
                     <> "model: "
-                    <> state.pickerConnectionId
+                    <> displayPickerText state.pickerConnectionId
                     <> "/"
-                    <> current
+                    <> displayPickerText current
                     <> " · all providers")
         rows =
             map
@@ -148,61 +282,92 @@ formatCatalogListingState color current currentDialect state =
                                 roleMuted color ("  " <> formatOptionName opt)
                         label = case opt.modelLabel of
                             Nothing -> ""
-                            Just l -> roleMuted color ("  " <> l)
+                            Just l ->
+                                roleMuted color
+                                    ("  " <> displayPickerText l)
                     in mark <> label)
                 state.pickerAll
     in Text.intercalate "\n" (header : rows)
 
--- | Pure frame used by the interactive loop (and tests).
+-- | Backwards-compatible pure frame seeded from the current provider default.
 renderPickerFrame :: Bool -> PickerState -> Text
-renderPickerFrame color state =
-    let visible = visibleOptions state
-        n = length visible
-        idx = if n == 0 then 0 else min state.pickerIndex (n - 1)
-        windowStart =
-            max 0
-                $ min
-                    (max 0 (n - pickerViewportSize))
-                    (idx - pickerViewportSize `div` 2)
-        window =
-            take pickerViewportSize (drop windowStart visible)
-        header =
-            rolePrompt color "model"
-                <> roleMuted color
-                    (" · all providers · current "
-                        <> state.pickerConnectionId
+renderPickerFrame color models =
+    renderModelPickerFrame color $
+        initialModelPickerState
+            (defaultEffortFor models.pickerProvider)
+            models
+
+-- | Pure integrated model-picker frame used by the interactive loop and tests.
+renderModelPickerFrame :: Bool -> ModelPickerState -> Text
+renderModelPickerFrame color state =
+    Text.intercalate "\n" $
+        [ header
+        , searchLine
+        , scrollIndicator (windowStart > 0) "↑ more"
+        ]
+        <> paddedBody
+        <> [ scrollIndicator
+                (windowStart + length window < optionCount)
+                "↓ more"
+           , ""
+           ]
+        <> selectedDetailLines color selected
+        <> [ ""
+           , roleMuted color
+                "↑↓ select · ←→ reasoning effort · ↵ confirm · esc cancel"
+           ]
+  where
+    models = state.modelPickerModels
+    visible = visibleOptions models
+    optionCount = length visible
+    selectedIndex =
+        if optionCount == 0
+            then 0
+            else min models.pickerIndex (optionCount - 1)
+    windowStart =
+        max 0 $
+            min
+                (max 0 (optionCount - pickerViewportSize))
+                (selectedIndex - pickerViewportSize `div` 2)
+    window = take pickerViewportSize (drop windowStart visible)
+    body = case visible of
+        [] -> [roleMuted color "  No matching models"]
+        _ ->
+            zipWith
+                (\index option ->
+                    renderRow
+                        color
+                        (index == selectedIndex)
+                        models.pickerConnectionId
+                        models.pickerCurrent
+                        models.pickerCurrentDialect
+                        (effortForOption state option)
+                        option)
+                [windowStart ..]
+                window
+    paddedBody =
+        body
+            <> replicate
+                (max 0 (pickerViewportSize - length body))
+                ""
+    selected = selectedOption models
+    header =
+        rolePrompt color "Models"
+            <> roleMuted color
+                (displayPickerText
+                    (" · current "
+                        <> models.pickerConnectionId
                         <> "/"
-                        <> state.pickerCurrent)
-        filterLine
-            | Text.null state.pickerFilter =
-                roleMuted color "filter: (type to narrow)"
-            | otherwise =
-                roleMuted color "filter: "
-                    <> roleWarn color state.pickerFilter
-        body = case visible of
-            [] -> [roleMuted color "(no matches)"]
-            _ ->
-                zipWith
-                    (\i opt -> renderRow color (i == idx)
-                        state.pickerConnectionId
-                        state.pickerCurrent
-                        state.pickerCurrentDialect
-                        opt)
-                    [windowStart ..]
-                    window
-        position
-            | n == 0 = roleMuted color "0 models"
-            | otherwise =
-                roleMuted color
-                    (Text.pack (show (idx + 1))
-                        <> "/"
-                        <> Text.pack (show n)
-                        <> " models")
-        footer =
-            roleMuted color
-                "↑↓ or scroll · click/enter · esc · type to filter"
-    in Text.intercalate "\n"
-        (header : filterLine : body <> [position, footer])
+                        <> models.pickerCurrent))
+    searchLine
+        | Text.null models.pickerFilter =
+            roleMuted color "/ Type to search"
+        | otherwise =
+            roleMuted color "/ "
+                <> roleWarn color models.pickerFilter
+    scrollIndicator visible_ label
+        | visible_ = roleMuted color ("    " <> label)
+        | otherwise = ""
 
 pickerViewportSize :: Int
 pickerViewportSize = 12
@@ -213,36 +378,159 @@ renderRow
     -> Text
     -> Text
     -> DialectId
+    -> ReasoningEffort
     -> ModelOption
     -> Text
-renderRow color selected currentConnection current currentDialect opt =
-    let cursor = if selected then roleWarn color "› " else "  "
-        name
-            | selected = roleSuccess color (formatOptionName opt)
-            | otherwise = roleMuted color (formatOptionName opt)
-        currentMark
-            | isCurrent currentConnection current currentDialect opt =
-                roleSuccess color " ✓"
-            | otherwise = ""
-        label = case opt.modelLabel of
-            Nothing -> ""
-            Just l -> roleMuted color ("  " <> l)
-    in cursor <> name <> currentMark <> label
+renderRow
+        color
+        selected
+        currentConnection
+        current
+        currentDialect
+        effort
+        option =
+    if selected
+        then roleSelected color
+            ("› " <> clippedName <> padding <> "← " <> indicator <> " →")
+        else "  " <> clippedName <> padding <> roleMuted color indicator
+  where
+    plainName =
+        displayPickerText $
+            option.modelTarget.targetConnectionId
+                <> "/"
+                <> option.modelTarget.targetModelId
+                <> if isCurrent currentConnection current currentDialect option
+                    then " ✓"
+                    else ""
+    clippedName = Text.take modelNameWidth plainName
+    padding =
+        Text.replicate
+            (max 2 (modelNameWidth - Text.length clippedName + 2))
+            " "
+    indicator = renderEffortIndicator option effort
+
+modelNameWidth :: Int
+modelNameWidth = 44
+
+-- | Render a compact absolute effort gauge plus its canonical label.
+renderEffortIndicator :: ModelOption -> ReasoningEffort -> Text
+renderEffortIndicator _option effort =
+    Text.replicate filled "■"
+        <> Text.replicate (barWidth - filled) "□"
+        <> " "
+        <> reasoningEffortText effort
+  where
+    barWidth = fromEnum (maxBound :: ReasoningEffort)
+    filled = min barWidth (fromEnum effort)
+
+selectedDetailLines :: Bool -> Maybe ModelOption -> [Text]
+selectedDetailLines color = \case
+    Nothing ->
+        [ rolePrompt color "No model selected"
+        , roleMuted color "Try a different search."
+        ]
+    Just option ->
+        [ rolePrompt color $
+            displayPickerText
+                (option.modelTarget.targetConnectionId
+                    <> "/"
+                    <> option.modelTarget.targetModelId)
+        , roleMuted color $
+            displayPickerText $
+                Text.intercalate
+                    " · "
+                    ( maybe [] pure option.modelLabel
+                        <> [dialectSlug option.modelTarget.targetDialect]
+                        <> contextDetail option
+                    )
+        ]
+
+contextDetail :: ModelOption -> [Text]
+contextDetail option
+    | maybe False
+        (Text.isInfixOf "context" . Text.toCaseFold)
+        option.modelLabel = []
+    | otherwise =
+        maybe [] (pure . formatContextLength) option.modelContextWindow
+
+formatContextLength :: Int -> Text
+formatContextLength contextLength
+    | contextLength >= 1000000 =
+        compactDecimal 1000000 "M context"
+    | contextLength >= 1000 =
+        compactDecimal 1000 "k context"
+    | otherwise = Text.pack (show contextLength) <> " context"
+  where
+    compactDecimal unit suffix =
+        let tenths = contextLength * 10 `div` unit
+            whole = tenths `div` 10
+            fraction = tenths `mod` 10
+            amount
+                | fraction == 0 = show whole
+                | otherwise = show whole <> "." <> show fraction
+        in Text.pack amount <> suffix
+
+adjustSelectedEffort :: Int -> ModelPickerState -> ModelPickerState
+adjustSelectedEffort delta state =
+    case selectedOption state.modelPickerModels of
+        Nothing -> state
+        Just option ->
+            let efforts = modelEffortOptions option
+                current = effortForOption state option
+                currentIndex = fromMaybe 0 (elemIndex current efforts)
+                nextIndex =
+                    max 0 (min (length efforts - 1) (currentIndex + delta))
+                next = fromMaybe current (atMay nextIndex efforts)
+            in state
+                { modelPickerEfforts =
+                    Map.insert
+                        (modelIdentity option)
+                        next
+                        state.modelPickerEfforts
+                }
+
+effortForOption :: ModelPickerState -> ModelOption -> ReasoningEffort
+effortForOption state option =
+    fromMaybe
+        (initialModelEffort
+            state.modelPickerModels
+            (defaultEffortFor state.modelPickerModels.pickerProvider)
+            option)
+        (Map.lookup (modelIdentity option) state.modelPickerEfforts)
+
+modelIdentity :: ModelOption -> (Text, Text, DialectId)
+modelIdentity option =
+    ( option.modelTarget.targetConnectionId
+    , option.modelTarget.targetModelId
+    , option.modelTarget.targetDialect
+    )
+
+atMay :: Int -> [a] -> Maybe a
+atMay index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing
 
 -- Matches Style.glyphSession without pulling unicode env probing here.
 glyphSessionLike :: Text
 glyphSessionLike = "⧉ "
 
 formatOptionName :: ModelOption -> Text
-formatOptionName opt =
-    opt.modelTarget.targetConnectionId
-        <> " · "
-        <> opt.modelTarget.targetModelId
-        <> " · "
-        <> dialectSlug opt.modelTarget.targetDialect
+formatOptionName option =
+    displayPickerText $
+        option.modelTarget.targetConnectionId
+            <> " · "
+            <> option.modelTarget.targetModelId
+            <> " · "
+            <> dialectSlug option.modelTarget.targetDialect
+
+displayPickerText :: Text -> Text
+displayPickerText =
+    Text.replace "\n" "↵" . displayTerminalText
 
 isCurrent :: Text -> Text -> DialectId -> ModelOption -> Bool
-isCurrent connectionId current dialect opt =
-    opt.modelTarget.targetConnectionId == connectionId
-        && opt.modelTarget.targetModelId == current
-        && opt.modelTarget.targetDialect == dialect
+isCurrent connectionId current dialect option =
+    option.modelTarget.targetConnectionId == connectionId
+        && option.modelTarget.targetModelId == current
+        && option.modelTarget.targetDialect == dialect

--- a/packages/agent-cli/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli/src/Agent/CLI/Models.hs
@@ -62,6 +62,7 @@ data ModelTarget = ModelTarget
 
 data ModelOption = ModelOption
     { modelTarget :: !ModelTarget
+    , modelContextWindow :: !(Maybe Int)
     , modelLabel :: !(Maybe Text)
     , modelFallbackPriority :: !(Maybe Int)
     }
@@ -82,6 +83,8 @@ data PickerState = PickerState
 data PickerEvent
     = PickerUp
     | PickerDown
+    | PickerLeft
+    | PickerRight
     | PickerConfirm
     | PickerCancel
     | PickerBackspace
@@ -104,6 +107,7 @@ modelOptionFromCatalog catalog model = do
             , targetWireModelId = model.catalogModelWireId
             , targetDialect = model.catalogModelDialect
             }
+        , modelContextWindow = model.catalogModelContextWindow
         , modelLabel = model.catalogModelLabel
         , modelFallbackPriority = model.catalogModelFallbackPriority
         }
@@ -145,6 +149,7 @@ rawModelOption provider model =
             , targetWireModelId = model
             , targetDialect = dialectIdForModel provider model
             }
+        , modelContextWindow = Nothing
         , modelLabel = Nothing
         , modelFallbackPriority = Nothing
         }
@@ -169,6 +174,7 @@ ensureCurrentInList connectionId provider current currentDialect options
                 , targetWireModelId = current
                 , targetDialect = currentDialect
                 }
+            , modelContextWindow = Nothing
             , modelLabel = Just "current"
             , modelFallbackPriority = Nothing
             }
@@ -304,6 +310,8 @@ applyPickerEvent event state = case event of
     PickerConfirm -> Left (selectedOption state)
     PickerUp -> Right (move (-1) state)
     PickerDown -> Right (move 1 state)
+    PickerLeft -> Right state
+    PickerRight -> Right state
     PickerBackspace ->
         Right $ clampSelection state
             { pickerFilter = Text.dropEnd 1 state.pickerFilter

--- a/packages/agent-cli/src/Agent/CLI/Permission.hs
+++ b/packages/agent-cli/src/Agent/CLI/Permission.hs
@@ -111,6 +111,8 @@ applyApprovalPolicyKey key state = case key of
                     (approvalPolicyChoices !! state.approvalPolicyIndex)))
     PickerKeyUp -> Right (move (-1) state)
     PickerKeyDown -> Right (move 1 state)
+    PickerKeyLeft -> Right state
+    PickerKeyRight -> Right state
     PickerKeyChar c -> case Text.toLower (Text.singleton c) of
         "p" -> Left (ApprovalPolicySelected PromptMutating)
         "r" -> Left (ApprovalPolicySelected DenyMutating)
@@ -167,6 +169,8 @@ applyPermissionKey key state = case key of
     PickerKeyConfirm -> Left (choiceFromIndex state.permIndex)
     PickerKeyUp -> Right state { permIndex = move (-1) state.permIndex }
     PickerKeyDown -> Right state { permIndex = move 1 state.permIndex }
+    PickerKeyLeft -> Right state
+    PickerKeyRight -> Right state
     PickerKeyChar 'A' -> Left PermissionAllowAll
     PickerKeyChar c ->
         case Text.toLower (Text.singleton c) of

--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -59,6 +59,8 @@ import System.Posix.Terminal
 data PickerKey
     = PickerKeyUp
     | PickerKeyDown
+    | PickerKeyLeft
+    | PickerKeyRight
     | PickerKeyConfirm
     | PickerKeyCancel
     | PickerKeyBackspace
@@ -87,8 +89,14 @@ decodePickerKey = \case
     "J" -> Just PickerKeyDown
     "\ESC[A" -> Just PickerKeyUp
     "\ESC[B" -> Just PickerKeyDown
+    "\ESC[C" -> Just PickerKeyRight
+    "\ESC[D" -> Just PickerKeyLeft
+    "\ESCOC" -> Just PickerKeyRight
+    "\ESCOD" -> Just PickerKeyLeft
     "\ESC[OA" -> Just PickerKeyUp
     "\ESC[OB" -> Just PickerKeyDown
+    "\ESC[OC" -> Just PickerKeyRight
+    "\ESC[OD" -> Just PickerKeyLeft
     "\DEL" -> Just PickerKeyBackspace
     "\b" -> Just PickerKeyBackspace
     sequence_
@@ -100,6 +108,8 @@ decodePickerKey = \case
             case final of
                 'A' -> Just PickerKeyUp
                 'B' -> Just PickerKeyDown
+                'C' -> Just PickerKeyRight
+                'D' -> Just PickerKeyLeft
                 _ -> Nothing
     [c] -> Just (PickerKeyChar c)
     _ -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -115,6 +115,8 @@ applyPlanEnterKey key state@(PlanEnterState reason index) = case key of
     PickerKeyConfirm -> Left (enterChoiceFromIndex index)
     PickerKeyUp -> Right (PlanEnterState reason (movePlanIndex 2 (-1) index))
     PickerKeyDown -> Right (PlanEnterState reason (movePlanIndex 2 1 index))
+    PickerKeyLeft -> Right state
+    PickerKeyRight -> Right state
     PickerKeyChar c -> case planDecisionForKey c of
         Just PlanApprove -> Left PlanEnter
         Just PlanCancel -> Left PlanStayNormal
@@ -178,6 +180,8 @@ applyPlanExitKey key state@(PlanExitState index) = case key of
     PickerKeyConfirm -> Left (exitChoiceFromIndex index)
     PickerKeyUp -> Right (PlanExitState (movePlanIndex 3 (-1) index))
     PickerKeyDown -> Right (PlanExitState (movePlanIndex 3 1 index))
+    PickerKeyLeft -> Right state
+    PickerKeyRight -> Right state
     PickerKeyChar c ->
         maybe (Right state) Left (planDecisionForKey c)
     PickerKeyBackspace -> Right state

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -119,6 +119,7 @@ import Agent.Provider
     , providerSlug
     , tokenProviderBillingMode
     )
+import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Responses.Types (ResponseCreateParams(model))
 import Agent.TUI.Model (UiEvent(..))
 import Control.Monad
@@ -369,6 +370,7 @@ requestAccountProviderSwitch
                     sessionId <- ensureTransitionSessionId persist
                     let transition = ProviderTransition
                             { transitionTarget = choice.modelTarget
+                            , transitionEffort = Nothing
                             , transitionAccountSelectionId =
                                 Just selectionId
                             , transitionAccountId = Just accountId
@@ -630,6 +632,7 @@ chooseAutomaticProviderTransition
                             emitUiEvent runtime (UiSystemMessage message)
                     pure $ Just ProviderTransition
                         { transitionTarget = choice.modelTarget
+                        , transitionEffort = Nothing
                         , transitionAccountSelectionId =
                             (.selectedSelectionId) <$> selected
                         , transitionAccountId =
@@ -705,6 +708,7 @@ chooseStartupProviderTransition
                         emitUiEvent runtime (UiSystemMessage message)
                     pure $ Just ProviderTransition
                         { transitionTarget = choice.modelTarget
+                        , transitionEffort = Nothing
                         , transitionAccountSelectionId =
                             (.selectedSelectionId) <$> selected
                         , transitionAccountId =
@@ -731,6 +735,7 @@ prepareProviderTransition cause unavailable pending rawChoice persist = do
             sessionId <- ensureTransitionSessionId persist
             pure $ Right ProviderTransition
                 { transitionTarget = choice.modelTarget
+                , transitionEffort = Nothing
                 , transitionAccountSelectionId = Nothing
                 , transitionAccountId = Nothing
                 , transitionSessionId = sessionId
@@ -869,7 +874,13 @@ commitProviderTransition scope home projectRoot (Just transition) persist = do
                 PersistencePending pending sessionId tempDir ->
                     writeIORef slotRef $ PersistencePending
                         pending
-                            { createTarget = transition.transitionTarget }
+                            { createTarget = transition.transitionTarget
+                            , createEffort =
+                                maybe
+                                    pending.createEffort
+                                    reasoningEffortText
+                                    transition.transitionEffort
+                            }
                         sessionId
                         tempDir
                 PersistenceActive handle -> do
@@ -883,6 +894,11 @@ commitProviderTransition scope home projectRoot (Just transition) persist = do
                             , metaTransportModel =
                                 Just transition.transitionTarget.targetWireModelId
                             , metaDialect = transition.transitionTarget.targetDialect
+                            , metaEffort =
+                                maybe
+                                    previousMeta.metaEffort
+                                    reasoningEffortText
+                                    transition.transitionEffort
                             , metaLegacySubagentTarget =
                                 Just
                                     (sessionLegacySubagentTarget previousMeta)

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -13,6 +13,7 @@ module Agent.CLI.ProviderTransition
 
 import Agent.CLI.Models (ModelTarget(..))
 import Agent.CLI.Options (CliOptions(..))
+import Agent.ReasoningEffort (ReasoningEffort)
 import Agent.Error (ApiError)
 import Agent.Loop (TurnInput)
 import Agent.Provider (BillingMode, Provider)
@@ -40,6 +41,9 @@ data TransitionCause
 
 data ProviderTransition = ProviderTransition
     { transitionTarget :: !ModelTarget
+    -- | Explicit effort selected with the target model. 'Nothing' keeps the
+    -- resumed session's effort or lets the target provider choose its default.
+    , transitionEffort :: !(Maybe ReasoningEffort)
     -- | Stable credential-source key to select after rebuilding the provider.
     , transitionAccountSelectionId :: !(Maybe Text)
     -- | Provider account id used by transports whose live pool selects by id.
@@ -71,7 +75,7 @@ applyProviderTransition options transition =
         , optModel = Just transition.transitionTarget.targetModelId
         , optCwd = Nothing
         , optWorktree = False
-        , optEffort = Nothing
+        , optEffort = transition.transitionEffort
         , optResume = transition.transitionSessionId <|> options.optResume
         }
 

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -551,6 +551,8 @@ applyResumeKey key state = case key of
     PickerKeyConfirm -> Left (selectedResume state)
     PickerKeyUp -> Right (move (-1) state)
     PickerKeyDown -> Right (move 1 state)
+    PickerKeyLeft -> Right state
+    PickerKeyRight -> Right state
     PickerKeyBackspace ->
         Right $ clampSel state
             { resumeFilter = Text.dropEnd 1 state.resumeFilter

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -39,7 +39,8 @@ import Agent.CLI.Models
       ModelTarget(targetDialect, targetConnectionId, targetProvider,
                   targetModelId) )
 import Agent.CLI.Options
-    ( isOneShot,
+    ( defaultEffortFor,
+      isOneShot,
       CliOptions(optMotionMode, optManagedTurnFile, optScreenMode,
                  optProvider, optModel, optWorktree, optEffort, optPrompt,
                  optPromptFile, optResume, optCwd, optCodeMode),
@@ -60,7 +61,7 @@ import Agent.CLI.ProviderTransition
                          transitionUnavailableProviders, transitionPendingTurn,
                          transitionTarget, transitionAccountSelectionId,
                          transitionAccountId, transitionAutomaticBilling,
-                         transitionSessionId),
+                         transitionSessionId, transitionEffort),
       TransitionCause(AutomaticFallback, ManualTransition) )
 import Agent.CLI.Recap ()
 import Agent.CLI.Render ( putTextLn )
@@ -97,7 +98,9 @@ import Agent.CLI.Session
       sessionsRoot,
       SessionMeta(metaId, metaCwd) )
 import Agent.CLI.Session.Attachments ()
-import Agent.CLI.Session.Choices ( modelChoice )
+import Agent.CLI.ModelPicker
+    ( ModelPickerSelection(modelPickerEffort, modelPickerOption) )
+import Agent.CLI.Session.Choices ( modelChoiceWithEffort )
 import Agent.CLI.Session.History ()
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
@@ -203,7 +206,7 @@ import Data.Functor ()
 import Data.IORef
     ( IORef, atomicModifyIORef', newIORef, readIORef, writeIORef )
 import Data.List ()
-import Data.Maybe ( isJust, isNothing )
+import Data.Maybe ( fromMaybe, isJust, isNothing )
 import Data.Text ( Text )
 import Data.Time.Clock ( getCurrentTime )
 import System.Console.ANSI ()
@@ -485,27 +488,38 @@ runAgent
                                             (Left
                                                 "No configured models are available.")
                                     Just current ->
-                                        modelChoice
+                                        modelChoiceWithEffort
                                             catalog
                                             (Just runtime)
                                             color
                                             current.targetConnectionId
                                             current.targetProvider
                                             current.targetModelId
-                                            current.targetDialect >>= \case
+                                            current.targetDialect
+                                            (fromMaybe
+                                                (defaultEffortFor
+                                                    current.targetProvider)
+                                                ( (nextTransition
+                                                        >>= (.transitionEffort))
+                                                    <|> nextOptions.optEffort
+                                                ))
+                                            >>= \case
                                                 Nothing ->
                                                     pure (Right Nothing)
-                                                Just choice ->
+                                                Just selection ->
                                                     pure $ Right $ Just $
                                                         recoveryModelTransition
                                                             nextOptions
                                                             nextTransition
-                                                            choice.modelTarget
-                    recoveryModelTransition nextOptions nextTransition target =
+                                                            selection.modelPickerOption.modelTarget
+                                                            selection.modelPickerEffort
+                    recoveryModelTransition
+                            nextOptions nextTransition target selectedEffort =
                         case nextTransition of
                             Just active ->
                                 active
                                     { transitionTarget = target
+                                    , transitionEffort = Just selectedEffort
                                     , transitionAccountSelectionId = Nothing
                                     , transitionAccountId = Nothing
                                     , transitionUnavailableProviders = Set.empty
@@ -515,6 +529,7 @@ runAgent
                             Nothing ->
                                 ProviderTransition
                                     { transitionTarget = target
+                                    , transitionEffort = Just selectedEffort
                                     , transitionAccountSelectionId = Nothing
                                     , transitionAccountId = Nothing
                                     , transitionSessionId = nextOptions.optResume

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -85,7 +85,9 @@ import Agent.CLI.Secret ()
 import Agent.CLI.Session ()
 import Agent.CLI.Session.Attachments ()
 import Agent.CLI.Session.Choices
-    ( atMay, effortChoice, modelChoice )
+    ( atMay, effortChoice, modelChoiceWithEffort )
+import Agent.CLI.ModelPicker
+    ( ModelPickerSelection(modelPickerEffort, modelPickerOption) )
 import Agent.CLI.Session.History ()
 import Agent.CLI.Session.Interaction ( setSessionEffort )
 import Agent.CLI.Session.Lifecycle ()
@@ -445,7 +447,7 @@ handleSelection
         if modelTargetRequiresRebuild
                 connectionId provider (dialectId dialect) choice
             then
-                switchModelTarget color choice continue
+                switchModelTarget color choice Nothing continue
             else do
                 message <- applyModelChange
                     home projectRoot provider connectionId name
@@ -504,22 +506,27 @@ handleSelection
         color <- resolveColor stderr
         params <- readIORef paramsRef
         let current = currentModel params
-        modelChoice
+        modelChoiceWithEffort
             catalog fullscreen color connectionId provider current
-                (dialectId dialect) >>= \case
+                (dialectId dialect) (currentEffort params) >>= \case
             Nothing -> next
-            Just rawChoice -> do
+            Just selection -> do
+                let rawChoice = selection.modelPickerOption
+                    selectedEffort = selection.modelPickerEffort
                 choice <- resolveModelOptionDialect rawChoice
                 if choice.modelTarget.targetProvider == provider
                     && choice.modelTarget.targetConnectionId == connectionId
                     && choice.modelTarget.targetModelId == current
                     && choice.modelTarget.targetDialect == dialectId dialect
                   then do
+                    setSessionEffort env selectedEffort
                     let message =
                             "model: "
                                 <> connectionId
                                 <> "/"
                                 <> choice.modelTarget.targetModelId
+                                <> " · effort "
+                                <> reasoningEffortText selectedEffort
                     displayInfo message $
                         Text.putStrLn
                             (roleMuted color
@@ -535,14 +542,15 @@ handleSelection
                         choice.modelTarget.targetWireModelId
                         choice.modelTarget.targetDialect
                         paramsRef render conversationRef persist
+                    setSessionEffort env selectedEffort
                     displayInfo message $
                         Text.putStrLn
                             (roleMuted color
                                 (glyphOk <> message))
                     next
                   else
-                    switchModelTarget color choice next
-    switchModelTarget color choice next =
+                    switchModelTarget color choice (Just selectedEffort) next
+    switchModelTarget color choice selectedEffort next =
         requestModelTargetSwitch fullscreen choice persist >>= \case
             Left err
                 | choice.modelTarget.targetProvider == GeminiProvider
@@ -563,12 +571,22 @@ handleSelection
                                         Text.hPutStrLn stderr
                                             (roleError color retryErr)
                                     next
-                                Right result -> pure result
+                                Right result ->
+                                    pure
+                                        (applyTransitionEffort
+                                            selectedEffort
+                                            result)
             Left err -> do
                 displayError err $
                     Text.hPutStrLn stderr (roleError color err)
                 next
-            Right result -> pure result
+            Right result ->
+                pure (applyTransitionEffort selectedEffort result)
+    applyTransitionEffort selectedEffort = \case
+        RunSwitchProvider transition ->
+            RunSwitchProvider
+                transition { transitionEffort = selectedEffort }
+        result -> result
     attachPendingTurn result pending =
         case result of
             RunSwitchProvider transition ->

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Session.Choices
     , atMay
     , effortChoice
     , modelChoice
+    , modelChoiceWithEffort
     , showAccountUsage
     ) where
 
@@ -12,7 +13,13 @@ import Agent.CLI.ModelConfig
     ( ModelCatalog
     , builtinConnectionId
     )
-import Agent.CLI.ModelPicker (pickModelWithOptions)
+import Agent.CLI.ModelPicker
+    ( ModelPickerSelection(..)
+    , initialModelEffort
+    , modelEffortOptions
+    , pickModelWithEffort
+    , renderEffortIndicator
+    )
 import Agent.CLI.Models
     ( ModelOption(..)
     , ModelTarget(..)
@@ -32,9 +39,10 @@ import Agent.CLI.Style
 import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.TUI.App
     ( FullscreenRuntime
+    , requestFullscreenAdjustableFilterChoice
     , requestFullscreenChoice
-    , requestFullscreenFilterChoice
     )
+import Agent.CLI.Options (defaultEffortFor)
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
     , formatUsageReport
@@ -76,75 +84,142 @@ modelChoice
     -> IO (Maybe ModelOption)
 modelChoice
         catalog fullscreen color connectionId provider current currentDialect =
-    discoverModelOptions connectionId provider >>= \(title, discovered) ->
-        case fullscreen of
-            Nothing ->
-                pickModelWithOptions
-                    catalog discovered color connectionId provider current
-                    currentDialect
-            Just runtime -> do
-                picker <-
-                    initialPickerStateResolvedWith
-                        catalog
-                        discovered
-                        connectionId
-                        provider
-                        current
-                        currentDialect
-                let options = picker.pickerAll
-                    rows =
-                        [ ( option.modelTarget.targetConnectionId
-                                <> " · "
-                                <> option.modelTarget.targetModelId
-                                <> " · "
-                                <> dialectSlug option.modelTarget.targetDialect
-                          , fromMaybe "" option.modelLabel
-                          )
-                        | option <- options
-                        ]
-                requestFullscreenFilterChoice
-                    runtime
-                    title
-                    picker.pickerIndex
-                    rows
-                    >>= \case
-                        Just index
-                            | index >= 0
-                            , index < length options ->
-                                pure (Just (options !! index))
-                        _ -> pure Nothing
+    fmap (fmap (.modelPickerOption)) $
+        modelChoiceWithEffort
+            catalog
+            fullscreen
+            color
+            connectionId
+            provider
+            current
+            currentDialect
+            (defaultEffortFor provider)
 
-discoverModelOptions :: Text -> Provider -> IO (Text, [ModelOption])
+-- | Choose a model and its reasoning effort in one searchable surface.
+modelChoiceWithEffort
+    :: ModelCatalog
+    -> Maybe FullscreenRuntime
+    -> Bool
+    -> Text
+    -> Provider
+    -> Text
+    -> DialectId
+    -> ReasoningEffort
+    -> IO (Maybe ModelPickerSelection)
+modelChoiceWithEffort
+        catalog
+        fullscreen
+        color
+        connectionId
+        provider
+        current
+        currentDialect
+        currentEffort = do
+    discovered <- discoverModelOptions connectionId provider
+    case fullscreen of
+        Nothing ->
+            pickModelWithEffort
+                catalog
+                discovered
+                color
+                connectionId
+                provider
+                current
+                currentDialect
+                currentEffort
+        Just runtime -> do
+            picker <-
+                initialPickerStateResolvedWith
+                    catalog
+                    discovered
+                    connectionId
+                    provider
+                    current
+                    currentDialect
+            let options = picker.pickerAll
+                row option =
+                    let efforts = modelEffortOptions option
+                        initial =
+                            initialModelEffort picker currentEffort option
+                        initialIndex =
+                            fromMaybe 0 (elemIndex initial efforts)
+                    in ( modelRowLabel picker option
+                       , modelDetail option
+                       , map (renderEffortIndicator option) efforts
+                       , initialIndex
+                       )
+            requestFullscreenAdjustableFilterChoice
+                runtime
+                "Models"
+                picker.pickerIndex
+                (map row options)
+                >>= \case
+                    Just (modelIndex, effortIndex)
+                        | Just option <- atMay modelIndex options
+                        , Just effort <-
+                            atMay effortIndex (modelEffortOptions option) ->
+                                pure $ Just ModelPickerSelection
+                                    { modelPickerOption = option
+                                    , modelPickerEffort = effort
+                                    }
+                    _ -> pure Nothing
+
+discoverModelOptions :: Text -> Provider -> IO [ModelOption]
 discoverModelOptions connectionId provider
     | provider == OpenRouterProvider
     , connectionId == builtinConnectionId OpenRouterProvider =
         OpenRouterModels.fetchOpenRouterModels >>= \case
-            Left _ -> pure ("Model · configured only", [])
-            Right models ->
-                pure
-                    ( "Model · OpenRouter live"
-                    , map openRouterModelOption models
-                    )
-    | otherwise = pure ("Model", [])
+            Left _ -> pure []
+            Right models -> pure (map openRouterModelOption models)
+    | otherwise = pure []
 
 openRouterModelOption :: OpenRouterModels.OpenRouterModel -> ModelOption
 openRouterModelOption model =
     (rawModelOption OpenRouterProvider model.modelId)
-        { modelLabel = Just $
+        { modelContextWindow = model.modelContextLength
+        , modelLabel = Just $
             Text.intercalate
                 " · "
-                ( [model.modelDisplayName]
-                    <> maybe
-                        []
-                        (pure . formatContextLength)
-                        model.modelContextLength
-                    <> [ if model.modelSupportsTools
+                ( [ model.modelDisplayName
+                  , if model.modelSupportsTools
                             then "tools"
                             else "no tools"
-                       , "OpenRouter live"
-                       ]
+                  , "OpenRouter live"
+                  ]
                 )
         }
+
+modelRowLabel :: PickerState -> ModelOption -> Text
+modelRowLabel picker option =
+    option.modelTarget.targetConnectionId
+        <> "/"
+        <> option.modelTarget.targetModelId
+        <> if
+            option.modelTarget.targetConnectionId == picker.pickerConnectionId
+                && option.modelTarget.targetModelId == picker.pickerCurrent
+                && option.modelTarget.targetDialect
+                    == picker.pickerCurrentDialect
+            then " ✓"
+            else ""
+
+modelDetail :: ModelOption -> Text
+modelDetail option =
+    Text.intercalate
+        " · "
+        ( maybe [] pure option.modelLabel
+            <> [ option.modelTarget.targetConnectionId
+               , dialectSlug option.modelTarget.targetDialect
+               ]
+            <> if maybe False
+                    (Text.isInfixOf "context" . Text.toCaseFold)
+                    option.modelLabel
+                then []
+                else
+                    maybe
+                        []
+                        (pure . formatContextLength)
+                        option.modelContextWindow
+        )
 
 formatContextLength :: Int -> Text
 formatContextLength contextLength

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -25,6 +25,7 @@ module Agent.CLI.Style
     , roleWarn
     , roleMuted
     , roleSuccess
+    , roleSelected
     , glyphTool
     , glyphToolOut
     , glyphToolAccent
@@ -207,6 +208,14 @@ roleSuccess :: Bool -> Text -> Text
 roleSuccess color =
     style color
         [ terminalGreen
+        ]
+
+-- | Theme-respecting selection wash for raw terminal overlays.
+roleSelected :: Bool -> Text -> Text
+roleSelected color =
+    style color
+        [ SetConsoleIntensity BoldIntensity
+        , SetSwapForegroundBackground True
         ]
 
 supportsUnicodeChrome :: Bool

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -15,7 +15,9 @@ module Agent.CLI.TUI.App
     , completionRequiresRedraw
     , conversationScrollbarRenderer
     , choiceRowColumns
+    , filterChoiceRowLimit
     , choiceClosesOnUiTransition
+    , adjustChoiceValue
     , drawApp
     , elapsedMillisSince
     , appEventLogicalBytes
@@ -59,6 +61,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
     , requestFullscreenFilterChoice
+    , requestFullscreenAdjustableFilterChoice
     , requestFullscreenOnboarding
     , requestFullscreenResume
     , requestFullscreenSecret

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -705,9 +705,15 @@ handleEventInner' event = case event of
                     , choiceRows = rows
                     , choiceSearch = False
                     , choiceQuery = ""
+                    , choiceAdjustments = Nothing
+                    , choiceAdjustmentIndices = []
                     , choiceCloseOnTurnEnd = False
                     }
-                , appChoiceReply = Just (atomically . putTMVar reply)
+                , appChoiceReply =
+                    Just
+                        (atomically
+                            . putTMVar reply
+                            . fmap (.choiceSelectionIndex))
                 , appAgentHover = Nothing
                 }
         vScrollToBeginning (viewportScroll OverlayViewport)
@@ -725,9 +731,58 @@ handleEventInner' event = case event of
                     , choiceRows = rows
                     , choiceSearch = True
                     , choiceQuery = ""
+                    , choiceAdjustments = Nothing
+                    , choiceAdjustmentIndices = []
                     , choiceCloseOnTurnEnd = False
                     }
-                , appChoiceReply = Just (atomically . putTMVar reply)
+                , appChoiceReply =
+                    Just
+                        (atomically
+                            . putTMVar reply
+                            . fmap (.choiceSelectionIndex))
+                , appAgentHover = Nothing
+                }
+        vScrollToBeginning (viewportScroll OverlayViewport)
+    AppEvent
+        (AppAskAdjustableFilterChoice title initial adjustableRows reply) -> do
+        state <- get
+        liftIO (state.appRuntime.runtimeNativeProgress False)
+        let rows =
+                [ (label, detail)
+                | (label, detail, _, _) <- adjustableRows
+                ]
+            adjustments =
+                [ values
+                | (_, _, values, _) <- adjustableRows
+                ]
+            adjustmentIndices =
+                [ max 0 (min (max 0 (length values - 1)) valueIndex)
+                | (_, _, values, valueIndex) <- adjustableRows
+                ]
+            replySelection = fmap \selection ->
+                ( selection.choiceSelectionIndex
+                , fromMaybe 0 selection.choiceSelectionAdjustment
+                )
+        modify' \current ->
+            current
+                { appChoice = Just ChoiceOverlay
+                    { choicePresentation = ChoiceDialog
+                    , choiceTitle = title
+                    , choiceBody = ""
+                    , choiceIndex =
+                        max 0 (min (max 0 (length rows - 1)) initial)
+                    , choiceRows = rows
+                    , choiceSearch = True
+                    , choiceQuery = ""
+                    , choiceAdjustments = Just adjustments
+                    , choiceAdjustmentIndices = adjustmentIndices
+                    , choiceCloseOnTurnEnd = False
+                    }
+                , appChoiceReply =
+                    Just
+                        (atomically
+                            . putTMVar reply
+                            . replySelection)
                 , appAgentHover = Nothing
                 }
         vScrollToBeginning (viewportScroll OverlayViewport)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -654,6 +654,17 @@ appEventLogicalBytes = \case
             (saturatingAdd
                 (logicalTextBytes title)
                 (textRowsLogicalBytes rows))
+    AppAskAdjustableFilterChoice title _ rows _ ->
+        saturatingAdd 256 $
+            saturatingAdd
+                (logicalTextBytes title)
+                ( foldl'
+                    (\size (label, detail, values, _) ->
+                        saturatingAdd size
+                            (logicalTextsBytes (label : detail : values)))
+                    0
+                    rows
+                )
     AppAskText _ title body draft _ ->
         saturatingAdd 256 (logicalTextsBytes [title, body, draft])
     AppAskResume browser _ _ _ _ ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -384,6 +384,47 @@ resolveResume confirmed = do
             }
     resumeNativeProgressIfRunning
 
+-- | Move the selected source row's adjustable value without disturbing its
+-- search query or list selection. Values clamp at their endpoints.
+adjustChoiceValue :: Int -> ChoiceOverlay -> ChoiceOverlay
+adjustChoiceValue delta choice =
+    case choice.choiceAdjustments of
+        Nothing -> choice
+        Just adjustmentRows ->
+            case selectedChoiceIndex choice of
+                Nothing -> choice
+                Just sourceIndex ->
+                    case listAt sourceIndex adjustmentRows of
+                        Nothing -> choice
+                        Just values ->
+                            let current =
+                                    fromMaybe 0 $
+                                        listAt
+                                            sourceIndex
+                                            choice.choiceAdjustmentIndices
+                                next =
+                                    max 0 $
+                                        min
+                                            (max 0 (length values - 1))
+                                            (current + delta)
+                            in choice
+                                { choiceAdjustmentIndices =
+                                    replaceAt
+                                        sourceIndex
+                                        next
+                                        choice.choiceAdjustmentIndices
+                                }
+  where
+    listAt index values
+        | index < 0 = Nothing
+        | otherwise = case drop index values of
+            value : _ -> Just value
+            [] -> Nothing
+    replaceAt index value values =
+        case splitAt index values of
+            (before, _ : after) -> before <> (value : after)
+            _ -> values
+
 confirmResumeId :: Text -> EventM Name AppState ()
 confirmResumeId sessionId = do
     state <- get
@@ -456,6 +497,8 @@ handleFilterChoiceKey :: V.Event -> EventM Name AppState ()
 handleFilterChoiceKey event = case event of
     V.EvKey V.KUp [] -> moveFilteredChoice (-1)
     V.EvKey V.KDown [] -> moveFilteredChoice 1
+    V.EvKey V.KLeft [] -> adjustFilteredChoice (-1)
+    V.EvKey V.KRight [] -> adjustFilteredChoice 1
     V.EvKey V.KBackTab [] -> moveFilteredChoice (-1)
     V.EvKey (V.KChar '\t') [] -> moveFilteredChoice 1
     V.EvKey V.KPageUp [] ->
@@ -497,6 +540,13 @@ handleFilterChoiceKey event = case event of
                                             `mod` count
                             })
                         <$> state.appChoice
+                }
+
+    adjustFilteredChoice delta =
+        modify' \state ->
+            state
+                { appChoice =
+                    adjustChoiceValue delta <$> state.appChoice
                 }
 
     updateChoiceQuery update = do
@@ -726,7 +776,7 @@ resolveChoice confirmed = do
         Just reply ->
             liftIO $ reply $
                 if confirmed
-                    then state.appChoice >>= selectedChoiceIndex
+                    then state.appChoice >>= selectedChoice
                     else Nothing
     modify' \current ->
         current

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -860,6 +860,21 @@ requestFullscreenPermission runtime workspace call = do
     enqueueAppEvent runtime (AppAskPermission summary reply)
     atomically (readTMVar reply)
 
+-- | Open a searchable choice whose right-hand value can be adjusted with
+-- left/right. Both returned indices refer to the original unfiltered row and
+-- that row's adjustment list.
+requestFullscreenAdjustableFilterChoice
+    :: FullscreenRuntime
+    -> Text
+    -> Int
+    -> [(Text, Text, [Text], Int)]
+    -> IO (Maybe (Int, Int))
+requestFullscreenAdjustableFilterChoice runtime title initial rows = do
+    reply <- newEmptyTMVarIO
+    enqueueAppEvent runtime
+        (AppAskAdjustableFilterChoice title initial rows reply)
+    atomically (readTMVar reply)
+
 requestFullscreenChoice
     :: FullscreenRuntime
     -> Text

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -195,8 +195,9 @@ handleEffortControlClick applyUiEvent = do
                     current = ui.uiPrompt.promptEffort
                     initial = fromMaybe 0 (elemIndex current efforts)
                     choose = \case
-                        Just index
-                            | index >= 0
+                        Just selection
+                            | let index = selection.choiceSelectionIndex
+                            , index >= 0
                             , index < length efforts -> do
                                 let level = efforts !! index
                                 when (level /= current) $
@@ -213,6 +214,8 @@ handleEffortControlClick applyUiEvent = do
                             , choiceRows = [(effort, "") | effort <- efforts]
                             , choiceSearch = False
                             , choiceQuery = ""
+                            , choiceAdjustments = Nothing
+                            , choiceAdjustmentIndices = []
                             , choiceCloseOnTurnEnd = True
                             }
                         , appChoiceReply = Just choose

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -7,6 +7,7 @@ module Agent.CLI.TUI.Render.Internal
     , backgroundActivityText
     , conversationScrollbarRenderer
     , choiceRowColumns
+    , filterChoiceRowLimit
     , quickStartVisible
     , quickStartWideVisible
     , quickStartRows
@@ -186,6 +187,7 @@ import Agent.CLI.TUI.Render.Blocks (todoStatusAttr)
 import Agent.CLI.TUI.Render.Overlays
     ( drawNotice, drawFollowStatus, drawFooter, drawPermission, drawResume
     , drawChoice, drawTextPrompt, drawMetaConsole, choiceRowColumns
+    , filterChoiceRowLimit
     , onboardingVisibleRowIndices
     , normalizeTextOverlayInsertion, maskedSecretText, textOverlayDisplayText
     , resumeSearchCursorColumn )

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -9,6 +9,7 @@ module Agent.CLI.TUI.Render.Overlays
     , drawTextPrompt
     , drawMetaConsole
     , choiceRowColumns
+    , filterChoiceRowLimit
     , onboardingVisibleRowIndices
     , normalizeTextOverlayInsertion
     , maskedSecretText
@@ -60,8 +61,10 @@ import Agent.CLI.TUI.Types
       MetaConsoleOverlay(metaConsoleDraft, metaConsoleCursor),
       ResumeOverlay(resumeOverlayBrowser),
       ChoiceOverlay(choicePresentation, choiceIndex, choiceRows,
-                    choiceTitle, choiceBody, choiceSearch, choiceQuery),
+                    choiceTitle, choiceBody, choiceSearch, choiceQuery,
+                    choiceAdjustments, choiceAdjustmentIndices),
       choiceVisibleRows,
+      selectedChoiceIndex,
       ChoicePresentation(ChoiceOnboarding, ChoiceDialog),
       AppState(appRuntime,
                appDictation, appTextPrompt, appChoice, appMetaConsole,
@@ -257,6 +260,8 @@ drawFooter state =
                 then "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc close  │  Ctrl+C cancel turn"
                 else "Enter submit  │  Shift+Enter newline  │  PgUp/PgDn scroll  │  Esc cancel"
         (_, Nothing, Just choice, _, _, _)
+            | isJust choice.choiceAdjustments ->
+                ""
             | choice.choiceSearch ->
                 "type to filter  │  ↑↓ navigate  │  Enter choose  │  Esc cancel"
         (_, Nothing, Just _, _, _, _) ->
@@ -521,9 +526,21 @@ drawChoice appState choice
 
 drawFilterChoice :: AppState -> ChoiceOverlay -> Widget Name
 drawFilterChoice appState choice =
-    centerLayer $
-        hLimitPercent 82 $
-            vLimitPercent 78 $
+    Widget Greedy Greedy do
+        context <- getContext
+        let adjustable = isJust choice.choiceAdjustments
+            dialogHeight = filterChoiceDialogHeight context.availHeight
+            compact =
+                dialogHeight < filterChoiceFixedRows adjustable + 1
+            rowLimit =
+                filterChoiceRowLimit context.availHeight adjustable
+            compactContent =
+                ( if context.availHeight > 1
+                    then [filterChoiceQuery choice]
+                    else []
+                )
+                    <> [filterChoiceRows rowLimit appState choice]
+            decoratedContent =
                 overrideAttr Border.borderAttr Theme.borderActiveAttr $
                     withBorderStyle unicodeRounded $
                         borderWithLabel
@@ -532,18 +549,34 @@ drawFilterChoice appState choice =
                                 vBox
                                     [ filterChoiceQuery choice
                                     , Border.hBorder
-                                    , filterChoiceRows appState choice
+                                    , filterChoiceRows
+                                        rowLimit
+                                        appState
+                                        choice
+                                    , adjustableChoiceDetail choice
                                     , Border.hBorder
                                     , withAttr Theme.footerAttr $
                                         terminalTxt
-                                            "type to filter  │  ↑↓ navigate  │  Enter choose  │  Esc cancel"
+                                            (choiceFooter choice)
                                     ]
+        render $
+            centerLayer $
+                hLimitPercent 82 $
+                    vLimit dialogHeight $
+                        if compact
+                            then vBox compactContent
+                            else decoratedContent
 
 filterChoiceQuery :: ChoiceOverlay -> Widget Name
 filterChoiceQuery choice =
-    let prefix = "search: "
+    let adjustable = isJust choice.choiceAdjustments
+        prefix = if adjustable then "/ " else "search: "
         query = if Text.null choice.choiceQuery
-            then withAttr Theme.mutedAttr (txt "(type to filter)")
+            then withAttr Theme.mutedAttr $
+                txt
+                    (if adjustable
+                        then "Type to search"
+                        else "(type to filter)")
             else terminalTxt choice.choiceQuery
         content = hBox
             [ terminalTxt prefix
@@ -555,8 +588,8 @@ filterChoiceQuery choice =
                 + terminalTextWidth choice.choiceQuery
     in showCursor OverlayCursor (Location (cursorColumn, 0)) content
 
-filterChoiceRows :: AppState -> ChoiceOverlay -> Widget Name
-filterChoiceRows appState choice =
+filterChoiceRows :: Int -> AppState -> ChoiceOverlay -> Widget Name
+filterChoiceRows rowLimit appState choice =
     case visible of
         [] ->
             padTop (Pad 1) $
@@ -569,14 +602,83 @@ filterChoiceRows appState choice =
                     visibleIndex
                     originalIndex
                     row
+                    (choiceAdjustmentText choice originalIndex)
                 | (visibleIndex, (originalIndex, row)) <-
                     zip [start ..] rows
                 ]
   where
     visible = choiceVisibleRows choice
     count = length visible
-    start = max 0 (min choice.choiceIndex (max 0 (count - 14)))
-    rows = take 14 (drop start visible)
+    start = max 0 (min choice.choiceIndex (max 0 (count - rowLimit)))
+    rows = take rowLimit (drop start visible)
+
+-- | Number of searchable choice rows that fit below the fixed dialog chrome.
+-- Adjustable choices reserve two additional lines for the selected model's
+-- metadata. The lower bound keeps keyboard navigation visible even in a very
+-- short terminal; the outer height limit may still crop decorative chrome.
+filterChoiceRowLimit :: Int -> Bool -> Int
+filterChoiceRowLimit terminalHeight adjustable =
+    if compact
+        then max 1 (min 14 (availableHeight - queryRows))
+        else max 1 (min 14 (dialogHeight - fixedRows))
+  where
+    availableHeight = max 1 terminalHeight
+    dialogHeight = filterChoiceDialogHeight terminalHeight
+    fixedRows = filterChoiceFixedRows adjustable
+    compact = dialogHeight < fixedRows + 1
+    queryRows
+        | availableHeight > 1 = 1
+        | otherwise = 0
+
+filterChoiceDialogHeight :: Int -> Int
+filterChoiceDialogHeight terminalHeight =
+    min availableHeight (max 14 percentHeight)
+  where
+    availableHeight = max 1 terminalHeight
+    percentHeight = max 1 (availableHeight * 78 `div` 100)
+
+filterChoiceFixedRows :: Bool -> Int
+filterChoiceFixedRows adjustable
+    | adjustable = 10
+    | otherwise = 8
+
+choiceAdjustmentText :: ChoiceOverlay -> Int -> Maybe Text
+choiceAdjustmentText choice sourceIndex = do
+    rows <- choice.choiceAdjustments
+    values <- listAt sourceIndex rows
+    valueIndex <- listAt sourceIndex choice.choiceAdjustmentIndices
+    listAt valueIndex values
+
+adjustableChoiceDetail :: ChoiceOverlay -> Widget Name
+adjustableChoiceDetail choice =
+    case choice.choiceAdjustments of
+        Nothing -> emptyWidget
+        Just _ ->
+            case
+                selectedChoiceIndex choice >>= \index ->
+                    listAt index choice.choiceRows
+            of
+                Just (_, detail)
+                    | not (Text.null (Text.strip detail)) ->
+                        vLimit 2 $
+                            padTop (Pad 1) $
+                                withAttr Theme.mutedAttr
+                                    (terminalTxtWrap detail)
+                _ -> emptyWidget
+
+choiceFooter :: ChoiceOverlay -> Text
+choiceFooter choice
+    | isJust choice.choiceAdjustments =
+        "↑↓ select · ←→ reasoning effort · ↵ confirm · esc cancel"
+    | otherwise =
+        "type to filter  │  ↑↓ navigate  │  Enter choose  │  Esc cancel"
+
+listAt :: Int -> [a] -> Maybe a
+listAt index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing
 
 drawDialogChoice :: AppState -> ChoiceOverlay -> Widget Name
 drawDialogChoice appState choice =
@@ -604,6 +706,7 @@ drawDialogChoice appState choice =
                                             visibleIndex
                                             originalIndex
                                             row
+                                            Nothing
                                         | (visibleIndex, (originalIndex, row)) <-
                                             zip [start ..] rows
                                         ]
@@ -866,10 +969,18 @@ choiceRow
     -> Int
     -> Int
     -> (Text, Text)
+    -> Maybe Text
     -> Widget Name
-choiceRow appState selected visibleIndex originalIndex (label, detail) =
+choiceRow
+        appState selected visibleIndex originalIndex (label, detail)
+        adjustment =
     let prefix = if selected == visibleIndex then "› " else "  "
         name = ChoiceRow originalIndex
+        shownRight = case adjustment of
+            Nothing -> detail
+            Just value
+                | selected == visibleIndex -> "← " <> value <> " →"
+                | otherwise -> value
         row =
             Widget Greedy Fixed do
                 context <- getContext
@@ -877,7 +988,7 @@ choiceRow appState selected visibleIndex originalIndex (label, detail) =
                         choiceRowColumns
                             context.availWidth
                             (prefix <> label)
-                            detail
+                            shownRight
                 render $
                     hBox
                         [ terminalTxt shownLabel

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -9,7 +9,9 @@ module Agent.CLI.TUI.Types
     , DictationSession(..)
     , ChoicePresentation(..)
     , ChoiceOverlay(..)
+    , ChoiceSelection(..)
     , choiceVisibleRows
+    , selectedChoice
     , selectedChoiceIndex
     , FullscreenInput(..)
     , FullscreenInputBuffer(..)
@@ -132,6 +134,11 @@ data AppEvent
         !Int
         ![(Text, Text)]
         !(TMVar (Maybe Int))
+    | AppAskAdjustableFilterChoice
+        !Text
+        !Int
+        ![(Text, Text, [Text], Int)]
+        !(TMVar (Maybe (Int, Int)))
     | AppAskText
         !TextInputMode
         !Text
@@ -307,7 +314,7 @@ data AppState = AppState
     , appRuntime :: !FullscreenRuntime
     , appSlashIndex :: !Int
     , appChoice :: !(Maybe ChoiceOverlay)
-    , appChoiceReply :: !(Maybe (Maybe Int -> IO ()))
+    , appChoiceReply :: !(Maybe (Maybe ChoiceSelection -> IO ()))
     , appResume :: !(Maybe ResumeOverlay)
     , appResumeReply :: !(Maybe (TMVar (Maybe ResumeEntry)))
     , appResumeLoad :: !(Maybe (Text -> IO (Either Text ResumeEntry)))
@@ -387,8 +394,19 @@ data ChoiceOverlay = ChoiceOverlay
     , choiceRows :: ![(Text, Text)]
     , choiceSearch :: !Bool
     , choiceQuery :: !Text
+    -- | Optional values that can be adjusted horizontally for each source
+    -- row. The parallel index list stores the current value per source row.
+    , choiceAdjustments :: !(Maybe [[Text]])
+    , choiceAdjustmentIndices :: ![Int]
     , choiceCloseOnTurnEnd :: !Bool
     }
+    deriving (Eq, Show)
+
+data ChoiceSelection = ChoiceSelection
+    { choiceSelectionIndex :: !Int
+    , choiceSelectionAdjustment :: !(Maybe Int)
+    }
+    deriving (Eq, Show)
 
 -- | Rows currently visible in a choice overlay.  Searchable overlays retain
 -- each row's source index so callers can return the original choice even
@@ -411,10 +429,22 @@ choiceVisibleRows choice
 -- | Resolve the selected row to its source index.  Empty searchable results
 -- have no selection; static choices retain their historical index behavior.
 selectedChoiceIndex :: ChoiceOverlay -> Maybe Int
-selectedChoiceIndex choice
-    | not choice.choiceSearch = Just choice.choiceIndex
-    | otherwise =
-        fst <$> listAt choice.choiceIndex (choiceVisibleRows choice)
+selectedChoiceIndex = fmap (.choiceSelectionIndex) . selectedChoice
+
+-- | Resolve the selected row and its optional adjustable value to source
+-- indices. Search filtering never changes either returned source index.
+selectedChoice :: ChoiceOverlay -> Maybe ChoiceSelection
+selectedChoice choice = do
+    sourceIndex <-
+        if not choice.choiceSearch
+            then Just choice.choiceIndex
+            else fst <$> listAt choice.choiceIndex (choiceVisibleRows choice)
+    pure ChoiceSelection
+        { choiceSelectionIndex = sourceIndex
+        , choiceSelectionAdjustment = do
+            _ <- choice.choiceAdjustments
+            listAt sourceIndex choice.choiceAdjustmentIndices
+        }
   where
     listAt index values
         | index < 0 = Nothing

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -9,6 +9,7 @@ import Agent.CLI.ModelConfig
     )
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..))
+import Agent.ReasoningEffort (ReasoningEffort(..))
 import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
@@ -22,6 +23,8 @@ spec = do
         it "maps arrows while keeping printable keys available to search" do
             decodePickerKey "\ESC[A" `shouldBe` Just PickerUp
             decodePickerKey "\ESC[B" `shouldBe` Just PickerDown
+            decodePickerKey "\ESC[D" `shouldBe` Just PickerLeft
+            decodePickerKey "\ESC[C" `shouldBe` Just PickerRight
             decodePickerKey "k" `shouldBe` Just (PickerType 'k')
             decodePickerKey "j" `shouldBe` Just (PickerType 'j')
 
@@ -53,8 +56,9 @@ spec = do
             defaultModelFor catalog XAIProvider
                 `shouldSatisfy` maybe False (\model -> Text.isInfixOf model frame)
             frame `shouldSatisfy` Text.isInfixOf "grok-4.6"
-            frame `shouldSatisfy` Text.isInfixOf "enter"
-            frame `shouldSatisfy` Text.isInfixOf "filter"
+            frame `shouldSatisfy` Text.isInfixOf "confirm"
+            frame `shouldSatisfy` Text.isInfixOf "reasoning effort"
+            frame `shouldSatisfy` Text.isInfixOf "Type to search"
 
         it "keeps large live catalogs inside a scrolling viewport" do
             let options =
@@ -74,9 +78,64 @@ spec = do
                         , pickerIndex = 20
                         }
                 frame = renderPickerFrame False state
-            length (Text.lines frame) `shouldBe` 16
+            length (Text.lines frame) `shouldBe` 21
             frame `shouldSatisfy` Text.isInfixOf "vendor/model-20"
             frame `shouldNotSatisfy` Text.isInfixOf "vendor/model-0 "
+
+        it "adjusts effort for the selected model without changing models" do
+            let models =
+                    initialPickerState
+                        catalog
+                        "xai"
+                        XAIProvider
+                        "grok-4.6"
+                        GrokBuildDialect
+                state0 = initialModelPickerState EffortMedium models
+            state1 <- rightState (applyModelPickerEvent PickerRight state0)
+            case applyModelPickerEvent PickerConfirm state1 of
+                Left (Just selection) -> do
+                    selection.modelPickerOption.modelTarget.targetModelId
+                        `shouldBe` "grok-4.6"
+                    selection.modelPickerEffort `shouldBe` EffortHigh
+                other ->
+                    expectationFailure
+                        ("expected confirmed selection, got " <> show other)
+
+        it "renders effort gauges and selected model metadata" do
+            let models =
+                    initialPickerState
+                        catalog
+                        "xai"
+                        XAIProvider
+                        "grok-4.6"
+                        GrokBuildDialect
+                frame =
+                    renderModelPickerFrame False
+                        (initialModelPickerState EffortHigh models)
+            frame `shouldSatisfy` Text.isInfixOf "■■■□□ high"
+            frame `shouldSatisfy` Text.isInfixOf "←"
+            frame `shouldSatisfy` Text.isInfixOf "→"
+            frame `shouldSatisfy` Text.isInfixOf "context"
+
+        it "makes untrusted catalog control characters inert" do
+            let hostile =
+                    (rawModelOption
+                        OpenRouterProvider
+                        "vendor/evil\n\ESC]8;;https://example.test\BEL")
+                        { modelLabel = Just "label\r\ESC[2J" }
+                models =
+                    (initialPickerState
+                        catalog
+                        "openrouter"
+                        OpenRouterProvider
+                        hostile.modelTarget.targetModelId
+                        GenericResponsesDialect)
+                        { pickerAll = [hostile] }
+                frame =
+                    renderPickerFrame False models
+            frame `shouldNotSatisfy` Text.isInfixOf "\ESC"
+            frame `shouldNotSatisfy` Text.isInfixOf "\BEL"
+            length (Text.lines frame) `shouldBe` 21
 
     describe "formatCatalogListing" do
         it "lists the current model and entries from every provider" do
@@ -130,3 +189,10 @@ readPackagedCatalog = do
     case decodeModelConfig "models.default.json" bytes of
         Left err -> fail (Text.unpack err)
         Right catalog -> pure catalog
+
+rightState
+    :: Either result ModelPickerState
+    -> IO ModelPickerState
+rightState = \case
+    Right state -> pure state
+    Left _ -> expectationFailure "expected picker state" >> fail "unreachable"

--- a/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelsSpec.hs
@@ -88,6 +88,13 @@ spec = do
                 (modelsForProvider catalog ClaudeCodeProvider)
                 `shouldSatisfy` all (== ClaudeCodeDialect)
 
+        it "keeps structured context metadata on picker options" do
+            let grok =
+                    find
+                        ((== "grok-4.6") . (.modelTarget.targetModelId))
+                        (modelsForProvider catalog XAIProvider)
+            fmap (.modelContextWindow) grok `shouldBe` Just (Just 500000)
+
         it "keeps every catalog dialect consistent with model inference" do
             all
                 (\option ->
@@ -335,9 +342,10 @@ spec = do
         it "confirms the selected model id" do
             applyPickerEvent PickerConfirm state0
                 `shouldBe` Left (Just
-                    (testOption XAIProvider "xai"
+                    ((testOption XAIProvider "xai"
                         "grok-4.6" "grok-4.6" GrokBuildDialect
-                        (Just "default") (Just 10)))
+                        (Just "default") (Just 10))
+                        { modelContextWindow = Just 500000 }))
 
         it "cancels without a selection" do
             applyPickerEvent PickerCancel state0 `shouldBe` Left Nothing
@@ -394,6 +402,7 @@ testOption provider connection model wireModel dialect label priority =
             , targetWireModelId = wireModel
             , targetDialect = dialect
             }
+        , modelContextWindow = Nothing
         , modelLabel = label
         , modelFallbackPriority = priority
         }

--- a/packages/agent-cli/test/Agent/CLI/PickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PickerSpec.hs
@@ -14,6 +14,14 @@ spec = do
         it "decodes modified CSI arrows" do
             decodePickerKey "\ESC[1;2A" `shouldBe` Just PickerKeyUp
             decodePickerKey "\ESC[1;5B" `shouldBe` Just PickerKeyDown
+            decodePickerKey "\ESC[1;2C" `shouldBe` Just PickerKeyRight
+            decodePickerKey "\ESC[1;5D" `shouldBe` Just PickerKeyLeft
+
+        it "decodes normal and SS3 horizontal arrows" do
+            decodePickerKey "\ESC[C" `shouldBe` Just PickerKeyRight
+            decodePickerKey "\ESC[D" `shouldBe` Just PickerKeyLeft
+            decodePickerKey "\ESCOC" `shouldBe` Just PickerKeyRight
+            decodePickerKey "\ESCOD" `shouldBe` Just PickerKeyLeft
 
         it "ignores Kitty key releases instead of moving twice" do
             decodePickerKey "\ESC[1;1:1A" `shouldBe` Just PickerKeyUp

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.Options (CliOptions(..), defaultCliOptions, isOneShot)
 import Agent.CLI.ProviderTransition
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (BillingMode(..), Provider(..))
+import Agent.ReasoningEffort (ReasoningEffort(..))
 import Agent.Tools.PlanMode (PlanModeState(..))
 import Data.IORef (newIORef, readIORef)
 import Data.Maybe (isNothing)
@@ -32,6 +33,14 @@ spec = do
             let transitioned = applyProviderTransition defaultCliOptions
                     (transition (Just "session-1") Nothing)
             transitioned.optResume `shouldBe` Just "session-1"
+
+        it "carries an effort selected with the target model" do
+            let selected =
+                    (transition Nothing Nothing)
+                        { transitionEffort = Just EffortHigh }
+                transitioned =
+                    applyProviderTransition defaultCliOptions selected
+            transitioned.optEffort `shouldBe` Just EffortHigh
 
     describe "setPendingExitAfter" do
         it "preserves the plan state while changing exit behavior" do
@@ -96,6 +105,7 @@ transition sessionId pending = ProviderTransition
         , targetWireModelId = "gpt-5.6-sol"
         , targetDialect = CodexDialect
         }
+    , transitionEffort = Nothing
     , transitionAccountSelectionId = Nothing
     , transitionAccountId = Nothing
     , transitionSessionId = sessionId

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -13,6 +13,7 @@ import Agent.CLI.TUI.App
     , applyMetaConsoleEdit
     , applyTextPromptEdit
     , advanceCompletionFlashes
+    , adjustChoiceValue
     , agentEntryWindow
     , agentPaneEntryLimit
     , agentPaneVisible
@@ -21,6 +22,7 @@ import Agent.CLI.TUI.App
     , completionRequiresRedraw
     , conversationScrollbarRenderer
     , choiceRowColumns
+    , filterChoiceRowLimit
     , choiceClosesOnUiTransition
     , elapsedMillisSince
     , externalUrlCommand
@@ -66,9 +68,11 @@ import Agent.CLI.TUI.Types
     , AppState(..)
     , ChoiceOverlay(..)
     , ChoicePresentation(..)
+    , ChoiceSelection(..)
     , FullscreenInput(..)
     , choiceVisibleRows
     , selectedChoiceIndex
+    , selectedChoice
     , FullscreenRuntime(..)
     , HistoryCommit(..)
     , MetaConsoleOverlay(..)
@@ -526,6 +530,27 @@ spec = do
                 searchable { choiceQuery = "missing" }
                 `shouldBe` Nothing
 
+        it "adjusts the selected source row while filtered" do
+            let adjustable =
+                    searchable
+                        { choiceAdjustments =
+                            Just
+                                [ ["low", "medium", "high"]
+                                , ["none", "low", "medium", "high"]
+                                , ["low", "high"]
+                                ]
+                        , choiceAdjustmentIndices = [1, 2, 0]
+                        }
+                adjusted = adjustChoiceValue 1 adjustable
+            selectedChoice adjusted
+                `shouldBe`
+                    Just ChoiceSelection
+                        { choiceSelectionIndex = 1
+                        , choiceSelectionAdjustment = Just 3
+                        }
+            adjustChoiceValue 1 adjusted
+                `shouldBe` adjusted
+
     describe "prompt target refresh" do
         it "preserves the live draft and cursor across a provider restart" do
             let before =
@@ -883,6 +908,15 @@ spec = do
         it "preserves both columns when they already fit" do
             choiceRowColumns 40 "› model" "default"
                 `shouldBe` ("› model", "default")
+
+        it "keeps adjustable picker rows inside short terminal dialogs" do
+            filterChoiceRowLimit 24 True `shouldBe` 8
+            filterChoiceRowLimit 18 True `shouldBe` 4
+            filterChoiceRowLimit 80 True `shouldBe` 14
+
+        it "collapses chrome before sacrificing rows in tiny terminals" do
+            filterChoiceRowLimit 8 True `shouldBe` 7
+            filterChoiceRowLimit 1 True `shouldBe` 1
 
     describe "onboarding layout" do
         it "uses the complete 18-row surface when it fits" do
@@ -1971,6 +2005,8 @@ choiceOverlay closeOnTurnEnd = ChoiceOverlay
     , choiceRows = [("one", "")]
     , choiceSearch = False
     , choiceQuery = ""
+    , choiceAdjustments = Nothing
+    , choiceAdjustmentIndices = []
     , choiceCloseOnTurnEnd = closeOnTurnEnd
     }
 

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -612,6 +612,8 @@ applyAction action harness =
                                 , choiceRows = rows
                                 , choiceSearch = False
                                 , choiceQuery = ""
+                                , choiceAdjustments = Nothing
+                                , choiceAdjustmentIndices = []
                                 , choiceCloseOnTurnEnd = False
                                 }
                         , appTextPrompt = Nothing


### PR DESCRIPTION
## Summary

- add a searchable model picker with integrated per-model reasoning-effort controls in fullscreen and minimal modes
- show model metadata and context details with responsive scrolling and terminal-safe catalog rendering
- carry the selected effort through model changes, provider transitions, and session persistence

## Testing

- `printf ':quit\n' | cabal repl agent-cli:lib:agent-cli` — 211 modules loaded
- full `agent-cli-test` suite — 1,507 examples passed, 1 pending
- exercised fullscreen and minimal picker interactions in live tmux sessions
