### PR TITLE
Refresh TUI model immediately on account switch

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -71,6 +71,7 @@ import Agent.CLI.ProviderTransition
     , ProviderTransition(..)
     , TransitionCause(..)
     , transitionCommitsImmediately
+    , withOptimisticPromptTarget
     )
 import Agent.CLI.Render
     ( RenderConfig(..)
@@ -315,8 +316,10 @@ requestAccountProviderSwitch
     -> Provider
     -> Text
     -> Text
+    -> Text
     -> DialectId
     -> Provider
+    -> Text
     -> Text
     -> Text
     -> Persistence
@@ -327,10 +330,12 @@ requestAccountProviderSwitch
     currentProvider
     currentConnection
     currentModelId
+    currentAccount
     currentDialect
     selectedProvider
     selectionId
     accountId
+    selectedAccount
     persist = do
         currentTransportModel <-
             persistenceTransportModel currentModelId persist
@@ -347,10 +352,18 @@ requestAccountProviderSwitch
             if currentProvider == selectedProvider
                 then pure rawChoice
                 else resolveModelOptionDialect rawChoice
-        validateSelectedAccountTarget
-            selectedProvider
-            selectionId
-            accountId >>= \case
+        let setPromptTarget modelId account =
+                forM_ fullscreen $ \runtime ->
+                    emitUiEvent runtime (UiSetPromptTarget modelId account)
+        withOptimisticPromptTarget
+            (setPromptTarget
+                choice.modelTarget.targetModelId
+                selectedAccount)
+            (setPromptTarget currentModelId currentAccount) $
+            validateSelectedAccountTarget
+                selectedProvider
+                selectionId
+                accountId >>= \case
                 Left err -> pure (Left err)
                 Right () -> do
                     sessionId <- ensureTransitionSessionId persist

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -8,6 +8,7 @@ module Agent.CLI.ProviderTransition
     , resumePendingTurnIfPresent
     , setPendingExitAfter
     , transitionCommitsImmediately
+    , withOptimisticPromptTarget
     ) where
 
 import Agent.CLI.Models (ModelTarget(..))
@@ -17,6 +18,7 @@ import Agent.Loop (TurnInput)
 import Agent.Provider (BillingMode, Provider)
 import Agent.Tools.PlanMode (PlanModeState)
 import Control.Applicative ((<|>))
+import Control.Exception.Safe (mask, onException)
 import Data.IORef (IORef, atomicModifyIORef')
 import Data.Set (Set)
 import Data.Text (Text)
@@ -97,3 +99,19 @@ resumePendingTurnIfPresent pendingTurnRef resume noPendingTurn =
 transitionCommitsImmediately :: ProviderTransition -> Bool
 transitionCommitsImmediately transition =
     transition.transitionCause == ManualTransition
+
+-- | Publish a provisional prompt target before a slow validation action,
+-- restoring the prior target if that action rejects, throws, or is cancelled.
+withOptimisticPromptTarget
+    :: IO ()
+    -> IO ()
+    -> IO (Either err value)
+    -> IO (Either err value)
+withOptimisticPromptTarget publish rollback action =
+    mask \restoreMask -> do
+        result <-
+            (publish >> restoreMask action)
+                `onException` rollback
+        case result of
+            Left err -> rollback >> pure (Left err)
+            Right value -> pure (Right value)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -324,16 +324,19 @@ selectRequestedAccount env requestedProvider selector =
                     pure (Right Nothing)
         | otherwise = do
             params <- readIORef env.sessionParams
+            currentAccount <- readIORef env.sessionAccount
             requestAccountProviderSwitch
                 env.sessionModelCatalog
                 (Just runtime)
                 env.sessionProvider
                 env.sessionConnection
                 (currentModel params)
+                currentAccount
                 (dialectId env.sessionDialect)
                 selectedProvider
                 selectedSelectionId
                 selectedAccountId
+                selectedLabel
                 env.sessionPersist
                 >>= \case
                     Left err -> pure (Left err)
@@ -709,29 +712,32 @@ handleSelection
                                         env.sessionLastFailedTurn
                                         retryPendingTurn
                                         next
-                        | otherwise =
-                            readIORef paramsRef >>= \params ->
-                                requestAccountProviderSwitch
-                                    catalog fullscreen provider connectionId
-                                    (currentModel params) (dialectId dialect)
-                                    selectedProvider selectedSelectionId
-                                    selectedAccountId persist >>= \case
-                                        Left err -> do
-                                            displayError err (pure ())
-                                            next
-                                        Right result -> do
-                                            displayInfo
-                                                ("switching to "
-                                                    <> selectedLabel
-                                                    <> " ("
-                                                    <> providerSlug
-                                                        selectedProvider
-                                                    <> ")")
-                                                (pure ())
-                                            resumePendingTurnIfPresent
-                                                env.sessionLastFailedTurn
-                                                (pure . attachPendingTurn result)
-                                                (pure result)
+                        | otherwise = do
+                            params <- readIORef paramsRef
+                            currentAccount <- readIORef env.sessionAccount
+                            requestAccountProviderSwitch
+                                catalog fullscreen provider connectionId
+                                (currentModel params) currentAccount
+                                (dialectId dialect)
+                                selectedProvider selectedSelectionId
+                                selectedAccountId selectedLabel
+                                persist >>= \case
+                                    Left err -> do
+                                        displayError err (pure ())
+                                        next
+                                    Right result -> do
+                                        displayInfo
+                                            ("switching to "
+                                                <> selectedLabel
+                                                <> " ("
+                                                <> providerSlug
+                                                    selectedProvider
+                                                <> ")")
+                                            (pure ())
+                                        resumePendingTurnIfPresent
+                                            env.sessionLastFailedTurn
+                                            (pure . attachPendingTurn result)
+                                            (pure result)
             Nothing -> do
                 displayError
                     "Account switching is unavailable for this session."

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -602,6 +602,8 @@ uiEventLogicalBytes = \case
     UiQueuedInputStarted -> 128
     UiSetDraft text _ -> logicalTextBytes text
     UiSetPrompt prompt -> promptStateLogicalBytes prompt
+    UiSetPromptTarget model account ->
+        logicalTextBytes model + logicalTextBytes account
     UiSetPromptEffort text -> logicalTextBytes text
     UiSetPromptLimitStatus status ->
         maybe 128 (logicalTextBytes . (.promptLimitText)) status

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -546,6 +546,7 @@ uiEventMayExposeSyntax = \case
     UiLoop (ToolOutputUpdated _ _) -> False
     UiSetDraft _ _ -> False
     UiSetPrompt _ -> False
+    UiSetPromptTarget _ _ -> False
     UiSetPromptEffort _ -> False
     UiSetPromptLimitStatus _ -> False
     UiSetAwaitingInput _ -> False

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -35,6 +35,7 @@ import Agent.CLI.ModelConfig
     )
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Project (ProjectSettings(..), loadProjectSettings)
+import Agent.CLI.ProviderTransition (withOptimisticPromptTarget)
 import Agent.CLI.ReplMode
     ( ReplMode(..)
     , cycleReplMode
@@ -58,10 +59,18 @@ import Agent.TUI.Model
     , reduceUi
     )
 import Agent.Tools.PlanMode (PlanModeEnv(..), PlanModeState(..), newPlanModeEnv)
