### PR TITLE
Refine fullscreen transcript presentation and navigation

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -986,12 +986,18 @@ paintDiffRelative color workspace diff =
                     <> renderToolPath color workspace destination
             Nothing -> ""
         shown = map paintLine diffLines
+        unmarkedHidden =
+            max 0
+                (diffHiddenLines - sum
+                    [ rows
+                    | SearchReplaceOmitted rows _ _ <- diffLines
+                    ])
         more =
-            if diffHiddenLines == 0
+            if unmarkedHidden == 0
                 then []
                 else
                     [ roleMuted color
-                        ("  … " <> Text.pack (show diffHiddenLines) <> " more")
+                        ("  … " <> Text.pack (show unmarkedHidden) <> " more")
                     ]
         body = shown <> more
     in Text.intercalate "\n" (filter (not . Text.null) (header : body))
@@ -1003,6 +1009,9 @@ paintDiffRelative color workspace diff =
             style color [terminalGreen] ("  +" <> line)
         SearchReplaceContext line ->
             roleMuted color ("   " <> line)
+        SearchReplaceOmitted rows _ _ ->
+            roleMuted color
+                ("  … " <> Text.pack (show rows) <> " omitted")
 
 renderToolPath :: Bool -> Text -> Text -> Text
 renderToolPath color =

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -1001,6 +1001,8 @@ paintDiffRelative color workspace diff =
             style color [terminalRed] ("  -" <> line)
         SearchReplaceAdded line ->
             style color [terminalGreen] ("  +" <> line)
+        SearchReplaceContext line ->
+            roleMuted color ("   " <> line)
 
 renderToolPath :: Bool -> Text -> Text -> Text
 renderToolPath color =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -11,6 +11,7 @@ module Agent.CLI.TUI.App
     , agentPaneEntryLimit
     , agentPaneVisible
     , backgroundActivityText
+    , cacheableBlock
     , completionFlashTransitions
     , completionRequiresRedraw
     , conversationScrollbarRenderer

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -27,6 +27,7 @@ module Agent.CLI.TUI.App
     , launchExternalUrlCommand
     , hasQueuedFullscreenInput
     , initialFullscreenAppState
+    , isCommandPaletteKey
     , mergeConversationView
     , motionDemandFor
     , motionDemandForTerminalFocus

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -416,6 +416,8 @@ handleEventInner' event = case event of
                     , appSlashIndex = 0
                     , appSlashDismissed = False
                     }
+    AppEvent (AppCommandPaletteSelected action) ->
+        handleCommandPaletteSelection action
     AppEvent (AppSetModelIds modelIds) -> do
         state <- get
         if state.appSlashCatalog.slashCatalogModelIds == modelIds
@@ -1006,7 +1008,11 @@ handleEventInner' event = case event of
     VtyEvent vtyEvent -> do
         clearAgentHover
         state <- get
-        if isMetaConsoleToggle vtyEvent && metaConsoleToggleAvailable state
+        if isCommandPaletteKey vtyEvent
+                && commandPaletteAvailable state
+            then openCommandPalette
+            else if isMetaConsoleToggle vtyEvent
+                && metaConsoleToggleAvailable state
             then
                 case state.appMetaConsole of
                     Just _ -> closeMetaConsole
@@ -1031,6 +1037,62 @@ handleEventInner' event = case event of
                             (Nothing, Nothing, Nothing, Nothing) ->
                                 handleNormalKey vtyEvent
     _ -> pure ()
+
+-- | Ctrl-P is deliberately accepted in both Vty's modified-key form and the
+-- legacy C0 control-character form. The latter still occurs in terminals
+-- without keyboard disambiguation support.
+isCommandPaletteKey :: V.Event -> Bool
+isCommandPaletteKey = \case
+    V.EvKey (V.KChar 'p') modifiers ->
+        V.MCtrl `elem` modifiers
+            && V.MMeta `notElem` modifiers
+            && V.MAlt `notElem` modifiers
+    V.EvKey (V.KChar '\DLE') [] -> True
+    _ -> False
+
+commandPaletteAvailable :: AppState -> Bool
+commandPaletteAvailable state =
+    isNothing state.appResume
+        && isNothing state.appTextPrompt
+        && isNothing state.appChoice
+        && isNothing state.appUi.uiPermission
+        && isNothing state.appMetaConsole
+        && isNothing state.appDictation
+
+handleCommandPaletteSelection
+    :: CommandPaletteAction
+    -> EventM Name AppState ()
+handleCommandPaletteSelection = \case
+    CommandPaletteDismiss -> pure ()
+    CommandPaletteInsert inserted -> do
+        state <- get
+        let ui = state.appUi
+            before = Text.take ui.uiCursor ui.uiDraft
+            after = Text.drop ui.uiCursor ui.uiDraft
+        applyLocalUiEvent
+            (UiSetDraft
+                (before <> inserted <> after)
+                (ui.uiCursor + Text.length inserted))
+        applyLocalUiEvent (UiFocusChanged FocusComposer)
+    CommandPaletteSubmit command -> do
+        state <- get
+        let queued = not state.appUi.uiAwaitingInput
+        result <- liftIO $ atomically $
+            Composer.appendFullscreenInput
+                state.appRuntime.runtimeInput
+                FullscreenInput
+                    { fullscreenInputLine = ReplText command
+                    , fullscreenInputQueued = queued
+                    , fullscreenInputDisplay = Nothing
+                    }
+        case result of
+            Left message ->
+                applyLocalUiEvent $
+                    UiSetNotice (Just (warningNotice message))
+            Right ()
+                | queued -> pure ()
+                | otherwise ->
+                    applyLocalUiEvent (UiSetAwaitingInput False)
 
 eventClearsMarkdownLinkCursor :: BrickEvent Name AppEvent -> Bool
 eventClearsMarkdownLinkCursor = \case

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -1083,7 +1083,8 @@ handleCommandPaletteSelection = \case
                 FullscreenInput
                     { fullscreenInputLine = ReplText command
                     , fullscreenInputQueued = queued
-                    , fullscreenInputDisplay = Nothing
+                    , fullscreenInputDisplay =
+                        if queued then Just command else Nothing
                     }
         case result of
             Left message ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -1091,7 +1091,12 @@ handleCommandPaletteSelection = \case
                 applyLocalUiEvent $
                     UiSetNotice (Just (warningNotice message))
             Right ()
-                | queued -> pure ()
+                | queued -> do
+                    applyLocalUiEvent (UiInputQueued command)
+                    applyLocalUiEvent
+                        (UiSetDraft
+                            state.appUi.uiDraft
+                            state.appUi.uiCursor)
                 | otherwise ->
                     applyLocalUiEvent (UiSetAwaitingInput False)
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -684,6 +684,13 @@ appEventLogicalBytes = \case
                 skills)
     AppSetModelIds modelIds ->
         saturatingAdd 256 (logicalTextsBytes modelIds)
+    AppCommandPaletteSelected action ->
+        case action of
+            CommandPaletteSubmit text ->
+                saturatingAdd 128 (logicalTextBytes text)
+            CommandPaletteInsert text ->
+                saturatingAdd 128 (logicalTextBytes text)
+            CommandPaletteDismiss -> 128
     AppSetTheme{} ->
         256
     AppAgentSnapshot target entries ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -823,6 +823,23 @@ uiStateLogicalBytes ui =
                         (toolCallLogicalBytes call))
             0
             ui.uiToolCalls
+        , Map.foldl'
+            (\size group ->
+                saturatingAdd size $
+                    foldl'
+                        (\groupSize item ->
+                            saturatingAdd groupSize $
+                                saturatingAdd 192 $
+                                    logicalTextsBytes
+                                        [ item.inspectionCallId
+                                        , item.inspectionToolName
+                                        , item.inspectionTitle
+                                        , item.inspectionBody
+                                        ])
+                        128
+                        group.inspectionGroupItems)
+            0
+            ui.uiInspectionGroups
         , foldl'
             (\size todo ->
                 saturatingAdd size

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -772,14 +772,22 @@ conversationBlocks target state =
     case target of
         AgentRoot ->
             concatMap
-                (toList . (.historyTurnBlocks))
+                ( toList
+                    . Transcript.coalesceInspectionBlocks
+                    . (.historyTurnBlocks)
+                )
                 (toList state.appHistoryWindow.historyWindowTurns)
-                <> toList state.appUi.uiBlocks
+                <> toList
+                    (Transcript.coalesceInspectionBlocks state.appUi.uiBlocks)
         AgentChild _ ->
-            maybe [] (toList . (.uiBlocks))
+            maybe
+                []
+                (toList . Transcript.coalesceInspectionBlocks . (.uiBlocks))
                 (conversationUiForTarget target state)
         AgentNative _ ->
-            maybe [] (toList . (.uiBlocks))
+            maybe
+                []
+                (toList . Transcript.coalesceInspectionBlocks . (.uiBlocks))
                 (conversationUiForTarget target state)
 
 historyBlock :: HistoryWindow -> BlockId -> Maybe UiBlock
@@ -808,14 +816,7 @@ selectedConversationBlock
     -> Maybe UiBlock
 selectedConversationBlock target state =
     selectedConversationBlockId target state >>= \ident ->
-        case target of
-            AgentRoot ->
-                historyBlock state.appHistoryWindow ident
-                    <|> lookupBlock ident state.appUi
-            AgentChild _ ->
-                conversationUiForTarget target state >>= lookupBlock ident
-            AgentNative _ ->
-                conversationUiForTarget target state >>= lookupBlock ident
+        find ((== ident) . (.blockId)) (conversationBlocks target state)
 
 selectConversationBlock
     :: AgentTarget

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -384,6 +384,43 @@ resolveResume confirmed = do
             }
     resumeNativeProgressIfRunning
 
+openCommandPalette :: EventM Name AppState ()
+openCommandPalette = do
+    state <- get
+    let catalog = state.appSlashCatalog
+        rows = commandPaletteRows catalog
+        reply = \case
+            Just selection ->
+                case commandPaletteActionAt
+                        selection.choiceSelectionIndex
+                        catalog of
+                    Just CommandPaletteDismiss -> pure ()
+                    Just action ->
+                        enqueueAppEvent
+                            state.appRuntime
+                            (AppCommandPaletteSelected action)
+                    Nothing -> pure ()
+            Nothing -> pure ()
+    liftIO (state.appRuntime.runtimeNativeProgress False)
+    modify' \current ->
+        current
+            { appChoice = Just ChoiceOverlay
+                { choicePresentation = ChoiceDialog
+                , choiceTitle = "Commands & shortcuts"
+                , choiceBody = ""
+                , choiceIndex = 0
+                , choiceRows = rows
+                , choiceSearch = True
+                , choiceQuery = ""
+                , choiceAdjustments = Nothing
+                , choiceAdjustmentIndices = []
+                , choiceCloseOnTurnEnd = False
+                }
+            , appChoiceReply = Just reply
+            , appAgentHover = Nothing
+            }
+    vScrollToBeginning (viewportScroll OverlayViewport)
+
 -- | Move the selected source row's adjustable value without disturbing its
 -- search query or list selection. Values clamp at their endpoints.
 adjustChoiceValue :: Int -> ChoiceOverlay -> ChoiceOverlay
@@ -528,7 +565,13 @@ handleFilterChoiceKey event = case event of
     V.EvMouseDown _ _ V.BScrollDown _ ->
         vScrollBy (viewportScroll OverlayViewport) mouseScrollLines
     V.EvKey V.KEnter [] -> resolveChoice True
-    V.EvKey V.KEsc [] -> resolveChoice False
+    V.EvKey V.KEsc [] -> do
+        state <- get
+        case state.appChoice of
+            Just choice
+                | not (Text.null choice.choiceQuery) ->
+                    updateChoiceQuery (const "")
+            _ -> resolveChoice False
     V.EvKey V.KBS [] -> updateChoiceQuery (Text.dropEnd 1)
     V.EvKey (V.KChar char) []
         | isPrint char ->
@@ -636,10 +679,7 @@ activateControl = \case
         activateQuickStartCommand "/worktree"
     QuickStartResume ->
         activateQuickStartCommand "/resume"
-    QuickStartCommands ->
-        applyLocalUiEventWith
-            (UiSetDraft "/" 1)
-            (applyUiEvent (UiFocusChanged FocusComposer))
+    QuickStartCommands -> openCommandPalette
     QuickStartModel ->
         Composer.handlePromptControlClick
             applyLocalUiEventWith

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -833,6 +833,10 @@ copyCodeBlock target blockId codeIndex = do
 resolveChoice :: Bool -> EventM Name AppState ()
 resolveChoice confirmed = do
     state <- get
+    let previewingTheme =
+            maybe False
+                ((== ChoiceTheme) . (.choicePresentation))
+                state.appChoice
     case state.appChoiceReply of
         Nothing -> pure ()
         Just reply ->
@@ -845,6 +849,9 @@ resolveChoice confirmed = do
             { appChoice = Nothing
             , appChoiceReply = Nothing
             }
+    -- Cached transcript images already contain resolved attributes.  Closing
+    -- a live preview must repaint them with the persisted theme.
+    when previewingTheme invalidateCache
     resumeNativeProgressIfRunning
 
 handleTextPromptKey :: V.Event -> EventM Name AppState ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -122,7 +122,10 @@ import Agent.TUI.Motion ( MotionDemand(..)
     , quietIndicator
     , waitingIndicator
     )
