### PR TITLE
Keep file edit diffs visible after completion

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -121,7 +121,7 @@ import Agent.TUI.Presentation
     , parseSearchReplaceDiff
     , summarizeToolCall
     , summarizeToolCallRelative
-    , toolCallDiff
+    , toolCallDiffs
     , toolDetail
     , toolVerb
     , workspaceRelativeDisplayPath
@@ -866,7 +866,9 @@ formatToolBody color = formatToolBodyRelative color ""
 formatToolBodyRelative :: Bool -> Text -> ToolCall -> Text
 formatToolBodyRelative color workspace call = case canonicalToolName call.name of
     "exec" -> roleToolCommand color call.arguments
-    _ -> maybe "" (paintDiffRelative color workspace) (toolCallDiff call)
+    _ ->
+        Text.intercalate "\n" $
+            map (paintDiffRelative color workspace) (toolCallDiffs call)
 
 -- | Compact unified-diff preview for @search_replace@ arguments.
 formatSearchReplaceDiff :: Bool -> Text -> Text
@@ -890,6 +892,14 @@ paintDiffRelative color workspace diff =
             Just SearchReplaceWrite ->
                 roleMuted color "  write "
                     <> renderToolPath color workspace diffPath
+            Just SearchReplaceUpdate ->
+                roleMuted color "  update "
+                    <> renderToolPath color workspace diffPath
+            Just (SearchReplaceMove destination) ->
+                roleMuted color "  move "
+                    <> renderToolPath color workspace diffPath
+                    <> roleMuted color " → "
+                    <> renderToolPath color workspace destination
             Nothing -> ""
         shown = map paintLine diffLines
         more =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -142,7 +142,8 @@ import qualified Agent.CLI.TUI.Scroll as Scroll ()
 import qualified Data.Sequence as Seq ()
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text
-    ( lines,
+    ( isPrefixOf,
+      lines,
       null,
       strip,
       unlines,
@@ -270,7 +271,7 @@ drawBlock state target ui block =
                     (visibleShellBody block)
                     (toolImageSections state target block)
             BlockEdit ->
-                accentBlock
+                accentBlockWithSections
                     state
                     target
                     ui
@@ -280,7 +281,7 @@ drawBlock state target ui block =
                     (blockStateGlyph state target block
                         <> block.blockTitle
                         <> detailSuffix block)
-                    (visibleBody block)
+                    (editBodyWidgets (visibleBody block))
             BlockSystem ->
                 withAttr Theme.mutedAttr
                     (terminalTxtWrap block.blockBody)
@@ -510,24 +511,25 @@ blockStateGlyph state target block = case block.blockState of
                 state.appMotionElapsedMillis
                 <> " "
 
-accentBlock
-    :: AppState
-    -> AgentTarget
-    -> UiState
-    -> UiBlock
-    -> Maybe Int
-    -> AttrName
-    -> Text
-    -> Text
-    -> Widget Name
-accentBlock state target ui block waveElapsed accent title body =
-    accentBlockWithSections state target ui block waveElapsed accent title
-        (bodySections body)
-
 bodySections :: Text -> [Widget Name]
 bodySections body
     | Text.null (Text.strip body) = []
     | otherwise = [terminalTxtWrap body]
+
+editBodyWidgets :: Text -> [Widget Name]
+editBodyWidgets body
+    | Text.null (Text.strip body) = []
+    | otherwise = [vBox (map editLineWidget (Text.lines body))]
+  where
+    editLineWidget line
+        | "  -" `Text.isPrefixOf` line =
+            withAttr Theme.errorAttr (terminalTxtWrap line)
+        | "  +" `Text.isPrefixOf` line =
+            withAttr Theme.successAttr (terminalTxtWrap line)
+        | "  …" `Text.isPrefixOf` line
+            || "… +" `Text.isPrefixOf` line =
+                withAttr Theme.mutedAttr (terminalTxtWrap line)
+        | otherwise = terminalTxtWrap line
 
 accentMarkdownBlock
     :: AppState

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -379,6 +379,23 @@ spec = do
                 `shouldSatisfy` Text.isInfixOf "delete src/Old.hs"
 
     describe "formatToolBody" do
+        it "renders compact multi-file apply_patch diffs" do
+            let patch =
+                    "*** Begin Patch\n\
+                    \*** Update File: src/A.hs\n\
+                    \@@\n\
+                    \-old\n\
+                    \+new\n\
+                    \*** Add File: src/B.hs\n\
+                    \+created\n\
+                    \*** End Patch"
+            formatToolBody False (customToolCall "patch" "apply_patch" patch)
+                `shouldBe`
+                    "  -old\n\
+                    \  +new\n\
+                    \  create src/B.hs\n\
+                    \  +created"
+
         it "does not dump todo_write arguments into linear chrome" do
             formatToolBody False
                 (functionToolCall

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -667,16 +667,22 @@ timestampNewMessageBlocks firstNewIndex timestamp state
                     state.uiBlocks
             }
 
-completeTool :: Int -> ToolCallResult -> UiState -> UiState
-completeTool blockIndex result state =
-    state
+completeTool :: Int -> ToolCall -> ToolCallResult -> UiState -> UiState
+completeTool blockIndex call result state =
+    let resultState = toolResultState result.output
+        diff = formatToolDiffRelative state.uiWorkspaceRoot call
+        body
+            | resultState == BlockComplete
+            , not (Text.null (Text.strip diff)) = diff
+            | otherwise = result.output
+    in state
         { uiBlocks =
             Seq.adjust
                 (\block ->
                     if block.blockCallId == Just result.callId
                         then block
-                            { blockBody = result.output
-                            , blockState = toolResultState result.output
+                            { blockBody = body
+                            , blockState = resultState
                             }
                         else block)
                 blockIndex
@@ -730,7 +736,7 @@ finishVisibleTool result state =
                 reconcileVisibleShellContinuation
                     call
                     result
-                    (completeTool blockIndex displayed next)
+                    (completeTool blockIndex call displayed next)
             | blockIndex < Seq.length state.uiBlocks
             , isShellProcessTool call.name
             , Just (sessionId, output) <-
@@ -738,7 +744,7 @@ finishVisibleTool result state =
             , Map.notMember sessionId next.uiShellProcesses ->
                 retainRunningShell blockIndex sessionId output next
             | blockIndex < Seq.length state.uiBlocks ->
-                completeTool blockIndex displayed next
+                completeTool blockIndex call displayed next
         Just _ -> next
 
 trackedShellOwner :: ToolCall -> UiState -> Maybe BlockId

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -12,6 +12,7 @@ module Agent.TUI.Presentation
     , formatToolOutput
     , formatToolOutputRelative
     , liveTodoPanelLines
+    , parseApplyPatchDiffs
     , parseSearchReplaceDiff
     , parseWriteFileDiff
     , parseTodoList
@@ -29,6 +30,7 @@ module Agent.TUI.Presentation
     , toolCallTitle
     , toolCallTitleRelative
     , toolCallDiff
+    , toolCallDiffs
     , toolDetail
     , toolPathArgument
     , toolVerb
@@ -127,6 +129,10 @@ data SearchReplaceAction
     | SearchReplaceDelete
     -- | Whole-file write where the previous contents are unknown.
     | SearchReplaceWrite
+    -- | One file in a potentially multi-file patch was updated.
+    | SearchReplaceUpdate
+    -- | A patch moved a file to the given destination.
+    | SearchReplaceMove !Text
     deriving (Eq, Show)
 
 data SearchReplaceLine
@@ -178,12 +184,95 @@ parseWriteFileDiff arguments =
         , diffHiddenLines = length raw - length shown
         }
 
--- | Diff preview carried by a tool call's arguments, when the tool has one.
+-- | Compact previews parsed from Codex's freeform @apply_patch@ language.
+-- The execution parser lives in the Codex dialect package, which depends on
+-- this presentation package, so this deliberately permissive parser only
+-- extracts file boundaries and changed lines for display.
+parseApplyPatchDiffs :: Text -> [SearchReplaceDiff]
+parseApplyPatchDiffs patch =
+    case Text.lines (Text.strip patch) of
+        first : rest
+            | Text.strip first == "*** Begin Patch" ->
+                suppressFirstUpdateHeader (parseHunks (dropEnvironment rest))
+        _ -> []
+  where
+    dropEnvironment (line : rest)
+        | "*** Environment ID:" `Text.isPrefixOf` Text.strip line = rest
+    dropEnvironment lines_ = lines_
+
+    parseHunks [] = []
+    parseHunks (line : rest)
+        | Just path <- patchPath "*** Add File: " line =
+            let (body, remaining) = span (not . patchBoundary) rest
+            in makeDiff path (Just SearchReplaceCreate)
+                    (mapMaybe addedLine body)
+                : parseHunks remaining
+        | Just path <- patchPath "*** Delete File: " line =
+            makeDiff path (Just SearchReplaceDelete) []
+                : parseHunks rest
+        | Just path <- patchPath "*** Update File: " line =
+            let (body, remaining) = span (not . patchBoundary) rest
+                (action, changes) = case body of
+                    moveLine : more
+                        | Just destination <-
+                            patchPath "*** Move to: " moveLine ->
+                                (Just (SearchReplaceMove destination), more)
+                    _ -> (Just SearchReplaceUpdate, body)
+            in makeDiff path action (mapMaybe changedLine changes)
+                : parseHunks remaining
+        | otherwise = parseHunks rest
+
+    suppressFirstUpdateHeader = \case
+        diff : rest
+            | diff.diffAction == Just SearchReplaceUpdate ->
+                diff { diffAction = Nothing } : rest
+        diffs -> diffs
+
+    makeDiff path action raw =
+        let shown = take 20 raw
+        in SearchReplaceDiff
+            { diffPath = path
+            , diffAction = action
+            , diffLines = shown
+            , diffHiddenLines = length raw - length shown
+            }
+
+    patchBoundary line =
+        any (`Text.isPrefixOf` line)
+            [ "*** Add File: "
+            , "*** Delete File: "
+            , "*** Update File: "
+            , "*** End Patch"
+            ]
+
+    patchPath prefix line =
+        nonEmptyText =<< Text.stripPrefix prefix line
+
+    addedLine line = case Text.uncons line of
+        Just ('+', text) -> Just (SearchReplaceAdded text)
+        _ -> Nothing
+
+    changedLine line = case Text.uncons line of
+        Just ('-', text) -> Just (SearchReplaceRemoved text)
+        Just ('+', text) -> Just (SearchReplaceAdded text)
+        _ -> Nothing
+
+    nonEmptyText text =
+        let stripped = Text.strip text
+        in if Text.null stripped then Nothing else Just stripped
+
+-- | Diff previews carried by a tool call's arguments.
+toolCallDiffs :: ToolCall -> [SearchReplaceDiff]
+toolCallDiffs call = case canonicalToolName call.name of
+    "search_replace" -> [parseSearchReplaceDiff call.arguments]
+    "apply_patch" -> parseApplyPatchDiffs call.arguments
+    "Write" -> [parseWriteFileDiff call.arguments]
+    _ -> []
+
+-- | First diff preview carried by a tool call, retained for callers that only
+-- need to identify whether a preview exists.
 toolCallDiff :: ToolCall -> Maybe SearchReplaceDiff
-toolCallDiff call = case canonicalToolName call.name of
-    "search_replace" -> Just (parseSearchReplaceDiff call.arguments)
-    "Write" -> Just (parseWriteFileDiff call.arguments)
-    _ -> Nothing
+toolCallDiff = listToMaybe . toolCallDiffs
 
 formatSearchReplaceDiff :: Text -> Text
 formatSearchReplaceDiff = formatSearchReplaceDiffRelative ""
@@ -195,7 +284,8 @@ formatSearchReplaceDiffRelative workspace arguments =
 -- | Diff body for a tool block; empty when the tool carries no diff.
 formatToolDiffRelative :: Text -> ToolCall -> Text
 formatToolDiffRelative workspace call =
-    maybe "" (formatDiffRelative workspace) (toolCallDiff call)
+    Text.intercalate "\n" $
+        map (formatDiffRelative workspace) (toolCallDiffs call)
 
 formatDiffRelative :: Text -> SearchReplaceDiff -> Text
 formatDiffRelative workspace diff =
@@ -206,6 +296,12 @@ formatDiffRelative workspace diff =
             Just SearchReplaceCreate -> "  create " <> displayedPath
             Just SearchReplaceDelete -> "  delete " <> displayedPath
             Just SearchReplaceWrite -> "  write " <> displayedPath
+            Just SearchReplaceUpdate -> "  update " <> displayedPath
+            Just (SearchReplaceMove destination) ->
+                "  move "
+                    <> displayedPath
+                    <> " → "
+                    <> workspaceRelativeDisplayPath workspace destination
             Nothing -> ""
         shown = map formatLine diffLines
         more

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1273,7 +1273,7 @@ spec = describe "fullscreen UI reducer" do
         finished.uiRetryCountdown `shouldBe` Nothing
         uiNeedsTick finished `shouldBe` False
 
-    it "shows worktree-relative paths for edits" do
+    it "keeps worktree-relative diffs after successful edits" do
         let workspace =
                 "/Users/marc/.haskell-agent/worktrees/haskell-agent/wt"
             path = workspace <> "/nix/modules/telegram.nix"
@@ -1309,31 +1309,73 @@ spec = describe "fullscreen UI reducer" do
                     `shouldBe` "Edited nix/modules/telegram.nix"
             _ -> expectationFailure "expected one running edit block"
         case Foldable.toList finished.uiBlocks of
-            [block] ->
+            [block] -> do
                 block.blockBody
-                    `shouldBe`
-                        "The file nix/modules/telegram.nix has been updated successfully."
+                    `shouldBe` "  -old\n  +new"
+                block.blockState `shouldBe` BlockComplete
             _ -> expectationFailure "expected one completed edit block"
 
-    it "shows a search-replace diff while the tool is running" do
+    it "shows an apply_patch diff while running and after completion" do
         let call =
-                functionToolCall
-                    "edit-1"
-                    "search_replace"
-                    "{\"file_path\":\"A.hs\",\"old_string\":\"old\",\"new_string\":\"new\"}"
-            blocks =
-                Foldable.toList $
-                    (.uiBlocks) $
-                        apply
-                            [ UiLoop TurnStarted
-                            , UiLoop (ToolStarted call)
-                            ]
-        case blocks of
+                customToolCall
+                    "patch-1"
+                    "apply_patch"
+                    "*** Begin Patch\n\
+                    \*** Update File: A.hs\n\
+                    \@@\n\
+                    \-old\n\
+                    \+new\n\
+                    \*** End Patch"
+            started =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    ]
+            finished =
+                reduceUi
+                    (UiLoop
+                        (ToolFinished
+                            ToolCallResult
+                                { callId = "patch-1"
+                                , output = "Updated A.hs"
+                                , callKind = CustomCallKind
+                                }))
+                    started
+        case Foldable.toList started.uiBlocks of
             [block] -> do
                 block.blockKind `shouldBe` BlockEdit
                 block.blockBody `shouldSatisfy` Text.isInfixOf "-old"
                 block.blockBody `shouldSatisfy` Text.isInfixOf "+new"
             _ -> expectationFailure "expected one running edit block"
+        case Foldable.toList finished.uiBlocks of
+            [block] -> do
+                block.blockBody `shouldBe` "  -old\n  +new"
+                block.blockState `shouldBe` BlockComplete
+            _ -> expectationFailure "expected one completed edit block"
+
+    it "replaces a preview with the error when an edit fails" do
+        let call =
+                functionToolCall
+                    "edit-failed"
+                    "search_replace"
+                    "{\"file_path\":\"A.hs\",\"old_string\":\"old\",\"new_string\":\"new\"}"
+            failed =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    , UiLoop
+                        (ToolFinished
+                            ToolCallResult
+                                { callId = "edit-failed"
+                                , output = "Error: stale edit"
+                                , callKind = FunctionCallKind
+                                })
+                    ]
+        case Foldable.toList failed.uiBlocks of
+            [block] -> do
+                block.blockBody `shouldBe` "Error: stale edit"
+                block.blockState `shouldBe` BlockFailed
+            _ -> expectationFailure "expected one failed edit block"
 
     it "keeps todo_write in a live panel instead of scrollback" do
         let call =

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -267,6 +267,46 @@ spec = describe "tool presentation" do
         length parsed.diffLines `shouldBe` 20
         parsed.diffHiddenLines `shouldBe` 10
 
+    it "formats compact multi-file apply_patch diffs" do
+        let workspace = "/workspace"
+            patch =
+                Text.unlines
+                    [ "*** Begin Patch"
+                    , "*** Update File: /workspace/src/A.hs"
+                    , "@@"
+                    , " *** Add File: this-is-context"
+                    , "-old"
+                    , "+new"
+                    , "*** Add File: /workspace/src/B.hs"
+                    , "+one"
+                    , "*** Update File: /workspace/src/Old.hs"
+                    , "*** Move to: /workspace/src/New.hs"
+                    , "@@"
+                    , "-before"
+                    , "+after"
+                    , "*** Delete File: /workspace/src/C.hs"
+                    , "*** End Patch"
+                    ]
+            call = customToolCall "patch" "apply_patch" patch
+            parsed = parseApplyPatchDiffs patch
+        map (.diffAction) parsed
+            `shouldBe`
+                [ Nothing
+                , Just SearchReplaceCreate
+                , Just (SearchReplaceMove "/workspace/src/New.hs")
+                , Just SearchReplaceDelete
+                ]
+        formatToolDiffRelative workspace call
+            `shouldBe`
+                "  -old\n\
+                \  +new\n\
+                \  create src/B.hs\n\
+                \  +one\n\
+                \  move src/Old.hs → src/New.hs\n\
+                \  -before\n\
+                \  +after\n\
+                \  delete src/C.hs"
+
     it "formats structured collaboration output" do
         let call = functionToolCall
                 "agents" "collaboration.list_agents" "{}"


### PR DESCRIPTION
## Summary
- parse compact diff previews for `apply_patch`, `search_replace`, and Claude `Write` tool calls
- keep edit diffs visible after successful tool completion, including multi-file add/delete/update/move patches
- color added and removed lines in the TUI and cover the behavior with presentation, model, and CLI tests

## Verification
- `agent-tui:test:agent-tui-test`: 203 examples, 0 failures
- focused `Agent.CLI.RenderSpec`: 70 examples, 0 failures
- live TUI smoke test confirmed the diff remains visible after completion