### PR TITLE
Subdue inspection tool styling

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -92,6 +92,7 @@ import Agent.CLI.Style
     , paintBackgroundLines
     , osc8Link
     , roleError
+    , roleInspectName
     , roleMuted
     , roleToolArrow
     , roleToolCommand
@@ -790,8 +791,9 @@ formatToolStarted color = formatToolStartedRelative color ""
 
 formatToolStartedRelative :: Bool -> Text -> ToolCall -> Text
 formatToolStartedRelative color workspace call =
-    let marker
-            | isInspectionTool call.name = glyphInspect
+    let inspection = isInspectionTool call.name
+        marker
+            | inspection = glyphInspect
             | otherwise = glyphTool
         arrow = roleToolArrow color marker
         detail = toolDetail call
@@ -804,7 +806,9 @@ formatToolStartedRelative color workspace call =
                         else roleToolCommand color detail
             in arrow <> prompt <> command
         ToolChrome verb kind ->
-            let name = roleToolName color verb
+            let name
+                    | inspection = roleInspectName color verb
+                    | otherwise = roleToolName color verb
                 paintedDetail = case kind of
                     ToolDetailNone -> ""
                     ToolDetailMuted
@@ -813,9 +817,13 @@ formatToolStartedRelative color workspace call =
                     ToolDetailPath
                         | Text.null detail -> ""
                         | otherwise ->
-                            " " <> renderToolPath color workspace detail
+                            " "
+                                <> if inspection
+                                    then renderInspectionPath color workspace detail
+                                    else renderToolPath color workspace detail
                     ToolDetailCommand
                         | Text.null detail -> ""
+                        | inspection -> " " <> roleToolDetail color detail
                         | otherwise -> " " <> roleToolCommand color detail
             in arrow <> name <> paintedDetail
 
@@ -941,9 +949,17 @@ paintDiffRelative color workspace diff =
             style color [terminalGreen] ("  +" <> line)
 
 renderToolPath :: Bool -> Text -> Text -> Text
-renderToolPath color workspace path =
+renderToolPath color =
+    renderToolPathWith (roleToolPath color) color
+
+renderInspectionPath :: Bool -> Text -> Text -> Text
+renderInspectionPath color =
+    renderToolPathWith (roleToolDetail color) color
+
+renderToolPathWith :: (Text -> Text) -> Bool -> Text -> Text -> Text
+renderToolPathWith paint color workspace path =
     let displayed = workspaceRelativeDisplayPath workspace path
-        styled = roleToolPath color displayed
+        styled = paint displayed
         absolute = absoluteToolPath workspace path
     in if "/" `Text.isPrefixOf` absolute
         then osc8Link color (fileUri (Text.unpack absolute)) styled

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -15,6 +15,7 @@ module Agent.CLI.Style
     , endBackground
     , rolePrompt
     , roleToolArrow
+    , roleInspectName
     , roleToolName
     , roleToolDetail
     , roleToolPath
@@ -160,6 +161,13 @@ rolePrompt color =
 
 roleToolArrow :: Bool -> Text -> Text
 roleToolArrow color = style color [terminalMuted]
+
+roleInspectName :: Bool -> Text -> Text
+roleInspectName color =
+    style color
+        [ SetConsoleIntensity BoldIntensity
+        , terminalMuted
+        ]
 
 roleToolName :: Bool -> Text -> Text
 roleToolName color =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
