### PR TITLE
Add syntax highlighting to edit previews

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -104,7 +104,7 @@ import Agent.CLI.TUI.ImagePreview ( NativePreviewPlacement(..)
     , renderTuiImagePreview
     , sameNativePreviewLayout
     )
-import Agent.TUI.Markdown ( codeWidgetWithSyntaxHighlighting , markdownWidgetWithLinks , markdownWidgetWithSyntaxHighlightingAndLinks )
+import Agent.TUI.Markdown ( codeWidgetWithSyntaxHighlighting , diffSyntaxLanguages , markdownWidgetWithLinks , markdownWidgetWithSyntaxHighlightingAndLinks )
 import Agent.TUI.FencedCode ( FencedBlock(..)
     , fencedBlocks
     )
@@ -608,6 +608,8 @@ syntaxLanguagesForBlock block =
         BlockShell
             | Just language <- blockCodeLanguage block ->
                 [language]
+        BlockEdit ->
+            diffSyntaxLanguages block.blockDetail block.blockBody
         _ -> []
 
 resumeNativeProgressIfRunning :: EventM Name AppState ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -48,6 +48,7 @@ import Agent.Loop ()
 import Agent.Syntax ( SyntaxHighlighter )
 import Agent.TUI.Markdown
     ( codeWidgetWithSyntaxHighlighting,
+      diffWidgetWithSyntaxHighlighting,
       markdownWidgetWithLinks,
       markdownWidgetWithSyntaxHighlightingAndLinks )
 import Agent.TUI.Model
@@ -116,7 +117,7 @@ import Control.Exception.Safe ()
 import Control.Monad ()
 import Control.Monad.IO.Class ()
 import Control.Monad.State.Strict ()
-import Data.Char ( isDigit )
+import Data.Char ()
 import Data.Foldable ()
 import Data.IORef ()
 import Data.List ()
@@ -145,14 +146,11 @@ import qualified Agent.CLI.TUI.Scroll as Scroll ()
 import qualified Data.Sequence as Seq ()
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text
-    ( dropWhile,
-      isPrefixOf,
-      length,
+    ( length,
       lines,
       null,
       strip,
       take,
-      uncons,
       unlines,
       unwords,
       words,
@@ -321,7 +319,12 @@ drawBlock state target ui block =
                     (blockStateGlyph state target block)
                     block.blockTitle
                     block.blockDetail
-                    (editBodyWidgets (visibleBody block))
+                    [ diffWidgetWithSyntaxHighlighting
+                        state.appSyntaxHighlighter
+                        block.blockDetail
+                        (visibleBody block)
+                    | not (Text.null (Text.strip (visibleBody block)))
+                    ]
             BlockSystem ->
                 withAttr Theme.mutedAttr
                     (terminalTxtWrap block.blockBody)
@@ -661,31 +664,6 @@ toolBodySections syntaxHighlighter completeBody visible
     | Just language <- toolOutputCodeLanguage completeBody =
         [codeWidgetWithSyntaxHighlighting syntaxHighlighter language visible]
     | otherwise = bodySections visible
-
-editBodyWidgets :: Text -> [Widget Name]
-editBodyWidgets body
-    | Text.null (Text.strip body) = []
-    | otherwise = [vBox (map editLineWidget (Text.lines body))]
-  where
-    editLineWidget line
-        | isEditLine '-' line =
-            withAttr Theme.errorAttr (terminalTxtWrap line)
-        | isEditLine '+' line =
-            withAttr Theme.successAttr (terminalTxtWrap line)
-        | "  …" `Text.isPrefixOf` line
-            || "… +" `Text.isPrefixOf` line =
-                withAttr Theme.mutedAttr (terminalTxtWrap line)
-        | otherwise = terminalTxtWrap line
-
-    isEditLine marker line =
-        case Text.uncons (Text.dropWhile (== ' ') line) of
-            Just (first, rest)
-                | first == marker -> True
-                | first >= '0' && first <= '9' ->
-                    case Text.uncons (Text.dropWhile (== ' ') (Text.dropWhile isDigit rest)) of
-                        Just (actual, _) -> actual == marker
-                        Nothing -> False
-            _ -> False
 
 accentMarkdownBlock
     :: AppState

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -259,11 +259,11 @@ spec = do
             let patch =
                     Text.unlines
                         [ "*** Begin Patch"
-                        , "*** Update File: Main.hs"
+                        , "*** Update File: Main module.hs"
                         , "@@"
                         , "-main = old"
                         , "+main = new"
-                        , "*** Update File: web/app.ts"
+                        , "*** Update File: web/my app.ts"
                         , "@@"
                         , "-const oldValue = 1"
                         , "+const newValue = 2"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -255,6 +255,32 @@ spec = do
             syntaxLanguagesForBlocks (toList conversation.uiBlocks)
                 `shouldBe` Set.singleton "javascript"
 
+        it "requests grammars for every file in an edit preview" do
+            let patch =
+                    Text.unlines
+                        [ "*** Begin Patch"
+                        , "*** Update File: Main.hs"
+                        , "@@"
+                        , "-main = old"
+                        , "+main = new"
+                        , "*** Update File: web/app.ts"
+                        , "@@"
+                        , "-const oldValue = 1"
+                        , "+const newValue = 2"
+                        , "*** End Patch"
+                        ]
+                conversation =
+                    reduceUi
+                        (UiLoop
+                            (ToolStarted
+                                (customToolCall
+                                    "edit-1"
+                                    "apply_patch"
+                                    patch)))
+                        initialUiState
+            syntaxLanguagesForBlocks (toList conversation.uiBlocks)
+                `shouldBe` Set.fromList ["haskell", "typescript"]
+
     describe "externalUrlCommand" do
         it "opens HTTP(S) URLs without passing through a shell" do
             let url = "https://github.com/digitallyinduced/haskell-agent"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -267,6 +267,11 @@ spec = do
                         , "@@"
                         , "-const oldValue = 1"
                         , "+const newValue = 2"
+                        , "*** Update File: scripts/old module.py"
+                        , "*** Move to: crates/new module.rs"
+                        , "@@"
+                        , "-# source comment"
+                        , "+// destination comment"
                         , "*** End Patch"
                         ]
                 conversation =
@@ -279,7 +284,9 @@ spec = do
                                     patch)))
                         initialUiState
             syntaxLanguagesForBlocks (toList conversation.uiBlocks)
