### PR TITLE
Collapse completed shell commands in the TUI

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -325,7 +325,8 @@ mergeConversationView previous incoming
                     Just old
                         | sameConversationBlock old block ->
                             block
-                                { blockExpanded = old.blockExpanded
+                                { blockExpanded =
+                                    preservedBlockExpansion old block
                                 }
                     _ -> block)
             incoming.uiBlocks
@@ -339,6 +340,14 @@ mergeConversationView previous incoming
                 , sameConversationBlock old new ->
                     Just ident
             _ -> incoming.uiSelectedBlock
+
+preservedBlockExpansion :: UiBlock -> UiBlock -> Bool
+preservedBlockExpansion previous incoming
+    | previous.blockKind == BlockShell
+    , previous.blockState `elem` [BlockStreaming, BlockRunning]
+    , incoming.blockState `notElem` [BlockStreaming, BlockRunning] =
+        incoming.blockExpanded
+    | otherwise = previous.blockExpanded
 
 sameConversationBlock :: UiBlock -> UiBlock -> Bool
 sameConversationBlock previous incoming =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -12,7 +12,7 @@ import Agent.CLI.Clipboard ( formatImageSize )
 import Agent.CLI.Command ()
 import Agent.CLI.Dictation ()
 import Agent.CLI.ImagePreview ()
-import Agent.CLI.Input ()
+import Agent.CLI.Input ( truncateDisplayText )
 import Agent.CLI.Interrupt ()
 import Agent.CLI.Permission ()
 import Agent.CLI.Recap ()
@@ -149,8 +149,11 @@ import qualified Data.Text as Text
       lines,
       null,
       strip,
+      take,
       uncons,
       unlines,
+      unwords,
+      words,
       pack )
 import qualified Data.Text.Encoding as TextEncoding ()
 import qualified Agent.TUI.Theme as Theme
@@ -290,7 +293,8 @@ drawBlock state target ui block =
                     state.appSyntaxHighlighter
                     waveElapsed
                     (statusAttr state target block)
-                    (blockStateGlyph state target block <> block.blockTitle)
+                    (blockStateGlyph state target block
+                        <> shellBlockTitle block)
                     (if block.blockExpanded then block.blockDetail else "")
                     (visibleShellBody block)
                     (if block.blockExpanded
@@ -576,7 +580,7 @@ blockStateGlyph :: AppState -> AgentTarget -> UiBlock -> Text
 blockStateGlyph state target block
     | block.blockKind == BlockShell
     , not block.blockExpanded =
-        "› "
+        "› " <> collapsedShellStateGlyph
     | otherwise = case block.blockState of
         BlockRunning -> liveGlyph
         BlockStreaming -> liveGlyph
@@ -585,6 +589,13 @@ blockStateGlyph state target block
         BlockDenied -> "⊘ "
         BlockCancelled -> "⊘ "
   where
+    collapsedShellStateGlyph = case block.blockState of
+        BlockRunning -> liveGlyph
+        BlockStreaming -> liveGlyph
+        BlockFailed -> "✗ "
+        BlockDenied -> "⊘ "
+        BlockCancelled -> "⊘ "
+        BlockComplete -> ""
     completedGlyph
         | block.blockKind == BlockInspect = "◇ "
         | block.blockKind
@@ -610,6 +621,19 @@ blockStateGlyph state target block
                 state.appRuntime.runtimeMotionMode
                 state.appMotionElapsedMillis
                 <> " "
+
+shellBlockTitle :: UiBlock -> Text
+shellBlockTitle block
+    | block.blockExpanded = block.blockTitle
+    | block.blockTitle `notElem` ["$ ghci", "$ exec"] = block.blockTitle
+    | Text.null invocation = block.blockTitle
+    | otherwise = block.blockTitle <> " · " <> invocation
+  where
+    invocation =
+        truncateDisplayText 120 $
+            Text.unwords $
+                Text.words $
+                    Text.take 512 block.blockDetail
 
 bodySections :: Text -> [Widget Name]
 bodySections body
@@ -729,9 +753,14 @@ accentBlockWithSections
         Theme.waveTroughForTheme
             theme
             state.appRuntime.runtimeWaveTrough
-    titleWidget = case waveElapsed of
+    titleWidget
+        | block.blockKind == BlockShell
+        , not block.blockExpanded =
+            singleLineTitle renderTitle title
+        | otherwise = renderTitle title
+    renderTitle fittedTitle = case waveElapsed of
         Nothing ->
-            withAttr accent (terminalTxtWrap title)
+            withAttr accent (terminalTxtWrap fittedTitle)
         Just elapsedMillis ->
             waveHeader
                 accent
@@ -739,7 +768,7 @@ accentBlockWithSections
                 trough
                 theme
                 elapsedMillis
-                title
+                fittedTitle
     paddedBody = map (padTop (Pad 1)) sections
     bodyWidgets
         | cacheableRunningBody state target ui block
@@ -752,6 +781,13 @@ accentBlockWithSections
                 (vBox paddedBody)
             ]
         | otherwise = paddedBody
