### PR TITLE
Keep long TUI inputs visible

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -166,7 +166,7 @@ import qualified Brick.Widgets.Border as Border
     ( borderAttr, hBorder )
 import qualified Agent.CLI.TUI.Bridge as Bridge ()
 import qualified Agent.CLI.TUI.Composer as Composer
-    ( wrapDraftWindow, draftCursorLocation, controlInteractionAttr )
+    ( wrapDraftWindow, controlInteractionAttr )
 import qualified Data.Map.Strict as Map ()
 import qualified Agent.CLI.TUI.Scroll as Scroll ()
 import qualified Data.Sequence as Seq ()
@@ -891,10 +891,7 @@ drawTextPrompt state prompt =
                                         withBorderStyle unicodeRounded $
                                             borderWithLabel (txt " Answer ") $
                                                 padLeftRight 1 $
-                                                    hBox
-                                                        [ renderTextDraft prompt
-                                                        , vLimit 1 (fill ' ')
-                                                        ]
+                                                    renderTextDraft prompt
                                     ]
 
 drawMetaConsole :: AppState -> MetaConsoleOverlay -> Widget Name
@@ -955,14 +952,34 @@ renderMetaConsoleDraft overlay =
 
 renderTextDraft :: TextOverlay -> Widget Name
 renderTextDraft prompt =
-    let displayDraft = textOverlayDisplayText prompt
-        content =
-            if Text.null displayDraft
-                then withAttr Theme.mutedAttr (txt " ")
-                else terminalTxt displayDraft
-        (row, column) =
-            Composer.draftCursorLocation displayDraft prompt.textCursor
-    in showCursor OverlayCursor (Location (column, row)) content
+    Widget Greedy Fixed do
+        context <- getContext
+        let maxRows = 8
+            rowLimit = max 1 (min maxRows context.availHeight)
+            width = max 1 context.availWidth
+            displayDraft = textOverlayDisplayText prompt
+            (rows, (cursorRow, cursorColumn)) =
+                Composer.wrapDraftWindow
+                    rowLimit
+                    width
+                    displayDraft
+                    prompt.textCursor
+            height = min rowLimit (length rows)
+            firstVisibleRow = max 0 (cursorRow - height + 1)
+            visibleRows = take height (drop firstVisibleRow rows)
+            visibleCursorRow = cursorRow - firstVisibleRow
+            renderRow row
+                | Text.null row = txt " "
+                | otherwise = terminalTxt row
+            content = vBox (map renderRow visibleRows)
+        render $
+            hBox
+                [ showCursor
+                    OverlayCursor
+                    (Location (cursorColumn, visibleCursorRow))
+                    content
+                , vLimit height (fill ' ')
+                ]
 
 -- | Replace every code point with one fixed-width masking glyph.
 maskedSecretText :: Text -> Text

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -24,7 +24,11 @@ import Agent.CLI.Clipboard ()
 import Agent.CLI.Command ()
 import Agent.CLI.Dictation ()
 import Agent.CLI.ImagePreview ()
-import Agent.CLI.Input ( terminalTextWidth, truncateDisplayText )
+import Agent.CLI.Input
+    ( terminalTextWidth
+    , truncateDisplayText
+    , visibleEditorText
+    )
 import Agent.CLI.Interrupt ()
 import Agent.CLI.Permission ()
 import Agent.CLI.Recap ()
@@ -348,8 +352,7 @@ drawResume state overlay =
 resumeHeader :: ResumeBrowser -> Widget Name
 resumeHeader browser =
     hBox
