### PR TITLE
Overlap yolo account prep with worktree startup

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -391,6 +391,7 @@ benchmark concurrency-bench
     ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
     build-depends:    agent-cli
                     , agent-core
+                    , async
                     , base >= 4.17 && < 5
                     , bytestring
                     , containers

--- a/packages/agent-cli/benchmark/Concurrency.hs
+++ b/packages/agent-cli/benchmark/Concurrency.hs
@@ -16,6 +16,7 @@ import Agent.Loop
     )
 import Agent.Error (ApiError(..))
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (poll, withAsync)
 import Control.Exception.Safe (SomeException, bracket, onException)
 import qualified Control.Exception.Safe as Exception
 import Control.Monad (forM_, when)
@@ -60,6 +61,18 @@ main = do
             benchmarkPendingInputs False (read count) (read samples)
         ["pending-seq", count, samples] ->
             benchmarkPendingInputs True (read count) (read samples)
+        ["startup-accounts-serial", worktreeMillis, accountMillis, samples] ->
+            benchmarkStartupOverlap
+                False
+                (read worktreeMillis)
+                (read accountMillis)
+                (read samples)
+        ["startup-accounts-overlap", worktreeMillis, accountMillis, samples] ->
+            benchmarkStartupOverlap
+                True
+                (read worktreeMillis)
+                (read accountMillis)
+                (read samples)
         _ -> benchmarkConcurrency args
 
 benchmarkConcurrency :: [String] -> IO ()
@@ -110,6 +123,52 @@ benchmarkPendingInputs useSequence count sampleCount = do
                 <> " cpu-ms=" <> show sample.sampleCpuMillis
                 <> " allocated-bytes=" <> show sample.sampleAllocatedBytes
             )
+
+benchmarkStartupOverlap :: Bool -> Int -> Int -> Int -> IO ()
+benchmarkStartupOverlap useOverlap worktreeMillis accountMillis sampleCount = do
+    statsEnabled <- getRTSStatsEnabled
+    when (not statsEnabled) $
+        fail "run with +RTS -T"
+    let action =
+            if useOverlap
+                then overlapStartup worktreeMillis accountMillis
+                else serialStartup worktreeMillis accountMillis
+        label =
+            if useOverlap
+                then "startup-accounts-overlap"
+                else "startup-accounts-serial"
+    samples <- mapM (const (measure action)) [1 .. max 1 sampleCount]
+    let sample = medianSample samples
+    putStrLn
+        ( label
+            <> " worktree-ms=" <> show worktreeMillis
+            <> " account-ms=" <> show accountMillis
+            <> " samples=" <> show sampleCount
+            <> " elapsed-ms=" <> show sample.sampleElapsedMillis
+            <> " cpu-ms=" <> show sample.sampleCpuMillis
+            <> " allocated-bytes=" <> show sample.sampleAllocatedBytes
+        )
+
+serialStartup :: Int -> Int -> IO Int
+serialStartup worktreeMillis accountMillis = do
+    threadDelay (worktreeMillis * 1000)
+    threadDelay (accountMillis * 1000)
+    pure 2
+
+overlapStartup :: Int -> Int -> IO Int
+overlapStartup worktreeMillis accountMillis =
+    withAsync
+        (threadDelay (accountMillis * 1000) >> pure 1)
+        \accountWorker -> do
+            threadDelay (worktreeMillis * 1000)
+            poll accountWorker >>= \case
+                Nothing -> do
+                    -- The real startup retires an unfinished speculative
+                    -- refresh and lets its established post-prompt probe run.
+                    threadDelay (accountMillis * 1000)
+                    pure 2
+                Just (Left err) -> Exception.throwIO err
+                Just (Right accountResult) -> pure (1 + accountResult)
 
 medianSample :: [Sample] -> Sample
 medianSample samples =

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -46,8 +46,8 @@ mkDerivation {
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-json agent-responses agent-responses-types
-    agent-store base brick bytestring containers deepseq directory
-    filepath JuicyPixels safe-exceptions text time vty
+    agent-store async base brick bytestring containers deepseq
+    directory filepath JuicyPixels safe-exceptions text time vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -43,7 +43,7 @@ import Agent.CLI.Options
       isOneShot,
       CliOptions(optMotionMode, optManagedTurnFile, optScreenMode,
                  optProvider, optModel, optWorktree, optEffort, optPrompt,
-                 optPromptFile, optResume, optCwd, optCodeMode),
+                 optPromptFile, optResume, optCwd, optCodeMode, optYolo),
       ScreenMode(ScreenMinimal) )
 import Agent.CLI.PendingInputs ()
 import Agent.CLI.Plan ()
