### PR TITLE
Add changelog release notes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -269,6 +269,7 @@
                     include = [
                         "app"
                         "cbits"
+                        "data"
                         "eval"
                         "ffi"
                         "include"

--- a/flake.nix
+++ b/flake.nix
@@ -284,6 +284,7 @@
                     include = [
                         "app"
                         "cbits"
+                        "data"
                         "eval"
                         "ffi"
                         "include"

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -11,7 +11,8 @@ maintainer:         marc@digitallyinduced.com
 copyright:          (c) 2026 digitally induced GmbH
 category:           Development
 build-type:         Simple
-data-files:         skills/add-model/SKILL.md
+data-files:         data/CHANGELOG.md
+                  , skills/add-model/SKILL.md
                   , skills/learn-about-user/SKILL.md
                   , skills/post-task-learning-review/SKILL.md
                   , skills/telegram-agent/SKILL.md
@@ -46,6 +47,7 @@ library
                     , Agent.CLI.AgentSessions.Render
                     , Agent.CLI.AgentViewport.Status
                     , Agent.CLI.Approval.Decision
+                    , Agent.CLI.Changelog
                     , Agent.CLI.Command.Types
                     , Agent.CLI.Command.Catalog
                     , Agent.CLI.Command.Instructions

--- a/packages/agent-cli/data/CHANGELOG.md
+++ b/packages/agent-cli/data/CHANGELOG.md
@@ -1,0 +1,11 @@
+# 0.1.0.0 — 2026-09-01
+
+## Features
+
+- **Release notes** are now available from `/changelog` and the start screen.
+- **Secret requests** now notify the terminal when the agent needs sensitive input.
+- **Plan questions** now accept custom replies in addition to predefined choices.
+
+## Bug Fixes
+
+- **File edit diffs** remain visible after the edit finishes.

--- a/packages/agent-cli/src/Agent/CLI/Changelog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Changelog.hs
@@ -1,0 +1,17 @@
+-- | Bundled release notes for the interactive changelog.
+module Agent.CLI.Changelog
+    ( loadReleaseNotes
+    ) where
+
+import Control.Exception.Safe (catchAny)
+import Data.Text (Text)
+import qualified Data.Text.IO as Text
+import Paths_agent_cli (getDataFileName)
+
+-- | Load the release notes shipped with this executable. Keeping the notes in
+-- the package makes the changelog available without network access.
+loadReleaseNotes :: IO Text
+loadReleaseNotes = do
+    path <- getDataFileName "data/CHANGELOG.md"
+    Text.readFile path `catchAny` \_ ->
+        pure "No release notes available (offline)."

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -410,6 +410,10 @@ parseSlash catalog raw line = case Text.words line of
                 if null args
                     then ReplShowTerminal
                     else ReplCommandError "usage: /terminal"
+            "changelog" ->
+                if null args
+                    then ReplChangelog
+                    else ReplCommandError "usage: /changelog"
             "agents" -> parseAgentsCommand args
             "mcp" -> case args of
                 [] -> ReplMcp

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -55,6 +55,7 @@ slashCommands =
     , cmd "copy-path" [] "/copy-path" "Copy the active worktree path" False
     , cmd "copy-session" [] "/copy-session" "Copy the current session id" False
     , cmd "terminal" ["ghostty"] "/terminal" "Show detected terminal capabilities" False
+    , cmd "changelog" [] "/changelog" "Show Haskell Agent release notes" False
     , cmd "agents" ["a"] "/agents [limit [N]]" "Browse agents, or show/set the concurrent subagent cap" True
     , cmd "mcp" ["mcps"] "/mcp [prompt <server> <name> [key=value…]]" "Manage MCP servers or run a server prompt" False
     , grokToolCmd "scheduler_create" "loop" [] "/loop [interval] <prompt>" "Run a prompt on a recurring interval" True

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -90,6 +90,7 @@ data ReplAction
     | ReplCopyPath
     | ReplCopySession
     | ReplShowTerminal
+    | ReplChangelog
     | ReplAgents
     | ReplShowAgentLimit
     | ReplSetAgentLimit Int

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -30,7 +30,8 @@ import Agent.CLI.Command
                  ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopy,
                  ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
                  ReplDesktop,
-                 ReplShowTerminal, ReplShowEffort, ReplSetEffort, ReplShowModel,
+                 ReplShowTerminal, ReplChangelog,
+                 ReplShowEffort, ReplSetEffort, ReplShowModel,
                  ReplSetModel, ReplToggleFast, ReplEnableCodeMode,
                  ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
                  ReplViewPlan, ReplQueue, ReplTranscript, ReplEditPrompt,
@@ -849,6 +850,12 @@ handleReplLine
                         let message = formatTerminalCapabilities terminal
                         displayInfo message $
                             Text.putStrLn (roleMuted color message)
+                        continue
+                    ReplChangelog -> do
+                        let message =
+                                "[View the Haskell Agent changelog]\
+                                \(https://github.com/digitallyinduced/haskell-agent/releases)"
+                        displayInfo message (Text.putStrLn message)
                         continue
                     action@ReplShowEffort -> handleSelectionAction env continue action
                     action@ReplSetEffort{} -> handleSelectionAction env continue action

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -15,6 +15,7 @@ import Agent.CLI.AgentViewport
 import Agent.CLI.Approval ( setApprovalPolicy, toggleAlwaysApprove )
 import Agent.CLI.Artifact ( fencedCodeBlock, lastDiffBlock )
 import Agent.CLI.Auth ()
+import Agent.CLI.Changelog (loadReleaseNotes)
 import Agent.CLI.Clipboard ( loadImagesFromPastedText )
 import Agent.CLI.Command
     ( CopyRequest(..),
@@ -213,6 +214,7 @@ import Agent.CLI.TUI.App
       commitFullscreenHistoryTurn,
       emitUiEvent,
       requestFullscreenChoiceWithBody,
+      requestFullscreenDocument,
       requestFullscreenFilterChoice,
       requestFullscreenSecret,
       requestFullscreenText,
@@ -852,10 +854,16 @@ handleReplLine
                             Text.putStrLn (roleMuted color message)
                         continue
                     ReplChangelog -> do
-                        let message =
-                                "[View the Haskell Agent changelog]\
-                                \(https://github.com/digitallyinduced/haskell-agent/releases)"
-                        displayInfo message (Text.putStrLn message)
+                        releaseNotes <- loadReleaseNotes
+                        case fullscreen of
+                            Just runtime -> do
+                                requestFullscreenDocument
+                                    runtime
+                                    "Release Notes"
+                                    releaseNotes
+                            Nothing ->
+                                displayInfo releaseNotes
+                                    (Text.putStrLn releaseNotes)
                         continue
                     action@ReplShowEffort -> handleSelectionAction env continue action
                     action@ReplSetEffort{} -> handleSelectionAction env continue action

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -60,6 +60,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
+    , requestFullscreenDocument
     , requestFullscreenFilterChoice
     , requestFullscreenAdjustableFilterChoice
     , requestFullscreenOnboarding

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -455,29 +455,40 @@ handleChoiceKey event = do
         _ -> handleStaticChoiceKey event
 
 handleStaticChoiceKey :: V.Event -> EventM Name AppState ()
-handleStaticChoiceKey = \case
-    V.EvKey V.KUp [] -> moveChoice (-1)
-    V.EvKey V.KDown [] -> moveChoice 1
-    V.EvKey V.KBackTab [] -> moveChoice (-1)
-    V.EvKey (V.KChar '\t') [] -> moveChoice 1
-    V.EvKey V.KPageUp [] ->
-        vScrollPage (viewportScroll OverlayViewport) Up
-    V.EvKey V.KPageDown [] ->
-        vScrollPage (viewportScroll OverlayViewport) Down
-    V.EvMouseDown _ _ V.BScrollUp _ ->
-        vScrollBy (viewportScroll OverlayViewport) (-mouseScrollLines)
-    V.EvMouseDown _ _ V.BScrollDown _ ->
-        vScrollBy (viewportScroll OverlayViewport) mouseScrollLines
-    V.EvKey V.KEnter [] -> resolveChoice True
-    V.EvKey V.KEsc [] -> resolveChoice False
-    V.EvKey (V.KChar 'q') [] -> resolveChoice False
-    V.EvKey (V.KChar 'c') modifiers
-        | V.MCtrl `elem` modifiers -> do
-            state <- get
-            _ <- handleCtrlC
-            when state.appUi.uiRunning (resolveChoice False)
-    _ -> pure ()
+handleStaticChoiceKey event = do
+    choice <- gets (.appChoice)
+    case (choice, event) of
+        (Just current, V.EvKey V.KUp [])
+            | current.choicePresentation == ChoiceDocument ->
+                scrollNotes (-1)
+        (Just current, V.EvKey V.KDown [])
+            | current.choicePresentation == ChoiceDocument ->
+                scrollNotes 1
+        (_, V.EvKey V.KUp []) -> moveChoice (-1)
+        (_, V.EvKey V.KDown []) -> moveChoice 1
+        (_, V.EvKey V.KBackTab []) -> moveChoice (-1)
+        (_, V.EvKey (V.KChar '\t') []) -> moveChoice 1
+        (_, V.EvKey V.KPageUp []) ->
+            vScrollPage (viewportScroll OverlayViewport) Up
+        (_, V.EvKey V.KPageDown []) ->
+            vScrollPage (viewportScroll OverlayViewport) Down
+        (_, V.EvMouseDown _ _ V.BScrollUp _) ->
+            scrollNotes (-mouseScrollLines)
+        (_, V.EvMouseDown _ _ V.BScrollDown _) ->
+            scrollNotes mouseScrollLines
+        (_, V.EvKey V.KEnter []) -> resolveChoice True
+        (_, V.EvKey V.KEsc []) -> resolveChoice False
+        (_, V.EvKey (V.KChar 'q') []) -> resolveChoice False
+        (_, V.EvKey (V.KChar 'c') modifiers)
+            | V.MCtrl `elem` modifiers -> do
+                state <- get
+                _ <- handleCtrlC
+                when state.appUi.uiRunning (resolveChoice False)
+        _ -> pure ()
   where
+    scrollNotes =
+        vScrollBy (viewportScroll OverlayViewport)
+
     moveChoice delta =
         modify' \state ->
             state

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -626,6 +626,8 @@ activateControl = \case
         Composer.handlePromptControlClick
             applyLocalUiEventWith
             ReplChooseModel
+    QuickStartChangelog ->
+        activateQuickStartCommand "/changelog"
     ChoiceRow index ->
         confirmChoiceAt index
     ResumeRow sessionId ->
@@ -654,6 +656,7 @@ isInteractiveControl = \case
     QuickStartResume -> True
     QuickStartCommands -> True
     QuickStartModel -> True
+    QuickStartChangelog -> True
     ChoiceRow _ -> True
     ResumeRow _ -> True
     CodeCopy _ _ _ -> True
@@ -665,6 +668,7 @@ isQuickStartControl = \case
     QuickStartResume -> True
     QuickStartCommands -> True
     QuickStartModel -> True
+    QuickStartChangelog -> True
     _ -> False
 
 openMarkdownLink :: Text -> EventM Name AppState ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -899,6 +899,19 @@ requestFullscreenChoiceWithBody runtime title body initial rows = do
         (AppAskChoice ChoiceDialog title body initial rows reply)
     atomically (readTMVar reply)
 
+-- | Open a read-only, scrollable Markdown document and wait for dismissal.
+requestFullscreenDocument
+    :: FullscreenRuntime
+    -> Text
+    -> Text
+    -> IO ()
+requestFullscreenDocument runtime title body = do
+    reply <- newEmptyTMVarIO
+    enqueueAppEvent runtime
+        (AppAskChoice ChoiceDocument title body 0 [] reply)
+    _ <- atomically (readTMVar reply)
+    pure ()
+
 -- | Open a choice overlay whose rows can be narrowed by typing. The returned
 -- index always refers to the original row list, even while the visible rows
 -- are filtered.

--- a/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
@@ -24,6 +24,8 @@ import Agent.CLI.AgentViewport
     )
 import Agent.CLI.TUI.Types
     ( AppState(..)
+    , ChoiceOverlay(choicePresentation)
+    , ChoicePresentation(ChoiceDocument)
     , FullscreenRuntime(..)
     , TerminalFocus(..)
     )
@@ -170,7 +172,10 @@ appNextDeadlineMillis state =
 userActionPending :: AppState -> Bool
 userActionPending state =
     isJust state.appTextPrompt
-        || isJust state.appChoice
+        || maybe False
+            (\choice ->
+                choice.choicePresentation /= ChoiceDocument)
+            state.appChoice
         || isJust state.appResume
         || isJust state.appMetaConsole
         || isJust state.appUi.uiPermission

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -65,7 +65,7 @@ import Agent.CLI.TUI.Types
                     choiceAdjustments, choiceAdjustmentIndices),
       choiceVisibleRows,
       selectedChoiceIndex,
-      ChoicePresentation(ChoiceOnboarding, ChoiceDialog),
+      ChoicePresentation(ChoiceOnboarding, ChoiceDialog, ChoiceDocument),
       AppState(appRuntime,
                appDictation, appTextPrompt, appChoice, appMetaConsole,
                appMotionElapsedMillis, appUi, appTerminalFocus),
@@ -129,7 +129,7 @@ import Brick
 import Brick.BChan ()
 import Brick.Widgets.Border ( borderWithLabel )
 import Brick.Widgets.Border.Style ( unicodeRounded )
-import Brick.Widgets.Center ( centerLayer )
+import Brick.Widgets.Center ( centerLayer, hCenter )
 import Codec.Picture ()
 import Control.Applicative ()
 import Control.Concurrent ()
@@ -264,6 +264,8 @@ drawFooter state =
                 ""
             | choice.choiceSearch ->
                 "type to filter  │  ↑↓ navigate  │  Enter choose  │  Esc cancel"
+            | choice.choicePresentation == ChoiceDocument ->
+                "↑↓ scroll  │  PgUp/PgDn pages  │  Esc back"
         (_, Nothing, Just _, _, _, _) ->
             if state.appUi.uiRunning
                 then "↑↓ select  │  Enter choose  │  Esc close  │  Ctrl+C cancel turn"
@@ -522,6 +524,7 @@ drawChoice appState choice
     | choice.choiceSearch = drawFilterChoice appState choice
     | otherwise = case choice.choicePresentation of
         ChoiceDialog -> drawDialogChoice appState choice
+        ChoiceDocument -> drawDialogChoice appState choice
         ChoiceOnboarding -> drawOnboardingChoice appState choice
 
 drawFilterChoice :: AppState -> ChoiceOverlay -> Widget Name
@@ -688,7 +691,13 @@ drawDialogChoice appState choice =
                 overrideAttr Border.borderAttr Theme.borderActiveAttr $
                     withBorderStyle unicodeRounded $
                         borderWithLabel
-                            (waitingOverlayLabel appState choice.choiceTitle) $
+                            ( if choice.choicePresentation == ChoiceDocument
+                                then terminalTxt
+                                    (" " <> choice.choiceTitle <> " ")
+                                else waitingOverlayLabel
+                                    appState
+                                    choice.choiceTitle
+                            ) $
                             padAll 1 $
                                 vBox
                                     [ if Text.null (Text.strip choice.choiceBody)
@@ -710,6 +719,10 @@ drawDialogChoice appState choice =
                                         | (visibleIndex, (originalIndex, row)) <-
                                             zip [start ..] rows
                                         ]
+                                    , if choice.choicePresentation == ChoiceDocument
+                                        then withAttr Theme.footerAttr $
+                                            hCenter (txt "↑/↓ scroll  │  Esc back")
+                                        else emptyWidget
                                     ]
   where
     visible = choiceVisibleRows choice

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
@@ -53,7 +53,7 @@ import Agent.CLI.TUI.Types
       FullscreenRuntime(runtimeColor, runtimeMotionMode),
       Name(QuickStartModel, CodeCopy, ConversationChunkCache,
            ConversationReserve, QuickStartWorktree, QuickStartResume,
-           QuickStartCommands) )
+           QuickStartCommands, QuickStartChangelog) )
 import Agent.CLI.Terminal ()
 import Agent.CLI.Timestamp ()
 import Agent.Loop ()
