### PR TITLE
Make session materialization interrupt-safe

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
@@ -93,6 +93,7 @@ module Agent.CLI.Session
     , compatibleSessionPromptSnapshot
     , ensureSession
     , ensurePersistenceSessionId
+    , ensurePersistenceSessionIdWithMaterializationHook
     , ensureSessionWithPromptSnapshot
     , resumeHint
     , sessionUsageFromTurns
@@ -536,7 +537,7 @@ forkSessionAt root source turns requestedTitle targetCwd
                             cleanupFiles =
                                 cleanupForkFiles root sessionId (Just dir)
                             cleanupOwned = do
-                                cleanupSessionDatabaseIfOwned
+                                cleanupForkDatabaseIfOwned
                                     source.sessionPool
                                     storedMeta
                                 cleanupFiles
@@ -690,19 +691,24 @@ symbolicLinkStatusMaybe path =
             | otherwise -> ioError err
         Right status -> pure (Just status)
 
-cleanupSessionDatabaseIfOwned
+sessionDatabaseIsOwned
+    :: StorePool
+    -> Store.SessionMetadata
+    -> IO Bool
+sessionDatabaseIsOwned pool expected = do
+    loaded <- Store.loadSessionMetadata pool expected.sessionMetadataKey
+    pure (loaded == Right (Just expected))
+
+cleanupForkDatabaseIfOwned
     :: StorePool
     -> Store.SessionMetadata
     -> IO ()
-cleanupSessionDatabaseIfOwned pool expected = do
-    loaded <- Store.loadSessionMetadata pool expected.sessionMetadataKey
-    case loaded of
-        Right (Just actual)
-            | actual == expected -> do
-                now <- getCurrentTime
-                _ <- Store.deleteSession pool expected.sessionMetadataKey now
-                pure ()
-        _ -> pure ()
+cleanupForkDatabaseIfOwned pool expected = do
+    owned <- sessionDatabaseIsOwned pool expected
+    when owned do
+        now <- getCurrentTime
+        _ <- Store.deleteSession pool expected.sessionMetadataKey now
+        pure ()
 
 cleanupForkFiles :: OsPath -> Text -> Maybe OsPath -> IO ()
 cleanupForkFiles root sessionId dir = do
@@ -726,34 +732,41 @@ createReservedSession spec sessionId tempDir promptSnapshot =
         sessionId
         tempDir
         promptSnapshot
-        (const (pure ()))
+        (pure ())
+        Nothing
 
--- | Create a durable session and run its ownership handoff while async
--- exceptions remain masked. The PostgreSQL write is interruptible, but any
--- ambiguous partial commit is removed before the exception is rethrown.
+-- | Create a durable session and publish it while async exceptions remain
+-- masked. Stable metadata in host-owned recovery state makes the
+-- interruptible PostgreSQL write idempotent: a later attempt can adopt an
+-- exact committed row or retry the same reservation.
 createReservedSessionWithHandoff
     :: SessionCreate
     -> Text
     -> OsPath
     -> Maybe SessionPromptSnapshot
-    -> (SessionHandle -> IO ())
+    -> IO ()
+    -> Maybe (SessionHandle -> IO ())
     -> IO SessionHandle
 createReservedSessionWithHandoff
         spec
         sessionId
         tempDir
         promptSnapshot
-        handoff =
+        afterStored
+        publication =
     mask \restore -> do
         let pool = spec.createPool
         ensurePrivateDir spec.createRoot
         dir <- either (fail . Text.unpack) pure
             (sessionDirForId spec.createRoot sessionId)
+        recoveredMeta <- case publication of
+            Nothing -> pure Nothing
+            Just _ -> loadMaterializationMeta spec.createRoot sessionId
         now <- normalizePostgresTimestamp <$> getCurrentTime
         let title = case spec.createTitleHint of
                 Just hint | not (Text.null hint) -> hint
                 _ -> "untitled"
-            meta = SessionMeta
+            generatedMeta = SessionMeta
                 { metaVersion = sessionSchemaVersion
                 , metaId = sessionId
                 , metaCreatedAt = now
@@ -785,6 +798,7 @@ createReservedSessionWithHandoff
                 , metaLastRecapMainTurns = 0
                 , metaPromptSnapshot = promptSnapshot
                 }
+            meta = fromMaybe generatedMeta recoveredMeta
             handle = SessionHandle
                 { sessionPool = pool
                 , sessionDir = dir
@@ -793,44 +807,153 @@ createReservedSessionWithHandoff
                 , sessionTranscriptPath = dir </> unsafeEncodeUtf "transcript.jsonl"
                 , sessionMeta = meta
                 }
-        let createStored = case promptSnapshot of
+            storedMeta = toStoredMetadata meta
+            recoveryPath =
+                sessionMaterializationMetaPath spec.createRoot sessionId
+        case (publication, recoveredMeta) of
+            (Just _, Nothing) ->
+                writeLazyFileAtomically recoveryPath 0o600 (Aeson.encode meta)
+            _ -> pure ()
+        let createStored = case meta.metaPromptSnapshot of
                 Nothing -> Store.createSession pool (toStoredMetadata meta)
                 Just snapshot ->
                     Store.createSessionWithInitialPromptEpoch
                         pool
-                        (toStoredMetadata meta)
+                        storedMeta
                         (toStoredPromptSnapshot snapshot)
             cleanupCreated =
