### PR TITLE
Preserve paste provenance for steering prompts

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -852,7 +852,7 @@ prepareAgentIterationTracked
                         runtime
                         Nothing
                         (requestCancel toolEnv.toolCancel)
-                        (const (pure (Right ())))
+                        (\_ _ -> pure (Right ()))
                         (const (pure ()))
                         (pure ())
                         (\level ->
@@ -937,7 +937,7 @@ resetFullscreenSessionActions runtime =
         runtime
         Nothing
         (pure ())
-        (const (pure (Right ())))
+        (\_ _ -> pure (Right ()))
         (const (pure ()))
         (pure ())
         (const (pure ()))

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -76,7 +76,7 @@ import Agent.CLI.Runtime.Recap
     ( runSessionRecap, runSessionTurnSummary )
 import Agent.CLI.Runtime.Repl
     ( finishTurn,
-      preparePromptSkillInputs,
+      preparePromptSkillInputsWithPaste,
       repl,
       replWithDraft,
       runPendingTurn )
@@ -1120,7 +1120,7 @@ sessionRunnerContinuation =
         , runnerRunPendingTurn = runPendingTurn
         , runnerFinishTurn = finishTurn
         , runnerFinishStartup = finishStartup
-        , runnerPreparePromptSkillInputs = preparePromptSkillInputs
+        , runnerPreparePromptSkillInputs = preparePromptSkillInputsWithPaste
         , runnerRunSessionRecap = runSessionRecap
         , runnerRunSessionTurnSummary = runSessionTurnSummary
         }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Runtime.Repl
     , runPendingTurn
     , finishTurn
     , preparePromptSkillInputs
+    , preparePromptSkillInputsWithPaste
     ) where
 
 import Agent.CLI.AccountPicker ()
@@ -65,7 +66,10 @@ import Agent.CLI.Request ()
 import Agent.CLI.Runtime.Persistence ()
 import Agent.CLI.Runtime.Recap ()
 import Agent.CLI.Runtime.Repl.Commands
