### PR TITLE
Preserve gateway model names with typed decoding

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.GatewayClient
     ( GatewayCredential(..)
     , GatewayModel(..)
+    , GatewayModelCatalogResponse(..)
     , GatewayModelProtocol(..)
     , GatewayModelAccess
     , GatewayAuthorization(..)
@@ -34,7 +35,6 @@ module Agent.CLI.GatewayClient
     , gatewayPollDecoder
     , loadGatewayCredential
     , loadGatewayCredentialAt
-    , gatewayModelsDecoder
     , fetchGatewayModels
     , newGatewayModelAccess
     , newGatewayModelAccessWith
@@ -60,7 +60,7 @@ import Control.Concurrent.STM (atomically, retry)
 import Control.Exception.Safe (bracket, bracketOnError, tryAny)
 import Control.Monad (when)
 import Crypto.Hash (Digest, SHA256, hash)
-import Data.Aeson ((.=))
+import Data.Aeson ((.=), (.:))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as AesonTypes
 import Data.ByteArray qualified as ByteArray
@@ -129,6 +129,32 @@ data GatewayModel = GatewayModel
     , gatewayModelProtocol :: !GatewayModelProtocol
     }
     deriving (Eq, Show)
+
+newtype GatewayModelCatalogResponse = GatewayModelCatalogResponse
+    { gatewayModelCatalogData :: [GatewayModel]
+    }
+    deriving (Eq, Show)
+
+instance Aeson.FromJSON GatewayModelCatalogResponse where
+    parseJSON =
+        Aeson.withObject "GatewayModelCatalogResponse" \object ->
+            GatewayModelCatalogResponse
+                . normalizeGatewayModels
+                <$> object .: "data"
+
+instance Aeson.FromJSON GatewayModel where
+    parseJSON =
+        Aeson.withObject "GatewayModel" \object ->
+            GatewayModel
+                <$> object .: "id"
+                <*> object .: "protocol"
+
+instance Aeson.FromJSON GatewayModelProtocol where
+    parseJSON =
+        Aeson.withText "GatewayModelProtocol" \case
+            "responses" -> pure GatewayResponsesProtocol
+            "anthropic" -> pure GatewayAnthropicProtocol
+            _ -> fail "Gateway model protocol is invalid."
 
 -- | A gateway-scoped model catalog and its most recently successful refresh.
 --
@@ -220,28 +246,6 @@ gatewayCredentialDecoder =
             <$> Hermes.atKey "base_url" Hermes.text
             <*> Hermes.atKey "websocket_url" Hermes.text
             <*> Hermes.atKey "access_token" Hermes.text
-
--- | Decode the unified gateway catalog. Every alias carries the wire protocol
--- required to invoke it; unknown protocols fail closed.
-gatewayModelsDecoder :: Hermes.Decoder [GatewayModel]
-gatewayModelsDecoder =
-    Hermes.object do
-        models <- Hermes.atKey "data" (Hermes.list gatewayModelDecoder)
-        pure (normalizeGatewayModels models)
-
-gatewayModelDecoder :: Hermes.Decoder GatewayModel
-gatewayModelDecoder =
-    Hermes.object $
-        GatewayModel
-            <$> Hermes.atKey "id" Hermes.text
-            <*> Hermes.atKey "protocol" gatewayModelProtocolDecoder
-
-gatewayModelProtocolDecoder :: Hermes.Decoder GatewayModelProtocol
-gatewayModelProtocolDecoder =
-    Hermes.text >>= \case
-        "responses" -> pure GatewayResponsesProtocol
-        "anthropic" -> pure GatewayAnthropicProtocol
-        _ -> fail "Gateway model protocol is invalid."
 
 -- | Construct a cached model-list handle for a validated gateway credential.
 newGatewayModelAccess :: GatewayCredential -> IO GatewayModelAccess
@@ -338,17 +342,18 @@ fetchGatewayModels credential =
                 Right value
                     | statusIsSuccessful (HTTP.responseStatus value) ->
                         case
