### PR TITLE
Improve terminal color hierarchy

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Render.hs
@@ -81,20 +81,31 @@ slashMenuWindowStart visible count selected
 
 drawSlashRow :: Int -> Int -> SlashSuggestion -> Widget Name
 drawSlashRow selected index suggestion =
-    let prefix = if selected == index then "❯ " else "  "
+    let isSelected = selected == index
+        prefix = if isSelected then "❯ " else "  "
+        rowAttr =
+            if isSelected
+                then Theme.selectedMutedAttr
+                else Theme.assistantAttr
+        commandAttr =
+            if isSelected
+                then Theme.selectedAttr
+                else Theme.assistantAttr
+        summaryAttr =
+            if isSelected
+                then Theme.selectedMutedAttr
+                else Theme.mutedAttr
         row =
-            hBox
-                [ terminalTxt
-                    (prefix <> suggestion.slashSuggestionDisplay)
-                , vLimit 1 (fill ' ')
-                , withAttr Theme.mutedAttr
-                    (terminalTxt suggestion.slashSuggestionSummary)
-                ]
-        styled =
-            if selected == index
-                then withAttr Theme.selectedAttr row
-                else row
-    in clickable (SlashRow index) styled
+            withAttr rowAttr $
+                hBox
+                    [ withAttr commandAttr $
+                        terminalTxt
+                            (prefix <> suggestion.slashSuggestionDisplay)
+                    , vLimit 1 (fill ' ')
+                    , withAttr summaryAttr
+                        (terminalTxt suggestion.slashSuggestionSummary)
+                    ]
+    in clickable (SlashRow index) row
 
 drawQueuedInputs :: UiState -> Widget Name
 drawQueuedInputs state =
