### PR TITLE
Make repository tests portable in Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -608,9 +608,12 @@
                                         [ "lib/libhaskell-agent-bridge.dylib" ];
                             }))
                             [
+                                pkgs.bash
+                                pkgs.coreutils
                                 pkgs.git
                                 bun_1_4
                                 pkgs.postgresql_18
+                                pkgs.python3
                             ]);
                         agent-telegram = localPackage (pkgs.haskell.lib.addTestToolDepends
                             (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-telegram/package.nix { }) {

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -524,7 +524,7 @@ spec = describe "repository delivery service" do
                 let descendantPid = root <> "/gh-descendant.pid"
                 setEnv "GH_RETAIN_PIPE_MARKER" descendantPid
                 snapshot <- expectRight =<< repositorySnapshot root
-                result <- timeout 5_000_000
+                result <- timeout 30_000_000
                     (previewPullRequest
                         root snapshot.snapshotId "main" "Title" "Body")
                 result `shouldSatisfy` \case
@@ -691,6 +691,8 @@ withFakeGh root action = do
     originalRetainPipeMarker <- lookupEnv "GH_RETAIN_PIPE_MARKER"
     originalGhHost <- lookupEnv "GH_HOST"
     withTempDirectory "repository-delivery-gh" \bin -> do
+        bashExecutable <-
+            maybe (fail "bash not found") pure =<< findExecutable "bash"
         realGit <- maybe (fail "git not found") pure =<< findExecutable "git"
         localRemote <- Text.unpack . Text.strip
             <$> git root ["remote", "get-url", "origin"]
@@ -707,7 +709,7 @@ withFakeGh root action = do
             readyMarker = root <> "/pull-request-ready"
         _ <- git root ["remote", "set-url", "origin", githubRemote]
         writeFile gitExecutable $ unlines
-            [ "#!/bin/bash"
+            [ "#!" <> bashExecutable
             , "set -eu"
             , "args=()"
             , "for arg in \"$@\"; do"

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -221,7 +221,8 @@ spec = describe "repository review service" do
                 link = root <> "/pipe-link"
             createNamedPipe untrackedPipe
                 (ownerReadMode `unionFileModes` ownerWriteMode)
-            blocked <- timeout 10_000_000 (repositorySnapshot root)
+            blocked <- timeout specialFileRegressionTimeoutMicros
+                (repositorySnapshot root)
             blocked `shouldSatisfy` \case
                 Just (Left (InvalidRepositoryRequest _)) -> True
                 Just (Right _) -> True
@@ -231,7 +232,8 @@ spec = describe "repository review service" do
             createNamedPipe hiddenPipe
                 (ownerReadMode `unionFileModes` ownerWriteMode)
             createSymbolicLink ".git/hidden-pipe" link
-            linked <- timeout 10_000_000 (repositorySnapshot root)
+            linked <- timeout specialFileRegressionTimeoutMicros
+                (repositorySnapshot root)
             linked `shouldSatisfy` \case
                 Just (Right snapshot) ->
                     any
@@ -240,7 +242,7 @@ spec = describe "repository review service" do
                 _ -> False
             case linked of
                 Just (Right snapshot) ->
-                    timeout 10_000_000
+                    timeout specialFileRegressionTimeoutMicros
                         (repositoryDiff
                             root
                             snapshot.snapshotId
@@ -827,3 +829,9 @@ changePathCase = go
     go (character : rest)
         | isLower character = toUpper character : rest
         | otherwise = character : go rest
+
+-- A loaded Nix check can substantially delay the Git subprocesses that run
+-- before special paths are inspected. Keep this as a deadlock guard rather
+-- than a scheduler-sensitive performance assertion.
+specialFileRegressionTimeoutMicros :: Int
+specialFileRegressionTimeoutMicros = 75_000_000

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -12,7 +12,7 @@ import Control.Concurrent.MVar
     , putMVar
     , takeMVar
     )
-import Control.Exception.Safe (bracket, throwString)
+import Control.Exception.Safe (bracket, throwString, tryAny)
 import Control.Monad (forM_, when)
 import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isLower, toUpper)
@@ -28,6 +28,7 @@ import System.Directory
     ( createDirectory
     , doesDirectoryExist
     , doesFileExist
+    , findExecutable
     , getTemporaryDirectory
     , removeFile
     , removePathForcibly
@@ -53,6 +54,7 @@ import System.Posix.Files
     , setFileMode
     , unionFileModes
     )
+import System.Posix.Signals (nullSignal, signalProcess)
 import Test.Hspec
 
 spec :: Spec
@@ -219,7 +221,7 @@ spec = describe "repository review service" do
                 link = root <> "/pipe-link"
             createNamedPipe untrackedPipe
                 (ownerReadMode `unionFileModes` ownerWriteMode)
-            blocked <- timeout 2_000_000 (repositorySnapshot root)
+            blocked <- timeout 10_000_000 (repositorySnapshot root)
             blocked `shouldSatisfy` \case
                 Just (Left (InvalidRepositoryRequest _)) -> True
                 Just (Right _) -> True
@@ -229,7 +231,7 @@ spec = describe "repository review service" do
             createNamedPipe hiddenPipe
                 (ownerReadMode `unionFileModes` ownerWriteMode)
             createSymbolicLink ".git/hidden-pipe" link
-            linked <- timeout 2_000_000 (repositorySnapshot root)
+            linked <- timeout 10_000_000 (repositorySnapshot root)
             linked `shouldSatisfy` \case
                 Just (Right snapshot) ->
                     any
@@ -238,7 +240,7 @@ spec = describe "repository review service" do
                 _ -> False
             case linked of
                 Just (Right snapshot) ->
-                    timeout 2_000_000
+                    timeout 10_000_000
                         (repositoryDiff
                             root
                             snapshot.snapshotId
@@ -273,6 +275,9 @@ spec = describe "repository review service" do
 
     it "honors the common-directory advisory transaction lock" $
         withRepository \root -> do
+            pythonExecutable <-
+                maybe (fail "python3 not found") pure
+                    =<< findExecutable "python3"
             let lockPath =
                     root
                         <> "/.git/haskell-agent-worktree.lock"
@@ -284,7 +289,7 @@ spec = describe "repository review service" do
                         <> "open(" <> show readyPath <> ",'w').close();"
                         <> "time.sleep(30)"
             (_, _, _, locker) <-
-                createProcess (proc "/usr/bin/python3" ["-c", script])
+                createProcess (proc pythonExecutable ["-c", script])
             _ <- awaitFileContents readyPath 200
             pending <- async (repositorySnapshot root)
             blocked <- timeout 200_000 (waitCatch pending)
@@ -567,8 +572,8 @@ spec = describe "repository review service" do
                     snapshot.snapshotId
                     "/bin/sh"
                     [ "-c"
-                    , "/usr/bin/yes o | /usr/bin/head -c 1048576; "
-                        <> "/usr/bin/yes e | /usr/bin/head -c 1048576 >&2"
+                    , "yes o | head -c 1048576; "
+                        <> "yes e | head -c 1048576 >&2"
                     ]
                     (\stream bytes ->
                         atomicModifyIORef' byteCounts \(out, err) ->
@@ -617,10 +622,10 @@ spec = describe "repository review service" do
                     [ "-c"
                     , "/bin/sh -c 'trap \"\" TERM; echo $$ > "
                         <> shellQuote pidFile
-                        <> "; exec /bin/sleep 30' & "
+                        <> "; exec sleep 30' & "
                         <> "while [ ! -s "
                         <> shellQuote pidFile
-                        <> " ]; do /bin/sleep 0.01; done; exit 0"
+                        <> " ]; do sleep 0.01; done; exit 0"
                     ]
                     (\_ _ -> pure ())
                     (\cancelled exitCode ->
@@ -634,6 +639,9 @@ spec = describe "repository review service" do
 
     it "joins a successful commit hook descendant that retains Git output" $
         withRepository \root -> do
+            pythonExecutable <-
+                maybe (fail "python3 not found") pure
+                    =<< findExecutable "python3"
             appendFile (root <> "/tracked.txt") "hook completion\n"
             before <- expectRight =<< repositorySnapshot root
             staged <- expectRight
@@ -642,7 +650,7 @@ spec = describe "repository review service" do
             let pidFile = root <> "/completed-hook-child.pid"
                 hook = root <> "/.git/hooks/pre-commit"
             writeFile hook
-                ( "#!/usr/bin/python3\n"
+                ( "#!" <> pythonExecutable <> "\n"
                     <> "import os, signal, time\n"
                     <> "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
                     <> "pid = os.fork()\n"
@@ -658,7 +666,7 @@ spec = describe "repository review service" do
                     `unionFileModes` ownerWriteMode
                     `unionFileModes` ownerExecuteMode)
 
-            result <- timeout 5_000_000
+            result <- timeout 30_000_000
                 (commitRepository root staged.snapshotId "completed hook\n")
             result `shouldSatisfy` \case
                 Just (Right _) -> True
@@ -681,7 +689,7 @@ spec = describe "repository review service" do
                     <> "trap '' TERM\n"
                     <> "/bin/sh -c 'trap \"\" TERM; echo $$ > "
                     <> shellQuote pidFile
-                    <> "; exec /bin/sleep 30' &\n"
+                    <> "; exec sleep 30' &\n"
                     <> "wait\n"
                 )
             setFileMode hook
@@ -710,7 +718,7 @@ spec = describe "repository review service" do
                     "/bin/sh"
                     [ "-c"
                     , "trap '' TERM; "
-                        <> "(trap '' TERM; exec /bin/sleep 30) & wait"
+                        <> "(trap '' TERM; exec sleep 30) & wait"
                     ]
                     (\_ _ -> pure ())
                     (\cancelled exitCode -> do
@@ -790,12 +798,12 @@ awaitFileContents path attempts
             False -> threadDelay 10_000 >> awaitFileContents path (attempts - 1)
 
 processExists :: Text.Text -> IO Bool
-processExists pid = do
-    (exitCode, _, _) <-
-        readCreateProcessWithExitCode
-            (proc "/bin/kill" ["-0", Text.unpack pid])
-            ""
-    pure (exitCode == ExitSuccess)
+processExists pid =
+    case reads (Text.unpack pid) of
+        [(processId, "")] -> do
+            result <- tryAny (signalProcess nullSignal processId)
+            pure (either (const False) (const True) result)
+        _ -> pure False
 
 awaitProcessGone :: Text.Text -> Int -> IO Bool
 awaitProcessGone pid attempts =

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -582,9 +582,11 @@ spec = describe "Codex dialect" do
                     notice <- waitForBackgroundNotice
                         notices
                         ("codex-shell:" <> Text.pack (show commandId))
-                    notice.noticeBody `shouldSatisfy`
+                    let (_, resultSection) =
+                            Text.breakOn "\nResult:\n" notice.noticeBody
+                    resultSection `shouldSatisfy`
                         Text.isInfixOf "late-output"
-                    notice.noticeBody `shouldNotSatisfy`
+                    resultSection `shouldNotSatisfy`
                         Text.isInfixOf "early-output"
 
     it "retracts a retained-command notice when explicitly collected" do


### PR DESCRIPTION
## Summary
- declare Bash, coreutils, and Python as agent-cli test tools
- resolve generated-script interpreters instead of assuming FHS paths
- use portable process probes and allow loaded CI enough time for bounded process/FIFO regressions
- scope a newly merged Codex completion assertion to the result section instead of the echoed command

## Why
PR #888 exposed Linux Nix failures from test fixtures that assumed `/bin/bash`, `/usr/bin/python3`, `/usr/bin/yes`, `/usr/bin/head`, `/bin/sleep`, and `/bin/kill`. The production bridge/runtime changes were not implicated. After merging current master, hosted CI also exposed a deterministic false positive in the new completion-notice test because its sentinel appeared in the displayed command.

## Validation
- `TMPDIR="$HOME/t" nix develop --command cabal build agent-cli-test -j1`
- focused isolated runs for all 10 affected repository delivery/review cases (10/10 pass)
- focused Codex completion-notice test build/run
- `git diff --check`

Follow-up to #888.
