### PR TITLE
Highlight recognized slash commands while typing

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -34,6 +34,7 @@ module Agent.CLI.Command
     , slashCompletionCandidatesWithModels
     , slashCompletionCandidatesWithSkills
     , slashCompletionCandidatesWithSkillsAndModels
+    , slashCommandHighlightToken
     , slashMenuFor
     , slashMenuForCatalog
     , slashMenuForWithModels
@@ -162,6 +163,24 @@ lookupSlashCommand =
 lookupSlashCommandIn :: SlashCatalog -> Text -> Maybe SlashCommand
 lookupSlashCommandIn catalog raw =
     Map.lookup (normalizeSlashName raw) catalog.slashCatalogCommandByName
+
+-- | The leading command token when it is a prefix of an available slash
+-- command, alias, or runtime skill. This stays independent of the completion
+-- menu because a completed no-argument command may close that menu while its
+-- token should remain highlighted.
+slashCommandHighlightToken :: SlashCatalog -> Text -> Maybe Text
+slashCommandHighlightToken catalog text =
+    case Text.uncons text of
+        Just ('/', _) ->
+            let token = Text.takeWhile (not . isSpace) text
+                query = Text.toLower (Text.drop 1 token)
+                names =
+                    Map.keys catalog.slashCatalogCommandByName
+                        <> Map.keys catalog.slashCatalogSkillByName
+            in if any (query `Text.isPrefixOf`) names
+                then Just token
+                else Nothing
+        _ -> Nothing
 
 lookupSlashCommandFrom :: [SlashCommand] -> Text -> Maybe SlashCommand
 lookupSlashCommandFrom commands raw =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -15,6 +15,7 @@ module Agent.CLI.TUI.Composer
     , dictationKeyAction
     , dictationProgressNotice
     , draftCursorLocation
+    , draftWindowStart
     , drawComposer
     , drawQueuedInputs
     , drawSlashMenu

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Edit.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Edit.hs
@@ -1,6 +1,7 @@
 -- | Pure text decoding and visual layout for the fullscreen composer.
 module Agent.CLI.TUI.Composer.Edit
     ( decodePaste
+    , draftWindowStart
     , draftCursorLocation
     , verticalCursorMove
     , wrapDraft
@@ -140,12 +141,18 @@ wrapDraftWindow :: Int -> Int -> Text -> Int -> ([Text], (Int, Int))
 wrapDraftWindow requestedRows requestedWidth text requestedCursor =
     let rows = max 1 requestedRows
         cursor = max 0 (min (Text.length text) requestedCursor)
-        before = Text.take cursor text
-        start = precedingLineStart rows before
+        start = draftWindowStart rows text cursor
         after = Text.drop cursor text
         end = cursor + followingLinesLength rows after
         window = Text.take (end - start) (Text.drop start text)
     in wrapDraft requestedWidth window (cursor - start)
+
+-- | Source offset at which 'wrapDraftWindow' starts its bounded layout.
+draftWindowStart :: Int -> Text -> Int -> Int
+draftWindowStart requestedRows text requestedCursor =
+    let rows = max 1 requestedRows
+        cursor = max 0 (min (Text.length text) requestedCursor)
+    in precedingLineStart rows (Text.take cursor text)
 
 precedingLineStart :: Int -> Text -> Int
 precedingLineStart lineCount text =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Render.hs
@@ -12,9 +12,10 @@ module Agent.CLI.TUI.Composer.Render
 import Agent.CLI.Command
     ( SlashMenu(..)
     , SlashSuggestion(..)
+    , slashCommandHighlightToken
     )
 import Agent.CLI.Input (truncateDisplayText, displayEditorText)
-import Agent.CLI.TUI.Composer.Edit (wrapDraftWindow)
+import Agent.CLI.TUI.Composer.Edit (draftWindowStart, wrapDraftWindow)
 import Agent.CLI.TUI.Composer.Logic (currentSlashMenu)
 import Agent.CLI.TUI.History (HistoryWindow, historyWindowHasBlocks)
 import Agent.CLI.TUI.Types
@@ -26,7 +27,7 @@ import qualified Brick.Types as B
 import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
 import qualified Brick.Widgets.Border.Style as BorderStyle
-import Data.List (intersperse)
+import Data.List (intersperse, mapAccumL)
 import Data.Sequence (ViewL(..))
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
@@ -143,6 +144,17 @@ drawComposer appState =
                     draftWidth
                     state.uiDraft
                     state.uiCursor
+            slashCommandLength =
+                case slashCommandHighlightToken
+                        appState.appSlashCatalog
+                        state.uiDraft of
+                    Just token
+                        | draftWindowStart
+                            maxComposerRows
+                            state.uiDraft
+                            state.uiCursor == 0 ->
+                                Text.length token
+                    _ -> 0
             bodyHeight = min maxComposerRows (length draftRows)
             leading =
                 filter (not . Text.null)
@@ -178,6 +190,7 @@ drawComposer appState =
                                 (renderDraft
                                     focused
                                     bodyHeight
+                                    slashCommandLength
                                     state
                                     draftLayout)
                             ]
