### PR TITLE
Fix literal CSI text from Command-modified keys

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -78,7 +78,6 @@ import Agent.CLI.Terminal ( TerminalCapabilities(..)
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
     , kittySuperCsiBodies
-    , kittySuperVCsiBodies
     , shiftEnterCsiBodies
     )
 import qualified Agent.TUI.Theme as Theme
@@ -834,17 +833,19 @@ fullscreenVtyConfig =
                | character <- ['a'..'z']
                , body <- kittyCtrlCsiBodies character
                ]
+            -- The Kitty disambiguation mode reports every Command-modified
+            -- printable key as CSI-u, not only shortcuts we handle. Vty
+            -- otherwise emits an unknown sequence's body as literal text
+            -- (for example Cmd+ß appeared as "[223;9u"). Decode the
+            -- characters available on ASCII and Latin-1 keyboard layouts;
+            -- Composer will act on supported shortcuts and ignore the rest.
             <> [ ( Nothing
                  , "\ESC[" <> body
-                 , V.EvKey (V.KChar 'v') [V.MMeta]
+                 , V.EvKey (V.KChar character) [V.MMeta]
                  )
-               | body <- kittySuperVCsiBodies
-               ]
-            <> [ ( Nothing
-                 , "\ESC[" <> body
-                 , V.EvKey (V.KChar 'k') [V.MMeta]
-                 )
-               | body <- kittySuperCsiBodies 'k'
+               | character <-
+                    [' '..'~'] <> ['\x00a0'..'\x00ff']
+               , body <- kittySuperCsiBodies character
                ]
             <> [ ( Nothing
                  , "\ESC[" <> body

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -663,6 +663,14 @@ spec = do
                   , V.EvKey (V.KChar 'k') [V.MMeta]
                   )
                 , ( Nothing
+                  , "\ESC[223;9u"
+                  , V.EvKey (V.KChar 'ß') [V.MMeta]
+                  )
+                , ( Nothing
+                  , "\ESC[223;9:1u"
+                  , V.EvKey (V.KChar 'ß') [V.MMeta]
+                  )
+                , ( Nothing
                   , "\ESC[114;5u"
                   , V.EvKey (V.KChar 'r') [V.MCtrl]
                   )


### PR DESCRIPTION
## Summary
- decode Kitty CSI-u sequences for Command-modified ASCII and Latin-1 printable keys
- preserve supported Command shortcuts while allowing unsupported chords to be ignored instead of inserted as literal CSI text
- add regression coverage for Command+ß (`ESC[223;9u` and its event-type variant)

## Validation
- `git diff --check`
- confirmed `ß` is included in the generated Latin-1 mapping

## Testing limitations
- `nix develop -c cabal repl agent-cli:lib:agent-cli` was blocked because Nix could not stat the local session directory (`Operation not permitted`)
- direct `cabal repl agent-cli:lib:agent-cli` was blocked by the missing `packages/agent-openai/data/prompt.md` build input
- consequently, the full test suite and live tmux TUI smoke test were not run locally