+
+singleLineTitle :: (Text -> Widget n) -> Text -> Widget n
+singleLineTitle renderTitle title =
+    Widget Fixed Fixed do
+        context <- getContext
+        render $
+            renderTitle (truncateDisplayText context.availWidth title)
 
 -- Skip non-empty running bodies: live tool output changes without a new
 -- block id, and Brick cache keys must stay stable.

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -291,9 +291,11 @@ drawBlock state target ui block =
                     waveElapsed
                     (statusAttr state target block)
                     (blockStateGlyph state target block <> block.blockTitle)
-                    block.blockDetail
+                    (if block.blockExpanded then block.blockDetail else "")
                     (visibleShellBody block)
-                    (toolImageSections state target block)
+                    (if block.blockExpanded
+                        then toolImageSections state target block
+                        else [])
             BlockEdit ->
                 accentBlockWithSections
                     state
@@ -571,13 +573,17 @@ conversationBlockHovered state target ui block =
                    ]
 
 blockStateGlyph :: AppState -> AgentTarget -> UiBlock -> Text
-blockStateGlyph state target block = case block.blockState of
-    BlockRunning -> liveGlyph
-    BlockStreaming -> liveGlyph
-    BlockComplete -> completedGlyph
-    BlockFailed -> "✗ "
-    BlockDenied -> "⊘ "
-    BlockCancelled -> "⊘ "
+blockStateGlyph state target block
+    | block.blockKind == BlockShell
+    , not block.blockExpanded =
+        "› "
+    | otherwise = case block.blockState of
+        BlockRunning -> liveGlyph
+        BlockStreaming -> liveGlyph
+        BlockComplete -> completedGlyph
+        BlockFailed -> "✗ "
+        BlockDenied -> "⊘ "
+        BlockCancelled -> "⊘ "
   where
     completedGlyph
         | block.blockKind == BlockInspect = "◇ "
@@ -821,12 +827,7 @@ truncatedLines shownCount body =
 visibleShellBody :: UiBlock -> Text
 visibleShellBody block
     | block.blockExpanded = block.blockBody
-    | otherwise =
-        let rows = Text.lines block.blockBody
-            shown
-                | length rows <= 5 = rows
-                | otherwise = take 2 rows <> ["…"] <> drop (length rows - 3) rows
-        in Text.unlines shown
+    | otherwise = ""
 
 detailSuffix :: UiBlock -> Text
 detailSuffix block

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -26,6 +26,7 @@ import Agent.CLI.TUI.App
     , completionRequiresRedraw
     , conversationScrollbarRenderer
     , choiceRowColumns
+    , drawApp
     , filterChoiceRowLimit
     , choiceClosesOnUiTransition
     , elapsedMillisSince
