### PR TITLE
Require bounded forks for child model overrides

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -66,8 +66,11 @@ subscriptionSubagentModelGuidance provider billing
             , "judgment. Do not use Luna as a blanket default; when uncertain,"
             , "prefer the stronger tier. Honor an explicitly requested model."
             , "Omit the override when the parent model already matches the chosen"
-            , "tier. Do not spawn a subagent when doing the work directly would"
-            , "be faster."
+            , "tier. Full-history forks (`fork_turns` omitted or `\"all\"`)"
+            , "inherit the parent model and reasoning effort and do not accept"
+            , "overrides. When setting `model` or `reasoning_effort`, set"
+            , "`fork_turns` to `\"none\"` or a positive integer string. Do not"
+            , "spawn a subagent when doing the work directly would be faster."
             ]
     | otherwise = Nothing
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -646,6 +646,7 @@ runAgentTools
                     inferredTarget.targetConnectionId
                     transportModel
                     inferredTarget.targetWireModelId
+                    effortText
                     dialectId
                     legacySubagentTarget
                     subagentSessions subagentStoreRoot agentTypesRef

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -129,6 +129,7 @@ prepareCollaborationSpawn
     -> Text
     -> (Text -> Text)
     -> Text
+    -> Text
     -> DialectId
     -> Maybe LegacySubagentTarget
     -> IORef (Map SubagentId SubagentSession)
@@ -143,14 +144,20 @@ prepareCollaborationSpawn
         connection
         mapModel
         currentEffectiveModel
+        currentEffort
         currentDialect
         legacyTarget
         sessionsRef storeRootRef typesRef sourceRef agentId spawnOptions = do
     recordAgentSpec typesRef agentId GrokSubagentSpec
         { agentType = defaultSubagentType
         , modelOverride = spawnOptions.collaborationModel
-        , reasoningEffortOverride =
-            spawnOptions.collaborationReasoningEffort
+        , reasoningEffortOverride = case
+                spawnOptions.collaborationReasoningEffort of
+            Just effort -> Just effort
+            Nothing
+                | inheritsFullHistory spawnOptions.collaborationForkTurns ->
+                    Just currentEffort
+                | otherwise -> Nothing
         }
     let effectiveModel =
             maybe currentEffectiveModel mapModel spawnOptions.collaborationModel
@@ -426,7 +433,7 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
         childModel <- lookupAgentModel runtime.subagentTypes env.subId
         childEffort <- lookupAgentReasoningEffort runtime.subagentTypes env.subId
         parentParams <- readIORef runtime.subagentParams
-        let (provisionalModel, _) =
+        let (provisionalModel, provisionalEffort) =
                 resolveChildModelAndEffort
                     OpenAIProvider
                     parentParams
@@ -438,6 +445,7 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                 runtime
                 OpenAIProvider
                 provisionalModel
+                provisionalEffort
                 (dialectId codexDialect)
                 env
                 sendToRoot
@@ -597,7 +605,7 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                 inheritedGrokChildModel
                     runtime
                     (fromMaybe "" parentParams.model)
-            (provisionalModel, _) =
+            (provisionalModel, provisionalEffort) =
                 resolveChildModelAndEffort
                     provider
                     parentParams
@@ -611,6 +619,7 @@ runHttpSubagent runtime dialect provider sendToRoot mkBackend =
                 runtime
                 provider
                 provisionalEffectiveModel
