### PR TITLE
Handle revised OpenAI dictation hypotheses

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -684,9 +684,8 @@ receiveChatGPTDictation connection state finished onTranscript =
             Nothing ->
                 pure ()
             Just transcript ->
-                unless (Text.null transcript) $
-                    ignoreSynchronousException
-                        (onTranscript transcript)
+                ignoreSynchronousException
+                    (onTranscript transcript)
 
 receiverFailure :: SomeException -> Either Text ()
 receiverFailure err =
@@ -709,23 +708,14 @@ applyChatGPTDictationEvent event state =
         ChatGPTSpeechStopped utteranceId ->
             ensureChatGPTUtterance utteranceId state
         ChatGPTTranscriptDelta utteranceId revision text ->
-            replaceChatGPTTranscript utteranceId revision text state
+            replaceChatGPTTranscript
+                utteranceId revision text False state
         ChatGPTTranscriptSegment utteranceId revision text ->
-            replaceChatGPTTranscript utteranceId revision text state
+            replaceChatGPTTranscript
+                utteranceId revision text False state
         ChatGPTTranscriptFinal utteranceId revision text ->
-            let withUtterance =
-                    ensureChatGPTUtterance utteranceId state
-            in withUtterance
-                { transcriptByUtterance =
-                    Map.insert
-                        utteranceId
-                        ChatGPTUtteranceTranscript
-                            { revision
-                            , text
-                            , final = True
-                            }
-                        withUtterance.transcriptByUtterance
-                }
+            replaceChatGPTTranscript
+                utteranceId revision text True state
         _ ->
             state
 
@@ -733,9 +723,10 @@ replaceChatGPTTranscript
     :: Text
     -> Int
     -> Text
+    -> Bool
     -> ChatGPTStreamState
     -> ChatGPTStreamState
-replaceChatGPTTranscript utteranceId revision text state =
+replaceChatGPTTranscript utteranceId revision text final state =
     let withUtterance = ensureChatGPTUtterance utteranceId state
     in withUtterance
         { transcriptByUtterance =
@@ -747,7 +738,7 @@ replaceChatGPTTranscript utteranceId revision text state =
                         else ChatGPTUtteranceTranscript
                             { revision
                             , text
-                            , final = False
+                            , final
                             })
                 utteranceId
                 withUtterance.transcriptByUtterance

--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -154,9 +154,9 @@ data ChatGPTDictationEvent
     | ChatGPTSessionUpdated !Text
     | ChatGPTSpeechStarted !Text
     | ChatGPTSpeechStopped !Text
-    | ChatGPTTranscriptDelta !Text !Text
-    | ChatGPTTranscriptSegment !Text !Text
-    | ChatGPTTranscriptFinal !Text !Text
+    | ChatGPTTranscriptDelta !Text !Int !Text
+    | ChatGPTTranscriptSegment !Text !Int !Text
+    | ChatGPTTranscriptFinal !Text !Int !Text
     | ChatGPTTranscriptFailed !Text
     | ChatGPTSessionError !Bool !Text
     | ChatGPTEventUnknown
@@ -184,16 +184,19 @@ chatGPTDictationEventDecoder = Json.discriminatedObject "type" \case
         Json.object $
             ChatGPTTranscriptDelta
                 <$> Json.atKey "utterance_id" Json.text
+                <*> Json.atKey "revision" Json.int
                 <*> Json.atKey "text" Json.text
     "transcript.segment" ->
         Json.object $
             ChatGPTTranscriptSegment
                 <$> Json.atKey "utterance_id" Json.text
+                <*> Json.atKey "revision" Json.int
                 <*> Json.atKey "text" Json.text
     "transcript.final" ->
         Json.object $
             ChatGPTTranscriptFinal
                 <$> Json.atKey "utterance_id" Json.text
+                <*> Json.atKey "revision" Json.int
                 <*> Json.atKey "text" Json.text
     "transcript.failed" ->
         Json.object $