-                `shouldBe` Set.fromList ["haskell", "typescript"]
+                `shouldBe`
+                    Set.fromList
+                        ["haskell", "python", "rust", "typescript"]
 
     describe "externalUrlCommand" do
         it "opens HTTP(S) URLs without passing through a shell" do

--- a/packages/agent-syntax/src/Agent/Syntax.hs
+++ b/packages/agent-syntax/src/Agent/Syntax.hs
@@ -14,6 +14,7 @@ module Agent.Syntax
     , newSyntaxHighlighter
     , newSyntaxHighlighterFrom
     , resolveFenceLanguage
+    , resolvePathLanguage
     ) where
 
 import Control.Applicative ((<|>))
@@ -568,16 +569,34 @@ resolveFenceLanguage info = do
                 Just path -> languageFromPath path
                 Nothing
                     | Text.any (`elem` ['/', '\\']) normalized ->
-                        languageFromPath $
-                            Text.map
-                                (\character ->
-                                    if character == '\\'
-                                        then '/'
-                                        else character)
-                                normalized
+                        languageFromPath (normalizePathSeparators normalized)
                     | otherwise -> normalized
-        aliased = Map.findWithDefault candidate candidate languageAliases
-    if aliased `elem` plainTextAliases || Text.null aliased
+    normalizeLanguage candidate
+
+-- | Resolve a complete file path to the identifier used for syntax lookup.
+--
+-- Unlike Markdown fence info, file paths may contain whitespace and must not
+-- be truncated to their first whitespace-delimited token.
+resolvePathLanguage :: Text -> Maybe Text
+resolvePathLanguage =
+    normalizeLanguage
+        . languageFromPath
+        . normalizePathSeparators
+        . Text.toLower
+        . Text.strip
+
+normalizePathSeparators :: Text -> Text
+normalizePathSeparators =
+    Text.map
+        (\character ->
+            if character == '\\'
+                then '/'
+                else character)
+
+normalizeLanguage :: Text -> Maybe Text
+normalizeLanguage candidate =
+    let aliased = Map.findWithDefault candidate candidate languageAliases
+    in if aliased `elem` plainTextAliases || Text.null aliased
         then Nothing
         else Just aliased
 

--- a/packages/agent-syntax/test/Agent/SyntaxSpec.hs
+++ b/packages/agent-syntax/test/Agent/SyntaxSpec.hs
@@ -38,6 +38,15 @@ spec = describe "syntax highlighting" do
             map resolveFenceLanguage ["text", "txt", "plain", "plaintext"]
                 `shouldBe` replicate 4 Nothing
 
