### PR TITLE
Address changelog review feedback

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -32,6 +32,7 @@ module Agent.CLI.TUI.App
     , motionDemandForTerminalFocus
     , motionModeForTerminalFocus
     , lambdaArtWidget
+    , quickStartCardHeight
     , quickStartRows
     , quickStartVisible
     , quickStartWideVisible

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -8,6 +8,7 @@ module Agent.CLI.TUI.Render.Internal
     , conversationScrollbarRenderer
     , choiceRowColumns
     , filterChoiceRowLimit
+    , quickStartCardHeight
     , quickStartVisible
     , quickStartWideVisible
     , quickStartCardWidth
@@ -196,7 +197,8 @@ import Agent.CLI.TUI.Render.Overlays
     , normalizeTextOverlayInsertion, maskedSecretText, textOverlayDisplayText
     , resumeSearchCursorColumn )
 import Agent.CLI.TUI.Render.Transcript
-    ( stickyPromptLayers, quickStartVisible, quickStartWideVisible
+    ( stickyPromptLayers, quickStartCardHeight
+    , quickStartVisible, quickStartWideVisible
     , quickStartCardWidth, quickStartRows, drawQuickStartCard
     , startupCapabilityLines )
 import Agent.CLI.TUI.Render.Workspace

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
@@ -5,6 +5,7 @@ module Agent.CLI.TUI.Render.Transcript
     , stickyPromptLayers
     , drawEmptyConversation
     , drawConversationBlocks
+    , quickStartCardHeight
     , quickStartVisible
     , quickStartWideVisible
     , quickStartCardWidth
@@ -379,13 +380,24 @@ quickStartCardWidth :: Int -> Int
 quickStartCardWidth width =
     max 1 (min 112 (width - 4))
 
+quickStartCardHeight :: Bool -> Int
+quickStartCardHeight showLogo =
+    cardChromeRows
+        + contentFixedRows
+        + length quickStartRows
+        + toolRows
+  where
+    cardChromeRows = 4
+    contentFixedRows = 4
+    toolRows = if showLogo then 2 else 1
+
 quickStartVisible :: Int -> Int -> Bool
 quickStartVisible width height =
-    width >= 48 && height >= 13
+    width >= 48 && height >= quickStartCardHeight False
 
 quickStartWideVisible :: Int -> Int -> Bool
 quickStartWideVisible width height =
-    width >= 88 && height >= 14
+    width >= 88 && height >= quickStartCardHeight True
 
 quickStartRows :: [(Name, Text, Text)]
 quickStartRows =

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -491,6 +491,7 @@ spec = do
                     , "copy-path"
                     , "copy-session"
                     , "terminal"
+                    , "changelog"
                     , "agents"
                     , "mcp"
                     , "loop"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -47,6 +47,7 @@ import Agent.CLI.TUI.App
     , motionDemandForTerminalFocus
     , motionModeForTerminalFocus
     , lambdaArtWidget
+    , quickStartCardHeight
     , quickStartRows
     , quickStartVisible
     , quickStartWideVisible
@@ -882,14 +883,14 @@ spec = do
             rendered 0 `shouldNotBe` rendered 400
 
         it "shows quick-start actions only when the empty pane has room" do
-            quickStartVisible 100 30 `shouldBe` True
+            quickStartVisible 100 14 `shouldBe` True
             quickStartVisible 47 30 `shouldBe` False
-            quickStartVisible 100 12 `shouldBe` False
+            quickStartVisible 100 13 `shouldBe` False
 
         it "adds the quiet logo only in wide render contexts" do
-            quickStartWideVisible 88 14 `shouldBe` True
-            quickStartWideVisible 87 14 `shouldBe` False
-            quickStartWideVisible 88 13 `shouldBe` False
+            quickStartWideVisible 88 15 `shouldBe` True
+            quickStartWideVisible 87 15 `shouldBe` False
+            quickStartWideVisible 88 14 `shouldBe` False
 
         it "caps the quick-start card instead of filling wide terminals" do
             quickStartCardWidth 48 `shouldBe` 44
@@ -916,6 +917,10 @@ spec = do
                         { appSlashCatalog = catalog }
             B.vSize (drawQuickStartCard state 96 True)
                 `shouldBe` B.Fixed
+
+        it "reserves space for every quick-start action at boundary heights" do
+            quickStartCardHeight False `shouldBe` 14
+            quickStartCardHeight True `shouldBe` 15
 
         it "surfaces the high-value startup commands including changelog" do
             quickStartRows


### PR DESCRIPTION
## Summary
- add `/changelog` to the exhaustive slash-command catalog expectation
- derive quick-start card minimum heights from the action row count
- cover narrow and wide boundary heights so new actions cannot be clipped

## Testing
- focused object-code GHCi tests for the exhaustive catalog, quick-start layout, and changelog (7 examples, 0 failures)
- live tmux smoke tests at 80×28 and 120×35 confirming `View changelog`, tools, and skills remain visible

Follow-up to #880.