### PR TITLE
Fix session history migration tests

### DIFF
--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -487,7 +487,8 @@ legacyTypedToolOutputMigrations =
 legacyPromptEpochPrerequisiteStatements :: [ByteString]
 legacyPromptEpochPrerequisiteStatements =
     [ "CREATE TABLE harness.sessions (\
-      \ session_id uuid PRIMARY KEY\
+      \ session_id uuid PRIMARY KEY,\
+      \ deleted_at timestamptz\
       \ )"
     , "CREATE OR REPLACE FUNCTION\
       \ harness.reject_session_fact_mutation()\

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -638,8 +638,7 @@ spec = describe "PostgreSQL session schema" do
                                     Right (Just page) -> do
                                         map
                                             (\storedTurn ->
-                                                storedTurn.storedTurn
-                                                    .sessionTurnUserText
+                                                storedTurn.storedTurn.sessionTurnUserText
                                             )
                                             (toList page.sessionPageTurns)
                                             `shouldBe`


### PR DESCRIPTION
## Summary
- fix the raw-session-history record-dot assertion that failed to parse in the Linux flake check
- make the synthetic legacy sessions fixture match the historical schema expected by the archived-session migration

## Validation
- `TMPDIR=$HOME/t nix develop --command cabal test agent-store-test -j1 --test-show-details=direct`
- 35 examples, 0 failures
- `git diff --check`