-                cleanupSessionDatabaseIfOwned pool (toStoredMetadata meta)
+                cleanupForkDatabaseIfOwned pool storedMeta
                     `finally` cleanupDirectory
             cleanupDirectory = do
                 _ <- tryIO (removePathForcibly dir)
                 pure ()
-        -- Directory creation acquires ownership while masked. Every subsequent
-        -- interruptible operation is covered by cleanupCreated.
-        createDirectory dir
-        created <-
-            restore
-                (setFileMode (unsafeToFilePath dir) 0o700 >> createStored)
-                `onException` cleanupCreated
-        handle' <- case created of
-            Left err -> do
-                cleanupCreated
+            publish = do
+                -- The pending-to-active handoff remains masked after durable
+                -- creation.
+                case publication of
+                    Nothing -> pure ()
+                    Just handoff -> do
+                        handoff handle
+                        removeSessionMaterializationMeta
+                            spec.createRoot
+                            sessionId
+                pure handle
+            publishConfirmed = case publication of
+                Nothing -> publish
+                Just _ -> restore afterStored >> publish
+            failStored err =
                 fail
                     ("could not create PostgreSQL session: "
                         <> Text.unpack (renderStoreError err))
-            Right False -> do
-                -- The conflicting database row is not ours.
-                cleanupDirectory
+            failConflict =
                 fail "could not allocate a unique PostgreSQL session id"
-            Right True -> pure handle
-        -- The pending-to-active handoff remains masked after durable creation.
-        handoff handle'
-        pure handle'
+            adoptStored onMissing onConflict =
+                restore
+                    (Store.loadSessionMetadata pool sessionId) >>= \case
+                        Right (Just actual)
+                            | actual == storedMeta -> publishConfirmed
+                        Right Nothing -> onMissing
+                        Right (Just _) -> onConflict
+                        Left err -> failStored err
+            createAndPublish = do
+                let exceptionCleanup = case publication of
+                        Nothing -> cleanupCreated
+                        Just _ -> pure ()
+                created <-
+                    restore
+                        (do
+                            setFileMode (unsafeToFilePath dir) 0o700
+                            createStored)
+                        `onException` exceptionCleanup
+                case created of
+                    Left err -> case publication of
+                        Nothing -> cleanupCreated >> failStored err
+                        Just _ ->
+                            adoptStored
+                                (failStored err)
+                                (cleanupDirectory >> failConflict)
+                    Right False -> case publication of
+                        Nothing -> do
+                            cleanupDirectory
+                            failConflict
+                        Just _ ->
+                            adoptStored
+                                (cleanupDirectory >> failConflict)
+                                (cleanupDirectory >> failConflict)
+                    Right True -> publishConfirmed
+        case recoveredMeta of
+            Nothing ->
+                tryIO (createDirectory dir) >>= \case
+                    Left err -> do
+                        removeSessionMaterializationMeta
+                            spec.createRoot
+                            sessionId
+                        ioError err
+                    Right () -> createAndPublish
+            Just _ -> do
+                -- A previous attempt may have committed before interruption.
+                -- Reuse its exact metadata so a missing row can be retried and
+                -- an existing exact-match row can be adopted.
+                ensureMaterializationDirectory dir
+                adoptStored
+                    createAndPublish
+                    (cleanupDirectory >> failConflict)
+
+sessionMaterializationMetaPath :: OsPath -> Text -> OsPath
+sessionMaterializationMetaPath root sessionId =
+    sessionTempsRoot root
+        </> unsafeEncodeUtf
+            (".materialization-" <> Text.unpack sessionId <> ".json")
+
+removeSessionMaterializationMeta :: OsPath -> Text -> IO ()
+removeSessionMaterializationMeta root sessionId = do
+    _ <- tryIO (removeFile (sessionMaterializationMetaPath root sessionId))
+    pure ()
+
+ensureMaterializationDirectory :: OsPath -> IO ()
+ensureMaterializationDirectory dir =
+    symbolicLinkStatusMaybe dir >>= \case
+        Nothing -> do
+            createDirectory dir
+            setFileMode (unsafeToFilePath dir) 0o700
+        Just status
+            | isDirectory status && not (isSymbolicLink status) ->
+                setFileMode (unsafeToFilePath dir) 0o700
+            | otherwise ->
+                fail "reserved session path is not a private directory"
+
+loadMaterializationMeta
+    :: OsPath
+    -> Text
+    -> IO (Maybe SessionMeta)
+loadMaterializationMeta root sessionId = do
+    let path = sessionMaterializationMetaPath root sessionId
+    symbolicLinkStatusMaybe path >>= \case
+        Nothing -> pure Nothing
+        Just status
+            | isRegularFile status && not (isSymbolicLink status) -> do
+                bytes <-
+                    retryOnFileBusy (LBS.readFile (unsafeToFilePath path))
+                meta <- either (fail . Text.unpack) pure
+                    (decodeLazy sessionMetaDecoder bytes)
+                unless (meta.metaId == sessionId) $
+                    fail
+                        "materialization metadata session id does not match reservation"
+                unless (meta.metaVersion == sessionSchemaVersion) $
+                    fail "unsupported materialization metadata version"
+                pure (Just meta)
+            | otherwise ->
+                fail "materialization metadata is not a private regular file"
 
 -- | Create the session directory on first use when persistence is still pending.
 ensureSession :: IORef PersistenceState -> IO SessionHandle
