### PR TITLE
Fix startup notice transcript ordering

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
@@ -286,10 +286,18 @@ commitLiveHistoryTurn durableTurn commit state =
                         unarchivedLiveStart
                             state.appUi.uiBlocks
                             durableTurn.historyTurnBlocks
+        -- System blocks emitted between durable turns still belong before the
+        -- turn being committed. Leaving them in 'appUi' makes
+        -- 'drawTranscript' render them after the whole durable history,
+        -- which moves startup diagnostics below the response they preceded.
+        -- Keep reset semantics strict: a reset starts a fresh transcript.
+        precedingBlocks
+            | commit == HistoryCommitReset = Seq.empty
+            | otherwise = Seq.take start state.appUi.uiBlocks
         (nextBlockId, remappedBlocks, blockIdRemap) =
             remapHistoryBlocks
                 state.appNextHistoryBlockId
-                durableTurn.historyTurnBlocks
+                (precedingBlocks <> durableTurn.historyTurnBlocks)
         remappedTurn =
             durableTurn { historyTurnBlocks = remappedBlocks }
         baseWindow =
@@ -323,7 +331,7 @@ commitLiveHistoryTurn durableTurn commit state =
                         (applyHistoryPage replacementPage baseWindow)
                 _ ->
                     appendHistoryTurn remappedTurn baseWindow
-        ui = truncateUiBlocks start state.appUi
+        ui = truncateUiBlocks 0 state.appUi
         remappedPreviews =
             remapSubmittedImagePreviewBlocks
                 blockIdRemap

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -88,6 +88,7 @@ import Agent.CLI.TUI.History
     , HistoryPage(..)
     , HistoryRequest(..)
     , HistoryTurn(..)
+    , HistoryWindow(..)
     , applyHistoryPage
     , emptyHistoryWindow
     )
@@ -1063,6 +1064,31 @@ spec = do
                 `shouldBe` V.char V.defAttr '┃'
 
     describe "history replacement viewport" do
+        it "keeps startup system messages ahead of the first committed turn" do
+            timeout 2_000_000 startupMessagesPrecedeFirstCommittedTurn
+                `shouldReturn`
+                    Just
+                        [ "agents.md: loaded 2 files"
+                        , "first prompt"
+                        , "first response"
+                        ]
+
+        it "keeps inter-turn system messages ahead of the next turn" do
+            timeout 2_000_000 interTurnMessagesPrecedeNextCommittedTurn
+                `shouldReturn`
+                    Just
+                        [ "first prompt"
+                        , "first response"
+                        , "background notice"
+                        , "second prompt"
+                        , "second response"
+                        ]
+
+        it "does not carry a pre-reset system message into new history" do
+            timeout 2_000_000 resetDoesNotRetainPriorSystemMessages
+                `shouldReturn`
+                    Just ["new prompt", "new response"]
+
         it "shows the new durable tail immediately while focused" do
             timeout 2_000_000
                 (fst <$> replacementAfterHistoryReplacement ReplaceWhileFocused)
@@ -1603,6 +1629,106 @@ replacementPreservesFollow follow = do
             ]
     (_, finalState) <- runFullscreenScriptWithState initialState script
     pure (finalState.appUi.uiFollow == follow)