-        [ search
-        , vLimit 1 (fill ' ')
+        [ padRight Max search
         , withAttr Theme.mutedAttr $
             terminalTxt
                 (resumeSourceLabel browser.resumeBrowserSource <> "  f")
@@ -361,18 +364,17 @@ resumeHeader browser =
         | otherwise = "search: "
     search
         | browser.resumeBrowserSearching =
-            showCursor
+            singleLineOverlayInput
                 ResumeSearchCursor
-                (Location
-                    (resumeSearchCursorColumn
-                        prefix
-                        browser.resumeBrowserQuery, 0))
-                (terminalTxt
-                    (prefix <> browser.resumeBrowserQuery <> " "))
+                prefix
+                browser.resumeBrowserQuery
+                " "
         | Text.null browser.resumeBrowserQuery =
             withAttr Theme.mutedAttr (terminalTxt prefix)
         | otherwise =
-            terminalTxt (prefix <> browser.resumeBrowserQuery)
+            singleLineOverlayText
+                prefix
+                browser.resumeBrowserQuery
 
 resumeSearchCursorColumn :: Text -> Text -> Int
 resumeSearchCursorColumn prefix query =
@@ -578,22 +580,85 @@ filterChoiceQuery :: ChoiceOverlay -> Widget Name
 filterChoiceQuery choice =
     let adjustable = isJust choice.choiceAdjustments
         prefix = if adjustable then "/ " else "search: "
-        query = if Text.null choice.choiceQuery
-            then withAttr Theme.mutedAttr $
-                txt
-                    (if adjustable
-                        then "Type to search"
-                        else "(type to filter)")
-            else terminalTxt choice.choiceQuery
-        content = hBox
-            [ terminalTxt prefix
-            , query
-            , terminalTxt " "
-            ]
-        cursorColumn =
-            terminalTextWidth prefix
-                + terminalTextWidth choice.choiceQuery
-    in showCursor OverlayCursor (Location (cursorColumn, 0)) content
+        emptyHint =
+            if adjustable
+                then "Type to search"
+                else "(type to filter)"
+    in singleLineOverlayInput
+        OverlayCursor
+        prefix
+        choice.choiceQuery
+        emptyHint
+
+-- | Render an append-only single-line input inside its available width.
+-- Keep the fixed prompt visible when possible and horizontally window the
+-- editable value around its cursor. One trailing cell is reserved so Vty can
+-- always paint the insertion cursor.
+singleLineOverlayInput
+    :: Name
+    -> Text
+    -> Text
+    -> Text
+    -> Widget Name
+singleLineOverlayInput cursorName prefix value emptyHint =
+    singleLineOverlayField
+        (Just cursorName)
+        prefix
+        value
+        emptyHint
+
+singleLineOverlayText :: Text -> Text -> Widget Name
+singleLineOverlayText prefix value =
+    singleLineOverlayField Nothing prefix value " "
+
+singleLineOverlayField
+    :: Maybe Name
+    -> Text
+    -> Text
+    -> Text
+    -> Widget Name
+singleLineOverlayField cursorName prefix value emptyHint =
+    Widget Greedy Fixed do
+        context <- getContext
+        let width = max 1 context.availWidth
+            availableTextWidth = max 0 (width - 1)
+            prefixWidth = terminalTextWidth prefix
+            (shown, cursorColumn)
+                | prefixWidth < availableTextWidth =
+                    let (shownValue, valueCursorColumn) =
+                            visibleEditorText
+                                (availableTextWidth - prefixWidth)
+                                value
+                                (Text.length value)
+                    in
+                        ( prefix <> shownValue
+                        , prefixWidth + valueCursorColumn
+                        )
+                | otherwise =
+                    visibleEditorText
+                        availableTextWidth
+                        (prefix <> value)
+                        (Text.length prefix + Text.length value)
+            suffix
+                | Text.null value = emptyHint
+                | otherwise = " "
+            shownSuffix =
+                truncateDisplayText
+                    (max 1 (width - terminalTextWidth shown))
+                    suffix
+            content =
+                hBox
+                    [ terminalTxt shown
+                    , withAttr Theme.mutedAttr (terminalTxt shownSuffix)
+                    ]
+            renderedContent = case cursorName of
+                Nothing -> content
+                Just name ->
+                    showCursor
+                        name
+                        (Location (cursorColumn, 0))
+                        content
+        render renderedContent
 
 filterChoiceRows :: Int -> AppState -> ChoiceOverlay -> Widget Name
 filterChoiceRows rowLimit appState choice =

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -302,6 +302,43 @@ spec = do
             normalizeTextOverlayInsertion TextInputSecret value
                 `shouldBe` "first"
 
+        it "wraps long plain answers so the draft tail stays visible" do
+            runtime <- newScriptRuntime initialUiState
+            let marker = "TAILVISIBLE"
+                draft = Text.replicate 1000 "a" <> marker
+                size = (80, 24)
+                state =
+                    (initialFullscreenAppState
+                        runtime
+                        []
+                        AgentRoot
+                        []
+                        0)
+                        { appTextPrompt =
+                            Just
+                                (textOverlay draft (Text.length draft))
+                                    { textTitle = "Request changes"
+                                    , textBody =
+                                        "What should be changed in the plan?"
+                                    }
+                        }
+                rendered =
+                    Text.unlines $
+                        map
+                            (Text.concat . map spanText . toList)
+                            (toList
+                                (displayOpsForPic
+                                    (renderWidget
+                                        Nothing
+                                        (drawApp state)
+                                        size)
+                                    size))
+                spanText = \case
+                    TextSpan _ _ _ text -> LazyText.toStrict text
+                    Skip width -> Text.replicate width " "
+                    RowEnd width -> Text.replicate width " "
+            rendered `shouldSatisfy` Text.isInfixOf marker
+
     describe "text overlay grapheme editing" do
         it "moves across a ZWJ emoji as one visible glyph" do
             let emoji = Text.pack ['\x1f469', '\x200d', '\x1f4bb']

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -12,6 +12,10 @@ import Agent.CLI.Command
     ( SlashCatalog(slashCatalogToolNames)
     , defaultSlashCatalog
     )
+import Agent.CLI.Resume
+    ( ResumeBrowser(..)
+    , initialResumeBrowser
+    )
 import Agent.CLI.TUI.App
     ( applyStoredFullscreenWindowTitle
     , applyMetaConsoleEdit
@@ -85,6 +89,7 @@ import Agent.CLI.TUI.Types
     , HistoryCommit(..)
     , MetaConsoleOverlay(..)
     , Name(..)
+    , ResumeOverlay(..)
     , TerminalFocus(..)
     , TextInputMode(..)
     , TextOverlay(..)
@@ -156,6 +161,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.Lazy as LazyText
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import qualified Graphics.Vty as V
 import qualified Graphics.Vty.Output.Mock as VMock
 import Graphics.Vty.PictureToSpans (displayOpsForPic)
@@ -338,6 +344,66 @@ spec = do
                     Skip width -> Text.replicate width " "
                     RowEnd width -> Text.replicate width " "
             rendered `shouldSatisfy` Text.isInfixOf marker
+
+    describe "search overlay input viewport" do
+        it "keeps the tail of a long searchable choice query visible" do
+            runtime <- newScriptRuntime initialUiState
+            let marker = "CHOICETAIL"
+                query = Text.replicate 1000 "a" <> marker
+                state =
+                    (initialFullscreenAppState
+                        runtime
+                        []
+                        AgentRoot
+                        []
+                        0)
+                        { appChoice =
+                            Just
+                                (choiceOverlay False)
+                                    { choiceSearch = True
+                                    , choiceQuery = query
+                                    }
+                        }
+            renderedAppText (80, 24) state
+                `shouldSatisfy` Text.isInfixOf marker
+
+        it "keeps a long resume query visible while editing and afterward" do
+            runtime <- newScriptRuntime initialUiState
+            let marker = "RESUMETAIL"
+                query = Text.replicate 1000 "a" <> marker
+                browser =
+                    (initialResumeBrowser
+                        (posixSecondsToUTCTime 0)
+                        [])
+                        { resumeBrowserQuery = query
+                        , resumeBrowserSearching = True
+                        }
+                state =
+                    (initialFullscreenAppState
+                        runtime
+                        []
+                        AgentRoot
+                        []
+                        0)
+                        { appResume =
+                            Just ResumeOverlay
+                                { resumeOverlayBrowser = browser
+                                }
+                        }
+                inactiveState =
+                    state
+                        { appResume =
+                            Just ResumeOverlay
+                                { resumeOverlayBrowser =
+                                    browser
+                                        { resumeBrowserSearching = False
+                                        }
+                                }
+                        }
+            renderedAppText (80, 24) state
+                `shouldSatisfy` Text.isInfixOf marker
+            renderedAppText (80, 24) inactiveState
+                `shouldSatisfy` Text.isInfixOf marker
 
     describe "text overlay grapheme editing" do
         it "moves across a ZWJ emoji as one visible glyph" do
@@ -2446,6 +2512,21 @@ markerBlock blockId body = UiBlock
     , blockExpanded = False
     , blockCallId = Nothing
     }
+
+renderedAppText :: (Int, Int) -> AppState -> Text
+renderedAppText size state =
+    Text.unlines $
+        map
+            (Text.concat . map spanText . toList)
+            (toList
+                (displayOpsForPic
+                    (renderWidget Nothing (drawApp state) size)
+                    size))
+  where
+    spanText = \case
+        TextSpan _ _ _ text -> LazyText.toStrict text
+        Skip width -> Text.replicate width " "
+        RowEnd width -> Text.replicate width " "
 
 encoded :: Text -> ByteString.ByteString
 encoded = TextEncoding.encodeUtf8


### PR DESCRIPTION
## Summary
- soft-wrap long fullscreen text-prompt responses and keep the cursor/tail visible
- horizontally window long searchable-choice and resume-search queries using terminal-cell widths
- keep a retained resume query bounded so it cannot crowd the source label
- add full-render regression coverage for plan feedback and both search overlays

## Testing
- `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code` (110 examples, 0 failures)
- live tmux smoke test at 100×30:
  - 1,000+ character plan feedback wrapped and kept `TAILVISIBLE` visible
  - 600+ character model-picker and resume-search queries kept `FINALCHOICE` / `FINALRESUME` visible
  - leaving resume search mode kept the retained query bounded beside the source label
