### PR TITLE
Route dictation through the organization gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ credential types are configured. OpenAI credentials can come from
 `OPENAI_API_KEY`, `CODEX_API_KEY`, or a managed OpenAI account.
 For Grok models, dictation uses the configured xAI subscription or API-key
 credential; set `XAI_STT_LANGUAGE` to override xAI's default `en`.
+When an organization gateway is connected, the recording is sent only to the
+gateway's authenticated `/v1/audio/transcriptions` endpoint. The gateway uses
+its organization-managed transcription pool and returns a final transcript
+after recording stops; it never falls back to local provider credentials.
 Dictation is currently unavailable for providers without a speech-to-text
 integration.
 

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -48,9 +48,11 @@ module Agent.CLI.GatewayClient
     , fetchGatewayModels
     , newGatewayModelAccess
     , newGatewayModelAccessWith
+    , newGatewayModelAccessWithDictation
     , refreshGatewayModels
     , cachedGatewayModels
     , gatewayModelIds
+    , transcribeGatewayPcm
     , runGatewayCommand
     , saveGatewayCredentialAt
     , showGatewayStatus
@@ -59,6 +61,10 @@ module Agent.CLI.GatewayClient
     ) where
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
+import Agent.OpenAI.Transcription
+    ( encodePcm16Wav
+    , openAITranscriptionSampleRate
+    )
 import Agent.CLI.Runtime.Options (GatewayCommand (..))
 import Agent.CLI.PrivateFileLock
     ( withPrivateFileLock
@@ -88,7 +94,7 @@ import Control.Exception.Safe
     , throwString
     , tryAny
     )
-import Control.Monad (when)
+import Control.Monad (unless, when)
 import Crypto.Hash (Digest, SHA256, hash)
 import Data.Aeson ((.=), (.:))
 import Data.Aeson qualified as Aeson
@@ -100,7 +106,13 @@ import Data.ByteString.Builder qualified as Builder
 import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy qualified as LBS
 import Data.Char (isDigit, isPrint, isSpace)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IORef