-ensureSession slotRef = do
+ensureSession = ensureSessionWithMaterializationHook (pure ())
+
+ensureSessionWithMaterializationHook
+    :: IO ()
+    -> IORef PersistenceState
+    -> IO SessionHandle
+ensureSessionWithMaterializationHook afterStored slotRef = do
     slot <- readIORef slotRef
     case slot of
         PersistenceActive handle -> pure handle
@@ -840,13 +963,26 @@ ensureSession slotRef = do
                 sessionId
                 tempDir
                 Nothing
-                (writeIORef slotRef . PersistenceActive)
+                afterStored
+                (Just (writeIORef slotRef . PersistenceActive))
 
 -- | Return a durable, resumable session ID, materializing pending persistence.
 ensurePersistenceSessionId :: Persistence -> IO (Maybe Text)
-ensurePersistenceSessionId PersistenceDisabled = pure Nothing
-ensurePersistenceSessionId (PersistenceEnabled slotRef) = do
-    handle <- ensureSession slotRef
+ensurePersistenceSessionId =
+    ensurePersistenceSessionIdWithMaterializationHook (pure ())
+
+-- | Instrument the boundary after durable ownership is confirmed and before
+-- the masked pending-to-active handoff.
+ensurePersistenceSessionIdWithMaterializationHook
+    :: IO ()
+    -> Persistence
+    -> IO (Maybe Text)
+ensurePersistenceSessionIdWithMaterializationHook _ PersistenceDisabled =
+    pure Nothing
+ensurePersistenceSessionIdWithMaterializationHook
+        afterStored
+        (PersistenceEnabled slotRef) = do
+    handle <- ensureSessionWithMaterializationHook afterStored slotRef
     pure (Just handle.sessionMeta.metaId)
 
 -- | Ensure the durable session exists and atomically persist the
@@ -859,44 +995,45 @@ ensureSessionWithPromptSnapshot
     -> IO SessionHandle
 ensureSessionWithPromptSnapshot slotRef candidate = do
     slot <- readIORef slotRef
-    case slot of
+    handle <- case slot of
         PersistencePending spec sessionId tempDir ->
             createReservedSessionWithHandoff
                 spec
                 sessionId
                 tempDir
                 (Just candidate)
-                (writeIORef slotRef . PersistenceActive)
-        PersistenceActive handle -> do
-            let snapshot =
-                    maybe candidate
-                        (`mergePromptSnapshotContext` candidate)
-                        handle.sessionMeta.metaPromptSnapshot
-            case handle.sessionMeta.metaPromptSnapshot of
-                Just previous
-                    | promptSnapshotsEquivalent previous snapshot ->
-                        pure handle
-                _ -> do
-                    Store.appendSessionPromptEpoch
-                        handle.sessionPool
-                        handle.sessionMeta.metaId
-                        (toStoredPromptSnapshot snapshot) >>= \case
-                            Left err ->
-                                fail
-                                    ("could not persist PostgreSQL prompt epoch: "
-                                        <> Text.unpack (renderStoreError err))
-                            Right Nothing ->
-                                fail
-                                    ("session not found: "
-                                        <> Text.unpack handle.sessionMeta.metaId)
-                            Right (Just _) -> do
-                                let next = handle
-                                        { sessionMeta = handle.sessionMeta
-                                            { metaPromptSnapshot = Just snapshot
-                                            }
-                                        }
-                                writeIORef slotRef (PersistenceActive next)
-                                pure next
+                (pure ())
+                (Just (writeIORef slotRef . PersistenceActive))
+        PersistenceActive active -> pure active
+    let snapshot =
+            maybe candidate
+                (`mergePromptSnapshotContext` candidate)
+                handle.sessionMeta.metaPromptSnapshot
+    case handle.sessionMeta.metaPromptSnapshot of
+        Just previous
+            | promptSnapshotsEquivalent previous snapshot ->
+                pure handle
+        _ -> do
+            Store.appendSessionPromptEpoch
+                handle.sessionPool
+                handle.sessionMeta.metaId
+                (toStoredPromptSnapshot snapshot) >>= \case
+                    Left err ->
+                        fail
+                            ("could not persist PostgreSQL prompt epoch: "
+                                <> Text.unpack (renderStoreError err))
+                    Right Nothing ->
+                        fail
+                            ("session not found: "
+                                <> Text.unpack handle.sessionMeta.metaId)
+                    Right (Just _) -> do
+                        let next = handle
+                                { sessionMeta = handle.sessionMeta
+                                    { metaPromptSnapshot = Just snapshot
+                                    }
+                                }
+                        writeIORef slotRef (PersistenceActive next)
+                        pure next
 
 mergePromptSnapshotContext
     :: SessionPromptSnapshot
@@ -2019,7 +2156,11 @@ allocateSessionTemp root = do
             durableExists <-
                 maybe False (const True)
                     <$> symbolicLinkStatusMaybe durableDir
-            if durableExists
+            recoveryExists <-
+                maybe False (const True)
+                    <$> symbolicLinkStatusMaybe
+                        (sessionMaterializationMetaPath root sessionId)
+            if durableExists || recoveryExists
                 then go tempRoot now (attempt + 1)
                 else tryIO (createDirectory tempDir) >>= \case
                     Left _ -> go tempRoot now (attempt + 1)
