### PR TITLE
Render Markdown tables with full borders

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -153,11 +153,23 @@ renderTable table = case table.tableRows of
             normalizedRows = normalizedHeader : normalizedBody
             widths = columnWidths normalizedRows
             alignments = table.tableAlignments
-            rule = md [terminalMuted] $ Text.intercalate "  "
-                [Text.replicate (width + 2) "─" | width <- widths]
+            top = md [terminalMuted] (tableBorder '┌' '┬' '┐' widths)
+            divider = md [terminalMuted] (tableBorder '├' '┼' '┤' widths)
+            bottom = md [terminalMuted] (tableBorder '└' '┴' '┘' widths)
             headerRow = styleTableRow True alignments widths normalizedHeader
             bodyRows = map (styleTableRow False alignments widths) normalizedBody
-        in headerRow : rule : intersperse rule bodyRows
+            logicalRows = headerRow : bodyRows
+        in top : (intersperse divider logicalRows <> [bottom])
+
+tableBorder :: Char -> Char -> Char -> [Int] -> Text
+tableBorder left middle right widths =
+    Text.singleton left
+        <> Text.intercalate
+            (Text.singleton middle)
+            [ Text.replicate (width + 2) "─"
+            | width <- widths
+            ]
+        <> Text.singleton right
 
 columnWidths :: [[Text]] -> [Int]
 columnWidths rows =
@@ -178,8 +190,7 @@ styleTableRow isHeader alignments widths cells =
                 padding = max 0 (w - width')
                 (leftPadding, rightPadding) = alignmentPadding alignment padding
                 base
-                    | isHeader =
-                        [SetConsoleIntensity BoldIntensity, terminalYellow]
+                    | isHeader = [SetConsoleIntensity BoldIntensity]
                     | otherwise = []
             in " "
                 <> Text.replicate leftPadding " "
@@ -190,7 +201,10 @@ styleTableRow isHeader alignments widths cells =
             (alignments <> repeat Block.AlignDefault)
             widths
             (cells <> repeat "")
-    in Text.intercalate "  " (take (length widths) parts)
+        border = md [terminalMuted] "│"
+    in border
+        <> Text.intercalate border (take (length widths) parts)
+        <> border
 
 alignmentPadding :: Block.TableAlignment -> Int -> (Int, Int)
 alignmentPadding alignment padding = case alignment of

--- a/packages/agent-cli/src/Agent/CLI/Markdown.hs
+++ b/packages/agent-cli/src/Agent/CLI/Markdown.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Markdown
     ( MarkdownFragmentSplit(..)
     , renderMarkdown
+    , renderMarkdownAtWidth
     , renderMarkdownFragment
     , splitMarkdownFragment
     ) where
@@ -36,6 +37,7 @@ import Agent.TUI.TextWidth
     )
 import Data.Char (isAlphaNum, isAscii, isSpace)
 import Data.List (intersperse, transpose)
+import qualified Data.List as List
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Console.ANSI
@@ -48,23 +50,33 @@ import System.Console.ANSI
 -- When 'False', return @text@ unchanged (pipes, redirects, tests).
 -- Nested spans restore the terminal-owned 'agentBackground' after each 'Reset'.
 renderMarkdown :: Bool -> Text -> Text
-renderMarkdown color text
+renderMarkdown color = renderMarkdownWithin color Nothing
+
+-- | Render Markdown while constraining table rows to a terminal width.
+renderMarkdownAtWidth :: Bool -> Int -> Text -> Text
+renderMarkdownAtWidth color width =
+    renderMarkdownWithin color (Just (max 1 width))
+
+renderMarkdownWithin :: Bool -> Maybe Int -> Text -> Text
+renderMarkdownWithin color availableWidth text
     | not color = text
     | otherwise = Text.concat (map renderChunk (fenceChunks cleaned))
   where
     cleaned = displayTerminalText text
-    renderChunk (FenceText prose) = renderProse prose
+    renderChunk (FenceText prose) = renderProse availableWidth prose
     renderChunk (FenceBlock block) =
         renderFenceBody block.fencedBody
 
-renderProse :: Text -> Text
-renderProse text =
+renderProse :: Maybe Int -> Text -> Text
+renderProse availableWidth text =
     let endsWithNewline = Text.isSuffixOf "\n" text
         lines_ = Text.splitOn "\n" text
         linesForParse
             | endsWithNewline && not (null lines_) = init lines_
             | otherwise = lines_
-        rendered = Text.intercalate "\n" (renderBlocks linesForParse)
+        rendered =
+            Text.intercalate "\n"
+                (renderBlocks availableWidth linesForParse)
     in if endsWithNewline then rendered <> "\n" else rendered
 
 renderFenceBody :: Text -> Text
@@ -83,13 +95,13 @@ renderFenceBody body =
 md :: [SGR] -> Text -> Text
 md = styleBase True agentBackground
 
-renderBlocks :: [Text] -> [Text]
-renderBlocks = go
+renderBlocks :: Maybe Int -> [Text] -> [Text]
+renderBlocks availableWidth = go
   where
     go [] = []
     go (line : rest)
         | Just (table, after) <- Block.takeTableRows (line : rest) =
-            renderTable table ++ go after
+            renderTable availableWidth table ++ go after
         | Just (level, title) <- Block.headingParts line =
             -- Hide the markdown `#` markers (grok pretty mode); color the title.
             renderInlineWith (headingPrefixStyle level) (parseInline title)
@@ -142,8 +154,34 @@ listMarkerStyle =
 quoteStyle :: [SGR]
 quoteStyle = [terminalMuted]
 
-renderTable :: Block.MarkdownTable -> [Text]
-renderTable table = case table.tableRows of
+inlineCodeStyle :: [SGR]
+inlineCodeStyle =
+    [ SetConsoleIntensity BoldIntensity
+    , terminalCyan
+    ]
+
+inlineLinkStyle :: [SGR]
+inlineLinkStyle =
+    [ terminalBlue
+    , SetUnderlining SingleUnderline
+    ]
+
+inlineUrlStyle :: [SGR]
+inlineUrlStyle = [terminalMuted]
+
+safeInlineUrl :: Text -> Bool
+safeInlineUrl url =
+    not (Text.null url)
+        && displayTerminalText url == url
+
+data TableFragment = TableFragment
+    { tableFragmentStyles :: ![SGR]
+    , tableFragmentUrl :: !(Maybe Text)
+    , tableFragmentText :: !Text
+    }
+
+renderTable :: Maybe Int -> Block.MarkdownTable -> [Text]
+renderTable availableWidth table = case table.tableRows of
     [] -> []
     (headerCells : bodyCells) ->
         let columnCount = length headerCells
@@ -151,60 +189,321 @@ renderTable table = case table.tableRows of
             normalizedHeader = normalize headerCells
             normalizedBody = map normalize bodyCells
             normalizedRows = normalizedHeader : normalizedBody
-            widths = columnWidths normalizedRows
+            styledRows =
+                [ [ tableCellFragments
+                        (if rowIndex == 0
+                            then [SetConsoleIntensity BoldIntensity]
+                            else [])
+                        cell
+                  | cell <- row
+                  ]
+                | (rowIndex, row) <-
+                    zip [0 :: Int ..] normalizedRows
+                ]
+            naturalWidths =
+                map
+                    (maximum . (1 :) . map tableFragmentsWidth)
+                    (transpose styledRows)
+            minimumWidths =
+                map
+                    (maximum . (1 :) . map tableFragmentsMinimumWidth)
+                    (transpose styledRows)
             alignments = table.tableAlignments
