### PR TITLE
Style file paths separately in tool headers

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -145,15 +145,13 @@ import qualified Agent.CLI.TUI.Scroll as Scroll ()
 import qualified Data.Sequence as Seq ()
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text
-    ( breakOn,
-      dropWhile,
+    ( dropWhile,
       isPrefixOf,
       length,
       lines,
       null,
       strip,
       take,
-      stripStart,
       uncons,
       unlines,
       unwords,
@@ -280,6 +278,7 @@ drawBlock state target ui block =
                     (inspectionStatusAttr block)
                     (blockStateGlyph state target block)
                     block.blockTitle
+                    block.blockDetail
                     (toolBodySections
                         state.appSyntaxHighlighter
                         block.blockBody
@@ -321,6 +320,7 @@ drawBlock state target ui block =
                     (statusAttr state target block)
                     (blockStateGlyph state target block)
                     block.blockTitle
+                    block.blockDetail
                     (editBodyWidgets (visibleBody block))
             BlockSystem ->
                 withAttr Theme.mutedAttr
@@ -774,13 +774,12 @@ accentFileBlockWithSections
     -> AttrName
     -> Text
     -> Text
+    -> Text
     -> [Widget Name]
     -> Widget Name
 accentFileBlockWithSections
-    state target ui block waveElapsed accent glyph heading sections =
-    let (verb, suffix) = Text.breakOn " " heading
-        path = Text.stripStart suffix
-    in accentBlockWithHeader
+    state target ui block waveElapsed accent glyph verb path sections =
+    accentBlockWithHeader
         state
         target
         ui

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -145,12 +145,15 @@ import qualified Agent.CLI.TUI.Scroll as Scroll ()
 import qualified Data.Sequence as Seq ()
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text
-    ( dropWhile,
+    ( breakOn,
+      dropWhile,
       isPrefixOf,
+      length,
       lines,
       null,
       strip,
       take,
+      stripStart,
       uncons,
       unlines,
       unwords,
@@ -180,6 +183,7 @@ import qualified Agent.TUI.Theme as Theme
       todoInProgressAttr,
       todoPendingAttr,
       toolAttr,
+      toolPathAttr,
       userAttr,
       userMutedAttr,
       waitingDimAttr,
@@ -267,16 +271,15 @@ drawBlock state target ui block =
                         (visibleBody block)
                         <> toolImageSections state target block)
             BlockInspect ->
-                accentBlockWithSections
+                accentFileBlockWithSections
                     state
                     target
                     ui
                     block
                     waveElapsed
                     (inspectionStatusAttr block)
-                    (blockStateGlyph state target block
-                        <> block.blockTitle
-                        <> detailSuffix block)
+                    (blockStateGlyph state target block)
+                    block.blockTitle
                     (toolBodySections
                         state.appSyntaxHighlighter
                         block.blockBody
@@ -309,16 +312,15 @@ drawBlock state target ui block =
                         then toolImageSections state target block
                         else [])
             BlockEdit ->
-                accentBlockWithSections
+                accentFileBlockWithSections
                     state
                     target
                     ui
                     block
                     waveElapsed
                     (statusAttr state target block)
-                    (blockStateGlyph state target block
-                        <> block.blockTitle
-                        <> detailSuffix block)
+                    (blockStateGlyph state target block)
+                    block.blockTitle
                     (editBodyWidgets (visibleBody block))
             BlockSystem ->
                 withAttr Theme.mutedAttr
@@ -758,6 +760,58 @@ accentBlockWithSections
     accent
     title
     sections =
+    accentBlockWithHeader
+        state target ui block waveElapsed accent title Nothing sections
+
+-- File-oriented calls keep the action animated/status-colored while the path
+-- has its own stable semantic color, matching first-party tool-call chrome.
+accentFileBlockWithSections
+    :: AppState
+    -> AgentTarget
+    -> UiState
+    -> UiBlock
+    -> Maybe Int
+    -> AttrName
+    -> Text
+    -> Text
+    -> [Widget Name]
+    -> Widget Name
+accentFileBlockWithSections
+    state target ui block waveElapsed accent glyph heading sections =
+    let (verb, suffix) = Text.breakOn " " heading
+        path = Text.stripStart suffix
+    in accentBlockWithHeader
+        state
+        target
+        ui
+        block
+        waveElapsed
+        accent
+        (glyph <> verb)
+        (if Text.null path then Nothing else Just path)
+        sections
+
+accentBlockWithHeader
+    :: AppState
+    -> AgentTarget
+    -> UiState
+    -> UiBlock
+    -> Maybe Int
+    -> AttrName
+    -> Text
+    -> Maybe Text
+    -> [Widget Name]
+    -> Widget Name
+accentBlockWithHeader
+    state
+    target
+    ui
+    block
+    waveElapsed
+    accent
+    title
+    path
+    sections =
     accentRail
         motionGlyphSet
         accent
@@ -778,7 +832,17 @@ accentBlockWithSections
         , not block.blockExpanded =
             singleLineTitle renderTitle title
         | otherwise = renderTitle title
-    renderTitle fittedTitle = case waveElapsed of
+    renderTitle fittedTitle = case path of
+        Nothing -> animatedTitle fittedTitle
+        Just value ->
+            hBox
+                [ hLimit
+                    (Text.length fittedTitle)
+                    (animatedTitle fittedTitle)
+                , withAttr Theme.toolPathAttr
+                    (terminalTxtWrap (" " <> value))
+                ]
+    animatedTitle fittedTitle = case waveElapsed of
         Nothing ->
             withAttr accent (terminalTxtWrap fittedTitle)
         Just elapsedMillis ->

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -307,7 +307,9 @@ spec = do
                             (Just ItemCompleted)
                         ]
             map (.blockTitle) (toList ui.uiBlocks)
-                `shouldBe` ["Read nix/modules/telegram.nix"]
+                `shouldBe` ["Read"]
+            map (.blockDetail) (toList ui.uiBlocks)
+                `shouldBe` ["nix/modules/telegram.nix"]
             map (.agentStepTitle)
                 (responseItemStepPreviewsRelative workspace 1
                     [ functionCallItem

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -48,6 +48,7 @@ import Agent.TUI.Presentation
     , isInspectionTool
     , todoListFromToolArguments
     , todoListFromToolOutput
+    , toolCallHeaderRelative
     , toolCallInput
     , toolCallTitleRelative
     )
@@ -538,17 +539,19 @@ startToolCall call state
     | otherwise =
         let
             kind = toolBlockKind call.name
-            title = toolCallTitleRelative state.uiWorkspaceRoot call
+            activity = toolCallTitleRelative state.uiWorkspaceRoot call
+            (title, headerDetail) =
+                toolCallHeaderRelative state.uiWorkspaceRoot call
             blockIndex = Seq.length state.uiBlocks
             body = formatToolDiffRelative state.uiWorkspaceRoot call
-            detail = toolCallInput call
+            detail = fromMaybe (toolCallInput call) headerDetail
         in appendBlock kind title body detail
             BlockRunning (Just call.callId)
             state
                 { uiRunning = True
                 , uiGenerating = False
                 , uiAwaitingInput = False
-                , uiActivity = title
+                , uiActivity = activity
                 , uiToolCalls =
                     Map.insert
                         call.callId
@@ -932,8 +935,10 @@ updateVisibleToolCall call state =
     case Map.lookup call.callId state.uiToolCalls of
         Nothing -> state
         Just (blockIndex, previous) ->
-            let title =
+            let activity =
                     toolCallTitleRelative state.uiWorkspaceRoot call
+                (title, headerDetail) =
+                    toolCallHeaderRelative state.uiWorkspaceRoot call
                 body = formatToolDiffRelative state.uiWorkspaceRoot call
                 blocks
                     | isTodoTool previous.name = state.uiBlocks
@@ -948,14 +953,17 @@ updateVisibleToolCall call state =
                                             if Text.null body
                                                 then block.blockBody
                                                 else body
-                                        , blockDetail = toolCallInput call
+                                        , blockDetail =
+                                            fromMaybe
+                                                (toolCallInput call)
+                                                headerDetail
                                         }
                                     else block)
                             blockIndex
                             state.uiBlocks
             in state
                 { uiBlocks = blocks
-                , uiActivity = title
+                , uiActivity = activity
                 , uiToolCalls =
                     Map.insert
                         call.callId

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -29,6 +29,7 @@ module Agent.TUI.Presentation
     , todoListHasOpenWork
     , todoStatusGlyph
     , toolCallInput
+    , toolCallHeaderRelative
     , toolCallTitle
     , toolCallTitleRelative
     , toolCallDiff
@@ -123,6 +124,18 @@ toolCallTitleRelative workspace call
     | canonicalToolName call.name == "run_ghci" = "$ ghci"
     | canonicalToolName call.name == "exec" = "$ exec"
     | otherwise = summarizeToolCallRelative workspace call
+
+-- | Separate a filesystem action from its path so renderers can style the
+-- path without guessing from the human-readable title. Non-filesystem calls
+-- retain their complete title and have no separate header detail.
+toolCallHeaderRelative :: Text -> ToolCall -> (Text, Maybe Text)
+toolCallHeaderRelative workspace call =
+    case toolPathArgument call of
+        Just path ->
+            ( toolVerb call.name
+            , Just (workspaceRelativeDisplayPath workspace path)
+            )
+        Nothing -> (toolCallTitleRelative workspace call, Nothing)
 
 -- | Full invocation text that benefits from dedicated code rendering.
 toolCallInput :: ToolCall -> Text

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -445,7 +445,7 @@ mkTheme background foreground muted accent link =
         , (waitingMidAttr, accentA)
         , (toolAttr, linkA)
         , (inspectAttr, mutedA `V.withStyle` V.bold)
-        , (toolPathAttr, yellowA)
+        , (toolPathAttr, accentA)
         , (todoPendingAttr, base)
         , (todoInProgressAttr, accentA `V.withStyle` V.bold)
         , (todoCompletedAttr, mutedA)

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -51,6 +51,7 @@ module Agent.TUI.Theme
     , todoInProgressAttr
     , todoPendingAttr
     , toolAttr
+    , toolPathAttr
     , userAttr
     , userMutedAttr
     , waitingDimAttr
@@ -181,7 +182,7 @@ fixedThemePalette = \case
         (RGBColor 65 210 190) (RGBColor 80 170 255))
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
-userAttr, userMutedAttr, assistantAttr, thinkingAttr, thinkingBodyAttr, toolAttr :: AttrName
+userAttr, userMutedAttr, assistantAttr, thinkingAttr, thinkingBodyAttr, toolAttr, toolPathAttr :: AttrName
 inspectAttr :: AttrName
 todoPendingAttr, todoInProgressAttr, todoCompletedAttr, todoCancelledAttr :: AttrName
 errorAttr, successAttr, selectedAttr, selectedMutedAttr, borderAttr, borderActiveAttr :: AttrName
@@ -207,6 +208,7 @@ thinkingAttr = attrName "thinking"
 thinkingBodyAttr = attrName "thinking-body"
 toolAttr = attrName "tool"
 inspectAttr = attrName "inspect"
+toolPathAttr = attrName "tool-path"
 todoPendingAttr = attrName "todo-pending"
 todoInProgressAttr = attrName "todo-in-progress"
 todoCompletedAttr = attrName "todo-completed"
@@ -288,6 +290,7 @@ terminalDefault =
         , (waitingMidAttr, palette V.yellow)
         , (toolAttr, palette V.cyan)
         , (inspectAttr, palette V.brightBlack `V.withStyle` V.bold)
+        , (toolPathAttr, palette V.brightYellow)
         , (todoPendingAttr, V.defAttr)
         , (todoInProgressAttr, palette V.yellow `V.withStyle` V.bold)
         , (todoCompletedAttr, palette V.brightBlack)
@@ -356,6 +359,7 @@ monochrome =
         , (waitingMidAttr, V.defAttr)
         , (toolAttr, V.defAttr)
         , (inspectAttr, V.defAttr `V.withStyle` V.bold)
+        , (toolPathAttr, V.defAttr `V.withStyle` V.underline)
         , (todoPendingAttr, V.defAttr)
         , (todoInProgressAttr, V.defAttr `V.withStyle` V.bold)
         , (todoCompletedAttr, V.defAttr)
@@ -441,6 +445,7 @@ mkTheme background foreground muted accent link =
         , (waitingMidAttr, accentA)
         , (toolAttr, linkA)
         , (inspectAttr, mutedA `V.withStyle` V.bold)
+        , (toolPathAttr, yellowA)
         , (todoPendingAttr, base)
         , (todoInProgressAttr, accentA `V.withStyle` V.bold)
         , (todoCompletedAttr, mutedA)

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1368,9 +1368,11 @@ spec = describe "fullscreen UI reducer" do
                                 }))
                     started
         case Foldable.toList started.uiBlocks of