@@ -2185,7 +2326,11 @@ cleanupStaleSessionTemp root candidate =
                             Just status
                                 | isSymbolicLink status -> pure False
                                 | otherwise ->
-                                    removePathForcibly candidate >> pure True)
+                                    removePathForcibly candidate
+                                        >> removeSessionMaterializationMeta
+                                            root
+                                            (toText sessionId)
+                                        >> pure True)
                         `finally` FileLock.unlockFile lock
                 pure case removed of
                     Left exception ->
@@ -2267,6 +2412,7 @@ removeSessionTemp root sessionId =
     case sessionTempDirForId root sessionId of
         Left err -> pure (Left err)
         Right tempDir -> do
+            removeSessionMaterializationMeta root sessionId
             exists <- doesDirectoryExist tempDir
             if not exists
                 then pure (Right ())

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
@@ -536,7 +536,7 @@ forkSessionAt root source turns requestedTitle targetCwd
                             cleanupFiles =
                                 cleanupForkFiles root sessionId (Just dir)
                             cleanupOwned = do
-                                cleanupForkDatabaseIfOwned
+                                cleanupSessionDatabaseIfOwned
                                     source.sessionPool
                                     storedMeta
                                 cleanupFiles
@@ -690,11 +690,11 @@ symbolicLinkStatusMaybe path =
             | otherwise -> ioError err
         Right status -> pure (Just status)
 
-cleanupForkDatabaseIfOwned
+cleanupSessionDatabaseIfOwned
     :: StorePool
     -> Store.SessionMetadata
     -> IO ()
-cleanupForkDatabaseIfOwned pool expected = do
+cleanupSessionDatabaseIfOwned pool expected = do
     loaded <- Store.loadSessionMetadata pool expected.sessionMetadataKey
     case loaded of
         Right (Just actual)
@@ -720,74 +720,113 @@ createReservedSession
     -> OsPath
     -> Maybe SessionPromptSnapshot
     -> IO SessionHandle