-import Control.Exception.Safe (bracket, throwIO)
+import Control.Concurrent.Async (cancel, wait, waitCatch, withAsync)
+import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
+import Control.Exception.Safe
+    ( bracket
+    , throwIO
+    , throwString
+    , tryAny
+    )
 import qualified Data.ByteString.Lazy as LBS
+import Data.Either (isLeft)
 import qualified Data.Text as Text
-import Data.IORef (newIORef, readIORef)
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import System.Directory
     ( getCurrentDirectory
     , getTemporaryDirectory
@@ -147,6 +156,71 @@ spec = do
             target.modelTarget.targetModelId `shouldBe` "openai/gpt-5.1"
             target.modelTarget.targetWireModelId `shouldBe` "openai/gpt-5.1"
             target.modelTarget.targetDialect `shouldBe` GrokBuildDialect
+
+    describe "withOptimisticPromptTarget" do
+        it "publishes the target before validation finishes" do
+            events <- newIORef ([] :: [Text.Text])
+            started <- newEmptyMVar
+            release <- newEmptyMVar
+            let record event = modifyIORef' events (<> [event])
+                validate = do
+                    putMVar started ()
+                    takeMVar release
+                    pure (Right () :: Either Text.Text ())
+            withAsync
+                (withOptimisticPromptTarget
+                    (record "target")
+                    (record "current")
+                    validate)
+                \running -> do
+                    takeMVar started
+                    readIORef events `shouldReturn` ["target"]
+                    putMVar release ()
+                    wait running `shouldReturn` Right ()
+                    readIORef events `shouldReturn` ["target"]
+
+        it "restores the current target when validation rejects the switch" do
+            events <- newIORef ([] :: [Text.Text])
+            let record event = modifyIORef' events (<> [event])
+            result <-
+                withOptimisticPromptTarget
+                    (record "target")
+                    (record "current")
+                    (pure (Left "unavailable" :: Either Text.Text ()))
+            result `shouldBe` Left "unavailable"
+            readIORef events `shouldReturn` ["target", "current"]
+
+        it "restores the current target when validation throws" do
+            events <- newIORef ([] :: [Text.Text])
+            let record event = modifyIORef' events (<> [event])
+            result <- tryAny $
+                withOptimisticPromptTarget
+                    (record "target")
+                    (record "current")
+                    (throwString "validation failed"
+                        :: IO (Either Text.Text ()))
+            result `shouldSatisfy` isLeft
+            readIORef events `shouldReturn` ["target", "current"]
+
+        it "restores the current target when validation is cancelled" do
+            events <- newIORef ([] :: [Text.Text])
+            started <- newEmptyMVar
+            blocked <- newEmptyMVar :: IO (MVar ())
+            let record event = modifyIORef' events (<> [event])
+                validate = do
+                    putMVar started ()
+                    _ <- takeMVar blocked
+                    pure (Right () :: Either Text.Text ())
+            withAsync
+                (withOptimisticPromptTarget
+                    (record "target")
+                    (record "current")
+                    validate)
+                \running -> do
+                    takeMVar started
+                    cancel running
+                    waitCatch running >>= (`shouldSatisfy` isLeft)
+            readIORef events `shouldReturn` ["target", "current"]
 
     describe "devArgs" do
         it "starts fresh REPL sessions on gpt-5.6-sol in yolo mode" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -526,7 +526,7 @@ spec = do
                 searchable { choiceQuery = "missing" }
                 `shouldBe` Nothing
 
-    describe "prompt model refresh" do
+    describe "prompt target refresh" do
         it "preserves the live draft and cursor across a provider restart" do
             let before =
                     reduceUi
@@ -534,14 +534,14 @@ spec = do
                         initialUiState
                 after =
                     reduceUi
-                        (UiSetPrompt
-                            before.uiPrompt
-                                { promptModel = "gpt-5.6-sol"
-                                })
+                        (UiSetPromptTarget
+                            "gpt-5.6-sol"
+                            "OpenAI account")
                         before
             after.uiDraft `shouldBe` "half typed prompt"
             after.uiCursor `shouldBe` 7
             after.uiPrompt.promptModel `shouldBe` "gpt-5.6-sol"
+            after.uiPrompt.promptAccount `shouldBe` "OpenAI account"
 
     describe "fullscreenVtyConfig" do
         it "maps the Kitty-encoded Esc key so its payload cannot leak" do

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -142,6 +142,14 @@ reduceUi event state = case event of
             }
     UiSetPrompt prompt ->
         state { uiPrompt = prompt }