+                provisionalEffort
                 (maybe
                     (dialectId dialect)
                     (dialectIdForModel provider . runtime.subagentMapModel)
@@ -745,11 +754,14 @@ prepareChild
     :: SubagentRuntime
     -> Provider
     -> Text
+    -> Text
     -> DialectId
     -> SubagentSpawnEnv
     -> Maybe (InterAgentMessage -> IO (Either Text Text))
     -> IO PreparedChild
-prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoot = do
+prepareChild
+        runtime provider currentEffectiveModel currentEffort currentDialect
+        env sendToRoot = do
     parentParams <- readIORef runtime.subagentParams
     childEnv <- do
         freshEnv <- defaultToolEnv env.subCwd
@@ -794,6 +806,7 @@ prepareChild runtime provider currentEffectiveModel currentDialect env sendToRoo
                     session.subSessionConnection
                     runtime.subagentMapModel
                     session.subSessionEffectiveModel
+                    currentEffort
                     session.subSessionDialect
                     (Just LegacySubagentTarget
                         { legacyTargetProvider =
@@ -850,6 +863,12 @@ resolveChildModelAndEffort
         , model == "gpt-5.6-luna"
         , inheritedEffort `notElem` ["xhigh", "max"] = "high"
         | otherwise = inheritedEffort
+
+inheritsFullHistory :: Maybe Text -> Bool
+inheritsFullHistory = \case
+    Nothing -> True
+    Just turns ->
+        Text.toLower (Text.strip turns) `elem` ["", "all"]
 
 runPreparedChild
     :: SubagentRuntime

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -376,6 +376,10 @@ spec = describe "systemPrompt" do
             maybe False (Text.isInfixOf "Do not use Luna as a blanket default")
         subscriptionGuidance `shouldSatisfy`
             maybe False (Text.isInfixOf "Honor an explicitly requested model")
+        subscriptionGuidance `shouldSatisfy`
+            maybe False
+                (Text.isInfixOf
+                    "Full-history forks (`fork_turns` omitted or `\"all\"`)")
         subscriptionSubagentModelGuidance OpenAIProvider ApiBilled
             `shouldBe` Nothing
         subscriptionSubagentModelGuidance XAIProvider SubscriptionBilled

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -26,6 +26,7 @@ import Agent.CLI.Subagents.Runtime
     , validatePersistedSubagentTarget
     )
 import Agent.CLI.Request (requestParams)
+import Agent.GrokBuild.Dialect.Task (lookupAgentReasoningEffort)
 import Agent.Responses.Types
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import Agent.Subagents
@@ -64,7 +65,7 @@ toFilePath path = either (error . show) id (decodeUtf path)
 spec :: Spec
 spec = describe "Agent.CLI.SubagentStore" do
     describe "nested subagent model inheritance" do
-        it "uses the immediate parent's effective model when no override is set" do
+        it "inherits the immediate parent's model and effort for full-history forks" do
             sessionsRef <- newIORef Map.empty
             storeRootRef <- newIORef Nothing
             typesRef <- newIORef Map.empty
@@ -75,6 +76,7 @@ spec = describe "Agent.CLI.SubagentStore" do
                 "openai"
                 id
                 "gpt-5.6-luna"
+                "medium"
                 CodexDialect
                 Nothing
                 sessionsRef
@@ -88,12 +90,50 @@ spec = describe "Agent.CLI.SubagentStore" do
                     , collaborationForkTurns = Nothing
                     }
             Just session <- Map.lookup agentId <$> readIORef sessionsRef
+            lookupAgentReasoningEffort typesRef agentId
+                `shouldReturn` Just "medium"
             let rootParams =
                     requestParams OpenAIProvider "gpt-5.6-sol" "" [] "medium"
             resolveChildModelAndEffort
                 OpenAIProvider
                 rootParams
                 session.subSessionEffectiveModel
+                Nothing
+                (Just "medium")
+                `shouldBe` ("gpt-5.6-luna", "medium")
+
+        it "keeps the Luna floor for bounded forks without an effort override" do
+            sessionsRef <- newIORef Map.empty
+            storeRootRef <- newIORef Nothing
+            typesRef <- newIORef Map.empty
+            forkSourceRef <- newIORef Nothing
+            let agentId = SubagentId "agent-bounded"
+            prepareCollaborationSpawn
+                OpenAIProvider
+                "openai"
+                id
+                "gpt-5.6-luna"
+                "medium"
+                CodexDialect
+                Nothing
+                sessionsRef
+                storeRootRef
+                typesRef
+                forkSourceRef
+                agentId
+                CollaborationSpawnOptions
+                    { collaborationModel = Nothing
+                    , collaborationReasoningEffort = Nothing
+                    , collaborationForkTurns = Just "3"
+                    }
+            lookupAgentReasoningEffort typesRef agentId
+                `shouldReturn` Nothing
+            let rootParams =
+                    requestParams OpenAIProvider "gpt-5.6-sol" "" [] "medium"
+            resolveChildModelAndEffort
+                OpenAIProvider
+                rootParams
+                "gpt-5.6-luna"
                 Nothing
                 Nothing
                 `shouldBe` ("gpt-5.6-luna", "high")

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -195,12 +195,13 @@ spawnAgentParameters ctx encryptMessage =
     , PropertySchema "model" PropertyString False $ Just
         (Text.intercalate " " $
             [ "Model override for the new agent. Omit unless an explicit override is needed."
+            , "Model or reasoning-effort overrides require `fork_turns` to be `none` or a positive integer."
             ]
                 <> maybe [] pure ctx.multiSpawnModelGuidance)
     , PropertySchema "reasoning_effort" PropertyString False $ Just
-        "Reasoning effort override for the new agent. Omit to inherit the parent effort."
+        "Reasoning effort override for the new agent. Omit to inherit the parent effort. Overrides require `fork_turns` to be `none` or a positive integer."
     , PropertySchema "fork_turns" PropertyString False $ Just
-        "Optional number of turns to fork. Defaults to `all`. Use `none`, `all`, or a positive integer string such as `3` to fork only the most recent turns."
+        "Optional number of turns to fork. Defaults to `all`. Full-history forks (`all` or omitted) inherit the parent model and reasoning effort and do not accept overrides. Use `none` or a positive integer string such as `3` when setting `model` or `reasoning_effort`."
     ]
 
 spawnAgentDescription :: Text