-createReservedSession spec sessionId tempDir promptSnapshot = do
-    let pool = spec.createPool
-    ensurePrivateDir spec.createRoot
-    dir <- either (fail . Text.unpack) pure
-        (sessionDirForId spec.createRoot sessionId)
-    createDirectory dir
-    setFileMode (unsafeToFilePath dir) 0o700
-    now <- normalizePostgresTimestamp <$> getCurrentTime
-    let title = case spec.createTitleHint of
-            Just hint | not (Text.null hint) -> hint
-            _ -> "untitled"
-        meta = SessionMeta
-            { metaVersion = sessionSchemaVersion
-            , metaId = sessionId
-            , metaCreatedAt = now
-            , metaUpdatedAt = now
-            , metaProvider = spec.createTarget.targetProvider
-            , metaConnection = spec.createTarget.targetConnectionId
-            , metaModel = spec.createTarget.targetModelId
-            , metaTransportModel = Just spec.createTarget.targetWireModelId
-            , metaDialect = spec.createTarget.targetDialect
-            , metaLegacySubagentTarget = Just LegacySubagentTarget
-                { legacyTargetProvider = spec.createTarget.targetProvider
-                , legacyTargetConnection = spec.createTarget.targetConnectionId
-                , legacyTargetEffectiveModel =
-                    spec.createTarget.targetWireModelId
-                , legacyTargetDialect = spec.createTarget.targetDialect
+createReservedSession spec sessionId tempDir promptSnapshot =
+    createReservedSessionWithHandoff
+        spec
+        sessionId
+        tempDir
+        promptSnapshot
+        (const (pure ()))
+
+-- | Create a durable session and run its ownership handoff while async
+-- exceptions remain masked. The PostgreSQL write is interruptible, but any
+-- ambiguous partial commit is removed before the exception is rethrown.
+createReservedSessionWithHandoff
+    :: SessionCreate
+    -> Text
+    -> OsPath
+    -> Maybe SessionPromptSnapshot
+    -> (SessionHandle -> IO ())
+    -> IO SessionHandle
+createReservedSessionWithHandoff
+        spec
+        sessionId
+        tempDir
+        promptSnapshot
+        handoff =
+    mask \restore -> do
+        let pool = spec.createPool
+        ensurePrivateDir spec.createRoot
+        dir <- either (fail . Text.unpack) pure
+            (sessionDirForId spec.createRoot sessionId)
+        now <- normalizePostgresTimestamp <$> getCurrentTime
+        let title = case spec.createTitleHint of
+                Just hint | not (Text.null hint) -> hint
+                _ -> "untitled"
+            meta = SessionMeta
+                { metaVersion = sessionSchemaVersion
+                , metaId = sessionId
+                , metaCreatedAt = now
+                , metaUpdatedAt = now
+                , metaProvider = spec.createTarget.targetProvider
+                , metaConnection = spec.createTarget.targetConnectionId
+                , metaModel = spec.createTarget.targetModelId
+                , metaTransportModel = Just spec.createTarget.targetWireModelId
+                , metaDialect = spec.createTarget.targetDialect
+                , metaLegacySubagentTarget = Just LegacySubagentTarget
+                    { legacyTargetProvider = spec.createTarget.targetProvider
+                    , legacyTargetConnection = spec.createTarget.targetConnectionId
+                    , legacyTargetEffectiveModel =
+                        spec.createTarget.targetWireModelId
+                    , legacyTargetDialect = spec.createTarget.targetDialect
+                    }
+                , metaCwd = spec.createCwd
+                , metaEffort = spec.createEffort
+                , metaTitle = title
+                , metaTitleIsManual = spec.createTitleIsManual
+                , metaTitleRefreshIndex = 0
+                , metaTitleUserTurns = 0
+                , metaLastResponseId = Nothing
+                , metaInputTokens = 0
+                , metaOutputTokens = 0
+                , metaCachedTokens = 0
+                , metaLastRecap = Nothing
+                , metaLastTurnSummary = Nothing
+                , metaLastRecapMainTurns = 0
+                , metaPromptSnapshot = promptSnapshot
                 }
-            , metaCwd = spec.createCwd
-            , metaEffort = spec.createEffort
-            , metaTitle = title
-            , metaTitleIsManual = spec.createTitleIsManual
-            , metaTitleRefreshIndex = 0
-            , metaTitleUserTurns = 0
-            , metaLastResponseId = Nothing
-            , metaInputTokens = 0
-            , metaOutputTokens = 0
-            , metaCachedTokens = 0
-            , metaLastRecap = Nothing
-            , metaLastTurnSummary = Nothing
-            , metaLastRecapMainTurns = 0
-            , metaPromptSnapshot = promptSnapshot
-            }
-        handle = SessionHandle
-            { sessionPool = pool
-            , sessionDir = dir
-            , sessionTempDir = tempDir
-            , sessionMetaPath = dir </> unsafeEncodeUtf "meta.json"
-            , sessionTranscriptPath = dir </> unsafeEncodeUtf "transcript.jsonl"
-            , sessionMeta = meta
-            }
-    let createStored = case promptSnapshot of
-            Nothing -> Store.createSession pool (toStoredMetadata meta)
-            Just snapshot ->
-                Store.createSessionWithInitialPromptEpoch
-                    pool
-                    (toStoredMetadata meta)
-                    (toStoredPromptSnapshot snapshot)
-    createStored >>= \case
-        Left err -> do
-            _ <- tryIO (removePathForcibly dir)
-            fail
-                ("could not create PostgreSQL session: "
-                    <> Text.unpack (renderStoreError err))
-        Right False -> do
-            _ <- tryIO (removePathForcibly dir)
-            fail "could not allocate a unique PostgreSQL session id"
-        Right True -> pure handle
+            handle = SessionHandle
+                { sessionPool = pool
+                , sessionDir = dir
+                , sessionTempDir = tempDir
+                , sessionMetaPath = dir </> unsafeEncodeUtf "meta.json"
+                , sessionTranscriptPath = dir </> unsafeEncodeUtf "transcript.jsonl"
+                , sessionMeta = meta
+                }
+        let createStored = case promptSnapshot of
+                Nothing -> Store.createSession pool (toStoredMetadata meta)
+                Just snapshot ->
+                    Store.createSessionWithInitialPromptEpoch
+                        pool
+                        (toStoredMetadata meta)
+                        (toStoredPromptSnapshot snapshot)
+            cleanupCreated =
+                cleanupSessionDatabaseIfOwned pool (toStoredMetadata meta)
+                    `finally` cleanupDirectory
+            cleanupDirectory = do
+                _ <- tryIO (removePathForcibly dir)
+                pure ()
+        -- Directory creation acquires ownership while masked. Every subsequent
+        -- interruptible operation is covered by cleanupCreated.
+        createDirectory dir
+        created <-
+            restore
+                (setFileMode (unsafeToFilePath dir) 0o700 >> createStored)
+                `onException` cleanupCreated
+        handle' <- case created of
+            Left err -> do
+                cleanupCreated
+                fail
+                    ("could not create PostgreSQL session: "
+                        <> Text.unpack (renderStoreError err))
+            Right False -> do
+                -- The conflicting database row is not ours.
+                cleanupDirectory
+                fail "could not allocate a unique PostgreSQL session id"
+            Right True -> pure handle
+        -- The pending-to-active handoff remains masked after durable creation.
+        handoff handle'
+        pure handle'
 
 -- | Create the session directory on first use when persistence is still pending.
 ensureSession :: IORef PersistenceState -> IO SessionHandle
@@ -795,10 +834,13 @@ ensureSession slotRef = do
     slot <- readIORef slotRef
     case slot of
         PersistenceActive handle -> pure handle
-        PersistencePending spec sessionId tempDir -> do
-            handle <- createReservedSession spec sessionId tempDir Nothing
-            writeIORef slotRef (PersistenceActive handle)
-            pure handle
+        PersistencePending spec sessionId tempDir ->
+            createReservedSessionWithHandoff
+                spec
+                sessionId
+                tempDir
+                Nothing
+                (writeIORef slotRef . PersistenceActive)
 
 -- | Return a durable, resumable session ID, materializing pending persistence.
 ensurePersistenceSessionId :: Persistence -> IO (Maybe Text)
@@ -818,14 +860,13 @@ ensureSessionWithPromptSnapshot
 ensureSessionWithPromptSnapshot slotRef candidate = do
     slot <- readIORef slotRef
     case slot of
-        PersistencePending spec sessionId tempDir -> do
-            handle <- createReservedSession
+        PersistencePending spec sessionId tempDir ->
+            createReservedSessionWithHandoff
                 spec
                 sessionId
                 tempDir
                 (Just candidate)
-            writeIORef slotRef (PersistenceActive handle)
-            pure handle
+                (writeIORef slotRef . PersistenceActive)
         PersistenceActive handle -> do
             let snapshot =
                     maybe candidate

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
@@ -28,11 +28,10 @@ import Agent.Store.Postgres.Managed (stopManagedPostgres)
 import Agent.Store.Postgres.Connection (StorePool)
 import qualified Agent.Store.Postgres.Session as Store
 import Agent.Store.Types (renderStoreError)
-import Control.Concurrent
-    ( newEmptyMVar, putMVar, readMVar, takeMVar, threadDelay )
+import Control.Concurrent (newEmptyMVar, putMVar, readMVar, takeMVar)
 import Control.Concurrent.Async
-    ( cancelWith, concurrently, mapConcurrently, withAsync )
-import Control.Exception (AsyncException(UserInterrupt))
+    ( cancelWith, concurrently, mapConcurrently, waitCatch, withAsync )
+import Control.Exception (AsyncException(UserInterrupt), fromException)
 import Control.Exception.Safe (bracket)
 import Control.Monad (replicateM)
 import qualified Data.Aeson as Aeson
@@ -1527,7 +1526,7 @@ spec = describe "Agent.CLI.Session" do
                 loadSession pool root reservedId
                     `shouldReturn` Right (handle.sessionMeta, [])
 
-        it "cleans an interrupted pending materialization" $
+        it "keeps committed materialization retryable across interrupts" $
             withTempStore \store root -> do
                 let pool = trustedPool store
                 persist@(PersistenceEnabled slot) <-
@@ -1536,32 +1535,90 @@ spec = describe "Agent.CLI.Session" do
                 let
                     sessionDir =
                         root </> unsafeEncodeUtf (Text.unpack reservedId)
-                    waitForSessionDir 0 =
-                        expectationFailure
-                            "session materialization did not create its directory"
-                    waitForSessionDir attempts =
-                        doesDirectoryExist sessionDir >>= \case
-                            True -> pure ()
-                            False -> do
-                                threadDelay 1000
-                                waitForSessionDir (attempts - 1)
-                withAsync (ensurePersistenceSessionId persist) \worker -> do
-                    waitForSessionDir (5000 :: Int)
-                    cancelWith worker UserInterrupt
+                stored <- newEmptyMVar
+                release <- newEmptyMVar
+                let afterStored = putMVar stored () >> takeMVar release
+                    interruptMaterialization =
+                        withAsync
+                            (ensurePersistenceSessionIdWithMaterializationHook
+                                afterStored
+                                persist)
+                            \worker -> do
+                                takeMVar stored
+                                cancelWith worker UserInterrupt
+                                waitCatch worker >>= \case
+                                    Left exception ->
+                                        (fromException exception
+                                            :: Maybe AsyncException)
+                                            `shouldBe` Just UserInterrupt
+                                    Right sessionId ->
+                                        expectationFailure
+                                            ("interrupted materialization returned: "
+                                                <> show sessionId)
+                interruptMaterialization
+                interruptMaterialization
                 readIORef slot >>= \case
-                    PersistencePending _ actualId actualTempDir -> do
+                    PersistencePending _ actualId _ ->
                         actualId `shouldBe` reservedId
-                        actualTempDir `shouldBe` tempDir
                     PersistenceActive handle ->
                         expectationFailure
-                            ("interrupted session became active: "
+                            ("interrupted session published before retry: "
                                 <> Text.unpack handle.sessionMeta.metaId)
-                doesDirectoryExist sessionDir `shouldReturn` False
+                let recoveryPath =
+                        sessionTempsRoot root
+                            </> unsafeEncodeUtf
+                                (".materialization-"
+                                    <> Text.unpack reservedId
+                                    <> ".json")
+                doesFileExist recoveryPath `shouldReturn` True
+                ensurePersistenceSessionId persist
+                    `shouldReturn` Just reservedId
+                readIORef slot >>= \case
+                    PersistenceActive handle -> do
+                        handle.sessionMeta.metaId `shouldBe` reservedId
+                        handle.sessionTempDir `shouldBe` tempDir
+                        loadSession pool root reservedId
+                            `shouldReturn` Right (handle.sessionMeta, [])
+                    PersistencePending _ actualId _ ->
+                        expectationFailure
+                            ("committed session remained pending: "
+                                <> Text.unpack actualId)
+                doesDirectoryExist sessionDir `shouldReturn` True
                 doesDirectoryExist tempDir `shouldReturn` True
-                Store.loadSessionMetadata pool reservedId
-                    `shouldReturn` Right Nothing
-                cleanupPendingPersistence persist
-                doesDirectoryExist tempDir `shouldReturn` False
+                doesFileExist recoveryPath `shouldReturn` False
+
+        it "persists a prompt snapshot after interrupted materialization" $
+            withTempStore \store root -> do
+                let pool = trustedPool store
+                persist@(PersistenceEnabled slot) <-
+                    newPendingPersistence (testCreate pool root)
+                PersistencePending _ reservedId _ <- readIORef slot
+                stored <- newEmptyMVar
+                release <- newEmptyMVar
+                let afterStored = putMVar stored () >> takeMVar release
+                withAsync
+                    (ensurePersistenceSessionIdWithMaterializationHook
+                        afterStored
+                        persist)
+                    \worker -> do
+                        takeMVar stored
+                        cancelWith worker UserInterrupt
+                        waitCatch worker >>= \case
+                            Left exception ->
+                                (fromException exception :: Maybe AsyncException)
+                                    `shouldBe` Just UserInterrupt
+                            Right sessionId ->
+                                expectationFailure
+                                    ("interrupted materialization returned: "
+                                        <> show sessionId)
+                let candidate = testPromptSnapshot reservedId
+                handle <- ensureSessionWithPromptSnapshot slot candidate
+                handle.sessionMeta.metaPromptSnapshot
+                    `shouldBe` Just candidate
+                promptEpoch <-
+                    Store.loadLatestSessionPromptEpoch pool reservedId
+                fmap (fmap (.sessionPromptEpochIndex)) promptEpoch
+                    `shouldBe` Right (Just 0)
 
         it "creates and advances immutable prompt epochs before first use" $
             withTempStore \store root -> do

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
@@ -28,8 +28,11 @@ import Agent.Store.Postgres.Managed (stopManagedPostgres)
 import Agent.Store.Postgres.Connection (StorePool)
 import qualified Agent.Store.Postgres.Session as Store
 import Agent.Store.Types (renderStoreError)
-import Control.Concurrent (newEmptyMVar, putMVar, readMVar, takeMVar)
-import Control.Concurrent.Async (concurrently, mapConcurrently)
+import Control.Concurrent
+    ( newEmptyMVar, putMVar, readMVar, takeMVar, threadDelay )
+import Control.Concurrent.Async
+    ( cancelWith, concurrently, mapConcurrently, withAsync )
+import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe (bracket)
 import Control.Monad (replicateM)
 import qualified Data.Aeson as Aeson
@@ -1523,6 +1526,42 @@ spec = describe "Agent.CLI.Session" do
                 handle.sessionTempDir `shouldBe` tempDir
                 loadSession pool root reservedId
                     `shouldReturn` Right (handle.sessionMeta, [])
+
+        it "cleans an interrupted pending materialization" $
+            withTempStore \store root -> do
+                let pool = trustedPool store
+                persist@(PersistenceEnabled slot) <-
+                    newPendingPersistence (testCreate pool root)
+                PersistencePending _ reservedId tempDir <- readIORef slot
+                let
+                    sessionDir =
+                        root </> unsafeEncodeUtf (Text.unpack reservedId)
+                    waitForSessionDir 0 =
+                        expectationFailure
+                            "session materialization did not create its directory"
+                    waitForSessionDir attempts =
+                        doesDirectoryExist sessionDir >>= \case
+                            True -> pure ()
+                            False -> do
+                                threadDelay 1000
+                                waitForSessionDir (attempts - 1)
+                withAsync (ensurePersistenceSessionId persist) \worker -> do
+                    waitForSessionDir (5000 :: Int)
+                    cancelWith worker UserInterrupt
+                readIORef slot >>= \case
+                    PersistencePending _ actualId actualTempDir -> do
+                        actualId `shouldBe` reservedId
+                        actualTempDir `shouldBe` tempDir
+                    PersistenceActive handle ->
+                        expectationFailure
+                            ("interrupted session became active: "
+                                <> Text.unpack handle.sessionMeta.metaId)
+                doesDirectoryExist sessionDir `shouldReturn` False
+                doesDirectoryExist tempDir `shouldReturn` True
+                Store.loadSessionMetadata pool reservedId
+                    `shouldReturn` Right Nothing
+                cleanupPendingPersistence persist
+                doesDirectoryExist tempDir `shouldReturn` False
 
         it "creates and advances immutable prompt epochs before first use" $
             withTempStore \store root -> do

--- a/packages/agent-cli/src/Agent/CLI/Interrupt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Interrupt.hs
@@ -13,6 +13,7 @@ module Agent.CLI.Interrupt
     , noteIdleCtrlC
     , isWrappedUserInterrupt
     , catchUserInterrupt
+    , retryUserInterruptOnce
     , noteFullscreenCtrlC
     ) where
 
@@ -31,6 +32,7 @@ import Control.Exception.Safe
     , catchAny
     , catchAsync
     , catchIO
+    , mask
     , throwIO
     )
 import Control.Monad (void)