-            [block] ->
+            [block] -> do
                 block.blockTitle
-                    `shouldBe` "Edited nix/modules/telegram.nix"
+                    `shouldBe` "Edited"
+                block.blockDetail
+                    `shouldBe` "nix/modules/telegram.nix"
             _ -> expectationFailure "expected one running edit block"
         case Foldable.toList finished.uiBlocks of
             [block] -> do
@@ -1401,7 +1403,28 @@ spec = describe "fullscreen UI reducer" do
             [block] -> do
                 block.blockKind `shouldBe` BlockInspect
                 block.blockState `shouldBe` BlockComplete
+                block.blockTitle `shouldBe` "Read"
+                block.blockDetail `shouldBe` "src/Main.hs"
             _ -> expectationFailure "expected one completed inspection block"
+
+    it "keeps non-filesystem inspection labels intact" do
+        let call =
+                functionToolCall
+                    "session-1"
+                    "read_agent_session"
+                    "{\"session_id\":\"session-1\"}"
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted call)
+                    ]
+        case Foldable.toList state.uiBlocks of
+            [block] -> do
+                block.blockKind `shouldBe` BlockInspect
+                block.blockTitle
+                    `shouldBe` "Read agent session session-1"
+                block.blockDetail `shouldBe` ""
+            _ -> expectationFailure "expected one inspection block"
 
     it "shows an apply_patch diff while running and after completion" do
         let call =

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -10,6 +10,22 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "tool presentation" do
+    it "separates only real filesystem paths from tool actions" do
+        let readFile =
+                functionToolCall
+                    "read-file"
+                    "read_file"
+                    "{\"target_file\":\"src/Main.hs\"}"
+            readSession =
+                functionToolCall
+                    "read-session"
+                    "read_agent_session"
+                    "{\"session_id\":\"session-1\"}"
+        toolCallHeaderRelative "/workspace" readFile
+            `shouldBe` ("Read", Just "src/Main.hs")
+        toolCallHeaderRelative "/workspace" readSession
+            `shouldBe` ("Read agent session session-1", Nothing)
+
     it "distinguishes inspection tools from actions after canonicalization" do
         map isInspectionTool
             [ "read_file"

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -62,6 +62,13 @@ spec = do
                     (Theme.themeAttrMap Theme.Daylight))
                 `shouldBe` V.SetTo (RGBColor 255 255 255)
 
