### PR TITLE
Hide endpoint URLs from prompt footer

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -48,6 +48,7 @@ import Agent.CLI.Session.History
     , readLiveTranscript
     )
 import Agent.CLI.Style (roleError)
+import Agent.CLI.Status (formatFooterAccount)
 import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.TUI.App
     ( emitUiEvent
@@ -140,7 +141,7 @@ buildPromptState activeDialect params planState policy account accountSelectable
                 (reasoningEffortsForDialect activeDialect)
         , promptMode =
             replModeLabel (replModeFromState planState policy)
-        , promptAccount = account
+        , promptAccount = formatFooterAccount account
         , promptAccountSelectable = accountSelectable
         , promptUsage = usage
         , promptLimitStatus = Nothing

--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Status
     ( applyReplMode
     , cycleReplInteraction
     , formatContextUsage
+    , formatFooterAccount
     , formatReplStatusLine
     , formatTokenUsage
     , formatTokenUsageOrZero
@@ -49,7 +50,7 @@ formatReplStatusLine
 formatReplStatusLine color width model effort mode account usage rate =
     let left =
             "  " <> Text.intercalate " · " (filter (not . Text.null)
-                [model, effort, replModeLabel mode, account])
+                [model, effort, replModeLabel mode, formatFooterAccount account])
         right = formatUsageWithRate usage rate
         padded = case width of
             Just cols | cols > 0 ->
@@ -57,6 +58,16 @@ formatReplStatusLine color width model effort mode account usage rate =
             _ | Text.null right -> left
             _ -> left <> "  " <> right
     in roleMuted color padded
+
+-- | Keep endpoint URLs out of persistent prompt chrome. Gateway accounts use
+-- their base URL as an identifier, but that implementation detail is too
+-- noisy for the footer. Human-readable account identifiers remain visible.
+formatFooterAccount :: Text -> Text
+formatFooterAccount account
+    | any (`Text.isInfixOf` lowered) ["http://", "https://"] = ""
+    | otherwise = account
+  where
+    lowered = Text.toLower account
 
 -- | Keep the status on one physical row so composer redraws never inherit a
 -- wrapped status line. Prefer interaction state over token totals.

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -283,6 +283,14 @@ spec = do
                 ReplModePlan "" emptyTokenUsage Nothing
                 `shouldBe` "  gpt-5.1 · low · plan"
 
+        it "does not show endpoint URLs used as account identifiers" do
+            formatReplStatusLine False Nothing "fable" "medium"
+                ReplModeAlwaysApprove
+                "https://platform.example.com"
+                emptyTokenUsage
+                Nothing
+                `shouldBe` "  fable · medium · yolo"
+
         it "appends session usage when no width is known" do
             formatReplStatusLine False Nothing "grok-4.6" "high" ReplModeNormal ""
                 TokenUsage { inputTokens = 1200, outputTokens = 340, cachedTokens = 0 }
@@ -321,6 +329,19 @@ spec = do
             line `shouldBe` "  模型模型 · hi…"
 
     describe "buildPromptState" do
+        it "keeps endpoint URLs out of the fullscreen composer footer" do
+            let prompt =
+                    buildPromptState
+                        CodexDialect
+                        defaultResponseCreateParams
+                        PlanInactive
+                        ApproveAll
+                        "Gateway · https://platform.example.com"
+                        True
+                        emptyTokenUsage
+                        0
+            prompt.promptAccount `shouldBe` ""
+
         it "replaces stale Grok metadata before a fallback turn starts" do
             let stalePrompt =
                     initialUiState.uiPrompt


### PR DESCRIPTION
## Summary

- omit URL-backed gateway account identifiers from persistent prompt chrome
- apply the same filtering to inline and fullscreen footer rendering
- preserve human-readable account labels such as email addresses
- add regression coverage for both UI paths

## Validation

- loaded `Agent.CLI.Status` and `Agent.CLI.Session.Interaction` in GHCi
- evaluated focused GHCi assertions confirming URL labels are hidden and email labels remain
- exercised the live fullscreen CLI in tmux
- `git diff --check`

## Test-suite note

The aggregate test REPL currently cannot start because unrelated macOS `foreign export` modules require object-code mode; the affected spec module itself typechecked during the attempted load.