@@ -154,8 +155,11 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.Lazy as LazyText
 import qualified Graphics.Vty as V
 import qualified Graphics.Vty.Output.Mock as VMock
+import Graphics.Vty.PictureToSpans (displayOpsForPic)
+import Graphics.Vty.Span (SpanOp(..))
 import qualified Agent.CLI.TUI.Composer as Composer
 import System.Timeout (timeout)
 import Test.Hspec
@@ -1133,6 +1137,44 @@ spec = do
                         `shouldBe`
                             initialUiState { uiTodos = previous.uiTodos }
 
+        it "keeps child shell auto-collapse across a completion snapshot" do
+            let call =
+                    functionToolCall
+                        "shell-1"
+                        "shell_command"
+                        "{\"command\":\"git status\"}"
+                running =
+                    foldl
+                        (flip reduceUi)
+                        initialUiState
+                        [ UiLoop TurnStarted
+                        , UiLoop (ToolStarted call)
+                        ]
+                completed =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished ToolCallResult
+                                { callId = "shell-1"
+                                , output = "Exit code: 0\nclean"
+                                , callKind = FunctionCallKind
+                                }))
+                        running
+                merged = mergeConversationView running completed
+                reopened =
+                    mergeConversationView
+                        (reduceUi UiToggleSelected completed)
+                        completed
+            fmap (.blockExpanded)
+                (find
+                    ((== BlockShell) . (.blockKind))
+                    merged.uiBlocks)
+                `shouldBe` Just False
+            fmap (.blockExpanded)
+                (find
+                    ((== BlockShell) . (.blockKind))
+                    reopened.uiBlocks)
+                `shouldBe` Just True
+
         it "keeps a child's live todo list across empty snapshot refreshes" do
             let todoCall =
                     functionToolCall
@@ -1167,6 +1209,64 @@ spec = do
                 `shouldBe` ["Keep this list"]
             map (.todoLineStatus) updated.uiTodos
                 `shouldBe` [TodoDisplayCompleted]
+
+    describe "shell block rendering" do
+        it "renders a completed command as one line until it is reopened" do
+            let call =
+                    functionToolCall
+                        "shell-render"
+                        "shell_command"
+                        "{\"command\":\"printf shell-command\"}"
+                running =
+                    foldl
+                        (flip reduceUi)
+                        initialUiState
+                        [ UiLoop TurnStarted
+                        , UiLoop (ToolStarted call)
+                        ]
+                completed =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished ToolCallResult
+                                { callId = "shell-render"
+                                , output =
+                                    "exit: 0\nshell-output-marker\nsecond-line"
+                                , callKind = FunctionCallKind
+                                }))
+                        running
+                reopened = reduceUi UiToggleSelected completed
+            runtime <- newScriptRuntime completed
+            let size = (80, 20)
+                renderShell ui =
+                    Text.unlines $
+                        map
+                            (Text.concat . map spanText . toList)
+                            (toList
+                                (displayOpsForPic
+                                    (renderWidget
+                                        Nothing
+                                        (drawApp
+                                            ((initialFullscreenAppState
+                                                runtime
+                                                []
+                                                AgentRoot
+                                                []
+                                                0)
+                                                { appUi = ui }))
+                                        size)
+                                    size))
+                spanText = \case
+                    TextSpan _ _ _ text -> LazyText.toStrict text
+                    Skip width -> Text.replicate width " "
+                    RowEnd width -> Text.replicate width " "
+                collapsedText = renderShell completed
+                reopenedText = renderShell reopened
+            collapsedText `shouldSatisfy`
+                Text.isInfixOf "$ printf shell-command"
+            collapsedText `shouldNotSatisfy`
+                Text.isInfixOf "shell-output-marker"
+            reopenedText `shouldSatisfy`
+                Text.isInfixOf "shell-output-marker"
 
     describe "conversation scrollbar" do
         it "uses a visible trough that repaints old thumb cells" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1212,29 +1212,58 @@ spec = do
 
     describe "shell block rendering" do
         it "renders a completed command as one line until it is reopened" do
