### PR TITLE
Improve MCP call presentation

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -72,6 +72,7 @@ import Agent.TUI.Presentation
     ( TodoDisplayLine(todoLineText, todoLineStatus),
       parseTodoList,
       todoStatusGlyph,
+      toolOutputCodeLanguage,
       TodoDisplayStatus(..) )
 import Agent.TUI.TextWidth ( displayTerminalText )
 import Agent.ToolDispatch ()
@@ -257,7 +258,10 @@ drawBlock state target ui block =
                     (blockStateGlyph state target block
                         <> block.blockTitle
                         <> detailSuffix block)
-                    (bodySections (visibleBody block)
+                    (toolBodySections
+                        state.appSyntaxHighlighter
+                        block.blockBody
+                        (visibleBody block)
                         <> toolImageSections state target block)
             BlockInspect ->
                 accentBlockWithSections
@@ -270,7 +274,10 @@ drawBlock state target ui block =
                     (blockStateGlyph state target block
                         <> block.blockTitle
                         <> detailSuffix block)
-                    (bodySections (visibleBody block)
+                    (toolBodySections
+                        state.appSyntaxHighlighter
+                        block.blockBody
+                        (visibleBody block)
                         <> toolImageSections state target block)
             BlockTodo ->
                 accentBlockWithSections
@@ -611,6 +618,17 @@ bodySections :: Text -> [Widget Name]
 bodySections body
     | Text.null (Text.strip body) = []
     | otherwise = [terminalTxtWrap body]
+
+toolBodySections
+    :: Maybe SyntaxHighlighter
+    -> Text
+    -> Text
+    -> [Widget Name]
+toolBodySections syntaxHighlighter completeBody visible
+    | Text.null (Text.strip visible) = []
+    | Just language <- toolOutputCodeLanguage completeBody =
+        [codeWidgetWithSyntaxHighlighting syntaxHighlighter language visible]
+    | otherwise = bodySections visible
 
 editBodyWidgets :: Text -> [Widget Name]
 editBodyWidgets body

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -52,8 +52,11 @@ library
     build-depends:    agent-core >= 0.1 && < 0.2
                     , agent-json >= 0.1 && < 0.2
                     , agent-syntax >= 0.1 && < 0.2
+                    , aeson >= 2.1 && < 2.3
+                    , aeson-pretty >= 0.8 && < 0.9
                     , base >= 4.17 && < 5
                     , brick >= 2.9 && < 3
+                    , bytestring >= 0.11 && < 0.13
                     , containers >= 0.6 && < 0.8
                     , text >= 2.0 && < 2.2
                     , vty >= 6.4 && < 7

--- a/packages/agent-tui/package.nix
+++ b/packages/agent-tui/package.nix
@@ -1,12 +1,14 @@
-{ mkDerivation, agent-core, agent-json, agent-syntax, base, brick
-, containers, hspec, lib, QuickCheck, text, vty
+{ mkDerivation, aeson, aeson-pretty, agent-core, agent-json
+, agent-syntax, base, brick, bytestring, containers, hspec, lib
+, QuickCheck, text, vty
 }:
 mkDerivation {
   pname = "agent-tui";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    agent-core agent-json agent-syntax base brick containers text vty
+    aeson aeson-pretty agent-core agent-json agent-syntax base brick
+    bytestring containers text vty
   ];
   testHaskellDepends = [
     agent-core agent-syntax base brick containers hspec QuickCheck text

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -34,6 +34,7 @@ module Agent.TUI.Presentation
     , toolCallDiff
     , toolCallDiffs
     , toolDetail
+    , toolOutputCodeLanguage
     , toolPathArgument
     , toolVerb
     , workspaceRelativeDisplayPath
@@ -425,6 +426,16 @@ beautifyJson text =
         Just value@Aeson.Object{} -> prettyJsonValue value
         Just value@Aeson.Array{} -> prettyJsonValue value
         _ -> text
+
+-- | Select syntax highlighting for structured tool output. Primitive JSON
+-- values stay as ordinary text; objects and arrays benefit from JSON token
+-- colors without changing the retained transcript body.
+toolOutputCodeLanguage :: Text -> Maybe Text
+toolOutputCodeLanguage text =
+    case decodeJsonValue text of
+        Just Aeson.Object{} -> Just "json"
+        Just Aeson.Array{} -> Just "json"
+        _ -> Nothing
 
 decodeJsonValue :: Text -> Maybe Aeson.Value
 decodeJsonValue =

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -48,11 +48,17 @@ import Agent.ToolDispatch
     , canonicalToolName
     )
 import Control.Applicative ((<|>))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encode.Pretty as AesonPretty
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Char (isDigit, isSpace)
+import qualified Data.Foldable as Foldable
 import Data.List (mapAccumL)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 
 summarizeToolCall :: ToolCall -> Text
 summarizeToolCall = summarizeToolCallRelative ""
@@ -61,7 +67,10 @@ summarizeToolCall = summarizeToolCallRelative ""
 -- shown relative to that workspace.
 summarizeToolCallRelative :: Text -> ToolCall -> Text
 summarizeToolCallRelative workspace call =
-    let verb = toolVerb call.name
+    let verb = case canonicalToolName call.name of
+            "mcp_call" -> mcpCallDisplayName call.arguments
+            "use_tool" -> mcpCallDisplayName call.arguments
+            _ -> toolVerb call.name
         detail = case toolPathArgument call of
             Just path -> workspaceRelativeDisplayPath workspace path
             Nothing -> toolDetail call
@@ -377,6 +386,8 @@ formatToolOutput :: ToolCall -> Text -> Text
 formatToolOutput call output = case canonicalToolName call.name of
     "computer" -> "Screenshot captured"
     "exec" -> completedExecOutput output
+    "mcp_call" -> formatMcpOutput output
+    "use_tool" -> formatMcpOutput output
     name | name `elem` ["spawn_agent", "spawn_agent_in_worktree"] ->
         maybe output ("Agent: " <>) (nonEmptyJsonText "task_name" output)
     "wait_agent" ->
@@ -393,6 +404,48 @@ formatToolOutput call output = case canonicalToolName call.name of
     "todo_write" -> formatTodoList output
     "update_plan" -> formatTodoList output
     _ -> output
+
+-- | MCP servers commonly return a compact @CallToolResult@ envelope whose
+-- text block is itself JSON. Show the useful text payload rather than escaped
+-- transport JSON when every content block is textual, then indent JSON values.
+-- This is presentation-only; the canonical tool result remains unchanged.
+formatMcpOutput :: Text -> Text
+formatMcpOutput output =
+    case decodeJsonValue output of
+        Just value ->
+            case mcpTextBlocks value of
+                Just texts | not (null texts) ->
+                    Text.intercalate "\n" (map beautifyJson texts)
+                _ -> prettyJsonValue value
+        Nothing -> output
+
+beautifyJson :: Text -> Text
+beautifyJson text =
+    case decodeJsonValue text of
+        Just value@Aeson.Object{} -> prettyJsonValue value
+        Just value@Aeson.Array{} -> prettyJsonValue value
+        _ -> text
+
+decodeJsonValue :: Text -> Maybe Aeson.Value
+decodeJsonValue =
+    Aeson.decodeStrict' . TextEncoding.encodeUtf8 . Text.strip
+
+prettyJsonValue :: Aeson.Value -> Text
+prettyJsonValue =
+    TextEncoding.decodeUtf8
+        . LazyByteString.toStrict
+        . AesonPretty.encodePretty
+
+mcpTextBlocks :: Aeson.Value -> Maybe [Text]
+mcpTextBlocks (Aeson.Object object) = do
+    Aeson.Array blocks <- KeyMap.lookup "content" object
+    traverse textBlock (Foldable.toList blocks)
+  where
+    textBlock (Aeson.Object block) = do
+        Aeson.String text <- KeyMap.lookup "text" block
+        pure text
+    textBlock _ = Nothing
+mcpTextBlocks _ = Nothing
 
 -- The exec protocol keeps status and timing metadata for the model. In the
 -- transcript, the invocation itself already communicates successful
@@ -771,6 +824,29 @@ mcpToolDisplayName name =
             , not (Text.null toolName) ->
                 server <> ": " <> toolName
         _ -> name
+
+-- | The generic MCP wrapper keeps the selected tool in its arguments. Display
+-- that identity as @server: tool@ instead of the unhelpful @mcp_call@ name.
+mcpCallDisplayName :: Text -> Text
+mcpCallDisplayName arguments =
+    case nonEmptyJsonText "name" arguments
+        <|> nonEmptyJsonText "tool_name" arguments of
+        Just qualifiedName -> qualifiedMcpDisplayName qualifiedName
+        Nothing -> "MCP call"
+
+qualifiedMcpDisplayName :: Text -> Text
+qualifiedMcpDisplayName name =
+    case Text.breakOn "__" name of
+        (server, rest)
+            | not (Text.null server)
+            , Just tool <- Text.stripPrefix "__" rest
+            , not (Text.null tool) ->
+                unescape server <> ": " <> unescape tool
+        _ -> name
+  where
+    unescape =
+        Text.replace "%5F%5F" "__"
+            . Text.replace "%25" "%"
 
 toolDetail :: ToolCall -> Text
 toolDetail call = case canonicalToolName call.name of

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -856,8 +856,8 @@ qualifiedMcpDisplayName name =
         _ -> name
   where
     unescape =
-        Text.replace "%5F%5F" "__"
-            . Text.replace "%25" "%"
+        Text.replace "%25" "%"
+            . Text.replace "%5F%5F" "__"
 
 toolDetail :: ToolCall -> Text
 toolDetail call = case canonicalToolName call.name of

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -162,6 +162,52 @@ spec = describe "tool presentation" do
         todoListFromToolArguments "{\"todos\":[]}" `shouldBe` Just []
         todoListFromToolArguments "Todos have been modified" `shouldBe` Nothing
 
+    it "names generic MCP calls after the selected function" do
+        let call =
+                functionToolCall
+                    "mcp"
+                    "mcp_call"
+                    "{\"name\":\"seo-mcp__search_performance\",\
+                    \\"arguments\":{\"days\":90}}"
+        summarizeToolCall call
+            `shouldBe` "seo-mcp: search_performance"
+        toolCallTitle call
+            `shouldBe` "seo-mcp: search_performance"
+        permissionToolCallPrompt call
+            `shouldBe` "Allow seo-mcp: search_performance?"
+
+    it "unwraps MCP text envelopes and pretty-prints embedded JSON" do
+        let call =
+                functionToolCall
+                    "mcp"
+                    "mcp_call"
+                    "{\"name\":\"seo-mcp__search_performance\"}"
+        formatToolOutput call
+            "{\"content\":[{\"type\":\"text\",\"text\":\"{\\\"bing\\\":\
+            \{\\\"configured\\\":true},\\\"rows\\\":[{\\\"clicks\\\":5}]}\"}],\
+            \\"structuredContent\":{\"bing\":{\"configured\":true}}}"
+            `shouldBe`
+                "{\n\
+                \    \"bing\": {\n\
+                \        \"configured\": true\n\
+                \    },\n\
+                \    \"rows\": [\n\
+                \        {\n\
+                \            \"clicks\": 5\n\
+                \        }\n\
+                \    ]\n\
+                \}"
+        formatToolOutput call "{\"ok\":true,\"rows\":[1,2]}"
+            `shouldBe`
+                "{\n\
+                \    \"ok\": true,\n\
+                \    \"rows\": [\n\
+                \        1,\n\
+                \        2\n\
+                \    ]\n\
+                \}"
+        formatToolOutput call "plain text" `shouldBe` "plain text"
+
     it "extracts tool details from function and custom calls" do
         toolDetail
             (functionToolCall "read" "read_file"

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -207,6 +207,11 @@ spec = describe "tool presentation" do
                 \    ]\n\
                 \}"
         formatToolOutput call "plain text" `shouldBe` "plain text"
+        toolOutputCodeLanguage
+            (formatToolOutput call "{\"ok\":true,\"rows\":[1,2]}")
+            `shouldBe` Just "json"
+        toolOutputCodeLanguage "plain text" `shouldBe` Nothing
+        toolOutputCodeLanguage "42" `shouldBe` Nothing
 
     it "extracts tool details from function and custom calls" do
         toolDetail

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -175,6 +175,12 @@ spec = describe "tool presentation" do
             `shouldBe` "seo-mcp: search_performance"
         permissionToolCallPrompt call
             `shouldBe` "Allow seo-mcp: search_performance?"
+        summarizeToolCall
+            (functionToolCall
+                "mcp"
+                "mcp_call"
+                "{\"name\":\"a%255F%255Fb__tool%5F%5Fname\"}")
+            `shouldBe` "a%5F%5Fb: tool__name"
 
     it "unwraps MCP text envelopes and pretty-prints embedded JSON" do
         let call =


### PR DESCRIPTION
## Summary
- label generic MCP calls with the selected server and function name
- unwrap MCP text envelopes and pretty-print embedded or top-level JSON
- syntax-highlight structured tool output with the existing JSON grammar
- preserve plain-text and primitive JSON responses as normal transcript text

## Validation
- `nix develop -c cabal repl agent-tui:test:agent-tui-test` — 216 examples, 0 failures
- `nix develop -c cabal repl agent-cli:lib:agent-cli` — 200 modules loaded
- live agent launched and exited successfully in a real tmux TTY
- `git diff --check origin/master...HEAD`