### PR TITLE
Highlight collapsed transcript blocks on hover

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -939,14 +939,20 @@ handleEventInner' event = case event of
                             _ -> pure ()
     -- The patched vty-unix backend represents no-button pointer motion as
     -- MouseUp Nothing so Brick can route it through clickable extents.
-    MouseUp (AgentRow target) Nothing _ ->
+    MouseUp (AgentRow target) Nothing _ -> do
+        setHoveredControl Nothing
         rememberAgentHover target
-    MouseUp (AgentPopover target) Nothing _ ->
+    MouseUp (AgentPopover target) Nothing _ -> do
+        setHoveredControl Nothing
         keepAgentHover target
     MouseUp AgentPane Nothing _ ->
-        pure ()
+        setHoveredControl Nothing
+    MouseUp name@(ConversationBlock _ _) Nothing _ -> do
+        clearAgentHover
+        setHoveredControl (Just name)
     MouseUp MarkdownLink{} Nothing _ -> do
         clearAgentHover
+        setHoveredControl Nothing
         setMarkdownLinkCursor True
     MouseUp link@MarkdownLink{} (Just V.BLeft) _ -> do
         clearAgentHover
@@ -983,6 +989,7 @@ handleEventInner' event = case event of
             >> queueConversationReflow
     VtyEvent V.EvResize{} -> do
         clearAgentHover
+        setHoveredControl Nothing
         invalidateCache
         -- A focused resize can leave cells from the previous geometry. Hidden
         -- terminals defer the reset until their focus-gained refresh.
@@ -1042,6 +1049,10 @@ eventClearsMarkdownLinkCursor = \case
 -- prevents its normal Command-hover OSC 8 detection; the app still receives
 -- pointer motion, so it can set the cursor precisely for the clickable link
 -- extent.
+setHoveredControl :: Maybe Name -> EventM Name AppState ()
+setHoveredControl hovered =
+    modify' \state -> state{appHoveredControl = hovered}
+
 setMarkdownLinkCursor :: Bool -> EventM Name AppState ()
 setMarkdownLinkCursor hovered = do
     state <- get

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -439,6 +439,9 @@ noteTerminalFocusLost = do
             , appLastAutoRecapAttemptAt = Nothing
             , appSyntaxHighlighter = Nothing
             , appSyntaxRequested = Set.empty
+            , appHoveredControl = Nothing
+            , appPressedControl = Nothing
+            , appAgentHover = Nothing
             }
     invalidateCache
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -93,6 +93,7 @@ import Brick
       vBox,
       vLimit,
       withAttr,
+      withDefAttr,
       withBorderStyle,
       AttrName,
       Context(availWidth),
@@ -152,20 +153,28 @@ import qualified Data.Text.Encoding as TextEncoding ()
 import qualified Agent.TUI.Theme as Theme
     ( assistantAttr,
       borderActiveAttr,
+      borderAttr,
       completionFlashAttr,
       controlLinkAttr,
+      dimAttr,
       errorAttr,
       mutedAttr,
       successAttr,
+      syntaxCommentAttr,
       thinkingAttr,
       thinkingBodyAttr,
+      transcriptHoverAttr,
+      transcriptHoverMutedAttr,
+      transcriptHoverMutedCancelledAttr,
+      transcriptHoverMutedItalicAttr,
       todoCancelledAttr,
       todoCompletedAttr,
       todoInProgressAttr,
       todoPendingAttr,
       toolAttr,
       userAttr,
-      userMutedAttr )
+      userMutedAttr,
+      waitingDimAttr )
 import qualified Agent.CLI.TUI.Transcript as Transcript ()
 import qualified Graphics.Vty as V ()
 import qualified Graphics.Vty.CrossPlatform as Vty ()
@@ -179,10 +188,8 @@ terminalTxtWrap = txtWrap . displayTerminalText
 
 drawBlock :: AppState -> AgentTarget -> UiState -> UiBlock -> Widget Name
 drawBlock state target ui block =
-    let selected =
-            ui.uiSelectedBlock == Just block.blockId
-                || (target == AgentRoot
-                    && state.appHistorySelectedBlock == Just block.blockId)
+    let selected = blockSelected state target ui block
+        hovered = conversationBlockHovered state target ui block
         highlighted =
             selected
                 && state.appUi.uiFocus == FocusScrollback
@@ -318,20 +325,30 @@ drawBlock state target ui block =
                         overrideAttr Border.borderAttr Theme.borderActiveAttr $
                             Border.border content
                 else content