@@ -212,3 +214,11 @@ catchUserInterrupt action onInterrupt =
     handleSyncException (e :: SomeException)
         | isWrappedUserInterrupt e = onInterrupt
         | otherwise = throwIO e
+
+-- | Retry an idempotent action after at most one user interrupt. Both attempts
+-- run in the caller's original masking state, so another interrupt during the
+-- recovery attempt propagates instead of disabling force-exit indefinitely.
+retryUserInterruptOnce :: IO a -> IO a
+retryUserInterruptOnce action =
+    mask \restore ->
+        catchUserInterrupt (restore action) (restore action)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -31,7 +31,11 @@ import Agent.CLI.Error ()
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input ()
 import Agent.CLI.Interrupt
-    (InterruptState, catchUserInterrupt, withCtrlCHandler)
+    ( InterruptState
+    , catchUserInterrupt
+    , retryUserInterruptOnce
+    , withCtrlCHandler
+    )
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
 import Agent.CLI.Login ()
@@ -896,17 +900,16 @@ printResumeHint
     :: String
     -> Persistence
     -> IO ()
-printResumeHint progName persist =
-    catchUserInterrupt
-        (ensurePersistenceSessionId persist >>= \case
-            Nothing -> pure ()
-            Just sessionId -> do
-                -- Drop an in-place "Thinking…" status so the hint is its own line.
-                Text.hPutStr stderr "\r\ESC[K"
-                clearNativeProgress stderr
-                color <- resolveColor stderr
-                putTextLn stderr
-                    (roleMuted color (resumeHint progName sessionId)))
-        -- A repeated Ctrl-C may arrive while the pending session or footer is
-        -- being written. Retry the stable reservation before cleanup runs.
-        (printResumeHint progName persist)
+printResumeHint progName persist = do
+    -- A commit interrupted before publication is safe to adopt once. Keep the
+    -- retry bounded so a later double Ctrl-C can still force a hung exit.
+    sessionId <- retryUserInterruptOnce (ensurePersistenceSessionId persist)
+    case sessionId of
+        Nothing -> pure ()
+        Just sessionId -> do
+            -- Drop an in-place "Thinking…" status so the hint is its own line.
+            Text.hPutStr stderr "\r\ESC[K"
+            clearNativeProgress stderr
+            color <- resolveColor stderr
+            putTextLn stderr
+                (roleMuted color (resumeHint progName sessionId))

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -897,12 +897,16 @@ printResumeHint
     -> Persistence
     -> IO ()
 printResumeHint progName persist =
