### PR TITLE
Stream OpenAI dictation transcripts in real time

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -401,13 +401,13 @@ data ChatGPTStreamEndpoint = ChatGPTStreamEndpoint
 
 data ChatGPTStreamState = ChatGPTStreamState
     { utteranceOrder :: ![Text]
-    , finalByUtterance :: !(Map.Map Text Text)
+    , textByUtterance :: !(Map.Map Text Text)
     }
 
 emptyChatGPTStreamState :: ChatGPTStreamState
 emptyChatGPTStreamState = ChatGPTStreamState
     { utteranceOrder = []
-    , finalByUtterance = Map.empty
+    , textByUtterance = Map.empty
     }
 
 streamChatGPTDictation
@@ -643,18 +643,12 @@ receiveChatGPTDictation connection state finished onTranscript =
                         pure (Left message)
                     ChatGPTSessionError True message ->
                         pure (Left message)
-                    ChatGPTTranscriptFinal _ _ -> do
-                        current <- modifyMVar state \previous ->
-                            let next =
-                                    applyChatGPTDictationEvent
-                                        event
-                                        previous
-                            in pure (next, next)
-                        let transcript = renderChatGPTTranscript current
-                        unless (Text.null transcript) $
-                            ignoreSynchronousException
-                                (onTranscript transcript)
-                        loop
+                    ChatGPTTranscriptDelta _ _ ->
+                        updateTranscript event >> loop
+                    ChatGPTTranscriptSegment _ _ ->
+                        updateTranscript event >> loop
+                    ChatGPTTranscriptFinal _ _ ->
+                        updateTranscript event >> loop
                     _ -> do
                         modifyMVar state \previous ->
                             pure
@@ -664,6 +658,17 @@ receiveChatGPTDictation connection state finished onTranscript =
                                 , ()
                                 )
                         loop
+    updateTranscript event = do
+        current <- modifyMVar state \previous ->
+            let next =
+                    applyChatGPTDictationEvent
+                        event
+                        previous
+            in pure (next, next)
+        let transcript = renderChatGPTTranscript current
+        unless (Text.null transcript) $
+            ignoreSynchronousException
+                (onTranscript transcript)
 
 receiverFailure :: SomeException -> Either Text ()
 receiverFailure err =
@@ -685,31 +690,51 @@ applyChatGPTDictationEvent event state =
             ensureChatGPTUtterance utteranceId state
         ChatGPTSpeechStopped utteranceId ->
             ensureChatGPTUtterance utteranceId state
+        ChatGPTTranscriptDelta utteranceId text ->
+            appendChatGPTTranscript utteranceId text state
+        ChatGPTTranscriptSegment utteranceId text ->
+            appendChatGPTTranscript utteranceId text state
         ChatGPTTranscriptFinal utteranceId text ->
             let withUtterance =
                     ensureChatGPTUtterance utteranceId state
             in withUtterance
-                { finalByUtterance =
+                { textByUtterance =
                     Map.insert
                         utteranceId
                         text
-                        withUtterance.finalByUtterance
+                        withUtterance.textByUtterance
                 }
         _ ->
             state
+
+appendChatGPTTranscript
+    :: Text
+    -> Text
+    -> ChatGPTStreamState
+    -> ChatGPTStreamState
+appendChatGPTTranscript utteranceId text state =
+    let withUtterance = ensureChatGPTUtterance utteranceId state
+    in withUtterance
+        { textByUtterance =
+            Map.insertWith
+                (\new previous -> previous <> new)
+                utteranceId
+                text
+                withUtterance.textByUtterance
+        }
 
 ensureChatGPTUtterance
     :: Text
     -> ChatGPTStreamState
     -> ChatGPTStreamState
 ensureChatGPTUtterance utteranceId state
-    | Map.member utteranceId state.finalByUtterance =
+    | Map.member utteranceId state.textByUtterance =
         state
     | otherwise =
         state
             { utteranceOrder = state.utteranceOrder <> [utteranceId]
-            , finalByUtterance =
-                Map.insert utteranceId "" state.finalByUtterance
+            , textByUtterance =
+                Map.insert utteranceId "" state.textByUtterance
             }
 
 renderChatGPTTranscript :: ChatGPTStreamState -> Text
@@ -719,7 +744,7 @@ renderChatGPTTranscript state =
         | utteranceId <- state.utteranceOrder
         , Just transcript <- [Map.lookup
             utteranceId
-            state.finalByUtterance]
+            state.textByUtterance]
         , not (Text.null (Text.strip transcript))
         ]
 
