### PR TITLE
Address unified catalog review feedback

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -313,7 +313,7 @@ fetchGatewayModels credential =
                         (Text.unpack
                             (Text.dropWhileEnd (== '/')
                                 (Text.strip credential.gatewayBaseUrl)
-                                <> "/v1/model-catalog"))
+                                <> "/v1/models"))
                 HTTP.httpLbs
                     initial
                         { HTTP.method = "GET"

--- a/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
@@ -561,7 +561,11 @@ validateConfig source config = do
                     (connectionSupportsDialect
                         connectionId
                         OpenAIProvider
-                        dialect) $
+                        dialect
+                        || connectionSupportsDialect
+                            connectionId
+                            ClaudeCodeProvider
+                            dialect) $
                     Left
                         ( "model " <> modelId <> " uses dialect "
                             <> raw.modelFileDialect

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -6,6 +6,7 @@ import Agent.OsPath (fromText, unsafeToFilePath)
 import Agent.Provider (Provider(..))
 import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.Either (isRight)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -131,9 +132,9 @@ spec = describe "Agent.CLI.ModelConfig" do
             `shouldBe` True
         connectionSupportsDialect
             organizationGatewayConnectionId
-            OpenAIProvider
+            ClaudeCodeProvider
             ClaudeCodeDialect
-            `shouldBe` False
+            `shouldBe` True
 
         let remapped =
                 "{\"version\":1,\"models\":[{\"id\":\"company-remapped\",\"connection\":\"organization-gateway\",\"model\":\"private-upstream\",\"dialect\":\"codex\"}]}"
@@ -146,7 +147,7 @@ spec = describe "Agent.CLI.ModelConfig" do
         mergeModelConfigs
             ("models.default.json", defaults)
             (Just ("models.json", ownedTools))
-            `shouldSatisfy` leftContains "incompatible with connection"
+            `shouldSatisfy` isRight
 
     it "adds a custom Responses connection and model" do
         defaults <- readPackagedDefaults


### PR DESCRIPTION
## Summary
- fetch the documented unified catalog from `/v1/models`
- validate organization-gateway metadata against both Responses and Claude transports
- cover Claude gateway metadata acceptance

## Validation
- `cabal test --offline agent-cli-runtime:test:agent-cli-runtime-test --test-options='--match "Agent.CLI.ModelConfig"'` (12 examples)\n- `cabal test --offline agent-cli-runtime:test:agent-cli-runtime-test --test-options='--match "gateway device authorization"'` (20 examples)\n\nFollow-up to review comments on #899. Depends on digitallyinduced/haskell-agent-gateway#37 for the `/v1/models` protocol field.