### PR TITLE
Add selectable terminal themes

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -261,6 +261,7 @@ parseSlash catalog raw line = case Text.words line of
                     then ReplToggleFast
                     else ReplCommandError "usage: /fast"
             "model" -> parseModelCommand args
+            "theme" -> parseThemeCommand args
             "plan" ->
                 let description =
                         Text.strip (Text.drop (Text.length command) line)
@@ -718,6 +719,14 @@ parseModelCommand = \case
             ReplCommandError "usage: /model [NAME]"
         | otherwise -> ReplSetModel name
     _ -> ReplCommandError "usage: /model [NAME]"
+
+parseThemeCommand :: [Text] -> ReplAction
+parseThemeCommand = \case
+    [] -> ReplShowTheme
+    [name]
+        | not (Text.null (Text.strip name)) -> ReplSetTheme name
+        | otherwise -> ReplCommandError "usage: /theme [NAME]"
+    _ -> ReplCommandError "usage: /theme [NAME]"
 
 -- | Rebuild from the constructor: 'input' is also a field on 'CustomToolCall'.
 setReasoningEffort

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -17,6 +17,7 @@ slashCommands =
     , cmd "find" [] "/find [TEXT]" "Search this conversation in a pager" True
     , cmd "permissions" [] "/permissions" "Choose the tool approval policy" False
     , cmd "model" ["m"] "/model [NAME]" "Open the model picker, or set a model" True
+    , cmd "theme" ["t"] "/theme [NAME]" "Open the theme picker, or set a theme" True
     , cmd "effort" [] "/effort [none|low|medium|high|xhigh|max]" "Show or set reasoning effort" True
     , codexCmd "fast" [] "/fast" "Toggle the Fast service tier" False
     , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)" True

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -49,6 +49,8 @@ data ReplAction
     | ReplToggleFast
     | ReplShowModel
     | ReplSetModel Text
+    | ReplShowTheme
+    | ReplSetTheme Text
     | ReplEnableCodeMode
     | ReplToggleAlwaysApprove
     | ReplPlan (Maybe Text)

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -28,6 +28,11 @@ import Agent.Json (RawJson, rawJsonDecoder)
 import Agent.Json.Decode (defaultKey, optionalKey)
 import Agent.Json.Decode qualified as Hermes
 import Agent.OsPath (unsafeToFilePath)
+import Agent.TUI.Theme
+    ( ThemeKind(..)
+    , parseThemeKind
+    , themeKindText
+    )
 import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Control.Exception.Safe (displayException, tryIO)
 import Control.Monad (forM_, unless, when)
@@ -298,6 +303,7 @@ instance Aeson.ToJSON WorktreeConfig where
 
 data HarnessConfig = HarnessConfig
     { configVersion :: !Int
+    , configTheme :: !ThemeKind
     , configMcpInitStrategy :: !McpInitStrategy
     , configMcpServers :: !(Map Text McpServerConfig)
     , configWebFetch :: !WebFetchConfig
@@ -311,6 +317,7 @@ instance Aeson.ToJSON HarnessConfig where
     toJSON config =
         Aeson.object
             [ "version" Aeson..= config.configVersion
+            , "theme" Aeson..= themeKindText config.configTheme
             , "mcpInitStrategy" Aeson..= config.configMcpInitStrategy
             , "mcpServers" Aeson..= config.configMcpServers
             , "webFetch" Aeson..= config.configWebFetch
@@ -322,6 +329,7 @@ instance Aeson.ToJSON HarnessConfig where
 defaultHarnessConfig :: HarnessConfig
 defaultHarnessConfig = HarnessConfig
     { configVersion = harnessConfigSchemaVersion
+    , configTheme = Midnight
     , configMcpInitStrategy = McpInitAuto
     , configMcpServers = Map.empty
     , configWebFetch = WebFetchConfig
@@ -448,6 +456,7 @@ harnessConfigDecoder =
     Hermes.object $
         HarnessConfig
             <$> defaultKey harnessConfigSchemaVersion "version" Hermes.int
+            <*> defaultKey Midnight "theme" themeKindDecoder
             <*> defaultKey McpInitAuto
                 "mcpInitStrategy" mcpInitStrategyDecoder
             <*> defaultKey Map.empty "mcpServers"
@@ -463,6 +472,17 @@ harnessConfigDecoder =
 textMapDecoder :: Hermes.Decoder (Map Text Text)
 textMapDecoder =
     Hermes.objectAsMap pure Hermes.text
+
+themeKindDecoder :: Hermes.Decoder ThemeKind
+themeKindDecoder =
+    Hermes.text >>= \value ->
+        maybe
+            (fail
+                ("unknown theme "
+                    <> Text.unpack value
+                    <> " (expected auto, midnight, daylight, tokyonight, rosepine-moon, or oscura-midnight)"))
+            pure
+            (parseThemeKind value)
 
 -- | @~/.haskell-agent/config.json@ for a supplied home directory.
 harnessConfigPath :: OsPath -> OsPath

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -12,7 +12,10 @@ import Agent.CLI.Clipboard ()
 import Agent.CLI.CodeModeRuntime ()
 import Agent.CLI.Command ()
 import Agent.CLI.Compaction ()
-import Agent.CLI.Config ()
+import Agent.CLI.Config
+    ( HarnessConfig(configTheme)
+    , loadHarnessConfig
+    )
 import Agent.CLI.Connectivity ()
 import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
@@ -148,7 +151,7 @@ import Agent.CLI.TUI.App
       clearFullscreenHistorySource,
       emitUiEvent,
       newFullscreenInputBuffer,
-      newFullscreenRuntime,
+      newFullscreenRuntimeWithTheme,
       queuedFullscreenInputDisplays,
       runFullscreen,
       setFullscreenHistorySource,
@@ -690,6 +693,10 @@ prepareAgentIterationTracked
     syntaxLoadDurationRef <- newIORef Nothing
     startupFinishedRef <- newIORef False
     home <- getHomeDirectory
+    configuredTheme <-
+        loadHarnessConfig home >>= \case
+            Left err -> failPreparation (Text.unpack err)
+            Right config -> pure config.configTheme
     let root = sessionsRoot home
     databaseConfig <- managedPostgresConfigForHome home
     databaseStore <- openStore databaseConfig >>= \case
@@ -786,7 +793,8 @@ prepareAgentIterationTracked
         Just runtime -> pure (Just runtime)
         Nothing
             | fullscreenEnabled ->
-                Just <$> newFullscreenRuntime
+                Just <$> newFullscreenRuntimeWithTheme
+                    configuredTheme
                     fullscreenInputs
                     (readIORef cancelToolRef >>= id)
                     (\level ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -30,10 +30,10 @@ import Agent.CLI.Command
                  ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
                  ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopy,
                  ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
-                 ReplDesktop,
-                 ReplShowTerminal, ReplChangelog,
+                 ReplDesktop, ReplShowTerminal, ReplChangelog,
                  ReplShowEffort, ReplSetEffort, ReplShowModel,
-                 ReplSetModel, ReplToggleFast, ReplEnableCodeMode,
+                 ReplSetModel, ReplShowTheme, ReplSetTheme,
+                 ReplToggleFast, ReplEnableCodeMode,
                  ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
                  ReplViewPlan, ReplQueue, ReplTranscript, ReplEditPrompt,
                  ReplContext, ReplHistory, ReplFind,
@@ -872,6 +872,8 @@ handleReplLine
                     action@ReplToggleFast -> handleSelectionAction env continue action
                     action@ReplShowModel -> handleSelectionAction env continue action
                     action@ReplSetModel{} -> handleSelectionAction env continue action
+                    action@ReplShowTheme -> handleSelectionAction env continue action
+                    action@ReplSetTheme{} -> handleSelectionAction env continue action
                     ReplEnableCodeMode ->
                         requestCodeModeRestart fullscreen persist
                     ReplToggleAlwaysApprove

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -24,9 +24,12 @@ import Agent.CLI.Command
     ( currentEffort,
       currentModel,
       ReplAction(ReplSetModel, ReplShowEffort, ReplSetEffort, ReplToggleFast,
-                 ReplShowModel) )
+                 ReplShowModel, ReplShowTheme, ReplSetTheme) )
 import Agent.CLI.Compaction ()
-import Agent.CLI.Config ()
+import Agent.CLI.Config
+    ( HarnessConfig(configTheme)
+    , updateHarnessConfig
+    )
 import Agent.CLI.Connectivity ()
 import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
@@ -112,10 +115,15 @@ import Agent.CLI.Style
 import Agent.CLI.Subagents.Runtime ()
 import Agent.CLI.TUI.App
     ( emitUiEvent,
+      enqueueAppEvent,
+      requestFullscreenThemeChoice,
       requestFullscreenChoiceWithBody,
       withFullscreenSuspended )
 import Agent.CLI.TUI.SessionHistory ()
-import Agent.CLI.TUI.Types ()
+import Agent.CLI.TUI.Types
+    ( AppEvent(AppSetTheme)
+    , FullscreenRuntime(runtimeThemeRef)
+    )
 import Agent.CLI.Terminal ( resolveColor )
 import Agent.CLI.Tools ()
 import Agent.CLI.Turn ()
@@ -153,6 +161,12 @@ import Agent.TUI.Model
     ( progressNotice,
       UiEvent(UiSetNotice, UiSystemMessage, UiErrorMessage) )
 import Agent.TUI.Motion ()
+import Agent.TUI.Theme
+    ( parseThemeKind
+    , themeKindAt
+    , themeKindRows
+    , themeKindText
+    )
 import Agent.ToolDispatch ()
 import Agent.Tools.MultiAgents ()
 import Agent.Tools.PlanMode ()
@@ -192,7 +206,7 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ()
-import qualified Data.Text as Text ( stripPrefix )
+import qualified Data.Text as Text
 import qualified Data.Text.IO as Text ( putStrLn, hPutStrLn )
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Usage as XAIUsage ()
@@ -475,6 +489,21 @@ handleSelection
                             Text.putStrLn
                                 (roleMuted color (glyphOk <> message))
                         continue
+    Right ReplShowTheme ->
+        chooseTheme continue
+    Right (ReplSetTheme name) ->
+        case parseThemeKind name of
+            Nothing -> do
+                color <- resolveColor stderr
+                let message =
+                        "unknown theme '"
+                            <> Text.strip name
+                            <> "' (try /theme for the picker)"
+                displayError message $
+                    Text.hPutStrLn stderr (roleError color message)
+                continue
+            Just theme ->
+                setTheme theme continue
     _ -> error "handleSelection: unsupported input"
   where
     displayInfo message minimalAction = case fullscreen of
@@ -604,6 +633,48 @@ handleSelection
                                 })
                             (resolveConfiguredModel catalog name)
                 Right <$> resolveModelOptionDialect choice
