### PR TITLE
Differentiate inspection and action activity glyphs

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -83,6 +83,7 @@ import Agent.CLI.Style
     ( agentBackground
     , glyphCancel
     , glyphErr
+    , glyphInspect
     , glyphTool
     , glyphToolAccent
     , glyphToolOut
@@ -118,6 +119,7 @@ import Agent.TUI.Presentation
     , SearchReplaceLine(..)
     , formatToolOutput
     , formatToolOutputRelative
+    , isInspectionTool
     , parseSearchReplaceDiff
     , summarizeToolCall
     , summarizeToolCallRelative
@@ -771,7 +773,10 @@ formatToolStarted color = formatToolStartedRelative color ""
 
 formatToolStartedRelative :: Bool -> Text -> ToolCall -> Text
 formatToolStartedRelative color workspace call =
-    let arrow = roleToolArrow color glyphTool
+    let marker
+            | isInspectionTool call.name = glyphInspect
+            | otherwise = glyphTool
+        arrow = roleToolArrow color marker
         detail = toolDetail call
     in case toolChrome call.name of
         ToolChromeShell ->

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -27,6 +27,7 @@ module Agent.CLI.Style
     , roleSuccess
     , roleSelected
     , glyphTool
+    , glyphInspect
     , glyphToolOut
     , glyphToolAccent
     , glyphOk
@@ -236,9 +237,10 @@ pickGlyph fancy ascii
     | supportsUnicodeChrome = fancy
     | otherwise = ascii
 
-glyphTool, glyphToolOut, glyphToolAccent, glyphOk, glyphErr :: Text
+glyphTool, glyphInspect, glyphToolOut, glyphToolAccent, glyphOk, glyphErr :: Text
 glyphWarn, glyphCancel, glyphSession, glyphThink :: Text
 glyphTool = pickGlyph "◆ " "* "
+glyphInspect = pickGlyph "◇ " "o "
 glyphToolOut = pickGlyph "┊ " "| "
 glyphToolAccent = pickGlyph "❙ " "| "
 glyphOk = pickGlyph "✓ " "+ "

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -687,7 +687,7 @@ toolImageBlockId callId ui =
             | (active, _) <- Map.toList ui.uiToolCalls
             , Just block <- [blockForCall active]
             , block.blockState == BlockRunning
-            , block.blockKind `elem` [BlockTool, BlockShell]
+            , block.blockKind `elem` [BlockTool, BlockInspect, BlockShell]
             ]
         of
             [] -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
@@ -196,7 +196,14 @@ completionFlashTransitions previous next =
     , blockWasLive oldBlock.blockState
     , block.blockState == BlockComplete
     , block.blockKind
-        `elem` [BlockThinking, BlockTool, BlockTodo, BlockShell, BlockEdit]
+        `elem`
+            [ BlockThinking
+            , BlockTool
+            , BlockInspect
+            , BlockTodo
+            , BlockShell
+            , BlockEdit
+            ]
     ]
   where
     previousById =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -53,8 +53,8 @@ import Agent.TUI.Model
     ( blockCodeLanguage,
       BlockId,
       BlockKind(BlockUser, BlockAssistant, BlockThinking, BlockTool,
-                BlockTodo, BlockShell, BlockEdit, BlockSystem, BlockRecap,
-                BlockError),
+                BlockInspect, BlockTodo, BlockShell, BlockEdit, BlockSystem,
+                BlockRecap, BlockError),
       BlockState(BlockComplete, BlockFailed, BlockCancelled, BlockDenied,
                  BlockRunning, BlockStreaming),
       Focus(FocusScrollback),
@@ -235,6 +235,19 @@ drawBlock state target ui block =
                     (blockStateGlyph state target block <> block.blockTitle)
                     (visibleBody block)
             BlockTool ->
+                accentBlockWithSections
+                    state
+                    target
+                    ui
+                    block
+                    waveElapsed
+                    (statusAttr state target block)
+                    (blockStateGlyph state target block
+                        <> block.blockTitle
+                        <> detailSuffix block)
+                    (bodySections (visibleBody block)
+                        <> toolImageSections state target block)
+            BlockInspect ->
                 accentBlockWithSections
                     state
                     target