-            top = md [terminalMuted] (tableBorder '┌' '┬' '┐' widths)
-            divider = md [terminalMuted] (tableBorder '├' '┼' '┤' widths)
-            bottom = md [terminalMuted] (tableBorder '└' '┴' '┘' widths)
-            headerRow = styleTableRow True alignments widths normalizedHeader
-            bodyRows = map (styleTableRow False alignments widths) normalizedBody
-            logicalRows = headerRow : bodyRows
-        in top : (intersperse divider logicalRows <> [bottom])
+            borderWidth = columnCount + 1
+            gridMinimumWidth = borderWidth + sum minimumWidths
+            paddedGridMinimumWidth =
+                gridMinimumWidth + 2 * columnCount
+            renderGrid horizontalPadding widths =
+                let top =
+                        md [terminalMuted] $
+                            tableBorder
+                                horizontalPadding '┌' '┬' '┐' widths
+                    divider =
+                        md [terminalMuted] $
+                            tableBorder
+                                horizontalPadding '├' '┼' '┤' widths
+                    bottom =
+                        md [terminalMuted] $
+                            tableBorder
+                                horizontalPadding '└' '┴' '┘' widths
+                    logicalRows =
+                        map
+                            (renderTableLogicalRow
+                                alignments horizontalPadding widths)
+                            styledRows
+                in top
+                    : (concat (intersperse [divider] logicalRows)
+                        <> [bottom])
+        in case availableWidth of
+            Nothing -> renderGrid 1 naturalWidths
+            Just requestedWidth
+                | available < gridMinimumWidth ->
+                    renderCompactTable available styledRows
+                | otherwise ->
+                    let horizontalPadding =
+                            if available >= paddedGridMinimumWidth
+                                then 1
+                                else 0
+                        chromeWidth =
+                            borderWidth
+                                + 2 * horizontalPadding * columnCount
+                        contentBudget =
+                            max 0 (available - chromeWidth)
+                        widths =
+                            fitTableColumnWidths
+                                contentBudget minimumWidths naturalWidths
+                    in renderGrid horizontalPadding widths
+              where
+                available = max 1 requestedWidth
 
-tableBorder :: Char -> Char -> Char -> [Int] -> Text
-tableBorder left middle right widths =
+tableBorder :: Int -> Char -> Char -> Char -> [Int] -> Text
+tableBorder horizontalPadding left middle right widths =
     Text.singleton left
         <> Text.intercalate
             (Text.singleton middle)