-    ensurePersistenceSessionId persist >>= \case
-        Nothing -> pure ()
-        Just sessionId -> do
-            -- Drop an in-place "Thinking…" status so the hint is its own line.
-            Text.hPutStr stderr "\r\ESC[K"
-            clearNativeProgress stderr
-            color <- resolveColor stderr
-            putTextLn stderr
-                (roleMuted color (resumeHint progName sessionId))
+    catchUserInterrupt
+        (ensurePersistenceSessionId persist >>= \case
+            Nothing -> pure ()
+            Just sessionId -> do
+                -- Drop an in-place "Thinking…" status so the hint is its own line.
+                Text.hPutStr stderr "\r\ESC[K"
+                clearNativeProgress stderr
+                color <- resolveColor stderr
+                putTextLn stderr
+                    (roleMuted color (resumeHint progName sessionId)))
+        -- A repeated Ctrl-C may arrive while the pending session or footer is
+        -- being written. Retry the stable reservation before cleanup runs.
+        (printResumeHint progName persist)

--- a/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Interrupt
 import qualified Control.Exception as Base
 import Control.Exception (AsyncException(ThreadKilled, UserInterrupt))
 import Control.Exception.Safe (finally, throwIO, toSyncException)
+import Data.IORef
 import Test.Hspec
 
 spec :: Spec