+    describe "file path language resolution" do
+        it "uses the complete path when filenames contain whitespace" do
+            resolvePathLanguage "Main module.hs"
+                `shouldBe` Just "haskell"
+            resolvePathLanguage "src/my module.py"
+                `shouldBe` Just "python"
+            resolvePathLanguage "web\\typed module.ts"
+                `shouldBe` Just "typescript"
+
     it "loads the packaged grammar set and highlights representative languages" do
         highlighter <- requireHighlighter
         mapM_

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -2,6 +2,8 @@
 module Agent.TUI.Markdown
     ( Inline(..)
     , codeWidgetWithSyntaxHighlighting
+    , diffSyntaxLanguages
+    , diffWidgetWithSyntaxHighlighting
     , inlinePlainText
     , markdownWidget
     , markdownWidgetWithLinks
@@ -26,6 +28,7 @@ import Agent.Syntax
     ( SyntaxHighlighter
     , SyntaxSpan(..)
     , highlightCode
+    , resolveFenceLanguage
     )
 import Agent.TUI.TextWidth
     ( displayTerminalText
@@ -148,6 +151,255 @@ codeWidgetWithSyntaxHighlighting
 codeWidgetWithSyntaxHighlighting syntaxHighlighter language =
     renderCodeBodyWith wrapStyledCode syntaxHighlighter language
         . codeBodyLines
+
+-- | Languages needed to render a compact edit preview. The first file path is
+-- supplied separately, while later files are introduced by body headers.
+diffSyntaxLanguages :: Text -> Text -> [Text]
+diffSyntaxLanguages initialPath body =
+    List.nub
+        [ language
+        | line <- parseDiffLines initialPath body
+        , Just path <- [line.diffPathHint]
+        , Just language <- [resolveFenceLanguage (diffFenceInfo path)]
+        ]
+
+-- | Render a compact edit preview with token-level syntax foregrounds over
+-- full-width added/removed backgrounds.
+diffWidgetWithSyntaxHighlighting
+    :: Maybe SyntaxHighlighter
+    -> Text
+    -> Text
+    -> Widget n
+diffWidgetWithSyntaxHighlighting syntaxHighlighter initialPath body =
+    B.Widget B.Greedy B.Fixed do
+        context <- B.getContext
+        codeAttr <- B.lookupAttrName Theme.codeAttr
+        baseAttr <- B.lookupAttrName Theme.assistantAttr
+        mutedAttr <- B.lookupAttrName Theme.mutedAttr
+        addedAttr <- B.lookupAttrName Theme.diffAddedAttr
+        removedAttr <- B.lookupAttrName Theme.diffRemovedAttr
+        styledRows <-
+            fmap concat $
+                traverse
+                    (resolveDiffRun
+                        syntaxHighlighter
+                        codeAttr
+                        baseAttr
+                        mutedAttr
+                        addedAttr
+                        removedAttr)
+                    (diffRuns (parseDiffLines initialPath body))
+        let availableWidth = max 1 context.availWidth
+            rows =
+                concatMap
+                    (renderStyledDiffRow availableWidth)
+                    styledRows
+            image = V.vertCat rows
+            boundedImage
+                | V.imageWidth image > availableWidth =
+                    V.cropRight availableWidth image
+                | otherwise = image
+        pure B.emptyResult { B.image = boundedImage }
+
+data DiffLineKind
+    = DiffLineAdded
+    | DiffLineRemoved
+    | DiffLineHeader
+    | DiffLineMeta
+    | DiffLinePlain
+    deriving (Eq)
+
+data ParsedDiffLine = ParsedDiffLine
+    { diffLineKind :: !DiffLineKind
+    , diffPathHint :: !(Maybe Text)
+    , diffLineText :: !Text
+    }
+
+data DiffRun
+    = DiffChangedRun !DiffLineKind !(Maybe Text) ![Text]
+    | DiffPlainRun !ParsedDiffLine
+
+data StyledDiffRow = StyledDiffRow
+    { styledDiffBackground :: !(Maybe V.Attr)
+    , styledDiffFragments :: ![(V.Attr, Text)]
+    }
+
+parseDiffLines :: Text -> Text -> [ParsedDiffLine]
+parseDiffLines initialPath = go (nonEmptyText initialPath) . Text.lines
+  where
+    go _ [] = []
+    go currentPath (line : rest)
+        | Just nextPath <- diffHeaderPath line =
+            ParsedDiffLine DiffLineHeader (Just nextPath) line
+                : go (Just nextPath) rest
+        | Just source <- Text.stripPrefix "  -" line =
+            ParsedDiffLine DiffLineRemoved currentPath source
+                : go currentPath rest
+        | Just source <- Text.stripPrefix "  +" line =
+            ParsedDiffLine DiffLineAdded currentPath source
+                : go currentPath rest
+        | "  …" `Text.isPrefixOf` line
+            || "… +" `Text.isPrefixOf` line =
+            ParsedDiffLine DiffLineMeta currentPath line
+                : go currentPath rest
+        | otherwise =
+            ParsedDiffLine DiffLinePlain currentPath line
+                : go currentPath rest
+
+diffHeaderPath :: Text -> Maybe Text
+diffHeaderPath line =
+    actionPath
+        [ "  create "
+        , "  delete "
+        , "  write "
+        , "  update "
+        ]
+  where
+    actionPath [] = movePath
+    actionPath (prefix : rest) =
+        case Text.stripPrefix prefix line of
+            Just path -> nonEmptyText path
+            Nothing -> actionPath rest
+
+    movePath = do
+        moved <- Text.stripPrefix "  move " line
+        let (source, destinationWithArrow) = Text.breakOn " → " moved
+        case Text.stripPrefix " → " destinationWithArrow of
+            Just destination -> nonEmptyText destination
+            Nothing -> nonEmptyText source
+
+nonEmptyText :: Text -> Maybe Text
+nonEmptyText value =
+    let stripped = Text.strip value
+    in if Text.null stripped then Nothing else Just stripped
+
+diffRuns :: [ParsedDiffLine] -> [DiffRun]
+diffRuns [] = []
+diffRuns (line : rest)
+    | changedKind line.diffLineKind =
+        let (matching, remaining) =
+                span
+                    (\next ->
+                        next.diffLineKind == line.diffLineKind
+                            && next.diffPathHint == line.diffPathHint)
+                    rest
+        in DiffChangedRun
+                line.diffLineKind
+                line.diffPathHint
+                (map (.diffLineText) (line : matching))
+                : diffRuns remaining
+    | otherwise =
+        DiffPlainRun line : diffRuns rest
+  where
+    changedKind kind =
+        kind == DiffLineAdded || kind == DiffLineRemoved
+
+resolveDiffRun
+    :: Maybe SyntaxHighlighter
+    -> V.Attr
+    -> V.Attr
+    -> V.Attr
+    -> V.Attr
+    -> V.Attr
+    -> DiffRun
+    -> B.RenderM n [StyledDiffRow]
+resolveDiffRun
+    syntaxHighlighter
+    codeAttr
+    baseAttr
+    mutedAttr
+    addedAttr
+    removedAttr = \case
+        DiffPlainRun line ->
+            pure
+                [ StyledDiffRow
+                    Nothing
+                    [ ( if line.diffLineKind == DiffLineMeta
+                            then mutedAttr
+                            else baseAttr
+                      , displayTerminalText line.diffLineText
+                      )
+                    ]
+                ]
+        DiffChangedRun kind path sourceLines -> do
+            let background =
+                    if kind == DiffLineAdded then addedAttr else removedAttr
+                prefix =
+                    if kind == DiffLineAdded then "  +" else "  -"
+                highlightedLines = do
+                    highlighter <- syntaxHighlighter
+                    sourcePath <- path
+                    either (const Nothing) Just $
+                        highlightCode
+                            highlighter
+                            (diffFenceInfo sourcePath)
+                            (Text.intercalate "\n" sourceLines)
+            contentRows <-
+                case highlightedLines of
+                    Just rows
+                        | length rows == length sourceLines ->
+                            traverse
+                                (traverse
+                                    (\span_ -> do
+                                        attr <-
+                                            B.lookupAttrName
+                                                (Theme.syntaxClassAttr
+                                                    span_.syntaxClass)
+                                        pure
+                                            ( withDiffBackground
+                                                background
+                                                attr
+                                            , displayTerminalText
+                                                span_.syntaxText
+                                            )))
+                                rows
+                    _ ->
+                        pure
+                            [ [ ( withDiffBackground background codeAttr
+                                , displayTerminalText source
+                                )
+                              ]
+                            | source <- sourceLines
+                            ]
+            pure
+                [ StyledDiffRow
+                    (Just background)
+                    ((background, prefix) : content)
+                | content <- contentRows
+                ]
+
+withDiffBackground :: V.Attr -> V.Attr -> V.Attr
+withDiffBackground background attr =
+    case V.attrBackColor background of
+        V.SetTo color -> attr `V.withBackColor` color
+        _ -> attr
+
+-- A bare filename is unambiguously a path in an edit preview. Prefixing it
+-- keeps the general fence parser's support for dotted language identifiers
+-- (for example, @asp.net@) while still resolving root-level file extensions.
+diffFenceInfo :: Text -> Text
+diffFenceInfo path
+    | Text.any (`elem` ['/', '\\']) path = path
+    | otherwise = "./" <> path
+
+renderStyledDiffRow :: Int -> StyledDiffRow -> [V.Image]
+renderStyledDiffRow availableWidth row =
+    map renderPhysicalRow $
+        wrapStyledCode availableWidth row.styledDiffFragments
+  where
+    renderPhysicalRow fragments =
+        let content = renderStyledLine fragments
+        in case row.styledDiffBackground of
+            Nothing -> content
+            Just background ->
+                let padding =
+                        max 0 (availableWidth - V.imageWidth content)
+                in V.horizCat
+                    [ content
+                    , if padding == 0
+                        then V.emptyImage
+                        else V.charFill background ' ' padding 1
+                    ]
 
 renderChunk
     :: Ord n

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -42,7 +42,7 @@ import qualified Brick.Types as B
 import Data.Bits ((.|.))
 import Data.Char (isDigit, isSpace)
 import qualified Data.List as List
-import Data.Maybe (fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
@@ -159,7 +159,7 @@ diffSyntaxLanguages initialPath body =
     List.nub
         [ language
         | line <- parseDiffLines initialPath body
-        , Just path <- [line.diffPathHint]
+        , path <- diffPathHints line.diffPaths
         , Just language <- [resolvePathLanguage path]
         ]
 
@@ -209,15 +209,21 @@ data DiffLineKind
     | DiffLinePlain
     deriving (Eq)
 
+data DiffPaths = DiffPaths
+    { diffRemovedPath :: !(Maybe Text)
+    , diffAddedPath :: !(Maybe Text)
+    }
+    deriving (Eq)
+
 data ParsedDiffLine = ParsedDiffLine
     { diffLineKind :: !DiffLineKind
-    , diffPathHint :: !(Maybe Text)
+    , diffPaths :: !DiffPaths
     , diffLinePrefix :: !Text
     , diffLineText :: !Text
     }
 
 data DiffRun
-    = DiffChangedRun !DiffLineKind !(Maybe Text) ![(Text, Text)]
+    = DiffChangedRun !DiffLineKind !DiffPaths ![(Text, Text)]
     | DiffPlainRun !ParsedDiffLine
 
 data StyledDiffRow = StyledDiffRow
@@ -226,23 +232,26 @@ data StyledDiffRow = StyledDiffRow
     }
 
 parseDiffLines :: Text -> Text -> [ParsedDiffLine]
-parseDiffLines initialPath = go (nonEmptyText initialPath) . Text.lines
+parseDiffLines initialPath =
+    go
+        (maybe emptyDiffPaths sameDiffPaths (nonEmptyText initialPath))
+        . Text.lines
   where
     go _ [] = []
-    go currentPath (line : rest)
-        | Just nextPath <- diffHeaderPath line =
-            ParsedDiffLine DiffLineHeader (Just nextPath) "" line
-                : go (Just nextPath) rest
+    go currentPaths (line : rest)
+        | Just nextPaths <- diffHeaderPaths line =
+            ParsedDiffLine DiffLineHeader nextPaths "" line
+                : go nextPaths rest
         | Just (kind, prefix, source) <- changedDiffLine line =
-            ParsedDiffLine kind currentPath prefix source
-                : go currentPath rest
+            ParsedDiffLine kind currentPaths prefix source
+                : go currentPaths rest
         | "  …" `Text.isPrefixOf` line
             || "… +" `Text.isPrefixOf` line =
-            ParsedDiffLine DiffLineMeta currentPath "" line
-                : go currentPath rest
+            ParsedDiffLine DiffLineMeta currentPaths "" line
+                : go currentPaths rest
         | otherwise =
-            ParsedDiffLine DiffLinePlain currentPath "" line
-                : go currentPath rest
+            ParsedDiffLine DiffLinePlain currentPaths "" line
+                : go currentPaths rest
 
 changedDiffLine :: Text -> Maybe (DiffLineKind, Text, Text)
 changedDiffLine line =
@@ -273,8 +282,8 @@ numberedDiffLine line = do
                 , source
                 )
 
-diffHeaderPath :: Text -> Maybe Text
-diffHeaderPath line =
+diffHeaderPaths :: Text -> Maybe DiffPaths
+diffHeaderPaths line =
     actionPath
         [ "  create "
         , "  delete "
@@ -285,15 +294,47 @@ diffHeaderPath line =
     actionPath [] = movePath
     actionPath (prefix : rest) =
         case Text.stripPrefix prefix line of
-            Just path -> nonEmptyText path
+            Just path -> sameDiffPaths <$> nonEmptyText path
             Nothing -> actionPath rest
 
     movePath = do
         moved <- Text.stripPrefix "  move " line
         let (source, destinationWithArrow) = Text.breakOn " → " moved
+        sourcePath <- nonEmptyText source
         case Text.stripPrefix " → " destinationWithArrow of
-            Just destination -> nonEmptyText destination
-            Nothing -> nonEmptyText source
+            Just destination -> do
+                destinationPath <- nonEmptyText destination
+                pure
+                    (DiffPaths
+                        { diffRemovedPath = Just sourcePath
+                        , diffAddedPath = Just destinationPath
+                        })
+            Nothing -> pure (sameDiffPaths sourcePath)
+
+emptyDiffPaths :: DiffPaths
+emptyDiffPaths =
+    DiffPaths
+        { diffRemovedPath = Nothing
+        , diffAddedPath = Nothing
+        }
+
+sameDiffPaths :: Text -> DiffPaths
+sameDiffPaths path =
+    DiffPaths
+        { diffRemovedPath = Just path
+        , diffAddedPath = Just path
+        }
+
+diffPathHints :: DiffPaths -> [Text]
+diffPathHints paths =
+    List.nub (catMaybes [paths.diffRemovedPath, paths.diffAddedPath])
+
+diffPathForKind :: DiffLineKind -> DiffPaths -> Maybe Text
+diffPathForKind kind paths =
+    case kind of
+        DiffLineRemoved -> paths.diffRemovedPath
+        DiffLineAdded -> paths.diffAddedPath
+        _ -> Nothing
 
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText value =
@@ -308,11 +349,11 @@ diffRuns (line : rest)
                 span
                     (\next ->
                         next.diffLineKind == line.diffLineKind
-                            && next.diffPathHint == line.diffPathHint)
+                            && next.diffPaths == line.diffPaths)
                     rest
         in DiffChangedRun
                 line.diffLineKind
-                line.diffPathHint
+                line.diffPaths
                 (map
                     (\changed ->
                         (changed.diffLinePrefix, changed.diffLineText))
@@ -351,13 +392,13 @@ resolveDiffRun
                       )
                     ]
                 ]
