### PR TITLE
Batch PostgreSQL session item reads

### DIFF
--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/CustomCall.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/CustomCall.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.CustomCall
     ( CustomCallRow (..)
     , loadCustomCallStatement
+    , loadCustomCallsStatement
     ) where
 
 import Data.Text (Text)
@@ -26,12 +27,33 @@ loadCustomCallStatement = mkStatement
     \ FROM harness.session_custom_tool_calls\
     \ WHERE response_item_id = $1::uuid"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowMaybe $
-        CustomCallRow
-            <$> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowMaybe customCallRowDecoder)
     True
+
+loadCustomCallsStatement :: Statement Text [(Text, CustomCallRow)]
+loadCustomCallsStatement = mkStatement
+    "SELECT child.response_item_id::text, child.provider_item_id,\
+    \ child.call_id, child.tool_name, child.input_text, child.status_name,\
+    \ child.extra_fields_text\
+    \ FROM harness.session_custom_tool_calls child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> customCallRowDecoder)
+    True
+
+customCallRowDecoder :: Decoders.Row CustomCallRow
+customCallRowDecoder =
+    CustomCallRow
+        <$> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/CustomOutput.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/CustomOutput.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.CustomOutput
     ( CustomOutputRow (..)
     , loadCustomOutputStatement
+    , loadCustomOutputsStatement
     ) where
 
 import Data.Text (Text)
@@ -27,13 +28,34 @@ loadCustomOutputStatement = mkStatement
     \ FROM harness.session_custom_tool_call_outputs\
     \ WHERE response_item_id = $1::uuid"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowMaybe $
-        CustomOutputRow
-            <$> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowMaybe customOutputRowDecoder)
     True
+
+loadCustomOutputsStatement :: Statement Text [(Text, CustomOutputRow)]
+loadCustomOutputsStatement = mkStatement
+    "SELECT child.response_item_id::text, child.provider_item_id,\
+    \ child.call_id, child.tool_name, child.output_kind, child.output_text,\
+    \ child.status_name, child.extra_fields_text\
+    \ FROM harness.session_custom_tool_call_outputs child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> customOutputRowDecoder)
+    True
+
+customOutputRowDecoder :: Decoders.Row CustomOutputRow
+customOutputRowDecoder =
+    CustomOutputRow
+        <$> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Reference.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Reference.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.Reference
     ( ReferenceRow (..)
     , loadReferenceStatement
+    , loadReferencesStatement
     ) where
 
 import Data.Text (Text)
@@ -21,8 +22,28 @@ loadReferenceStatement = mkStatement
     \ FROM harness.session_item_references\
     \ WHERE response_item_id = $1::uuid"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowMaybe $
-        ReferenceRow
-            <$> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowMaybe referenceRowDecoder)
     True
+
+loadReferencesStatement :: Statement Text [(Text, ReferenceRow)]
+loadReferencesStatement = mkStatement
+    "SELECT child.response_item_id::text, child.provider_item_id,\
+    \ child.extra_fields_text\
+    \ FROM harness.session_item_references child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> referenceRowDecoder)
+    True
+
+referenceRowDecoder :: Decoders.Row ReferenceRow
+referenceRowDecoder =
+    ReferenceRow
+        <$> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Tagged.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Mapping/Statements/Tagged.hs
@@ -1,6 +1,7 @@
 module Agent.Store.Postgres.SessionItem.Mapping.Statements.Tagged
     ( TaggedRow (..)
     , loadTaggedStatement
+    , loadTaggedItemsStatement
     ) where
 
 import Data.Text (Text)
@@ -21,8 +22,27 @@ loadTaggedStatement = mkStatement
     \ FROM harness.session_tagged_items\
     \ WHERE response_item_id = $1::uuid"
     (Encoders.param (Encoders.nonNullable Encoders.text))