+        blockRow =
+            case block.blockKind of
+                BlockUser -> framed
+                _ ->
+                    hBox
+                        [ withAttr
+                            (if highlighted
+                                then Theme.borderActiveAttr
+                                else Theme.mutedAttr)
+                            marker
+                        , framed
+                        ]
+        hoveredRow =
+            (if hovered
+                then
+                    withDefAttr Theme.transcriptHoverAttr
+                        . hoverReadableAttrs
+                else id) $
+                padRight Max blockRow
         rendered =
-            clickable (ConversationBlock target block.blockId) $
-                padBottom (Pad 1) $
-                    case block.blockKind of
-                        BlockUser -> framed
-                        _ ->
-                            hBox
-                                [ withAttr
-                                    (if highlighted
-                                        then Theme.borderActiveAttr
-                                        else Theme.mutedAttr)
-                                    marker
-                                , framed
-                                ]
+            padBottom (Pad 1) $
+                clickable
+                    (ConversationBlock target block.blockId)
+                    hoveredRow
     in if cacheableBlock state target ui block
         then cached
             (ConversationBlockCache
@@ -342,6 +359,28 @@ drawBlock state target ui block =
                 (codeCopyCacheState state target block.blockId))
             rendered
         else rendered
+
+-- The hover band occupies palette bright-black, so semantic gray foregrounds
+-- inherit dimmed terminal text instead of disappearing into the background.
+hoverReadableAttrs :: Widget Name -> Widget Name
+hoverReadableAttrs =
+    overrideAttr Theme.mutedAttr Theme.transcriptHoverMutedAttr
+        . overrideAttr
+            Theme.thinkingBodyAttr
+            Theme.transcriptHoverMutedItalicAttr
+        . overrideAttr
+            Theme.todoCompletedAttr
+            Theme.transcriptHoverMutedAttr
+        . overrideAttr
+            Theme.todoCancelledAttr
+            Theme.transcriptHoverMutedCancelledAttr
+        . overrideAttr
+            Theme.syntaxCommentAttr
+            Theme.transcriptHoverMutedItalicAttr
+        . overrideAttr Theme.dimAttr Theme.transcriptHoverMutedAttr
+        . overrideAttr Theme.waitingDimAttr Theme.transcriptHoverMutedAttr
+        . overrideAttr Theme.borderAttr Theme.transcriptHoverMutedAttr
+        . overrideAttr Theme.controlLinkAttr Theme.transcriptHoverMutedAttr
 
 submittedUserMessage
     :: AppState
@@ -499,6 +538,33 @@ cacheableBlock state target ui block =
             ((/= block.blockId) . (.retryCountdownBlockId))
             ui.uiRetryCountdown
         && not (blockFlashing state target block)
+        && not (conversationBlockHovered state target ui block)
+
+blockSelected :: AppState -> AgentTarget -> UiState -> UiBlock -> Bool
+blockSelected state target ui block =
+    ui.uiSelectedBlock == Just block.blockId
+        || (target == AgentRoot
+            && state.appHistorySelectedBlock == Just block.blockId)
+
+conversationBlockHovered
+    :: AppState
+    -> AgentTarget
+    -> UiState
+    -> UiBlock
+    -> Bool
+conversationBlockHovered state target ui block =
+    state.appHoveredControl
+        == Just (ConversationBlock target block.blockId)
+        && not (blockSelected state target ui block)
+        && not block.blockExpanded
+        && block.blockKind
+            `elem` [ BlockThinking
+                   , BlockTool
+                   , BlockInspect
+                   , BlockTodo
+                   , BlockShell
+                   , BlockEdit
+                   ]
 
 blockStateGlyph :: AppState -> AgentTarget -> UiBlock -> Text
 blockStateGlyph state target block = case block.blockState of

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -747,6 +747,50 @@ spec = do
             V.shutdown wrapped
             readIORef events `shouldReturn` [Left reset, Right ()]
 