-import Agent.TUI.Presentation ( permissionToolCallPromptRelative )
+import Agent.TUI.Presentation
+    ( diffHeaderParts
+    , permissionToolCallPromptRelative
+    )
 import Agent.Loop (ImageAttachment(..), LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -123,9 +123,7 @@ import Agent.TUI.Motion ( MotionDemand(..)
     , waitingIndicator
     )
 import Agent.TUI.Presentation
-    ( diffHeaderParts
-    , permissionToolCallPromptRelative
-    )
+    ( permissionToolCallPromptRelative )
 import Agent.Loop (ImageAttachment(..), LoopEvent(..))
 import Agent.ToolDispatch (ToolCall(..))
 import Brick

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -261,8 +261,14 @@ handleUiEvents uiEvents = do
                         || (Bridge.eventFollows uiEvent
                             && next.appUi.uiFollow)
                 invalidates =
-                    invalidated || uiEvent == UiConversationCleared
+                    invalidated || uiEventInvalidatesCache uiEvent
             in (next, progress, follows, invalidates)
+
+uiEventInvalidatesCache :: UiEvent -> Bool
+uiEventInvalidatesCache = \case
+    UiConversationCleared -> True
+    UiLoop (ToolRetracted _) -> True
+    _ -> False
 
 applyConversationUiEvent :: Int -> UiEvent -> AppState -> AppState
 applyConversationUiEvent renderedContentHeight uiEvent state =
@@ -612,8 +618,17 @@ syntaxLanguagesForBlock block =
             | Just language <- blockCodeLanguage block ->
                 [language]
         BlockEdit ->
-            diffSyntaxLanguages block.blockDetail block.blockBody
+            diffSyntaxLanguages (editInitialPath block) block.blockBody
         _ -> []
+  where
+    editInitialPath block
+        | Text.null (Text.strip block.blockDetail) =
+            editTitlePath block.blockTitle
+        | otherwise = block.blockDetail
+
+    editTitlePath title =
+        let (_, suffix) = Text.breakOn " " title
+        in Text.strip (Text.drop 1 suffix)
 
 resumeNativeProgressIfRunning :: EventM Name AppState ()
 resumeNativeProgressIfRunning = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -45,7 +45,7 @@ import Agent.CLI.TUI.Types
 import Agent.CLI.Terminal ()
 import Agent.CLI.Timestamp ()
 import Agent.Loop ()
-import Agent.Syntax ( SyntaxHighlighter )
+import Agent.Syntax ( SyntaxHighlighter, resolveFenceLanguage )
 import Agent.TUI.Markdown
     ( codeWidgetWithSyntaxHighlighting,
       diffWidgetWithSyntaxHighlighting,
@@ -70,7 +70,11 @@ import Agent.TUI.Motion
       waitingIndicator,
       MotionMode(MotionOff) )
 import Agent.TUI.Presentation
-    ( TodoDisplayLine(todoLineText, todoLineStatus),
+    ( DiffDisplayLine(..),
+      DiffLineKind(..),
+      TodoDisplayLine(todoLineText, todoLineStatus),
+      diffHeaderParts,
+      parseDiffDisplayLine,
       parseTodoList,
       todoStatusGlyph,
       toolOutputCodeLanguage,
@@ -163,9 +167,16 @@ import qualified Agent.TUI.Theme as Theme
       completionFlashAttr,
       controlLinkAttr,
       dimAttr,
+      diffAddedAttr,
+      diffAddedGutterAttr,
+      diffContextGutterAttr,
+      diffPathAttr,
+      diffRemovedAttr,
+      diffRemovedGutterAttr,
       errorAttr,
       inspectAttr,
       mutedAttr,
+      strongAttr,
       successAttr,
       syntaxCommentAttr,
       thinkingAttr,

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -71,9 +71,7 @@ import Agent.TUI.Motion
       waitingIndicator,
       MotionMode(MotionOff) )
 import Agent.TUI.Presentation
-    ( DiffDisplayLine(..),
-      DiffLineKind(..),
-      TodoDisplayLine(todoLineText, todoLineStatus),
+    ( TodoDisplayLine(todoLineText, todoLineStatus),
       diffHeaderParts,
       parseDiffDisplayLine,
       parseTodoList,
@@ -170,12 +168,7 @@ import qualified Agent.TUI.Theme as Theme
       completionFlashAttr,
       controlLinkAttr,
       dimAttr,
-      diffAddedAttr,
-      diffAddedGutterAttr,
-      diffContextGutterAttr,
       diffPathAttr,
-      diffRemovedAttr,
-      diffRemovedGutterAttr,
       errorAttr,
       inspectAttr,
       mutedAttr,

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -45,7 +45,7 @@ import Agent.CLI.TUI.Types
 import Agent.CLI.Terminal ()
 import Agent.CLI.Timestamp ()
 import Agent.Loop ()
-import Agent.Syntax ( SyntaxHighlighter, resolveFenceLanguage )
+import Agent.Syntax ( SyntaxHighlighter )
 import Agent.TUI.Markdown
     ( codeWidgetWithSyntaxHighlighting,
       diffWidgetWithSyntaxHighlighting,
@@ -72,8 +72,6 @@ import Agent.TUI.Motion
       MotionMode(MotionOff) )
 import Agent.TUI.Presentation
     ( TodoDisplayLine(todoLineText, todoLineStatus),
-      diffHeaderParts,
-      parseDiffDisplayLine,
       parseTodoList,
       todoStatusGlyph,
       toolOutputCodeLanguage,
@@ -168,11 +166,9 @@ import qualified Agent.TUI.Theme as Theme
       completionFlashAttr,
       controlLinkAttr,
       dimAttr,
-      diffPathAttr,
       errorAttr,
       inspectAttr,
       mutedAttr,
-      strongAttr,
       successAttr,
       syntaxCommentAttr,
       thinkingAttr,

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -60,6 +60,7 @@ import Agent.TUI.Model
       BlockState(BlockComplete, BlockFailed, BlockCancelled, BlockDenied,
                  BlockRunning, BlockStreaming),
       Focus(FocusScrollback),
+      InspectionGroup(inspectionGroupOpen),
       RetryCountdown(retryCountdownBlockId),
       UiBlock(blockId, blockTimestamp, blockTitle, blockKind, blockState,
               blockDetail, blockExpanded, blockBody),
@@ -145,12 +146,14 @@ import qualified Brick.Widgets.Border as Border
 import qualified Agent.CLI.TUI.Bridge as Bridge ()
 import qualified Agent.CLI.TUI.Composer as Composer
     ( controlAttr )
-import qualified Data.Map.Strict as Map ( findWithDefault, member )
+import qualified Data.Map.Strict as Map ( findWithDefault, lookup, member )
 import qualified Agent.CLI.TUI.Scroll as Scroll ()
 import qualified Data.Sequence as Seq ()
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text
-    ( length,
+    ( breakOn,
+      drop,
+      length,
       lines,
       null,
       strip,
@@ -332,7 +335,7 @@ drawBlock state target ui block =
                     block.blockDetail
                     [ diffWidgetWithSyntaxHighlighting
                         state.appSyntaxHighlighter
-                        block.blockDetail
+                        (editInitialPath block)
                         (visibleBody block)
                     | not (Text.null (Text.strip (visibleBody block)))
                     ]
@@ -572,7 +575,10 @@ cacheableBlock state target ui block =
         -- Keep it out of Brick's cache until the reducer closes the group.
         && not
             ( block.blockKind == BlockInspect
-                && Map.member block.blockId ui.uiInspectionGroups
+                && maybe
+                    False
+                    (.inspectionGroupOpen)
+                    (Map.lookup block.blockId ui.uiInspectionGroups)
             )
         && maybe
             True
@@ -665,6 +671,13 @@ shellBlockTitle block
             Text.unwords $
                 Text.words $
                     Text.take 512 block.blockDetail
+
+editInitialPath :: UiBlock -> Text
+editInitialPath block
+    | Text.null (Text.strip block.blockDetail) =
+        let (_, suffix) = Text.breakOn " " block.blockTitle
+        in Text.strip (Text.drop 1 suffix)
+    | otherwise = block.blockDetail
 
 bodySections :: Text -> [Widget Name]
 bodySections body

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -63,7 +63,7 @@ import Agent.TUI.Model
       RetryCountdown(retryCountdownBlockId),
       UiBlock(blockId, blockTimestamp, blockTitle, blockKind, blockState,
               blockDetail, blockExpanded, blockBody),
-      UiState(uiRetryCountdown, uiSelectedBlock, uiFocus) )
+      UiState(uiRetryCountdown, uiSelectedBlock, uiFocus, uiInspectionGroups) )
 import Agent.TUI.Motion
     ( foregroundIndicator,
       nativeProgressAnimationEnabled,
@@ -568,6 +568,12 @@ cacheableBlock :: AppState -> AgentTarget -> UiState -> UiBlock -> Bool
 cacheableBlock state target ui block =
     block.blockState
         `notElem` [BlockStreaming, BlockRunning]
+        -- A completed tail inspection can still accept another adjacent call.
+        -- Keep it out of Brick's cache until the reducer closes the group.
+        && not
+            ( block.blockKind == BlockInspect
+                && Map.member block.blockId ui.uiInspectionGroups
+            )
         && maybe
             True
             ((/= block.blockId) . (.retryCountdownBlockId))

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -5,6 +5,7 @@ module Agent.CLI.TUI.Render.Internal
     , agentPaneVisible
     , agentPaneEntryLimit
     , backgroundActivityText
+    , cacheableBlock
     , conversationScrollbarRenderer
     , choiceRowColumns
     , filterChoiceRowLimit
@@ -190,7 +191,7 @@ import qualified Graphics.Vty as V
       vertCat )
 import qualified Graphics.Vty.CrossPlatform as Vty ()
 
-import Agent.CLI.TUI.Render.Blocks (todoStatusAttr)
+import Agent.CLI.TUI.Render.Blocks (cacheableBlock, todoStatusAttr)
 import Agent.CLI.TUI.Render.Overlays
     ( drawNotice, drawFollowStatus, drawFooter, drawPermission, drawResume
     , drawChoice, drawTextPrompt, drawMetaConsole, choiceRowColumns

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -741,9 +741,15 @@ adjustableChoiceDetail choice =
 choiceFooter :: ChoiceOverlay -> Text
 choiceFooter choice
     | isJust choice.choiceAdjustments =
-        "↑↓ select · ←→ reasoning effort · ↵ confirm · esc cancel"
+        "↑↓ select · ←→ reasoning effort · ↵ confirm · "
+            <> escapeHint
     | otherwise =
-        "type to filter  │  ↑↓ navigate  │  Enter choose  │  Esc cancel"
+        "type to filter  │  ↑↓ navigate  │  Enter choose  │  "
+            <> escapeHint
+  where
+    escapeHint
+        | Text.null choice.choiceQuery = "Esc cancel"
+        | otherwise = "Esc clear search"
 
 listAt :: Int -> [a] -> Maybe a
 listAt index values

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
@@ -411,7 +411,7 @@ quickStartRows :: [(Name, Text, Text)]
 quickStartRows =
     [ (QuickStartWorktree, "New worktree", "/worktree")
     , (QuickStartResume, "Resume session", "/resume")
-    , (QuickStartCommands, "Browse commands", "/")
+    , (QuickStartCommands, "Browse commands", "Ctrl-P")
     , (QuickStartModel, "Manage models", "/model")
     , (QuickStartChangelog, "View changelog", "/changelog")
     ]

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
@@ -146,7 +146,10 @@ import qualified Agent.TUI.Theme as Theme
       strongAttr,
       userAttr )
 import qualified Agent.CLI.TUI.Transcript as Transcript
-    ( transcriptChunks, transcriptChunkCacheKey )
+    ( coalesceInspectionBlocks
+    , transcriptChunks
+    , transcriptChunkCacheKey
+    )
 import qualified Graphics.Vty.CrossPlatform as Vty ()
 
 
@@ -170,7 +173,10 @@ drawTranscript state =
   where
     historicalBlocks =
         concatMap
-            (toList . (.historyTurnBlocks))
+            ( toList
+                . Transcript.coalesceInspectionBlocks
+                . (.historyTurnBlocks)
+            )
             (toList state.appHistoryWindow.historyWindowTurns)
     olderGap =
         historyGapWidget
@@ -238,7 +244,9 @@ drawConversationBlocks state target ui =
     vBox $
         map
             (drawTranscriptChunk state target ui)
-            (Transcript.transcriptChunks ui.uiBlocks)
+            ( Transcript.transcriptChunks
+                (Transcript.coalesceInspectionBlocks ui.uiBlocks)
+            )
 
 historyRangeWidgets :: AppState -> [Widget Name]
 historyRangeWidgets state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
@@ -46,6 +46,7 @@ coalesceInspectionBlocks =
                 inspectionRunBody representative.blockExpanded run
             , blockDetail = ""
             , blockState = inspectionRunState run
+            , blockInspectionGroupable = False
             }
 
 coalescibleInspection :: UiBlock -> Bool

--- a/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
@@ -52,6 +52,7 @@ coalescibleInspection :: UiBlock -> Bool
 coalescibleInspection block =
     block.blockKind == BlockInspect
         && block.blockState == BlockComplete
+        && block.blockInspectionGroupable
         && inspectionCategory block.blockTitle /= InspectionView
 
 inspectionRunTitle :: [UiBlock] -> Text

--- a/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
@@ -139,7 +139,9 @@ inspectionRunBody expanded =
         "  "
             <> inspectionStateGlyph block.blockState
             <> " "
-            <> block.blockTitle
+            <> if Text.null (Text.strip block.blockDetail)
+                then block.blockTitle
+                else block.blockTitle <> " " <> block.blockDetail
 
 inspectionStateGlyph :: BlockState -> Text
 inspectionStateGlyph = \case

--- a/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
@@ -1,14 +1,160 @@
 -- | Stable chunking and cache policy for the retained conversation transcript.
 module Agent.CLI.TUI.Transcript
-    ( transcriptChunkCacheKey
+    ( coalesceInspectionBlocks
+    , transcriptChunkCacheKey
     , transcriptChunkSize
     , transcriptChunks
     ) where
 
-import Agent.TUI.Model (BlockId, UiBlock(..))
+import Agent.TUI.Model
+    ( BlockId
+    , BlockKind(BlockInspect)
+    , BlockState(..)
+    , UiBlock(..)
+    )
 import Data.Foldable (toList)
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | Collapse adjacent, finished read-only tool calls into one visual event.
+--
+-- New live calls are grouped by the reducer. This projection gives restored
+-- transcripts written by older versions the same compact treatment without
+-- changing persisted history. The newest block ID represents the run, matching
+-- normal selection after tools finish and keeping interaction stable.
+coalesceInspectionBlocks :: Seq UiBlock -> Seq UiBlock
+coalesceInspectionBlocks =
+    Seq.fromList . go . toList
+  where
+    go [] = []
+    go (block : rest)
+        | coalescibleInspection block =
+            let (following, remaining) =
+                    span coalescibleInspection rest
+                run = block : following
+            in mergeRun run : go remaining
+        | otherwise = block : go rest
+
+    mergeRun [block] = block
+    mergeRun run =
+        let representative = last run
+        in representative
+            { blockTitle = inspectionRunTitle run
+            , blockBody =
+                inspectionRunBody representative.blockExpanded run
+            , blockDetail = ""
+            , blockState = inspectionRunState run
+            }
+
+coalescibleInspection :: UiBlock -> Bool
+coalescibleInspection block =
+    block.blockKind == BlockInspect
+        && block.blockState == BlockComplete
+        && inspectionCategory block.blockTitle /= InspectionView
+
+inspectionRunTitle :: [UiBlock] -> Text
+inspectionRunTitle blocks =
+    Text.intercalate ", " summaries <> statusSuffix
+  where
+    classified = map (inspectionCategory . (.blockTitle)) blocks
+    categoryCount category =
+        length (filter (== category) classified)
+    known =
+        [ (InspectionRead, "Read", "file", "files")
+        , (InspectionList, "Listed", "dir", "dirs")
+        , (InspectionSearch, "Searched", "query", "queries")
+        , (InspectionView, "Viewed", "item", "items")
+        , (InspectionFetch, "Fetched", "source", "sources")
+        , (InspectionOther, "Inspected", "item", "items")
+        ]
+    summaries =
+        [ verb
+            <> " "
+            <> Text.pack (show count)
+            <> " "
+            <> if count == 1 then singular else plural
+        | (category, verb, singular, plural) <- known
+        , let count = categoryCount category
+        , count > 0
+        ]
+    failed =
+        length
+            (filter
+                ((== BlockFailed) . (.blockState))
+                blocks)
+    interrupted =
+        length
+            (filter
+                ((`elem` [BlockCancelled, BlockDenied]) . (.blockState))
+                blocks)
+    suffixes =
+        [ Text.pack (show failed) <> " failed" | failed > 0 ]
+            <> [ Text.pack (show interrupted) <> " interrupted"
+               | interrupted > 0
+               ]
+    statusSuffix =
+        case suffixes of
+            [] -> ""
+            _ -> " · " <> Text.intercalate ", " suffixes
+
+data InspectionCategory
+    = InspectionRead
+    | InspectionList
+    | InspectionSearch
+    | InspectionView
+    | InspectionFetch
+    | InspectionOther
+    deriving (Eq)
+
+inspectionCategory :: Text -> InspectionCategory
+inspectionCategory title
+    | startsWith "Read" = InspectionRead
+    | startsWith "Listed" || startsWith "Globbed" = InspectionList
+    | startsWith "Searched" = InspectionSearch
+    | startsWith "Viewed" = InspectionView
+    | startsWith "Fetched" = InspectionFetch
+    | otherwise = InspectionOther
+  where
+    startsWith prefix =
+        title == prefix || (prefix <> " ") `Text.isPrefixOf` title
+
+inspectionRunBody :: Bool -> [UiBlock] -> Text
+inspectionRunBody expanded =
+    Text.intercalate "\n" . concatMap renderItem
+  where
+    renderItem block
+        | not expanded = [inspectionItemTitle block]
+        | Text.null (Text.strip block.blockBody) =
+            [inspectionItemTitle block, ""]
+        | otherwise =
+            [ inspectionItemTitle block
+            , Text.unlines
+                (map ("    " <>) (Text.lines block.blockBody))
+            ]
+
+    inspectionItemTitle block =
+        "  "
+            <> inspectionStateGlyph block.blockState
+            <> " "
+            <> block.blockTitle
+
+inspectionStateGlyph :: BlockState -> Text
+inspectionStateGlyph = \case
+    BlockComplete -> "◇"
+    BlockFailed -> "✗"
+    BlockCancelled -> "⊘"
+    BlockDenied -> "⊘"
+    BlockStreaming -> "◆"
+    BlockRunning -> "◆"
+
+inspectionRunState :: [UiBlock] -> BlockState
+inspectionRunState blocks
+    | any ((== BlockFailed) . (.blockState)) blocks = BlockFailed
+    | any ((== BlockDenied) . (.blockState)) blocks = BlockDenied
+    | any ((== BlockCancelled) . (.blockState)) blocks = BlockCancelled
+    | otherwise = BlockComplete
 
 -- | Group retained blocks so completed history can be cached as larger images.
 transcriptChunks :: Seq UiBlock -> [Seq UiBlock]

--- a/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Transcript.hs
@@ -39,13 +39,15 @@ coalesceInspectionBlocks =
 
     mergeRun [block] = block
     mergeRun run =
-        let representative = last run
+        let
+            representative = last run
+            expanded = any (.blockExpanded) run
         in representative
             { blockTitle = inspectionRunTitle run
-            , blockBody =
-                inspectionRunBody representative.blockExpanded run
+            , blockBody = inspectionRunBody expanded run
             , blockDetail = ""
             , blockState = inspectionRunState run
+            , blockExpanded = expanded
             , blockInspectionGroupable = False
             }
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -10,7 +10,12 @@ module Agent.CLI.TUI.Types
     , ChoicePresentation(..)
     , ChoiceOverlay(..)
     , ChoiceSelection(..)
+    , CommandPaletteAction(..)
+    , CommandPaletteEntry(..)
     , activeTheme
+    , commandPaletteEntries
+    , commandPaletteRows
+    , commandPaletteActionAt
     , choiceVisibleRows
     , selectedChoice
     , selectedChoiceIndex
@@ -32,7 +37,13 @@ module Agent.CLI.TUI.Types
     ) where
 
 import Agent.CLI.AgentViewport (AgentEntry, AgentTarget)
-import Agent.CLI.Command (SkillCommand, SlashCatalog)
+import Agent.CLI.Command
+    ( ReplAction(..)
+    , SkillCommand(..)
+    , SlashCatalog(..)
+    , SlashCommand(..)
+    , parseReplLineWithCatalog
+    )
 import Agent.CLI.Dictation (DictationTarget)
 import Agent.CLI.Input.Types (ReplLine)
 import Agent.CLI.Interrupt (CtrlCDecision)
@@ -161,6 +172,7 @@ data AppEvent
       -- ^ Legacy compatibility; prefer 'AppSetSlashCatalog'.
     | AppSetModelIds ![Text]
       -- ^ Legacy compatibility; prefer 'AppSetSlashCatalog'.
+    | AppCommandPaletteSelected !CommandPaletteAction
     | AppSetTheme !ThemeKind
       -- ^ Apply a theme to the retained fullscreen UI.
     | AppSetImagePreviews ![(ImageAttachment, TuiImagePreview)]
@@ -241,6 +253,126 @@ data HistoryCommit
     | HistoryCommitReplace
     | HistoryCommitReset
     deriving (Eq, Show)
+
+-- | What accepting a command-palette row should do. Commands which are
+-- complete without arguments are submitted through the normal REPL input
+-- buffer. Commands needing more input leave their canonical prefix in the
+-- composer. Shortcut rows are discoverability-only.
+data CommandPaletteAction
+    = CommandPaletteSubmit !Text
+    | CommandPaletteInsert !Text
+    | CommandPaletteDismiss
+    deriving (Eq, Show)
+
+data CommandPaletteEntry = CommandPaletteEntry
+    { commandPaletteLabel :: !Text
+    , commandPaletteDetail :: !Text
+    , commandPaletteAction :: !CommandPaletteAction
+    }
+    deriving (Eq, Show)
+
+-- | Build the palette from the live canonical catalog. Keeping this derived
+-- avoids a second, inevitably stale list of slash commands.
+commandPaletteEntries :: SlashCatalog -> [CommandPaletteEntry]
+commandPaletteEntries catalog =
+    map slashEntry catalog.slashCatalogCommands
+        <> map skillEntry catalog.slashCatalogSkills
+        <> shortcutEntries
+  where
+    slashEntry command =
+        let action =
+                commandAction ("/" <> command.slashName)
+        in CommandPaletteEntry
+            { commandPaletteLabel =
+                "Command · " <> command.slashSummary
+            , commandPaletteDetail =
+                Text.intercalate "  ·  " $
+                    [command.slashUsage]
+                        <> aliasPart command.slashAliases
+                        <> keybindingPart command.slashName
+                        <> [actionDetail action]
+            , commandPaletteAction = action
+            }
+
+    skillEntry skill =
+        let action =
+                commandAction ("/" <> skill.skillCommandName)
+        in CommandPaletteEntry
+            { commandPaletteLabel =
+                "Skill · " <> skill.skillCommandSummary
+            , commandPaletteDetail =
+                Text.intercalate "  ·  "
+                    [ "/"
+                        <> skill.skillCommandName
+                        <> maybe
+                            ""
+                            (" " <>)
+                            skill.skillCommandArgumentHint
+                    , actionDetail action
+                    ]
+            , commandPaletteAction = action
+            }
+
+    -- The catalog's @slashTakesArguments@ says whether arguments are accepted,
+    -- not whether they are mandatory. Ask the canonical parser whether the
+    -- bare command is executable instead of guessing from display syntax.
+    commandAction command =
+        case parseReplLineWithCatalog catalog command of
+            ReplCommandError{} -> CommandPaletteInsert (command <> " ")
+            _ -> CommandPaletteSubmit command
+
+    actionDetail = \case
+        CommandPaletteInsert{} -> "Enter inserts command"
+        _ -> "Enter runs command"
+
+    aliasPart [] = []
+    aliasPart aliases =
+        ["aliases " <> Text.intercalate ", " (map ("/" <>) aliases)]
+
+    keybindingPart = \case
+        "quit" -> ["Ctrl-Q; Ctrl-D on empty composer"]
+        _ -> []
+
+    shortcutEntries =
+        [ shortcut "Ctrl-P" "Open commands and keyboard shortcuts"
+        , shortcut "Ctrl-C" "Interrupt; press again to exit"
+        , shortcut "Ctrl-Enter / Ctrl-O" "Send queued prompt now"
+        , shortcut "Shift-Enter" "Insert a newline"
+        , shortcut "Tab" "Focus scrollback"
+        , shortcut "Ctrl-R" "Start dictation"
+        , shortcut "Alt-K" "Toggle Meta Console"
+        , shortcut "Ctrl-V / Cmd-V" "Paste text or an image"
+        ]
+    shortcut keys description =
+        CommandPaletteEntry
+            { commandPaletteLabel = "Shortcut · " <> description
+            , commandPaletteDetail = keys
+            , commandPaletteAction = CommandPaletteDismiss
+            }
+
+commandPaletteRows :: SlashCatalog -> [(Text, Text)]
+commandPaletteRows =
+    map
+        (\entry ->
+            ( entry.commandPaletteLabel
+            , entry.commandPaletteDetail
+            ))
+        . commandPaletteEntries
+
+commandPaletteActionAt
+    :: Int
+    -> SlashCatalog
+    -> Maybe CommandPaletteAction
+commandPaletteActionAt index catalog
+    | index < 0 = Nothing
+    | otherwise =
+        (.commandPaletteAction)
+            <$> listAt index (commandPaletteEntries catalog)
+  where
+    listAt offset values =
+        case drop offset values of
+            value : _ -> Just value
+            [] -> Nothing
 
 data FullscreenRuntime = FullscreenRuntime
     { runtimeEvents :: !(BChan AppEvent)

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -810,7 +810,7 @@ spec = do
             runtime <- newScriptRuntime ui
             let initialState =
                     initialFullscreenAppState runtime [] AgentRoot [] 0
-            _ <-
+            (rendered, finalState) <-
                 runFullscreenScriptWithState
                     initialState
                     [ FullscreenScriptApp
@@ -822,6 +822,10 @@ spec = do
                 Composer.readFullscreenInputs runtime.runtimeInput
             (.fullscreenInputDisplay) <$> toList inputs
                 `shouldBe` [Just "/clear"]
+            finalState.appUi.uiQueuedInputs
+                `shouldBe` Seq.singleton "/clear"
+            rendered `shouldSatisfy`
+                ByteString.isInfixOf (encoded "/clear")
 
         it "renders and dismisses changelog release notes without choice rows" do
             runtime <- newScriptRuntime initialUiState

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -115,6 +115,7 @@ import Agent.CLI.TUI.ImagePreview
     ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
     )
+import Agent.CLI.TUI.Render.Blocks (cacheableBlock)
 import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
     , TerminalKind(..)
@@ -212,6 +213,53 @@ spec = do
             toolImageBlockId "code-mode:1:show_image" ui `shouldBe` Nothing
             toolImageBlockId "code-mode:1:show_image" initialUiState
                 `shouldBe` Nothing
+
+    describe "inspection block caching" do
+        it "does not cache a completed group while it can still be extended" do
+            let call =
+                    functionToolCall
+                        "read-1"
+                        "read_file"
+                        "{\"target_file\":\"src/Main.hs\"}"
+                running =
+                    reduceUi
+                        (UiLoop (ToolStarted call))
+                        initialUiState
+                completed =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished
+                                (ToolCallResult
+                                    "read-1"
+                                    "module Main where"
+                                    FunctionCallKind)))
+                        running
+            runtime <- newScriptRuntime completed
+            let appState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+            case Seq.lookup 0 completed.uiBlocks of
+                Nothing -> expectationFailure "expected an inspection block"
+                Just inspection ->
+                    cacheableBlock
+                        appState
+                        AgentRoot
+                        completed
+                        inspection
+                        `shouldBe` False
+
+            let closed =
+                    reduceUi
+                        (UiSystemMessage "Continuing")
+                        completed
+            case Seq.lookup 0 closed.uiBlocks of
+                Nothing -> expectationFailure "expected an inspection block"
+                Just inspection ->
+                    cacheableBlock
+                        (appState { appUi = closed })
+                        AgentRoot
+                        closed
+                        inspection
+                        `shouldBe` True
 
     describe "background activity status" do
         it "names a running agent and its current step" do
@@ -752,6 +800,28 @@ spec = do
             (.fullscreenInputLine) <$> toList inputs
                 `shouldBe` [ReplText "/diff"]
             finalState.appUi.uiDraft `shouldBe` draft
+
+        it "shows palette commands queued during a running turn" do
+            let ui =
+                    initialUiState
+                        { uiRunning = True
+                        , uiAwaitingInput = False
+                        }
+            runtime <- newScriptRuntime ui
+            let initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+            _ <-
+                runFullscreenScriptWithState
+                    initialState
+                    [ FullscreenScriptApp
+                        (AppCommandPaletteSelected
+                            (CommandPaletteSubmit "/clear"))
+                    , FullscreenScriptHalt
+                    ]
+            inputs <- atomically $
+                Composer.readFullscreenInputs runtime.runtimeInput
+            (.fullscreenInputDisplay) <$> toList inputs
+                `shouldBe` [Just "/clear"]
 
         it "renders and dismisses changelog release notes without choice rows" do
             runtime <- newScriptRuntime initialUiState
@@ -2124,6 +2194,7 @@ replacementAfterHistoryReplacement scenario = do
             , blockState = BlockComplete
             , blockExpanded = False
             , blockCallId = Nothing
+            , blockInspectionGroupable = False
             }
         durableTurn = HistoryTurn
             { historyTurnCursor = HistoryCursor 0
@@ -2694,6 +2765,7 @@ markerBlock blockId body = UiBlock
     , blockState = BlockComplete
     , blockExpanded = False
     , blockCallId = Nothing
+    , blockInspectionGroupable = False
     }
 
 renderedAppText :: (Int, Int) -> AppState -> Text

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -9,7 +9,7 @@ import Agent.CLI.AgentViewport
 import Agent.CLI.Input (ReplLine(..), terminalTextWidth)
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.Command
-    ( SlashCatalog(slashCatalogToolNames)
+    ( SlashCatalog(..)
     , defaultSlashCatalog
     )
 import Agent.CLI.Resume
@@ -41,6 +41,7 @@ import Agent.CLI.TUI.App
     , fullscreenSurface
     , fullscreenApp
     , initialFullscreenAppState
+    , isCommandPaletteKey
     , isMetaConsoleToggle
     , mergeConversationView
     , newFullscreenInputBuffer
@@ -81,7 +82,12 @@ import Agent.CLI.TUI.Types
     , ChoiceOverlay(..)
     , ChoicePresentation(..)
     , ChoiceSelection(..)
+    , CommandPaletteAction(..)
+    , CommandPaletteEntry(..)
     , FullscreenInput(..)
+    , commandPaletteActionAt
+    , commandPaletteEntries
+    , commandPaletteRows
     , choiceVisibleRows
     , selectedChoiceIndex
     , selectedChoice
@@ -603,6 +609,141 @@ spec = do
                 `shouldBe` Composer.fullscreenInputCountLimit
 
     describe "choice overlay lifecycle" do
+        it "derives searchable command rows and aliases from the slash catalog" do
+            let entries = commandPaletteEntries defaultSlashCatalog
+                commandEntries =
+                    filter
+                        (Text.isPrefixOf "Command · "
+                            . (.commandPaletteLabel))
+                        entries
+                modelEntry =
+                    find
+                        (Text.isPrefixOf "/model"
+                            . (.commandPaletteDetail))
+                        entries
+                diffEntry =
+                    find
+                        (Text.isPrefixOf "/diff"
+                            . (.commandPaletteDetail))
+                        entries
+                searchEntry =
+                    find
+                        (Text.isPrefixOf "/search"
+                            . (.commandPaletteDetail))
+                        entries
+            length commandEntries
+                `shouldBe`
+                    length defaultSlashCatalog.slashCatalogCommands
+            (.commandPaletteDetail) <$> modelEntry
+                `shouldSatisfy`
+                    maybe False (Text.isInfixOf "aliases /m")
+            (.commandPaletteAction) <$> modelEntry
+                `shouldBe` Just (CommandPaletteSubmit "/model")
+            (.commandPaletteAction) <$> diffEntry
+                `shouldBe` Just (CommandPaletteSubmit "/diff")
+            (.commandPaletteAction) <$> searchEntry
+                `shouldBe` Just (CommandPaletteInsert "/search ")
+            commandPaletteRows defaultSlashCatalog
+                `shouldSatisfy`
+                    any
+                        ((== "Ctrl-P") . snd)
+
+        it "maps a filtered palette selection back to its source command" do
+            let catalog = defaultSlashCatalog
+                rows = commandPaletteRows catalog
+                query = "Open the model picker"
+                sourceIndex =
+                    fst <$> find
+                        (Text.isInfixOf query . fst . snd)
+                        (zip [0 ..] rows)
+                filtered =
+                    (choiceOverlay False)
+                        { choiceSearch = True
+                        , choiceQuery = query
+                        , choiceRows = rows
+                        , choiceIndex = 0
+                        }
+            selectedChoiceIndex filtered `shouldBe` sourceIndex
+            (sourceIndex >>= (`commandPaletteActionAt` catalog))
+                `shouldBe` Just (CommandPaletteSubmit "/model")
+
+        it "recognizes Ctrl-P in modified and legacy terminal encodings" do
+            isCommandPaletteKey
+                (V.EvKey (V.KChar 'p') [V.MCtrl])
+                `shouldBe` True
+            isCommandPaletteKey
+                (V.EvKey (V.KChar '\DLE') [])
+                `shouldBe` True
+            isCommandPaletteKey
+                (V.EvKey (V.KChar 'p') [V.MAlt])
+                `shouldBe` False
+
+        it "clears palette search on the first Escape, then closes it" do
+            runtime <- newScriptRuntime initialUiState
+            let initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+                openAndSearch =
+                    [ FullscreenScriptVty
+                        (V.EvKey (V.KChar 'p') [V.MCtrl])
+                    , FullscreenScriptVty
+                        (V.EvKey (V.KChar 'm') [])
+                    , FullscreenScriptVty (V.EvKey V.KEsc [])
+                    ]
+            (_, searchedState) <-
+                runFullscreenScriptWithState
+                    initialState
+                    (openAndSearch <> [FullscreenScriptHalt])
+            (.choiceQuery) <$> searchedState.appChoice
+                `shouldBe` Just ""
+            (_, closedState) <-
+                runFullscreenScriptWithState
+                    initialState
+                    (openAndSearch
+                        <> [ FullscreenScriptVty (V.EvKey V.KEsc [])
+                           , FullscreenScriptHalt
+                           ])
+            closedState.appChoice `shouldBe` Nothing
+
+        it "inserts required command prefixes at the composer cursor" do
+            let ui =
+                    reduceUi (UiSetDraft "ask later" 4) initialUiState
+            runtime <- newScriptRuntime ui
+            let initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, finalState) <-
+                runFullscreenScriptWithState
+                    initialState
+                    [ FullscreenScriptApp
+                        (AppCommandPaletteSelected
+                            (CommandPaletteInsert "/search "))
+                    , FullscreenScriptHalt
+                    ]
+            finalState.appUi.uiDraft `shouldBe` "ask /search later"
+            finalState.appUi.uiCursor `shouldBe` 12
+
+        it "dispatches complete commands while preserving a draft" do
+            let draft = "? unfinished prompt"
+                ui =
+                    reduceUi
+                        (UiSetDraft draft (Text.length draft))
+                        initialUiState
+            runtime <- newScriptRuntime ui
+            let initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, finalState) <-
+                runFullscreenScriptWithState
+                    initialState
+                    [ FullscreenScriptApp
+                        (AppCommandPaletteSelected
+                            (CommandPaletteSubmit "/diff"))
+                    , FullscreenScriptHalt
+                    ]
+            inputs <- atomically $
+                Composer.readFullscreenInputs runtime.runtimeInput
+            (.fullscreenInputLine) <$> toList inputs
+                `shouldBe` [ReplText "/diff"]
+            finalState.appUi.uiDraft `shouldBe` draft
+
         it "renders and dismisses changelog release notes without choice rows" do
             runtime <- newScriptRuntime initialUiState
             reply <- newEmptyTMVarIO
@@ -1075,7 +1216,7 @@ spec = do
                 `shouldBe`
                     [ (QuickStartWorktree, "New worktree", "/worktree")
                     , (QuickStartResume, "Resume session", "/resume")
-                    , (QuickStartCommands, "Browse commands", "/")
+                    , (QuickStartCommands, "Browse commands", "Ctrl-P")
                     , (QuickStartModel, "Manage models", "/model")
                     , (QuickStartChangelog, "View changelog", "/changelog")
                     ]

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -26,6 +26,7 @@ import Agent.CLI.TUI.App
     , agentPaneEntryLimit
     , agentPaneVisible
     , backgroundActivityText
+    , cacheableBlock
     , completionFlashTransitions
     , completionRequiresRedraw
     , conversationScrollbarRenderer
@@ -115,7 +116,6 @@ import Agent.CLI.TUI.ImagePreview
     ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
     )