@@ -73,9 +73,9 @@ import Agent.CLI.Runtime.HistorySource
 import Agent.CLI.Runtime.Orchestration.Background ()
 import Agent.CLI.Runtime.Orchestration.Concurrent ()
 import Agent.CLI.Runtime.Orchestration.Initialized
-    ( PreparedStartupAuth
-    , prepareStartupAuth
+    ( PreparedStartupAuthWorker
     , runAgentInitialized
+    , withPreparedStartupAuth
     )
 import Agent.CLI.Runtime.Orchestration.Restart
     ( RestartCallbacks(..), runFullscreenRestartLoop )
@@ -193,7 +193,6 @@ import Agent.Tools.Secret ()
 import Agent.Tools.Types ( defaultToolEnv, ToolEnv(toolCancel) )
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ( (<|>) )
-import Control.Concurrent.Async ( Async, withAsync )
 import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar
     ( newEmptyMVar, newMVar, readMVar, tryPutMVar )
@@ -804,7 +803,7 @@ prepareAgentIterationTracked
     writeIORef uiRuntimeRef fullscreen
     resumeLock <- readIORef resumeLockRef
     let runAction
-            :: Maybe (Async PreparedStartupAuth)
+            :: Maybe PreparedStartupAuthWorker
             -> IO RunResult
         runAction preparedAuth =
             do
@@ -915,16 +914,16 @@ prepareAgentIterationTracked
         action
             | options.optWorktree
             , isNothing resumed
-            , isNothing transition =
+            , isNothing transition = do
                 let prepareAccountUsage =
-                        isNothing fullscreen
+                        options.optYolo
+                            || isNothing fullscreen
                             || isJust options.optProvider
                             || isJust options.optModel
-                in withAsync
-                    (prepareStartupAuth
-                        prepareAccountUsage
-                        options.optProvider) $
-                    runAction . Just
+                withPreparedStartupAuth
+                    prepareAccountUsage
+                    options.optProvider
+                    (runAction . Just)
             | otherwise = runAction Nothing
         cleanup = do
             writeIORef uiRuntimeRef Nothing

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -1,7 +1,7 @@
 module Agent.CLI.Runtime.Orchestration.Initialized
-    ( PreparedStartupAuth
-    , prepareStartupAuth
+    ( PreparedStartupAuthWorker
     , runAgentInitialized
+    , withPreparedStartupAuth
     ) where
 
 import Agent.CLI.AccountPicker ()
@@ -58,7 +58,7 @@ import Agent.CLI.Models
       ModelOption(modelTarget),
       ModelTarget(targetWireModelId, ModelTarget, targetConnectionId,
                   targetProvider, targetModelId, targetDialect) )
-import Agent.CLI.Options ( CliOptions(optModel, optProvider) )
+import Agent.CLI.Options ( CliOptions(optModel, optProvider, optYolo) )
 import Agent.CLI.PendingInputs ()
 import Agent.CLI.Plan ()
 import Agent.CLI.Project
@@ -180,13 +180,21 @@ import Agent.Tools.Secret ()
 import Agent.Tools.Types ()
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ( (<|>) )
-import Control.Concurrent.Async ( Async, concurrently, wait )
+import Control.Concurrent.Async
+    ( Async, cancel, concurrently, poll, wait, withAsync )
 import Control.Concurrent.Chan ()
-import Control.Concurrent.MVar ( modifyMVar_, newMVar, readMVar )
+import Control.Concurrent.MVar
+    ( modifyMVar_
+    , newEmptyMVar
+    , newMVar
+    , readMVar
+    , takeMVar
+    , tryPutMVar
+    )
 import Control.Concurrent.STM ()
 import Control.Exception ()
 import Control.Exception.Safe ( onException )
-import Control.Monad ( when )
+import Control.Monad ( void, when )
 import Data.Functor ()
 import Data.IORef ( IORef, newIORef, readIORef, writeIORef )
 import Data.List ()
@@ -224,6 +232,11 @@ data PreparedStartupAuth = PreparedStartupAuth
     , preparedAccountUsage :: !(Maybe PreparedProviderAccounts)
     }
 