@@ -231,6 +232,11 @@ runSpawn ctx workspace call args
         pure (Left (spawnToolName workspace <> " requires a non-empty message"))
     | not (validForkTurns args.forkTurns) =
         pure (Left "fork_turns must be none, all, or a positive integer string")
+    | hasSpawnOverride args && usesFullHistory args.forkTurns =
+        pure (Left
+            "full-history forks inherit the parent model and reasoning effort; \
+            \set fork_turns to none or a positive integer when overriding \
+            \model or reasoning_effort")
     | otherwise = mask \restore ->
         resolveSpawnWorkspace ctx workspace >>= \case
             Left err -> pure (Left err)
@@ -370,6 +376,17 @@ validForkTurns = \case
             || case readExactInt stripped of
                 Just count -> count > 0
                 _ -> False
+
+hasSpawnOverride :: SpawnAgentArgs -> Bool
+hasSpawnOverride args =
+    any (/= Nothing)
+        [ sanitizeOverride args.model
+        , sanitizeOverride args.reasoningEffort
+        ]
+
+usesFullHistory :: Maybe Text -> Bool
+usesFullHistory forkTurns =
+    normalizeForkTurns forkTurns == Just "all"
 
 sanitizeOverride :: Maybe Text -> Maybe Text
 sanitizeOverride value = value >>= \raw ->

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -261,6 +261,44 @@ spec = describe "Agent.Tools.MultiAgents" do
             }
         closeSubagentRegistry registry
 
+    it "rejects model overrides on implicit full-history forks" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let call = ToolCall
+                { callId = "spawn-model-full-history"
+                , name = "collaboration.spawn_agent"
+                , arguments =
+                    "{\"task_name\":\"worker\",\"message\":\"task\",\
+                    \\"model\":\"gpt-test\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <- dispatchToolCall defaultLoopDispatch
+            (appToolHandlers (multiAgentTools (rootContext registry Nothing))) call
+        result.output `shouldSatisfy`
+            Text.isInfixOf "full-history forks inherit the parent model"
+        closeSubagentRegistry registry
+
+    it "rejects reasoning-effort overrides on explicit full-history forks" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ())
+        let call = ToolCall
+                { callId = "spawn-effort-full-history"
+                , name = "collaboration.spawn_agent"
+                , arguments =
+                    "{\"task_name\":\"worker\",\"message\":\"task\",\
+                    \\"reasoning_effort\":\"high\",\"fork_turns\":\"all\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <- dispatchToolCall defaultLoopDispatch
+            (appToolHandlers (multiAgentTools (rootContext registry Nothing))) call
+        result.output `shouldSatisfy`
+            Text.isInfixOf "set fork_turns to none or a positive integer"
+        closeSubagentRegistry registry
+
     it "spawns an isolated child in a host-provided worktree" do
         childCwd <- newEmptyTMVarIO
         cleaned <- newIORef False


### PR DESCRIPTION
## Summary
- reject child model or reasoning-effort overrides for implicit and explicit full-history forks
- document the inheritance rule in collaboration tool schemas and subscription-backed OpenAI guidance
- cover both full-history rejection paths with focused regression tests

## Testing
- `nix develop -c cabal repl agent-core:test:agent-core-test` with `:main --match "Agent.Tools.MultiAgents"` (22 examples, 0 failures)
- `nix develop -c cabal repl agent-cli:test:agent-cli-test` with `:main --match "subscription-backed OpenAI subagents"` (1 example, 0 failures)
- tmux TTY smoke: loaded the CLI in GHCi, opened the live onboarding UI, and exited with Esc
- `git diff origin/master...HEAD --check`