### PR TITLE
Bound unfocused streaming redraw staleness

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -287,7 +287,11 @@ handleEvent event = do
         AppHistoryLiveStarted -> True
         AppConversationReflow -> True
         AppSyncSubmittedImagePlacements -> True
-        AppMotionTick -> True
+        -- The unfocused scheduler normally uses the one-second MotionOff
+        -- cadence. Let that bounded frame expose accumulated output when a
+        -- terminal tab omits EvGainedFocus, while per-delta events remain
+        -- suppressed below.
+        AppMotionTick -> False
         AppRecapPoll -> True
         _ -> False
 

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1133,6 +1133,10 @@ spec = do
             timeout 2_000_000 unfocusedStreamingRemainsThrottled
                 `shouldReturn` Just True
 
+        it "renders accumulated streaming output on the bounded refresh tick" do
+            timeout 2_000_000 unfocusedStreamingRefreshesOnMotionTick
+                `shouldReturn` Just True
+
     describe "motion demand" do
         it "distinguishes foreground, waiting, background, and static modes" do
             let idle =
@@ -1870,12 +1874,29 @@ unfocusedStreamingRemainsThrottled = do
         initialState =
             initialFullscreenAppState runtime [] AgentRoot [] 0
         script =
-            [ FullscreenScriptVty V.EvLostFocus
+            [ FullscreenScriptApp (AppUi (UiLoop TurnStarted))
+            , FullscreenScriptVty V.EvLostFocus
             , FullscreenScriptApp (AppUi (UiLoop (TextDelta marker)))
             , FullscreenScriptHalt
             ]
     rendered <- runFullscreenScript initialState script
     pure $ not (encoded marker `ByteString.isInfixOf` rendered)
+
+unfocusedStreamingRefreshesOnMotionTick :: IO Bool
+unfocusedStreamingRefreshesOnMotionTick = do
+    runtime <- newScriptRuntime initialUiState
+    let marker = "BOUNDED_STREAMING_REFRESH"
+        initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+        script =
+            [ FullscreenScriptApp (AppUi (UiLoop TurnStarted))
+            , FullscreenScriptVty V.EvLostFocus
+            , FullscreenScriptApp (AppUi (UiLoop (TextDelta marker)))
+            , FullscreenScriptApp AppMotionTick
+            , FullscreenScriptHalt
+            ]
+    rendered <- runFullscreenScript initialState script
+    pure $ encoded marker `ByteString.isInfixOf` rendered
 
 newScriptRuntime :: UiState -> IO FullscreenRuntime
 newScriptRuntime ui = do


### PR DESCRIPTION
## Summary
- retain high-frequency streaming redraw throttling while the terminal is unfocused
- allow the existing one-second `MotionOff` tick to paint accumulated output
- cover both immediate throttling and bounded refresh when `EvGainedFocus` is missing

## Root cause
Terminal tab transitions can emit `EvLostFocus` without a matching `EvGainedFocus`. Streaming events still updated the in-memory TUI state, but unfocused handling used `continueWithoutRedraw` for both per-delta events and `AppMotionTick`. Although a running turn kept the existing one-second `MotionOff` scheduler alive, every fallback tick was also suppressed, so the terminal could keep showing its pre-`please continue` frame until input, stop, or resume forced a draw.

This change keeps per-delta redraws suppressed, but permits the bounded motion tick to reveal their accumulated state.

## Validation
- focused regression suite: 8 examples, 0 failures
- full `agent-cli` suite: 1,407 examples, 0 failures, 1 expected platform skip
- `nix build .#checks.aarch64-darwin.agent-cli-executable --no-link --max-jobs 1 --cores 4`
- real fullscreen tmux smoke: injected focus-out without focus-in; streamed marker rendered while the turn still showed `Writing…`

Additional note: the broader `.#checks.aarch64-darwin.agent-cli` aggregate was attempted twice while developing the fix; its `agent-core` dependency phase had seven existing process/timing artifact failures unrelated to these TUI files. The full `agent-cli` component suite and production executable check pass.