-            let call =
+            let completeCall resultCallId resultCallKind call output =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished ToolCallResult
+                                { callId = resultCallId
+                                , output
+                                , callKind = resultCallKind
+                                }))
+                        (foldl
+                            (flip reduceUi)
+                            initialUiState
+                            [ UiLoop TurnStarted
+                            , UiLoop (ToolStarted call)
+                            ])
+                call =
                     functionToolCall
                         "shell-render"
                         "shell_command"
                         "{\"command\":\"printf shell-command\"}"
-                running =
-                    foldl
-                        (flip reduceUi)
-                        initialUiState
-                        [ UiLoop TurnStarted
-                        , UiLoop (ToolStarted call)
-                        ]
-                completed =
-                    reduceUi
-                        (UiLoop
-                            (ToolFinished ToolCallResult
-                                { callId = "shell-render"
-                                , output =
-                                    "exit: 0\nshell-output-marker\nsecond-line"
-                                , callKind = FunctionCallKind
-                                }))
-                        running
+                completed = completeCall
+                    "shell-render"
+                    FunctionCallKind
+                    call
+                    "exit: 0\nshell-output-marker\nsecond-line"
                 reopened = reduceUi UiToggleSelected completed
+                ghciCompleted =
+                    completeCall
+                        "ghci-render"
+                        FunctionCallKind
+                        (functionToolCall
+                            "ghci-render"
+                            "run_ghci"
+                            "{\"expression\":\"putStrLn \\\"invocation-marker\\\"\"}")
+                        "exit: 0\nghci-output-marker"
+                execCompleted =
+                    completeCall
+                        "exec-render"
+                        CustomCallKind
+                        (customToolCall
+                            "exec-render"
+                            "exec"
+                            "text(\"exec-invocation-marker\");")
+                        "Script completed\nexec-output-marker"
+                failed =
+                    completeCall
+                        "failed-render"
+                        FunctionCallKind
+                        (functionToolCall
+                            "failed-render"
+                            "shell_command"
+                            "{\"command\":\"false\"}")
+                        "exit: 7\nfailed-output-marker"
             runtime <- newScriptRuntime completed
             let size = (80, 20)
                 renderShell ui =
@@ -1261,12 +1290,27 @@ spec = do
                     RowEnd width -> Text.replicate width " "
                 collapsedText = renderShell completed
                 reopenedText = renderShell reopened
+                ghciText = renderShell ghciCompleted
+                execText = renderShell execCompleted
+                failedText = renderShell failed
             collapsedText `shouldSatisfy`
                 Text.isInfixOf "$ printf shell-command"
             collapsedText `shouldNotSatisfy`
                 Text.isInfixOf "shell-output-marker"
             reopenedText `shouldSatisfy`
                 Text.isInfixOf "shell-output-marker"
+            ghciText `shouldSatisfy`
+                Text.isInfixOf "$ ghci · putStrLn \"invocation-marker\""
+            ghciText `shouldNotSatisfy`
+                Text.isInfixOf "ghci-output-marker"
+            execText `shouldSatisfy`
+                Text.isInfixOf "$ exec · text(\"exec-invocation-marker\");"
+            execText `shouldNotSatisfy`
+                Text.isInfixOf "exec-output-marker"
+            failedText `shouldSatisfy`
+                Text.isInfixOf "› ✗ $ false"
+            failedText `shouldNotSatisfy`
+                Text.isInfixOf "failed-output-marker"
 
     describe "conversation scrollbar" do
         it "uses a visible trough that repaints old thumb cells" do

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -270,7 +270,7 @@ spec = do
                     rendered `shouldSatisfy`
                         Text.isInfixOf ("◇ " <> inspectBlock.blockTitle)
                     rendered `shouldSatisfy`