-                            Hermes.decodeEither
-                                gatewayModelsDecoder
+                            Aeson.eitherDecodeStrict'
                                 (LBS.toStrict (HTTP.responseBody value))
+                                :: Either String GatewayModelCatalogResponse
                             of
                             Left _ ->
                                 Left
                                     "Gateway returned an unreadable models response."
-                            Right models
-                                | null models ->
+                            Right catalog
+                                | null catalog.gatewayModelCatalogData ->
                                     Left "Gateway returned an empty model catalog."
-                                | otherwise -> Right models
+                                | otherwise ->
+                                    Right catalog.gatewayModelCatalogData
                     | otherwise ->
                         Left $
                             "Gateway models returned HTTP "

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -3,7 +3,9 @@ module Agent.CLI.GatewayClientSpec (spec) where
 import Agent.CLI.GatewayClient
 import Agent.Json.Decode qualified as Hermes
 import Control.Exception.Safe (bracket, throwString)
+import Data.Aeson qualified as Aeson
 import Data.Bits ((.&.))
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.Either (isLeft)
 import Data.IORef (atomicModifyIORef', newIORef)
@@ -21,11 +23,17 @@ import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
 import System.Posix.Files (fileMode, getFileStatus)
 import Test.Hspec
 
+decodeGatewayModels :: BS.ByteString -> Either String [GatewayModel]
+decodeGatewayModels bytes =
+    (.gatewayModelCatalogData)
+        <$> ( Aeson.eitherDecodeStrict' bytes
+                :: Either String GatewayModelCatalogResponse
+            )
+
 spec :: Spec
 spec = describe "gateway device authorization" do
     it "decodes, trims, and deduplicates the typed gateway catalog" do
-        Hermes.decodeEither
-            gatewayModelsDecoder
+        decodeGatewayModels
             "{\"object\":\"list\",\"data\":[{\"id\":\" gpt-5.6-sol \",\"protocol\":\"responses\"},{\"id\":\"\",\"protocol\":\"responses\"},{\"id\":\"gpt-5.6-sol\",\"protocol\":\"responses\"},{\"id\":\"sonnet\",\"protocol\":\"anthropic\"},{\"id\":\"bad id\",\"protocol\":\"responses\"}]}"
             `shouldBe`
                 Right
@@ -34,8 +42,7 @@ spec = describe "gateway device authorization" do
                     ]
 
     it "rejects unknown gateway model protocols" do
-        Hermes.decodeEither
-            gatewayModelsDecoder
+        decodeGatewayModels
             "{\"object\":\"list\",\"data\":[{\"id\":\"model\",\"protocol\":\"router\"}]}"
             `shouldSatisfy` isLeft
 

--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -18,7 +18,10 @@ module Agent.CLI.ModelPicker
     , decodePickerKey
     ) where
 
-import Agent.CLI.ModelConfig (ModelCatalog)
+import Agent.CLI.ModelConfig
+    ( ModelCatalog
+    , organizationGatewayConnectionId
+    )
 import Agent.CLI.Models
 import Agent.CLI.Options
     ( defaultEffortFor
@@ -292,9 +295,11 @@ formatCatalogListingState color state =
                                 state.pickerCurrentDialect
                                 opt =
                                 roleSuccess color
-                                    (glyphOk <> formatOptionName opt)
+                                    (glyphOk
+                                        <> formatOptionName gatewayMode opt)
                             | otherwise =
-                                roleMuted color ("  " <> formatOptionName opt)
+                                roleMuted color
+                                    ("  " <> formatOptionName gatewayMode opt)
                         label = case opt.modelLabel of
                             Nothing -> ""
                             Just l ->
@@ -302,6 +307,7 @@ formatCatalogListingState color state =
                                     ("  " <> displayPickerText l)
                     in mark <> label)
                 state.pickerAll
+        gatewayMode = pickerUsesGateway state
     in Text.intercalate "\n" (header : rows)
 
 -- | Backwards-compatible pure frame seeded from the current provider default.
@@ -326,7 +332,7 @@ renderModelPickerFrame color state =
                 "↓ more"
            , ""
            ]