-import Agent.CLI.TUI.Render.Blocks (cacheableBlock)
 import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
     , TerminalKind(..)

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -352,7 +352,8 @@ spec = do
             let editBlock =
                     (markerBlock (BlockId 1) "  update scripts/check.py")
                         { blockKind = BlockEdit
-                        , blockTitle = "Edited src/Agent/Syntax.hs"
+                        , blockTitle = "Edited"
+                        , blockDetail = "src/Agent/Syntax.hs"
                         }
             syntaxLanguagesForBlocks [editBlock]
                 `shouldBe` Set.fromList ["haskell", "python"]

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -300,6 +300,15 @@ spec = do
                     Set.fromList
                         ["haskell", "python", "rust", "typescript"]
 
+        it "requests grammars used by edit titles and diff headers" do
+            let editBlock =
+                    (markerBlock (BlockId 1) "  update scripts/check.py")
+                        { blockKind = BlockEdit
+                        , blockTitle = "Edited src/Agent/Syntax.hs"
+                        }
+            syntaxLanguagesForBlocks [editBlock]
+                `shouldBe` Set.fromList ["haskell", "python"]
+
     describe "externalUrlCommand" do
         it "opens HTTP(S) URLs without passing through a shell" do
             let url = "https://github.com/digitallyinduced/haskell-agent"

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -669,6 +669,7 @@ block identifier =
         , blockState = BlockComplete
         , blockExpanded = False
         , blockCallId = Nothing
+        , blockInspectionGroupable = False
         }
 
 isRight :: Either a b -> Bool

--- a/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
@@ -106,6 +106,36 @@ spec = describe "fullscreen transcript caching" do
                     Text.isInfixOf "    src/B.hs:2"
             _ -> expectationFailure "expected one inspection summary"
 
+    it "does not recoalesce an inspection summary with later calls" do
+        let first =
+                (groupableInspection 1)
+                    { blockTitle = "Read"
+                    , blockDetail = "src/A.hs"
+                    }
+            second =
+                (groupableInspection 2)
+                    { blockTitle = "Listed"
+                    , blockDetail = "src"
+                    }
+            search =
+                (groupableInspection 3)
+                    { blockTitle = "Searched"
+                    , blockDetail = "needle"
+                    }
+            initial =
+                coalesceInspectionBlocks (Seq.fromList [first, second])
+            continued =
+                toList
+                    (coalesceInspectionBlocks (initial Seq.|> search))
+        case continued of
+            [summary, later] -> do
+                summary.blockTitle `shouldBe` "Read 1 file, Listed 1 dir"
+                summary.blockBody
+                    `shouldBe` "  ◇ Read src/A.hs\n  ◇ Listed src"
+                summary.blockInspectionGroupable `shouldBe` False
+                later.blockTitle `shouldBe` "Searched"
+            _ -> expectationFailure "expected a summary and a later call"
+
     it "does not merge running, failed, or non-adjacent inspection blocks" do
         let inspect ident state =
                 (groupableInspection ident)

--- a/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
@@ -59,15 +59,13 @@ spec = describe "fullscreen transcript caching" do
 
     it "coalesces adjacent completed inspection blocks under the newest ID" do
         let first =
