### PR TITLE
Notify terminal for secret requests

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Notification.hs
+++ b/packages/agent-cli/src/Agent/CLI/Notification.hs
@@ -22,6 +22,7 @@ data AttentionRequest
     = InputRequested
     | PermissionRequested
     | PlanModeRequested
+    | SecretRequested
     deriving (Eq, Show)
 
 attentionNotificationSequence :: AttentionRequest -> Text
@@ -33,6 +34,7 @@ notificationTitle = \case
     InputRequested -> "Haskell Agent: input requested"
     PermissionRequested -> "Haskell Agent: permission required"
     PlanModeRequested -> "Haskell Agent: plan mode requested"
+    SecretRequested -> "Haskell Agent: secret requested"
 
 -- | Notify only when the destination is a TTY, keeping pipes and redirected
 -- stderr free of terminal control sequences. Notification failures must never

--- a/packages/agent-cli/src/Agent/CLI/Secret.hs
+++ b/packages/agent-cli/src/Agent/CLI/Secret.hs
@@ -7,7 +7,7 @@ module Agent.CLI.Secret
 
 import Agent.CLI.CancelWatch (withStdinPaused)
 import Agent.CLI.Notification
-    ( AttentionRequest(InputRequested)
+    ( AttentionRequest(SecretRequested)
     , notifyAttention
     )
 import Control.Exception.Safe (bracket_, finally, tryIO)
@@ -41,7 +41,7 @@ promptSecretLine escPaused prompt purpose =
         if not tty
             then pure Nothing
             else do
-                notifyAttention stderr InputRequested
+                notifyAttention stderr SecretRequested
                 Text.hPutStr stderr (secretPromptMessage prompt purpose)
                 hFlush stderr
                 result <-

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -148,7 +148,7 @@ import Control.Concurrent (threadDelay)
 import Control.Monad (forever, unless, void, when, (>=>))
 import Control.Concurrent.STM ( STM , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
 import Agent.CLI.Notification
-    ( AttentionRequest(PermissionRequested)
+    ( AttentionRequest(PermissionRequested, SecretRequested)
     , notifyAttention
     )
 import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoRecapRetryInterval )
@@ -960,6 +960,7 @@ requestFullscreenSecret
     -> IO (Maybe Text)
 requestFullscreenSecret runtime title body = do
     reply <- newEmptyTMVarIO
+    notifyAttention stderr SecretRequested
     enqueueAppEvent runtime
         (AppAskText
             TextInputSecret

--- a/packages/agent-cli/test/Agent/CLI/NotificationSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NotificationSpec.hs
@@ -17,3 +17,7 @@ spec =
         it "distinguishes plan-mode requests" do
             attentionNotificationSequence PlanModeRequested
                 `shouldBe` "\ESC]9;Haskell Agent: plan mode requested\ESC\\"
+
+        it "distinguishes secret requests" do
+            attentionNotificationSequence SecretRequested
+                `shouldBe` "\ESC]9;Haskell Agent: secret requested\ESC\\"


### PR DESCRIPTION
## Summary
- add a dedicated terminal attention notification for secret prompts
- trigger it from both line-mode and fullscreen secret requests
- cover the OSC 9 notification sequence

## Validation
- focused GHCi notification sequence check
- real-TTY tmux smoke test, including tmux passthrough bytes
- `git diff --check`