@@ -54,3 +55,26 @@ spec = do
                 (Base.throwIO ThreadKilled)
                 (pure ())
                 `shouldThrow` anyException
+
+    describe "retryUserInterruptOnce" do
+        it "recovers from one UserInterrupt" do
+            attempts <- newIORef (0 :: Int)
+            retryUserInterruptOnce
+                (do
+                    attempt <- atomicModifyIORef' attempts \count ->
+                        let next = count + 1
+                        in (next, next)
+                    if attempt == 1
+                        then Base.throwIO UserInterrupt
+                        else pure ("recovered" :: String))
+                `shouldReturn` "recovered"
+            readIORef attempts `shouldReturn` 2
+
+        it "propagates a UserInterrupt from the recovery attempt" do
+            attempts <- newIORef (0 :: Int)
+            retryUserInterruptOnce
+                (atomicModifyIORef' attempts
+                    (\count -> (count + 1, ()))
+                    >> Base.throwIO UserInterrupt)
+                `shouldThrow` (== UserInterrupt)
+            readIORef attempts `shouldReturn` 2


### PR DESCRIPTION
## Summary
- make pending PostgreSQL materialization idempotent across repeated `UserInterrupt`s by persisting stable, host-owned recovery metadata
- adopt an exact committed row or retry the same reservation before the masked pending-to-active handoff
- retry footer materialization once, while preserving repeated Ctrl+C force-exit and prompt-epoch recovery

## Review feedback addressed
Addresses https://github.com/digitallyinduced/haskell-agent/pull/877#discussion_r3898854238 and the follow-up findings on this PR.

## Testing
- `cabal repl agent-cli-runtime-test`: PostgreSQL session persistence — 16 examples, 0 failures
- `cabal repl agent-cli-test --repl-options=-fobject-code`: bounded interrupt retry — 2 examples, 0 failures
- `cabal repl agent-cli`: production source compiles
- tmux source run: normal double Ctrl+C printed `2026-09-01-4821f756`, and that exact ID resumed
- tmux stalled-footer run: stopped the isolated managed PostgreSQL cluster; repeated Ctrl+C propagated as `Interrupted.` instead of recursively retrying forever

## CI note
Two Nix runs completed the build but failed in the same 16 unrelated repository-delivery/review tests because generated `git`, `python3`, and `kill` fixtures were missing on the runner (`No such file or directory`). The changed focused suites passed, and the current-head Codex review was clean; the PR was merged with this runner failure documented.