-                (block 1)
-                    { blockKind = BlockInspect
-                    , blockTitle = "Read src/A.hs"
+                (groupableInspection 1)
+                    { blockTitle = "Read src/A.hs"
                     , blockBody = "module A where"
                     }
             second =
-                (block 2)
-                    { blockKind = BlockInspect
-                    , blockTitle = "Listed src"
+                (groupableInspection 2)
+                    { blockTitle = "Listed src"
                     , blockBody = "A.hs"
                     }
             grouped =
@@ -83,15 +81,13 @@ spec = describe "fullscreen transcript caching" do
 
     it "retains expanded inspection details" do
         let first =
-                (block 1)
-                    { blockKind = BlockInspect
-                    , blockTitle = "Searched needle"
+                (groupableInspection 1)
+                    { blockTitle = "Searched needle"
                     , blockBody = "src/A.hs:1"
                     }
             second =
-                (block 2)
-                    { blockKind = BlockInspect
-                    , blockTitle = "Searched another"
+                (groupableInspection 2)
+                    { blockTitle = "Searched another"
                     , blockBody = "src/B.hs:2"
                     , blockExpanded = True
                     }
@@ -110,9 +106,8 @@ spec = describe "fullscreen transcript caching" do
 
     it "does not merge running, failed, or non-adjacent inspection blocks" do
         let inspect ident state =
-                (block ident)
-                    { blockKind = BlockInspect
-                    , blockTitle = "Read src/A.hs"
+                (groupableInspection ident)
+                    { blockTitle = "Read src/A.hs"
                     , blockState = state
                     }
             input = Seq.fromList
@@ -132,12 +127,28 @@ spec = describe "fullscreen transcript caching" do
                     , blockTitle = "Viewed screenshot.png"
                     }
             readFile =
-                (block 2)
-                    { blockKind = BlockInspect
-                    , blockTitle = "Read src/A.hs"
+                (groupableInspection 2)
+                    { blockTitle = "Read src/A.hs"
                     }
         map (.blockId)
             (toList (coalesceInspectionBlocks (Seq.fromList [viewed, readFile])))
+            `shouldBe` map BlockId [1, 2]
+
+    it "keeps lifecycle-sensitive inspections standalone" do
+        let taskOutput =
+                (block 1)
+                    { blockKind = BlockInspect
+                    , blockTitle = "Read task task-1"
+                    }
+            session =
+                (block 2)
+                    { blockKind = BlockInspect
+                    , blockTitle = "Read agent session session-1"
+                    }
+        map (.blockId)
+            (toList
+                (coalesceInspectionBlocks
+                    (Seq.fromList [taskOutput, session])))
             `shouldBe` map BlockId [1, 2]
   where
     completeChunk =
@@ -154,4 +165,12 @@ block number = UiBlock
     , blockState = BlockComplete
     , blockExpanded = False
     , blockCallId = Nothing
+    , blockInspectionGroupable = False
     }
+
+groupableInspection :: Int -> UiBlock
+groupableInspection number =
+    (block number)
+        { blockKind = BlockInspect
+        , blockInspectionGroupable = True
+        }

--- a/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
@@ -60,12 +60,14 @@ spec = describe "fullscreen transcript caching" do
     it "coalesces adjacent completed inspection blocks under the newest ID" do
         let first =
                 (groupableInspection 1)
-                    { blockTitle = "Read src/A.hs"
+                    { blockTitle = "Read"
+                    , blockDetail = "src/A.hs"
                     , blockBody = "module A where"
                     }
             second =
                 (groupableInspection 2)
-                    { blockTitle = "Listed src"
+                    { blockTitle = "Listed"
+                    , blockDetail = "src"
                     , blockBody = "A.hs"
                     }
             grouped =

--- a/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
@@ -86,12 +86,12 @@ spec = describe "fullscreen transcript caching" do
                 (groupableInspection 1)
                     { blockTitle = "Searched needle"
                     , blockBody = "src/A.hs:1"
+                    , blockExpanded = True
                     }
             second =
                 (groupableInspection 2)
                     { blockTitle = "Searched another"
                     , blockBody = "src/B.hs:2"
-                    , blockExpanded = True
                     }
             grouped =
                 toList
@@ -100,6 +100,7 @@ spec = describe "fullscreen transcript caching" do
             [summary] -> do
                 summary.blockTitle `shouldBe` "Searched 2 queries"
                 summary.blockState `shouldBe` BlockComplete
+                summary.blockExpanded `shouldBe` True
                 summary.blockBody `shouldSatisfy`
                     Text.isInfixOf "    src/A.hs:1"
                 summary.blockBody `shouldSatisfy`

--- a/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUITranscriptSpec.hs
@@ -1,7 +1,8 @@
 module Agent.CLI.TUITranscriptSpec (spec) where
 
 import Agent.CLI.TUI.Transcript
-    ( transcriptChunkCacheKey
+    ( coalesceInspectionBlocks
+    , transcriptChunkCacheKey
     , transcriptChunkSize
     , transcriptChunks
     )
@@ -11,7 +12,9 @@ import Agent.TUI.Model
     , BlockState(..)
     , UiBlock(..)
     )
+import Data.Foldable (toList)
 import qualified Data.Sequence as Seq
+import qualified Data.Text as Text
 import Test.Hspec
 
 spec :: Spec
@@ -53,6 +56,89 @@ spec = describe "fullscreen transcript caching" do
             `shouldBe` Nothing
         transcriptChunkCacheKey (const True) [BlockId 99] completeChunk
             `shouldBe` Just (BlockId 1, BlockId transcriptChunkSize)
+
+    it "coalesces adjacent completed inspection blocks under the newest ID" do
+        let first =
+                (block 1)
+                    { blockKind = BlockInspect
+                    , blockTitle = "Read src/A.hs"
+                    , blockBody = "module A where"
+                    }
+            second =
+                (block 2)
+                    { blockKind = BlockInspect
+                    , blockTitle = "Listed src"
+                    , blockBody = "A.hs"
+                    }
+            grouped =
+                toList
+                    (coalesceInspectionBlocks (Seq.fromList [first, second]))
+        case grouped of
+            [summary] -> do
+                summary.blockId `shouldBe` BlockId 2
+                summary.blockTitle `shouldBe` "Read 1 file, Listed 1 dir"
+                summary.blockBody
+                    `shouldBe` "  ◇ Read src/A.hs\n  ◇ Listed src"
+            _ -> expectationFailure "expected one inspection summary"
+
+    it "retains expanded inspection details" do
+        let first =
+                (block 1)
+                    { blockKind = BlockInspect
+                    , blockTitle = "Searched needle"
+                    , blockBody = "src/A.hs:1"
+                    }
+            second =
+                (block 2)
+                    { blockKind = BlockInspect
+                    , blockTitle = "Searched another"
+                    , blockBody = "src/B.hs:2"
+                    , blockExpanded = True
+                    }
+            grouped =
+                toList
+                    (coalesceInspectionBlocks (Seq.fromList [first, second]))
+        case grouped of
+            [summary] -> do
+                summary.blockTitle `shouldBe` "Searched 2 queries"
+                summary.blockState `shouldBe` BlockComplete
+                summary.blockBody `shouldSatisfy`
+                    Text.isInfixOf "    src/A.hs:1"
+                summary.blockBody `shouldSatisfy`
+                    Text.isInfixOf "    src/B.hs:2"
+            _ -> expectationFailure "expected one inspection summary"
+
+    it "does not merge running, failed, or non-adjacent inspection blocks" do
+        let inspect ident state =
+                (block ident)
+                    { blockKind = BlockInspect
+                    , blockTitle = "Read src/A.hs"
+                    , blockState = state
+                    }
+            input = Seq.fromList
+                [ inspect 1 BlockComplete
+                , inspect 2 BlockRunning
+                , block 3
+                , inspect 4 BlockComplete
+                , inspect 5 BlockFailed
+                ]
+        map (.blockId) (toList (coalesceInspectionBlocks input))
+            `shouldBe` map BlockId [1, 2, 3, 4, 5]
+
+    it "keeps image inspections standalone" do
+        let viewed =
+                (block 1)
+                    { blockKind = BlockInspect
+                    , blockTitle = "Viewed screenshot.png"
+                    }
+            readFile =
+                (block 2)
+                    { blockKind = BlockInspect
+                    , blockTitle = "Read src/A.hs"
+                    }
+        map (.blockId)
+            (toList (coalesceInspectionBlocks (Seq.fromList [viewed, readFile])))
+            `shouldBe` map BlockId [1, 2]
   where
     completeChunk =
         Seq.fromList (map block [1 .. transcriptChunkSize])

--- a/packages/agent-cli/test/Agent/CLI/TranscriptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TranscriptSpec.hs
@@ -145,6 +145,7 @@ testBlock = UiBlock
     , blockState = BlockComplete
     , blockExpanded = False
     , blockCallId = Nothing
+    , blockInspectionGroupable = False
     }
 
 testTime :: UTCTime

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -2,8 +2,11 @@
 module Agent.TUI.Markdown
     ( Inline(..)
     , codeWidgetWithSyntaxHighlighting
+    , codeWidgetWithSyntaxHighlightingOn
+    , diffCodeWidgetWithSyntaxHighlighting
     , diffSyntaxLanguages
     , diffWidgetWithSyntaxHighlighting
+    , highlightDiffCodeRows
     , inlinePlainText
     , markdownWidget
     , markdownWidgetWithLinks
@@ -25,11 +28,18 @@ import Agent.TUI.Markdown.Inline
     )
 import qualified Agent.TUI.Markdown.Block as Block
 import Agent.Syntax
-    ( SyntaxHighlighter
+    ( HighlightedLine
+    , SyntaxHighlighter
     , SyntaxSpan(..)
     , highlightCode
     , resolvePathLanguage
     )
+import Agent.TUI.Presentation
+    ( DiffDisplayLine(..)
+    , diffHeaderParts
+    , parseDiffDisplayLine
+    )
+import qualified Agent.TUI.Presentation as Presentation
 import Agent.TUI.TextWidth
     ( displayTerminalText
     , graphemeCellWidth
@@ -152,6 +162,22 @@ codeWidgetWithSyntaxHighlighting syntaxHighlighter language =
     renderCodeBodyWith wrapStyledCode syntaxHighlighter language
         . codeBodyLines
 
+-- | Render code while applying one semantic background to every highlighted
+-- token.
+codeWidgetWithSyntaxHighlightingOn
+    :: Maybe SyntaxHighlighter
+    -> Text
+    -> AttrName
+    -> Text
+    -> Widget n
+codeWidgetWithSyntaxHighlightingOn syntaxHighlighter language background =
+    renderCodeBodyWithBackground
+        wrapStyledCode
+        (Just background)
+        syntaxHighlighter
+        language
+        . codeBodyLines
+
 -- | Languages needed to render a compact edit preview. The first file path is
 -- supplied separately, while later files are introduced by body headers.
 diffSyntaxLanguages :: Text -> Text -> [Text]
@@ -204,6 +230,7 @@ diffWidgetWithSyntaxHighlighting syntaxHighlighter initialPath body =
 data DiffLineKind
     = DiffLineAdded
     | DiffLineRemoved
+    | DiffLineContext
     | DiffLineHeader
     | DiffLineMeta
     | DiffLinePlain
@@ -223,7 +250,7 @@ data ParsedDiffLine = ParsedDiffLine
     }
 
 data DiffRun
-    = DiffChangedRun !DiffLineKind !DiffPaths ![(Text, Text)]
+    = DiffChangedRun !DiffPaths ![ParsedDiffLine]
     | DiffPlainRun !ParsedDiffLine
 
 data StyledDiffRow = StyledDiffRow
@@ -242,6 +269,16 @@ parseDiffLines initialPath =
         | Just nextPaths <- diffHeaderPaths line =
             ParsedDiffLine DiffLineHeader nextPaths "" line
                 : go nextPaths rest
+        | Just displayLine <- parseDiffDisplayLine line =
+            ParsedDiffLine
+                (displayLineKind displayLine.diffDisplayKind)
+                currentPaths
+                ( displayLine.diffDisplayGutter
+                    <> " │ "
+                    <> displayLine.diffDisplayMarker
+                )
+                displayLine.diffDisplayCode
+                : go currentPaths rest
         | Just (kind, prefix, source) <- changedDiffLine line =
             ParsedDiffLine kind currentPaths prefix source
                 : go currentPaths rest
@@ -252,6 +289,12 @@ parseDiffLines initialPath =
         | otherwise =
             ParsedDiffLine DiffLinePlain currentPaths "" line
                 : go currentPaths rest
+
+displayLineKind :: Presentation.DiffLineKind -> DiffLineKind
+displayLineKind = \case
+    Presentation.DiffLineAdded -> DiffLineAdded
+    Presentation.DiffLineRemoved -> DiffLineRemoved
+    Presentation.DiffLineContext -> DiffLineContext
 
 changedDiffLine :: Text -> Maybe (DiffLineKind, Text, Text)
 changedDiffLine line =
@@ -329,13 +372,6 @@ diffPathHints :: DiffPaths -> [Text]
 diffPathHints paths =
     List.nub (catMaybes [paths.diffRemovedPath, paths.diffAddedPath])
 
-diffPathForKind :: DiffLineKind -> DiffPaths -> Maybe Text
-diffPathForKind kind paths =
-    case kind of
-        DiffLineRemoved -> paths.diffRemovedPath
-        DiffLineAdded -> paths.diffAddedPath
-        _ -> Nothing
-
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText value =
     let stripped = Text.strip value
@@ -344,26 +380,22 @@ nonEmptyText value =
 diffRuns :: [ParsedDiffLine] -> [DiffRun]
 diffRuns [] = []
 diffRuns (line : rest)
-    | changedKind line.diffLineKind =
+    | codeLineKind line.diffLineKind =
         let (matching, remaining) =
                 span
                     (\next ->
-                        next.diffLineKind == line.diffLineKind
+                        codeLineKind next.diffLineKind
                             && next.diffPaths == line.diffPaths)
                     rest
-        in DiffChangedRun
-                line.diffLineKind
-                line.diffPaths
-                (map
-                    (\changed ->
-                        (changed.diffLinePrefix, changed.diffLineText))
-                    (line : matching))
+        in DiffChangedRun line.diffPaths (line : matching)
                 : diffRuns remaining
     | otherwise =
         DiffPlainRun line : diffRuns rest
   where
-    changedKind kind =
-        kind == DiffLineAdded || kind == DiffLineRemoved
+    codeLineKind kind =
+        kind == DiffLineAdded
+            || kind == DiffLineRemoved
+            || kind == DiffLineContext
 
 resolveDiffRun
     :: Maybe SyntaxHighlighter
@@ -381,63 +413,112 @@ resolveDiffRun
     mutedAttr
     addedAttr
     removedAttr = \case
-        DiffPlainRun line ->
-            pure
-                [ StyledDiffRow
-                    Nothing
-                    [ ( if line.diffLineKind == DiffLineMeta
-                            then mutedAttr
-                            else baseAttr
-                      , displayTerminalText line.diffLineText
-                      )
+        DiffPlainRun line
+            | line.diffLineKind == DiffLineHeader
+            , Just (action, path) <- diffHeaderParts line.diffLineText -> do
+                strongAttr <- B.lookupAttrName Theme.strongAttr
+                pathAttr <- B.lookupAttrName Theme.diffPathAttr
+                pure
+                    [ StyledDiffRow
+                        Nothing
+                        [ ( strongAttr
+                          , displayTerminalText
+                                ("  " <> Text.toTitle action <> " ")
+                          )
+                        , (pathAttr, displayTerminalText path)
+                        ]
                     ]
-                ]
-        DiffChangedRun kind paths changedLines -> do
-            let background =
-                    if kind == DiffLineAdded then addedAttr else removedAttr
-                sourceLines = map snd changedLines
+            | otherwise ->
+                pure
+                    [ StyledDiffRow
+                        Nothing
+                        [ ( if line.diffLineKind == DiffLineMeta
+                                then mutedAttr
+                                else baseAttr
+                          , displayTerminalText line.diffLineText
+                          )
+                        ]
+                    ]
+        DiffChangedRun paths changedLines -> do
+            let displayLines = map parsedDisplayLine changedLines
                 highlightedLines = do
                     highlighter <- syntaxHighlighter
-                    sourcePath <- diffPathForKind kind paths
-                    language <- resolvePathLanguage sourcePath
                     either (const Nothing) Just $
-                        highlightCode
+                        highlightDiffCodeRowsWithLanguages
                             highlighter
-                            language
-                            (Text.intercalate "\n" sourceLines)
+                            (paths.diffRemovedPath >>= resolvePathLanguage)
+                            (paths.diffAddedPath >>= resolvePathLanguage)
+                            displayLines
             contentRows <-
                 case highlightedLines of
-                    Just rows
-                        | length rows == length sourceLines ->
-                            traverse
-                                (traverse
-                                    (\span_ -> do
-                                        attr <-
-                                            B.lookupAttrName
-                                                (Theme.syntaxClassAttr
-                                                    span_.syntaxClass)
-                                        pure
-                                            ( withDiffBackground
-                                                background
-                                                attr
-                                            , displayTerminalText
-                                                span_.syntaxText
-                                            )))
-                                rows
+                    Just rows ->
+                        traverse
+                            (\(line, spans) ->
+                                traverse
+                                    (resolveSpan (lineBackground line))
+                                    spans)
+                            (zip changedLines rows)
                     _ ->
                         pure
-                            [ [ ( withDiffBackground background codeAttr
-                                , displayTerminalText source
+                            [ [ ( maybe
+                                    codeAttr
+                                    (`withDiffBackground` codeAttr)
+                                    (lineBackground line)
+                                , displayTerminalText line.diffLineText
                                 )
                               ]
-                            | source <- sourceLines
+                            | line <- changedLines
                             ]
-            pure
-                [ StyledDiffRow
-                    (Just background)
-                    ((background, prefix) : content)
-                | ((prefix, _), content) <- zip changedLines contentRows
-                ]
+            traverse makeStyledRow (zip changedLines contentRows)
+          where
+            lineBackground line =
+                case line.diffLineKind of
+                    DiffLineAdded -> Just addedAttr
+                    DiffLineRemoved -> Just removedAttr
+                    _ -> Nothing
+
+            resolveSpan background span_ = do
+                attr <-
+                    B.lookupAttrName
+                        (Theme.syntaxClassAttr span_.syntaxClass)
+                pure
+                    ( maybe attr (`withDiffBackground` attr) background
+                    , displayTerminalText span_.syntaxText
+                    )
+
+            makeStyledRow (line, content) = do
+                gutterAttr <-
+                    B.lookupAttrName $
+                        case line.diffLineKind of
+                            DiffLineAdded -> Theme.diffAddedGutterAttr
+                            DiffLineRemoved -> Theme.diffRemovedGutterAttr
+                            _ -> Theme.diffContextGutterAttr
+                pure
+                    StyledDiffRow
+                        { styledDiffBackground = lineBackground line
+                        , styledDiffFragments =
+                            ( gutterAttr
+                            , displayTerminalText line.diffLinePrefix
+                            )
+                                : content
+                        }
+
+parsedDisplayLine :: ParsedDiffLine -> DiffDisplayLine
+parsedDisplayLine line =
+    DiffDisplayLine
+        { diffDisplayGutter = ""
+        , diffDisplayMarker =
+            case line.diffLineKind of
+                DiffLineAdded -> "+"
+                DiffLineRemoved -> "-"
+                _ -> " "
+        , diffDisplayCode = line.diffLineText
+        , diffDisplayKind =
+            case line.diffLineKind of
+                DiffLineAdded -> Presentation.DiffLineAdded
+                DiffLineRemoved -> Presentation.DiffLineRemoved
+                _ -> Presentation.DiffLineContext
+        }
 
 withDiffBackground :: V.Attr -> V.Attr -> V.Attr
 withDiffBackground background attr =
@@ -463,6 +544,146 @@ renderStyledDiffRow availableWidth row =
                         then V.emptyImage
                         else V.charFill background ' ' padding 1
                     ]
+
+-- | Render one contiguous diff region while preserving lexical state in the
+-- old and new source streams independently.
+diffCodeWidgetWithSyntaxHighlighting
+    :: Maybe SyntaxHighlighter
+    -> Text
+    -> [DiffDisplayLine]
+    -> Widget n
+diffCodeWidgetWithSyntaxHighlighting syntaxHighlighter language displayLines =
+    B.Widget B.Greedy B.Fixed do
+        codeAttr <- B.lookupAttrName Theme.codeAttr
+        addedBackground <- B.lookupAttrName Theme.diffAddedAttr
+        removedBackground <- B.lookupAttrName Theme.diffRemovedAttr
+        styledLines <-
+            case syntaxHighlighter >>= highlighted of
+                Just highlightedLines ->
+                    traverse (traverse resolveSyntaxSpan) highlightedLines
+                Nothing ->
+                    pure
+                        [ [(codeAttr, displayTerminalText line.diffDisplayCode)]
+                        | line <- displayLines
+                        ]
+        B.render $
+            vBox
+                (zipWith
+                    (diffLineWidget
+                        codeAttr
+                        addedBackground
+                        removedBackground)
+                    displayLines
+                    styledLines)
+  where
+    highlighted highlighter =
+        either (const Nothing) Just $
+            highlightDiffCodeRows highlighter language displayLines
+
+    resolveSyntaxSpan span_ = do
+        attr <- B.lookupAttrName (Theme.syntaxClassAttr span_.syntaxClass)
+        pure (attr, displayTerminalText span_.syntaxText)
+
+    diffLineWidget
+        codeAttr
+        addedBackground
+        removedBackground
+        displayLine
+        fragments =
+        hBox
+            [ withAttr gutterAttr
+                (txt (displayTerminalText gutter))
+            , resolvedCodeLineWidget codeAttr bodyBackground fragments
+            ]
+      where
+        (gutterAttr, bodyBackground) =
+            case displayLine.diffDisplayKind of
+                Presentation.DiffLineAdded ->
+                    (Theme.diffAddedGutterAttr, Just addedBackground)
+                Presentation.DiffLineRemoved ->
+                    (Theme.diffRemovedGutterAttr, Just removedBackground)
+                Presentation.DiffLineContext ->
+                    (Theme.diffContextGutterAttr, Nothing)
+        gutter =
+            displayLine.diffDisplayGutter
+                <> " │ "
+                <> displayLine.diffDisplayMarker
+
+-- | Highlight displayed diff rows by tokenizing the old and new source
+-- streams separately. Context rows use the new stream's styling.
+highlightDiffCodeRows
+    :: SyntaxHighlighter
+    -> Text
+    -> [DiffDisplayLine]
+    -> Either Text [HighlightedLine]
+highlightDiffCodeRows highlighter language =
+    highlightDiffCodeRowsWithLanguages
+        highlighter
+        (Just language)
+        (Just language)
+
+highlightDiffCodeRowsWithLanguages
+    :: SyntaxHighlighter
+    -> Maybe Text
+    -> Maybe Text
+    -> [DiffDisplayLine]
+    -> Either Text [HighlightedLine]
+highlightDiffCodeRowsWithLanguages
+    highlighter
+    oldLanguage
+    newLanguage
+    displayLines = do
+    oldHighlighted <- highlightStream oldLanguage oldLines
+    newHighlighted <- highlightStream newLanguage newLines
+    maybe
+        (Left "Syntax highlighter returned misaligned diff rows")
+        Right
+        (selectRows displayLines oldHighlighted newHighlighted)
+  where
+    oldLines =
+        [ line.diffDisplayCode
+        | line <- displayLines
+        , line.diffDisplayKind /= Presentation.DiffLineAdded
+        ]
+    newLines =
+        [ line.diffDisplayCode
+        | line <- displayLines
+        , line.diffDisplayKind /= Presentation.DiffLineRemoved
+        ]
+
+    highlightStream _ [] = Right []
+    highlightStream Nothing _ =
+        Left "No syntax language is available for a diff stream"
+    highlightStream (Just language) lines_ = do
+        highlighted <-
+            highlightCode
+                highlighter
+                language
+                (Text.intercalate "\n" lines_)
+        if length highlighted == length lines_
+            then Right highlighted
+            else Left "Syntax highlighter changed the diff line count"
+
+    selectRows [] [] [] = Just []
+    selectRows [] _ _ = Nothing
+    selectRows (line : rest) oldRows newRows =
+        case line.diffDisplayKind of
+            Presentation.DiffLineRemoved ->
+                case oldRows of
+                    oldRow : remainingOld ->
+                        (oldRow :) <$> selectRows rest remainingOld newRows
+                    [] -> Nothing
+            Presentation.DiffLineAdded ->
+                case newRows of
+                    newRow : remainingNew ->
+                        (newRow :) <$> selectRows rest oldRows remainingNew
+                    [] -> Nothing
+            Presentation.DiffLineContext ->
+                case (oldRows, newRows) of
+                    (_ : remainingOld, newRow : remainingNew) ->
+                        (newRow :)
+                            <$> selectRows rest remainingOld remainingNew
+                    _ -> Nothing
 
 renderChunk
     :: Ord n
@@ -593,36 +814,15 @@ renderCodeBodyWithBackground
                         [ [(codeAttr, displayTerminalText line)]
                         | line <- bodyLines
                         ]
-        let applyBackground =
-                maybe id inheritBackground backgroundAttr
-            backgroundCodeAttr = applyBackground codeAttr
-            backgroundLines =
-                map
-                    (map (\(attr, text) -> (applyBackground attr, text)))
-                    styledLines
         let availableWidth = max 1 context.availWidth
-            horizontalPadding =
-                if availableWidth >= 3 then 1 else 0
-            contentWidth =
-                max 1 (availableWidth - 2 * horizontalPadding)
-            rows =
-                concatMap (wrapLine contentWidth) backgroundLines
             image =
-                V.vertCat
-                    [ fillBackgroundRow
-                        availableWidth
-                        backgroundCodeAttr $
-                        renderCodeRow
-                            backgroundCodeAttr
-                            horizontalPadding
-                            row
-                    | row <- rows
-                    ]
-            boundedImage
-                | V.imageWidth image > availableWidth =
-                    V.cropRight availableWidth image
-                | otherwise = image
-        pure B.emptyResult { B.image = boundedImage }
+                renderResolvedCodeImage
+                    wrapLine
+                    backgroundAttr
+                    codeAttr
+                    availableWidth
+                    styledLines
+        pure B.emptyResult { B.image = image }
   where
     highlighted highlighter =
         either (const Nothing) Just $
@@ -634,13 +834,69 @@ renderCodeBodyWithBackground
         attr <- B.lookupAttrName (Theme.syntaxClassAttr span_.syntaxClass)
         pure (attr, displayTerminalText span_.syntaxText)
 
+resolvedCodeLineWidget
+    :: V.Attr
+    -> Maybe V.Attr
+    -> [(V.Attr, Text)]
+    -> Widget n
+resolvedCodeLineWidget codeAttr backgroundAttr fragments =
+    B.Widget B.Greedy B.Fixed do
+        context <- B.getContext
+        let availableWidth = max 1 context.availWidth
+            image =
+                renderResolvedCodeImage
+                    wrapStyledCode
+                    backgroundAttr
+                    codeAttr
+                    availableWidth
+                    [fragments]
+        pure B.emptyResult { B.image = image }
+
+renderResolvedCodeImage
+    :: (Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]])
+    -> Maybe V.Attr
+    -> V.Attr
+    -> Int
+    -> [[(V.Attr, Text)]]
+    -> V.Image
+renderResolvedCodeImage
+    wrapLine
+    backgroundAttr
+    codeAttr
+    availableWidth
+    styledLines =
+    boundedImage
+  where
+    applyBackground =
+        maybe id inheritBackground backgroundAttr
+    backgroundCodeAttr = applyBackground codeAttr
+    backgroundLines =
+        map
+            (map (\(attr, text) -> (applyBackground attr, text)))
+            styledLines
+    horizontalPadding =
+        if availableWidth >= 3 then 1 else 0
+    contentWidth =
+        max 1 (availableWidth - 2 * horizontalPadding)
+    rows =
+        concatMap (wrapLine contentWidth) backgroundLines
+    image =
+        V.vertCat
+            [ fillBackgroundRow row
+            | row <- rows
+            ]
+    boundedImage
+        | V.imageWidth image > availableWidth =
+            V.cropRight availableWidth image
+        | otherwise = image
+
     inheritBackground background attr =
         case V.attrBackColor background of
             V.SetTo color -> attr `V.withBackColor` color
             _ -> attr
 
-    fillBackgroundRow availableWidth backgroundCodeAttr row =
-        case backgroundName of
+    fillBackgroundRow fragments =
+        case backgroundAttr of
             Just _
                 | remaining > 0 ->
                     V.horizCat
@@ -653,6 +909,11 @@ renderCodeBodyWithBackground
                         ]
             _ -> row
       where
+        row =
+            renderCodeRow
+                backgroundCodeAttr
+                horizontalPadding
+                fragments
         remaining = availableWidth - V.imageWidth row
 
 renderCodeRow

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -556,7 +556,22 @@ renderCodeBodyWith
     -> Text
     -> [Text]
     -> Widget n
-renderCodeBodyWith wrapLine syntaxHighlighter language bodyLines =
+renderCodeBodyWith wrapLine =
+    renderCodeBodyWithBackground wrapLine Nothing
+
+renderCodeBodyWithBackground
+    :: (Int -> [(V.Attr, Text)] -> [[(V.Attr, Text)]])
+    -> Maybe AttrName
+    -> Maybe SyntaxHighlighter
+    -> Text
+    -> [Text]
+    -> Widget n
+renderCodeBodyWithBackground
+    wrapLine
+    backgroundName
+    syntaxHighlighter
+    language
+    bodyLines =
     -- Keep tokenization inside the render action. Brick's 'cached' inspects a
     -- widget's size policy before consulting its cache; returning a concrete
     -- vBox here would therefore force tokenization on every streamed redraw.
@@ -567,6 +582,7 @@ renderCodeBodyWith wrapLine syntaxHighlighter language bodyLines =
     B.Widget B.Greedy B.Fixed do
         context <- B.getContext
         codeAttr <- B.lookupAttrName Theme.codeAttr
+        backgroundAttr <- traverse B.lookupAttrName backgroundName
         styledLines <-
             case syntaxHighlighter >>= highlighted of
                 Just highlightedLines
@@ -577,19 +593,29 @@ renderCodeBodyWith wrapLine syntaxHighlighter language bodyLines =
                         [ [(codeAttr, displayTerminalText line)]
                         | line <- bodyLines
                         ]
+        let applyBackground =
+                maybe id inheritBackground backgroundAttr
+            backgroundCodeAttr = applyBackground codeAttr
+            backgroundLines =
+                map
+                    (map (\(attr, text) -> (applyBackground attr, text)))
+                    styledLines
         let availableWidth = max 1 context.availWidth
             horizontalPadding =
                 if availableWidth >= 3 then 1 else 0
             contentWidth =
                 max 1 (availableWidth - 2 * horizontalPadding)
             rows =
-                concatMap (wrapLine contentWidth) styledLines
+                concatMap (wrapLine contentWidth) backgroundLines
             image =
                 V.vertCat
-                    [ renderCodeRow
-                        codeAttr
-                        horizontalPadding
-                        row
+                    [ fillBackgroundRow
+                        availableWidth
+                        backgroundCodeAttr $
+                        renderCodeRow
+                            backgroundCodeAttr
+                            horizontalPadding
+                            row
                     | row <- rows
                     ]
             boundedImage
@@ -607,6 +633,27 @@ renderCodeBodyWith wrapLine syntaxHighlighter language bodyLines =
     resolveSyntaxSpan span_ = do
         attr <- B.lookupAttrName (Theme.syntaxClassAttr span_.syntaxClass)
         pure (attr, displayTerminalText span_.syntaxText)
+
+    inheritBackground background attr =
+        case V.attrBackColor background of
+            V.SetTo color -> attr `V.withBackColor` color
+            _ -> attr
+
+    fillBackgroundRow availableWidth backgroundCodeAttr row =
+        case backgroundName of
+            Just _
+                | remaining > 0 ->
+                    V.horizCat
+                        [ row
+                        , V.charFill
+                            backgroundCodeAttr
+                            ' '
+                            remaining
+                            1
+                        ]
+            _ -> row
+      where
+        remaining = availableWidth - V.imageWidth row
 
 renderCodeRow
     :: V.Attr

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -184,8 +184,11 @@ diffSyntaxLanguages :: Text -> Text -> [Text]
 diffSyntaxLanguages initialPath body =
     List.nub
         [ language
-        | line <- parseDiffLines initialPath body
-        , path <- diffPathHints line.diffPaths
+        | path <-
+            catMaybes [nonEmptyText initialPath]
+                <> concatMap
+                    (diffPathHints . (.diffPaths))
+                    (parseDiffLines initialPath body)
         , Just language <- [resolvePathLanguage path]
         ]
 

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -677,6 +677,8 @@ renderInspectionGroup group block =
         , blockState = inspectionGroupState items
         , blockDetail = inspectionGroupDetail items
         , blockCallId = (.inspectionCallId) <$> listToMaybe items
+        , blockInspectionGroupable =
+            block.blockInspectionGroupable && length items == 1
         }
   where
     items = group.inspectionGroupItems

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -9,6 +9,8 @@ module Agent.TUI.Model
     , PermissionOverlay(..)
     , PromptLimitStatus(..)
     , PromptState(..)
+    , InspectionGroup(..)
+    , InspectionItem(..)
     , UiBlock(..)
     , UiEvent(..)
     , UiNotice(..)
@@ -277,6 +279,7 @@ reduceUi event state = case event of
             , uiTurnStartBlock = 0
             , uiAttemptStartBlock = 0
             , uiToolCalls = Map.empty
+            , uiInspectionGroups = Map.empty
             , uiShellProcesses = Map.empty
             , uiShellPolls = Map.empty
             , uiRetryCountdown = Nothing
@@ -329,6 +332,7 @@ reduceUi event state = case event of
             , uiNoticeElapsedMillis = 0
             , uiCompletionRemainingMillis = 0
             , uiToolCalls = Map.empty
+            , uiInspectionGroups = Map.empty
             , uiShellProcesses = processes
             , uiShellPolls =
                 retainShellPolls processes state.uiShellPolls
@@ -386,6 +390,7 @@ reduceLoop event state = case event of
                 , uiTurnStartBlock = Seq.length state.uiBlocks
                 , uiAttemptStartBlock = Seq.length state.uiBlocks
                 , uiToolCalls = Map.empty
+                , uiInspectionGroups = Map.empty
                 }
     ReasoningDelta delta ->
         appendOrExtend BlockThinking "Thought" delta BlockStreaming $
@@ -429,6 +434,7 @@ reduceLoop event state = case event of
                 , uiNoticeElapsedMillis = 0
                 , uiAttemptStartBlock = Seq.length finalized.uiBlocks
                 , uiToolCalls = Map.empty
+                , uiInspectionGroups = Map.empty
                 }
     ToolStarted call
         | Map.member call.callId state.uiToolCalls
@@ -516,7 +522,7 @@ startToolCall :: ToolCall -> UiState -> UiState
 startToolCall call state
     | Just sessionId <- emptyWriteStdinSession call
     , Map.member sessionId state.uiShellProcesses =
-        state
+        closeInspectionGroups state
             { uiRunning = True
             , uiGenerating = False
             , uiAwaitingInput = False
@@ -525,7 +531,7 @@ startToolCall call state
                 Map.insert call.callId sessionId state.uiShellPolls
             }
     | isTodoTool call.name =
-        state
+        closeInspectionGroups state
             { uiRunning = True
             , uiGenerating = False
             , uiAwaitingInput = False
@@ -536,6 +542,9 @@ startToolCall call state
                     (Seq.length state.uiBlocks, call)
                     state.uiToolCalls
             }
+    | toolBlockKind call.name == BlockInspect
+    , isGroupableInspectionTool call.name =
+        startInspectionCall call state
     | otherwise =
         let
             kind = toolBlockKind call.name
@@ -558,6 +567,245 @@ startToolCall call state
                         (blockIndex, call)
                         state.uiToolCalls
                 }
+
+startInspectionCall :: ToolCall -> UiState -> UiState
+startInspectionCall call state =
+    case Seq.viewr state.uiBlocks of
+        _ Seq.:> block
+            | block.blockKind == BlockInspect
+            , Just group <- Map.lookup block.blockId state.uiInspectionGroups
+            , group.inspectionGroupOpen ->
+                extend block group
+        _ -> start
+  where
+    activity = toolCallTitleRelative state.uiWorkspaceRoot call
+    (title, headerDetail) =
+        toolCallHeaderRelative state.uiWorkspaceRoot call
+    detail = fromMaybe "" headerDetail
+    item = InspectionItem
+        { inspectionCallId = call.callId
+        , inspectionToolName = canonicalToolName call.name
+        , inspectionTitle = title
+        , inspectionDetail = detail
+        , inspectionBody =
+            formatToolDiffRelative state.uiWorkspaceRoot call
+        , inspectionState = BlockRunning
+        }
+    common current =
+        current
+            { uiRunning = True
+            , uiGenerating = False
+            , uiAwaitingInput = False
+            , uiActivity = activity
+            }
+    extend block group =
+        let
+            blockIndex = Seq.length state.uiBlocks - 1
+            updatedGroup =
+                group
+                    { inspectionGroupItems =
+                        group.inspectionGroupItems <> [item]
+                    }
+        in common state
+            { uiBlocks =
+                Seq.adjust
+                    (renderInspectionGroup updatedGroup)
+                    blockIndex
+                    state.uiBlocks
+            , uiInspectionGroups =
+                Map.insert
+                    block.blockId
+                    updatedGroup
+                    state.uiInspectionGroups
+            , uiToolCalls =
+                Map.insert
+                    call.callId
+                    (blockIndex, call)
+                    state.uiToolCalls
+            }
+    start =
+        let
+            prepared = closeInspectionGroups state
+            blockIndex = Seq.length prepared.uiBlocks
+            ident = BlockId prepared.uiNextBlockId
+            group = InspectionGroup
+                { inspectionGroupOpen = True
+                , inspectionGroupItems = [item]
+                }
+            appended =
+                appendBlock
+                    BlockInspect
+                    title
+                    item.inspectionBody
+                    detail
+                    BlockRunning
+                    (Just call.callId)
+                    (common prepared)
+        in appended
+            { uiInspectionGroups =
+                Map.insert ident group appended.uiInspectionGroups
+            , uiToolCalls =
+                Map.insert
+                    call.callId
+                    (blockIndex, call)
+                    appended.uiToolCalls
+            }
+
+-- | Close a burst when another visible event intervenes. A closed burst stays
+-- tracked only until all of its out-of-order results arrive.
+closeInspectionGroups :: UiState -> UiState
+closeInspectionGroups state =
+    state
+        { uiInspectionGroups =
+            Map.mapMaybe close state.uiInspectionGroups
+        }
+  where
+    close group
+        | any ((== BlockRunning) . (.inspectionState))
+            group.inspectionGroupItems =
+                Just group { inspectionGroupOpen = False }
+        | otherwise = Nothing
+
+renderInspectionGroup :: InspectionGroup -> UiBlock -> UiBlock
+renderInspectionGroup group block =
+    block
+        { blockTitle = inspectionGroupTitle items
+        , blockBody = inspectionGroupBody items
+        , blockState = inspectionGroupState items
+        , blockDetail = inspectionGroupDetail items
+        }
+  where
+    items = group.inspectionGroupItems
+
+inspectionGroupTitle :: [InspectionItem] -> Text
+inspectionGroupTitle [] = "Inspected"
+inspectionGroupTitle [item] = item.inspectionTitle
+inspectionGroupTitle items =
+    Text.intercalate ", " (inspectionSummaries items)
+        <> failureSuffix
+  where
+    failed =
+        length
+            (filter
+                ((`elem` [BlockFailed, BlockDenied]) . (.inspectionState))
+                items)
+    failureSuffix
+        | failed == 0 = ""
+        | otherwise =
+            " · " <> Text.pack (show failed) <> " failed"
+
+inspectionGroupDetail :: [InspectionItem] -> Text
+inspectionGroupDetail [item] = item.inspectionDetail
+inspectionGroupDetail _ = ""
+
+inspectionSummaries :: [InspectionItem] -> [Text]
+inspectionSummaries =
+    map render . foldl add []
+  where
+    add counts item =
+        let label = inspectionSummaryLabel item.inspectionToolName
+        in case break ((== label) . fst) counts of
+            (before, (_, count) : after) ->
+                before <> [(label, count + 1)] <> after
+            _ -> counts <> [(label, 1)]
+    render :: (Text, Int) -> Text
+    render (label, count) =
+        label
+            <> " "
+            <> Text.pack (show count)
+            <> if count == 1 then " item" else " items"
+
+inspectionSummaryLabel :: Text -> Text
+inspectionSummaryLabel name
+    | name `elem` ["read_file", "read_tool_output", "mcp_read_resource"] =
+        "Read"
+    | name
+        `elem` ["list_dir", "mcp_list_resources", "list_agents", "ListAgents", "Glob"] =
+        "Listed"
+    | name
+        `elem`
+            [ "grep"
+            , "search_tool_output"
+            , "mcp_search"
+            , "search_tool"
+            , "conversation_search"
+            , "skill_search"
+            , "WebSearch"
+            , "ToolSearch"
+            ] =
+        "Searched"
+    | otherwise = "Inspected"
+
+-- Image rendering and long-running task-output polling attach lifecycle data
+-- to one exact block, so only compact read/list/search calls join a burst.
+isGroupableInspectionTool :: Text -> Bool
+isGroupableInspectionTool rawName =
+    canonicalToolName rawName
+        `elem`
+            [ "read_file"
+            , "list_dir"
+            , "grep"
+            , "read_tool_output"
+            , "search_tool_output"
+            , "mcp_search"
+            , "search_tool"
+            , "mcp_list_resources"
+            , "mcp_read_resource"
+            , "conversation_search"
+            , "skill_search"
+            , "view_skill"
+            , "list_agents"
+            , "Glob"
+            , "WebSearch"
+            , "ToolSearch"
+            , "ListAgents"
+            ]
+
+inspectionGroupBody :: [InspectionItem] -> Text
+inspectionGroupBody [item] = item.inspectionBody
+inspectionGroupBody items =
+    Text.intercalate "\n" headers
+        <> if null details
+            then ""
+            else "\n\n" <> Text.intercalate "\n\n" details
+  where
+    headers = map inspectionItemHeader items
+    details =
+        [ inspectionItemTitle item <> "\n"
+            <> Text.unlines
+                (map ("    " <>) (Text.lines item.inspectionBody))
+        | item <- items
+        , not (Text.null (Text.strip item.inspectionBody))
+        ]
+
+inspectionItemHeader :: InspectionItem -> Text
+inspectionItemHeader item =
+    "  "
+        <> inspectionStateGlyph item.inspectionState
+        <> " "
+        <> inspectionItemTitle item
+
+inspectionItemTitle :: InspectionItem -> Text
+inspectionItemTitle item
+    | Text.null item.inspectionDetail = item.inspectionTitle
+    | otherwise = item.inspectionTitle <> " " <> item.inspectionDetail
+
+inspectionStateGlyph :: BlockState -> Text
+inspectionStateGlyph = \case
+    BlockComplete -> "◇"
+    BlockFailed -> "✗"
+    BlockCancelled -> "⊘"
+    BlockDenied -> "⊘"
+    BlockStreaming -> "◆"
+    BlockRunning -> "◆"
+
+inspectionGroupState :: [InspectionItem] -> BlockState
+inspectionGroupState items
+    | any ((== BlockRunning) . (.inspectionState)) items = BlockRunning
+    | any ((`elem` [BlockFailed, BlockDenied]) . (.inspectionState)) items =
+        BlockFailed
+    | any ((== BlockCancelled) . (.inspectionState)) items = BlockCancelled
+    | otherwise = BlockComplete
 
 replaceOrAppendRecap :: Text -> BlockState -> UiState -> UiState
 replaceOrAppendRecap body blockState state =
@@ -623,6 +871,11 @@ removeBlockAt index state =
                         then Nothing
                         else Just (adjustIndex blockIndex, call))
                 state.uiToolCalls
+        , uiInspectionGroups =
+            Map.filterWithKey
+                (\blockId _ ->
+                    any ((== blockId) . (.blockId)) remaining)
+                state.uiInspectionGroups
         , uiShellProcesses = processes
         , uiShellPolls = retainShellPolls processes state.uiShellPolls
         , uiTurnStartBlock = adjustIndex state.uiTurnStartBlock
@@ -639,8 +892,12 @@ appendBlock
     -> UiState
     -> UiState
 appendBlock kind title body detail blockState callId state =
-    let index = Seq.length state.uiBlocks
-        ident = BlockId state.uiNextBlockId
+    let prepared =
+            if kind == BlockInspect
+                then state
+                else closeInspectionGroups state
+        index = Seq.length prepared.uiBlocks
+        ident = BlockId prepared.uiNextBlockId
         block = UiBlock
             { blockId = ident
             , blockKind = kind
@@ -655,12 +912,12 @@ appendBlock kind title body detail blockState callId state =
                         && blockState `elem` [BlockStreaming, BlockRunning])
             , blockCallId = callId
             }
-    in state
-        { uiBlocks = state.uiBlocks Seq.|> block
-        , uiNextBlockId = state.uiNextBlockId + 1
+    in prepared
+        { uiBlocks = prepared.uiBlocks Seq.|> block
+        , uiNextBlockId = prepared.uiNextBlockId + 1
         , uiSelectedBlock = Just ident
         , uiSelectedBlockIndex = Just index
-        , uiBlockIndices = Map.insert ident index state.uiBlockIndices
+        , uiBlockIndices = Map.insert ident index prepared.uiBlockIndices
         }
 
 -- | Attach one captured wall-clock label to newly appended conversation
@@ -693,18 +950,64 @@ completeTool blockIndex call result state =
             | resultState == BlockComplete
             , not (Text.null (Text.strip diff)) = diff
             | otherwise = result.output
-    in state
-        { uiBlocks =
-            Seq.adjust
-                (\block ->
-                    if block.blockCallId == Just result.callId
-                        then
-                            setBlockState resultState block
-                                { blockBody = body }
-                        else block)
-                blockIndex
-                state.uiBlocks
-        }
+    in case Seq.lookup blockIndex state.uiBlocks of
+        Just block
+            | Just group <-
+                Map.lookup block.blockId state.uiInspectionGroups
+            , any
+                ((== result.callId) . (.inspectionCallId))
+                group.inspectionGroupItems ->
+                    let
+                        updatedGroup =
+                            group
+                                { inspectionGroupItems =
+                                    map
+                                        (\item ->
+                                            if item.inspectionCallId
+                                                == result.callId
+                                                then item
+                                                    { inspectionBody = body
+                                                    , inspectionState =
+                                                        resultState
+                                                    }
+                                                else item)
+                                        group.inspectionGroupItems
+                                }
+                        groups
+                            | updatedGroup.inspectionGroupOpen
+                                || any
+                                    ((== BlockRunning)
+                                        . (.inspectionState))
+                                    updatedGroup.inspectionGroupItems =
+                                    Map.insert
+                                        block.blockId
+                                        updatedGroup
+                                        state.uiInspectionGroups
+                            | otherwise =
+                                Map.delete
+                                    block.blockId
+                                    state.uiInspectionGroups
+                    in state
+                        { uiBlocks =
+                            Seq.adjust
+                                (renderInspectionGroup updatedGroup)
+                                blockIndex
+                                state.uiBlocks
+                        , uiInspectionGroups = groups
+                        }
+        _ ->
+            state
+                { uiBlocks =
+                    Seq.adjust
+                        (\block ->
+                            if block.blockCallId == Just result.callId
+                                then
+                                    setBlockState resultState block
+                                        { blockBody = body }
+                                else block)
+                        blockIndex
+                        state.uiBlocks
+                }
 
 finishToolResult :: ToolCallResult -> UiState -> UiState
 finishToolResult result state =
@@ -900,7 +1203,7 @@ appendShellOutput blockIndex output blockState state =
 finalizeAttempt :: BlockState -> UiState -> UiState
 finalizeAttempt terminalState state =
     let
-        blocks =
+        terminalBlocks =
             Seq.mapWithIndex
                 (\index block ->
                     if index >= state.uiAttemptStartBlock
@@ -908,12 +1211,46 @@ finalizeAttempt terminalState state =
                         then setBlockState terminalState block
                         else block)
                 state.uiBlocks
+        blocks =
+            finalizeInspectionBlocks
+                terminalState
+                state.uiBlockIndices
+                state.uiInspectionGroups
+                terminalBlocks
         processes = retainShellProcesses blocks state.uiShellProcesses
     in state
         { uiBlocks = blocks
         , uiShellProcesses = processes
         , uiShellPolls = retainShellPolls processes state.uiShellPolls
         }
+
+finalizeInspectionBlocks
+    :: BlockState
+    -> Map.Map BlockId Int
+    -> Map.Map BlockId InspectionGroup
+    -> Seq UiBlock
+    -> Seq UiBlock
+finalizeInspectionBlocks terminalState indices groups blocks =
+    Map.foldlWithKey' finalizeGroup blocks groups
+  where
+    finalizeGroup blocks blockId group =
+        case Map.lookup blockId indices of
+            Nothing -> blocks
+            Just index ->
+                let finalized =
+                        group
+                            { inspectionGroupItems =
+                                map finish group.inspectionGroupItems
+                            }
+                in Seq.adjust
+                    (renderInspectionGroup finalized)
+                    index
+                    blocks
+
+    finish item
+        | item.inspectionState `elem` [BlockRunning, BlockStreaming] =
+            item { inspectionState = terminalState }
+        | otherwise = item
 
 updateToolCall :: ToolCall -> UiState -> UiState
 updateToolCall call state =
@@ -940,8 +1277,41 @@ updateVisibleToolCall call state =
                 (title, headerDetail) =
                     toolCallHeaderRelative state.uiWorkspaceRoot call
                 body = formatToolDiffRelative state.uiWorkspaceRoot call
+                inspectionUpdate = do
+                    block <- Seq.lookup blockIndex state.uiBlocks
+                    group <-
+                        Map.lookup block.blockId state.uiInspectionGroups
+                    guard $
+                        any
+                            ((== call.callId) . (.inspectionCallId))
+                            group.inspectionGroupItems
+                    let updatedGroup =
+                            group
+                                { inspectionGroupItems =
+                                    map updateItem group.inspectionGroupItems
+                                }
+                    pure (block.blockId, updatedGroup)
+                updateItem item
+                    | item.inspectionCallId == call.callId =
+                        item
+                            { inspectionToolName =
+                                canonicalToolName call.name
+                            , inspectionTitle = title
+                            , inspectionDetail =
+                                fromMaybe "" headerDetail
+                            , inspectionBody =
+                                if Text.null body
+                                    then item.inspectionBody
+                                    else body
+                            }
+                    | otherwise = item
                 blocks
                     | isTodoTool previous.name = state.uiBlocks
+                    | Just (_, group) <- inspectionUpdate =
+                        Seq.adjust
+                            (renderInspectionGroup group)
+                            blockIndex
+                            state.uiBlocks
                     | otherwise =
                         Seq.adjust
                             (\block ->
@@ -961,9 +1331,18 @@ updateVisibleToolCall call state =
                                     else block)
                             blockIndex
                             state.uiBlocks
+                groups =
+                    case inspectionUpdate of
+                        Just (blockId, group) ->
+                            Map.insert
+                                blockId
+                                group
+                                state.uiInspectionGroups
+                        Nothing -> state.uiInspectionGroups
             in state
                 { uiBlocks = blocks
                 , uiActivity = activity
+                , uiInspectionGroups = groups
                 , uiToolCalls =
                     Map.insert
                         call.callId
@@ -1019,6 +1398,48 @@ retractVisibleToolCall callId state =
         Just (blockIndex, _) ->
             case Seq.lookup blockIndex state.uiBlocks of
                 Just block
+                    | Just group <-
+                        Map.lookup block.blockId state.uiInspectionGroups
+                    , let remaining =
+                            filter
+                                ((/= callId) . (.inspectionCallId))
+                                group.inspectionGroupItems
+                    , length remaining
+                        < length group.inspectionGroupItems ->
+                            if null remaining
+                                then
+                                    removeBlockAt
+                                        blockIndex
+                                        state
+                                            { uiToolCalls =
+                                                Map.delete
+                                                    callId
+                                                    state.uiToolCalls
+                                            }
+                                else
+                                    let updatedGroup =
+                                            group
+                                                { inspectionGroupItems =
+                                                    remaining
+                                                }
+                                    in state
+                                        { uiBlocks =
+                                            Seq.adjust
+                                                (renderInspectionGroup
+                                                    updatedGroup)
+                                                blockIndex
+                                                state.uiBlocks
+                                        , uiInspectionGroups =
+                                            Map.insert
+                                                block.blockId
+                                                updatedGroup
+                                                state.uiInspectionGroups
+                                        , uiToolCalls =
+                                            Map.delete
+                                                callId
+                                                state.uiToolCalls
+                                        }
+                Just block
                     | block.blockCallId == Just callId ->
                         removeBlockAt blockIndex state
                 _ ->
@@ -1043,6 +1464,11 @@ discardResponseAttempt state =
             Map.filter (< boundary) state.uiBlockIndices
         , uiToolCalls =
             Map.filter ((< boundary) . fst) state.uiToolCalls
+        , uiInspectionGroups =
+            Map.filterWithKey
+                (\blockId _ ->
+                    any ((== blockId) . (.blockId)) blocks)
+                state.uiInspectionGroups
         , uiShellProcesses = processes
         , uiShellPolls = retainShellPolls processes state.uiShellPolls
         , uiGenerating = False
@@ -1053,25 +1479,57 @@ updateToolOutput callId output state =
     case Map.lookup callId state.uiToolCalls of
         Nothing -> state
         Just (blockIndex, _) ->
-            state
-                { uiBlocks =
-                    Seq.adjust
-                        (\block ->
-                            if block.blockCallId == Just callId
-                                && block.blockState == BlockRunning
-                                then block { blockBody = output }
-                                else block)
-                        blockIndex
-                        state.uiBlocks
-                }
+            case Seq.lookup blockIndex state.uiBlocks of
+                Just block
+                    | Just group <-
+                        Map.lookup block.blockId state.uiInspectionGroups ->
+                            let updatedGroup =
+                                    group
+                                        { inspectionGroupItems =
+                                            map
+                                                (\item ->
+                                                    if item.inspectionCallId
+                                                        == callId
+                                                        && item.inspectionState
+                                                            == BlockRunning
+                                                        then item
+                                                            { inspectionBody =
+                                                                output
+                                                            }
+                                                        else item)
+                                                group.inspectionGroupItems
+                                        }
+                            in state
+                                { uiBlocks =
+                                    Seq.adjust
+                                        (renderInspectionGroup updatedGroup)
+                                        blockIndex
+                                        state.uiBlocks
+                                , uiInspectionGroups =
+                                    Map.insert
+                                        block.blockId
+                                        updatedGroup
+                                        state.uiInspectionGroups
+                                }
+                _ ->
+                    state
+                        { uiBlocks =
+                            Seq.adjust
+                                (\block ->
+                                    if block.blockCallId == Just callId
+                                        && block.blockState == BlockRunning
+                                        then block { blockBody = output }
+                                        else block)
+                                blockIndex
+                                state.uiBlocks
+                        }
 
 finalizeTurn :: BlockState -> UiState -> UiState
 finalizeTurn terminalState state =
     let
         generationMillis = state.uiGenerationLastDeltaMillis
         shellOwners = Map.elems state.uiShellProcesses
-    in state
-        { uiBlocks =
+        terminalBlocks =
             Seq.mapWithIndex
                 (\index block ->
                     if (index >= state.uiTurnStartBlock
@@ -1081,6 +1539,14 @@ finalizeTurn terminalState state =
                         then setBlockState terminalState block
                         else block)
                 state.uiBlocks
+        blocks =
+            finalizeInspectionBlocks
+                terminalState
+                state.uiBlockIndices
+                state.uiInspectionGroups
+                terminalBlocks
+    in state
+        { uiBlocks = blocks
         , uiRunning = False
         , uiGenerating = False
         , uiGenerationMillis = generationMillis
@@ -1103,6 +1569,7 @@ finalizeTurn terminalState state =
                 | notice.noticeKind == NoticeProgress -> 0
             _ -> state.uiNoticeElapsedMillis
         , uiToolCalls = Map.empty
+        , uiInspectionGroups = Map.empty
         , uiShellProcesses = Map.empty
         , uiShellPolls = Map.empty
         }

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -688,17 +688,25 @@ inspectionGroupTitle [] = "Inspected"
 inspectionGroupTitle [item] = item.inspectionTitle
 inspectionGroupTitle items =
     Text.intercalate ", " (inspectionSummaries items)
-        <> failureSuffix
+        <> statusSuffix
   where
     failed =
         length
             (filter
-                ((`elem` [BlockFailed, BlockDenied]) . (.inspectionState))
+                ((== BlockFailed) . (.inspectionState))
                 items)
-    failureSuffix
-        | failed == 0 = ""
-        | otherwise =
-            " · " <> Text.pack (show failed) <> " failed"
+    denied =
+        length
+            (filter
+                ((== BlockDenied) . (.inspectionState))
+                items)
+    suffixes =
+        [ Text.pack (show failed) <> " failed" | failed > 0 ]
+            <> [ Text.pack (show denied) <> " denied" | denied > 0 ]
+    statusSuffix =
+        case suffixes of
+            [] -> ""
+            _ -> " · " <> Text.intercalate ", " suffixes
 
 inspectionGroupDetail :: [InspectionItem] -> Text
 inspectionGroupDetail [item] = item.inspectionDetail
@@ -808,8 +816,8 @@ inspectionStateGlyph = \case
 inspectionGroupState :: [InspectionItem] -> BlockState
 inspectionGroupState items
     | any ((== BlockRunning) . (.inspectionState)) items = BlockRunning
-    | any ((`elem` [BlockFailed, BlockDenied]) . (.inspectionState)) items =
-        BlockFailed
+    | any ((== BlockFailed) . (.inspectionState)) items = BlockFailed
+    | any ((== BlockDenied) . (.inspectionState)) items = BlockDenied
     | any ((== BlockCancelled) . (.inspectionState)) items = BlockCancelled
     | otherwise = BlockComplete
 

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -642,7 +642,13 @@ startInspectionCall call state =
                     (Just call.callId)
                     (common prepared)
         in appended
-            { uiInspectionGroups =
+            { uiBlocks =
+                Seq.adjust
+                    (\block ->
+                        block { blockInspectionGroupable = True })
+                    blockIndex
+                    appended.uiBlocks
+            , uiInspectionGroups =
                 Map.insert ident group appended.uiInspectionGroups
             , uiToolCalls =
                 Map.insert
@@ -892,10 +898,7 @@ appendBlock
     -> UiState
     -> UiState
 appendBlock kind title body detail blockState callId state =
-    let prepared =
-            if kind == BlockInspect
-                then state
-                else closeInspectionGroups state
+    let prepared = closeInspectionGroups state
         index = Seq.length prepared.uiBlocks
         ident = BlockId prepared.uiNextBlockId
         block = UiBlock
@@ -911,6 +914,7 @@ appendBlock kind title body detail blockState callId state =
                     || (kind == BlockShell
                         && blockState `elem` [BlockStreaming, BlockRunning])
             , blockCallId = callId
+            , blockInspectionGroupable = False
             }
     in prepared
         { uiBlocks = prepared.uiBlocks Seq.|> block

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -657,20 +657,17 @@ startInspectionCall call state =
                     appended.uiToolCalls
             }
 
--- | Close a burst when another visible event intervenes. A closed burst stays
--- tracked only until all of its out-of-order results arrive.
+-- | Close a burst when another visible event intervenes. Keep its item
+-- metadata until the turn ends so a provider can still retract an individual
+-- completed call without removing the rest of the grouped block.
 closeInspectionGroups :: UiState -> UiState
 closeInspectionGroups state =
     state
         { uiInspectionGroups =
-            Map.mapMaybe close state.uiInspectionGroups
+            Map.map
+                (\group -> group { inspectionGroupOpen = False })
+                state.uiInspectionGroups
         }
-  where
-    close group
-        | any ((== BlockRunning) . (.inspectionState))
-            group.inspectionGroupItems =
-                Just group { inspectionGroupOpen = False }
-        | otherwise = Nothing
 
 renderInspectionGroup :: InspectionGroup -> UiBlock -> UiBlock
 renderInspectionGroup group block =
@@ -679,6 +676,7 @@ renderInspectionGroup group block =
         , blockBody = inspectionGroupBody items
         , blockState = inspectionGroupState items
         , blockDetail = inspectionGroupDetail items
+        , blockCallId = (.inspectionCallId) <$> listToMaybe items
         }
   where
     items = group.inspectionGroupItems
@@ -985,27 +983,17 @@ completeTool blockIndex call result state =
                                                 else item)
                                         group.inspectionGroupItems
                                 }
-                        groups
-                            | updatedGroup.inspectionGroupOpen
-                                || any
-                                    ((== BlockRunning)
-                                        . (.inspectionState))
-                                    updatedGroup.inspectionGroupItems =
-                                    Map.insert
-                                        block.blockId
-                                        updatedGroup
-                                        state.uiInspectionGroups
-                            | otherwise =
-                                Map.delete
-                                    block.blockId
-                                    state.uiInspectionGroups
                     in state
                         { uiBlocks =
                             Seq.adjust
                                 (renderInspectionGroup updatedGroup)
                                 blockIndex
                                 state.uiBlocks
-                        , uiInspectionGroups = groups
+                        , uiInspectionGroups =
+                            Map.insert
+                                block.blockId
+                                updatedGroup
+                                state.uiInspectionGroups
                         }
         _ ->
             state
@@ -1398,66 +1386,79 @@ retractVisibleToolCall :: Text -> UiState -> UiState
 retractVisibleToolCall callId state =
     case Map.lookup callId state.uiToolCalls of
         Nothing ->
-            case Seq.findIndexL
-                ((== Just callId) . (.blockCallId))
-                state.uiBlocks of
-                Just blockIndex -> removeBlockAt blockIndex state
-                Nothing -> state
+            case inspectionBlockIndexForCall callId state of
+                Just blockIndex ->
+                    fromMaybe state
+                        (retractInspectionItemAt callId blockIndex state)
+                Nothing ->
+                    case Seq.findIndexL
+                        ((== Just callId) . (.blockCallId))
+                        state.uiBlocks of
+                        Just blockIndex -> removeBlockAt blockIndex state
+                        Nothing -> state
         Just (_, call)
             | isTodoTool call.name ->
                 state
                     { uiToolCalls = Map.delete callId state.uiToolCalls }
         Just (blockIndex, _) ->
-            case Seq.lookup blockIndex state.uiBlocks of
-                Just block
-                    | Just group <-
-                        Map.lookup block.blockId state.uiInspectionGroups
-                    , let remaining =
-                            filter
-                                ((/= callId) . (.inspectionCallId))
-                                group.inspectionGroupItems
-                    , length remaining
-                        < length group.inspectionGroupItems ->
-                            if null remaining
-                                then
-                                    removeBlockAt
-                                        blockIndex
-                                        state
-                                            { uiToolCalls =
-                                                Map.delete
-                                                    callId
-                                                    state.uiToolCalls
-                                            }
-                                else
-                                    let updatedGroup =
-                                            group
-                                                { inspectionGroupItems =
-                                                    remaining
-                                                }
-                                    in state
-                                        { uiBlocks =
-                                            Seq.adjust
-                                                (renderInspectionGroup
-                                                    updatedGroup)
-                                                blockIndex
-                                                state.uiBlocks
-                                        , uiInspectionGroups =
-                                            Map.insert
-                                                block.blockId
-                                                updatedGroup
-                                                state.uiInspectionGroups
-                                        , uiToolCalls =
-                                            Map.delete
-                                                callId
-                                                state.uiToolCalls
-                                        }
-                Just block
-                    | block.blockCallId == Just callId ->
-                        removeBlockAt blockIndex state
-                _ ->
+            case retractInspectionItemAt callId blockIndex state of
+                Just retracted -> retracted
+                Nothing ->
+                    case Seq.lookup blockIndex state.uiBlocks of
+                        Just block
+                            | block.blockCallId == Just callId ->
+                                removeBlockAt blockIndex state
+                        _ ->
+                            state
+                                { uiToolCalls =
+                                    Map.delete callId state.uiToolCalls }
+
+inspectionBlockIndexForCall :: Text -> UiState -> Maybe Int
+inspectionBlockIndexForCall callId state =
+    listToMaybe
+        [ blockIndex
+        | (blockId, group) <- Map.toList state.uiInspectionGroups
+        , any
+            ((== callId) . (.inspectionCallId))
+            group.inspectionGroupItems
+        , Just blockIndex <- [Map.lookup blockId state.uiBlockIndices]
+        ]
+
+retractInspectionItemAt :: Text -> Int -> UiState -> Maybe UiState
+retractInspectionItemAt callId blockIndex state = do
+    block <- Seq.lookup blockIndex state.uiBlocks
+    group <- Map.lookup block.blockId state.uiInspectionGroups
+    let remaining =
+            filter
+                ((/= callId) . (.inspectionCallId))
+                group.inspectionGroupItems
+    guard (length remaining < length group.inspectionGroupItems)
+    pure $
+        if null remaining
+            then
+                removeBlockAt
+                    blockIndex
                     state
                         { uiToolCalls =
-                            Map.delete callId state.uiToolCalls }
+                            Map.delete callId state.uiToolCalls
+                        }
+            else
+                let updatedGroup =
+                        group { inspectionGroupItems = remaining }
+                in state
+                    { uiBlocks =
+                        Seq.adjust
+                            (renderInspectionGroup updatedGroup)
+                            blockIndex
+                            state.uiBlocks
+                    , uiInspectionGroups =
+                        Map.insert
+                            block.blockId
+                            updatedGroup
+                            state.uiInspectionGroups
+                    , uiToolCalls =
+                        Map.delete callId state.uiToolCalls
+                    }
 
 discardResponseAttempt :: UiState -> UiState
 discardResponseAttempt state =

--- a/packages/agent-tui/src/Agent/TUI/Model/State.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/State.hs
@@ -55,6 +55,7 @@ initialUiState = UiState
     , uiTurnStartBlock = 0
     , uiAttemptStartBlock = 0
     , uiToolCalls = Map.empty
+    , uiInspectionGroups = Map.empty
     , uiShellProcesses = Map.empty
     , uiShellPolls = Map.empty
     , uiTodos = []

--- a/packages/agent-tui/src/Agent/TUI/Model/Types.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Types.hs
@@ -100,6 +100,9 @@ data UiBlock = UiBlock
     , blockState :: !BlockState
     , blockExpanded :: !Bool
     , blockCallId :: !(Maybe Text)
+    -- | Whether restored adjacent blocks may be folded into an inspection
+    -- burst. This preserves the reducer's explicit tool eligibility decision.
+    , blockInspectionGroupable :: !Bool
     }
     deriving (Eq, Show)
 

--- a/packages/agent-tui/src/Agent/TUI/Model/Types.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Types.hs
@@ -9,6 +9,8 @@ module Agent.TUI.Model.Types
     , PermissionOverlay(..)
     , PromptLimitStatus(..)
     , PromptState(..)
+    , InspectionGroup(..)
+    , InspectionItem(..)
     , UiBlock(..)
     , UiEvent(..)
     , UiNotice(..)
@@ -70,6 +72,22 @@ data BlockState
     | BlockFailed
     | BlockCancelled
     | BlockDenied
+    deriving (Eq, Show)
+
+data InspectionItem = InspectionItem
+    { inspectionCallId :: !Text
+    , inspectionToolName :: !Text
+    , inspectionTitle :: !Text
+    , inspectionDetail :: !Text
+    , inspectionBody :: !Text
+    , inspectionState :: !BlockState
+    }
+    deriving (Eq, Show)
+
+data InspectionGroup = InspectionGroup
+    { inspectionGroupOpen :: !Bool
+    , inspectionGroupItems :: ![InspectionItem]
+    }
     deriving (Eq, Show)
 
 data UiBlock = UiBlock
@@ -145,6 +163,8 @@ data UiState = UiState
     , uiTurnStartBlock :: !Int
     , uiAttemptStartBlock :: !Int
     , uiToolCalls :: !(Map.Map Text (Int, ToolCall))
+    -- | Live metadata for compact read/list/search bursts.
+    , uiInspectionGroups :: !(Map.Map BlockId InspectionGroup)
     -- | Background shell session IDs mapped to the block that owns their
     -- lifecycle. Empty write_stdin calls update that block instead of adding
     -- one retained block per poll.

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -60,6 +60,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Char (isDigit, isSpace)
 import qualified Data.Foldable as Foldable
+import Data.List (sortOn)
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -273,13 +274,48 @@ parseApplyPatchDiffs patch =
         diffs -> diffs
 
     makeDiff path action raw =
-        let shown = take 20 raw
+        let shown = cappedPatchPreview 20 raw
         in SearchReplaceDiff
             { diffPath = path
             , diffAction = action
             , diffLines = shown
             , diffHiddenLines = length raw - length shown
             }
+
+    -- Prefer actual changes when long context runs exceed the preview budget.
+    -- Remaining slots show the context closest to those changes, in source
+    -- order, so an approval preview cannot consist entirely of unchanged rows.
+    cappedPatchPreview limit raw
+        | length raw <= limit = raw
+        | null changed = take limit raw
+        | otherwise =
+            [ line
+            | (index, line) <- indexed
+            , index `elem` selectedIndices
+            ]
+      where
+        indexed = zip [0 :: Int ..] raw
+        changed =
+            filter (isChanged . snd) indexed
+        shownChanges = take limit changed
+        changedIndices = map fst shownChanges
+        contextBudget = limit - length shownChanges
+        contextByProximity =
+            sortOn
+                (\(index, _) ->
+                    ( minimum
+                        (map (abs . (index -)) changedIndices)
+                    , index
+                    ))
+                (filter (not . isChanged . snd) indexed)
+        selectedIndices =
+            changedIndices
+                <> map fst (take contextBudget contextByProximity)
+
+    isChanged = \case
+        SearchReplaceContext _ -> False
+        SearchReplaceRemoved _ -> True
+        SearchReplaceAdded _ -> True
 
     patchBoundary line =
         any (`Text.isPrefixOf` line)

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -169,6 +169,7 @@ data SearchReplaceLine
     = SearchReplaceRemoved !Text
     | SearchReplaceAdded !Text
     | SearchReplaceContext !Text
+    | SearchReplaceOmitted !Int !Int !Int
     deriving (Eq, Show)
 
 data DiffLineKind
@@ -275,11 +276,13 @@ parseApplyPatchDiffs patch =
 
     makeDiff path action raw =
         let shown = cappedPatchPreview 20 raw
+            shownRows =
+                length (filter (not . isOmission) shown)
         in SearchReplaceDiff
             { diffPath = path
             , diffAction = action
             , diffLines = shown
-            , diffHiddenLines = length raw - length shown
+            , diffHiddenLines = length raw - shownRows
             }
 
     -- Prefer actual changes when long context runs exceed the preview budget.
@@ -289,10 +292,7 @@ parseApplyPatchDiffs patch =
         | length raw <= limit = raw
         | null changed = take limit raw
         | otherwise =
-            [ line
-            | (index, line) <- indexed
-            , index `elem` selectedIndices
-            ]
+            markOmissions raw selectedIndices
       where
         indexed = zip [0 :: Int ..] raw
         changed =
@@ -312,10 +312,48 @@ parseApplyPatchDiffs patch =
             changedIndices
                 <> map fst (take contextBudget contextByProximity)
 
+    markOmissions raw selectedIndices =
+        go 0
+            [ (index, line)
+            | (index, line) <- zip [0 :: Int ..] raw
+            , index `elem` selectedIndices
+            ]
+      where
+        go offset [] = omission (drop offset raw)
+        go offset ((index, line) : rest) =
+            omission (take (index - offset) (drop offset raw))
+                <> [line]
+                <> go (index + 1) rest
+
+        omission [] = []
+        omission hidden =
+            [ SearchReplaceOmitted
+                (length hidden)
+                (sum (map oldLineSpan hidden))
+                (sum (map newLineSpan hidden))
+            ]
+
     isChanged = \case
         SearchReplaceContext _ -> False
         SearchReplaceRemoved _ -> True
         SearchReplaceAdded _ -> True
+        SearchReplaceOmitted{} -> False
+
+    isOmission = \case
+        SearchReplaceOmitted{} -> True
+        _ -> False
+
+    oldLineSpan = \case
+        SearchReplaceRemoved _ -> 1
+        SearchReplaceAdded _ -> 0
+        SearchReplaceContext _ -> 1
+        SearchReplaceOmitted _ oldLines _ -> oldLines
+
+    newLineSpan = \case
+        SearchReplaceRemoved _ -> 0
+        SearchReplaceAdded _ -> 1
+        SearchReplaceContext _ -> 1
+        SearchReplaceOmitted _ _ newLines -> newLines
 
     patchBoundary line =
         any (`Text.isPrefixOf` line)
@@ -402,10 +440,16 @@ formatDiffRelativeAt workspace reportedStart diff =
             Nothing -> ""
         lineStart = reportedStart <|> actionLineStart diffAction
         shown = formatDisplayLines lineStart diffLines
+        unmarkedHidden =
+            max 0
+                (diffHiddenLines - sum
+                    [ rows
+                    | SearchReplaceOmitted rows _ _ <- diffLines
+                    ])
         more
-            | diffHiddenLines == 0 = []
+            | unmarkedHidden == 0 = []
             | otherwise =
-                ["  … " <> Text.pack (show diffHiddenLines) <> " more"]
+                ["  … " <> Text.pack (show unmarkedHidden) <> " more"]
     in Text.intercalate "\n" (filter (not . Text.null) (header : shown <> more))
   where
     formatDisplayLines start lines_ =
@@ -440,23 +484,36 @@ formatDiffRelativeAt workspace reportedStart diff =
                         (advance oldLine)
                         (advance newLine)
                         rest
+            SearchReplaceOmitted _ oldLines newLines ->
+                (Nothing, Nothing, line)
+                    : numberLines
+                        (advanceBy oldLines oldLine)
+                        (advanceBy newLines newLine)
+                        rest
 
     advance = fmap (+ 1)
+    advanceBy count = fmap (+ count)
 
     formatNumberedLine
         :: Int
         -> (Maybe Int, Maybe Int, SearchReplaceLine)
         -> Text
     formatNumberedLine width (oldLine, newLine, line) =
-        "  "
-            <> numberColumn width oldLine
-            <> " "
-            <> numberColumn width newLine
-            <> " │ "
-            <> case line of
-                SearchReplaceRemoved text -> "-" <> text
-                SearchReplaceAdded text -> "+" <> text
-                SearchReplaceContext text -> " " <> text
+        case line of
+            SearchReplaceOmitted rows _ _ ->
+                "  … " <> Text.pack (show rows) <> " omitted"
+            SearchReplaceRemoved text -> formatVisibleLine "-" text
+            SearchReplaceAdded text -> formatVisibleLine "+" text
+            SearchReplaceContext text -> formatVisibleLine " " text
+      where
+        formatVisibleLine marker text =
+            "  "
+                <> numberColumn width oldLine
+                <> " "
+                <> numberColumn width newLine
+                <> " │ "
+                <> marker
+                <> text
 
     numberColumn :: Int -> Maybe Int -> Text
     numberColumn width =

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -3,6 +3,8 @@ module Agent.TUI.Presentation
     ( SearchReplaceAction(..)
     , SearchReplaceDiff(..)
     , SearchReplaceLine(..)
+    , DiffDisplayLine(..)
+    , DiffLineKind(..)
     , TodoDisplayLine(..)
     , TodoDisplayStatus(..)
     , formatSearchReplaceDiff
@@ -12,9 +14,11 @@ module Agent.TUI.Presentation
     , formatTodoList
     , formatToolOutput
     , formatToolOutputRelative
+    , diffHeaderParts
     , isInspectionTool
     , liveTodoPanelLines
     , parseApplyPatchDiffs
+    , parseDiffDisplayLine
     , parseSearchReplaceDiff
     , parseWriteFileDiff
     , parseTodoList
@@ -56,8 +60,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Char (isDigit, isSpace)
 import qualified Data.Foldable as Foldable
-import Data.List (mapAccumL)
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -164,6 +167,21 @@ data SearchReplaceAction
 data SearchReplaceLine
     = SearchReplaceRemoved !Text
     | SearchReplaceAdded !Text
+    | SearchReplaceContext !Text
+    deriving (Eq, Show)
+
+data DiffLineKind
+    = DiffLineRemoved
+    | DiffLineAdded
+    | DiffLineContext
+    deriving (Eq, Show)
+
+data DiffDisplayLine = DiffDisplayLine
+    { diffDisplayGutter :: !Text
+    , diffDisplayMarker :: !Text
+    , diffDisplayCode :: !Text
+    , diffDisplayKind :: !DiffLineKind
+    }
     deriving (Eq, Show)
 
 data SearchReplaceDiff = SearchReplaceDiff
@@ -281,6 +299,7 @@ parseApplyPatchDiffs patch =
     changedLine line = case Text.uncons line of
         Just ('-', text) -> Just (SearchReplaceRemoved text)
         Just ('+', text) -> Just (SearchReplaceAdded text)
+        Just (' ', text) -> Just (SearchReplaceContext text)
         _ -> Nothing
 
     nonEmptyText text =
@@ -346,42 +365,109 @@ formatDiffRelativeAt workspace reportedStart diff =
                     <> workspaceRelativeDisplayPath workspace destination
             Nothing -> ""
         lineStart = reportedStart <|> actionLineStart diffAction
-        shown = maybe (map formatLine diffLines) (`formatNumberedLines` diffLines)
-            lineStart
+        shown = formatDisplayLines lineStart diffLines
         more
             | diffHiddenLines == 0 = []
             | otherwise =
                 ["  … " <> Text.pack (show diffHiddenLines) <> " more"]
     in Text.intercalate "\n" (filter (not . Text.null) (header : shown <> more))
   where
-    formatLine = \case
-        SearchReplaceRemoved line -> "  -" <> line
-        SearchReplaceAdded line -> "  +" <> line
+    formatDisplayLines start lines_ =
+        let numbered = numberLines start start lines_
+            largest =
+                maximum
+                    (1 :
+                        [ number
+                        | (oldLine, newLine, _) <- numbered
+                        , number <- maybeToList oldLine <> maybeToList newLine
+                        ])
+            width = max 3 (length (show largest))
+        in map (formatNumberedLine width) numbered
+
+    numberLines
+        :: Maybe Int
+        -> Maybe Int
+        -> [SearchReplaceLine]
+        -> [(Maybe Int, Maybe Int, SearchReplaceLine)]
+    numberLines _ _ [] = []
+    numberLines oldLine newLine (line : rest) =
+        case line of
+            SearchReplaceRemoved _ ->
+                (oldLine, Nothing, line)
+                    : numberLines (advance oldLine) newLine rest
+            SearchReplaceAdded _ ->
+                (Nothing, newLine, line)
+                    : numberLines oldLine (advance newLine) rest
+            SearchReplaceContext _ ->
+                (oldLine, newLine, line)
+                    : numberLines
+                        (advance oldLine)
+                        (advance newLine)
+                        rest
+
+    advance = fmap (+ 1)
+
+    formatNumberedLine
+        :: Int
+        -> (Maybe Int, Maybe Int, SearchReplaceLine)
+        -> Text
+    formatNumberedLine width (oldLine, newLine, line) =
+        "  "
+            <> numberColumn width oldLine
+            <> " "
+            <> numberColumn width newLine
+            <> " │ "
+            <> case line of
+                SearchReplaceRemoved text -> "-" <> text
+                SearchReplaceAdded text -> "+" <> text
+                SearchReplaceContext text -> " " <> text
+
+    numberColumn :: Int -> Maybe Int -> Text
+    numberColumn width =
+        Text.justifyRight width ' ' . maybe "" (Text.pack . show)
 
     actionLineStart = \case
         Just SearchReplaceCreate -> Just 1
         Just SearchReplaceWrite -> Just 1
         _ -> Nothing
 
-formatNumberedLines :: Int -> [SearchReplaceLine] -> [Text]
-formatNumberedLines start lines_ =
-    let numbered = snd (mapAccumL numberLine (start, start) lines_)
-        width = maximum (1 : map (Text.length . Text.pack . show . fst) numbered)
-    in map (formatNumbered width) numbered
+-- | Split a formatted multi-file header into its semantic action and path.
+diffHeaderParts :: Text -> Maybe (Text, Text)
+diffHeaderParts line =
+    firstMatch
+        [ "create"
+        , "delete"
+        , "write"
+        , "update"
+        , "move"
+        ]
   where
-    numberLine (oldLine, newLine) = \case
-        SearchReplaceRemoved line ->
-            ((oldLine + 1, newLine), (oldLine, SearchReplaceRemoved line))
-        SearchReplaceAdded line ->
-            ((oldLine, newLine + 1), (newLine, SearchReplaceAdded line))
+    firstMatch [] = Nothing
+    firstMatch (action : rest) =
+        case Text.stripPrefix ("  " <> action <> " ") line of
+            Just path
+                | not (Text.null (Text.strip path)) ->
+                    Just (action, path)
+            _ -> firstMatch rest
 
-    formatNumbered width (lineNumber, changedLine) =
-        "  "
-            <> Text.justifyRight width ' ' (Text.pack (show lineNumber))
-            <> " "
-            <> case changedLine of
-                SearchReplaceRemoved line -> "-" <> line
-                SearchReplaceAdded line -> "+" <> line
+-- | Decode the stable line-number gutter emitted by 'formatDiffRelative'.
+parseDiffDisplayLine :: Text -> Maybe DiffDisplayLine
+parseDiffDisplayLine line =
+    let (gutter, separatorAndPayload) = Text.breakOn " │ " line
+    in do
+        payload <- Text.stripPrefix " │ " separatorAndPayload
+        (marker, code) <- Text.uncons payload
+        kind <- case marker of
+            '-' -> Just DiffLineRemoved
+            '+' -> Just DiffLineAdded
+            ' ' -> Just DiffLineContext
+            _ -> Nothing
+        pure DiffDisplayLine
+            { diffDisplayGutter = gutter
+            , diffDisplayMarker = Text.singleton marker
+            , diffDisplayCode = code
+            , diffDisplayKind = kind
+            }
 
 searchReplaceLineStart :: Text -> Maybe Int
 searchReplaceLineStart output =

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -11,9 +11,13 @@ module Agent.TUI.Theme
     , controlLinkActiveAttr
     , controlLinkAttr
     , controlLinkHoverAttr
-    , diffAddedAttr
-    , diffRemovedAttr
     , dimAttr
+    , diffAddedAttr
+    , diffAddedGutterAttr
+    , diffContextGutterAttr
+    , diffPathAttr
+    , diffRemovedAttr
+    , diffRemovedGutterAttr
     , emphasisAttr
     , headingAttr
     , inspectAttr
@@ -111,10 +115,20 @@ data ThemeKind
 
 data ThemePalette = ThemePalette
     { themePaletteBackground :: !V.Color
+    , themePaletteRaised :: !V.Color
+    , themePaletteFocused :: !V.Color
     , themePaletteForeground :: !V.Color
+    , themePaletteStrong :: !V.Color
+    , themePaletteSecondary :: !V.Color
     , themePaletteMuted :: !V.Color
+    , themePaletteBorder :: !V.Color
+    , themePaletteBorderActive :: !V.Color
     , themePaletteAccent :: !V.Color
     , themePaletteLink :: !V.Color
+    , themePaletteSuccess :: !V.Color
+    , themePaletteError :: !V.Color
+    , themePaletteWarning :: !V.Color
+    , themePaletteCyan :: !V.Color
     }
 
 themeKindText :: ThemeKind -> Text
@@ -168,21 +182,91 @@ themeKindAt index =
 fixedThemePalette :: ThemeKind -> Maybe ThemePalette
 fixedThemePalette = \case
     Auto -> Nothing
-    Midnight -> Just (ThemePalette
-        (RGBColor 26 27 38) (RGBColor 220 220 230) (RGBColor 120 125 145)
-        (RGBColor 187 154 247) (RGBColor 122 162 247))
-    Daylight -> Just (ThemePalette
-        (RGBColor 250 247 242) (RGBColor 45 42 46) (RGBColor 110 105 100)
-        (RGBColor 144 80 150) (RGBColor 45 100 170))
-    TokyoNight -> Just (ThemePalette
-        (RGBColor 26 27 38) (RGBColor 192 202 245) (RGBColor 86 95 137)
-        (RGBColor 187 154 247) (RGBColor 122 162 247))
-    RosePineMoon -> Just (ThemePalette
-        (RGBColor 25 23 36) (RGBColor 224 222 244) (RGBColor 144 140 170)
-        (RGBColor 235 188 186) (RGBColor 196 167 231))
-    OscuraMidnight -> Just (ThemePalette
-        (RGBColor 8 12 18) (RGBColor 220 235 245) (RGBColor 105 130 145)
-        (RGBColor 65 210 190) (RGBColor 80 170 255))
+    Midnight -> Just ThemePalette
+        { themePaletteBackground = RGBColor 20 20 20
+        , themePaletteRaised = RGBColor 36 36 36
+        , themePaletteFocused = RGBColor 44 44 44
+        , themePaletteForeground = RGBColor 200 200 200
+        , themePaletteStrong = RGBColor 225 225 225
+        , themePaletteSecondary = RGBColor 120 120 120
+        , themePaletteMuted = RGBColor 108 108 108
+        , themePaletteBorder = RGBColor 50 50 55
+        , themePaletteBorderActive = RGBColor 60 60 65
+        , themePaletteAccent = RGBColor 187 154 247
+        , themePaletteLink = RGBColor 122 162 247
+        , themePaletteSuccess = RGBColor 158 206 106
+        , themePaletteError = RGBColor 247 118 142
+        , themePaletteWarning = RGBColor 224 175 104
+        , themePaletteCyan = RGBColor 137 221 255
+        }
+    Daylight -> Just ThemePalette
+        { themePaletteBackground = RGBColor 250 247 242
+        , themePaletteRaised = RGBColor 255 255 255
+        , themePaletteFocused = RGBColor 242 237 230
+        , themePaletteForeground = RGBColor 45 42 46
+        , themePaletteStrong = RGBColor 30 28 31
+        , themePaletteSecondary = RGBColor 82 78 76
+        , themePaletteMuted = RGBColor 110 105 100
+        , themePaletteBorder = RGBColor 198 191 183
+        , themePaletteBorderActive = RGBColor 117 111 105
+        , themePaletteAccent = RGBColor 144 80 150
+        , themePaletteLink = RGBColor 45 100 170
+        , themePaletteSuccess = RGBColor 52 132 79
+        , themePaletteError = RGBColor 184 54 72
+        , themePaletteWarning = RGBColor 161 108 24
+        , themePaletteCyan = RGBColor 30 120 145
+        }
+    TokyoNight -> Just ThemePalette
+        { themePaletteBackground = RGBColor 26 27 38
+        , themePaletteRaised = RGBColor 36 40 59
+        , themePaletteFocused = RGBColor 47 53 73
+        , themePaletteForeground = RGBColor 192 202 245
+        , themePaletteStrong = RGBColor 218 224 255
+        , themePaletteSecondary = RGBColor 120 128 170
+        , themePaletteMuted = RGBColor 86 95 137
+        , themePaletteBorder = RGBColor 59 66 97
+        , themePaletteBorderActive = RGBColor 86 95 137
+        , themePaletteAccent = RGBColor 187 154 247
+        , themePaletteLink = RGBColor 122 162 247
+        , themePaletteSuccess = RGBColor 158 206 106
+        , themePaletteError = RGBColor 247 118 142
+        , themePaletteWarning = RGBColor 224 175 104
+        , themePaletteCyan = RGBColor 137 221 255
+        }
+    RosePineMoon -> Just ThemePalette
+        { themePaletteBackground = RGBColor 25 23 36
+        , themePaletteRaised = RGBColor 38 35 58
+        , themePaletteFocused = RGBColor 49 46 69
+        , themePaletteForeground = RGBColor 224 222 244
+        , themePaletteStrong = RGBColor 240 238 255
+        , themePaletteSecondary = RGBColor 174 169 202
+        , themePaletteMuted = RGBColor 144 140 170
+        , themePaletteBorder = RGBColor 68 64 89
+        , themePaletteBorderActive = RGBColor 110 106 134
+        , themePaletteAccent = RGBColor 235 188 186
+        , themePaletteLink = RGBColor 196 167 231
+        , themePaletteSuccess = RGBColor 156 207 154
+        , themePaletteError = RGBColor 235 111 146
+        , themePaletteWarning = RGBColor 246 193 119
+        , themePaletteCyan = RGBColor 156 207 216
+        }
+    OscuraMidnight -> Just ThemePalette
+        { themePaletteBackground = RGBColor 8 12 18
+        , themePaletteRaised = RGBColor 20 27 35
+        , themePaletteFocused = RGBColor 28 37 46
+        , themePaletteForeground = RGBColor 220 235 245
+        , themePaletteStrong = RGBColor 238 247 252
+        , themePaletteSecondary = RGBColor 139 162 176
+        , themePaletteMuted = RGBColor 105 130 145
+        , themePaletteBorder = RGBColor 39 54 66
+        , themePaletteBorderActive = RGBColor 70 92 106
+        , themePaletteAccent = RGBColor 65 210 190
+        , themePaletteLink = RGBColor 80 170 255
+        , themePaletteSuccess = RGBColor 101 210 154
+        , themePaletteError = RGBColor 242 112 135
+        , themePaletteWarning = RGBColor 224 175 104
+        , themePaletteCyan = RGBColor 105 205 225
+        }
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
 userAttr, userMutedAttr, assistantAttr, slashCommandAttr :: AttrName
@@ -195,12 +279,13 @@ transcriptHoverMutedAttr, transcriptHoverMutedItalicAttr :: AttrName
 transcriptHoverMutedCancelledAttr :: AttrName
 headingAttr, codeAttr, dimAttr, emphasisAttr, inlineCodeAttr, linkAttr, strongAttr :: AttrName
 controlLinkAttr, controlLinkHoverAttr, controlLinkActiveAttr :: AttrName
-diffAddedAttr, diffRemovedAttr :: AttrName
 lambdaDimAttr, lambdaTrailAttr, lambdaGlowAttr, lambdaSparkAttr :: AttrName
 syntaxNormalAttr, syntaxKeywordAttr, syntaxTypeAttr, syntaxFunctionAttr :: AttrName
 syntaxVariableAttr, syntaxStringAttr, syntaxNumberAttr, syntaxCommentAttr :: AttrName
 syntaxOperatorAttr, syntaxAnnotationAttr, syntaxPreprocessorAttr :: AttrName
 syntaxWarningAttr, syntaxErrorAttr :: AttrName
+diffAddedAttr, diffRemovedAttr, diffAddedGutterAttr, diffRemovedGutterAttr :: AttrName
+diffContextGutterAttr, diffPathAttr :: AttrName
 waitingDimAttr, waitingMidAttr, completionFlashAttr :: AttrName
 baseAttr = attrName "base"
 headerAttr = attrName "header"
@@ -244,8 +329,6 @@ strongAttr = attrName "markdown-strong"
 controlLinkAttr = attrName "control-link"
 controlLinkHoverAttr = attrName "control-link-hover"
 controlLinkActiveAttr = attrName "control-link-active"
-diffAddedAttr = attrName "diff-added"
-diffRemovedAttr = attrName "diff-removed"
 syntaxNormalAttr = attrName "syntax-normal"
 syntaxKeywordAttr = attrName "syntax-keyword"
 syntaxTypeAttr = attrName "syntax-type"
@@ -259,6 +342,12 @@ syntaxAnnotationAttr = attrName "syntax-annotation"
 syntaxPreprocessorAttr = attrName "syntax-preprocessor"
 syntaxWarningAttr = attrName "syntax-warning"
 syntaxErrorAttr = attrName "syntax-error"
+diffAddedAttr = attrName "diff-added"
+diffRemovedAttr = attrName "diff-removed"
+diffAddedGutterAttr = attrName "diff-added-gutter"
+diffRemovedGutterAttr = attrName "diff-removed-gutter"
+diffContextGutterAttr = attrName "diff-context-gutter"
+diffPathAttr = attrName "diff-path"
 
 syntaxClassAttr :: SyntaxClass -> AttrName
 syntaxClassAttr = \case
@@ -306,6 +395,10 @@ terminalDefault =
         , (todoCancelledAttr, palette V.brightBlack `V.withStyle` V.strikethrough)
         , (errorAttr, palette V.red `V.withStyle` V.bold)
         , (successAttr, palette V.green)
+        , (diffAddedGutterAttr, palette V.green `V.withStyle` V.bold)
+        , (diffRemovedGutterAttr, palette V.red `V.withStyle` V.bold)
+        , (diffContextGutterAttr, palette V.brightBlack)
+        , (diffPathAttr, palette V.yellow)
         , (completionFlashAttr,
             palette V.brightGreen `V.withStyle` V.bold)
         , (selectedAttr, raisedPanelAttr `V.withStyle` V.bold)
@@ -384,6 +477,12 @@ monochrome =
         , (todoCancelledAttr, V.defAttr `V.withStyle` V.strikethrough)
         , (errorAttr, V.defAttr `V.withStyle` V.bold)
         , (successAttr, V.defAttr)
+        , (diffAddedAttr, V.defAttr)
+        , (diffRemovedAttr, V.defAttr)
+        , (diffAddedGutterAttr, V.defAttr `V.withStyle` V.bold)
+        , (diffRemovedGutterAttr, V.defAttr `V.withStyle` V.bold)
+        , (diffContextGutterAttr, V.defAttr `V.withStyle` V.dim)
+        , (diffPathAttr, V.defAttr `V.withStyle` V.underline)
         , (completionFlashAttr, V.defAttr `V.withStyle` V.bold)
         , (selectedAttr, V.defAttr
             `V.withStyle` (V.bold .|. V.reverseVideo))
@@ -415,8 +514,6 @@ monochrome =
         , (controlLinkHoverAttr, V.defAttr
             `V.withStyle` (V.underline .|. V.bold))
         , (controlLinkActiveAttr, V.defAttr `V.withStyle` V.reverseVideo)
-        , (diffAddedAttr, V.defAttr)
-        , (diffRemovedAttr, V.defAttr)
         , (syntaxNormalAttr, V.defAttr)
         , (syntaxKeywordAttr, V.defAttr `V.withStyle` V.bold)
         , (syntaxTypeAttr, V.defAttr `V.withStyle` V.bold)
@@ -441,26 +538,20 @@ themeAttrMap theme =
     maybe terminalDefault themePaletteAttrMap (fixedThemePalette theme)
 
 themePaletteAttrMap :: ThemePalette -> AttrMap
-themePaletteAttrMap palette =
-    mkTheme
-        palette.themePaletteBackground
-        palette.themePaletteForeground
-        palette.themePaletteMuted
-        palette.themePaletteAccent
-        palette.themePaletteLink
+themePaletteAttrMap = mkTheme
 
-mkTheme :: V.Color -> V.Color -> V.Color -> V.Color -> V.Color -> AttrMap
-mkTheme background foreground muted accent link =
+mkTheme :: ThemePalette -> AttrMap
+mkTheme palette =
     attrMap (V.defAttr `V.withBackColor` background)
         [ (baseAttr, base)
-        , (headerAttr, base `V.withStyle` V.bold)
+        , (headerAttr, strongA `V.withStyle` V.bold)
         , (footerAttr, mutedA)
         , (mutedAttr, mutedA)
-        , (userAttr, panel `V.withStyle` V.bold)
-        , (userMutedAttr, panelMuted)
+        , (userAttr, raisedStrong `V.withStyle` V.bold)
+        , (userMutedAttr, raisedMuted)
         , (assistantAttr, base)
         , (slashCommandAttr, linkA)
-        , (thinkingAttr, accentA)
+        , (thinkingAttr, secondaryA)
         , (thinkingBodyAttr, mutedA `V.withStyle` (V.dim .|. V.italic))
         , (waitingDimAttr, mutedA)
         , (waitingMidAttr, accentA)
@@ -473,32 +564,43 @@ mkTheme background foreground muted accent link =
         , (todoCancelledAttr, mutedA `V.withStyle` V.strikethrough)
         , (errorAttr, redA `V.withStyle` V.bold)
         , (successAttr, greenA)
+        , (diffAddedAttr, diffAddedA)
+        , (diffRemovedAttr, diffRemovedA)
+        , (diffAddedGutterAttr,
+            diffAddedGutterA `V.withStyle` V.bold)
+        , (diffRemovedGutterAttr,
+            diffRemovedGutterA `V.withStyle` V.bold)
+        , (diffContextGutterAttr, mutedA)
+        , (diffPathAttr, yellowA)
         , (completionFlashAttr, greenA `V.withStyle` V.bold)
-        , (selectedAttr, panel `V.withStyle` V.bold)
-        , (selectedMutedAttr, panelMuted)
-        , (borderAttr, mutedA `V.withStyle` V.dim)
-        , (borderActiveAttr, mutedA)
+        , (selectedAttr, focusedStrong `V.withStyle` V.bold)
+        , (selectedMutedAttr, focusedMuted)
+        , (transcriptHoverAttr, focused)
+        , (transcriptHoverMutedAttr,
+            focusedMuted `V.withStyle` V.dim)
+        , (transcriptHoverMutedItalicAttr,
+            focusedMuted `V.withStyle` (V.dim .|. V.italic))
+        , (transcriptHoverMutedCancelledAttr,
+            focusedMuted `V.withStyle` (V.dim .|. V.strikethrough))
+        , (borderAttr, borderA `V.withStyle` V.dim)
+        , (borderActiveAttr, borderActiveA)
         , (headingAttr, accentA `V.withStyle` V.bold)
         , (codeAttr, linkA)
         -- Overlay dimming uses 'forceAttr', so it must preserve the page
         -- background instead of falling back to the terminal's colors.
         , (dimAttr, mutedA `V.withBackColor` background)
         , (emphasisAttr, base `V.withStyle` V.italic)
-        , (inlineCodeAttr, linkA `V.withStyle` V.reverseVideo)
+        , (inlineCodeAttr, raisedCyan)
         , (lambdaDimAttr, mutedA)
         , (lambdaTrailAttr, mutedA)
-        , (lambdaGlowAttr, base `V.withStyle` V.bold)
-        , (lambdaSparkAttr, base `V.withStyle` V.bold)
+        , (lambdaGlowAttr, strongA `V.withStyle` V.bold)
+        , (lambdaSparkAttr, strongA `V.withStyle` V.bold)
         , (linkAttr, linkA `V.withStyle` V.underline)
-        , (strongAttr, base `V.withStyle` V.bold)
+        , (strongAttr, strongA `V.withStyle` V.bold)
         , (controlLinkAttr, mutedA `V.withBackColor` background)
         , (controlLinkHoverAttr,
-            panel `V.withStyle` V.underline)
-        , (controlLinkActiveAttr, panel `V.withStyle` V.bold)
-        , (diffAddedAttr,
-            greenA `V.withBackColor` diffAddedBackground)
-        , (diffRemovedAttr,
-            redA `V.withBackColor` diffRemovedBackground)
+            raisedStrong `V.withStyle` V.underline)
+        , (controlLinkActiveAttr, focusedStrong `V.withStyle` V.bold)
         , (syntaxNormalAttr, base)
         , (syntaxKeywordAttr, accentA)
         , (syntaxTypeAttr, yellowA)
@@ -514,21 +616,64 @@ mkTheme background foreground muted accent link =
         , (syntaxErrorAttr, redA `V.withStyle` V.bold)
         ]
   where
+    background = palette.themePaletteBackground
+    raised = palette.themePaletteRaised
+    focusedBackground = palette.themePaletteFocused
+    foreground = palette.themePaletteForeground
+    strong = palette.themePaletteStrong
+    secondary = palette.themePaletteSecondary
+    muted = palette.themePaletteMuted
+    border = palette.themePaletteBorder
+    borderActive = palette.themePaletteBorderActive
+    accent = palette.themePaletteAccent
+    link = palette.themePaletteLink
+    success = palette.themePaletteSuccess
+    failure = palette.themePaletteError
+    warning = palette.themePaletteWarning
+    cyan = palette.themePaletteCyan
     base =
         V.defAttr
             `V.withForeColor` foreground
             `V.withBackColor` background
-    panel =
+    strongA =
         V.defAttr
-            `V.withForeColor` foreground
-            `V.withBackColor` lighten background
-    panelMuted =
+            `V.withForeColor` strong
+            `V.withBackColor` background
+    secondaryA =
         V.defAttr
-            `V.withForeColor` muted
-            `V.withBackColor` lighten background
+            `V.withForeColor` secondary
+            `V.withBackColor` background
     mutedA =
         V.defAttr
             `V.withForeColor` muted
+            `V.withBackColor` background
+    raisedStrong =
+        V.defAttr
+            `V.withForeColor` strong
+            `V.withBackColor` raised
+    raisedMuted =
+        V.defAttr
+            `V.withForeColor` secondary
+            `V.withBackColor` raised
+    focused =
+        V.defAttr
+            `V.withForeColor` foreground
+            `V.withBackColor` focusedBackground
+    focusedStrong =
+        V.defAttr
+            `V.withForeColor` strong
+            `V.withBackColor` focusedBackground
+    focusedMuted =
+        V.defAttr
+            `V.withForeColor` secondary
+            `V.withBackColor` focusedBackground
+    borderA =
+        V.defAttr
+            `V.withForeColor` border
+            `V.withBackColor` background
+    borderActiveA =
+        V.defAttr
+            `V.withForeColor` borderActive
             `V.withBackColor` background
     accentA =
         V.defAttr
@@ -540,38 +685,44 @@ mkTheme background foreground muted accent link =
             `V.withBackColor` background
     redA =
         V.defAttr
-            `V.withForeColor` (RGBColor 220 100 120)
+            `V.withForeColor` failure
             `V.withBackColor` background
     greenA =
         V.defAttr
-            `V.withForeColor` (RGBColor 100 210 150)
+            `V.withForeColor` success
             `V.withBackColor` background
     yellowA =
         V.defAttr
-            `V.withForeColor` (RGBColor 230 190 100)
+            `V.withForeColor` warning
             `V.withBackColor` background
     cyanA =
         V.defAttr
-            `V.withForeColor` (RGBColor 90 200 220)
+            `V.withForeColor` cyan
             `V.withBackColor` background
+    raisedCyan =
+        V.defAttr
+            `V.withForeColor` cyan
+            `V.withBackColor` raised
+    diffAddedA =
+        V.defAttr
+            `V.withForeColor` foreground
+            `V.withBackColor` diffAddedBackground
+    diffRemovedA =
+        V.defAttr
+            `V.withForeColor` foreground
+            `V.withBackColor` diffRemovedBackground
+    diffAddedGutterA =
+        V.defAttr
+            `V.withForeColor` success
+            `V.withBackColor` diffAddedBackground
+    diffRemovedGutterA =
+        V.defAttr
+            `V.withForeColor` failure
+            `V.withBackColor` diffRemovedBackground
     diffAddedBackground =
-        fromMaybe background $
-            blendRgb background (RGBColor 45 150 85) 0.22
+        fromMaybe raised (blendRgb background success 0.16)
     diffRemovedBackground =
-        fromMaybe background $
-            blendRgb background (RGBColor 180 55 75) 0.22
-
-    lighten (RGBColor r g b) =
-        RGBColor
-            (lightenChannel r)
-            (lightenChannel g)
-            (lightenChannel b)
-    lighten color = color
-
-    lightenChannel :: Word8 -> Word8
-    lightenChannel channel =
-        fromIntegral
-            (min (255 :: Int) (fromIntegral channel + 14))
+        fromMaybe raised (blendRgb background failure 0.16)
 
 palette :: V.Color -> V.Attr
 palette = V.withForeColor V.defAttr

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -259,6 +259,23 @@ spec = describe "fullscreen Markdown rendering" do
         Text.filter (/= ' ') (Text.concat rows)
             `shouldBe` Text.filter (/= ' ') code
 
+    it "fills a semantic code background across the available row" do
+        let width = 18
+            widget :: Widget ()
+            widget =
+                codeWidgetWithSyntaxHighlightingOn
+                    Nothing
+                    "haskell"
+                    Theme.diffAddedAttr
+                    "value = 1"
+            image =
+                V.picImage $
+                    renderWidget
+                        (Just (Theme.themeAttrMap Theme.Midnight))
+                        [widget]
+                        (width, 2)
+        V.imageWidth image `shouldBe` width
+
     it "preserves spaces inside wrapped code and string literals" do
         let code = "putStrLn \"alpha beta gamma delta epsilon\""
             widget :: Widget ()

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -1,7 +1,15 @@
 module Agent.TUI.MarkdownSpec (spec) where
 
 import Agent.TUI.Markdown
-import Agent.Syntax (loadSyntaxHighlighterFrom)
+import Agent.Syntax
+    ( SyntaxClass(SyntaxComment)
+    , SyntaxSpan(syntaxClass)
+    , loadSyntaxHighlighterFrom
+    )
+import Agent.TUI.Presentation
+    ( DiffDisplayLine(..)
+    , DiffLineKind(..)
+    )
 import Agent.TUI.TextWidth
     ( displayTerminalText
     , graphemeCellWidth
@@ -275,6 +283,41 @@ spec = describe "fullscreen Markdown rendering" do
                         [widget]
                         (width, 2)
         V.imageWidth image `shouldBe` width
+
+    it "preserves lexical state across old and new diff streams" do
+        syntaxDirectory <- sourceSyntaxDirectory
+        loadSyntaxHighlighterFrom syntaxDirectory >>= \case
+            Left message -> expectationFailure (Text.unpack message)
+            Right highlighter -> do
+                let line kind marker code =
+                        DiffDisplayLine
+                            { diffDisplayGutter = ""
+                            , diffDisplayMarker = marker
+                            , diffDisplayCode = code
+                            , diffDisplayKind = kind
+                            }
+                    diffLines =
+                        [ line DiffLineContext " " "{-"
+                        , line DiffLineRemoved "-" "-}"
+                        , line DiffLineAdded "+" "new inside comment"
+                        , line DiffLineContext " " "new context remains comment"
+                        , line DiffLineContext " " "-}"
+                        ]
+                case highlightDiffCodeRows highlighter "haskell" diffLines of
+                    Left message -> expectationFailure (Text.unpack message)
+                    Right [_, removedLine, addedLine, contextLine, _] -> do
+                        removedLine `shouldSatisfy` (not . null)
+                        addedLine `shouldSatisfy` (not . null)
+                        contextLine `shouldSatisfy` (not . null)
+                        map (.syntaxClass) removedLine
+                            `shouldSatisfy` all (== SyntaxComment)
+                        map (.syntaxClass) addedLine
+                            `shouldSatisfy` all (== SyntaxComment)
+                        map (.syntaxClass) contextLine
+                            `shouldSatisfy` all (== SyntaxComment)
+                    Right _ ->
+                        expectationFailure
+                            "expected one highlighted row per diff row"
 
     it "preserves spaces inside wrapped code and string literals" do
         let code = "putStrLn \"alpha beta gamma delta epsilon\""

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1377,7 +1377,7 @@ spec = describe "fullscreen UI reducer" do
         case Foldable.toList finished.uiBlocks of
             [block] -> do
                 block.blockBody
-                    `shouldBe` "  -old\n  +new"
+                    `shouldBe` "          │ -old\n          │ +new"
                 block.blockState `shouldBe` BlockComplete
             _ -> expectationFailure "expected one completed edit block"
 
@@ -1426,6 +1426,124 @@ spec = describe "fullscreen UI reducer" do
                 block.blockDetail `shouldBe` ""
             _ -> expectationFailure "expected one inspection block"
 
+    it "groups consecutive read, list, and search calls into one burst" do
+        let readA =
+                functionToolCall
+                    "read-a"
+                    "read_file"
+                    "{\"target_file\":\"src/A.hs\"}"
+            readB =
+                functionToolCall
+                    "read-b"
+                    "read_file"
+                    "{\"target_file\":\"src/B.hs\"}"
+            listSrc =
+                functionToolCall
+                    "list-src"
+                    "list_dir"
+                    "{\"target_directory\":\"src\"}"
+            finish callId output =
+                UiLoop
+                    (ToolFinished
+                        ToolCallResult
+                            { callId
+                            , output
+                            , callKind = FunctionCallKind
+                            })
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted readA)
+                    , finish "read-a" "module A where"
+                    , UiLoop (ToolStarted readB)
+                    , finish "read-b" "module B where"
+                    , UiLoop (ToolStarted listSrc)
+                    , finish "list-src" "A.hs\nB.hs"
+                    ]
+        case Foldable.toList state.uiBlocks of
+            [block] -> do
+                block.blockKind `shouldBe` BlockInspect
+                block.blockTitle `shouldBe` "Read 2 items, Listed 1 item"
+                block.blockBody `shouldSatisfy` Text.isInfixOf "Read src/A.hs"
+                block.blockBody `shouldSatisfy` Text.isInfixOf "module B where"
+                block.blockState `shouldBe` BlockComplete
+            _ -> expectationFailure "expected one grouped inspection block"
+
+    it "keeps a parallel inspection burst running and exposes failures" do
+        let readCall =
+                functionToolCall
+                    "read-a"
+                    "read_file"
+                    "{\"target_file\":\"src/A.hs\"}"
+            searchCall =
+                functionToolCall
+                    "search-a"
+                    "grep"
+                    "{\"pattern\":\"needle\",\"path\":\"src\"}"
+            started =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted readCall)
+                    , UiLoop (ToolStarted searchCall)
+                    ]
+            firstFinished =
+                reduceUi
+                    (UiLoop
+                        (ToolFinished
+                            (ToolCallResult
+                                "read-a"
+                                "module A where"
+                                FunctionCallKind)))
+                    started
+            failed =
+                reduceUi
+                    (UiLoop
+                        (ToolFinished
+                            (ToolCallResult
+                                "search-a"
+                                "Error: search failed"
+                                FunctionCallKind)))
+                    firstFinished
+        map (.blockState) (Foldable.toList firstFinished.uiBlocks)
+            `shouldBe` [BlockRunning]
+        case Foldable.toList failed.uiBlocks of
+            [block] -> do
+                block.blockState `shouldBe` BlockFailed
+                block.blockTitle `shouldSatisfy`
+                    Text.isSuffixOf "· 1 failed"
+                block.blockBody `shouldSatisfy`
+                    Text.isInfixOf "✗ Searched needle"
+                block.blockBody `shouldSatisfy`
+                    Text.isInfixOf "Error: search failed"
+            _ -> expectationFailure "expected one failed inspection burst"
+
+    it "does not group inspections across an intervening visible event" do
+        let first =
+                functionToolCall
+                    "read-a"
+                    "read_file"
+                    "{\"target_file\":\"src/A.hs\"}"
+            second =
+                functionToolCall
+                    "read-b"
+                    "read_file"
+                    "{\"target_file\":\"src/B.hs\"}"
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted first)
+                    , UiLoop
+                        (ToolFinished
+                            (ToolCallResult
+                                "read-a"
+                                "module A where"
+                                FunctionCallKind))
+                    , UiSystemMessage "Checking another source"
+                    , UiLoop (ToolStarted second)
+                    ]
+        map (.blockKind) (Foldable.toList state.uiBlocks)
+            `shouldBe` [BlockInspect, BlockSystem, BlockInspect]
+
     it "shows an apply_patch diff while running and after completion" do
         let call =
                 customToolCall