@@ -401,13 +404,20 @@ data ChatGPTStreamEndpoint = ChatGPTStreamEndpoint
 
 data ChatGPTStreamState = ChatGPTStreamState
     { utteranceOrder :: ![Text]
-    , textByUtterance :: !(Map.Map Text Text)
+    , transcriptByUtterance ::
+        !(Map.Map Text ChatGPTUtteranceTranscript)
+    }
+
+data ChatGPTUtteranceTranscript = ChatGPTUtteranceTranscript
+    { revision :: !Int
+    , text :: !Text
+    , final :: !Bool
     }
 
 emptyChatGPTStreamState :: ChatGPTStreamState
 emptyChatGPTStreamState = ChatGPTStreamState
     { utteranceOrder = []
-    , textByUtterance = Map.empty
+    , transcriptByUtterance = Map.empty
     }
 
 streamChatGPTDictation
@@ -643,11 +653,11 @@ receiveChatGPTDictation connection state finished onTranscript =
                         pure (Left message)
                     ChatGPTSessionError True message ->
                         pure (Left message)
-                    ChatGPTTranscriptDelta _ _ ->
+                    ChatGPTTranscriptDelta _ _ _ ->
                         updateTranscript event >> loop
-                    ChatGPTTranscriptSegment _ _ ->
+                    ChatGPTTranscriptSegment _ _ _ ->
                         updateTranscript event >> loop
-                    ChatGPTTranscriptFinal _ _ ->
+                    ChatGPTTranscriptFinal _ _ _ ->
                         updateTranscript event >> loop
                     _ -> do
                         modifyMVar state \previous ->
@@ -659,16 +669,24 @@ receiveChatGPTDictation connection state finished onTranscript =
                                 )
                         loop
     updateTranscript event = do
-        current <- modifyMVar state \previous ->
+        notification <- modifyMVar state \previous ->
             let next =
                     applyChatGPTDictationEvent
                         event
                         previous
-            in pure (next, next)
-        let transcript = renderChatGPTTranscript current
-        unless (Text.null transcript) $
-            ignoreSynchronousException
-                (onTranscript transcript)
+                before = renderChatGPTTranscript previous
+                after = renderChatGPTTranscript next
+            in pure
+                ( next
+                , if after == before then Nothing else Just after
+                )
+        case notification of
+            Nothing ->
+                pure ()
+            Just transcript ->
+                unless (Text.null transcript) $
+                    ignoreSynchronousException
+                        (onTranscript transcript)
 
 receiverFailure :: SomeException -> Either Text ()
 receiverFailure err =
@@ -690,37 +708,49 @@ applyChatGPTDictationEvent event state =
             ensureChatGPTUtterance utteranceId state
         ChatGPTSpeechStopped utteranceId ->
             ensureChatGPTUtterance utteranceId state
-        ChatGPTTranscriptDelta utteranceId text ->
-            appendChatGPTTranscript utteranceId text state
-        ChatGPTTranscriptSegment utteranceId text ->
-            appendChatGPTTranscript utteranceId text state
-        ChatGPTTranscriptFinal utteranceId text ->
+        ChatGPTTranscriptDelta utteranceId revision text ->
+            replaceChatGPTTranscript utteranceId revision text state
+        ChatGPTTranscriptSegment utteranceId revision text ->
+            replaceChatGPTTranscript utteranceId revision text state
+        ChatGPTTranscriptFinal utteranceId revision text ->
             let withUtterance =
                     ensureChatGPTUtterance utteranceId state
             in withUtterance