-    (Decoders.rowMaybe $
-        TaggedRow
-            <$> Decoders.column (Decoders.nonNullable Decoders.text)
-            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    (Decoders.rowMaybe taggedRowDecoder)
     True
+
+loadTaggedItemsStatement :: Statement Text [(Text, TaggedRow)]
+loadTaggedItemsStatement = mkStatement
+    "SELECT child.response_item_id::text, child.wire_tag, child.fields_text\
+    \ FROM harness.session_tagged_items child\
+    \ WHERE child.response_item_id = ANY (ARRAY(\
+    \   SELECT item.response_item_id\
+    \   FROM harness.session_response_items item\
+    \   WHERE item.turn_id = $1::uuid\
+    \ ))"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowList $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> taggedRowDecoder)
+    True
+
+taggedRowDecoder :: Decoders.Row TaggedRow
+taggedRowDecoder =
+    TaggedRow
+        <$> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/SessionItem/Read.hs
@@ -65,14 +65,26 @@ loadResponseItemsWith adaptiveBatching turnId = do
             adaptiveBatching && shouldBatch "function_call" rows
         functionOutputsBatched =
             adaptiveBatching && shouldBatch "function_call_output" rows
+        customCallsBatched =
+            adaptiveBatching && shouldBatch "custom_tool_call" rows
+        customOutputsBatched =
+            adaptiveBatching && shouldBatch "custom_tool_call_output" rows
         reasoningBatched =
             adaptiveBatching && shouldBatch "reasoning" rows
+        referencesBatched =
+            adaptiveBatching && shouldBatch "item_reference" rows
+        taggedItemsBatched =
+            adaptiveBatching && shouldBatch "tagged" rows
     messages <- loadIf messagesBatched loadMessagesStatement
     functionCalls <- loadIf functionCallsBatched loadFunctionCallsStatement
     functionOutputs <- loadIf
         functionOutputsBatched
         loadFunctionOutputsStatement
+    customCalls <- loadIf customCallsBatched loadCustomCallsStatement
+    customOutputs <- loadIf customOutputsBatched loadCustomOutputsStatement
     reasoningItems <- loadIf reasoningBatched loadReasoningItemsStatement
+    references <- loadIf referencesBatched loadReferencesStatement
+    taggedItems <- loadIf taggedItemsBatched loadTaggedItemsStatement
     contentParts <- loadIf
         ( (messagesBatched
                 && any ((== "parts") . (.messageRowContentKind) . snd) messages)
@@ -88,11 +100,19 @@ loadResponseItemsWith adaptiveBatching turnId = do
             messagesBatched
             functionCallsBatched
             functionOutputsBatched
+            customCallsBatched
+            customOutputsBatched
             reasoningBatched
+            referencesBatched
+            taggedItemsBatched
             (Map.fromList messages)
             (Map.fromList functionCalls)
             (Map.fromList functionOutputs)
+            (Map.fromList customCalls)
+            (Map.fromList customOutputs)
             (Map.fromList reasoningItems)
+            (Map.fromList references)
+            (Map.fromList taggedItems)
             (groupChildren contentParts)
             (groupChildren summaries))
   where
@@ -133,10 +153,18 @@ loadResponseItem
     -> Bool
     -> Bool
     -> Bool
+    -> Bool
+    -> Bool
+    -> Bool
+    -> Bool
     -> Map.Map Text MessageRow
     -> Map.Map Text FunctionCallRow
     -> Map.Map Text FunctionOutputRow
+    -> Map.Map Text CustomCallRow
+    -> Map.Map Text CustomOutputRow
     -> Map.Map Text ReasoningRow
+    -> Map.Map Text ReferenceRow
+    -> Map.Map Text TaggedRow
     -> Map.Map Text [ContentPartRow]
     -> Map.Map Text [SummaryRow]
     -> BaseRow
@@ -145,11 +173,19 @@ loadResponseItem
         messagesBatched
         functionCallsBatched
         functionOutputsBatched
+        customCallsBatched
+        customOutputsBatched
         reasoningBatched
+        referencesBatched
+        taggedItemsBatched
         messages
         functionCalls
         functionOutputs
+        customCalls
+        customOutputs
         reasoningItems
+        references
+        taggedItems
         contentParts
         summaries
         base =
@@ -176,8 +212,20 @@ loadResponseItem
                         (Map.lookup base.baseRowId functionOutputs)
                         base
                 else loadFunctionOutput base