@@ -1460,7 +1578,8 @@ spec = describe "fullscreen UI reducer" do
             _ -> expectationFailure "expected one running edit block"
         case Foldable.toList finished.uiBlocks of
             [block] -> do
-                block.blockBody `shouldBe` "  -old\n  +new"
+                block.blockBody
+                    `shouldBe` "          │ -old\n          │ +new"
                 block.blockState `shouldBe` BlockComplete
             _ -> expectationFailure "expected one completed edit block"
 

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1468,6 +1468,7 @@ spec = describe "fullscreen UI reducer" do
                 block.blockBody `shouldSatisfy` Text.isInfixOf "Read src/A.hs"
                 block.blockBody `shouldSatisfy` Text.isInfixOf "module B where"
                 block.blockState `shouldBe` BlockComplete
+                block.blockInspectionGroupable `shouldBe` False
             _ -> expectationFailure "expected one grouped inspection block"
 
     it "retracts completed inspection-group calls independently" do

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1405,6 +1405,7 @@ spec = describe "fullscreen UI reducer" do
                 block.blockState `shouldBe` BlockComplete
                 block.blockTitle `shouldBe` "Read"
                 block.blockDetail `shouldBe` "src/Main.hs"
+                block.blockInspectionGroupable `shouldBe` True
             _ -> expectationFailure "expected one completed inspection block"
 
     it "keeps non-filesystem inspection labels intact" do