@@ -453,6 +453,7 @@ quickStartRows =
     , (QuickStartResume, "Resume session", "/resume")
     , (QuickStartCommands, "Browse commands", "/")
     , (QuickStartModel, "Manage models", "/model")
+    , (QuickStartChangelog, "View changelog", "/changelog")
     ]
 
 drawQuickStartDashboard

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -384,6 +384,7 @@ data AgentHover = AgentHover
 
 data ChoicePresentation
     = ChoiceDialog
+    | ChoiceDocument
     | ChoiceOnboarding
     deriving (Eq, Show)
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -105,6 +105,7 @@ data Name
     | QuickStartResume
     | QuickStartCommands
     | QuickStartModel
+    | QuickStartChangelog
     | ChoiceRow !Int
     | ResumeViewport
     | ResumeRow !Text

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -249,6 +249,11 @@ spec = do
             parseReplLine "/undo now"
                 `shouldBe` ReplCommandError "usage: /rewind"
 
+        it "opens the changelog without arguments" do
+            parseReplLine "/changelog" `shouldBe` ReplChangelog
+            parseReplLine "/changelog now"
+                `shouldBe` ReplCommandError "usage: /changelog"
+
         it "compacts with optional focus text" do
             parseReplLine "/compact" `shouldBe` ReplCompact Nothing
             parseReplLine "/compact focus auth"