-                        Text.isInfixOf ("◆ " <> actionBlock.blockTitle)
+                        Text.isInfixOf ("› " <> actionBlock.blockTitle)
                 _ -> expectationFailure "expected inspection and action blocks"
 
         it "keeps live todos to one row each so the prompt stays visible" do
@@ -338,6 +338,7 @@ spec = do
                                 , output = "tool output"
                                 , callKind = FunctionCallKind
                                 })
+                        , UiToggleSelected
                         , UiAssistantHistory
                             "## Result\n\nMarkdown **kept**."
                         , UiTurnEnded BlockComplete

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -648,6 +648,8 @@ appendBlock kind title body detail blockState callId state =
             , blockState
             , blockExpanded =
                 kind `elem` [BlockUser, BlockAssistant, BlockSystem, BlockRecap, BlockError]
+                    || (kind == BlockShell
+                        && blockState `elem` [BlockStreaming, BlockRunning])
             , blockCallId = callId
             }
     in state
@@ -693,10 +695,9 @@ completeTool blockIndex call result state =
             Seq.adjust
                 (\block ->
                     if block.blockCallId == Just result.callId
-                        then block
-                            { blockBody = body
-                            , blockState = resultState
-                            }
+                        then
+                            setBlockState resultState block
+                                { blockBody = body }
                         else block)
                 blockIndex
                 state.uiBlocks
@@ -805,8 +806,7 @@ reconcileVisibleShellContinuation call result state =
                                                 Nothing -> state.uiBlocks
                                                 Just (blockIndex, _) ->
                                                     Seq.adjust
-                                                        (\block ->
-                                                            block { blockState })
+                                                        (setBlockState blockState)
                                                         blockIndex
                                                         state.uiBlocks
                                     in state
@@ -827,10 +827,8 @@ retainRunningShell blockIndex sessionId output state =
                 { uiBlocks =
                     Seq.adjust
                         (\block ->
-                            block
-                                { blockBody = output
-                                , blockState = BlockRunning
-                                })
+                            setBlockState BlockRunning block
+                                { blockBody = output })
                         blockIndex
                         state.uiBlocks
                 , uiShellProcesses =
@@ -890,10 +888,8 @@ appendShellOutput blockIndex output blockState state =
         { uiBlocks =
             Seq.adjust
                 (\block ->
-                    block
-                        { blockBody = block.blockBody <> output
-                        , blockState
-                        })
+                    setBlockState blockState block
+                        { blockBody = block.blockBody <> output })
                 blockIndex
                 state.uiBlocks
         }
@@ -906,7 +902,7 @@ finalizeAttempt terminalState state =
                 (\index block ->
                     if index >= state.uiAttemptStartBlock
                         && block.blockState == BlockRunning
-                        then block { blockState = terminalState }
+                        then setBlockState terminalState block
                         else block)
                 state.uiBlocks
         processes = retainShellProcesses blocks state.uiShellProcesses
@@ -1074,7 +1070,7 @@ finalizeTurn terminalState state =
                             || block.blockId `elem` shellOwners)
                         && block.blockState
                             `elem` [BlockStreaming, BlockRunning]
-                        then block { blockState = terminalState }
+                        then setBlockState terminalState block
                         else block)
                 state.uiBlocks
         , uiRunning = False
@@ -1103,6 +1099,21 @@ finalizeTurn terminalState state =
         , uiShellPolls = Map.empty
         }
 
+-- Shell commands start open while output is live, then compact to a one-line
+-- summary. Preserve any manual folding while they are still running; a user
+-- can also expand the completed block again with the normal block toggle.
+setBlockState :: BlockState -> UiBlock -> UiBlock
+setBlockState blockState block =
+    block
+        { blockState
+        , blockExpanded =
+            if block.blockKind == BlockShell
+                && block.blockState `elem` [BlockStreaming, BlockRunning]
+                && blockState `notElem` [BlockStreaming, BlockRunning]
+                then False
+                else block.blockExpanded
+        }
+
 infoNotice, successNotice, warningNotice, progressNotice, errorNotice
     :: Text -> UiNotice
 infoNotice = transientNotice NoticeInfo