@@ -266,14 +279,17 @@ controlInteractionAttr state name
 renderDraft
     :: Bool
     -> Int
+    -> Int
     -> UiState
     -> ([Text], (Int, Int))
     -> Widget Name
-renderDraft focused height state (rows, (row, column)) =
+renderDraft focused height slashCommandLength state (rows, (row, column)) =
     padRight Max cursorContent
   where
     firstVisibleRow = max 0 (row - height + 1)
-    visibleRows = take height (drop firstVisibleRow rows)
+    (_, highlightedRows) =
+        mapAccumL splitHighlightedRow slashCommandLength rows
+    visibleRows = take height (drop firstVisibleRow highlightedRows)
     visibleCursorRow = row - firstVisibleRow
     content
         | Text.null state.uiDraft =
@@ -294,9 +310,24 @@ renderDraft focused height state (rows, (row, column)) =
 
     -- Empty visual rows still need one cell so Brick preserves their height
     -- and can place the insertion cursor on them.
-    renderRow row
-        | Text.null row = txt " "
-        | otherwise = terminalTxt (displayEditorText row)
+    renderRow (highlighted, rest)
+        | Text.null highlighted && Text.null rest = txt " "
+        | otherwise =
+            hBox
+                ( [ withAttr Theme.slashCommandAttr
+                        (terminalTxt (displayEditorText highlighted))
+                  | not (Text.null highlighted)
+                  ]
+                    <> [ terminalTxt (displayEditorText rest)
+                       | not (Text.null rest)
+                       ]
+                )
+
+    splitHighlightedRow remaining rowText =
+        let highlightedLength = min remaining (Text.length rowText)
+        in ( remaining - highlightedLength
+           , Text.splitAt highlightedLength rowText
+           )
 
 terminalTxt :: Text -> Widget n
 terminalTxt text =

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -615,6 +615,32 @@ spec = do
             displays "/ra" 3 `shouldSatisfy` ("/reload-auth" `elem`)
             displays "look at /mo" 11 `shouldBe` []
 
+        it "identifies available command prefixes for live highlighting" do
+            map (slashCommandHighlightToken defaultSlashCatalog)
+                [ "/"
+                , "/res"
+                , "/resume"
+                , "/resume session-id"
+                , "/M"
+                , "/yolo now"
+                ]
+                `shouldBe`
+                    map Just
+                        [ "/"
+                        , "/res"
+                        , "/resume"
+                        , "/resume"
+                        , "/M"
+                        , "/yolo"
+                        ]
+            map (slashCommandHighlightToken defaultSlashCatalog)
+                [ "/blorp test"
+                , "/absolute/path/template.png"
+                , "look at /resume"
+                , " /resume"
+                ]
+                `shouldBe` replicate 4 Nothing
+
         it "offers argument rows" do
             let menu = slashMenuFor "/effort h" 9
             fmap (.slashMenuReplaceStart) menu `shouldBe` Just 8
@@ -721,6 +747,10 @@ spec = do
                 (map (.slashSuggestionDisplay) . (.slashMenuSuggestions))
                 (slashMenuForCatalog enabled "/loo" 4)
                 `shouldBe` Just ["/loop"]
+            slashCommandHighlightToken disabled "/loo"
+                `shouldBe` Nothing
+            slashCommandHighlightToken enabled "/loo"
+                `shouldBe` Just "/loo"
 
         it "expands /loop while preserving the submitted slash text" do
             case parseReplLineWithCatalog enabled
@@ -856,6 +886,10 @@ spec = do
             let help = formatSlashHelpWithSkills False skills (Just "deploy")
             Text.unpack help `shouldSatisfy` ("Deploy the service" `isInfixOf`)
             Text.unpack help `shouldSatisfy` ("skill · repo · agents" `isInfixOf`)
+            slashCommandHighlightToken
+                (slashCatalogWithSkills skills defaultSlashCatalog)
+                "/dep production"
+                `shouldBe` Just "/dep"
 
         it "offers Codex-style dollar skill mentions inside prompts" do
             fmap (map (.slashSuggestionDisplay) . (.slashMenuSuggestions))

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -120,6 +120,10 @@ spec = describe "fullscreen composer" do
             (rows, location) = wrapDraftWindow 8 10 draft cursor
         rows `shouldBe` map (Text.pack . show) [93 :: Int .. 100]
         location `shouldBe` (7, 3)
+        Text.drop (draftWindowStart 8 draft cursor) draft
+            `shouldBe` Text.intercalate
+                "\n"
+                (map (Text.pack . show) [93 :: Int .. 100])
 
     it "keeps enough following rows when the cursor is near the start" do
         let draft =
@@ -129,6 +133,7 @@ spec = describe "fullscreen composer" do
             (rows, location) = wrapDraftWindow 8 10 draft 0
         take 8 rows `shouldBe` map (Text.pack . show) [1 :: Int .. 8]
         location `shouldBe` (0, 0)