+
+startupMessagesPrecedeFirstCommittedTurn :: IO [Text]
+startupMessagesPrecedeFirstCommittedTurn = do
+    runtime <- newScriptRuntime initialUiState
+    let startupMessage = "agents.md: loaded 2 files"
+        durableUi =
+            reduceUi (UiAssistantHistory "first response") $
+                reduceUi (UiUserSubmitted "first prompt") initialUiState
+        durableTurn = HistoryTurn
+            { historyTurnCursor = HistoryCursor 0
+            , historyTurnBlocks = durableUi.uiBlocks
+            }
+        initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+    (_, finalState) <-
+        runFullscreenScriptWithState
+            initialState
+            [ FullscreenScriptApp (AppUi (UiSystemMessage startupMessage))
+            , FullscreenScriptApp (AppUi (UiUserSubmitted "first prompt"))
+            , FullscreenScriptApp
+                (AppHistoryCommitted
+                    (HistoryGeneration 0)
+                    durableTurn
+                    HistoryCommitAppend)
+            , FullscreenScriptHalt
+            ]
+    pure $
+        map (.blockBody) $
+            concatMap
+                (toList . (.historyTurnBlocks))
+                (toList finalState.appHistoryWindow.historyWindowTurns)
+                <> toList finalState.appUi.uiBlocks
+
+interTurnMessagesPrecedeNextCommittedTurn :: IO [Text]
+interTurnMessagesPrecedeNextCommittedTurn = do
+    runtime <- newScriptRuntime initialUiState
+    let turn cursor prompt response =
+            let durableUi =
+                    reduceUi (UiAssistantHistory response) $
+                        reduceUi (UiUserSubmitted prompt) initialUiState
+            in HistoryTurn
+                { historyTurnCursor = HistoryCursor cursor
+                , historyTurnBlocks = durableUi.uiBlocks
+                }
+        commit cursor prompt response =
+            FullscreenScriptApp
+                (AppHistoryCommitted
+                    (HistoryGeneration 0)
+                    (turn cursor prompt response)
+                    HistoryCommitAppend)
+        initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+    (_, finalState) <-
+        runFullscreenScriptWithState
+            initialState
+            [ FullscreenScriptApp (AppUi (UiUserSubmitted "first prompt"))
+            , commit 0 "first prompt" "first response"
+            , FullscreenScriptApp (AppUi (UiSystemMessage "background notice"))
+            , FullscreenScriptApp (AppUi (UiUserSubmitted "second prompt"))
+            , commit 1 "second prompt" "second response"
+            , FullscreenScriptHalt
+            ]
+    pure $
+        map (.blockBody) $
+            concatMap
+                (toList . (.historyTurnBlocks))
+                (toList finalState.appHistoryWindow.historyWindowTurns)
+                <> toList finalState.appUi.uiBlocks
+
+resetDoesNotRetainPriorSystemMessages :: IO [Text]
+resetDoesNotRetainPriorSystemMessages = do
+    runtime <- newScriptRuntime initialUiState
+    let durableUi =
+            reduceUi (UiAssistantHistory "new response") $
+                reduceUi (UiUserSubmitted "new prompt") initialUiState
+        durableTurn = HistoryTurn
+            { historyTurnCursor = HistoryCursor 0
+            , historyTurnBlocks = durableUi.uiBlocks
+            }
+        initialState =
+            initialFullscreenAppState runtime [] AgentRoot [] 0
+    (_, finalState) <-
+        runFullscreenScriptWithState
+            initialState
+            [ FullscreenScriptApp
+                (AppUi (UiSystemMessage "old-session startup message"))
+            , FullscreenScriptApp (AppUi (UiUserSubmitted "new prompt"))
+            , FullscreenScriptApp
+                (AppHistoryCommitted
+                    (HistoryGeneration 1)
+                    durableTurn
+                    HistoryCommitReset)
+            , FullscreenScriptHalt
+            ]
+    pure $
+        map (.blockBody) $
+            concatMap
+                (toList . (.historyTurnBlocks))
+                (toList finalState.appHistoryWindow.historyWindowTurns)
+                <> toList finalState.appUi.uiBlocks
 
 committedPreviewKeys :: IO [BlockId]
 committedPreviewKeys = do


### PR DESCRIPTION
## Summary
- archive pre-turn system messages with the following durable turn
- preserve chronological ordering across startup and inter-turn notices
- discard old transient notices when durable history is reset

## Validation
- GHCi: `Agent.CLI.TUIAppSpec` (97 examples, 0 failures)
- live tmux smoke: confirmed `agents.md` notice remains before the submitted prompt and completed answer