### PR TITLE
Make failed-response display journaling linear

### DIFF
--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -1,19 +1,24 @@
 module Main (main) where
 
 import Agent.Cancel (newCancelFlag)
+import Agent.Error (ApiError(..))
 import qualified Agent.Json.Decode as Json
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
     , BackendStateStore(..)
     , LoopConfig(..)
+    , LoopError(..)
     , LoopEvent(..)
+    , LoopExecution(..)
     , LoopResult
+    , TurnInput(..)
     , defaultLoopDispatch
     , defaultLoopMaxTurns
     , emptyBackendSnapshot
     , emptyTurnOutput
     , runLoop
+    , runLoopInputsDetailed
     )
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -55,6 +60,7 @@ import Text.Printf (printf)
 
 data Workload
     = StreamingEvents
+    | StreamingFailureEvents
     | ParallelToolEvents
     | QueuedEvents
 
@@ -107,11 +113,13 @@ main = do
         _ ->
             die $
                 "usage: loop-events-bench WORKLOAD EVENTS SINK_DELAY_US SAMPLES\n"
-                    <> "workloads: streaming, parallel-tools, queued-events"
+                    <> "workloads: streaming, streaming-failure, "
+                    <> "parallel-tools, queued-events"
 
 parseWorkload :: String -> IO Workload
 parseWorkload = \case
     "streaming" -> pure StreamingEvents
+    "streaming-failure" -> pure StreamingFailureEvents
     "parallel-tools" -> pure ParallelToolEvents
     "queued-events" -> pure QueuedEvents
     other -> die ("unknown workload: " <> other)
@@ -171,6 +179,8 @@ runWorkload workload eventCount sinkDelayMicros = do
     backend <- case workload of
         StreamingEvents ->
             pure $ streamingBackend eventCount producerFinishedRef
+        StreamingFailureEvents ->
+            pure $ streamingFailureBackend eventCount producerFinishedRef
         ParallelToolEvents ->
             parallelToolBackend eventCount producerFinishedRef
         QueuedEvents ->
@@ -191,6 +201,7 @@ runWorkload workload eventCount sinkDelayMicros = do
                 }
             , loopTools = case workload of
                 StreamingEvents -> emptyRegistry
+                StreamingFailureEvents -> emptyRegistry
                 ParallelToolEvents -> streamingRegistry
                 QueuedEvents -> emptyRegistry
             , loopDispatch = defaultLoopDispatch
@@ -202,14 +213,21 @@ runWorkload workload eventCount sinkDelayMicros = do
             , loopInterrupt = pure ()
             , loopCancel = cancel
             }
-    result <- runLoop config Nothing "benchmark"
-    forceSuccess result
+    displayChecksum <- case workload of
+        StreamingFailureEvents -> do
+            execution <-
+                runLoopInputsDetailed config Nothing [UserMessage "benchmark"]
+            forceStreamingFailure execution
+        _ -> do
+            result <- runLoop config Nothing "benchmark"
+            forceSuccess result
+            pure 0
     checksum <- readIORef checksumRef
     producerFinished <- readIORef producerFinishedRef >>= \case
         Just timestamp -> pure timestamp
         Nothing -> die "benchmark producer did not record completion"
     pure WorkloadResult
-        { resultChecksum = checksum
+        { resultChecksum = checksum + displayChecksum
         , resultProducerFinished = producerFinished
         }
 
@@ -226,6 +244,16 @@ streamingBackend eventCount producerFinishedRef =
                 emptyTurnOutput "stream-response" [] (Just "done")
             , backendState = emptyBackendSnapshot
             }
+
+streamingFailureBackend
+    :: Int
+    -> IORef (Maybe Word64)
+    -> Backend
+streamingFailureBackend eventCount producerFinishedRef =
+    Backend \_state _previous _inputs onEvent -> do
+        replicateM_ eventCount (onEvent (TextDelta "x"))
+        getMonotonicTimeNSec >>= writeIORef producerFinishedRef . Just
+        pure (Left (ConnectionError "benchmark failure"))
 
 queuedEventsBackend
     :: Int
@@ -311,6 +339,14 @@ forceSuccess :: Either error LoopResult -> IO ()
 forceSuccess = \case
     Right result -> result `seq` pure ()
     Left _ -> die "agent loop benchmark failed"
