### PR TITLE
Show line numbers in file diffs

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -115,7 +115,7 @@ import Control.Exception.Safe ()
 import Control.Monad ()
 import Control.Monad.IO.Class ()
 import Control.Monad.State.Strict ()
-import Data.Char ()
+import Data.Char ( isDigit )
 import Data.Foldable ()
 import Data.IORef ()
 import Data.List ()
@@ -144,10 +144,12 @@ import qualified Agent.CLI.TUI.Scroll as Scroll ()
 import qualified Data.Sequence as Seq ()
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text
-    ( isPrefixOf,
+    ( dropWhile,
+      isPrefixOf,
       lines,
       null,
       strip,
+      uncons,
       unlines,
       pack )
 import qualified Data.Text.Encoding as TextEncoding ()
@@ -614,14 +616,24 @@ editBodyWidgets body
     | otherwise = [vBox (map editLineWidget (Text.lines body))]
   where
     editLineWidget line
-        | "  -" `Text.isPrefixOf` line =
+        | isEditLine '-' line =
             withAttr Theme.errorAttr (terminalTxtWrap line)
-        | "  +" `Text.isPrefixOf` line =
+        | isEditLine '+' line =
             withAttr Theme.successAttr (terminalTxtWrap line)
         | "  …" `Text.isPrefixOf` line
             || "… +" `Text.isPrefixOf` line =
                 withAttr Theme.mutedAttr (terminalTxtWrap line)
         | otherwise = terminalTxtWrap line
+
+    isEditLine marker line =
+        case Text.uncons (Text.dropWhile (== ' ') line) of
+            Just (first, rest)
+                | first == marker -> True
+                | first >= '0' && first <= '9' ->
+                    case Text.uncons (Text.dropWhile (== ' ') (Text.dropWhile isDigit rest)) of
+                        Just (actual, _) -> actual == marker
+                        Nothing -> False
+            _ -> False
 
 accentMarkdownBlock
     :: AppState

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/SearchReplace.hs
@@ -178,14 +178,19 @@ replaceInFile env args = do
     when (count > 1 && not args.replaceAll) $
         throwE
             "The string to replace was found multiple times in the file. Use replace_all to replace all occurrences, or include more context to only edit one occurrence."
-    let updated = replaceOccurrences args.oldString args.newString args.replaceAll content
+    let (beforeMatch, _) = Text.breakOn args.oldString content
+        lineStart = Text.count "\n" beforeMatch + 1
+        updated = replaceOccurrences args.oldString args.newString args.replaceAll content
     ExceptT (writeTextFile path updated)
     pure $
-        if args.replaceAll && count > 1
+        (if args.replaceAll && count > 1
             then "The file " <> display
                 <> " has been updated. All occurrences were successfully replaced."
             else "The file " <> display
-                <> " has been updated successfully."
+                <> " has been updated successfully.")
+            <> if count == 1
+                then "\nChanged lines start at " <> Text.pack (show lineStart) <> "."
+                else ""
 
 resolvePath :: ToolEnv -> Text -> ExceptT Text IO OsPath
 resolvePath env path =

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/SearchReplaceSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/SearchReplaceSpec.hs
@@ -43,6 +43,25 @@ spec = describe "search_replace" do
             result.output
                 `shouldBe` "The file src/Main.hs has been created successfully."
 
+    it "reports the resolved start line for a unique replacement" do
+        withSystemTempDirectory "agent-search-replace" \dir -> do
+            let source = dir </> "Main.hs"
+            writeFile source "first\nold\nlast\n"
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            typesRef <- newIORef Map.empty
+            coding <- newGrokCodingTools env Nothing Nothing typesRef
+            result <-
+                dispatchToolCall testConfig
+                    (map (.appToolHandler) coding.grokAppTools)
+                    (functionToolCall
+                        "edit-line"
+                        "search_replace"
+                        "{\"file_path\":\"Main.hs\",\"old_string\":\"old\",\
+                        \\"new_string\":\"new\"}")
+            coding.grokClose
+            result.output `shouldSatisfy`
+                Text.isSuffixOf "\nChanged lines start at 2."
+
 testConfig :: ToolDispatchConfig
 testConfig = ToolDispatchConfig
     { toolDispatchUnknownTool = \name -> "unknown:" <> name

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -43,6 +43,7 @@ module Agent.TUI.Model
 
 import Agent.TUI.Presentation
     ( formatToolDiffRelative
+    , formatToolDiffRelativeWithOutput
     , formatToolOutputRelative
     , isInspectionTool
     , todoListFromToolArguments
@@ -678,7 +679,11 @@ timestampNewMessageBlocks firstNewIndex timestamp state
 completeTool :: Int -> ToolCall -> ToolCallResult -> UiState -> UiState
 completeTool blockIndex call result state =
     let resultState = toolResultState result.output
-        diff = formatToolDiffRelative state.uiWorkspaceRoot call
+        diff =
+            formatToolDiffRelativeWithOutput
+                state.uiWorkspaceRoot
+                call
+                result.output
         body
             | resultState == BlockComplete
             , not (Text.null (Text.strip diff)) = diff

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -8,6 +8,7 @@ module Agent.TUI.Presentation
     , formatSearchReplaceDiff
     , formatSearchReplaceDiffRelative
     , formatToolDiffRelative
+    , formatToolDiffRelativeWithOutput
     , formatTodoList
     , formatToolOutput
     , formatToolOutputRelative
@@ -47,7 +48,8 @@ import Agent.ToolDispatch
     , canonicalToolName
     )
 import Control.Applicative ((<|>))
-import Data.Char (isSpace)
+import Data.Char (isDigit, isSpace)
+import Data.List (mapAccumL)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -288,8 +290,24 @@ formatToolDiffRelative workspace call =
     Text.intercalate "\n" $
         map (formatDiffRelative workspace) (toolCallDiffs call)
 
+-- | Completed diff body, enriched with exact source location metadata emitted
+-- by edit tools. While a tool is running we deliberately keep the preview
+-- unnumbered rather than guessing where a search string will match.
+formatToolDiffRelativeWithOutput :: Text -> ToolCall -> Text -> Text
+formatToolDiffRelativeWithOutput workspace call output =
+    Text.intercalate "\n" $
+        map (formatDiffRelativeAt workspace lineStart) (toolCallDiffs call)
+  where
+    lineStart
+        | canonicalToolName call.name == "search_replace" =
+            searchReplaceLineStart output
+        | otherwise = Nothing
+
 formatDiffRelative :: Text -> SearchReplaceDiff -> Text
-formatDiffRelative workspace diff =
+formatDiffRelative workspace = formatDiffRelativeAt workspace Nothing
+
+formatDiffRelativeAt :: Text -> Maybe Int -> SearchReplaceDiff -> Text
+formatDiffRelativeAt workspace reportedStart diff =
     let SearchReplaceDiff { diffPath, diffAction, diffLines, diffHiddenLines } =
             diff
         displayedPath = workspaceRelativeDisplayPath workspace diffPath
@@ -304,7 +322,9 @@ formatDiffRelative workspace diff =
                     <> " → "
                     <> workspaceRelativeDisplayPath workspace destination
             Nothing -> ""
-        shown = map formatLine diffLines
+        lineStart = reportedStart <|> actionLineStart diffAction
+        shown = maybe (map formatLine diffLines) (`formatNumberedLines` diffLines)
+            lineStart
         more
             | diffHiddenLines == 0 = []
             | otherwise =
@@ -314,6 +334,44 @@ formatDiffRelative workspace diff =
     formatLine = \case
         SearchReplaceRemoved line -> "  -" <> line
         SearchReplaceAdded line -> "  +" <> line
+
+    actionLineStart = \case
+        Just SearchReplaceCreate -> Just 1
+        Just SearchReplaceWrite -> Just 1
+        _ -> Nothing
+
+formatNumberedLines :: Int -> [SearchReplaceLine] -> [Text]
+formatNumberedLines start lines_ =
+    let numbered = snd (mapAccumL numberLine (start, start) lines_)
+        width = maximum (1 : map (Text.length . Text.pack . show . fst) numbered)
+    in map (formatNumbered width) numbered
+  where
+    numberLine (oldLine, newLine) = \case
+        SearchReplaceRemoved line ->
+            ((oldLine + 1, newLine), (oldLine, SearchReplaceRemoved line))
+        SearchReplaceAdded line ->
+            ((oldLine, newLine + 1), (newLine, SearchReplaceAdded line))
+
+    formatNumbered width (lineNumber, changedLine) =
+        "  "
+            <> Text.justifyRight width ' ' (Text.pack (show lineNumber))
+            <> " "
+            <> case changedLine of
+                SearchReplaceRemoved line -> "-" <> line
+                SearchReplaceAdded line -> "+" <> line
+
+searchReplaceLineStart :: Text -> Maybe Int
+searchReplaceLineStart output =
+    case Text.breakOn marker output of
+        (_, rest)
+            | Text.null rest -> Nothing
+            | otherwise ->
+                let digits = Text.takeWhile isDigit (Text.drop (Text.length marker) rest)
+                in case reads (Text.unpack digits) of
+                    [(lineNumber, "")] | lineNumber > 0 -> Just lineNumber
+                    _ -> Nothing
+  where
+    marker = "Changed lines start at "
 
 formatToolOutput :: ToolCall -> Text -> Text
 formatToolOutput call output = case canonicalToolName call.name of

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -150,7 +150,7 @@ spec = describe "tool presentation" do
         formatToolDiffRelative ""
             (functionToolCall "w" "Write"
                 "{\"file_path\":\"src/New.hs\",\"content\":\"main = pure ()\\n\"}")
-            `shouldBe` "  write src/New.hs\n  +main = pure ()"
+            `shouldBe` "  write src/New.hs\n  1 +main = pure ()"
         todoListFromToolArguments
             "{\"todos\":[{\"content\":\"Find repos\",\"status\":\"in_progress\",\
             \\"activeForm\":\"Finding repos\"},{\"content\":\"Fix\",\"status\":\"pending\"}]}"
@@ -297,6 +297,22 @@ spec = describe "tool presentation" do
         length parsed.diffLines `shouldBe` 20
         parsed.diffHiddenLines `shouldBe` 10
 
+    it "uses resolved search-replace line numbers in completed diffs" do
+        let call = customToolCall "edit" "search_replace"
+                "{\"file_path\":\"src/Main.hs\",\
+                \\"old_string\":\"old one\\nold two\",\
+                \\"new_string\":\"new one\\nnew two\\nnew three\"}"
+            output =
+                "The file src/Main.hs has been updated successfully.\n\
+                \Changed lines start at 95."
+        formatToolDiffRelativeWithOutput "/workspace" call output
+            `shouldBe`
+                "  95 -old one\n\
+                \  96 -old two\n\
+                \  95 +new one\n\
+                \  96 +new two\n\
+                \  97 +new three"
+
     it "formats compact multi-file apply_patch diffs" do
         let workspace = "/workspace"
             patch =
@@ -331,7 +347,7 @@ spec = describe "tool presentation" do
                 "  -old\n\
                 \  +new\n\
                 \  create src/B.hs\n\
-                \  +one\n\
+                \  1 +one\n\
                 \  move src/Old.hs → src/New.hs\n\
                 \  -before\n\
                 \  +after\n\


### PR DESCRIPTION
## Summary
- add aligned source line numbers to completed file-edit diffs
- number create and write previews from line 1
- preserve unnumbered output when an exact edit location is unavailable
- retain success/error coloring for numbered diff lines

## Validation
- agent TUI specs: 215 examples, 0 failures
- edit-tool specs: 58 examples, 0 failures, 5 environment-dependent pending
- live tmux TUI launch and keyboard navigation
- `git diff --check`