-        DiffChangedRun kind path changedLines -> do
+        DiffChangedRun kind paths changedLines -> do
             let background =
                     if kind == DiffLineAdded then addedAttr else removedAttr
                 sourceLines = map snd changedLines
                 highlightedLines = do
                     highlighter <- syntaxHighlighter
-                    sourcePath <- path
+                    sourcePath <- diffPathForKind kind paths
                     language <- resolvePathLanguage sourcePath
                     either (const Nothing) Just $
                         highlightCode

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -28,7 +28,7 @@ import Agent.Syntax
     ( SyntaxHighlighter
     , SyntaxSpan(..)
     , highlightCode
-    , resolveFenceLanguage
+    , resolvePathLanguage
     )
 import Agent.TUI.TextWidth
     ( displayTerminalText
@@ -40,7 +40,7 @@ import qualified Agent.TUI.Theme as Theme
 import Brick
 import qualified Brick.Types as B
 import Data.Bits ((.|.))
-import Data.Char (isSpace)
+import Data.Char (isDigit, isSpace)
 import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -160,7 +160,7 @@ diffSyntaxLanguages initialPath body =
         [ language
         | line <- parseDiffLines initialPath body
         , Just path <- [line.diffPathHint]
-        , Just language <- [resolveFenceLanguage (diffFenceInfo path)]
+        , Just language <- [resolvePathLanguage path]
         ]
 
 -- | Render a compact edit preview with token-level syntax foregrounds over
@@ -212,11 +212,12 @@ data DiffLineKind
 data ParsedDiffLine = ParsedDiffLine
     { diffLineKind :: !DiffLineKind
     , diffPathHint :: !(Maybe Text)
+    , diffLinePrefix :: !Text
     , diffLineText :: !Text
     }
 
 data DiffRun
-    = DiffChangedRun !DiffLineKind !(Maybe Text) ![Text]
+    = DiffChangedRun !DiffLineKind !(Maybe Text) ![(Text, Text)]
     | DiffPlainRun !ParsedDiffLine
 
 data StyledDiffRow = StyledDiffRow
@@ -230,21 +231,47 @@ parseDiffLines initialPath = go (nonEmptyText initialPath) . Text.lines
     go _ [] = []
     go currentPath (line : rest)
         | Just nextPath <- diffHeaderPath line =
-            ParsedDiffLine DiffLineHeader (Just nextPath) line
+            ParsedDiffLine DiffLineHeader (Just nextPath) "" line
                 : go (Just nextPath) rest
-        | Just source <- Text.stripPrefix "  -" line =
-            ParsedDiffLine DiffLineRemoved currentPath source
-                : go currentPath rest
-        | Just source <- Text.stripPrefix "  +" line =
-            ParsedDiffLine DiffLineAdded currentPath source
+        | Just (kind, prefix, source) <- changedDiffLine line =
+            ParsedDiffLine kind currentPath prefix source
                 : go currentPath rest
         | "  …" `Text.isPrefixOf` line
             || "… +" `Text.isPrefixOf` line =
-            ParsedDiffLine DiffLineMeta currentPath line
+            ParsedDiffLine DiffLineMeta currentPath "" line
                 : go currentPath rest
         | otherwise =
-            ParsedDiffLine DiffLinePlain currentPath line
+            ParsedDiffLine DiffLinePlain currentPath "" line
                 : go currentPath rest
+
+changedDiffLine :: Text -> Maybe (DiffLineKind, Text, Text)
+changedDiffLine line =
+    case Text.stripPrefix "  -" line of
+        Just source -> Just (DiffLineRemoved, "  -", source)
+        Nothing ->
+            case Text.stripPrefix "  +" line of
+                Just source -> Just (DiffLineAdded, "  +", source)
+                Nothing -> numberedDiffLine line
+
+numberedDiffLine :: Text -> Maybe (DiffLineKind, Text, Text)
+numberedDiffLine line = do
+    afterIndent <- Text.stripPrefix "  " line
+    let (padding, afterPadding) = Text.span (== ' ') afterIndent
+        (digits, afterDigits) = Text.span isDigit afterPadding
+    if Text.null digits
+        then Nothing
+        else do
+            markerAndSource <- Text.stripPrefix " " afterDigits
+            (marker, source) <- Text.uncons markerAndSource
+            kind <- case marker of
+                '-' -> Just DiffLineRemoved
+                '+' -> Just DiffLineAdded
+                _ -> Nothing
+            pure
+                ( kind
+                , "  " <> padding <> digits <> " " <> Text.singleton marker
+                , source
+                )
 
 diffHeaderPath :: Text -> Maybe Text
 diffHeaderPath line =
@@ -286,7 +313,10 @@ diffRuns (line : rest)
         in DiffChangedRun
                 line.diffLineKind
                 line.diffPathHint
-                (map (.diffLineText) (line : matching))
+                (map
+                    (\changed ->
+                        (changed.diffLinePrefix, changed.diffLineText))
+                    (line : matching))
                 : diffRuns remaining
     | otherwise =
         DiffPlainRun line : diffRuns rest
@@ -321,18 +351,18 @@ resolveDiffRun
                       )
                     ]
                 ]