@@ -204,7 +204,6 @@ completionFlashTransitions previous next =
         `elem`
             [ BlockThinking
             , BlockTool
-            , BlockInspect
             , BlockTodo
             , BlockShell
             , BlockEdit

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -159,6 +159,7 @@ import qualified Agent.TUI.Theme as Theme
       controlLinkAttr,
       dimAttr,
       errorAttr,
+      inspectAttr,
       mutedAttr,
       successAttr,
       syntaxCommentAttr,
@@ -263,7 +264,7 @@ drawBlock state target ui block =
                     ui
                     block
                     waveElapsed
-                    (statusAttr state target block)
+                    (inspectionStatusAttr block)
                     (blockStateGlyph state target block
                         <> block.blockTitle
                         <> detailSuffix block)
@@ -367,6 +368,7 @@ drawBlock state target ui block =
 hoverReadableAttrs :: Widget Name -> Widget Name
 hoverReadableAttrs =
     overrideAttr Theme.mutedAttr Theme.transcriptHoverMutedAttr
+        . overrideAttr Theme.inspectAttr Theme.transcriptHoverMutedAttr
         . overrideAttr
             Theme.thinkingBodyAttr
             Theme.transcriptHoverMutedItalicAttr
@@ -833,6 +835,15 @@ statusAttr state target block
         BlockComplete -> Theme.successAttr
         BlockRunning -> Theme.toolAttr
         BlockStreaming -> Theme.thinkingAttr
+
+inspectionStatusAttr :: UiBlock -> AttrName
+inspectionStatusAttr block = case block.blockState of
+    BlockFailed -> Theme.errorAttr
+    BlockCancelled -> Theme.mutedAttr
+    BlockDenied -> Theme.errorAttr
+    BlockComplete -> Theme.inspectAttr
+    BlockRunning -> Theme.inspectAttr
+    BlockStreaming -> Theme.inspectAttr
 
 thinkingBlockAttr :: AppState -> AgentTarget -> UiBlock -> AttrName
 thinkingBlockAttr state target block

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -1,7 +1,16 @@
 module Agent.CLI.RenderSpec (spec) where
 
 import Agent.CLI.Render
-import Agent.CLI.Style (motionGlyphSet)
+import Agent.CLI.Style
+    ( glyphInspect
+    , glyphTool
+    , motionGlyphSet
+    , roleInspectName
+    , roleToolArrow
+    , roleToolDetail
+    , roleToolName
+    , roleToolPath
+    )
 import Agent.Error (ApiError(..), ErrorType(..), credentialsExhausted)
 import Agent.Loop
     ( LoopError(..)
@@ -323,6 +332,28 @@ spec = do
                     "wait_commands_or_subagents"
                     "{\"task_ids\":[\"t1\"]}")
                 `shouldBe` "◆ Waited"
+
+        it "keeps inspection labels and paths in subdued gray" do
+            formatToolStarted True
+                (functionToolCall
+                    "inspect-read"
+                    "read_file"
+                    "{\"target_file\":\"src/A.hs\"}")
+                `shouldBe`
+                    roleToolArrow True glyphInspect
+                        <> roleInspectName True "Read"
+                        <> " "
+                        <> roleToolDetail True "src/A.hs"
+            formatToolStarted True
+                (functionToolCall
+                    "action-edit"
+                    "search_replace"
+                    "{\"file_path\":\"src/A.hs\"}")
+                `shouldBe`
+                    roleToolArrow True glyphTool
+                        <> roleToolName True "Edited"
+                        <> " "
+                        <> roleToolPath True "src/A.hs"
 
         it "keeps unknown tool names" do
             formatToolStarted False (functionToolCall "c5" "custom_tool" "{\"x\":1}")

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -33,6 +33,11 @@ spec = do
             let out = styleBase True agentBackground [] "hi"
             out `shouldSatisfy` (not . Text.isInfixOf "48;")
 
+        it "uses bold terminal gray for inspection labels" do
+            let out = roleInspectName True "Read"
+            out `shouldSatisfy` Text.isInfixOf "\ESC[1;90m"
+            out `shouldSatisfy` (not . Text.isInfixOf "\ESC[1;35m")
+
     describe "paintBackgroundLines" do
         it "leaves text unchanged when color is off" do
             paintBackgroundLines False agentBackground "a\nb" `shouldBe` "a\nb"
@@ -47,6 +52,7 @@ spec = do
 
     describe "roles" do
         it "keeps tool labels readable with color off" do
+            roleInspectName False "Read" `shouldBe` "Read"
             roleToolName False "Read" `shouldBe` "Read"
             roleToolPath False "src/A.hs" `shouldBe` "src/A.hs"
             roleToolCommand False "git status" `shouldBe` "git status"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1559,6 +1559,29 @@ spec = do
             completionFlashTransitions completed completed
                 `shouldBe` []
 
+        it "does not schedule completion flashes for inspection blocks" do
+            let call =
+                    functionToolCall
+                        "inspect-1"
+                        "read_file"
+                        "{\"target_file\":\"README.md\"}"
+                running =
+                    reduceUi
+                        (UiLoop (ToolStarted call))
+                        (reduceUi (UiLoop TurnStarted) initialUiState)
+                completed =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished
+                                ToolCallResult
+                                    { callId = "inspect-1"
+                                    , output = "contents"
+                                    , callKind = FunctionCallKind
+                                    }))
+                        running
+            completionFlashTransitions running completed
+                `shouldBe` []
+
         it "ignores assistant streams and unsuccessful terminal states" do
             let assistantRunning =
                     reduceUi

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -14,6 +14,7 @@ module Agent.TUI.Theme
     , dimAttr
     , emphasisAttr
     , headingAttr