+        draftWindowStart 8 draft 0 `shouldBe` 0
 
     it "distinguishes the cursor positions before and after a full-row newline" do
         wrapDraft 2 "ab\nc" 2

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -26,6 +26,7 @@ module Agent.TUI.Theme
     , mutedAttr
     , selectedAttr
     , selectedMutedAttr
+    , slashCommandAttr
     , transcriptHoverAttr
     , transcriptHoverMutedAttr
     , transcriptHoverMutedCancelledAttr
@@ -184,7 +185,8 @@ fixedThemePalette = \case
         (RGBColor 65 210 190) (RGBColor 80 170 255))
 
 baseAttr, headerAttr, footerAttr, mutedAttr :: AttrName
-userAttr, userMutedAttr, assistantAttr, thinkingAttr, thinkingBodyAttr, toolAttr, toolPathAttr :: AttrName
+userAttr, userMutedAttr, assistantAttr, slashCommandAttr :: AttrName
+thinkingAttr, thinkingBodyAttr, toolAttr, toolPathAttr :: AttrName
 inspectAttr :: AttrName
 todoPendingAttr, todoInProgressAttr, todoCompletedAttr, todoCancelledAttr :: AttrName
 errorAttr, successAttr, selectedAttr, selectedMutedAttr, borderAttr, borderActiveAttr :: AttrName
@@ -207,6 +209,7 @@ mutedAttr = attrName "muted"
 userAttr = attrName "user"
 userMutedAttr = attrName "user-muted"
 assistantAttr = attrName "assistant"
+slashCommandAttr = attrName "slash-command"
 thinkingAttr = attrName "thinking"
 thinkingBodyAttr = attrName "thinking-body"
 toolAttr = attrName "tool"
@@ -289,6 +292,7 @@ terminalDefault =
         , (userAttr, raisedPanelAttr `V.withStyle` V.bold)
         , (userMutedAttr, raisedPanelMutedAttr)
         , (assistantAttr, V.defAttr)
+        , (slashCommandAttr, palette V.blue)
         , (thinkingAttr, palette V.yellow)
         , (thinkingBodyAttr, palette V.brightBlack `V.withStyle` (V.dim .|. V.italic))
         , (waitingDimAttr, palette V.brightBlack)
@@ -366,6 +370,7 @@ monochrome =
         , (userAttr, V.defAttr `V.withStyle` V.bold)
         , (userMutedAttr, V.defAttr `V.withStyle` V.dim)
         , (assistantAttr, V.defAttr)
+        , (slashCommandAttr, V.defAttr `V.withStyle` V.bold)
         , (thinkingAttr, V.defAttr)
         , (thinkingBodyAttr, V.defAttr `V.withStyle` (V.dim .|. V.italic))
         , (waitingDimAttr, V.defAttr)
@@ -454,6 +459,7 @@ mkTheme background foreground muted accent link =
         , (userAttr, panel `V.withStyle` V.bold)
         , (userMutedAttr, panelMuted)
         , (assistantAttr, base)
+        , (slashCommandAttr, linkA)
         , (thinkingAttr, accentA)
         , (thinkingBodyAttr, mutedA `V.withStyle` (V.dim .|. V.italic))
         , (waitingDimAttr, mutedA)

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -69,6 +69,22 @@ spec = do
                     (Theme.themeAttrMap Theme.Daylight))
                 `shouldBe` V.SetTo (RGBColor 144 80 150)
 
+        it "uses the link color for recognized slash commands" do
+            let terminal =
+                    attrMapLookup Theme.slashCommandAttr Theme.terminalDefault
+                midnight =
+                    attrMapLookup
+                        Theme.slashCommandAttr
+                        (Theme.themeAttrMap Theme.Midnight)
+                noColor =
+                    attrMapLookup Theme.slashCommandAttr Theme.monochrome
+            V.attrForeColor terminal `shouldBe` V.SetTo V.blue
+            V.attrForeColor midnight
+                `shouldBe` V.SetTo (RGBColor 122 162 247)
+            V.attrBackColor midnight
+                `shouldBe` V.SetTo (RGBColor 26 27 38)
+            V.attrStyle noColor `shouldBe` V.SetTo V.bold
+
         it "sets a daylight background on semantic text attributes" do
             map
                 ( V.attrBackColor
@@ -82,6 +98,7 @@ spec = do
                 , Theme.footerAttr
                 , Theme.mutedAttr
                 , Theme.assistantAttr
+                , Theme.slashCommandAttr
                 , Theme.thinkingAttr
                 , Theme.toolAttr
                 , Theme.inspectAttr


### PR DESCRIPTION
## Summary

- highlight available slash-command prefixes and completed command tokens in the fullscreen composer
- use the active command, alias, and skill catalog while leaving arguments, unknown commands, and paths unstyled
- add a semantic theme attribute with fixed-background and monochrome handling, including wrapped and scrolled drafts

## Testing

- multi-package GHCi load: 213 modules
- focused agent-cli specs: 5 examples, 0 failures
- focused agent-tui specs: 2 examples, 0 failures
- live tmux smoke test: recognized command tokens were styled independently from arguments, while unknown input remained unchanged
- `git diff --check`