+
+forceStreamingFailure :: LoopExecution -> IO Int
+forceStreamingFailure execution =
+    case execution.executionResult of
+        Left (LoopTransportAfterOutput (ConnectionError _)) ->
+            evaluate $
+                sum (map eventWeight execution.executionUncommittedDisplayEvents)
+        _ -> die "agent loop failure benchmark did not fail after output"
 
 eventWeight :: LoopEvent -> Int
 eventWeight = \case

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -598,7 +598,7 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                     ResponseRestarted _ ->
                         modifyIORef'
                             uncommittedDisplayEventsRef
-                            (event :)
+                            (recordDisplayEvent event)
                     ResponseAttemptDiscarded ->
                         modifyIORef'
                             uncommittedDisplayEventsRef
@@ -629,7 +629,8 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                 pending <- readIORef pendingRef
                 (finishedChunks, currentChunks) <- readIORef uncommittedTextRef
                 displayEvents <-
-                    reverse <$> readIORef uncommittedDisplayEventsRef
+                    displayEventsFromJournal
+                        <$> readIORef uncommittedDisplayEventsRef
                 providerTelemetry <-
                     reverse <$> readIORef providerTelemetryRef
                 let uncommittedText = Text.intercalate "\n\n" $
@@ -904,69 +905,101 @@ replayableDisplayEvent = \case
     ToolRetracted _ -> True
     _ -> False
 
--- The journal is stored newest-first. A restart is the boundary between the
--- current provider attempt and older attempts that remain visible.
-recordDisplayEvent :: LoopEvent -> [LoopEvent] -> [LoopEvent]
+-- The journal and each text chunk list are stored newest-first. Keeping
+-- adjacent deltas as chunks avoids repeatedly copying the accumulated prefix.
+-- A restart is the boundary between the current provider attempt and older
+-- attempts that remain visible.
+data DisplayJournalEntry
+    = DisplayTextChunks ![Text]
+    | DisplayEvent !LoopEvent
+
+recordDisplayEvent
+    :: LoopEvent
+    -> [DisplayJournalEntry]
+    -> [DisplayJournalEntry]
 recordDisplayEvent event events = case event of
     TextDelta delta ->
         case events of
-            TextDelta previous : rest ->
-                TextDelta (previous <> delta) : rest
-            _ -> event : events
+            DisplayTextChunks chunks : rest ->
+                DisplayTextChunks (delta : chunks) : rest
+            _ -> DisplayTextChunks [delta] : events
     ToolUpdated call ->
-        event : removeCurrentToolUpdates call.callId events
+        DisplayEvent event : removeCurrentToolUpdates call.callId events
     ToolArgumentsUpdated call ->
-        event : removeCurrentToolUpdates call.callId events
+        DisplayEvent event : removeCurrentToolUpdates call.callId events
     ToolOutputUpdated callId output ->
-        ToolOutputUpdated callId (boundLoopToolOutput output)
+        DisplayEvent (ToolOutputUpdated callId (boundLoopToolOutput output))
             : removeCurrentToolOutput callId events
     ToolFinished result ->
-        ToolFinished
-            result
-                { output = boundLoopToolOutput result.output
-                }
+        DisplayEvent
+            (ToolFinished
+                result
+                    { output = boundLoopToolOutput result.output
+                    })
             : removeCurrentToolOutput result.callId events
     ToolRetracted callId ->
         removeCurrentToolEvents callId events
-    _ -> event : events
+    _ -> DisplayEvent event : events
 
-discardCurrentDisplayAttempt :: [LoopEvent] -> [LoopEvent]
+displayEventsFromJournal :: [DisplayJournalEntry] -> [LoopEvent]
+displayEventsFromJournal =
+    map entryToEvent . reverse
+  where
+    entryToEvent = \case
+        DisplayTextChunks chunks ->
+            TextDelta (Text.concat (reverse chunks))
+        DisplayEvent event -> event
+
+discardCurrentDisplayAttempt
+    :: [DisplayJournalEntry]
+    -> [DisplayJournalEntry]
 discardCurrentDisplayAttempt =
     dropWhile \case
-        ResponseRestarted _ -> False
+        DisplayEvent (ResponseRestarted _) -> False
         _ -> True
 