+    ( IORef
+    , modifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -249,6 +261,10 @@ data GatewayModelAccess = GatewayModelAccess
     { gatewayModelFetch :: !(IO (Either Text [GatewayModel]))
     , gatewayModelCache :: !(IORef (Maybe [GatewayModel]))
     , gatewayModelRefreshLock :: !(MVar ())
+    , gatewayDictation
+        :: !(((BS.ByteString -> IO ()) -> IO ())
+            -> (Text -> IO ())
+            -> IO (Either Text Text))
     }
 
 -- | The hosted gateway selected by the interactive @/login@ flow.
@@ -334,8 +350,10 @@ gatewayCredentialDecoder =
 
 -- | Construct a cached model-list handle for a validated gateway credential.
 newGatewayModelAccess :: GatewayCredential -> IO GatewayModelAccess
-newGatewayModelAccess =
-    newGatewayModelAccessWith . fetchGatewayModels
+newGatewayModelAccess credential =
+    newGatewayModelAccessWithDictation
+        (fetchGatewayModels credential)
+        (transcribeGatewayPcmWith credential)
 
 -- | Injectable constructor used by tests and alternative trusted transports.
 -- The resulting value remains opaque, so the fetch action cannot be read back
@@ -343,14 +361,223 @@ newGatewayModelAccess =
 newGatewayModelAccessWith
     :: IO (Either Text [GatewayModel])
     -> IO GatewayModelAccess
-newGatewayModelAccessWith fetch = do
+newGatewayModelAccessWith fetch =
+    newGatewayModelAccessWithDictation
+        fetch
+        (\_ _ ->
+            pure
+                (Left
+                    "Dictation is not available through this gateway connection."))
+
+-- | Injectable constructor for tests and trusted alternative gateway
+-- transports. The action stays opaque with the credential-bearing model
+-- access handle.
+newGatewayModelAccessWithDictation
+    :: IO (Either Text [GatewayModel])
+    -> (((BS.ByteString -> IO ()) -> IO ())
+        -> (Text -> IO ())
+        -> IO (Either Text Text))
+    -> IO GatewayModelAccess
+newGatewayModelAccessWithDictation fetch dictation = do
     cache <- newIORef Nothing
     refreshLock <- newMVar ()
     pure GatewayModelAccess
         { gatewayModelFetch = fetch
         , gatewayModelCache = cache
         , gatewayModelRefreshLock = refreshLock
+        , gatewayDictation = dictation
         }
+
+-- | Record PCM through the opaque, gateway-bound dictation action.
+transcribeGatewayPcm
+    :: GatewayModelAccess
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO (Either Text Text)
+transcribeGatewayPcm access = access.gatewayDictation
+
+transcribeGatewayPcmWith
+    :: GatewayCredential
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO (Either Text Text)
+transcribeGatewayPcmWith admitted produceAudio onTranscript =
+    withGatewayCredentialTurnLease do
+        loadGatewayCredential >>= \case
+            Right (Just current)
+                | current == admitted ->
+                    captureGatewayWav produceAudio >>= \case
+                        Left err -> pure (Left err)
+                        Right wav ->
+                            postGatewayTranscription current wav >>= \case
+                                Left err -> pure (Left err)
+                                Right transcript -> do
+                                    onTranscript transcript
+                                    pure (Right transcript)
+            _ ->
+                pure $
+                    Left
+                        "The organization gateway changed before dictation started."
+
+captureGatewayWav
+    :: ((BS.ByteString -> IO ()) -> IO ())
+    -> IO (Either Text LBS.ByteString)
+captureGatewayWav produceAudio =
+    tryAny capture >>= \case
+        Left _ ->
+            pure (Left "Gateway dictation audio capture failed.")
+        Right result -> pure result
+  where
+    capture = do
+        chunks <- newIORef []
+        capturedBytes <- newIORef 0
+        produceAudio \chunk ->
+            unless (BS.null chunk) do
+                total <- (+ BS.length chunk) <$> readIORef capturedBytes
+                when (total > gatewayMaxPcmBytes) $
+                    throwString
+                        "gateway dictation audio exceeded the client limit"
+                writeIORef capturedBytes total
+                modifyIORef' chunks (chunk :)
+        pcm <- BS.concat . reverse <$> readIORef chunks
+        pure $
+            case encodePcm16Wav openAITranscriptionSampleRate pcm of
+                Left _ ->
+                    Left "Gateway dictation captured invalid audio."
+                Right wav -> Right wav
+
+gatewayMaxPcmBytes :: Int
+gatewayMaxPcmBytes = 4 * 1024 * 1024 - 4096
+
+postGatewayTranscription
+    :: GatewayCredential
+    -> LBS.ByteString
+    -> IO (Either Text Text)
+postGatewayTranscription credential wav =
+    case validateGatewayCredential credential of
+        Left _ -> pure (Left "Gateway credential is invalid.")
+        Right () -> do
+            boundary <- gatewayTranscriptionBoundary
+            let body = gatewayTranscriptionBody boundary wav
+                endpoint =
+                    Text.dropWhileEnd (== '/')
+                        (Text.strip credential.gatewayBaseUrl)
+                        <> "/v1/audio/transcriptions"
+            outcome <- tryAny do
+                manager <- newTlsManager
+                initial <- HTTP.parseRequest (Text.unpack endpoint)
+                let request =
+                        initial
+                            { HTTP.method = "POST"
+                            , HTTP.requestHeaders =
+                                [ ( hAuthorization
+                                  , "Bearer "
+                                        <> TextEncoding.encodeUtf8
+                                            credential.gatewayAccessToken
+                                  )
+                                , ( hContentType
+                                  , "multipart/form-data; boundary=" <> boundary
+                                  )
+                                , (hAccept, "application/json")
+                                ]
+                            , HTTP.requestBody = HTTP.RequestBodyLBS body
+                            , HTTP.checkResponse = \_ _ -> pure ()
+                            -- Never forward the gateway bearer to a redirect.
+                            , HTTP.redirectCount = 0
+                            , HTTP.responseTimeout =
+                                HTTP.responseTimeoutMicro
+                                    (2 * 60 * 1_000_000)
+                            }
+                HTTP.withResponse request manager \response -> do
+                    responseBody <-
+                        readBoundedBody
+                            gatewayMaxResponseBytes
+                            (HTTP.responseBody response)
+                    pure
+                        ( HTTP.responseStatus response
+                        , responseBody
+                        )
+            pure case outcome of
+                Left _ ->
+                    Left "Could not reach the organization gateway for dictation."
+                Right (_status, Nothing) ->
+                    Left "Gateway dictation returned an oversized response."
+                Right (status, Just responseBody)
+                    | statusIsSuccessful status ->
+                        decodeGatewayTranscript responseBody
+                    | statusCode status == 404 ->
+                        Left
+                            "Dictation is not supported by this organization gateway."
+                    | otherwise ->
+                        Left $
+                            "Gateway dictation returned HTTP "
+                                <> Text.pack (show (statusCode status))
+
+gatewayMaxResponseBytes :: Int
+gatewayMaxResponseBytes = 64 * 1024
+
+readBoundedBody
+    :: Int
+    -> HTTP.BodyReader
+    -> IO (Maybe BS.ByteString)
+readBoundedBody limit = go 0 []
+  where
+    go total chunks reader = do
+        chunk <- HTTP.brRead reader
+        if BS.null chunk
+            then pure (Just (BS.concat (reverse chunks)))
+            else
+                let next = total + BS.length chunk
+                in if next > limit
+                    then pure Nothing
+                    else go next (chunk : chunks) reader
+
+gatewayTranscriptionBoundary :: IO BS.ByteString
+gatewayTranscriptionBoundary =
+    ("----haskell-agent-gateway-" <>)
+        . Base64Url.encodeUnpadded
+        <$> getEntropy 18
+
+gatewayTranscriptionBody
+    :: BS.ByteString
+    -> LBS.ByteString
+    -> LBS.ByteString
+gatewayTranscriptionBody boundary wav =
+    LBS.fromStrict
+        ( "--" <> boundary <> "\r\n"
+        <> "Content-Disposition: form-data; name=\"model\"\r\n\r\n"
+        <> "dictation\r\n"
+        <> "--" <> boundary <> "\r\n"
+        <> "Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n"
+        <> "Content-Type: audio/wav\r\n\r\n"
+        )
+        <> wav
+        <> LBS.fromStrict
+            ("\r\n--" <> boundary <> "--\r\n")
+
+newtype GatewayTranscript =
+    GatewayTranscript { gatewayTranscriptText :: Text }
+
+instance Aeson.FromJSON GatewayTranscript where
+    parseJSON =
+        Aeson.withObject "GatewayTranscript" \object ->
+            GatewayTranscript <$> object .: "text"
+
+decodeGatewayTranscript :: BS.ByteString -> Either Text Text
+decodeGatewayTranscript body =
+    case
+        Aeson.eitherDecodeStrict' body
+            :: Either String GatewayTranscript
+        of
+        Left _ ->
+            Left "Gateway dictation returned an unreadable response."
+        Right response
+            | Text.null transcript ->
+                Left "Gateway dictation returned an empty transcript."
+            | otherwise -> Right transcript
+          where
+            transcript =
+                Text.strip response.gatewayTranscriptText
 
 -- | Refresh the gateway's authorized model aliases.
 --

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -119,6 +119,34 @@ spec = describe "gateway device authorization" do
             `shouldReturn` Left "gateway unavailable"
         cachedGatewayModels access `shouldReturn` Nothing
 
+    it "keeps gateway dictation behind the opaque model access" do
+        events <- newIORef ([] :: [Text.Text])
+        access <-
+            newGatewayModelAccessWithDictation
+                (pure (Right
+                    [GatewayModel
+                        "company-model"
+                        GatewayResponsesProtocol]))
+                (\produceAudio onTranscript -> do
+                    produceAudio \chunk ->
+                        atomicModifyIORef' events \current ->
+                            (current <> ["audio:" <> Text.pack (show chunk)], ())
+                    onTranscript "gateway transcript"
+                    pure (Right "gateway transcript"))
+        result <-
+            transcribeGatewayPcm
+                access
+                (\send -> send "pcm")
+                (\transcript ->
+                    atomicModifyIORef' events \current ->
+                        (current <> ["text:" <> transcript], ()))
+        result `shouldBe` Right "gateway transcript"
+        atomicModifyIORef' events (\current -> (current, current))
+            `shouldReturn`
+                [ "audio:\"pcm\""
+                , "text:gateway transcript"
+                ]
+
     it "clears cached gateway models when a fetch throws" do
         calls <- newIORef (0 :: Int)
         access <-

--- a/packages/agent-cli/src/Agent/CLI/Dictation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation.hs
@@ -3,9 +3,13 @@ module Agent.CLI.Dictation
     ( DictationBackend(..)
     , DictationControl(..)
     , DictationResult(..)
+    , DictationTarget(..)
     , dictate
     , dictateForProvider
+    , dictateForTarget
     , dictateWith
+    , dictateWithTarget
+    , dictationTargetForSession
     , dictationBackendForProvider
     , insertDictation
     , transcribeAudio
@@ -17,6 +21,10 @@ import Agent.CLI.Auth
     , loadOpenAiDictationAuth
     )
 import Agent.CLI.Transcription (transcribeAudio)
+import Agent.CLI.GatewayClient
+    ( GatewayModelAccess
+    , transcribeGatewayPcm
+    )
 import Agent.OpenAI.Transcription
     ( openAITranscriptionSampleRate
     , transcribePcmWithOpenAI
@@ -88,6 +96,23 @@ data DictationBackend
     | XAIDictation
     deriving (Eq, Show)
 
+-- | Dictation is either scoped to the active direct provider or routed
+-- entirely through the organization gateway. Keeping these constructors
+-- distinct prevents a gateway session from falling back to local credentials.
+data DictationTarget
+    = DirectDictation !Provider
+    | GatewayDictation !GatewayModelAccess
+
+-- | Select the only dictation transport allowed by the current session
+-- boundary. A connected gateway is authoritative regardless of the model's
+-- underlying provider.
+dictationTargetForSession
+    :: Provider
+    -> Maybe GatewayModelAccess
+    -> DictationTarget
+dictationTargetForSession provider =
+    maybe (DirectDictation provider) GatewayDictation
+
 -- | Select dictation from the active model provider. Providers without a
 -- speech-to-text integration fail explicitly rather than spending credentials
 -- from an unrelated provider.
@@ -109,11 +134,14 @@ dictate = dictateForProvider XAIProvider
 
 -- | Stream the default microphone using the active model provider.
 dictateForProvider :: Provider -> IO Text
-dictateForProvider provider = do
+dictateForProvider = dictateForTarget . DirectDictation
+
+dictateForTarget :: DictationTarget -> IO Text
+dictateForTarget target = do
     Text.hPutStrLn stderr "● Starting dictation…"
     hFlush stderr
     result <-
-        dictateWith provider
+        dictateWithTarget target
             DictationControl
                 { dictationWaitForStop = do
                     Text.hPutStr stderr "● Listening… press Enter to stop"
@@ -129,20 +157,41 @@ dictateForProvider provider = do
 -- | Record microphone audio until the caller signals stop. Providers that
 -- stream partial transcripts deliver them through the control callback.
 dictateWith :: Provider -> DictationControl -> IO DictationResult
-dictateWith provider control =
+dictateWith provider =
+    dictateWithTarget (DirectDictation provider)
+
+dictateWithTarget
+    :: DictationTarget
+    -> DictationControl
+    -> IO DictationResult
+dictateWithTarget target control =
     try run >>= \case
         Left (err :: SomeException) ->
             pure (DictationFailed (Text.pack (displayException err)))
         Right result ->
             pure result
   where
-    run =
-        case dictationBackendForProvider provider of
-            Left err ->
-                pure (DictationFailed err)
-            Right backend -> do
-                requireExecutable "ffmpeg"
-                runBackend backend
+    run = do
+        requireExecutable "ffmpeg"
+        case target of
+            DirectDictation provider ->
+                case dictationBackendForProvider provider of
+                    Left err ->
+                        pure (DictationFailed err)
+                    Right backend ->
+                        runBackend backend
+            GatewayDictation gateway ->
+                transcribeGatewayPcm
+                    gateway
+                    (streamMicrophone
+                        openAITranscriptionSampleRate
+                        control.dictationWaitForStop)
+                    control.dictationOnTranscript >>= \case
+                        Left err -> pure (DictationFailed err)
+                        Right transcript ->
+                            pure
+                                (DictationTranscript
+                                    (Text.strip transcript))
     runBackend = \case
         OpenAIDictation ->
             loadOpenAiDictationAuth >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Input
     , readReplLineWithInitial
     , readReplLineWithCatalog
     , readReplLineWithCatalogForProvider
+    , readReplLineWithCatalogForTarget
     , readReplLineWithSkills
     , readReplLineWithSkillsAndModels
     , readModalText
@@ -40,7 +41,8 @@ import Agent.CLI.Clipboard
     , readClipboardText
     )
 import Agent.CLI.Dictation
-    ( dictateForProvider
+    ( DictationTarget(..)
+    , dictateForTarget
     , insertDictation
     )
 import Agent.CLI.Command
@@ -136,20 +138,23 @@ import System.Posix.Terminal
 readReplLine :: InterruptState -> Text -> IO ReplLine
 readReplLine interrupt prompt =
     readReplLineConfigured
-        (Just XAIProvider)
+        (Just (DirectDictation XAIProvider))
         defaultSlashCatalog False interrupt prompt ""
 
 -- | Read a prompt whose dictation backend follows the active model provider.
 readReplLineForProvider :: Provider -> InterruptState -> Text -> IO ReplLine
 readReplLineForProvider provider interrupt prompt =
     readReplLineConfigured
-        (Just provider)
+        (Just (DirectDictation provider))
         defaultSlashCatalog False interrupt prompt ""
 
 -- | Like 'readReplLine', restoring @initial@ as the in-progress draft.
 readReplLineWithInitial :: InterruptState -> Text -> Text -> IO ReplLine
 readReplLineWithInitial =
-    readReplLineConfigured (Just XAIProvider) defaultSlashCatalog True
+    readReplLineConfigured
+        (Just (DirectDictation XAIProvider))
+        defaultSlashCatalog
+        True
 
 readReplLineWithCatalog
     :: SlashCatalog
@@ -168,7 +173,19 @@ readReplLineWithCatalogForProvider
     -> Text
     -> IO ReplLine
 readReplLineWithCatalogForProvider provider catalog =
-    readReplLineConfigured (Just provider) catalog True
+    readReplLineWithCatalogForTarget
+        (DirectDictation provider)
+        catalog
+
+readReplLineWithCatalogForTarget
+    :: DictationTarget
+    -> SlashCatalog
+    -> InterruptState
+    -> Text
+    -> Text
+    -> IO ReplLine
+readReplLineWithCatalogForTarget target catalog =
+    readReplLineConfigured (Just target) catalog True
 
 readReplLineWithSkills
     :: [SkillCommand]
@@ -178,7 +195,7 @@ readReplLineWithSkills
     -> IO ReplLine
 readReplLineWithSkills skills =
     readReplLineConfigured
-        (Just XAIProvider)
+        (Just (DirectDictation XAIProvider))
         (slashCatalogWithSkills skills defaultSlashCatalog)
         True
 
@@ -191,14 +208,14 @@ readReplLineWithSkillsAndModels
     -> IO ReplLine
 readReplLineWithSkillsAndModels skills modelIds =
     readReplLineConfigured
-        (Just XAIProvider)
+        (Just (DirectDictation XAIProvider))
         ((slashCatalogWithSkills skills defaultSlashCatalog)
             { slashCatalogModelIds = modelIds
             })
         True
 
 readReplLineConfigured
-    :: Maybe Provider
+    :: Maybe DictationTarget
     -> SlashCatalog
     -> Bool
     -> InterruptState
@@ -237,7 +254,7 @@ readModalText interrupt prompt initial =
 
 readLineConfigured
     :: Bool
-    -> Maybe Provider
+    -> Maybe DictationTarget
     -> SlashCatalog
     -> Bool
     -> InterruptState
@@ -284,7 +301,7 @@ readLineConfigured
 -- prompt redraw so slash suggestions can update after every keystroke.
 readInlineEditor
     :: Bool
-    -> Maybe Provider
+    -> Maybe DictationTarget
     -> SlashCatalog
     -> Bool
     -> InterruptState
@@ -367,7 +384,7 @@ readInlineEditor
                 result <- tryAny $
                     maybe
                         (fail "Dictation is unavailable in this prompt.")
-                        dictateForProvider
+                        dictateForTarget
                         dictationProvider
                 case result of
                     Left err ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -29,14 +29,16 @@ import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ()
+import Agent.CLI.Dictation
+    ( dictationTargetForSession )
 import Agent.CLI.GatewayClient
     ( cachedGatewayModels
     , gatewayModelIds
     )
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input
-    ( readReplLineWithCatalog
-    , readReplLineWithCatalogForProvider
+    ( readReplLineWithCatalogForProvider
+    , readReplLineWithCatalogForTarget
     )
 import Agent.CLI.Interrupt ()
 import Agent.CLI.LearnedSkills ()
@@ -393,8 +395,11 @@ replWithDraft env@SessionEnv
                             then Text.pack clearFromCursorToLineEndCode
                             else mempty
             result <- case gatewayAccess of
-                Just _ ->
-                    readReplLineWithCatalog
+                Just gateway ->
+                    readReplLineWithCatalogForTarget
+                        (dictationTargetForSession
+                            env.sessionProvider
+                            (Just gateway))
                         slashCatalog
                         interrupt chromePrompt draft
                 Nothing ->

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -69,6 +69,7 @@ import Agent.CLI.Request
 import Agent.CLI.Tools
 import Agent.CLI.Error
 import Agent.CLI.Dialects
+import Agent.CLI.Dictation (dictationTargetForSession)
 import Agent.CLI.TUI.App
 import Agent.TUI.Model
 import Agent.TUI.Motion
@@ -977,7 +978,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
     forM_ fullscreen \runtime ->
         setFullscreenSessionActions
             runtime
-            (if isJust gatewayAccess then Nothing else Just provider)
+            (Just (dictationTargetForSession provider gatewayAccess))
             (requestCancel toolEnv.toolCancel)
             (\pasted text -> do
                 images <- loadImagesFromPastedText text

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -5,7 +5,7 @@ module Agent.CLI.TUI.App.Run where
 import Agent.CLI.Clipboard ( formatImageSize )
 import Agent.CLI.Dictation ( DictationControl(..)
     , DictationResult(..)
-    , dictateWith
+    , dictateWithTarget
     , insertDictation
     )
 import Agent.CLI.Secret (sanitizeSecretPromptText)
@@ -358,13 +358,13 @@ runFullscreen runtime workerAction = do
     dictationWorker = forever do
         job <- atomically (readTQueue runtime.runtimeDictationJobs)
         actions <- readIORef runtime.runtimeSessionActions
-        result <- case actions.sessionProvider of
+        result <- case actions.sessionDictationTarget of
             Nothing ->
                 pure $ DictationFailed
                     "Dictation is unavailable for the active session"
-            Just provider ->
-                dictateWith
-                    provider
+            Just target ->
+                dictateWithTarget
+                    target
                     DictationControl
                         { dictationWaitForStop =
                             job.dictationJobWaitForStop

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -7,10 +7,10 @@ import Agent.CLI.TUI.App.Mailbox
     , enqueueAppEvent
     )
 
-import Agent.Provider (Provider)
 import Agent.CLI.Clipboard ( formatImageSize )
 import Agent.CLI.Dictation ( DictationControl(..)
     , DictationResult(..)
+    , DictationTarget
     , dictateWith
     , insertDictation
     )
@@ -314,7 +314,7 @@ newFullscreenRuntimeWithSyntaxLoaderAndTheme
         themeRef <- newIORef theme
         windowTitle <- newIORef Nothing
         sessionActions <- newIORef FullscreenSessionActions
-            { sessionProvider = Nothing
+            { sessionDictationTarget = Nothing
             , sessionCancel = cancelAction
             , sessionSteer = \_ _ -> pure (Right ())
             , sessionBtw = const (pure ())
@@ -382,7 +382,7 @@ newFullscreenRuntimeWithSyntaxLoaderAndTheme
 
 setFullscreenSessionActions
     :: FullscreenRuntime
-    -> Maybe Provider
+    -> Maybe DictationTarget
     -> IO ()
     -> (Bool -> Text -> IO (Either Text ()))
     -> (Text -> IO ())
@@ -394,7 +394,7 @@ setFullscreenSessionActions
     -> IO ()
 setFullscreenSessionActions
     runtime
-    provider
+    dictationTarget
     cancelAction
     steerAction
     btwAction
@@ -404,7 +404,7 @@ setFullscreenSessionActions
     agentSnapshot
     agentSelect =
         writeIORef runtime.runtimeSessionActions FullscreenSessionActions
-            { sessionProvider = provider
+            { sessionDictationTarget = dictationTarget
             , sessionCancel = cancelAction
             , sessionSteer = steerAction
             , sessionBtw = btwAction

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -33,6 +33,7 @@ module Agent.CLI.TUI.Types
 
 import Agent.CLI.AgentViewport (AgentEntry, AgentTarget)
 import Agent.CLI.Command (SkillCommand, SlashCatalog)
+import Agent.CLI.Dictation (DictationTarget)
 import Agent.CLI.Input.Types (ReplLine)
 import Agent.CLI.Interrupt (CtrlCDecision)
 import Agent.CLI.Permission (PermissionChoice)
@@ -50,7 +51,6 @@ import Agent.CLI.TUI.History
     )
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import Agent.Loop (ImageAttachment)
-import Agent.Provider (Provider)
 import Agent.TUI.Model (BlockId, UiEvent, UiState)
 import Agent.TUI.Theme (ThemeKind, themeKindAt)
 import Agent.Syntax (SyntaxHighlighter)
@@ -300,7 +300,7 @@ data DictationSession = DictationSession
 -- Replacing the record atomically prevents the retained UI from calling into
 -- resources belonging to a backend that has already shut down.
 data FullscreenSessionActions = FullscreenSessionActions
-    { sessionProvider :: !(Maybe Provider)
+    { sessionDictationTarget :: !(Maybe DictationTarget)
     , sessionCancel :: !(IO ())
     , sessionSteer :: !(Bool -> Text -> IO (Either Text ()))
     , sessionBtw :: !(Text -> IO ())

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -7,6 +7,7 @@ import Agent.CLI.AgentViewport
     , AgentTarget(..)
     )
 import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.Dictation (DictationTarget(..))
 import Agent.CLI.TUI.App
     ( appEventLogicalBytes
     , emitUiEvent
@@ -347,7 +348,7 @@ spec = describe "fullscreen TUI bridge" do
         runtime.runtimeCancel
         setFullscreenSessionActions
             runtime
-            (Just XAIProvider)
+            (Just (DirectDictation XAIProvider))
             (modifyIORef' calls (<> ["new cancel"]))
             (\pasted _ -> do
                 modifyIORef' calls (<> ["new steer"])
@@ -367,7 +368,12 @@ spec = describe "fullscreen TUI bridge" do
         runtime.runtimeAgentSelect AgentRoot
         decision <- runtime.runtimeCtrlC
         actions <- readIORef runtime.runtimeSessionActions
-        actions.sessionProvider `shouldBe` Just XAIProvider
+        case actions.sessionDictationTarget of
+            Just (DirectDictation provider) ->
+                provider `shouldBe` XAIProvider
+            _ ->
+                expectationFailure
+                    "expected direct xAI dictation target"
         readIORef calls `shouldReturn`
             ["old cancel", "new cancel", "new steer", "new btw", "new recap", "new effort", "new agent"]
         decision `shouldBe` SoftCancel

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -2,9 +2,12 @@ module Agent.CLI.TUIComposerSpec (spec) where
 
 import Agent.CLI.Dictation
     ( DictationBackend(..)
+    , DictationTarget(..)
     , dictationBackendForProvider
+    , dictationTargetForSession
     , insertDictation
     )
+import Agent.CLI.GatewayClient (newGatewayModelAccessWith)
 import Agent.Provider (Provider(..))
 import Agent.CLI.Input
     ( ReplLine(..)
@@ -245,6 +248,18 @@ spec = describe "fullscreen composer" do
         dictationBackendForProvider ClaudeCodeProvider
             `shouldBe` Left
                 "Dictation is not supported for claude-code models"
+
+    it "keeps organization-gateway dictation inside the gateway boundary" do
+        case dictationTargetForSession XAIProvider Nothing of
+            DirectDictation provider ->
+                provider `shouldBe` XAIProvider
+            GatewayDictation _ ->
+                expectationFailure "expected direct dictation"
+        gateway <- newGatewayModelAccessWith (pure (Right []))
+        case dictationTargetForSession XAIProvider (Just gateway) of
+            GatewayDictation _ -> pure ()
+            DirectDictation _ ->
+                expectationFailure "expected gateway dictation"
 
     it "keeps dictation stop keys inside the composer" do
         dictationKeyAction (V.EvKey V.KEnter [])


### PR DESCRIPTION
## Summary
- keep gateway dictation behind opaque gateway model access
- upload bounded WAV recordings to the same-origin gateway endpoint with redirect and response limits
- wire REPL and fullscreen dictation to fail closed instead of falling back to local provider authentication

## Testing
- multi-package GHCi loaded 260 library modules
- exact post-rebase runtime test: 1 example, 0 failures
- agent-cli object-code test loaded 97 modules; fullscreen gateway dictation: 1 example, 0 failures
- rebuilt fullscreen executable rendered in tmux
- `git diff --check`