+    , inspectAttr
     , inlineCodeAttr
     , lambdaDimAttr
     , lambdaGlowAttr
@@ -181,6 +182,7 @@ fixedThemePalette = \case
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
 userAttr, userMutedAttr, assistantAttr, thinkingAttr, thinkingBodyAttr, toolAttr :: AttrName
+inspectAttr :: AttrName
 todoPendingAttr, todoInProgressAttr, todoCompletedAttr, todoCancelledAttr :: AttrName
 errorAttr, successAttr, selectedAttr, selectedMutedAttr, borderAttr, borderActiveAttr :: AttrName
 transcriptHoverAttr :: AttrName
@@ -204,6 +206,7 @@ assistantAttr = attrName "assistant"
 thinkingAttr = attrName "thinking"
 thinkingBodyAttr = attrName "thinking-body"
 toolAttr = attrName "tool"
+inspectAttr = attrName "inspect"
 todoPendingAttr = attrName "todo-pending"
 todoInProgressAttr = attrName "todo-in-progress"
 todoCompletedAttr = attrName "todo-completed"
@@ -284,6 +287,7 @@ terminalDefault =
         , (waitingDimAttr, palette V.brightBlack)
         , (waitingMidAttr, palette V.yellow)
         , (toolAttr, palette V.cyan)
+        , (inspectAttr, palette V.brightBlack `V.withStyle` V.bold)
         , (todoPendingAttr, V.defAttr)
         , (todoInProgressAttr, palette V.yellow `V.withStyle` V.bold)
         , (todoCompletedAttr, palette V.brightBlack)
@@ -351,6 +355,7 @@ monochrome =
         , (waitingDimAttr, V.defAttr)
         , (waitingMidAttr, V.defAttr)
         , (toolAttr, V.defAttr)
+        , (inspectAttr, V.defAttr `V.withStyle` V.bold)
         , (todoPendingAttr, V.defAttr)
         , (todoInProgressAttr, V.defAttr `V.withStyle` V.bold)
         , (todoCompletedAttr, V.defAttr)
@@ -435,6 +440,7 @@ mkTheme background foreground muted accent link =
         , (waitingDimAttr, mutedA)
         , (waitingMidAttr, accentA)
         , (toolAttr, linkA)
+        , (inspectAttr, mutedA `V.withStyle` V.bold)
         , (todoPendingAttr, base)
         , (todoInProgressAttr, accentA `V.withStyle` V.bold)
         , (todoCompletedAttr, mutedA)
@@ -558,7 +564,8 @@ waveTrough = RGBColor 36 40 59
 runningWavePeak :: V.Color
 runningWavePeak = RGBColor 187 154 247
 
