### PR TITLE
Yield long-running shell commands by default

### DIFF
--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -134,9 +134,9 @@ shellCommandTool env session =
             , PropertySchema "workdir" PropertyString False $ Just
                 "Working directory for the command. Defaults to the turn cwd."
             , PropertySchema "timeout_ms" PropertyInteger False $ Just
-                "Maximum foreground command runtime. Defaults to 10000 ms. Mutually exclusive with yield_time_ms."
+                "Maximum command runtime; commands that reach it are stopped. Mutually exclusive with yield_time_ms."
             , PropertySchema "yield_time_ms" PropertyInteger False $ Just
-                "Return a session_id if the command is still running after this many milliseconds. Mutually exclusive with timeout_ms."
+                "Wait before returning a session_id for a command that is still running. Defaults to 10000 ms when neither timing control is set. Mutually exclusive with timeout_ms."
             ])
         AlwaysPrompt
         TurnSequential
@@ -153,7 +153,7 @@ shellCommandResourceClaims env call =
     case decodeToolArguments shellCommandArgsDecoder call.arguments of
         Left err -> pure (Left err)
         Right args
-            | args.yieldTimeMs /= Nothing ->
+            | args.yieldTimeMs /= Nothing || args.timeoutMs == Nothing ->
                 pure (Left "yielding shell commands remain exclusive")
             | not (shellCommandIsReadOnly args.command) ->
                 pure (Left "shell command is not in the read-only allowlist")
@@ -172,7 +172,11 @@ shellDescription =
     "Runs a shell command and returns its output.\n\
     \- `workdir` is optional; omit it to use the turn cwd. Do not use `cd` unless absolutely necessary.\n\
     \- Use `$TMPDIR` for temporary files; literal `/tmp` and `/private/tmp` paths are rejected.\n\
-    \- For a long-running command, set `yield_time_ms`; if it is still running, use `write_stdin` with the returned session_id to poll or send input."
+    \- By default, a command that is still running after 10000 ms is retained and returned with a session_id; use `write_stdin` to poll or send input.\n\
+    \- Set `timeout_ms` only when the command should be stopped after a fixed runtime, or `yield-time_ms` to change the initial wait."
+
+defaultShellYieldMs :: Int
+defaultShellYieldMs = 10000
 
 runShell
     :: ToolEnv
@@ -193,34 +197,40 @@ runShell env session emitOutput args
                 blockedShellCommandReasonAt dir args.command >>= \case
                     Just reason -> pure (Left reason)
                     Nothing -> case args.yieldTimeMs of