-        DiffChangedRun kind path sourceLines -> do
+        DiffChangedRun kind path changedLines -> do
             let background =
                     if kind == DiffLineAdded then addedAttr else removedAttr
-                prefix =
-                    if kind == DiffLineAdded then "  +" else "  -"
+                sourceLines = map snd changedLines
                 highlightedLines = do
                     highlighter <- syntaxHighlighter
                     sourcePath <- path
+                    language <- resolvePathLanguage sourcePath
                     either (const Nothing) Just $
                         highlightCode
                             highlighter
-                            (diffFenceInfo sourcePath)
+                            language
                             (Text.intercalate "\n" sourceLines)
             contentRows <-
                 case highlightedLines of
@@ -365,7 +395,7 @@ resolveDiffRun
                 [ StyledDiffRow
                     (Just background)
                     ((background, prefix) : content)
-                | content <- contentRows
+                | ((prefix, _), content) <- zip changedLines contentRows
                 ]
 
 withDiffBackground :: V.Attr -> V.Attr -> V.Attr
@@ -373,14 +403,6 @@ withDiffBackground background attr =
     case V.attrBackColor background of
         V.SetTo color -> attr `V.withBackColor` color
         _ -> attr
-
--- A bare filename is unambiguously a path in an edit preview. Prefixing it
--- keeps the general fence parser's support for dotted language identifiers
--- (for example, @asp.net@) while still resolving root-level file extensions.
-diffFenceInfo :: Text -> Text
-diffFenceInfo path
-    | Text.any (`elem` ['/', '\\']) path = path
-    | otherwise = "./" <> path
 
 renderStyledDiffRow :: Int -> StyledDiffRow -> [V.Image]
 renderStyledDiffRow availableWidth row =

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -11,6 +11,8 @@ module Agent.TUI.Theme
     , controlLinkActiveAttr
     , controlLinkAttr
     , controlLinkHoverAttr