@@ -160,7 +171,7 @@ drawComposer appState =
                         hBox
                             [ withAttr
                                 (if focused
-                                    then Theme.borderActiveAttr
+                                    then Theme.headerAttr
                                     else Theme.mutedAttr)
                                 (txt "❯ ")
                             , withAttr Theme.assistantAttr

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -22,6 +22,7 @@ module Agent.TUI.Theme
     , linkAttr
     , mutedAttr
     , selectedAttr
+    , selectedMutedAttr
     , strongAttr
     , successAttr
     , syntaxAnnotationAttr
@@ -79,7 +80,7 @@ import Graphics.Vty.Attributes.Color (Color(..))
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
 userAttr, userMutedAttr, assistantAttr, thinkingAttr, thinkingBodyAttr, toolAttr :: AttrName
 todoPendingAttr, todoInProgressAttr, todoCompletedAttr, todoCancelledAttr :: AttrName
-errorAttr, successAttr, selectedAttr, borderAttr, borderActiveAttr :: AttrName
+errorAttr, successAttr, selectedAttr, selectedMutedAttr, borderAttr, borderActiveAttr :: AttrName
 headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
 lambdaDimAttr, lambdaTrailAttr, lambdaGlowAttr, lambdaSparkAttr :: AttrName
@@ -105,6 +106,7 @@ todoCancelledAttr = attrName "todo-cancelled"
 errorAttr = attrName "error"
 successAttr = attrName "success"
 selectedAttr = attrName "selected"
+selectedMutedAttr = attrName "selected-muted"
 borderAttr = attrName "border"
 borderActiveAttr = attrName "border-active"
 headingAttr = attrName "markdown-heading"
@@ -164,8 +166,8 @@ terminalDefault =
         , (headerAttr, V.defAttr `V.withStyle` V.bold)
         , (footerAttr, palette V.brightBlack)
         , (mutedAttr, palette V.brightBlack)
-        , (userAttr, userPanelAttr `V.withStyle` V.bold)
-        , (userMutedAttr, userPanelAttr `V.withStyle` V.dim)
+        , (userAttr, raisedPanelAttr `V.withStyle` V.bold)
+        , (userMutedAttr, raisedPanelMutedAttr)
         , (assistantAttr, V.defAttr)
         , (thinkingAttr, palette V.yellow)
         , (thinkingBodyAttr, palette V.brightBlack `V.withStyle` (V.dim .|. V.italic))
@@ -180,9 +182,10 @@ terminalDefault =
         , (successAttr, palette V.green)
         , (completionFlashAttr,
             palette V.brightGreen `V.withStyle` V.bold)
-        , (selectedAttr, V.defAttr `V.withStyle` V.reverseVideo)
-        , (borderAttr, palette V.brightBlack)
-        , (borderActiveAttr, V.defAttr)
+        , (selectedAttr, raisedPanelAttr `V.withStyle` V.bold)
+        , (selectedMutedAttr, raisedPanelMutedAttr)
+        , (borderAttr, palette V.brightBlack `V.withStyle` V.dim)
+        , (borderActiveAttr, palette V.brightBlack)
         , (headingAttr, palette V.magenta `V.withStyle` V.bold)
         , (codeAttr, palette V.cyan)
         , (dimAttr, palette V.brightBlack)
@@ -197,7 +200,8 @@ terminalDefault =
         , (strongAttr, V.defAttr `V.withStyle` V.bold)
         , (controlLinkAttr, palette V.brightBlack)
         , (controlLinkHoverAttr, V.defAttr `V.withStyle` V.underline)
-        , (controlLinkActiveAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (controlLinkActiveAttr,
+            raisedPanelAttr `V.withStyle` V.bold)
         , (syntaxNormalAttr, palette V.cyan)
         , (syntaxKeywordAttr, palette V.magenta)
         , (syntaxTypeAttr, palette V.yellow)
@@ -238,9 +242,11 @@ monochrome =
         , (errorAttr, V.defAttr `V.withStyle` V.bold)
         , (successAttr, V.defAttr)
         , (completionFlashAttr, V.defAttr `V.withStyle` V.bold)
-        , (selectedAttr, V.defAttr `V.withStyle` V.reverseVideo)
-        , (borderAttr, V.defAttr)
-        , (borderActiveAttr, V.defAttr `V.withStyle` V.bold)
+        , (selectedAttr, V.defAttr
+            `V.withStyle` (V.bold .|. V.reverseVideo))
+        , (selectedMutedAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (borderAttr, V.defAttr `V.withStyle` V.dim)
+        , (borderActiveAttr, V.defAttr)
         , (headingAttr, V.defAttr `V.withStyle` V.bold)
         , (codeAttr, V.defAttr)
         , (dimAttr, V.defAttr)
@@ -276,11 +282,20 @@ monochrome =
 palette :: V.Color -> V.Attr
 palette = V.withForeColor V.defAttr
 
--- | User-prompt panel: a full-width wash one step off the page background.
--- Bright black is the ANSI gray slot, so Ghostty light/dark palettes keep
--- the card readable without fixing an RGB background.
-userPanelAttr :: V.Attr
-userPanelAttr = V.withBackColor V.defAttr V.brightBlack
+-- | A raised neutral surface made entirely from terminal palette slots.
+-- Bright black supplies the surface, while the white slots stay readable on
+-- themes whose default foreground is itself a muted gray.
+raisedPanelAttr :: V.Attr
+raisedPanelAttr =
+    V.defAttr
+        `V.withForeColor` V.brightWhite
+        `V.withBackColor` V.brightBlack
+
+raisedPanelMutedAttr :: V.Attr
+raisedPanelMutedAttr =
+    V.defAttr
+        `V.withForeColor` V.white
+        `V.withBackColor` V.brightBlack
 
 -- | Default dark-page trough (#24283b). Live rails blend toward this so the
 -- bar nearly vanishes when @COLORFGBG@ is unavailable.

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -13,7 +13,7 @@ import Test.Hspec
 spec :: Spec
 spec = do
     describe "structural theme attributes" do
-        it "uses the terminal ANSI palette without fixing a background" do
+        it "uses terminal ANSI slots rather than fixed RGB colors" do
             map terminalForeground
                 [ Theme.borderActiveAttr
                 , Theme.controlLinkAttr
@@ -23,17 +23,21 @@ spec = do
                 , Theme.lambdaTrailAttr
                 , Theme.lambdaGlowAttr
                 , Theme.lambdaSparkAttr
+                , Theme.selectedAttr
+                , Theme.selectedMutedAttr
                 , Theme.todoPendingAttr
                 ]
                 `shouldBe`
-                    [ V.Default
+                    [ V.SetTo V.brightBlack
                     , V.SetTo V.brightBlack
                     , V.Default
-                    , V.Default
+                    , V.SetTo V.brightWhite
                     , V.SetTo V.brightBlack
                     , V.SetTo V.brightBlack
                     , V.Default
                     , V.SetTo V.brightWhite
+                    , V.SetTo V.brightWhite
+                    , V.SetTo V.white
                     , V.Default
                     ]
 
@@ -47,19 +51,35 @@ spec = do
                 allSyntaxClasses
                 `shouldBe` replicate (length allSyntaxClasses) V.Default
 
-        it "uses reverse video for selections on light and dark themes" do
-            V.attrStyle
-                (attrMapLookup Theme.selectedAttr Theme.terminalDefault)
-                `shouldBe` V.SetTo V.reverseVideo
+        it "uses a readable neutral panel for selections" do
+            let selected =
+                    attrMapLookup Theme.selectedAttr Theme.terminalDefault
+                selectedMuted =
+                    attrMapLookup Theme.selectedMutedAttr Theme.terminalDefault
+            V.attrForeColor selected `shouldBe` V.SetTo V.brightWhite
+            V.attrBackColor selected `shouldBe` V.SetTo V.brightBlack
+            V.attrStyle selected `shouldBe` V.SetTo V.bold
+            V.attrForeColor selectedMuted `shouldBe` V.SetTo V.white
+            V.attrBackColor selectedMuted `shouldBe` V.SetTo V.brightBlack
+
+        it "keeps idle chrome quieter than focused chrome" do
+            let border = attrMapLookup Theme.borderAttr Theme.terminalDefault
+                active =
+                    attrMapLookup Theme.borderActiveAttr Theme.terminalDefault
+            V.attrForeColor border `shouldBe` V.SetTo V.brightBlack
+            V.attrForeColor active `shouldBe` V.SetTo V.brightBlack
+            V.attrStyle border `shouldBe` V.SetTo V.dim
+            V.attrStyle active `shouldBe` V.Default
 
         it "gives user messages a palette gray panel distinct from assistant messages" do
             let user = attrMapLookup Theme.userAttr Theme.terminalDefault
                 userMuted = attrMapLookup Theme.userMutedAttr Theme.terminalDefault
                 assistant = attrMapLookup Theme.assistantAttr Theme.terminalDefault
+            V.attrForeColor user `shouldBe` V.SetTo V.brightWhite
             V.attrBackColor user `shouldBe` V.SetTo V.brightBlack
+            V.attrForeColor userMuted `shouldBe` V.SetTo V.white
             V.attrBackColor userMuted `shouldBe` V.SetTo V.brightBlack
             V.attrBackColor assistant `shouldBe` V.Default
-            V.attrForeColor userMuted `shouldBe` V.Default
 
         it "does not introduce colors in monochrome mode" do
             map
@@ -77,12 +97,17 @@ spec = do
                         (V.Default, V.Default)
 
         it "does not paint user message panels in monochrome mode" do
-            V.attrBackColor
-                (attrMapLookup Theme.userAttr Theme.monochrome)
-                `shouldBe` V.Default
-            V.attrBackColor
-                (attrMapLookup Theme.userMutedAttr Theme.monochrome)
-                `shouldBe` V.Default
+            map
+                ( \name ->
+                    let attr = attrMapLookup name Theme.monochrome
+                    in (V.attrForeColor attr, V.attrBackColor attr)
+                )
+                [ Theme.userAttr
+                , Theme.userMutedAttr
+                , Theme.selectedAttr
+                , Theme.selectedMutedAttr
+                ]
+                `shouldBe` replicate 4 (V.Default, V.Default)
 
     describe "live accent wave" do
         it "fades a named accent through distinct RGB values" do


### PR DESCRIPTION
## Summary
- improve contrast on raised user and selection surfaces while continuing to inherit the terminal's ANSI palette
- distinguish selected command text from secondary descriptions and make inactive borders quieter
- preserve monochrome behavior and cover the structural theme hierarchy with tests

## Testing
- `printf ':main\n:q\n' | cabal repl agent-tui:agent-tui-test` — 204 examples, 0 failures
- live tmux smoke test of the composer and slash suggestion menu