-                        Just requestedYield -> do
-                            let yieldMs = clampMs requestedYield
-                            startCodexShellCommand
-                                session
-                                dir
-                                (Text.unpack args.command)
-                                yieldMs
-                                (\out err -> emitOutput (commandBody out err))
-                                >>= pure . fmap renderShellResult
-                        Nothing -> do
-                            let timeoutMs =
-                                    clampMs
-                                        (fromMaybe 10000 args.timeoutMs)
-                            result <- runShellCommandStreaming
-                                env
-                                dir
-                                (Text.unpack args.command)
-                                timeoutMs
-                                (\out err ->
-                                    emitOutput (commandBody out err))
-                            if result.commandCancelled
-                                then pure $ Left "Error: Command cancelled"
-                                else if result.commandTimedOut
-                                then pure $ Left $
-                                    "Error: Command timed out after "
-                                        <> Text.pack (show timeoutMs)
-                                        <> "ms"
-                                else pure $ Right $ renderFinished result
+                        Just requestedYield ->
+                            runWithYield dir requestedYield
+                        Nothing -> case args.timeoutMs of
+                            Nothing ->
+                                runWithYield dir defaultShellYieldMs
+                            Just requestedTimeout ->
+                                runWithTimeout dir requestedTimeout
+  where
+    runWithYield dir requestedYield = do
+        let yieldMs = clampMs requestedYield
+        startCodexShellCommand
+            session
+            dir
+            (Text.unpack args.command)
+            yieldMs
+            (\out err -> emitOutput (commandBody out err))
+            >>= pure . fmap renderShellResult
+
+    runWithTimeout dir requestedTimeout = do
+        let timeoutMs = clampMs requestedTimeout
+        result <- runShellCommandStreaming
+            env
+            dir
+            (Text.unpack args.command)
+            timeoutMs
+            (\out err -> emitOutput (commandBody out err))
+        if result.commandCancelled
+            then pure $ Left "Error: Command cancelled"
+            else if result.commandTimedOut
+            then pure $ Left $
+                "Error: Command timed out after "
+                    <> Text.pack (show timeoutMs)
+                    <> "ms"
+            else pure $ Right $ renderFinished result
 
 data WriteStdinArgs = WriteStdinArgs
     { sessionId :: Int

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -117,6 +117,69 @@ spec = describe "Codex dialect" do
                     result.output
                         `shouldSatisfy` Text.isInfixOf "cwd-defaulted"
 
+    it "retains commands after the default ten-second yield" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket
+                (newCodexCodingTools env Nothing Nothing)
+                (.codexClose)
+                \coding -> do
+                    let handlers = appToolHandlers coding.codexAppTools
+                    started <- dispatchToolCall
+                        testDispatchConfig
+                        handlers
+                        (functionToolCall
+                            "shell-default-yield"
+                            "shell_command"
+                            "{\"command\":\"printf started; trap 'exit 0' INT; while :; do sleep 1; done\"}")
+                    started.output `shouldSatisfy`
+                        Text.isPrefixOf "Process still running."
+                    started.output `shouldSatisfy` Text.isInfixOf "started"
+                    started.output `shouldNotSatisfy`
+                        Text.isInfixOf "timed out"
+                    sessionId <- expectShellSessionId started.output
+
+                    interrupted <- dispatchToolCall
+                        testDispatchConfig
+                        handlers
+                        (functionToolCall
+                            "shell-default-yield-interrupt"
+                            "write_stdin"
+                            ("{\"session_id\":" <> sessionId
+                                <> ",\"chars\":\"\\u0003\","
+                                <> "\"yield_time_ms\":5000}"))
+                    interrupted.output `shouldSatisfy`
+                        Text.isPrefixOf "Exit code:"
+
+                    stale <- dispatchToolCall
+                        testDispatchConfig
+                        handlers
+                        (functionToolCall
+                            "shell-default-yield-stale"
+                            "write_stdin"
+                            ("{\"session_id\":" <> sessionId <> "}"))
+                    stale.output `shouldSatisfy`
+                        Text.isInfixOf "Unknown session_id"
+
+    it "keeps timeout_ms as an explicit hard timeout" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket
+                (newCodexCodingTools env Nothing Nothing)
+                (.codexClose)
+                \coding -> do
+                    result <- dispatchToolCall
+                        testDispatchConfig
+                        (appToolHandlers coding.codexAppTools)
+                        (functionToolCall
+                            "shell-explicit-timeout"
+                            "shell_command"
+                            "{\"command\":\"sleep 1\",\"timeout_ms\":10}")
+                    result.output `shouldSatisfy`
+                        Text.isInfixOf "timed out after 10ms"
+                    result.output `shouldNotSatisfy`
+                        Text.isInfixOf "session_id:"
+
     it "rejects literal system temp paths in shell commands" do
         withTempDir \dir -> do
             env <- defaultToolEnv (unsafeEncodeUtf dir)
@@ -413,19 +476,7 @@ spec = describe "Codex dialect" do
                             "{\"command\":\"sleep 0.2; printf done\",\"yield_time_ms\":1}")
                     started.output `shouldSatisfy`
                         Text.isPrefixOf "Process still running."
-                    sessionId <-
-                        case
-                            [ ident
-                            | line <- Text.lines started.output
-                            , Just ident <-
-                                [Text.stripPrefix "session_id: " line]
-                            ]
-                        of
-                            [ident] -> pure ident
-                            _ ->
-                                expectationFailure
-                                    "expected one retained shell session id"
-                                    >> pure "0"
+                    sessionId <- expectShellSessionId started.output
                     continued <- dispatchToolCall
                         testDispatchConfig
                         handlers
@@ -500,6 +551,19 @@ waitForFile path = go (100 :: Int)
         doesFileExist path >>= \case
             True -> pure True
             False -> threadDelay 10000 >> go (remaining - 1)
+
+expectShellSessionId :: Text.Text -> IO Text.Text
+expectShellSessionId output =
+    case
+        [ ident
+        | line <- Text.lines output
+        , Just ident <- [Text.stripPrefix "session_id: " line]
+        ]
+    of
+        [ident] -> pure ident
+        _ ->
+            expectationFailure "expected one retained shell session id"
+                >> pure "0"
 
 testDispatchConfig :: ToolDispatchConfig
 testDispatchConfig = ToolDispatchConfig


### PR DESCRIPTION
## Summary
- retain shell commands that run beyond the default 10-second foreground wait and return a managed session ID
- preserve `timeout_ms` as an explicit hard timeout and `yield-time_ms` as a custom foreground wait
- treat default-yielding commands as exclusive and document the updated Codex-compatible contract
- add regressions for the default handoff, interruption/cleanup, and explicit timeout behavior

## Validation
- `TMPDIR="$PWD/dist-newstyle/tmp" nix develop -c cabal repl agent-codex-dialect:test:agent-codex-dialect-test` → 18 examples, 0 failures, 2 pending (`sandbox-exec` unavailable)
- `git diff --check origin/master...HEAD`