-    ( handleReplLine, preparePromptSkillInputs )
+    ( handleReplLine
+    , preparePromptSkillInputs
+    , preparePromptSkillInputsWithPaste
+    )
 import Agent.CLI.Runtime.Types
     ( PendingTurnPresentation
     , RunResult(RunSwitchProvider)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Runtime.Repl.Commands
     ( handleReplLine
     , preparePromptSkillInputs
+    , preparePromptSkillInputsWithPaste
     ) where
 
 import Agent.CLI.AccountPicker ()

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -838,7 +838,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             runtime
             (Just provider)
             (requestCancel toolEnv.toolCancel)
-            (\text -> do
+            (\pasted text -> do
                 images <- loadImagesFromPastedText text
                 let input = case images of
                         Just attached@(_:_) ->
@@ -847,7 +847,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                                 (map ImageAttachmentItem attached)
                         _ -> UserMessage text
                 callbacks.runnerPreparePromptSkillInputs
-                    env text [input] >>= \case
+                    env pasted text [input] >>= \case
                         Left err ->
                             emitUiEvent runtime (UiErrorMessage err)
                                 >> pure (Left err)
@@ -898,6 +898,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                         skillInputs <-
                             callbacks.runnerPreparePromptSkillInputs
                                 env
+                                False
                                 request.managedTurnText
                                 inputs
                                 >>= either
@@ -928,6 +929,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             skillInputs <-
                 callbacks.runnerPreparePromptSkillInputs
                     env
+                    False
                     text
                     [UserMessage text]
                     >>= either

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Types.hs
@@ -22,7 +22,11 @@ data SessionRunnerContinuation = SessionRunnerContinuation
         :: PendingTurnPresentation -> SessionEnv -> PendingTurn -> IO RunResult
     , runnerFinishTurn :: SessionEnv -> Bool -> TurnResult -> IO RunResult
     , runnerPreparePromptSkillInputs
-        :: SessionEnv -> Text -> [TurnInput] -> IO (Either Text [TurnInput])
+        :: SessionEnv
+        -> Bool
+        -> Text
+        -> [TurnInput]
+        -> IO (Either Text [TurnInput])
     , runnerRunSessionRecap :: Bool -> SessionEnv -> RecapKind -> IO ()
     , runnerRunSessionTurnSummary :: SessionEnv -> IO ()
     }

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -266,7 +266,7 @@ newFullscreenRuntimeWithSyntaxLoader
         sessionActions <- newIORef FullscreenSessionActions
             { sessionProvider = Nothing
             , sessionCancel = cancelAction
-            , sessionSteer = const (pure (Right ()))
+            , sessionSteer = \_ _ -> pure (Right ())
             , sessionBtw = const (pure ())
             , sessionRecap = pure ()
             , sessionRestartEffort = restartEffortAction
@@ -280,9 +280,9 @@ newFullscreenRuntimeWithSyntaxLoader
             , runtimeInput = inputBuffer
             , runtimeCancel =
                 readIORef sessionActions >>= (.sessionCancel)
-            , runtimeSteer = \text ->
+            , runtimeSteer = \pasted text ->
                 readIORef sessionActions >>= \actions ->
-                    actions.sessionSteer text
+                    actions.sessionSteer pasted text
             , runtimeBtw = \question ->
                 readIORef sessionActions >>= \actions ->
                     actions.sessionBtw question
@@ -332,7 +332,7 @@ setFullscreenSessionActions
     :: FullscreenRuntime
     -> Maybe Provider
     -> IO ()
-    -> (Text -> IO (Either Text ()))
+    -> (Bool -> Text -> IO (Either Text ()))
     -> (Text -> IO ())
     -> IO ()
     -> (Text -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -34,6 +34,7 @@ module Agent.CLI.TUI.Composer
     , queuedFullscreenInputDisplays
     , readFullscreenInputs
     , slashMenuWindowStart
+    , steeringPrompt
     , takeFullscreenInput
     , takeFullscreenInputOr
     , requestDictationStop
@@ -306,6 +307,15 @@ prepareBracketedPaste awaitingInput draft cursor pasted =
             )
         else (pastedDraft, pastedCursor, Nothing)
 
+steeringPrompt :: UiState -> Bool -> Text -> Maybe (Bool, Text)
+steeringPrompt ui pasted text
+    | not ui.uiRunning = Nothing
+    | otherwise =
+        case parseReplLine text of
+            ReplPrompt prompt -> Just (pasted, prompt)
+            ReplExpandedPrompt _ prompt -> Just (pasted, prompt)
+            _ -> Nothing
+
 -- | Handle one composer key. The host supplies Ctrl-C policy and conversation
 -- page scrolling because those actions also affect non-composer UI state.
 handleComposerKey
@@ -543,10 +553,12 @@ handleComposerKey
                 _ <- liftIO (state.appRuntime.runtimeBtw question)
                 pure True
             Nothing ->
-                case steeringPrompt state.appUi text of
-                    Just prompt -> do
+                case steeringPrompt state.appUi pasted text of
+                    Just (steeringPasted, prompt) -> do
                         result <- liftIO
-                            (state.appRuntime.runtimeSteer prompt)
+                            (state.appRuntime.runtimeSteer
+                                steeringPasted
+                                prompt)
                         case result of
                             Left message -> do
                                 applyUiEvent
@@ -574,14 +586,6 @@ handleComposerKey
                     , appHistoryDraft = ""
                     }
             vScrollToEnd (viewportScroll ConversationViewport)
-
-    steeringPrompt ui text
-        | not ui.uiRunning = Nothing
-        | otherwise =
-            case parseReplLine text of
-                ReplPrompt prompt -> Just prompt
-                ReplExpandedPrompt _ prompt -> Just prompt
-                _ -> Nothing
 
     sendNow = do
         state <- get

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -235,7 +235,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeMailbox :: !AppEventMailbox
     , runtimeInput :: !FullscreenInputBuffer
     , runtimeCancel :: !(IO ())
-    , runtimeSteer :: !(Text -> IO (Either Text ()))
+    , runtimeSteer :: !(Bool -> Text -> IO (Either Text ()))
     , runtimeBtw :: !(Text -> IO ())
     , runtimeRecap :: !(IO ())
     , runtimeRestartEffort :: !(Text -> IO ())
@@ -288,7 +288,7 @@ data DictationSession = DictationSession
 data FullscreenSessionActions = FullscreenSessionActions
     { sessionProvider :: !(Maybe Provider)
     , sessionCancel :: !(IO ())
-    , sessionSteer :: !(Text -> IO (Either Text ()))
+    , sessionSteer :: !(Bool -> Text -> IO (Either Text ()))
     , sessionBtw :: !(Text -> IO ())
     , sessionRecap :: !(IO ())
     , sessionRestartEffort :: !(Text -> IO ())

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -326,7 +326,7 @@ spec = describe "fullscreen TUI bridge" do
                 state.mailboxPendingBytes
                     `shouldSatisfy` (>= BS.length encoded)
 
-    it "rebinds provider-specific actions without replacing the runtime" do
+    it "rebinds provider actions and forwards steering paste provenance" do
         calls <- newIORef ([] :: [String])
         input <- newFullscreenInputBuffer
         runtime <- newFullscreenRuntime
@@ -349,9 +349,10 @@ spec = describe "fullscreen TUI bridge" do
             runtime
             (Just XAIProvider)
             (modifyIORef' calls (<> ["new cancel"]))
-            (const
-                (modifyIORef' calls (<> ["new steer"])
-                    >> pure (Right ())))
+            (\pasted _ -> do
+                modifyIORef' calls (<> ["new steer"])
+                pasted `shouldBe` True
+                pure (Right ()))
             (const (modifyIORef' calls (<> ["new btw"])))
             (modifyIORef' calls (<> ["new recap"]))
             (const (modifyIORef' calls (<> ["new effort"])))
@@ -359,7 +360,7 @@ spec = describe "fullscreen TUI bridge" do
             (pure (AgentRoot, []))
             (const (modifyIORef' calls (<> ["new agent"])))
         runtime.runtimeCancel
-        runtime.runtimeSteer "guidance"
+        _ <- runtime.runtimeSteer True "guidance"
         runtime.runtimeBtw "question"
         runtime.runtimeRecap
         runtime.runtimeRestartEffort "high"

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -76,6 +76,15 @@ spec = describe "fullscreen composer" do
             (ReplText "ordinary follow-up")
             `shouldBe` Nothing
 
+    it "preserves paste provenance for steering prompts" do
+        steeringPrompt
+            initialUiState { uiRunning = True }
+            True
+            "WHERE listings.agent_id = $1"
+            `shouldBe` Just (True, "WHERE listings.agent_id = $1")
+        steeringPrompt initialUiState True "not running"
+            `shouldBe` Nothing
+
     it "dismisses slash completion or preserves the draft while idle" do
         composerEscapeAction True True
             `shouldBe` EscapeDismissSlashMenu


### PR DESCRIPTION
## Summary
- propagate paste provenance through fullscreen steering callbacks
- use paste-aware skill preparation for active-turn steering
- retain normal skill detection for typed steering prompts
- add composer and runtime forwarding regressions

Follow-up to #864; addresses the review finding on the fullscreen active-turn path.

## Validation
- loaded/compiled all 211 `agent-cli` modules through GHCi
- focused composer regression: 1 example, 0 failures
- focused runtime forwarding regression: 1 example, 0 failures
- live tmux smoke test: bracketed-pasted `WHERE listings.source_id = $5` during an active streamed turn showed `Steering the current turn…` with no unknown-skill error
- `git diff --check`