+    chooseTheme next =
+        case fullscreen of
+            Nothing -> do
+                color <- resolveColor stderr
+                let message = "theme selection requires fullscreen mode"
+                Text.hPutStrLn stderr (roleError color message)
+                next
+            Just runtime -> do
+                current <- readIORef runtime.runtimeThemeRef
+                let initial =
+                        fromMaybe 0 $
+                            findIndex
+                                (== current)
+                                (map themeKindAt [0 .. length themeKindRows - 1])
+                requestFullscreenThemeChoice
+                    runtime
+                    initial
+                    themeKindRows >>= \case
+                    Nothing -> next
+                    Just index -> setTheme (themeKindAt index) next
+    setTheme theme next =
+        case fullscreen of
+            Nothing -> do
+                color <- resolveColor stderr
+                let message = "theme selection requires fullscreen mode"
+                Text.hPutStrLn stderr (roleError color message)
+                next
+            Just runtime -> do
+                updateHarnessConfig
+                    env.sessionHome
+                    (\config -> Right config { configTheme = theme })
+                    >>= \case
+                    Left err -> do
+                        color <- resolveColor stderr
+                        Text.hPutStrLn stderr (roleError color err)
+                        next
+                    Right _ -> do
+                        enqueueAppEvent runtime (AppSetTheme theme)
+                        emitUiEvent runtime
+                            (UiSystemMessage
+                                ("theme set to " <> themeKindText theme))
+                        next
     switchModelTarget color choice selectedEffort next =
         requestModelTargetSwitch fullscreen choice persist >>= \case
             Left err

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -43,6 +43,7 @@ module Agent.CLI.TUI.App
     , nextMotionSchedule
     , newFullscreenInputBuffer
     , newFullscreenRuntime
+    , newFullscreenRuntimeWithTheme
     , newFullscreenRuntimeWithSyntaxLoader
     , selectedAgentConversation
     , loadSyntaxHighlighterForRuntime
@@ -64,6 +65,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
     , requestFullscreenDocument
+    , requestFullscreenThemeChoice
     , requestFullscreenFilterChoice
     , requestFullscreenAdjustableFilterChoice
     , requestFullscreenOnboarding

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -192,7 +192,14 @@ fullscreenApp = App
         vScrollToEnd (viewportScroll ConversationViewport)
     , appAttrMap = \state ->
         if state.appRuntime.runtimeColor
-            then Theme.terminalDefault
+            then
+                Theme.themeAttrMap
+                    (case state.appChoice of
+                        Just choice
+                            | choice.choicePresentation == ChoiceTheme ->
+                                Theme.themeKindAt choice.choiceIndex
+                            | otherwise -> state.appTheme
+                        Nothing -> state.appTheme)
             else Theme.monochrome
     }
 
@@ -685,6 +692,10 @@ handleEventInner' event = case event of
                 AppSyncSubmittedImagePlacements
     AppEvent AppSyncSubmittedImagePlacements ->
         syncSubmittedImagePlacements
+    AppEvent (AppSetTheme theme) -> do
+        state <- get
+        liftIO (writeIORef state.appRuntime.runtimeThemeRef theme)
+        modify' \current -> current { appTheme = theme }
     AppEvent (AppAskPermission summary reply) -> do
         state <- get
         liftIO (state.appRuntime.runtimeNativeProgress False)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -696,6 +696,7 @@ handleEventInner' event = case event of
         state <- get
         liftIO (writeIORef state.appRuntime.runtimeThemeRef theme)
         modify' \current -> current { appTheme = theme }
+        invalidateCache
     AppEvent (AppAskPermission summary reply) -> do
         state <- get
         liftIO (state.appRuntime.runtimeNativeProgress False)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -193,13 +193,7 @@ fullscreenApp = App
     , appAttrMap = \state ->
         if state.appRuntime.runtimeColor
             then
-                Theme.themeAttrMap
-                    (case state.appChoice of
-                        Just choice
-                            | choice.choicePresentation == ChoiceTheme ->
-                                Theme.themeKindAt choice.choiceIndex
-                            | otherwise -> state.appTheme
-                        Nothing -> state.appTheme)
+                Theme.themeAttrMap (activeTheme state)
             else Theme.monochrome
     }
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -683,6 +683,8 @@ appEventLogicalBytes = \case
                 skills)
     AppSetModelIds modelIds ->
         saturatingAdd 256 (logicalTextsBytes modelIds)