+    describe "fullscreen transcript hover" do
+        it "tracks pointer motion without selecting the transcript row" do
+            runtime <- newScriptRuntime initialUiState
+            let blockId = BlockId 42
+                name = ConversationBlock AgentRoot blockId
+                initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, hovered) <-
+                runFullscreenScriptWithState
+                    initialState
+                    [ FullscreenScriptMouseUp name
+                    , FullscreenScriptHalt
+                    ]
+            hovered.appHoveredControl `shouldBe` Just name
+            hovered.appUi.uiSelectedBlock `shouldBe` Nothing
+
+        it "clears the hovered transcript row after the pointer leaves" do
+            runtime <- newScriptRuntime initialUiState
+            let name = ConversationBlock AgentRoot (BlockId 42)
+                initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, finalState) <-
+                runFullscreenScriptWithState
+                    initialState
+                    [ FullscreenScriptMouseUp name
+                    , FullscreenScriptMouseUp ConversationViewport
+                    , FullscreenScriptHalt
+                    ]
+            finalState.appHoveredControl `shouldBe` Nothing
+
+        it "clears the hovered transcript row when terminal focus is lost" do
+            runtime <- newScriptRuntime initialUiState
+            let name = ConversationBlock AgentRoot (BlockId 42)
+                initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, finalState) <-
+                runFullscreenScriptWithState
+                    initialState
+                    [ FullscreenScriptMouseUp name
+                    , FullscreenScriptVty V.EvLostFocus
+                    , FullscreenScriptHalt
+                    ]
+            finalState.appHoveredControl `shouldBe` Nothing
+
     describe "fullscreen window title" do
         it "replays the stored session title as UTF-8 OSC bytes" do
             titles <- newIORef ([] :: [ByteString.ByteString])
@@ -1552,6 +1596,7 @@ spec = do
 data FullscreenScriptEvent
     = FullscreenScriptApp !AppEvent
     | FullscreenScriptVty !V.Event
+    | FullscreenScriptMouseUp !Name
     | FullscreenScriptHalt
 
 data ReplacementScenario
@@ -2125,6 +2170,9 @@ runFullscreenScriptWithState initialState script = do
                     fullscreenApp.appHandleEvent (AppEvent event)
                 AppEvent (FullscreenScriptVty event) ->
                     fullscreenApp.appHandleEvent (VtyEvent event)
+                AppEvent (FullscreenScriptMouseUp name) ->
+                    fullscreenApp.appHandleEvent
+                        (MouseUp name Nothing (B.Location (0, 0)))
                 AppEvent FullscreenScriptHalt ->
                     halt
                 VtyEvent event ->

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -23,6 +23,10 @@ module Agent.TUI.Theme
     , mutedAttr
     , selectedAttr
     , selectedMutedAttr
+    , transcriptHoverAttr
+    , transcriptHoverMutedAttr
+    , transcriptHoverMutedCancelledAttr
+    , transcriptHoverMutedItalicAttr
     , strongAttr
     , successAttr
     , syntaxAnnotationAttr
@@ -81,6 +85,9 @@ baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
 userAttr, userMutedAttr, assistantAttr, thinkingAttr, thinkingBodyAttr, toolAttr :: AttrName
 todoPendingAttr, todoInProgressAttr, todoCompletedAttr, todoCancelledAttr :: AttrName
 errorAttr, successAttr, selectedAttr, selectedMutedAttr, borderAttr, borderActiveAttr :: AttrName
+transcriptHoverAttr :: AttrName
+transcriptHoverMutedAttr, transcriptHoverMutedItalicAttr :: AttrName
+transcriptHoverMutedCancelledAttr :: AttrName
 headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
 lambdaDimAttr, lambdaTrailAttr, lambdaGlowAttr, lambdaSparkAttr :: AttrName
@@ -107,6 +114,11 @@ errorAttr = attrName "error"
 successAttr = attrName "success"
 selectedAttr = attrName "selected"
 selectedMutedAttr = attrName "selected-muted"
+transcriptHoverAttr = attrName "transcript-hover"
+transcriptHoverMutedAttr = attrName "transcript-hover-muted"
+transcriptHoverMutedItalicAttr = attrName "transcript-hover-muted-italic"
+transcriptHoverMutedCancelledAttr =
+    attrName "transcript-hover-muted-cancelled"
 borderAttr = attrName "border"
 borderActiveAttr = attrName "border-active"
 headingAttr = attrName "markdown-heading"
@@ -184,6 +196,12 @@ terminalDefault =
             palette V.brightGreen `V.withStyle` V.bold)
         , (selectedAttr, raisedPanelAttr `V.withStyle` V.bold)
         , (selectedMutedAttr, raisedPanelMutedAttr)
+        , (transcriptHoverAttr, raisedPanelMutedAttr)
+        , (transcriptHoverMutedAttr, V.defAttr `V.withStyle` V.dim)
+        , (transcriptHoverMutedItalicAttr,
+            V.defAttr `V.withStyle` (V.dim .|. V.italic))
+        , (transcriptHoverMutedCancelledAttr,
+            V.defAttr `V.withStyle` (V.dim .|. V.strikethrough))
         , (borderAttr, palette V.brightBlack `V.withStyle` V.dim)
         , (borderActiveAttr, palette V.brightBlack)
         , (headingAttr, palette V.magenta `V.withStyle` V.bold)