--- | Quiet gray-blue peak (#3b4261) so reasoning rails sit behind tool rails.
+-- | Quiet gray-blue peak (#3b4261) so reasoning and inspection rails sit
+-- behind action-tool rails.
 thinkingWavePeak :: V.Color
 thinkingWavePeak = RGBColor 59 66 97
 
@@ -653,7 +660,7 @@ waveCellForTheme theme True trough peak brightness glyph
 
 wavePeakFor :: AttrName -> V.Color
 wavePeakFor attr
-    | attr == thinkingAttr = thinkingWavePeak
+    | attr == thinkingAttr || attr == inspectAttr = thinkingWavePeak
     | otherwise = runningWavePeak
 
 wavePeakForTheme :: ThemeKind -> AttrName -> V.Color
@@ -661,7 +668,8 @@ wavePeakForTheme theme attr =
     case fixedThemePalette theme of
         Nothing -> wavePeakFor attr
         Just palette
-            | attr == thinkingAttr -> palette.themePaletteMuted
+            | attr == thinkingAttr || attr == inspectAttr ->
+                palette.themePaletteMuted
             | otherwise -> palette.themePaletteAccent
 
 waitingPeakForTheme :: ThemeKind -> V.Color

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -75,6 +75,7 @@ spec = do
                 , Theme.assistantAttr
                 , Theme.thinkingAttr
                 , Theme.toolAttr
+                , Theme.inspectAttr
                 , Theme.errorAttr
                 , Theme.successAttr
                 , Theme.codeAttr
@@ -111,6 +112,25 @@ spec = do
             V.attrForeColor active `shouldBe` V.SetTo V.brightBlack
             V.attrStyle border `shouldBe` V.SetTo V.dim
             V.attrStyle active `shouldBe` V.Default
+
+        it "styles inspection summaries as bold muted text" do
+            let terminalInspection =
+                    attrMapLookup Theme.inspectAttr Theme.terminalDefault
+                terminalMuted =
+                    attrMapLookup Theme.mutedAttr Theme.terminalDefault
+                daylight = Theme.themeAttrMap Theme.Daylight
+                daylightInspection =
+                    attrMapLookup Theme.inspectAttr daylight
+                daylightMuted =
+                    attrMapLookup Theme.mutedAttr daylight
+            V.attrForeColor terminalInspection
+                `shouldBe` V.attrForeColor terminalMuted
+            V.attrStyle terminalInspection `shouldBe` V.SetTo V.bold
+            V.attrForeColor daylightInspection
+                `shouldBe` V.attrForeColor daylightMuted
+            V.attrBackColor daylightInspection
+                `shouldBe` V.attrBackColor daylightMuted
+            V.attrStyle daylightInspection `shouldBe` V.SetTo V.bold
 
         it "gives user messages a palette gray panel distinct from assistant messages" do
             let user = attrMapLookup Theme.userAttr Theme.terminalDefault
@@ -196,6 +216,8 @@ spec = do
                 `shouldBe` RGBColor 144 80 150
             Theme.wavePeakForTheme Theme.Daylight Theme.thinkingAttr
                 `shouldBe` RGBColor 110 105 100
+            Theme.wavePeakForTheme Theme.Daylight Theme.inspectAttr
+                `shouldBe` RGBColor 110 105 100
             V.attrBackColor
                 (Theme.waitingPulseAttrForTheme
                     Theme.Daylight
@@ -225,6 +247,8 @@ spec = do
             Theme.runningWavePeak `shouldBe` RGBColor 187 154 247
             Theme.waveTrough `shouldBe` RGBColor 36 40 59
             Theme.wavePeakFor Theme.thinkingAttr
+                `shouldBe` Theme.thinkingWavePeak
+            Theme.wavePeakFor Theme.inspectAttr
                 `shouldBe` Theme.thinkingWavePeak
             Theme.wavePeakFor Theme.toolAttr
                 `shouldBe` Theme.runningWavePeak


### PR DESCRIPTION
## Summary
- render read and search inspection tools with bold, muted styling
- keep inspection rails and details subdued while preserving action-tool accents and error states
- cover terminal-default, monochrome, and fixed-palette themes with focused rendering tests

## Testing
- `nix develop -c cabal repl agent-tui:test:agent-tui-test` (`:main --match inspection`)
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code` (`:main --match inspection`)
- live fullscreen tmux smoke check using the Daylight theme