@@ -1543,6 +1544,38 @@ spec = describe "fullscreen UI reducer" do
                     ]
         map (.blockKind) (Foldable.toList state.uiBlocks)
             `shouldBe` [BlockInspect, BlockSystem, BlockInspect]
+
+    it "keeps lifecycle-sensitive inspections outside compact bursts" do
+        let taskOutput =
+                functionToolCall
+                    "task-output"
+                    "get_task_output"
+                    "{\"task_id\":\"task-1\"}"
+            session =
+                functionToolCall
+                    "session-read"
+                    "read_agent_session"
+                    "{\"session_id\":\"session-1\"}"
+            finish callId =
+                UiLoop
+                    (ToolFinished
+                        (ToolCallResult
+                            callId
+                            "done"
+                            FunctionCallKind))
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted taskOutput)
+                    , finish "task-output"
+                    , UiLoop (ToolStarted session)
+                    , finish "session-read"
+                    ]
+            blocks = Foldable.toList state.uiBlocks
+        map (.blockKind) blocks
+            `shouldBe` [BlockInspect, BlockInspect]
+        map (.blockInspectionGroupable) blocks
+            `shouldBe` [False, False]
 
     it "shows an apply_patch diff while running and after completion" do
         let call =

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1470,6 +1470,52 @@ spec = describe "fullscreen UI reducer" do
                 block.blockState `shouldBe` BlockComplete
             _ -> expectationFailure "expected one grouped inspection block"
 