-                { textByUtterance =
+                { transcriptByUtterance =
                     Map.insert
                         utteranceId
-                        text
-                        withUtterance.textByUtterance
+                        ChatGPTUtteranceTranscript
+                            { revision
+                            , text
+                            , final = True
+                            }
+                        withUtterance.transcriptByUtterance
                 }
         _ ->
             state
 
-appendChatGPTTranscript
+replaceChatGPTTranscript
     :: Text
+    -> Int
     -> Text
     -> ChatGPTStreamState
     -> ChatGPTStreamState
-appendChatGPTTranscript utteranceId text state =
+replaceChatGPTTranscript utteranceId revision text state =
     let withUtterance = ensureChatGPTUtterance utteranceId state
     in withUtterance
-        { textByUtterance =
-            Map.insertWith
-                (\new previous -> previous <> new)
+        { transcriptByUtterance =
+            Map.adjust
+                (\previous ->
+                    if previous.final
+                        || revision < previous.revision
+                        then previous
+                        else ChatGPTUtteranceTranscript
+                            { revision
+                            , text
+                            , final = False
+                            })
                 utteranceId
-                text
-                withUtterance.textByUtterance
+                withUtterance.transcriptByUtterance
         }
 
 ensureChatGPTUtterance
@@ -728,24 +758,31 @@ ensureChatGPTUtterance
     -> ChatGPTStreamState
     -> ChatGPTStreamState
 ensureChatGPTUtterance utteranceId state
-    | Map.member utteranceId state.textByUtterance =
+    | Map.member utteranceId state.transcriptByUtterance =
         state
     | otherwise =
         state
             { utteranceOrder = state.utteranceOrder <> [utteranceId]
-            , textByUtterance =
-                Map.insert utteranceId "" state.textByUtterance
+            , transcriptByUtterance =
+                Map.insert
+                    utteranceId
+                    ChatGPTUtteranceTranscript
+                        { revision = -1
+                        , text = ""
+                        , final = False
+                        }
+                    state.transcriptByUtterance
             }
 
 renderChatGPTTranscript :: ChatGPTStreamState -> Text
 renderChatGPTTranscript state =
     Text.unwords
-        [ transcript
+        [ transcript.text
         | utteranceId <- state.utteranceOrder
         , Just transcript <- [Map.lookup
             utteranceId
-            state.textByUtterance]
-        , not (Text.null (Text.strip transcript))
+            state.transcriptByUtterance]
+        , not (Text.null (Text.strip transcript.text))
         ]
 
 chatGPTSessionStartMessage :: Int -> Text

--- a/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
@@ -83,13 +83,13 @@ spec = describe "OpenAI transcription" do
                 <> "\"utterance_id\":\"utterance-1\",\"revision\":1,"
                 <> "\"text\":\"hello \"}")
             `shouldBe` Right
-                (ChatGPTTranscriptDelta "utterance-1" "hello ")
+                (ChatGPTTranscriptDelta "utterance-1" 1 "hello ")
         decodeChatGPTDictationEvent
             ("{\"type\":\"transcript.final\",\"sequence_no\":3,"
                 <> "\"utterance_id\":\"utterance-1\",\"revision\":1,"
                 <> "\"text\":\"hello world\"}")
             `shouldBe` Right
-                (ChatGPTTranscriptFinal "utterance-1" "hello world")
+                (ChatGPTTranscriptFinal "utterance-1" 1 "hello world")
         decodeChatGPTDictationEvent
             ("{\"type\":\"session.error\",\"sequence_no\":2,\"fatal\":true,"
                 <> "\"error\":{\"code\":\"failed\",\"message\":\"bad audio\","
@@ -207,21 +207,35 @@ spec = describe "OpenAI transcription" do
                     , "sequence_no" .= (3 :: Int)
                     , "utterance_id" .= ("utterance-1" :: Text)
                     , "revision" .= (1 :: Int)
-                    , "text" .= ("hello " :: Text)
+                    , "text" .= ("hello wor" :: Text)
                     ]
                 sendEvent connection $ Aeson.object
                     [ "type" .= ("transcript.delta" :: Text)
                     , "sequence_no" .= (4 :: Int)
                     , "utterance_id" .= ("utterance-1" :: Text)
                     , "revision" .= (2 :: Int)
-                    , "text" .= ("from " :: Text)
+                    , "text" .= ("hello world" :: Text)
+                    ]
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("transcript.delta" :: Text)
+                    , "sequence_no" .= (5 :: Int)
+                    , "utterance_id" .= ("utterance-1" :: Text)
+                    , "revision" .= (1 :: Int)
+                    , "text" .= ("stale hypothesis" :: Text)
                     ]
                 sendEvent connection $ Aeson.object
                     [ "type" .= ("transcript.final" :: Text)
-                    , "sequence_no" .= (5 :: Int)
+                    , "sequence_no" .= (6 :: Int)
                     , "utterance_id" .= ("utterance-1" :: Text)
                     , "revision" .= (3 :: Int)
                     , "text" .= ("hello from stream" :: Text)
+                    ]
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("transcript.delta" :: Text)
+                    , "sequence_no" .= (7 :: Int)
+                    , "utterance_id" .= ("utterance-1" :: Text)
+                    , "revision" .= (4 :: Int)
+                    , "text" .= ("late interim" :: Text)
                     ]
                 close <- WS.receiveData connection
                 decodeValue close `shouldBe` Aeson.object