+    , diffAddedAttr
+    , diffRemovedAttr
     , dimAttr
     , emphasisAttr
     , headingAttr
@@ -191,6 +193,7 @@ transcriptHoverMutedAttr, transcriptHoverMutedItalicAttr :: AttrName
 transcriptHoverMutedCancelledAttr :: AttrName
 headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
+diffAddedAttr, diffRemovedAttr :: AttrName
 lambdaDimAttr, lambdaTrailAttr, lambdaGlowAttr, lambdaSparkAttr :: AttrName
 syntaxNormalAttr, syntaxKeywordAttr, syntaxTypeAttr, syntaxFunctionAttr :: AttrName
 syntaxVariableAttr, syntaxStringAttr, syntaxNumberAttr, syntaxCommentAttr :: AttrName
@@ -238,6 +241,8 @@ strongAttr = attrName "markdown-strong"
 controlLinkAttr = attrName "control-link"
 controlLinkHoverAttr = attrName "control-link-hover"
 controlLinkActiveAttr = attrName "control-link-active"
+diffAddedAttr = attrName "diff-added"
+diffRemovedAttr = attrName "diff-removed"
 syntaxNormalAttr = attrName "syntax-normal"
 syntaxKeywordAttr = attrName "syntax-keyword"
 syntaxTypeAttr = attrName "syntax-type"
@@ -325,6 +330,14 @@ terminalDefault =
         , (controlLinkHoverAttr, V.defAttr `V.withStyle` V.underline)
         , (controlLinkActiveAttr,
             raisedPanelAttr `V.withStyle` V.bold)
+        , (diffAddedAttr,
+            V.defAttr
+                `V.withForeColor` V.brightGreen
+                `V.withBackColor` Color240 22)
+        , (diffRemovedAttr,
+            V.defAttr
+                `V.withForeColor` V.brightRed
+                `V.withBackColor` Color240 52)
         , (syntaxNormalAttr, palette V.cyan)
         , (syntaxKeywordAttr, palette V.magenta)
         , (syntaxTypeAttr, palette V.yellow)