@@ -526,6 +531,8 @@ spec = do
                 `shouldBe` Just "transcript"
             fmap (.slashName) (lookupSlashCommand "/welcome")
                 `shouldBe` Just "home"
+            fmap (.slashName) (lookupSlashCommand "/changelog")
+                `shouldBe` Just "changelog"
             fmap (.slashName) (lookupSlashCommand "/undo")
                 `shouldBe` Just "rewind"
 

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -811,13 +811,14 @@ spec = do
             quickStartWideVisible 103 35 `shouldBe` False
             quickStartWideVisible 140 28 `shouldBe` False
 
-        it "surfaces the existing high-value startup commands" do
+        it "surfaces the high-value startup commands including changelog" do
             quickStartRows
                 `shouldBe`
                     [ (QuickStartWorktree, "New worktree", "/worktree")
                     , (QuickStartResume, "Resume session", "/resume")
                     , (QuickStartCommands, "Browse commands", "/")
                     , (QuickStartModel, "Manage models", "/model")
+                    , (QuickStartChangelog, "View changelog", "/changelog")
                     ]
 
         it "packs capability names into bounded startup rows" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -134,6 +134,7 @@ import Control.Concurrent.STM
     , newEmptyTMVarIO
     , newTChanIO
     , retry
+    , tryReadTMVar
     )
 import Control.Monad (replicateM_)
 import qualified Data.ByteString as ByteString