+data PreparedStartupAuthWorker = PreparedStartupAuthWorker
+    { preparedStartupAsync :: !(Async PreparedStartupAuth)
+    , retirePreparedStartup :: !(IO ())
+    }
+
 prepareStartupAuth :: Bool -> Maybe Provider -> IO PreparedStartupAuth
 prepareStartupAuth prepareAccountUsage requestedProvider = do
     authResult <- loadAuth requestedProvider
@@ -238,6 +251,25 @@ prepareStartupAuth prepareAccountUsage requestedProvider = do
         , preparedAccountUsage = accountUsage
         }
 
+withPreparedStartupAuth
+    :: Bool
+    -> Maybe Provider
+    -> (PreparedStartupAuthWorker -> IO a)
+    -> IO a
+withPreparedStartupAuth prepareAccountUsage requestedProvider action =
+    withAsync
+        (prepareStartupAuth prepareAccountUsage requestedProvider)
+        \worker -> do
+            retire <- newEmptyMVar
+            withAsync
+                (takeMVar retire >> cancel worker)
+                \_ ->
+                    action PreparedStartupAuthWorker
+                        { preparedStartupAsync = worker
+                        , retirePreparedStartup =
+                            void (tryPutMVar retire ())
+                        }
+
 runAgentInitialized
     :: (AgentRunMode -> CliOptions -> IO DevResult)
     -> AgentProcessRuntime
@@ -249,7 +281,7 @@ runAgentInitialized
     -> Maybe SessionLock
     -> OsPath
     -> StartupRuntime
-    -> Maybe (Async PreparedStartupAuth)
+    -> Maybe PreparedStartupAuthWorker
     -> IO RunResult
 runAgentInitialized
         runAgentChild processRuntime options transition home root resumed resumeLock cwd startup preparedAuth =
@@ -268,7 +300,7 @@ runAgentInitializedWithLock
     -> Maybe SessionLock
     -> OsPath
     -> StartupRuntime
-    -> Maybe (Async PreparedStartupAuth)
+    -> Maybe PreparedStartupAuthWorker
     -> IO RunResult
 runAgentInitializedWithLock
         runAgentChild processRuntime
@@ -404,6 +436,7 @@ runAgentInitializedWithLock
             Nothing -> do
                 (startupAuth, accountUsage) <- loadPreparedOrStartupAuth
                     preparedAuth
+                    (options.optYolo && checkStartupUsageInBackground)
                     startup
                     transition
                     requestedProvider
@@ -470,7 +503,8 @@ runAgentInitializedWithLock
             | not
                 (loadedAuthSupportsUsageAccountSelection initialLoaded) ->
                     pure (initialLoaded, Nothing)
-            | checkStartupUsageInBackground -> do
+            | checkStartupUsageInBackground
+            , isNothing preparedAccountUsage -> do
                 -- Make the remembered model/account usable immediately. The
                 -- scoped availability worker below checks the account pool
                 -- after the prompt is ready and triggers startup fallback if
@@ -743,7 +777,7 @@ runAgentInitializedWithLock
         activeSelectionRef
         baseToolEnv
         catalog
-        checkStartupUsageInBackground
+        (checkStartupUsageInBackground && isNothing preparedAccountUsage)
         configuredOptionTarget
         customResponses
         cwd
@@ -780,30 +814,50 @@ runAgentInitializedWithLock
         unavailableProviders
 
 loadPreparedOrStartupAuth