@@ -397,6 +410,8 @@ monochrome =
         , (controlLinkHoverAttr, V.defAttr
             `V.withStyle` (V.underline .|. V.bold))
         , (controlLinkActiveAttr, V.defAttr `V.withStyle` V.reverseVideo)
+        , (diffAddedAttr, V.defAttr)
+        , (diffRemovedAttr, V.defAttr)
         , (syntaxNormalAttr, V.defAttr)
         , (syntaxKeywordAttr, V.defAttr `V.withStyle` V.bold)
         , (syntaxTypeAttr, V.defAttr `V.withStyle` V.bold)
@@ -474,6 +489,10 @@ mkTheme background foreground muted accent link =
         , (controlLinkHoverAttr,
             panel `V.withStyle` V.underline)
         , (controlLinkActiveAttr, panel `V.withStyle` V.bold)
+        , (diffAddedAttr,
+            greenA `V.withBackColor` diffAddedBackground)
+        , (diffRemovedAttr,
+            redA `V.withBackColor` diffRemovedBackground)
         , (syntaxNormalAttr, base)
         , (syntaxKeywordAttr, accentA)
         , (syntaxTypeAttr, yellowA)
@@ -529,6 +548,12 @@ mkTheme background foreground muted accent link =
         V.defAttr
             `V.withForeColor` (RGBColor 90 200 220)
             `V.withBackColor` background
+    diffAddedBackground =
+        fromMaybe background $
+            blendRgb background (RGBColor 45 150 85) 0.22
+    diffRemovedBackground =
+        fromMaybe background $
+            blendRgb background (RGBColor 180 55 75) 0.22
 
     lighten (RGBColor r g b) =
         RGBColor

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -265,6 +265,66 @@ spec = describe "fullscreen Markdown rendering" do
         Text.concat (renderedCodePayloadRows 18 widget)
             `shouldBe` code
 
+    it "discovers every language used by a multi-file edit preview" do
+        diffSyntaxLanguages
+            "Main.hs"
+            (Text.unlines
+                [ "  -main = old"
+                , "  update web/app.ts"
+                , "  +const answer = 42"
+                , "  move scripts/old.py → crates/new.rs"
+                , "  +fn main() {}"
+                ])
+            `shouldBe` ["haskell", "typescript", "rust"]
+
+    it "syntax-highlights edit lines over full-width diff backgrounds" do
+        syntaxDirectory <- sourceSyntaxDirectory
+        loadSyntaxHighlighterFrom syntaxDirectory >>= \case
+            Left message -> expectationFailure (Text.unpack message)
+            Right highlighter -> do
+                let width = 32
+                    widget :: Widget ()
+                    widget =
+                        diffWidgetWithSyntaxHighlighting
+                            (Just highlighter)
+                            "Main.hs"
+                            "  -message = \"before\"\n  +message = \"after\""
+                    picture =
+                        renderWidget
+                            (Just Theme.terminalDefault)
+                            [widget]
+                            (width, 4)
+                    rows =
+                        map toList $
+                            toList $
+                                displayOpsForPic picture (width, 4)
+                    findText expected =
+                        find (containsText expected) (concat rows)
+                    stringForeground =
+                        V.attrForeColor $
+                            attrMapLookup
+                                Theme.syntaxStringAttr
+                                Theme.terminalDefault
+                    removedBackground =
+                        V.attrBackColor $
+                            attrMapLookup
+                                Theme.diffRemovedAttr
+                                Theme.terminalDefault
+                    addedBackground =
+                        V.attrBackColor $
+                            attrMapLookup
+                                Theme.diffAddedAttr
+                                Theme.terminalDefault
+                V.imageWidth (V.picImage picture) `shouldBe` width
+                fmap (V.attrForeColor . spanAttr) (findText "\"before\"")
+                    `shouldBe` Just stringForeground
+                fmap (V.attrBackColor . spanAttr) (findText "\"before\"")
+                    `shouldBe` Just removedBackground
+                fmap (V.attrForeColor . spanAttr) (findText "\"after\"")
+                    `shouldBe` Just stringForeground
+                fmap (V.attrBackColor . spanAttr) (findText "\"after\"")
+                    `shouldBe` Just addedBackground
+
     it "renders terminal controls as inert visible glyphs" do
         let unsafe = "\ESC]0;owned\BEL\t\r"
             prose = Text.concat (renderRows 40 unsafe)

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -25,6 +25,7 @@ import Control.Monad (forM_)
 import Data.Char (isControl)
 import Data.Foldable (toList)
 import Data.List (find, findIndex, isInfixOf, sortOn)
+import Data.Maybe (isJust)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
 import qualified Graphics.Vty as V
@@ -267,12 +268,12 @@ spec = describe "fullscreen Markdown rendering" do
 
     it "discovers every language used by a multi-file edit preview" do
         diffSyntaxLanguages
-            "Main.hs"
+            "Main module.hs"
             (Text.unlines
                 [ "  -main = old"
-                , "  update web/app.ts"
+                , "  update web/my app.ts"
                 , "  +const answer = 42"
-                , "  move scripts/old.py → crates/new.rs"
+                , "  move scripts/old.py → crates/new module.rs"
                 , "  +fn main() {}"
                 ])
             `shouldBe` ["haskell", "typescript", "rust"]
@@ -287,8 +288,8 @@ spec = describe "fullscreen Markdown rendering" do
                     widget =
                         diffWidgetWithSyntaxHighlighting
                             (Just highlighter)
-                            "Main.hs"
-                            "  -message = \"before\"\n  +message = \"after\""
+                            "Main module.hs"
+                            "  12 -message = \"before\"\n  12 +message = \"after\""
                     picture =
                         renderWidget
                             (Just Theme.terminalDefault)
