### PR TITLE
Print resume command when exiting empty sessions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -86,6 +86,7 @@ import Agent.CLI.Secret ()
 import Agent.CLI.Session
     ( addSessionUsage,
       ensureSession,
+      ensurePersistenceSessionId,
       compatibleSessionPromptSnapshot,
       resumeHint,
       sessionTitleFromPrompt,
@@ -93,7 +94,7 @@ import Agent.CLI.Session
       Persistence(..),
       PersistenceState(PersistenceActive, PersistencePending),
       LegacySubagentTarget,
-      SessionHandle(sessionMeta, sessionDir),
+      SessionHandle(sessionDir),
       SessionMeta(metaId, metaLastResponseId, metaPromptSnapshot, metaTitle),
       SessionTurn,
       SessionPromptSnapshot(..) )
@@ -895,16 +896,13 @@ printResumeHint
     :: String
     -> Persistence
     -> IO ()
-printResumeHint progName = \case
-    PersistenceDisabled -> pure ()
-    PersistenceEnabled slotRef -> do
-        slot <- readIORef slotRef
-        case slot of
-            PersistencePending _ _ _ -> pure ()
-            PersistenceActive handle -> do
-                -- Drop an in-place "Thinking…" status so the hint is its own line.
-                Text.hPutStr stderr "\r\ESC[K"
-                clearNativeProgress stderr
-                color <- resolveColor stderr
-                putTextLn stderr
-                    (roleMuted color (resumeHint progName handle.sessionMeta.metaId))
+printResumeHint progName persist =
+    ensurePersistenceSessionId persist >>= \case
+        Nothing -> pure ()
+        Just sessionId -> do
+            -- Drop an in-place "Thinking…" status so the hint is its own line.
+            Text.hPutStr stderr "\r\ESC[K"
+            clearNativeProgress stderr
+            color <- resolveColor stderr
+            putTextLn stderr
+                (roleMuted color (resumeHint progName sessionId))

--- a/packages/agent-cli/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session.hs
@@ -76,6 +76,7 @@ module Agent.CLI.Session
     , writeSessionMeta
     , compatibleSessionPromptSnapshot
     , ensureSession
+    , ensurePersistenceSessionId
     , ensureSessionWithPromptSnapshot
     , resumeHint
     , sessionUsageFromTurns
@@ -713,6 +714,13 @@ ensureSession slotRef = do
             handle <- createReservedSession spec sessionId tempDir Nothing
             writeIORef slotRef (PersistenceActive handle)
             pure handle
+
+-- | Return a durable, resumable session ID, materializing pending persistence.
+ensurePersistenceSessionId :: Persistence -> IO (Maybe Text)
+ensurePersistenceSessionId PersistenceDisabled = pure Nothing
+ensurePersistenceSessionId (PersistenceEnabled slotRef) = do
+    handle <- ensureSession slotRef
+    pure (Just handle.sessionMeta.metaId)
 
 -- | Ensure the durable session exists and atomically persist the
 -- provider-visible request prefix before it can be sent. Subsequent calls only

--- a/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionSpec.hs
@@ -1325,21 +1325,23 @@ spec = describe "Agent.CLI.Session" do
                 loadSession pool root sessionId
                     `shouldReturn` Right (meta, [turn])
 
-        it "keeps pending persistence lazy" $
+        it "materializes pending persistence into a resumable session ID" $
             withTempStore \store root -> do
                 let pool = trustedPool store
-                PersistenceEnabled slot <-
+                persist@(PersistenceEnabled slot) <-
                     newPendingPersistence (testCreate pool root)
                 listDirectory root `shouldReturn` []
                 PersistencePending _ reservedId tempDir <- readIORef slot
                 doesDirectoryExist tempDir `shouldReturn` True
                 modeOf tempDir `shouldReturn` 0o700
-                handle <- ensureSession slot
+                ensurePersistenceSessionId persist
+                    `shouldReturn` Just reservedId
+                PersistenceActive handle <- readIORef slot
                 doesDirectoryExist handle.sessionDir `shouldReturn` True
                 handle.sessionMeta.metaId `shouldBe` reservedId
                 handle.sessionTempDir `shouldBe` tempDir
-                PersistenceActive again <- readIORef slot
-                again.sessionMeta.metaId `shouldBe` handle.sessionMeta.metaId
+                loadSession pool root reservedId
+                    `shouldReturn` Right (handle.sessionMeta, [])
 
         it "creates and advances immutable prompt epochs before first use" $
             withTempStore \store root -> do


### PR DESCRIPTION
## Summary
- materialize pending session persistence before printing the exit footer
- print a real, durable session ID even when Ctrl+C exits before the first turn
- cover pending-to-active persistence and PostgreSQL reload in a regression test

## Testing
- `nix develop ... -c cabal repl agent-cli-test`
  - `Agent.CLI.Session / PostgreSQL session persistence / materializes pending persistence into a resumable session ID`
  - 1 example, 0 failures
- tmux: reproduced the old missing footer, then verified the fix prints:
  - `Resume this session with: 'agent-cli' --resume 2026-08-31-b780397d`
- tmux: ran the emitted resume command and confirmed:
  - `session: 2026-08-31-b780397d (resumed)`