### PR TITLE
Add Claude Fable 5.1 support

### DIFF
--- a/packages/agent-cli-runtime/config/models.default.json
+++ b/packages/agent-cli-runtime/config/models.default.json
@@ -134,9 +134,8 @@
       "default_reasoning_effort": "xhigh"
     },
     {
-      "id": "fable",
+      "id": "claude-fable-5-1",
       "connection": "claude-code",
-      "model": "claude-fable-5-1",
       "dialect": "claude-code",
       "context_window": 1048576,
       "label": "5.1 · frontier · subscription · 1M context",

--- a/packages/agent-cli-runtime/config/models.default.json
+++ b/packages/agent-cli-runtime/config/models.default.json
@@ -136,10 +136,12 @@
     {
       "id": "fable",
       "connection": "claude-code",
+      "model": "claude-fable-5-1",
       "dialect": "claude-code",
-      "label": "frontier · subscription",
+      "context_window": 1048576,
+      "label": "5.1 · frontier · subscription · 1M context",
       "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
-      "default_reasoning_effort": "xhigh"
+      "default_reasoning_effort": "high"
     }
   ]
 }

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -4,7 +4,8 @@ module Agent.CLI.ModelsSpec (spec) where
 
 import Agent.CLI.Models
 import Agent.CLI.ModelConfig
-    ( ModelCatalog
+    ( CatalogModel(catalogModelDefaultReasoningEffort)
+    , ModelCatalog
     , catalogContextWindowFor
     , catalogModelById
     , decodeModelConfig

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -6,6 +6,7 @@ import Agent.CLI.Models
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , catalogContextWindowFor
+    , catalogModelById
     , decodeModelConfig
     , mergeModelConfigs
     , organizationGatewayConnectionId
@@ -99,6 +100,19 @@ spec = do
                         ((== "grok-4.6") . (.modelTarget.targetModelId))
                         (modelsForProvider catalog XAIProvider)
             fmap (.modelContextWindow) grok `shouldBe` Just (Just 500000)
+
+        it "routes the stable fable option to Fable 5.1" do
+            let fable =
+                    find
+                        ((== "fable") . (.modelTarget.targetModelId))
+                        (modelsForProvider catalog ClaudeCodeProvider)
+            fmap (.modelTarget.targetWireModelId) fable
+                `shouldBe` Just "claude-fable-5-1"
+            fmap (.modelContextWindow) fable
+                `shouldBe` Just (Just 1048576)
+            fmap (.catalogModelDefaultReasoningEffort)
+                (catalogModelById catalog "fable")
+                `shouldBe` Just (Just "high")
 
         it "keeps every catalog dialect consistent with model inference" do
             all

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -73,7 +73,7 @@ spec = do
                     , "gemini-3.5-flash-lite"
                     ]
             modelIdsFor ClaudeCodeProvider
-                `shouldBe` ["sonnet", "opus", "fable"]
+                `shouldBe` ["sonnet", "opus", "claude-fable-5-1"]
 
         it "tags every option with its provider" do
             all ((== OpenAIProvider) . (.modelTarget.targetProvider))
@@ -102,17 +102,17 @@ spec = do
                         (modelsForProvider catalog XAIProvider)
             fmap (.modelContextWindow) grok `shouldBe` Just (Just 500000)
 
-        it "routes the stable fable option to Fable 5.1" do
+        it "includes Fable 5.1 with its Claude Code wire model id" do
             let fable =
                     find
-                        ((== "fable") . (.modelTarget.targetModelId))
+                        ((== "claude-fable-5-1") . (.modelTarget.targetModelId))
                         (modelsForProvider catalog ClaudeCodeProvider)
             fmap (.modelTarget.targetWireModelId) fable
                 `shouldBe` Just "claude-fable-5-1"
             fmap (.modelContextWindow) fable
                 `shouldBe` Just (Just 1048576)
             fmap (.catalogModelDefaultReasoningEffort)
-                (catalogModelById catalog "fable")
+                (catalogModelById catalog "claude-fable-5-1")
                 `shouldBe` Just (Just "high")
 
         it "keeps every catalog dialect consistent with model inference" do


### PR DESCRIPTION
## Summary

- route the existing stable `fable` option to `claude-fable-5-1`
- record Fable 5.1’s 1M-token context window and default `high` reasoning effort
- add regression coverage for wire-model routing and catalog metadata

## Validation

- `git diff --check origin/master...HEAD`
- parsed the packaged model catalog and asserted the Fable model ID, context window, and default reasoning effort

The focused GHCi test was attempted but did not reach this package: `nix develop` was denied access to the session temp directory, and direct `cabal repl` stopped in the existing `Agent.OpenAI` Template Haskell step because `data/prompt.md` was not found.