-    :: Maybe (Async PreparedStartupAuth)
+    :: Maybe PreparedStartupAuthWorker
+    -> Bool
     -> StartupRuntime
     -> Maybe ProviderTransition
     -> Maybe Provider
     -> IO ((LoadedAuth, Bool), Maybe PreparedProviderAccounts)
-loadPreparedOrStartupAuth prepared startup transition requestedProvider =
+loadPreparedOrStartupAuth
+    prepared
+    usePreparedOnlyIfReady
+    startup
+    transition
+    requestedProvider =
     case prepared of
-        Nothing ->
-            (, Nothing)
-                <$> loadStartupAuth startup transition requestedProvider
-        Just worker ->
-            wait worker >>= \case
-                preparedResult
-                    | Right loaded <- preparedResult.preparedAuthResult
+        Nothing -> loadFallback
+        Just preparedWorker -> do
+            let worker = preparedWorker.preparedStartupAsync
+            preparedResult <-
+                if usePreparedOnlyIfReady
+                    then
+                        poll worker >>= \case
+                            Nothing -> do
+                                -- Some HTTP clients take time to acknowledge
+                                -- async cancellation. Ask the scoped retirement
+                                -- worker to handle that wait so startup can
+                                -- continue to the post-prompt availability
+                                -- probe.
+                                preparedWorker.retirePreparedStartup
+                                pure Nothing
+                            Just _ -> Just <$> wait worker
+                    else Just <$> wait worker
+            case preparedResult of
+                Just result
+                    | Right loaded <- result.preparedAuthResult
                     , maybe True (== loaded.loadedProvider) requestedProvider ->
-                        (, preparedResult.preparedAccountUsage)
+                        (, result.preparedAccountUsage)
                             <$> loadStartupAuthFromResult
                                 startup
                                 transition
                                 requestedProvider
-                                preparedResult.preparedAuthResult
-                _ ->
-                    (, Nothing)
-                        <$> loadStartupAuth startup transition requestedProvider
+                                result.preparedAuthResult
+                _ -> loadFallback
+  where
+    loadFallback =
+        (, Nothing) <$> loadStartupAuth startup transition requestedProvider
 
 trackCredentialAccount
     :: IORef Text


### PR DESCRIPTION
## Summary
- start full account preparation alongside managed worktree creation for fullscreen `--worktree --yolo` startup
- consume prepared account usage when it finishes during Git setup; otherwise retire it without blocking the prompt and preserve the existing post-prompt availability probe
- keep cancellation structured and scoped even when an HTTP client acknowledges cancellation slowly
- add retained serial/overlap startup-account workloads to the optimized concurrency benchmark

## Benchmark
Built with GHC 9.10.3 and `-O2`; each result is the median of 9 samples with RTS allocation statistics enabled:

```console
cabal build --offline -O2 agent-cli:bench:concurrency-bench
bin=$(cabal list-bin -O2 agent-cli:bench:concurrency-bench)
$bin startup-accounts-serial 100 80 9 +RTS -T
$bin startup-accounts-overlap 100 80 9 +RTS -T
```

Representative result after rebasing onto current `origin/master`:

| workload | elapsed | CPU | allocated |
|---|---:|---:|---:|
| serial, worktree 100ms / accounts 80ms | 182.517ms | 0.221ms | 13,048 B |
| overlap, worktree 100ms / accounts 80ms | 101.594ms | 0.167ms | 16,120 B |

Additional coverage before rebase showed 82.338ms -> 51.469ms for 50ms/30ms and expected parity (252.168ms vs 252.961ms) when account preparation is slower than worktree creation and the post-prompt fallback must take over. The change trades about 3KB in the successful overlap case for lower account-ready latency.

## Validation
- `cabal repl agent-cli:lib:agent-cli` (211 modules loaded)
- `cabal build --offline -O2 agent-cli:bench:concurrency-bench agent-cli:exe:agent-cli`
- `TMPDIR=<short-private-path> cabal test --offline agent-cli:test:agent-cli-test --test-show-details=direct` (1,498 examples, 0 failures, 1 pending)
- tmux smoke: optimized CLI reached the interactive prompt after creating an isolated managed worktree with `--worktree --yolo --provider openrouter`
- `git diff --check origin/master...HEAD`