+    UiSetPromptTarget model account ->
+        state
+            { uiPrompt =
+                state.uiPrompt
+                    { promptModel = model
+                    , promptAccount = account
+                    }
+            }
     UiSetPromptEffort effort ->
         state
             { uiPrompt = state.uiPrompt { promptEffort = effort }

--- a/packages/agent-tui/src/Agent/TUI/Model/Types.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Types.hs
@@ -168,6 +168,7 @@ data UiEvent
     | UiQueuedInputStarted
     | UiSetDraft !Text !Int
     | UiSetPrompt !PromptState
+    | UiSetPromptTarget !Text !Text
     | UiSetPromptEffort !Text
     | UiSetPromptLimitStatus !(Maybe PromptLimitStatus)
     | UiSetAwaitingInput !Bool

--- a/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
@@ -141,6 +141,7 @@ generatedUiEvent = frequency
     , (4, UiSetDraft <$> generatedText <*> chooseInt (-20, 120))
     , (3, UiInputQueued <$> generatedText)
     , (3, UiInputPromoted <$> generatedText)
+    , (3, UiSetPromptTarget <$> generatedText <*> generatedText)
     , (3, UiSetPromptEffort <$> generatedText)
     , (3, UiSetRepository <$> generatedText <*> generatedText <*> generatedText)
     , (3, UiSetNotice <$> generatedNotice)

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -153,6 +153,31 @@ spec = describe "fullscreen UI reducer" do
         state.uiCursor `shouldBe` 20
         state.uiAwaitingInput `shouldBe` True
 
+    it "updates the prompt model and account together during a provider switch" do
+        let initialPrompt =
+                initialUiState.uiPrompt
+                    { promptModel = "fabel"
+                    , promptEffort = "high"
+                    , promptAccount = "Claude subscription"
+                    }
+            before =
+                apply
+                    [ UiSetPrompt initialPrompt
+                    , UiSetDraft "half typed prompt" 7
+                    ]
+            after =
+                reduceUi
+                    (UiSetPromptTarget "gpt-5.6-sol" "OpenAI account")
+                    before
+        after.uiPrompt
+            `shouldBe`
+                initialPrompt
+                    { promptModel = "gpt-5.6-sol"
+                    , promptAccount = "OpenAI account"
+                    }
+        after.uiDraft `shouldBe` "half typed prompt"
+        after.uiCursor `shouldBe` 7
+
     it "discards partial output and updates effort when restarting a turn" do
         let initialPrompt =
                 initialUiState.uiPrompt


### PR DESCRIPTION
## Summary
- update the fullscreen prompt model and account atomically as soon as an account is selected
- keep slow provider validation and backend restart off the visible update path
- restore the previous prompt target when validation fails, throws, or is cancelled

## Validation
- `agent-cli-test --match=withOptimisticPromptTarget` (4 examples)
- `agent-tui-test` (201 examples)
- live tmux smoke test switching OpenAI ↔ xAI; the footer changed within the first ~0.2 s capture, before restart completed