@@ -735,7 +760,7 @@ chatGPTSessionStartMessage sampleRate =
             , "max_utterance_duration_ms" .= (30_000 :: Int)
             , "session_ttl_ms" .= (300_000 :: Int)
             , "provider_mode" .= ("streaming_sse" :: Text)
-            , "transcript_delivery_mode" .= ("final_only" :: Text)
+            , "transcript_delivery_mode" .= ("delta" :: Text)
             , "vad" .= Aeson.object
                 [ "type" .= ("server_vad" :: Text)
                 , "threshold" .= (0.5 :: Double)

--- a/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
@@ -79,6 +79,12 @@ spec = describe "OpenAI transcription" do
                 <> "\"session\":{\"status\":\"closed\"}}")
             `shouldBe` Right (ChatGPTSessionUpdated "closed")
         decodeChatGPTDictationEvent
+            ("{\"type\":\"transcript.delta\",\"sequence_no\":2,"
+                <> "\"utterance_id\":\"utterance-1\",\"revision\":1,"
+                <> "\"text\":\"hello \"}")
+            `shouldBe` Right
+                (ChatGPTTranscriptDelta "utterance-1" "hello ")
+        decodeChatGPTDictationEvent
             ("{\"type\":\"transcript.final\",\"sequence_no\":3,"
                 <> "\"utterance_id\":\"utterance-1\",\"revision\":1,"
                 <> "\"text\":\"hello world\"}")
@@ -168,7 +174,7 @@ spec = describe "OpenAI transcription" do
                         , "session_ttl_ms" .= (300_000 :: Int)
                         , "provider_mode" .= ("streaming_sse" :: Text)
                         , "transcript_delivery_mode" .=
-                            ("final_only" :: Text)
+                            ("delta" :: Text)
                         , "vad" .= Aeson.object
                             [ "type" .= ("server_vad" :: Text)
                             , "threshold" .= (0.5 :: Double)
@@ -197,10 +203,24 @@ spec = describe "OpenAI transcription" do
                     , "utterance_id" .= ("utterance-1" :: Text)
                     ]
                 sendEvent connection $ Aeson.object
-                    [ "type" .= ("transcript.final" :: Text)
+                    [ "type" .= ("transcript.delta" :: Text)
                     , "sequence_no" .= (3 :: Int)
                     , "utterance_id" .= ("utterance-1" :: Text)
                     , "revision" .= (1 :: Int)
+                    , "text" .= ("hello " :: Text)
+                    ]
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("transcript.delta" :: Text)
+                    , "sequence_no" .= (4 :: Int)
+                    , "utterance_id" .= ("utterance-1" :: Text)
+                    , "revision" .= (2 :: Int)
+                    , "text" .= ("from " :: Text)
+                    ]
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("transcript.final" :: Text)
+                    , "sequence_no" .= (5 :: Int)
+                    , "utterance_id" .= ("utterance-1" :: Text)
+                    , "revision" .= (3 :: Int)
                     , "text" .= ("hello from stream" :: Text)
                     ]
                 close <- WS.receiveData connection
@@ -209,7 +229,7 @@ spec = describe "OpenAI transcription" do
                     ]
                 sendEvent connection $ Aeson.object
                     [ "type" .= ("session.updated" :: Text)
-                    , "sequence_no" .= (4 :: Int)
+                    , "sequence_no" .= (6 :: Int)
                     , "session" .= sessionValue "closed"
                     ]
         withWebSocketServer server \port -> do
@@ -228,7 +248,12 @@ spec = describe "OpenAI transcription" do
                     (\text -> modifyIORef' callbacks (<> [text]))
             result `shouldBe` Just (Right "hello from stream")
         readIORef captures `shouldReturn` 1
-        readIORef callbacks `shouldReturn` ["hello from stream"]
+        readIORef callbacks
+            `shouldReturn`
+                [ "hello "
+                , "hello from "
+                , "hello from stream"
+                ]
 
     it "falls back to ChatGPT multipart and reuses audio after a 401" do
         recorded <- newIORef []


### PR DESCRIPTION
## Summary
- request delta transcript delivery from the ChatGPT dictation stream
- publish delta and segment updates while audio capture is still active
- preserve utterance ordering and replace interim text with the authoritative final transcript
- extend the WebSocket integration spec to cover progressive callbacks

## Testing
- `cabal repl agent-openai:test:agent-openai-test`, then `:main --match "OpenAI transcription"` (9 examples, 0 failures)
- `git diff --check`
- live CLI prompt exercised through tmux; Ctrl+R dictation affordance/key path rendered correctly (the nested harness could not allocate a second session temp directory for microphone capture)