@@ -491,11 +504,22 @@ blockStateGlyph :: AppState -> AgentTarget -> UiBlock -> Text
 blockStateGlyph state target block = case block.blockState of
     BlockRunning -> liveGlyph
     BlockStreaming -> liveGlyph
-    BlockComplete -> "✓ "
+    BlockComplete -> completedGlyph
     BlockFailed -> "✗ "
     BlockDenied -> "⊘ "
     BlockCancelled -> "⊘ "
   where
+    completedGlyph
+        | block.blockKind == BlockInspect = "◇ "
+        | block.blockKind
+            `elem` [ BlockThinking
+                   , BlockTool
+                   , BlockTodo
+                   , BlockShell
+                   , BlockEdit
+                   ] =
+            "◆ "
+        | otherwise = "✓ "
     liveGlyph
         | target == AgentRoot
         , userActionPending state =

--- a/packages/agent-cli/src/Agent/CLI/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/Transcript.hs
@@ -156,6 +156,7 @@ blockHeading = \case
     BlockAssistant -> "Assistant"
     BlockThinking -> "Thinking"
     BlockTool -> "Tool"
+    BlockInspect -> "Inspect"
     BlockTodo -> "Todo"
     BlockShell -> "Shell"
     BlockEdit -> "Edit"

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -292,7 +292,7 @@ spec = do
     describe "formatToolStarted" do
         it "renders English verbs for known tools" do
             formatToolStarted False (functionToolCall "c1" "read_file" "{\"target_file\":\"src/A.hs\"}")
-                `shouldBe` "◆ Read src/A.hs"
+                `shouldBe` "◇ Read src/A.hs"
             formatToolStarted False (functionToolCall "c2" "run_terminal_cmd" "{\"command\":\"git status\"}")
                 `shouldBe` "◆ $ git status"
             formatToolStarted False (functionToolCall "c3" "search_replace" "{\"file_path\":\"src/A.hs\"}")
@@ -320,7 +320,7 @@ spec = do
             formatToolStarted False (functionToolCall "c10" "Bash" "{\"command\":\"git status\"}")
                 `shouldBe` "◆ $ git status"
             formatToolStarted False (functionToolCall "c11" "Read" "{\"file_path\":\"src/A.hs\"}")
-                `shouldBe` "◆ Read src/A.hs"
+                `shouldBe` "◇ Read src/A.hs"
             formatToolStarted False (functionToolCall "c12" "Edit" "{\"file_path\":\"src/A.hs\"}")
                 `shouldBe` "◆ Edited src/A.hs"
             formatToolStarted False
@@ -328,7 +328,7 @@ spec = do
                 `shouldBe` "◆ Wrote src/B.hs"
             formatToolStarted False
                 (functionToolCall "c14" "WebFetch" "{\"url\":\"https://example.com\"}")
-                `shouldBe` "◆ Fetched https://example.com"
+                `shouldBe` "◇ Fetched https://example.com"
             formatToolStarted False
                 (functionToolCall "c15" "mcp__playwright__browser_click" "{}")
                 `shouldBe` "◆ playwright: browser_click"
@@ -574,7 +574,7 @@ spec = do
                 let lines_ = filter (not . Text.null) (Text.lines body)
                 length lines_ `shouldBe` 80
                 lines_ `shouldMatchList`
