### PR TITLE
Use unified organization gateway model catalog

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -66,8 +66,32 @@ Supported dialects are:
 
 Custom connections are selected manually and are not considered for automatic
 billing fallback. Shipped connection names (`openai`, `xai`, `openrouter`,
-`meta`, `gemini`, and `claude-code`) are reserved. Invalid catalogs are
-reported at startup.
+`meta`, `gemini`, `claude-code`, and `organization-gateway`) are reserved.
+Invalid catalogs are reported at startup.
+
+When an organization gateway advertises a private alias that uses a
+non-default model protocol, add gateway-only metadata without defining a
+connection:
+
+```json
+{
+  "version": 1,
+  "models": [
+    {
+      "id": "company-coder",
+      "connection": "organization-gateway",
+      "dialect": "generic-responses",
+      "context_window": 131072,
+      "label": "company"
+    }
+  ]
+}
+```
+
+Gateway-only entries are never added to direct-provider catalogs or pickers,
+and they cannot remap the alias sent over the wire. The live `/v1/models`
+response remains authoritative: metadata is used only when the gateway
+advertises the same alias.
 
 The built-in `add-model` skill handles requests such as “use the model running
 at this URL”, “add this OpenRouter model”, or “OpenAI released a new model”.

--- a/flake.nix
+++ b/flake.nix
@@ -608,9 +608,11 @@
                                         [ "lib/libhaskell-agent-bridge.dylib" ];
                             }))
                             [
+                                pkgs.coreutils
                                 pkgs.git
                                 bun_1_4
                                 pkgs.postgresql_18
+                                pkgs.python3
                             ]);
                         agent-telegram = localPackage (pkgs.haskell.lib.addTestToolDepends
                             (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-telegram/package.nix { }) {

--- a/packages/agent-claude/src/Agent/Claude/Auth.hs
+++ b/packages/agent-claude/src/Agent/Claude/Auth.hs
@@ -3,6 +3,7 @@
 module Agent.Claude.Auth
     ( ClaudeCodeAuth(..)
     , loadClaudeCodeAuth
+    , loadClaudeCodeGatewayAuth
     , parseClaudeCodeAuthStatus
     ) where
 
@@ -50,30 +51,25 @@ data ClaudeCodeAuth = ClaudeCodeAuth
 -- claude.ai subscription. This only reads the CLI's status metadata and never
 -- reads or returns credential material.
 loadClaudeCodeAuth :: IO (Either Text ClaudeCodeAuth)
-loadClaudeCodeAuth = do
-    gatewayUrl <- nonEmptyEnvironment "HASKELL_AGENT_GATEWAY_URL"
-    gatewayToken <- nonEmptyEnvironment "HASKELL_AGENT_GATEWAY_TOKEN"
-    case (gatewayUrl, gatewayToken) of
-        (Nothing, Nothing) -> loadLocalClaudeCodeAuth
-        (Just url, Just token) ->
-            resolveClaudeExecutable >>= \case
-                Left err -> pure (Left err)
-                Right executablePath ->
-                    pure $
-                        Right ClaudeCodeAuth
-                            { executable = executablePath
-                            , accountLabel = "Claude via gateway"
-                            , subscriptionType = Nothing
-                            , transport =
-                                ClaudeCodeGateway
-                                    { gatewayBaseUrl = url
-                                    , gatewayToken = token
-                                    }
-                            }
-        _ ->
+loadClaudeCodeAuth = loadLocalClaudeCodeAuth
+
+-- | Build gateway auth only from an explicit, parent-owned transport. Ambient
+-- environment variables must never turn a long-lived organization bearer into
+-- child-process credentials.
+loadClaudeCodeGatewayAuth
+    :: ClaudeCodeTransport
+    -> IO (Either Text ClaudeCodeAuth)
+loadClaudeCodeGatewayAuth transport =
+    resolveClaudeExecutable >>= \case
+        Left err -> pure (Left err)
+        Right executablePath ->
             pure $
-                Left
-                    "Claude gateway mode requires both HASKELL_AGENT_GATEWAY_URL and HASKELL_AGENT_GATEWAY_TOKEN."
+                Right ClaudeCodeAuth
+                    { executable = executablePath
+                    , accountLabel = "Claude via gateway"
+                    , subscriptionType = Nothing
+                    , transport
+                    }
 
 loadLocalClaudeCodeAuth :: IO (Either Text ClaudeCodeAuth)
 loadLocalClaudeCodeAuth =
@@ -186,10 +182,6 @@ drainCapped handle = go BS.empty
                         then BS.take cap (acc <> chunk)
                         else acc
                 in go acc'
-
-nonEmptyEnvironment :: String -> IO (Maybe Text)
-nonEmptyEnvironment name =
-    lookupEnv name >>= pure . (>>= nonEmptyText . Text.pack)
 
 parseClaudeCodeAuthStatus
     :: FilePath

--- a/packages/agent-claude/test/Agent/Claude/AuthSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/AuthSpec.hs
@@ -160,7 +160,7 @@ spec = do
                                 , transport = ClaudeCodeLocalSubscription
                                 }
 
-        it "uses gateway credentials without requiring a local Claude login" $
+        it "uses explicit gateway credentials without requiring a local Claude login" $
             withScratchDirectory "agent-claude-gateway-auth" \root -> do
                 let executable = root </> "fake-claude"
                 writeFile executable "#!/bin/sh\nexit 77\n"
@@ -169,12 +169,14 @@ spec = do
                         `unionFileModes` ownerWriteMode
                         `unionFileModes` ownerExecuteMode
                 withEnvironmentVariables
-                    [ ("CLAUDE_CODE_EXECUTABLE", Just executable)
-                    , ("HASKELL_AGENT_GATEWAY_URL", Just "https://gateway.example/")
-                    , ("HASKELL_AGENT_GATEWAY_TOKEN", Just "gateway-secret")
-                    ]
+                    [("CLAUDE_CODE_EXECUTABLE", Just executable)]
                     do
-                        result <- loadClaudeCodeAuth
+                        result <-
+                            loadClaudeCodeGatewayAuth
+                                ClaudeCodeGateway
+                                    { gatewayBaseUrl = "https://gateway.example/"
+                                    , gatewayToken = "gateway-secret"
+                                    }
                         result `shouldBe`
                             Right ClaudeCodeAuth
                                 { executable
@@ -188,15 +190,28 @@ spec = do
                                 }
                         show result `shouldNotContain` "gateway-secret"
 
-        it "rejects partially configured gateway credentials" $
-            withEnvironmentVariables
-                [ ("HASKELL_AGENT_GATEWAY_URL", Just "https://gateway.example")
-                , ("HASKELL_AGENT_GATEWAY_TOKEN", Nothing)
-                ]
-                do
-                    loadClaudeCodeAuth `shouldReturn`
-                        Left
-                            "Claude gateway mode requires both HASKELL_AGENT_GATEWAY_URL and HASKELL_AGENT_GATEWAY_TOKEN."
+        it "does not activate gateway mode from ambient credentials" $
+            withScratchDirectory "agent-claude-local-auth" \root -> do
+                let executable = root </> "fake-claude"
+                writeFile executable fakeAuthScript
+                setFileMode executable $
+                    ownerReadMode
+                        `unionFileModes` ownerWriteMode
+                        `unionFileModes` ownerExecuteMode
+                withEnvironmentVariables
+                    [ ("CLAUDE_CODE_EXECUTABLE", Just executable)
+                    , ("CLAUDE_TEST_PRESERVED", Just "yes")
+                    , ("HASKELL_AGENT_GATEWAY_URL", Just "https://gateway.example")
+                    , ("HASKELL_AGENT_GATEWAY_TOKEN", Just "must-not-leak")
+                    ]
+                    do
+                        loadClaudeCodeAuth `shouldReturn`
+                            Right ClaudeCodeAuth
+                                { executable
+                                , accountLabel = "auth@example.com"
+                                , subscriptionType = Just "max"
+                                , transport = ClaudeCodeLocalSubscription
+                                }
 
 isLeftContaining :: Text.Text -> Either Text.Text a -> Bool
 isLeftContaining needle = \case

--- a/packages/agent-cli-runtime/config/models.default.json
+++ b/packages/agent-cli-runtime/config/models.default.json
@@ -17,6 +17,9 @@
       "api": "builtin",
       "provider": "openrouter"
     },
+    "organization-gateway": {
+      "api": "gateway"
+    },
     "meta": {
       "api": "responses",
       "base_url": "https://api.meta.ai/v1",

--- a/packages/agent-cli-runtime/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Auth.hs
@@ -149,6 +149,8 @@ loadAuth requestedProvider =
             case requestedProvider of
                 Nothing -> pure (gatewayLoadedAuth gateway)
                 Just OpenAIProvider -> pure (gatewayLoadedAuth gateway)
+                Just ClaudeCodeProvider ->
+                    pure (Right (gatewayClaudeLoadedAuth gateway))
                 Just _ ->
                     pure
                         (Left
@@ -202,6 +204,24 @@ gatewayLoadedAuth gateway = do
             , loadedSelectionId = Just gatewayAuthSelectionId
             , loadedOpenAiPool = Nothing
             }
+
+gatewayClaudeLoadedAuth :: GatewayCredential -> LoadedAuth
+gatewayClaudeLoadedAuth gateway =
+    let credential = Credential
+            { accessToken = ""
+            , accountId = "gateway-claude"
+            , leaseId = Nothing
+            , provider = ClaudeCodeProvider
+            }
+    in LoadedAuth
+        { loadedProvider = ClaudeCodeProvider
+        , loadedTokenProvider =
+            staticCredentialProvider SubscriptionBilled credential
+        , loadedAccountLabel =
+            const (pure ("Claude via " <> gateway.gatewayBaseUrl))
+        , loadedSelectionId = Just gatewayAuthSelectionId
+        , loadedOpenAiPool = Nothing
+        }
 
 credentialForGateway :: GatewayCredential -> Credential
 credentialForGateway gateway =

--- a/packages/agent-cli-runtime/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Auth.hs
@@ -61,10 +61,10 @@ import Agent.CLI.Auth.Gemini
     )
 import Agent.CLI.Auth.OpenAI
     ( loadOpenAi
-    , loadOpenAiDictationAuth
     , openAiAuthStateChanged
     , preferredOpenAiTokenProvider
     )
+import qualified Agent.CLI.Auth.OpenAI as OpenAIAuth
 import Agent.CLI.Auth.Types
     ( GrokAuthState(..)
     , LoadedAuth(..)
@@ -97,7 +97,6 @@ import Agent.CLI.GatewayClient
     )
 import Agent.Error (ApiError(..))
 import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
-import Agent.Transport.WebSocket (webSocketHandshakeFailureStatus)
 import qualified Agent.Claude.Auth as ClaudeCode
 import Agent.Provider
     ( AccountFailure(..)
@@ -111,9 +110,6 @@ import Agent.Provider
     , providerSlug
     , seedTokenProvider
     , tokenProvider
-    , tokenProviderBillingMode
-    , tokenProviderWithNextToken
-    , withAccountFailureClassifier
     )
 import Agent.OpenRouter.Credential (credentialFromApiKey)
 import qualified Agent.Gemini.Auth as GeminiAuth
@@ -140,87 +136,28 @@ import System.Directory.OsPath (doesFileExist, getHomeDirectory)
 import System.OsPath (unsafeEncodeUtf, (</>))
 
 loadAuth :: Maybe Provider -> IO (Either Text LoadedAuth)
-loadAuth (Just OpenAIProvider) = loadOpenAiWithGateway
-loadAuth (Just provider) = loadProvider provider
-loadAuth Nothing =
-    loadGatewayCredential >>= \case
-        Right (Just gateway) -> loadGatewayPreferredAuth gateway
-        Right Nothing -> loadDetectedProvider
-        Left gatewayErr ->
-            loadSubscriptionFallback
-                gatewayErr
-                loadDetectedSubscriptionProvider
-
-loadOpenAiWithGateway :: IO (Either Text LoadedAuth)
-loadOpenAiWithGateway =
+loadAuth requestedProvider =
     loadGatewayCredential >>= \case
         Left gatewayErr ->
-            loadSubscriptionFallback
-                gatewayErr
-                (loadProvider OpenAIProvider)
-        Right (Just gateway) -> loadGatewayPreferredAuth gateway
-        Right Nothing -> loadProvider OpenAIProvider
-
-loadSubscriptionFallback
-    :: Text
-    -> IO (Either Text LoadedAuth)
-    -> IO (Either Text LoadedAuth)
-loadSubscriptionFallback gatewayErr loadFallback =
-    loadFallback >>= \case
-        Right loaded
-            | tokenProviderBillingMode
-                loaded.loadedTokenProvider
-                == SubscriptionBilled ->
-                    pure (Right loaded)
-        Right _ ->
-            pure $ Left $
-                "cannot load gateway credential: "
-                    <> gatewayErr
-                    <> "; refusing automatic fallback to "
-                    <> "API-credit billing"
-        Left providerErr ->
-            pure $ Left $
-                "cannot load gateway credential: "
-                    <> gatewayErr
-                    <> "; "
-                    <> providerErr
+            pure (Left ("cannot load gateway credential: " <> gatewayErr))
+        Right (Just gateway) ->
+            case requestedProvider of
+                Nothing -> pure (gatewayLoadedAuth gateway)
+                Just OpenAIProvider -> pure (gatewayLoadedAuth gateway)
+                Just _ ->
+                    pure
+                        (Left
+                            "organization gateway is active; disconnect it before selecting another provider")
+        Right Nothing ->
+            case requestedProvider of
+                Nothing -> loadDetectedProvider
+                Just provider -> loadProvider provider
 
 loadDetectedProvider :: IO (Either Text LoadedAuth)
 loadDetectedProvider =
     runExceptT (detectProvider Nothing) >>= \case
         Left err -> pure (Left err)
         Right provider -> loadProvider provider
-
-loadDetectedSubscriptionProvider :: IO (Either Text LoadedAuth)
-loadDetectedSubscriptionProvider =
-    go Nothing []
-        [ OpenAIProvider
-        , XAIProvider
-        , OpenRouterProvider
-        , GeminiProvider
-        ]
-  where
-    go firstApi errors = \case
-        [] ->
-            pure $ case firstApi of
-                Just loaded -> Right loaded
-                Nothing -> Left (Text.intercalate "; " (reverse errors))
-        provider : remaining ->
-            loadProvider provider >>= \case
-                Right loaded
-                    | tokenProviderBillingMode
-                        loaded.loadedTokenProvider
-                        == SubscriptionBilled ->
-                            pure (Right loaded)
-                    | otherwise ->
-                        go
-                            (case firstApi of
-                                Just current -> Just current
-                                Nothing -> Just loaded)
-                            errors
-                            remaining
-                Left err ->
-                    go firstApi (err : errors) remaining
 
 loadProvider :: Provider -> IO (Either Text LoadedAuth)
 loadProvider provider = runExceptT do
@@ -233,58 +170,20 @@ loadProvider provider = runExceptT do
 
 -- | Load local OpenAI credentials without consulting the gateway.
 --
--- Explicit account selection and gateway failover use this entry point so a
--- saved gateway can never shadow the user's local ChatGPT account pool.
+-- Explicit local-account operations use this entry point so a saved gateway
+-- cannot shadow the requested ChatGPT account.
 loadDirectOpenAiAuth :: IO (Either Text LoadedAuth)
 loadDirectOpenAiAuth =
     runExceptT loadOpenAi
 
-loadGatewayPreferredAuth
-    :: GatewayCredential
-    -> IO (Either Text LoadedAuth)
-loadGatewayPreferredAuth gateway =
-    case gatewayLoadedAuth gateway of
-        Left gatewayErr ->
-            loadDirectOpenAiAuth >>= \case
-                Right directAuth
-                    | tokenProviderBillingMode
-                        directAuth.loadedTokenProvider
-                        == SubscriptionBilled ->
-                            pure (Right directAuth)
-                Right _ ->
-                    pure $ Left $
-                        gatewayErr
-                            <> "; refusing automatic fallback to "
-                            <> "API-credit billing"
-                Left directErr ->
-                    pure $ Left $
-                        gatewayErr <> "; direct OpenAI auth unavailable: "
-                            <> directErr
-        Right gatewayAuth ->
-            loadDirectOpenAiAuth >>= \case
-                Right directAuth
-                    | tokenProviderBillingMode
-                        directAuth.loadedTokenProvider
-                        == SubscriptionBilled -> do
-                            let gatewayCredential =
-                                    credentialForGateway gateway
-                            combined <-
-                                gatewayFallbackTokenProvider
-                                    gatewayCredential
-                                    directAuth.loadedTokenProvider
-                            pure $ Right gatewayAuth
-                                { loadedTokenProvider = combined
-                                , loadedAccountLabel = \credential ->
-                                    if credential == gatewayCredential
-                                        then pure gateway.gatewayBaseUrl
-                                        else
-                                            directAuth.loadedAccountLabel
-                                                credential
-                                , loadedOpenAiPool =
-                                    directAuth.loadedOpenAiPool
-                                }
-                _ ->
-                    pure (Right gatewayAuth)
+-- | Dictation must not send an organization gateway bearer to a direct
+-- provider transcription endpoint.
+loadOpenAiDictationAuth :: IO (Maybe LoadedAuth)
+loadOpenAiDictationAuth =
+    loadGatewayCredential >>= \case
+        Right Nothing -> OpenAIAuth.loadOpenAiDictationAuth
+        Right (Just _) -> pure Nothing
+        Left _ -> pure Nothing
 
 gatewayLoadedAuth :: GatewayCredential -> Either Text LoadedAuth
 gatewayLoadedAuth gateway = do
@@ -308,72 +207,36 @@ credentialForGateway gateway =
         , provider = OpenAIProvider
         }
 
--- | Prefer the gateway until that exact credential is rejected or exhausted,
--- then stay on the local same-billing OpenAI pool for the rest of the session.
---
--- A gateway failure is not forwarded to the local pool because it describes a
--- different credential and would otherwise cool down an unrelated account.
-gatewayFallbackTokenProvider
-    :: Credential
-    -> TokenProvider
-    -> IO TokenProvider
-gatewayFallbackTokenProvider gatewayCredential directProvider = do
-    gatewayPreferred <- newIORef True
-    pure $
-        withAccountFailureClassifier classifyGatewayFailure $
-            tokenProviderWithNextToken directProvider \failed ->
-                case failed of
-                    Nothing ->
-                        readIORef gatewayPreferred >>= \case
-                            True -> pure (Right gatewayCredential)
-                            False -> getNextToken directProvider Nothing
-                    Just reported
-                        | reported.credential == gatewayCredential -> do
-                            writeIORef gatewayPreferred False
-                            getNextToken directProvider Nothing
-                        | otherwise -> do
-                            writeIORef gatewayPreferred False
-                            getNextToken directProvider (Just reported)
-  where
-    -- A gateway WebSocket handshake 403 rejects this gateway credential
-    -- before any turn effects occur. Treat only that distinct credential as
-    -- failed so the local ChatGPT fallback becomes reachable; ordinary direct
-    -- ChatGPT 403s remain permission failures and never rotate accounts.
-    classifyGatewayFailure credential = \case
-        err
-            | credential == gatewayCredential
-            , webSocketHandshakeFailureStatus err == Just 403 ->
-                Just AccountAuthenticationRejected
-        _ -> Nothing
-
 -- | Load one specific account for providers whose HTTP backends can swap
 -- token sources without reconnecting a long-lived transport.
+--
+-- A connected gateway remains authoritative even if a caller asks for a local
+-- account. Callers must disconnect the gateway before selecting a local
+-- source.
 loadAuthForAccount :: Provider -> Text -> IO (Either Text LoadedAuth)
 loadAuthForAccount provider selectionId =
-    if provider == OpenAIProvider
-        then
-            if selectionId == gatewayAuthSelectionId
-                then loadGatewayCredential >>= \case
-                    Left err ->
-                        pure (Left
-                            ("cannot load gateway credential: " <> err))
-                    Right (Just gateway) ->
-                        -- Restore the normal preferred-gateway provider,
-                        -- including same-billing local-account failover.
-                        loadGatewayPreferredAuth gateway
-                    Right Nothing ->
-                        pure (Left "no gateway credential is connected")
-                else loadDirectOpenAiAccountAuth selectionId
-        else loadProvider
+    loadGatewayCredential >>= \case
+        Left err ->
+            pure (Left ("cannot load gateway credential: " <> err))
+        Right (Just gateway)
+            | provider == OpenAIProvider
+            , selectionId == gatewayAuthSelectionId ->
+                pure (gatewayLoadedAuth gateway)
+            | otherwise ->
+                pure
+                    (Left
+                        "organization gateway is active; disconnect it before selecting another account")
+        Right Nothing -> loadLocalAccount provider selectionId
   where
-    loadProvider = runExceptT case provider of
-        XAIProvider -> loadXai (Just selectionId)
-        OpenRouterProvider -> loadOpenRouter (Just selectionId)
-        GeminiProvider -> loadGemini (Just selectionId)
-        OpenAIProvider ->
-            throwE "OpenAI account selection is handled by the live account pool"
-        ClaudeCodeProvider ->
-            throwE "Claude Code accounts are managed by `claude auth login`"
+    loadLocalAccount OpenAIProvider accountId =
+        loadDirectOpenAiAccountAuth accountId
+    loadLocalAccount selectedProvider selectedSelectionId =
+        runExceptT case selectedProvider of
+            XAIProvider -> loadXai (Just selectedSelectionId)
+            OpenRouterProvider -> loadOpenRouter (Just selectedSelectionId)
+            GeminiProvider -> loadGemini (Just selectedSelectionId)
+            ClaudeCodeProvider ->
+                throwE "Claude Code accounts are managed by `claude auth login`"
 
 loadDirectOpenAiAccountAuth :: Text -> IO (Either Text LoadedAuth)
 loadDirectOpenAiAccountAuth accountId =

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -1,6 +1,8 @@
 -- | HTTPS device authorization and restricted gateway credential storage.
 module Agent.CLI.GatewayClient
     ( GatewayCredential(..)
+    , GatewayModel(..)
+    , GatewayModelProtocol(..)
     , GatewayModelAccess
     , GatewayAuthorization(..)
     , GatewayAuthorizationCodeResponse(..)
@@ -38,10 +40,12 @@ module Agent.CLI.GatewayClient
     , newGatewayModelAccessWith
     , refreshGatewayModels
     , cachedGatewayModels
+    , gatewayModelIds
     , runGatewayCommand
     , saveGatewayCredentialAt
     , showGatewayStatus
     , validateBaseUrl
+    , validateGatewayCredential
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
@@ -115,13 +119,24 @@ data GatewayCredential = GatewayCredential
     }
     deriving (Eq)
 
+data GatewayModelProtocol
+    = GatewayResponsesProtocol
+    | GatewayAnthropicProtocol
+    deriving (Eq, Show)
+
+data GatewayModel = GatewayModel
+    { gatewayModelId :: !Text
+    , gatewayModelProtocol :: !GatewayModelProtocol
+    }
+    deriving (Eq, Show)
+
 -- | A gateway-scoped model catalog and its most recently successful refresh.
 --
 -- The constructor is deliberately hidden: callers can list models but cannot
 -- accidentally inspect or log the credential captured by its fetch action.
 data GatewayModelAccess = GatewayModelAccess
-    { gatewayModelFetch :: !(IO (Either Text [Text]))
-    , gatewayModelCache :: !(IORef (Maybe [Text]))
+    { gatewayModelFetch :: !(IO (Either Text [GatewayModel]))
+    , gatewayModelCache :: !(IORef (Maybe [GatewayModel]))
     , gatewayModelRefreshLock :: !(MVar ())
     }
 
@@ -206,28 +221,27 @@ gatewayCredentialDecoder =
             <*> Hermes.atKey "websocket_url" Hermes.text
             <*> Hermes.atKey "access_token" Hermes.text
 
--- | Decode the OpenAI-compatible @GET /v1/models@ response exposed by a
--- gateway.  Gateways may return either normal model objects or compact string
--- ids in @data@; callers always receive a stable, display-safe list with blank
--- and duplicate ids removed.
-gatewayModelsDecoder :: Hermes.Decoder [Text]
+-- | Decode the unified gateway catalog. Every alias carries the wire protocol
+-- required to invoke it; unknown protocols fail closed.
+gatewayModelsDecoder :: Hermes.Decoder [GatewayModel]
 gatewayModelsDecoder =
     Hermes.object do
-        modelIds <- Hermes.atKey "data" (Hermes.list gatewayModelIdDecoder)
-        pure (normalizeGatewayModelIds modelIds)
+        models <- Hermes.atKey "data" (Hermes.list gatewayModelDecoder)
+        pure (normalizeGatewayModels models)
 
-gatewayModelIdDecoder :: Hermes.Decoder Text
-gatewayModelIdDecoder =
-    Hermes.withOwnedRawJson \raw ->
-        case Hermes.decodeEither Hermes.text raw of
-            Right modelId -> pure modelId
-            Left _ ->
-                case Hermes.decodeEither modelObjectDecoder raw of
-                    Right modelId -> pure modelId
-                    Left _ -> fail "Gateway model entry is invalid."
-  where
-    modelObjectDecoder =
-        Hermes.object (Hermes.atKey "id" Hermes.text)
+gatewayModelDecoder :: Hermes.Decoder GatewayModel
+gatewayModelDecoder =
+    Hermes.object $
+        GatewayModel
+            <$> Hermes.atKey "id" Hermes.text
+            <*> Hermes.atKey "protocol" gatewayModelProtocolDecoder
+
+gatewayModelProtocolDecoder :: Hermes.Decoder GatewayModelProtocol
+gatewayModelProtocolDecoder =
+    Hermes.text >>= \case
+        "responses" -> pure GatewayResponsesProtocol
+        "anthropic" -> pure GatewayAnthropicProtocol
+        _ -> fail "Gateway model protocol is invalid."
 
 -- | Construct a cached model-list handle for a validated gateway credential.
 newGatewayModelAccess :: GatewayCredential -> IO GatewayModelAccess
@@ -238,7 +252,7 @@ newGatewayModelAccess =
 -- The resulting value remains opaque, so the fetch action cannot be read back
 -- or accidentally included in diagnostics.
 newGatewayModelAccessWith
-    :: IO (Either Text [Text])
+    :: IO (Either Text [GatewayModel])
     -> IO GatewayModelAccess
 newGatewayModelAccessWith fetch = do
     cache <- newIORef Nothing
@@ -254,7 +268,9 @@ newGatewayModelAccessWith fetch = do
 -- A failed refresh deliberately clears the previous value.  Continuing to
 -- show a stale authorization list would let an organization revocation look
 -- like an available model.
-refreshGatewayModels :: GatewayModelAccess -> IO (Either Text [Text])
+refreshGatewayModels
+    :: GatewayModelAccess
+    -> IO (Either Text [GatewayModel])
 refreshGatewayModels
         GatewayModelAccess
             { gatewayModelFetch
@@ -271,13 +287,13 @@ refreshGatewayModels
                     Left err -> do
                         writeIORef gatewayModelCache Nothing
                         pure (Left err)
-                    Right modelIds -> do
-                        let normalized = normalizeGatewayModelIds modelIds
+                    Right models -> do
+                        let normalized = normalizeGatewayModels models
                         writeIORef gatewayModelCache (Just normalized)
                         pure (Right normalized)
 
 -- | Read the most recent successful gateway refresh without issuing I/O.
-cachedGatewayModels :: GatewayModelAccess -> IO (Maybe [Text])
+cachedGatewayModels :: GatewayModelAccess -> IO (Maybe [GatewayModel])
 cachedGatewayModels GatewayModelAccess { gatewayModelCache } =
     readIORef gatewayModelCache
 
@@ -285,7 +301,7 @@ cachedGatewayModels GatewayModelAccess { gatewayModelCache } =
 --
 -- Errors deliberately omit exception and response-body detail: both may
 -- contain external content, while request headers contain the bearer token.
-fetchGatewayModels :: GatewayCredential -> IO (Either Text [Text])
+fetchGatewayModels :: GatewayCredential -> IO (Either Text [GatewayModel])
 fetchGatewayModels credential =
     case validateGatewayCredential credential of
         Left _ -> pure (Left "Gateway credential is invalid.")
@@ -297,7 +313,7 @@ fetchGatewayModels credential =
                         (Text.unpack
                             (Text.dropWhileEnd (== '/')
                                 (Text.strip credential.gatewayBaseUrl)
-                                <> "/v1/models"))
+                                <> "/v1/model-catalog"))
                 HTTP.httpLbs
                     initial
                         { HTTP.method = "GET"
@@ -329,7 +345,10 @@ fetchGatewayModels credential =
                             Left _ ->
                                 Left
                                     "Gateway returned an unreadable models response."
-                            Right modelIds -> Right modelIds
+                            Right models
+                                | null models ->
+                                    Left "Gateway returned an empty model catalog."
+                                | otherwise -> Right models
                     | otherwise ->
                         Left $
                             "Gateway models returned HTTP "
@@ -338,18 +357,23 @@ fetchGatewayModels credential =
                                         (statusCode
                                             (HTTP.responseStatus value)))
 
-normalizeGatewayModelIds :: [Text] -> [Text]
-normalizeGatewayModelIds = go Set.empty
+gatewayModelIds :: [GatewayModel] -> [Text]
+gatewayModelIds = fmap (.gatewayModelId)
+
+normalizeGatewayModels :: [GatewayModel] -> [GatewayModel]
+normalizeGatewayModels = go Set.empty
   where
     go _ [] = []
-    go seen (raw : rest)
+    go seen (model : rest)
         | Text.null modelId = go seen rest
         | Text.any (\char -> isSpace char || not (isPrint char)) modelId =
             go seen rest
         | modelId `Set.member` seen = go seen rest
-        | otherwise = modelId : go (Set.insert modelId seen) rest
+        | otherwise =
+            model { gatewayModelId = modelId }
+                : go (Set.insert modelId seen) rest
       where
-        modelId = Text.strip raw
+        modelId = Text.strip model.gatewayModelId
 
 data GatewayDeviceAuthorization = GatewayDeviceAuthorization
     { deviceCode :: !Text

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -1,6 +1,7 @@
 -- | HTTPS device authorization and restricted gateway credential storage.
 module Agent.CLI.GatewayClient
     ( GatewayCredential(..)
+    , GatewayModelAccess
     , GatewayAuthorization(..)
     , GatewayAuthorizationCodeResponse(..)
     , GatewayDeviceAuthorization(..)
@@ -27,6 +28,12 @@ module Agent.CLI.GatewayClient
     , gatewayPollDecoder
     , loadGatewayCredential
     , loadGatewayCredentialAt
+    , gatewayModelsDecoder
+    , fetchGatewayModels
+    , newGatewayModelAccess
+    , newGatewayModelAccessWith
+    , refreshGatewayModels
+    , cachedGatewayModels
     , runGatewayCommand
     , saveGatewayCredentialAt
     , showGatewayStatus
@@ -40,6 +47,7 @@ import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
 import Agent.OsPath (unsafeToFilePath)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM (atomically, retry)
 import Control.Exception.Safe (bracket, bracketOnError, tryAny)
 import Control.Monad (when)
@@ -53,14 +61,18 @@ import Data.ByteString.Base64.URL qualified as Base64Url
 import Data.ByteString.Builder qualified as Builder
 import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as LBS
-import Data.Char (isDigit)
+import Data.Char (isDigit, isPrint, isSpace)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
 import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.TLS (newTlsManager)
 import Network.HTTP.Types
-    ( hContentType
+    ( hAccept
+    , hAuthorization
+    , hContentType
     , statusCode
     , statusIsSuccessful
     )
@@ -98,6 +110,16 @@ data GatewayCredential = GatewayCredential
     , gatewayAccessToken :: !Text
     }
     deriving (Eq)
+
+-- | A gateway-scoped model catalog and its most recently successful refresh.
+--
+-- The constructor is deliberately hidden: callers can list models but cannot
+-- accidentally inspect or log the credential captured by its fetch action.
+data GatewayModelAccess = GatewayModelAccess
+    { gatewayModelFetch :: !(IO (Either Text [Text]))
+    , gatewayModelCache :: !(IORef (Maybe [Text]))
+    , gatewayModelRefreshLock :: !(MVar ())
+    }
 
 -- | The hosted gateway selected by the interactive @/login@ flow.
 defaultGatewayBaseUrl :: Text
@@ -179,6 +201,151 @@ gatewayCredentialDecoder =
             <$> Hermes.atKey "base_url" Hermes.text
             <*> Hermes.atKey "websocket_url" Hermes.text
             <*> Hermes.atKey "access_token" Hermes.text
+
+-- | Decode the OpenAI-compatible @GET /v1/models@ response exposed by a
+-- gateway.  Gateways may return either normal model objects or compact string
+-- ids in @data@; callers always receive a stable, display-safe list with blank
+-- and duplicate ids removed.
+gatewayModelsDecoder :: Hermes.Decoder [Text]
+gatewayModelsDecoder =
+    Hermes.object do
+        modelIds <- Hermes.atKey "data" (Hermes.list gatewayModelIdDecoder)
+        pure (normalizeGatewayModelIds modelIds)
+
+gatewayModelIdDecoder :: Hermes.Decoder Text
+gatewayModelIdDecoder =
+    Hermes.withOwnedRawJson \raw ->
+        case Hermes.decodeEither Hermes.text raw of
+            Right modelId -> pure modelId
+            Left _ ->
+                case Hermes.decodeEither modelObjectDecoder raw of
+                    Right modelId -> pure modelId
+                    Left _ -> fail "Gateway model entry is invalid."
+  where
+    modelObjectDecoder =
+        Hermes.object (Hermes.atKey "id" Hermes.text)
+
+-- | Construct a cached model-list handle for a validated gateway credential.
+newGatewayModelAccess :: GatewayCredential -> IO GatewayModelAccess
+newGatewayModelAccess =
+    newGatewayModelAccessWith . fetchGatewayModels
+
+-- | Injectable constructor used by tests and alternative trusted transports.
+-- The resulting value remains opaque, so the fetch action cannot be read back
+-- or accidentally included in diagnostics.
+newGatewayModelAccessWith
+    :: IO (Either Text [Text])
+    -> IO GatewayModelAccess
+newGatewayModelAccessWith fetch = do
+    cache <- newIORef Nothing
+    refreshLock <- newMVar ()
+    pure GatewayModelAccess
+        { gatewayModelFetch = fetch
+        , gatewayModelCache = cache
+        , gatewayModelRefreshLock = refreshLock
+        }
+
+-- | Refresh the gateway's authorized model aliases.
+--
+-- A failed refresh deliberately clears the previous value.  Continuing to
+-- show a stale authorization list would let an organization revocation look
+-- like an available model.
+refreshGatewayModels :: GatewayModelAccess -> IO (Either Text [Text])
+refreshGatewayModels
+        GatewayModelAccess
+            { gatewayModelFetch
+            , gatewayModelCache
+            , gatewayModelRefreshLock
+            } =
+    withMVar gatewayModelRefreshLock \_ ->
+        tryAny gatewayModelFetch >>= \case
+            Left _ -> do
+                writeIORef gatewayModelCache Nothing
+                pure (Left "Could not refresh organization gateway models.")
+            Right result ->
+                case result of
+                    Left err -> do
+                        writeIORef gatewayModelCache Nothing
+                        pure (Left err)
+                    Right modelIds -> do
+                        let normalized = normalizeGatewayModelIds modelIds
+                        writeIORef gatewayModelCache (Just normalized)
+                        pure (Right normalized)
+
+-- | Read the most recent successful gateway refresh without issuing I/O.
+cachedGatewayModels :: GatewayModelAccess -> IO (Maybe [Text])
+cachedGatewayModels GatewayModelAccess { gatewayModelCache } =
+    readIORef gatewayModelCache
+
+-- | Fetch the aliases currently offered to this gateway credential.
+--
+-- Errors deliberately omit exception and response-body detail: both may
+-- contain external content, while request headers contain the bearer token.
+fetchGatewayModels :: GatewayCredential -> IO (Either Text [Text])
+fetchGatewayModels credential =
+    case validateGatewayCredential credential of
+        Left _ -> pure (Left "Gateway credential is invalid.")
+        Right () -> do
+            response <- tryAny do
+                manager <- newTlsManager
+                initial <-
+                    HTTP.parseRequest
+                        (Text.unpack
+                            (Text.dropWhileEnd (== '/')
+                                (Text.strip credential.gatewayBaseUrl)
+                                <> "/v1/models"))
+                HTTP.httpLbs
+                    initial
+                        { HTTP.method = "GET"
+                        , HTTP.requestHeaders =
+                            [ ( hAuthorization
+                              , "Bearer "
+                                    <> TextEncoding.encodeUtf8
+                                        credential.gatewayAccessToken
+                              )
+                            , (hAccept, "application/json")
+                            ]
+                        , HTTP.checkResponse = \_ _ -> pure ()
+                        -- Never follow a redirect with the gateway bearer.
+                        , HTTP.redirectCount = 0
+                        , HTTP.responseTimeout =
+                            HTTP.responseTimeoutMicro (5 * 1_000_000)
+                        }
+                    manager
+            pure case response of
+                Left _ ->
+                    Left "Could not reach the gateway models endpoint."
+                Right value
+                    | statusIsSuccessful (HTTP.responseStatus value) ->
+                        case
+                            Hermes.decodeEither
+                                gatewayModelsDecoder
+                                (LBS.toStrict (HTTP.responseBody value))
+                            of
+                            Left _ ->
+                                Left
+                                    "Gateway returned an unreadable models response."
+                            Right modelIds -> Right modelIds
+                    | otherwise ->
+                        Left $
+                            "Gateway models returned HTTP "
+                                <> Text.pack
+                                    (show
+                                        (statusCode
+                                            (HTTP.responseStatus value)))
+
+normalizeGatewayModelIds :: [Text] -> [Text]
+normalizeGatewayModelIds = go Set.empty
+  where
+    go _ [] = []
+    go seen (raw : rest)
+        | Text.null modelId = go seen rest
+        | Text.any (\char -> isSpace char || not (isPrint char)) modelId =
+            go seen rest
+        | modelId `Set.member` seen = go seen rest
+        | otherwise = modelId : go (Set.insert modelId seen) rest
+      where
+        modelId = Text.strip raw
 
 data GatewayDeviceAuthorization = GatewayDeviceAuthorization
     { deviceCode :: !Text
@@ -314,8 +481,24 @@ saveGatewayCredentialAt home credential =
 
 validateGatewayCredential :: GatewayCredential -> Either Text ()
 validateGatewayCredential credential = do
-    _ <- validateBaseUrl credential.gatewayBaseUrl
+    baseUrl <- validateBaseUrl credential.gatewayBaseUrl
     validateGatewayWebSocketUrl credential.gatewayWebSocketUrl
+    baseOrigin <-
+        parseGatewayOrigin
+            "Gateway URL is invalid."
+            baseUrl
+    websocketOrigin <-
+        parseGatewayOrigin
+            "Gateway WebSocket URL is invalid."
+            credential.gatewayWebSocketUrl
+    let expectedWebSocketOrigin =
+            case baseOrigin of
+                ("https:", host, port) -> ("wss:", host, port)
+                ("http:", host, port) -> ("ws:", host, port)
+                origin -> origin
+    whenEither
+        (websocketOrigin /= expectedWebSocketOrigin)
+        "Gateway base and WebSocket URLs must use the same origin."
     whenEither
         (Text.null (Text.strip credential.gatewayAccessToken))
         "Gateway access token cannot be empty."

--- a/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
@@ -10,6 +10,7 @@ module Agent.CLI.ModelConfig
     , ModelConnection(..)
     , ResponsesConnection(..)
     , builtinConnectionId
+    , organizationGatewayConnectionId
     , catalogConnection
     , catalogContextWindowFor
     , catalogContextWindowForTransport
@@ -160,6 +161,13 @@ modelCatalogUserPath home =
 
 builtinConnectionId :: Provider -> Text
 builtinConnectionId = providerSlug
+
+-- | Reserved persisted routing identity for organization-gateway sessions.
+--
+-- Gateway requests currently use the OpenAI transport, but must not be
+-- indistinguishable from direct OpenAI sessions after the gateway is removed.
+organizationGatewayConnectionId :: Text
+organizationGatewayConnectionId = "organization-gateway"
 
 catalogConnection :: ModelCatalog -> Text -> Maybe ModelConnection
 catalogConnection catalog connectionId =
@@ -336,7 +344,9 @@ decodeConfigFile source bytes =
 mergeConfigFiles :: ConfigFile -> Maybe ConfigFile -> Either Text ConfigFile
 mergeConfigFiles defaults Nothing = Right defaults
 mergeConfigFiles defaults (Just user) = do
-    let reserved = map builtinConnectionId allBuiltinProviders
+    let reserved =
+            organizationGatewayConnectionId
+                : map builtinConnectionId allBuiltinProviders
         overriddenReserved =
             filter (`Map.member` user.configConnections) reserved
     unless (null overriddenReserved) $

--- a/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
@@ -177,8 +177,8 @@ builtinConnectionId = providerSlug
 
 -- | Reserved persisted routing identity for organization-gateway sessions.
 --
--- Gateway requests currently use the OpenAI transport, but must not be
--- indistinguishable from direct OpenAI sessions after the gateway is removed.
+-- The target provider distinguishes Responses from Anthropic while the
+-- reserved connection keeps both protocols separate from direct accounts.
 organizationGatewayConnectionId :: Text
 organizationGatewayConnectionId = "organization-gateway"
 
@@ -259,7 +259,9 @@ connectionBuiltinProvider connection = case connection.connectionKind of
 connectionSupportsDialect :: Text -> Provider -> DialectId -> Bool
 connectionSupportsDialect connection provider dialect
     | connection == organizationGatewayConnectionId =
-        provider == OpenAIProvider && gatewaySupportsDialect dialect
+        (provider == OpenAIProvider && gatewaySupportsDialect dialect)
+            || (provider == ClaudeCodeProvider
+                && dialect == ClaudeCodeDialect)
     | otherwise = providerSupportsDialect provider dialect
 
 catalogDefaultForProvider :: ModelCatalog -> Provider -> Maybe CatalogModel

--- a/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
@@ -15,8 +15,10 @@ module Agent.CLI.ModelConfig
     , catalogContextWindowFor
     , catalogContextWindowForTransport
     , catalogDefaultForProvider
+    , catalogGatewayModelById
     , catalogModelById
     , catalogModelsForConnection
+    , connectionSupportsDialect
     , connectionBuiltinProvider
     , decodeModelConfig
     , loadModelCatalog
@@ -28,7 +30,7 @@ module Agent.CLI.ModelConfig
     ) where
 
 import Agent.Dialect
-    ( DialectId
+    ( DialectId(..)
     , parseDialect
     , providerSupportsDialect
     )
@@ -66,6 +68,7 @@ data ResponsesConnection = ResponsesConnection
 data ConnectionKind
     = BuiltinConnection !Provider
     | CustomResponsesConnection !ResponsesConnection
+    | OrganizationGatewayConnection
     deriving (Eq, Show)
 
 data ModelConnection = ModelConnection
@@ -90,6 +93,7 @@ data ModelCatalog = ModelCatalog
     { catalogConnections :: !(Map Text ModelConnection)
     , catalogModels :: ![CatalogModel]
     , catalogModelsById :: !(Map Text CatalogModel)
+    , catalogGatewayModelsById :: !(Map Text CatalogModel)
     }
     deriving (Eq, Show)
 
@@ -175,7 +179,7 @@ catalogConnection catalog connectionId =
 
 catalogContextWindowFor :: ModelCatalog -> Text -> Text -> Maybe Int
 catalogContextWindowFor catalog connectionId modelId = do
-    model <- catalogModelById catalog modelId
+    model <- catalogModelForConnection catalog connectionId modelId
     if model.catalogModelConnectionId == connectionId
         then model.catalogModelContextWindow
         else Nothing
@@ -191,7 +195,7 @@ catalogContextWindowForTransport
     -> Text
     -> Maybe Int
 catalogContextWindowForTransport catalog connectionId modelId wireModelId = do
-    selected <- catalogModelById catalog modelId
+    selected <- catalogModelForConnection catalog connectionId modelId
     if selected.catalogModelConnectionId /= connectionId
         then Nothing
         else
@@ -215,6 +219,21 @@ catalogModelById :: ModelCatalog -> Text -> Maybe CatalogModel
 catalogModelById catalog modelId =
     Map.lookup modelId catalog.catalogModelsById
 
+catalogGatewayModelById :: ModelCatalog -> Text -> Maybe CatalogModel
+catalogGatewayModelById catalog modelId =
+    Map.lookup modelId catalog.catalogGatewayModelsById
+
+catalogModelForConnection
+    :: ModelCatalog
+    -> Text
+    -> Text
+    -> Maybe CatalogModel
+catalogModelForConnection catalog connectionId modelId
+    | connectionId == organizationGatewayConnectionId =
+        catalogGatewayModelById catalog modelId
+    | otherwise =
+        catalogModelById catalog modelId
+
 catalogModelsForConnection :: Text -> ModelCatalog -> [CatalogModel]
 catalogModelsForConnection wanted =
     filter ((== wanted) . (.catalogModelConnectionId)) . (.catalogModels)
@@ -223,6 +242,16 @@ connectionBuiltinProvider :: ModelConnection -> Maybe Provider
 connectionBuiltinProvider connection = case connection.connectionKind of
     BuiltinConnection provider -> Just provider
     CustomResponsesConnection _ -> Nothing
+    OrganizationGatewayConnection -> Nothing
+
+-- | Validate persisted model-facing protocol identity against its routing
+-- connection. Organization gateways use the OpenAI transport while supporting
+-- any Responses-hostable agent dialect.
+connectionSupportsDialect :: Text -> Provider -> DialectId -> Bool
+connectionSupportsDialect connection provider dialect
+    | connection == organizationGatewayConnectionId =
+        provider == OpenAIProvider && gatewaySupportsDialect dialect
+    | otherwise = providerSupportsDialect provider dialect
 
 catalogDefaultForProvider :: ModelCatalog -> Provider -> Maybe CatalogModel
 catalogDefaultForProvider catalog provider =
@@ -355,22 +384,22 @@ mergeConfigFiles defaults (Just user) = do
                 <> plural overriddenReserved <> ": "
                 <> Text.intercalate ", " overriddenReserved
             )
-    ensureUniqueModelIds "shipped model config" defaults.configModels
-    ensureUniqueModelIds "user model config" user.configModels
-    let defaultIds = map (.modelFileId) defaults.configModels
-        userById = Map.fromList
-            [ (model.modelFileId, model)
+    ensureUniqueModelRoutes "shipped model config" defaults.configModels
+    ensureUniqueModelRoutes "user model config" user.configModels
+    let defaultKeys = map modelMergeKey defaults.configModels
+        userByKey = Map.fromList
+            [ (modelMergeKey model, model)
             | model <- user.configModels
             ]
         replacedDefaults =
             map
                 (\model ->
                     fromMaybe model
-                        (Map.lookup model.modelFileId userById))
+                        (Map.lookup (modelMergeKey model) userByKey))
                 defaults.configModels
         appendedModels =
             filter
-                ((`notElem` defaultIds) . (.modelFileId))
+                ((`notElem` defaultKeys) . modelMergeKey)
                 user.configModels
     pure ConfigFile
         { configVersion = 1
@@ -381,7 +410,7 @@ mergeConfigFiles defaults (Just user) = do
 
 validateConfig :: Text -> ConfigFile -> Either Text ModelCatalog
 validateConfig source config = do
-    ensureUniqueModelIds source config.configModels
+    ensureUniqueModelRoutes source config.configModels
     connections <- Map.traverseWithKey validateConnection
         config.configConnections
     models <- traverse (validateModel connections) config.configModels
@@ -393,6 +422,15 @@ validateConfig source config = do
             Map.fromList
                 [ (model.catalogModelId, model)
                 | model <- models
+                , model.catalogModelConnectionId
+                    /= organizationGatewayConnectionId
+                ]
+        , catalogGatewayModelsById =
+            Map.fromList
+                [ (model.catalogModelId, model)
+                | model <- models
+                , model.catalogModelConnectionId
+                    == organizationGatewayConnectionId
                 ]
         }
   where
@@ -446,6 +484,14 @@ validateConfig source config = do
                     , responsesRequestTimeoutSeconds =
                         raw.connectionRequestTimeoutSeconds
                     }
+            "gateway" -> do
+                when (connectionId /= organizationGatewayConnectionId) $
+                    Left
+                        ( "gateway connection " <> connectionId
+                            <> " must use the reserved id "
+                            <> organizationGatewayConnectionId
+                        )
+                pure OrganizationGatewayConnection
             other ->
                 Left ("connection " <> connectionId
                     <> " has unsupported api " <> other)
@@ -487,6 +533,24 @@ validateConfig source config = do
                             <> connectionId
                         )
             CustomResponsesConnection _ -> pure ()
+            OrganizationGatewayConnection -> do
+                when (wireId /= modelId) $
+                    Left
+                        ( "model " <> modelId
+                            <> " cannot override its wire model on organization gateway connection "
+                            <> connectionId
+                        )
+                unless
+                    (connectionSupportsDialect
+                        connectionId
+                        OpenAIProvider
+                        dialect) $
+                    Left
+                        ( "model " <> modelId <> " uses dialect "
+                            <> raw.modelFileDialect
+                            <> " which is incompatible with connection "
+                            <> connectionId
+                        )
         traverse_
             (\priority -> when (priority < 0) $
                 Left ("model " <> modelId
@@ -563,8 +627,8 @@ validateEnvName connectionId raw =
             Left ("connection " <> connectionId
                 <> " has invalid api_key_env " <> raw)
 
-ensureUniqueModelIds :: Text -> [ModelFile] -> Either Text ()
-ensureUniqueModelIds source models =
+ensureUniqueModelRoutes :: Text -> [ModelFile] -> Either Text ()
+ensureUniqueModelRoutes source models =
     case duplicateIds of
         [] -> Right ()
         duplicates ->
@@ -573,15 +637,29 @@ ensureUniqueModelIds source models =
   where
     counts = foldl'
         (\current model ->
-            Map.insertWith (+) (Text.strip model.modelFileId) (1 :: Int) current)
+            Map.insertWith (+) (modelMergeKey model) (1 :: Int) current)
         Map.empty
         models
     duplicateIds =
-        Map.keys (Map.filter (> 1) counts)
+        map snd (Map.keys (Map.filter (> 1) counts))
+
+modelMergeKey :: ModelFile -> (Bool, Text)
+modelMergeKey model =
+    ( Text.strip model.modelFileConnection
+        == organizationGatewayConnectionId
+    , Text.strip model.modelFileId
+    )
 
 allBuiltinProviders :: [Provider]
 allBuiltinProviders =
     [OpenAIProvider, XAIProvider, OpenRouterProvider, GeminiProvider]
+
+gatewaySupportsDialect :: DialectId -> Bool
+gatewaySupportsDialect = \case
+    CodexDialect -> True
+    GrokBuildDialect -> True
+    GenericResponsesDialect -> True
+    ClaudeCodeDialect -> False
 
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText value

--- a/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
@@ -38,6 +38,7 @@ import Agent.CLI.ModelConfig
     , organizationGatewayConnectionId
     , catalogConnection
     , catalogDefaultForProvider
+    , catalogGatewayModelById
     , catalogModelById
     )
 import Agent.Dialect
@@ -100,11 +101,14 @@ data PickerEvent
 modelOptionFromCatalog :: ModelCatalog -> CatalogModel -> Maybe ModelOption
 modelOptionFromCatalog catalog model = do
     connection <- catalogConnection catalog model.catalogModelConnectionId
-    let provider = case connection.connectionKind of
-            BuiltinConnection value -> value
+    provider <- case connection.connectionKind of
+            BuiltinConnection value -> Just value
             -- Custom endpoints currently reuse the provider-independent
             -- Responses plumbing hosted under the OpenRouter runtime branch.
-            CustomResponsesConnection _ -> OpenRouterProvider
+            CustomResponsesConnection _ -> Just OpenRouterProvider
+            -- Gateway-only entries provide protocol and presentation metadata
+            -- for live aliases. They must never enter the direct model catalog.
+            OrganizationGatewayConnection -> Nothing
     pure ModelOption
         { modelTarget = ModelTarget
             { targetProvider = provider
@@ -221,14 +225,12 @@ gatewayModelOptions catalog provider =
   where
     gatewayOption modelId =
         let configured =
-                resolveConfiguredModel catalog modelId >>= \option ->
-                    let target = option.modelTarget
-                    in if target.targetProvider == provider
-                        && target.targetConnectionId
-                            == builtinConnectionId provider
-                        then Just option
-                        else Nothing
-            configuredTarget = (.modelTarget) <$> configured
+                catalogGatewayModelById catalog modelId >>= \model ->
+                    if provider == OpenAIProvider
+                        && model.catalogModelConnectionId
+                            == organizationGatewayConnectionId
+                    then Just model
+                    else Nothing
         in ModelOption
             { modelTarget = ModelTarget
                 { targetProvider = provider
@@ -238,14 +240,14 @@ gatewayModelOptions catalog provider =
                 , targetDialect =
                     maybe
                         (dialectIdForModel provider modelId)
-                        (.targetDialect)
-                        configuredTarget
+                        (.catalogModelDialect)
+                        configured
                 }
             , modelContextWindow =
-                configured >>= (.modelContextWindow)
-            , modelLabel = configured >>= (.modelLabel)
+                configured >>= (.catalogModelContextWindow)
+            , modelLabel = configured >>= (.catalogModelLabel)
             , modelFallbackPriority =
-                configured >>= (.modelFallbackPriority)
+                configured >>= (.catalogModelFallbackPriority)
             }
 
 -- | Prepend @current@ when it is missing so the active model stays visible.

--- a/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Models
     , defaultModelFor
     , defaultModelOptionFor
     , resolveConfiguredModel
+    , resolveSavedModelTarget
     , resolveModelOptionById
     , rawModelOption
     , gatewayModelOptions
@@ -125,6 +126,41 @@ modelsForProvider catalog provider =
     filter
         ((== builtinConnectionId provider) . (.modelTarget.targetConnectionId))
         (modelCatalog catalog)
+
+resolveSavedModelTarget
+    :: ModelCatalog
+    -> Bool
+    -> Provider
+    -> Text
+    -> Text
+    -> Maybe Text
+    -> DialectId
+    -> Either Text ModelTarget
+resolveSavedModelTarget
+        catalog deferToGateway provider connection model transport dialect
+    | deferToGateway =
+        Right persistedTarget
+    | otherwise =
+        case resolveConfiguredModel catalog model of
+            Just option
+                | option.modelTarget.targetConnectionId == connection ->
+                    Right option.modelTarget
+            _
+                | connection == builtinConnectionId provider ->
+                    Right persistedTarget
+                | otherwise ->
+                    Left $
+                        "saved model "
+                            <> connection <> "/" <> model
+                            <> " is not present in ~/.haskell-agent/models.json"
+  where
+    persistedTarget = ModelTarget
+        { targetProvider = provider
+        , targetConnectionId = connection
+        , targetModelId = model
+        , targetWireModelId = fromMaybe model transport
+        , targetDialect = dialect
+        }
 
 catalogModelIds :: ModelCatalog -> [Text]
 catalogModelIds =

--- a/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
@@ -35,6 +35,7 @@ import Agent.CLI.ModelConfig
     , ModelCatalog(..)
     , ModelConnection(..)
     , builtinConnectionId
+    , organizationGatewayConnectionId
     , catalogConnection
     , catalogDefaultForProvider
     , catalogModelById
@@ -140,6 +141,11 @@ resolveSavedModelTarget
         catalog deferToGateway provider connection model transport dialect
     | deferToGateway =
         Right persistedTarget
+    | connection == organizationGatewayConnectionId =
+        Left $
+            "saved model "
+                <> connection <> "/" <> model
+                <> " requires an active organization gateway"
     | otherwise =
         case resolveConfiguredModel catalog model of
             Just option
@@ -204,11 +210,10 @@ rawModelOption provider model =
 -- to the active gateway connection and sends the advertised alias verbatim.
 gatewayModelOptions
     :: ModelCatalog
-    -> Text
     -> Provider
     -> [Text]
     -> [ModelOption]
-gatewayModelOptions catalog connectionId provider =
+gatewayModelOptions catalog provider =
     map gatewayOption
         . nub
         . filter (not . Text.null)
@@ -219,14 +224,15 @@ gatewayModelOptions catalog connectionId provider =
                 resolveConfiguredModel catalog modelId >>= \option ->
                     let target = option.modelTarget
                     in if target.targetProvider == provider
-                        && target.targetConnectionId == connectionId
+                        && target.targetConnectionId
+                            == builtinConnectionId provider
                         then Just option
                         else Nothing
             configuredTarget = (.modelTarget) <$> configured
         in ModelOption
             { modelTarget = ModelTarget
                 { targetProvider = provider
-                , targetConnectionId = connectionId
+                , targetConnectionId = organizationGatewayConnectionId
                 , targetModelId = modelId
                 , targetWireModelId = modelId
                 , targetDialect =

--- a/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
@@ -40,6 +40,7 @@ import Agent.CLI.ModelConfig
     , catalogDefaultForProvider
     , catalogGatewayModelById
     , catalogModelById
+    , connectionSupportsDialect
     )
 import Agent.Dialect
     ( DialectId(..)
@@ -226,9 +227,12 @@ gatewayModelOptions catalog provider =
     gatewayOption modelId =
         let configured =
                 catalogGatewayModelById catalog modelId >>= \model ->
-                    if provider == OpenAIProvider
-                        && model.catalogModelConnectionId
+                    if model.catalogModelConnectionId
                             == organizationGatewayConnectionId
+                        && connectionSupportsDialect
+                            organizationGatewayConnectionId
+                            provider
+                            model.catalogModelDialect
                     then Just model
                     else Nothing
         in ModelOption

--- a/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
@@ -12,11 +12,14 @@ module Agent.CLI.Models
     , defaultModelFor
     , defaultModelOptionFor
     , resolveConfiguredModel
+    , resolveModelOptionById
     , rawModelOption
+    , gatewayModelOptions
     , ensureCurrentInList
     , initialPickerState
     , initialPickerStateResolved
     , initialPickerStateResolvedWith
+    , initialPickerStateForOptions
     , visibleOptions
     , selectedOption
     , applyPickerEvent
@@ -43,7 +46,7 @@ import qualified Agent.OpenRouter.Options as OpenRouter
 import qualified Agent.OpenRouter.Request as OpenRouter
 import Agent.Provider (Provider(..))
 import Data.Char (isPrint)
-import Data.List (findIndex, nubBy)
+import Data.List (find, findIndex, nub, nubBy)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -74,6 +77,7 @@ data PickerState = PickerState
     , pickerProvider :: !Provider
     , pickerCurrent :: !Text
     , pickerCurrentDialect :: !DialectId
+    , pickerScopeLabel :: !Text
     , pickerAll :: ![ModelOption]
     , pickerFilter :: !Text
     , pickerIndex :: !Int
@@ -139,6 +143,10 @@ resolveConfiguredModel :: ModelCatalog -> Text -> Maybe ModelOption
 resolveConfiguredModel catalog modelId =
     catalogModelById catalog modelId >>= modelOptionFromCatalog catalog
 
+resolveModelOptionById :: [ModelOption] -> Text -> Maybe ModelOption
+resolveModelOptionById options modelId =
+    find ((== modelId) . (.modelTarget.targetModelId)) options
+
 rawModelOption :: Provider -> Text -> ModelOption
 rawModelOption provider model =
     ModelOption
@@ -153,6 +161,50 @@ rawModelOption provider model =
         , modelLabel = Nothing
         , modelFallbackPriority = Nothing
         }
+
+-- | Convert the exact aliases advertised by an organization gateway into
+-- model options.  Catalog entries may contribute presentation metadata and
+-- dialect identity, but never transport identity: every option remains pinned
+-- to the active gateway connection and sends the advertised alias verbatim.
+gatewayModelOptions
+    :: ModelCatalog
+    -> Text
+    -> Provider
+    -> [Text]
+    -> [ModelOption]
+gatewayModelOptions catalog connectionId provider =
+    map gatewayOption
+        . nub
+        . filter (not . Text.null)
+        . map Text.strip
+  where
+    gatewayOption modelId =
+        let configured =
+                resolveConfiguredModel catalog modelId >>= \option ->
+                    let target = option.modelTarget
+                    in if target.targetProvider == provider
+                        && target.targetConnectionId == connectionId
+                        then Just option
+                        else Nothing
+            configuredTarget = (.modelTarget) <$> configured
+        in ModelOption
+            { modelTarget = ModelTarget
+                { targetProvider = provider
+                , targetConnectionId = connectionId
+                , targetModelId = modelId
+                , targetWireModelId = modelId
+                , targetDialect =
+                    maybe
+                        (dialectIdForModel provider modelId)
+                        (.targetDialect)
+                        configuredTarget
+                }
+            , modelContextWindow =
+                configured >>= (.modelContextWindow)
+            , modelLabel = configured >>= (.modelLabel)
+            , modelFallbackPriority =
+                configured >>= (.modelFallbackPriority)
+            }
 
 -- | Prepend @current@ when it is missing so the active model stays visible.
 ensureCurrentInList
@@ -189,6 +241,8 @@ initialPickerState
     -> PickerState
 initialPickerState catalog connectionId provider current currentDialect =
     pickerStateFromOptions
+        True
+        "all providers"
         connectionId
         provider
         current
@@ -235,7 +289,32 @@ initialPickerStateResolvedWith
     resolved <- resolveModelOptionsDialects options
     pure $
         pickerStateFromOptions
+            True
+            "all providers"
             connectionId provider current currentDialect resolved
+
+-- | Build a picker from an authoritative option list.  Unlike the general
+-- catalog picker, this never re-inserts an unlisted current model.
+initialPickerStateForOptions
+    :: Text
+    -> [ModelOption]
+    -> Text
+    -> Provider
+    -> Text
+    -> DialectId
+    -> IO PickerState
+initialPickerStateForOptions
+        scopeLabel options connectionId provider current currentDialect = do
+    resolved <- resolveModelOptionsDialects (deduplicateOptions options)
+    pure $
+        pickerStateFromOptions
+            False
+            scopeLabel
+            connectionId
+            provider
+            current
+            currentDialect
+            resolved
 
 deduplicateOptions :: [ModelOption] -> [ModelOption]
 deduplicateOptions = nubBy sameIdentity
@@ -252,17 +331,23 @@ prioritizeCurrentConnection current options =
         <> filter ((/= current) . (.modelTarget.targetConnectionId)) options
 
 pickerStateFromOptions
-    :: Text
+    :: Bool
+    -> Text
+    -> Text
     -> Provider
     -> Text
     -> DialectId
     -> [ModelOption]
     -> PickerState
 pickerStateFromOptions
+        includeCurrent scopeLabel
         connectionId provider current currentDialect options =
     let allOpts =
-            ensureCurrentInList
-                connectionId provider current currentDialect options
+            if includeCurrent
+                then
+                    ensureCurrentInList
+                        connectionId provider current currentDialect options
+                else options
         idx = fromMaybe 0 $
             findIndex
                 (isCurrent connectionId current currentDialect)
@@ -272,6 +357,7 @@ pickerStateFromOptions
         , pickerProvider = provider
         , pickerCurrent = current
         , pickerCurrentDialect = currentDialect
+        , pickerScopeLabel = scopeLabel
         , pickerAll = allOpts
         , pickerFilter = ""
         , pickerIndex = idx

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Codec.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Codec.hs
@@ -18,9 +18,10 @@ module Agent.CLI.Session.Codec
 
 import Agent.CLI.Session.StoreCodec (fromStoredResponseItem, toStoredResponseItem)
 import Agent.CLI.Session.Types
+import Agent.CLI.ModelConfig (connectionSupportsDialect)
 import Agent.CLI.Json (decodeLazy)
 import qualified Agent.Json.Decode as Hermes
-import Agent.Dialect (dialectSlug, parseDialect, providerSupportsDialect)
+import Agent.Dialect (dialectSlug, parseDialect)
 import Agent.FileRetry (retryOnFileBusy)
 import Agent.Loop (TokenUsage(..))
 import Agent.Telemetry
@@ -169,7 +170,11 @@ fromStoredPromptSnapshot stored = do
             <> stored.sessionPromptDialect))
         Right
         (parseDialect stored.sessionPromptDialect)
-    unless (providerSupportsDialect provider dialect) $
+    unless
+        (connectionSupportsDialect
+            stored.sessionPromptConnection
+            provider
+            dialect) $
         Left
             ( "stored prompt dialect "
                 <> stored.sessionPromptDialect
@@ -213,7 +218,11 @@ fromStoredMetadata stored = do
         (Left ("unknown stored dialect: " <> stored.sessionMetadataDialect))
         Right
         (parseDialect stored.sessionMetadataDialect)
-    unless (providerSupportsDialect provider dialect) $
+    unless
+        (connectionSupportsDialect
+            stored.sessionMetadataConnection
+            provider
+            dialect) $
         Left
             ( "stored dialect "
                 <> stored.sessionMetadataDialect
@@ -279,7 +288,11 @@ fromStoredLegacyTarget stored = do
         (Left ("unknown stored legacy dialect: " <> stored.sessionLegacyDialect))
         Right
         (parseDialect stored.sessionLegacyDialect)
-    unless (providerSupportsDialect provider dialect) $
+    unless
+        (connectionSupportsDialect
+            stored.sessionLegacyConnection
+            provider
+            dialect) $
         Left
             ( "stored legacy dialect "
                 <> stored.sessionLegacyDialect

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Types.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Types.hs
@@ -24,12 +24,12 @@ module Agent.CLI.Session.Types
     ) where
 
 import Agent.CLI.Models (ModelTarget)
+import Agent.CLI.ModelConfig (connectionSupportsDialect)
 import Agent.Dialect
     ( DialectId
     , dialectSlug
     , legacyDialectIdForProvider
     , parseDialect
-    , providerSupportsDialect
     )
 import Agent.Json.Decode (optionalKey)
 import qualified Agent.Json.Decode as Hermes
@@ -140,7 +140,8 @@ sessionPromptSnapshotDecoder = Hermes.object do
             <> Text.unpack dialectText))
         pure
         (parseDialect dialectText)
-    unless (providerSupportsDialect provider dialect) $
+    connection <- Hermes.atKey "connection" Hermes.text
+    unless (connectionSupportsDialect connection provider dialect) $
         fail
             ( "prompt snapshot dialect "
                 <> Text.unpack dialectText
@@ -150,7 +151,7 @@ sessionPromptSnapshotDecoder = Hermes.object do
     SessionPromptSnapshot version
         <$> Hermes.atKey "createdAt" Hermes.utcTime
         <*> pure provider
-        <*> Hermes.atKey "connection" Hermes.text
+        <*> pure connection
         <*> Hermes.atKey "model" Hermes.text
         <*> pure dialect
         <*> (unsafeEncodeUtf . Text.unpack <$> Hermes.atKey "cwd" Hermes.text)
@@ -212,17 +213,17 @@ legacySubagentTargetDecoder = Hermes.object do
                 fail
                     ("unknown legacy subagent dialect: "
                         <> Text.unpack dialectText)
-        unless (providerSupportsDialect provider dialect) $
+        connection <- fromMaybe (providerSlug provider)
+            <$> optionalKey "connection" Hermes.text
+        when (Text.null (Text.strip connection)) $
+            fail "legacy subagent connection must not be empty"
+        unless (connectionSupportsDialect connection provider dialect) $
             fail
                 ( "legacy subagent dialect "
                     <> Text.unpack (dialectSlug dialect)
                     <> " is incompatible with provider "
                     <> Text.unpack (providerSlug provider)
                 )
-        connection <- fromMaybe (providerSlug provider)
-            <$> optionalKey "connection" Hermes.text
-        when (Text.null (Text.strip connection)) $
-            fail "legacy subagent connection must not be empty"
         LegacySubagentTarget provider connection
             <$> Hermes.atKey "effectiveModel" Hermes.text
             <*> pure dialect
@@ -273,7 +274,7 @@ sessionMetaDecoder = Hermes.object do
             Just text -> case parseDialect text of
                 Just parsed -> pure parsed
                 Nothing -> fail ("unknown dialect: " <> Text.unpack text)
-        unless (providerSupportsDialect provider dialect) $
+        unless (connectionSupportsDialect connection provider dialect) $
             fail
                 ( "dialect "
                     <> Text.unpack (dialectSlug dialect)

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -23,15 +23,30 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "gateway device authorization" do
-    it "decodes, trims, and deduplicates gateway model ids" do
+    it "decodes, trims, and deduplicates the typed gateway catalog" do
         Hermes.decodeEither
             gatewayModelsDecoder
-            "{\"object\":\"list\",\"data\":[{\"id\":\" gpt-5.6-sol \"},{\"id\":\"\"},{\"id\":\"gpt-5.6-sol\"},{\"id\":\"gpt-5.6-terra\"},\"gpt-5.6-terra\",\"bad id\",\"bad\\nid\",\"\\u001b[31m\",\"  \"]}"
-            `shouldBe` Right ["gpt-5.6-sol", "gpt-5.6-terra"]
+            "{\"object\":\"list\",\"data\":[{\"id\":\" gpt-5.6-sol \",\"protocol\":\"responses\"},{\"id\":\"\",\"protocol\":\"responses\"},{\"id\":\"gpt-5.6-sol\",\"protocol\":\"responses\"},{\"id\":\"sonnet\",\"protocol\":\"anthropic\"},{\"id\":\"bad id\",\"protocol\":\"responses\"}]}"
+            `shouldBe`
+                Right
+                    [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol
+                    , GatewayModel "sonnet" GatewayAnthropicProtocol
+                    ]
+
+    it "rejects unknown gateway model protocols" do
+        Hermes.decodeEither
+            gatewayModelsDecoder
+            "{\"object\":\"list\",\"data\":[{\"id\":\"model\",\"protocol\":\"router\"}]}"
+            `shouldSatisfy` isLeft
 
     it "clears cached gateway models when refresh fails" do
         results <- newIORef
-            [ Right [" gpt-5.6-sol ", "", "gpt-5.6-sol", "gpt-5.6-terra"]
+            [ Right
+                [ GatewayModel " gpt-5.6-sol " GatewayResponsesProtocol
+                , GatewayModel "" GatewayResponsesProtocol
+                , GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol
+                , GatewayModel "sonnet" GatewayAnthropicProtocol
+                ]
             , Left "gateway unavailable"
             ]
         access <-
@@ -40,9 +55,17 @@ spec = describe "gateway device authorization" do
                     result : remaining -> (remaining, result)
                     [] -> ([], Left "unexpected refresh")
         refreshGatewayModels access
-            `shouldReturn` Right ["gpt-5.6-sol", "gpt-5.6-terra"]
+            `shouldReturn`
+                Right
+                    [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol
+                    , GatewayModel "sonnet" GatewayAnthropicProtocol
+                    ]
         cachedGatewayModels access
-            `shouldReturn` Just ["gpt-5.6-sol", "gpt-5.6-terra"]
+            `shouldReturn`
+                Just
+                    [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol
+                    , GatewayModel "sonnet" GatewayAnthropicProtocol
+                    ]
         refreshGatewayModels access
             `shouldReturn` Left "gateway unavailable"
         cachedGatewayModels access `shouldReturn` Nothing
@@ -54,10 +77,18 @@ spec = describe "gateway device authorization" do
                 call <- atomicModifyIORef' calls \count ->
                     (count + 1, count)
                 if call == 0
-                    then pure (Right ["company-model"])
+                    then
+                        pure
+                            (Right
+                                [ GatewayModel
+                                    "company-model"
+                                    GatewayResponsesProtocol
+                                ])
                     else throwString "transport details"
         refreshGatewayModels access
-            `shouldReturn` Right ["company-model"]
+            `shouldReturn`
+                Right
+                    [GatewayModel "company-model" GatewayResponsesProtocol]
         refreshGatewayModels access
             `shouldReturn`
                 Left "Could not refresh organization gateway models."

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -2,10 +2,11 @@ module Agent.CLI.GatewayClientSpec (spec) where
 
 import Agent.CLI.GatewayClient
 import Agent.Json.Decode qualified as Hermes
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, throwString)
 import Data.Bits ((.&.))
 import Data.ByteString.Lazy qualified as LBS
 import Data.Either (isLeft)
+import Data.IORef (atomicModifyIORef', newIORef)
 import Data.Text qualified as Text
 import System.Directory
     ( createDirectory
@@ -22,6 +23,55 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "gateway device authorization" do
+    it "decodes, trims, and deduplicates gateway model ids" do
+        Hermes.decodeEither
+            gatewayModelsDecoder
+            "{\"object\":\"list\",\"data\":[{\"id\":\" gpt-5.6-sol \"},{\"id\":\"\"},{\"id\":\"gpt-5.6-sol\"},{\"id\":\"gpt-5.6-terra\"},\"gpt-5.6-terra\",\"bad id\",\"bad\\nid\",\"\\u001b[31m\",\"  \"]}"
+            `shouldBe` Right ["gpt-5.6-sol", "gpt-5.6-terra"]
+
+    it "clears cached gateway models when refresh fails" do
+        results <- newIORef
+            [ Right [" gpt-5.6-sol ", "", "gpt-5.6-sol", "gpt-5.6-terra"]
+            , Left "gateway unavailable"
+            ]
+        access <-
+            newGatewayModelAccessWith $
+                atomicModifyIORef' results \case
+                    result : remaining -> (remaining, result)
+                    [] -> ([], Left "unexpected refresh")
+        refreshGatewayModels access
+            `shouldReturn` Right ["gpt-5.6-sol", "gpt-5.6-terra"]
+        cachedGatewayModels access
+            `shouldReturn` Just ["gpt-5.6-sol", "gpt-5.6-terra"]
+        refreshGatewayModels access
+            `shouldReturn` Left "gateway unavailable"
+        cachedGatewayModels access `shouldReturn` Nothing
+
+    it "clears cached gateway models when a fetch throws" do
+        calls <- newIORef (0 :: Int)
+        access <-
+            newGatewayModelAccessWith do
+                call <- atomicModifyIORef' calls \count ->
+                    (count + 1, count)
+                if call == 0
+                    then pure (Right ["company-model"])
+                    else throwString "transport details"
+        refreshGatewayModels access
+            `shouldReturn` Right ["company-model"]
+        refreshGatewayModels access
+            `shouldReturn`
+                Left "Could not refresh organization gateway models."
+        cachedGatewayModels access `shouldReturn` Nothing
+
+    it "does not expose a gateway bearer in model-list validation errors" do
+        let credential =
+                GatewayCredential
+                    "not a gateway URL"
+                    "wss://gateway/v1/responses"
+                    "gateway-bearer-secret"
+        fetchGatewayModels credential
+            `shouldReturn` Left "Gateway credential is invalid."
+
     it "decodes the device response contract" do
         let payload =
                 "{\"device_code\":\"had_secret\",\"user_code\":\"ABCD-1234\",\
@@ -268,6 +318,15 @@ spec = describe "gateway device authorization" do
                     "secret")
                 `shouldReturn`
                     Left "gateway WebSocket URL must use wss"
+            saveGatewayCredentialAt
+                home
+                (GatewayCredential
+                    "https://gateway"
+                    "wss://other.example/v1/responses"
+                    "secret")
+                `shouldReturn`
+                    Left
+                        "Gateway base and WebSocket URLs must use the same origin."
             saveGatewayCredentialAt
                 home
                 (GatewayCredential

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -176,6 +176,13 @@ spec = describe "Agent.CLI.ModelConfig" do
             (Just ("models.json", overlay))
             `shouldSatisfy` leftContains "cannot redefine reserved connection"
 
+        let gatewayOverlay =
+                "{\"version\":1,\"connections\":{\"organization-gateway\":{\"api\":\"responses\",\"base_url\":\"http://localhost:8000/v1\"}}}"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just ("models.json", gatewayOverlay))
+            `shouldSatisfy` leftContains "cannot redefine reserved connection"
+
     it "reports invalid custom references and authentication variables" do
         defaults <- readPackagedDefaults
         let overlay =

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -61,6 +61,68 @@ spec = describe "Agent.CLI.ModelConfig" do
                 , "gemini-3.1-pro-preview"
                 , "gemini-3.5-flash-lite"
                 ]
+        Map.lookup organizationGatewayConnectionId catalog.catalogConnections
+            `shouldBe`
+                Just ModelConnection
+                    { connectionId = organizationGatewayConnectionId
+                    , connectionKind = OrganizationGatewayConnection
+                    }
+
+    it "loads protocol metadata for organization gateway aliases" do
+        defaults <- readPackagedDefaults
+        let overlay = LBS.pack $ unlines
+                [ "{"
+                , "  \"version\": 1,"
+                , "  \"models\": [{"
+                , "    \"id\": \"company-coder\","
+                , "    \"connection\": \"organization-gateway\","
+                , "    \"dialect\": \"generic-responses\","
+                , "    \"context_window\": 131072,"
+                , "    \"label\": \"company\""
+                , "  }]"
+                , "}"
+                ]
+        catalog <- expectRight
+            (mergeModelConfigs
+                ("models.default.json", defaults)
+                (Just ("models.json", overlay)))
+        catalogModelsForConnection organizationGatewayConnectionId catalog
+            `shouldBe`
+                [ CatalogModel
+                    { catalogModelId = "company-coder"
+                    , catalogModelConnectionId =
+                        organizationGatewayConnectionId
+                    , catalogModelWireId = "company-coder"
+                    , catalogModelDialect = GenericResponsesDialect
+                    , catalogModelContextWindow = Just 131_072
+                    , catalogModelLabel = Just "company"
+                    , catalogModelDefault = False
+                    , catalogModelFallbackPriority = Nothing
+                    }
+                ]
+        connectionSupportsDialect
+            organizationGatewayConnectionId
+            OpenAIProvider
+            GenericResponsesDialect
+            `shouldBe` True
+        connectionSupportsDialect
+            organizationGatewayConnectionId
+            OpenAIProvider
+            ClaudeCodeDialect
+            `shouldBe` False
+
+        let remapped =
+                "{\"version\":1,\"models\":[{\"id\":\"company-remapped\",\"connection\":\"organization-gateway\",\"model\":\"private-upstream\",\"dialect\":\"codex\"}]}"
+            ownedTools =
+                "{\"version\":1,\"models\":[{\"id\":\"company-claude\",\"connection\":\"organization-gateway\",\"dialect\":\"claude-code\"}]}"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just ("models.json", remapped))
+            `shouldSatisfy` leftContains "cannot override its wire model"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just ("models.json", ownedTools))
+            `shouldSatisfy` leftContains "incompatible with connection"
 
     it "adds a custom Responses connection and model" do
         defaults <- readPackagedDefaults

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -7,6 +7,7 @@ import Agent.CLI.ModelConfig
     ( CatalogModel(..)
     , ModelCatalog(..)
     , decodeModelConfig
+    , organizationGatewayConnectionId
     , packagedModelCatalogPath
     )
 import Agent.Dialect
@@ -180,7 +181,6 @@ spec = do
             let options =
                     gatewayModelOptions
                         catalog
-                        "openai"
                         OpenAIProvider
                         [ " gpt-5.6-sol "
                         , "company-private"
@@ -193,10 +193,35 @@ spec = do
                 (\option ->
                     let target = option.modelTarget
                     in target.targetProvider == OpenAIProvider
-                        && target.targetConnectionId == "openai"
+                        && target.targetConnectionId
+                            == organizationGatewayConnectionId
                         && target.targetWireModelId == target.targetModelId)
                 options
                 `shouldBe` True
+
+        it "rejects a persisted gateway route after disconnection" do
+            let resolve deferToGateway =
+                    resolveSavedModelTarget
+                        catalog
+                        deferToGateway
+                        OpenAIProvider
+                        organizationGatewayConnectionId
+                        "company-private"
+                        (Just "company-private")
+                        CodexDialect
+            resolve True
+                `shouldBe`
+                    Right
+                        (ModelTarget
+                            OpenAIProvider
+                            organizationGatewayConnectionId
+                            "company-private"
+                            "company-private"
+                            CodexDialect)
+            resolve False
+                `shouldBe`
+                    Left
+                        "saved model organization-gateway/company-private requires an active organization gateway"
 
         it "pins mapped aliases to the gateway while retaining safe metadata" do
             let known =
@@ -234,7 +259,6 @@ spec = do
             case
                 gatewayModelOptions
                     mappedCatalog
-                    "openai"
                     OpenAIProvider
                     ["company-known", "company-foreign"]
                 of
@@ -243,7 +267,7 @@ spec = do
                         `shouldBe`
                             ModelTarget
                                 OpenAIProvider
-                                "openai"
+                                organizationGatewayConnectionId
                                 "company-known"
                                 "company-known"
                                 GenericResponsesDialect
@@ -253,7 +277,7 @@ spec = do
                         `shouldBe`
                             ModelTarget
                                 OpenAIProvider
-                                "openai"
+                                organizationGatewayConnectionId
                                 "company-foreign"
                                 "company-foreign"
                                 (dialectIdForModel
@@ -269,14 +293,13 @@ spec = do
             let options =
                     gatewayModelOptions
                         catalog
-                        "openai"
                         OpenAIProvider
                         ["gpt-5.6-terra"]
             state <-
                 initialPickerStateForOptions
                     "organization gateway"
                     options
-                    "openai"
+                    organizationGatewayConnectionId
                     OpenAIProvider
                     "revoked-model"
                     CodexDialect

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -4,7 +4,8 @@ module Agent.CLI.ModelsSpec (spec) where
 
 import Agent.CLI.Models
 import Agent.CLI.ModelConfig
-    ( ModelCatalog
+    ( CatalogModel(..)
+    , ModelCatalog(..)
     , decodeModelConfig
     , packagedModelCatalogPath
     )
@@ -16,6 +17,7 @@ import Agent.Provider (Provider(..))
 import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Lazy as LBS
 import Data.List (find, nub)
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, listToMaybe)
 import qualified Data.Text as Text
 import System.Environment (lookupEnv, setEnv, unsetEnv)
@@ -143,6 +145,115 @@ spec = do
                             "default · frontier · free · coding · 1M context")
             fmap (.modelLabel) (listToMaybe (matching "qwen/example-new"))
                 `shouldBe` Just (Just "OpenRouter live")
+
+    describe "gatewayModelOptions" do
+        it "uses only advertised aliases and pins them to the gateway" do
+            let options =
+                    gatewayModelOptions
+                        catalog
+                        "openai"
+                        OpenAIProvider
+                        [ " gpt-5.6-sol "
+                        , "company-private"
+                        , "gpt-5.6-sol"
+                        , ""
+                        ]
+            map (.modelTarget.targetModelId) options
+                `shouldBe` ["gpt-5.6-sol", "company-private"]
+            all
+                (\option ->
+                    let target = option.modelTarget
+                    in target.targetProvider == OpenAIProvider
+                        && target.targetConnectionId == "openai"
+                        && target.targetWireModelId == target.targetModelId)
+                options
+                `shouldBe` True
+
+        it "pins mapped aliases to the gateway while retaining safe metadata" do
+            let known =
+                    CatalogModel
+                        { catalogModelId = "company-known"
+                        , catalogModelConnectionId = "openai"
+                        , catalogModelWireId = "upstream-mapped-known"
+                        , catalogModelDialect = GenericResponsesDialect
+                        , catalogModelContextWindow = Nothing
+                        , catalogModelLabel = Just "company label"
+                        , catalogModelDefault = False
+                        , catalogModelFallbackPriority = Just 9
+                        }
+                conflicting =
+                    known
+                        { catalogModelId = "company-foreign"
+                        , catalogModelConnectionId = "xai"
+                        , catalogModelWireId = "upstream-mapped-foreign"
+                        , catalogModelDialect = GrokBuildDialect
+                        , catalogModelLabel = Just "foreign label"
+                        }
+                mappedCatalog =
+                    catalog
+                        { catalogModels =
+                            known : conflicting : catalog.catalogModels
+                        , catalogModelsById =
+                            Map.insert
+                                known.catalogModelId
+                                known
+                                (Map.insert
+                                    conflicting.catalogModelId
+                                    conflicting
+                                    catalog.catalogModelsById)
+                        }
+            case
+                gatewayModelOptions
+                    mappedCatalog
+                    "openai"
+                    OpenAIProvider
+                    ["company-known", "company-foreign"]
+                of
+                [active, foreignOption] -> do
+                    active.modelTarget
+                        `shouldBe`
+                            ModelTarget
+                                OpenAIProvider
+                                "openai"
+                                "company-known"
+                                "company-known"
+                                GenericResponsesDialect
+                    active.modelLabel `shouldBe` Just "company label"
+                    active.modelFallbackPriority `shouldBe` Just 9
+                    foreignOption.modelTarget
+                        `shouldBe`
+                            ModelTarget
+                                OpenAIProvider
+                                "openai"
+                                "company-foreign"
+                                "company-foreign"
+                                (dialectIdForModel
+                                    OpenAIProvider
+                                    "company-foreign")
+                    foreignOption.modelLabel `shouldBe` Nothing
+                    foreignOption.modelFallbackPriority `shouldBe` Nothing
+                other ->
+                    expectationFailure $
+                        "expected two gateway options, got " <> show other
+
+        it "does not reinsert a stale current model into an authoritative picker" do
+            let options =
+                    gatewayModelOptions
+                        catalog
+                        "openai"
+                        OpenAIProvider
+                        ["gpt-5.6-terra"]
+            state <-
+                initialPickerStateForOptions
+                    "organization gateway"
+                    options
+                    "openai"
+                    OpenAIProvider
+                    "revoked-model"
+                    CodexDialect
+            state.pickerScopeLabel `shouldBe` "organization gateway"
+            map (.modelTarget.targetModelId) state.pickerAll
+                `shouldBe` ["gpt-5.6-terra"]
 
     describe "modelTargetRequiresRebuild" do
         let sameDialect =

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -147,6 +147,35 @@ spec = do
                 `shouldBe` Just (Just "OpenRouter live")
 
     describe "gatewayModelOptions" do
+        it "defers resumed custom connections to the gateway catalog" do
+            let expected = ModelTarget
+                    OpenRouterProvider
+                    "removed-custom"
+                    "company-private"
+                    "upstream-private"
+                    GenericResponsesDialect
+                resolve =
+                    resolveSavedModelTarget
+                        catalog
+                        True
+                        OpenRouterProvider
+                        "removed-custom"
+                        "company-private"
+                        (Just "upstream-private")
+                        GenericResponsesDialect
+            resolve `shouldBe` Right expected
+            resolveSavedModelTarget
+                catalog
+                False
+                OpenRouterProvider
+                "removed-custom"
+                "company-private"
+                (Just "upstream-private")
+                GenericResponsesDialect
+                `shouldBe`
+                    Left
+                        "saved model removed-custom/company-private is not present in ~/.haskell-agent/models.json"
+
         it "uses only advertised aliases and pins them to the gateway" do
             let options =
                     gatewayModelOptions

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -4,9 +4,10 @@ module Agent.CLI.ModelsSpec (spec) where
 
 import Agent.CLI.Models
 import Agent.CLI.ModelConfig
-    ( CatalogModel(..)
-    , ModelCatalog(..)
+    ( ModelCatalog
+    , catalogContextWindowFor
     , decodeModelConfig
+    , mergeModelConfigs
     , organizationGatewayConnectionId
     , packagedModelCatalogPath
     )
@@ -17,8 +18,8 @@ import Agent.Dialect
 import Agent.Provider (Provider(..))
 import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.List (find, nub)
-import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, listToMaybe)
 import qualified Data.Text as Text
 import System.Environment (lookupEnv, setEnv, unsetEnv)
@@ -223,39 +224,79 @@ spec = do
                     Left
                         "saved model organization-gateway/company-private requires an active organization gateway"
 
-        it "pins mapped aliases to the gateway while retaining safe metadata" do
-            let known =
-                    CatalogModel
-                        { catalogModelId = "company-known"
-                        , catalogModelConnectionId = "openai"
-                        , catalogModelWireId = "upstream-mapped-known"
-                        , catalogModelDialect = GenericResponsesDialect
-                        , catalogModelContextWindow = Nothing
-                        , catalogModelLabel = Just "company label"
-                        , catalogModelDefault = False
-                        , catalogModelFallbackPriority = Just 9
+        it "loads only valid gateway-scoped alias metadata" do
+            defaults <- readPackagedDefaults
+            let overlay = LBS8.pack $ unlines
+                    [ "{"
+                    , "  \"version\": 1,"
+                    , "  \"models\": ["
+                    , "    {"
+                    , "      \"id\": \"company-known\","
+                    , "      \"connection\": \"organization-gateway\","
+                    , "      \"dialect\": \"generic-responses\","
+                    , "      \"label\": \"company label\","
+                    , "      \"fallback_priority\": 9"
+                    , "    },"
+                    , "    {"
+                    , "      \"id\": \"company-foreign\","
+                    , "      \"connection\": \"xai\","
+                    , "      \"dialect\": \"grok-build\","
+                    , "      \"label\": \"foreign label\""
+                    , "    },"
+                    , "    {"
+                    , "      \"id\": \"gpt-5.6-sol\","
+                    , "      \"connection\": \"organization-gateway\","
+                    , "      \"dialect\": \"generic-responses\","
+                    , "      \"context_window\": 777777,"
+                    , "      \"label\": \"company standard alias\""
+                    , "    }"
+                    , "  ]"
+                    , "}"
+                    ]
+            mappedCatalog <- case
+                mergeModelConfigs
+                    ("models.default.json", defaults)
+                    (Just ("models.json", overlay))
+                of
+                    Left err -> expectationFailure (Text.unpack err) >> pure catalog
+                    Right loaded -> pure loaded
+            resolveConfiguredModel mappedCatalog "company-known"
+                `shouldBe` Nothing
+            map (.modelTarget.targetModelId) (modelCatalog mappedCatalog)
+                `shouldSatisfy` notElem "company-known"
+            fmap (.modelTarget)
+                (resolveConfiguredModel mappedCatalog "gpt-5.6-sol")
+                `shouldBe`
+                    Just
+                        (ModelTarget
+                            OpenAIProvider
+                            "openai"
+                            "gpt-5.6-sol"
+                            "gpt-5.6-sol"
+                            CodexDialect)
+            catalogContextWindowFor
+                mappedCatalog
+                organizationGatewayConnectionId
+                "gpt-5.6-sol"
+                `shouldBe` Just 777_777
+            gatewayModelOptions
+                mappedCatalog
+                OpenAIProvider
+                ["gpt-5.6-sol"]
+                `shouldBe`
+                    [ ModelOption
+                        { modelTarget =
+                            ModelTarget
+                                OpenAIProvider
+                                organizationGatewayConnectionId
+                                "gpt-5.6-sol"
+                                "gpt-5.6-sol"
+                                GenericResponsesDialect
+                        , modelContextWindow = Just 777_777
+                        , modelLabel = Just "company standard alias"
+                        , modelFallbackPriority = Nothing
                         }
-                conflicting =
-                    known
-                        { catalogModelId = "company-foreign"
-                        , catalogModelConnectionId = "xai"
-                        , catalogModelWireId = "upstream-mapped-foreign"
-                        , catalogModelDialect = GrokBuildDialect
-                        , catalogModelLabel = Just "foreign label"
-                        }
-                mappedCatalog =
-                    catalog
-                        { catalogModels =
-                            known : conflicting : catalog.catalogModels
-                        , catalogModelsById =
-                            Map.insert
-                                known.catalogModelId
-                                known
-                                (Map.insert
-                                    conflicting.catalogModelId
-                                    conflicting
-                                    catalog.catalogModelsById)
-                        }
+                    ]
             case
                 gatewayModelOptions
                     mappedCatalog
@@ -586,8 +627,12 @@ withEnv name value action =
 
 readPackagedCatalog :: IO ModelCatalog
 readPackagedCatalog = do
-    path <- packagedModelCatalogPath
-    bytes <- LBS.readFile path
+    bytes <- readPackagedDefaults
     case decodeModelConfig "models.default.json" bytes of
         Left err -> fail (Text.unpack err)
         Right catalog -> pure catalog
+
+readPackagedDefaults :: IO LBS.ByteString
+readPackagedDefaults = do
+    path <- packagedModelCatalogPath
+    LBS.readFile path

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
@@ -1,6 +1,12 @@
 module Agent.CLI.SessionSpec (spec) where
 
 import Agent.CLI.Session
+import Agent.CLI.Session.Codec
+    ( fromStoredMetadata
+    , fromStoredPromptSnapshot
+    , toStoredMetadata
+    , toStoredPromptSnapshot
+    )
 import Agent.CLI.SessionLock (acquireSessionLock, releaseSessionLock)
 import Agent.CLI.Request (requestParams)
 import Agent.CLI.Session.StoreCodec
@@ -8,6 +14,7 @@ import Agent.CLI.Session.StoreCodec
     , toStoredResponseItem
     )
 import Agent.CLI.Models (ModelTarget(..))
+import Agent.CLI.ModelConfig (organizationGatewayConnectionId)
 import Agent.Dialect (DialectId(..))
 import Agent.Json (RawJson, rawJsonFromEncoding)
 import Agent.Json.Decode qualified as Hermes
@@ -1445,6 +1452,40 @@ spec = describe "Agent.CLI.Session" do
             Hermes.decodeEither sessionMetaDecoder
                 (LBS.toStrict (Aeson.encode meta))
                 `shouldBe` Right meta
+
+        it "round-trips gateway protocol identity through every metadata codec" do
+            let prompt =
+                    (testPromptSnapshot "gateway-session")
+                        { promptSnapshotProvider = OpenAIProvider
+                        , promptSnapshotConnection =
+                            organizationGatewayConnectionId
+                        , promptSnapshotModel = "company-coder"
+                        , promptSnapshotDialect = GenericResponsesDialect
+                        }
+                legacy = LegacySubagentTarget
+                    { legacyTargetProvider = OpenAIProvider
+                    , legacyTargetConnection =
+                        organizationGatewayConnectionId
+                    , legacyTargetEffectiveModel = "company-coder"
+                    , legacyTargetDialect = GenericResponsesDialect
+                    }
+                meta =
+                    (testMeta "gateway-session")
+                        { metaProvider = OpenAIProvider
+                        , metaConnection = organizationGatewayConnectionId
+                        , metaModel = "company-coder"
+                        , metaTransportModel = Just "company-coder"
+                        , metaDialect = GenericResponsesDialect
+                        , metaLegacySubagentTarget = Just legacy
+                        , metaPromptSnapshot = Just prompt
+                        }
+            Hermes.decodeEither sessionMetaDecoder
+                (LBS.toStrict (Aeson.encode meta))
+                `shouldBe` Right meta
+            fromStoredMetadata (toStoredMetadata meta)
+                `shouldBe` Right (meta { metaPromptSnapshot = Nothing })
+            fromStoredPromptSnapshot (toStoredPromptSnapshot prompt)
+                `shouldBe` Right prompt
 
         it "infers transcript effects when importing legacy JSON turns" do
             let legacy userText = Aeson.object

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -145,6 +145,7 @@ library
                     , Agent.CLI.CancelWatch
                     , Agent.CLI.Clipboard
                     , Agent.CLI.Claude
+                    , Agent.CLI.ClaudeGatewayProxy
                     , Agent.CLI.CodeModeRuntime
                     , Agent.CLI.Compaction
                     , Agent.CLI.Context
@@ -312,6 +313,8 @@ library
                     , vector
                     , vty >= 6.4 && < 7
                     , vty-crossplatform >= 0.4 && < 0.5
+                    , wai
+                    , warp
 
 executable agent-cli
     import:           common-options
@@ -466,6 +469,7 @@ test-suite agent-cli-test
                     , Agent.CLI.BtwSpec
                     , Agent.CLI.CancelWatchSpec
                     , Agent.CLI.ClipboardSpec
+                    , Agent.CLI.ClaudeGatewayProxySpec
                     , Agent.CLI.ClaudeSpec
                     , Agent.CLI.CommandSpec
                     , Agent.CLI.ComputerUseSpec
@@ -567,6 +571,8 @@ test-suite agent-cli-test
                     , filepath
                     , haskeline >= 0.8 && < 0.9
                     , hspec >= 2.11 && < 2.12
+                    , http-client
+                    , http-types
                     , JuicyPixels
                     , process
                     , QuickCheck >= 2.14 && < 2.16
@@ -577,6 +583,8 @@ test-suite agent-cli-test
                     , transformers
                     , unix
                     , vty >= 6.4 && < 7
+                    , wai
+                    , warp
     if os(darwin)
         c-sources:    test/cbits/HaskellAgentBridgeBrowserSmoke.c
                     , test/cbits/HaskellAgentBridgeImageSmoke.c

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -10,7 +10,7 @@
 , JuicyPixels, lib, memory, mtl, network, network-uri
 , optparse-applicative, process, QuickCheck, retry, safe-exceptions
 , scientific, stm, tagsoup, text, time, transformers, unix, vector
-, vty, vty-crossplatform
+, vty, vty-crossplatform, wai, warp
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -32,7 +32,7 @@ mkDerivation {
     hasql-pool http-client http-client-tls http-types JuicyPixels
     memory mtl network network-uri optparse-applicative process retry
     safe-exceptions scientific stm tagsoup text time transformers unix
-    vector vty vty-crossplatform
+    vector vty vty-crossplatform wai warp
   ];
   executableHaskellDepends = [
     aeson agent-cli-runtime agent-responses agent-responses-types

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -95,7 +95,7 @@ import Control.Exception.Safe
 import Control.Monad (void)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
@@ -109,7 +109,7 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     , toolsTransportModel :: !Text
     , toolsDialect :: !DialectId
     , toolsAllowedModels :: !(Maybe [Text])
-    , toolsChildModelAllowed :: !(Maybe (Text -> IO Bool))
+    , toolsResolveModelOption :: !(Maybe (Text -> IO (Maybe ModelOption)))
     , toolsCwd :: !OsPath
     , toolsEffort :: !Text
     , toolsCurrentSessionId :: !(IO (Maybe Text))
@@ -318,9 +318,9 @@ createAgentSessionTool env = jsonTool
         (runCreateAgentSession env))
   where
     modelPropertyType =
-        case env.toolsChildModelAllowed of
-            Just _ -> PropertyString
-            Nothing ->
+        if isJust env.toolsResolveModelOption
+            then PropertyString
+            else
                 maybe
                     PropertyString
                     (PropertyEnum . normalizedAllowedModels)
@@ -343,20 +343,60 @@ runCreateAgentSession env args
         pure (Left "create_agent_session title must be at most 100 characters")
     | otherwise = do
         let model = fromMaybe env.toolsModel normalizedOverride
-        modelAllowed <- case env.toolsChildModelAllowed of
-            Just isAllowed -> isAllowed model
-            Nothing ->
-                pure
-                    (allowedModelOverride
-                        env.toolsAllowedModels
-                        normalizedOverride)
-        if not modelAllowed
-            then
-                pure
-                    (Left
-                        "The requested session model is not allowed by this organization.")
-            else do
-                target <- case normalizedOverride of
+        resolveSessionTarget env normalizedOverride model >>= \case
+            Left err -> pure (Left err)
+            Right target -> do
+                let title = case Text.strip <$> args.title of
+                        Just value | not (Text.null value) -> value
+                        _ -> sessionTitleFromPrompt args.message
+                    spec = SessionCreate
+                        { createPool = env.toolsPool
+                        , createRoot = env.toolsRoot
+                        , createTarget = target.modelTarget
+                        , createCwd = env.toolsCwd
+                        , createEffort =
+                            fromMaybe env.toolsEffort args.reasoningEffort
+                        , createTitleHint = Just title
+                        , createTitleIsManual =
+                            maybe False
+                                (not . Text.null . Text.strip)
+                                args.title
+                        }
+                handle <- createSession spec
+                launchToolSessionTurn env handle args.message >>= \case
+                    Left err -> pure $ Left $
+                        "created session " <> handle.sessionMeta.metaId
+                            <> " but failed to start it: " <> err
+                    Right result -> pure (Right result)
+  where
+    normalizedOverride = normalizeModelOverride args.model
+
+resolveSessionTarget
+    :: AgentSessionToolsEnv
+    -> Maybe Text
+    -> Text
+    -> IO (Either Text ModelOption)
+resolveSessionTarget env normalizedOverride model =
+    case normalizedOverride of
+        Just requested
+            | Just resolve <- env.toolsResolveModelOption ->
+                resolve requested >>= \case
+                    Nothing -> pure (Left notAllowed)
+                    Just option -> pure (Right option)
+        _ -> do
+            modelAllowed <- case env.toolsResolveModelOption of
+                Just resolve -> isJust <$> resolve model
+                Nothing -> pure
+                    (case normalizedOverride of
+                        Nothing -> True
+                        Just requested ->
+                            maybe
+                                True
+                                (elem requested . normalizedAllowedModels)
+                                env.toolsAllowedModels)
+            if not modelAllowed
+                then pure (Left notAllowed)
+                else Right <$> case normalizedOverride of
                     Nothing ->
                         pure ModelOption
                             { modelTarget = ModelTarget
@@ -384,38 +424,9 @@ runCreateAgentSession env args
                             , modelLabel = Nothing
                             , modelFallbackPriority = Nothing
                             }
-                let title = case Text.strip <$> args.title of
-                        Just value | not (Text.null value) -> value
-                        _ -> sessionTitleFromPrompt args.message
-                    spec = SessionCreate
-                        { createPool = env.toolsPool
-                        , createRoot = env.toolsRoot
-                        , createTarget = target.modelTarget
-                        , createCwd = env.toolsCwd
-                        , createEffort =
-                            fromMaybe env.toolsEffort args.reasoningEffort
-                        , createTitleHint = Just title
-                        , createTitleIsManual =
-                            maybe False
-                                (not . Text.null . Text.strip)
-                                args.title
-                        }
-                handle <- createSession spec
-                launchToolSessionTurn env handle args.message >>= \case
-                    Left err -> pure $ Left $
-                        "created session " <> handle.sessionMeta.metaId
-                            <> " but failed to start it: " <> err
-                    Right result -> pure (Right result)
   where
-    normalizedOverride = normalizeModelOverride args.model
-    allowedModelOverride allowed requested =
-        case requested of
-            Nothing -> True
-            Just requestedModel ->
-                maybe
-                    True
-                    (elem requestedModel . normalizedAllowedModels)
-                    allowed
+    notAllowed =
+        "The requested session model is not allowed by this organization."
 
 normalizeModelOverride :: Maybe Text -> Maybe Text
 normalizeModelOverride requested = do

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -109,6 +109,7 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     , toolsTransportModel :: !Text
     , toolsDialect :: !DialectId
     , toolsAllowedModels :: !(Maybe [Text])
+    , toolsChildModelAllowed :: !(Maybe (Text -> IO Bool))
     , toolsCwd :: !OsPath
     , toolsEffort :: !Text
     , toolsCurrentSessionId :: !(IO (Maybe Text))
@@ -317,10 +318,13 @@ createAgentSessionTool env = jsonTool
         (runCreateAgentSession env))
   where
     modelPropertyType =
-        maybe
-            PropertyString
-            (PropertyEnum . normalizedAllowedModels)
-            env.toolsAllowedModels
+        case env.toolsChildModelAllowed of
+            Just _ -> PropertyString
+            Nothing ->
+                maybe
+                    PropertyString
+                    (PropertyEnum . normalizedAllowedModels)
+                    env.toolsAllowedModels
     modelPropertyDescription =
         case env.toolsAllowedModels of
             Nothing ->
@@ -337,59 +341,71 @@ runCreateAgentSession env args
         pure (Left "create_agent_session requires a non-empty message")
     | maybe False ((> 100) . Text.length . Text.strip) args.title =
         pure (Left "create_agent_session title must be at most 100 characters")
-    | not (allowedModelOverride env.toolsAllowedModels normalizedOverride) =
-        pure
-            (Left
-                "The requested session model is not allowed by this organization.")
     | otherwise = do
         let model = fromMaybe env.toolsModel normalizedOverride
-        target <- case normalizedOverride of
+        modelAllowed <- case env.toolsChildModelAllowed of
+            Just isAllowed -> isAllowed model
             Nothing ->
-                pure ModelOption
-                    { modelTarget = ModelTarget
-                        { targetProvider = env.toolsProvider
-                        , targetConnectionId = env.toolsConnection
-                        , targetModelId = model
-                        , targetWireModelId = env.toolsTransportModel
-                        , targetDialect = env.toolsDialect
+                pure
+                    (allowedModelOverride
+                        env.toolsAllowedModels
+                        normalizedOverride)
+        if not modelAllowed
+            then
+                pure
+                    (Left
+                        "The requested session model is not allowed by this organization.")
+            else do
+                target <- case normalizedOverride of
+                    Nothing ->
+                        pure ModelOption
+                            { modelTarget = ModelTarget
+                                { targetProvider = env.toolsProvider
+                                , targetConnectionId = env.toolsConnection
+                                , targetModelId = model
+                                , targetWireModelId = env.toolsTransportModel
+                                , targetDialect = env.toolsDialect
+                                }
+                            , modelContextWindow = Nothing
+                            , modelLabel = Nothing
+                            , modelFallbackPriority = Nothing
+                            }
+                    Just _ ->
+                        resolveModelOptionDialect ModelOption
+                            { modelTarget = ModelTarget
+                                { targetProvider = env.toolsProvider
+                                , targetConnectionId = env.toolsConnection
+                                , targetModelId = model
+                                , targetWireModelId = model
+                                , targetDialect =
+                                    dialectIdForModel env.toolsProvider model
+                                }
+                            , modelContextWindow = Nothing
+                            , modelLabel = Nothing
+                            , modelFallbackPriority = Nothing
+                            }
+                let title = case Text.strip <$> args.title of
+                        Just value | not (Text.null value) -> value
+                        _ -> sessionTitleFromPrompt args.message
+                    spec = SessionCreate
+                        { createPool = env.toolsPool
+                        , createRoot = env.toolsRoot
+                        , createTarget = target.modelTarget
+                        , createCwd = env.toolsCwd
+                        , createEffort =
+                            fromMaybe env.toolsEffort args.reasoningEffort
+                        , createTitleHint = Just title
+                        , createTitleIsManual =
+                            maybe False
+                                (not . Text.null . Text.strip)
+                                args.title
                         }
-                    , modelContextWindow = Nothing
-                    , modelLabel = Nothing
-                    , modelFallbackPriority = Nothing
-                    }
-            Just _ ->
-                resolveModelOptionDialect ModelOption
-                    { modelTarget = ModelTarget
-                        { targetProvider = env.toolsProvider
-                        , targetConnectionId = env.toolsConnection
-                        , targetModelId = model
-                        , targetWireModelId = model
-                        , targetDialect =
-                            dialectIdForModel env.toolsProvider model
-                        }
-                    , modelContextWindow = Nothing
-                    , modelLabel = Nothing
-                    , modelFallbackPriority = Nothing
-                    }
-        let title = case Text.strip <$> args.title of
-                Just value | not (Text.null value) -> value
-                _ -> sessionTitleFromPrompt args.message
-            spec = SessionCreate
-                { createPool = env.toolsPool
-                , createRoot = env.toolsRoot
-                , createTarget = target.modelTarget
-                , createCwd = env.toolsCwd
-                , createEffort = fromMaybe env.toolsEffort args.reasoningEffort
-                , createTitleHint = Just title
-                , createTitleIsManual =
-                    maybe False (not . Text.null . Text.strip) args.title
-                }
-        handle <- createSession spec
-        launchToolSessionTurn env handle args.message >>= \case
-            Left err -> pure $ Left $
-                "created session " <> handle.sessionMeta.metaId
-                    <> " but failed to start it: " <> err
-            Right result -> pure (Right result)
+                handle <- createSession spec
+                launchToolSessionTurn env handle args.message >>= \case
+                    Left err -> pure $ Left $
+                        "created session " <> handle.sessionMeta.metaId
+                            <> " but failed to start it: " <> err
+                    Right result -> pure (Right result)
   where
     normalizedOverride = normalizeModelOverride args.model
     allowedModelOverride allowed requested =

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -108,6 +108,7 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     , toolsModel :: !Text
     , toolsTransportModel :: !Text
     , toolsDialect :: !DialectId
+    , toolsAllowedModels :: !(Maybe [Text])
     , toolsCwd :: !OsPath
     , toolsEffort :: !Text
     , toolsCurrentSessionId :: !(IO (Maybe Text))
@@ -305,8 +306,8 @@ createAgentSessionTool env = jsonTool
         "Initial task or message for the new agent session."
     , PropertySchema "title" PropertyString False $ Just
         "Optional session title. Defaults to a title derived from the message."
-    , PropertySchema "model" PropertyString False $ Just
-        "Optional model override. Defaults to the current session model."
+    , PropertySchema "model" modelPropertyType False $ Just
+        modelPropertyDescription
     , PropertySchema "reasoning_effort" PropertyString False $ Just
         "Optional reasoning-effort override. Defaults to the current session effort."
     ]
@@ -314,6 +315,18 @@ createAgentSessionTool env = jsonTool
     TurnSequential
     (typedTool "create_agent_session" createAgentSessionArgsDecoder
         (runCreateAgentSession env))
+  where
+    modelPropertyType =
+        maybe
+            PropertyString
+            (PropertyEnum . normalizedAllowedModels)
+            env.toolsAllowedModels
+    modelPropertyDescription =
+        case env.toolsAllowedModels of
+            Nothing ->
+                "Optional model override. Defaults to the current session model."
+            Just _ ->
+                "Optional organization-approved model override. Defaults to the current session model."
 
 runCreateAgentSession
     :: AgentSessionToolsEnv
@@ -324,9 +337,13 @@ runCreateAgentSession env args
         pure (Left "create_agent_session requires a non-empty message")
     | maybe False ((> 100) . Text.length . Text.strip) args.title =
         pure (Left "create_agent_session title must be at most 100 characters")
+    | not (allowedModelOverride env.toolsAllowedModels normalizedOverride) =
+        pure
+            (Left
+                "The requested session model is not allowed by this organization.")
     | otherwise = do
-        let model = fromMaybe env.toolsModel args.model
-        target <- case args.model of
+        let model = fromMaybe env.toolsModel normalizedOverride
+        target <- case normalizedOverride of
             Nothing ->
                 pure ModelOption
                     { modelTarget = ModelTarget
@@ -373,6 +390,25 @@ runCreateAgentSession env args
                 "created session " <> handle.sessionMeta.metaId
                     <> " but failed to start it: " <> err
             Right result -> pure (Right result)
+  where
+    normalizedOverride = normalizeModelOverride args.model
+    allowedModelOverride allowed requested =
+        case requested of
+            Nothing -> True
+            Just requestedModel ->
+                maybe
+                    True
+                    (elem requestedModel . normalizedAllowedModels)
+                    allowed
+
+normalizeModelOverride :: Maybe Text -> Maybe Text
+normalizeModelOverride requested = do
+    stripped <- Text.strip <$> requested
+    if Text.null stripped then Nothing else Just stripped
+
+normalizedAllowedModels :: [Text] -> [Text]
+normalizedAllowedModels =
+    filter (not . Text.null) . map Text.strip
 
 data ReadAgentSessionArgs = ReadAgentSessionArgs
     { sessionId :: Text

--- a/packages/agent-cli/src/Agent/CLI/ClaudeGatewayProxy.hs
+++ b/packages/agent-cli/src/Agent/CLI/ClaudeGatewayProxy.hs
@@ -1,0 +1,169 @@
+module Agent.CLI.ClaudeGatewayProxy (withClaudeGatewayProxy) where
+
+import Agent.CLI.GatewayClient
+    ( GatewayCredential(..)
+    , validateGatewayCredential
+    )
+import Agent.Claude (ClaudeCodeTransport(..))
+import Control.Concurrent.Async (withAsync)
+import Control.Exception.Safe (bracket, tryAny)
+import Control.Monad (unless)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Builder (Builder, byteString)
+import Data.Char (intToDigit)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Types
+import Network.Socket qualified as Socket
+import Network.Wai
+import Network.Wai.Handler.Warp qualified as Warp
+import System.IO (IOMode(ReadMode), hSetBinaryMode, withFile)
+
+-- | Keep the organization bearer in the parent process. Claude receives only
+-- a random, session-scoped capability accepted by this loopback-only proxy.
+withClaudeGatewayProxy
+    :: GatewayCredential
+    -> (ClaudeCodeTransport -> IO value)
+    -> IO (Either Text value)
+withClaudeGatewayProxy rawCredential callback =
+    case validateGatewayCredential rawCredential of
+        Left _ -> pure (Left proxyError)
+        Right () -> do
+            manager <- newTlsManager
+            capability <- randomCapability
+            bracket Warp.openFreePort (Socket.close . snd) \(port, socket) ->
+                withAsync
+                    (Warp.runSettingsSocket
+                        (Warp.setHost "127.0.0.1" Warp.defaultSettings)
+                        socket
+                        (proxyApplication manager rawCredential capability))
+                    \_ ->
+                        Right <$> callback ClaudeCodeGateway
+                            { gatewayBaseUrl =
+                                "http://127.0.0.1:" <> Text.pack (show port)
+                            , gatewayToken = capability
+                            }
+
+proxyError :: Text
+proxyError = "The Claude gateway transport is unavailable."
+
+randomCapability :: IO Text
+randomCapability =
+    withFile "/dev/urandom" ReadMode \handle -> do
+        hSetBinaryMode handle True
+        bytes <- BS.hGet handle 32
+        if BS.length bytes /= 32
+            then fail "unable to create Claude gateway capability"
+            else pure (Text.pack (concatMap hexByte (BS.unpack bytes)))
+  where
+    hexByte byte =
+        [ intToDigit (fromIntegral byte `div` 16)
+        , intToDigit (fromIntegral byte `mod` 16)
+        ]
+
+proxyApplication
+    :: HTTP.Manager
+    -> GatewayCredential
+    -> Text
+    -> Application
+proxyApplication manager credential capability request respond
+    | requestMethod request /= "POST"
+        || pathInfo request /= ["anthropic", "v1", "messages"] =
+        respondJson status404
+    | lookup hAuthorization request.requestHeaders
+        /= Just ("Bearer " <> Text.encodeUtf8 capability) =
+        respondJson status401
+    | otherwise =
+        readBoundedRequestBody (32 * 1024 * 1024) request >>= \case
+            Nothing -> respondJson status413
+            Just body ->
+                tryAny (forward manager credential request body respond)
+                    >>= \case
+                        Left _ -> respondJson status502
+                        Right received -> pure received
+  where
+    respondJson status =
+        respond
+            (responseLBS status [(hContentType, "application/json")] "{}")
+
+forward
+    :: HTTP.Manager
+    -> GatewayCredential
+    -> Request
+    -> ByteString
+    -> (Response -> IO ResponseReceived)
+    -> IO ResponseReceived
+forward manager credential downstream body respond = do
+    initial <-
+        HTTP.parseRequest $
+            Text.unpack credential.gatewayBaseUrl <> "/anthropic/v1/messages"
+    HTTP.withResponse
+        initial
+            { HTTP.method = "POST"
+            , HTTP.requestHeaders =
+                ( hAuthorization
+                , "Bearer " <> Text.encodeUtf8 credential.gatewayAccessToken
+                )
+                    : filter
+                        (\(name, _) ->
+                            name `elem`
+                                [ hAccept
+                                , hContentType
+                                , "anthropic-version"
+                                , "anthropic-beta"
+                                , hUserAgent
+                                ])
+                        downstream.requestHeaders
+            , HTTP.requestBody = HTTP.RequestBodyBS body
+            , HTTP.redirectCount = 0
+            , HTTP.checkResponse = \_ _ -> pure ()
+            , HTTP.responseTimeout =
+                HTTP.responseTimeoutMicro (10 * 60 * 1_000_000)
+            }
+        manager
+        \upstream ->
+            respond $
+                responseStream
+                    upstream.responseStatus
+                    (filter
+                        (\(name, _) ->
+                            name
+                                `notElem`
+                                    [ hConnection
+                                    , hContentLength
+                                    , "Transfer-Encoding"
+                                    ])
+                        upstream.responseHeaders)
+                    \send flush ->
+                        streamBody upstream.responseBody send flush
+
+streamBody
+    :: HTTP.BodyReader
+    -> (Builder -> IO ())
+    -> IO ()
+    -> IO ()
+streamBody reader send flush = go
+  where
+    go =
+        HTTP.brRead reader >>= \chunk ->
+            unless (BS.null chunk) (send (byteString chunk) >> flush >> go)
+
+readBoundedRequestBody :: Int -> Request -> IO (Maybe ByteString)
+readBoundedRequestBody limit request = go 0 []
+  where
+    go size chunks =
+        getRequestBodyChunk request >>= \chunk ->
+            if BS.null chunk
+                then pure (Just (BS.concat (reverse chunks)))
+                else
+                    let next = size + BS.length chunk
+                    in if next > limit
+                        then drain >> pure Nothing
+                        else go next (chunk : chunks)
+    drain =
+        getRequestBodyChunk request >>= \chunk ->
+            unless (BS.null chunk) drain

--- a/packages/agent-cli/src/Agent/CLI/Dictation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation.hs
@@ -161,14 +161,18 @@ dictateWith provider control =
             loadAuth (Just XAIProvider) >>= \case
                 Left err ->
                     pure (DictationFailed err)
-                Right loaded ->
-                    finish =<<
-                        transcribePcmWithXAI
-                            loaded.loadedTokenProvider
-                            (streamMicrophone
-                                16_000
-                                control.dictationWaitForStop)
-                            control.dictationOnTranscript
+                Right loaded
+                    | loaded.loadedProvider /= XAIProvider ->
+                        pure $ DictationFailed
+                            "xAI dictation requires direct xAI credentials"
+                    | otherwise ->
+                        finish =<<
+                            transcribePcmWithXAI
+                                loaded.loadedTokenProvider
+                                (streamMicrophone
+                                    16_000
+                                    control.dictationWaitForStop)
+                                control.dictationOnTranscript
     finish = \case
         Left err ->
             pure (DictationFailed (Text.pack (show err)))

--- a/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
@@ -2,11 +2,14 @@
 -- gateway for native clients that do not own a long-running CLI session.
 module Agent.CLI.GatewayModels
     ( loadGatewayModelOptionsAt
+    , modelOptionsForGatewayModels
     , modelOptionsForGatewayState
     ) where
 
 import Agent.CLI.GatewayClient
-    ( loadGatewayCredentialAt
+    ( GatewayModel(..)
+    , GatewayModelProtocol(..)
+    , loadGatewayCredentialAt
     , newGatewayModelAccess
     , refreshGatewayModels
     )
@@ -19,8 +22,10 @@ import Agent.CLI.Models
     , gatewayModelOptions
     , modelCatalog
     )
-import Agent.Provider (Provider (OpenAIProvider))
+import Agent.Provider
+    ( Provider (ClaudeCodeProvider, OpenAIProvider) )
 import Data.Text (Text)
+import Data.Text qualified as Text
 import System.OsPath (OsPath)
 
 loadGatewayModelOptionsAt
@@ -43,15 +48,39 @@ loadGatewayModelOptionsAt home cwd =
                             pure
                                 (Left
                                     "The organization gateway does not offer any models.")
-                        Right modelIds ->
+                        Right models ->
                             pure
                                 (Right
                                     ( catalog
                                     , Just
-                                        (modelOptionsForGatewayState
-                                            catalog
-                                            (Just modelIds))
+                                        (modelOptionsForGatewayModels
+                                            catalog models)
                                     ))
+
+modelOptionsForGatewayModels
+    :: ModelCatalog
+    -> [GatewayModel]
+    -> [ModelOption]
+modelOptionsForGatewayModels catalog models =
+    gatewayModelOptions catalog OpenAIProvider responseIds
+        <> gatewayModelOptions catalog ClaudeCodeProvider anthropicIds
+  where
+    responseIds =
+        [ model.gatewayModelId
+        | model <- models
+        , model.gatewayModelProtocol == GatewayResponsesProtocol
+        , publicAlias model.gatewayModelId
+        ]
+    anthropicIds =
+        [ model.gatewayModelId
+        | model <- models
+        , model.gatewayModelProtocol == GatewayAnthropicProtocol
+        , publicAlias model.gatewayModelId
+        , model.gatewayModelId `notElem` responseIds
+        ]
+    publicAlias modelId =
+        not ("router-" `Text.isPrefixOf` modelId)
+            && modelId /= "traumimmo-translation"
 
 modelOptionsForGatewayState
     :: ModelCatalog

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -40,8 +40,7 @@ import Agent.CLI.Clipboard
     , readClipboardText
     )
 import Agent.CLI.Dictation
-    ( dictate
-    , dictateForProvider
+    ( dictateForProvider
     , insertDictation
     )
 import Agent.CLI.Command
@@ -65,7 +64,7 @@ import Agent.CLI.Interrupt
     , InterruptState
     , noteIdleCtrlC
     )
-import Agent.Provider (Provider)
+import Agent.Provider (Provider(XAIProvider))
 import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
     , detectTerminalCapabilities
@@ -137,7 +136,7 @@ import System.Posix.Terminal
 readReplLine :: InterruptState -> Text -> IO ReplLine
 readReplLine interrupt prompt =
     readReplLineConfigured
-        Nothing
+        (Just XAIProvider)
         defaultSlashCatalog False interrupt prompt ""
 
 -- | Read a prompt whose dictation backend follows the active model provider.
@@ -150,7 +149,7 @@ readReplLineForProvider provider interrupt prompt =
 -- | Like 'readReplLine', restoring @initial@ as the in-progress draft.
 readReplLineWithInitial :: InterruptState -> Text -> Text -> IO ReplLine
 readReplLineWithInitial =
-    readReplLineConfigured Nothing defaultSlashCatalog True
+    readReplLineConfigured (Just XAIProvider) defaultSlashCatalog True
 
 readReplLineWithCatalog
     :: SlashCatalog
@@ -179,7 +178,7 @@ readReplLineWithSkills
     -> IO ReplLine
 readReplLineWithSkills skills =
     readReplLineConfigured
-        Nothing
+        (Just XAIProvider)
         (slashCatalogWithSkills skills defaultSlashCatalog)
         True
 
@@ -192,7 +191,7 @@ readReplLineWithSkillsAndModels
     -> IO ReplLine
 readReplLineWithSkillsAndModels skills modelIds =
     readReplLineConfigured
-        Nothing
+        (Just XAIProvider)
         ((slashCatalogWithSkills skills defaultSlashCatalog)
             { slashCatalogModelIds = modelIds
             })
@@ -366,7 +365,10 @@ readInlineEditor
             DictateIntoEditor -> do
                 finishEditorLine prompt next
                 result <- tryAny $
-                    maybe dictate dictateForProvider dictationProvider
+                    maybe
+                        (fail "Dictation is unavailable in this prompt.")
+                        dictateForProvider
+                        dictationProvider
                 case result of
                     Left err ->
                         Text.putStrLn

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -875,9 +875,9 @@ loginAccountDetail account
                 <> markdownText 160 account.loginAccountId
             , "Status: " <> gatewayStatus
             , ""
-            , "The gateway is preferred for OpenAI requests. If its saved "
-                <> "authorization is rejected, compatible local ChatGPT "
-                <> "accounts remain available as fallbacks."
+            , "The gateway controls provider, model, and account routing for "
+                <> "this organization. Local accounts are unavailable until "
+                <> "the gateway is disconnected."
             ]
       where
         gatewayStatus = case account.loginUsage of

--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -5,6 +5,8 @@ module Agent.CLI.ModelPicker
     , pickModel
     , pickModelWithOptions
     , pickModelWithEffort
+    , pickModelState
+    , pickModelStateWithEffort
     , formatCatalogListing
     , initialModelPickerState
     , applyModelPickerEvent
@@ -153,16 +155,33 @@ pickModelWithEffort
         current
         currentDialect
         currentEffort = do
-    isTty <- hIsTerminalDevice stdin
     models <-
         initialPickerStateResolvedWith
             catalog discovered connectionId provider current currentDialect
+    pickModelStateWithEffort color currentEffort models
+
+-- | Open a picker for a pre-scoped, authoritative option list.
+pickModelState :: Bool -> PickerState -> IO (Maybe ModelOption)
+pickModelState color models =
+    fmap (fmap (.modelPickerOption)) $
+        pickModelStateWithEffort
+            color
+            (defaultEffortFor models.pickerProvider)
+            models
+
+-- | Open the integrated model/effort picker for a pre-scoped option list.
+pickModelStateWithEffort
+    :: Bool
+    -> ReasoningEffort
+    -> PickerState
+    -> IO (Maybe ModelPickerSelection)
+pickModelStateWithEffort color currentEffort models = do
+    isTty <- hIsTerminalDevice stdin
     let state0 = initialModelPickerState currentEffort models
     if not isTty
         then do
             Text.hPutStrLn stderr
-                (formatCatalogListingState
-                    color current currentDialect models)
+                (formatCatalogListingState color models)
             hFlush stderr
             pure Nothing
         else do
@@ -249,32 +268,28 @@ formatCatalogListing
     state <-
         initialPickerStateResolved
             catalog connectionId provider current currentDialect
-    pure (formatCatalogListingState
-        color current currentDialect state)
+    pure (formatCatalogListingState color state)
 
 formatCatalogListingState
     :: Bool
-    -> Text
-    -> DialectId
     -> PickerState
     -> Text
-formatCatalogListingState color current currentDialect state =
+formatCatalogListingState color state =
     let header =
             roleMuted color
                 (glyphSessionLike
                     <> "model: "
-                    <> displayPickerText state.pickerConnectionId
-                    <> "/"
-                    <> displayPickerText current
-                    <> " · all providers")
+                    <> pickerCurrentLabel state
+                    <> " · "
+                    <> state.pickerScopeLabel)
         rows =
             map
                 (\opt ->
                     let mark
                             | isCurrent
                                 state.pickerConnectionId
-                                current
-                                currentDialect
+                                state.pickerCurrent
+                                state.pickerCurrentDialect
                                 opt =
                                 roleSuccess color
                                     (glyphOk <> formatOptionName opt)
@@ -355,10 +370,10 @@ renderModelPickerFrame color state =
         rolePrompt color "Models"
             <> roleMuted color
                 (displayPickerText
-                    (" · current "
-                        <> models.pickerConnectionId
-                        <> "/"
-                        <> models.pickerCurrent))
+                    (" · "
+                        <> models.pickerScopeLabel
+                        <> " · current "
+                        <> pickerCurrentLabel models))
     searchLine
         | Text.null models.pickerFilter =
             roleMuted color "/ Type to search"
@@ -368,6 +383,18 @@ renderModelPickerFrame color state =
     scrollIndicator visible_ label
         | visible_ = roleMuted color ("    " <> label)
         | otherwise = ""
+
+pickerCurrentLabel :: PickerState -> Text
+pickerCurrentLabel state
+    | any
+        (\option ->
+            option.modelTarget.targetConnectionId
+                == state.pickerConnectionId
+                && option.modelTarget.targetModelId
+                    == state.pickerCurrent)
+        state.pickerAll =
+            state.pickerConnectionId <> "/" <> state.pickerCurrent
+    | otherwise = "(not offered in this scope)"
 
 pickerViewportSize :: Int
 pickerViewportSize = 12

--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -28,12 +28,12 @@ import Agent.CLI.Json (decodeLazy)
 import Agent.Json.Decode (defaultKey, optionalKey)
 import Agent.Json.Decode qualified as Hermes
 import Agent.CLI.Models (ModelTarget(..))
+import Agent.CLI.ModelConfig (connectionSupportsDialect)
 import Agent.Dialect
     ( DialectId
     , dialectSlug
     , legacyDialectIdForProvider
     , parseDialect
-    , providerSupportsDialect
     )
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (Provider, parseProvider, providerSlug)
@@ -155,7 +155,7 @@ projectModelDecoder = Hermes.object do
             Just text -> case parseDialect text of
                 Just parsed -> pure parsed
                 Nothing -> fail ("unknown dialect: " <> Text.unpack text)
-        unless (providerSupportsDialect provider dialect) $
+        unless (connectionSupportsDialect connection provider dialect) $
             fail
                 ( "dialect "
                     <> Text.unpack (dialectSlug dialect)

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -27,10 +27,9 @@ import Agent.CLI.Session.History
     )
 import Agent.CLI.Auth
     ( LoadedAuth(..)
+    , gatewayAuthSelectionId
     , loadAuth
-    , loadDirectOpenAiAuth
     , loadAuthForAccount
-    , preferredOpenAiTokenProvider
     )
 import Agent.CLI.Error
     ( formatApiErrorAt
@@ -165,22 +164,11 @@ loadSelectedAccountAuth
 loadSelectedAccountAuth provider selectionId accountId =
     case provider of
         OpenAIProvider ->
-            loadDirectOpenAiAuth >>= \case
-                Left err -> pure (Left err)
-                Right loaded -> case loaded.loadedOpenAiPool of
-                    Nothing ->
-                        pure (Left
-                            "OpenAI account selection requires a live account pool")
-                    Just pool -> do
-                        preferred <- newIORef (Just accountId)
-                        pure $ Right loaded
-                            { loadedTokenProvider =
-                                preferredOpenAiTokenProvider
-                                    preferred
-                                    pool
-                                    loaded.loadedTokenProvider
-                            , loadedSelectionId = Just accountId
-                            }
+            loadAuthForAccount
+                OpenAIProvider
+                (if selectionId == gatewayAuthSelectionId
+                    then selectionId
+                    else accountId)
         ClaudeCodeProvider ->
             loadAuth (Just ClaudeCodeProvider)
         _ -> loadAuthForAccount provider selectionId
@@ -482,49 +470,55 @@ requestAutomaticProviderFallback
     -> PendingTurn
     -> IO (Maybe ProviderTransition)
 requestAutomaticProviderFallback env apiError pending = do
-    forM_ env.sessionFullscreen \runtime ->
-        emitUiEvent runtime UiTurnRestarted
-    sessionId <- ensureTransitionSessionId env.sessionPersist
-    unavailable <- readIORef env.sessionUnavailableProviders
-    currentModel <-
-        fromMaybe "" . (.model) <$> readIORef env.sessionParams
-    case env.sessionTokenProvider of
-        Nothing -> pure Nothing
-        Just tokenProvider ->
-            chooseAutomaticProviderTransition
-                env.sessionModelCatalog
-                env.sessionCwd
-                env.sessionRender.renderStderr
-                env.sessionFullscreen
-                (tokenProviderBillingMode tokenProvider)
-                env.sessionProvider
-                currentModel
-                unavailable
-                sessionId
-                pending
-                apiError
+    readIORef env.sessionGatewayModels >>= \case
+        Just _ -> pure Nothing
+        Nothing -> do
+            forM_ env.sessionFullscreen \runtime ->
+                emitUiEvent runtime UiTurnRestarted
+            sessionId <- ensureTransitionSessionId env.sessionPersist
+            unavailable <- readIORef env.sessionUnavailableProviders
+            currentModel <-
+                fromMaybe "" . (.model) <$> readIORef env.sessionParams
+            case env.sessionTokenProvider of
+                Nothing -> pure Nothing
+                Just tokenProvider ->
+                    chooseAutomaticProviderTransition
+                        env.sessionModelCatalog
+                        env.sessionCwd
+                        env.sessionRender.renderStderr
+                        env.sessionFullscreen
+                        (tokenProviderBillingMode tokenProvider)
+                        env.sessionProvider
+                        currentModel
+                        unavailable
+                        sessionId
+                        pending
+                        apiError
 
 requestStartupProviderFallback
     :: SessionEnv
     -> ApiError
     -> IO (Maybe ProviderTransition)
 requestStartupProviderFallback env apiError = do
-    unavailable <- readIORef env.sessionUnavailableProviders
-    currentModel <-
-        fromMaybe "" . (.model) <$> readIORef env.sessionParams
-    case env.sessionTokenProvider of
-        Nothing -> pure Nothing
-        Just tokenProvider ->
-            chooseStartupProviderTransition
-                env.sessionModelCatalog
-                env.sessionCwd
-                env.sessionFullscreen
-                (tokenProviderBillingMode tokenProvider)
-                env.sessionProvider
-                currentModel
-                unavailable
-                Nothing
-                apiError
+    readIORef env.sessionGatewayModels >>= \case
+        Just _ -> pure Nothing
+        Nothing -> do
+            unavailable <- readIORef env.sessionUnavailableProviders
+            currentModel <-
+                fromMaybe "" . (.model) <$> readIORef env.sessionParams
+            case env.sessionTokenProvider of
+                Nothing -> pure Nothing
+                Just tokenProvider ->
+                    chooseStartupProviderTransition
+                        env.sessionModelCatalog
+                        env.sessionCwd
+                        env.sessionFullscreen
+                        (tokenProviderBillingMode tokenProvider)
+                        env.sessionProvider
+                        currentModel
+                        unavailable
+                        Nothing
+                        apiError
 
 continueAutomaticFallback
     :: Maybe OsPath

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -39,6 +39,7 @@ import Agent.CLI.Error
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , builtinConnectionId
+    , connectionSupportsDialect
     , loadModelCatalogAt
     )
 import Agent.CLI.Models
@@ -100,7 +101,6 @@ import Agent.Claude
 import Agent.Dialect
     ( DialectId
     , dialectSlug
-    , providerSupportsDialect
     )
 import Agent.Error
     ( ApiError(..)
@@ -809,7 +809,8 @@ loadValidatedProviderTarget
     -> IO (Either Text LoadedAuth)
 loadValidatedProviderTarget probeAvailability choice =
     if not
-        (providerSupportsDialect
+        (connectionSupportsDialect
+            choice.modelTarget.targetConnectionId
             choice.modelTarget.targetProvider
             choice.modelTarget.targetDialect)
     then

--- a/packages/agent-cli/src/Agent/CLI/ProviderAvailability.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderAvailability.hs
@@ -16,6 +16,7 @@ module Agent.CLI.ProviderAvailability
 
 import Agent.CLI.Auth (LoadedAuth(..))
 import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.OpenAI.WebSocketClient (isGatewayWebSocketCredential)
 import qualified Agent.OpenAI.Usage as OpenAI
 import qualified Agent.OpenRouter.Usage as OpenRouter
 import Agent.Provider
@@ -49,6 +50,7 @@ probeLoadedAvailability loaded =
                         pure (xaiUsageFailure now snapshot)
         OpenAIProvider
             | billing == SubscriptionBilled
+            , not (isGatewayWebSocketCredential credential)
             , not (nullAccountId credential.accountId) ->
                 OpenAI.fetchUsage
                     credential.accessToken credential.accountId >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
@@ -28,6 +28,7 @@ import Agent.CLI.Config
     , McpServerConfig(..)
     , WebFetchConfig(..)
     )
+import Agent.CLI.GatewayClient (cachedGatewayModels)
 import Agent.CLI.Interrupt (withTurnCancel)
 import Agent.CLI.MetaConsole
     ( MetaAction(..)
@@ -40,12 +41,13 @@ import Agent.CLI.MetaConsole
     , runMetaConsoleWithCancel
     )
 import Agent.CLI.ModelConfig
-    ( CatalogModel(..)
+    ( builtinConnectionId
+    , CatalogModel(..)
     , ModelCatalog(..)
     )
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.SessionEnv (SessionEnv(..))
-import Agent.Provider (providerSlug)
+import Agent.Provider (Provider(OpenAIProvider), providerSlug)
 import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Responses.Types (ResponseCreateParams(..))
 import Control.Applicative ((<|>))
@@ -351,6 +353,20 @@ buildMetaContext env config = do
     params <- readIORef env.sessionParams
     policy <- readIORef env.sessionPolicy
     shellMode <- env.sessionShellMode
+    gatewayAccess <- readIORef env.sessionGatewayModels
+    availableModels <- case gatewayAccess of
+        Nothing ->
+            pure
+                [ (model.catalogModelId, model.catalogModelConnectionId)
+                | model <- env.sessionModelCatalog.catalogModels
+                ]
+        Just access ->
+            maybe
+                []
+                (map
+                    (\modelId ->
+                        (modelId, builtinConnectionId OpenAIProvider)))
+                <$> cachedGatewayModels access
     pure $
         Aeson.object
             [ "session" .= Aeson.object
@@ -364,10 +380,10 @@ buildMetaContext env config = do
                 ]
             , "availableModels" .=
                 [ Aeson.object
-                    [ "id" .= model.catalogModelId
-                    , "connection" .= model.catalogModelConnectionId
+                    [ "id" .= modelId
+                    , "connection" .= connectionId
                     ]
-                | model <- env.sessionModelCatalog.catalogModels
+                | (modelId, connectionId) <- availableModels
                 ]
             , "harness" .= redactMetaContext (Aeson.toJSON config)
             ]

--- a/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
@@ -28,7 +28,7 @@ import Agent.CLI.Config
     , McpServerConfig(..)
     , WebFetchConfig(..)
     )
-import Agent.CLI.GatewayClient (cachedGatewayModels)
+import Agent.CLI.GatewayClient (cachedGatewayModels, gatewayModelIds)
 import Agent.CLI.Interrupt (withTurnCancel)
 import Agent.CLI.MetaConsole
     ( MetaAction(..)
@@ -41,13 +41,13 @@ import Agent.CLI.MetaConsole
     , runMetaConsoleWithCancel
     )
 import Agent.CLI.ModelConfig
-    ( builtinConnectionId
+    ( organizationGatewayConnectionId
     , CatalogModel(..)
     , ModelCatalog(..)
     )
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.SessionEnv (SessionEnv(..))
-import Agent.Provider (Provider(OpenAIProvider), providerSlug)
+import Agent.Provider (providerSlug)
 import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Responses.Types (ResponseCreateParams(..))
 import Control.Applicative ((<|>))
@@ -363,9 +363,11 @@ buildMetaContext env config = do
         Just access ->
             maybe
                 []
-                (map
+                ( map
                     (\modelId ->
-                        (modelId, builtinConnectionId OpenAIProvider)))
+                        (modelId, organizationGatewayConnectionId))
+                    . gatewayModelIds
+                )
                 <$> cachedGatewayModels access
     pure $
         Aeson.object

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -18,6 +18,11 @@ import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ( formatApiErrorAt )
+import Agent.CLI.GatewayClient
+    ( GatewayModelAccess
+    , loadGatewayCredential
+    , newGatewayModelAccess
+    )
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input ()
 import Agent.CLI.Interrupt
@@ -433,6 +438,17 @@ withRestoredCurrentDirectory action = do
     originalCwd <- getCurrentDirectory
     action `finally` setCurrentDirectory originalCwd
 
+recoveryGatewayAccess
+    :: Provider
+    -> Maybe ProviderTransition
+    -> IO (Either Text (Maybe GatewayModelAccess))
+recoveryGatewayAccess _ _ =
+    loadGatewayCredential >>= \case
+        Left err -> pure (Left ("Could not load gateway credentials: " <> err))
+        Right Nothing -> pure (Right Nothing)
+        Right (Just credential) ->
+            Right . Just <$> newGatewayModelAccess credential
+
 runAgent
     :: AgentProcessRuntime
     -> AgentRunMode
@@ -487,31 +503,39 @@ runAgent
                                             (Left
                                                 "No configured models are available.")
                                     Just current ->
-                                        modelChoiceWithEffort
-                                            catalog
-                                            (Just runtime)
-                                            color
-                                            current.targetConnectionId
+                                        recoveryGatewayAccess
                                             current.targetProvider
-                                            current.targetModelId
-                                            current.targetDialect
-                                            (fromMaybe
-                                                (defaultEffortFor
-                                                    current.targetProvider)
-                                                ( (nextTransition
-                                                        >>= (.transitionEffort))
-                                                    <|> nextOptions.optEffort
-                                                ))
-                                            >>= \case
-                                                Nothing ->
-                                                    pure (Right Nothing)
-                                                Just selection ->
-                                                    pure $ Right $ Just $
-                                                        recoveryModelTransition
-                                                            nextOptions
-                                                            nextTransition
-                                                            selection.modelPickerOption.modelTarget
-                                                            selection.modelPickerEffort
+                                            nextTransition >>= \case
+                                                Left err -> pure (Left err)
+                                                Right gatewayAccess ->
+                                                    modelChoiceWithEffort
+                                                        catalog
+                                                        gatewayAccess
+                                                        (Just runtime)
+                                                        color
+                                                        current.targetConnectionId
+                                                        current.targetProvider
+                                                        current.targetModelId
+                                                        current.targetDialect
+                                                        (fromMaybe
+                                                            (defaultEffortFor
+                                                                current.targetProvider)
+                                                            ( (nextTransition
+                                                                    >>= (.transitionEffort))
+                                                                <|> nextOptions.optEffort
+                                                            ))
+                                                        >>= \case
+                                                            Left err ->
+                                                                pure (Left err)
+                                                            Right Nothing ->
+                                                                pure (Right Nothing)
+                                                            Right (Just selection) ->
+                                                                pure $ Right $ Just $
+                                                                    recoveryModelTransition
+                                                                        nextOptions
+                                                                        nextTransition
+                                                                        selection.modelPickerOption.modelTarget
+                                                                        selection.modelPickerEffort
                     recoveryModelTransition
                             nextOptions nextTransition target selectedEffort =
                         case nextTransition of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -407,7 +407,8 @@ runAgentInitializedWithLock
                     then projectTarget
                     else Nothing
         requestedProvider
-            | isJust connectedGateway = Just OpenAIProvider
+            | isJust connectedGateway =
+                options.optProvider <|> Just OpenAIProvider
             | otherwise =
                 (.targetProvider) <$> targetHint
                     <|> options.optProvider

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -56,7 +56,9 @@ import Agent.CLI.McpStatus ()
 import Agent.CLI.ModelConfig
     ( catalogConnection,
       loadModelCatalogAt,
-      ConnectionKind(BuiltinConnection, CustomResponsesConnection),
+      organizationGatewayConnectionId,
+      ConnectionKind(BuiltinConnection, CustomResponsesConnection,
+                     OrganizationGatewayConnection),
       ModelConnection(connectionId, connectionKind),
       ResponsesConnection(responsesApiKeyEnv, responsesApiKeyOptional) )
 import Agent.CLI.Models
@@ -379,8 +381,7 @@ runAgentInitializedWithLock
                     meta.metaTransportModel
                     meta.metaDialect
         projectTargetResult
-            | isJust connectedGateway
-                || isJust transitionTarget
+            | isJust transitionTarget
                 || isJust options.optModel
                 || isJust resumed =
                     Right Nothing
@@ -388,13 +389,18 @@ runAgentInitializedWithLock
             Nothing -> Right Nothing
             Just remembered ->
                 let target = remembered.projectModelTarget
-                in
-                Just <$> savedTarget
-                    target.targetProvider
-                    target.targetConnectionId
-                    target.targetModelId
-                    (Just target.targetWireModelId)
-                    target.targetDialect
+                in if isJust connectedGateway
+                then Right (Just target)
+                else if target.targetConnectionId
+                    == organizationGatewayConnectionId
+                then Right Nothing
+                else
+                    Just <$> savedTarget
+                        target.targetProvider
+                        target.targetConnectionId
+                        target.targetModelId
+                        (Just target.targetWireModelId)
+                        target.targetDialect
     resumedTarget <-
         either (startupDie startup . Text.unpack) pure resumedTargetResult
     projectTarget <-
@@ -425,6 +431,7 @@ runAgentInitializedWithLock
                         CustomResponsesConnection responses -> Just
                             (connection.connectionId, responses)
                         BuiltinConnection _ -> Nothing
+                        OrganizationGatewayConnection -> Nothing
         checkStartupUsageInBackground =
             isJust fullscreen
                 && isNothing transition

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -382,9 +382,7 @@ runAgentInitializedWithLock
                                 <> connection <> "/" <> model
                                 <> " is not present in ~/.haskell-agent/models.json"
         resumedTargetResult
-            | isJust connectedGateway
-                || isJust transitionTarget
-                || isJust options.optModel =
+            | isJust transitionTarget || isJust options.optModel =
                 Right Nothing
             | otherwise = case fst <$> resumed of
             Nothing -> Right Nothing

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -21,6 +21,7 @@ import Agent.CLI.Auth
     ( LoadedAuth(loadedAccountLabel, LoadedAuth, loadedOpenAiPool,
                  loadedProvider, loadedTokenProvider, loadedSelectionId),
       gatewayAuthSelectionId,
+      isGatewayLoadedAuth,
       preferredOpenAiTokenProvider,
       loadAuth,
       loadAuthForAccount,
@@ -36,6 +37,12 @@ import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ( deriveDatabaseScopes )
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ()
+import Agent.CLI.GatewayClient
+    ( GatewayModelAccess
+    , loadGatewayCredential
+    , newGatewayModelAccess
+    , refreshGatewayModels
+    )
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input ()
 import Agent.CLI.Interrupt ()
@@ -342,6 +349,12 @@ runAgentInitializedWithLock
         catalogResult
     setStartupRepository fullscreen home branch cwd
     markStartupStage startup "Loading credentials…"
+    connectedGateway <-
+        loadGatewayCredential >>= \case
+            Left err ->
+                startupDie startup
+                    ("Could not load gateway credentials: " <> Text.unpack err)
+            Right credential -> pure credential
     let transitionTarget = (.transitionTarget) <$> transition
         pendingTurn = transition >>= (.transitionPendingTurn)
         unavailableProviders =
@@ -369,7 +382,9 @@ runAgentInitializedWithLock
                                 <> connection <> "/" <> model
                                 <> " is not present in ~/.haskell-agent/models.json"
         resumedTargetResult
-            | isJust transitionTarget || isJust options.optModel =
+            | isJust connectedGateway
+                || isJust transitionTarget
+                || isJust options.optModel =
                 Right Nothing
             | otherwise = case fst <$> resumed of
             Nothing -> Right Nothing
@@ -381,7 +396,8 @@ runAgentInitializedWithLock
                     meta.metaTransportModel
                     meta.metaDialect
         projectTargetResult
-            | isJust transitionTarget
+            | isJust connectedGateway
+                || isJust transitionTarget
                 || isJust options.optModel
                 || isJust resumed =
                     Right Nothing
@@ -407,19 +423,24 @@ runAgentInitializedWithLock
                 <|> if isNothing options.optModel
                     then projectTarget
                     else Nothing
-        requestedProvider =
-            (.targetProvider) <$> targetHint
-                <|> options.optProvider
-                <|> if isNothing options.optModel
-                    then projectModelProvider projectSettings
-                    else Nothing
+        requestedProvider
+            | isJust connectedGateway = Just OpenAIProvider
+            | otherwise =
+                (.targetProvider) <$> targetHint
+                    <|> options.optProvider
+                    <|> if isNothing options.optModel
+                        then projectModelProvider projectSettings
+                        else Nothing
         targetConnection =
             targetHint >>= catalogConnection catalog . (.targetConnectionId)
-        customResponses = targetConnection >>= \connection ->
-            case connection.connectionKind of
-                CustomResponsesConnection responses -> Just
-                    (connection.connectionId, responses)
-                BuiltinConnection _ -> Nothing
+        customResponses
+            | isJust connectedGateway = Nothing
+            | otherwise =
+                targetConnection >>= \connection ->
+                    case connection.connectionKind of
+                        CustomResponsesConnection responses -> Just
+                            (connection.connectionId, responses)
+                        BuiltinConnection _ -> Nothing
         checkStartupUsageInBackground =
             isJust fullscreen
                 && isNothing transition
@@ -491,7 +512,8 @@ runAgentInitializedWithLock
     (loaded, startupAccountIds) <- case customResponses of
         Just _ -> pure (initialLoaded, Nothing)
         Nothing
-            | Just active <- transition
+            | not (isGatewayLoadedAuth initialLoaded)
+            , Just active <- transition
             , Just selectionId <- active.transitionAccountSelectionId ->
                 pure
                     ( initialLoaded
@@ -564,13 +586,15 @@ runAgentInitializedWithLock
                                             ))
     case (transitionTarget, resumed) of
         (Just target, _)
-            | loaded.loadedProvider /= target.targetProvider ->
+            | not (isGatewayLoadedAuth loaded)
+            , loaded.loadedProvider /= target.targetProvider ->
                 startupDie startup $ "provider transition requested "
                     <> Text.unpack (providerSlug target.targetProvider)
                     <> " but auth resolved "
                     <> Text.unpack (providerSlug loaded.loadedProvider)
         (Nothing, Just (meta, _))
-            | loaded.loadedProvider /= meta.metaProvider ->
+            | not (isGatewayLoadedAuth loaded)
+            , loaded.loadedProvider /= meta.metaProvider ->
                 startupDie startup $ "session provider is "
                     <> Text.unpack (providerSlug meta.metaProvider)
                     <> " but auth resolved "
@@ -586,6 +610,11 @@ runAgentInitializedWithLock
                     "automatic provider fallback would cross from subscription \
                     \billing to API-credit billing"
         _ -> pure ()
+    initialGatewayModels <-
+        loadGatewayModelAccess loaded >>= either
+            (startupDie startup . Text.unpack)
+            pure
+    gatewayModelsRef <- newIORef initialGatewayModels
     activeAccountRef <- newIORef ""
     activeAccountIdRef <-
         newIORef (maybe "" snd startupAccountIds)
@@ -716,12 +745,19 @@ runAgentInitializedWithLock
                         resolveActiveAccountLabel
                         selectableTokenProvider
                 _ -> switchableTokenProvider
-        selectHttpAccount selectedSelectionId =
-            loadAuthForAccount loaded.loadedProvider selectedSelectionId
-                >>= \case
+        selectHttpAccount selectedSelectionId
+            | isGatewayLoadedAuth loaded =
+                pure $ Left $ CredentialError
+                    "Account switching is unavailable while connected to the organization gateway. Disconnect the gateway first."
+            | otherwise =
+                loadAuthForAccount loaded.loadedProvider selectedSelectionId
+                    >>= \case
                     Left err ->
                         pure (Left (CredentialError err))
                     Right selected
+                        | selected.loadedProvider /= loaded.loadedProvider ->
+                            pure $ Left $ CredentialError
+                                "selected account belongs to a different provider"
                         | tokenProviderBillingMode
                             selected.loadedTokenProvider
                             /= tokenProviderBillingMode
@@ -729,43 +765,58 @@ runAgentInitializedWithLock
                             pure $ Left $ CredentialError
                                 "selected account uses a different billing mode"
                         | otherwise ->
-                            probeLoadedAuthCredential selected >>= \case
-                                Left err -> pure (Left err)
-                                Right (credential, usable) -> do
-                                    label <-
-                                        usable.loadedAccountLabel credential
-                                    when
-                                        (loaded.loadedProvider
-                                            == OpenAIProvider) $
-                                        writeIORef
-                                            preferredOpenAiAccountRef
-                                            (if selectedSelectionId
-                                                    == gatewayAuthSelectionId
-                                                then Nothing
-                                                else Just credential.accountId)
-                                    let selectionId =
-                                            fromMaybe
-                                                selectedSelectionId
-                                                usable.loadedSelectionId
-                                    modifyMVar_ activeHttpAuth \current -> do
-                                        writeIORef
-                                            activeAccountIdRef
-                                            credential.accountId
-                                        writeIORef
-                                            activeSelectionRef
-                                            selectionId
-                                        writeIORef activeAccountRef label
-                                        pure ActiveHttpAuth
-                                            { activeHttpGeneration =
-                                                current.activeHttpGeneration + 1
-                                            , activeHttpProvider =
-                                                usable.loadedTokenProvider
-                                            , activeHttpResolveLabel =
+                            loadGatewayModelAccess selected >>= \case
+                                Left err ->
+                                    pure (Left (CredentialError err))
+                                Right selectedGatewayModels ->
+                                    probeLoadedAuthCredential selected >>= \case
+                                        Left err -> pure (Left err)
+                                        Right (credential, usable) -> do
+                                            label <-
                                                 usable.loadedAccountLabel
-                                            , activeHttpAccountId =
-                                                credential.accountId
-                                            }
-                                    pure (Right label)
+                                                    credential
+                                            when
+                                                (loaded.loadedProvider
+                                                    == OpenAIProvider) $
+                                                writeIORef
+                                                    preferredOpenAiAccountRef
+                                                    (if selectedSelectionId
+                                                            == gatewayAuthSelectionId
+                                                        then Nothing
+                                                        else
+                                                            Just
+                                                                credential.accountId)
+                                            let selectionId =
+                                                    fromMaybe
+                                                        selectedSelectionId
+                                                        usable.loadedSelectionId
+                                            modifyMVar_
+                                                activeHttpAuth
+                                                \current -> do
+                                                    writeIORef
+                                                        gatewayModelsRef
+                                                        selectedGatewayModels
+                                                    writeIORef
+                                                        activeAccountIdRef
+                                                        credential.accountId
+                                                    writeIORef
+                                                        activeSelectionRef
+                                                        selectionId
+                                                    writeIORef
+                                                        activeAccountRef
+                                                        label
+                                                    pure ActiveHttpAuth
+                                                        { activeHttpGeneration =
+                                                            current.activeHttpGeneration
+                                                                + 1
+                                                        , activeHttpProvider =
+                                                            usable.loadedTokenProvider
+                                                        , activeHttpResolveLabel =
+                                                            usable.loadedAccountLabel
+                                                        , activeHttpAccountId =
+                                                            credential.accountId
+                                                        }
+                                            pure (Right label)
 
     runAgentTools
         runAgentChild
@@ -777,6 +828,7 @@ runAgentInitializedWithLock
         activeSelectionRef
         baseToolEnv
         catalog
+        gatewayModelsRef
         (checkStartupUsageInBackground && isNothing preparedAccountUsage)
         configuredOptionTarget
         customResponses
@@ -877,3 +929,24 @@ trackCredentialAccount accountRef accountIdRef selectionRef resolveLabel provide
                     writeIORef selectionRef credential.accountId
                 resolveLabel credential >>= writeIORef accountRef
                 pure (Right credential)
+
+loadGatewayModelAccess
+    :: LoadedAuth
+    -> IO (Either Text (Maybe GatewayModelAccess))
+loadGatewayModelAccess loaded
+    | not (isGatewayLoadedAuth loaded) = pure (Right Nothing)
+    | otherwise =
+        loadGatewayCredential >>= \case
+            Left err ->
+                pure (Left ("Could not load gateway credentials: " <> err))
+            Right Nothing ->
+                pure (Left "No organization gateway credential is connected.")
+            Right (Just credential) -> do
+                access <- newGatewayModelAccess credential
+                refreshGatewayModels access >>= \case
+                    Left err -> pure (Left err)
+                    Right [] ->
+                        pure
+                            (Left
+                                "The organization gateway does not offer any models.")
+                    Right _ -> pure (Right (Just access))

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -54,17 +54,17 @@ import Agent.CLI.ManagedTurn ()
 import Agent.CLI.McpManager ()
 import Agent.CLI.McpStatus ()
 import Agent.CLI.ModelConfig
-    ( builtinConnectionId,
-      catalogConnection,
+    ( catalogConnection,
       loadModelCatalogAt,
       ConnectionKind(BuiltinConnection, CustomResponsesConnection),
       ModelConnection(connectionId, connectionKind),
       ResponsesConnection(responsesApiKeyEnv, responsesApiKeyOptional) )
 import Agent.CLI.Models
     ( resolveConfiguredModel,
+      resolveSavedModelTarget,
       ModelOption(modelTarget),
-      ModelTarget(targetWireModelId, ModelTarget, targetConnectionId,
-                  targetProvider, targetModelId, targetDialect) )
+      ModelTarget(targetWireModelId, targetConnectionId, targetProvider,
+                  targetModelId, targetDialect) )
 import Agent.CLI.Options ( CliOptions(optModel, optProvider, optYolo) )
 import Agent.CLI.PendingInputs ()
 import Agent.CLI.Plan ()
@@ -362,32 +362,17 @@ runAgentInitializedWithLock
         configuredOptionTarget =
             (.modelTarget)
                 <$> (options.optModel >>= resolveConfiguredModel catalog)
-        savedTarget provider connection model transport dialect =
-            case resolveConfiguredModel catalog model of
-                Just option
-                    | option.modelTarget.targetConnectionId == connection ->
-                        Right option.modelTarget
-                _
-                    | connection == builtinConnectionId provider ->
-                        Right ModelTarget
-                            { targetProvider = provider
-                            , targetConnectionId = connection
-                            , targetModelId = model
-                            , targetWireModelId = fromMaybe model transport
-                            , targetDialect = dialect
-                            }
-                    | otherwise ->
-                        Left $
-                            "saved model "
-                                <> connection <> "/" <> model
-                                <> " is not present in ~/.haskell-agent/models.json"
+        savedTarget =
+            resolveSavedModelTarget catalog False
         resumedTargetResult
             | isJust transitionTarget || isJust options.optModel =
                 Right Nothing
             | otherwise = case fst <$> resumed of
             Nothing -> Right Nothing
             Just meta ->
-                Just <$> savedTarget
+                Just <$> resolveSavedModelTarget
+                    catalog
+                    (isJust connectedGateway)
                     meta.metaProvider
                     meta.metaConnection
                     meta.metaModel

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -12,6 +12,7 @@ import Agent.CLI.AgentViewport ()
 import Agent.CLI.Approval ()
 import Agent.CLI.Artifact ()
 import Agent.CLI.Auth.Types (LoadedAuth(..), isGatewayLoadedAuth)
+import Agent.CLI.ClaudeGatewayProxy (withClaudeGatewayProxy)
 import Agent.CLI.Clipboard ()
 import Agent.CLI.CodeModeRuntime ()
 import Agent.CLI.Command ()
@@ -32,6 +33,7 @@ import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ( formatApiErrorAt )
+import Agent.CLI.GatewayClient (loadGatewayCredential)
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input ()
 import Agent.CLI.LearnedSkills ()
@@ -129,6 +131,7 @@ import Agent.Claude
       claudeCodeOneShotBackend,
       defaultClaudeCodeOptions,
       loadClaudeCodeAuth,
+      loadClaudeCodeGatewayAuth,
       withClaudeCodeBackendWithHost )
 import Agent.Claude.Control
     ( ClaudeCodeHostHandlers(..)
@@ -834,10 +837,11 @@ runAgentProviders
                                 , interruptBackend = pure ()
                                 , resetBackendState = pure ()
                                 }
-                    ClaudeCodeProvider -> do
-                        claudeAuth <-
-                            loadClaudeCodeAuth
-                                >>= either (startupDie startup . Text.unpack) pure
+                    ClaudeCodeProvider ->
+                        withSelectedClaudeAuth
+                            loaded
+                            (startupDie startup . Text.unpack)
+                            \claudeAuth -> do
                         let permission =
                                 ClaudeCodeManual
                             claudeOptions =
@@ -1120,6 +1124,25 @@ runAgentProviders
                 startupDie startup
                     (Text.unpack (formatApiErrorAt now err))
 
+
+withSelectedClaudeAuth
+    :: LoadedAuth
+    -> (Text -> IO value)
+    -> (ClaudeCodeAuth -> IO value)
+    -> IO value
+withSelectedClaudeAuth loaded onError action
+    | not (isGatewayLoadedAuth loaded) =
+        loadClaudeCodeAuth >>= either onError action
+    | otherwise =
+        loadGatewayCredential >>= \case
+            Left err -> onError err
+            Right Nothing ->
+                onError "No organization gateway credential is connected."
+            Right (Just credential) -> do
+                result <- withClaudeGatewayProxy credential \transport ->
+                    loadClaudeCodeGatewayAuth transport
+                        >>= either onError action
+                either onError pure result
 
 sessionRunnerContinuation :: SessionRunner.SessionRunnerContinuation
 sessionRunnerContinuation =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -11,7 +11,7 @@ import Agent.CLI.AgentSessions ()
 import Agent.CLI.AgentViewport ()
 import Agent.CLI.Approval ()
 import Agent.CLI.Artifact ()
-import Agent.CLI.Auth.Types (LoadedAuth(..))
+import Agent.CLI.Auth.Types (LoadedAuth(..), isGatewayLoadedAuth)
 import Agent.CLI.Clipboard ()
 import Agent.CLI.CodeModeRuntime ()
 import Agent.CLI.Command ()
@@ -359,10 +359,12 @@ runAgentProviders
                                 httpFallbackActive <- newIORef startsOnHttp
                                 switchRequests <-
                                     newChan :: IO (Chan AccountSwitchRequest)
-                                let selectAccount = case loaded.loadedOpenAiPool of
-                                        Nothing -> Nothing
-                                        Just pool ->
-                                            Just \selectedAccountId -> do
+                                let selectAccount
+                                        | isGatewayLoadedAuth loaded = Nothing
+                                        | otherwise = case loaded.loadedOpenAiPool of
+                                            Nothing -> Nothing
+                                            Just pool ->
+                                                Just \selectedAccountId -> do
                                                     _ <- OpenAI.discoverAccounts pool
                                                     OpenAI.getAccessTokenForAccount
                                                         pool
@@ -648,6 +650,7 @@ runAgentProviders
                                                 pure (RunProviderStartFailed err)
                                         _
                                             | shouldProbeAtStartup
+                                            , not (isGatewayLoadedAuth loaded)
                                             , isProviderUnavailable err ->
                                                 chooseStartupProviderTransition
                                                     catalog

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -8,7 +8,9 @@ import Agent.CLI.AgentViewport ()
 import Agent.CLI.Approval ()
 import Agent.CLI.Artifact ()
 import Agent.CLI.Auth
-    ( LoadedAuth(loadedTokenProvider) )
+    ( LoadedAuth(loadedTokenProvider)
+    , isGatewayLoadedAuth
+    )
 import Agent.CLI.Clipboard ()
 import Agent.CLI.Claude (newClaudeSessionRuntimeSlot)
 import Agent.CLI.CodeModeRuntime
@@ -26,6 +28,7 @@ import Agent.CLI.Database ()
 import Agent.CLI.Database.Store (DatabaseScopes)
 import Agent.CLI.Dialects (CodingTools(..))
 import Agent.CLI.Error ()
+import Agent.CLI.GatewayClient (GatewayModelAccess)
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input ()
 import Agent.CLI.Interrupt
@@ -109,7 +112,8 @@ import Agent.CLI.Session.History
       replaceLiveConversation )
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
-    ( SessionRequest(codexCatalogSession, SessionRequest, catalog, modelInfo,
+    ( SessionRequest(codexCatalogSession, SessionRequest, catalog,
+                     gatewayModelsRef, modelInfo,
                      connectionId, options, provider, dialect, policyRef, allTools,
                      claudeRuntimeSlot, claudeBridgeTools,
                      recordImageGenerationInputs, clearImageGenerationHistory,
@@ -183,7 +187,8 @@ import Agent.OpenRouter.LoopBackend ()
 import Agent.OpenRouter.Options (ClientOptions)
 import Agent.OsPath ()
 import Agent.Provider
-    (Credential, Provider, TokenProvider, tokenProviderBillingMode)
+    (Credential, Provider(OpenAIProvider), TokenProvider,
+     tokenProviderBillingMode)
 import Agent.ReasoningEffort ()
 import Agent.Responses.GenericBackend ()
 import Agent.Responses.GenericClient (GenericClientOptions)
@@ -225,7 +230,7 @@ import Data.IORef
       writeIORef )
 import Data.List ()
 import Data.Map.Strict (Map)
-import Data.Maybe ( isNothing, fromMaybe )
+import Data.Maybe ( isJust, isNothing, fromMaybe )
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Time.Clock ( getCurrentTime, utctDay )
@@ -269,6 +274,7 @@ runAgentSession
     -> IO ()
     -> IORef Bool
     -> ModelCatalog
+    -> IORef (Maybe GatewayModelAccess)
     -> Bool
     -> (SessionHandle -> IO ())
     -> Bool
@@ -351,6 +357,7 @@ runAgentSession
     clearImageGenerationHistory
     bashEnabledRef
     catalog
+    gatewayModelsRef
     checkStartupUsageInBackground
     claimCurrentSession
     claudeBypassEnabled
@@ -369,7 +376,7 @@ runAgentSession
     fullscreen
     gatewayTools
     ghciEnabledRef
-    grokAllowedChildModels
+    allowedChildModels
     home
     inferredTarget
     interrupt
@@ -447,7 +454,9 @@ runAgentSession
                 stateDirectory
                 provider
                 dialect
-                (Just loaded.loadedTokenProvider)
+                (if isGatewayLoadedAuth loaded
+                    then Nothing
+                    else Just loaded.loadedTokenProvider)
                 model
         let initializeCodeMode =
                 if options.optCodeMode
@@ -619,10 +628,14 @@ runAgentSession
                 , subagentCreateWorktree = Just createSubagentWorktree
                 , subagentSessionTmp = toolEnv.toolSessionTmp
                 , subagentSpawnModelGuidance =
-                    subscriptionSubagentModelGuidance
-                        provider
-                        (tokenProviderBillingMode tokenProvider)
-                , subagentAllowedChildModels = grokAllowedChildModels
+                    if provider == OpenAIProvider
+                        && isJust allowedChildModels
+                        then Nothing
+                        else
+                            subscriptionSubagentModelGuidance
+                                provider
+                                (tokenProviderBillingMode tokenProvider)
+                , subagentAllowedChildModels = allowedChildModels
                 , subagentOpenAiChild = openaiChild
                 }
         let conversationRef = startup.startupSessionState.sessionConversation
@@ -723,6 +736,7 @@ runAgentSession
                         sessionCompactRunner =
                             SessionRequest
                                 { catalog
+                                , gatewayModelsRef
                                 , claudeRuntimeSlot
                                 , claudeBridgeTools
                                 , modelInfo = codexModelInfo
@@ -803,7 +817,8 @@ runAgentSession
                                 , codexCatalogSession = catalogSession
                                 }
                     withStartupAvailability action
-                        | shouldProbeAtStartup =
+                        | shouldProbeAtStartup
+                        , not (isGatewayLoadedAuth loaded) =
                             withAsync
                                 (probeLoadedAvailability
                                     loaded

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -156,7 +156,7 @@ import Agent.CLI.Subagents.Runtime
                       subagentLegacyTarget, subagentConnection, subagentMapModel,
                       subagentCreateWorktree, subagentSessionTmp,
                       subagentSpawnModelGuidance, subagentAllowedChildModels,
-                      subagentChildModelAllowed) )
+                      subagentResolveChildModel, subagentChildModelAllowed) )
 import Agent.CLI.Subagents.Runtime.Types
     (SubagentSession, SubagentStoreRoot)
 import Agent.CLI.TUI.App
@@ -204,7 +204,7 @@ import Agent.Subagents.TaskPath ()
 import Agent.TUI.Model ()
 import Agent.TUI.Motion ()
 import Agent.Tools.MultiAgents
-    (MultiAgentContext, SubagentWorktree)
+    (CollaborationModelTarget, MultiAgentContext, SubagentWorktree)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks)
 import Agent.Tools.Secret ()
 import Agent.ToolDispatch (canonicalToolName)
@@ -295,6 +295,7 @@ runAgentSession
     -> [AppTool]
     -> IORef Bool
     -> Maybe [Text]
+    -> Maybe (Text -> IO (Maybe CollaborationModelTarget))
     -> Maybe (Text -> IO Bool)
     -> OsPath
     -> ModelTarget
@@ -379,6 +380,7 @@ runAgentSession
     gatewayTools
     ghciEnabledRef
     allowedChildModels
+    resolveChildModel
     childModelAllowed
     home
     inferredTarget
@@ -639,6 +641,7 @@ runAgentSession
                                 provider
                                 (tokenProviderBillingMode tokenProvider)
                 , subagentAllowedChildModels = allowedChildModels
+                , subagentResolveChildModel = resolveChildModel
                 , subagentChildModelAllowed = childModelAllowed
                 , subagentOpenAiChild = openaiChild
                 }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -155,7 +155,8 @@ import Agent.CLI.Subagents.Runtime
                       subagentSessions, subagentStoreRoot, subagentTypes,
                       subagentLegacyTarget, subagentConnection, subagentMapModel,
                       subagentCreateWorktree, subagentSessionTmp,
-                      subagentSpawnModelGuidance, subagentAllowedChildModels) )
+                      subagentSpawnModelGuidance, subagentAllowedChildModels,
+                      subagentChildModelAllowed) )
 import Agent.CLI.Subagents.Runtime.Types
     (SubagentSession, SubagentStoreRoot)
 import Agent.CLI.TUI.App
@@ -294,6 +295,7 @@ runAgentSession
     -> [AppTool]
     -> IORef Bool
     -> Maybe [Text]
+    -> Maybe (Text -> IO Bool)
     -> OsPath
     -> ModelTarget
     -> InterruptState
@@ -377,6 +379,7 @@ runAgentSession
     gatewayTools
     ghciEnabledRef
     allowedChildModels
+    childModelAllowed
     home
     inferredTarget
     interrupt
@@ -636,6 +639,7 @@ runAgentSession
                                 provider
                                 (tokenProviderBillingMode tokenProvider)
                 , subagentAllowedChildModels = allowedChildModels
+                , subagentChildModelAllowed = childModelAllowed
                 , subagentOpenAiChild = openaiChild
                 }
         let conversationRef = startup.startupSessionState.sessionConversation

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -64,7 +64,10 @@ import Agent.CLI.McpStatus
       formatMcpProgress,
       summarizeMcpStatuses )
 import Agent.CLI.ModelConfig
-    (ModelCatalog, ResponsesConnection(..), builtinConnectionId)
+    ( ModelCatalog
+    , ResponsesConnection(..)
+    , builtinConnectionId
+    )
 import Agent.CLI.Models
     ( defaultModelFor,
       gatewayModelOptions,
@@ -444,7 +447,6 @@ runAgentTools
                         case
                             gatewayModelOptions
                                 catalog
-                                (builtinConnectionId OpenAIProvider)
                                 OpenAIProvider
                                 modelIds
                             of
@@ -737,8 +739,6 @@ runAgentTools
                                         (resolveModelOptionById
                                             (gatewayModelOptions
                                                 catalog
-                                                (builtinConnectionId
-                                                    OpenAIProvider)
                                                 OpenAIProvider
                                                 modelIds)
                                             (Text.strip requested))

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -10,7 +10,7 @@ import Agent.CLI.AgentSessions
       AgentSessionToolsEnv(toolsSessionStatus, AgentSessionToolsEnv,
                            toolsPool, toolsRoot, toolsProvider, toolsConnection, toolsModel,
                            toolsTransportModel, toolsDialect, toolsAllowedModels,
-                           toolsChildModelAllowed,
+                           toolsResolveModelOption,
                            toolsCwd, toolsEffort,
                            toolsCurrentSessionId, toolsLaunchTurn) )
 import Agent.CLI.AgentViewport ()
@@ -703,18 +703,28 @@ runAgentTools
                     _ ->
                         Nothing
         childModelAllowed
+            | Just resolve <- gatewayChildModelOption =
+                Just \modelId -> isJust <$> resolve modelId
+            | otherwise = Nothing
+        gatewayChildModelOption
             | isNothing gatewayAllowedChildModels = Nothing
             | otherwise =
-                Just \modelId ->
+                Just \requested ->
                     readIORef gatewayModelsRef >>= \case
-                        Nothing -> pure False
+                        Nothing -> pure Nothing
                         Just access ->
                             cachedGatewayModels access >>= \case
-                                Nothing -> pure False
+                                Nothing -> pure Nothing
                                 Just modelIds ->
                                     pure
-                                        (Text.strip modelId
-                                            `elem` map Text.strip modelIds)
+                                        (resolveModelOptionById
+                                            (gatewayModelOptions
+                                                catalog
+                                                (builtinConnectionId
+                                                    OpenAIProvider)
+                                                OpenAIProvider
+                                                modelIds)
+                                            (Text.strip requested))
         sendToRoot message = do
             enqueuePendingInput pendingNotices (AgentMessage message) >>= \case
                 Left err -> pure (Left err)
@@ -1073,7 +1083,7 @@ runAgentTools
             , toolsTransportModel = inferredTarget.targetWireModelId
             , toolsDialect = dialectId
             , toolsAllowedModels = gatewayAllowedChildModels
-            , toolsChildModelAllowed = childModelAllowed
+            , toolsResolveModelOption = gatewayChildModelOption
             , toolsCwd = cwd
             , toolsEffort = effortText
             , toolsCurrentSessionId =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -9,7 +9,8 @@ import Agent.CLI.AgentSessions
       sessionThreadStatus,
       AgentSessionToolsEnv(toolsSessionStatus, AgentSessionToolsEnv,
                            toolsPool, toolsRoot, toolsProvider, toolsConnection, toolsModel,
-                           toolsTransportModel, toolsDialect, toolsCwd, toolsEffort,
+                           toolsTransportModel, toolsDialect, toolsAllowedModels,
+                           toolsCwd, toolsEffort,
                            toolsCurrentSessionId, toolsLaunchTurn) )
 import Agent.CLI.AgentViewport ()
 import Agent.CLI.Approval ()
@@ -39,6 +40,10 @@ import Agent.CLI.Dialects
       filterBashTools,
       filterGhciTools )
 import Agent.CLI.Error ( formatException )
+import Agent.CLI.GatewayClient
+    ( GatewayModelAccess
+    , cachedGatewayModels
+    )
 import Agent.CLI.GatewayBridge ( managedGatewayTools )
 import Agent.CLI.Input ()
 import Agent.CLI.Interrupt (InterruptState)
@@ -61,8 +66,10 @@ import Agent.CLI.ModelConfig
     (ModelCatalog, ResponsesConnection(..), builtinConnectionId)
 import Agent.CLI.Models
     ( defaultModelFor,
+      gatewayModelOptions,
       rawModelOption,
       resolveConfiguredModel,
+      resolveModelOptionById,
       resolvePersistedDialect,
       ModelOption(modelTarget),
       ModelTarget(targetProvider, targetConnectionId, targetModelId, targetDialect,
@@ -325,6 +332,7 @@ runAgentTools
     -> IORef Text
     -> ToolEnv
     -> ModelCatalog
+    -> IORef (Maybe GatewayModelAccess)
     -> Bool
     -> Maybe ModelTarget
     -> Maybe (Text, ResponsesConnection)
@@ -371,6 +379,7 @@ runAgentTools
     activeSelectionRef
     baseToolEnv
     catalog
+    gatewayModelsRef
     checkStartupUsageInBackground
     configuredOptionTarget
     customResponses
@@ -413,6 +422,77 @@ runAgentTools
         loadHarnessConfig home >>= \case
             Left err -> startupDie startup (Text.unpack err)
             Right config -> pure config
+    (gatewaySelection, gatewayAllowedChildModels) <-
+        if not (isGatewayLoadedAuth loaded)
+            then pure (Nothing, Nothing)
+            else do
+                access <-
+                    readIORef gatewayModelsRef >>= \case
+                        Nothing ->
+                            startupDie startup
+                                "The organization gateway model catalog is unavailable."
+                        Just value -> pure value
+                cachedGatewayModels access >>= \case
+                    Nothing ->
+                        startupDie startup
+                            "The organization gateway model catalog is unavailable."
+                    Just modelIds ->
+                        case
+                            gatewayModelOptions
+                                catalog
+                                (builtinConnectionId OpenAIProvider)
+                                OpenAIProvider
+                                modelIds
+                            of
+                            [] ->
+                                startupDie startup
+                                    "The organization gateway does not offer any models."
+                            firstAvailable : remainingAvailable -> do
+                                let available =
+                                        firstAvailable : remainingAvailable
+                                    resolveTarget target =
+                                        resolveModelOptionById
+                                            available
+                                            target.targetModelId
+                                selected <- case options.optModel of
+                                    Just requested ->
+                                        case
+                                            resolveModelOptionById
+                                                available
+                                                requested
+                                            of
+                                            Nothing ->
+                                                startupDie startup $
+                                                    "Model '"
+                                                        <> Text.unpack requested
+                                                        <> "' is not available through your organization gateway."
+                                            Just selected ->
+                                                pure selected
+                                    Nothing ->
+                                        pure $
+                                            fromMaybe firstAvailable $
+                                                ( transitionTarget
+                                                    >>= resolveTarget
+                                                )
+                                                    <|> ( configuredOptionTarget
+                                                            >>= resolveTarget
+                                                        )
+                                                    <|> ( resumedTarget
+                                                            >>= resolveTarget
+                                                        )
+                                                    <|> ( projectTarget
+                                                            >>= resolveTarget
+                                                        )
+                                                    <|> ( targetHint
+                                                            >>= resolveTarget
+                                                        )
+                                pure
+                                    ( Just selected
+                                    , Just
+                                        (map
+                                            (.modelTarget.targetModelId)
+                                            available)
+                                    )
     let basePlanHooks
             | startup.startupBackground =
                 PlanModeHooks
@@ -451,18 +531,28 @@ runAgentTools
             fromMaybe
                 (error "validated default model is missing")
                 (defaultModelFor catalog provider)
-        model = fromMaybe
-            (maybe fallbackModel (.targetModelId) targetHint)
-            options.optModel
+        unrestrictedModel =
+            fromMaybe
+                (maybe fallbackModel (.targetModelId) targetHint)
+                options.optModel
+        model =
+            maybe
+                unrestrictedModel
+                (.modelTarget.targetModelId)
+                gatewaySelection
         rawTarget = (rawModelOption provider model).modelTarget
         inferredTarget0 =
-            fromMaybe rawTarget $
-                transitionTarget
-                    <|> configuredOptionTarget
-                    <|> resumedTarget
-                    <|> if isNothing options.optModel
-                        then projectTarget
-                        else Nothing
+            maybe
+                ( fromMaybe rawTarget $
+                    transitionTarget
+                        <|> configuredOptionTarget
+                        <|> resumedTarget
+                        <|> if isNothing options.optModel
+                            then projectTarget
+                            else Nothing
+                )
+                (.modelTarget)
+                gatewaySelection
         transportModel = case customResponses of
             Just _ ->
                 \name ->
@@ -521,17 +611,19 @@ runAgentTools
                 <$> persistedTarget
         mappedTargetChanged =
             maybe False snd resolvedPersistedTarget
-        dialectId = case transitionTarget of
-            Just target -> target.targetDialect
-            Nothing -> case options.optModel of
-                Just _ -> inferredTarget.targetDialect
-                Nothing
-                    | mappedTargetChanged -> inferredTarget.targetDialect
-                    | otherwise ->
-                        maybe
-                            inferredTarget.targetDialect
-                            fst
-                            resolvedPersistedTarget
+        dialectId = case gatewaySelection of
+            Just selected -> selected.modelTarget.targetDialect
+            Nothing -> case transitionTarget of
+                Just target -> target.targetDialect
+                Nothing -> case options.optModel of
+                    Just _ -> inferredTarget.targetDialect
+                    Nothing
+                        | mappedTargetChanged -> inferredTarget.targetDialect
+                        | otherwise ->
+                            maybe
+                                inferredTarget.targetDialect
+                                fst
+                                resolvedPersistedTarget
         dialect = dialectForId dialectId
         resumeTargetChanged = case fst <$> resumed of
             Just meta ->
@@ -601,11 +693,14 @@ runAgentTools
                         pure (Just openaiLoaded.loadedTokenProvider)
         _ ->
             pure Nothing
-    let grokAllowedChildModels = case provider of
-            XAIProvider ->
-                Just (grokRootChildModels (isJust openaiChild))
-            _ ->
-                Nothing
+    let allowedChildModels =
+            case gatewayAllowedChildModels of
+                Just modelIds -> Just modelIds
+                Nothing -> case provider of
+                    XAIProvider ->
+                        Just (grokRootChildModels (isJust openaiChild))
+                    _ ->
+                        Nothing
         sendToRoot message = do
             enqueuePendingInput pendingNotices (AgentMessage message) >>= \case
                 Left err -> pure (Left err)
@@ -653,10 +748,13 @@ runAgentTools
                     subagentForkSource)
             , multiSendToRoot = Just sendToRoot
             , multiSpawnModelGuidance =
-                subscriptionSubagentModelGuidance
-                    provider
-                    (tokenProviderBillingMode tokenProvider)
-            , multiAllowedChildModels = grokAllowedChildModels
+                if isJust gatewayAllowedChildModels
+                    then Nothing
+                    else
+                        subscriptionSubagentModelGuidance
+                            provider
+                            (tokenProviderBillingMode tokenProvider)
+            , multiAllowedChildModels = allowedChildModels
             }
     promptRequest <- loadPrompt options
     let promptText = fmap (\request -> request.managedTurnText) promptRequest
@@ -959,6 +1057,7 @@ runAgentTools
             , toolsModel = model
             , toolsTransportModel = inferredTarget.targetWireModelId
             , toolsDialect = dialectId
+            , toolsAllowedModels = gatewayAllowedChildModels
             , toolsCwd = cwd
             , toolsEffort = effortText
             , toolsCurrentSessionId =
@@ -1100,6 +1199,7 @@ runAgentTools
         (clearImageGenerationHistory imageGenerationHistory)
         bashEnabledRef
         catalog
+        gatewayModelsRef
         checkStartupUsageInBackground
         claimCurrentSession
         claudeBypassEnabled
@@ -1118,7 +1218,7 @@ runAgentTools
         fullscreen
         gatewayTools
         ghciEnabledRef
-        grokAllowedChildModels
+        allowedChildModels
         home
         inferredTarget
         interrupt

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -250,7 +250,10 @@ import Agent.Subagents.TaskPath ( taskPathRoot )
 import Agent.TUI.Model ( UiEvent(UiSetNotice) )
 import Agent.TUI.Motion ()
 import Agent.Tools.MultiAgents
-    ( MultiAgentContext(..), SubagentWorktree(..) )
+    ( CollaborationModelTarget(..)
+    , MultiAgentContext(..)
+    , SubagentWorktree(..)
+    )
 import Agent.Tools.PlanMode
     ( PlanModeEnv(planSessionDir),
       activatePlanMode,
@@ -706,6 +709,20 @@ runAgentTools
             | Just resolve <- gatewayChildModelOption =
                 Just \modelId -> isJust <$> resolve modelId
             | otherwise = Nothing
+        resolveCollaborationChildModel
+            | Just resolve <- gatewayChildModelOption =
+                Just \modelId ->
+                    fmap toCollaborationTarget <$> resolve modelId
+            | otherwise = Nothing
+        toCollaborationTarget option =
+            let target = option.modelTarget
+            in CollaborationModelTarget
+                { collaborationTargetProvider = target.targetProvider
+                , collaborationTargetConnection = target.targetConnectionId
+                , collaborationTargetEffectiveModel =
+                    target.targetWireModelId
+                , collaborationTargetDialect = target.targetDialect
+                }
         gatewayChildModelOption
             | isNothing gatewayAllowedChildModels = Nothing
             | otherwise =
@@ -757,6 +774,7 @@ runAgentTools
                     subagentStoreRoot
                     registry
                     subagentSessions
+                    resolveCollaborationChildModel
                     agentTypesRef)
             , multiCreateWorktree = Just createSubagentWorktree
             , multiPrepareSpawn = Just
@@ -779,6 +797,7 @@ runAgentTools
                             provider
                             (tokenProviderBillingMode tokenProvider)
             , multiAllowedChildModels = allowedChildModels
+            , multiResolveChildModel = resolveCollaborationChildModel
             , multiChildModelAllowed = childModelAllowed
             }
     promptRequest <- loadPrompt options
@@ -1245,6 +1264,7 @@ runAgentTools
         gatewayTools
         ghciEnabledRef
         allowedChildModels
+        resolveCollaborationChildModel
         childModelAllowed
         home
         inferredTarget

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -10,6 +10,7 @@ import Agent.CLI.AgentSessions
       AgentSessionToolsEnv(toolsSessionStatus, AgentSessionToolsEnv,
                            toolsPool, toolsRoot, toolsProvider, toolsConnection, toolsModel,
                            toolsTransportModel, toolsDialect, toolsAllowedModels,
+                           toolsChildModelAllowed,
                            toolsCwd, toolsEffort,
                            toolsCurrentSessionId, toolsLaunchTurn) )
 import Agent.CLI.AgentViewport ()
@@ -315,7 +316,7 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ()
-import qualified Data.Text as Text ( intercalate, pack, unpack )
+import qualified Data.Text as Text ( intercalate, pack, strip, unpack )
 import qualified Data.Text.IO as Text ()
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Client as XAIClient ()
@@ -701,6 +702,19 @@ runAgentTools
                         Just (grokRootChildModels (isJust openaiChild))
                     _ ->
                         Nothing
+        childModelAllowed
+            | isNothing gatewayAllowedChildModels = Nothing
+            | otherwise =
+                Just \modelId ->
+                    readIORef gatewayModelsRef >>= \case
+                        Nothing -> pure False
+                        Just access ->
+                            cachedGatewayModels access >>= \case
+                                Nothing -> pure False
+                                Just modelIds ->
+                                    pure
+                                        (Text.strip modelId
+                                            `elem` map Text.strip modelIds)
         sendToRoot message = do
             enqueuePendingInput pendingNotices (AgentMessage message) >>= \case
                 Left err -> pure (Left err)
@@ -755,6 +769,7 @@ runAgentTools
                             provider
                             (tokenProviderBillingMode tokenProvider)
             , multiAllowedChildModels = allowedChildModels
+            , multiChildModelAllowed = childModelAllowed
             }
     promptRequest <- loadPrompt options
     let promptText = fmap (\request -> request.managedTurnText) promptRequest
@@ -1058,6 +1073,7 @@ runAgentTools
             , toolsTransportModel = inferredTarget.targetWireModelId
             , toolsDialect = dialectId
             , toolsAllowedModels = gatewayAllowedChildModels
+            , toolsChildModelAllowed = childModelAllowed
             , toolsCwd = cwd
             , toolsEffort = effortText
             , toolsCurrentSessionId =
@@ -1219,6 +1235,7 @@ runAgentTools
         gatewayTools
         ghciEnabledRef
         allowedChildModels
+        childModelAllowed
         home
         inferredTarget
         interrupt

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -45,6 +45,7 @@ import Agent.CLI.GatewayClient
     ( GatewayModelAccess
     , cachedGatewayModels
     )
+import Agent.CLI.GatewayModels (modelOptionsForGatewayModels)
 import Agent.CLI.GatewayBridge ( managedGatewayTools )
 import Agent.CLI.Input ()
 import Agent.CLI.Interrupt (InterruptState)
@@ -450,12 +451,9 @@ runAgentTools
                     Nothing ->
                         startupDie startup
                             "The organization gateway model catalog is unavailable."
-                    Just modelIds ->
+                    Just models ->
                         case
-                            gatewayModelOptions
-                                catalog
-                                OpenAIProvider
-                                modelIds
+                            modelOptionsForGatewayModels catalog models
                             of
                             [] ->
                                 startupDie startup
@@ -747,13 +745,11 @@ runAgentTools
                         Just access ->
                             cachedGatewayModels access >>= \case
                                 Nothing -> pure Nothing
-                                Just modelIds ->
+                                Just models ->
                                     pure
                                         (resolveModelOptionById
-                                            (gatewayModelOptions
-                                                catalog
-                                                OpenAIProvider
-                                                modelIds)
+                                            (modelOptionsForGatewayModels
+                                                catalog models)
                                             (Text.strip requested))
         sendToRoot message = do
             enqueuePendingInput pendingNotices (AgentMessage message) >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -29,8 +29,12 @@ import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ()
+import Agent.CLI.GatewayClient ( cachedGatewayModels )
 import Agent.CLI.GatewayBridge ()
-import Agent.CLI.Input ( readReplLineWithCatalogForProvider )
+import Agent.CLI.Input
+    ( readReplLineWithCatalog
+    , readReplLineWithCatalogForProvider
+    )
 import Agent.CLI.Interrupt ()
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
@@ -173,7 +177,7 @@ import Control.Exception.Safe ()
 import Control.Monad ( when, forM_ )
 import Data.IORef ( readIORef, writeIORef )
 import Data.List ()
-import Data.Maybe ( fromMaybe, isJust )
+import Data.Maybe ( fromMaybe, isJust, isNothing )
 import Data.Text ( Text )
 import Data.Time.Clock ()
 import System.Console.ANSI ( getTerminalSize )
@@ -233,6 +237,7 @@ replWithDraft env@SessionEnv
     , sessionConversation = conversationRef
     , sessionProvider = provider
     , sessionModelCatalog = catalog
+    , sessionGatewayModels = gatewayModelsRef
     , sessionDialect = dialect
     , sessionStartupUnavailable = startupUnavailableRef
     , sessionParams = paramsRef
@@ -259,6 +264,10 @@ replWithDraft env@SessionEnv
                 (filter (.invocationSkill.skillUserInvocable) skillInvocations)
     activeToolNames <- readActiveToolNames
     params <- readIORef paramsRef
+    gatewayAccess <- readIORef gatewayModelsRef
+    modelIds <- case gatewayAccess of
+        Nothing -> pure (catalogModelIds catalog)
+        Just access -> fromMaybe [] <$> cachedGatewayModels access
     let slashCatalog =
             mkSlashCatalog
                 (maybe False (\info ->
@@ -267,7 +276,7 @@ replWithDraft env@SessionEnv
                             == Just "priority")
                     env.sessionModelInfo)
                 (dialectId dialect) activeToolNames skillCommands
-                (catalogModelIds catalog)
+                modelIds
     stdoutColor <- resolveColor stdout
     planState <- readIORef planMode.planStateRef
     let planActive = planState == PlanActive
@@ -307,7 +316,9 @@ replWithDraft env@SessionEnv
                                 promptState
                                 draft
                                 unavailable
-            withAsync (refreshAccountLimit runtime) \_ ->
+            withAsync
+                (refreshAccountLimit (isNothing gatewayAccess) runtime)
+                \_ ->
                 readPrompt
         Nothing -> Right <$> withMVar render.renderLock \_ -> do
             -- The inline editor redraws its ANSI frame with several writes.
@@ -360,10 +371,16 @@ replWithDraft env@SessionEnv
                         <> if stdoutColor
                             then Text.pack clearFromCursorToLineEndCode
                             else mempty
-            result <- readReplLineWithCatalogForProvider
-                provider
-                slashCatalog
-                interrupt chromePrompt draft
+            result <- case gatewayAccess of
+                Just _ ->
+                    readReplLineWithCatalog
+                        slashCatalog
+                        interrupt chromePrompt draft
+                Nothing ->
+                    readReplLineWithCatalogForProvider
+                        provider
+                        slashCatalog
+                        interrupt chromePrompt draft
             when terminal.terminalSemanticPrompts $
                 emitTerminalSequence terminal stdout osc133PromptEnd
             Text.putStr (endBackground stdoutColor)
@@ -397,7 +414,7 @@ replWithDraft env@SessionEnv
                 policy
                 mline
   where
-    refreshAccountLimit runtime =
+    refreshAccountLimit allowOpenAi runtime =
         case (provider, tokenProvider) of
             (XAIProvider, Just tokens)
                 | tokenProviderBillingMode tokens == SubscriptionBilled ->
@@ -406,7 +423,8 @@ replWithDraft env@SessionEnv
                         XAIUsage.fetchGrokUsage
                         formatGrokLimitStatus
             (OpenAIProvider, Just tokens)
-                | tokenProviderBillingMode tokens == SubscriptionBilled ->
+                | allowOpenAi
+                , tokenProviderBillingMode tokens == SubscriptionBilled ->
                     getNextToken tokens Nothing >>= \case
                         Left _ -> pure ()
                         Right credential

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -29,7 +29,10 @@ import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ()
-import Agent.CLI.GatewayClient ( cachedGatewayModels )
+import Agent.CLI.GatewayClient
+    ( cachedGatewayModels
+    , gatewayModelIds
+    )
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input
     ( readReplLineWithCatalog
@@ -275,7 +278,8 @@ replWithDraft env@SessionEnv
     gatewayAccess <- readIORef gatewayModelsRef
     modelIds <- case gatewayAccess of
         Nothing -> pure (catalogModelIds catalog)
-        Just access -> fromMaybe [] <$> cachedGatewayModels access
+        Just access ->
+            maybe [] gatewayModelIds <$> cachedGatewayModels access
     let slashCatalog =
             mkSlashCatalog
                 (maybe False (\info ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -92,6 +92,7 @@ import Agent.CLI.Input
                ReplChooseEffort, ReplChooseAccount, ReplRemovePendingImage,
                ReplPasted) )
 import Agent.CLI.Interrupt ()
+import Agent.CLI.GatewayClient ( loadGatewayCredential )
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
 import Agent.CLI.Login
@@ -361,6 +362,7 @@ handleReplLine
             , sessionHome = home
             , sessionTokenProvider = tokenProvider
             , sessionOpenAiPool = openAiPool
+            , sessionGatewayModels = gatewayModelsRef
             , sessionSkills = skillsRef
             , sessionSkillInvocations = skillInvocationsRef
             , sessionRefreshSkills = refreshSkills
@@ -1144,22 +1146,35 @@ handleReplLine
                     action@ReplRename{} -> handleSessionAction env slashCatalog continue action
                     action@ReplRenameAuto -> handleSessionAction env slashCatalog continue action
                     ReplLogin -> do
+                        gatewayBefore <- loadGatewayCredential
                         case fullscreen of
                             Just runtime ->
                                 runFullscreenLoginManager runtime
                             Nothing -> do
                                 color <- resolveColor stderr
                                 runLoginManager color
-                        continue
+                        gatewayAfter <- loadGatewayCredential
+                        if gatewayAfter /= gatewayBefore
+                            then requestGatewayRestart fullscreen persist
+                            else continue
                     ReplUsage -> do
-                        case fullscreen of
+                        readIORef gatewayModelsRef >>= \case
+                            Just _ ->
+                                displayInfo
+                                    "usage: managed by the organization gateway"
+                                    (Text.putStrLn
+                                        (roleMuted stdoutColor
+                                            "usage: managed by the organization gateway"))
                             Nothing ->
-                                showAccountUsage
-                                    provider tokenProvider openAiPool
-                            Just runtime ->
-                                accountUsageText
-                                    False provider tokenProvider openAiPool
-                                    >>= emitUiEvent runtime . UiSystemMessage
+                                case fullscreen of
+                                    Nothing ->
+                                        showAccountUsage
+                                            provider tokenProvider openAiPool
+                                    Just runtime ->
+                                        accountUsageText
+                                            False provider tokenProvider openAiPool
+                                            >>= emitUiEvent runtime
+                                                . UiSystemMessage
                         continue
                     ReplReloadAuth -> do
                         reloadResult <- reloadAuth provider tokenProvider
@@ -2065,6 +2080,28 @@ requestMetaRestart fullscreen persist = do
         PersistenceEnabled slotRef -> do
             handle <- ensureSession slotRef
             report "restarting to apply Meta Console changes…"
+            pure (RunRestart handle.sessionMeta.metaId)
+
+requestGatewayRestart
+    :: Maybe FullscreenRuntime
+    -> Persistence
+    -> IO RunResult
+requestGatewayRestart fullscreen persist = do
+    color <- resolveColor stderr
+    let report message =
+            case fullscreen of
+                Nothing ->
+                    putTextLn stderr
+                        (roleMuted color (glyphSession <> message))
+                Just runtime ->
+                    emitUiEvent runtime (UiSystemMessage message)
+    case persist of
+        PersistenceDisabled -> do
+            report "gateway routing changed; restart the agent to continue"
+            pure RunQuit
+        PersistenceEnabled slotRef -> do
+            handle <- ensureSession slotRef
+            report "restarting to apply organization gateway routing…"
             pure (RunRestart handle.sessionMeta.metaId)
 
 requestCodeModeRestart

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -31,6 +31,7 @@ import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ( formatApiErrorInlineAt )
+import Agent.CLI.GatewayClient ( refreshGatewayModels )
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input
     ( ReplLine(ReplChooseAccount, ReplChooseModel, ReplChooseEffort) )
@@ -42,11 +43,13 @@ import Agent.CLI.Lsp ()
 import Agent.CLI.ManagedTurn ()
 import Agent.CLI.McpManager ()
 import Agent.CLI.McpStatus ()
-import Agent.CLI.ModelConfig ()
+import Agent.CLI.ModelConfig ( builtinConnectionId )
 import Agent.CLI.Models
-    ( modelTargetRequiresRebuild,
+    ( gatewayModelOptions,
+      modelTargetRequiresRebuild,
       rawModelOption,
       resolveConfiguredModel,
+      resolveModelOptionById,
       resolveModelOptionDialect,
       ModelOption(modelTarget),
       ModelTarget(targetDialect, targetProvider, targetModelId,
@@ -218,6 +221,22 @@ selectRequestedAccount
     -> Maybe Text
     -> IO (Either Text (Maybe RunResult))
 selectRequestedAccount env requestedProvider selector =
+    readIORef env.sessionGatewayModels >>= \case
+        Just _ ->
+            pure $ Left
+                "Account switching is unavailable while connected to the organization gateway. Disconnect the gateway first."
+        Nothing ->
+            selectRequestedAccountWithoutGateway
+                env
+                requestedProvider
+                selector
+
+selectRequestedAccountWithoutGateway
+    :: SessionEnv
+    -> Provider
+    -> Maybe Text
+    -> IO (Either Text (Maybe RunResult))
+selectRequestedAccountWithoutGateway env requestedProvider selector =
     case env.sessionFullscreen of
         Nothing ->
             pure
@@ -365,6 +384,7 @@ handleSelection
             , sessionProvider = provider
             , sessionConnection = connectionId
             , sessionModelCatalog = catalog
+            , sessionGatewayModels = gatewayModelsRef
             , sessionDialect = dialect
             , sessionParams = paramsRef
             , sessionPersist = persist
@@ -432,32 +452,27 @@ handleSelection
         chooseModel continue
     Right (ReplSetModel name) -> do
         color <- resolveColor stdout
-        let rawChoice = rawModelOption provider name
-        choice <-
-            resolveModelOptionDialect $
-                fromMaybe
-                    (rawChoice
-                        { modelTarget =
-                            rawChoice.modelTarget
-                                { targetConnectionId = connectionId
-                                , targetDialect = dialectId dialect
-                                }
-                        })
-                    (resolveConfiguredModel catalog name)
-        if modelTargetRequiresRebuild
-                connectionId provider (dialectId dialect) choice
-            then
-                switchModelTarget color choice Nothing continue
-            else do
-                message <- applyModelChange
-                    home projectRoot provider connectionId name
-                    choice.modelTarget.targetWireModelId
-                    choice.modelTarget.targetDialect
-                    paramsRef render conversationRef persist
-                displayInfo message $
-                    Text.putStrLn
-                        (roleMuted color (glyphOk <> message))
+        resolveRequestedModel name >>= \case
+            Left err -> do
+                displayError err $
+                    Text.hPutStrLn stderr (roleError color err)
                 continue
+            Right choice ->
+                if modelTargetRequiresRebuild
+                        connectionId provider (dialectId dialect) choice
+                    then
+                        switchModelTarget color choice Nothing continue
+                    else do
+                        message <- applyModelChange
+                            home projectRoot provider connectionId
+                            choice.modelTarget.targetModelId
+                            choice.modelTarget.targetWireModelId
+                            choice.modelTarget.targetDialect
+                            paramsRef render conversationRef persist
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphOk <> message))
+                        continue
     _ -> error "handleSelection: unsupported input"
   where
     displayInfo message minimalAction = case fullscreen of
@@ -505,12 +520,17 @@ handleSelection
     chooseModel next = do
         color <- resolveColor stderr
         params <- readIORef paramsRef
+        gatewayAccess <- readIORef gatewayModelsRef
         let current = currentModel params
         modelChoiceWithEffort
-            catalog fullscreen color connectionId provider current
+            catalog gatewayAccess fullscreen color connectionId provider current
                 (dialectId dialect) (currentEffort params) >>= \case
-            Nothing -> next
-            Just selection -> do
+            Left err -> do
+                displayError err $
+                    Text.hPutStrLn stderr (roleError color err)
+                next
+            Right Nothing -> next
+            Right (Just selection) -> do
                 let rawChoice = selection.modelPickerOption
                     selectedEffort = selection.modelPickerEffort
                 choice <- resolveModelOptionDialect rawChoice
@@ -550,6 +570,42 @@ handleSelection
                     next
                   else
                     switchModelTarget color choice (Just selectedEffort) next
+    resolveRequestedModel name =
+        readIORef gatewayModelsRef >>= \case
+            Just access ->
+                refreshGatewayModels access >>= \case
+                    Left err -> pure (Left err)
+                    Right modelIds ->
+                        case
+                            resolveModelOptionById
+                                (gatewayModelOptions
+                                    catalog
+                                    (builtinConnectionId OpenAIProvider)
+                                    OpenAIProvider
+                                    modelIds)
+                                name
+                        of
+                            Nothing ->
+                                pure
+                                    (Left
+                                        ("Model '"
+                                            <> name
+                                            <> "' is not available through your organization gateway."))
+                            Just choice ->
+                                Right <$> resolveModelOptionDialect choice
+            Nothing -> do
+                let rawChoice = rawModelOption provider name
+                    choice =
+                        fromMaybe
+                            (rawChoice
+                                { modelTarget =
+                                    rawChoice.modelTarget
+                                        { targetConnectionId = connectionId
+                                        , targetDialect = dialectId dialect
+                                        }
+                                })
+                            (resolveConfiguredModel catalog name)
+                Right <$> resolveModelOptionDialect choice
     switchModelTarget color choice selectedEffort next =
         requestModelTargetSwitch fullscreen choice persist >>= \case
             Left err
@@ -602,7 +658,16 @@ handleSelection
                         <> ": "
                     )
                     message)
-    chooseAccount next =
+    chooseAccount next = do
+        gatewayAccess <- readIORef gatewayModelsRef
+        case gatewayAccess of
+            Just _ -> do
+                displayError
+                    "Account switching is unavailable while connected to the organization gateway. Disconnect the gateway first."
+                    (pure ())
+                next
+            Nothing -> chooseAccountFromOptions next
+    chooseAccountFromOptions next =
         case fullscreen of
             Just runtime -> do
                 currentSelectionId <- readIORef selectionRef

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -33,6 +33,7 @@ import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ( formatApiErrorInlineAt )
 import Agent.CLI.GatewayClient ( refreshGatewayModels )
+import Agent.CLI.GatewayModels (modelOptionsForGatewayModels)
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input
     ( ReplLine(ReplChooseAccount, ReplChooseModel, ReplChooseEffort) )
@@ -576,13 +577,10 @@ handleSelection
             Just access ->
                 refreshGatewayModels access >>= \case
                     Left err -> pure (Left err)
-                    Right modelIds ->
+                    Right models ->
                         case
                             resolveModelOptionById
-                                (gatewayModelOptions
-                                    catalog
-                                    OpenAIProvider
-                                    modelIds)
+                                (modelOptionsForGatewayModels catalog models)
                                 name
                         of
                             Nothing ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -43,7 +43,6 @@ import Agent.CLI.Lsp ()
 import Agent.CLI.ManagedTurn ()
 import Agent.CLI.McpManager ()
 import Agent.CLI.McpStatus ()
-import Agent.CLI.ModelConfig ( builtinConnectionId )
 import Agent.CLI.Models
     ( gatewayModelOptions,
       modelTargetRequiresRebuild,
@@ -580,7 +579,6 @@ handleSelection
                             resolveModelOptionById
                                 (gatewayModelOptions
                                     catalog
-                                    (builtinConnectionId OpenAIProvider)
                                     OpenAIProvider
                                     modelIds)
                                 name

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -16,6 +16,7 @@ import Agent.CLI.GatewayClient
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , builtinConnectionId
+    , organizationGatewayConnectionId
     )
 import Agent.CLI.ModelPicker
     ( ModelPickerSelection(..)
@@ -142,11 +143,10 @@ modelChoiceWithEffort
                                 "The organization gateway does not offer any models.")
                     Right modelIds -> do
                         let gatewayConnectionId =
-                                builtinConnectionId OpenAIProvider
+                                organizationGatewayConnectionId
                             options =
                                 gatewayModelOptions
                                     catalog
-                                    gatewayConnectionId
                                     OpenAIProvider
                                     modelIds
                         picker <-

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -13,6 +13,7 @@ import Agent.CLI.GatewayClient
     ( GatewayModelAccess
     , refreshGatewayModels
     )
+import Agent.CLI.GatewayModels (modelOptionsForGatewayModels)
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , builtinConnectionId
@@ -141,14 +142,11 @@ modelChoiceWithEffort
                         pure
                             (Left
                                 "The organization gateway does not offer any models.")
-                    Right modelIds -> do
+                    Right models -> do
                         let gatewayConnectionId =
                                 organizationGatewayConnectionId
                             options =
-                                gatewayModelOptions
-                                    catalog
-                                    OpenAIProvider
-                                    modelIds
+                                modelOptionsForGatewayModels catalog models
                         picker <-
                             initialPickerStateForOptions
                                 "organization gateway"

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -9,6 +9,10 @@ module Agent.CLI.Session.Choices
     ) where
 
 import Agent.CLI.Error (formatApiErrorInlineAt)
+import Agent.CLI.GatewayClient
+    ( GatewayModelAccess
+    , refreshGatewayModels
+    )
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , builtinConnectionId
@@ -17,13 +21,15 @@ import Agent.CLI.ModelPicker
     ( ModelPickerSelection(..)
     , initialModelEffort
     , modelEffortOptions
-    , pickModelWithEffort
+    , pickModelStateWithEffort
     , renderEffortIndicator
     )
 import Agent.CLI.Models
     ( ModelOption(..)
     , ModelTarget(..)
     , PickerState(..)
+    , gatewayModelOptions
+    , initialPickerStateForOptions
     , initialPickerStateResolvedWith
     , rawModelOption
     )
@@ -75,18 +81,21 @@ import System.IO (stdout)
 
 modelChoice
     :: ModelCatalog
+    -> Maybe GatewayModelAccess
     -> Maybe FullscreenRuntime
     -> Bool
     -> Text
     -> Provider
     -> Text
     -> DialectId
-    -> IO (Maybe ModelOption)
+    -> IO (Either Text (Maybe ModelOption))
 modelChoice
-        catalog fullscreen color connectionId provider current currentDialect =
-    fmap (fmap (.modelPickerOption)) $
+        catalog gatewayAccess fullscreen color connectionId provider current
+        currentDialect =
+    fmap (fmap (fmap (.modelPickerOption))) $
         modelChoiceWithEffort
             catalog
+            gatewayAccess
             fullscreen
             color
             connectionId
@@ -98,6 +107,7 @@ modelChoice
 -- | Choose a model and its reasoning effort in one searchable surface.
 modelChoiceWithEffort
     :: ModelCatalog
+    -> Maybe GatewayModelAccess
     -> Maybe FullscreenRuntime
     -> Bool
     -> Text
@@ -105,9 +115,10 @@ modelChoiceWithEffort
     -> Text
     -> DialectId
     -> ReasoningEffort
-    -> IO (Maybe ModelPickerSelection)
+    -> IO (Either Text (Maybe ModelPickerSelection))
 modelChoiceWithEffort
         catalog
+        gatewayAccess
         fullscreen
         color
         connectionId
@@ -115,54 +126,84 @@ modelChoiceWithEffort
         current
         currentDialect
         currentEffort = do
-    discovered <- discoverModelOptions connectionId provider
-    case fullscreen of
-        Nothing ->
-            pickModelWithEffort
-                catalog
-                discovered
-                color
-                connectionId
-                provider
-                current
-                currentDialect
-                currentEffort
-        Just runtime -> do
-            picker <-
-                initialPickerStateResolvedWith
-                    catalog
-                    discovered
-                    connectionId
-                    provider
-                    current
-                    currentDialect
-            let options = picker.pickerAll
-                row option =
-                    let efforts = modelEffortOptions option
-                        initial =
-                            initialModelEffort picker currentEffort option
-                        initialIndex =
-                            fromMaybe 0 (elemIndex initial efforts)
-                    in ( modelRowLabel picker option
-                       , modelDetail option
-                       , map (renderEffortIndicator option) efforts
-                       , initialIndex
-                       )
-            requestFullscreenAdjustableFilterChoice
-                runtime
-                "Models"
-                picker.pickerIndex
-                (map row options)
-                >>= \case
-                    Just (modelIndex, effortIndex)
-                        | Just option <- atMay modelIndex options
-                        , Just effort <-
-                            atMay effortIndex (modelEffortOptions option) ->
-                                pure $ Just ModelPickerSelection
-                                    { modelPickerOption = option
-                                    , modelPickerEffort = effort
-                                    }
-                    _ -> pure Nothing
+    scopedPicker >>= \case
+        Left err -> pure (Left err)
+        Right (title, picker) ->
+            Right <$> presentPicker title picker
+  where
+    scopedPicker =
+        case gatewayAccess of
+            Just access ->
+                refreshGatewayModels access >>= \case
+                    Left err -> pure (Left err)
+                    Right [] ->
+                        pure
+                            (Left
+                                "The organization gateway does not offer any models.")
+                    Right modelIds -> do
+                        let gatewayConnectionId =
+                                builtinConnectionId OpenAIProvider
+                            options =
+                                gatewayModelOptions
+                                    catalog
+                                    gatewayConnectionId
+                                    OpenAIProvider
+                                    modelIds
+                        picker <-
+                            initialPickerStateForOptions
+                                "organization gateway"
+                                options
+                                gatewayConnectionId
+                                OpenAIProvider
+                                current
+                                currentDialect
+                        pure
+                            (Right
+                                ("Models · organization gateway", picker))
+            Nothing -> do
+                discovered <- discoverModelOptions connectionId provider
+                picker <-
+                    initialPickerStateResolvedWith
+                        catalog
+                        discovered
+                        connectionId
+                        provider
+                        current
+                        currentDialect
+                pure (Right ("Models", picker))
+
+    presentPicker title picker =
+        case fullscreen of
+            Nothing ->
+                pickModelStateWithEffort color currentEffort picker
+            Just runtime -> do
+                let options = picker.pickerAll
+                    row option =
+                        let efforts = modelEffortOptions option
+                            initial =
+                                initialModelEffort picker currentEffort option
+                            initialIndex =
+                                fromMaybe 0 (elemIndex initial efforts)
+                        in ( modelRowLabel picker option
+                           , modelDetail option
+                           , map (renderEffortIndicator option) efforts
+                           , initialIndex
+                           )
+                requestFullscreenAdjustableFilterChoice
+                    runtime
+                    title
+                    picker.pickerIndex
+                    (map row options)
+                    >>= \case
+                        Just (modelIndex, effortIndex)
+                            | Just option <- atMay modelIndex options
+                            , Just effort <-
+                                atMay effortIndex (modelEffortOptions option) ->
+                                    pure $ Just ModelPickerSelection
+                                        { modelPickerOption = option
+                                        , modelPickerEffort = effort
+                                        }
+                        _ -> pure Nothing
 
 discoverModelOptions :: Text -> Provider -> IO [ModelOption]
 discoverModelOptions connectionId provider

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -790,6 +790,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionProvider = provider
             , sessionConnection = connectionId
             , sessionModelCatalog = catalog
+            , sessionGatewayModels = gatewayModelsRef
             , sessionDialect = dialect
             , sessionRecordImageGenerationInputs =
                 recordImageGenerationInputs
@@ -859,10 +860,11 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
         setSessionEffortText env level
         writeIORef restartEffortRef (Just level)
         requestCancel toolEnv.toolCancel
+    gatewayAccess <- readIORef gatewayModelsRef
     forM_ fullscreen \runtime ->
         setFullscreenSessionActions
             runtime
-            (Just provider)
+            (if isJust gatewayAccess then Nothing else Just provider)
             (requestCancel toolEnv.toolCancel)
             (\pasted text -> do
                 images <- loadImagesFromPastedText text

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -25,6 +25,7 @@ import Agent.CLI.Compaction
     , OccupancySnapshot
     )
 import Agent.CLI.Database.Store (DatabaseScopes)
+import Agent.CLI.GatewayClient (GatewayModelAccess)
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.ManagedTurn (ManagedTurnRequest)
 import Agent.CLI.ModelConfig (ModelCatalog)
@@ -102,6 +103,7 @@ data SessionBackend = SessionBackend
 
 data SessionRequest = SessionRequest
     { catalog :: !ModelCatalog
+    , gatewayModelsRef :: !(IORef (Maybe GatewayModelAccess))
     , claudeRuntimeSlot :: !ClaudeSessionRuntimeSlot
     , claudeBridgeTools :: ![AppTool]
     , modelInfo :: !(Maybe ModelInfo)

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -5,6 +5,7 @@ module Agent.CLI.SessionEnv
 
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.AgentViewport (AgentViewportEnv)
+import Agent.CLI.GatewayClient (GatewayModelAccess)
 import Agent.CLI.ModelConfig (ModelCatalog)
 import Agent.CLI.Btw (BtwBackendFactory)
 import Agent.CLI.Recap (RecapRequest)
@@ -51,6 +52,7 @@ data SessionEnv = SessionEnv
     , sessionProvider :: !Provider
     , sessionConnection :: !Text
     , sessionModelCatalog :: !ModelCatalog
+    , sessionGatewayModels :: !(IORef (Maybe GatewayModelAccess))
     , sessionDialect :: !Dialect
     , sessionRecordImageGenerationInputs :: !([ImageAttachment] -> IO ())
     , sessionUnavailableProviders :: !(IORef (Set Provider))

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -458,9 +458,8 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                     childModel
                     childEffort
         sessionTmp <- readIORef runtime.subagentSessionTmp
-        case allowedChildModelError
-                runtime.subagentAllowedChildModels
-                model
+        modelPolicyError <- allowedChildModelErrorFor runtime model
+        case modelPolicyError
                 <|> activeSubagentTargetError
                     OpenAIProvider runtime.subagentConnection
                     model prepared.preparedSession of
@@ -834,6 +833,7 @@ prepareChild
                     NoHostChildAgentProtocol -> Nothing
             , multiSpawnModelGuidance = runtime.subagentSpawnModelGuidance
             , multiAllowedChildModels = runtime.subagentAllowedChildModels
+            , multiChildModelAllowed = runtime.subagentChildModelAllowed
             }
     pure PreparedChild
         { preparedParentParams = parentParams
@@ -880,6 +880,26 @@ allowedChildModelError (Just allowed) model
     | model `elem` map Text.strip allowed = Nothing
     | otherwise =
         Just "The child model is not allowed by this organization."
+
+allowedChildModelErrorFor
+    :: SubagentRuntime
+    -> Text
+    -> IO (Maybe Text)
+allowedChildModelErrorFor runtime model =
+    case runtime.subagentChildModelAllowed of
+        Nothing ->
+            pure
+                (allowedChildModelError
+                    runtime.subagentAllowedChildModels
+                    model)
+        Just isAllowed ->
+            isAllowed model >>= \allowed ->
+                pure
+                    (if allowed
+                        then Nothing
+                        else
+                            Just
+                                "The child model is not allowed by this organization.")
 
 runPreparedChild
     :: SubagentRuntime

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -113,6 +113,7 @@ import Agent.Tools.Types
     )
 import Control.Concurrent.MVar
     (modifyMVar, modifyMVar_, newMVar)
+import Control.Applicative ((<|>))
 import Control.Exception.Safe (finally, throwIO)
 import Control.Monad (unless)
 import Data.IORef
@@ -457,9 +458,12 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                     childModel
                     childEffort
         sessionTmp <- readIORef runtime.subagentSessionTmp
-        case activeSubagentTargetError
-                OpenAIProvider runtime.subagentConnection
-                model prepared.preparedSession of
+        case allowedChildModelError
+                runtime.subagentAllowedChildModels
+                model
+                <|> activeSubagentTargetError
+                    OpenAIProvider runtime.subagentConnection
+                    model prepared.preparedSession of
             Just err -> pure (Left (LoopUnexpected err))
             Nothing -> do
                 coding <-
@@ -869,6 +873,13 @@ inheritsFullHistory = \case
     Nothing -> True
     Just turns ->
         Text.toLower (Text.strip turns) `elem` ["", "all"]
+
+allowedChildModelError :: Maybe [Text] -> Text -> Maybe Text
+allowedChildModelError Nothing _ = Nothing
+allowedChildModelError (Just allowed) model
+    | model `elem` map Text.strip allowed = Nothing
+    | otherwise =
+        Just "The child model is not allowed by this organization."
 
 runPreparedChild
     :: SubagentRuntime

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -44,6 +44,7 @@ import Agent.CLI.Subagents.Runtime.Target
      validatePersistedSubagentTarget)
 import Agent.CLI.Subagents.Runtime.OpenAI
     (freshOpenAiBackend, freshOpenAiBackendWithTurnState)
+import Agent.CLI.ModelConfig (connectionSupportsDialect)
 import Agent.CLI.Tools
     (hostedSearchToolNames, requireToolRegistry, schemasFromAppTools)
 import Agent.CLI.Dialects
@@ -56,8 +57,7 @@ import Agent.CLI.Dialects
 import Agent.Codex.Dialect.Subagent (codexSubagentSuffix)
 import Agent.Dialect
     (ChildAgentProtocol(..), Dialect, DialectId, codexDialect,
-     dialectChildAgentProtocol, dialectForId, dialectId, dialectIdForModel,
-     providerSupportsDialect)
+     dialectChildAgentProtocol, dialectForId, dialectId, dialectIdForModel)
 import Agent.InterAgentMessage (InterAgentMessage, interAgentMessagePayload)
 import Agent.Loop
     (Backend(..), BackendSnapshot(..), BackendStateStore(..), LoopConfig(..),
@@ -334,7 +334,8 @@ restoreAgentFromDisk
             Right storedTarget
                 | Nothing <- resolvedTarget
                 , not
-                    (providerSupportsDialect
+                    (connectionSupportsDialect
+                        storedTarget.targetConnection
                         storedTarget.targetProvider
                         storedTarget.targetDialect) ->
                     pure $ Left $
@@ -1201,7 +1202,8 @@ ensureSubagentSessionResidentLocked
                         throwIO (userError (Text.unpack err))
                     Right storedTarget
                         | not
-                            (providerSupportsDialect
+                            (connectionSupportsDialect
+                                session.subSessionConnection
                                 session.subSessionProvider
                                 storedTarget.targetDialect) ->
                             throwIO $

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -103,7 +103,10 @@ import Agent.GrokBuild.Dialect.Task
     , recordAgentSpec
     )
 import Agent.Tools.MultiAgents
-    (CollaborationSpawnOptions(..), MultiAgentContext(..))
+    ( CollaborationModelTarget(..)
+    , CollaborationSpawnOptions(..)
+    , MultiAgentContext(..)
+    )
 import Agent.Tools.Types
     ( AppTool(..)
     , ToolEnv(..)
@@ -160,20 +163,37 @@ prepareCollaborationSpawn
                     Just currentEffort
                 | otherwise -> Nothing
         }
-    let effectiveModel =
-            maybe currentEffectiveModel mapModel spawnOptions.collaborationModel
-        childDialect =
-            maybe
-                currentDialect
-                (dialectIdForModel provider . mapModel)
-                spawnOptions.collaborationModel
+    let ( childProvider
+            , childConnection
+            , effectiveModel
+            , childDialect
+            ) =
+            case spawnOptions.collaborationResolvedModel of
+                Just target ->
+                    ( target.collaborationTargetProvider
+                    , target.collaborationTargetConnection
+                    , target.collaborationTargetEffectiveModel
+                    , target.collaborationTargetDialect
+                    )
+                Nothing ->
+                    ( provider
+                    , connection
+                    , maybe
+                        currentEffectiveModel
+                        mapModel
+                        spawnOptions.collaborationModel
+                    , maybe
+                        currentDialect
+                        (dialectIdForModel provider . mapModel)
+                        spawnOptions.collaborationModel
+                    )
     session <-
         lookupOrCreateSubagentSession
             sessionsRef
             storeRootRef
             typesRef
-            provider
-            connection
+            childProvider
+            childConnection
             legacyTarget
             effectiveModel
             childDialect
@@ -197,12 +217,13 @@ restoreAgentFromDisk
     -> SubagentStoreRoot
     -> SubagentRegistry
     -> IORef (Map SubagentId SubagentSession)
+    -> Maybe (Text -> IO (Maybe CollaborationModelTarget))
     -> GrokSubagentSpecs
     -> SubagentId
     -> IO (Either Text ())
 restoreAgentFromDisk
         provider connection mapModel parentEffectiveModel parentDialect legacyTarget
-        storeRootRef registry sessionsRef typesRef agentId = do
+        storeRootRef registry sessionsRef resolveChildModel typesRef agentId = do
     status <- getStatus registry agentId
     case status of
         NotFound -> restore
@@ -231,75 +252,109 @@ restoreAgentFromDisk
                             reopenInMemory Nothing Nothing
                     Right (Just (items, meta)) -> do
                         let fields = subagentDiskFields meta
-                            derivedIdentity =
-                                grokSpawnedChildIdentity
-                                    provider
-                                    connection
-                                    mapModel
-                                    parentEffectiveModel
-                                    parentDialect
-                                    fields.diskAgentModel
-                            ( expectedProvider
-                                , expectedConnection
-                                , expectedEffectiveModel
-                                , expectedDialect
-                                ) =
-                                    if provider == XAIProvider
-                                        then case meta of
-                                            CurrentSubagentDiskMeta _ stored
-                                                | stored.targetProvider
-                                                    == OpenAIProvider ->
-                                                    ( stored.targetProvider
-                                                    , stored.targetConnection
-                                                    , stored.targetEffectiveModel
-                                                    , stored.targetDialect
-                                                    )
-                                            _ ->
-                                                derivedIdentity
-                                        else
-                                            ( provider
-                                            , connection
-                                            , maybe
-                                                parentEffectiveModel
-                                                mapModel
-                                                fields.diskAgentModel
-                                            , maybe
-                                                parentDialect
-                                                (dialectIdForModel provider
-                                                    . mapModel)
-                                                fields.diskAgentModel
-                                            )
-                        case validatePersistedSubagentTarget
-                                expectedProvider
-                                expectedConnection
-                                expectedEffectiveModel
-                                expectedDialect
-                                legacyTarget
-                                meta of
+                            persistedAlias =
+                                fields.diskAgentModel
+                                    <|> case meta of
+                                        CurrentSubagentDiskMeta _ stored ->
+                                            Just stored.targetEffectiveModel
+                                        LegacySubagentDiskMeta{} ->
+                                            (.legacyTargetEffectiveModel)
+                                                <$> legacyTarget
+                        resolvedChildTarget <-
+                            case resolveChildModel of
+                                Just resolve -> case persistedAlias of
+                                    Nothing ->
+                                        pure $
+                                            Left
+                                                "Cannot restore the child because its organization model alias is missing."
+                                    Just requested ->
+                                        resolve requested >>= \case
+                                            Nothing ->
+                                                pure $
+                                                    Left
+                                                        "The child model is not allowed by this organization."
+                                            Just target ->
+                                                pure (Right (Just target))
+                                Nothing -> pure (Right Nothing)
+                        case resolvedChildTarget of
                             Left err -> pure (Left err)
-                            Right storedTarget
-                                | not
-                                    (providerSupportsDialect
-                                        storedTarget.targetProvider
-                                        storedTarget.targetDialect) ->
-                                    pure $ Left $
-                                        unsupportedDialectMessage
-                                            storedTarget.targetProvider
-                                            agentId
-                                            storedTarget.targetDialect
-                            Right storedTarget -> do
-                                session <-
-                                    getOrInstallSubagentSession
-                                        sessionsRef
-                                        storedTarget.targetProvider
-                                        storedTarget.targetConnection
-                                        storedTarget.targetEffectiveModel
-                                        storedTarget.targetDialect
-                                        agentId
-                                restoreSession session (Just (items, fields)) \_ ->
-                                    reopenPersisted fields >>= \case
-                                        Left err -> pure (Left err)
-                                        Right () -> pure (Right ())
+                            Right resolvedTarget ->
+                                restoreResolved fields resolvedTarget items meta
+    restoreResolved fields resolvedTarget items meta = do
+        let derivedIdentity =
+                grokSpawnedChildIdentity
+                    provider
+                    connection
+                    mapModel
+                    parentEffectiveModel
+                    parentDialect
+                    fields.diskAgentModel
+            ( expectedProvider
+                , expectedConnection
+                , expectedEffectiveModel
+                , expectedDialect
+                ) = case resolvedTarget of
+                    Just target ->
+                        ( target.collaborationTargetProvider
+                        , target.collaborationTargetConnection
+                        , target.collaborationTargetEffectiveModel
+                        , target.collaborationTargetDialect
+                        )
+                    Nothing | provider == XAIProvider ->
+                        case meta of
+                            CurrentSubagentDiskMeta _ stored
+                                | stored.targetProvider == OpenAIProvider ->
+                                    ( stored.targetProvider
+                                    , stored.targetConnection
+                                    , stored.targetEffectiveModel
+                                    , stored.targetDialect
+                                    )
+                            _ ->
+                                derivedIdentity
+                    Nothing ->
+                        ( provider
+                        , connection
+                        , maybe
+                            parentEffectiveModel
+                            mapModel
+                            fields.diskAgentModel
+                        , maybe
+                            parentDialect
+                            (dialectIdForModel provider . mapModel)
+                            fields.diskAgentModel
+                        )
+        case validatePersistedSubagentTarget
+                expectedProvider
+                expectedConnection
+                expectedEffectiveModel
+                expectedDialect
+                legacyTarget
+                meta of
+            Left err -> pure (Left err)
+            Right storedTarget
+                | Nothing <- resolvedTarget
+                , not
+                    (providerSupportsDialect
+                        storedTarget.targetProvider
+                        storedTarget.targetDialect) ->
+                    pure $ Left $
+                        unsupportedDialectMessage
+                            storedTarget.targetProvider
+                            agentId
+                            storedTarget.targetDialect
+            Right storedTarget -> do
+                session <-
+                    getOrInstallSubagentSession
+                        sessionsRef
+                        storedTarget.targetProvider
+                        storedTarget.targetConnection
+                        storedTarget.targetEffectiveModel
+                        storedTarget.targetDialect
+                        agentId
+                restoreSession session (Just (items, fields)) \_ ->
+                    reopenPersisted fields >>= \case
+                        Left err -> pure (Left err)
+                        Right () -> pure (Right ())
     restoreSession session loaded reopen =
         modifyMVar session.subSessionResidency \residency -> do
             currentStatus <- getStatus registry agentId
@@ -465,9 +520,12 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                     model prepared.preparedSession of
             Just err -> pure (Left (LoopUnexpected err))
             Nothing -> do
+                let childDialect =
+                        dialectForId
+                            prepared.preparedSession.subSessionDialect
                 coding <-
                     codingToolsFor
-                        codexDialect
+                        childDialect
                         prepared.preparedToolEnv
                         (Just runtime.subagentPlanHooks)
                         Nothing
@@ -478,32 +536,78 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                     coding.codingPlanMode
                 flip finally coding.codingClose do
                     today <- utctDay <$> getCurrentTime
+                    shellPath <-
+                        Text.pack . fromMaybe defaultShell <$> lookupEnv "SHELL"
                     ghciEnabled <- readIORef runtime.subagentGhciEnabled
                     bashEnabled <- readIORef runtime.subagentBashEnabled
-                    let codingTools =
+                    let childTools = case
+                                dialectChildAgentProtocol childDialect of
+                            CodexCollaborationProtocol -> coding.codingAppTools
+                            GrokTaskProtocol ->
+                                filterChildGrokTools
+                                    agentType coding.codingAppTools
+                            GenericTaskProtocol ->
+                                filterChildGrokTools
+                                    agentType coding.codingAppTools
+                            NoHostChildAgentProtocol ->
+                                []
+                        codingTools =
                             filterGhciTools ghciEnabled $
-                                filterBashTools bashEnabled $
-                                    filterChildGrokTools
-                                        agentType coding.codingAppTools
+                                filterBashTools bashEnabled childTools
                         tools =
                             codingTools <> runtime.subagentMcpTools
                         generatedInstructions =
-                            systemPromptForTools
-                                codexDialect
-                                (map (.appToolName) tools)
-                                env.subCwd
-                                sessionTmp
-                                today
-                                True
+                            case dialectChildAgentProtocol childDialect of
+                                CodexCollaborationProtocol ->
+                                    systemPromptForTools
+                                        childDialect
+                                        (map (.appToolName) tools)
+                                        env.subCwd
+                                        sessionTmp
+                                        today
+                                        True
+                                GrokTaskProtocol ->
+                                    Text.intercalate "\n\n" $
+                                        filter (not . Text.null)
+                                            [ grokSubagentSystemPrompt
+                                                codingGrokPromptTools
+                                                (hostedSearchToolNames childDialect
+                                                    ++ map (.appToolName) tools)
+                                                env.subCwd
+                                                today
+                                                (Text.pack SystemInfo.os)
+                                                shellPath
+                                                agentType
+                                                env.subId.unSubagentId
+                                            , sessionTempGuidance sessionTmp
+                                            ]
+                                GenericTaskProtocol ->
+                                    systemPromptForTools
+                                        childDialect
+                                        (map (.appToolName) tools)
+                                        env.subCwd
+                                        sessionTmp
+                                        today
+                                        True
+                                NoHostChildAgentProtocol ->
+                                    systemPrompt
+                                        childDialect
+                                        env.subCwd
+                                        sessionTmp
+                                        today
+                                        True
                         inheritParentPrompt =
-                            case prepared.preparedParentParams.model of
-                                Just parentModel ->
-                                    not
-                                        ( "grok"
-                                            `Text.isPrefixOf`
-                                                Text.toLower parentModel
-                                        )
-                                Nothing -> True
+                            case dialectChildAgentProtocol childDialect of
+                                CodexCollaborationProtocol ->
+                                    case prepared.preparedParentParams.model of
+                                        Just parentModel ->
+                                            not
+                                                ( "grok"
+                                                    `Text.isPrefixOf`
+                                                        Text.toLower parentModel
+                                                )
+                                        Nothing -> True
+                                _ -> False
                         baseInstructions =
                             if inheritParentPrompt
                                 then
@@ -513,19 +617,19 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                                 else generatedInstructions
                         instructions =
                             baseInstructions
-                                <> "\n\nYou are a Codex subagent. Complete the assigned task and "
-                                <> "report results clearly. Your agent id is "
-                                <> env.subId.unSubagentId
-                                <> "."
-                                <> case agentType of
-                                    "explore" ->
-                                        " Operate read-only: search and report, do not edit files."
-                                    "plan" ->
-                                        " Produce an implementation plan; do not edit implementation files."
-                                    _ ->
+                                <> "\n\n"
+                                <> case
+                                    dialectChildAgentProtocol childDialect of
+                                    CodexCollaborationProtocol ->
+                                        codexSubagentSuffix env.subId
+                                    GrokTaskProtocol ->
+                                        ""
+                                    GenericTaskProtocol ->
+                                        genericSubagentSuffix agentType env.subId
+                                    NoHostChildAgentProtocol ->
                                         ""
                         childParams = requestParams OpenAIProvider model instructions
-                            (schemasFromAppTools codexDialect tools) effort
+                            (schemasFromAppTools childDialect tools) effort
                     toolRegistry <- requireToolRegistry tools
                     httpFallbackActive <- newIORef False
                     turnState <- newCodexTurnState
@@ -584,7 +688,15 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                         prepared.preparedToolEnv toolRegistry
                         backend onEvent
                         (\config ->
-                            runLoopInputs config previous [AgentMessage prompt])
+                            case dialectChildAgentProtocol childDialect of
+                                CodexCollaborationProtocol ->
+                                    runLoopInputs
+                                        config previous [AgentMessage prompt]
+                                _ ->
+                                    runLoop
+                                        config
+                                        previous
+                                        (interAgentMessagePayload prompt))
 
 -- | Child xAI/OpenRouter/Gemini agent: HTTP backend, filtered tools by
 -- @subagent_type@.
@@ -833,6 +945,7 @@ prepareChild
                     NoHostChildAgentProtocol -> Nothing
             , multiSpawnModelGuidance = runtime.subagentSpawnModelGuidance
             , multiAllowedChildModels = runtime.subagentAllowedChildModels
+            , multiResolveChildModel = runtime.subagentResolveChildModel
             , multiChildModelAllowed = runtime.subagentChildModelAllowed
             }
     pure PreparedChild

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
@@ -15,7 +15,11 @@ import Agent.Loop (BackendSnapshot)
 import Agent.Provider (Provider, TokenProvider)
 import Agent.Responses.Types (ResponseCreateParams)
 import Agent.Subagents (SubagentId, SubagentRegistry)
-import Agent.Tools.MultiAgents (MultiAgentContext, SubagentWorktree)
+import Agent.Tools.MultiAgents
+    ( CollaborationModelTarget
+    , MultiAgentContext
+    , SubagentWorktree
+    )
 import Agent.Tools.PlanMode (PlanModeHooks)
 import Agent.Tools.Types (AppTool, ToolEnv)
 import Agent.Dialect (DialectId)
@@ -72,6 +76,8 @@ data SubagentRuntime = SubagentRuntime
         :: !(Maybe (OsPath -> IO (Either Text SubagentWorktree)))
     , subagentSpawnModelGuidance :: !(Maybe Text)
     , subagentAllowedChildModels :: !(Maybe [Text])
+    , subagentResolveChildModel
+        :: !(Maybe (Text -> IO (Maybe CollaborationModelTarget)))
     , subagentChildModelAllowed :: !(Maybe (Text -> IO Bool))
     , subagentOpenAiChild :: !(Maybe TokenProvider)
     }

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
@@ -72,6 +72,7 @@ data SubagentRuntime = SubagentRuntime
         :: !(Maybe (OsPath -> IO (Either Text SubagentWorktree)))
     , subagentSpawnModelGuidance :: !(Maybe Text)
     , subagentAllowedChildModels :: !(Maybe [Text])
+    , subagentChildModelAllowed :: !(Maybe (Text -> IO Bool))
     , subagentOpenAiChild :: !(Maybe TokenProvider)
     }
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -361,7 +361,7 @@ runFullscreen runtime workerAction = do
         result <- case actions.sessionProvider of
             Nothing ->
                 pure $ DictationFailed
-                    "Dictation is unavailable while the model is changing"
+                    "Dictation is unavailable for the active session"
             Just provider ->
                 dictateWith
                     provider

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -1,7 +1,7 @@
 module Agent.CLI.AgentSessionsSpec (spec) where
 
 import Agent.CLI.AgentSessions
-import Agent.CLI.Models (ModelTarget(..))
+import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
 import Agent.CLI.ManagedTurn (managedTurnRequestFromText)
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Session
@@ -117,11 +117,31 @@ spec = describe "Agent.CLI.AgentSessions" do
 
     it "uses refreshed organization models for persisted child sessions" $
         withTempEnv \env launched -> do
-            currentModels <- newIORef ["company-a"]
+            let gatewayOption model dialect = ModelOption
+                    { modelTarget = ModelTarget
+                        { targetProvider = OpenAIProvider
+                        , targetConnectionId = "openai"
+                        , targetModelId = model
+                        , targetWireModelId = model
+                        , targetDialect = dialect
+                        }
+                    , modelContextWindow = Nothing
+                    , modelLabel = Nothing
+                    , modelFallbackPriority = Nothing
+                    }
+            currentModels <-
+                newIORef [gatewayOption "company-a" CodexDialect]
             let scopedEnv = env
                     { toolsAllowedModels = Just ["company-a"]
-                    , toolsChildModelAllowed =
-                        Just (\model -> elem model <$> readIORef currentModels)
+                    , toolsResolveModelOption =
+                        Just \model ->
+                            lookup model
+                                . map
+                                    (\option ->
+                                        ( option.modelTarget.targetModelId
+                                        , option
+                                        ))
+                                <$> readIORef currentModels
                     }
                 createTool = head (agentSessionTools scopedEnv)
             case createTool.appToolSchema of
@@ -138,12 +158,15 @@ spec = describe "Agent.CLI.AgentSessions" do
                 "{\"message\":\"not yet\",\"model\":\"company-b\"}"
             rejected `shouldSatisfy`
                 Text.isInfixOf "not allowed by this organization"
-            writeIORef currentModels ["company-b"]
+            writeIORef
+                currentModels
+                [gatewayOption "company-b" GenericResponsesDialect]
             accepted <- runTool scopedEnv "create_agent_session"
                 "{\"message\":\"now approved\",\"model\":\"company-b\"}"
             accepted `shouldSatisfy` Text.isInfixOf "Status: running"
             [(handle, _)] <- readIORef launched
             handle.sessionMeta.metaModel `shouldBe` "company-b"
+            handle.sessionMeta.metaDialect `shouldBe` GenericResponsesDialect
 
     it "inherits the active dialect and resolves explicit model overrides" $
         withTempEnv \env launched -> do
@@ -606,7 +629,7 @@ withTempEnv action =
                 , toolsTransportModel = "model-1"
                 , toolsDialect = GrokBuildDialect
                 , toolsAllowedModels = Nothing
-                , toolsChildModelAllowed = Nothing
+                , toolsResolveModelOption = Nothing
                 , toolsCwd = fromFilePath "/tmp/work"
                 , toolsEffort = "low"
                 , toolsCurrentSessionId = pure Nothing

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -18,7 +18,12 @@ import Agent.ToolDispatch
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
+    , ToolSchema(..)
     , appToolHandlers
+    )
+import Agent.ToolDSL
+    ( PropertySchema(..)
+    , PropertyType(..)
     )
 import Agent.Store.Postgres
     ( closeStore
@@ -81,6 +86,34 @@ spec = describe "Agent.CLI.AgentSessions" do
             handle.sessionMeta.metaEffort `shouldBe` "high"
             loadSession env.toolsPool env.toolsRoot handle.sessionMeta.metaId
                 `shouldReturn` Right (handle.sessionMeta, [])
+
+    it "advertises and enforces organization-approved session models" $
+        withTempEnv \env launched -> do
+            let scopedEnv =
+                    env { toolsAllowedModels = Just ["company-a", "company-b"] }
+                createTool = head (agentSessionTools scopedEnv)
+            case createTool.appToolSchema of
+                JsonFunctionSchema properties ->
+                    [ propertyKind
+                    | PropertySchema propertyKey propertyKind _ _ <- properties
+                    , propertyKey == "model"
+                    ]
+                        `shouldBe`
+                            [PropertyEnum ["company-a", "company-b"]]
+                other ->
+                    expectationFailure
+                        ("expected JSON function schema, got " <> show other)
+            rejected <- runTool scopedEnv "create_agent_session"
+                "{\"message\":\"try forbidden\",\"model\":\"public-model\"}"
+            rejected `shouldSatisfy`
+                Text.isInfixOf "not allowed by this organization"
+            (null <$> readIORef launched) `shouldReturn` True
+
+            accepted <- runTool scopedEnv "create_agent_session"
+                "{\"message\":\"use approved\",\"model\":\" company-b \"}"
+            accepted `shouldSatisfy` Text.isInfixOf "Status: running"
+            [(handle, _)] <- readIORef launched
+            handle.sessionMeta.metaModel `shouldBe` "company-b"
 
     it "inherits the active dialect and resolves explicit model overrides" $
         withTempEnv \env launched -> do
@@ -542,6 +575,7 @@ withTempEnv action =
                 , toolsModel = "model-1"
                 , toolsTransportModel = "model-1"
                 , toolsDialect = GrokBuildDialect
+                , toolsAllowedModels = Nothing
                 , toolsCwd = fromFilePath "/tmp/work"
                 , toolsEffort = "low"
                 , toolsCurrentSessionId = pure Nothing

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -115,6 +115,36 @@ spec = describe "Agent.CLI.AgentSessions" do
             [(handle, _)] <- readIORef launched
             handle.sessionMeta.metaModel `shouldBe` "company-b"
 
+    it "uses refreshed organization models for persisted child sessions" $
+        withTempEnv \env launched -> do
+            currentModels <- newIORef ["company-a"]
+            let scopedEnv = env
+                    { toolsAllowedModels = Just ["company-a"]
+                    , toolsChildModelAllowed =
+                        Just (\model -> elem model <$> readIORef currentModels)
+                    }
+                createTool = head (agentSessionTools scopedEnv)
+            case createTool.appToolSchema of
+                JsonFunctionSchema properties ->
+                    [ propertyKind
+                    | PropertySchema propertyKey propertyKind _ _ <- properties
+                    , propertyKey == "model"
+                    ]
+                        `shouldBe` [PropertyString]
+                other ->
+                    expectationFailure
+                        ("expected JSON function schema, got " <> show other)
+            rejected <- runTool scopedEnv "create_agent_session"
+                "{\"message\":\"not yet\",\"model\":\"company-b\"}"
+            rejected `shouldSatisfy`
+                Text.isInfixOf "not allowed by this organization"
+            writeIORef currentModels ["company-b"]
+            accepted <- runTool scopedEnv "create_agent_session"
+                "{\"message\":\"now approved\",\"model\":\"company-b\"}"
+            accepted `shouldSatisfy` Text.isInfixOf "Status: running"
+            [(handle, _)] <- readIORef launched
+            handle.sessionMeta.metaModel `shouldBe` "company-b"
+
     it "inherits the active dialect and resolves explicit model overrides" $
         withTempEnv \env launched -> do
             let openRouterEnv = env
@@ -576,6 +606,7 @@ withTempEnv action =
                 , toolsTransportModel = "model-1"
                 , toolsDialect = GrokBuildDialect
                 , toolsAllowedModels = Nothing
+                , toolsChildModelAllowed = Nothing
                 , toolsCwd = fromFilePath "/tmp/work"
                 , toolsEffort = "low"
                 , toolsCurrentSessionId = pure Nothing

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.AgentSessionsSpec (spec) where
 
 import Agent.CLI.AgentSessions
 import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
+import Agent.CLI.ModelConfig (organizationGatewayConnectionId)
 import Agent.CLI.ManagedTurn (managedTurnRequestFromText)
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Session
@@ -120,7 +121,8 @@ spec = describe "Agent.CLI.AgentSessions" do
             let gatewayOption model dialect = ModelOption
                     { modelTarget = ModelTarget
                         { targetProvider = OpenAIProvider
-                        , targetConnectionId = "openai"
+                        , targetConnectionId =
+                            organizationGatewayConnectionId
                         , targetModelId = model
                         , targetWireModelId = model
                         , targetDialect = dialect
@@ -166,6 +168,8 @@ spec = describe "Agent.CLI.AgentSessions" do
             accepted `shouldSatisfy` Text.isInfixOf "Status: running"
             [(handle, _)] <- readIORef launched
             handle.sessionMeta.metaModel `shouldBe` "company-b"
+            handle.sessionMeta.metaConnection
+                `shouldBe` organizationGatewayConnectionId
             handle.sessionMeta.metaDialect `shouldBe` GenericResponsesDialect
 
     it "inherits the active dialect and resolves explicit model overrides" $

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -25,10 +25,8 @@ import Agent.Provider
     , FailedCredential(..)
     , Provider(..)
     , getNextToken
-    , runWithTokenProvider
     , tokenProvider
     , tokenProviderBillingMode
-    , tokenProviderWithNextToken
     )
 import qualified Agent.XAI.Auth as XAIAuth
 import Control.Exception.Safe (bracket)
@@ -172,7 +170,7 @@ spec = do
                         loaded.loadedSelectionId
                             `shouldBe` Just gatewayAuthSelectionId
 
-        it "falls back from a rejected gateway to local ChatGPT auth" $
+        it "keeps a gateway session gateway-only after rejection" $
             withTempHome \home ->
                 withCleanOpenAiEnv do
                     saveTestGateway home
@@ -185,10 +183,10 @@ spec = do
                         Left err -> expectationFailure (Text.unpack err)
                         Right loaded -> do
                             case loaded.loadedOpenAiPool of
-                                Nothing ->
+                                Nothing -> pure ()
+                                Just _ ->
                                     expectationFailure
-                                        "expected local OpenAI fallback pool"
-                                Just _ -> pure ()
+                                        "gateway auth must not attach a local account pool"
                             gatewayCredential <-
                                 getNextToken
                                     loaded.loadedTokenProvider
@@ -197,112 +195,19 @@ spec = do
                             gatewayCredential.accountId
                                 `shouldBe`
                                     "wss://gateway.example/v1/responses"
-                            localCredential <-
-                                getNextToken
-                                    loaded.loadedTokenProvider
-                                    (Just FailedCredential
-                                        { credential = gatewayCredential
-                                        , failure =
-                                            AccountAuthenticationRejected
-                                        , failureReason =
-                                            testAuthenticationReason
-                                        })
-                                    >>= expectRightResult
-                            localCredential.accountId
-                                `shouldBe` "local-account"
                             getNextToken
                                 loaded.loadedTokenProvider
-                                Nothing
-                                `shouldReturn` Right localCredential
-
-        it "falls back after a gateway WebSocket handshake 403" $
-            withTempHome \home ->
-                withCleanOpenAiEnv do
-                    saveTestGateway home
-                    storeOpenAiAccount
-                        "local-openai"
-                        "local-account"
-                        True
-                        farFutureAccessToken
-                    loadAuth (Just OpenAIProvider) >>= \case
-                        Left err -> expectationFailure (Text.unpack err)
-                        Right loaded -> do
-                            pool <- case loaded.loadedOpenAiPool of
-                                Nothing -> do
-                                    expectationFailure
-                                        "expected local OpenAI fallback pool"
-                                    fail "missing local OpenAI fallback pool"
-                                Just pool -> pure pool
-                            preferred <- newIORef Nothing
-                            let selectableProvider =
-                                    preferredOpenAiTokenProvider
-                                        preferred
-                                        pool
-                                        loaded.loadedTokenProvider
-                                -- The live runtime applies another acquisition
-                                -- decorator to track the active account.
-                                runtimeProvider =
-                                    tokenProviderWithNextToken
-                                        selectableProvider
-                                        (getNextToken selectableProvider)
-                            attempts <- newIORef ([] :: [Text])
-                            result <- runWithTokenProvider
-                                runtimeProvider
-                                \credential -> do
-                                    modifyIORef'
-                                        attempts
-                                        (<> [credential.accountId])
-                                    pure $
-                                        if credential.accountId
-                                            == "wss://gateway.example/v1/responses"
-                                            then Left $ HttpError 403
-                                                "WebSocket handshake returned HTTP 403"
-                                            else Right credential.accountId
-
-                            result `shouldBe` Right "local-account"
-                            readIORef attempts `shouldReturn`
-                                [ "wss://gateway.example/v1/responses"
-                                , "local-account"
-                                ]
-
-        it "does not replay an ordinary gateway request 403" $
-            withTempHome \home ->
-                withCleanOpenAiEnv do
-                    saveTestGateway home
-                    storeOpenAiAccount
-                        "local-openai"
-                        "local-account"
-                        True
-                        farFutureAccessToken
-                    loadAuth (Just OpenAIProvider) >>= \case
-                        Left err -> expectationFailure (Text.unpack err)
-                        Right loaded -> do
-                            pool <- case loaded.loadedOpenAiPool of
-                                Nothing -> do
-                                    expectationFailure
-                                        "expected local OpenAI fallback pool"
-                                    fail "missing local OpenAI fallback pool"
-                                Just pool -> pure pool
-                            preferred <- newIORef Nothing
-                            let provider =
-                                    preferredOpenAiTokenProvider
-                                        preferred
-                                        pool
-                                        loaded.loadedTokenProvider
-                                forbidden =
-                                    HttpError 403
-                                        "request forbidden after connection"
-                            attempts <- newIORef ([] :: [Text])
-                            result <- runWithTokenProvider provider
-                                \credential -> do
-                                    modifyIORef'
-                                        attempts
-                                        (<> [credential.accountId])
-                                    pure (Left forbidden :: Either ApiError Text)
-
-                            result `shouldBe` Left forbidden
-                            readIORef attempts `shouldReturn`
-                                ["wss://gateway.example/v1/responses"]
+                                (Just FailedCredential
+                                    { credential = gatewayCredential
+                                    , failure =
+                                        AccountAuthenticationRejected
+                                    , failureReason =
+                                        testAuthenticationReason
+                                    })
+                                `shouldReturn`
+                                    Left
+                                        (CredentialError
+                                            "static credential was rejected")
 
         it "does not turn a rejected gateway into API-credit spending" $
             withTempHome \home ->
@@ -343,7 +248,7 @@ spec = do
                                             "expected gateway rejection, got "
                                                 <> show other
 
-        it "uses local OpenAI auth when the gateway file is invalid" $
+        it "fails closed when the gateway file is invalid" $
             withTempHome \home ->
                 withCleanOpenAiEnv do
                     let path = toFilePath (gatewayCredentialPath home)
@@ -357,23 +262,61 @@ spec = do
                         True
                         farFutureAccessToken
                     loadAuth (Just OpenAIProvider) >>= \case
-                        Left err -> expectationFailure (Text.unpack err)
-                        Right loaded -> do
-                            loaded.loadedSelectionId `shouldBe` Nothing
-                            getNextToken
-                                loaded.loadedTokenProvider
-                                Nothing
-                                >>= \case
-                                    Left err ->
-                                        expectationFailure (show err)
-                                    Right credential ->
-                                        credential.accountId
-                                            `shouldBe` "local-account"
+                        Left err ->
+                            err `shouldSatisfy`
+                                Text.isPrefixOf "cannot load gateway credential:"
+                        Right _ ->
+                            expectationFailure
+                                "expected an invalid gateway to block local auth"
 
-        it "does not turn an invalid gateway into API-credit spending" $
+        it "fails closed for automatic provider detection when the gateway file is invalid" $
             withTempHome \home ->
                 withCleanOpenAiEnv $
                 withCleanGrokEnv do
+                    let path = toFilePath (gatewayCredentialPath home)
+                    createDirectoryIfMissing True
+                        (toFilePath home </> ".haskell-agent"
+                            </> "credentials")
+                    LBS.writeFile path "{not-json"
+                    storeOpenAiAccountWithBilling
+                        ApiBilled
+                        "api-openai"
+                        "api-account"
+                        True
+                        farFutureAccessToken
+                    loadAuth (Just XAIProvider) >>= \case
+                        Left err ->
+                            err `shouldSatisfy`
+                                Text.isInfixOf
+                                    "cannot load gateway credential:"
+                        Right _ ->
+                            expectationFailure
+                                "expected an invalid gateway to block automatic auth"
+
+        it "does not use another subscription provider when the gateway file is invalid" $
+            withTempHome \home ->
+                withCleanOpenAiEnv $
+                withCleanGrokEnv $
+                withEnv "GROK_ACCESS_TOKEN" (Just "xai-token") do
+                    let path = toFilePath (gatewayCredentialPath home)
+                    createDirectoryIfMissing True
+                        (toFilePath home </> ".haskell-agent"
+                            </> "credentials")
+                    LBS.writeFile path "{not-json"
+                    loadAuth Nothing >>= \case
+                        Left err ->
+                            err `shouldSatisfy`
+                                Text.isInfixOf
+                                    "cannot load gateway credential:"
+                        Right _ ->
+                            expectationFailure
+                                "expected an invalid gateway to block local auth"
+
+        it "does not let an explicit provider bypass an invalid gateway" $
+            withTempHome \home ->
+                withCleanOpenAiEnv $
+                withCleanGrokEnv $
+                withEnv "GROK_ACCESS_TOKEN" (Just "xai-token") do
                     let path = toFilePath (gatewayCredentialPath home)
                     createDirectoryIfMissing True
                         (toFilePath home </> ".haskell-agent"
@@ -389,59 +332,24 @@ spec = do
                         Left err ->
                             err `shouldSatisfy`
                                 Text.isInfixOf
-                                    "refusing automatic fallback to API-credit billing"
+                                    "cannot load gateway credential:"
                         Right _ ->
                             expectationFailure
-                                "expected invalid gateway to preserve the billing boundary"
+                                "expected an invalid gateway to block local auth"
 
-        it "uses another subscription provider when the gateway file is invalid" $
-            withTempHome \home ->
-                withCleanOpenAiEnv $
-                withCleanGrokEnv $
-                withEnv "GROK_ACCESS_TOKEN" (Just "xai-token") do
-                    let path = toFilePath (gatewayCredentialPath home)
-                    createDirectoryIfMissing True
-                        (toFilePath home </> ".haskell-agent"
-                            </> "credentials")
-                    LBS.writeFile path "{not-json"
-                    loadAuth Nothing >>= \case
-                        Left err -> expectationFailure (Text.unpack err)
-                        Right loaded ->
-                            loaded.loadedProvider `shouldBe` XAIProvider
-
-        it "skips API-credit auth to use another subscription provider" $
-            withTempHome \home ->
-                withCleanOpenAiEnv $
-                withCleanGrokEnv $
-                withEnv "GROK_ACCESS_TOKEN" (Just "xai-token") do
-                    let path = toFilePath (gatewayCredentialPath home)
-                    createDirectoryIfMissing True
-                        (toFilePath home </> ".haskell-agent"
-                            </> "credentials")
-                    LBS.writeFile path "{not-json"
-                    storeOpenAiAccountWithBilling
-                        ApiBilled
-                        "api-openai"
-                        "api-account"
-                        True
-                        farFutureAccessToken
-                    loadAuth Nothing >>= \case
-                        Left err -> expectationFailure (Text.unpack err)
-                        Right loaded -> do
-                            loaded.loadedProvider `shouldBe` XAIProvider
-                            tokenProviderBillingMode
-                                loaded.loadedTokenProvider
-                                `shouldBe` SubscriptionBilled
-
-        it "does not let a gateway override an explicit non-OpenAI provider" $
+        it "does not let an explicit non-OpenAI provider bypass the gateway" $
             withTempHome \home ->
                 withCleanGrokEnv $
                 withEnv "GROK_ACCESS_TOKEN" (Just "xai-token") do
                     saveTestGateway home
                     loadAuth (Just XAIProvider) >>= \case
-                        Left err -> expectationFailure (Text.unpack err)
-                        Right loaded ->
-                            loaded.loadedProvider `shouldBe` XAIProvider
+                        Left err ->
+                            err `shouldSatisfy`
+                                Text.isInfixOf
+                                    "organization gateway is active"
+                        Right _ ->
+                            expectationFailure
+                                "expected the gateway to block direct xAI auth"
 
     describe "loadOpenAiDictationAuth" do
         it "loads ChatGPT OAuth as subscription-billed OpenAI auth" $
@@ -665,7 +573,7 @@ spec = do
                         `shouldReturn` Right second
 
     describe "loadAuthForAccount" do
-        it "keeps local fallback when the gateway route is selected" $
+        it "keeps the gateway selected when its route is selected" $
             withTempHome \home ->
                 withCleanOpenAiEnv do
                     saveTestGateway home
@@ -686,21 +594,21 @@ spec = do
                                         loaded.loadedTokenProvider
                                         Nothing
                                         >>= expectRightResult
-                                localCredential <-
-                                    getNextToken
-                                        loaded.loadedTokenProvider
-                                        (Just FailedCredential
-                                            { credential = gatewayCredential
-                                            , failure =
-                                                AccountAuthenticationRejected
-                                            , failureReason =
-                                                testAuthenticationReason
-                                            })
-                                        >>= expectRightResult
-                                localCredential.accountId
-                                    `shouldBe` "local-account"
+                                getNextToken
+                                    loaded.loadedTokenProvider
+                                    (Just FailedCredential
+                                        { credential = gatewayCredential
+                                        , failure =
+                                            AccountAuthenticationRejected
+                                        , failureReason =
+                                            testAuthenticationReason
+                                        })
+                                    `shouldReturn`
+                                        Left
+                                            (CredentialError
+                                                "static credential was rejected")
 
-        it "loads the selected local OpenAI account while a gateway is connected" $
+        it "does not let a local OpenAI selection escape a connected gateway" $
             withTempHome \home ->
                 withCleanOpenAiEnv do
                     saveTestGateway home
@@ -719,21 +627,13 @@ spec = do
                         "local-account-b"
                         >>= \case
                             Left err ->
-                                expectationFailure (Text.unpack err)
-                            Right loaded -> do
-                                loaded.loadedSelectionId
-                                    `shouldBe` Just "local-account-b"
-                                getNextToken
-                                    loaded.loadedTokenProvider
-                                    Nothing
-                                    >>= \case
-                                        Left err ->
-                                            expectationFailure (show err)
-                                        Right credential ->
-                                            credential.accountId
-                                                `shouldBe` "local-account-b"
+                                err `shouldBe`
+                                    "organization gateway is active; disconnect it before selecting another account"
+                            Right _ ->
+                                expectationFailure
+                                    "expected the gateway to block a local account"
 
-        it "does not let a gateway override a selected non-OpenAI account" $
+        it "does not let a selected non-OpenAI account escape a gateway" $
             withTempHome \home ->
                 withCleanGrokEnv $
                 withEnv "GROK_ACCESS_TOKEN" (Just "xai-token") do
@@ -743,9 +643,11 @@ spec = do
                         (externalAuthSelectionId XAIProvider "environment")
                         >>= \case
                             Left err ->
-                                expectationFailure (Text.unpack err)
-                            Right loaded ->
-                                loaded.loadedProvider `shouldBe` XAIProvider
+                                err `shouldBe`
+                                    "organization gateway is active; disconnect it before selecting another account"
+                            Right _ ->
+                                expectationFailure
+                                    "expected the gateway to block another provider account"
 
         it "loads the selected managed Grok account" $
             withTempHome \_ ->

--- a/packages/agent-cli/test/Agent/CLI/ClaudeGatewayProxySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ClaudeGatewayProxySpec.hs
@@ -1,0 +1,80 @@
+module Agent.CLI.ClaudeGatewayProxySpec (spec) where
+
+import Agent.CLI.ClaudeGatewayProxy (withClaudeGatewayProxy)
+import Agent.CLI.GatewayClient (GatewayCredential(..))
+import Agent.Claude (ClaudeCodeTransport(..))
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.IORef
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Types
+import Network.Wai
+import Network.Wai.Handler.Warp qualified as Warp
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Claude gateway loopback proxy" do
+    it "keeps the organization bearer in the parent process" do
+        observed <- newIORef Nothing
+        Warp.testWithApplication (pure (upstream observed)) \port -> do
+            manager <- HTTP.newManager HTTP.defaultManagerSettings
+            let origin = "http://127.0.0.1:" <> Text.pack (show port)
+                credential =
+                    GatewayCredential
+                        { gatewayBaseUrl = origin
+                        , gatewayWebSocketUrl =
+                            "ws://127.0.0.1:" <> Text.pack (show port)
+                        , gatewayAccessToken = "organization-secret"
+                        }
+            result <-
+                withClaudeGatewayProxy credential \case
+                    ClaudeCodeLocalSubscription ->
+                        expectationFailure "expected gateway transport"
+                    ClaudeCodeGateway{gatewayBaseUrl, gatewayToken} -> do
+                        gatewayToken `shouldNotBe` "organization-secret"
+                        request <-
+                            HTTP.parseRequest
+                                (Text.unpack gatewayBaseUrl
+                                    <> "/anthropic/v1/messages")
+                        response <-
+                            HTTP.httpLbs
+                                request
+                                    { HTTP.method = "POST"
+                                    , HTTP.requestHeaders =
+                                        [ ( hAuthorization
+                                          , "Bearer "
+                                                <> Text.encodeUtf8 gatewayToken
+                                          )
+                                        , (hContentType, "application/json")
+                                        ]
+                                    , HTTP.requestBody =
+                                        HTTP.RequestBodyLBS
+                                            "{\"model\":\"sonnet\"}"
+                                    }
+                                manager
+                        response.responseStatus `shouldBe` status200
+            result `shouldBe` Right ()
+            readIORef observed
+                `shouldReturn`
+                    Just
+                        ( ["anthropic", "v1", "messages"]
+                        , Just "Bearer organization-secret"
+                        , "{\"model\":\"sonnet\"}"
+                        )
+
+upstream
+    :: IORef (Maybe ([Text], Maybe ByteString, LBS.ByteString))
+    -> Application
+upstream observed request respond = do
+    body <- strictRequestBody request
+    writeIORef observed $
+        Just
+            (request.pathInfo, lookup hAuthorization request.requestHeaders, body)
+    respond $
+        responseLBS
+            status200
+            [(hContentType, "application/json")]
+            "{\"ok\":true}"

--- a/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
@@ -1,10 +1,14 @@
 module Agent.CLI.GatewayModelsSpec (spec) where
 
 import Agent.CLI.GatewayModels
+import Agent.CLI.GatewayClient
+    ( GatewayModel(..)
+    , GatewayModelProtocol(..)
+    )
 import Agent.CLI.ModelConfig
 import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
 import Agent.Dialect (DialectId(..))
-import Agent.Provider (Provider(OpenAIProvider))
+import Agent.Provider (Provider(ClaudeCodeProvider, OpenAIProvider))
 import Data.Map.Strict qualified as Map
 import Test.Hspec
 
@@ -32,6 +36,23 @@ spec = describe "Agent.CLI.GatewayModels" do
             `shouldBe` ["router-default"]
         map (.modelTarget.targetConnectionId) options
             `shouldBe` ["openai"]
+
+    it "maps the unified catalog to Responses and Claude transports" do
+        let options =
+                modelOptionsForGatewayModels
+                    testCatalog
+                    [ GatewayModel "company-a" GatewayResponsesProtocol
+                    , GatewayModel "sonnet" GatewayAnthropicProtocol
+                    , GatewayModel "router-default" GatewayResponsesProtocol
+                    ]
+        map (.modelTarget.targetProvider) options
+            `shouldBe` [OpenAIProvider, ClaudeCodeProvider]
+        map (.modelTarget.targetModelId) options
+            `shouldBe` ["company-a", "sonnet"]
+        map (.modelTarget.targetConnectionId) options
+            `shouldBe` replicate 2 organizationGatewayConnectionId
+        map (.modelTarget.targetDialect) options
+            `shouldBe` [GenericResponsesDialect, ClaudeCodeDialect]
 
 testCatalog :: ModelCatalog
 testCatalog =

--- a/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
@@ -63,7 +63,7 @@ directModel =
     CatalogModel
         { catalogModelId = "router-default"
         , catalogModelConnectionId = "openai"
-        , catalogModelWireId = "company-local-router"
+        , catalogModelWireId = "router-default"
         , catalogModelDialect = CodexDialect
         , catalogModelContextWindow = Nothing
         , catalogModelLabel = Nothing

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -154,7 +154,9 @@ spec = do
             actionLabels
                 `shouldSatisfy` not . any (Text.isInfixOf "Refresh usage")
             loginAccountDetail gateway
-                `shouldSatisfy` Text.isInfixOf "preferred"
+                `shouldSatisfy`
+                    Text.isInfixOf
+                        "Local accounts are unavailable until the gateway is disconnected."
 
         it "offers usage refresh and opens each discovered account" do
             let rows = loginDashboardRows [openai, openRouter]

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -137,6 +137,20 @@ spec = do
             frame `shouldNotSatisfy` Text.isInfixOf "\BEL"
             length (Text.lines frame) `shouldBe` 21
 
+        it "does not display a stale current model outside an authoritative scope" do
+            state <-
+                initialPickerStateForOptions
+                    "organization gateway"
+                    [rawModelOption OpenAIProvider "company-model"]
+                    "openai"
+                    OpenAIProvider
+                    "revoked-model"
+                    CodexDialect
+            let frame = renderPickerFrame False state
+            frame `shouldSatisfy` Text.isInfixOf "organization gateway"
+            frame `shouldSatisfy` Text.isInfixOf "company-model"
+            frame `shouldNotSatisfy` Text.isInfixOf "revoked-model"
+
     describe "formatCatalogListing" do
         it "lists the current model and entries from every provider" do
             listing <-

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -2,6 +2,7 @@ module Agent.CLI.ProjectSpec (spec) where
 
 import Agent.CLI.Project
 import Agent.CLI.Models (ModelTarget(..))
+import Agent.CLI.ModelConfig (organizationGatewayConnectionId)
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..))
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
@@ -152,6 +153,22 @@ spec = describe "Agent.CLI.Project" do
                 updated.settingsAutoApprove `shouldBe` False
                 projectModelFor OpenAIProvider updated
                     `shouldBe` Just "gpt-project"
+
+        it "round-trips an organization gateway model dialect" $
+            withTempDir "agent-project-" \root -> do
+                let gatewayTarget =
+                        target
+                            OpenAIProvider
+                            organizationGatewayConnectionId
+                            "company-coder"
+                            "company-coder"
+                            GenericResponsesDialect
+                saveProjectModel root gatewayTarget
+                settings <- loadProjectSettings root
+                settings.settingsLastModel
+                    `shouldBe`
+                        Just ProjectModel
+                            { projectModelTarget = gatewayTarget }
 
         it "writes a top-level model switch to the checkout and user home" $
             withTempDir "agent-project-" \project ->

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -7,7 +7,7 @@ import Agent.CLI.RepositoryReview
     )
 import System.Timeout (timeout)
 import Control.Concurrent (threadDelay)
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, tryAny)
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
@@ -28,12 +28,14 @@ import System.Posix.Files
     , setFileMode
     , unionFileModes
     )
+import System.Posix.Process (getProcessStatus)
 import System.Process
     ( CreateProcess(..)
     , proc
     , readCreateProcessWithExitCode
     )
 import Test.Hspec
+import Text.Read (readMaybe)
 
 spec :: Spec
 spec = describe "repository delivery service" do
@@ -524,7 +526,7 @@ spec = describe "repository delivery service" do
                 let descendantPid = root <> "/gh-descendant.pid"
                 setEnv "GH_RETAIN_PIPE_MARKER" descendantPid
                 snapshot <- expectRight =<< repositorySnapshot root
-                result <- timeout 5_000_000
+                result <- timeout 20_000_000
                     (previewPullRequest
                         root snapshot.snapshotId "main" "Title" "Body")
                 result `shouldSatisfy` \case
@@ -692,6 +694,8 @@ withFakeGh root action = do
     originalGhHost <- lookupEnv "GH_HOST"
     withTempDirectory "repository-delivery-gh" \bin -> do
         realGit <- maybe (fail "git not found") pure =<< findExecutable "git"
+        python <- maybe (fail "python3 not found") pure
+            =<< findExecutable "python3"
         localRemote <- Text.unpack . Text.strip
             <$> git root ["remote", "get-url", "origin"]
         expectedHead <- Text.unpack . Text.strip
@@ -705,19 +709,31 @@ withFakeGh root action = do
             candidateQueryMarker =
                 root <> "/pull-request-candidates-queried"
             readyMarker = root <> "/pull-request-ready"
+            retainingChildScript = unlines
+                [ "import os"
+                , "import sys"
+                , "import time"
+                , "pid = os.fork()"
+                , "if pid:"
+                , "    marker = os.open("
+                    <> "sys.argv[1], "
+                    <> "os.O_WRONLY | os.O_CREAT | os.O_TRUNC, "
+                    <> "0o600)"
+                , "    os.write(marker, (str(pid) + \"\\n\").encode())"
+                , "    os.close(marker)"
+                , "    os._exit(0)"
+                , "time.sleep(30)"
+                ]
         _ <- git root ["remote", "set-url", "origin", githubRemote]
         writeFile gitExecutable $ unlines
-            [ "#!/bin/bash"
-            , "set -eu"
-            , "args=()"
-            , "for arg in \"$@\"; do"
-            , "  if [[ \"$arg\" == " <> shellQuote githubRemote <> " ]]; then"
-            , "    args+=(" <> shellQuote localRemote <> ")"
-            , "  else"
-            , "    args+=(\"$arg\")"
-            , "  fi"
-            , "done"
-            , "exec " <> shellQuote realGit <> " \"${args[@]}\""
+            [ "#!" <> python
+            , "import os"
+            , "import sys"
+            , "source = " <> show githubRemote
+            , "target = " <> show localRemote
+            , "git = " <> show realGit
+            , "arguments = [target if arg == source else arg for arg in sys.argv[1:]]"
+            , "os.execv(git, [git] + arguments)"
             ]
         setFileMode gitExecutable
             (ownerReadMode
@@ -729,9 +745,9 @@ withFakeGh root action = do
             , "pwd > " <> shellQuote (root <> "/../gh-cwd.txt")
             , "[ \"${GH_HOST:-}\" = '' ] || exit 65"
             , "if [ \"${GH_RETAIN_PIPE_MARKER:-}\" != '' ] && [ \"$1 $2\" = 'auth status' ]; then"
-            , "  sleep 30 &"
-            , "  printf '%s\\n' \"$!\" > \"$GH_RETAIN_PIPE_MARKER\""
-            , "  exit 0"
+            , "  exec " <> shellQuote python
+                <> " -c " <> shellQuote retainingChildScript
+                <> " \"$GH_RETAIN_PIPE_MARKER\""
             , "fi"
             , "print_pr() {"
             , "  draft=${GH_FAKE_DRAFT:-true}"
@@ -896,9 +912,25 @@ processGoneWithin remaining pid
                 processGoneWithin (remaining - 100_000) pid
   where
     processExists = do
-        (exitCode, _, _) <-
-            readCreateProcessWithExitCode (proc "kill" ["-0", pid]) ""
-        pure (exitCode == ExitSuccess)
+        reaped <- case readMaybe pid of
+            Nothing -> pure Nothing
+            Just processId ->
+                tryAny (getProcessStatus False False processId) >>= \case
+                    Right status -> pure status
+                    Left _ -> pure Nothing
+        case reaped of
+            Just _ -> pure False
+            Nothing -> do
+                (exitCode, _, _) <-
+                    readCreateProcessWithExitCode
+                        (proc "/bin/sh"
+                            [ "-c"
+                            , "kill -0 \"$1\" >/dev/null 2>&1"
+                            , "sh"
+                            , pid
+                            ])
+                        ""
+                pure (exitCode == ExitSuccess)
 
 shellQuote :: String -> String
 shellQuote value = "'" <> concatMap escape value <> "'"

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -28,6 +28,7 @@ import System.Directory
     ( createDirectory
     , doesDirectoryExist
     , doesFileExist
+    , findExecutable
     , getTemporaryDirectory
     , removeFile
     , removePathForcibly
@@ -219,7 +220,7 @@ spec = describe "repository review service" do
                 link = root <> "/pipe-link"
             createNamedPipe untrackedPipe
                 (ownerReadMode `unionFileModes` ownerWriteMode)
-            blocked <- timeout 2_000_000 (repositorySnapshot root)
+            blocked <- timeout 10_000_000 (repositorySnapshot root)
             blocked `shouldSatisfy` \case
                 Just (Left (InvalidRepositoryRequest _)) -> True
                 Just (Right _) -> True
@@ -229,7 +230,7 @@ spec = describe "repository review service" do
             createNamedPipe hiddenPipe
                 (ownerReadMode `unionFileModes` ownerWriteMode)
             createSymbolicLink ".git/hidden-pipe" link
-            linked <- timeout 2_000_000 (repositorySnapshot root)
+            linked <- timeout 10_000_000 (repositorySnapshot root)
             linked `shouldSatisfy` \case
                 Just (Right snapshot) ->
                     any
@@ -238,7 +239,7 @@ spec = describe "repository review service" do
                 _ -> False
             case linked of
                 Just (Right snapshot) ->
-                    timeout 2_000_000
+                    timeout 10_000_000
                         (repositoryDiff
                             root
                             snapshot.snapshotId
@@ -283,8 +284,9 @@ spec = describe "repository review service" do
                         <> "fcntl.flock(f,fcntl.LOCK_EX);"
                         <> "open(" <> show readyPath <> ",'w').close();"
                         <> "time.sleep(30)"
+            python <- requireExecutable "python3"
             (_, _, _, locker) <-
-                createProcess (proc "/usr/bin/python3" ["-c", script])
+                createProcess (proc python ["-c", script])
             _ <- awaitFileContents readyPath 200
             pending <- async (repositorySnapshot root)
             blocked <- timeout 200_000 (waitCatch pending)
@@ -559,6 +561,8 @@ spec = describe "repository review service" do
     it "drains large stdout and stderr streams without pipe deadlock" $
         withRepository \root -> do
             snapshot <- expectRight =<< repositorySnapshot root
+            yes <- requireExecutable "yes"
+            headCommand <- requireExecutable "head"
             byteCounts <- newIORef (0, 0)
             terminal <- newEmptyMVar
             check <- expectRight
@@ -567,8 +571,10 @@ spec = describe "repository review service" do
                     snapshot.snapshotId
                     "/bin/sh"
                     [ "-c"
-                    , "/usr/bin/yes o | /usr/bin/head -c 1048576; "
-                        <> "/usr/bin/yes e | /usr/bin/head -c 1048576 >&2"
+                    , shellQuote yes <> " o | "
+                        <> shellQuote headCommand <> " -c 1048576; "
+                        <> shellQuote yes <> " e | "
+                        <> shellQuote headCommand <> " -c 1048576 >&2"
                     ]
                     (\stream bytes ->
                         atomicModifyIORef' byteCounts \(out, err) ->
@@ -617,10 +623,10 @@ spec = describe "repository review service" do
                     [ "-c"
                     , "/bin/sh -c 'trap \"\" TERM; echo $$ > "
                         <> shellQuote pidFile
-                        <> "; exec /bin/sleep 30' & "
+                        <> "; exec sleep 30' & "
                         <> "while [ ! -s "
                         <> shellQuote pidFile
-                        <> " ]; do /bin/sleep 0.01; done; exit 0"
+                        <> " ]; do sleep 0.01; done; exit 0"
                     ]
                     (\_ _ -> pure ())
                     (\cancelled exitCode ->
@@ -641,8 +647,9 @@ spec = describe "repository review service" do
                     (StagePath "tracked.txt")
             let pidFile = root <> "/completed-hook-child.pid"
                 hook = root <> "/.git/hooks/pre-commit"
+            python <- requireExecutable "python3"
             writeFile hook
-                ( "#!/usr/bin/python3\n"
+                ( "#!" <> python <> "\n"
                     <> "import os, signal, time\n"
                     <> "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
                     <> "pid = os.fork()\n"
@@ -658,7 +665,7 @@ spec = describe "repository review service" do
                     `unionFileModes` ownerWriteMode
                     `unionFileModes` ownerExecuteMode)
 
-            result <- timeout 5_000_000
+            result <- timeout 20_000_000
                 (commitRepository root staged.snapshotId "completed hook\n")
             result `shouldSatisfy` \case
                 Just (Right _) -> True
@@ -681,7 +688,7 @@ spec = describe "repository review service" do
                     <> "trap '' TERM\n"
                     <> "/bin/sh -c 'trap \"\" TERM; echo $$ > "
                     <> shellQuote pidFile
-                    <> "; exec /bin/sleep 30' &\n"
+                    <> "; exec sleep 30' &\n"
                     <> "wait\n"
                 )
             setFileMode hook
@@ -710,7 +717,7 @@ spec = describe "repository review service" do
                     "/bin/sh"
                     [ "-c"
                     , "trap '' TERM; "
-                        <> "(trap '' TERM; exec /bin/sleep 30) & wait"
+                        <> "(trap '' TERM; exec sleep 30) & wait"
                     ]
                     (\_ _ -> pure ())
                     (\cancelled exitCode -> do
@@ -793,9 +800,22 @@ processExists :: Text.Text -> IO Bool
 processExists pid = do
     (exitCode, _, _) <-
         readCreateProcessWithExitCode
-            (proc "/bin/kill" ["-0", Text.unpack pid])
+            (proc "/bin/sh"
+                [ "-c"
+                , "kill -0 \"$1\" >/dev/null 2>&1"
+                , "sh"
+                , Text.unpack pid
+                ])
             ""
     pure (exitCode == ExitSuccess)
+
+requireExecutable :: String -> IO FilePath
+requireExecutable name =
+    findExecutable name >>= \case
+        Just executable -> pure executable
+        Nothing ->
+            expectationFailure (name <> " executable not found")
+                >> fail "unreachable"
 
 awaitProcessGone :: Text.Text -> Int -> IO Bool
 awaitProcessGone pid attempts =

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -38,7 +38,8 @@ import Agent.Subagents
     , newSubagentRegistry
     )
 import Agent.Subagents.TaskPath (parseTaskPath)
-import Agent.Tools.MultiAgents (CollaborationSpawnOptions(..))
+import Agent.Tools.MultiAgents
+    (CollaborationModelTarget(..), CollaborationSpawnOptions(..))
 import Control.Concurrent.Async (mapConcurrently, wait, withAsync)
 import Control.Concurrent.MVar
     ( newEmptyMVar
@@ -86,6 +87,7 @@ spec = describe "Agent.CLI.SubagentStore" do
                 agentId
                 CollaborationSpawnOptions
                     { collaborationModel = Nothing
+                    , collaborationResolvedModel = Nothing
                     , collaborationReasoningEffort = Nothing
                     , collaborationForkTurns = Nothing
                     }
@@ -123,6 +125,7 @@ spec = describe "Agent.CLI.SubagentStore" do
                 agentId
                 CollaborationSpawnOptions
                     { collaborationModel = Nothing
+                    , collaborationResolvedModel = Nothing
                     , collaborationReasoningEffort = Nothing
                     , collaborationForkTurns = Just "3"
                     }
@@ -137,6 +140,45 @@ spec = describe "Agent.CLI.SubagentStore" do
                 Nothing
                 Nothing
                 `shouldBe` ("gpt-5.6-luna", "high")
+
+        it "uses an authoritative resolved target for collaboration overrides" do
+            sessionsRef <- newIORef Map.empty
+            storeRootRef <- newIORef Nothing
+            typesRef <- newIORef Map.empty
+            forkSourceRef <- newIORef Nothing
+            let agentId = SubagentId "agent-gateway-target"
+            prepareCollaborationSpawn
+                OpenAIProvider
+                "openai"
+                (const "incorrect-wire-model")
+                "parent-model"
+                "medium"
+                CodexDialect
+                Nothing
+                sessionsRef
+                storeRootRef
+                typesRef
+                forkSourceRef
+                agentId
+                CollaborationSpawnOptions
+                    { collaborationModel = Just "company-model"
+                    , collaborationResolvedModel =
+                        Just CollaborationModelTarget
+                            { collaborationTargetProvider = OpenAIProvider
+                            , collaborationTargetConnection = "openai"
+                            , collaborationTargetEffectiveModel =
+                                "company-model"
+                            , collaborationTargetDialect =
+                                GenericResponsesDialect
+                            }
+                    , collaborationReasoningEffort = Nothing
+                    , collaborationForkTurns = Just "none"
+                    }
+            Just session <- Map.lookup agentId <$> readIORef sessionsRef
+            session.subSessionProvider `shouldBe` OpenAIProvider
+            session.subSessionConnection `shouldBe` "openai"
+            session.subSessionEffectiveModel `shouldBe` "company-model"
+            session.subSessionDialect `shouldBe` GenericResponsesDialect
 
         it "keeps an explicit child model override" do
             let rootParams =
@@ -277,6 +319,7 @@ spec = describe "Agent.CLI.SubagentStore" do
                             storeRootRef
                             registry
                             sessionsRef
+                            Nothing
                             typesRef
                             agentId
                             `shouldReturn` Right ()
@@ -287,6 +330,60 @@ spec = describe "Agent.CLI.SubagentStore" do
                         session.subSessionEffectiveModel
                             `shouldBe` "gpt-5.6-luna"
                         session.subSessionDialect `shouldBe` CodexDialect
+
+        it "restores gateway child metadata through the live resolver" do
+            withTempDir \dir -> do
+                let agentId = SubagentId "agent-gateway-restored"
+                    resolved = CollaborationModelTarget
+                        { collaborationTargetProvider = OpenAIProvider
+                        , collaborationTargetConnection = "openai"
+                        , collaborationTargetEffectiveModel = "company-model"
+                        , collaborationTargetDialect =
+                            GenericResponsesDialect
+                        }
+                    snapshot =
+                        (testSnapshot
+                            [messageItem RoleUser "gateway"]
+                            (Completed (Just "OK"))
+                            OpenAIProvider
+                            "openai"
+                            "company-model"
+                            GenericResponsesDialect)
+                            { snapshotAgentModel = Just "company-model" }
+                saveSubagentState dir agentId snapshot `shouldReturn` Right ()
+                sessionsRef <- newIORef Map.empty
+                storeRootRef <- newIORef (Just dir)
+                typesRef <- newIORef Map.empty
+                bracket
+                    (newSubagentRegistry defaultSubagentConfig dir
+                        (\_ _ _ _ -> fail "unexpected subagent runner invocation")
+                        (\_ _ -> pure ()))
+                    closeSubagentRegistry
+                    \registry -> do
+                        restoreAgentFromDisk
+                            OpenAIProvider
+                            "openai"
+                            id
+                            "parent-model"
+                            CodexDialect
+                            Nothing
+                            storeRootRef
+                            registry
+                            sessionsRef
+                            (Just \model ->
+                                pure
+                                    (if model == "company-model"
+                                        then Just resolved
+                                        else Nothing))
+                            typesRef
+                            agentId
+                            `shouldReturn` Right ()
+                        Just session <-
+                            Map.lookup agentId <$> readIORef sessionsRef
+                        session.subSessionEffectiveModel
+                            `shouldBe` "company-model"
+                        session.subSessionDialect
+                            `shouldBe` GenericResponsesDialect
 
     it "round-trips transcript items and meta" do
         withTempDir \dir -> do
@@ -778,6 +875,7 @@ restoreTestAgent storeRootRef registry sessionsRef typesRef agentId =
         storeRootRef
         registry
         sessionsRef
+        Nothing
         typesRef
         agentId
 

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.SubagentStoreSpec (spec) where
 
 import Agent.CLI.Compaction (estimatedOccupancy)
+import Agent.CLI.ModelConfig (organizationGatewayConnectionId)
 import Agent.CLI.SubagentStore
 import Agent.CLI.Session (LegacySubagentTarget(..))
 import Agent.Dialect (DialectId(..))
@@ -336,7 +337,8 @@ spec = describe "Agent.CLI.SubagentStore" do
                 let agentId = SubagentId "agent-gateway-restored"
                     resolved = CollaborationModelTarget
                         { collaborationTargetProvider = OpenAIProvider
-                        , collaborationTargetConnection = "openai"
+                        , collaborationTargetConnection =
+                            organizationGatewayConnectionId
                         , collaborationTargetEffectiveModel = "company-model"
                         , collaborationTargetDialect =
                             GenericResponsesDialect
@@ -346,7 +348,7 @@ spec = describe "Agent.CLI.SubagentStore" do
                             [messageItem RoleUser "gateway"]
                             (Completed (Just "OK"))
                             OpenAIProvider
-                            "openai"
+                            organizationGatewayConnectionId
                             "company-model"
                             GenericResponsesDialect)
                             { snapshotAgentModel = Just "company-model" }
@@ -380,6 +382,8 @@ spec = describe "Agent.CLI.SubagentStore" do
                             `shouldReturn` Right ()
                         Just session <-
                             Map.lookup agentId <$> readIORef sessionsRef
+                        session.subSessionConnection
+                            `shouldBe` organizationGatewayConnectionId
                         session.subSessionEffectiveModel
                             `shouldBe` "company-model"
                         session.subSessionDialect

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -351,6 +351,7 @@ spec = describe "schemasFromAppTools" do
                         , multiSendToRoot = Nothing
                         , multiSpawnModelGuidance = Nothing
                         , multiAllowedChildModels = Nothing
+                        , multiResolveChildModel = Nothing
                         , multiChildModelAllowed = Nothing
                         }
                     schemas =

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -351,6 +351,7 @@ spec = describe "schemasFromAppTools" do
                         , multiSendToRoot = Nothing
                         , multiSpawnModelGuidance = Nothing
                         , multiAllowedChildModels = Nothing
+                        , multiChildModelAllowed = Nothing
                         }
                     schemas =
                         schemasFromAppTools

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -15,6 +15,7 @@ import qualified Agent.CLI.BtwSpec as BtwSpec
 import qualified Agent.CLI.BrowserToolsSpec as BrowserToolsSpec
 import qualified Agent.CLI.CancelWatchSpec as CancelWatchSpec
 import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
+import qualified Agent.CLI.ClaudeGatewayProxySpec as ClaudeGatewayProxySpec
 import qualified Agent.CLI.ClaudeSpec as ClaudeSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
 import qualified Agent.CLI.ComputerUseSpec as ComputerUseSpec
@@ -117,6 +118,7 @@ main = hspec do
 #endif
     CancelWatchSpec.spec
     ClipboardSpec.spec
+    ClaudeGatewayProxySpec.spec
     ClaudeSpec.spec
     CommandSpec.spec
     ComputerUseSpec.spec

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -4,6 +4,7 @@
 -- @codex-rs/core/src/tools/handlers/multi_agents_spec.rs@ (v2).
 module Agent.Tools.MultiAgents
     ( MultiAgentContext(..)
+    , CollaborationModelTarget(..)
     , CollaborationSpawnOptions(..)
     , SubagentWorktree(..)
     , multiAgentTools
@@ -44,6 +45,8 @@ import Agent.InterAgentMessage
     , plainInterAgentContent
     )
 import Agent.OsPath (toText)
+import Agent.Dialect (DialectId)
+import Agent.Provider (Provider)
 import System.OsPath (OsPath)
 import Agent.ToolArgs
     ( objectArgs
@@ -85,8 +88,16 @@ data SubagentWorktree = SubagentWorktree
     , subagentWorktreeCleanup :: !(IO (Either Text ()))
     }
 
+data CollaborationModelTarget = CollaborationModelTarget
+    { collaborationTargetProvider :: !Provider
+    , collaborationTargetConnection :: !Text
+    , collaborationTargetEffectiveModel :: !Text
+    , collaborationTargetDialect :: !DialectId
+    } deriving (Eq, Show)
+
 data CollaborationSpawnOptions = CollaborationSpawnOptions
     { collaborationModel :: !(Maybe Text)
+    , collaborationResolvedModel :: !(Maybe CollaborationModelTarget)
     , collaborationReasoningEffort :: !(Maybe Text)
     , collaborationForkTurns :: !(Maybe Text)
     } deriving (Eq, Show)
@@ -114,6 +125,11 @@ data MultiAgentContext = MultiAgentContext
     , multiSpawnModelGuidance :: !(Maybe Text)
       -- | When set, spawn_subagent may only use these model slugs (or inherit).
     , multiAllowedChildModels :: !(Maybe [Text])
+      -- | Optional live resolver for organization-scoped model aliases.
+      -- Unknown explicit aliases are denied and resolved transport metadata is
+      -- carried atomically into spawn preparation.
+    , multiResolveChildModel
+        :: !(Maybe (Text -> IO (Maybe CollaborationModelTarget)))
       -- | Optional live policy used instead of the advertised snapshot above.
       -- This lets hosts enforce organization catalog refreshes without
       -- rebuilding every tool definition in an active session.
@@ -243,17 +259,15 @@ runSpawn ctx workspace call args
             \set fork_turns to none or a positive integer when overriding \
             \model or reasoning_effort")
     | otherwise = do
-        modelAllowed <- childModelOverrideAllowed ctx args.model
-        if not modelAllowed
-            then
-                pure
-                    (Left
-                        "The requested child model is not allowed by this organization.")
-            else mask \restore ->
+        resolveChildModelOverride ctx args.model >>= \case
+            Left err -> pure (Left err)
+            Right resolvedModel -> mask \restore ->
                 resolveSpawnWorkspace ctx workspace >>= \case
                     Left err -> pure (Left err)
                     Right (childCwd, worktree) ->
-                        restore (spawnInWorkspace ctx call args childCwd worktree)
+                        restore
+                            (spawnInWorkspace
+                                ctx call args resolvedModel childCwd worktree)
 
 -- | Spawn a tracked child in the caller's shared workspace.
 --
@@ -293,14 +307,16 @@ spawnInWorkspace
     :: MultiAgentContext
     -> ToolCall
     -> SpawnAgentArgs
+    -> Maybe CollaborationModelTarget
     -> OsPath
     -> Maybe SubagentWorktree
     -> IO (Either Text Text)
-spawnInWorkspace ctx call args childCwd worktree = mask \restore -> do
+spawnInWorkspace ctx call args resolvedModel childCwd worktree = mask \restore -> do
     ownedWorktree <- traverse makeIdempotentWorktree worktree
     rootTurnId <- ctx.multiRootTurnId
     let spawnOptions = CollaborationSpawnOptions
             { collaborationModel = sanitizeOverride args.model
+            , collaborationResolvedModel = resolvedModel
             , collaborationReasoningEffort =
                 sanitizeOverride args.reasoningEffort
             , collaborationForkTurns = normalizeForkTurns args.forkTurns
@@ -415,21 +431,34 @@ allowedModelOverride allowed override =
                 (elem requested . map Text.strip)
                 allowed
 
-childModelOverrideAllowed
+resolveChildModelOverride
     :: MultiAgentContext
     -> Maybe Text
-    -> IO Bool
-childModelOverrideAllowed ctx override =
+    -> IO (Either Text (Maybe CollaborationModelTarget))
+resolveChildModelOverride ctx override =
     case sanitizeOverride override of
-        Nothing -> pure True
+        Nothing -> pure (Right Nothing)
         Just requested ->
-            case ctx.multiChildModelAllowed of
-                Just isAllowed -> isAllowed requested
-                Nothing ->
+            case ctx.multiResolveChildModel of
+                Just resolve ->
+                    resolve requested >>= \case
+                        Nothing -> pure (Left notAllowed)
+                        Just target -> pure (Right (Just target))
+                Nothing -> do
+                    allowed <- case ctx.multiChildModelAllowed of
+                        Just isAllowed -> isAllowed requested
+                        Nothing ->
+                            pure
+                                (allowedModelOverride
+                                    ctx.multiAllowedChildModels
+                                    (Just requested))
                     pure
-                        (allowedModelOverride
-                            ctx.multiAllowedChildModels
-                            (Just requested))
+                        (if allowed
+                            then Right Nothing
+                            else Left notAllowed)
+  where
+    notAllowed =
+        "The requested child model is not allowed by this organization."
 
 allowedModelGuidance :: Maybe [Text] -> [Text]
 allowedModelGuidance = \case

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -114,6 +114,10 @@ data MultiAgentContext = MultiAgentContext
     , multiSpawnModelGuidance :: !(Maybe Text)
       -- | When set, spawn_subagent may only use these model slugs (or inherit).
     , multiAllowedChildModels :: !(Maybe [Text])
+      -- | Optional live policy used instead of the advertised snapshot above.
+      -- This lets hosts enforce organization catalog refreshes without
+      -- rebuilding every tool definition in an active session.
+    , multiChildModelAllowed :: !(Maybe (Text -> IO Bool))
     }
 
 multiAgentNamespace :: Text
@@ -238,15 +242,18 @@ runSpawn ctx workspace call args
             "full-history forks inherit the parent model and reasoning effort; \
             \set fork_turns to none or a positive integer when overriding \
             \model or reasoning_effort")
-    | not (allowedModelOverride ctx.multiAllowedChildModels args.model) =
-        pure
-            (Left
-                "The requested child model is not allowed by this organization.")
-    | otherwise = mask \restore ->
-        resolveSpawnWorkspace ctx workspace >>= \case
-            Left err -> pure (Left err)
-            Right (childCwd, worktree) ->
-                restore (spawnInWorkspace ctx call args childCwd worktree)
+    | otherwise = do
+        modelAllowed <- childModelOverrideAllowed ctx args.model
+        if not modelAllowed
+            then
+                pure
+                    (Left
+                        "The requested child model is not allowed by this organization.")
+            else mask \restore ->
+                resolveSpawnWorkspace ctx workspace >>= \case
+                    Left err -> pure (Left err)
+                    Right (childCwd, worktree) ->
+                        restore (spawnInWorkspace ctx call args childCwd worktree)
 
 -- | Spawn a tracked child in the caller's shared workspace.
 --
@@ -407,6 +414,22 @@ allowedModelOverride allowed override =
                 True
                 (elem requested . map Text.strip)
                 allowed
+
+childModelOverrideAllowed
+    :: MultiAgentContext
+    -> Maybe Text
+    -> IO Bool
+childModelOverrideAllowed ctx override =
+    case sanitizeOverride override of
+        Nothing -> pure True
+        Just requested ->
+            case ctx.multiChildModelAllowed of
+                Just isAllowed -> isAllowed requested
+                Nothing ->
+                    pure
+                        (allowedModelOverride
+                            ctx.multiAllowedChildModels
+                            (Just requested))
 
 allowedModelGuidance :: Maybe [Text] -> [Text]
 allowedModelGuidance = \case

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -197,7 +197,8 @@ spawnAgentParameters ctx encryptMessage =
             [ "Model override for the new agent. Omit unless an explicit override is needed."
             , "Model or reasoning-effort overrides require `fork_turns` to be `none` or a positive integer."
             ]
-                <> maybe [] pure ctx.multiSpawnModelGuidance)
+                <> maybe [] pure ctx.multiSpawnModelGuidance
+                <> allowedModelGuidance ctx.multiAllowedChildModels)
     , PropertySchema "reasoning_effort" PropertyString False $ Just
         "Reasoning effort override for the new agent. Omit to inherit the parent effort. Overrides require `fork_turns` to be `none` or a positive integer."
     , PropertySchema "fork_turns" PropertyString False $ Just
@@ -237,6 +238,10 @@ runSpawn ctx workspace call args
             "full-history forks inherit the parent model and reasoning effort; \
             \set fork_turns to none or a positive integer when overriding \
             \model or reasoning_effort")
+    | not (allowedModelOverride ctx.multiAllowedChildModels args.model) =
+        pure
+            (Left
+                "The requested child model is not allowed by this organization.")
     | otherwise = mask \restore ->
         resolveSpawnWorkspace ctx workspace >>= \case
             Left err -> pure (Left err)
@@ -392,6 +397,31 @@ sanitizeOverride :: Maybe Text -> Maybe Text
 sanitizeOverride value = value >>= \raw ->
     let stripped = Text.strip raw
     in if Text.null stripped then Nothing else Just stripped
+
+allowedModelOverride :: Maybe [Text] -> Maybe Text -> Bool
+allowedModelOverride allowed override =
+    case sanitizeOverride override of
+        Nothing -> True
+        Just requested ->
+            maybe
+                True
+                (elem requested . map Text.strip)
+                allowed
+
+allowedModelGuidance :: Maybe [Text] -> [Text]
+allowedModelGuidance = \case
+    Nothing -> []
+    Just rawAllowed ->
+        let allowed = filter (not . Text.null) (map Text.strip rawAllowed)
+            rendered =
+                if null allowed
+                    then "(none)"
+                    else Text.intercalate ", " allowed
+        in
+            [ "Allowed child model IDs: "
+                <> rendered
+                <> ". Omit to inherit the parent model."
+            ]
 
 normalizeForkTurns :: Maybe Text -> Maybe Text
 normalizeForkTurns value =

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -213,7 +213,7 @@ spec = describe "Agent.Tools.MultiAgents" do
                 , name = "spawn_agent"
                 , arguments =
                     "{\"task_name\":\"worker\",\"message\":\"task\",\
-                    \\"model\":\"gpt-denied\"}"
+                    \\"model\":\"gpt-denied\",\"fork_turns\":\"none\"}"
                 , callKind = FunctionCallKind
                 , argumentsEncrypted = False
                 }
@@ -251,7 +251,7 @@ spec = describe "Agent.Tools.MultiAgents" do
                 "task"
                 (Just " gpt-allowed ")
                 Nothing
-                Nothing
+                (Just "none")
         result `shouldSatisfy` isRightResult
         options <- atomically (takeTMVar prepared)
         options.collaborationModel `shouldBe` Just "gpt-allowed"
@@ -280,7 +280,7 @@ spec = describe "Agent.Tools.MultiAgents" do
         denied <-
             spawnSharedSubagent
                 context call "worker" "task"
-                (Just "company-b") Nothing Nothing
+                (Just "company-b") Nothing (Just "none")
         denied
             `shouldBe`
                 Left
@@ -289,7 +289,7 @@ spec = describe "Agent.Tools.MultiAgents" do
         accepted <-
             spawnSharedSubagent
                 context call "worker" "task"
-                (Just "company-b") Nothing Nothing
+                (Just "company-b") Nothing (Just "none")
         accepted `shouldSatisfy` isRightResult
         options <- atomically (takeTMVar prepared)
         options.collaborationModel `shouldBe` Just "company-b"

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -189,6 +189,136 @@ spec = describe "Agent.Tools.MultiAgents" do
             any (Text.isInfixOf "Prefer `gpt-5.6-luna` for small tasks.")
         closeSubagentRegistry registry
 
+    it "advertises and enforces the allowed child-model list" do
+        prepared <- newEmptyTMVarIO
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))
+            (\_ _ -> pure ())
+        let context = (rootContext registry Nothing)
+                { multiAllowedChildModels = Just ["gpt-allowed"]
+                , multiPrepareSpawn = Just
+                    (\_ options -> atomically (putTMVar prepared options))
+                }
+            tools = multiAgentTools context
+            descriptions =
+                [ description
+                | tool <- tools
+                , tool.appToolName == "spawn_agent"
+                , property <- fromMaybe [] (jsonToolParameters tool)
+                , property.propertyName == "model"
+                , description <- maybe [] pure property.description
+                ]
+            denied = ToolCall
+                { callId = "denied-model"
+                , name = "spawn_agent"
+                , arguments =
+                    "{\"task_name\":\"worker\",\"message\":\"task\",\
+                    \\"model\":\"gpt-denied\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        descriptions `shouldSatisfy`
+            any (Text.isInfixOf "Allowed child model IDs: gpt-allowed.")
+        result <- dispatchToolCall defaultLoopDispatch (appToolHandlers tools) denied
+        result.output
+            `shouldBe`
+                "Error: The requested child model is not allowed by this organization."
+        atomically (isEmptyTMVar prepared) `shouldReturn` True
+        closeSubagentRegistry registry
+
+    it "allows a listed child-model override under an allowlist" do
+        prepared <- newEmptyTMVarIO
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))
+            (\_ _ -> pure ())
+        let context = (rootContext registry Nothing)
+                { multiAllowedChildModels = Just ["gpt-allowed"]
+                , multiPrepareSpawn = Just
+                    (\_ options -> atomically (putTMVar prepared options))
+                }
+            call = ToolCall
+                { callId = "listed-model"
+                , name = "host-tool"
+                , arguments = "{}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <-
+            spawnSharedSubagent
+                context
+                call
+                "worker"
+                "task"
+                (Just " gpt-allowed ")
+                Nothing
+                Nothing
+        result `shouldSatisfy` isRightResult
+        options <- atomically (takeTMVar prepared)
+        options.collaborationModel `shouldBe` Just "gpt-allowed"
+        closeSubagentRegistry registry
+
+    it "allows an inherited child model under an allowlist" do
+        prepared <- newEmptyTMVarIO
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))
+            (\_ _ -> pure ())
+        let context = (rootContext registry Nothing)
+                { multiAllowedChildModels = Just ["gpt-allowed"]
+                , multiPrepareSpawn = Just
+                    (\_ options -> atomically (putTMVar prepared options))
+                }
+            call = ToolCall
+                { callId = "inherit-allowed"
+                , name = "host-tool"
+                , arguments = "{}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <-
+            spawnSharedSubagent
+                context
+                call
+                "worker"
+                "task"
+                Nothing
+                Nothing
+                Nothing
+        result `shouldSatisfy` isRightResult
+        options <- atomically (takeTMVar prepared)
+        options.collaborationModel `shouldBe` Nothing
+        closeSubagentRegistry registry
+
+    it "treats a blank child-model override as inheritance under an allowlist" do
+        prepared <- newEmptyTMVarIO
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))
+            (\_ _ -> pure ())
+        let context = (rootContext registry Nothing)
+                { multiAllowedChildModels = Just ["gpt-allowed"]
+                , multiPrepareSpawn = Just
+                    (\_ options -> atomically (putTMVar prepared options))
+                }
+            call = ToolCall
+                { callId = "blank-inherit"
+                , name = "host-tool"
+                , arguments = "{}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        result <-
+            spawnSharedSubagent
+                context
+                call
+                "worker"
+                "task"
+                (Just "   ")
+                Nothing
+                Nothing
+        result `shouldSatisfy` isRightResult
+        options <- atomically (takeTMVar prepared)
+        options.collaborationModel `shouldBe` Nothing
+        closeSubagentRegistry registry
+
     it "keeps isolation off spawn_agent and exposes a dedicated worktree tool" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -257,6 +257,44 @@ spec = describe "Agent.Tools.MultiAgents" do
         options.collaborationModel `shouldBe` Just "gpt-allowed"
         closeSubagentRegistry registry
 
+    it "enforces refreshed child-model policy without rebuilding tools" do
+        prepared <- newEmptyTMVarIO
+        currentModels <- newIORef ["company-a"]
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))
+            (\_ _ -> pure ())
+        let context = (rootContext registry Nothing)
+                { multiAllowedChildModels = Just ["company-a"]
+                , multiChildModelAllowed = Just
+                    (\model -> elem model <$> readIORef currentModels)
+                , multiPrepareSpawn = Just
+                    (\_ options -> atomically (putTMVar prepared options))
+                }
+            call = ToolCall
+                { callId = "refreshed-policy"
+                , name = "host-tool"
+                , arguments = "{}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+        denied <-
+            spawnSharedSubagent
+                context call "worker" "task"
+                (Just "company-b") Nothing Nothing
+        denied
+            `shouldBe`
+                Left
+                    "The requested child model is not allowed by this organization."
+        writeIORef currentModels ["company-b"]
+        accepted <-
+            spawnSharedSubagent
+                context call "worker" "task"
+                (Just "company-b") Nothing Nothing
+        accepted `shouldSatisfy` isRightResult
+        options <- atomically (takeTMVar prepared)
+        options.collaborationModel `shouldBe` Just "company-b"
+        closeSubagentRegistry registry
+
     it "allows an inherited child model under an allowlist" do
         prepared <- newEmptyTMVarIO
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
@@ -635,6 +673,7 @@ spec = describe "Agent.Tools.MultiAgents" do
                 , multiSendToRoot = Just deliverRoot
                 , multiSpawnModelGuidance = Nothing
                 , multiAllowedChildModels = Nothing
+                , multiChildModelAllowed = Nothing
                 }
         result <- dispatchToolCall defaultLoopDispatch
             (appToolHandlers (multiAgentTools context))
@@ -673,6 +712,7 @@ rootContext registry sendToRoot = MultiAgentContext
     , multiSendToRoot = sendToRoot
     , multiSpawnModelGuidance = Nothing
     , multiAllowedChildModels = Nothing
+    , multiChildModelAllowed = Nothing
     }
 
 childContext :: SubagentRegistry -> SubagentId -> Int -> IO MultiAgentContext

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -1,6 +1,7 @@
 module Agent.Tools.MultiAgentsSpec (spec) where
 
 import Agent.InterAgentMessage
+import Agent.Dialect (DialectId(..))
 import Agent.Loop
     ( LoopError(..)
     , LoopResult(..)
@@ -10,6 +11,7 @@ import Agent.Loop
 import System.OsPath (unsafeEncodeUtf)
 import Agent.Subagents
 import Agent.Subagents.TaskPath (joinTaskPath, taskPathRoot, taskPathText)
+import Agent.Provider (Provider(..))
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
@@ -108,6 +110,7 @@ spec = describe "Agent.Tools.MultiAgents" do
             `shouldBe` Just "/root/artifact_analysis"
         options `shouldBe` CollaborationSpawnOptions
             { collaborationModel = Just "gpt-5.6-luna"
+            , collaborationResolvedModel = Nothing
             , collaborationReasoningEffort = Just "high"
             , collaborationForkTurns = Just "none"
             }
@@ -141,6 +144,7 @@ spec = describe "Agent.Tools.MultiAgents" do
         options <- atomically (takeTMVar prepared)
         options `shouldBe` CollaborationSpawnOptions
             { collaborationModel = Nothing
+            , collaborationResolvedModel = Nothing
             , collaborationReasoningEffort = Nothing
             , collaborationForkTurns = Just "none"
             }
@@ -259,14 +263,20 @@ spec = describe "Agent.Tools.MultiAgents" do
 
     it "enforces refreshed child-model policy without rebuilding tools" do
         prepared <- newEmptyTMVarIO
-        currentModels <- newIORef ["company-a"]
+        resolverCalls <- newIORef (0 :: Int)
+        currentModels <- newIORef
+            [ ("company-a", CollaborationModelTarget
+                OpenAIProvider "openai" "company-a" CodexDialect)
+            ]
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))
             (\_ _ -> pure ())
         let context = (rootContext registry Nothing)
                 { multiAllowedChildModels = Just ["company-a"]
-                , multiChildModelAllowed = Just
-                    (\model -> elem model <$> readIORef currentModels)
+                , multiResolveChildModel = Just
+                    (\model -> do
+                        modifyIORef' resolverCalls (+ 1)
+                        lookup model <$> readIORef currentModels)
                 , multiPrepareSpawn = Just
                     (\_ options -> atomically (putTMVar prepared options))
                 }
@@ -285,7 +295,12 @@ spec = describe "Agent.Tools.MultiAgents" do
             `shouldBe`
                 Left
                     "The requested child model is not allowed by this organization."
-        writeIORef currentModels ["company-b"]
+        let companyB = CollaborationModelTarget
+                OpenAIProvider
+                "openai"
+                "company-b"
+                GenericResponsesDialect
+        writeIORef currentModels [("company-b", companyB)]
         accepted <-
             spawnSharedSubagent
                 context call "worker" "task"
@@ -293,6 +308,8 @@ spec = describe "Agent.Tools.MultiAgents" do
         accepted `shouldSatisfy` isRightResult
         options <- atomically (takeTMVar prepared)
         options.collaborationModel `shouldBe` Just "company-b"
+        options.collaborationResolvedModel `shouldBe` Just companyB
+        readIORef resolverCalls `shouldReturn` 2
         closeSubagentRegistry registry
 
     it "allows an inherited child model under an allowlist" do
@@ -424,6 +441,7 @@ spec = describe "Agent.Tools.MultiAgents" do
         options <- atomically (takeTMVar prepared)
         options `shouldBe` CollaborationSpawnOptions
             { collaborationModel = Just "gpt-test"
+            , collaborationResolvedModel = Nothing
             , collaborationReasoningEffort = Just "high"
             , collaborationForkTurns = Just "3"
             }
@@ -673,6 +691,7 @@ spec = describe "Agent.Tools.MultiAgents" do
                 , multiSendToRoot = Just deliverRoot
                 , multiSpawnModelGuidance = Nothing
                 , multiAllowedChildModels = Nothing
+                , multiResolveChildModel = Nothing
                 , multiChildModelAllowed = Nothing
                 }
         result <- dispatchToolCall defaultLoopDispatch
@@ -712,6 +731,7 @@ rootContext registry sendToRoot = MultiAgentContext
     , multiSendToRoot = sendToRoot
     , multiSpawnModelGuidance = Nothing
     , multiAllowedChildModels = Nothing
+    , multiResolveChildModel = Nothing
     , multiChildModelAllowed = Nothing
     }
 

--- a/packages/agent-grok-build-dialect/benchmark/WorkflowSnapshots.hs
+++ b/packages/agent-grok-build-dialect/benchmark/WorkflowSnapshots.hs
@@ -101,4 +101,5 @@ main =
         , multiSendToRoot = Nothing
         , multiSpawnModelGuidance = Nothing
         , multiAllowedChildModels = Nothing
+        , multiChildModelAllowed = Nothing
         }

--- a/packages/agent-grok-build-dialect/benchmark/WorkflowSnapshots.hs
+++ b/packages/agent-grok-build-dialect/benchmark/WorkflowSnapshots.hs
@@ -101,5 +101,6 @@ main =
         , multiSendToRoot = Nothing
         , multiSpawnModelGuidance = Nothing
         , multiAllowedChildModels = Nothing
+        , multiResolveChildModel = Nothing
         , multiChildModelAllowed = Nothing
         }

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
@@ -224,7 +224,7 @@ sanitizeOptional value = value >>= \raw ->
 
 taskTool :: OsPath -> MultiAgentContext -> GrokSubagentSpecs -> AppTool
 taskTool baseCwd ctx specsRef =
-    jsonAppToolWithExecution "task" (taskDescription ctx.multiAllowedChildModels)
+    jsonAppToolWithExecution "task" (taskDescription advertisedModels)
         [ PropertySchema "prompt" PropertyString True $ Just
             "The full task prompt for the subagent to execute."
         , PropertySchema "description" PropertyString True $ Just
@@ -238,13 +238,18 @@ taskTool baseCwd ctx specsRef =
         , PropertySchema "cwd" PropertyString False $ Just
             "Explicit working directory for the subagent. Mutually exclusive with isolation=\"worktree\"."
         , PropertySchema "model" PropertyString False $ Just
-            (taskModelProperty ctx.multiAllowedChildModels)
+            (taskModelProperty advertisedModels)
         , PropertySchema "isolation" (PropertyEnum ["none", "worktree"]) False $ Just
             "Isolation mode: \"none\" (default, shared workspace) or \"worktree\" (isolated git worktree). Worktree mode prevents child edits from affecting the parent workspace until explicitly applied."
         ]
         (taskApproval ctx)
         TurnSequential
         (typedTool "task" taskArgsDecoder (runTask baseCwd ctx specsRef))
+  where
+    advertisedModels =
+        case ctx.multiChildModelAllowed of
+            Just _ -> Nothing
+            Nothing -> ctx.multiAllowedChildModels
 
 taskApproval :: MultiAgentContext -> ApprovalRule
 taskApproval ctx = case ctx.multiSelfId of
@@ -296,8 +301,8 @@ runTask baseCwd ctx typesRef args
     , Just iso <- args.isolation
     , isWorktreeIsolation iso =
         pure (Left "cwd and isolation are mutually exclusive.")
-    | otherwise =
-        case resolveRequestedGrokChildModel ctx.multiAllowedChildModels args.model of
+    | otherwise = do
+        resolveTaskChildModel ctx args.model >>= \case
             Left err -> pure (Left err)
             Right model -> mask \restore ->
                 resolveTaskWorkspace baseCwd ctx args >>= \case
@@ -310,6 +315,29 @@ runTask baseCwd ctx typesRef args
                                 ctx
                                 typesRef
                                 args { model })
+
+resolveTaskChildModel
+    :: MultiAgentContext
+    -> Maybe Text
+    -> IO (Either Text (Maybe Text))
+resolveTaskChildModel ctx requested =
+    case ctx.multiChildModelAllowed of
+        Nothing ->
+            pure
+                (resolveRequestedGrokChildModel
+                    ctx.multiAllowedChildModels
+                    requested)
+        Just isAllowed ->
+            case sanitizeOptional requested of
+                Nothing -> pure (Right Nothing)
+                Just model ->
+                    isAllowed model >>= \allowed ->
+                        pure
+                            (if allowed
+                                then Right (Just model)
+                                else
+                                    Left
+                                        "The requested child model is not allowed by this organization.")
 
 spawnFresh
     :: OsPath

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
@@ -47,7 +47,12 @@ import Agent.ToolDSL
     , PropertyType(..)
     )
 import Agent.ToolDispatch (typedTool)
-import Agent.Tools.MultiAgents (MultiAgentContext(..), SubagentWorktree(..))
+import Agent.Tools.MultiAgents
+    ( CollaborationModelTarget
+    , CollaborationSpawnOptions(..)
+    , MultiAgentContext(..)
+    , SubagentWorktree(..)
+    )
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
@@ -60,7 +65,7 @@ import Control.Monad (void)
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath (doesDirectoryExist)
@@ -304,7 +309,7 @@ runTask baseCwd ctx typesRef args
     | otherwise = do
         resolveTaskChildModel ctx args.model >>= \case
             Left err -> pure (Left err)
-            Right model -> mask \restore ->
+            Right (model, resolvedModel) -> mask \restore ->
                 resolveTaskWorkspace baseCwd ctx args >>= \case
                     Left err -> pure (Left err)
                     Right (childCwd, worktree) ->
@@ -314,30 +319,42 @@ runTask baseCwd ctx typesRef args
                                 worktree
                                 ctx
                                 typesRef
-                                args { model })
+                                args { model }
+                                resolvedModel)
 
 resolveTaskChildModel
     :: MultiAgentContext
     -> Maybe Text
-    -> IO (Either Text (Maybe Text))
+    -> IO (Either Text (Maybe Text, Maybe CollaborationModelTarget))
 resolveTaskChildModel ctx requested =
-    case ctx.multiChildModelAllowed of
-        Nothing ->
-            pure
-                (resolveRequestedGrokChildModel
-                    ctx.multiAllowedChildModels
-                    requested)
-        Just isAllowed ->
-            case sanitizeOptional requested of
-                Nothing -> pure (Right Nothing)
-                Just model ->
-                    isAllowed model >>= \allowed ->
-                        pure
-                            (if allowed
-                                then Right (Just model)
-                                else
-                                    Left
-                                        "The requested child model is not allowed by this organization.")
+    case sanitizeOptional requested of
+        Nothing -> pure (Right (Nothing, Nothing))
+        Just model ->
+            case ctx.multiResolveChildModel of
+                Just resolve ->
+                    resolve model >>= \case
+                        Nothing -> pure (Left organizationModelDenied)
+                        Just target ->
+                            pure (Right (Just model, Just target))
+                Nothing ->
+                    case ctx.multiChildModelAllowed of
+                        Nothing ->
+                            pure
+                                (fmap
+                                    (\modelOverride ->
+                                        (modelOverride, Nothing))
+                                    (resolveRequestedGrokChildModel
+                                        ctx.multiAllowedChildModels
+                                        (Just model)))
+                        Just isAllowed ->
+                            isAllowed model >>= \allowed ->
+                                pure
+                                    (if allowed
+                                        then Right (Just model, Nothing)
+                                        else Left organizationModelDenied)
+  where
+    organizationModelDenied =
+        "The requested child model is not allowed by this organization."
 
 spawnFresh
     :: OsPath
@@ -345,8 +362,9 @@ spawnFresh
     -> MultiAgentContext
     -> GrokSubagentSpecs
     -> TaskArgs
+    -> Maybe CollaborationModelTarget
     -> IO (Either Text Text)
-spawnFresh childCwd worktree ctx typesRef args = mask \restore -> do
+spawnFresh childCwd worktree ctx typesRef args resolvedModel = mask \restore -> do
     ownedWorktree <- traverse makeIdempotentWorktree worktree
     rootTurnId <- ctx.multiRootTurnId
     let spec = GrokSubagentSpec
@@ -359,7 +377,7 @@ spawnFresh childCwd worktree ctx typesRef args = mask \restore -> do
             }
         worktreePath = (.subagentWorktreePath) <$> ownedWorktree
         prepare agentId = do
-            recordAgentSpec typesRef agentId spec
+            prepareGrokSpawn ctx typesRef spec resolvedModel agentId
             pure $ case ownedWorktree of
                 Nothing -> mempty
                 Just lease ->
@@ -524,16 +542,57 @@ spawnManagedGrokSubagent
 spawnManagedGrokSubagent childCwd ctx typesRef spec prompt nickname
     | Text.null (Text.strip prompt) =
         pure (Left "subagent prompt must be non-empty")
-    | otherwise =
-        spawnSubagentWithCwdPreparedForTurn
-            ctx.multiRegistry
-            Nothing
-            childCwd
-            (\agentId -> recordAgentSpec typesRef agentId spec >> pure mempty)
-            ctx.multiSelfId
-            ctx.multiDepth
-            prompt
-            nickname
+    | otherwise = do
+        resolvedSpec <-
+            case ctx.multiResolveChildModel of
+                Nothing -> pure (Right (spec, Nothing))
+                Just _ ->
+                    resolveTaskChildModel ctx spec.modelOverride >>= \case
+                        Left err -> pure (Left err)
+                        Right (model, resolvedModel) ->
+                            pure
+                                (Right
+                                    ( spec { modelOverride = model }
+                                    , resolvedModel
+                                    ))
+        case resolvedSpec of
+            Left err -> pure (Left err)
+            Right (preparedSpec, resolvedModel) ->
+                spawnSubagentWithCwdPreparedForTurn
+                    ctx.multiRegistry
+                    Nothing
+                    childCwd
+                    (\agentId -> do
+                        prepareGrokSpawn
+                            ctx typesRef preparedSpec resolvedModel agentId
+                        pure mempty)
+                    ctx.multiSelfId
+                    ctx.multiDepth
+                    prompt
+                    nickname
+
+prepareGrokSpawn
+    :: MultiAgentContext
+    -> GrokSubagentSpecs
+    -> GrokSubagentSpec
+    -> Maybe CollaborationModelTarget
+    -> SubagentId
+    -> IO ()
+prepareGrokSpawn ctx typesRef spec resolvedModel agentId = do
+    case ctx.multiPrepareSpawn of
+        Just prepare
+            | isNothing spec.modelOverride || isJust resolvedModel ->
+                prepare agentId CollaborationSpawnOptions
+                    { collaborationModel = spec.modelOverride
+                    , collaborationResolvedModel = resolvedModel
+                    , collaborationReasoningEffort =
+                        spec.reasoningEffortOverride
+                    , collaborationForkTurns = Just "none"
+                    }
+        _ -> pure ()
+    -- The host hook records collaboration defaults; retain the Grok task's
+    -- actual type and effort after it installs the authoritative target.
+    recordAgentSpec typesRef agentId spec
 
 formatTaskStarted :: SubagentId -> TaskArgs -> Maybe OsPath -> Text
 formatTaskStarted agentId args worktreePath =

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
@@ -514,6 +514,7 @@ rootContext registry = MultiAgentContext
     , multiSendToRoot = Nothing
     , multiSpawnModelGuidance = Nothing
     , multiAllowedChildModels = Nothing
+    , multiResolveChildModel = Nothing
     , multiChildModelAllowed = Nothing
     }
 
@@ -530,6 +531,7 @@ childContext registry = MultiAgentContext
     , multiSendToRoot = Nothing
     , multiSpawnModelGuidance = Nothing
     , multiAllowedChildModels = Nothing
+    , multiResolveChildModel = Nothing
     , multiChildModelAllowed = Nothing
     }
 

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
@@ -502,32 +502,36 @@ call tools name arguments =
         (functionToolCall "call-1" name arguments)
 
 rootContext registry = MultiAgentContext
-    registry
-    (unsafeEncodeUtf "/tmp")
-    Nothing
-    0
-    taskPathRoot
-    (pure Nothing)
-    Nothing
-    Nothing
-    Nothing
-    Nothing
-    Nothing
-    Nothing
+    { multiRegistry = registry
+    , multiCwd = unsafeEncodeUtf "/tmp"
+    , multiSelfId = Nothing
+    , multiDepth = 0
+    , multiTaskPath = taskPathRoot
+    , multiRootTurnId = pure Nothing
+    , multiResumeFromDisk = Nothing
+    , multiCreateWorktree = Nothing
+    , multiPrepareSpawn = Nothing
+    , multiSendToRoot = Nothing
+    , multiSpawnModelGuidance = Nothing
+    , multiAllowedChildModels = Nothing
+    , multiChildModelAllowed = Nothing
+    }
 
 childContext registry = MultiAgentContext
-    registry
-    (unsafeEncodeUtf "/tmp")
-    (Just (SubagentId "agent-parent"))
-    1
-    taskPathRoot
-    (pure Nothing)
-    Nothing
-    Nothing
-    Nothing
-    Nothing
-    Nothing
-    Nothing
+    { multiRegistry = registry
+    , multiCwd = unsafeEncodeUtf "/tmp"
+    , multiSelfId = Just (SubagentId "agent-parent")
+    , multiDepth = 1
+    , multiTaskPath = taskPathRoot
+    , multiRootTurnId = pure Nothing
+    , multiResumeFromDisk = Nothing
+    , multiCreateWorktree = Nothing
+    , multiPrepareSpawn = Nothing
+    , multiSendToRoot = Nothing
+    , multiSpawnModelGuidance = Nothing
+    , multiAllowedChildModels = Nothing
+    , multiChildModelAllowed = Nothing
+    }
 
 withRegistry action =
     bracket

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
@@ -43,6 +43,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
                 Nothing
+                Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
             parameters = fromMaybe [] (jsonToolParameters tool)
         let isolationTypes =
@@ -110,6 +111,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
                     (pure Nothing) Nothing Nothing Nothing Nothing Nothing
                     (Just (grokRootChildModels True))
                     Nothing
+                    Nothing
                 tool = taskTool cwd ctx typesRef
             tool.appToolDescription `shouldSatisfy`
                 Text.isInfixOf "gpt-5.6-luna"
@@ -139,6 +141,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing
                 (Just (grokRootChildModels True))
                 Nothing
+                Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -163,6 +166,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             let ctx = MultiAgentContext registry cwd Nothing 0 taskPathRoot
                     (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
                     Nothing
+                    Nothing
                 tool = taskTool cwd ctx typesRef
             result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
                 (functionToolCall "c1" "task"
@@ -183,6 +187,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
                 (\_ _ -> pure ())
             let ctx = MultiAgentContext registry cwd Nothing 0 taskPathRoot
                     (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
+                    Nothing
                     Nothing
                 tool = taskTool cwd ctx typesRef
             _ <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
@@ -214,6 +219,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
                 pure (Left "persisted subagent dialect is incompatible")
             ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) (Just restore) Nothing Nothing Nothing Nothing Nothing
+                Nothing
                 Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
@@ -251,6 +257,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             ctx = MultiAgentContext registry (fromFilePath "/tmp") (Just childId) 1 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
                 Nothing
+                Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         expectAlwaysReadOnly tool.appToolApproval
         closeSubagentRegistry registry
@@ -264,6 +271,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         let createIsolated = cleanupLease cleaned
             ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot (pure Nothing)
                 Nothing (Just createIsolated) Nothing Nothing Nothing Nothing Nothing
+                Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -285,6 +293,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing (Just (cleanupLease cleaned)) Nothing Nothing Nothing Nothing
+                Nothing
                 Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
@@ -42,6 +42,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
+                Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
             parameters = fromMaybe [] (jsonToolParameters tool)
         let isolationTypes =
@@ -108,6 +109,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             let ctx = MultiAgentContext registry cwd Nothing 0 taskPathRoot
                     (pure Nothing) Nothing Nothing Nothing Nothing Nothing
                     (Just (grokRootChildModels True))
+                    Nothing
                 tool = taskTool cwd ctx typesRef
             tool.appToolDescription `shouldSatisfy`
                 Text.isInfixOf "gpt-5.6-luna"
@@ -136,6 +138,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing
                 (Just (grokRootChildModels True))
+                Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -159,6 +162,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             typesRef <- newIORef Map.empty
             let ctx = MultiAgentContext registry cwd Nothing 0 taskPathRoot
                     (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
+                    Nothing
                 tool = taskTool cwd ctx typesRef
             result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
                 (functionToolCall "c1" "task"
@@ -179,6 +183,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
                 (\_ _ -> pure ())
             let ctx = MultiAgentContext registry cwd Nothing 0 taskPathRoot
                     (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
+                    Nothing
                 tool = taskTool cwd ctx typesRef
             _ <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
                 (functionToolCall "c1" "task" raceArgs)
@@ -209,6 +214,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
                 pure (Left "persisted subagent dialect is incompatible")
             ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) (Just restore) Nothing Nothing Nothing Nothing Nothing
+                Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -244,6 +250,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         let childId = SubagentId "agent-child"
             ctx = MultiAgentContext registry (fromFilePath "/tmp") (Just childId) 1 taskPathRoot
                 (pure Nothing) Nothing Nothing Nothing Nothing Nothing Nothing
+                Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         expectAlwaysReadOnly tool.appToolApproval
         closeSubagentRegistry registry
@@ -256,7 +263,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let createIsolated = cleanupLease cleaned
             ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot (pure Nothing)
-                Nothing (Just createIsolated) Nothing Nothing Nothing Nothing
+                Nothing (Just createIsolated) Nothing Nothing Nothing Nothing Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task"
@@ -278,6 +285,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         typesRef <- newIORef Map.empty
         let ctx = MultiAgentContext registry (fromFilePath "/tmp") Nothing 0 taskPathRoot
                 (pure Nothing) Nothing (Just (cleanupLease cleaned)) Nothing Nothing Nothing Nothing
+                Nothing
             tool = taskTool (fromFilePath "/tmp") ctx typesRef
         result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
             (functionToolCall "c1" "task" worktreeArgs)

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
@@ -1,8 +1,10 @@
 module Agent.GrokBuild.TaskSpec (spec) where
 
 import Agent.GrokBuild.Dialect.Task
+import Agent.Dialect (DialectId(..))
 import Agent.Loop (LoopError(..), LoopResult(..), defaultLoopDispatch, emptyTokenUsage)
 import Agent.InterAgentMessage (interAgentMessagePayload)
+import Agent.Provider (Provider(..))
 import System.OsPath (OsPath, unsafeEncodeUtf)
 import Agent.Subagents
 import Agent.ToolDispatch
@@ -13,7 +15,12 @@ import Agent.ToolDispatch
     )
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.Subagents.TaskPath (taskPathRoot)
-import Agent.Tools.MultiAgents (MultiAgentContext(..), SubagentWorktree(..))
+import Agent.Tools.MultiAgents
+    ( CollaborationModelTarget(..)
+    , CollaborationSpawnOptions(..)
+    , MultiAgentContext(..)
+    , SubagentWorktree(..)
+    )
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
@@ -22,7 +29,7 @@ import Agent.Tools.Types
     , jsonToolParameters
     )
 import Control.Concurrent.MVar
-import Data.Either (isLeft)
+import Data.Either (isLeft, isRight)
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
@@ -150,6 +157,166 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
             Text.isInfixOf "Unknown spawn_subagent model"
         Map.null <$> readIORef typesRef `shouldReturn` True
         closeSubagentRegistry registry
+
+    it "carries an authoritative live target through task preparation" do
+        withSystemTempDirectory "agent-grok-task" \dir -> do
+            let cwd = fromFilePath dir
+                target = CollaborationModelTarget
+                    { collaborationTargetProvider = OpenAIProvider
+                    , collaborationTargetConnection = "organization-gateway"
+                    , collaborationTargetEffectiveModel = "company-grok"
+                    , collaborationTargetDialect = GrokBuildDialect
+                    }
+            registry <- completedRegistry cwd
+            typesRef <- newIORef Map.empty
+            resolverCalls <- newIORef []
+            validatorCalls <- newIORef (0 :: Int)
+            prepared <- newIORef []
+            let resolve model = do
+                    modifyIORef' resolverCalls (model :)
+                    pure (if model == "company-grok" then Just target else Nothing)
+                validate _ = do
+                    modifyIORef' validatorCalls (+ 1)
+                    pure False
+                ctx = (testContext registry cwd)
+                    { multiPrepareSpawn = Just
+                        (\_ options -> modifyIORef' prepared (options :))
+                    , multiAllowedChildModels = Just ["stale-alias"]
+                    , multiResolveChildModel = Just resolve
+                    , multiChildModelAllowed = Just validate
+                    }
+                tool = taskTool cwd ctx typesRef
+            result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+                (functionToolCall "c1" "task"
+                    "{\"prompt\":\"hello\",\"description\":\"gateway child\",\
+                    \\"subagent_type\":\"explore\",\"model\":\"company-grok\"}")
+            result.output `shouldSatisfy`
+                Text.isInfixOf "Subagent started in background"
+            readIORef resolverCalls `shouldReturn` ["company-grok"]
+            readIORef validatorCalls `shouldReturn` 0
+            readIORef prepared `shouldReturn`
+                [ CollaborationSpawnOptions
+                    { collaborationModel = Just "company-grok"
+                    , collaborationResolvedModel = Just target
+                    , collaborationReasoningEffort = Nothing
+                    , collaborationForkTurns = Just "none"
+                    }
+                ]
+            specs <- Map.elems <$> readIORef typesRef
+            specs `shouldBe`
+                [ GrokSubagentSpec
+                    { agentType = "explore"
+                    , modelOverride = Just "company-grok"
+                    , reasoningEffortOverride = Nothing
+                    }
+                ]
+            closeSubagentRegistry registry
+
+    it "prepares inherited task children without resolving an alias" do
+        withSystemTempDirectory "agent-grok-task" \dir -> do
+            let cwd = fromFilePath dir
+            registry <- completedRegistry cwd
+            typesRef <- newIORef Map.empty
+            resolverCalls <- newIORef (0 :: Int)
+            prepared <- newIORef []
+            let ctx = (testContext registry cwd)
+                    { multiPrepareSpawn = Just
+                        (\_ options -> modifyIORef' prepared (options :))
+                    , multiResolveChildModel = Just
+                        (\_ -> modifyIORef' resolverCalls (+ 1) >> pure Nothing)
+                    }
+                tool = taskTool cwd ctx typesRef
+            result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+                (functionToolCall "c1" "task"
+                    "{\"prompt\":\"hello\",\"description\":\"inherit target\"}")
+            result.output `shouldSatisfy`
+                Text.isInfixOf "Subagent started in background"
+            readIORef resolverCalls `shouldReturn` 0
+            readIORef prepared `shouldReturn`
+                [ CollaborationSpawnOptions
+                    { collaborationModel = Nothing
+                    , collaborationResolvedModel = Nothing
+                    , collaborationReasoningEffort = Nothing
+                    , collaborationForkTurns = Just "none"
+                    }
+                ]
+            closeSubagentRegistry registry
+
+    it "rejects an unknown live alias before task preparation" do
+        registry <- completedRegistry (fromFilePath "/tmp")
+        typesRef <- newIORef Map.empty
+        prepared <- newIORef False
+        let ctx = (testContext registry (fromFilePath "/tmp"))
+                { multiPrepareSpawn = Just
+                    (\_ _ -> writeIORef prepared True)
+                , multiResolveChildModel = Just (const (pure Nothing))
+                }
+            tool = taskTool (fromFilePath "/tmp") ctx typesRef
+        result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+            (functionToolCall "c1" "task"
+                "{\"prompt\":\"hello\",\"description\":\"denied\",\
+                \\"model\":\"removed-company-model\"}")
+        result.output `shouldSatisfy`
+            Text.isInfixOf "not allowed by this organization"
+        readIORef prepared `shouldReturn` False
+        Map.null <$> readIORef typesRef `shouldReturn` True
+        null <$> listAgents registry Nothing `shouldReturn` True
+        closeSubagentRegistry registry
+
+    it "leaves unresolved explicit Luna routing to the direct provider runtime" do
+        withSystemTempDirectory "agent-grok-task" \dir -> do
+            let cwd = fromFilePath dir
+            registry <- completedRegistry cwd
+            typesRef <- newIORef Map.empty
+            prepared <- newIORef False
+            let ctx = (testContext registry cwd)
+                    { multiPrepareSpawn = Just
+                        (\_ _ -> writeIORef prepared True)
+                    , multiAllowedChildModels =
+                        Just (grokRootChildModels True)
+                    }
+                tool = taskTool cwd ctx typesRef
+            result <- dispatchToolCall defaultLoopDispatch [tool.appToolHandler]
+                (functionToolCall "c1" "task"
+                    "{\"prompt\":\"hello\",\"description\":\"direct luna\",\
+                    \\"model\":\"luna\"}")
+            result.output `shouldSatisfy`
+                Text.isInfixOf "Subagent started in background"
+            readIORef prepared `shouldReturn` False
+            closeSubagentRegistry registry
+
+    it "prepares inherited managed children for scheduler and workflow use" do
+        withSystemTempDirectory "agent-grok-task" \dir -> do
+            let cwd = fromFilePath dir
+            registry <- completedRegistry cwd
+            typesRef <- newIORef Map.empty
+            prepared <- newIORef []
+            resolverCalls <- newIORef (0 :: Int)
+            let ctx = (testContext registry cwd)
+                    { multiPrepareSpawn = Just
+                        (\_ options -> modifyIORef' prepared (options :))
+                    , multiResolveChildModel = Just
+                        (\_ -> modifyIORef' resolverCalls (+ 1) >> pure Nothing)
+                    }
+                managedSpec = GrokSubagentSpec
+                    { agentType = runtimeSubagentType
+                    , modelOverride = Nothing
+                    , reasoningEffortOverride = Nothing
+                    }
+            spawned <-
+                spawnManagedGrokSubagent
+                    cwd ctx typesRef managedSpec "scheduled work" Nothing
+            spawned `shouldSatisfy` isRight
+            readIORef resolverCalls `shouldReturn` 0
+            readIORef prepared `shouldReturn`
+                [ CollaborationSpawnOptions
+                    { collaborationModel = Nothing
+                    , collaborationResolvedModel = Nothing
+                    , collaborationReasoningEffort = Nothing
+                    , collaborationForkTurns = Just "none"
+                    }
+                ]
+            closeSubagentRegistry registry
 
     it "defaults run_in_background and spawns a background agent" do
         withSystemTempDirectory "agent-grok-task" \dir -> do
@@ -360,3 +527,32 @@ cleanupLease cleaned _ =
         , subagentWorktreeCleanup =
             writeIORef cleaned True >> pure (Right ())
         }
+
+testContext :: SubagentRegistry -> OsPath -> MultiAgentContext
+testContext registry cwd = MultiAgentContext
+    { multiRegistry = registry
+    , multiCwd = cwd
+    , multiSelfId = Nothing
+    , multiDepth = 0
+    , multiTaskPath = taskPathRoot
+    , multiRootTurnId = pure Nothing
+    , multiResumeFromDisk = Nothing
+    , multiCreateWorktree = Nothing
+    , multiPrepareSpawn = Nothing
+    , multiSendToRoot = Nothing
+    , multiSpawnModelGuidance = Nothing
+    , multiAllowedChildModels = Nothing
+    , multiResolveChildModel = Nothing
+    , multiChildModelAllowed = Nothing
+    }
+
+completedRegistry :: OsPath -> IO SubagentRegistry
+completedRegistry cwd =
+    newSubagentRegistry defaultSubagentConfig cwd
+        (\_ _ prompt _ -> pure $ Right LoopResult
+            { finalResponseId = "c"
+            , finalText = Just ("done:" <> interAgentMessagePayload prompt)
+            , turnsUsed = 1
+            , tokenUsage = emptyTokenUsage
+            })
+        (\_ _ -> pure ())


### PR DESCRIPTION
## Summary
- make the authenticated gateway model catalog authoritative while connected
- map each advertised alias to its Responses or Anthropic transport and remove synthetic Router Default/Codex entries
- proxy Claude gateway traffic through a loopback capability so the organization bearer remains parent-owned

## Validation
- `cabal test --offline agent-cli-runtime:test:agent-cli-runtime-test --test-options='--match "gateway device authorization"'` (20 examples)\n- `cabal test --offline agent-cli:test:agent-cli-test --test-options='--match "Claude gateway loopback proxy"'`\n- `cabal test --offline agent-cli:test:agent-cli-test --test-options='--match "Agent.CLI.GatewayModels"'`\n- `cabal test --offline agent-claude:test:agent-claude-test` (47 examples)