+    it "retracts completed inspection-group calls independently" do
+        let readA =
+                functionToolCall
+                    "read-a"
+                    "read_file"
+                    "{\"target_file\":\"src/A.hs\"}"
+            readB =
+                functionToolCall
+                    "read-b"
+                    "read_file"
+                    "{\"target_file\":\"src/B.hs\"}"
+            finish callId output =
+                UiLoop
+                    (ToolFinished
+                        ToolCallResult
+                            { callId
+                            , output
+                            , callKind = FunctionCallKind
+                            })
+            completed =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted readA)
+                    , finish "read-a" "module A where"
+                    , UiLoop (ToolStarted readB)
+                    , finish "read-b" "module B where"
+                    , UiSystemMessage "Checking the result"
+                    ]
+            withoutB =
+                reduceUi (UiLoop (ToolRetracted "read-b")) completed
+            withoutEither =
+                reduceUi (UiLoop (ToolRetracted "read-a")) withoutB
+        completed.uiToolCalls `shouldBe` Map.empty
+        case Foldable.toList withoutB.uiBlocks of
+            [inspection, systemMessage] -> do
+                inspection.blockBody `shouldSatisfy`
+                    Text.isInfixOf "module A where"
+                inspection.blockBody `shouldNotSatisfy`
+                    Text.isInfixOf "module B where"
+                inspection.blockCallId `shouldBe` Just "read-a"
+                systemMessage.blockBody `shouldBe` "Checking the result"
+            _ -> expectationFailure "expected inspection and system blocks"
+        map (.blockBody) (Foldable.toList withoutEither.uiBlocks)
+            `shouldBe` ["Checking the result"]
+        withoutEither.uiInspectionGroups `shouldBe` Map.empty
+
     it "keeps a parallel inspection burst running and exposes failures" do
         let readCall =
                 functionToolCall

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1518,6 +1518,44 @@ spec = describe "fullscreen UI reducer" do
                     Text.isInfixOf "Error: search failed"
             _ -> expectationFailure "expected one failed inspection burst"
 