-                    [ "◆ Listed packages/agent-" <> Text.pack (show i)
+                    [ "◇ Listed packages/agent-" <> Text.pack (show i)
                     | i <- [1 :: Int .. 80]
                     ]
 
@@ -591,7 +591,7 @@ spec = do
                 hClose handle
                 body <- Text.readFile path
                 body `shouldSatisfy` (Text.isInfixOf "Thinking…")
-                body `shouldSatisfy` ("◆ Listed ." `Text.isInfixOf`)
+                body `shouldSatisfy` ("◇ Listed ." `Text.isInfixOf`)
 
         it "reuses the live spinner when a tool round starts another turn" do
             withRenderConfig True False \config _handle _path -> do

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -61,6 +61,7 @@ spec = do
     describe "chrome glyphs" do
         it "exposes the shared Unicode markers" do
             glyphTool `shouldSatisfy` (`elem` ["◆ ", "* "])
+            glyphInspect `shouldSatisfy` (`elem` ["◇ ", "o "])
             glyphToolAccent `shouldSatisfy` (`elem` ["❙ ", "| "])
             glyphOk `shouldSatisfy` (`elem` ["✓ ", "+ "])
             glyphErr `shouldSatisfy` (`elem` ["✗ ", "x "])

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -228,6 +228,51 @@ spec = do
                 Text.isInfixOf "Inspect AppState before continuing."
             rendered `shouldNotSatisfy` Text.isInfixOf "`AppState`"
 
+        it "distinguishes completed inspection and action blocks" do
+            let inspectCall =
+                    functionToolCall
+                        "inspect-1"
+                        "read_file"
+                        "{\"target_file\":\"flake.nix\"}"
+                actionCall =
+                    functionToolCall
+                        "action-1"
+                        "shell_command"
+                        "{\"command\":\"pwd\"}"
+                finish callId output =
+                    ToolCallResult
+                        { callId
+                        , output
+                        , callKind = FunctionCallKind
+                        }
+                ui =
+                    foldl
+                        (flip reduceUi)
+                        baseState.appUi
+                        [ UiLoop TurnStarted
+                        , UiLoop (ToolStarted inspectCall)
+                        , UiLoop (ToolFinished (finish "inspect-1" "contents"))
+                        , UiLoop (ToolStarted actionCall)
+                        , UiLoop (ToolFinished (finish "action-1" "checkout"))
+                        ]
+                app = baseState { appUi = ui }
+                size = (80, 24)
+                rendered =
+                    Text.unlines $
+                        pictureRows
+                            (renderWidget
+                                (Just Theme.monochrome)
+                                (drawApp app)
+                                size)
+                            size
+            case toList ui.uiBlocks of
+                [inspectBlock, actionBlock] -> do
+                    rendered `shouldSatisfy`
+                        Text.isInfixOf ("◇ " <> inspectBlock.blockTitle)
+                    rendered `shouldSatisfy`
+                        Text.isInfixOf ("◆ " <> actionBlock.blockTitle)
+                _ -> expectationFailure "expected inspection and action blocks"
+
         it "keeps live todos to one row each so the prompt stays visible" do
             let todoCall =
                     functionToolCall

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -44,6 +44,7 @@ module Agent.TUI.Model
 import Agent.TUI.Presentation
     ( formatToolDiffRelative
     , formatToolOutputRelative
+    , isInspectionTool
     , todoListFromToolArguments
     , todoListFromToolOutput
     , toolCallInput
@@ -1307,6 +1308,7 @@ toolBlockKind rawName
         BlockEdit
     | name `elem` ["todo_write", "update_plan"] =
         BlockTodo
+    | isInspectionTool rawName = BlockInspect
     | otherwise = BlockTool
   where
     name = canonicalToolName rawName

--- a/packages/agent-tui/src/Agent/TUI/Model/Types.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Types.hs
@@ -30,6 +30,7 @@ data BlockKind
     | BlockAssistant
     | BlockThinking
     | BlockTool
+    | BlockInspect
     | BlockTodo
     | BlockShell
     | BlockEdit

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -628,6 +628,7 @@ isInspectionTool rawName =
             , "search_tool_output"
             , "view_image"
             , "mcp_search"
+            , "search_tool"
             , "mcp_list_resources"
             , "mcp_read_resource"
             , "database_schema"

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -11,6 +11,7 @@ module Agent.TUI.Presentation
     , formatTodoList
     , formatToolOutput
     , formatToolOutputRelative
+    , isInspectionTool
     , liveTodoPanelLines
     , parseApplyPatchDiffs
     , parseSearchReplaceDiff
@@ -611,6 +612,37 @@ firstPlanStepFromArguments arguments =
             Hermes.VObject ->
                 Hermes.object (Hermes.atKeyOptional "step" Hermes.text)
             _ -> pure Nothing
+
+-- | Read-only discovery and inspection tools use an outline marker in the
+-- activity chrome. Keep this list explicit: an unknown or generic MCP call
+-- may mutate external state and therefore remains an action.
+isInspectionTool :: Text -> Bool
+isInspectionTool rawName =
+    canonicalToolName rawName
+        `elem`
+            [ "read_file"
+            , "list_dir"
+            , "grep"
+            , "get_task_output"
+            , "read_tool_output"
+            , "search_tool_output"
+            , "view_image"
+            , "mcp_search"
+            , "mcp_list_resources"
+            , "mcp_read_resource"
+            , "database_schema"
+            , "database_query"
+            , "conversation_search"
+            , "skill_search"
+            , "view_skill"
+            , "read_agent_session"
+            , "list_agents"
+            , "Glob"
+            , "WebFetch"
+            , "WebSearch"
+            , "ToolSearch"
+            , "ListAgents"
+            ]
 
 toolVerb :: Text -> Text
 toolVerb name = case canonicalToolName name of

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1315,6 +1315,30 @@ spec = describe "fullscreen UI reducer" do
                 block.blockState `shouldBe` BlockComplete
             _ -> expectationFailure "expected one completed edit block"
 
+    it "retains inspection tools as a distinct completed block kind" do
+        let call =
+                functionToolCall
+                    "read-1"
+                    "Read"
+                    "{\"file_path\":\"src/Main.hs\"}"
+            result =
+                ToolCallResult
+                    { callId = "read-1"
+                    , output = "module Main where"
+                    , callKind = FunctionCallKind
+                    }
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    , UiLoop (ToolFinished result)
+                    ]
+        case Foldable.toList state.uiBlocks of
+            [block] -> do
+                block.blockKind `shouldBe` BlockInspect
+                block.blockState `shouldBe` BlockComplete
+            _ -> expectationFailure "expected one completed inspection block"
+
     it "shows an apply_patch diff while running and after completion" do
         let call =
                 customToolCall

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -10,6 +10,35 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "tool presentation" do
+    it "distinguishes inspection tools from actions after canonicalization" do
+        map isInspectionTool
+            [ "read_file"
+            , "list_dir"
+            , "grep"
+            , "Read"
+            , "Grep"
+            , "Glob"
+            , "WebFetch"
+            , "ToolSearch"
+            , "read_tool_output"
+            , "mcp_search"
+            , "database_query"
+            , "conversation_search"
+            , "view_skill"
+            , "read_agent_session"
+            , "list_agents"
+            ]
+            `shouldBe` replicate 15 True
+        map isInspectionTool
+            [ "run_terminal_cmd"
+            , "search_replace"
+            , "apply_patch"
+            , "task"
+            , "mcp_call"
+            , "mcp__playwright__browser_click"
+            ]
+            `shouldBe` replicate 6 False
+
     it "shows filesystem paths relative to the workspace" do
         let workspace =
                 "/Users/marc/.haskell-agent/worktrees/haskell-agent/wt"

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -22,13 +22,14 @@ spec = describe "tool presentation" do
             , "ToolSearch"
             , "read_tool_output"
             , "mcp_search"
+            , "search_tool"
             , "database_query"
             , "conversation_search"
             , "view_skill"
             , "read_agent_session"
             , "list_agents"
             ]
-            `shouldBe` replicate 15 True
+            `shouldBe` replicate 16 True
         map isInspectionTool
             [ "run_terminal_cmd"
             , "search_replace"


### PR DESCRIPTION
## Summary
- classify inspection-oriented tool calls after canonical alias resolution
- render `◇` for inspection activity and `◆` for thought/action activity in fullscreen and append-only CLI output
- retain distinct completion, failure, and cancellation markers while adding regression coverage

## Testing
- full `agent-tui` suite in GHCi — 205 examples passed
- focused CLI renderer and style specs in GHCi — 7 examples passed after rebase
- live tmux TTY smoke check covering read, search, thought, and edit output