@@ -229,7 +243,7 @@ spec = describe "OpenAI transcription" do
                     ]
                 sendEvent connection $ Aeson.object
                     [ "type" .= ("session.updated" :: Text)
-                    , "sequence_no" .= (6 :: Int)
+                    , "sequence_no" .= (8 :: Int)
                     , "session" .= sessionValue "closed"
                     ]
         withWebSocketServer server \port -> do
@@ -250,8 +264,8 @@ spec = describe "OpenAI transcription" do
         readIORef captures `shouldReturn` 1
         readIORef callbacks
             `shouldReturn`
-                [ "hello "
-                , "hello from "
+                [ "hello wor"
+                , "hello world"
                 , "hello from stream"
                 ]
 

--- a/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
@@ -217,24 +217,31 @@ spec = describe "OpenAI transcription" do
                     , "text" .= ("hello world" :: Text)
                     ]
                 sendEvent connection $ Aeson.object
-                    [ "type" .= ("transcript.delta" :: Text)
+                    [ "type" .= ("transcript.final" :: Text)
                     , "sequence_no" .= (5 :: Int)
                     , "utterance_id" .= ("utterance-1" :: Text)
                     , "revision" .= (1 :: Int)
-                    , "text" .= ("stale hypothesis" :: Text)
+                    , "text" .= ("stale final" :: Text)
                     ]
                 sendEvent connection $ Aeson.object
-                    [ "type" .= ("transcript.final" :: Text)
+                    [ "type" .= ("transcript.delta" :: Text)
                     , "sequence_no" .= (6 :: Int)
                     , "utterance_id" .= ("utterance-1" :: Text)
                     , "revision" .= (3 :: Int)
+                    , "text" .= ("" :: Text)
+                    ]
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("transcript.final" :: Text)
+                    , "sequence_no" .= (7 :: Int)
+                    , "utterance_id" .= ("utterance-1" :: Text)
+                    , "revision" .= (4 :: Int)
                     , "text" .= ("hello from stream" :: Text)
                     ]
                 sendEvent connection $ Aeson.object
                     [ "type" .= ("transcript.delta" :: Text)
-                    , "sequence_no" .= (7 :: Int)
+                    , "sequence_no" .= (8 :: Int)
                     , "utterance_id" .= ("utterance-1" :: Text)
-                    , "revision" .= (4 :: Int)
+                    , "revision" .= (5 :: Int)
                     , "text" .= ("late interim" :: Text)
                     ]
                 close <- WS.receiveData connection
@@ -243,7 +250,7 @@ spec = describe "OpenAI transcription" do
                     ]
                 sendEvent connection $ Aeson.object
                     [ "type" .= ("session.updated" :: Text)
-                    , "sequence_no" .= (8 :: Int)
+                    , "sequence_no" .= (9 :: Int)
                     , "session" .= sessionValue "closed"
                     ]
         withWebSocketServer server \port -> do
@@ -266,6 +273,7 @@ spec = describe "OpenAI transcription" do
             `shouldReturn`
                 [ "hello wor"
                 , "hello world"
+                , ""
                 , "hello from stream"
                 ]
 


### PR DESCRIPTION
## Summary
- address the post-merge review feedback from #904
- decode and retain ChatGPT transcript revision numbers
- replace interim utterance hypotheses instead of concatenating revisions
- ignore stale revisions and prevent late interim events from overwriting final text
- suppress callbacks when an ignored event does not change rendered text

## Testing
- `cabal repl agent-openai:test:agent-openai-test`, then `:main --match "OpenAI transcription"` (9 examples, 0 failures)
- integration coverage includes revised hypotheses, a stale revision, and a post-final interim event
- `git diff --check`