+    AppSetTheme{} ->
+        256
     AppAgentSnapshot target entries ->
         foldl'
             (\size entry ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -489,7 +489,13 @@ handleStaticChoiceKey event = do
     scrollNotes =
         vScrollBy (viewportScroll OverlayViewport)
 
-    moveChoice delta =
+    moveChoice delta = do
+        previewingTheme <-
+            gets
+                ( maybe False
+                    ((== ChoiceTheme) . (.choicePresentation))
+                    . (.appChoice)
+                )
         modify' \state ->
             state
                 { appChoice =
@@ -503,6 +509,7 @@ handleStaticChoiceKey event = do
                                 })
                         <$> state.appChoice
                 }
+        when previewingTheme invalidateCache
 
 handleFilterChoiceKey :: V.Event -> EventM Name AppState ()
 handleFilterChoiceKey event = case event of

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -426,6 +426,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appNextHistoryBlockId = -1
         , appPermissionReply = Nothing
         , appRuntime = runtime
+        , appTheme = runtime.runtimeTheme
         , appSlashIndex = 0
         , appChoice = Nothing
         , appChoiceReply = Nothing

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -126,6 +126,7 @@ import qualified Agent.CLI.TUI.Scroll as Scroll
 import qualified Agent.CLI.TUI.Transcript as Transcript
 import Agent.CLI.TUI.Types
 import Agent.TUI.Model
+import Agent.TUI.Theme (ThemeKind(..))
 import Agent.TUI.Motion ( MotionDemand(..)
     , MotionMode(..)
     , backgroundIndicator
@@ -204,7 +205,29 @@ newFullscreenRuntime
     -> UiState
     -> IO FullscreenRuntime
 newFullscreenRuntime =
-    newFullscreenRuntimeWithSyntaxLoader newSyntaxHighlighter
+    newFullscreenRuntimeWithSyntaxLoaderAndTheme
+        Midnight
+        newSyntaxHighlighter
+
+newFullscreenRuntimeWithTheme
+    :: ThemeKind
+    -> FullscreenInputBuffer
+    -> IO ()
+    -> (Text -> IO ())
+    -> IO CtrlCDecision
+    -> (Text -> IO Bool)
+    -> (Text -> IO ())
+    -> (Bool -> IO ())
+    -> IO (AgentTarget, [AgentEntry])
+    -> (AgentTarget -> IO ())
+    -> IO ()
+    -> (NominalDiffTime -> IO ())
+    -> MotionMode
+    -> Bool
+    -> UiState
+    -> IO FullscreenRuntime
+newFullscreenRuntimeWithTheme theme =
+    newFullscreenRuntimeWithSyntaxLoaderAndTheme theme newSyntaxHighlighter
 
 newFullscreenRuntimeWithSyntaxLoader
     :: IO (Either Text SyntaxHighlighter)
@@ -224,6 +247,31 @@ newFullscreenRuntimeWithSyntaxLoader
     -> UiState
     -> IO FullscreenRuntime
 newFullscreenRuntimeWithSyntaxLoader
+    syntaxLoader =
+    newFullscreenRuntimeWithSyntaxLoaderAndTheme
+        Midnight
+        syntaxLoader
+
+newFullscreenRuntimeWithSyntaxLoaderAndTheme
+    :: ThemeKind
+    -> IO (Either Text SyntaxHighlighter)
+    -> FullscreenInputBuffer
+    -> IO ()
+    -> (Text -> IO ())
+    -> IO CtrlCDecision
+    -> (Text -> IO Bool)
+    -> (Text -> IO ())
+    -> (Bool -> IO ())
+    -> IO (AgentTarget, [AgentEntry])
+    -> (AgentTarget -> IO ())
+    -> IO ()
+    -> (NominalDiffTime -> IO ())
+    -> MotionMode
+    -> Bool
+    -> UiState
+    -> IO FullscreenRuntime
+newFullscreenRuntimeWithSyntaxLoaderAndTheme
+    theme
     syntaxLoader
     inputBuffer
     cancelAction
@@ -264,6 +312,7 @@ newFullscreenRuntimeWithSyntaxLoader
         imagePreviewProtocol <- detectImagePreviewProtocol stdout
         imagePreviewInTmux <- isJust <$> lookupEnv "TMUX"
         colorFgBg <- lookupEnv "COLORFGBG"
+        themeRef <- newIORef theme
         windowTitle <- newIORef Nothing
         sessionActions <- newIORef FullscreenSessionActions
             { sessionProvider = Nothing
@@ -317,6 +366,8 @@ newFullscreenRuntimeWithSyntaxLoader
                 imagePreviewProtocol == PreviewKitty
                     && not imagePreviewInTmux
             , runtimeColor = color
+            , runtimeTheme = theme
+            , runtimeThemeRef = themeRef
             , runtimeWaveTrough = Theme.waveTroughFromColorFgBg colorFgBg
             , runtimeLoadSyntaxHighlighter = syntaxLoader
             , runtimeSyntaxLoadFinished = syntaxLoadFinished
@@ -860,6 +911,17 @@ requestFullscreenPermission runtime workspace call = do
     let summary = approvalToolCallPromptRelative workspace call
     notifyAttention stderr PermissionRequested
     enqueueAppEvent runtime (AppAskPermission summary reply)
+    atomically (readTMVar reply)
+
+requestFullscreenThemeChoice
+    :: FullscreenRuntime
+    -> Int
+    -> [(Text, Text)]
+    -> IO (Maybe Int)
+requestFullscreenThemeChoice runtime initial rows = do
+    reply <- newEmptyTMVarIO
+    enqueueAppEvent runtime
+        (AppAskChoice ChoiceTheme "Theme" "Choose a theme. Arrow keys preview it live; Enter applies it, Esc cancels." initial rows reply)
     atomically (readTMVar reply)
 
 -- | Open a searchable choice whose right-hand value can be adjusted with

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -38,6 +38,7 @@ import Agent.CLI.TUI.Types
                appHoveredControl, appPressedControl, appRuntime),
       FullscreenRuntime(runtimeWaveTrough, runtimeMotionMode,
                         runtimeNativeImagePreviews, runtimeColor),
+      activeTheme,
       Name(ConversationBodyCache, CodeBlockCache, ConversationBlock,
            ConversationBlockCache, ConversationImage, CodeCopy,
            MarkdownLink) )
@@ -174,7 +175,8 @@ import qualified Agent.TUI.Theme as Theme
       toolAttr,
       userAttr,
       userMutedAttr,
-      waitingDimAttr )
+      waitingDimAttr,
+      waveTroughForTheme )
 import qualified Agent.CLI.TUI.Transcript as Transcript ()
 import qualified Graphics.Vty as V ()
 import qualified Graphics.Vty.CrossPlatform as Vty ()
@@ -698,11 +700,17 @@ accentBlockWithSections
         motionGlyphSet
         accent
         state.appRuntime.runtimeColor
-        state.appRuntime.runtimeWaveTrough
+        trough
+        theme
         waveElapsed $
         padLeft (Pad 2) $
             vBox (titleWidget : bodyWidgets)
   where
+    theme = activeTheme state
+    trough =
+        Theme.waveTroughForTheme
+            theme
+            state.appRuntime.runtimeWaveTrough
     titleWidget = case waveElapsed of
         Nothing ->
             withAttr accent (terminalTxtWrap title)
@@ -710,7 +718,8 @@ accentBlockWithSections
             waveHeader
                 accent
                 state.appRuntime.runtimeColor