-removeCurrentToolUpdates :: Text -> [LoopEvent] -> [LoopEvent]
+removeCurrentToolUpdates
+    :: Text
+    -> [DisplayJournalEntry]
+    -> [DisplayJournalEntry]
 removeCurrentToolUpdates callId =
     filterCurrentAttempt \case
-        ToolUpdated call -> call.callId /= callId
-        ToolArgumentsUpdated call -> call.callId /= callId
+        DisplayEvent (ToolUpdated call) -> call.callId /= callId
+        DisplayEvent (ToolArgumentsUpdated call) -> call.callId /= callId
         _ -> True
 
-removeCurrentToolOutput :: Text -> [LoopEvent] -> [LoopEvent]
+removeCurrentToolOutput
+    :: Text
+    -> [DisplayJournalEntry]
+    -> [DisplayJournalEntry]
 removeCurrentToolOutput callId =
     filterCurrentAttempt \case
-        ToolOutputUpdated identifier _ -> identifier /= callId
+        DisplayEvent (ToolOutputUpdated identifier _) ->
+            identifier /= callId
         _ -> True
 
-removeCurrentToolEvents :: Text -> [LoopEvent] -> [LoopEvent]
+removeCurrentToolEvents
+    :: Text
+    -> [DisplayJournalEntry]
+    -> [DisplayJournalEntry]
 removeCurrentToolEvents callId =
     filterCurrentAttempt \case
-        ToolStarted call -> call.callId /= callId
-        ToolUpdated call -> call.callId /= callId
-        ToolArgumentsUpdated call -> call.callId /= callId
-        ToolOutputUpdated identifier _ -> identifier /= callId
-        ToolFinished result -> result.callId /= callId
+        DisplayEvent (ToolStarted call) -> call.callId /= callId
+        DisplayEvent (ToolUpdated call) -> call.callId /= callId
+        DisplayEvent (ToolArgumentsUpdated call) -> call.callId /= callId
+        DisplayEvent (ToolOutputUpdated identifier _) ->
+            identifier /= callId
+        DisplayEvent (ToolFinished result) -> result.callId /= callId
         _ -> True
 
 filterCurrentAttempt
-    :: (LoopEvent -> Bool)
-    -> [LoopEvent]
-    -> [LoopEvent]
+    :: (DisplayJournalEntry -> Bool)
+    -> [DisplayJournalEntry]
+    -> [DisplayJournalEntry]
 filterCurrentAttempt keep = go
   where
     go [] = []
-    go allEvents@(ResponseRestarted _ : _) = allEvents
+    go allEvents@(DisplayEvent (ResponseRestarted _) : _) = allEvents
     go (event : rest)
         | keep event = event : go rest
         | otherwise = go rest

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1285,6 +1285,27 @@ spec = describe "runLoop" do
         readIORef observed `shouldReturn`
             [TurnStarted, TextDelta "partial", ResponseAttemptFailed]
 
+    it "coalesces retained text without crossing tool boundaries" do
+        let call =
+                functionToolCall "c1" "shell_command"
+                    "{\"command\":\"git status\"}"
+            backend = Backend \_state _prev _inputs onEvent -> do
+                onEvent (TextDelta "before")
+                onEvent (TextDelta " tool")
+                onEvent (ToolStarted call)
+                onEvent (TextDelta "after")
+                onEvent (TextDelta " tool")
+                pure (Left (ConnectionError "down"))
+        config <- testConfig backend
+        execution <-
+            runLoopInputsDetailed config Nothing [UserMessage "hello"]
+        execution.executionUncommittedDisplayEvents
+            `shouldBe`
+                [ TextDelta "before tool"
+                , ToolStarted call
+                , TextDelta "after tool"
+                ]
+
     it "retains tool-only activity as display metadata on failure" do
         let call =
                 functionToolCall "c1" "shell_command"
@@ -1306,9 +1327,11 @@ spec = describe "runLoop" do
 
     it "keeps earlier restarted attempts in display metadata" do
         let backend = Backend \_state _prev _inputs onEvent -> do
-                onEvent (TextDelta "first")
+                onEvent (TextDelta "fir")
+                onEvent (TextDelta "st")
                 onEvent (ResponseRestarted "retrying")