@@ -316,6 +317,8 @@ spec = describe "fullscreen Markdown rendering" do
                                 Theme.diffAddedAttr
                                 Theme.terminalDefault
                 V.imageWidth (V.picImage picture) `shouldBe` width
+                findText "  12 -" `shouldSatisfy` isJust
+                findText "  12 +" `shouldSatisfy` isJust
                 fmap (V.attrForeColor . spanAttr) (findText "\"before\"")
                     `shouldBe` Just stringForeground
                 fmap (V.attrBackColor . spanAttr) (findText "\"before\"")

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -276,7 +276,7 @@ spec = describe "fullscreen Markdown rendering" do
                 , "  move scripts/old.py → crates/new module.rs"
                 , "  +fn main() {}"
                 ])
-            `shouldBe` ["haskell", "typescript", "rust"]
+            `shouldBe` ["haskell", "typescript", "python", "rust"]
 
     it "syntax-highlights edit lines over full-width diff backgrounds" do
         syntaxDirectory <- sourceSyntaxDirectory
@@ -327,6 +327,43 @@ spec = describe "fullscreen Markdown rendering" do
                     `shouldBe` Just stringForeground
                 fmap (V.attrBackColor . spanAttr) (findText "\"after\"")
                     `shouldBe` Just addedBackground
+
+    it "uses source and destination grammars for moved diff lines" do
+        syntaxDirectory <- sourceSyntaxDirectory
+        loadSyntaxHighlighterFrom syntaxDirectory >>= \case
+            Left message -> expectationFailure (Text.unpack message)
+            Right highlighter -> do
+                let widget :: Widget ()
+                    widget =
+                        diffWidgetWithSyntaxHighlighting
+                            (Just highlighter)
+                            "old module.py"
+                            (Text.unlines
+                                [ "  move old module.py → new module.rs"
+                                , "  -# source comment"
+                                , "  +// destination comment"
+                                ])
+                    rows =
+                        concat $
+                            map toList $
+                                toList $
+                                    displayOpsForPic
+                                        (renderWidget
+                                            (Just Theme.terminalDefault)
+                                            [widget]
+                                            (40, 4))
+                                        (40, 4)
+                    commentForeground =
+                        V.attrForeColor $
+                            attrMapLookup
+                                Theme.syntaxCommentAttr
+                                Theme.terminalDefault
+                fmap (V.attrForeColor . spanAttr)
+                    (find (containsText "source comment") rows)
+                    `shouldBe` Just commentForeground
+                fmap (V.attrForeColor . spanAttr)
+                    (find (containsText "destination comment") rows)
+                    `shouldBe` Just commentForeground
 
     it "renders terminal controls as inert visible glyphs" do
         let unsafe = "\ESC]0;owned\BEL\t\r"

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -103,6 +103,30 @@ spec = do
                 allSyntaxClasses
                 `shouldBe` replicate (length allSyntaxClasses) V.Default
 
+        it "uses distinct full-row backgrounds for added and removed lines" do
+            let added =
+                    attrMapLookup Theme.diffAddedAttr Theme.terminalDefault
+                removed =
+                    attrMapLookup Theme.diffRemovedAttr Theme.terminalDefault
+            V.attrBackColor added `shouldBe` V.SetTo (Color240 22)
+            V.attrBackColor removed `shouldBe` V.SetTo (Color240 52)
+            V.attrForeColor added `shouldBe` V.SetTo V.brightGreen
+            V.attrForeColor removed `shouldBe` V.SetTo V.brightRed
+
+        it "tints diff bands against the selected fixed-theme background" do
+            let theme = Theme.themeAttrMap Theme.Daylight
+                page =
+                    V.attrBackColor (attrMapLookup Theme.baseAttr theme)
+                added =
+                    V.attrBackColor
+                        (attrMapLookup Theme.diffAddedAttr theme)
+                removed =
+                    V.attrBackColor
+                        (attrMapLookup Theme.diffRemovedAttr theme)
+            added `shouldNotBe` page
+            removed `shouldNotBe` page
+            added `shouldNotBe` removed
+
         it "uses a readable neutral panel for selections" do
             let selected =
                     attrMapLookup Theme.selectedAttr Theme.terminalDefault
@@ -199,6 +223,15 @@ spec = do
                 , Theme.transcriptHoverAttr
                 ]
                 `shouldBe` replicate 5 (V.Default, V.Default)
+
+        it "does not paint diff bands in monochrome mode" do
+            map
+                ( \name ->
+                    let attr = attrMapLookup name Theme.monochrome
+                    in (V.attrForeColor attr, V.attrBackColor attr)
+                )
+                [Theme.diffAddedAttr, Theme.diffRemovedAttr]
+                `shouldBe` replicate 2 (V.Default, V.Default)
 
         it "retains reverse video for muted monochrome hover text" do
             let theme = Theme.monochrome


### PR DESCRIPTION
## Summary

- Preserve language-aware token colors inside added and removed edit lines.
- Render changed rows with full-width, theme-aware backgrounds and a monochrome fallback.
- Discover syntax grammars from complete file paths, including root-level, multi-file, and whitespace-containing paths.
- Track source and destination paths independently for cross-extension moves, using the source grammar for removed lines and the destination grammar for added lines.
- Preserve numbered diff prefixes while highlighting only source text.

## Testing

- Multi-package GHCi load: 214 modules.
- agent-syntax tests: 14 examples, 0 failures.
- agent-tui tests: 229 examples, 0 failures.
- agent-cli on-demand syntax tests: 3 examples, 0 failures.
- Live tmux smoke test verified the separately styled edit path, root-path syntax colors, and terminal diff backgrounds.
- Rebased onto master at 81320a55; the final merge-tree against 38e2b342 was conflict-free.