-        "custom_tool_call" -> loadCustomCall base
-        "custom_tool_call_output" -> loadCustomOutput base
+        "custom_tool_call" ->
+            if customCallsBatched
+                then pure $
+                    loadCustomCallValue
+                        (Map.lookup base.baseRowId customCalls)
+                        base
+                else loadCustomCall base
+        "custom_tool_call_output" ->
+            if customOutputsBatched
+                then pure $
+                    loadCustomOutputValue
+                        (Map.lookup base.baseRowId customOutputs)
+                        base
+                else loadCustomOutput base
         "reasoning" ->
             if reasoningBatched
                 then pure $
@@ -187,8 +235,20 @@ loadResponseItem
                         (Map.findWithDefault [] base.baseRowId summaries)
                         base
                 else loadReasoning base
-        "item_reference" -> loadItemReference base
-        "tagged" -> loadTagged base
+        "item_reference" ->
+            if referencesBatched
+                then pure $
+                    loadItemReferenceValue
+                        (Map.lookup base.baseRowId references)
+                        base
+                else loadItemReference base
+        "tagged" ->
+            if taggedItemsBatched
+                then pure $
+                    loadTaggedValue
+                        (Map.lookup base.baseRowId taggedItems)
+                        base
+                else loadTagged base
         value ->
             pure (Left ("unknown response item storage kind: " <> value))
 
@@ -329,6 +389,48 @@ loadCustomCall base =
         loadCustomCallStatement
         (StoredCustomToolCallItem . customCallFromRow)
 
+loadCustomCallValue
+    :: Maybe CustomCallRow
+    -> BaseRow
+    -> Either Text StoredResponseItem
+loadCustomCallValue stored base =
+    loadCoreChildValue
+        "custom_tool_call"
+        base
+        stored
+        (StoredCustomToolCallItem . customCallFromRow)
+
+loadCustomOutputValue
+    :: Maybe CustomOutputRow
+    -> BaseRow
+    -> Either Text StoredResponseItem
+loadCustomOutputValue stored base =
+    case validateCoreBase "custom_tool_call_output" base of
+        Left err -> Left err
+        Right () -> do
+            row <- maybe
+                (missingChild "custom_tool_call_output" base)
+                Right
+                stored
+            kind <- toolOutputKindFromText row.customOutputRowKind
+            Right $
+                StoredCustomToolCallOutputItem StoredCustomToolCallOutput
+                    { storedCustomToolCallOutputProviderItemId =
+                        row.customOutputRowProviderItemId
+                    , storedCustomToolCallOutputCallId =
+                        row.customOutputRowCallId
+                    , storedCustomToolCallOutputName =
+                        row.customOutputRowName
+                    , storedCustomToolCallOutputValue = StoredToolOutput
+                        { storedToolOutputKind = kind
+                        , storedToolOutputText = row.customOutputRowText
+                        }
+                    , storedCustomToolCallOutputStatus =
+                        row.customOutputRowStatus
+                    , storedCustomToolCallOutputExtraFields =
+                        StoredOpaqueObject row.customOutputRowExtraFields
+                    }
+
 loadCustomOutput
     :: BaseRow
     -> Transaction.Transaction (Either Text StoredResponseItem)
@@ -339,29 +441,7 @@ loadCustomOutput base =
             stored <- Transaction.statement
                 base.baseRowId
                 loadCustomOutputStatement
-            pure do
-                row <- maybe
-                    (missingChild "custom_tool_call_output" base)
-                    Right
-                    stored
-                kind <- toolOutputKindFromText row.customOutputRowKind
-                Right $
-                    StoredCustomToolCallOutputItem StoredCustomToolCallOutput
-                        { storedCustomToolCallOutputProviderItemId =
-                            row.customOutputRowProviderItemId
-                        , storedCustomToolCallOutputCallId =
-                            row.customOutputRowCallId
-                        , storedCustomToolCallOutputName =
-                            row.customOutputRowName
-                        , storedCustomToolCallOutputValue = StoredToolOutput
-                            { storedToolOutputKind = kind
-                            , storedToolOutputText = row.customOutputRowText
-                            }
-                        , storedCustomToolCallOutputStatus =
-                            row.customOutputRowStatus
-                        , storedCustomToolCallOutputExtraFields =
-                            StoredOpaqueObject row.customOutputRowExtraFields
-                        }
+            pure (loadCustomOutputValue stored base)
 
 loadReasoningValue
     :: Maybe ReasoningRow