-                onEvent (TextDelta "second")
+                onEvent (TextDelta "sec")
+                onEvent (TextDelta "ond")
                 pure (Left (ConnectionError "down"))
         config <- testConfig backend
         execution <-
@@ -1325,9 +1348,11 @@ spec = describe "runLoop" do
     it "still marks failure after a later retry attempt is discarded" do
         observed <- newIORef []
         let backend = Backend \_state _prev _inputs onEvent -> do
-                onEvent (TextDelta "first")
+                onEvent (TextDelta "fir")
+                onEvent (TextDelta "st")
                 onEvent (ResponseRestarted "retrying")
-                onEvent (TextDelta "discard me")
+                onEvent (TextDelta "discard")
+                onEvent (TextDelta " me")
                 onEvent ResponseAttemptDiscarded
                 pure (Left (ConnectionError "down"))
         config0 <- testConfig backend
@@ -1344,14 +1369,18 @@ spec = describe "runLoop" do
                 [ TextDelta "first"
                 , ResponseRestarted "retrying"
                 ]
-        readIORef observed `shouldReturn`
-            [ TurnStarted
-            , TextDelta "first"
-            , ResponseRestarted "retrying"
-            , TextDelta "discard me"
-            , ResponseAttemptDiscarded
-            , ResponseAttemptFailed
-            ]
+        observedEvents <- readIORef observed
+        filter
+            (\case
+                TextDelta _ -> False
+                _ -> True)
+            observedEvents
+            `shouldBe`
+                [ TurnStarted
+                , ResponseRestarted "retrying"
+                , ResponseAttemptDiscarded
+                , ResponseAttemptFailed
+                ]
 
     it "treats a transport failure after a discarded attempt as pre-output" do
         let backend = Backend \_state _prev _inputs onEvent -> do


### PR DESCRIPTION
## Summary

- retain adjacent streamed text as chunks in the failed-response display journal
- flatten each contiguous text run once when projecting `LoopExecution`
- preserve tool, retry, and discarded-attempt boundaries with regression coverage
- add an integrated `streaming-failure` workload that forces retained display output

This follows up on #882 and addresses [the P1 review comment](https://github.com/digitallyinduced/haskell-agent/pull/882#discussion_r2464742452).

## Benchmark

GHC 9.10.3, `loop-events-bench` built with `-O2`, Apple Silicon macOS, `+RTS -T`, median of 7 samples. Each event is a one-character streamed delta; inputs are constructed outside the measured interval.

Command:

```sh
nix develop -c cabal build --offline agent-core:bench:loop-events-bench
bin=$(nix develop -c cabal list-bin agent-core:bench:loop-events-bench)
for count in 1000 2000 5000 10000; do
  "$bin" streaming-failure "$count" 0 7 +RTS -T
done
```

| Deltas | Old CPU (ms) | New CPU (ms) | Old allocation | New allocation |
| ---: | ---: | ---: | ---: | ---: |
| 1,000 | 0.219 | 0.194 | 1,191,584 B | 622,992 B |
| 2,000 | 0.479 | 0.421 | 3,354,352 B | 1,217,992 B |
| 5,000 | 2.592 | 1.105 | 15,842,656 B | 3,002,992 B |
| 10,000 | 7.695 | 2.196 | 56,656,496 B | 5,977,992 B |

At 10,000 deltas this reduces CPU time by 71.5% and allocation by 89.4%. A repeated new 10,000-delta run measured 2.333 ms CPU and the same 5,977,992 B allocation.

The existing successful-stream baseline remains linear and does not regress: at 10,000 deltas it changed from 2.268 ms / 5,560,696 B to 2.014 ms / 5,480,312 B (repeat: 2.182 ms / 5,479,568 B). Measurement showed that the old lazy append chain was discarded before forcing on success; the quadratic cost occurred when retained failed output was materialized.

## Validation

- `Agent.LoopSpec`: 78 examples, 0 failures in GHCi
- `Agent.CLI.TurnSpec`: 31 examples, 0 failures in GHCi
- `Agent.CLI.SessionHistorySpec`: 10 examples, 0 failures in GHCi
- `Agent.CLI.TUIHistorySpec`: 22 examples, 0 failures in GHCi
- independent read-only diff review: no findings