-        <> selectedDetailLines color selected
+        <> selectedDetailLines gatewayMode color selected
         <> [ ""
            , roleMuted color
                 "↑↓ select · ←→ reasoning effort · ↵ confirm · esc cancel"
@@ -351,6 +357,7 @@ renderModelPickerFrame color state =
             zipWith
                 (\index option ->
                     renderRow
+                        gatewayMode
                         color
                         (index == selectedIndex)
                         models.pickerConnectionId
@@ -366,6 +373,7 @@ renderModelPickerFrame color state =
                 (max 0 (pickerViewportSize - length body))
                 ""
     selected = selectedOption models
+    gatewayMode = pickerUsesGateway models
     header =
         rolePrompt color "Models"
             <> roleMuted color
@@ -393,7 +401,10 @@ pickerCurrentLabel state
                 && option.modelTarget.targetModelId
                     == state.pickerCurrent)
         state.pickerAll =
-            state.pickerConnectionId <> "/" <> state.pickerCurrent
+            displayModelName
+                (pickerUsesGateway state)
+                state.pickerConnectionId
+                state.pickerCurrent
     | otherwise = "(not offered in this scope)"
 
 pickerViewportSize :: Int
@@ -402,6 +413,7 @@ pickerViewportSize = 12
 renderRow
     :: Bool
     -> Bool
+    -> Bool
     -> Text
     -> Text
     -> DialectId
@@ -409,6 +421,7 @@ renderRow
     -> ModelOption
     -> Text
 renderRow
+        gatewayMode
         color
         selected
         currentConnection
@@ -422,13 +435,14 @@ renderRow
         else "  " <> clippedName <> padding <> roleMuted color indicator
   where
     plainName =
-        displayPickerText $
-            option.modelTarget.targetConnectionId
-                <> "/"
-                <> option.modelTarget.targetModelId
+        displayPickerText
+            (displayModelName
+                gatewayMode
+                option.modelTarget.targetConnectionId
+                option.modelTarget.targetModelId
                 <> if isCurrent currentConnection current currentDialect option
                     then " ✓"
-                    else ""
+                    else "")
     clippedName = Text.take modelNameWidth plainName
     padding =
         Text.replicate
@@ -450,8 +464,8 @@ renderEffortIndicator _option effort =
     barWidth = fromEnum (maxBound :: ReasoningEffort)
     filled = min barWidth (fromEnum effort)
 
-selectedDetailLines :: Bool -> Maybe ModelOption -> [Text]
-selectedDetailLines color = \case
+selectedDetailLines :: Bool -> Bool -> Maybe ModelOption -> [Text]
+selectedDetailLines gatewayMode color = \case
     Nothing ->
         [ rolePrompt color "No model selected"
         , roleMuted color "Try a different search."
@@ -459,9 +473,10 @@ selectedDetailLines color = \case
     Just option ->
         [ rolePrompt color $
             displayPickerText
-                (option.modelTarget.targetConnectionId
-                    <> "/"
-                    <> option.modelTarget.targetModelId)
+                (displayModelName
+                    gatewayMode
+                    option.modelTarget.targetConnectionId
+                    option.modelTarget.targetModelId)
         , roleMuted color $
             displayPickerText $
                 Text.intercalate
@@ -543,14 +558,27 @@ atMay index values
 glyphSessionLike :: Text
 glyphSessionLike = "⧉ "
 
-formatOptionName :: ModelOption -> Text
-formatOptionName option =
+formatOptionName :: Bool -> ModelOption -> Text
+formatOptionName gatewayMode option =
     displayPickerText $
-        option.modelTarget.targetConnectionId
-            <> " · "
-            <> option.modelTarget.targetModelId
+        ( if gatewayMode
+            then option.modelTarget.targetModelId
+            else
+                option.modelTarget.targetConnectionId
+                    <> " · "
+                    <> option.modelTarget.targetModelId
+        )
             <> " · "
             <> dialectSlug option.modelTarget.targetDialect
+
+pickerUsesGateway :: PickerState -> Bool
+pickerUsesGateway state =
+    state.pickerConnectionId == organizationGatewayConnectionId
+
+displayModelName :: Bool -> Text -> Text -> Text
+displayModelName gatewayMode connectionId modelId
+    | gatewayMode = modelId
+    | otherwise = connectionId <> "/" <> modelId
 
 displayPickerText :: Text -> Text
 displayPickerText =

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -183,7 +183,7 @@ modelChoiceWithEffort
                             initialIndex =
                                 fromMaybe 0 (elemIndex initial efforts)
                         in ( modelRowLabel picker option
-                           , modelDetail option
+                           , modelDetail picker option
                            , map (renderEffortIndicator option) efforts
                            , initialIndex
                            )
@@ -230,9 +230,13 @@ openRouterModelOption model =
 
 modelRowLabel :: PickerState -> ModelOption -> Text
 modelRowLabel picker option =
-    option.modelTarget.targetConnectionId
-        <> "/"
-        <> option.modelTarget.targetModelId
+    ( if picker.pickerConnectionId == organizationGatewayConnectionId
+        then option.modelTarget.targetModelId
+        else
+            option.modelTarget.targetConnectionId
+                <> "/"
+                <> option.modelTarget.targetModelId
+    )
         <> if
             option.modelTarget.targetConnectionId == picker.pickerConnectionId
                 && option.modelTarget.targetModelId == picker.pickerCurrent
@@ -241,14 +245,16 @@ modelRowLabel picker option =
             then " ✓"
             else ""
 
-modelDetail :: ModelOption -> Text
-modelDetail option =
+modelDetail :: PickerState -> ModelOption -> Text
+modelDetail picker option =
     Text.intercalate
         " · "
         ( maybe [] pure option.modelLabel
             <> [ option.modelTarget.targetConnectionId
-               , dialectSlug option.modelTarget.targetDialect
+               | picker.pickerConnectionId
+                    /= organizationGatewayConnectionId
                ]
+            <> [dialectSlug option.modelTarget.targetDialect]
             <> if maybe False
                     (Text.isInfixOf "context" . Text.toCaseFold)
                     option.modelLabel

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.Models
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , decodeModelConfig
+    , organizationGatewayConnectionId
     , packagedModelCatalogPath
     )
 import Agent.Dialect (DialectId(..))
@@ -116,6 +117,31 @@ spec = do
             frame `shouldSatisfy` Text.isInfixOf "←"
             frame `shouldSatisfy` Text.isInfixOf "→"
             frame `shouldSatisfy` Text.isInfixOf "context"
+
+        it "shows gateway aliases without the internal connection prefix" do
+            let baseOption =
+                    rawModelOption OpenAIProvider "gpt-5.6-sol"
+                option =
+                    baseOption
+                        { modelTarget =
+                            baseOption.modelTarget
+                                { targetConnectionId =
+                                    organizationGatewayConnectionId
+                                }
+                        }
+            models <-
+                initialPickerStateForOptions
+                    "organization gateway"
+                    [option]
+                    organizationGatewayConnectionId
+                    OpenAIProvider
+                    "gpt-5.6-sol"
+                    CodexDialect
+            let frame = renderPickerFrame False models
+            frame `shouldSatisfy` Text.isInfixOf "gpt-5.6-sol"
+            frame `shouldNotSatisfy`
+                Text.isInfixOf
+                    (organizationGatewayConnectionId <> "/gpt-5.6-sol")
 
         it "makes untrusted catalog control characters inert" do
             let hostile =


### PR DESCRIPTION
## Summary
- decode the unified organization gateway model catalog through typed Aeson `FromJSON` instances for the response, model, and protocol types
- preserve catalog normalization while rejecting unknown gateway protocols
- show public gateway model aliases verbatim in both terminal and fullscreen model pickers, without exposing the internal `organization-gateway/` connection prefix

## Validation
- `Agent.CLI.GatewayClientSpec`: 15 examples, 0 failures
- `Agent.CLI.ModelPickerSpec`: 12 examples, 0 failures
- live tmux picker smoke: displayed `gpt-5.6-sol` as the current model, row, and detail, with no internal connection prefix
- `git diff --check`