-            [ Text.replicate (width + 2) "─"
+            [ Text.replicate
+                (width + 2 * horizontalPadding)
+                "─"
             | width <- widths
             ]
         <> Text.singleton right
 
-columnWidths :: [[Text]] -> [Int]
-columnWidths rows =
-    let cols = transpose rows
-    in map (maximum . (0 :) . map renderedWidth) cols
+fitTableColumnWidths :: Int -> [Int] -> [Int] -> [Int]
+fitTableColumnWidths budget minimumWidths naturalWidths
+    | null preferred = []
+    | sum preferred <= budget = preferred
+    | otherwise =
+        grow minimum (max 0 (budget - sum minimum))
   where
-    renderedWidth =
-        terminalDisplayWidth
-            . inlinePlainText
-            . parseInline
+    minimum = map (max 1) minimumWidths
+    preferred =
+        zipWith max
+            (minimum <> repeat 1)
+            (map (max 1) naturalWidths)
 
-styleTableRow :: Bool -> [Block.TableAlignment] -> [Int] -> [Text] -> Text
-styleTableRow isHeader alignments widths cells =
-    let cellText alignment w c =
-            let inlines = parseInline c
-                visible = inlinePlainText inlines
-                width' = terminalDisplayWidth visible
-                padding = max 0 (w - width')
-                (leftPadding, rightPadding) = alignmentPadding alignment padding
-                base
-                    | isHeader = [SetConsoleIntensity BoldIntensity]
-                    | otherwise = []
-            in " "
-                <> Text.replicate leftPadding " "
-                <> renderInlineWith base inlines
-                <> Text.replicate rightPadding " "
-                <> " "
-        parts = zipWith3 cellText
-            (alignments <> repeat Block.AlignDefault)
+    grow widths remaining
+        | remaining <= 0 = widths
+        | otherwise =
+            let (remaining', widths') =
+                    List.mapAccumL grant remaining (zip preferred widths)
+            in if remaining' == remaining
+                then widths
+                else grow widths' remaining'
+
+    grant remaining (wanted, current)
+        | remaining > 0
+        , current < wanted =
+            (remaining - 1, current + 1)
+        | otherwise =
+            (remaining, current)
+
+renderCompactTable :: Int -> [[[TableFragment]]] -> [Text]
+renderCompactTable width =
+    concatMap $
+        map renderTableFragments
+            . wrapTableFragments width
+            . List.intercalate [tableSeparator]
+  where
+    tableSeparator =
+        TableFragment [terminalMuted] Nothing " │ "
+
+renderTableLogicalRow
+    :: [Block.TableAlignment]
+    -> Int
+    -> [Int]
+    -> [[TableFragment]]
+    -> [Text]
+renderTableLogicalRow alignments horizontalPadding widths cells =
+    map renderPhysicalRow physicalRows
+  where
+    border = md [terminalMuted] "│"
+    normalizedAlignments = alignments <> repeat Block.AlignDefault
+    wrappedCells =
+        zipWith
+            (\width fragments ->
+                wrapTableFragments (max 1 width) fragments)
             widths
-            (cells <> repeat "")
-        border = md [terminalMuted] "│"
-    in border
-        <> Text.intercalate border (take (length widths) parts)
-        <> border
+            (cells <> repeat [])
+    rowHeight = maximum (1 : map length wrappedCells)
+    physicalRows =
+        transpose
+            [ take rowHeight (wrapped <> repeat [])
+            | wrapped <- wrappedCells
+            ]
+    renderPhysicalRow fragments =
+        border
+            <> Text.intercalate
+                border
+                [ renderTableCell
+                    alignment horizontalPadding width cellFragments
+                | (alignment, width, cellFragments) <-
+                    zip3 normalizedAlignments widths fragments
+                ]
+            <> border
+
+renderTableCell
+    :: Block.TableAlignment
+    -> Int
+    -> Int
+    -> [TableFragment]
+    -> Text
+renderTableCell alignment horizontalPadding width fragments =
+    Text.replicate (horizontalPadding + leftPadding) " "
+        <> renderTableFragments fragments
+        <> Text.replicate (rightPadding + horizontalPadding) " "
+  where
+    padding = max 0 (width - tableFragmentsWidth fragments)
+    (leftPadding, rightPadding) =
+        alignmentPadding alignment padding
+
+tableCellFragments :: [SGR] -> Text -> [TableFragment]
+tableCellFragments base = concatMap (go base Nothing) . parseInline
+  where
+    go context link = \case
+        InlineText text -> one context link text
+        InlineCode text -> one (context <> inlineCodeStyle) link text
+        InlineStrong children ->
+            concatMap
+                (go (context <> [SetConsoleIntensity BoldIntensity]) link)
+                children
+        InlineEmphasis children ->
+            concatMap
+                (go (context <> [SetItalicized True]) link)
+                children
+        InlineLink url children ->
+            let linkTarget
+                    | safeInlineUrl url = Just url
+                    | otherwise = link
+                label =
+                    concatMap
+                        (go (context <> inlineLinkStyle) linkTarget)
+                        children
+                suffix
+                    | Text.null url || inlinePlainText children == url = []
+                    | otherwise =
+                        one
+                            (context <> inlineUrlStyle)
+                            linkTarget
+                            (" (" <> url <> ")")
+            in label <> suffix
+
+    one styles link text =
+        [TableFragment styles link text]
+
+renderTableFragments :: [TableFragment] -> Text
+renderTableFragments = go
+  where
+    go [] = ""
+    go (fragment : rest) =
+        case fragment.tableFragmentUrl of
+            Nothing -> renderFragment fragment <> go rest
+            Just url ->
+                let (linked, after) =
+                        span
+                            (\next ->
+                                next.tableFragmentUrl == Just url)
+                            rest
+                in osc8Link True url
+                    (Text.concat (map renderFragment (fragment : linked)))
+                        <> go after
+
+    renderFragment fragment
+        | null fragment.tableFragmentStyles =
+            fragment.tableFragmentText
+        | otherwise =
+            md
+                fragment.tableFragmentStyles
+                fragment.tableFragmentText
+
+tableFragmentsWidth :: [TableFragment] -> Int
+tableFragmentsWidth =
+    sum . map (terminalDisplayWidth . (.tableFragmentText))
+
+tableFragmentsMinimumWidth :: [TableFragment] -> Int
+tableFragmentsMinimumWidth fragments =
+    maximum
+        (1
+            : [ graphemeCellWidth cluster
+              | fragment <- fragments
+              , cluster <- graphemeClusters fragment.tableFragmentText
+              ])
+
+type StyledTableCell = ([SGR], Maybe Text, Text, Int)
+
+wrapTableFragments :: Int -> [TableFragment] -> [[TableFragment]]
+wrapTableFragments width fragments =
+    map groupStyledTableCells (wrapCells (styledTableCells fragments))
+  where
+    width' = max 1 width
+
+    wrapCells [] = [[]]
+    wrapCells remaining =
+        let (fitting, overflow) = takeFitting remaining
+        in case overflow of
+            [] -> [dropTrailingSpace fitting]
+            _ ->
+                case lastSpaceIndex fitting of
+                    Just index
+                        | index > 0 ->
+                            let (line, carried) = splitAt index fitting
+                                next =
+                                    dropWhile styledTableCellIsSpace
+                                        (carried <> overflow)
+                            in dropTrailingSpace line : wrapCells next
+                    _ -> fitting : wrapCells overflow
+
+    takeFitting = go 0 []
+      where
+        go _ taken [] = (reverse taken, [])
+        go used taken allCells@(cell@(_, _, _, cellWidth) : rest)
+            | used > 0
+            , used + cellWidth > width' =
+                (reverse taken, allCells)
+            | otherwise =
+                go (used + cellWidth) (cell : taken) rest
+
+    lastSpaceIndex =
+        List.foldl'
+            (\found (index, cell) ->
+                if styledTableCellIsSpace cell
+                    then Just index
+                    else found)
+            Nothing
+            . zip [0 :: Int ..]
+
+    dropTrailingSpace =
+        reverse . dropWhile styledTableCellIsSpace . reverse
+
+styledTableCells :: [TableFragment] -> [StyledTableCell]
+styledTableCells fragments =
+    [ ( fragment.tableFragmentStyles
+      , fragment.tableFragmentUrl
+      , cluster
+      , graphemeCellWidth cluster
+      )
+    | fragment <- fragments
+    , cluster <- graphemeClusters fragment.tableFragmentText
+    ]
+
+styledTableCellIsSpace :: StyledTableCell -> Bool
+styledTableCellIsSpace (_, _, cluster, _) =
+    not (Text.null cluster) && Text.all isSpace cluster
+
+groupStyledTableCells :: [StyledTableCell] -> [TableFragment]
+groupStyledTableCells =
+    reverse . List.foldl' appendCell []
+  where
+    appendCell grouped (styles, url, cluster, _) =
+        case grouped of
+            previous : rest
+                | previous.tableFragmentStyles == styles
+                , previous.tableFragmentUrl == url ->
+                    previous
+                        { tableFragmentText =
+                            previous.tableFragmentText <> cluster
+                        }
+                        : rest
+            _ -> TableFragment styles url cluster : grouped
 
 alignmentPadding :: Block.TableAlignment -> Int -> (Int, Int)
 alignmentPadding alignment padding = case alignment of
@@ -244,7 +543,7 @@ renderInlineWith base = Text.concat . map (go base)
   where
     go context = \case
         InlineText text -> styled context text
-        InlineCode text -> styled (context <> codeStyle) text
+        InlineCode text -> styled (context <> inlineCodeStyle) text
         InlineStrong children ->
             renderInlineWith
                 (context <> [SetConsoleIntensity BoldIntensity])
@@ -253,32 +552,20 @@ renderInlineWith base = Text.concat . map (go base)
             renderInlineWith (context <> [SetItalicized True]) children
         InlineLink url children ->
             let label =
-                    renderInlineWith (context <> linkStyle) children
+                    renderInlineWith (context <> inlineLinkStyle) children
                 suffix
                     | Text.null url || inlinePlainText children == url = ""
                     | otherwise =
-                        styled (context <> urlStyle) (" (" <> url <> ")")
+                        styled
+                            (context <> inlineUrlStyle)
+                            (" (" <> url <> ")")
                 displayedLink = label <> suffix
-            in if safeUrl url
+            in if safeInlineUrl url
                 then osc8Link True url displayedLink
                 else displayedLink
 
     styled [] value = value
     styled styles value = md styles value
-
-    safeUrl url =
-        not (Text.null url)
-            && displayTerminalText url == url
-
-    codeStyle =
-        [ SetConsoleIntensity BoldIntensity
-        , terminalCyan
-        ]
-    linkStyle =
-        [ terminalBlue
-        , SetUnderlining SingleUnderline
-        ]
-    urlStyle = [terminalMuted]
 
 -- | Split an inline markdown stream into a prefix that can be rendered without
 -- future input and a suffix beginning at a possibly incomplete construct.

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -32,6 +32,7 @@ import Agent.CLI.Notification
     , notifyAttention
     )
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
+import Agent.CLI.Render (renderAssistantTextForHandle)
 import Agent.CLI.Style
     ( agentBackground
     , glyphWarn
@@ -144,7 +145,9 @@ decideExit provider interrupt resolveColor planBody = do
     isTty <- hIsTerminalDevice stdin
     putTextLn stderr ""
     putTextLn stderr (roleMuted color "── plan ──")
-    Text.hPutStrLn stderr (renderPlanMarkdown color planBody)
+    renderedPlan <-
+        renderAssistantTextForHandle stderr color planBody
+    Text.hPutStrLn stderr renderedPlan
     hFlush stderr
     putTextLn stderr (roleMuted color "──────────")
     if not isTty

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -39,6 +39,7 @@ module Agent.CLI.Render
     , formatTurnStatus
     , putTextLn
     , renderAssistantText
+    , renderAssistantTextForHandle
     , renderEvent
     , renderPrintedText
     , resetRenderPrintedText
@@ -571,6 +572,14 @@ renderAssistantTextAtWidth :: Bool -> Int -> Text -> Text
 renderAssistantTextAtWidth color width text =
     paintBackgroundLines color agentBackground
         (renderMarkdownAtWidth color width text)
+
+renderAssistantTextForHandle :: Handle -> Bool -> Text -> IO Text
+renderAssistantTextForHandle handle color text = do
+    availableWidth <- terminalColumns handle
+    pure $
+        case availableWidth of
+            Nothing -> renderAssistantText color text
+            Just width -> renderAssistantTextAtWidth color width text
 
 -- | Stream assistant text append-only. Ordinary prose is emitted as soon as
 -- incomplete inline constructs permit, while line prefixes that may introduce

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -44,6 +44,7 @@ module Agent.CLI.Render
     , resetRenderPrintedText
     , setRenderActivity
     , streamMarkdown
+    , streamMarkdownAtWidth
     , summarizeToolCall
     , summarizeToolCallRelative
     , thinkingMaxWidth
@@ -53,12 +54,15 @@ module Agent.CLI.Render
 
 import Agent.CLI.Markdown
     ( renderMarkdown
+    , renderMarkdownAtWidth
     )
 import Agent.CLI.Render.MarkdownStream
     ( MarkdownStreamState
     , emptyMarkdownStreamState
     , feedMarkdownStream
+    , feedMarkdownStreamAtWidth
     , flushMarkdownStream
+    , flushMarkdownStreamAtWidth
     )
 import Agent.CLI.Render.Status
     ( formatActivityLine
@@ -162,8 +166,9 @@ import Agent.TUI.Motion
     , motionIntervalMicros
     , nativeProgressAnimationEnabled
     )
+import System.Console.ANSI (hGetTerminalSize)
 import System.Environment (lookupEnv)
-import System.IO (Handle, hFlush)
+import System.IO (Handle, hFlush, hIsTerminalDevice)
 
 summarizeToolCall :: ToolCall -> Text
 summarizeToolCall call =
@@ -340,6 +345,17 @@ streamMarkdown :: Text -> RenderState -> (RenderState, Text)
 streamMarkdown input state =
     let (markdown', output) =
             feedMarkdownStream state.stateMarkdownState input
+    in (state{stateMarkdownState = markdown'}, output)
+
+streamMarkdownAtWidth
+    :: Int
+    -> Text
+    -> RenderState
+    -> (RenderState, Text)
+streamMarkdownAtWidth width input state =
+    let (markdown', output) =
+            feedMarkdownStreamAtWidth
+                width state.stateMarkdownState input
     in (state{stateMarkdownState = markdown'}, output)
 
 renderEvent :: RenderConfig -> LoopEvent -> IO ()
@@ -551,6 +567,11 @@ renderAssistantText :: Bool -> Text -> Text
 renderAssistantText color text =
     paintBackgroundLines color agentBackground (renderMarkdown color text)
 
+renderAssistantTextAtWidth :: Bool -> Int -> Text -> Text
+renderAssistantTextAtWidth color width text =
+    paintBackgroundLines color agentBackground
+        (renderMarkdownAtWidth color width text)
+
 -- | Stream assistant text append-only. Ordinary prose is emitted as soon as
 -- incomplete inline constructs permit, while line prefixes that may introduce
 -- blocks are held until they can be classified. Fences and tables are buffered
@@ -565,8 +586,16 @@ streamAssistantDelta config delta
     | Text.null delta = pure ()
     | otherwise = do
         let safe = Text.filter (/= '\ESC') delta
+        availableWidth <-
+            if Text.any (== '\n') safe
+                then terminalColumns config.renderStdout
+                else pure Nothing
+        let transition =
+                case availableWidth of
+                    Nothing -> streamMarkdown safe
+                    Just width -> streamMarkdownAtWidth width safe
         ready <-
-            modifyRenderState config (streamMarkdown safe)
+            modifyRenderState config transition
         unless (Text.null ready) do
             modifyRenderState config \state ->
                 (state{statePrintedText = True, stateLiveActive = True}, ())
@@ -582,13 +611,19 @@ streamAssistantDelta config delta
 -- Returns whether anything was written.
 finalizeAssistantBuffer :: RenderConfig -> Maybe Text -> IO Bool
 finalizeAssistantBuffer config assistantText = do
+    availableWidth <- terminalColumns config.renderStdout
     (pendingOutput, live) <-
         modifyRenderState config \state ->
             ( state
                 { stateMarkdownState = emptyMarkdownStreamState
                 , stateLiveActive = False
                 }
-            , ( flushMarkdownStream state.stateMarkdownState
+            , ( case availableWidth of
+                    Nothing ->
+                        flushMarkdownStream state.stateMarkdownState
+                    Just width ->
+                        flushMarkdownStreamAtWidth
+                            width state.stateMarkdownState
               , state.stateLiveActive
               )
             )
@@ -614,11 +649,21 @@ finalizeAssistantBuffer config assistantText = do
                         (state{statePrintedText = True}, ())
                     Text.hPutStr config.renderStdout $
                         if Text.null pendingOutput
-                            then renderAssistantText True raw
+                            then case availableWidth of
+                                Nothing -> renderAssistantText True raw
+                                Just width ->
+                                    renderAssistantTextAtWidth True width raw
                             else paintBackgroundLines
                                 True agentBackground pendingOutput
                     hFlush config.renderStdout
                     pure True
+
+terminalColumns :: Handle -> IO (Maybe Int)
+terminalColumns handle = do
+    isTerminal <- hIsTerminalDevice handle
+    if isTerminal
+        then fmap (max 1 . snd) <$> hGetTerminalSize handle
+        else pure Nothing
 
 -- | Clear a leftover thinking status line. Safe to call when none is visible.
 -- Commits a streamed reasoning block first so cancel/error still leave the

--- a/packages/agent-cli/src/Agent/CLI/Render/MarkdownStream.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render/MarkdownStream.hs
@@ -2,13 +2,16 @@ module Agent.CLI.Render.MarkdownStream
     ( MarkdownStreamState
     , emptyMarkdownStreamState
     , feedMarkdownStream
+    , feedMarkdownStreamAtWidth
     , flushMarkdownStream
+    , flushMarkdownStreamAtWidth
     , streamMarkdownText
     ) where
 
 import Agent.CLI.Markdown
     ( MarkdownFragmentSplit(..)
     , renderMarkdown
+    , renderMarkdownAtWidth
     , renderMarkdownFragment
     , splitMarkdownFragment
     )
@@ -29,6 +32,7 @@ data MarkdownStreamState = MarkdownStreamState
     , context :: !(Maybe Char)
     , streamMode :: !MarkdownStreamMode
     , blockPending :: !Text
+    , renderWidth :: !(Maybe Int)
     }
 
 data MarkdownStreamMode
@@ -40,7 +44,7 @@ data MarkdownStreamMode
 
 emptyMarkdownStreamState :: MarkdownStreamState
 emptyMarkdownStreamState =
-    MarkdownStreamState "" Nothing StreamLineStart ""
+    MarkdownStreamState "" Nothing StreamLineStart "" Nothing
 
 streamMarkdownText
     :: MarkdownStreamState
@@ -52,7 +56,23 @@ feedMarkdownStream
     :: MarkdownStreamState
     -> Text
     -> (MarkdownStreamState, Text)
-feedMarkdownStream state input = case state.streamMode of
+feedMarkdownStream state =
+    feedMarkdownStreamCurrent state{renderWidth = Nothing}
+
+feedMarkdownStreamAtWidth
+    :: Int
+    -> MarkdownStreamState
+    -> Text
+    -> (MarkdownStreamState, Text)
+feedMarkdownStreamAtWidth width state =
+    feedMarkdownStreamCurrent
+        state{renderWidth = Just (max 1 width)}
+
+feedMarkdownStreamCurrent
+    :: MarkdownStreamState
+    -> Text
+    -> (MarkdownStreamState, Text)
+feedMarkdownStreamCurrent state input = case state.streamMode of
     StreamLineStart -> feedLineStart state input
     StreamProse -> feedProse state input
     StreamFence marker -> feedFence marker state input
@@ -86,14 +106,14 @@ classifyCompleteLine
     -> (MarkdownStreamState, Text)
 classifyCompleteLine state line rest
     | Just (marker, _) <- fenceOpener (dropLineEnding line) =
-        feedMarkdownStream
+        feedMarkdownStreamCurrent
             state
                 { streamMode = StreamFence marker
                 , blockPending = line
                 }
             rest
     | isPossibleTableHeader line =
-        feedMarkdownStream
+        feedMarkdownStreamCurrent
             state
                 { streamMode = StreamTableCandidate
                 , blockPending = line
@@ -101,13 +121,13 @@ classifyCompleteLine state line rest
             rest
     | lineIsBlock line =
         let (nextState, output) =
-                feedMarkdownStream
+                feedMarkdownStreamCurrent
                     state
                         { streamMode = StreamLineStart
                         , blockPending = ""
                         }
                     rest
-        in (nextState, renderMarkdown True line <> output)
+        in (nextState, renderBuffered state line <> output)
     | otherwise =
         feedProse
             state
@@ -177,7 +197,7 @@ feedProse state input =
                             , blockPending = ""
                             }
                     (nextState, following) =
-                        feedMarkdownStream reset (Text.drop 1 rest)
+                        feedMarkdownStreamCurrent reset (Text.drop 1 rest)
                 in (nextState, rendered <> following)
 
 feedFence
@@ -202,8 +222,9 @@ feedFence marker state input =
                         , pending = ""
                         , context = Nothing
                         }
-                (nextState, following) = feedMarkdownStream reset rest
-            in (nextState, renderMarkdown True block <> following)
+                (nextState, following) =
+                    feedMarkdownStreamCurrent reset rest
+            in (nextState, renderBuffered state block <> following)
 
 feedTableCandidate
     :: MarkdownStreamState
@@ -215,7 +236,7 @@ feedTableCandidate state input =
     in case lines_ of
         header : separator : after
             | isTableStart header separator ->
-                feedMarkdownStream
+                feedMarkdownStreamCurrent
                     state
                         { streamMode = StreamTable
                         , blockPending = header <> separator
@@ -228,9 +249,9 @@ feedTableCandidate state input =
                             , blockPending = ""
                             }
                     (nextState, following) =
-                        feedMarkdownStream reset
+                        feedMarkdownStreamCurrent reset
                             (separator <> Text.concat after <> partial)
-                in (nextState, renderMarkdown True header <> following)
+                in (nextState, renderBuffered state header <> following)
         _ -> (state{blockPending = buffered}, "")
 
 feedTable
@@ -257,22 +278,36 @@ feedTable state input =
                         , blockPending = ""
                         }
                 (nextState, following) =
-                    feedMarkdownStream reset
+                    feedMarkdownStreamCurrent reset
                         (line <> Text.concat rest <> partial)
-            in (nextState, renderMarkdown True table <> following)
+            in (nextState, renderBuffered state table <> following)
 
 flushMarkdownStream :: MarkdownStreamState -> Text
-flushMarkdownStream state = case state.streamMode of
+flushMarkdownStream = flushMarkdownStreamCurrent
+
+flushMarkdownStreamAtWidth :: Int -> MarkdownStreamState -> Text
+flushMarkdownStreamAtWidth width state =
+    flushMarkdownStreamCurrent
+        state{renderWidth = Just (max 1 width)}
+
+flushMarkdownStreamCurrent :: MarkdownStreamState -> Text
+flushMarkdownStreamCurrent state = case state.streamMode of
     StreamProse ->
         renderMarkdownFragment True state.context state.pending
     StreamLineStart ->
-        renderMarkdown True state.blockPending
+        renderBuffered state state.blockPending
     StreamFence _ ->
-        renderMarkdown True state.blockPending
+        renderBuffered state state.blockPending
     StreamTableCandidate ->
-        renderMarkdown True state.blockPending
+        renderBuffered state state.blockPending
     StreamTable ->
-        renderMarkdown True state.blockPending
+        renderBuffered state state.blockPending
+
+renderBuffered :: MarkdownStreamState -> Text -> Text
+renderBuffered state =
+    case state.renderWidth of
+        Nothing -> renderMarkdown True
+        Just width -> renderMarkdownAtWidth True width
 
 takeCompleteLine :: Text -> Maybe (Text, Text)
 takeCompleteLine text =

--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -28,7 +28,7 @@ import Agent.CLI.Options
 import Agent.CLI.Render
     ( RenderConfig(..)
     , putTextLn
-    , renderAssistantText
+    , renderAssistantTextForHandle
     )
 import Agent.CLI.ReplMode
     ( replModeFromState
@@ -228,5 +228,8 @@ runBtwQuestion registerCancel env question = do
             case fullscreen of
                 Just runtime ->
                     emitUiEvent runtime (UiAssistantHistory answer)
-                Nothing ->
-                    putTextLn stdoutHandle (renderAssistantText color answer)
+                Nothing -> do
+                    rendered <-
+                        renderAssistantTextForHandle
+                            stdoutHandle color answer
+                    putTextLn stdoutHandle rendered

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -41,7 +41,7 @@ import Agent.CLI.Render
     , formatLoopErrorPersistedAt
     , formatTurnStatus
     , putTextLn
-    , renderAssistantText
+    , renderAssistantTextForHandle
     , renderPrintedText
     , resetRenderPrintedText
     , stateLastTokensPerSecond
@@ -672,7 +672,10 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                 (Just _, _, _) -> pure ()
                 (Nothing, False, Just text) | not (Text.null (Text.strip text)) -> do
                     useColor <- resolveColor stdoutHandle
-                    putTextLn stdoutHandle (renderAssistantText useColor text)
+                    rendered <-
+                        renderAssistantTextForHandle
+                            stdoutHandle useColor text
+                    putTextLn stdoutHandle rendered
                 _ -> pure ()
             let newItems =
                     turnNewItems

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -257,11 +257,15 @@ spec = do
         it "renders a basic pipe table" do
             let sample = "| file | status |\n| --- | --- |\n| a.hs | ok |"
                 out = renderMarkdown True sample
-            out `shouldSatisfy` Text.isInfixOf "file"
-            out `shouldSatisfy` Text.isInfixOf "a.hs"
+                cleaned = stripAnsi out
+            cleaned `shouldSatisfy` Text.isInfixOf "┌──────┬────────┐"
+            cleaned `shouldSatisfy` Text.isInfixOf "│ file │ status │"
+            cleaned `shouldSatisfy` Text.isInfixOf "├──────┼────────┤"
+            cleaned `shouldSatisfy` Text.isInfixOf "│ a.hs │ ok     │"
+            cleaned `shouldSatisfy` Text.isInfixOf "└──────┴────────┘"
             out `shouldSatisfy` (not . Text.isInfixOf "|")
 
-        it "renders borderless tables with GFM column alignment" do
+        it "renders full-grid tables with GFM column alignment" do
             let sample =
                     "| Name | Footprint |\n\
                     \| --- | ---: |\n\
@@ -272,22 +276,22 @@ spec = do
                         (filter (not . Text.null . Text.strip)
                             (Text.lines (renderMarkdown True sample)))
                 bodyRows =
-                    filter
-                        (\row -> not (Text.isInfixOf "─" row))
-                        (drop 2 rows)
+                    drop 1 (filter (Text.isPrefixOf "│") rows)
                 valueEnd needle row =
                     let offset = Text.length (fst (Text.breakOn needle row))
                     in offset + Text.length needle
-            rows `shouldSatisfy` all
-                (\row -> not (Text.any (`elem` ("┌┐└┘├┤┬┴┼│" :: String)) row))
-            rows `shouldSatisfy` any (Text.isInfixOf "─")
+                contentRows = filter (Text.isPrefixOf "│") rows
+            rows `shouldSatisfy` any (Text.isPrefixOf "┌")
+            rows `shouldSatisfy` any (Text.isPrefixOf "├")
+            rows `shouldSatisfy` any (Text.isPrefixOf "└")
+            contentRows `shouldSatisfy` all (Text.isSuffixOf "│")
             case bodyRows of
                 webkit : control : _ ->
                     valueEnd "27.7 GiB" webkit
                         `shouldBe` valueEnd "4.6 GiB" control
                 _ -> expectationFailure "expected two table body rows"
 
-        prop "right-aligns generated table values without box borders" $
+        prop "right-aligns generated table values inside a full grid" $
             forAll generatedRightAlignedTable $ \(firstValue, secondValue) ->
                 let sample =
                         "Name | Value\n--- | ---:\nfirst | " <> firstValue
@@ -297,17 +301,22 @@ spec = do
                             (filter (not . Text.null . Text.strip)
                                 (Text.lines (renderMarkdown True sample)))
                     bodyRows =
-                        filter (not . Text.isInfixOf "─") (drop 2 rows)
+                        drop 1 (filter (Text.isPrefixOf "│") rows)
                     valueEnd needle row =
                         Text.length (fst (Text.breakOn needle row))
                             + Text.length needle
-                    noBoxBorders = all
-                        (not . Text.any (`elem` ("┌┐└┘├┤┬┴┼│" :: String)))
-                        rows
+                    hasFullGrid = case rows of
+                        top : (_ : rest) ->
+                            Text.isPrefixOf "┌" top
+                                && any (Text.isPrefixOf "└") rest
+                                && all
+                                    (Text.isSuffixOf "│")
+                                    (filter (Text.isPrefixOf "│") rows)
+                        _ -> False
                 in case bodyRows of
                     firstRow : secondRow : _ ->
                         counterexample (show rows) $
-                            ( noBoxBorders
+                            ( hasFullGrid
                             , valueEnd firstValue firstRow
                             )
                                 === (True, valueEnd secondValue secondRow)

--- a/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MarkdownSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Markdown
     ( MarkdownFragmentSplit(..)
     , renderMarkdown
+    , renderMarkdownAtWidth
     , renderMarkdownFragment
     , splitMarkdownFragment
     )
@@ -21,13 +22,34 @@ import Test.QuickCheck
     )
 
 stripAnsi :: Text -> Text
-stripAnsi text = case Text.break (== '\ESC') text of
-    (before, rest)
-        | Text.null rest -> before
-        | otherwise ->
-            let afterEsc = Text.drop 1 rest
-                dropped = Text.drop 1 (Text.dropWhile (/= 'm') afterEsc)
-            in before <> stripAnsi dropped
+stripAnsi = go
+  where
+    go text =
+        case Text.break (== '\ESC') text of
+            (before, rest)
+                | Text.null rest -> before
+                | Just after <- Text.stripPrefix "\ESC[" rest ->
+                    before <> go (dropCsi after)
+                | Just after <- Text.stripPrefix "\ESC]" rest ->
+                    before <> go (dropOsc after)
+                | otherwise ->
+                    before <> go (Text.drop 1 rest)
+
+    dropCsi =
+        Text.drop 1
+            . Text.dropWhile
+                (\character ->
+                    not (character >= '@' && character <= '~'))
+
+    dropOsc text =
+        case Text.break
+            (\character -> character == '\BEL' || character == '\ESC')
+            text of
+            (_, rest)
+                | Text.null rest -> ""
+                | Text.isPrefixOf "\BEL" rest -> Text.drop 1 rest
+                | Text.isPrefixOf "\ESC\\" rest -> Text.drop 2 rest
+                | otherwise -> dropOsc (Text.drop 1 rest)
 
 osc8Payload :: Text -> Text -> Maybe Text
 osc8Payload url output = do
@@ -290,6 +312,87 @@ spec = do
                     valueEnd "27.7 GiB" webkit
                         `shouldBe` valueEnd "4.6 GiB" control
                 _ -> expectationFailure "expected two table body rows"
+
+        it "constrains table grids to the requested terminal width" do
+            let sample =
+                    "| Product | Description | Difference |\n\
+                    \| --- | --- | ---: |\n\
+                    \| Codex | Compact and fast | 18% |\n\
+                    \| Other | Polished borders | 24% |"
+                rows =
+                    map stripAnsi
+                        (filter (not . Text.null . Text.strip)
+                            (Text.lines
+                                (renderMarkdownAtWidth True 24 sample)))
+                content = Text.concat rows
+            map terminalTextWidth rows `shouldSatisfy` all (<= 24)
+            rows `shouldSatisfy` any (Text.isPrefixOf "┌")
+            filter (Text.isPrefixOf "│") rows
+                `shouldSatisfy` all (Text.isSuffixOf "│")
+            content `shouldSatisfy` Text.isInfixOf "Codex"
+            content `shouldSatisfy` Text.isInfixOf "24%"
+
+        it "reflows a grid when the terminal is one cell too narrow" do
+            let sample =
+                    "| Name | Value |\n\
+                    \| --- | ---: |\n\
+                    \| alpha | 12345 |"
+                naturalRows =
+                    map stripAnsi
+                        (filter (not . Text.null . Text.strip)
+                            (Text.lines (renderMarkdown True sample)))
+                available =
+                    maximum (map terminalTextWidth naturalRows) - 1
+                constrainedRows =
+                    map stripAnsi
+                        (filter (not . Text.null . Text.strip)
+                            (Text.lines
+                                (renderMarkdownAtWidth
+                                    True available sample)))
+            map terminalTextWidth constrainedRows
+                `shouldSatisfy` all (<= available)
+            constrainedRows `shouldSatisfy`
+                any (Text.isPrefixOf "┌")
+            filter (Text.isPrefixOf "│") constrainedRows
+                `shouldSatisfy` all (Text.isSuffixOf "│")
+
+        it "uses wrapped compact rows below the minimum grid width" do
+            let sample =
+                    "| A | B | C |\n\
+                    \| --- | --- | --- |\n\
+                    \| x | y | z |"
+                rows =
+                    map stripAnsi
+                        (filter (not . Text.null . Text.strip)
+                            (Text.lines
+                                (renderMarkdownAtWidth True 6 sample)))
+                content = Text.concat rows
+            map terminalTextWidth rows `shouldSatisfy` all (<= 6)
+            content `shouldSatisfy` (not . Text.isInfixOf "┌")
+            mapM_
+                (\value ->
+                    content `shouldSatisfy` Text.isInfixOf value)
+                ["A", "B", "C", "x", "y", "z"]
+
+        it "accounts for displayed link destinations while wrapping tables" do
+            let url = "https://example.com/docs"
+                sample =
+                    "| Kind | Value |\n\
+                    \| --- | --- |\n\
+                    \| link | [docs](" <> url <> ") |"
+                out = renderMarkdownAtWidth True 20 sample
+                rows =
+                    map stripAnsi
+                        (filter (not . Text.null . Text.strip)
+                            (Text.lines out))
+                visibleContent =
+                    Text.filter
+                        (\character ->
+                            character /= ' ' && character /= '│')
+                        (Text.concat rows)
+            map terminalTextWidth rows `shouldSatisfy` all (<= 20)
+            out `shouldSatisfy` Text.isInfixOf ("\ESC]8;;" <> url)
+            visibleContent `shouldSatisfy` Text.isInfixOf url
 
         prop "right-aligns generated table values inside a full grid" $
             forAll generatedRightAlignedTable $ \(firstValue, secondValue) ->

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -1,5 +1,6 @@
 module Agent.CLI.RenderSpec (spec) where
 
+import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Render
 import Agent.CLI.Style
     ( glyphInspect
@@ -183,6 +184,23 @@ spec = do
             output `shouldSatisfy` Text.isInfixOf "Control Center"
             output `shouldSatisfy` Text.isInfixOf "─"
             output `shouldSatisfy` (not . Text.isInfixOf "|")
+
+        it "constrains streamed tables to the terminal width" do
+            let input =
+                    "Product | Description | Difference\n\
+                    \--- | --- | ---:\n\
+                    \Codex | Compact and fast | 18%\n\
+                    \Other | Polished borders | 24%\n\
+                    \after\n"
+                (_state, output) =
+                    streamMarkdownAtWidth 24 input emptyRenderState
+                rows =
+                    filter (not . Text.null . Text.strip) $
+                        Text.lines (stripTerminalControls output)
+            map terminalTextWidth rows `shouldSatisfy` all (<= 24)
+            output `shouldSatisfy` Text.isInfixOf "Codex"
+            output `shouldSatisfy` Text.isInfixOf "24%"
+            output `shouldSatisfy` Text.isInfixOf "after"
 
         it "streams ordinary prose before its newline" do
             let (state1, first) = streamMarkdown "hello" emptyRenderState

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -329,8 +329,8 @@ tableRowsWidget
 tableRowsWidget table rows headerCells =
     B.Widget B.Greedy B.Fixed do
         context <- B.getContext
-        borderAttr <- B.lookupAttrName Theme.mutedAttr
-        headerAttr <- B.lookupAttrName Theme.headingAttr
+        borderAttr <- B.lookupAttrName Theme.borderAttr
+        headerAttr <- B.lookupAttrName Theme.strongAttr
         bodyAttr <- B.lookupAttrName Theme.assistantAttr
         styledRows <-
             traverse
@@ -338,15 +338,15 @@ tableRowsWidget table rows headerCells =
                     traverse
                         (resolveInline
                             (if rowIndex == 0
-                                then Theme.headingAttr
+                                then Theme.strongAttr
                                 else Theme.assistantAttr)
                             . parseInline)
                         cells)
                 (zip [0 :: Int ..] normalizedRows)
         let availableWidth = max 1 context.availWidth
-            columnGap = 2
+            borderWidth = columnCount + 1
             gridMinimumWidth =
-                columnGap * max 0 (columnCount - 1) + sum minimumWidths
+                borderWidth + sum minimumWidths
             paddedGridMinimumWidth =
                 gridMinimumWidth + 2 * columnCount
             gridFits = availableWidth >= gridMinimumWidth
@@ -355,27 +355,37 @@ tableRowsWidget table rows headerCells =
                     then 1
                     else 0
             chromeWidth =
-                columnGap * max 0 (columnCount - 1)
-                    + 2 * horizontalPadding * columnCount
+                borderWidth + 2 * horizontalPadding * columnCount
             contentBudget = max 0 (availableWidth - chromeWidth)
             widths =
                 fitColumnWidths
                     contentBudget minimumWidths naturalWidths
-            divider = tableRule borderAttr horizontalPadding columnGap widths
+            top =
+                tableRule
+                    borderAttr horizontalPadding '┌' '┬' '┐' widths
+            divider =
+                tableRule
+                    borderAttr horizontalPadding '├' '┼' '┤' widths
+            bottom =
+                tableRule
+                    borderAttr horizontalPadding '└' '┴' '┘' widths
             renderedRows =
                 case styledRows of
                     [] -> []
                     header : body ->
-                        renderTableRow
-                            headerAttr horizontalPadding columnGap
-                            table.tableAlignments widths header
-                            : divider
-                            : List.intersperse divider
-                                (map
-                                    (renderTableRow
-                                        bodyAttr horizontalPadding columnGap
-                                        table.tableAlignments widths)
-                                    body)
+                        let logicalRows =
+                                renderTableRow
+                                    borderAttr headerAttr horizontalPadding
+                                    table.tableAlignments widths header
+                                    : map
+                                        (renderTableRow
+                                            borderAttr bodyAttr
+                                            horizontalPadding
+                                            table.tableAlignments widths)
+                                        body
+                        in top
+                            : (List.intersperse divider logicalRows
+                                <> [bottom])
             image =
                 if gridFits
                     then V.vertCat renderedRows
@@ -485,37 +495,50 @@ renderStyledLine fragments =
         | (attr, text) <- fragments
         ]
 
-tableRule :: V.Attr -> Int -> Int -> [Int] -> V.Image
-tableRule attr horizontalPadding columnGap widths =
+tableRule
+    :: V.Attr
+    -> Int
+    -> Char
+    -> Char
+    -> Char
+    -> [Int]
+    -> V.Image
+tableRule attr horizontalPadding left middle right widths =
     V.text' attr $
-        Text.intercalate (Text.replicate columnGap " ")
-            [ Text.replicate
-                (width + 2 * horizontalPadding)
-                "─"
-            | width <- widths
-            ]
+        Text.singleton left
+            <> Text.intercalate
+                (Text.singleton middle)
+                [ Text.replicate
+                    (width + 2 * horizontalPadding)
+                    "─"
+                | width <- widths
+                ]
+            <> Text.singleton right
 
 renderTableRow
     :: V.Attr
-    -> Int
+    -> V.Attr
     -> Int
     -> [Block.TableAlignment]
     -> [Int]
     -> [[(V.Attr, Text)]]
     -> V.Image
-renderTableRow paddingAttr horizontalPadding columnGap alignments widths cells =
+renderTableRow
+    borderAttr paddingAttr horizontalPadding alignments widths cells =
     V.vertCat
         [ V.horizCat $
-            List.intersperse gap
-                [ renderTableCell
-                    paddingAttr alignment horizontalPadding width fragments
-                | (alignment, width, fragments) <-
-                    zip3 normalizedAlignments widths rowFragments
-                ]
+            border
+                : (List.intersperse border
+                    [ renderTableCell
+                        paddingAttr alignment horizontalPadding width fragments
+                    | (alignment, width, fragments) <-
+                        zip3 normalizedAlignments widths rowFragments
+                    ]
+                    <> [border])
         | rowFragments <- physicalRows
         ]
   where
-    gap = V.charFill paddingAttr ' ' columnGap 1
+    border = V.char borderAttr '│'
     normalizedAlignments = alignments <> repeat Block.AlignDefault
     wrappedCells =
         zipWith

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -368,19 +368,31 @@ spec = describe "fullscreen Markdown rendering" do
         rendered `shouldSatisfy` (not . null)
 
     describe "tables" do
-        it "renders naturally sized columns with a segmented rule" do
+        it "renders naturally sized columns inside a full grid" do
             renderRows 80
                 "| A | BB |\n| --- | --- |\n| x | yy |"
                 `shouldBe`
-                    [ " A    BB"
-                    , "───  ────"
-                    , " x    yy"
+                    [ "┌───┬────┐"
+                    , "│ A │ BB │"
+                    , "├───┼────┤"
+                    , "│ x │ yy │"
+                    , "└───┴────┘"
                     ]
-            renderRows 80
-                "| A | BB |\n| --- | --- |\n| x | yy |"
-                `shouldSatisfy` all (not . Text.isInfixOf "│")
 
-        it "wraps constrained cells without clipping content" do
+        it "draws a divider between every logical row" do
+            renderRows 80
+                "| A | B |\n| --- | --- |\n| x | y |\n| u | v |"
+                `shouldBe`
+                    [ "┌───┬───┐"
+                    , "│ A │ B │"
+                    , "├───┼───┤"
+                    , "│ x │ y │"
+                    , "├───┼───┤"
+                    , "│ u │ v │"
+                    , "└───┴───┘"
+                    ]
+
+        it "wraps constrained cells without clipping content or borders" do
             let rows =
                     renderRows 48 $
                         Text.unlines
@@ -388,12 +400,14 @@ spec = describe "fullscreen Markdown rendering" do
                             , "| --- | --- | --- |"
                             , "| Codex | short description | 0123456789ABCDEFVISIBLE |"
                             ]
+                contentRows = filter (Text.isPrefixOf "│") rows
             map rowDisplayWidth rows
                 `shouldSatisfy` all (<= 48)
+            contentRows `shouldSatisfy` (not . null)
+            contentRows `shouldSatisfy`
+                all (Text.isSuffixOf "│")
             Text.unlines rows `shouldSatisfy` Text.isInfixOf "VISIBLE"
             Text.unlines rows `shouldSatisfy` Text.isInfixOf "description"
-            Text.unlines rows `shouldSatisfy`
-                (not . Text.isInfixOf "│")
 
         it "keeps short columns natural while sharing constrained space" do
             let longLeft = Text.replicate 50 "l"
@@ -434,7 +448,8 @@ spec = describe "fullscreen Markdown rendering" do
             mapM_ (\value ->
                 compactText `shouldSatisfy` Text.isInfixOf value)
                 ["A", "B", "C", "x", "y", "z"]
-            Text.unlines grid `shouldSatisfy` Text.isInfixOf "─"
+            expectFirstRow grid
+                (shouldSatisfyText (Text.isPrefixOf "┌"))
             map rowDisplayWidth grid `shouldSatisfy` all (<= 7)
 
         it "preserves every ASCII column down to a one-cell viewport" do
@@ -451,28 +466,25 @@ spec = describe "fullscreen Markdown rendering" do
         it "switches cell padding only when the padded grid fits" do
             let input =
                     "| A | B |\n| --- | --- |\n| x | y |"
-                compactGrid = renderRows 7 input
-                paddedGrid = renderRows 8 input
+                compactGrid = renderRows 8 input
+                paddedGrid = renderRows 9 input
             expectFirstRow compactGrid
-                (shouldSatisfyText (not . Text.isInfixOf "┌"))
+                (`shouldBe` "┌─┬─┐")
             expectFirstRow paddedGrid
-                (shouldSatisfyText (const True))
-            case drop 1 paddedGrid of
-                rule : _ ->
-                    rule `shouldSatisfy` Text.isInfixOf "───"
-                [] -> expectationFailure "missing table rule"
+                (`shouldBe` "┌───┬───┐")
 
         it "accounts for wide glyphs when choosing grid or compact layout" do
             let input =
                     "| A | B |\n| --- | --- |\n| 漢 | z |"
-                compact = renderRows 4 input
-                grid = renderRows 5 input
+                compact = renderRows 5 input
+                grid = renderRows 6 input
             Text.unlines compact `shouldSatisfy` Text.isInfixOf "漢"
             Text.unlines compact `shouldSatisfy` Text.isInfixOf "z"
             expectFirstRow compact
-                (shouldSatisfyText (not . Text.isInfixOf "─"))
-            Text.unlines grid `shouldSatisfy` Text.isInfixOf "─"
-            map rowDisplayWidth grid `shouldSatisfy` all (<= 5)
+                (shouldSatisfyText (not . Text.isPrefixOf "┌"))
+            expectFirstRow grid
+                (shouldSatisfyText (Text.isPrefixOf "┌"))
+            map rowDisplayWidth grid `shouldSatisfy` all (<= 6)
 
         it "preserves styled text and hyperlink metadata while wrapping" do
             let url = "https://example.com"
@@ -550,8 +562,7 @@ spec = describe "fullscreen Markdown rendering" do
             plain `shouldSatisfy` Text.isInfixOf "c|d"
             plain `shouldSatisfy` Text.isInfixOf "e|f"
             plain `shouldSatisfy` (not . Text.isInfixOf "`")
-            Text.unlines rows `shouldSatisfy`
-                (not . Text.isInfixOf "│")
+            Text.unlines rows `shouldSatisfy` Text.isInfixOf "│"
 
         it "handles odd and even backslash runs before pipes" do
             let oddEscaped =
@@ -594,7 +605,7 @@ spec = describe "fullscreen Markdown rendering" do
             plain `shouldSatisfy` Text.isInfixOf "one"
             plain `shouldSatisfy` Text.isInfixOf "two"
             plain `shouldSatisfy` (not . Text.isInfixOf "EXTRA")
-            plain `shouldSatisfy` (not . Text.isInfixOf "│")
+            plain `shouldSatisfy` Text.isInfixOf "│"
 
         it "accepts alignment markers and rejects malformed separators" do
             let aligned =
@@ -605,13 +616,13 @@ spec = describe "fullscreen Markdown rendering" do
                 malformed =
                     renderRows 80
                         "| A | B |\n| ---x | --- |\n| x | y |"
-                body = last aligned
-            Text.unlines aligned `shouldSatisfy`
-                (Text.isInfixOf "─")
-            body `shouldSatisfy` Text.isInfixOf "1"
-            body `shouldSatisfy` Text.isInfixOf "y"
+                rendered = Text.unlines aligned
+            expectFirstRow aligned
+                (shouldSatisfyText (Text.isPrefixOf "┌"))
+            rendered `shouldSatisfy` Text.isInfixOf "1"
+            rendered `shouldSatisfy` Text.isInfixOf "y"
             Text.unlines malformed `shouldSatisfy`
-                (not . Text.isInfixOf "─")
+                (not . Text.isInfixOf "┌")
             Text.unlines malformed `shouldSatisfy`
                 Text.isInfixOf "---x"
 
@@ -620,8 +631,8 @@ spec = describe "fullscreen Markdown rendering" do
                     renderRows 80
                         "A | B\n--- | ---\nx | y"
                 plain = Text.unlines rows
-            Text.unlines rows `shouldSatisfy`
-                (Text.isInfixOf "─")
+            expectFirstRow rows
+                (shouldSatisfyText (Text.isPrefixOf "┌"))
             plain `shouldSatisfy` Text.isInfixOf "x"
             plain `shouldSatisfy` Text.isInfixOf "y"
 
@@ -633,9 +644,9 @@ spec = describe "fullscreen Markdown rendering" do
                     renderRows 80
                         "| a \\| b\n| --- |\n| value |"
             Text.unlines mismatched `shouldSatisfy`
-                (not . Text.isInfixOf "─")
+                (not . Text.isInfixOf "┌")
             Text.unlines escapedOnly `shouldSatisfy`
-                (not . Text.isInfixOf "─")
+                (not . Text.isInfixOf "┌")
 
         it "renders a header-only table and leaves following prose outside it" do
             let headerOnly =
@@ -645,8 +656,11 @@ spec = describe "fullscreen Markdown rendering" do
                     renderRows 80
                         "| A | B |\n| --- | --- |\n| x | y |\nafter table"
                 proseIndex = findIndex (Text.isInfixOf "after table") withProse
-            length headerOnly `shouldBe` 2
-            Text.unlines headerOnly `shouldSatisfy` Text.isInfixOf "─"
+            headerOnly `shouldBe`
+                [ "┌───┬───┐"
+                , "│ A │ B │"
+                , "└───┴───┘"
+                ]
             proseIndex `shouldSatisfy` maybe False (const True)
 
 sourceSyntaxDirectory :: IO FilePath


### PR DESCRIPTION
## Summary
- render pipe tables as complete Unicode grids in fullscreen and CLI output
- use neutral bold headers and themed border chrome
- constrain streaming and direct CLI tables to each output handle's detected terminal width, wrapping cells or using compact rows when a grid cannot fit
- preserve display-width handling, GFM alignment, inline styling, hyperlinks, and narrow-width content

## Testing
- `Agent.TUI.MarkdownSpec` in GHCi: 48 examples, 0 failures
- `Agent.CLI.MarkdownSpec` in GHCi: 37 examples, 0 failures (including 200 generated cases)
- `Agent.CLI.RenderSpec` in GHCi: 73 examples, 0 failures
- production renderers smoke-tested in tmux, including the handle-aware direct path at 24 columns and compact fallback at 6 columns