-                state.appRuntime.runtimeWaveTrough
+                trough
+                theme
                 elapsedMillis
                 title
     paddedBody = map (padTop (Pad 1)) sections

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -65,6 +65,7 @@ import Agent.CLI.TUI.Types
     ( AppState(appMetaConsole, appMotionElapsedMillis, appTerminalFocus,
                appAgentEntries, appRuntime, appImagePreviews, appResume,
                appTextPrompt, appChoice, appUi),
+      activeTheme,
       FullscreenRuntime(runtimeNativeImagePreviews, runtimeWaveTrough,
                         runtimeColor, runtimeMotionMode),
       Name(ComposerImageRemove) )
@@ -174,7 +175,8 @@ import qualified Agent.TUI.Theme as Theme
       mutedAttr,
       successAttr,
       thinkingAttr,
-      waitingPulseAttr )
+      waitingPulseAttrForTheme,
+      waveTroughForTheme )
 import qualified Agent.CLI.TUI.Transcript as Transcript ()
 import qualified Graphics.Vty as V
     ( Attr,
@@ -473,7 +475,11 @@ drawPromptActivity state
     mode = state.appRuntime.runtimeMotionMode
     motionMillis = state.appMotionElapsedMillis
     colorEnabled = state.appRuntime.runtimeColor
-    trough = state.appRuntime.runtimeWaveTrough
+    theme = activeTheme state
+    trough =
+        Theme.waveTroughForTheme
+            theme
+            state.appRuntime.runtimeWaveTrough
     effectiveMode =
         motionModeForTerminalFocus state.appTerminalFocus mode
     busy =
@@ -484,7 +490,8 @@ drawPromptActivity state
     diamond =
         raw
             ( V.char
-                (Theme.waitingPulseAttr
+                (Theme.waitingPulseAttrForTheme
+                    theme
                     colorEnabled
                     effectiveMode
                     trough

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -65,7 +65,8 @@ import Agent.CLI.TUI.Types
                     choiceAdjustments, choiceAdjustmentIndices),
       choiceVisibleRows,
       selectedChoiceIndex,
-      ChoicePresentation(ChoiceOnboarding, ChoiceDialog, ChoiceDocument),
+      ChoicePresentation(ChoiceOnboarding, ChoiceDialog, ChoiceDocument,
+                         ChoiceTheme),
       AppState(appRuntime,
                appDictation, appTextPrompt, appChoice, appMetaConsole,
                appMotionElapsedMillis, appUi, appTerminalFocus),
@@ -526,6 +527,7 @@ drawChoice appState choice
         ChoiceDialog -> drawDialogChoice appState choice
         ChoiceDocument -> drawDialogChoice appState choice
         ChoiceOnboarding -> drawOnboardingChoice appState choice
+        ChoiceTheme -> drawDialogChoice appState choice
 
 drawFilterChoice :: AppState -> ChoiceOverlay -> Widget Name
 drawFilterChoice appState choice =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -70,6 +70,7 @@ import Agent.CLI.TUI.Types
       AppState(appRuntime,
                appDictation, appTextPrompt, appChoice, appMetaConsole,
                appMotionElapsedMillis, appUi, appTerminalFocus),
+      activeTheme,
       FullscreenRuntime(runtimeMotionMode, runtimeColor, runtimeWaveTrough),
       Name(ChoiceRow, PermissionRow, ResumeViewport,
            ResumeSearchCursor, ResumeRow, OverlayViewport, MarkdownLink,
@@ -192,7 +193,8 @@ import qualified Agent.TUI.Theme as Theme
       strongAttr,
       successAttr,
       thinkingAttr,
-      waitingPulseAttr )
+      waitingPulseAttrForTheme,
+      waveTroughForTheme )
 import qualified Agent.CLI.TUI.Transcript as Transcript ()
 import qualified Graphics.Vty as V
     ( char )
@@ -844,12 +846,15 @@ waitingOverlayLabel state label =
         [ txt " "
         , raw
             ( V.char
-                (Theme.waitingPulseAttr
+                (Theme.waitingPulseAttrForTheme
+                    (activeTheme state)
                     state.appRuntime.runtimeColor
                     (motionModeForTerminalFocus
                         state.appTerminalFocus
                         state.appRuntime.runtimeMotionMode)
-                    state.appRuntime.runtimeWaveTrough
+                    (Theme.waveTroughForTheme
+                        (activeTheme state)
+                        state.appRuntime.runtimeWaveTrough)
                     state.appMotionElapsedMillis)
                 ( case Text.uncons
                     (waitingIndicator

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -10,6 +10,7 @@ module Agent.CLI.TUI.Types
     , ChoicePresentation(..)
     , ChoiceOverlay(..)
     , ChoiceSelection(..)
+    , activeTheme
     , choiceVisibleRows
     , selectedChoice
     , selectedChoiceIndex
@@ -51,7 +52,7 @@ import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.Loop (ImageAttachment)
 import Agent.Provider (Provider)
 import Agent.TUI.Model (BlockId, UiEvent, UiState)
-import Agent.TUI.Theme (ThemeKind)
+import Agent.TUI.Theme (ThemeKind, themeKindAt)
 import Agent.Syntax (SyntaxHighlighter)
 import Agent.TUI.Motion (MotionDemand, MotionMode)
 import Brick (Location)
@@ -460,6 +461,15 @@ selectedChoice choice = do
         | otherwise = case drop index values of
             value : _ -> Just value
             [] -> Nothing
+
+-- | The selected picker row previews its palette before it is persisted.
+activeTheme :: AppState -> ThemeKind
+activeTheme state =
+    case state.appChoice of
+        Just choice
+            | choice.choicePresentation == ChoiceTheme ->
+                themeKindAt choice.choiceIndex
+        _ -> state.appTheme
 
 data ResumeOverlay = ResumeOverlay
     { resumeOverlayBrowser :: !ResumeBrowser

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -51,6 +51,7 @@ import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.Loop (ImageAttachment)
 import Agent.Provider (Provider)
 import Agent.TUI.Model (BlockId, UiEvent, UiState)
+import Agent.TUI.Theme (ThemeKind)
 import Agent.Syntax (SyntaxHighlighter)
 import Agent.TUI.Motion (MotionDemand, MotionMode)
 import Brick (Location)
@@ -159,6 +160,8 @@ data AppEvent
       -- ^ Legacy compatibility; prefer 'AppSetSlashCatalog'.
     | AppSetModelIds ![Text]
       -- ^ Legacy compatibility; prefer 'AppSetSlashCatalog'.
+    | AppSetTheme !ThemeKind
+      -- ^ Apply a theme to the retained fullscreen UI.
     | AppSetImagePreviews ![(ImageAttachment, TuiImagePreview)]
     | AppCommitImagePreviews ![(ImageAttachment, TuiImagePreview)]
     | AppToolImage !Text !TuiImagePreview
@@ -266,6 +269,8 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeImagePreviewIdBase :: !Int
     , runtimeNativeImagePreviews :: !Bool
     , runtimeColor :: !Bool
+    , runtimeTheme :: !ThemeKind
+    , runtimeThemeRef :: !(IORef ThemeKind)
     , runtimeWaveTrough :: !V.Color
     , runtimeLoadSyntaxHighlighter
         :: !(IO (Either Text SyntaxHighlighter))
@@ -313,6 +318,7 @@ data AppState = AppState
     , appNextHistoryBlockId :: !Int
     , appPermissionReply :: !(Maybe (TMVar (Maybe PermissionChoice)))
     , appRuntime :: !FullscreenRuntime
+    , appTheme :: !ThemeKind
     , appSlashIndex :: !Int
     , appChoice :: !(Maybe ChoiceOverlay)
     , appChoiceReply :: !(Maybe (Maybe ChoiceSelection -> IO ()))
@@ -386,6 +392,7 @@ data ChoicePresentation
     = ChoiceDialog
     | ChoiceDocument
     | ChoiceOnboarding
+    | ChoiceTheme
     deriving (Eq, Show)
 
 data ChoiceOverlay = ChoiceOverlay

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -319,6 +319,18 @@ spec = do
             parseReplLine "/model openai/gpt-5.1"
                 `shouldBe` ReplSetModel "openai/gpt-5.1"
 
+        it "opens and selects a theme" do
+            parseReplLine "/theme" `shouldBe` ReplShowTheme
+            parseReplLine "/t" `shouldBe` ReplShowTheme
+            parseReplLine "/theme TokyoNight"
+                `shouldBe` ReplSetTheme "TokyoNight"
+            parseReplLine "/t daylight"
+                `shouldBe` ReplSetTheme "daylight"
+
+        it "rejects extra theme arguments" do
+            parseReplLine "/theme tokyo night"
+                `shouldBe` ReplCommandError "usage: /theme [NAME]"
+
         it "opens the resume picker" do
             parseReplLine "/resume" `shouldBe` ReplResume Nothing
             parseReplLine "/resume abc-123" `shouldBe` ReplResume (Just "abc-123")
@@ -453,6 +465,7 @@ spec = do
                     , "find"
                     , "permissions"
                     , "model"
+                    , "theme"
                     , "effort"
                     , "fast"
                     , "plan"

--- a/packages/agent-tui/src/Agent/TUI/Accent.hs
+++ b/packages/agent-tui/src/Agent/TUI/Accent.hs
@@ -25,10 +25,11 @@ accentRail
     -> AttrName
     -> Bool
     -> V.Color
+    -> Theme.ThemeKind
     -> Maybe Int
     -> Widget n
     -> Widget n
-accentRail glyphs attrName colorEnabled trough waveElapsed content =
+accentRail glyphs attrName colorEnabled trough theme waveElapsed content =
     Widget Greedy Fixed do
         context <- getContext
         attr <- lookupAttrName attrName
@@ -37,14 +38,15 @@ accentRail glyphs attrName colorEnabled trough waveElapsed content =
         let
             height = max 1 (V.imageHeight inner.image)
             glyph = accentBarChar glyphs
-            peak = Theme.wavePeakFor attrName
+            peak = Theme.wavePeakForTheme theme attrName
             rows = waveRowsFor height
             rail = case waveElapsed of
                 Nothing ->
                     V.charFill attr glyph 1 height
                 Just elapsedMillis ->
                     V.vertCat
-                        [ Theme.waveCell
+                        [ Theme.waveCellForTheme
+                            theme
                             colorEnabled
                             trough
                             peak
@@ -57,17 +59,25 @@ accentRail glyphs attrName colorEnabled trough waveElapsed content =
 
 -- | Live header: the leading spinner rides the same wave as row 0 of the
 -- rail; the rest of the title stays muted so the rail is what moves.
-waveHeader :: AttrName -> Bool -> V.Color -> Int -> Text.Text -> Widget n
-waveHeader attrName colorEnabled trough elapsedMillis title =
+waveHeader
+    :: AttrName
+    -> Bool
+    -> V.Color
+    -> Theme.ThemeKind
+    -> Int
+    -> Text.Text
+    -> Widget n
+waveHeader attrName colorEnabled trough theme elapsedMillis title =
     case Text.uncons title of
         Nothing -> emptyWidget
         Just (glyph, rest) ->
             hBox
                 [ raw
-                    ( Theme.waveCell
+                    ( Theme.waveCellForTheme
+                        theme
                         colorEnabled
                         trough
-                        (Theme.wavePeakFor attrName)
+                        (Theme.wavePeakForTheme theme attrName)
                         (waveBrightness elapsedMillis 0 (waveRowsFor 1))
                         glyph
                     )

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -68,6 +68,12 @@ module Agent.TUI.Theme
     , wavePeakFor
     , waveTrough
     , waveTroughFromColorFgBg
+    , ThemeKind(..)
+    , parseThemeKind
+    , themeKindText
+    , themeKindRows
+    , themeKindAt
+    , themeAttrMap
     ) where
 
 import Agent.Syntax (SyntaxClass(..))
@@ -77,9 +83,70 @@ import Control.Applicative ((<|>))
 import Data.Bits ((.|.))
 import Data.Maybe (fromMaybe)
 import Data.Word (Word8)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Text.Read (readMaybe)
 import qualified Graphics.Vty as V
 import Graphics.Vty.Attributes.Color (Color(..))
+
+-- | Built-in fullscreen color schemes.  'Auto' delegates to the terminal's
+-- configured palette, preserving the pre-theme behavior.
+data ThemeKind
+    = Auto
+    | Midnight
+    | Daylight
+    | TokyoNight
+    | RosePineMoon
+    | OscuraMidnight
+    deriving (Eq, Ord, Show, Read, Enum, Bounded)
+
+themeKindText :: ThemeKind -> Text
+themeKindText = \case
+    Auto -> "Auto"
+    Midnight -> "Midnight"
+    Daylight -> "Daylight"
+    TokyoNight -> "Tokyo Night"
+    RosePineMoon -> "Rose Pine Moon"
+    OscuraMidnight -> "Oscura Midnight"
+
+parseThemeKind :: Text -> Maybe ThemeKind
+parseThemeKind raw =
+    case Text.toCaseFold (Text.strip raw) of
+        "auto" -> Just Auto
+        "system" -> Just Auto
+        "midnight" -> Just Midnight
+        "night" -> Just Midnight
+        "daylight" -> Just Daylight
+        "day" -> Just Daylight
+        "tokyonight" -> Just TokyoNight
+        "tokyo-night" -> Just TokyoNight
+        "tokyo night" -> Just TokyoNight
+        "rosepine-moon" -> Just RosePineMoon
+        "rose pine moon" -> Just RosePineMoon
+        "rosé pine moon" -> Just RosePineMoon
+        "oscuramidnight" -> Just OscuraMidnight
+        "oscura-midnight" -> Just OscuraMidnight
+        "oscura midnight" -> Just OscuraMidnight
+        _ -> Nothing
+
+themeKindRows :: [(Text, Text)]
+themeKindRows =
+    [ (themeKindText kind, themeDescription kind)
+    | kind <- [Auto, Midnight, Daylight, TokyoNight, RosePineMoon, OscuraMidnight]
+    ]
+  where
+    themeDescription = \case
+        Auto -> "Use the terminal's native colors"
+        Midnight -> "Dark blue-violet"
+        Daylight -> "Light warm paper"
+        TokyoNight -> "Dark indigo"
+        RosePineMoon -> "Dark rose and lavender"
+        OscuraMidnight -> "Deep black with cyan accents"
+
+themeKindAt :: Int -> ThemeKind
+themeKindAt index =
+    [Auto, Midnight, Daylight, TokyoNight, RosePineMoon, OscuraMidnight]
+        !! max 0 (min 5 index)
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
 userAttr, userMutedAttr, assistantAttr, thinkingAttr, thinkingBodyAttr, toolAttr :: AttrName
@@ -305,6 +372,107 @@ monochrome =
         , (syntaxErrorAttr, V.defAttr
             `V.withStyle` (V.bold .|. V.reverseVideo))
         ]
+
+-- | Resolve a selectable theme to a Brick attribute map.  The semantic
+-- attribute names intentionally stay identical across themes so renderers do
+-- not need to know which palette is active.
+themeAttrMap :: ThemeKind -> AttrMap
+themeAttrMap Auto = terminalDefault
+themeAttrMap Midnight = mkTheme
+    (RGBColor 26 27 38) (RGBColor 220 220 230) (RGBColor 120 125 145)
+    (RGBColor 187 154 247) (RGBColor 122 162 247)
+themeAttrMap Daylight = mkTheme
+    (RGBColor 250 247 242) (RGBColor 45 42 46) (RGBColor 110 105 100)
+    (RGBColor 144 80 150) (RGBColor 45 100 170)
+themeAttrMap TokyoNight = mkTheme
+    (RGBColor 26 27 38) (RGBColor 192 202 245) (RGBColor 86 95 137)
+    (RGBColor 187 154 247) (RGBColor 122 162 247)
+themeAttrMap RosePineMoon = mkTheme
+    (RGBColor 25 23 36) (RGBColor 224 222 244) (RGBColor 144 140 170)
+    (RGBColor 235 188 186) (RGBColor 196 167 231)
+themeAttrMap OscuraMidnight = mkTheme
+    (RGBColor 8 12 18) (RGBColor 220 235 245) (RGBColor 105 130 145)
+    (RGBColor 65 210 190) (RGBColor 80 170 255)
+
+mkTheme :: V.Color -> V.Color -> V.Color -> V.Color -> V.Color -> AttrMap
+mkTheme background foreground muted accent link =
+    attrMap (V.defAttr `V.withBackColor` background)
+        [ (baseAttr, base)
+        , (headerAttr, base `V.withStyle` V.bold)
+        , (footerAttr, mutedA)
+        , (mutedAttr, mutedA)
+        , (userAttr, panel `V.withStyle` V.bold)
+        , (userMutedAttr, panelMuted)
+        , (assistantAttr, base)
+        , (thinkingAttr, accentA)
+        , (thinkingBodyAttr, mutedA `V.withStyle` (V.dim .|. V.italic))
+        , (waitingDimAttr, mutedA)
+        , (waitingMidAttr, accentA)
+        , (toolAttr, linkA)
+        , (todoPendingAttr, base)
+        , (todoInProgressAttr, accentA `V.withStyle` V.bold)
+        , (todoCompletedAttr, mutedA)
+        , (todoCancelledAttr, mutedA `V.withStyle` V.strikethrough)
+        , (errorAttr, redA `V.withStyle` V.bold)
+        , (successAttr, greenA)
+        , (completionFlashAttr, greenA `V.withStyle` V.bold)
+        , (selectedAttr, panel `V.withStyle` V.bold)
+        , (selectedMutedAttr, panelMuted)
+        , (borderAttr, mutedA `V.withStyle` V.dim)
+        , (borderActiveAttr, mutedA)
+        , (headingAttr, accentA `V.withStyle` V.bold)
+        , (codeAttr, linkA)
+        , (dimAttr, mutedA)
+        , (emphasisAttr, base `V.withStyle` V.italic)
+        , (inlineCodeAttr, linkA `V.withStyle` V.reverseVideo)
+        , (lambdaDimAttr, mutedA)
+        , (lambdaTrailAttr, mutedA)
+        , (lambdaGlowAttr, base `V.withStyle` V.bold)
+        , (lambdaSparkAttr, V.defAttr `V.withForeColor` foreground
+            `V.withStyle` V.bold)
+        , (linkAttr, linkA `V.withStyle` V.underline)
+        , (strongAttr, base `V.withStyle` V.bold)
+        , (controlLinkAttr, mutedA)
+        , (controlLinkHoverAttr, base `V.withStyle` V.underline)
+        , (controlLinkActiveAttr, panel `V.withStyle` V.bold)
+        , (syntaxNormalAttr, base)
+        , (syntaxKeywordAttr, accentA)
+        , (syntaxTypeAttr, yellowA)
+        , (syntaxFunctionAttr, linkA)
+        , (syntaxVariableAttr, cyanA)
+        , (syntaxStringAttr, greenA)
+        , (syntaxNumberAttr, accentA)
+        , (syntaxCommentAttr, mutedA `V.withStyle` V.italic)
+        , (syntaxOperatorAttr, yellowA)
+        , (syntaxAnnotationAttr, greenA)
+        , (syntaxPreprocessorAttr, yellowA)
+        , (syntaxWarningAttr, yellowA `V.withStyle` V.bold)
+        , (syntaxErrorAttr, redA `V.withStyle` V.bold)
+        ]
+  where
+    base = V.defAttr `V.withForeColor` foreground
+    panel =
+        V.defAttr
+            `V.withForeColor` foreground
+            `V.withBackColor` lighten background
+    panelMuted =
+        V.defAttr
+            `V.withForeColor` muted
+            `V.withBackColor` lighten background
+    mutedA = V.defAttr `V.withForeColor` muted
+    accentA = V.defAttr `V.withForeColor` accent
+    linkA = V.defAttr `V.withForeColor` link
+    redA = V.defAttr `V.withForeColor` (RGBColor 220 100 120)
+    greenA = V.defAttr `V.withForeColor` (RGBColor 100 210 150)
+    yellowA = V.defAttr `V.withForeColor` (RGBColor 230 190 100)
+    cyanA = V.defAttr `V.withForeColor` (RGBColor 90 200 220)
+
+    lighten (RGBColor r g b) =
+        RGBColor
+            (min 255 (r + 14))
+            (min 255 (g + 14))
+            (min 255 (b + 14))
+    lighten color = color
 
 palette :: V.Color -> V.Attr
 palette = V.withForeColor V.defAttr

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -63,11 +63,15 @@ module Agent.TUI.Theme
     , thinkingWavePeak
     , waitingAccentPeak
     , waveCell
+    , waveCellForTheme
     , waveForeground
     , waveForegroundFrom
     , wavePeakFor
+    , wavePeakForTheme
+    , waveTroughForTheme
     , waveTrough
     , waveTroughFromColorFgBg
+    , waitingPulseAttrForTheme
     , ThemeKind(..)
     , parseThemeKind
     , themeKindText
@@ -99,6 +103,14 @@ data ThemeKind
     | RosePineMoon
     | OscuraMidnight
     deriving (Eq, Ord, Show, Read, Enum, Bounded)
+
+data ThemePalette = ThemePalette
+    { themePaletteBackground :: !V.Color
+    , themePaletteForeground :: !V.Color
+    , themePaletteMuted :: !V.Color
+    , themePaletteAccent :: !V.Color
+    , themePaletteLink :: !V.Color
+    }
 
 themeKindText :: ThemeKind -> Text
 themeKindText = \case
@@ -147,6 +159,25 @@ themeKindAt :: Int -> ThemeKind
 themeKindAt index =
     [Auto, Midnight, Daylight, TokyoNight, RosePineMoon, OscuraMidnight]
         !! max 0 (min 5 index)
+
+fixedThemePalette :: ThemeKind -> Maybe ThemePalette
+fixedThemePalette = \case
+    Auto -> Nothing
+    Midnight -> Just (ThemePalette
+        (RGBColor 26 27 38) (RGBColor 220 220 230) (RGBColor 120 125 145)
+        (RGBColor 187 154 247) (RGBColor 122 162 247))
+    Daylight -> Just (ThemePalette
+        (RGBColor 250 247 242) (RGBColor 45 42 46) (RGBColor 110 105 100)
+        (RGBColor 144 80 150) (RGBColor 45 100 170))
+    TokyoNight -> Just (ThemePalette
+        (RGBColor 26 27 38) (RGBColor 192 202 245) (RGBColor 86 95 137)
+        (RGBColor 187 154 247) (RGBColor 122 162 247))
+    RosePineMoon -> Just (ThemePalette
+        (RGBColor 25 23 36) (RGBColor 224 222 244) (RGBColor 144 140 170)
+        (RGBColor 235 188 186) (RGBColor 196 167 231))
+    OscuraMidnight -> Just (ThemePalette
+        (RGBColor 8 12 18) (RGBColor 220 235 245) (RGBColor 105 130 145)
+        (RGBColor 65 210 190) (RGBColor 80 170 255))
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
 userAttr, userMutedAttr, assistantAttr, thinkingAttr, thinkingBodyAttr, toolAttr :: AttrName
@@ -377,22 +408,17 @@ monochrome =
 -- attribute names intentionally stay identical across themes so renderers do
 -- not need to know which palette is active.
 themeAttrMap :: ThemeKind -> AttrMap
-themeAttrMap Auto = terminalDefault
-themeAttrMap Midnight = mkTheme
-    (RGBColor 26 27 38) (RGBColor 220 220 230) (RGBColor 120 125 145)
-    (RGBColor 187 154 247) (RGBColor 122 162 247)
-themeAttrMap Daylight = mkTheme
-    (RGBColor 250 247 242) (RGBColor 45 42 46) (RGBColor 110 105 100)
-    (RGBColor 144 80 150) (RGBColor 45 100 170)
-themeAttrMap TokyoNight = mkTheme
-    (RGBColor 26 27 38) (RGBColor 192 202 245) (RGBColor 86 95 137)
-    (RGBColor 187 154 247) (RGBColor 122 162 247)
-themeAttrMap RosePineMoon = mkTheme
-    (RGBColor 25 23 36) (RGBColor 224 222 244) (RGBColor 144 140 170)
-    (RGBColor 235 188 186) (RGBColor 196 167 231)
-themeAttrMap OscuraMidnight = mkTheme
-    (RGBColor 8 12 18) (RGBColor 220 235 245) (RGBColor 105 130 145)
-    (RGBColor 65 210 190) (RGBColor 80 170 255)
+themeAttrMap theme =
+    maybe terminalDefault themePaletteAttrMap (fixedThemePalette theme)
+
+themePaletteAttrMap :: ThemePalette -> AttrMap
+themePaletteAttrMap palette =
+    mkTheme
+        palette.themePaletteBackground
+        palette.themePaletteForeground
+        palette.themePaletteMuted
+        palette.themePaletteAccent
+        palette.themePaletteLink
 
 mkTheme :: V.Color -> V.Color -> V.Color -> V.Color -> V.Color -> AttrMap
 mkTheme background foreground muted accent link =
@@ -430,8 +456,7 @@ mkTheme background foreground muted accent link =
         , (lambdaDimAttr, mutedA)
         , (lambdaTrailAttr, mutedA)
         , (lambdaGlowAttr, base `V.withStyle` V.bold)
-        , (lambdaSparkAttr, V.defAttr `V.withForeColor` foreground
-            `V.withStyle` V.bold)
+        , (lambdaSparkAttr, base `V.withStyle` V.bold)
         , (linkAttr, linkA `V.withStyle` V.underline)
         , (strongAttr, base `V.withStyle` V.bold)
         , (controlLinkAttr, mutedA `V.withBackColor` background)
@@ -453,7 +478,10 @@ mkTheme background foreground muted accent link =
         , (syntaxErrorAttr, redA `V.withStyle` V.bold)
         ]
   where
-    base = V.defAttr `V.withForeColor` foreground
+    base =
+        V.defAttr
+            `V.withForeColor` foreground
+            `V.withBackColor` background
     panel =
         V.defAttr
             `V.withForeColor` foreground
@@ -462,13 +490,34 @@ mkTheme background foreground muted accent link =
         V.defAttr
             `V.withForeColor` muted
             `V.withBackColor` lighten background
-    mutedA = V.defAttr `V.withForeColor` muted
-    accentA = V.defAttr `V.withForeColor` accent
-    linkA = V.defAttr `V.withForeColor` link
-    redA = V.defAttr `V.withForeColor` (RGBColor 220 100 120)
-    greenA = V.defAttr `V.withForeColor` (RGBColor 100 210 150)
-    yellowA = V.defAttr `V.withForeColor` (RGBColor 230 190 100)
-    cyanA = V.defAttr `V.withForeColor` (RGBColor 90 200 220)
+    mutedA =
+        V.defAttr
+            `V.withForeColor` muted
+            `V.withBackColor` background
+    accentA =
+        V.defAttr
+            `V.withForeColor` accent
+            `V.withBackColor` background
+    linkA =
+        V.defAttr
+            `V.withForeColor` link
+            `V.withBackColor` background
+    redA =
+        V.defAttr
+            `V.withForeColor` (RGBColor 220 100 120)
+            `V.withBackColor` background
+    greenA =
+        V.defAttr
+            `V.withForeColor` (RGBColor 100 210 150)
+            `V.withBackColor` background
+    yellowA =
+        V.defAttr
+            `V.withForeColor` (RGBColor 230 190 100)
+            `V.withBackColor` background
+    cyanA =
+        V.defAttr
+            `V.withForeColor` (RGBColor 90 200 220)
+            `V.withBackColor` background
 
     lighten (RGBColor r g b) =
         RGBColor
@@ -523,6 +572,15 @@ waveTroughFromColorFgBg :: Maybe String -> V.Color
 waveTroughFromColorFgBg env =
     maybe waveTrough ansiIndexRgb (env >>= colorFgBgBackground)
 
+-- | A fixed theme owns the page background; automatic mode keeps the
+-- terminal-derived trough so rails disappear into the surrounding terminal.
+waveTroughForTheme :: ThemeKind -> V.Color -> V.Color
+waveTroughForTheme theme terminalTrough =
+    maybe
+        terminalTrough
+        (\palette -> palette.themePaletteBackground)
+        (fixedThemePalette theme)
+
 colorFgBgBackground :: String -> Maybe Word8
 colorFgBgBackground spec =
     case break (== ';') spec of
@@ -539,17 +597,28 @@ ansiIndexRgb index =
     in RGBColor red green blue
 
 waitingPulseAttr :: Bool -> MotionMode -> V.Color -> Int -> V.Attr
-waitingPulseAttr False _ _ _ =
+waitingPulseAttr =
+    waitingPulseAttrForTheme Auto
+
+waitingPulseAttrForTheme
+    :: ThemeKind
+    -> Bool
+    -> MotionMode
+    -> V.Color
+    -> Int
+    -> V.Attr
+waitingPulseAttrForTheme _ False _ _ _ =
     V.defAttr
-waitingPulseAttr True mode trough elapsedMillis
-    | mode /= MotionFull =
-        V.defAttr `V.withForeColor` waitingAccentPeak
-    | otherwise =
-        waveForegroundFrom
-            True
-            trough
-            waitingAccentPeak
-            (0.3 + 0.7 * pulseBrightness elapsedMillis)
+waitingPulseAttrForTheme theme True mode trough elapsedMillis =
+    themeBackground theme trough
+        (if mode /= MotionFull
+            then V.defAttr `V.withForeColor` (waitingPeakForTheme theme)
+            else
+                waveForegroundFrom
+                    True
+                    trough
+                    (waitingPeakForTheme theme)
+                    (0.3 + 0.7 * pulseBrightness elapsedMillis))
 
 -- | Paint a rail cell. Near-zero brightness uses a default-attr space so the
 -- bar disappears into the real page even when the trough RGB is approximate.
@@ -563,10 +632,50 @@ waveCell True trough peak brightness glyph
     | otherwise =
         V.char (waveForegroundFrom True trough peak brightness) glyph
 
+waveCellForTheme
+    :: ThemeKind
+    -> Bool
+    -> V.Color
+    -> V.Color
+    -> Double
+    -> Char
+    -> V.Image
+waveCellForTheme _ False _ _ _ glyph =
+    V.char V.defAttr glyph
+waveCellForTheme theme True trough peak brightness glyph
+    | brightness <= 0.04 =
+        V.char (themeBackground theme trough V.defAttr) ' '
+    | otherwise =
+        V.char
+            (themeBackground theme trough
+                (waveForegroundFrom True trough peak brightness))
+            glyph
+
 wavePeakFor :: AttrName -> V.Color
 wavePeakFor attr
     | attr == thinkingAttr = thinkingWavePeak
     | otherwise = runningWavePeak
+
+wavePeakForTheme :: ThemeKind -> AttrName -> V.Color
+wavePeakForTheme theme attr =
+    case fixedThemePalette theme of
+        Nothing -> wavePeakFor attr
+        Just palette
+            | attr == thinkingAttr -> palette.themePaletteMuted
+            | otherwise -> palette.themePaletteAccent
+
+waitingPeakForTheme :: ThemeKind -> V.Color
+waitingPeakForTheme theme =
+    maybe
+        waitingAccentPeak
+        (\palette -> palette.themePaletteLink)
+        (fixedThemePalette theme)
+
+themeBackground :: ThemeKind -> V.Color -> V.Attr -> V.Attr
+themeBackground theme background attr =
+    case fixedThemePalette theme of
+        Nothing -> attr
+        Just _ -> attr `V.withBackColor` background
 
 -- | Paint a live accent cell at the given traveling-wave brightness.
 --

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -422,7 +422,9 @@ mkTheme background foreground muted accent link =
         , (borderActiveAttr, mutedA)
         , (headingAttr, accentA `V.withStyle` V.bold)
         , (codeAttr, linkA)
-        , (dimAttr, mutedA)
+        -- Overlay dimming uses 'forceAttr', so it must preserve the page
+        -- background instead of falling back to the terminal's colors.
+        , (dimAttr, mutedA `V.withBackColor` background)
         , (emphasisAttr, base `V.withStyle` V.italic)
         , (inlineCodeAttr, linkA `V.withStyle` V.reverseVideo)
         , (lambdaDimAttr, mutedA)
@@ -432,8 +434,9 @@ mkTheme background foreground muted accent link =
             `V.withStyle` V.bold)
         , (linkAttr, linkA `V.withStyle` V.underline)
         , (strongAttr, base `V.withStyle` V.bold)
-        , (controlLinkAttr, mutedA)
-        , (controlLinkHoverAttr, base `V.withStyle` V.underline)
+        , (controlLinkAttr, mutedA `V.withBackColor` background)
+        , (controlLinkHoverAttr,
+            panel `V.withStyle` V.underline)
         , (controlLinkActiveAttr, panel `V.withStyle` V.bold)
         , (syntaxNormalAttr, base)
         , (syntaxKeywordAttr, accentA)
@@ -469,10 +472,15 @@ mkTheme background foreground muted accent link =
 
     lighten (RGBColor r g b) =
         RGBColor
-            (min 255 (r + 14))
-            (min 255 (g + 14))
-            (min 255 (b + 14))
+            (lightenChannel r)
+            (lightenChannel g)
+            (lightenChannel b)
     lighten color = color
+
+    lightenChannel :: Word8 -> Word8
+    lightenChannel channel =
+        fromIntegral
+            (min (255 :: Int) (fromIntegral channel + 14))
 
 palette :: V.Color -> V.Attr
 palette = V.withForeColor V.defAttr

--- a/packages/agent-tui/test/Agent/TUI/AccentSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/AccentSpec.hs
@@ -61,7 +61,13 @@ spec = describe "accent rail" do
 
 sampleRail :: Maybe Int -> Int -> Widget ()
 sampleRail waveElapsed rows =
-    accentRail MotionUnicode Theme.toolAttr True Theme.waveTrough waveElapsed $
+    accentRail
+        MotionUnicode
+        Theme.toolAttr
+        True
+        Theme.waveTrough
+        Theme.Auto
+        waveElapsed $
         vBox (replicate rows (str "body"))
 
 containsAccentBar :: String -> Bool

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -43,6 +43,23 @@ spec = do
                     ]
 
     describe "syntax theme attributes" do
+        it "keeps the daylight page background while dimming overlays" do
+            V.attrBackColor
+                (attrMapLookup Theme.dimAttr (Theme.themeAttrMap Theme.Daylight))
+                `shouldBe` V.SetTo (RGBColor 250 247 242)
+
+        it "keeps daylight controls on the page instead of the terminal background" do
+            V.attrBackColor
+                (attrMapLookup
+                    Theme.controlLinkAttr
+                    (Theme.themeAttrMap Theme.Daylight))
+                `shouldBe` V.SetTo (RGBColor 250 247 242)
+            V.attrBackColor
+                (attrMapLookup
+                    Theme.controlLinkHoverAttr
+                    (Theme.themeAttrMap Theme.Daylight))
+                `shouldBe` V.SetTo (RGBColor 255 255 255)
+
         it "leaves every syntax background to the terminal theme" do
             map
                 ( V.attrBackColor

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -60,6 +60,29 @@ spec = do
                     (Theme.themeAttrMap Theme.Daylight))
                 `shouldBe` V.SetTo (RGBColor 255 255 255)
 
+        it "sets a daylight background on semantic text attributes" do
+            map
+                ( V.attrBackColor
+                    . (\name ->
+                        attrMapLookup
+                            name
+                            (Theme.themeAttrMap Theme.Daylight))
+                )
+                [ Theme.baseAttr
+                , Theme.headerAttr
+                , Theme.footerAttr
+                , Theme.mutedAttr
+                , Theme.assistantAttr
+                , Theme.thinkingAttr
+                , Theme.toolAttr
+                , Theme.errorAttr
+                , Theme.successAttr
+                , Theme.codeAttr
+                , Theme.linkAttr
+                , Theme.syntaxKeywordAttr
+                ]
+                `shouldSatisfy` all (/= V.Default)
+
         it "leaves every syntax background to the terminal theme" do
             map
                 ( V.attrBackColor
@@ -164,6 +187,24 @@ spec = do
                 `shouldBe` V.SetTo (V.reverseVideo .|. V.dim)
 
     describe "live accent wave" do
+        it "derives daylight motion colors from its palette" do
+            Theme.waveTroughForTheme
+                Theme.Daylight
+                (RGBColor 0 0 0)
+                `shouldBe` RGBColor 250 247 242
+            Theme.wavePeakForTheme Theme.Daylight Theme.toolAttr
+                `shouldBe` RGBColor 144 80 150
+            Theme.wavePeakForTheme Theme.Daylight Theme.thinkingAttr
+                `shouldBe` RGBColor 110 105 100
+            V.attrBackColor
+                (Theme.waitingPulseAttrForTheme
+                    Theme.Daylight
+                    True
+                    MotionOff
+                    (RGBColor 250 247 242)
+                    0)
+                `shouldBe` V.SetTo (RGBColor 250 247 242)
+
         it "fades a named accent through distinct RGB values" do
             let tool = attrMapLookup Theme.toolAttr Theme.terminalDefault
                 samples =


### PR DESCRIPTION
## Summary

- add `/theme` and `/t` commands for picking or naming a terminal palette
- preview palette changes while navigating the picker, then persist the confirmed choice
- load the saved selection when the fullscreen session initializes

## Testing

- `cabal repl agent-cli:lib:agent-cli`
- `cabal test agent-cli:test:agent-cli-test --test-options=--match=theme`
- native terminal launch in tmux