+        it "uses the readable daylight accent for tool paths" do
+            V.attrForeColor
+                (attrMapLookup
+                    Theme.toolPathAttr
+                    (Theme.themeAttrMap Theme.Daylight))
+                `shouldBe` V.SetTo (RGBColor 144 80 150)
+
         it "sets a daylight background on semantic text attributes" do
             map
                 ( V.attrBackColor

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -27,6 +27,7 @@ spec = do
                 , Theme.selectedAttr
                 , Theme.selectedMutedAttr
                 , Theme.todoPendingAttr
+                , Theme.toolPathAttr
                 ]
                 `shouldBe`
                     [ V.SetTo V.brightBlack
@@ -40,6 +41,7 @@ spec = do
                     , V.SetTo V.brightWhite
                     , V.SetTo V.white
                     , V.Default
+                    , V.SetTo V.brightYellow
                     ]
 
     describe "syntax theme attributes" do
@@ -76,6 +78,7 @@ spec = do
                 , Theme.thinkingAttr
                 , Theme.toolAttr
                 , Theme.inspectAttr
+                , Theme.toolPathAttr
                 , Theme.errorAttr
                 , Theme.successAttr
                 , Theme.codeAttr


### PR DESCRIPTION
## Summary

- render file-operation actions and paths with independent semantic attributes
- add a dedicated path color across terminal, fixed-palette, and monochrome themes
- preserve action status animation and allow long paths to wrap

## Testing

- multi-package GHCi load (214 modules)
- focused theme specs (12 examples)
- fullscreen startup and interaction smoke check in tmux