@@ -245,6 +263,15 @@ monochrome =
         , (selectedAttr, V.defAttr
             `V.withStyle` (V.bold .|. V.reverseVideo))
         , (selectedMutedAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (transcriptHoverAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (transcriptHoverMutedAttr,
+            V.defAttr `V.withStyle` (V.reverseVideo .|. V.dim))
+        , (transcriptHoverMutedItalicAttr,
+            V.defAttr `V.withStyle`
+                (V.reverseVideo .|. V.dim .|. V.italic))
+        , (transcriptHoverMutedCancelledAttr,
+            V.defAttr `V.withStyle`
+                (V.reverseVideo .|. V.dim .|. V.strikethrough))
         , (borderAttr, V.defAttr `V.withStyle` V.dim)
         , (borderActiveAttr, V.defAttr)
         , (headingAttr, V.defAttr `V.withStyle` V.bold)

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -4,7 +4,8 @@ import Agent.Syntax (SyntaxClass(..))
 import Agent.TUI.Motion (MotionMode(..))
 import qualified Agent.TUI.Theme as Theme
 import Brick (AttrName)
-import Brick.AttrMap (attrMapLookup)
+import Brick.AttrMap (attrMapLookup, mapAttrName, setDefaultAttr)
+import Data.Bits ((.|.))
 import Data.List (nub)
 import qualified Graphics.Vty as V
 import Graphics.Vty.Attributes.Color (Color(..))
@@ -81,6 +82,25 @@ spec = do
             V.attrBackColor userMuted `shouldBe` V.SetTo V.brightBlack
             V.attrBackColor assistant `shouldBe` V.Default
 
+        it "keeps muted transcript text readable on the palette hover band" do
+            let theme = Theme.terminalDefault
+                hover =
+                    attrMapLookup
+                        Theme.transcriptHoverAttr
+                        theme
+                hoveredTheme =
+                    mapAttrName
+                        Theme.transcriptHoverMutedAttr
+                        Theme.mutedAttr
+                        (setDefaultAttr hover theme)
+                hoveredMuted =
+                    attrMapLookup Theme.mutedAttr hoveredTheme
+            V.attrBackColor hover `shouldBe` V.SetTo V.brightBlack
+            V.attrForeColor hover `shouldBe` V.SetTo V.white
+            V.attrForeColor hoveredMuted `shouldBe` V.SetTo V.white
+            V.attrBackColor hoveredMuted `shouldBe` V.SetTo V.brightBlack
+            V.attrStyle hoveredMuted `shouldBe` V.SetTo V.dim
+
         it "does not introduce colors in monochrome mode" do
             map
                 ( \syntaxClass ->
@@ -106,8 +126,25 @@ spec = do
                 , Theme.userMutedAttr
                 , Theme.selectedAttr
                 , Theme.selectedMutedAttr
+                , Theme.transcriptHoverAttr
                 ]
-                `shouldBe` replicate 4 (V.Default, V.Default)
+                `shouldBe` replicate 5 (V.Default, V.Default)
+
+        it "retains reverse video for muted monochrome hover text" do
+            let theme = Theme.monochrome
+                hover =
+                    attrMapLookup
+                        Theme.transcriptHoverAttr
+                        theme
+                hoveredTheme =
+                    mapAttrName
+                        Theme.transcriptHoverMutedAttr
+                        Theme.mutedAttr
+                        (setDefaultAttr hover theme)
+                hoveredMuted =
+                    attrMapLookup Theme.mutedAttr hoveredTheme
+            V.attrStyle hoveredMuted
+                `shouldBe` V.SetTo (V.reverseVideo .|. V.dim)
 
     describe "live accent wave" do
         it "fades a named accent through distinct RGB values" do


### PR DESCRIPTION
## Summary
- track pointer motion over collapsed transcript blocks
- paint a subtle full-width palette hover band without hiding semantic text
- keep hover correct across focus changes, caching, inspection blocks, and monochrome mode

## Validation
- `TMPDIR="$HOME/.t" nix develop "path:$PWD" -c cabal build -j1 agent-tui-test agent-cli-test exe:agent-cli`
- `agent-tui-test` (209 examples, 0 failures)
- `agent-cli-test --match "fullscreen transcript hover"` (3 examples, 0 failures)
- full `agent-cli-test` (1576 examples; one unrelated session-shutdown timeout, exact seeded rerun passed)
- live fullscreen tmux mouse enter/leave check on a collapsed inspection block