@@ -436,26 +516,43 @@ loadItemReference base =
         loadReferenceStatement
         (StoredItemReferenceItem . referenceFromRow)
 
+loadItemReferenceValue
+    :: Maybe ReferenceRow
+    -> BaseRow
+    -> Either Text StoredResponseItem
+loadItemReferenceValue stored base =
+    loadCoreChildValue
+        "item_reference"
+        base
+        stored
+        (StoredItemReferenceItem . referenceFromRow)
+
+loadTaggedValue
+    :: Maybe TaggedRow
+    -> BaseRow
+    -> Either Text StoredResponseItem
+loadTaggedValue stored base = do
+    representation <-
+        representationFromText base.baseRowRepresentation
+    case representation of
+        StoredCoreRepresentation ->
+            Left "tagged response item has a core representation"
+        StoredKnownRepresentation -> Right ()
+        StoredUnknownRepresentation -> Right ()
+    row <- maybe (missingChild "tagged" base) Right stored
+    Right $ StoredTaggedResponseItem StoredTaggedItem
+        { storedTaggedItemRepresentation = representation
+        , storedTaggedItemWireTag = row.taggedRowWireTag
+        , storedTaggedItemFields =
+            StoredOpaqueObject row.taggedRowFields
+        }
+
 loadTagged
     :: BaseRow
     -> Transaction.Transaction (Either Text StoredResponseItem)
 loadTagged base = do
     stored <- Transaction.statement base.baseRowId loadTaggedStatement
-    pure do
-        representation <-
-            representationFromText base.baseRowRepresentation
-        case representation of
-            StoredCoreRepresentation ->
-                Left "tagged response item has a core representation"
-            StoredKnownRepresentation -> Right ()
-            StoredUnknownRepresentation -> Right ()
-        row <- maybe (missingChild "tagged" base) Right stored
-        Right $ StoredTaggedResponseItem StoredTaggedItem
-            { storedTaggedItemRepresentation = representation
-            , storedTaggedItemWireTag = row.taggedRowWireTag
-            , storedTaggedItemFields =
-                StoredOpaqueObject row.taggedRowFields
-            }
+    pure (loadTaggedValue stored base)
 
 loadCoreChild
     :: Text


### PR DESCRIPTION
## Summary

- batch-load custom tool calls, custom tool outputs, item references, and tagged items while reconstructing large PostgreSQL session turns
- share row decoders between single-item and batch statements so validation and mapping behavior stay consistent
- retain per-item reads below the existing adaptive threshold

The local PostgreSQL indexes were already present and used. The observed slowdown came primarily from N+1 session-item reads, so this change reduces query volume without adding a migration or index.

## Performance

Command shape (benchmark target is configured with `-O2`, RTS stats enabled):

```console
cabal build agent-store:bench:real-session-load-bench
$(cabal list-bin agent-store:bench:real-session-load-bench) adaptive ~/.haskell-agent <scope> <session-id> <samples> +RTS -T
```

Before/after used the same local PostgreSQL data and checksum-verified workload:

| Workload | Items | Samples | Before wall | After wall | Wall change | Before CPU | After CPU | Allocation change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `2026-08-25-01e21021`, full | 17,492 | 7 | 757.713 ms | 453.187 ms | -40.2% | 646.358 ms | 372.430 ms | -21.1% |
| `2026-08-26-c726a94a`, full | 4,921 | 7 | 230.030 ms | 136.359 ms | -40.7% | 150.472 ms | 94.367 ms | -12.9% |
| `2026-08-25-01e21021`, active | — | 21 | 18.160 ms | 15.346 ms | -15.5% | 12.509 ms | 11.368 ms | -2.6% |

Checksums matched before and after (`26762955`, `6544627`, and `1182814`, respectively).

## Validation

- `cabal build agent-store:bench:real-session-load-bench`
- `TMPDIR="$HOME/.hatmp-pr2" cabal test agent-store-test --test-show-details=direct` — 35 examples, 0 failures
- post-rebase full-session benchmark smoke test — checksum `6544627`
- `git diff --check`