+    it "preserves denied inspection state separately from failures" do
+        let readA =
+                functionToolCall
+                    "read-a"
+                    "read_file"
+                    "{\"target_file\":\"src/A.hs\"}"
+            readB =
+                functionToolCall
+                    "read-b"
+                    "read_file"
+                    "{\"target_file\":\"src/B.hs\"}"
+            state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (ToolStarted readA)
+                    , UiLoop
+                        (ToolFinished
+                            (ToolCallResult
+                                "read-a"
+                                "module A where"
+                                FunctionCallKind))
+                    , UiLoop (ToolStarted readB)
+                    , UiLoop
+                        (ToolFinished
+                            (ToolCallResult
+                                "read-b"
+                                "Tool call rejected by user"
+                                FunctionCallKind))
+                    ]
+        case Foldable.toList state.uiBlocks of
+            [block] -> do
+                block.blockState `shouldBe` BlockDenied
+                block.blockTitle `shouldSatisfy`
+                    Text.isSuffixOf "· 1 denied"
+                block.blockTitle `shouldNotSatisfy`
+                    Text.isInfixOf "failed"
+            _ -> expectationFailure "expected one denied inspection burst"
+
     it "does not group inspections across an intervening visible event" do
         let first =
                 functionToolCall

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -166,7 +166,7 @@ spec = describe "tool presentation" do
         formatToolDiffRelative ""
             (functionToolCall "w" "Write"
                 "{\"file_path\":\"src/New.hs\",\"content\":\"main = pure ()\\n\"}")
-            `shouldBe` "  write src/New.hs\n  1 +main = pure ()"
+            `shouldBe` "  write src/New.hs\n        1 │ +main = pure ()"
         todoListFromToolArguments
             "{\"todos\":[{\"content\":\"Find repos\",\"status\":\"in_progress\",\
             \\"activeForm\":\"Finding repos\"},{\"content\":\"Fix\",\"status\":\"pending\"}]}"
@@ -380,11 +380,11 @@ spec = describe "tool presentation" do
                 \Changed lines start at 95."
         formatToolDiffRelativeWithOutput "/workspace" call output
             `shouldBe`
-                "  95 -old one\n\
-                \  96 -old two\n\
-                \  95 +new one\n\
-                \  96 +new two\n\
-                \  97 +new three"
+                "   95     │ -old one\n\
+                \   96     │ -old two\n\
+                \       95 │ +new one\n\
+                \       96 │ +new two\n\
+                \       97 │ +new three"
 
     it "formats compact multi-file apply_patch diffs" do
         let workspace = "/workspace"
@@ -417,14 +417,44 @@ spec = describe "tool presentation" do
                 ]
         formatToolDiffRelative workspace call
             `shouldBe`
-                "  -old\n\
-                \  +new\n\
+                "          │  *** Add File: this-is-context\n\
+                \          │ -old\n\
+                \          │ +new\n\
                 \  create src/B.hs\n\
-                \  1 +one\n\
+                \        1 │ +one\n\
                 \  move src/Old.hs → src/New.hs\n\
-                \  -before\n\
-                \  +after\n\
+                \          │ -before\n\
+                \          │ +after\n\
                 \  delete src/C.hs"
+
+    it "decodes semantic diff headers and numbered rows for rich rendering" do
+        diffHeaderParts "  update src/Main.hs"
+            `shouldBe` Just ("update", "src/Main.hs")
+        diffHeaderParts "    1     │ -old" `shouldBe` Nothing
+        parseDiffDisplayLine "    3     │ -old"
+            `shouldBe`
+                Just
+                    (DiffDisplayLine
+                        "    3    "
+                        "-"
+                        "old"
+                        DiffLineRemoved)
+        parseDiffDisplayLine "        4 │ +new"
+            `shouldBe`
+                Just
+                    (DiffDisplayLine
+                        "        4"
+                        "+"
+                        "new"
+                        DiffLineAdded)
+        parseDiffDisplayLine "    5   5 │  context"
+            `shouldBe`
+                Just
+                    (DiffDisplayLine
+                        "    5   5"
+                        " "
+                        "context"
+                        DiffLineContext)
 
     it "formats structured collaboration output" do
         let call = functionToolCall

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -427,6 +427,32 @@ spec = describe "tool presentation" do
                 \          │ +after\n\
                 \  delete src/C.hs"
 
+    it "keeps changed rows inside capped apply_patch previews" do
+        let contexts =
+                [ " context-" <> Text.pack (show number)
+                | number <- [1 :: Int .. 25]
+                ]
+            patch =
+                Text.unlines $
+                    [ "*** Begin Patch"
+                    , "*** Update File: src/Main.hs"
+                    , "@@"
+                    ]
+                        <> contexts
+                        <> [ "-old"
+                           , "+new"
+                           , "*** End Patch"
+                           ]
+        case parseApplyPatchDiffs patch of
+            [parsed] -> do
+                length parsed.diffLines `shouldBe` 20
+                parsed.diffHiddenLines `shouldBe` 7
+                parsed.diffLines `shouldSatisfy`
+                    elem (SearchReplaceRemoved "old")
+                parsed.diffLines `shouldSatisfy`
+                    elem (SearchReplaceAdded "new")
+            _ -> expectationFailure "expected one parsed patch"
+
     it "decodes semantic diff headers and numbered rows for rich rendering" do
         diffHeaderParts "  update src/Main.hs"
             `shouldBe` Just ("update", "src/Main.hs")

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -445,12 +445,56 @@ spec = describe "tool presentation" do
                            ]
         case parseApplyPatchDiffs patch of
             [parsed] -> do
-                length parsed.diffLines `shouldBe` 20
+                length
+                    (filter
+                        (\case
+                            SearchReplaceOmitted{} -> False
+                            _ -> True)
+                        parsed.diffLines)
+                    `shouldBe` 20
                 parsed.diffHiddenLines `shouldBe` 7
+                parsed.diffLines `shouldSatisfy`
+                    elem (SearchReplaceOmitted 7 7 7)
                 parsed.diffLines `shouldSatisfy`
                     elem (SearchReplaceRemoved "old")
                 parsed.diffLines `shouldSatisfy`
                     elem (SearchReplaceAdded "new")
+            _ -> expectationFailure "expected one parsed patch"
+
+    it "marks every omitted region inside capped patch previews" do
+        let contexts =
+                [ " context-" <> Text.pack (show number)
+                | number <- [1 :: Int .. 30]
+                ]
+            patch =
+                Text.unlines $
+                    [ "*** Begin Patch"
+                    , "*** Update File: src/Main.hs"
+                    , "@@"
+                    , "-first-old"
+                    , "+first-new"
+                    ]
+                        <> contexts
+                        <> [ "-last-old"
+                           , "+last-new"
+                           , "*** End Patch"
+                           ]
+        case parseApplyPatchDiffs patch of
+            [parsed] -> do
+                parsed.diffHiddenLines `shouldBe` 14
+                case break
+                    (== SearchReplaceOmitted 14 14 14)
+                    parsed.diffLines of
+                    (before, _ : after) -> do
+                        before `shouldSatisfy`
+                            elem (SearchReplaceAdded "first-new")
+                        after `shouldSatisfy`
+                            elem (SearchReplaceRemoved "last-old")
+                    _ ->
+                        expectationFailure
+                            "expected an internal omission marker"
+                formatToolDiffRelative "" (customToolCall "patch" "apply_patch" patch)
+                    `shouldSatisfy` Text.isInfixOf "  … 14 omitted"
             _ -> expectationFailure "expected one parsed patch"
 
     it "decodes semantic diff headers and numbered rows for rich rendering" do

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -45,6 +45,39 @@ spec = do
                     ]
 
     describe "syntax theme attributes" do
+        it "uses quiet semantic depth in the default Midnight theme" do
+            let theme = Theme.themeAttrMap Theme.Midnight
+                base = attrMapLookup Theme.baseAttr theme
+                user = attrMapLookup Theme.userAttr theme
+                selected = attrMapLookup Theme.selectedAttr theme
+                assistant = attrMapLookup Theme.assistantAttr theme
+                header = attrMapLookup Theme.headerAttr theme
+                muted = attrMapLookup Theme.mutedAttr theme
+                border = attrMapLookup Theme.borderAttr theme
+                activeBorder = attrMapLookup Theme.borderActiveAttr theme
+            V.attrBackColor base `shouldBe` V.SetTo (RGBColor 20 20 20)
+            V.attrBackColor user `shouldBe` V.SetTo (RGBColor 36 36 36)
+            V.attrBackColor selected `shouldBe` V.SetTo (RGBColor 44 44 44)
+            V.attrForeColor assistant
+                `shouldBe` V.SetTo (RGBColor 200 200 200)
+            V.attrForeColor header
+                `shouldBe` V.SetTo (RGBColor 225 225 225)
+            V.attrForeColor muted
+                `shouldBe` V.SetTo (RGBColor 108 108 108)
+            V.attrForeColor border
+                `shouldBe` V.SetTo (RGBColor 50 50 55)
+            V.attrForeColor activeBorder
+                `shouldBe` V.SetTo (RGBColor 60 60 65)
+
+        it "gives fixed-theme hover attributes explicit surfaces" do
+            let theme = Theme.themeAttrMap Theme.Midnight
+                hover = attrMapLookup Theme.transcriptHoverAttr theme
+                hoverMuted =
+                    attrMapLookup Theme.transcriptHoverMutedAttr theme
+            V.attrBackColor hover `shouldBe` V.SetTo (RGBColor 44 44 44)
+            V.attrBackColor hoverMuted
+                `shouldBe` V.SetTo (RGBColor 44 44 44)
+
         it "keeps the daylight page background while dimming overlays" do
             V.attrBackColor
                 (attrMapLookup Theme.dimAttr (Theme.themeAttrMap Theme.Daylight))
@@ -84,6 +117,34 @@ spec = do
             V.attrBackColor midnight
                 `shouldBe` V.SetTo (RGBColor 26 27 38)
             V.attrStyle noColor `shouldBe` V.SetTo V.bold
+
+        it "sets backgrounds on force-painted attributes in every fixed theme" do
+            mapM_
+                ( \kind ->
+                    map
+                        ( \name ->
+                            V.attrBackColor
+                                (attrMapLookup
+                                    name
+                                    (Theme.themeAttrMap kind))
+                        )
+                        forcePaintedAttributes
+                        `shouldSatisfy` all (/= V.Default)
+                )
+                [ Theme.Midnight
+                , Theme.Daylight
+                , Theme.TokyoNight
+                , Theme.RosePineMoon
+                , Theme.OscuraMidnight
+                ]
+
+        it "uses distinct semantic surfaces for fixed-theme diff rows" do
+            let theme = Theme.themeAttrMap Theme.Daylight
+                added = attrMapLookup Theme.diffAddedAttr theme
+                removed = attrMapLookup Theme.diffRemovedAttr theme
+            V.attrBackColor added `shouldNotBe` V.Default
+            V.attrBackColor removed `shouldNotBe` V.Default
+            V.attrBackColor added `shouldNotBe` V.attrBackColor removed
 
         it "sets a daylight background on semantic text attributes" do
             map
@@ -353,3 +414,17 @@ isRgbForeground = \case
 
 allSyntaxClasses :: [SyntaxClass]
 allSyntaxClasses = [minBound .. maxBound]
+
+forcePaintedAttributes :: [AttrName]
+forcePaintedAttributes =
+    [ Theme.dimAttr
+    , Theme.mutedAttr
+    , Theme.selectedAttr
+    , Theme.transcriptHoverAttr
+    , Theme.transcriptHoverMutedAttr
+    , Theme.transcriptHoverMutedItalicAttr
+    , Theme.transcriptHoverMutedCancelledAttr
+    , Theme.controlLinkAttr
+    , Theme.controlLinkHoverAttr
+    , Theme.controlLinkActiveAttr
+    ]

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -115,7 +115,11 @@ spec = do
             V.attrForeColor midnight
                 `shouldBe` V.SetTo (RGBColor 122 162 247)
             V.attrBackColor midnight
-                `shouldBe` V.SetTo (RGBColor 26 27 38)
+                `shouldBe`
+                    V.attrBackColor
+                        (attrMapLookup
+                            Theme.baseAttr
+                            (Theme.themeAttrMap Theme.Midnight))
             V.attrStyle noColor `shouldBe` V.SetTo V.bold
 
         it "sets backgrounds on force-painted attributes in every fixed theme" do


### PR DESCRIPTION
## Summary

- group consecutive read, list, and search activity into compact lifecycle-aware transcript bursts
- add deeper semantic theme surfaces and syntax-aware diff rows with accurate two-sided gutters
- add a searchable Ctrl-P command palette and cache-safe live theme previews

## Validation

- agent-tui GHCi suite: 229 examples, 0 failures
- focused fullscreen app GHCi suite: 114 examples, 0 failures
- focused transcript-cache GHCi suite: 9 examples, 0 failures
- live tmux smoke test covering command search, theme preview and cancel, retained inspection groups, and semantic diff rendering