@@ -1129,7 +1140,7 @@ finalizeStreams state =
             fmap
                 (\block ->
                     if block.blockState == BlockStreaming
-                        then block { blockState = BlockComplete }
+                        then setBlockState BlockComplete block
                         else block)
                 state.uiBlocks
         }

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -407,7 +407,36 @@ spec = describe "fullscreen UI reducer" do
                 block.blockKind `shouldBe` BlockShell
                 block.blockState `shouldBe` BlockComplete
                 block.blockBody `shouldBe` "exit: 0\nclean"
+                block.blockExpanded `shouldBe` False
             _ -> expectationFailure "expected one completed tool block"
+
+    it "expands a shell command while running and allows reopening it after completion" do
+        let call =
+                functionToolCall
+                    "c1"
+                    "run_terminal_cmd"
+                    "{\"command\":\"git status\"}"
+            running =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    ]
+            completed =
+                reduceUi
+                    (UiLoop
+                        (ToolFinished ToolCallResult
+                            { callId = "c1"
+                            , output = "exit: 0\nclean"
+                            , callKind = FunctionCallKind
+                            }))
+                    running
+            reopened = reduceUi UiToggleSelected completed
+        map (.blockExpanded) (Foldable.toList running.uiBlocks)
+            `shouldBe` [True]
+        map (.blockExpanded) (Foldable.toList completed.uiBlocks)
+            `shouldBe` [False]
+        map (.blockExpanded) (Foldable.toList reopened.uiBlocks)
+            `shouldBe` [True]
 
     it "updates an early tool start in place" do
         let early = functionToolCall "c1" "Task" "{}"
@@ -617,6 +646,7 @@ spec = describe "fullscreen UI reducer" do
                 block.blockTitle `shouldBe` "$ slow"
                 block.blockBody `shouldBe` "first\nsecond\nthird\n"
                 block.blockState `shouldBe` BlockComplete
+                block.blockExpanded `shouldBe` False
             _ -> expectationFailure "expected one coalesced shell block"
         polled.uiToolCalls `shouldBe` mempty
         polled.uiShellProcesses `shouldBe` mempty
@@ -1028,21 +1058,21 @@ spec = describe "fullscreen UI reducer" do
                 block.blockState `shouldBe` BlockComplete
             _ -> expectationFailure "expected one completed tool block"
 
-    it "preserves tool folding while live snapshots arrive" do
+    it "preserves manual shell folding while live snapshots arrive" do
         let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"work\"}"
             started =
                 apply
                     [ UiLoop TurnStarted
                     , UiLoop (ToolStarted call)
                     ]
-            expanded = reduceUi UiToggleSelected started
+            folded = reduceUi UiToggleSelected started
             updated =
                 reduceUi
                     (UiLoop (ToolOutputUpdated "c1" "live output"))
-                    expanded
+                    folded
         case Foldable.toList updated.uiBlocks of
             [block] -> do
-                block.blockExpanded `shouldBe` True
+                block.blockExpanded `shouldBe` False
                 block.blockBody `shouldBe` "live output"
             _ -> expectationFailure "expected one running tool block"
 


### PR DESCRIPTION
## Summary
- keep shell command blocks expanded while output is live
- collapse terminal shell blocks to a one-line command summary while retaining manual expansion
- preserve folding across child snapshots and cover reducer, merge, and renderer behavior

## Testing
- `cabal repl agent-tui:agent-tui-test` — 216 examples passed
- `cabal test agent-cli:agent-cli-test --test-options='--match shell'` — 19 examples passed
- both prior CI renderer regressions pass directly
- live CLI smoke check in tmux confirmed compact failure status and manual reopening