@@ -454,6 +455,34 @@ spec = do
                 `shouldBe` Composer.fullscreenInputCountLimit
 
     describe "choice overlay lifecycle" do
+        it "renders and dismisses changelog release notes without choice rows" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            let marker = "Bundled release note"
+                initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+                script =
+                    [ FullscreenScriptApp
+                        (AppAskChoice
+                            ChoiceDocument
+                            "Release Notes"
+                            marker
+                            0
+                            []
+                            reply)
+                    , FullscreenScriptVty (V.EvKey V.KDown [])
+                    , FullscreenScriptVty (V.EvKey V.KEsc [])
+                    , FullscreenScriptHalt
+                    ]
+            (rendered, finalState) <-
+                runFullscreenScriptWithState initialState script
+            rendered
+                `shouldSatisfy`
+                    ByteString.isInfixOf (encoded marker)
+            finalState.appChoice `shouldBe` Nothing
+            atomically (tryReadTMVar reply)
+                `shouldReturn` Just Nothing
+
         it "closes a running-turn choice on success or cancellation" do
             let running =
                     reduceUi (UiLoop TurnStarted) initialUiState

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -810,7 +810,7 @@ genAction =
         , (1, pure RestartTurn)
         , (2, pure ClearConversation)
         , (3, ShowChoice
-                <$> elements [ChoiceDialog, ChoiceOnboarding]
+                <$> elements [ChoiceDialog, ChoiceDocument, ChoiceOnboarding]
                 <*> genLineText
                 <*> genBodyText
                 <*> genChoiceRows


### PR DESCRIPTION
## Summary
- add `/changelog` to the slash-command catalog and start screen
- open bundled Markdown release notes in a centered, scrollable pager
- support arrow/page/mouse scrolling with Esc/q dismissal and an offline fallback

## Testing
- focused `changelog` examples via `cabal repl agent-cli:test:agent-cli-test` (3 examples, 0 failures)
- live tmux smoke test confirming the start-screen action, Release Notes pager, controls, and dismissal
